### PR TITLE
feat(lexer): add unicode identifier support

### DIFF
--- a/src/lexer/mod.zig
+++ b/src/lexer/mod.zig
@@ -5,6 +5,7 @@
 
 pub const token = @import("token.zig");
 pub const scanner = @import("scanner.zig");
+pub const unicode_util = @import("unicode.zig");
 
 pub const Token = token.Token;
 pub const Kind = token.Kind;
@@ -15,4 +16,5 @@ pub const keywords = token.keywords;
 test {
     _ = token;
     _ = scanner;
+    _ = unicode_util;
 }

--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const token = @import("token.zig");
+const unicode = @import("unicode.zig");
 
 const Token = token.Token;
 const Kind = token.Kind;
@@ -334,12 +335,36 @@ pub const Scanner = struct {
                 },
 
                 else => blk: {
-                    // 식별자 시작 문자인지 확인
-                    if (isIdentifierStart(c)) {
+                    // ASCII 식별자 시작
+                    if (isAsciiIdentStart(c)) {
                         self.scanIdentifierTail();
-                        // 키워드 확인
                         const text = self.tokenText();
                         break :blk token.keywords.get(text) orelse .identifier;
+                    }
+                    // \u 유니코드 이스케이프로 시작하는 식별자
+                    if (c == '\\') {
+                        // advance()에서 이미 \ 를 소비했으므로 current-1 부터
+                        self.current -= 1; // put back '\'
+                        if (self.scanIdentifierEscape()) {
+                            self.scanIdentifierTail();
+                            // 이스케이프 키워드는 키워드가 아닌 식별자로 취급
+                            break :blk .escaped_keyword;
+                        }
+                        self.current += 1; // re-consume '\'
+                        break :blk .syntax_error;
+                    }
+                    // Non-ASCII 유니코드 식별자
+                    if (c >= 0x80) {
+                        // advance()에서 1바이트 소비했으므로 나머지 UTF-8 바이트 소비
+                        const start_pos = self.current - 1;
+                        const remaining = self.source[start_pos..];
+                        const decoded = unicode.decodeUtf8(remaining);
+                        if (unicode.isIdentifierStart(decoded.codepoint)) {
+                            self.current = @intCast(start_pos + decoded.len);
+                            self.scanIdentifierTail();
+                            const text = self.tokenText();
+                            break :blk token.keywords.get(text) orelse .identifier;
+                        }
                     }
                     break :blk .syntax_error;
                 },
@@ -1041,31 +1066,76 @@ pub const Scanner = struct {
         }
     }
 
+    /// 식별자의 나머지 부분을 스캔한다. 유니코드 문자와 \u 이스케이프를 처리.
     fn scanIdentifierTail(self: *Scanner) void {
         while (!self.isAtEnd()) {
             const c = self.peek();
-            if (isIdentifierContinue(c)) {
-                self.current += 1;
+            // ASCII fast path
+            if (c < 0x80) {
+                if (isAsciiIdentContinue(c)) {
+                    self.current += 1;
+                } else if (c == '\\') {
+                    // \uXXXX 유니코드 이스케이프
+                    if (!self.scanIdentifierEscape()) break;
+                } else {
+                    break;
+                }
             } else {
-                break;
+                // Non-ASCII: UTF-8 디코딩 후 유니코드 ID_Continue 확인
+                const remaining = self.source[self.current..];
+                const decoded = unicode.decodeUtf8(remaining);
+                if (decoded.len == 0) break;
+                if (unicode.isIdentifierContinue(decoded.codepoint)) {
+                    self.current += decoded.len;
+                } else {
+                    break;
+                }
             }
         }
+    }
+
+    /// 식별자 안의 \uXXXX 또는 \u{XXXX} 이스케이프를 스캔한다.
+    /// 성공하면 true, 유효하지 않으면 false.
+    fn scanIdentifierEscape(self: *Scanner) bool {
+        if (self.peek() != '\\') return false;
+        if (self.peekAt(1) != 'u') return false;
+        self.current += 2; // skip \u
+
+        if (self.peek() == '{') {
+            self.current += 1;
+            while (!self.isAtEnd() and self.peek() != '}') {
+                self.current += 1;
+            }
+            if (!self.isAtEnd()) self.current += 1; // skip }
+        } else {
+            self.skipHexEscape(4);
+        }
+        return true;
     }
 
     // ====================================================================
     // 문자 분류
     // ====================================================================
 
-    /// ASCII 식별자 시작 문자인지. (추후 유니코드 PR에서 확장)
-    fn isIdentifierStart(c: u8) bool {
+    /// ASCII 식별자 시작 문자인지.
+    fn isAsciiIdentStart(c: u8) bool {
         return (c >= 'a' and c <= 'z') or
             (c >= 'A' and c <= 'Z') or
             c == '_' or c == '$';
     }
 
-    /// ASCII 식별자 계속 문자인지. (추후 유니코드 PR에서 확장)
-    fn isIdentifierContinue(c: u8) bool {
-        return isIdentifierStart(c) or (c >= '0' and c <= '9');
+    /// ASCII 식별자 계속 문자인지.
+    fn isAsciiIdentContinue(c: u8) bool {
+        return isAsciiIdentStart(c) or (c >= '0' and c <= '9');
+    }
+
+    /// 바이트가 식별자 시작 문자인지 (ASCII + non-ASCII).
+    fn isIdentifierStartByte(self: *Scanner, c: u8) bool {
+        if (c < 0x80) return isAsciiIdentStart(c);
+        // Non-ASCII: UTF-8 디코딩
+        const remaining = self.source[self.current - 1 ..];
+        const decoded = unicode.decodeUtf8(remaining);
+        return unicode.isIdentifierStart(decoded.codepoint);
     }
 };
 
@@ -1930,4 +2000,54 @@ test "Scanner: regex after comma" {
     scanner.next(); // ,
     scanner.next(); // /re/
     try std.testing.expectEqual(Kind.regexp, scanner.token.kind);
+}
+
+// ============================================================
+// Unicode identifier tests
+// ============================================================
+
+test "Scanner: unicode identifier (Latin)" {
+    // café = UTF-8: 63 61 66 C3 A9
+    const source = "caf\xC3\xA9";
+    var scanner = Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+
+    scanner.next();
+    try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
+    try std.testing.expectEqualStrings("caf\xC3\xA9", scanner.tokenText());
+}
+
+test "Scanner: unicode identifier (CJK)" {
+    // 변수 = UTF-8: EB B3 80 EC 88 98
+    const source = "\xEB\xB3\x80\xEC\x88\x98";
+    var scanner = Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+
+    scanner.next();
+    try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
+}
+
+test "Scanner: unicode identifier (Greek)" {
+    // α = UTF-8: CE B1
+    const source = "\xCE\xB1 = 1";
+    var scanner = Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+
+    scanner.next();
+    try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
+    try std.testing.expectEqualStrings("\xCE\xB1", scanner.tokenText());
+
+    scanner.next();
+    try std.testing.expectEqual(Kind.eq, scanner.token.kind);
+}
+
+test "Scanner: mixed ASCII and unicode in identifier" {
+    // test변수 = ASCII + CJK
+    const source = "test\xEB\xB3\x80\xEC\x88\x98";
+    var scanner = Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+
+    scanner.next();
+    try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
+    try std.testing.expectEqualStrings("test\xEB\xB3\x80\xEC\x88\x98", scanner.tokenText());
 }

--- a/src/lexer/unicode.zig
+++ b/src/lexer/unicode.zig
@@ -1,0 +1,206 @@
+//! Unicode utilities for the ZTS lexer.
+//!
+//! ECMAScript 식별자에 사용할 수 있는 유니코드 문자를 판별한다.
+//! - ID_Start: 식별자 시작 문자 (Unicode Lu, Ll, Lt, Lm, Lo, Nl + $ + _)
+//! - ID_Continue: 식별자 계속 문자 (ID_Start + Mn, Mc, Nd, Pc + ZWNJ + ZWJ)
+//!
+//! UTF-8 디코딩 유틸리티도 포함.
+//!
+//! 참고: https://tc39.es/ecma262/#sec-names-and-keywords
+
+const std = @import("std");
+
+/// UTF-8 바이트 시퀀스에서 코드포인트 하나를 디코딩한다.
+/// 반환: (코드포인트, 소비한 바이트 수). 유효하지 않으면 (0xFFFD, 1).
+pub fn decodeUtf8(bytes: []const u8) struct { codepoint: u21, len: u3 } {
+    if (bytes.len == 0) return .{ .codepoint = 0, .len = 0 };
+
+    const b0 = bytes[0];
+
+    // ASCII (0xxxxxxx)
+    if (b0 < 0x80) return .{ .codepoint = b0, .len = 1 };
+
+    // 2바이트 (110xxxxx 10xxxxxx)
+    if (b0 >= 0xC0 and b0 < 0xE0) {
+        if (bytes.len < 2) return .{ .codepoint = 0xFFFD, .len = 1 };
+        const cp = (@as(u21, b0 & 0x1F) << 6) | @as(u21, bytes[1] & 0x3F);
+        return .{ .codepoint = cp, .len = 2 };
+    }
+
+    // 3바이트 (1110xxxx 10xxxxxx 10xxxxxx)
+    if (b0 >= 0xE0 and b0 < 0xF0) {
+        if (bytes.len < 3) return .{ .codepoint = 0xFFFD, .len = 1 };
+        const cp = (@as(u21, b0 & 0x0F) << 12) |
+            (@as(u21, bytes[1] & 0x3F) << 6) |
+            @as(u21, bytes[2] & 0x3F);
+        return .{ .codepoint = cp, .len = 3 };
+    }
+
+    // 4바이트 (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
+    if (b0 >= 0xF0 and b0 < 0xF8) {
+        if (bytes.len < 4) return .{ .codepoint = 0xFFFD, .len = 1 };
+        const cp = (@as(u21, b0 & 0x07) << 18) |
+            (@as(u21, bytes[1] & 0x3F) << 12) |
+            (@as(u21, bytes[2] & 0x3F) << 6) |
+            @as(u21, bytes[3] & 0x3F);
+        return .{ .codepoint = cp, .len = 4 };
+    }
+
+    return .{ .codepoint = 0xFFFD, .len = 1 };
+}
+
+/// ECMAScript IdentifierStart 문자인지 판별한다.
+/// Unicode ID_Start + $ + _ + \ (유니코드 이스케이프 시작)
+pub fn isIdentifierStart(cp: u21) bool {
+    // ASCII fast path
+    if (cp < 0x80) {
+        return (cp >= 'a' and cp <= 'z') or
+            (cp >= 'A' and cp <= 'Z') or
+            cp == '_' or cp == '$';
+    }
+
+    // Unicode ID_Start 범위 (간소화된 버전)
+    // 전체 Unicode 테이블 대신 주요 범위만 커버.
+    // 정확한 판별은 추후 생성된 테이블로 교체 가능.
+    return isUnicodeIdStart(cp);
+}
+
+/// ECMAScript IdentifierPart 문자인지 판별한다.
+/// Unicode ID_Continue + $ + ZWNJ (U+200C) + ZWJ (U+200D)
+pub fn isIdentifierContinue(cp: u21) bool {
+    // ASCII fast path
+    if (cp < 0x80) {
+        return (cp >= 'a' and cp <= 'z') or
+            (cp >= 'A' and cp <= 'Z') or
+            (cp >= '0' and cp <= '9') or
+            cp == '_' or cp == '$';
+    }
+
+    // ZWNJ, ZWJ
+    if (cp == 0x200C or cp == 0x200D) return true;
+
+    return isUnicodeIdContinue(cp);
+}
+
+/// Unicode ID_Start 범위 판별 (간소화).
+/// 주요 유니코드 블록만 커버. 전체 테이블은 추후 Unicode Data에서 생성.
+fn isUnicodeIdStart(cp: u21) bool {
+    // Latin Extended
+    if (cp >= 0x00C0 and cp <= 0x024F) return cp != 0x00D7 and cp != 0x00F7;
+    // Greek and Coptic
+    if (cp >= 0x0370 and cp <= 0x03FF) return true;
+    // Cyrillic
+    if (cp >= 0x0400 and cp <= 0x04FF) return true;
+    // Armenian
+    if (cp >= 0x0530 and cp <= 0x058F) return true;
+    // Hebrew
+    if (cp >= 0x0590 and cp <= 0x05FF) return true;
+    // Arabic
+    if (cp >= 0x0600 and cp <= 0x06FF) return true;
+    // Devanagari
+    if (cp >= 0x0900 and cp <= 0x097F) return true;
+    // Bengali, Gurmukhi, Gujarati, Oriya, Tamil, Telugu, Kannada, Malayalam
+    if (cp >= 0x0980 and cp <= 0x0DFF) return true;
+    // Thai
+    if (cp >= 0x0E00 and cp <= 0x0E7F) return true;
+    // CJK Unified Ideographs
+    if (cp >= 0x4E00 and cp <= 0x9FFF) return true;
+    // Hangul Syllables
+    if (cp >= 0xAC00 and cp <= 0xD7AF) return true;
+    // CJK Compatibility Ideographs
+    if (cp >= 0xF900 and cp <= 0xFAFF) return true;
+    // Katakana, Hiragana
+    if (cp >= 0x3040 and cp <= 0x30FF) return true;
+    // CJK Extension B
+    if (cp >= 0x20000 and cp <= 0x2A6DF) return true;
+    // Emoji는 ID_Start가 아님
+
+    return false;
+}
+
+/// Unicode ID_Continue 범위 판별 (간소화).
+fn isUnicodeIdContinue(cp: u21) bool {
+    if (isUnicodeIdStart(cp)) return true;
+
+    // Combining marks (Mn, Mc)
+    if (cp >= 0x0300 and cp <= 0x036F) return true; // Combining Diacritical Marks
+    if (cp >= 0x0483 and cp <= 0x0487) return true; // Cyrillic combining
+    if (cp >= 0x0591 and cp <= 0x05BD) return true; // Hebrew combining
+    if (cp >= 0x0610 and cp <= 0x061A) return true; // Arabic combining
+    if (cp >= 0x064B and cp <= 0x065F) return true; // Arabic combining
+    if (cp >= 0x0670 and cp == 0x0670) return true;
+    if (cp >= 0x06D6 and cp <= 0x06DC) return true;
+    if (cp >= 0x0901 and cp <= 0x0903) return true; // Devanagari combining
+
+    // Decimal digits in other scripts
+    if (cp >= 0x0660 and cp <= 0x0669) return true; // Arabic-Indic digits
+    if (cp >= 0x06F0 and cp <= 0x06F9) return true; // Extended Arabic-Indic
+    if (cp >= 0x0966 and cp <= 0x096F) return true; // Devanagari digits
+
+    // Connector punctuation (Pc)
+    if (cp == 0x203F or cp == 0x2040) return true; // UNDERTIE, CHARACTER TIE
+    if (cp == 0xFE33 or cp == 0xFE34) return true; // PRESENTATION FORM
+    if (cp == 0xFE4D or cp == 0xFE4E or cp == 0xFE4F) return true;
+    if (cp == 0xFF3F) return true; // FULLWIDTH LOW LINE
+
+    return false;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+test "decodeUtf8: ASCII" {
+    const result = decodeUtf8("A");
+    try std.testing.expectEqual(@as(u21, 'A'), result.codepoint);
+    try std.testing.expectEqual(@as(u3, 1), result.len);
+}
+
+test "decodeUtf8: 2-byte UTF-8" {
+    // é = U+00E9 = 0xC3 0xA9
+    const result = decodeUtf8("\xC3\xA9");
+    try std.testing.expectEqual(@as(u21, 0x00E9), result.codepoint);
+    try std.testing.expectEqual(@as(u3, 2), result.len);
+}
+
+test "decodeUtf8: 3-byte UTF-8 (한)" {
+    // 한 = U+D55C = 0xED 0x95 0x9C
+    const result = decodeUtf8("\xED\x95\x9C");
+    try std.testing.expectEqual(@as(u21, 0xD55C), result.codepoint);
+    try std.testing.expectEqual(@as(u3, 3), result.len);
+}
+
+test "decodeUtf8: 4-byte UTF-8 (emoji)" {
+    // 😀 = U+1F600 = 0xF0 0x9F 0x98 0x80
+    const result = decodeUtf8("\xF0\x9F\x98\x80");
+    try std.testing.expectEqual(@as(u21, 0x1F600), result.codepoint);
+    try std.testing.expectEqual(@as(u3, 4), result.len);
+}
+
+test "isIdentifierStart: ASCII" {
+    try std.testing.expect(isIdentifierStart('a'));
+    try std.testing.expect(isIdentifierStart('Z'));
+    try std.testing.expect(isIdentifierStart('_'));
+    try std.testing.expect(isIdentifierStart('$'));
+    try std.testing.expect(!isIdentifierStart('0'));
+    try std.testing.expect(!isIdentifierStart('+'));
+}
+
+test "isIdentifierStart: Unicode" {
+    try std.testing.expect(isIdentifierStart(0x00E9)); // é (Latin)
+    try std.testing.expect(isIdentifierStart(0x4E2D)); // 中 (CJK)
+    try std.testing.expect(isIdentifierStart(0xD55C)); // 한 (Hangul)
+    try std.testing.expect(isIdentifierStart(0x03B1)); // α (Greek)
+    try std.testing.expect(isIdentifierStart(0x0410)); // А (Cyrillic)
+}
+
+test "isIdentifierContinue: digits and special" {
+    try std.testing.expect(isIdentifierContinue('0'));
+    try std.testing.expect(isIdentifierContinue('9'));
+    try std.testing.expect(isIdentifierContinue('a'));
+    try std.testing.expect(isIdentifierContinue('$'));
+    try std.testing.expect(isIdentifierContinue(0x200C)); // ZWNJ
+    try std.testing.expect(isIdentifierContinue(0x200D)); // ZWJ
+    try std.testing.expect(!isIdentifierContinue('+'));
+    try std.testing.expect(!isIdentifierContinue(' '));
+}


### PR DESCRIPTION
## Summary
- `unicode.zig`: UTF-8 디코딩 + Unicode ID_Start/ID_Continue 판별
- 유니코드 식별자 (café, 변수, α 등) 스캔
- `\uXXXX`, `\u{XXXX}` 이스케이프 시퀀스 처리
- ASCII fast path 유지

## Test plan
- [x] `zig build test` 통과 (102 tests)
- [x] 11개 유니코드 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)