### PR TITLE
fix(parser): escaped_keyword in identifier positions

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -2431,7 +2431,7 @@ pub const Parser = struct {
     /// type alias, interface, enum 등 선언 이름에 사용.
     fn parseSimpleIdentifier(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
-        if (self.current() == .identifier or self.current().isKeyword()) {
+        if (self.current() == .identifier or self.current() == .escaped_keyword or self.current().isKeyword()) {
             self.advance();
             return try self.ast.addNode(.{
                 .tag = .binding_identifier,
@@ -2574,7 +2574,7 @@ pub const Parser = struct {
 
     fn parseIdentifierName(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
-        if (self.current() == .identifier or self.current().isKeyword()) {
+        if (self.current() == .identifier or self.current() == .escaped_keyword or self.current().isKeyword()) {
             self.advance();
             return try self.ast.addNode(.{
                 .tag = .identifier_reference,
@@ -2631,7 +2631,7 @@ pub const Parser = struct {
     fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
         switch (self.current()) {
-            .identifier => {
+            .identifier, .escaped_keyword => {
                 self.advance();
                 return try self.ast.addNode(.{
                     .tag = .identifier_reference,


### PR DESCRIPTION
## Summary
- parseIdentifierName, parsePropertyKey, parseSimpleIdentifier에 escaped_keyword 처리 추가
- 유니코드 이스케이프 식별자 지원 (property access, key, name 위치)
- binding position은 제외 (negative test regression 방지)
- Test262: 80.1% → **82.4%** (+549건)

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `zig fmt --check src/` — 통과
- [x] `zig build test262-run` — 82.4%
- [x] statements 85.1% 달성

🤖 Generated with [Claude Code](https://claude.com/claude-code)