### PR TITLE
fix(ci): enforce test262 failures and enable parser conformance

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -50,50 +50,51 @@ jobs:
         run: zig build -Doptimize=ReleaseFast
 
       - name: Test262 — literals/numeric
-        run: zig build run -- --test262 tests/test262/test/language/literals/numeric/ || true
+        run: zig build run -- --test262 tests/test262/test/language/literals/numeric/
 
       - name: Test262 — literals/string
-        run: zig build run -- --test262 tests/test262/test/language/literals/string/ || true
+        run: zig build run -- --test262 tests/test262/test/language/literals/string/
 
       - name: Test262 — literals/bigint
-        run: zig build run -- --test262 tests/test262/test/language/literals/bigint/ || true
+        run: zig build run -- --test262 tests/test262/test/language/literals/bigint/
 
       - name: Test262 — literals/regexp
-        run: zig build run -- --test262 tests/test262/test/language/literals/regexp/ || true
+        run: zig build run -- --test262 tests/test262/test/language/literals/regexp/
 
       - name: Test262 — literals/boolean
-        run: zig build run -- --test262 tests/test262/test/language/literals/boolean/ || true
+        run: zig build run -- --test262 tests/test262/test/language/literals/boolean/
 
       - name: Test262 — literals/null
-        run: zig build run -- --test262 tests/test262/test/language/literals/null/ || true
+        run: zig build run -- --test262 tests/test262/test/language/literals/null/
 
       - name: Test262 — comments
-        run: zig build run -- --test262 tests/test262/test/language/comments/ || true
+        run: zig build run -- --test262 tests/test262/test/language/comments/
 
       - name: Test262 — white-space
-        run: zig build run -- --test262 tests/test262/test/language/white-space/ || true
+        run: zig build run -- --test262 tests/test262/test/language/white-space/
 
       - name: Test262 — line-terminators
-        run: zig build run -- --test262 tests/test262/test/language/line-terminators/ || true
+        run: zig build run -- --test262 tests/test262/test/language/line-terminators/
 
       - name: Test262 — template-literal
-        run: zig build run -- --test262 tests/test262/test/language/expressions/template-literal/ || true
+        run: zig build run -- --test262 tests/test262/test/language/expressions/template-literal/
 
-      # 렉서+파서 경계 (파서 구현 후 활성화)
-      # - name: Test262 — identifiers
-      #   run: zig build run -- --test262 tests/test262/test/language/identifiers/ || true
-      # - name: Test262 — keywords
-      #   run: zig build run -- --test262 tests/test262/test/language/keywords/ || true
-      # - name: Test262 — future-reserved-words
-      #   run: zig build run -- --test262 tests/test262/test/language/future-reserved-words/ || true
-      # - name: Test262 — asi
-      #   run: zig build run -- --test262 tests/test262/test/language/asi/ || true
+      - name: Test262 — identifiers
+        run: zig build run -- --test262 tests/test262/test/language/identifiers/
+
+      - name: Test262 — keywords
+        run: zig build run -- --test262 tests/test262/test/language/keywords/
+
+      - name: Test262 — future-reserved-words
+        run: zig build run -- --test262 tests/test262/test/language/future-reserved-words/
+
+      - name: Test262 — asi
+        run: zig build run -- --test262 tests/test262/test/language/asi/
 
   test262-parser:
     name: Test262 Parser Conformance
     runs-on: ubuntu-latest
     needs: test262-unit
-    if: false  # 파서 구현 후 활성화
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- `|| true` 제거 — test262 렉서 스텝 실패 시 CI가 실제로 실패하도록 변경
- 주석 처리된 렉서 카테고리 4개 활성화 (identifiers, keywords, future-reserved-words, asi)
- 파서 Test262 conformance job 활성화 (`if: false` 제거)

## Test plan
- [ ] 렉서 카테고리 14개 전부 CI에서 통과 확인
- [ ] 파서 full language/ conformance 실행 확인
- [ ] 실패 케이스가 있으면 CI가 빨간불 뜨는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)