### PR TITLE
feat(parser): super() extends-only + static prototype + #constructor

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1353,10 +1353,9 @@ pub const Parser = struct {
         }
 
         // 클래스 본문 — extends 있으면 has_super_class 설정 (super() 허용 판단)
+        // 중첩 class에서 외부 has_super_class를 상속하지 않도록 명시적 설정
         const class_ctx_saved = self.ctx;
-        if (!super_class.isNone()) {
-            self.ctx.has_super_class = true;
-        }
+        self.ctx.has_super_class = !super_class.isNone();
         const body = try self.parseClassBody();
         self.ctx = class_ctx_saved;
 


### PR DESCRIPTION
## Summary
- super() requires extends (has_super_class)
- static method prototype 금지
- #constructor field/method 금지

## Test plan
- [x] \`zig build test\` 전체 통과
- [x] Test262: 21375 → 21382 (+7건, 91.4%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)