### PR TITLE
refactor(lexer): rename token regexp → regexp_literal

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -665,7 +665,7 @@ pub const Scanner = struct {
                 self.current += 1; // consume closing /
                 // flags: g, i, m, s, u, v, y, d 등
                 self.scanRegExpFlags();
-                return .regexp;
+                return .regexp_literal;
             }
 
             // 줄바꿈은 정규식 안에서 불허 (U+2028/U+2029 포함)
@@ -2203,7 +2203,7 @@ test "Scanner: regex after =" {
     scanner.next(); // =
     try std.testing.expectEqual(Kind.eq, scanner.token.kind);
     scanner.next(); // /abc/gi
-    try std.testing.expectEqual(Kind.regexp, scanner.token.kind);
+    try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("/abc/gi", scanner.tokenText());
 }
 
@@ -2215,7 +2215,7 @@ test "Scanner: regex after (" {
     scanner.next(); // (
     try std.testing.expectEqual(Kind.l_paren, scanner.token.kind);
     scanner.next(); // /test/
-    try std.testing.expectEqual(Kind.regexp, scanner.token.kind);
+    try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
 }
 
 test "Scanner: division after identifier" {
@@ -2250,7 +2250,7 @@ test "Scanner: regex with character class" {
 
     scanner.next(); // =
     scanner.next(); // /[a/b]/
-    try std.testing.expectEqual(Kind.regexp, scanner.token.kind);
+    try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("/[a/b]/", scanner.tokenText());
 }
 
@@ -2261,7 +2261,7 @@ test "Scanner: regex with escape" {
 
     scanner.next(); // =
     scanner.next(); // /a\/b/
-    try std.testing.expectEqual(Kind.regexp, scanner.token.kind);
+    try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
 }
 
 test "Scanner: regex after return keyword" {
@@ -2272,7 +2272,7 @@ test "Scanner: regex after return keyword" {
     scanner.next(); // return
     try std.testing.expectEqual(Kind.kw_return, scanner.token.kind);
     scanner.next(); // /test/g
-    try std.testing.expectEqual(Kind.regexp, scanner.token.kind);
+    try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
 }
 
 test "Scanner: regex after comma" {
@@ -2282,7 +2282,7 @@ test "Scanner: regex after comma" {
 
     scanner.next(); // ,
     scanner.next(); // /re/
-    try std.testing.expectEqual(Kind.regexp, scanner.token.kind);
+    try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
 }
 
 // ============================================================

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -301,7 +301,7 @@ pub const Kind = enum(u8) {
     // ========================================================================
     // Regular Expression Literal
     // ========================================================================
-    regexp,
+    regexp_literal,
 
     // ========================================================================
     // Template Literals (연속 배치: isTemplateLiteral() range check)
@@ -436,7 +436,7 @@ pub const Kind = enum(u8) {
             .plus2,
             .minus2,
             .string_literal,
-            .regexp,
+            .regexp_literal,
             .no_substitution_template,
             .template_tail,
             => false,
@@ -643,7 +643,7 @@ const token_names = blk: {
             .octal_bigint => "<bigint>",
             .hex_bigint => "<bigint>",
             .string_literal => "<string>",
-            .regexp => "<regexp>",
+            .regexp_literal => "<regexp>",
             .no_substitution_template => "<template>",
             .template_head => "<template head>",
             .template_middle => "<template middle>",
@@ -750,7 +750,7 @@ test "Kind.isTemplateLiteral" {
     try std.testing.expect(Kind.template_middle.isTemplateLiteral());
     try std.testing.expect(Kind.template_tail.isTemplateLiteral());
     try std.testing.expect(!Kind.string_literal.isTemplateLiteral());
-    try std.testing.expect(!Kind.regexp.isTemplateLiteral()); // 직전
+    try std.testing.expect(!Kind.regexp_literal.isTemplateLiteral()); // 직전
     try std.testing.expect(!Kind.jsx_text.isTemplateLiteral()); // 직후
 }
 

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1931,7 +1931,7 @@ pub const Parser = struct {
                 // 보간 있는 템플릿 리터럴: `text${expr}...`
                 return self.parseTemplateLiteral();
             },
-            .regexp => {
+            .regexp_literal => {
                 self.advance();
                 return try self.ast.addNode(.{
                     .tag = .regexp_literal,


### PR DESCRIPTION
## Summary
- 렉서 토큰 `Kind.regexp` → `Kind.regexp_literal`로 리네이밍
- AST 태그 `regexp_literal`과 이름 일치시킴
- `string_literal` 토큰과 네이밍 컨벤션 통일

## Test plan
- [x] `zig build test` — 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)