### PR TITLE
fix(transformer/codegen): 5 pipeline crashes — method, arrow, switch, import, async

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -857,9 +857,10 @@ pub const Codegen = struct {
         const body: NodeIndex = @enumFromInt(extras[3]);
         const flags = extras[4];
 
-        if (flags & 2 != 0) try self.write("async ");
+        // flags: 0x01=async, 0x02=generator (파서 기준)
+        if (flags & 0x01 != 0) try self.write("async ");
         try self.write("function");
-        if (flags & 1 != 0) try self.writeByte('*');
+        if (flags & 0x02 != 0) try self.writeByte('*');
         if (!name.isNone()) {
             try self.writeByte(' ');
             try self.emitNode(name);
@@ -870,18 +871,30 @@ pub const Codegen = struct {
         try self.emitNode(body);
     }
 
+    /// arrow_function_expression: binary = { left=params, right=body, flags }
+    /// flags: 0x01 = async
     fn emitArrow(self: *Codegen, node: Node) !void {
-        const e = node.data.extra;
-        const extras = self.ast.extra_data.items[e .. e + 6];
-        const params_start = extras[1];
-        const params_len = extras[2];
-        const body: NodeIndex = @enumFromInt(extras[3]);
-        const flags = extras[4];
+        const params = node.data.binary.left;
+        const body = node.data.binary.right;
+        const flags = node.data.binary.flags;
 
-        if (flags & 2 != 0) try self.write("async ");
-        try self.writeByte('(');
-        try self.emitNodeList(params_start, params_len, ",");
-        try self.write(")=>");
+        if (flags & 0x01 != 0) try self.write("async ");
+
+        // params가 단일 binding_identifier이면 괄호 없이 출력
+        if (!params.isNone()) {
+            const param_node = self.ast.getNode(params);
+            if (param_node.tag == .binding_identifier) {
+                try self.emitNode(params);
+            } else {
+                // parenthesized params나 다른 패턴
+                try self.writeByte('(');
+                try self.emitNode(params);
+                try self.writeByte(')');
+            }
+        } else {
+            try self.write("()");
+        }
+        try self.write("=>");
         try self.emitNode(body);
     }
 
@@ -1056,12 +1069,34 @@ pub const Codegen = struct {
     // Import/Export 출력
     // ================================================================
 
+    /// import_declaration:
+    ///   side-effect: unary = { operand=source_node }
+    ///   with specs:  extra = [specs.start, specs.len, source_node]
     fn emitImport(self: *Codegen, node: Node) !void {
+        // side-effect import 감지
+        const maybe_operand = node.data.unary.operand;
+        if (!maybe_operand.isNone() and @intFromEnum(maybe_operand) < self.ast.nodes.items.len) {
+            const operand_node = self.ast.getNode(maybe_operand);
+            if (operand_node.tag == .string_literal) {
+                if (self.options.module_format == .cjs) {
+                    try self.write("require(");
+                    try self.emitNode(maybe_operand);
+                    try self.write(");");
+                } else {
+                    try self.write("import ");
+                    try self.emitNode(maybe_operand);
+                    try self.writeByte(';');
+                }
+                return;
+            }
+        }
+
+        // extra: [specs.start, specs.len, source_node]
         const e = node.data.extra;
-        const extras = self.ast.extra_data.items[e .. e + 5];
-        const source: NodeIndex = @enumFromInt(extras[0]);
-        const specs_start = extras[1];
-        const specs_len = extras[2];
+        const extras = self.ast.extra_data.items[e .. e + 3];
+        const specs_start = extras[0];
+        const specs_len = extras[1];
+        const source: NodeIndex = @enumFromInt(extras[2]);
 
         if (self.options.module_format == .cjs) {
             return self.emitImportCJS(source, specs_start, specs_len);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -154,7 +154,6 @@ pub const Transformer = struct {
             .sequence_expression,
             .class_body,
             .formal_parameters,
-            .switch_statement,
             .template_literal,
             // JSX
             .jsx_element,
@@ -213,12 +212,13 @@ pub const Transformer = struct {
             .function_declaration,
             .function_expression,
             .function,
-            .arrow_function_expression,
             => self.visitFunction(node),
+            .arrow_function_expression => self.visitArrowFunction(node),
             .class_declaration,
             .class_expression,
             => self.visitClass(node),
             .for_statement => self.visitForStatement(node),
+            .switch_statement => self.visitSwitchStatement(node),
             .switch_case => self.visitSwitchCase(node),
             .call_expression => self.visitCallExpression(node),
             .new_expression => self.visitNewExpression(node),
@@ -665,6 +665,22 @@ pub const Transformer = struct {
         });
     }
 
+    /// arrow_function_expression: binary = { left=params, right=body, flags }
+    /// flags: 0x01 = async
+    fn visitArrowFunction(self: *Transformer, node: Node) Error!NodeIndex {
+        const new_params = try self.visitNode(node.data.binary.left);
+        const new_body = try self.visitNode(node.data.binary.right);
+        return self.new_ast.addNode(.{
+            .tag = .arrow_function_expression,
+            .span = node.span,
+            .data = .{ .binary = .{
+                .left = new_params,
+                .right = new_body,
+                .flags = node.data.binary.flags,
+            } },
+        });
+    }
+
     /// class_declaration / class_expression
     /// extra_data = [name, super_class, body, type_params, implements_start, implements_len]
     /// class: extra = [name, super, body, type_params, impl_start, impl_len, deco_start, deco_len]
@@ -692,6 +708,16 @@ pub const Transformer = struct {
         const new_body = try self.visitNode(self.readNodeIdx(e, 3));
         return self.addExtraNode(.for_statement, node.span, &.{
             @intFromEnum(new_init), @intFromEnum(new_test), @intFromEnum(new_update), @intFromEnum(new_body),
+        });
+    }
+
+    /// switch_statement: extra = [discriminant, cases.start, cases.len]
+    fn visitSwitchStatement(self: *Transformer, node: Node) Error!NodeIndex {
+        const e = node.data.extra;
+        const new_disc = try self.visitNode(self.readNodeIdx(e, 0));
+        const new_cases = try self.visitExtraList(self.readU32(e, 1), self.readU32(e, 2));
+        return self.addExtraNode(.switch_statement, node.span, &.{
+            @intFromEnum(new_disc), new_cases.start, new_cases.len,
         });
     }
 
@@ -733,13 +759,14 @@ pub const Transformer = struct {
     }
 
     /// method_definition: extra_data = [key, value, flags, decorators_start, decorators_len]
+    /// method_definition: extra = [key, params.start, params.len, body, flags]
     fn visitMethodDefinition(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
         const new_key = try self.visitNode(self.readNodeIdx(e, 0));
-        const new_value = try self.visitNode(self.readNodeIdx(e, 1));
-        const new_decos = try self.visitExtraList(self.readU32(e, 3), self.readU32(e, 4));
+        const new_params = try self.visitExtraList(self.readU32(e, 1), self.readU32(e, 2));
+        const new_body = try self.visitNode(self.readNodeIdx(e, 3));
         return self.addExtraNode(.method_definition, node.span, &.{
-            @intFromEnum(new_key), @intFromEnum(new_value), self.readU32(e, 2), new_decos.start, new_decos.len,
+            @intFromEnum(new_key), new_params.start, new_params.len, @intFromEnum(new_body), self.readU32(e, 4),
         });
     }
 
@@ -782,14 +809,31 @@ pub const Transformer = struct {
         });
     }
 
-    /// import_declaration: extra_data = [source, specifiers_start, specifiers_len, attributes_start, attributes_len]
+    /// import_declaration:
+    ///   side-effect: unary = { operand=source_node }
+    ///   with specs:  extra = [specs.start, specs.len, source_node]
     fn visitImportDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
+        // side-effect import 감지: operand가 유효한 string_literal이면 unary 형태
+        const maybe_operand = node.data.unary.operand;
+        if (!maybe_operand.isNone() and @intFromEnum(maybe_operand) < self.old_ast.nodes.items.len) {
+            const operand_node = self.old_ast.getNode(maybe_operand);
+            if (operand_node.tag == .string_literal) {
+                // side-effect import: 그대로 복사
+                const new_source = try self.visitNode(maybe_operand);
+                return self.new_ast.addNode(.{
+                    .tag = .import_declaration,
+                    .span = node.span,
+                    .data = .{ .unary = .{ .operand = new_source, .flags = 0 } },
+                });
+            }
+        }
+
+        // extra 형태: [specs.start, specs.len, source_node]
         const e = node.data.extra;
-        const new_source = try self.visitNode(self.readNodeIdx(e, 0));
-        const new_specs = try self.visitExtraList(self.readU32(e, 1), self.readU32(e, 2));
-        const new_attrs = try self.visitExtraList(self.readU32(e, 3), self.readU32(e, 4));
+        const new_specs = try self.visitExtraList(self.readU32(e, 0), self.readU32(e, 1));
+        const new_source = try self.visitNode(self.readNodeIdx(e, 2));
         return self.addExtraNode(.import_declaration, node.span, &.{
-            @intFromEnum(new_source), new_specs.start, new_specs.len, new_attrs.start, new_attrs.len,
+            new_specs.start, new_specs.len, @intFromEnum(new_source),
         });
     }
 


### PR DESCRIPTION
## Summary
파서-transformer-codegen 간 데이터 구조 불일치 일괄 수정:
1. method_definition extra 구조 맞춤 (setter crash)
2. arrow_function 별도 visitor (binary 형태, async arrow crash)
3. switch_statement를 list에서 extra로 변경 (switch crash)
4. import_declaration side-effect/specs 분기 (import crash)
5. async/generator flags 비트 뒤바뀜 수정

## Test plan
- [x] `zig build test` — 전체 통과
- [x] 모든 ES2020+ feature crash-free 확인
- [x] async function → `async function` 정상 출력
- [x] generator → `function*` 정상 출력

🤖 Generated with [Claude Code](https://claude.com/claude-code)