### PR TITLE
feat(semantic): label validation for break/continue

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -541,8 +541,10 @@ pub const SemanticAnalyzer = struct {
                 self.visitNode(node.data.binary.right);
             },
             .static_block => {
-                // unary: { operand = body }
+                // static block은 함수와 같은 경계 — label은 넘지 못함
+                const saved_labels = self.saveLabelLen();
                 self.visitNode(node.data.unary.operand);
+                self.restoreLabelLen(saved_labels);
             },
 
             // ---- 스킵 (TS 타입 노드, 리터럴, 식별자 등) ----


### PR DESCRIPTION
## Summary
- semantic analyzer에 label 추적 추가 (파서 변경 없음)
- `break LABEL` / `continue LABEL`의 label 존재 여부 검증
- continue는 loop label만 허용
- 함수 경계에서 label 스코프 제한

## 변경 사항
- `LabelEntry` 스택 + `saveLabelLen`/`restoreLabelLen`
- `visitLabeledStatement`: label 등록 + 중복 체크 + body 순회 + pop
- `visitBreakContinue`: label 검색 + 유효성 검증
- 함수 visitor 3곳에서 label 스택 저장/복원

## Test plan
- [x] `zig build test` 통과
- [x] `zig build test262-run` — 96.1% (22481/23384, +18건)
- [x] `break LABEL` (존재하지 않는 label) → SyntaxError
- [x] `continue LABEL` (non-loop label) → SyntaxError
- [x] 함수 안에서 외부 label break → SyntaxError

🤖 Generated with [Claude Code](https://claude.com/claude-code)