### PR TITLE
fix(parser): remaining /simplify review items

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -57,6 +57,16 @@
 | 27 | /= vs regex 순서 (= /=test/ 케이스) | esbuild/Bun 동일 동작 | 문서화 완료, 수정 불필요 |
 | 28 | runner.zig failed_list 메모리 누수 (에러 경로) | arena allocator로 교체 | Phase 2 |
 
+### PR #18: feat(parser): base parser
+
+| # | 항목 | 이유 | 해결 시점 |
+|---|------|------|----------|
+| 29 | for-in/for-of 파싱 미구현 | 현재 for(;;)만 지원 | Phase 2 다음 PR |
+| 30 | 에러 메시지에 컨텍스트 부족 (`"("` → `"expected '(' after 'for'"`) | UX | Phase 5 (CLI) |
+| 31 | 나머지 parseXxx에서 scratch ArrayList 미적용 (block, array, object, function params) | 성능 | 최적화 PR |
+| 32 | shorthand property (`{x}` = `{x: x}`) 미지원 | 문법 | Phase 2 다음 PR |
+| 33 | spread in array/object (`...x`) 미지원 | 문법 | Phase 2 다음 PR |
+
 ---
 
 ## 추후 개선

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -202,7 +202,7 @@ pub const Parser = struct {
 
     fn parseVariableDeclaration(self: *Parser) !NodeIndex {
         const start = self.currentSpan().start;
-        const kind_flags: u16 = switch (self.current()) {
+        const kind_flags: u32 = switch (self.current()) {
             .kw_var => 0,
             .kw_let => 1,
             .kw_const => 2,
@@ -210,23 +210,26 @@ pub const Parser = struct {
         };
         self.advance(); // skip var/let/const
 
-        var declarators = std.ArrayList(NodeIndex).init(self.allocator);
-        defer declarators.deinit();
-
+        self.scratch.clearRetainingCapacity();
         while (true) {
             const decl = try self.parseVariableDeclarator();
-            try declarators.append(decl);
+            try self.scratch.append(decl);
             if (!self.eat(.comma)) break;
         }
 
         const end = self.currentSpan().end;
         _ = self.eat(.semicolon);
 
-        const list = try self.ast.addNodeList(declarators.items);
+        const list = try self.ast.addNodeList(self.scratch.items);
+        // extra_data: [kind_flags, list.start, list.len]
+        const extra_start = try self.ast.addExtra(kind_flags);
+        _ = try self.ast.addExtra(list.start);
+        _ = try self.ast.addExtra(list.len);
+
         return try self.ast.addNode(.{
             .tag = .variable_declaration,
             .span = .{ .start = start, .end = end },
-            .data = .{ .binary = .{ .left = @enumFromInt(list.start), .right = @enumFromInt(list.len), .flags = kind_flags } },
+            .data = .{ .extra = extra_start },
         });
     }
 
@@ -725,7 +728,9 @@ pub const Parser = struct {
 
     fn parseObjectProperty(self: *Parser) !NodeIndex {
         const start = self.currentSpan().start;
-        const key = try self.parsePrimaryExpression(); // 간단히 expression으로 키 파싱
+
+        // 키: identifier, string, number, 또는 computed [expr]
+        const key = try self.parsePropertyKey();
 
         var value = NodeIndex.none;
         if (self.eat(.colon)) {
@@ -766,6 +771,64 @@ pub const Parser = struct {
         self.addError(span, "identifier expected");
         self.advance();
         return try self.ast.addNode(.{ .tag = .invalid, .span = span, .data = .{ .none = {} } });
+    }
+
+    /// 객체 프로퍼티 키를 파싱한다.
+    /// 허용: identifier, string literal, numeric literal, computed [expr].
+    fn parsePropertyKey(self: *Parser) !NodeIndex {
+        const span = self.currentSpan();
+        switch (self.current()) {
+            .identifier, .kw_get, .kw_set, .kw_async, .kw_static => {
+                // 키워드도 프로퍼티 키로 사용 가능 (get, set 등)
+                self.advance();
+                return try self.ast.addNode(.{
+                    .tag = .identifier_reference,
+                    .span = span,
+                    .data = .{ .string_ref = span },
+                });
+            },
+            .string_literal => {
+                self.advance();
+                return try self.ast.addNode(.{
+                    .tag = .string_literal,
+                    .span = span,
+                    .data = .{ .string_ref = span },
+                });
+            },
+            .decimal, .float, .hex, .octal, .binary, .positive_exponential, .negative_exponential => {
+                self.advance();
+                return try self.ast.addNode(.{
+                    .tag = .numeric_literal,
+                    .span = span,
+                    .data = .{ .none = {} },
+                });
+            },
+            .l_bracket => {
+                // computed property: [expr]
+                self.advance();
+                const expr = try self.parseAssignmentExpression();
+                self.expect(.r_bracket);
+                return try self.ast.addNode(.{
+                    .tag = .computed_property_key,
+                    .span = .{ .start = span.start, .end = self.currentSpan().start },
+                    .data = .{ .unary = .{ .operand = expr } },
+                });
+            },
+            else => {
+                // 다른 키워드도 프로퍼티 키로 허용 (class, return 등)
+                if (self.current().isKeyword()) {
+                    self.advance();
+                    return try self.ast.addNode(.{
+                        .tag = .identifier_reference,
+                        .span = span,
+                        .data = .{ .string_ref = span },
+                    });
+                }
+                self.addError(span, "property key expected");
+                self.advance();
+                return try self.ast.addNode(.{ .tag = .invalid, .span = span, .data = .{ .none = {} } });
+            },
+        }
     }
 
     // ================================================================


### PR DESCRIPTION
## Summary
PR #18 /simplify 리뷰에서 미반영된 항목 수정

- variable_declaration: binary.left/right → extra_data (의미적 정확성)
- parseObjectProperty: 키를 identifier/string/number/computed로 제한
- BACKLOG #29-#33 등록

## Test plan
- [x] `zig build test` 통과
- [x] `zig fmt --check src/` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)