### PR TITLE
feat(parser,transformer): const enum support (D011)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1383,10 +1383,10 @@ pub const Codegen = struct {
     /// var Color;(function(Color){Color[Color["Red"]=0]="Red";Color[Color["Green"]=5]="Green";Color[Color["Blue"]=6]="Blue";})(Color||(Color={}));
     fn emitEnumIIFE(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
-        const extras = self.ast.extra_data.items[e .. e + 3];
-        const name_idx: NodeIndex = @enumFromInt(extras[0]);
-        const members_start = extras[1];
-        const members_len = extras[2];
+        const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+        const members_start = self.ast.extra_data.items[e + 1];
+        const members_len = self.ast.extra_data.items[e + 2];
+        // extras[3] = flags (0=일반, 1=const). const enum은 transformer에서 삭제됨.
 
         // enum 이름 텍스트 가져오기
         const name_node = self.ast.getNode(name_idx);
@@ -1792,4 +1792,10 @@ test "Codegen: enum with initializer" {
         "var Status;(function(Status){Status[Status[\"Active\"]=1]=\"Active\";Status[Status[\"Inactive\"]=0]=\"Inactive\";})(Status||(Status={}));",
         r.output,
     );
+}
+
+test "Codegen: const enum removed" {
+    var r = try e2e(std.testing.allocator, "const enum Dir { Up, Down }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("", r.output);
 }

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -162,7 +162,11 @@ pub const Parser = struct {
         return switch (self.current()) {
             .l_curly => self.parseBlockStatement(),
             .semicolon => self.parseEmptyStatement(),
-            .kw_var, .kw_let, .kw_const => self.parseVariableDeclaration(),
+            .kw_var, .kw_let => self.parseVariableDeclaration(),
+            .kw_const => if (self.peekNextKind() == .kw_enum)
+                self.parseConstEnum()
+            else
+                self.parseVariableDeclaration(),
             .kw_return => self.parseReturnStatement(),
             .kw_if => self.parseIfStatement(),
             .kw_while => self.parseWhileStatement(),
@@ -2450,8 +2454,21 @@ pub const Parser = struct {
         });
     }
 
+    /// const enum Foo { A, B, C }
+    /// const enum은 일반 enum과 동일하게 파싱하되, flags=1로 표시.
+    fn parseConstEnum(self: *Parser) ParseError2!NodeIndex {
+        self.advance(); // skip 'const'
+        return self.parseTsEnumDeclarationWithFlags(1);
+    }
+
     /// enum Foo { A, B, C }
     fn parseTsEnumDeclaration(self: *Parser) ParseError2!NodeIndex {
+        return self.parseTsEnumDeclarationWithFlags(0);
+    }
+
+    /// enum 파싱. flags: 0=일반 enum, 1=const enum.
+    /// extra = [name, members_start, members_len, flags]
+    fn parseTsEnumDeclarationWithFlags(self: *Parser, flags: u32) ParseError2!NodeIndex {
         const start = self.currentSpan().start;
         self.advance(); // skip 'enum'
 
@@ -2471,9 +2488,9 @@ pub const Parser = struct {
         const members = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
         self.restoreScratch(scratch_top);
 
-        const extra_start = try self.ast.addExtra(@intFromEnum(name));
-        _ = try self.ast.addExtra(members.start);
-        _ = try self.ast.addExtra(members.len);
+        const extra_start = try self.ast.addExtras(&.{
+            @intFromEnum(name), members.start, members.len, flags,
+        });
 
         return try self.ast.addNode(.{
             .tag = .ts_enum_declaration,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -470,12 +470,22 @@ pub const Transformer = struct {
 
     /// ts_enum_declaration: extra = [name, members_start, members_len]
     /// enum 노드를 새 AST에 복사. codegen에서 IIFE 패턴으로 출력.
+    /// extra = [name, members_start, members_len, flags]
+    /// flags: 0=일반 enum, 1=const enum
     fn visitEnumDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
+        const flags = self.readU32(e, 3);
+
+        // const enum (flags=1): isolatedModules 모드에서는 삭제 (D011)
+        // 같은 파일 내 인라이닝은 향후 구현
+        if (flags == 1) {
+            return .none; // const enum 선언 삭제
+        }
+
         const new_name = try self.visitNode(self.readNodeIdx(e, 0));
         const new_members = try self.visitExtraList(self.readU32(e, 1), self.readU32(e, 2));
         return self.addExtraNode(.ts_enum_declaration, node.span, &.{
-            @intFromEnum(new_name), new_members.start, new_members.len,
+            @intFromEnum(new_name), new_members.start, new_members.len, flags,
         });
     }
 


### PR DESCRIPTION
## Summary
- const enum 파싱 + 선언 삭제 (isolatedModules 모드)
- enum extra 4필드 확장

## Test plan
- [x] const enum 삭제 확인
- [x] 일반 enum IIFE 기존 테스트 통과
- [x] 전체 244/244 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)