### PR TITLE
fix(parser): skip hashbang comment at file start

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -137,6 +137,11 @@ pub const Parser = struct {
     pub fn parse(self: *Parser) !NodeIndex {
         self.advance(); // 첫 토큰 로드
 
+        // hashbang (#! ...) 건너뛰기
+        if (self.current() == .hashbang_comment) {
+            self.advance();
+        }
+
         var stmts = std.ArrayList(NodeIndex).init(self.allocator);
         defer stmts.deinit();
 


### PR DESCRIPTION
## Summary
- 파서에서 hashbang_comment 토큰 건너뛰기 추가
- `#! /usr/bin/env node` 로 시작하는 파일 파싱 지원

## Test plan
- [x] `zig build test` — 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)