### PR TITLE
feat(cli): add full transpile pipeline

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,10 +1,14 @@
 const std = @import("std");
 const lib = @import("zts_lib");
 const Scanner = lib.lexer.Scanner;
+const Parser = lib.parser.Parser;
+const Transformer = lib.transformer.Transformer;
+const Codegen = lib.codegen.Codegen;
 const runner = lib.test262.runner;
 
 pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
+    const stderr = std.io.getStdErr().writer();
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
@@ -14,38 +18,78 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     if (args.len < 2) {
-        try stdout.print("zts v0.1.0 - Zig TypeScript Transpiler\n\n", .{});
-        try stdout.print("Usage:\n", .{});
-        try stdout.print("  zts <file.ts>              Transpile a file\n", .{});
-        try stdout.print("  zts --test262 <directory>   Run Test262 tests\n", .{});
-        try stdout.print("  zts --tokenize <file>       Tokenize and print tokens\n", .{});
+        try printUsage(stdout);
         return;
     }
 
-    const command = args[1];
+    // 옵션 파싱
+    var input_file: ?[]const u8 = null;
+    var output_file: ?[]const u8 = null;
+    var minify = false;
+    var module_format: lib.codegen.codegen.ModuleFormat = .esm;
+    var drop_console = false;
+    var drop_debugger = false;
+    var is_test262 = false;
+    var is_tokenize = false;
+    var test262_dir: ?[]const u8 = null;
 
-    if (std.mem.eql(u8, command, "--test262")) {
-        if (args.len < 3) {
-            try stdout.print("Error: --test262 requires a directory path\n", .{});
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--test262")) {
+            is_test262 = true;
+            if (i + 1 < args.len) {
+                i += 1;
+                test262_dir = args[i];
+            }
+        } else if (std.mem.eql(u8, arg, "--tokenize")) {
+            is_tokenize = true;
+        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--out-file")) {
+            if (i + 1 < args.len) {
+                i += 1;
+                output_file = args[i];
+            }
+        } else if (std.mem.eql(u8, arg, "--minify")) {
+            minify = true;
+        } else if (std.mem.eql(u8, arg, "--format=cjs")) {
+            module_format = .cjs;
+        } else if (std.mem.eql(u8, arg, "--format=esm")) {
+            module_format = .esm;
+        } else if (std.mem.eql(u8, arg, "--drop=console")) {
+            drop_console = true;
+        } else if (std.mem.eql(u8, arg, "--drop=debugger")) {
+            drop_debugger = true;
+        } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            try printUsage(stdout);
+            return;
+        } else if (arg[0] != '-') {
+            input_file = arg;
+        } else {
+            try stderr.print("zts: unknown option: {s}\n", .{arg});
             return;
         }
-        const dir_path = args[2];
+    }
 
+    // --test262
+    if (is_test262) {
+        const dir_path = test262_dir orelse {
+            try stderr.print("Error: --test262 requires a directory path\n", .{});
+            return;
+        };
         const abs_path = try std.fs.cwd().realpathAlloc(allocator, dir_path);
         defer allocator.free(abs_path);
-
         try stdout.print("Running Test262: {s}\n", .{abs_path});
         const summary = try runner.runDirectory(allocator, abs_path);
         try summary.print(stdout);
         return;
     }
 
-    if (std.mem.eql(u8, command, "--tokenize")) {
-        if (args.len < 3) {
-            try stdout.print("Error: --tokenize requires a file path\n", .{});
+    // --tokenize
+    if (is_tokenize) {
+        const file_path = input_file orelse {
+            try stderr.print("Error: --tokenize requires a file path\n", .{});
             return;
-        }
-        const file_path = args[2];
+        };
         const source = try std.fs.cwd().readFileAlloc(allocator, file_path, 10 * 1024 * 1024);
         defer allocator.free(source);
 
@@ -66,7 +110,97 @@ pub fn main() !void {
         return;
     }
 
-    try stdout.print("zts: transpile not yet implemented. Use --tokenize or --test262\n", .{});
+    // 트랜스파일
+    const file_path = input_file orelse {
+        try printUsage(stdout);
+        return;
+    };
+
+    const source = std.fs.cwd().readFileAlloc(allocator, file_path, 100 * 1024 * 1024) catch |err| {
+        try stderr.print("zts: cannot read '{s}': {}\n", .{ file_path, err });
+        return;
+    };
+    defer allocator.free(source);
+
+    // 파싱
+    var scanner = Scanner.init(allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(allocator, &scanner);
+    defer parser.deinit();
+    _ = parser.parse() catch |err| {
+        try stderr.print("zts: parse error: {}\n", .{err});
+        return;
+    };
+
+    // 에러 출력
+    if (parser.errors.items.len > 0) {
+        for (parser.errors.items) |parse_err| {
+            const lc = scanner.getLineColumn(parse_err.span.start);
+            try stderr.print("{s}:{d}:{d}: error: {s}\n", .{
+                file_path,
+                lc.line + 1,
+                lc.column + 1,
+                parse_err.message,
+            });
+        }
+    }
+
+    // 변환
+    var transformer = Transformer.init(allocator, &parser.ast, .{
+        .drop_console = drop_console,
+        .drop_debugger = drop_debugger,
+    });
+    const root = transformer.transform() catch |err| {
+        try stderr.print("zts: transform error: {}\n", .{err});
+        return;
+    };
+    transformer.scratch.deinit();
+    defer transformer.new_ast.deinit();
+
+    // 코드 생성
+    var cg = Codegen.initWithOptions(allocator, &transformer.new_ast, .{
+        .module_format = module_format,
+        .minify = minify,
+    });
+    defer cg.deinit();
+    const output = cg.generate(root) catch |err| {
+        try stderr.print("zts: codegen error: {}\n", .{err});
+        return;
+    };
+
+    // 출력
+    if (output_file) |out_path| {
+        std.fs.cwd().writeFile(.{
+            .sub_path = out_path,
+            .data = output,
+        }) catch |err| {
+            try stderr.print("zts: cannot write '{s}': {}\n", .{ out_path, err });
+            return;
+        };
+    } else {
+        try stdout.writeAll(output);
+    }
+}
+
+fn printUsage(writer: anytype) !void {
+    try writer.print(
+        \\zts v0.1.0 - Zig TypeScript Transpiler
+        \\
+        \\Usage:
+        \\  zts <file.ts>                Transpile to stdout
+        \\  zts <file.ts> -o <out.js>    Transpile to file
+        \\
+        \\Options:
+        \\  -o, --out-file <path>        Output file path
+        \\  --minify                     Minify output
+        \\  --format=esm|cjs             Module format (default: esm)
+        \\  --drop=console               Remove console.* calls
+        \\  --drop=debugger              Remove debugger statements
+        \\  --tokenize                   Print tokens instead of transpiling
+        \\  --test262 <dir>              Run Test262 tests
+        \\  -h, --help                   Show this help
+        \\
+    , .{});
 }
 
 test "basic" {


### PR DESCRIPTION
## Summary
- \`zts <file.ts>\` 로 TS→JS 트랜스파일
- 옵션: \`-o\`, \`--minify\`, \`--format=cjs|esm\`, \`--drop=console|debugger\`
- 파싱 에러 출력 (파일:줄:열 형식)

## Test plan
- [x] \`const x: number = 42; type Foo = string;\` → \`const x = 42;\`
- [x] --minify 동작 확인
- [x] --drop=console 동작 확인
- [x] --format=cjs 동작 확인
- [x] -o 파일 출력 동작 확인
- [x] 전체 테스트 통과, 메모리 leak 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)