### PR TITLE
feat: add Ast string_table + Transformer pending_nodes

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1530,7 +1530,7 @@ pub const Codegen = struct {
 
         // enum 이름 텍스트 가져오기
         const name_node = self.ast.getNode(name_idx);
-        const name_text = self.ast.source[name_node.span.start..name_node.span.end];
+        const name_text = self.ast.getText(name_node.span);
 
         // var Color;
         try self.write("var ");
@@ -1553,7 +1553,7 @@ pub const Codegen = struct {
             const member_init_idx = member.data.binary.right;
 
             const member_name = self.ast.getNode(member_name_idx);
-            const member_text = self.ast.source[member_name.span.start..member_name.span.end];
+            const member_text = self.ast.getText(member_name.span);
 
             // Color[Color["Red"] = 0] = "Red";
             try self.write(name_text);
@@ -1569,7 +1569,7 @@ pub const Codegen = struct {
                 // 이니셜라이저가 숫자 리터럴이면 auto_value 업데이트
                 const init_node = self.ast.getNode(member_init_idx);
                 if (init_node.tag == .numeric_literal) {
-                    const num_text = self.ast.source[init_node.span.start..init_node.span.end];
+                    const num_text = self.ast.getText(init_node.span);
                     auto_value = std.fmt.parseInt(i64, num_text, 10) catch auto_value;
                     auto_value += 1;
                 }
@@ -1608,7 +1608,7 @@ pub const Codegen = struct {
         if (body_node.tag == .ts_module_declaration) {
             // 외부 namespace IIFE를 열고, 내부를 재귀 처리
             const name_node = self.ast.getNode(name_idx);
-            const name_text = self.ast.source[name_node.span.start..name_node.span.end];
+            const name_text = self.ast.getText(name_node.span);
 
             try self.write("var ");
             try self.write(name_text);
@@ -1628,7 +1628,7 @@ pub const Codegen = struct {
 
         // body가 block_statement인 경우 (일반 namespace)
         const name_node = self.ast.getNode(name_idx);
-        const name_text = self.ast.source[name_node.span.start..name_node.span.end];
+        const name_text = self.ast.getText(name_node.span);
 
         // var Foo;
         try self.write("var ");
@@ -1695,7 +1695,7 @@ pub const Codegen = struct {
                     const d_extras = self.ast.extra_data.items[de .. de + 3];
                     const name_idx: NodeIndex = @enumFromInt(d_extras[0]);
                     const var_name_node = self.ast.getNode(name_idx);
-                    const var_name = self.ast.source[var_name_node.span.start..var_name_node.span.end];
+                    const var_name = self.ast.getText(var_name_node.span);
                     try self.write(ns_name);
                     try self.writeByte('.');
                     try self.write(var_name);
@@ -1711,7 +1711,7 @@ pub const Codegen = struct {
                 const name_idx: NodeIndex = @enumFromInt(extras[0]);
                 if (!name_idx.isNone()) {
                     const fn_name_node = self.ast.getNode(name_idx);
-                    const fn_name = self.ast.source[fn_name_node.span.start..fn_name_node.span.end];
+                    const fn_name = self.ast.getText(fn_name_node.span);
                     try self.write(ns_name);
                     try self.writeByte('.');
                     try self.write(fn_name);

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -476,8 +476,9 @@ pub const Ast = struct {
     }
 
     /// span이 가리키는 소스 텍스트를 반환한다.
+    /// source와 string_table 모두 지원 (getText에 위임).
     pub fn getSourceText(self: *const Ast, span: Span) []const u8 {
-        return self.source[span.start..span.end];
+        return self.getText(span);
     }
 
     /// 합성 문자열을 string_table에 추가하고, 이를 가리키는 Span을 반환한다.
@@ -487,6 +488,8 @@ pub const Ast = struct {
     ///   const span = try ast.addString("React");
     ///   // 나중에 ast.getText(span)으로 "React" 반환
     pub fn addString(self: *Ast, text: []const u8) !Span {
+        // string_table은 bit 31 미만이어야 함 (bit 31은 마커로 사용)
+        std.debug.assert(self.string_table.items.len + text.len < STRING_TABLE_BIT);
         const start: u32 = @intCast(self.string_table.items.len);
         try self.string_table.appendSlice(text);
         const end: u32 = @intCast(self.string_table.items.len);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -390,13 +390,18 @@ pub const Transformer = struct {
         const scratch_top = self.scratch.items.len;
         defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
+        // pending_nodes save/restore: 중첩 visitExtraList 호출에 안전.
+        // 내부 리스트의 pending_nodes가 외부 리스트로 누출되지 않도록 한다.
+        const pending_top = self.pending_nodes.items.len;
+        defer self.pending_nodes.shrinkRetainingCapacity(pending_top);
+
         for (old_indices) |raw_idx| {
             const new_child = try self.visitNode(@enumFromInt(raw_idx));
 
             // pending_nodes 드레인: visitNode가 추가한 보류 노드를 먼저 삽입
-            if (self.pending_nodes.items.len > 0) {
-                try self.scratch.appendSlice(self.pending_nodes.items);
-                self.pending_nodes.clearRetainingCapacity();
+            if (self.pending_nodes.items.len > pending_top) {
+                try self.scratch.appendSlice(self.pending_nodes.items[pending_top..]);
+                self.pending_nodes.shrinkRetainingCapacity(pending_top);
             }
 
             if (!new_child.isNone()) {


### PR DESCRIPTION
## Summary
- `Ast.string_table` + `addString`/`getText`: 합성 문자열 저장소 (bit 31 마커로 source/string_table 투명 전환)
- `Transformer.pending_nodes`: 1→N 노드 확장 버퍼 (enum → `var Color;` + IIFE)
- Codegen `writeSpan`이 `getText` 사용하도록 수정

## Test plan
- [x] `Ast string_table` 유닛 테스트 (addString + getText, 여러 문자열, bit 31 마커)
- [x] `zig build test` 통과
- [x] `zig build test262` regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)