### PR TITLE
fix(parser): reject meta_property as assignment target

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -386,6 +386,14 @@ pub const Parser = struct {
             .object_assignment_target,
             => true,
 
+            // 7) meta_property (import.meta, new.target) — 절대로 assignment target이 될 수 없음.
+            //    is_top 여부와 무관하게 항상 에러. else 분기는 is_top=false일 때 에러를 내지 않으므로
+            //    destructuring 내부([import.meta] = arr)에서 잘못 통과하는 것을 방지.
+            .meta_property => {
+                self.addError(node.span, "invalid assignment target");
+                return false;
+            },
+
             else => {
                 if (is_top) self.addError(node.span, "invalid assignment target");
                 return false;


### PR DESCRIPTION
## Summary
- `import.meta`와 `new.target`(meta_property 노드)을 assignment target으로 명시적 거부
- 기존: `else` 브랜치에서 `is_top=true`일 때만 에러 → 중첩 destructuring에서 누락
- 수정: `is_top` 무관하게 항상 에러

## Test plan
- [x] `zig build test` 통과
- [x] `zig fmt --check src/` 통과
- [ ] `zig build test262-run` import.meta 관련 개선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)