### PR TITLE
feat(lexer,parser): escaped strict reserved word validation

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -93,6 +93,10 @@ pub const Scanner = struct {
     /// codegen에서 주석 보존에 사용한다.
     comments: std.ArrayList(Comment),
 
+    /// 이스케이프 디코딩 버퍼 (decodeIdentifierEscapes에서 사용).
+    /// Scanner 필드에 두어 dangling pointer 방지. 키워드 최대 길이(~12)+여유.
+    decode_buf: [64]u8 = undefined,
+
     /// 소스를 UTF-8로 읽고 Scanner를 초기화한다.
     /// BOM이 있으면 스킵한다 (D019).
     pub fn init(allocator: std.mem.Allocator, source: []const u8) Scanner {
@@ -418,10 +422,13 @@ pub const Scanner = struct {
                             const decoded = self.decodeIdentifierEscapes(text);
                             if (decoded) |name| {
                                 if (token.keywords.get(name)) |kw| {
-                                    // reserved keyword → escaped_keyword (항상 식별자 사용 불가)
-                                    // strict mode reserved/contextual → identifier (strict에서만 불가, 파서가 판별)
+                                    // reserved keyword/literal → escaped_keyword (항상 식별자 사용 불가)
+                                    // strict mode reserved (let, yield, implements 등) → escaped_strict_reserved
+                                    // contextual keyword (async, from 등) → identifier
                                     break :blk if (kw.isReservedKeyword() or kw.isLiteralKeyword())
                                         .escaped_keyword
+                                    else if (kw.isStrictModeReserved() or kw == .kw_let or kw == .kw_yield)
+                                        .escaped_strict_reserved
                                     else
                                         .identifier;
                                 }
@@ -457,6 +464,8 @@ pub const Scanner = struct {
                                 if (token.keywords.get(name)) |kw| {
                                     break :blk if (kw.isReservedKeyword() or kw.isLiteralKeyword())
                                         .escaped_keyword
+                                    else if (kw.isStrictModeReserved() or kw == .kw_let or kw == .kw_yield)
+                                        .escaped_strict_reserved
                                     else
                                         .identifier;
                                 }
@@ -1483,14 +1492,11 @@ pub const Scanner = struct {
 
     /// 이스케이프가 포함된 식별자 텍스트를 디코딩하여 실제 문자열을 반환한다.
     /// \uXXXX 와 \u{XXXX} 형태를 처리. BMP 문자만 지원 (키워드 매칭에 충분).
-    /// 스택 버퍼 사용 (할당 없음). 키워드 최대 길이 이내만 처리.
-    fn decodeIdentifierEscapes(self: *const Scanner, raw: []const u8) ?[]const u8 {
-        _ = self;
-        // 이스케이프가 없으면 그대로 반환
+    /// 인스턴스의 decode_buf를 사용하여 dangling pointer 방지.
+    fn decodeIdentifierEscapes(self: *Scanner, raw: []const u8) ?[]const u8 {
+        // 이스케이프가 없으면 그대로 반환 (소스 텍스트 포인터, 항상 유효)
         if (std.mem.indexOfScalar(u8, raw, '\\') == null) return raw;
 
-        // 스택 버퍼: 키워드는 최대 ~12자 (implements) 이므로 충분
-        var buf: [64]u8 = undefined;
         var out: usize = 0;
         var i: usize = 0;
 
@@ -1517,21 +1523,21 @@ pub const Scanner = struct {
                 }
                 // BMP 문자만 (키워드는 전부 ASCII)
                 if (codepoint < 0x80) {
-                    if (out >= buf.len) return null;
-                    buf[out] = @intCast(codepoint);
+                    if (out >= self.decode_buf.len) return null;
+                    self.decode_buf[out] = @intCast(codepoint);
                     out += 1;
                 } else {
                     return null; // non-ASCII codepoint → 키워드 아님
                 }
             } else {
-                if (out >= buf.len) return null;
-                buf[out] = raw[i];
+                if (out >= self.decode_buf.len) return null;
+                self.decode_buf[out] = raw[i];
                 out += 1;
                 i += 1;
             }
         }
 
-        return buf[0..out];
+        return self.decode_buf[0..out];
     }
 
     // ====================================================================

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -81,8 +81,11 @@ pub const Kind = enum(u8) {
     identifier,
     /// private 식별자 (`#name`)
     private_identifier,
-    /// 유니코드 이스케이프로 작성된 키워드 (키워드가 아닌 식별자로 취급)
+    /// 유니코드 이스케이프로 작성된 reserved keyword (항상 식별자로 사용 불가)
     escaped_keyword,
+    /// 유니코드 이스케이프로 작성된 strict mode reserved word (strict에서만 불가)
+    /// let, yield, implements, interface, package, private, protected, public, static
+    escaped_strict_reserved,
 
     // ========================================================================
     // ECMAScript Reserved Keywords (ES2024)
@@ -427,6 +430,7 @@ pub const Kind = enum(u8) {
             .identifier,
             .private_identifier,
             .escaped_keyword,
+            .escaped_strict_reserved,
             .kw_this,
             .kw_true,
             .kw_false,
@@ -625,6 +629,7 @@ const token_names = blk: {
             .identifier => "<identifier>",
             .private_identifier => "<private identifier>",
             .escaped_keyword => "<escaped keyword>",
+            .escaped_strict_reserved => "<escaped strict reserved>",
             // Punctuators
             .l_paren => "(",
             .r_paren => ")",

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -780,6 +780,7 @@ pub const Parser = struct {
     fn parseExpressionOrLabeledStatement(self: *Parser) ParseError2!NodeIndex {
         // identifier/keyword: statement — labeled statement 판별
         if (self.current() == .identifier or self.current() == .escaped_keyword or
+            self.current() == .escaped_strict_reserved or
             (self.current().isKeyword() and !self.current().isReservedKeyword() and !self.current().isLiteralKeyword()))
         {
             const peek = self.peekNext();
@@ -788,6 +789,8 @@ pub const Parser = struct {
                 self.checkYieldAwaitUse(self.currentSpan(), "label");
                 if (self.current() == .escaped_keyword) {
                     self.addError(self.currentSpan(), "escaped reserved word cannot be used as label");
+                } else if (self.current() == .escaped_strict_reserved and self.ctx.is_strict_mode) {
+                    self.addError(self.currentSpan(), "escaped reserved word cannot be used as label in strict mode");
                 } else if (self.ctx.is_strict_mode and self.current().isStrictModeReserved()) {
                     self.addError(self.currentSpan(), "reserved word in strict mode cannot be used as label");
                 }
@@ -3045,11 +3048,20 @@ pub const Parser = struct {
                 });
             },
             else => {
+                // escaped strict reserved → strict mode에서 에러, non-strict에서 identifier
+                if (self.current() == .escaped_strict_reserved) {
+                    if (self.ctx.is_strict_mode) {
+                        self.addError(span, "escaped reserved word cannot be used as identifier in strict mode");
+                    }
+                    self.advance();
+                    return try self.ast.addNode(.{
+                        .tag = .identifier_reference,
+                        .span = span,
+                        .data = .{ .string_ref = span },
+                    });
+                }
                 // contextual keyword, strict mode reserved, TS keyword는
                 // expression에서 식별자로 사용 가능 (reserved keyword만 불가)
-                // 단, yield/await는 generator/async 내부에서, strict mode reserved는 strict에서 불가
-                // await/yield는 조건부 예약어 — parseUnaryExpression에서 이미 처리했으므로
-                // 여기에 도달하면 식별자로 사용 가능한 컨텍스트
                 if (self.current().isKeyword() and
                     (!self.current().isReservedKeyword() or self.current() == .kw_await or self.current() == .kw_yield))
                 {
@@ -3404,7 +3416,6 @@ pub const Parser = struct {
                 return self.tryWrapDefaultValue(pat);
             },
             .escaped_keyword => {
-                // 이스케이프된 예약어는 식별자로 사용할 수 없음 (ECMAScript 12.1.1)
                 self.addError(self.currentSpan(), "escaped reserved word cannot be used as identifier");
                 const span = self.currentSpan();
                 self.advance();
@@ -3413,6 +3424,21 @@ pub const Parser = struct {
                     .span = span,
                     .data = .{ .string_ref = span },
                 });
+            },
+            .escaped_strict_reserved => {
+                if (self.ctx.is_strict_mode) {
+                    self.addError(self.currentSpan(), "escaped reserved word cannot be used as identifier in strict mode");
+                }
+                const span = self.currentSpan();
+                self.advance();
+                const node = try self.ast.addNode(.{
+                    .tag = .binding_identifier,
+                    .span = span,
+                    .data = .{ .string_ref = span },
+                });
+                _ = self.eat(.question);
+                _ = try self.tryParseTypeAnnotation();
+                return self.tryWrapDefaultValue(node);
             },
             else => {
                 // contextual 키워드는 바인딩 이름으로 사용 가능 (let, yield, async 등)
@@ -3482,6 +3508,18 @@ pub const Parser = struct {
                     .data = .{ .string_ref = span },
                 });
             },
+            .escaped_strict_reserved => {
+                if (self.ctx.is_strict_mode) {
+                    self.addError(self.currentSpan(), "escaped reserved word cannot be used as identifier in strict mode");
+                }
+                const span = self.currentSpan();
+                self.advance();
+                return try self.ast.addNode(.{
+                    .tag = .binding_identifier,
+                    .span = span,
+                    .data = .{ .string_ref = span },
+                });
+            },
             else => {
                 if (self.current().isKeyword()) {
                     self.checkKeywordBinding();
@@ -3503,10 +3541,13 @@ pub const Parser = struct {
     /// type alias, interface, enum 등 선언 이름에 사용.
     fn parseSimpleIdentifier(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
-        if (self.current() == .identifier or self.current() == .escaped_keyword or self.current().isKeyword()) {
-            // 예약어 체크 (바인딩 위치에서)
+        if (self.current() == .identifier or self.current() == .escaped_keyword or
+            self.current() == .escaped_strict_reserved or self.current().isKeyword())
+        {
             if (self.current() == .escaped_keyword) {
                 self.addError(span, "escaped reserved word cannot be used as identifier");
+            } else if (self.current() == .escaped_strict_reserved and self.ctx.is_strict_mode) {
+                self.addError(span, "escaped reserved word cannot be used as identifier in strict mode");
             } else {
                 self.checkKeywordBinding();
             }
@@ -3654,7 +3695,10 @@ pub const Parser = struct {
 
     fn parseIdentifierName(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
-        if (self.current() == .identifier or self.current() == .escaped_keyword or self.current().isKeyword()) {
+        if (self.current() == .identifier or self.current() == .escaped_keyword or
+            self.current() == .escaped_strict_reserved or self.current().isKeyword())
+        {
+            // IdentifierName: 예약어도 property name으로 사용 가능 (escaped 포함)
             self.advance();
             return try self.ast.addNode(.{
                 .tag = .identifier_reference,
@@ -3714,7 +3758,8 @@ pub const Parser = struct {
     fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
         switch (self.current()) {
-            .identifier, .escaped_keyword => {
+            .identifier, .escaped_keyword, .escaped_strict_reserved => {
+                // property key: 예약어도 사용 가능 (obj.let, class { yield() {} })
                 self.advance();
                 return try self.ast.addNode(.{
                     .tag = .identifier_reference,


### PR DESCRIPTION
## Summary
- 유니코드 이스케이프로 작성된 strict mode reserved word를 올바르게 감지하여 에러 처리
- `decodeIdentifierEscapes` dangling pointer 근본적 버그 수정
- future-reserved-words 100% 달성

## 변경 사항
### 렉서
- `escaped_strict_reserved` 토큰 추가 (`l\u0065t`, `yi\u0065ld`, `\u0069mplements` 등)
- `decodeIdentifierEscapes`: 스택 로컬 `buf` → Scanner 필드 `decode_buf`로 이동 (dangling pointer 방지)

### 파서
- binding/expression/label 위치에서 `escaped_strict_reserved` 처리
- strict mode이면 에러, non-strict이면 identifier로 허용
- property key에서는 escaped 포함 모든 키워드 허용

## Test plan
- [x] `zig build test` 통과
- [x] `zig build test262-run` — 95.3% (22286/23384)
- [x] future-reserved-words 100% (55/55)
- [x] `"use strict"; var l\u0065t = 1;` → SyntaxError
- [x] `var l\u0065t = 1;` → 허용 (non-strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)