### PR TITLE
fix(transformer/codegen): import specifier + arrow parentheses

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -880,13 +880,16 @@ pub const Codegen = struct {
 
         if (flags & 0x01 != 0) try self.write("async ");
 
-        // params가 단일 binding_identifier이면 괄호 없이 출력
+        // params 출력
         if (!params.isNone()) {
             const param_node = self.ast.getNode(params);
             if (param_node.tag == .binding_identifier) {
+                // 단일 파라미터: x => x
+                try self.emitNode(params);
+            } else if (param_node.tag == .parenthesized_expression) {
+                // 괄호 형태: (a, b) => a + b — parenthesized_expression이 이미 괄호를 포함
                 try self.emitNode(params);
             } else {
-                // parenthesized params나 다른 패턴
                 try self.writeByte('(');
                 try self.emitNode(params);
                 try self.writeByte(')');

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -270,12 +270,13 @@ pub const Transformer = struct {
             .jsx_closing_fragment,
             => self.copyNodeDirect(node),
 
-            // === import/export specifiers: 그대로 복사 ===
-            .import_specifier,
+            // === import/export specifiers ===
+            .import_specifier => self.visitBinaryNode(node),
+            .export_specifier => self.visitBinaryNode(node),
+            // default/namespace specifier는 string_ref(span) 복사 — 자식 노드 없음
             .import_default_specifier,
             .import_namespace_specifier,
             .import_attribute,
-            .export_specifier,
             => self.copyNodeDirect(node),
 
             // === Pattern 노드: 자식 재귀 방문 ===


### PR DESCRIPTION
## Summary
- transformer: import_specifier를 visitBinaryNode로 변경 (NodeIndex 무효화 수정)
- codegen: arrow function parenthesized_expression 이중 괄호 제거

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `(a, b) => a + b` → `(a,b)=>a + b` (이중 괄호 해결)

🤖 Generated with [Claude Code](https://claude.com/claude-code)