### PR TITLE
feat(parser): trailing comma + new import() + for-in single binding

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1954,6 +1954,8 @@ pub const Parser = struct {
         const scratch_top = self.saveScratch();
         try self.scratch.append(first);
         while (self.eat(.comma)) {
+            // trailing comma: 콤마 뒤에 )가 오면 arrow function 파라미터 trailing comma
+            if (self.current() == .r_paren) break;
             const elem = try self.parseAssignmentExpression();
             try self.scratch.append(elem);
         }


### PR DESCRIPTION
## Summary
- parenthesized expression trailing comma 지원 (arrow function params)
- new import() forbidden
- for-in/for-of single binding validation
- unicode whitespace support

## Test plan
- [x] \`zig build test\` 전체 통과
- [x] Test262: 21269 → 21277 (+8건, 91.0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)