### PR TITLE
feat(parser): literal keyword binding + generator statement position

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -534,9 +534,12 @@ pub const Parser = struct {
                 }
             },
             .kw_function => {
-                // strict mode에서 function declaration도 statement position 금지 (ECMAScript 14.6).
-                // Annex B (B.3.3)는 non-strict에서만 허용.
-                if (self.ctx.is_strict_mode) {
+                // generator declaration (function*)은 statement position에서 항상 금지
+                if (self.peekNextKind() == .star) {
+                    self.addError(self.currentSpan(), "generator declaration is not allowed in statement position");
+                } else if (self.ctx.is_strict_mode) {
+                    // strict mode에서 일반 function declaration도 금지 (ECMAScript 14.6).
+                    // Annex B (B.3.3)는 non-strict에서만 허용.
                     self.addError(self.currentSpan(), "function declaration is not allowed in statement position in strict mode");
                 }
             },


### PR DESCRIPTION
## Summary
- true/false/null 바인딩 검증 추가 (isLiteralKeyword)
- generator function* statement position에서 항상 금지
- const without init + import.meta script + eval/arguments strict (PR #104에서 이어짐)

## Test plan
- [x] `zig build test` 전체 통과
- [x] Test262: 20404 → 20419 (+15건, 87.3%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)