### PR TITLE
fix(codegen): optional chaining output + call expression crash

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -771,24 +771,36 @@ pub const Codegen = struct {
 
     fn emitStaticMember(self: *Codegen, node: Node) !void {
         try self.emitNode(node.data.binary.left);
-        try self.writeByte('.');
+        // flags=1 → optional chaining (a?.b)
+        if (node.data.binary.flags == 1) {
+            try self.write("?.");
+        } else {
+            try self.writeByte('.');
+        }
         try self.emitNode(node.data.binary.right);
     }
 
     fn emitComputedMember(self: *Codegen, node: Node) !void {
         try self.emitNode(node.data.binary.left);
+        // flags=1 → optional chaining (a?.[b])
+        if (node.data.binary.flags == 1) {
+            try self.write("?.");
+        }
         try self.writeByte('[');
         try self.emitNode(node.data.binary.right);
         try self.writeByte(']');
     }
 
-    /// call_expression: binary = { left=callee, right=@enumFromInt(args_start), flags=args_len }
+    /// call_expression: binary = { left=callee, right=@enumFromInt(args_start), flags=args_len|0x8000(optional) }
     fn emitCall(self: *Codegen, node: Node) !void {
         const callee = node.data.binary.left;
         const args_start: u32 = @intFromEnum(node.data.binary.right);
-        const args_len: u32 = node.data.binary.flags;
+        // flags 하위 15비트 = args_len, bit 15 = optional chaining (0x8000)
+        const args_len: u32 = node.data.binary.flags & 0x7FFF;
+        const is_optional = (node.data.binary.flags & 0x8000) != 0;
 
         try self.emitNode(callee);
+        if (is_optional) try self.write("?.");
         try self.writeByte('(');
         try self.emitNodeList(args_start, args_len, ",");
         try self.writeByte(')');

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -708,7 +708,10 @@ pub const Transformer = struct {
     fn visitCallExpression(self: *Transformer, node: Node) Error!NodeIndex {
         const new_callee = try self.visitNode(node.data.binary.left);
         const args_start: u32 = @intFromEnum(node.data.binary.right);
-        const args_len: u32 = node.data.binary.flags;
+        // flags의 하위 15비트 = args_len, bit 15 = optional chaining 플래그 (0x8000)
+        const raw_flags = node.data.binary.flags;
+        const args_len: u32 = raw_flags & 0x7FFF;
+        const is_optional: u16 = raw_flags & 0x8000;
         const new_args = try self.visitExtraList(args_start, args_len);
         return self.new_ast.addNode(.{
             .tag = .call_expression,
@@ -716,7 +719,7 @@ pub const Transformer = struct {
             .data = .{ .binary = .{
                 .left = new_callee,
                 .right = @enumFromInt(new_args.start),
-                .flags = @intCast(new_args.len),
+                .flags = @intCast(new_args.len | is_optional),
             } },
         });
     }


### PR DESCRIPTION
## Summary
- transformer: optional call의 flags에서 0x8000 비트 마스킹 (crash 수정)
- codegen: `a?.b`, `a?.[0]`, `a?.()` optional chaining 정상 출력

이전에 `a?.()` 코드가 transformer에서 index out of bounds crash를 일으킴.
flags에 args_len과 optional 비트(0x8000)가 합쳐져 있는데, 분리 없이 args_len으로 사용했기 때문.

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `echo 'a?.b; a?.(); a?.[0]; a?.b?.c;' | zig build run -- -` → 정상 출력
- [x] ES 다운레벨링 선행 조건 충족

🤖 Generated with [Claude Code](https://claude.com/claude-code)