### PR TITLE
fix(parser): literal keyword labels + await/yield conditional reserved + directive prologue

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -437,7 +437,7 @@ pub const Parser = struct {
                         self.addError(self.currentSpan(), "\"use strict\" not allowed in function with non-simple parameters");
                     }
                     self.ctx.is_strict_mode = true;
-                } else {
+                } else if (self.current() != .string_literal) {
                     in_directive_prologue = false;
                 }
             }
@@ -485,7 +485,8 @@ pub const Parser = struct {
             if (in_directive_prologue) {
                 if (self.isUseStrictDirective()) {
                     self.ctx.is_strict_mode = true;
-                } else {
+                } else if (self.current() != .string_literal) {
+                    // directive prologue는 문자열 expression statement가 연속되는 동안 유효
                     in_directive_prologue = false;
                 }
             }


### PR DESCRIPTION
## Summary
- true/false/null label 사용 차단
- await/yield를 조건부 예약어로 처리 (script에서 식별자 사용 허용)
- directive prologue가 non-"use strict" 문자열을 통과하도록 수정

## Test plan
- [x] `zig build test` 전체 통과
- [x] Test262: 20470 → 20478 (+8건)
- [x] directive-prologue 100% 달성

🤖 Generated with [Claude Code](https://claude.com/claude-code)