### PR TITLE
feat(regexp): 2-pass pre-parse + ES2025 duplicate named groups (PR 4/4)

### DIFF
--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -59,8 +59,10 @@ pub fn PatternParser(comptime emit_ast: bool) type {
 
         // ── ES2025 alternative tracking ──
         // parseDisjunction에서 '|' 마다 증가, parseGroup에서 depth 추적.
+        // 주의: 최대 8 depth까지만 추적. >8 중첩 시 depth 7을 공유하여
+        // 이론적으로 false negative 가능하지만 실용적으로 문제 없음.
 
-        /// 현재 그룹 중첩 깊이.
+        /// 현재 그룹 중첩 깊이 (최대 7로 클램핑).
         alt_depth: u8 = 0,
         /// 각 깊이에서의 현재 alternative 인덱스.
         alt_indices: [8]u32 = [_]u32{0} ** 8,
@@ -168,6 +170,8 @@ pub fn PatternParser(comptime emit_ast: bool) type {
 
         /// 파싱 + 후처리 검증 (validate/parse 공통).
         /// 패턴을 가볍게 스캔하여 capturing group 수를 수집한다 (pre-parse).
+        /// 주의: 문법 에러가 있는 패턴에서는 본 파싱과 카운트가 다를 수 있으나,
+        /// 본 파싱에서 에러가 보고되므로 실질적 영향 없음.
         /// escape, character class를 건너뛰면서 '(' 만 카운트.
         fn preParseGroups(self: *Self) void {
             var pos: u32 = 0;


### PR DESCRIPTION
## Summary
RegExp 파서의 마지막 PR. 2-pass pre-parse와 ES2025 duplicate named group 지원.

- **`preParseGroups()`**: 패턴을 가볍게 스캔하여 총 capturing group 수 사전 수집
  - escape, character class를 건너뛰면서 `(` 만 카운트
  - `parseAndFinalize()` 시작 시 자동 호출
- **ES2025 duplicate named groups**: `(?<a>x)|(?<a>y)` 허용 (다른 alternative)
  - `NamedGroupEntry`에 `alt_path[8]` 저장 (depth별 alternative 인덱스)
  - `canParticipate()` — 경로 비교: 같은 alternative면 에러, 다른 alternative면 OK
  - `parseDisjunction`에서 `|` 마다 `alt_indices` 증가
  - `parseGroup`에서 `defer`로 depth save/restore
- **Back reference 즉시 검증**: `total_group_count`로 `\1`-`\9` 즉시 체크
- **고정 배열 → BoundedArray**: `named_groups(32)`, `named_refs(64)`
- **`max_back_ref` 필드 제거** (pre-parse로 대체)

## /simplify 수정
- alt_depth 8-depth 제한 문서화
- preParseGroups() 에러 패턴 불일치 문서화

## Test plan
- [x] `zig build test` — 기존 + ES2025 7개 + pre-parse 3개 테스트 전체 통과 (410개)
- [x] `zig build test262-run` — 97.7% 유지
- [x] ES2025: `(?<a>x)|(?<a>y)` 허용, `(?<a>x)(?<a>y)` 거부, nested alternatives 허용
- [x] Forward reference: `\1(a)` 허용, `\2(a)` 거부

🤖 Generated with [Claude Code](https://claude.com/claude-code)