### PR TITLE
fix(parser): destructuring default values + dynamic import multi-args

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1910,9 +1910,16 @@ pub const Parser = struct {
                         .data = .{ .none = 0 },
                     });
                 }
-                // dynamic import: import("module")
+                // dynamic import: import("module") or import("module", options)
                 self.expect(.l_paren);
                 const arg = try self.parseAssignmentExpression();
+                // 두 번째 인자 (import assertions/options) — 있으면 파싱하고 무시
+                if (self.eat(.comma)) {
+                    if (self.current() != .r_paren) {
+                        _ = try self.parseAssignmentExpression();
+                        _ = self.eat(.comma); // trailing comma
+                    }
+                }
                 self.expect(.r_paren);
                 return try self.ast.addNode(.{
                     .tag = .import_expression,
@@ -2378,7 +2385,19 @@ pub const Parser = struct {
                 try self.scratch.append(rest);
                 break; // rest는 항상 마지막
             }
-            const elem = try self.parseBindingPattern();
+            var elem = try self.parseBindingName();
+            // default value: pattern = expr (배열/객체 패턴 뒤의 = default)
+            if (self.eat(.eq)) {
+                const default_val = try self.parseAssignmentExpression();
+                elem = try self.ast.addNode(.{
+                    .tag = .assignment_pattern,
+                    .span = .{ .start = self.ast.getNode(elem).span.start, .end = self.currentSpan().start },
+                    .data = .{ .binary = .{ .left = elem, .right = default_val, .flags = 0 } },
+                });
+            }
+            // TS: optional (?) + type annotation — 배열 패턴 요소에도 가능
+            _ = self.eat(.question);
+            _ = try self.tryParseTypeAnnotation();
             if (!elem.isNone()) try self.scratch.append(elem);
             if (!self.eat(.comma)) break;
         }

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -174,13 +174,14 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
     if (verbose and result == .fail and !meta.is_negative_parse and parser.errors.items.len > 0) {
         const err = parser.errors.items[0];
         const stderr = std.io.getStdErr().writer();
-        // 에러 위치부터 20자
+        // 에러 위치 앞 20자 + 뒤 30자
+        const before_start = if (err.span.start > 20) err.span.start - 20 else 0;
         const ctx_end = @min(err.span.start + 30, @as(u32, @intCast(source.len)));
-        const snippet = source[err.span.start..ctx_end];
-        // 개행 전까지만
-        var line_end: usize = 0;
+        const snippet = source[before_start..ctx_end];
+        // 개행 전까지만 (에러 위치부터)
+        var line_end: usize = err.span.start - before_start;
         while (line_end < snippet.len and snippet[line_end] != '\n') : (line_end += 1) {}
-        stderr.print("    error@{d}: {s} | {s}\n", .{ err.span.start, err.message, snippet[0..line_end] }) catch {};
+        stderr.print("    error@{d}: {s} | ...{s}\n", .{ err.span.start, err.message, snippet[0..line_end] }) catch {};
     }
 
     return result;


### PR DESCRIPTION
## Summary
- 배열 destructuring 패턴에서 default value (`[a, b = 1]`) 파싱 지원
- dynamic import의 두 번째 인자 지원 (`import('m', { type: 'json' })`)
- Test262 통과율: 65.8% → **68.8%** (16080/23384)

## Test plan
- [x] `zig build test` — 전체 통과 (254/254)
- [x] `zig build test262-run` — 68.8% 확인
- [x] destructuring 카테고리 100% 달성

🤖 Generated with [Claude Code](https://claude.com/claude-code)