### PR TITLE
feat(lexer): bare # syntax error + constructor special method

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -398,8 +398,13 @@ pub const Scanner = struct {
                             break :blk .hashbang_comment;
                         }
                     }
-                    // private identifier
+                    // private identifier — # 뒤에 식별자 문자가 있어야 함
+                    const before_tail = self.current;
                     self.scanIdentifierTail();
+                    if (self.current == before_tail) {
+                        // # 뒤에 식별자 문자 없음 → syntax error
+                        break :blk .syntax_error;
+                    }
                     break :blk .private_identifier;
                 },
 


### PR DESCRIPTION
## Summary
- 렉서: # 뒤에 식별자 문자 없으면 syntax error
- 파서: constructor getter/setter/generator/async 금지
- 파서: static field constructor 금지

## Test plan
- [x] \`zig build test\` 전체 통과
- [x] Test262: 21586 → 21620 (+34건, 92.5%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)