### PR TITLE
fix(parser): object method function context — 80.8% → 84.5%

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -2612,6 +2612,9 @@ pub const Parser = struct {
         while (self.current() != .r_paren and self.current() != .eof) {
             const param = try self.parseBindingIdentifier();
             try self.scratch.append(param);
+            if (!param.isNone() and self.ast.getNode(param).tag == .spread_element and self.current() == .comma) {
+                self.addError(self.currentSpan(), "rest parameter must be last formal parameter");
+            }
             if (!self.eat(.comma)) break;
         }
         self.expect(.r_paren);
@@ -2619,7 +2622,12 @@ pub const Parser = struct {
         // TS 리턴 타입
         _ = try self.tryParseReturnType();
 
-        const body = try self.parseBlockStatement();
+        // object method도 함수이므로 컨텍스트 설정 (return/break/continue 검증)
+        const saved_ctx = self.enterFunctionContext((flags & 0x08) != 0, (flags & 0x10) != 0);
+        self.has_simple_params = self.checkSimpleParams(scratch_top);
+        self.checkDuplicateParams(scratch_top);
+        const body = try self.parseFunctionBody();
+        self.restoreContext(saved_ctx);
 
         const param_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
         self.restoreScratch(scratch_top);


### PR DESCRIPTION
## Summary
`parseObjectMethodBody()`에서 `enterFunctionContext` 누락 수정.
object literal 메서드 안에서 `return` 등이 에러로 잡히던 문제 해결.

## Test262 결과
- **전체**: 80.8% → **84.5%** (+864건, +3.7pp)
- **100% 카테고리**: 7개 → **10개** (computed-property-names, destructuring, function-code 추가)
- **statements**: 84.3% → **87.4%**
- **expressions**: 79.2% → **84.3%**

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `zig build test262-run` — 84.5%, crash 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)