### PR TITLE
feat(semantic): strict eval/arguments + duplicate parameter

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -154,6 +154,16 @@ pub const Parser = struct {
         return self.scanner.tokenText();
     }
 
+    /// strict mode에서 eval/arguments를 바인딩 이름으로 사용하면 에러.
+    /// 식별자 토큰이 "eval" 또는 "arguments"인지 확인한다.
+    fn checkStrictBinding(self: *Parser, span: Span) void {
+        if (!self.is_strict_mode) return;
+        const text = self.ast.source[span.start..span.end];
+        if (std.mem.eql(u8, text, "eval") or std.mem.eql(u8, text, "arguments")) {
+            self.addError(span, "assignment to 'eval' or 'arguments' is not allowed in strict mode");
+        }
+    }
+
     // ================================================================
     // 컨텍스트 저장/복원 (D051: 함수 경계에서 컨텍스트 리셋)
     // ================================================================
@@ -2517,6 +2527,7 @@ pub const Parser = struct {
         switch (self.current()) {
             .identifier => {
                 const span = self.currentSpan();
+                self.checkStrictBinding(span);
                 self.advance();
                 const node = try self.ast.addNode(.{
                     .tag = .binding_identifier,
@@ -2601,6 +2612,7 @@ pub const Parser = struct {
         switch (self.current()) {
             .identifier => {
                 const span = self.currentSpan();
+                self.checkStrictBinding(span);
                 self.advance();
                 return try self.ast.addNode(.{
                     .tag = .binding_identifier,

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -57,6 +57,9 @@ pub const SemanticAnalyzer = struct {
     /// 현재 스코프 (스코프 스택 대신 인덱스 하나로 추적)
     current_scope: ScopeId = .none,
 
+    /// strict mode 여부 (파서에서 전달받음)
+    is_strict_mode: bool = false,
+
     /// 메모리 할당자
     allocator: std.mem.Allocator,
 
@@ -198,7 +201,7 @@ pub const SemanticAnalyzer = struct {
     }
 
     /// 두 심볼 종류의 재선언 가능 여부를 판단한다.
-    fn canRedeclare(_: *const SemanticAnalyzer, existing: SymbolKind, new: SymbolKind) bool {
+    fn canRedeclare(self: *const SemanticAnalyzer, existing: SymbolKind, new: SymbolKind) bool {
         // import는 항상 재선언 불가
         if (existing == .import_binding) return false;
 
@@ -206,9 +209,10 @@ pub const SemanticAnalyzer = struct {
         if (existing.allowsRedeclaration() and new.allowsRedeclaration()) return true;
 
         // parameter + var/function → 허용 (var/function이 parameter를 덮어씀)
-        // function f(x) { var x = 1; } — 항상 허용
-        // function f(x) { function x() {} } — non-strict에서 허용
         if (existing == .parameter and new.allowsRedeclaration()) return true;
+
+        // parameter + parameter → non-strict에서만 허용 (function f(a, a) {})
+        if (existing == .parameter and new == .parameter and !self.is_strict_mode) return true;
 
         // catch_binding + var → 허용 (var가 catch 스코프 밖으로 호이스팅)
         if (existing == .catch_binding and new == .variable_var) return true;

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -177,6 +177,7 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
     if (scanner.token.kind != .syntax_error and parser.errors.items.len == 0) {
         var analyzer = SemanticAnalyzer.init(allocator, &parser.ast);
         defer analyzer.deinit(); // deinit이 에러 메시지 메모리도 해제
+        analyzer.is_strict_mode = parser.is_strict_mode;
         analyzer.analyze();
         semantic_error_count = analyzer.errors.items.len;
     }


### PR DESCRIPTION
## Summary
- strict mode에서 eval/arguments 바인딩 금지 (checkStrictBinding 헬퍼)
- semantic analyzer에 is_strict_mode 필드 추가 — 파서에서 전달
- 중복 파라미터를 non-strict에서만 허용, strict에서는 에러

## Test262 결과
- **전체**: 79.9% → **80.1%** (+57건)
- **function-code**: 97.2% → **98.2%**
- **statements**: 83.1% → **83.6%**

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `zig build test262-run` — 80.1%, crash 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)