### PR TITLE
feat(lexer,codegen): comment preservation

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -18,6 +18,7 @@ const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
 const Span = @import("../lexer/token.zig").Span;
 const Kind = @import("../lexer/token.zig").Kind;
+const Comment = @import("../lexer/scanner.zig").Comment;
 
 /// 모듈 출력 형식
 pub const ModuleFormat = enum {
@@ -61,6 +62,10 @@ pub const Codegen = struct {
     /// 출력의 현재 줄/열 (소스맵 매핑용)
     gen_line: u32 = 0,
     gen_col: u32 = 0,
+    /// 소스에서 수집한 주석 리스트 (소스 순서, scanner.comments.items)
+    comments: []const Comment = &.{},
+    /// 다음으로 출력할 주석의 인덱스
+    next_comment_idx: usize = 0,
 
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
@@ -243,6 +248,35 @@ pub const Codegen = struct {
     }
 
     // ================================================================
+    // 주석 출력
+    // ================================================================
+
+    /// 현재 노드의 소스 위치(pos) 이전에 위치한 주석들을 출력한다.
+    /// minify 모드에서는 주석을 출력하지 않는다.
+    fn emitPendingComments(self: *Codegen, pos: u32) !void {
+        if (self.options.minify) return;
+        while (self.next_comment_idx < self.comments.len) {
+            const comment = self.comments[self.next_comment_idx];
+            if (comment.start >= pos) break;
+            // 소스에서 주석 텍스트를 그대로 출력 (// ... 또는 /* ... */)
+            try self.write(self.ast.source[comment.start..comment.end]);
+            try self.writeNewline();
+            self.next_comment_idx += 1;
+        }
+    }
+
+    /// 파일 끝에 남은 주석들(trailing comments)을 출력한다.
+    fn emitTrailingComments(self: *Codegen) !void {
+        if (self.options.minify) return;
+        while (self.next_comment_idx < self.comments.len) {
+            const comment = self.comments[self.next_comment_idx];
+            try self.write(self.ast.source[comment.start..comment.end]);
+            try self.writeNewline();
+            self.next_comment_idx += 1;
+        }
+    }
+
+    // ================================================================
     // 노드 출력
     // ================================================================
 
@@ -252,6 +286,11 @@ pub const Codegen = struct {
         if (idx.isNone()) return;
 
         const node = self.ast.getNode(idx);
+
+        // 이 노드 이전에 위치한 주석들을 출력
+        if (node.span.start != node.span.end) {
+            try self.emitPendingComments(node.span.start);
+        }
 
         // 소스맵 매핑: 유의미한 노드 출력 시 원본 위치 기록
         if (self.sm_builder != null and node.span.start != node.span.end) {
@@ -394,6 +433,8 @@ pub const Codegen = struct {
             try self.emitNode(@enumFromInt(raw_idx));
         }
         if (indices.len > 0) try self.writeNewline();
+        // 파일 끝에 남은 주석들 출력
+        try self.emitTrailingComments();
     }
 
     fn emitBlock(self: *Codegen, node: Node) !void {

--- a/src/lexer/mod.zig
+++ b/src/lexer/mod.zig
@@ -11,6 +11,7 @@ pub const Token = token.Token;
 pub const Kind = token.Kind;
 pub const Span = token.Span;
 pub const Scanner = scanner.Scanner;
+pub const Comment = scanner.Comment;
 pub const keywords = token.keywords;
 
 test {

--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -19,6 +19,17 @@ const Token = token.Token;
 const Kind = token.Kind;
 const Span = token.Span;
 
+/// 스캔 중 발견된 주석 하나를 나타낸다.
+/// start/end는 소스 코드의 byte offset이며, 구분자(// 또는 /* */)를 포함한다.
+pub const Comment = struct {
+    /// 주석 시작 byte offset (첫 번째 `/` 위치)
+    start: u32,
+    /// 주석 끝 byte offset (single-line: 줄바꿈 직전, multi-line: `*/` 직후)
+    end: u32,
+    /// true이면 `/* ... */`, false이면 `// ...`
+    is_multiline: bool,
+};
+
 /// 소스 코드를 토큰으로 분리하는 렉서.
 ///
 /// 사용법:
@@ -75,6 +86,10 @@ pub const Scanner = struct {
     /// `@jsxImportSource preact` → jsx_import_source_pragma = "preact"
     jsx_import_source_pragma: ?[]const u8 = null,
 
+    /// 스캔 중 발견된 주석 리스트 (소스 순서).
+    /// codegen에서 주석 보존에 사용한다.
+    comments: std.ArrayList(Comment),
+
     /// 소스를 UTF-8로 읽고 Scanner를 초기화한다.
     /// BOM이 있으면 스킵한다 (D019).
     pub fn init(allocator: std.mem.Allocator, source: []const u8) Scanner {
@@ -89,6 +104,7 @@ pub const Scanner = struct {
             .source = source,
             .line_offsets = line_offsets,
             .template_depth_stack = std.ArrayList(u32).init(allocator),
+            .comments = std.ArrayList(Comment).init(allocator),
         };
 
         // UTF-8 BOM 스킵 (0xEF 0xBB 0xBF)
@@ -106,6 +122,7 @@ pub const Scanner = struct {
     pub fn deinit(self: *Scanner) void {
         self.line_offsets.deinit();
         self.template_depth_stack.deinit();
+        self.comments.deinit();
     }
 
     // ====================================================================
@@ -693,6 +710,13 @@ pub const Scanner = struct {
 
         const comment_text = self.source[comment_start..self.current];
         self.checkPureComment(comment_text);
+
+        // 주석을 기록한다 (start = 첫 번째 '/' 위치, end = 줄바꿈 직전)
+        self.comments.append(.{
+            .start = self.start,
+            .end = self.current,
+            .is_multiline = false,
+        }) catch @panic("OOM: comments");
     }
 
     /// multi-line comment를 스캔한다 (/* ... */).
@@ -710,6 +734,14 @@ pub const Scanner = struct {
                 const comment_text = self.source[comment_start..self.current];
                 self.current += 2; // skip */
                 self.checkPureComment(comment_text);
+
+                // 주석을 기록한다 (start = 첫 번째 '/' 위치, end = '*/' 직후)
+                self.comments.append(.{
+                    .start = self.start,
+                    .end = self.current,
+                    .is_multiline = true,
+                }) catch @panic("OOM: comments");
+
                 return false; // 정상 종료
             }
             // 줄바꿈 추적 (소스맵 정확성)

--- a/src/main.zig
+++ b/src/main.zig
@@ -170,6 +170,8 @@ pub fn main() !void {
         .sourcemap = sourcemap,
         .ascii_only = ascii_only,
     });
+    // 스캐너에서 수집한 주석을 codegen에 전달 (주석 보존)
+    cg.comments = scanner.comments.items;
     if (sourcemap) {
         cg.addSourceFile(file_path) catch {};
     }


### PR DESCRIPTION
## Summary
- 렉서에서 주석 수집 (Comment 구조체)
- codegen에서 적절한 위치에 주석 출력
- minify 모드에서는 주석 생략

## Test plan
- [x] 단일행/블록 주석 보존 확인
- [x] TS 타입 스트리핑 + 주석 보존 동시 동작
- [x] 전체 테스트 243/243 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)