### PR TITLE
fix: annotate silent catch + unify @panic OOM messages

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -448,8 +448,8 @@ test "TsConfig.load - parse compilerOptions" {
 
     // 임시 디렉토리에 테스트용 tsconfig.json 생성
     const tmp_dir = "/tmp/zts_test_config_parse";
-    std.fs.cwd().makePath(tmp_dir) catch {};
-    defer std.fs.cwd().deleteTree(tmp_dir) catch {};
+    std.fs.cwd().makePath(tmp_dir) catch {}; // 이미 존재하면 무시
+    defer std.fs.cwd().deleteTree(tmp_dir) catch {}; // cleanup 실패 무시
 
     const tsconfig_content =
         \\{
@@ -495,8 +495,8 @@ test "TsConfig.load - JSONC with comments" {
     const allocator = std.testing.allocator;
 
     const tmp_dir = "/tmp/zts_test_config_jsonc";
-    std.fs.cwd().makePath(tmp_dir) catch {};
-    defer std.fs.cwd().deleteTree(tmp_dir) catch {};
+    std.fs.cwd().makePath(tmp_dir) catch {}; // 이미 존재하면 무시
+    defer std.fs.cwd().deleteTree(tmp_dir) catch {}; // cleanup 실패 무시
 
     const tsconfig_content =
         \\{
@@ -526,8 +526,8 @@ test "TsConfig.load - extends inheritance" {
     const allocator = std.testing.allocator;
 
     const tmp_dir = "/tmp/zts_test_config_extends";
-    std.fs.cwd().makePath(tmp_dir) catch {};
-    defer std.fs.cwd().deleteTree(tmp_dir) catch {};
+    std.fs.cwd().makePath(tmp_dir) catch {}; // 이미 존재하면 무시
+    defer std.fs.cwd().deleteTree(tmp_dir) catch {}; // cleanup 실패 무시
 
     // base.json: 기본 설정
     const base_content =
@@ -576,8 +576,8 @@ test "TsConfig.load - partial compilerOptions" {
     const allocator = std.testing.allocator;
 
     const tmp_dir = "/tmp/zts_test_config_partial";
-    std.fs.cwd().makePath(tmp_dir) catch {};
-    defer std.fs.cwd().deleteTree(tmp_dir) catch {};
+    std.fs.cwd().makePath(tmp_dir) catch {}; // 이미 존재하면 무시
+    defer std.fs.cwd().deleteTree(tmp_dir) catch {}; // cleanup 실패 무시
 
     // 일부 옵션만 있는 tsconfig
     const tsconfig_content =

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -190,7 +190,7 @@ pub const Parser = struct {
             .param_name_spans = std.ArrayList(Span).init(allocator),
             .bracket_stack = blk: {
                 var stack = std.ArrayList(BracketInfo).init(allocator);
-                stack.ensureTotalCapacity(8) catch {};
+                stack.ensureTotalCapacity(8) catch {}; // pre-alloc 실패해도 동작에 지장 없음
                 break :blk stack;
             },
             .allocator = allocator,
@@ -643,7 +643,7 @@ pub const Parser = struct {
                         return;
                     }
                 }
-                self.param_name_spans.append(node.span) catch @panic("OOM");
+                self.param_name_spans.append(node.span) catch @panic("OOM: param_name_spans");
             },
             .parenthesized_expression => self.collectCoverParamNames(node.data.unary.operand),
             .sequence_expression => {
@@ -1147,7 +1147,7 @@ pub const Parser = struct {
         switch (node.tag) {
             // 단말 노드: 이름 1개 추가
             .binding_identifier => {
-                self.param_name_spans.append(node.span) catch @panic("OOM");
+                self.param_name_spans.append(node.span) catch @panic("OOM: param_name_spans");
             },
             // x = default → 왼쪽이 실제 바인딩
             .assignment_pattern => {

--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -116,8 +116,8 @@ pub fn PatternParser(comptime emit_ast: bool) type {
             var nodes = std.ArrayList(ast.Node).init(alloc);
             var extra = std.ArrayList(u32).init(alloc);
             // 대부분의 정규식은 32개 미만 노드 → 재할당 최소화
-            nodes.ensureTotalCapacity(32) catch {};
-            extra.ensureTotalCapacity(64) catch {};
+            nodes.ensureTotalCapacity(32) catch {}; // pre-alloc 실패해도 동작에 지장 없음
+            extra.ensureTotalCapacity(64) catch {}; // pre-alloc 실패해도 동작에 지장 없음
             return .{
                 .source = source,
                 .flags = parsed_flags,

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -234,8 +234,8 @@ pub const SemanticAnalyzer = struct {
 
     /// class body 진입 시 private name 스코프를 push한다.
     fn pushClassScope(self: *SemanticAnalyzer) void {
-        self.class_private_declared.append(std.StringHashMap(PrivateNameInfo).init(self.allocator)) catch @panic("OOM");
-        self.class_private_refs.append(std.ArrayList(PrivateRef).init(self.allocator)) catch @panic("OOM");
+        self.class_private_declared.append(std.StringHashMap(PrivateNameInfo).init(self.allocator)) catch @panic("OOM: class_private_declared");
+        self.class_private_refs.append(std.ArrayList(PrivateRef).init(self.allocator)) catch @panic("OOM: class_private_refs");
     }
 
     /// class body 퇴장 시 private name 참조를 검증하고 pop한다.
@@ -279,11 +279,11 @@ pub const SemanticAnalyzer = struct {
                     self.allocator,
                     "Private field '{s}' has already been declared",
                     .{name},
-                ) catch @panic("OOM"));
+                ) catch @panic("OOM: duplicate_private_field"));
                 return;
             }
         }
-        current.put(name, .{ .span = span, .kind = kind }) catch @panic("OOM");
+        current.put(name, .{ .span = span, .kind = kind }) catch @panic("OOM: class_private_declared");
     }
 
     /// identifier 텍스트에서 unicode escape sequence를 해석하여 StringValue를 반환한다.
@@ -347,7 +347,7 @@ pub const SemanticAnalyzer = struct {
             return;
         }
         var current = &self.class_private_refs.items[self.class_private_refs.items.len - 1];
-        current.append(.{ .name = name, .span = span }) catch @panic("OOM");
+        current.append(.{ .name = name, .span = span }) catch @panic("OOM: class_private_refs");
     }
 
     /// 현재 class scope 안에 있는지 (private name 참조 가능 여부).
@@ -550,11 +550,11 @@ pub const SemanticAnalyzer = struct {
     // ================================================================
 
     fn addError(self: *SemanticAnalyzer, span: Span, name: []const u8) void {
-        self.addErrorMsg(span, std.fmt.allocPrint(self.allocator, "Identifier '{s}' has already been declared", .{name}) catch @panic("OOM"));
+        self.addErrorMsg(span, std.fmt.allocPrint(self.allocator, "Identifier '{s}' has already been declared", .{name}) catch @panic("OOM: redeclaration"));
     }
 
     fn addPrivateNameError(self: *SemanticAnalyzer, span: Span, name: []const u8) void {
-        self.addErrorMsg(span, std.fmt.allocPrint(self.allocator, "Private field '{s}' must be declared in an enclosing class", .{name}) catch @panic("OOM"));
+        self.addErrorMsg(span, std.fmt.allocPrint(self.allocator, "Private field '{s}' must be declared in an enclosing class", .{name}) catch @panic("OOM: private_field_undeclared"));
     }
 
     fn addErrorMsg(self: *SemanticAnalyzer, span: Span, msg: []const u8) void {
@@ -1149,7 +1149,7 @@ pub const SemanticAnalyzer = struct {
 
             // 중복 label 체크 (같은 label 이름이 현재 스택에 있으면 에러)
             if (self.findLabel(name) != null) {
-                self.addErrorMsg(label_node.span, std.fmt.allocPrint(self.allocator, "Label '{s}' has already been declared", .{name}) catch @panic("OOM"));
+                self.addErrorMsg(label_node.span, std.fmt.allocPrint(self.allocator, "Label '{s}' has already been declared", .{name}) catch @panic("OOM: duplicate_label"));
             }
 
             // body가 loop인지 판별 (continue label에 필요)
@@ -1160,7 +1160,7 @@ pub const SemanticAnalyzer = struct {
                     body_tag == .do_while_statement;
             } else false;
 
-            self.labels.append(.{ .name = name, .span = label_node.span, .is_loop = is_loop }) catch @panic("OOM");
+            self.labels.append(.{ .name = name, .span = label_node.span, .is_loop = is_loop }) catch @panic("OOM: labels");
             self.visitNode(body_idx);
             _ = self.labels.pop();
         } else {
@@ -1180,11 +1180,11 @@ pub const SemanticAnalyzer = struct {
         if (self.findLabel(name)) |entry| {
             // continue는 loop label만 가능
             if (node.tag == .continue_statement and !entry.is_loop) {
-                self.addErrorMsg(label_node.span, std.fmt.allocPrint(self.allocator, "Cannot continue to non-loop label '{s}'", .{name}) catch @panic("OOM"));
+                self.addErrorMsg(label_node.span, std.fmt.allocPrint(self.allocator, "Cannot continue to non-loop label '{s}'", .{name}) catch @panic("OOM: continue_non_loop"));
             }
         } else {
             // label이 존재하지 않음
-            self.addErrorMsg(label_node.span, std.fmt.allocPrint(self.allocator, "Undefined label '{s}'", .{name}) catch @panic("OOM"));
+            self.addErrorMsg(label_node.span, std.fmt.allocPrint(self.allocator, "Undefined label '{s}'", .{name}) catch @panic("OOM: undefined_label"));
         }
     }
 
@@ -1437,7 +1437,7 @@ pub const SemanticAnalyzer = struct {
                 self.allocator,
                 "'{s}' cannot be used as a binding identifier in strict mode",
                 .{name},
-            ) catch @panic("OOM"));
+            ) catch @panic("OOM: strict_binding"));
         }
     }
 
@@ -1582,9 +1582,9 @@ pub const SemanticAnalyzer = struct {
                 self.allocator,
                 "Duplicate export name '{s}'",
                 .{name},
-            ) catch @panic("OOM"));
+            ) catch @panic("OOM: duplicate_export"));
         } else {
-            self.exported_names.put(name, span) catch @panic("OOM");
+            self.exported_names.put(name, span) catch @panic("OOM: exported_names");
         }
     }
 
@@ -1601,7 +1601,7 @@ pub const SemanticAnalyzer = struct {
             self.allocator,
             "Export '{s}' is not defined",
             .{name},
-        ) catch @panic("OOM"));
+        ) catch @panic("OOM: undefined_export"));
     }
 
     // ================================================================

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -84,7 +84,7 @@ pub fn checkDuplicateConstructors(
 
         if (first_constructor_span) |_| {
             // 두 번째 constructor → 에러
-            addError(errors, node.span, std.fmt.allocPrint(allocator, "A class may only have one constructor", .{}) catch @panic("OOM"));
+            addError(errors, node.span, std.fmt.allocPrint(allocator, "A class may only have one constructor", .{}) catch @panic("OOM: duplicate_constructor"));
             return; // 첫 중복만 보고
         } else {
             first_constructor_span = node.span;
@@ -204,10 +204,10 @@ fn checkPrivateKeyStaticConflict(
                 allocator,
                 "Private field '{s}' has already been declared",
                 .{name},
-            ) catch @panic("OOM"));
+            ) catch @panic("OOM: private_static_conflict"));
         }
     } else {
-        declared.put(name, .{ .is_static = is_static, .span = key_node.span }) catch @panic("OOM");
+        declared.put(name, .{ .is_static = is_static, .span = key_node.span }) catch @panic("OOM: declared");
     }
 }
 
@@ -255,7 +255,7 @@ pub fn checkObjectDuplicateProto(
         if (!matchKeyName(ast, key_idx, "__proto__")) continue;
 
         if (first_proto_span) |_| {
-            addError(errors, node.span, std.fmt.allocPrint(allocator, "Property name __proto__ appears more than once in object literal", .{}) catch @panic("OOM"));
+            addError(errors, node.span, std.fmt.allocPrint(allocator, "Property name __proto__ appears more than once in object literal", .{}) catch @panic("OOM: duplicate_proto"));
             return; // 첫 중복만 보고
         } else {
             first_proto_span = node.span;
@@ -291,11 +291,11 @@ pub fn checkGetterSetterParams(
     const params_len = ast.extra_data.items[extra_start + 2];
 
     if ((flags & METHOD_FLAG_GETTER) != 0 and params_len != 0) {
-        addError(errors, node.span, std.fmt.allocPrint(allocator, "Getter must not have any formal parameters", .{}) catch @panic("OOM"));
+        addError(errors, node.span, std.fmt.allocPrint(allocator, "Getter must not have any formal parameters", .{}) catch @panic("OOM: getter_params"));
     }
 
     if ((flags & METHOD_FLAG_SETTER) != 0 and params_len != 1) {
-        addError(errors, node.span, std.fmt.allocPrint(allocator, "Setter must have exactly one formal parameter", .{}) catch @panic("OOM"));
+        addError(errors, node.span, std.fmt.allocPrint(allocator, "Setter must have exactly one formal parameter", .{}) catch @panic("OOM: setter_params"));
     }
 }
 
@@ -347,9 +347,9 @@ fn recordSeenName(
             allocator,
             "Duplicate parameter name '{s}'",
             .{name},
-        ) catch @panic("OOM"));
+        ) catch @panic("OOM: duplicate_param"));
     } else {
-        seen.put(name, span) catch @panic("OOM");
+        seen.put(name, span) catch @panic("OOM: seen");
     }
 }
 

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -202,7 +202,7 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
         // 개행 전까지만 (에러 위치부터)
         var line_end: usize = err.span.start - before_start;
         while (line_end < snippet.len and snippet[line_end] != '\n') : (line_end += 1) {}
-        stderr.print("    error@{d}: {s} | ...{s}\n", .{ err.span.start, err.message, snippet[0..line_end] }) catch {};
+        stderr.print("    error@{d}: {s} | ...{s}\n", .{ err.span.start, err.message, snippet[0..line_end] }) catch {}; // stderr 출력 실패 무시
     }
 
     return result;


### PR DESCRIPTION
## Summary
- `catch {}` 11곳에 의도 주석 추가 (config 테스트 8곳, test262 1곳, pre-alloc 3곳 중 1곳은 parser, 2곳은 regexp)
- `@panic("OOM")` 25개 → `@panic("OOM: {context}")` 형식으로 통일 (parser 2, analyzer 15, checker 8)

## Test plan
- [x] `zig build test` 전체 통과
- [x] 기능 변경 없음 — 주석 + panic 메시지 문자열만 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)