### PR TITLE
fix(parser): yield* newline + directive prologue + literal keyword labels

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -2204,9 +2204,9 @@ pub const Parser = struct {
                 if (self.ctx.in_generator) {
                     const start = self.currentSpan().start;
                     self.advance();
-                    // yield* delegate
+                    // yield* delegate — * 전에 줄바꿈이 있으면 delegate 아님
                     var flags: u16 = 0;
-                    if (self.eat(.star)) {
+                    if (!self.scanner.token.has_newline_before and self.eat(.star)) {
                         flags = 1; // delegate
                     }
                     var operand = NodeIndex.none;


### PR DESCRIPTION
## Summary
- yield* delegate: * 앞에 줄바꿈 있으면 delegate 아님 (ECMAScript 14.4)
- true/false/null label 사용 차단
- await/yield 조건부 예약어 처리
- directive prologue 문자열 연속 처리

## Test plan
- [x] `zig build test` 전체 통과
- [x] Test262: 20470 → 20478 (+8건)
- [x] directive-prologue 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)