### PR TITLE
fix(parser,codegen): resolve CJS export const segfault

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -827,7 +827,7 @@ pub const Codegen = struct {
 
     /// CJS: export const x = 1 → const x=1;exports.x=x;
     fn emitExportNamedCJS(self: *Codegen, decl: NodeIndex, specs_start: u32, specs_len: u32, source: NodeIndex) !void {
-        if (!decl.isNone()) {
+        if (!decl.isNone() and @intFromEnum(decl) < self.ast.nodes.items.len) {
             // export const x = 1 → const x=1; + exports.x=x;
             try self.emitNode(decl);
             // 선언에서 이름 추출하여 exports.name = name
@@ -848,27 +848,31 @@ pub const Codegen = struct {
         }
     }
 
-    /// 변수/함수/클래스 선언에서 이름을 추출하여 exports.name=name; 출력
+    /// 변수/함수/클래스 선언에서 이름을 추출하여 exports.name=name; 출력.
+    /// variable_declarator의 이름은 span 텍스트에서 직접 추출 (extra 경유 불필요).
     fn emitCJSExportBinding(self: *Codegen, decl_idx: NodeIndex) !void {
         const decl = self.ast.getNode(decl_idx);
         switch (decl.tag) {
             .variable_declaration => {
                 const e = decl.data.extra;
-                const extras = self.ast.extra_data.items[e .. e + 3];
-                const list_start = extras[1];
-                const list_len = extras[2];
+                const list_start = self.ast.extra_data.items[e + 1];
+                const list_len = self.ast.extra_data.items[e + 2];
                 const declarators = self.ast.extra_data.items[list_start .. list_start + list_len];
                 for (declarators) |raw_idx| {
                     const declarator = self.ast.getNode(@enumFromInt(raw_idx));
+                    // declarator의 첫 번째 extra가 name NodeIndex
                     const de = declarator.data.extra;
                     const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[de]);
-                    const name_node = self.ast.getNode(name_idx);
-                    const name = self.ast.source[name_node.span.start..name_node.span.end];
-                    try self.write("exports.");
-                    try self.write(name);
-                    try self.writeByte('=');
-                    try self.write(name);
-                    try self.writeByte(';');
+                    if (!name_idx.isNone()) {
+                        const name_node = self.ast.getNode(name_idx);
+                        // binding_identifier의 이름은 string_ref (span)
+                        const name = self.ast.source[name_node.data.string_ref.start..name_node.data.string_ref.end];
+                        try self.write("exports.");
+                        try self.write(name);
+                        try self.writeByte('=');
+                        try self.write(name);
+                        try self.writeByte(';');
+                    }
                 }
             },
             .function_declaration, .class_declaration => {
@@ -876,7 +880,7 @@ pub const Codegen = struct {
                 const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
                 if (!name_idx.isNone()) {
                     const name_node = self.ast.getNode(name_idx);
-                    const name = self.ast.source[name_node.span.start..name_node.span.end];
+                    const name = self.ast.source[name_node.data.string_ref.start..name_node.data.string_ref.end];
                     try self.write("exports.");
                     try self.write(name);
                     try self.writeByte('=');
@@ -1397,6 +1401,12 @@ test "Codegen: namespace IIFE" {
         "var Foo;(function(Foo){const x=1;})(Foo||(Foo={}));",
         r.output,
     );
+}
+
+test "Codegen CJS: export const" {
+    var r = try e2eCJS(std.testing.allocator, "export const x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const x=1;exports.x=x;", r.output);
 }
 
 test "Codegen CJS: export default" {

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -274,7 +274,10 @@ pub const Parser = struct {
         const start = self.currentSpan().start;
 
         // 바인딩 패턴 (identifier, [array], {object} destructuring)
-        const name = try self.parseBindingIdentifier();
+        // 주의: parseBindingPattern이 아닌 parseBindingName을 사용.
+        // parseBindingPattern은 `=`를 default value로 소비하지만,
+        // variable declarator에서 `=`는 initializer이므로 여기서 소비하면 안 됨.
+        const name = try self.parseBindingName();
 
         // TS 타입 어노테이션 (: Type)
         const type_ann = try self.tryParseTypeAnnotation();
@@ -1174,9 +1177,14 @@ pub const Parser = struct {
 
             const specifiers = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
             self.restoreScratch(scratch_top);
-            const extra_start = try self.ast.addExtra(specifiers.start);
-            _ = try self.ast.addExtra(specifiers.len);
-            _ = try self.ast.addExtra(@intFromEnum(source_node));
+
+            // extra_data layout: [declaration, specifiers_start, specifiers_len, source]
+            const extra_start = try self.ast.addExtras(&.{
+                @intFromEnum(NodeIndex.none), // declaration 없음
+                specifiers.start,
+                specifiers.len,
+                @intFromEnum(source_node),
+            });
 
             return try self.ast.addNode(.{
                 .tag = .export_named_declaration,
@@ -1186,11 +1194,18 @@ pub const Parser = struct {
         }
 
         // export var/let/const/function/class
+        // extra_data layout: [declaration, specifiers_start, specifiers_len, source]
         const decl = try self.parseStatement();
+        const extra_start = try self.ast.addExtras(&.{
+            @intFromEnum(decl),
+            0, // specifiers_start (사용 안 함)
+            0, // specifiers_len = 0
+            @intFromEnum(NodeIndex.none), // source 없음
+        });
         return try self.ast.addNode(.{
             .tag = .export_named_declaration,
             .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .unary = .{ .operand = decl, .flags = 0 } },
+            .data = .{ .extra = extra_start },
         });
     }
 
@@ -1816,6 +1831,38 @@ pub const Parser = struct {
     /// 하위 호환: 식별자만 필요한 곳에서 호출
     fn parseBindingIdentifier(self: *Parser) ParseError2!NodeIndex {
         return self.parseBindingPattern();
+    }
+
+    /// 바인딩 이름만 파싱한다 (identifier, [array], {object}).
+    /// `?`, 타입 어노테이션, default value `=`를 소비하지 않는다.
+    /// variable declarator에서 사용 — `=`는 initializer이므로 여기서 소비하면 안 됨.
+    fn parseBindingName(self: *Parser) ParseError2!NodeIndex {
+        switch (self.current()) {
+            .identifier => {
+                const span = self.currentSpan();
+                self.advance();
+                return try self.ast.addNode(.{
+                    .tag = .binding_identifier,
+                    .span = span,
+                    .data = .{ .string_ref = span },
+                });
+            },
+            .l_bracket => return self.parseArrayPattern(),
+            .l_curly => return self.parseObjectPattern(),
+            else => {
+                if (self.current().isKeyword()) {
+                    const span = self.currentSpan();
+                    self.advance();
+                    return try self.ast.addNode(.{
+                        .tag = .binding_identifier,
+                        .span = span,
+                        .data = .{ .string_ref = span },
+                    });
+                }
+                self.addError(self.currentSpan(), "binding pattern expected");
+                return NodeIndex.none;
+            },
+        }
     }
 
     /// 단순 식별자 이름만 파싱한다 (타입 어노테이션/기본값 없이).


### PR DESCRIPTION
## Summary
- export_named_declaration data 레이아웃 통일 (extra 4필드)
- parseBindingName 추가 (= 소비 방지)
- CJS export const 테스트 통과

## Test plan
- [x] 전체 테스트 통과 (0 failures, 0 segfaults)
- [x] CJS export const: `export const x = 1;` → `const x=1;exports.x=x;`
- [x] CJS export default 기존 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)