### PR TITLE
feat(parser): add try/catch/finally with optional catch binding

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1278,6 +1278,16 @@ test "Parser: try-catch-finally" {
     try std.testing.expect(parser.errors.items.len == 0);
 }
 
+test "Parser: try without catch or finally is error" {
+    var scanner = Scanner.init(std.testing.allocator, "try { foo(); }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len > 0);
+}
+
 test "Parser: optional catch binding (ES2019)" {
     var scanner = Scanner.init(std.testing.allocator, "try { foo(); } catch { bar(); }");
     defer scanner.deinit();


### PR DESCRIPTION
## Summary
- try/catch/finally 파싱
- ES2019 optional catch binding
- 4개 테스트

## Test plan
- [x] `zig build test` 통과
- [x] `zig fmt --check src/` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)