### PR TITLE
fix(lexer): reject numeric separator after leading zero

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -1105,6 +1105,8 @@ pub const Scanner = struct {
                     self.current += 1;
                     return self.scanBinaryLiteral();
                 },
+                // 0_ → numeric separator in leading zero literal is invalid
+                '_' => return .syntax_error,
                 else => {},
             }
         }


### PR DESCRIPTION
## Summary
- `0_7n`, `0_8` 같은 leading zero + numeric separator를 syntax error로 처리
- ECMAScript: numeric separator는 0x/0o/0b 접두사가 있는 리터럴에서만 허용

## Test plan
- [x] `zig build test` 통과
- [x] `zig build test262-run` — 96.8% (22636/23384, +12건)
- [x] regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)