### PR TITLE
feat(parser): reserved word + escaped keyword validation

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -2541,9 +2541,26 @@ pub const Parser = struct {
                 _ = try self.tryParseTypeAnnotation();
                 return self.tryWrapDefaultValue(pat);
             },
+            .escaped_keyword => {
+                // 이스케이프된 예약어는 식별자로 사용할 수 없음 (ECMAScript 12.1.1)
+                self.addError(self.currentSpan(), "escaped reserved word cannot be used as identifier");
+                const span = self.currentSpan();
+                self.advance();
+                return try self.ast.addNode(.{
+                    .tag = .binding_identifier,
+                    .span = span,
+                    .data = .{ .string_ref = span },
+                });
+            },
             else => {
-                // 키워드도 바인딩 이름으로 사용 가능한 경우 (let, yield 등)
+                // contextual 키워드는 바인딩 이름으로 사용 가능 (let, yield, async 등)
+                // 단, reserved keyword는 불가 (var, function, class, if 등)
                 if (self.current().isKeyword()) {
+                    if (self.current().isReservedKeyword()) {
+                        self.addError(self.currentSpan(), "reserved word cannot be used as identifier");
+                    } else if (self.is_strict_mode and self.current().isStrictModeReserved()) {
+                        self.addError(self.currentSpan(), "reserved word in strict mode cannot be used as identifier");
+                    }
                     const span = self.currentSpan();
                     self.advance();
                     const node2 = try self.ast.addNode(.{
@@ -2593,8 +2610,23 @@ pub const Parser = struct {
             },
             .l_bracket => return self.parseArrayPattern(),
             .l_curly => return self.parseObjectPattern(),
+            .escaped_keyword => {
+                self.addError(self.currentSpan(), "escaped reserved word cannot be used as identifier");
+                const span = self.currentSpan();
+                self.advance();
+                return try self.ast.addNode(.{
+                    .tag = .binding_identifier,
+                    .span = span,
+                    .data = .{ .string_ref = span },
+                });
+            },
             else => {
                 if (self.current().isKeyword()) {
+                    if (self.current().isReservedKeyword()) {
+                        self.addError(self.currentSpan(), "reserved word cannot be used as identifier");
+                    } else if (self.is_strict_mode and self.current().isStrictModeReserved()) {
+                        self.addError(self.currentSpan(), "reserved word in strict mode cannot be used as identifier");
+                    }
                     const span = self.currentSpan();
                     self.advance();
                     return try self.ast.addNode(.{
@@ -2614,6 +2646,14 @@ pub const Parser = struct {
     fn parseSimpleIdentifier(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
         if (self.current() == .identifier or self.current() == .escaped_keyword or self.current().isKeyword()) {
+            // 예약어 체크 (바인딩 위치에서)
+            if (self.current() == .escaped_keyword) {
+                self.addError(span, "escaped reserved word cannot be used as identifier");
+            } else if (self.current().isReservedKeyword()) {
+                self.addError(span, "reserved word cannot be used as identifier");
+            } else if (self.is_strict_mode and self.current().isStrictModeReserved()) {
+                self.addError(span, "reserved word in strict mode cannot be used as identifier");
+            }
             self.advance();
             return try self.ast.addNode(.{
                 .tag = .binding_identifier,
@@ -4884,4 +4924,51 @@ test "Parser: module mode is always strict" {
     _ = try parser.parse();
     try std.testing.expect(parser.errors.items.len > 0);
     try std.testing.expectEqualStrings("'with' is not allowed in strict mode", parser.errors.items[0].message);
+}
+
+// ================================================================
+// 예약어 검증 테스트
+// ================================================================
+
+test "Parser: reserved word as variable name is error" {
+    var scanner = Scanner.init(std.testing.allocator, "var var = 123;");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len > 0);
+}
+
+test "Parser: strict mode reserved word as binding in strict mode is error" {
+    var scanner = Scanner.init(std.testing.allocator,
+        \\"use strict";
+        \\var implements = 1;
+    );
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len > 0);
+}
+
+test "Parser: strict mode reserved word as binding in non-strict is valid" {
+    var scanner = Scanner.init(std.testing.allocator, "var implements = 1;");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len == 0);
+}
+
+test "Parser: let as variable name is valid in non-strict" {
+    var scanner = Scanner.init(std.testing.allocator, "var let = 1;");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len == 0);
 }


### PR DESCRIPTION
## Summary
- 바인딩 위치에서 예약어/이스케이프된 예약어 사용 감지
- parseBindingPattern, parseBindingName, parseSimpleIdentifier 3곳 수정
- strict mode reserved word (implements, interface 등) 검증 추가

## Test262 결과
- **전체**: 79.3% → **79.9%** (+0.6pp, 133건 추가 통과)
- **identifiers**: 37.7% → **50.8%** (+13.1pp)
- **future-reserved-words**: 61.8% → **90.9%** (+29.1pp)
- **directive-prologue**: 82.3% → **96.8%** (+14.5pp)

## Test plan
- [x] `zig build test` — 전체 유닛 테스트 통과 (새 테스트 4개 포함)
- [x] `zig build test262-run` — 79.9%, crash 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)