### PR TITLE
feat(transformer,codegen): enum → IIFE transformation

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -183,6 +183,9 @@ pub const Codegen = struct {
 
             .formal_parameter => try self.emitFormalParam(node),
 
+            // TS enum → IIFE 출력
+            .ts_enum_declaration => try self.emitEnumIIFE(node),
+
             // TS 노드는 transformer에서 제거됨 — 여기 도달하면 strip_types=false
             else => try self.writeNodeSpan(node),
         }
@@ -730,6 +733,88 @@ pub const Codegen = struct {
     }
 
     // ================================================================
+    // TS enum → IIFE 출력
+    // ================================================================
+
+    /// enum Color { Red, Green = 5, Blue } →
+    /// var Color;(function(Color){Color[Color["Red"]=0]="Red";Color[Color["Green"]=5]="Green";Color[Color["Blue"]=6]="Blue";})(Color||(Color={}));
+    fn emitEnumIIFE(self: *Codegen, node: Node) !void {
+        const e = node.data.extra;
+        const extras = self.ast.extra_data.items[e .. e + 3];
+        const name_idx: NodeIndex = @enumFromInt(extras[0]);
+        const members_start = extras[1];
+        const members_len = extras[2];
+
+        // enum 이름 텍스트 가져오기
+        const name_node = self.ast.getNode(name_idx);
+        const name_text = self.ast.source[name_node.span.start..name_node.span.end];
+
+        // var Color;
+        try self.write("var ");
+        try self.write(name_text);
+        try self.writeByte(';');
+
+        // (function(Color){ ... })(Color||(Color={}));
+        try self.write("(function(");
+        try self.write(name_text);
+        try self.write("){");
+
+        // 각 멤버 출력
+        const member_indices = self.ast.extra_data.items[members_start .. members_start + members_len];
+        var auto_value: i64 = 0;
+
+        for (member_indices) |raw_idx| {
+            const member = self.ast.getNode(@enumFromInt(raw_idx));
+            // ts_enum_member: binary = { left=name, right=init_val }
+            const member_name_idx = member.data.binary.left;
+            const member_init_idx = member.data.binary.right;
+
+            const member_name = self.ast.getNode(member_name_idx);
+            const member_text = self.ast.source[member_name.span.start..member_name.span.end];
+
+            // Color[Color["Red"] = 0] = "Red";
+            try self.write(name_text);
+            try self.writeByte('[');
+            try self.write(name_text);
+            try self.write("[\"");
+            try self.write(member_text);
+            try self.write("\"]=");
+
+            if (!member_init_idx.isNone()) {
+                // 이니셜라이저가 있으면 그대로 출력
+                try self.emitNode(member_init_idx);
+                // 이니셜라이저가 숫자 리터럴이면 auto_value 업데이트
+                const init_node = self.ast.getNode(member_init_idx);
+                if (init_node.tag == .numeric_literal) {
+                    const num_text = self.ast.source[init_node.span.start..init_node.span.end];
+                    auto_value = std.fmt.parseInt(i64, num_text, 10) catch auto_value;
+                    auto_value += 1;
+                }
+            } else {
+                // 자동 증가 값 출력
+                try self.emitInt(auto_value);
+                auto_value += 1;
+            }
+
+            try self.write("]=\"");
+            try self.write(member_text);
+            try self.write("\";");
+        }
+
+        try self.write("})(");
+        try self.write(name_text);
+        try self.write("||(");
+        try self.write(name_text);
+        try self.write("={}));");
+    }
+
+    fn emitInt(self: *Codegen, value: i64) !void {
+        var buf: [20]u8 = undefined;
+        const len = std.fmt.formatIntBuf(&buf, value, 10, .lower, .{});
+        try self.buf.appendSlice(buf[0..len]);
+    }
+
+    // ================================================================
     // 리스트 헬퍼
     // ================================================================
 
@@ -837,4 +922,22 @@ test "Codegen: return statement" {
     var r = try e2e(std.testing.allocator, "return;");
     defer r.deinit();
     try std.testing.expectEqualStrings("return;", r.output);
+}
+
+test "Codegen: enum IIFE" {
+    var r = try e2e(std.testing.allocator, "enum Color { Red, Green, Blue }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings(
+        "var Color;(function(Color){Color[Color[\"Red\"]=0]=\"Red\";Color[Color[\"Green\"]=1]=\"Green\";Color[Color[\"Blue\"]=2]=\"Blue\";})(Color||(Color={}));",
+        r.output,
+    );
+}
+
+test "Codegen: enum with initializer" {
+    var r = try e2e(std.testing.allocator, "enum Status { Active = 1, Inactive = 0 }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings(
+        "var Status;(function(Status){Status[Status[\"Active\"]=1]=\"Active\";Status[Status[\"Inactive\"]=0]=\"Inactive\";})(Status||(Status={}));",
+        r.output,
+    );
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -257,6 +257,11 @@ pub const Transformer = struct {
             .binding_rest_element => self.visitUnaryNode(node),
             .assignment_target_with_default => self.visitBinaryNode(node),
 
+            // === TS enum: 런타임 코드 생성 (codegen에서 IIFE 출력) ===
+            .ts_enum_declaration => self.visitEnumDeclaration(node),
+            .ts_enum_member => self.visitBinaryNode(node),
+            .ts_enum_body => self.visitListNode(node),
+
             // === 나머지: invalid + TS 타입 전용 노드 ===
             // TS 타입 노드는 isTypeOnlyNode 검사(위)에서 이미 .none으로 반환됨.
             // 여기 도달하면 strip_types=false인 경우 → 그대로 복사.
@@ -360,6 +365,25 @@ pub const Transformer = struct {
 
     // ================================================================
     // Extra 기반 노드 변환
+    // ================================================================
+
+    // ================================================================
+    // TS enum 변환
+    // ================================================================
+
+    /// ts_enum_declaration: extra = [name, members_start, members_len]
+    /// enum 노드를 새 AST에 복사. codegen에서 IIFE 패턴으로 출력.
+    fn visitEnumDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
+        const e = node.data.extra;
+        const new_name = try self.visitNode(self.readNodeIdx(e, 0));
+        const new_members = try self.visitExtraList(self.readU32(e, 1), self.readU32(e, 2));
+        return self.addExtraNode(.ts_enum_declaration, node.span, &.{
+            @intFromEnum(new_name), new_members.start, new_members.len,
+        });
+    }
+
+    // ================================================================
+    // 헬퍼
     // ================================================================
 
     /// extra_data에서 연속된 필드를 슬라이스로 읽기.
@@ -614,10 +638,8 @@ pub const Transformer = struct {
             .ts_import_equals_declaration,
             .ts_external_module_reference,
             .ts_export_assignment,
-            // TS enum (향후 IIFE 변환, 지금은 삭제)
-            .ts_enum_declaration,
-            .ts_enum_body,
-            .ts_enum_member,
+            // enum은 타입 전용이 아님 — 런타임 코드 생성이 필요
+            // visitNode의 switch에서 별도 처리
             => true,
             else => false,
         };
@@ -851,10 +873,11 @@ test "Integration: JS preserved alongside TS stripped" {
     try std.testing.expectEqual(@as(u32, 1), r.statementCount());
 }
 
-test "Integration: enum stripped" {
+test "Integration: enum preserved for codegen" {
+    // enum은 런타임 코드 생성 → 삭제되지 않고 codegen으로 전달
     var r = try parseAndTransform(std.testing.allocator, "enum Color { Red, Green, Blue }");
     defer r.deinit();
-    try std.testing.expectEqual(@as(u32, 0), r.statementCount());
+    try std.testing.expectEqual(@as(u32, 1), r.statementCount());
 }
 
 test "Integration: multiple JS statements preserved" {
@@ -883,5 +906,6 @@ test "Transformer: isTypeOnlyNode covers all TS type tags" {
     // TS 선언은 isTypeOnlyNode
     try std_lib.testing.expect(Transformer.isTypeOnlyNode(.ts_type_alias_declaration));
     try std_lib.testing.expect(Transformer.isTypeOnlyNode(.ts_interface_declaration));
-    try std_lib.testing.expect(Transformer.isTypeOnlyNode(.ts_enum_declaration));
+    // enum은 런타임 코드를 생성하므로 isTypeOnlyNode이 아님
+    try std_lib.testing.expect(!Transformer.isTypeOnlyNode(.ts_enum_declaration));
 }


### PR DESCRIPTION
## Summary
- transformer: enum을 타입 전용에서 제외, 런타임 코드 생성 노드로 분류
- codegen: TypeScript enum → JavaScript IIFE 패턴 출력
  - `enum Color { Red, Green, Blue }` → `var Color;(function(Color){...})(Color||(Color={}));`
  - 자동 증가 값 + 숫자 이니셜라이저 지원
- 기존 설계 유지: transformer가 AST 변환, codegen이 JS 출력

## Test plan
- [x] 기본 enum IIFE 출력 (`Red=0, Green=1, Blue=2`)
- [x] 이니셜라이저 포함 enum (`Active=1, Inactive=0`)
- [x] 통합 테스트 업데이트 (enum이 삭제되지 않음 확인)
- [x] 기존 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)