### PR TITLE
refactor(regexp): resolve remaining /simplify issues

### DIFF
--- a/src/regexp/diagnostics.zig
+++ b/src/regexp/diagnostics.zig
@@ -1,9 +1,4 @@
 //! RegExp 검증 에러 메시지.
+//! 하위 호환을 위해 flags.zig의 Error를 재수출.
 
-/// RegExp 검증 에러.
-pub const Error = struct {
-    /// 에러 메시지 (정적 문자열)
-    message: []const u8,
-    /// 에러 위치 (패턴/플래그 내의 byte offset, 0-based)
-    offset: u32 = 0,
-};
+pub const Error = @import("flags.zig").Error;

--- a/src/regexp/flags.zig
+++ b/src/regexp/flags.zig
@@ -7,7 +7,14 @@
 //!   - u와 v 동시 사용 금지 (/foo/uv → 에러, ES2024)
 
 const std = @import("std");
-const Error = @import("diagnostics.zig").Error;
+
+/// RegExp 검증 에러.
+pub const Error = struct {
+    /// 에러 메시지 (정적 문자열)
+    message: []const u8,
+    /// 에러 위치 (패턴/플래그 내의 byte offset, 0-based)
+    offset: u32 = 0,
+};
 
 /// 플래그 비트마스크.
 pub const Flags = packed struct(u8) {

--- a/src/regexp/mod.zig
+++ b/src/regexp/mod.zig
@@ -29,9 +29,9 @@ pub const unicode_property = @import("unicode_property.zig");
 /// flag_text: 닫는 `/` 뒤의 플래그 텍스트 (예: "gi")
 /// 에러가 있으면 에러 메시지를 반환, 없으면 null.
 pub fn validate(pattern: []const u8, flag_text: []const u8) ?[]const u8 {
-    // 1. 플래그 검증
-    if (flags.validate(flag_text) != null) {
-        return "invalid regular expression flags";
+    // 1. 플래그 검증 — 구체적인 에러 메시지를 보존
+    if (flags.validate(flag_text)) |err| {
+        return err.message;
     }
 
     // 2. 패턴 검증

--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -22,6 +22,9 @@ pub const ast = @import("ast.zig");
 /// 유니코드 프로퍼티 검증 테이블.
 pub const unicode_property = @import("unicode_property.zig");
 
+/// 렉서의 유니코드 식별자 판별 + UTF-8 디코딩.
+const unicode = @import("../lexer/unicode.zig");
+
 /// 패턴 파서. comptime emit_ast로 검증/AST 모드 분리.
 ///
 /// - emit_ast=false: 검증만 수행, 할당 없음 (현재 렉서에서 사용)
@@ -539,25 +542,13 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                     self.setError("unexpected quantifier without preceding atom");
                     return false;
                 },
-                '{' => {
-                    // unicode mode에서 standalone {는 에러
+                // non-unicode: literal로 취급. unicode: 에러.
+                '{', '}', ']' => {
                     if (self.flags.hasUnicodeMode()) {
-                        self.setError("unexpected quantifier without preceding atom");
-                        return false;
-                    }
-                    // non-unicode mode에서는 literal
-                    self.advance();
-                    if (emit_ast) {
-                        self.last_node = self.addNode(.character, .{
-                            .start = self.pos - 1,
-                            .end = self.pos,
-                        }, .{ '{', @intFromEnum(ast.CharacterKind.symbol), 0 });
-                    }
-                    return true;
-                },
-                '}' => {
-                    if (self.flags.hasUnicodeMode()) {
-                        self.setError("unexpected '}' in regular expression");
+                        self.setError(if (c == '{')
+                            "unexpected quantifier without preceding atom"
+                        else
+                            "unexpected character in regular expression");
                         return false;
                     }
                     self.advance();
@@ -565,21 +556,7 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                         self.last_node = self.addNode(.character, .{
                             .start = self.pos - 1,
                             .end = self.pos,
-                        }, .{ '}', @intFromEnum(ast.CharacterKind.symbol), 0 });
-                    }
-                    return true;
-                },
-                ']' => {
-                    if (self.flags.hasUnicodeMode()) {
-                        self.setError("unexpected ']' in regular expression");
-                        return false;
-                    }
-                    self.advance();
-                    if (emit_ast) {
-                        self.last_node = self.addNode(.character, .{
-                            .start = self.pos - 1,
-                            .end = self.pos,
-                        }, .{ ']', @intFromEnum(ast.CharacterKind.symbol), 0 });
+                        }, .{ c, @intFromEnum(ast.CharacterKind.symbol), 0 });
                     }
                     return true;
                 },
@@ -1333,17 +1310,13 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                 }
             }
 
-            // Non-ASCII: UTF-8 multi-byte 문자 (Unicode ID_Start/ID_Continue)
+            // Non-ASCII: UTF-8 디코딩 후 Unicode ID_Start/ID_Continue 확인
             if (gc >= 0x80) {
-                // unicode mode에서 non-ASCII는 에러 (유효한 Unicode escape를 사용해야 함)
-                if (self.flags.hasUnicodeMode()) {
-                    return false;
-                }
-                self.advance();
-                // multi-byte UTF-8: 후속 바이트 스킵
-                while (!self.isEnd() and (self.peek() & 0xC0) == 0x80) {
-                    self.advance();
-                }
+                const decoded = unicode.decodeUtf8(self.source[self.pos..]);
+                const cp = decoded.codepoint;
+                const valid = if (is_start) unicode.isIdentifierStart(cp) else unicode.isIdentifierContinue(cp);
+                if (!valid) return false;
+                self.pos += decoded.len;
                 return true;
             }
 


### PR DESCRIPTION
## Summary
전체 regexp 모듈 /simplify 리뷰에서 스킵했던 4건을 모두 해결.

- **parseGroupNameChar non-ASCII 수정** (스펙 위반 수정)
  - unicode mode에서 non-ASCII를 무조건 거부 → UTF-8 디코딩 후 ID_Start/ID_Continue 검증
  - lexer의 `unicode.decodeUtf8` + `isIdentifierStart`/`isIdentifierContinue` 재사용
  - Test262 +3건 통과 (22853 → 22856)
- **mod.zig validate()**: flags 에러의 구체적 message 보존 (기존: 일률 메시지)
- **diagnostics.zig**: Error를 flags.zig로 이동, diagnostics는 재수출만 (정리)
- **parseAtom**: `{`, `}`, `]` 3개 분기를 1개로 통합 (-25줄)

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `zig build test262-run` — 22856/23384 (97.7%, +3건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)