### PR TITLE
feat(lexer): connect Test262 runner to lexer with CLI

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -115,17 +115,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_exe_unit_tests.step);
 
     // Test262 러너 테스트
-    // test262.zig 내의 unit test를 실행한다.
-    // `zig build test262` 로 실행 가능.
-    const test262_mod = b.createModule(.{
-        .root_source_file = b.path("src/test262/runner.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    const test262_unit_tests = b.addTest(.{
-        .root_module = test262_mod,
-    });
-    const run_test262_unit_tests = b.addRunArtifact(test262_unit_tests);
+    // lib_mod에 이미 test262가 포함되어 있으므로 같은 모듈로 테스트.
+    // `zig build test262` = `zig build test` 와 동일하지만 명시적 스텝.
     const test262_step = b.step("test262", "Run Test262 runner tests");
-    test262_step.dependOn(&run_test262_unit_tests.step);
+    test262_step.dependOn(&run_lib_unit_tests.step);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,12 +1,74 @@
 const std = @import("std");
+const lib = @import("zts_lib");
+const Scanner = lib.lexer.Scanner;
+const runner = lib.test262.runner;
 
 pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
-    try stdout.print("zts v0.1.0 - Zig TypeScript Transpiler\n", .{});
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // CLI 인자 파싱
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len < 2) {
+        try stdout.print("zts v0.1.0 - Zig TypeScript Transpiler\n\n", .{});
+        try stdout.print("Usage:\n", .{});
+        try stdout.print("  zts <file.ts>              Transpile a file\n", .{});
+        try stdout.print("  zts --test262 <directory>   Run Test262 tests\n", .{});
+        try stdout.print("  zts --tokenize <file>       Tokenize and print tokens\n", .{});
+        return;
+    }
+
+    const command = args[1];
+
+    if (std.mem.eql(u8, command, "--test262")) {
+        if (args.len < 3) {
+            try stdout.print("Error: --test262 requires a directory path\n", .{});
+            return;
+        }
+        const dir_path = args[2];
+
+        const abs_path = try std.fs.cwd().realpathAlloc(allocator, dir_path);
+        defer allocator.free(abs_path);
+
+        try stdout.print("Running Test262: {s}\n", .{abs_path});
+        const summary = try runner.runDirectory(allocator, abs_path);
+        try summary.print(stdout);
+        return;
+    }
+
+    if (std.mem.eql(u8, command, "--tokenize")) {
+        if (args.len < 3) {
+            try stdout.print("Error: --tokenize requires a file path\n", .{});
+            return;
+        }
+        const file_path = args[2];
+        const source = try std.fs.cwd().readFileAlloc(allocator, file_path, 10 * 1024 * 1024);
+        defer allocator.free(source);
+
+        var scanner = Scanner.init(allocator, source);
+        defer scanner.deinit();
+
+        while (true) {
+            scanner.next();
+            const lc = scanner.getLineColumn(scanner.token.span.start);
+            try stdout.print("{d}:{d}\t{s}\t\"{s}\"\n", .{
+                lc.line + 1,
+                lc.column + 1,
+                scanner.token.kind.symbol(),
+                scanner.tokenText(),
+            });
+            if (scanner.token.kind == .eof) break;
+        }
+        return;
+    }
+
+    try stdout.print("zts: transpile not yet implemented. Use --tokenize or --test262\n", .{});
 }
 
 test "basic" {
     try std.testing.expect(true);
 }
-
-const lib = @import("zts_lib");

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const fs = std.fs;
 const mem = std.mem;
+const Scanner = @import("../lexer/scanner.zig").Scanner;
 
 /// Test262 테스트 파일의 YAML 메타데이터
 /// 각 .js 파일 상단의 /*--- ... ---*/ 블록을 파싱한 결과
@@ -145,21 +146,34 @@ pub fn parseMetadata(source: []const u8) TestMetadata {
 /// 판정 로직:
 /// - is_negative_parse == true → 파서가 에러를 던지면 pass
 /// - is_negative_parse == false → 파서가 에러 없이 완료되면 pass
-pub fn runTest(source: []const u8, meta: TestMetadata) TestResult {
-    _ = source;
+/// 단일 Test262 테스트를 실행한다.
+/// 렉서로 소스를 토크나이즈하고, 에러 발생 여부로 pass/fail을 판정.
+///
+/// 판정 로직:
+/// - is_negative_parse == true → 렉서가 에러를 던지면 pass
+/// - is_negative_parse == false → 렉서가 에러 없이 완료되면 pass
+pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata) TestResult {
+    _ = meta.is_module; // 렉서 단계에서는 module/script 구분 없음
 
-    // TODO: 렉서/파서 구현 후 실제 연결
-    // const result = parser.parse(source, .{ .module = meta.is_module });
-    // const had_error = result.hasErrors();
-    //
-    // if (meta.is_negative_parse) {
-    //     return if (had_error) .pass else .fail;
-    // } else {
-    //     return if (had_error) .fail else .pass;
-    // }
+    // 렉서로 전체 토크나이즈
+    var scanner = Scanner.init(allocator, source);
+    defer scanner.deinit();
 
-    _ = meta;
-    return .skip;
+    var had_error = false;
+    while (true) {
+        scanner.next();
+        if (scanner.token.kind == .syntax_error) {
+            had_error = true;
+            break;
+        }
+        if (scanner.token.kind == .eof) break;
+    }
+
+    if (meta.is_negative_parse) {
+        return if (had_error) .pass else .fail;
+    } else {
+        return if (had_error) .fail else .pass;
+    }
 }
 
 /// 디렉토리 내 모든 .js 파일을 재귀적으로 찾아 테스트를 실행한다.
@@ -186,7 +200,7 @@ pub fn runDirectory(allocator: mem.Allocator, dir_path: []const u8) !TestSummary
 
         // 메타데이터 파싱 & 테스트 실행
         const meta = parseMetadata(source);
-        const result = runTest(source, meta);
+        const result = runTest(allocator, source, meta);
 
         summary.total += 1;
         switch (result) {


### PR DESCRIPTION
## Summary
- `--test262` CLI로 Test262 테스트 실행
- `--tokenize` CLI로 파일 토크나이즈 출력
- Test262 러너가 Scanner를 직접 사용하여 pass/fail 판정

## Initial Test262 Pass Rates (렉서만)
| Category | Pass Rate |
|----------|-----------|
| boolean | 50.0% |
| null | 66.7% |
| numeric | 64.3% |
| string | 60.3% |
| bigint | 33.9% |
| regexp | 24.4% |
| comments | 67.3% |
| white-space | 70.1% |
| line-terminators | 73.2% |

대부분의 실패는 렉서가 아닌 파서 수준의 검증이 필요한 테스트 (negative parse tests에서 렉서가 에러를 감지 못하는 경우).

## Test plan
- [x] `zig build test` 통과 (115 tests)
- [x] `--test262` 실행 확인
- [x] `--tokenize` 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)