### PR TITLE
feat(parser): import/export top-level + block scope is_top_level

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -550,6 +550,16 @@ pub const Parser = struct {
                     self.addError(self.currentSpan(), "async function declaration is not allowed in statement position");
                 }
             },
+            .kw_export => {
+                self.addError(self.currentSpan(), "'export' is not allowed in statement position");
+            },
+            .kw_import => {
+                // import()와 import.meta는 expression이므로 제외
+                const peek = self.peekNextKind();
+                if (peek != .l_paren and peek != .dot) {
+                    self.addError(self.currentSpan(), "'import' is not allowed in statement position");
+                }
+            },
             else => {},
         }
         return self.parseStatement();


### PR DESCRIPTION
## Summary
- import/export: module의 top-level에서만 허용 (ECMAScript 15.2)
- parseBlockStatement에서 is_top_level=false 설정
- module-code: 435 → 483 (+48건)

## Test plan
- [x] `zig build test` 전체 통과
- [x] Test262: 20516 → 20562 (+46건, 87.7% → 87.9%)
- [x] /simplify 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)