### PR TITLE
feat(parser,transformer): parameter property modifier and this.x=x transform

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1737,19 +1737,36 @@ pub const Parser = struct {
     /// 바인딩 패턴을 파싱한다: identifier, [destructuring], {destructuring}
     fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
         // TS parameter property: public x, private x, protected x, readonly x
+        // flags 비트: 0x01=public, 0x02=private, 0x04=protected, 0x08=readonly
         if (self.current() == .kw_public or self.current() == .kw_private or
             self.current() == .kw_protected or self.current() == .kw_readonly)
         {
             const modifier_span = self.currentSpan();
             const next = self.peekNextKind();
             // modifier 뒤에 식별자가 오면 parameter property
-            if (next == .identifier or next == .l_bracket or next == .l_curly) {
-                self.advance(); // skip modifier
+            if (next == .identifier or next == .l_bracket or next == .l_curly or
+                next == .kw_readonly) // public readonly x
+            {
+                var modifier_flags: u16 = switch (self.current()) {
+                    .kw_public => 0x01,
+                    .kw_private => 0x02,
+                    .kw_protected => 0x04,
+                    .kw_readonly => 0x08,
+                    else => 0,
+                };
+                self.advance(); // skip first modifier
+
+                // 두 번째 modifier: public readonly x
+                if (self.current() == .kw_readonly) {
+                    modifier_flags |= 0x08;
+                    self.advance();
+                }
+
                 const inner = try self.parseBindingPattern();
                 return try self.ast.addNode(.{
                     .tag = .formal_parameter,
                     .span = .{ .start = modifier_span.start, .end = self.currentSpan().start },
-                    .data = .{ .unary = .{ .operand = inner, .flags = 0 } },
+                    .data = .{ .unary = .{ .operand = inner, .flags = modifier_flags } },
                 });
             }
         }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -447,15 +447,116 @@ pub const Transformer = struct {
 
     /// function/function_declaration/function_expression/arrow_function_expression
     /// extra_data = [name, params_start, params_len, body, flags, return_type]
+    ///
+    /// parameter property 변환:
+    ///   constructor(public x: number) {} →
+    ///   constructor(x) { this.x = x; }
     fn visitFunction(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
         const new_name = try self.visitNode(self.readNodeIdx(e, 0));
-        const new_params = try self.visitExtraList(self.readU32(e, 1), self.readU32(e, 2));
-        const new_body = try self.visitNode(self.readNodeIdx(e, 3));
+
+        // 파라미터 방문 + parameter property 수집
+        const params_start = self.readU32(e, 1);
+        const params_len = self.readU32(e, 2);
+        const old_params = self.old_ast.extra_data.items[params_start .. params_start + params_len];
+
+        const scratch_top = self.scratch.items.len;
+        defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+        // parameter property 이름을 수집 (this.x = x 문 생성용)
+        var prop_names: [32]NodeIndex = undefined; // 최대 32개 parameter property
+        var prop_count: usize = 0;
+
+        for (old_params) |raw_idx| {
+            const param_node = self.old_ast.getNode(@enumFromInt(raw_idx));
+
+            // formal_parameter가 unary로 저장된 경우 = parameter property
+            // flags != 0 → modifier 있음 (public/private/protected/readonly)
+            if (param_node.tag == .formal_parameter and param_node.data.unary.flags != 0) {
+                // parameter property: modifier를 제거하고 내부 패턴만 복사
+                const inner = try self.visitNode(param_node.data.unary.operand);
+                try self.scratch.append(inner);
+
+                // this.x = x 문 생성을 위해 이름 저장
+                if (prop_count < prop_names.len) {
+                    prop_names[prop_count] = inner;
+                    prop_count += 1;
+                }
+            } else {
+                const new_param = try self.visitNode(@enumFromInt(raw_idx));
+                if (!new_param.isNone()) {
+                    try self.scratch.append(new_param);
+                }
+            }
+        }
+
+        const new_params = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+
+        // 바디 방문
+        var new_body = try self.visitNode(self.readNodeIdx(e, 3));
+
+        // parameter property가 있으면 바디 앞에 this.x = x 문 삽입
+        if (prop_count > 0 and !new_body.isNone()) {
+            new_body = try self.insertParameterPropertyAssignments(new_body, prop_names[0..prop_count]);
+        }
+
         const none = @intFromEnum(NodeIndex.none);
         return self.addExtraNode(node.tag, node.span, &.{
             @intFromEnum(new_name), new_params.start, new_params.len,
-            @intFromEnum(new_body), self.readU32(e, 4), none, // return_type 제거
+            @intFromEnum(new_body), self.readU32(e, 4), none,
+        });
+    }
+
+    /// block_statement 바디 앞에 this.x = x; 문들을 삽입한다.
+    fn insertParameterPropertyAssignments(self: *Transformer, body_idx: NodeIndex, prop_names: []const NodeIndex) Error!NodeIndex {
+        const body = self.new_ast.getNode(body_idx);
+        if (body.tag != .block_statement) return body_idx;
+
+        const old_list = body.data.list;
+        const scratch_top = self.scratch.items.len;
+        defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+        // this.x = x 문들을 먼저 추가
+        for (prop_names) |name_idx| {
+            const name_node = self.new_ast.getNode(name_idx);
+            // this 노드
+            const this_node = try self.new_ast.addNode(.{
+                .tag = .this_expression,
+                .span = name_node.span,
+                .data = .{ .none = 0 },
+            });
+            // this.x (static member)
+            const member = try self.new_ast.addNode(.{
+                .tag = .static_member_expression,
+                .span = name_node.span,
+                .data = .{ .binary = .{ .left = this_node, .right = name_idx, .flags = 0 } },
+            });
+            // this.x = x (assignment)
+            const assign = try self.new_ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = name_node.span,
+                .data = .{ .binary = .{ .left = member, .right = name_idx, .flags = 0 } },
+            });
+            // expression_statement
+            const stmt = try self.new_ast.addNode(.{
+                .tag = .expression_statement,
+                .span = name_node.span,
+                .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+            });
+            try self.scratch.append(stmt);
+        }
+
+        // 기존 바디 문들을 추가
+        const old_stmts = self.new_ast.extra_data.items[old_list.start .. old_list.start + old_list.len];
+        for (old_stmts) |raw_idx| {
+            try self.scratch.append(@enumFromInt(raw_idx));
+        }
+
+        const new_list = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+        return self.new_ast.addNode(.{
+            .tag = .block_statement,
+            .span = body.span,
+            .data = .{ .list = new_list },
         });
     }
 


### PR DESCRIPTION
## Summary
- 파서: parameter property modifier를 flags 비트 플래그로 저장 (public/private/protected/readonly)
- transformer: modifier 파라미터 → 일반 파라미터 + `this.x = x;` 문 삽입

## Test plan
- [x] 전체 테스트 통과 (0 failures)
- [x] 기존 parameter property 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)