### PR TITLE
fix(parser): handle kw_target in new.target

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1899,7 +1899,7 @@ pub const Parser = struct {
                 // new.target — 메타 프로퍼티
                 if (self.current() == .dot) {
                     const peek = self.peekNextKind();
-                    if (peek == .identifier) {
+                    if (peek == .identifier or peek == .kw_target) {
                         self.advance(); // skip '.'
                         const target_span = self.currentSpan();
                         self.advance(); // skip 'target'


### PR DESCRIPTION
## Summary
- `new.target`에서 `target`이 `kw_target` 토큰일 때도 올바르게 파싱

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `zig fmt --check src/` — 통과
- [x] `zig build test262-run` — 80.1%

🤖 Generated with [Claude Code](https://claude.com/claude-code)