### PR TITLE
feat(parser,transformer,codegen): decorator support on class declarations

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -571,12 +571,23 @@ pub const Codegen = struct {
         try self.emitNode(body);
     }
 
+    /// class: extra = [name, super, body, type_params, impl_start, impl_len, deco_start, deco_len]
     fn emitClass(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
-        const extras = self.ast.extra_data.items[e .. e + 6];
-        const name: NodeIndex = @enumFromInt(extras[0]);
-        const super_class: NodeIndex = @enumFromInt(extras[1]);
-        const body: NodeIndex = @enumFromInt(extras[2]);
+        const name: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+        const super_class: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+        const body: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
+        const deco_start = self.ast.extra_data.items[e + 6];
+        const deco_len = self.ast.extra_data.items[e + 7];
+
+        // decorator 출력: @log\n@validate\nclass Foo {}
+        if (deco_len > 0) {
+            const deco_indices = self.ast.extra_data.items[deco_start .. deco_start + deco_len];
+            for (deco_indices) |raw_idx| {
+                try self.emitNode(@enumFromInt(raw_idx));
+                try self.writeByte('\n');
+            }
+        }
 
         try self.write("class");
         if (!name.isNone()) {

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -18,6 +18,7 @@ const Ast = ast_mod.Ast;
 const Node = ast_mod.Node;
 const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
+const NodeList = ast_mod.NodeList;
 
 /// 파서 에러 하나.
 pub const ParseError = struct {
@@ -705,15 +706,16 @@ pub const Parser = struct {
     }
 
     fn parseClassDeclaration(self: *Parser) ParseError2!NodeIndex {
-        return self.parseClass(.class_declaration);
+        return self.parseClassWithDecorators(.class_declaration, .{ .start = 0, .len = 0 });
     }
 
     fn parseClassExpression(self: *Parser) ParseError2!NodeIndex {
-        return self.parseClass(.class_expression);
+        return self.parseClassWithDecorators(.class_expression, .{ .start = 0, .len = 0 });
     }
 
     /// class 선언/표현식을 파싱한다.
-    fn parseClass(self: *Parser, tag: Tag) ParseError2!NodeIndex {
+    /// extra = [name, super_class, body, type_params, implements_start, implements_len, deco_start, deco_len]
+    fn parseClassWithDecorators(self: *Parser, tag: Tag, decorators: NodeList) ParseError2!NodeIndex {
         const start = self.currentSpan().start;
         self.advance(); // skip 'class'
 
@@ -737,7 +739,6 @@ pub const Parser = struct {
 
         // TS implements 절 (선택): class Foo implements Bar, Baz
         if (self.eat(.kw_implements)) {
-            // implements 타입 리스트 파싱 (AST에는 저장하지 않고 스킵 — 스트리핑 대상)
             _ = try self.parseType();
             while (self.eat(.comma)) {
                 _ = try self.parseType();
@@ -747,9 +748,17 @@ pub const Parser = struct {
         // 클래스 본문
         const body = try self.parseClassBody();
 
-        const extra_start = try self.ast.addExtra(@intFromEnum(name));
-        _ = try self.ast.addExtra(@intFromEnum(super_class));
-        _ = try self.ast.addExtra(@intFromEnum(body));
+        const none = @intFromEnum(NodeIndex.none);
+        const extra_start = try self.ast.addExtras(&.{
+            @intFromEnum(name),
+            @intFromEnum(super_class),
+            @intFromEnum(body),
+            @intFromEnum(type_params),
+            0, 0, // implements (스트리핑 대상이므로 빈 리스트)
+            decorators.start,
+            decorators.len,
+        });
+        _ = none;
 
         return try self.ast.addNode(.{
             .tag = tag,
@@ -2542,11 +2551,9 @@ pub const Parser = struct {
         }
         const decorators = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
         self.restoreScratch(scratch_top);
-        _ = decorators; // TODO: 데코레이터를 클래스 노드에 연결 (BACKLOG)
-
         // 데코레이터 뒤에 올 수 있는 것: class, export, abstract
         return switch (self.current()) {
-            .kw_class => self.parseClassDeclaration(),
+            .kw_class => self.parseClassWithDecorators(.class_declaration, decorators),
             .kw_export => self.parseExportDeclaration(),
             .kw_abstract => self.parseTsAbstractClass(),
             else => {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -562,15 +562,19 @@ pub const Transformer = struct {
 
     /// class_declaration / class_expression
     /// extra_data = [name, super_class, body, type_params, implements_start, implements_len]
+    /// class: extra = [name, super, body, type_params, impl_start, impl_len, deco_start, deco_len]
     fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
         const new_name = try self.visitNode(self.readNodeIdx(e, 0));
         const new_super = try self.visitNode(self.readNodeIdx(e, 1));
         const new_body = try self.visitNode(self.readNodeIdx(e, 2));
+        // decorator 리스트 복사
+        const new_decos = try self.visitExtraList(self.readU32(e, 6), self.readU32(e, 7));
         const none = @intFromEnum(NodeIndex.none);
         return self.addExtraNode(node.tag, node.span, &.{
             @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
             none, 0, 0, // type_params, implements 제거
+            new_decos.start, new_decos.len,
         });
     }
 


### PR DESCRIPTION
## Summary
- 파서: class extra를 8필드로 확장, decorator list를 class 노드에 연결
- transformer: class의 decorator 리스트 복사
- codegen: decorator를 @expr 형태로 class 앞에 출력

## Test plan
- [x] 전체 테스트 통과 (0 failures)
- [x] 기존 decorator 파서 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)