### PR TITLE
fix(lexer,parser): replace @panic("OOM") with error propagation

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1760,7 +1760,7 @@ const Transformer = @import("../transformer/transformer.zig").Transformer;
 /// end-to-end 헬퍼: 소스 → 파싱 → 변환 → codegen → JS 문자열
 fn generateJS(allocator: std.mem.Allocator, source: []const u8) !struct { output: []const u8, scanner: *Scanner, parser: *Parser, codegen_inst: *Codegen, transformed_ast: Ast } {
     const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = Scanner.init(allocator, source);
+    scanner_ptr.* = try Scanner.init(allocator, source);
 
     const parser_ptr = try allocator.create(Parser);
     parser_ptr.* = Parser.init(allocator, scanner_ptr);
@@ -1812,7 +1812,7 @@ const TransformOptions = @import("../transformer/transformer.zig").TransformOpti
 /// 풀 옵션 e2e. transform + codegen 옵션 모두 전달.
 fn e2eFull(allocator: std.mem.Allocator, source: []const u8, t_options: TransformOptions, cg_options: CodegenOptions) !TestResult {
     const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = Scanner.init(allocator, source);
+    scanner_ptr.* = try Scanner.init(allocator, source);
 
     const parser_ptr = try allocator.create(Parser);
     parser_ptr.* = Parser.init(allocator, scanner_ptr);

--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -100,13 +100,13 @@ pub const Scanner = struct {
 
     /// 소스를 UTF-8로 읽고 Scanner를 초기화한다.
     /// BOM이 있으면 스킵한다 (D019).
-    pub fn init(allocator: std.mem.Allocator, source: []const u8) Scanner {
+    pub fn init(allocator: std.mem.Allocator, source: []const u8) !Scanner {
         // 4GB 이상의 소스는 u32 offset으로 표현 불가 (D015)
         std.debug.assert(source.len <= std.math.maxInt(u32));
 
         var line_offsets = std.ArrayList(u32).init(allocator);
         // 첫 번째 줄의 시작 offset은 항상 0. 이 append가 실패하면 getLineColumn()이 동작 불가.
-        line_offsets.append(0) catch @panic("OOM: failed to allocate initial line offset");
+        try line_offsets.append(0);
 
         var scanner = Scanner{
             .source = source,
@@ -209,31 +209,31 @@ pub const Scanner = struct {
     }
 
     /// 줄 offset 테이블에 새 줄을 기록한다.
-    fn recordNewline(self: *Scanner) void {
+    fn recordNewline(self: *Scanner) !void {
         self.line += 1;
         self.line_start = self.current;
-        self.line_offsets.append(self.current) catch @panic("OOM: line_offsets");
+        try self.line_offsets.append(self.current);
     }
 
     /// 줄바꿈 문자를 처리한다.
     /// \n, \r\n, \r, U+2028 (LS), U+2029 (PS) 전부 인식 (D019).
     /// 줄바꿈이면 true를 반환하고 current를 전진시킨다.
-    fn handleNewline(self: *Scanner) bool {
+    fn handleNewline(self: *Scanner) !bool {
         const c = self.peek();
         if (c == '\n') {
             self.current += 1;
-            self.recordNewline();
+            try self.recordNewline();
             return true;
         }
         if (c == '\r') {
             self.current += 1;
             if (self.peek() == '\n') self.current += 1;
-            self.recordNewline();
+            try self.recordNewline();
             return true;
         }
         if (self.isLineSeparator()) {
             self.current += 3;
-            self.recordNewline();
+            try self.recordNewline();
             return true;
         }
         return false;
@@ -245,7 +245,7 @@ pub const Scanner = struct {
 
     /// 공백 문자를 스킵한다.
     /// 줄바꿈을 만나면 has_newline_before를 true로 설정.
-    fn skipWhitespace(self: *Scanner) void {
+    fn skipWhitespace(self: *Scanner) !void {
         while (!self.isAtEnd()) {
             const c = self.peek();
             switch (c) {
@@ -255,12 +255,12 @@ pub const Scanner = struct {
                 },
                 '\n', '\r' => {
                     // 줄바꿈
-                    _ = self.handleNewline();
+                    _ = try self.handleNewline();
                     self.token.has_newline_before = true;
                 },
                 0xE2 => {
                     // U+2028 (LS), U+2029 (PS) — 줄바꿈
-                    if (self.handleNewline()) {
+                    if (try self.handleNewline()) {
                         self.token.has_newline_before = true;
                     } else if (self.current + 2 < self.source.len) {
                         // Unicode Space_Separator (USP): U+2000-U+200A, U+202F, U+205F
@@ -325,7 +325,7 @@ pub const Scanner = struct {
 
     /// 다음 토큰을 스캔한다.
     /// 파서가 이 함수를 반복 호출하여 토큰을 소비한다.
-    pub fn next(self: *Scanner) void {
+    pub fn next(self: *Scanner) !void {
         self.token.has_newline_before = false;
         self.token.has_pure_comment_before = false;
         self.token.has_escape = false;
@@ -334,7 +334,7 @@ pub const Scanner = struct {
         // 주석을 만나면 스킵하고 다시 스캔해야 하므로 루프
         while (true) {
             // 공백 스킵 (줄바꿈 추적 포함)
-            self.skipWhitespace();
+            try self.skipWhitespace();
 
             // 토큰 시작 위치 기록
             self.start = self.current;
@@ -365,7 +365,7 @@ pub const Scanner = struct {
                     if (self.template_depth_stack.items.len > 0 and
                         self.brace_depth == self.template_depth_stack.items[self.template_depth_stack.items.len - 1])
                     {
-                        break :blk self.scanTemplateContinuation();
+                        break :blk try self.scanTemplateContinuation();
                     }
                     break :blk .r_curly;
                 },
@@ -381,7 +381,7 @@ pub const Scanner = struct {
                 '+' => self.scanPlus(),
                 '-' => self.scanMinus(),
                 '*' => self.scanStar(),
-                '/' => self.scanSlash(),
+                '/' => try self.scanSlash(),
                 '%' => self.scanPercent(),
                 '<' => self.scanLAngle(),
                 '>' => self.scanRAngle(),
@@ -394,8 +394,8 @@ pub const Scanner = struct {
 
                 // 리터럴 — 추후 PR에서 세부 구현
                 '0'...'9' => self.scanNumericLiteral(c),
-                '\'', '"' => self.scanStringLiteral(c),
-                '`' => self.scanTemplateLiteral(),
+                '\'', '"' => try self.scanStringLiteral(c),
+                '`' => try self.scanTemplateLiteral(),
 
                 '#' => blk: {
                     // hashbang (파일 시작) 또는 private identifier
@@ -540,9 +540,9 @@ pub const Scanner = struct {
     /// JSX 태그 안에서는 식별자에 하이픈(-)을 허용하고 (data-value),
     /// 속성 값 문자열은 이스케이프를 처리하지 않는다.
     /// 파서가 `<` 뒤에서 이 함수를 호출한다.
-    pub fn nextInsideJSXElement(self: *Scanner) void {
+    pub fn nextInsideJSXElement(self: *Scanner) !void {
         self.token.has_newline_before = false;
-        self.skipWhitespace();
+        try self.skipWhitespace();
         self.start = self.current;
 
         if (self.isAtEnd()) {
@@ -585,7 +585,7 @@ pub const Scanner = struct {
 
     /// JSX 자식 위치에서 다음 토큰을 스캔한다 (태그 사이의 텍스트).
     /// `<` 또는 `{`를 만날 때까지 텍스트를 소비한다.
-    pub fn nextJSXChild(self: *Scanner) void {
+    pub fn nextJSXChild(self: *Scanner) !void {
         self.token.has_newline_before = false;
         self.start = self.current;
 
@@ -605,7 +605,7 @@ pub const Scanner = struct {
             self.token.kind = .l_curly;
         } else {
             // JSX 텍스트: < 또는 { 또는 EOF 전까지 전부 소비
-            self.scanJSXText();
+            try self.scanJSXText();
             self.token.kind = .jsx_text;
         }
 
@@ -614,12 +614,12 @@ pub const Scanner = struct {
     }
 
     /// JSX 텍스트를 스캔한다. `<`, `{`, `}` 전까지 소비.
-    fn scanJSXText(self: *Scanner) void {
+    fn scanJSXText(self: *Scanner) !void {
         while (!self.isAtEnd()) {
             const c = self.peek();
             if (c == '<' or c == '{' or c == '}') break;
             if (isNewlineStart(c)) {
-                if (self.handleNewline()) {
+                if (try self.handleNewline()) {
                     self.token.has_newline_before = true;
                 } else {
                     self.current += 1; // 0xE2이지만 줄바꿈이 아닌 경우
@@ -718,14 +718,14 @@ pub const Scanner = struct {
         return .star;
     }
 
-    fn scanSlash(self: *Scanner) Kind {
+    fn scanSlash(self: *Scanner) !Kind {
         const next_char = self.peek();
         if (next_char == '/') {
-            self.scanSingleLineComment();
+            try self.scanSingleLineComment();
             return .undetermined;
         }
         if (next_char == '*') {
-            if (self.scanMultiLineComment()) return .syntax_error; // 미닫힌 주석
+            if (try self.scanMultiLineComment()) return .syntax_error; // 미닫힌 주석
             return .undetermined;
         }
 
@@ -825,7 +825,7 @@ pub const Scanner = struct {
 
     /// single-line comment를 스캔한다 (// ... \n).
     /// JSX pragma (@jsx, @jsxFrag, @jsxRuntime, @jsxImportSource)를 감지한다 (D026).
-    fn scanSingleLineComment(self: *Scanner) void {
+    fn scanSingleLineComment(self: *Scanner) !void {
         self.current += 1; // skip second '/'
 
         const comment_start = self.current;
@@ -848,19 +848,19 @@ pub const Scanner = struct {
         self.checkPureComment(comment_text);
 
         // 주석을 기록한다 (start = 첫 번째 '/' 위치, end = 줄바꿈 직전)
-        self.comments.append(.{
+        try self.comments.append(.{
             .start = self.start,
             .end = self.current,
             .is_multiline = false,
             .is_legal = isLegalComment(comment_text, false),
-        }) catch @panic("OOM: comments");
+        });
     }
 
     /// multi-line comment를 스캔한다 (/* ... */).
     /// @__PURE__ / @__NO_SIDE_EFFECTS__ 주석을 감지한다 (D025).
     /// @license / @preserve 주석도 감지한다 (D022, 추후 코드젠에서 활용).
     /// 미닫힌 주석이면 true(에러)를 반환.
-    fn scanMultiLineComment(self: *Scanner) bool {
+    fn scanMultiLineComment(self: *Scanner) !bool {
         self.current += 1; // skip '*'
 
         const comment_start = self.current;
@@ -873,18 +873,18 @@ pub const Scanner = struct {
                 self.checkPureComment(comment_text);
 
                 // 주석을 기록한다 (start = 첫 번째 '/' 위치, end = '*/' 직후)
-                self.comments.append(.{
+                try self.comments.append(.{
                     .start = self.start,
                     .end = self.current,
                     .is_multiline = true,
                     .is_legal = isLegalComment(comment_text, true),
-                }) catch @panic("OOM: comments");
+                });
 
                 return false; // 정상 종료
             }
             // 줄바꿈 추적 (소스맵 정확성)
             if (isNewlineStart(c)) {
-                if (self.handleNewline()) {
+                if (try self.handleNewline()) {
                     self.token.has_newline_before = true;
                 } else {
                     self.current += 1;
@@ -1414,7 +1414,7 @@ pub const Scanner = struct {
     /// 에러 감지:
     /// - 닫히지 않은 문자열 → syntax_error
     /// - 문자열 안 줄바꿈 (JS 스펙 위반) → syntax_error
-    fn scanStringLiteral(self: *Scanner, quote: u8) Kind {
+    fn scanStringLiteral(self: *Scanner, quote: u8) !Kind {
         while (!self.isAtEnd()) {
             const c = self.peek();
 
@@ -1476,10 +1476,10 @@ pub const Scanner = struct {
                     },
                     // 줄 연속: \ 뒤에 줄바꿈이 오면 줄바꿈을 건너뜀
                     '\n' => {
-                        _ = self.handleNewline();
+                        _ = try self.handleNewline();
                     },
                     '\r' => {
-                        _ = self.handleNewline();
+                        _ = try self.handleNewline();
                     },
                     // 그 외: legacy octal (\1..\7) 또는 알 수 없는 이스케이프 → 1바이트 스킵
                     // (엄격한 에러 검사는 파서에서)
@@ -1523,8 +1523,8 @@ pub const Scanner = struct {
     /// - no_substitution_template: `string` (보간 없음)
     /// - template_head: `text${ (보간 시작)
     /// - syntax_error: 닫히지 않은 템플릿
-    fn scanTemplateLiteral(self: *Scanner) Kind {
-        return self.scanTemplateContent(.no_substitution_template, .template_head);
+    fn scanTemplateLiteral(self: *Scanner) !Kind {
+        return try self.scanTemplateContent(.no_substitution_template, .template_head);
     }
 
     /// 템플릿 중간/끝을 스캔한다 (}에서 호출).
@@ -1533,15 +1533,15 @@ pub const Scanner = struct {
     /// - template_middle: }text${ (보간 계속)
     /// - template_tail: }text` (템플릿 끝)
     /// - syntax_error: 닫히지 않은 템플릿
-    fn scanTemplateContinuation(self: *Scanner) Kind {
+    fn scanTemplateContinuation(self: *Scanner) !Kind {
         // 스택에서 현재 템플릿 depth를 pop
         _ = self.template_depth_stack.pop();
-        return self.scanTemplateContent(.template_tail, .template_middle);
+        return try self.scanTemplateContent(.template_tail, .template_middle);
     }
 
     /// 템플릿 내용을 스캔하는 공통 로직.
     /// backtick을 만나면 complete_kind, ${를 만나면 interpolation_kind를 반환.
-    fn scanTemplateContent(self: *Scanner, complete_kind: Kind, interpolation_kind: Kind) Kind {
+    fn scanTemplateContent(self: *Scanner, complete_kind: Kind, interpolation_kind: Kind) !Kind {
         while (!self.isAtEnd()) {
             const c = self.peek();
 
@@ -1553,7 +1553,7 @@ pub const Scanner = struct {
             if (c == '$' and self.peekAt(1) == '{') {
                 self.current += 2; // skip ${
                 // 현재 brace depth를 스택에 push (나중에 }에서 매칭)
-                self.template_depth_stack.append(self.brace_depth) catch @panic("OOM: template_depth_stack");
+                try self.template_depth_stack.append(self.brace_depth);
                 self.brace_depth += 1;
                 return interpolation_kind;
             }
@@ -1634,7 +1634,7 @@ pub const Scanner = struct {
                         },
                         // 줄바꿈 이스케이프 처리 (템플릿에서는 유효)
                         '\n', '\r' => {
-                            _ = self.handleNewline();
+                            _ = try self.handleNewline();
                         },
                         // 그 외: non-escape character (유효)
                         else => {
@@ -1647,7 +1647,7 @@ pub const Scanner = struct {
 
             // 줄바꿈: 템플릿 리터럴에서는 허용됨 (일반 문자열과 다름)
             if (c == '\n' or c == '\r') {
-                _ = self.handleNewline();
+                _ = try self.handleNewline();
                 self.token.has_newline_before = true;
                 continue;
             }
@@ -1889,23 +1889,23 @@ pub const Scanner = struct {
 // ============================================================
 
 test "Scanner: empty source" {
-    var scanner = Scanner.init(std.testing.allocator, "");
+    var scanner = try Scanner.init(std.testing.allocator, "");
     defer scanner.deinit();
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.eof, scanner.token.kind);
 }
 
 test "Scanner: BOM skip" {
-    var scanner = Scanner.init(std.testing.allocator, "\xEF\xBB\xBF;");
+    var scanner = try Scanner.init(std.testing.allocator, "\xEF\xBB\xBF;");
     defer scanner.deinit();
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.semicolon, scanner.token.kind);
     try std.testing.expectEqual(@as(u32, 3), scanner.token.span.start);
 }
 
 test "Scanner: single character tokens" {
     const source = "(){};,~@:";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
     const expected = [_]Kind{
@@ -1914,16 +1914,16 @@ test "Scanner: single character tokens" {
         .colon,
     };
     for (expected) |kind| {
-        scanner.next();
+        try scanner.next();
         try std.testing.expectEqual(kind, scanner.token.kind);
     }
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.eof, scanner.token.kind);
 }
 
 test "Scanner: compound operators" {
     const source = "++ -- ** === !== => ... ?? ?. ??= &&= ||=";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
     const expected = [_]Kind{
@@ -1932,14 +1932,14 @@ test "Scanner: compound operators" {
         .amp2_eq, .pipe2_eq,
     };
     for (expected) |kind| {
-        scanner.next();
+        try scanner.next();
         try std.testing.expectEqual(kind, scanner.token.kind);
     }
 }
 
 test "Scanner: shift operators" {
     const source = "<< >> >>> <<= >>= >>>=";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
     const expected = [_]Kind{
@@ -1947,61 +1947,61 @@ test "Scanner: shift operators" {
         .shift_left_eq, .shift_right_eq, .shift_right3_eq,
     };
     for (expected) |kind| {
-        scanner.next();
+        try scanner.next();
         try std.testing.expectEqual(kind, scanner.token.kind);
     }
 }
 
 test "Scanner: identifiers and keywords" {
     const source = "const foo let bar";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.kw_const, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("foo", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.kw_let, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("bar", scanner.tokenText());
 }
 
 test "Scanner: whitespace and newlines set has_newline_before" {
     const source = "a\nb";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expect(!scanner.token.has_newline_before);
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expect(scanner.token.has_newline_before);
 }
 
 test "Scanner: CRLF counts as one newline" {
     const source = "a\r\nb";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // a
-    scanner.next(); // b
+    try scanner.next(); // a
+    try scanner.next(); // b
     try std.testing.expect(scanner.token.has_newline_before);
     try std.testing.expectEqual(@as(u32, 1), scanner.line);
 }
 
 test "Scanner: line offset table" {
     const source = "a\nb\nc";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
     // 전체를 스캔하여 line offset 테이블 구축
     while (scanner.token.kind != .eof or scanner.start == 0) {
-        scanner.next();
+        try scanner.next();
         if (scanner.token.kind == .eof) break;
     }
 
@@ -2013,12 +2013,12 @@ test "Scanner: line offset table" {
 
 test "Scanner: getLineColumn" {
     const source = "ab\ncde\nf";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
     // 전체 스캔
     while (true) {
-        scanner.next();
+        try scanner.next();
         if (scanner.token.kind == .eof) break;
     }
 
@@ -2040,21 +2040,21 @@ test "Scanner: getLineColumn" {
 
 test "Scanner: hashbang" {
     const source = "#!/usr/bin/env node\nconst x = 1;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.hashbang_comment, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.kw_const, scanner.token.kind);
 }
 
 test "Scanner: private identifier" {
     const source = "#name";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.private_identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("#name", scanner.tokenText());
 }
@@ -2062,69 +2062,69 @@ test "Scanner: private identifier" {
 test "Scanner: optional chaining vs ternary + number" {
     // ?. → optional chaining
     const source1 = "?.";
-    var s1 = Scanner.init(std.testing.allocator, source1);
+    var s1 = try Scanner.init(std.testing.allocator, source1);
     defer s1.deinit();
-    s1.next();
+    try s1.next();
     try std.testing.expectEqual(Kind.question_dot, s1.token.kind);
 
     // ?.5 → question + .5 (ternary + number)
     const source2 = "?.5";
-    var s2 = Scanner.init(std.testing.allocator, source2);
+    var s2 = try Scanner.init(std.testing.allocator, source2);
     defer s2.deinit();
-    s2.next();
+    try s2.next();
     try std.testing.expectEqual(Kind.question, s2.token.kind);
 }
 
 test "Scanner: string literal basic" {
     const source = "'hello' \"world\"";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 }
 
 test "Scanner: empty string literals" {
     const source = "'' \"\"";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("''", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("\"\"", scanner.tokenText());
 }
 
 test "Scanner: slash_eq operator" {
     const source = "/=";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.slash_eq, scanner.token.kind);
 }
 
 test "Scanner: CR alone as line terminator" {
     const source = "a\rb";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // a
-    scanner.next(); // b
+    try scanner.next(); // a
+    try scanner.next(); // b
     try std.testing.expect(scanner.token.has_newline_before);
     try std.testing.expectEqual(@as(u32, 1), scanner.line);
 }
 
 test "Scanner: whitespace only source" {
     const source = "   \t\t  \n  ";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.eof, scanner.token.kind);
     try std.testing.expect(scanner.token.has_newline_before);
 }
@@ -2132,20 +2132,20 @@ test "Scanner: whitespace only source" {
 test "Scanner: NBSP whitespace (U+00A0)" {
     // U+00A0 = C2 A0
     const source = "a\xC2\xA0b";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("a", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("b", scanner.tokenText());
 }
 
 test "Scanner: all assignment operators" {
     const source = "= += -= *= /= %= **= &= |= ^= <<= >>= >>>= &&= ||= ??=";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
     const expected = [_]Kind{
@@ -2155,7 +2155,7 @@ test "Scanner: all assignment operators" {
         .shift_right3_eq, .amp2_eq,    .pipe2_eq,      .question2_eq,
     };
     for (expected) |kind| {
-        scanner.next();
+        try scanner.next();
         try std.testing.expectEqual(kind, scanner.token.kind);
     }
 }
@@ -2166,14 +2166,14 @@ test "Scanner: all assignment operators" {
 
 test "Scanner: single-line comment is skipped" {
     const source = "a // comment\nb";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("a", scanner.tokenText());
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("b", scanner.tokenText());
     try std.testing.expect(scanner.token.has_newline_before);
@@ -2181,34 +2181,34 @@ test "Scanner: single-line comment is skipped" {
 
 test "Scanner: multi-line comment is skipped" {
     const source = "a /* comment */ b";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("a", scanner.tokenText());
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("b", scanner.tokenText());
 }
 
 test "Scanner: multi-line comment with newline sets has_newline_before" {
     const source = "a /*\n*/ b";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // a
-    scanner.next(); // b
+    try scanner.next(); // a
+    try scanner.next(); // b
     try std.testing.expect(scanner.token.has_newline_before);
 }
 
 test "Scanner: @__PURE__ comment sets flag" {
     const source = "/* @__PURE__ */ foo()";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("foo", scanner.tokenText());
     try std.testing.expect(scanner.token.has_pure_comment_before);
@@ -2216,106 +2216,106 @@ test "Scanner: @__PURE__ comment sets flag" {
 
 test "Scanner: #__PURE__ comment sets flag" {
     const source = "/* #__PURE__ */ bar()";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expect(scanner.token.has_pure_comment_before);
 }
 
 test "Scanner: @__NO_SIDE_EFFECTS__ comment sets flag" {
     const source = "/* @__NO_SIDE_EFFECTS__ */ function f() {}";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.kw_function, scanner.token.kind);
     try std.testing.expect(scanner.token.has_pure_comment_before);
 }
 
 test "Scanner: normal comment does not set pure flag" {
     const source = "/* normal comment */ x";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expect(!scanner.token.has_pure_comment_before);
 }
 
 test "Scanner: single-line comment at end of file" {
     const source = "a // comment";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.eof, scanner.token.kind);
 }
 
 test "Scanner: comment-only source" {
     const source = "// just a comment";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.eof, scanner.token.kind);
 }
 
 test "Scanner: slash after comment is not confused" {
     const source = "a /* */ / b";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // a
+    try scanner.next(); // a
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
-    scanner.next(); // /
+    try scanner.next(); // /
     try std.testing.expectEqual(Kind.slash, scanner.token.kind);
-    scanner.next(); // b
+    try scanner.next(); // b
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
 }
 
 test "Scanner: multi-line legal comment @license" {
     const source = "/* @license MIT */ var x;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
-    scanner.next();
+    try scanner.next();
     try std.testing.expect(scanner.comments.items.len > 0);
     try std.testing.expect(scanner.comments.items[0].is_legal);
 }
 
 test "Scanner: multi-line legal comment /*!" {
     const source = "/*! Copyright 2024 */ var x;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
-    scanner.next();
+    try scanner.next();
     try std.testing.expect(scanner.comments.items.len > 0);
     try std.testing.expect(scanner.comments.items[0].is_legal);
 }
 
 test "Scanner: single-line legal comment @license" {
     const source = "// @license MIT\nvar x;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
-    scanner.next();
+    try scanner.next();
     try std.testing.expect(scanner.comments.items.len > 0);
     try std.testing.expect(scanner.comments.items[0].is_legal);
 }
 
 test "Scanner: single-line legal comment @preserve" {
     const source = "// @preserve\nvar x;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
-    scanner.next();
+    try scanner.next();
     try std.testing.expect(scanner.comments.items.len > 0);
     try std.testing.expect(scanner.comments.items[0].is_legal);
 }
 
 test "Scanner: normal comment is not legal" {
     const source = "// just a comment\nvar x;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
-    scanner.next();
+    try scanner.next();
     try std.testing.expect(scanner.comments.items.len > 0);
     try std.testing.expect(!scanner.comments.items[0].is_legal);
 }
@@ -2326,134 +2326,134 @@ test "Scanner: normal comment is not legal" {
 
 test "Scanner: decimal integer" {
     const source = "123 0 42";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.decimal, scanner.token.kind);
     try std.testing.expectEqualStrings("123", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.decimal, scanner.token.kind);
     try std.testing.expectEqualStrings("0", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.decimal, scanner.token.kind);
 }
 
 test "Scanner: hex literal" {
     const source = "0xFF 0X1A";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.hex, scanner.token.kind);
     try std.testing.expectEqualStrings("0xFF", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.hex, scanner.token.kind);
 }
 
 test "Scanner: octal literal" {
     const source = "0o77 0O10";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.octal, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.octal, scanner.token.kind);
 }
 
 test "Scanner: binary literal" {
     const source = "0b1010 0B11";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.binary, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.binary, scanner.token.kind);
 }
 
 test "Scanner: float literal" {
     const source = "1.5 0.1 .5";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.float, scanner.token.kind);
     try std.testing.expectEqualStrings("1.5", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.float, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.float, scanner.token.kind);
     try std.testing.expectEqualStrings(".5", scanner.tokenText());
 }
 
 test "Scanner: exponential literal" {
     const source = "1e10 1E10 1e+10 1e-10";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.positive_exponential, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.positive_exponential, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.positive_exponential, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.negative_exponential, scanner.token.kind);
 }
 
 test "Scanner: bigint literal" {
     const source = "123n 0xFFn 0o77n 0b1010n";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.decimal_bigint, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.hex_bigint, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.octal_bigint, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.binary_bigint, scanner.token.kind);
 }
 
 test "Scanner: numeric separator" {
     const source = "1_000_000 0xFF_FF 0b1010_0001";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.decimal, scanner.token.kind);
     try std.testing.expectEqualStrings("1_000_000", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.hex, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.binary, scanner.token.kind);
 }
 
 test "Scanner: 1..toString is float then dot" {
     // 1..toString() → float(1.) dot identifier(toString) — 소수점 뒤 멤버 접근
     const source = "1..toString";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.float, scanner.token.kind);
     try std.testing.expectEqualStrings("1.", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.dot, scanner.token.kind);
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("toString", scanner.tokenText());
 }
 
 test "Scanner: float with exponent" {
     const source = "1.5e10";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.positive_exponential, scanner.token.kind);
     try std.testing.expectEqualStrings("1.5e10", scanner.tokenText());
 }
@@ -2464,99 +2464,99 @@ test "Scanner: float with exponent" {
 
 test "Scanner: string with escape sequences" {
     const source = "\"hello\\nworld\"";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("\"hello\\nworld\"", scanner.tokenText());
 }
 
 test "Scanner: string with hex escape" {
     const source = "'\\x41'";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 }
 
 test "Scanner: string with unicode escape \\uHHHH" {
     const source = "'\\u0041'";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 }
 
 test "Scanner: string with unicode escape \\u{}" {
     const source = "'\\u{1F600}'";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 }
 
 test "Scanner: string with escaped quote" {
     const source = "'it\\'s'";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 }
 
 test "Scanner: string with line continuation" {
     // '\' + newline = line continuation (valid)
     const source = "'hello\\\nworld'";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 }
 
 test "Scanner: unterminated string at EOF" {
     const source = "\"hello";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.syntax_error, scanner.token.kind);
 }
 
 test "Scanner: newline inside string is error" {
     const source = "\"hello\nworld\"";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.syntax_error, scanner.token.kind);
 }
 
 test "Scanner: string with backslash at EOF" {
     const source = "'test\\";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.syntax_error, scanner.token.kind);
 }
 
 test "Scanner: consecutive strings" {
     const source = "'a' \"b\" 'c'";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("'a'", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("\"b\"", scanner.tokenText());
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 }
 
@@ -2566,10 +2566,10 @@ test "Scanner: consecutive strings" {
 
 test "Scanner: no substitution template" {
     const source = "`hello world`";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.no_substitution_template, scanner.token.kind);
     try std.testing.expectEqualStrings("`hello world`", scanner.tokenText());
 }
@@ -2577,18 +2577,18 @@ test "Scanner: no substitution template" {
 test "Scanner: template with interpolation" {
     // `hello ${name}!`
     const source = "`hello ${name}!`";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.template_head, scanner.token.kind);
     try std.testing.expectEqualStrings("`hello ${", scanner.tokenText());
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("name", scanner.tokenText());
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.template_tail, scanner.token.kind);
     try std.testing.expectEqualStrings("}!`", scanner.tokenText());
 }
@@ -2596,105 +2596,105 @@ test "Scanner: template with interpolation" {
 test "Scanner: template with multiple interpolations" {
     // `${a} + ${b} = ${c}`
     const source = "`${a} + ${b} = ${c}`";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.template_head, scanner.token.kind);
 
-    scanner.next(); // a
+    try scanner.next(); // a
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
 
-    scanner.next(); // } + ${
+    try scanner.next(); // } + ${
     try std.testing.expectEqual(Kind.template_middle, scanner.token.kind);
 
-    scanner.next(); // b
+    try scanner.next(); // b
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
 
-    scanner.next(); // } = ${
+    try scanner.next(); // } = ${
     try std.testing.expectEqual(Kind.template_middle, scanner.token.kind);
 
-    scanner.next(); // c
+    try scanner.next(); // c
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
 
-    scanner.next(); // }`
+    try scanner.next(); // }`
     try std.testing.expectEqual(Kind.template_tail, scanner.token.kind);
 }
 
 test "Scanner: nested template literals" {
     // `a${`b${c}d`}e`
     const source = "`a${`b${c}d`}e`";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // `a${
+    try scanner.next(); // `a${
     try std.testing.expectEqual(Kind.template_head, scanner.token.kind);
 
-    scanner.next(); // `b${
+    try scanner.next(); // `b${
     try std.testing.expectEqual(Kind.template_head, scanner.token.kind);
 
-    scanner.next(); // c
+    try scanner.next(); // c
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
 
-    scanner.next(); // }d`
+    try scanner.next(); // }d`
     try std.testing.expectEqual(Kind.template_tail, scanner.token.kind);
 
-    scanner.next(); // }e`
+    try scanner.next(); // }e`
     try std.testing.expectEqual(Kind.template_tail, scanner.token.kind);
 }
 
 test "Scanner: template with object literal inside" {
     // `${{a: 1}}`
     const source = "`${{a: 1}}`";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // `${
+    try scanner.next(); // `${
     try std.testing.expectEqual(Kind.template_head, scanner.token.kind);
 
-    scanner.next(); // {
+    try scanner.next(); // {
     try std.testing.expectEqual(Kind.l_curly, scanner.token.kind);
 
-    scanner.next(); // a
+    try scanner.next(); // a
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
 
-    scanner.next(); // :
+    try scanner.next(); // :
     try std.testing.expectEqual(Kind.colon, scanner.token.kind);
 
-    scanner.next(); // 1
+    try scanner.next(); // 1
     try std.testing.expectEqual(Kind.decimal, scanner.token.kind);
 
-    scanner.next(); // }
+    try scanner.next(); // }
     try std.testing.expectEqual(Kind.r_curly, scanner.token.kind);
 
-    scanner.next(); // }`
+    try scanner.next(); // }`
     try std.testing.expectEqual(Kind.template_tail, scanner.token.kind);
 }
 
 test "Scanner: empty template" {
     const source = "``";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.no_substitution_template, scanner.token.kind);
 }
 
 test "Scanner: template with newline" {
     const source = "`line1\nline2`";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.no_substitution_template, scanner.token.kind);
 }
 
 test "Scanner: unterminated template" {
     const source = "`hello";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.syntax_error, scanner.token.kind);
 }
 
@@ -2705,91 +2705,91 @@ test "Scanner: unterminated template" {
 test "Scanner: regex after =" {
     // = /pattern/gi → eq, regexp
     const source = "= /abc/gi";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // =
+    try scanner.next(); // =
     try std.testing.expectEqual(Kind.eq, scanner.token.kind);
-    scanner.next(); // /abc/gi
+    try scanner.next(); // /abc/gi
     try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("/abc/gi", scanner.tokenText());
 }
 
 test "Scanner: regex after (" {
     const source = "(/test/)";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // (
+    try scanner.next(); // (
     try std.testing.expectEqual(Kind.l_paren, scanner.token.kind);
-    scanner.next(); // /test/
+    try scanner.next(); // /test/
     try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
 }
 
 test "Scanner: division after identifier" {
     // a / b → identifier, slash, identifier
     const source = "a / b";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // a
+    try scanner.next(); // a
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
-    scanner.next(); // /
+    try scanner.next(); // /
     try std.testing.expectEqual(Kind.slash, scanner.token.kind);
-    scanner.next(); // b
+    try scanner.next(); // b
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
 }
 
 test "Scanner: division after number" {
     const source = "10 / 2";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // 10
-    scanner.next(); // /
+    try scanner.next(); // 10
+    try scanner.next(); // /
     try std.testing.expectEqual(Kind.slash, scanner.token.kind);
 }
 
 test "Scanner: regex with character class" {
     // character class 안의 / 는 regex를 끝내지 않음
     const source = "= /[a/b]/";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // =
-    scanner.next(); // /[a/b]/
+    try scanner.next(); // =
+    try scanner.next(); // /[a/b]/
     try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
     try std.testing.expectEqualStrings("/[a/b]/", scanner.tokenText());
 }
 
 test "Scanner: regex with escape" {
     const source = "= /a\\/b/";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // =
-    scanner.next(); // /a\/b/
+    try scanner.next(); // =
+    try scanner.next(); // /a\/b/
     try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
 }
 
 test "Scanner: regex after return keyword" {
     const source = "return /test/g";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // return
+    try scanner.next(); // return
     try std.testing.expectEqual(Kind.kw_return, scanner.token.kind);
-    scanner.next(); // /test/g
+    try scanner.next(); // /test/g
     try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
 }
 
 test "Scanner: regex after comma" {
     const source = ", /re/";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // ,
-    scanner.next(); // /re/
+    try scanner.next(); // ,
+    try scanner.next(); // /re/
     try std.testing.expectEqual(Kind.regexp_literal, scanner.token.kind);
 }
 
@@ -2800,10 +2800,10 @@ test "Scanner: regex after comma" {
 test "Scanner: unicode identifier (Latin)" {
     // café = UTF-8: 63 61 66 C3 A9
     const source = "caf\xC3\xA9";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("caf\xC3\xA9", scanner.tokenText());
 }
@@ -2811,34 +2811,34 @@ test "Scanner: unicode identifier (Latin)" {
 test "Scanner: unicode identifier (CJK)" {
     // 변수 = UTF-8: EB B3 80 EC 88 98
     const source = "\xEB\xB3\x80\xEC\x88\x98";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
 }
 
 test "Scanner: unicode identifier (Greek)" {
     // α = UTF-8: CE B1
     const source = "\xCE\xB1 = 1";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("\xCE\xB1", scanner.tokenText());
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.eq, scanner.token.kind);
 }
 
 test "Scanner: mixed ASCII and unicode in identifier" {
     // test변수 = ASCII + CJK
     const source = "test\xEB\xB3\x80\xEC\x88\x98";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqual(Kind.identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("test\xEB\xB3\x80\xEC\x88\x98", scanner.tokenText());
 }
@@ -2849,10 +2849,10 @@ test "Scanner: mixed ASCII and unicode in identifier" {
 
 test "Scanner: JSX element identifier with hyphen" {
     const source = "data-testid";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.nextInsideJSXElement();
+    try scanner.nextInsideJSXElement();
     try std.testing.expectEqual(Kind.jsx_identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("data-testid", scanner.tokenText());
 }
@@ -2860,58 +2860,58 @@ test "Scanner: JSX element identifier with hyphen" {
 test "Scanner: JSX element tokens" {
     // <div className="hello">
     const source = "div className=\"hello\">";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.nextInsideJSXElement(); // div
+    try scanner.nextInsideJSXElement(); // div
     try std.testing.expectEqual(Kind.jsx_identifier, scanner.token.kind);
     try std.testing.expectEqualStrings("div", scanner.tokenText());
 
-    scanner.nextInsideJSXElement(); // className
+    try scanner.nextInsideJSXElement(); // className
     try std.testing.expectEqual(Kind.jsx_identifier, scanner.token.kind);
 
-    scanner.nextInsideJSXElement(); // =
+    try scanner.nextInsideJSXElement(); // =
     try std.testing.expectEqual(Kind.eq, scanner.token.kind);
 
-    scanner.nextInsideJSXElement(); // "hello"
+    try scanner.nextInsideJSXElement(); // "hello"
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 
-    scanner.nextInsideJSXElement(); // >
+    try scanner.nextInsideJSXElement(); // >
     try std.testing.expectEqual(Kind.r_angle, scanner.token.kind);
 }
 
 test "Scanner: JSX text content" {
     const source = "Hello World<";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.nextJSXChild(); // "Hello World"
+    try scanner.nextJSXChild(); // "Hello World"
     try std.testing.expectEqual(Kind.jsx_text, scanner.token.kind);
     try std.testing.expectEqualStrings("Hello World", scanner.tokenText());
 
-    scanner.nextJSXChild(); // <
+    try scanner.nextJSXChild(); // <
     try std.testing.expectEqual(Kind.l_angle, scanner.token.kind);
 }
 
 test "Scanner: JSX text with expression" {
     const source = "text{expr}more";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.nextJSXChild(); // "text"
+    try scanner.nextJSXChild(); // "text"
     try std.testing.expectEqual(Kind.jsx_text, scanner.token.kind);
     try std.testing.expectEqualStrings("text", scanner.tokenText());
 
-    scanner.nextJSXChild(); // {
+    try scanner.nextJSXChild(); // {
     try std.testing.expectEqual(Kind.l_curly, scanner.token.kind);
 }
 
 test "Scanner: JSX self-closing tag" {
     const source = "/>";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.nextInsideJSXElement();
+    try scanner.nextInsideJSXElement();
     try std.testing.expectEqual(Kind.slash, scanner.token.kind);
     // 파서가 slash + r_angle을 자체 닫힘 태그로 조합
 }
@@ -2919,10 +2919,10 @@ test "Scanner: JSX self-closing tag" {
 test "Scanner: JSX string without escape" {
     // JSX 속성 문자열은 이스케이프를 처리하지 않음
     const source = "\"hello\\nworld\"";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.nextInsideJSXElement();
+    try scanner.nextInsideJSXElement();
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
     // 전체 텍스트가 토큰에 포함됨 (이스케이프 안 함)
     try std.testing.expectEqualStrings("\"hello\\nworld\"", scanner.tokenText());
@@ -2934,58 +2934,58 @@ test "Scanner: JSX string without escape" {
 
 test "Scanner: @jsx pragma in single-line comment" {
     const source = "// @jsx h\nconst x = 1;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // const (comment is skipped)
+    try scanner.next(); // const (comment is skipped)
     try std.testing.expectEqual(Kind.kw_const, scanner.token.kind);
     try std.testing.expectEqualStrings("h", scanner.jsx_pragma.?);
 }
 
 test "Scanner: @jsx pragma in multi-line comment" {
     const source = "/** @jsx h */\nconst x = 1;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqualStrings("h", scanner.jsx_pragma.?);
 }
 
 test "Scanner: @jsxFrag pragma" {
     const source = "/** @jsxFrag Fragment */";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next(); // eof (comment only)
+    try scanner.next(); // eof (comment only)
     try std.testing.expectEqualStrings("Fragment", scanner.jsx_frag_pragma.?);
 }
 
 test "Scanner: @jsxRuntime pragma" {
     const source = "// @jsxRuntime automatic";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqualStrings("automatic", scanner.jsx_runtime_pragma.?);
 }
 
 test "Scanner: @jsxImportSource pragma" {
     const source = "/** @jsxImportSource preact */";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expectEqualStrings("preact", scanner.jsx_import_source_pragma.?);
 }
 
 test "Scanner: multiple pragmas in one file" {
     const source = "/** @jsx h */\n// @jsxFrag Fragment\nconst x = 1;";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
     // 전체 스캔
     while (true) {
-        scanner.next();
+        try scanner.next();
         if (scanner.token.kind == .eof) break;
     }
 
@@ -2995,10 +2995,10 @@ test "Scanner: multiple pragmas in one file" {
 
 test "Scanner: no pragma in normal comment" {
     const source = "/* just a comment */ x";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    scanner.next();
+    try scanner.next();
     try std.testing.expect(scanner.jsx_pragma == null);
     try std.testing.expect(scanner.jsx_frag_pragma == null);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -58,7 +58,7 @@ fn transpileFile(
     };
 
     // 파싱 — 모든 모듈이 arena_alloc을 사용하므로 개별 deinit 불필요
-    var scanner = Scanner.init(arena_alloc, source);
+    var scanner = try Scanner.init(arena_alloc, source);
     var parser = Parser.init(arena_alloc, &scanner);
     _ = parser.parse() catch |err| {
         try stderr.print("zts: parse error in '{s}': {}\n", .{ file_path, err });
@@ -338,11 +338,11 @@ pub fn main() !void {
         const source = try std.fs.cwd().readFileAlloc(allocator, file_path, 10 * 1024 * 1024);
         defer allocator.free(source);
 
-        var scanner = Scanner.init(allocator, source);
+        var scanner = try Scanner.init(allocator, source);
         defer scanner.deinit();
 
         while (true) {
-            scanner.next();
+            try scanner.next();
             const lc = scanner.getLineColumn(scanner.token.span.start);
             try stdout.print("{d}:{d}\t{s}\t\"{s}\"\n", .{
                 lc.line + 1,

--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -22,7 +22,7 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
         self.current() == .kw_protected or self.current() == .kw_readonly)
     {
         const modifier_span = self.currentSpan();
-        const next = self.peekNextKind();
+        const next = try self.peekNextKind();
         // modifier 뒤에 식별자가 오면 parameter property
         if (next == .identifier or next == .l_bracket or next == .l_curly or
             next == .kw_readonly) // public readonly x
@@ -34,12 +34,12 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
                 .kw_readonly => 0x08,
                 else => 0,
             };
-            self.advance(); // skip first modifier
+            try self.advance(); // skip first modifier
 
             // 두 번째 modifier: public readonly x
             if (self.current() == .kw_readonly) {
                 modifier_flags |= 0x08;
-                self.advance();
+                try self.advance();
             }
 
             const inner = try parseBindingPattern(self);
@@ -54,9 +54,9 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
     // rest parameter: ...pattern
     if (self.current() == .dot3) {
         const rest_start = self.currentSpan().start;
-        self.advance(); // skip '...'
+        try self.advance(); // skip '...'
         const pattern = try parseBindingPattern(self);
-        self.checkBindingRestInit(pattern);
+        try self.checkBindingRestInit(pattern);
         return try self.ast.addNode(.{
             .tag = .spread_element,
             .span = .{ .start = rest_start, .end = self.currentSpan().start },
@@ -67,28 +67,28 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
     switch (self.current()) {
         .identifier => {
             const span = self.currentSpan();
-            self.checkStrictBinding(span);
-            self.advance();
+            try self.checkStrictBinding(span);
+            try self.advance();
             const node = try self.ast.addNode(.{
                 .tag = .binding_identifier,
                 .span = span,
                 .data = .{ .string_ref = span },
             });
             // TS: optional (?) + type annotation
-            _ = self.eat(.question); // optional parameter
+            _ = try self.eat(.question); // optional parameter
             _ = try self.tryParseTypeAnnotation();
             // default value: pattern = expr
             return tryWrapDefaultValue(self, node);
         },
         .l_bracket => {
             const pat = try parseArrayPattern(self);
-            _ = self.eat(.question);
+            _ = try self.eat(.question);
             _ = try self.tryParseTypeAnnotation();
             return tryWrapDefaultValue(self, pat);
         },
         .l_curly => {
             const pat = try parseObjectPattern(self);
-            _ = self.eat(.question);
+            _ = try self.eat(.question);
             _ = try self.tryParseTypeAnnotation();
             return tryWrapDefaultValue(self, pat);
         },
@@ -98,10 +98,10 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
             // 다른 reserved keyword의 escaped 형태는 항상 사용 불가.
             const is_escaped_await = self.isEscapedKeyword("await");
             if (!is_escaped_await or self.is_module or self.ctx.in_async) {
-                self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier");
+                try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier");
             }
             const span = self.currentSpan();
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .binding_identifier,
                 .span = span,
@@ -110,17 +110,17 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
         },
         .escaped_strict_reserved => {
             if (self.is_strict_mode) {
-                self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier in strict mode");
+                try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier in strict mode");
             }
-            _ = self.checkYieldAwaitUse(self.currentSpan(), "identifier");
+            _ = try self.checkYieldAwaitUse(self.currentSpan(), "identifier");
             const span = self.currentSpan();
-            self.advance();
+            try self.advance();
             const node = try self.ast.addNode(.{
                 .tag = .binding_identifier,
                 .span = span,
                 .data = .{ .string_ref = span },
             });
-            _ = self.eat(.question);
+            _ = try self.eat(.question);
             _ = try self.tryParseTypeAnnotation();
             return tryWrapDefaultValue(self, node);
         },
@@ -128,9 +128,9 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
             // contextual 키워드는 바인딩 이름으로 사용 가능 (let, yield, async 등)
             // 단, reserved keyword / yield in generator / await in async 는 불가
             if (self.current().isKeyword()) {
-                self.checkKeywordBinding();
+                try self.checkKeywordBinding();
                 const span = self.currentSpan();
-                self.advance();
+                try self.advance();
                 const node2 = try self.ast.addNode(.{
                     .tag = .binding_identifier,
                     .span = span,
@@ -138,7 +138,7 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
                 });
                 return tryWrapDefaultValue(self, node2);
             }
-            self.addError(self.currentSpan(), "Binding pattern expected");
+            try self.addError(self.currentSpan(), "Binding pattern expected");
             return NodeIndex.none;
         },
     }
@@ -152,7 +152,7 @@ pub fn parseBindingIdentifier(self: *Parser) ParseError2!NodeIndex {
 /// `= expr` 이 있으면 assignment_pattern으로 감싼다. 없으면 원본 반환.
 /// 기본값 표현식에서는 `in` 연산자가 항상 허용된다 (ECMAScript: Initializer[+In]).
 pub fn tryWrapDefaultValue(self: *Parser, node: NodeIndex) ParseError2!NodeIndex {
-    if (self.eat(.eq)) {
+    if (try self.eat(.eq)) {
         const def_saved = self.enterAllowInContext(true);
         const default_val = try self.parseAssignmentExpression();
         self.restoreContext(def_saved);
@@ -172,8 +172,8 @@ pub fn parseBindingName(self: *Parser) ParseError2!NodeIndex {
     switch (self.current()) {
         .identifier => {
             const span = self.currentSpan();
-            self.checkStrictBinding(span);
-            self.advance();
+            try self.checkStrictBinding(span);
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .binding_identifier,
                 .span = span,
@@ -188,10 +188,10 @@ pub fn parseBindingName(self: *Parser) ParseError2!NodeIndex {
             // 다른 reserved keyword의 escaped 형태는 항상 사용 불가.
             const is_escaped_await = self.isEscapedKeyword("await");
             if (!is_escaped_await or self.is_module or self.ctx.in_async) {
-                self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier");
+                try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier");
             }
             const span = self.currentSpan();
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .binding_identifier,
                 .span = span,
@@ -200,11 +200,11 @@ pub fn parseBindingName(self: *Parser) ParseError2!NodeIndex {
         },
         .escaped_strict_reserved => {
             if (self.is_strict_mode) {
-                self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier in strict mode");
+                try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier in strict mode");
             }
-            _ = self.checkYieldAwaitUse(self.currentSpan(), "identifier");
+            _ = try self.checkYieldAwaitUse(self.currentSpan(), "identifier");
             const span = self.currentSpan();
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .binding_identifier,
                 .span = span,
@@ -213,16 +213,16 @@ pub fn parseBindingName(self: *Parser) ParseError2!NodeIndex {
         },
         else => {
             if (self.current().isKeyword()) {
-                self.checkKeywordBinding();
+                try self.checkKeywordBinding();
                 const span = self.currentSpan();
-                self.advance();
+                try self.advance();
                 return try self.ast.addNode(.{
                     .tag = .binding_identifier,
                     .span = span,
                     .data = .{ .string_ref = span },
                 });
             }
-            self.addError(self.currentSpan(), "Binding pattern expected");
+            try self.addError(self.currentSpan(), "Binding pattern expected");
             return NodeIndex.none;
         },
     }
@@ -236,26 +236,26 @@ pub fn parseSimpleIdentifier(self: *Parser) ParseError2!NodeIndex {
         self.current() == .escaped_strict_reserved or self.current().isKeyword())
     {
         if (self.current() == .escaped_keyword) {
-            self.addError(span, "Escaped reserved word cannot be used as identifier");
+            try self.addError(span, "Escaped reserved word cannot be used as identifier");
         } else if (self.current() == .escaped_strict_reserved and self.is_strict_mode) {
-            self.addError(span, "Escaped reserved word cannot be used as identifier in strict mode");
+            try self.addError(span, "Escaped reserved word cannot be used as identifier in strict mode");
         } else {
-            self.checkKeywordBinding();
+            try self.checkKeywordBinding();
         }
-        self.advance();
+        try self.advance();
         return try self.ast.addNode(.{
             .tag = .binding_identifier,
             .span = span,
             .data = .{ .string_ref = span },
         });
     }
-    self.addError(span, "Identifier expected");
+    try self.addError(span, "Identifier expected");
     return NodeIndex.none;
 }
 
 pub fn parseArrayPattern(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip [
+    try self.advance(); // skip [
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_bracket and self.current() != .eof) {
@@ -267,15 +267,15 @@ pub fn parseArrayPattern(self: *Parser) ParseError2!NodeIndex {
                 .span = hole_span,
                 .data = .{ .none = 0 },
             }));
-            self.advance();
+            try self.advance();
             continue;
         }
         if (self.current() == .dot3) {
             // rest element: ...pattern
             const rest_start = self.currentSpan().start;
-            self.advance(); // skip ...
+            try self.advance(); // skip ...
             const rest_arg = try parseBindingPattern(self);
-            self.checkBindingRestInit(rest_arg);
+            try self.checkBindingRestInit(rest_arg);
             const rest = try self.ast.addNode(.{
                 .tag = .rest_element,
                 .span = .{ .start = rest_start, .end = self.currentSpan().start },
@@ -288,14 +288,14 @@ pub fn parseArrayPattern(self: *Parser) ParseError2!NodeIndex {
         // default value: pattern = expr (배열/객체 패턴 뒤의 = default)
         var elem = try tryWrapDefaultValue(self, elem_raw);
         // TS: optional (?) + type annotation — 배열 패턴 요소에도 가능
-        _ = self.eat(.question);
+        _ = try self.eat(.question);
         _ = try self.tryParseTypeAnnotation();
         if (!elem.isNone()) try self.scratch.append(elem);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
 
     const end = self.currentSpan().end;
-    self.expect(.r_bracket);
+    try self.expect(.r_bracket);
 
     const elements = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -309,16 +309,16 @@ pub fn parseArrayPattern(self: *Parser) ParseError2!NodeIndex {
 
 pub fn parseObjectPattern(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip {
+    try self.advance(); // skip {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
         if (self.current() == .dot3) {
             // rest element: ...pattern
             const rest_start = self.currentSpan().start;
-            self.advance(); // skip ...
+            try self.advance(); // skip ...
             const rest_arg = try parseBindingPattern(self);
-            self.checkBindingRestInit(rest_arg);
+            try self.checkBindingRestInit(rest_arg);
             const rest = try self.ast.addNode(.{
                 .tag = .rest_element,
                 .span = .{ .start = rest_start, .end = self.currentSpan().start },
@@ -330,11 +330,11 @@ pub fn parseObjectPattern(self: *Parser) ParseError2!NodeIndex {
 
         const prop = try parseBindingProperty(self);
         if (!prop.isNone()) try self.scratch.append(prop);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
 
     const end = self.currentSpan().end;
-    self.expect(.r_curly);
+    try self.expect(.r_curly);
 
     const props = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -358,10 +358,10 @@ pub fn parseBindingProperty(self: *Parser) ParseError2!NodeIndex {
         (self.current() == .kw_yield and !self.ctx.in_generator and !self.is_strict_mode);
     if (is_shorthand_eligible) {
         const id_span = self.currentSpan();
-        const next = self.peekNextKind();
+        const next = try self.peekNextKind();
         if (next == .comma or next == .r_curly or next == .eq) {
             // shorthand property
-            self.advance();
+            try self.advance();
             const key = try self.ast.addNode(.{
                 .tag = .binding_identifier,
                 .span = id_span,
@@ -381,9 +381,9 @@ pub fn parseBindingProperty(self: *Parser) ParseError2!NodeIndex {
     // private name (#x) 은 object destructuring pattern에서 사용 불가
     // ECMAScript: ObjectAssignmentPattern의 PropertyName은 PrivateName을 포함하지 않음
     if (!key.isNone() and self.ast.getNode(key).tag == .private_identifier) {
-        self.addError(self.ast.getNode(key).span, "Private name is not allowed in destructuring pattern");
+        try self.addError(self.ast.getNode(key).span, "Private name is not allowed in destructuring pattern");
     }
-    self.expect(.colon);
+    try self.expect(.colon);
     const value_raw = try parseBindingPattern(self);
     // { x: pattern = defaultValue } 형태
     const value = try tryWrapDefaultValue(self, value_raw);

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -26,11 +26,11 @@ pub fn parseFunctionDeclaration(self: *Parser) ParseError2!NodeIndex {
 
 fn parseFunctionDeclarationWithFlags(self: *Parser, extra_flags: u32) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'function'
+    try self.advance(); // skip 'function'
 
     // generator: function* name()
     var flags = extra_flags;
-    if (self.eat(.star)) {
+    if (try self.eat(.star)) {
         flags |= FunctionFlags.is_generator;
     }
 
@@ -44,30 +44,30 @@ fn parseFunctionDeclarationWithFlags(self: *Parser, extra_flags: u32) ParseError
 
     const saved_ctx = self.enterFunctionContext(is_async, is_generator);
 
-    self.expect(.l_paren);
+    try self.expect(.l_paren);
     self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const param = try self.parseBindingIdentifier();
         try self.scratch.append(param);
-        self.checkRestParameterLast(param);
-        if (!self.eat(.comma)) break;
+        try self.checkRestParameterLast(param);
+        if (!try self.eat(.comma)) break;
     }
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     self.in_formal_parameters = false;
 
     // TS 리턴 타입 어노테이션
     const return_type = try self.tryParseReturnType();
 
     self.has_simple_params = self.checkSimpleParams(scratch_top);
-    self.checkDuplicateParams(scratch_top);
+    try self.checkDuplicateParams(scratch_top);
     const body = try self.parseFunctionBody();
 
     // retroactive strict mode checks: "use strict" directive가 있으면
     // 함수 이름과 파라미터를 소급 검증 (ECMAScript 14.1.2)
     if (self.is_strict_mode and !saved_ctx.is_strict_mode) {
-        self.checkStrictFunctionName(name);
-        self.checkStrictParamNames(scratch_top);
+        try self.checkStrictFunctionName(name);
+        try self.checkStrictParamNames(scratch_top);
     }
 
     self.restoreFunctionContext(saved_ctx);
@@ -92,10 +92,10 @@ fn parseFunctionDeclarationWithFlags(self: *Parser, extra_flags: u32) ParseError
 /// async 뒤에 function이 오면 async function declaration,
 /// 그 외는 expression statement로 처리.
 pub fn parseAsyncStatement(self: *Parser) ParseError2!NodeIndex {
-    const peek = self.peekNext();
+    const peek = try self.peekNext();
     // async [no LineTerminator here] function → async function declaration
     if (peek.kind == .kw_function and !peek.has_newline_before) {
-        self.advance(); // skip 'async'
+        try self.advance(); // skip 'async'
         return parseFunctionDeclarationWithFlags(self, FunctionFlags.is_async);
     }
     // async 뒤에 줄바꿈이 있거나 function이 아니면 → expression statement
@@ -110,7 +110,7 @@ pub fn parseFunctionDeclarationDefaultExport(self: *Parser) ParseError2!NodeInde
 
 /// export default async function / async function* — 이름이 선택적
 pub fn parseAsyncFunctionDeclarationDefaultExport(self: *Parser) ParseError2!NodeIndex {
-    self.advance(); // skip 'async'
+    try self.advance(); // skip 'async'
     return parseFunctionDeclarationWithFlagsOptionalName(self, FunctionFlags.is_async);
 }
 
@@ -118,10 +118,10 @@ pub fn parseAsyncFunctionDeclarationDefaultExport(self: *Parser) ParseError2!Nod
 /// export default에서만 사용.
 fn parseFunctionDeclarationWithFlagsOptionalName(self: *Parser, extra_flags: u32) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'function'
+    try self.advance(); // skip 'function'
 
     var flags = extra_flags;
-    if (self.eat(.star)) {
+    if (try self.eat(.star)) {
         flags |= FunctionFlags.is_generator;
     }
 
@@ -138,28 +138,28 @@ fn parseFunctionDeclarationWithFlagsOptionalName(self: *Parser, extra_flags: u32
 
     const saved_ctx = self.enterFunctionContext(is_async, is_generator);
 
-    self.expect(.l_paren);
+    try self.expect(.l_paren);
     self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const param = try self.parseBindingIdentifier();
         try self.scratch.append(param);
-        self.checkRestParameterLast(param);
-        if (!self.eat(.comma)) break;
+        try self.checkRestParameterLast(param);
+        if (!try self.eat(.comma)) break;
     }
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     self.in_formal_parameters = false;
 
     const return_type = try self.tryParseReturnType();
 
     self.has_simple_params = self.checkSimpleParams(scratch_top);
-    self.checkDuplicateParams(scratch_top);
+    try self.checkDuplicateParams(scratch_top);
     const body = try self.parseFunctionBody();
 
     // retroactive strict mode checks
     if (self.is_strict_mode and !saved_ctx.is_strict_mode) {
-        self.checkStrictFunctionName(name);
-        self.checkStrictParamNames(scratch_top);
+        try self.checkStrictFunctionName(name);
+        try self.checkStrictParamNames(scratch_top);
     }
 
     self.restoreFunctionContext(saved_ctx);
@@ -186,11 +186,11 @@ pub fn parseFunctionExpression(self: *Parser) ParseError2!NodeIndex {
 
 pub fn parseFunctionExpressionWithFlags(self: *Parser, extra_flags: u32) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'function'
+    try self.advance(); // skip 'function'
 
     // generator: function* () {}
     var flags: u32 = extra_flags;
-    if (self.eat(.star)) {
+    if (try self.eat(.star)) {
         flags |= FunctionFlags.is_generator;
     }
 
@@ -205,28 +205,28 @@ pub fn parseFunctionExpressionWithFlags(self: *Parser, extra_flags: u32) ParseEr
         name = try self.parseBindingIdentifier();
     }
 
-    self.expect(.l_paren);
+    try self.expect(.l_paren);
     self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const param = try self.parseBindingIdentifier();
         try self.scratch.append(param);
-        self.checkRestParameterLast(param);
-        if (!self.eat(.comma)) break;
+        try self.checkRestParameterLast(param);
+        if (!try self.eat(.comma)) break;
     }
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     self.in_formal_parameters = false;
 
     // TS 리턴 타입 어노테이션
     _ = try self.tryParseReturnType();
     self.has_simple_params = self.checkSimpleParams(scratch_top);
-    self.checkDuplicateParams(scratch_top);
+    try self.checkDuplicateParams(scratch_top);
     const body = try self.parseFunctionBodyExpr();
 
     // retroactive strict mode checks
     if (self.is_strict_mode and !saved_ctx.is_strict_mode) {
-        self.checkStrictFunctionName(name);
-        self.checkStrictParamNames(scratch_top);
+        try self.checkStrictFunctionName(name);
+        try self.checkStrictParamNames(scratch_top);
     }
 
     self.restoreFunctionContext(saved_ctx);
@@ -258,7 +258,7 @@ pub fn parseClassExpression(self: *Parser) ParseError2!NodeIndex {
 /// extra = [name, super_class, body, type_params, implements_start, implements_len, deco_start, deco_len]
 pub fn parseClassWithDecorators(self: *Parser, tag: Tag, decorators: NodeList) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'class'
+    try self.advance(); // skip 'class'
 
     // ECMAScript 10.2.1: "All parts of a ClassDeclaration or a ClassExpression
     // are strict mode code." — 클래스 이름, extends, 본문 모두 strict mode.
@@ -291,14 +291,14 @@ pub fn parseClassWithDecorators(self: *Parser, tag: Tag, decorators: NodeList) P
     // parseCallExpression을 사용하여 arrow function이 heritage에서 파싱되지 않도록 한다.
     // 예: `class extends () => {} {}` → SyntaxError (arrow의 {}가 class body와 충돌)
     var super_class = NodeIndex.none;
-    if (self.eat(.kw_extends)) {
+    if (try self.eat(.kw_extends)) {
         super_class = try self.parseCallExpression();
     }
 
     // TS implements 절 (선택): class Foo implements Bar, Baz
-    if (self.eat(.kw_implements)) {
+    if (try self.eat(.kw_implements)) {
         _ = try self.parseType();
-        while (self.eat(.comma)) {
+        while (try self.eat(.comma)) {
             _ = try self.parseType();
         }
     }
@@ -333,7 +333,7 @@ pub fn parseClassWithDecorators(self: *Parser, tag: Tag, decorators: NodeList) P
 
 fn parseClassBody(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.expect(.l_curly);
+    try self.expect(.l_curly);
 
     // class body 안에서는 in_class=true (super 허용 등)
     const saved_in_class = self.in_class;
@@ -343,7 +343,7 @@ fn parseClassBody(self: *Parser) ParseError2!NodeIndex {
     while (self.current() != .r_curly and self.current() != .eof) {
         // 세미콜론 스킵 (클래스 본문에서 허용)
         if (self.current() == .semicolon) {
-            self.advance();
+            try self.advance();
             continue;
         }
         const member = try parseClassMember(self);
@@ -353,7 +353,7 @@ fn parseClassBody(self: *Parser) ParseError2!NodeIndex {
     self.in_class = saved_in_class;
 
     const end = self.currentSpan().end;
-    self.expect(.r_curly);
+    try self.expect(.r_curly);
 
     const members = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -383,7 +383,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.current() == .kw_abstract or self.current() == .kw_override or
         self.current() == .kw_declare)
     {
-        self.advance(); // skip modifier (스트리핑 대상이므로 AST에 저장 불필요)
+        try self.advance(); // skip modifier (스트리핑 대상이므로 AST에 저장 불필요)
     }
 
     // static 키워드 (선택)
@@ -391,12 +391,12 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
     // static 뒤에 {, (, = 가 오면 이름으로 취급
     var flags: u16 = 0;
     if (self.current() == .kw_static) {
-        const next = self.peekNextKind();
+        const next = try self.peekNextKind();
         if (next == .l_curly) {
             // static { } — static block
             // static initializer는 자체 arguments 바인딩이 없음.
             // new.target은 허용 (undefined로 평가, ECMAScript 15.7.15)
-            self.advance(); // skip 'static'
+            try self.advance(); // skip 'static'
             const saved_in_static = self.in_static_initializer;
             const saved_new_target = self.allow_new_target;
             const saved_in_function = self.ctx.in_function;
@@ -433,7 +433,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         // static 뒤에 (나 = 가 오면 static은 메서드/프로퍼티 이름
         if (next != .l_paren and next != .eq and next != .semicolon) {
             flags |= 0x01; // static modifier
-            self.advance();
+            try self.advance();
         }
     }
 
@@ -443,7 +443,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.current() == .kw_public or self.current() == .kw_private or
         self.current() == .kw_protected)
     {
-        self.advance();
+        try self.advance();
     }
 
     // accessor (선택): TC39 Decorators proposal — `accessor x = 1`
@@ -452,35 +452,35 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
     // `accessor()`, `accessor;`, `accessor =` 는 "accessor"라는 이름의 일반 멤버.
     var is_accessor = false;
     if (self.current() == .kw_accessor) {
-        const next = self.peekNextKind();
+        const next = try self.peekNextKind();
         if (next != .l_paren and next != .eq and next != .semicolon and
             next != .r_curly and next != .eof)
         {
             is_accessor = true;
-            self.advance(); // skip 'accessor'
+            try self.advance(); // skip 'accessor'
         }
     }
 
     // get/set (선택)
-    if (self.current() == .kw_get and self.peekNextKind() != .l_paren) {
+    if (self.current() == .kw_get and try self.peekNextKind() != .l_paren) {
         flags |= 0x02; // getter
-        self.advance();
-    } else if (self.current() == .kw_set and self.peekNextKind() != .l_paren) {
+        try self.advance();
+    } else if (self.current() == .kw_set and try self.peekNextKind() != .l_paren) {
         flags |= 0x04; // setter
-        self.advance();
+        try self.advance();
     }
 
     // async (선택): async [no LineTerminator here] MethodName
     // 스펙: async와 다음 토큰(*/PropertyName) 사이에 줄바꿈이 없어야 함
-    if (self.current() == .kw_async and self.peekNextKind() != .l_paren and
-        !self.peekNext().has_newline_before)
+    if (self.current() == .kw_async and try self.peekNextKind() != .l_paren and
+        !(try self.peekNext()).has_newline_before)
     {
         flags |= 0x08; // async flag
-        self.advance();
+        try self.advance();
     }
 
     // generator (선택): *method() {}
-    if (self.eat(.star)) {
+    if (try self.eat(.star)) {
         flags |= 0x10; // generator flag
     }
 
@@ -509,16 +509,16 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.ctx.in_generator = (flags & 0x10) != 0;
         // class 메서드의 파라미터에서 super.prop 허용 (ECMAScript 15.7.5)
         self.allow_super_property = true;
-        self.expect(.l_paren);
+        try self.expect(.l_paren);
         self.in_formal_parameters = true;
         const param_top = self.saveScratch();
         while (self.current() != .r_paren and self.current() != .eof) {
             const param = try self.parseBindingIdentifier();
             try self.scratch.append(param);
-            self.checkRestParameterLast(param);
-            if (!self.eat(.comma)) break;
+            try self.checkRestParameterLast(param);
+            if (!try self.eat(.comma)) break;
         }
-        self.expect(.r_paren);
+        try self.expect(.r_paren);
         self.in_formal_parameters = false;
 
         // TS 리턴 타입 어노테이션: (): Type
@@ -535,20 +535,20 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
             else
                 @as([]const u8, "");
             if ((flags & 0x01) != 0 and std.mem.eql(u8, method_name, "prototype")) {
-                self.addError(mk.span, "Static class method cannot be named 'prototype'");
+                try self.addError(mk.span, "Static class method cannot be named 'prototype'");
             }
             // constructor는 일반 method만 가능 — getter/setter/generator/async 금지
             if ((flags & 0x01) == 0 and std.mem.eql(u8, method_name, "constructor")) {
                 // flags: 0x02=getter, 0x04=setter, 0x08=async, 0x10=generator
                 if ((flags & 0x1E) != 0) {
-                    self.addError(mk.span, "Class constructor cannot be a getter, setter, generator, or async");
+                    try self.addError(mk.span, "Class constructor cannot be a getter, setter, generator, or async");
                 }
             }
             // private name '#constructor' 금지
             if (mk.tag == .private_identifier) {
                 const pn = self.ast.source[mk.span.start..mk.span.end];
                 if (std.mem.eql(u8, pn, "#constructor")) {
-                    self.addError(mk.span, "Class member cannot be named '#constructor'");
+                    try self.addError(mk.span, "Class member cannot be named '#constructor'");
                 }
             }
         }
@@ -578,11 +578,11 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
                 }
             }
             self.has_simple_params = self.checkSimpleParams(param_top);
-            self.checkDuplicateParams(param_top);
+            try self.checkDuplicateParams(param_top);
             body = try self.parseFunctionBodyExpr();
             self.restoreFunctionContext(saved_ctx);
         } else {
-            _ = self.eat(.semicolon);
+            _ = try self.eat(.semicolon);
         }
         // 파라미터 전에 변경한 플래그 복원 (if/else 양쪽 공통)
         // restoreFunctionContext는 enterFunctionContext 시점의 (이미 false인) 값을
@@ -627,17 +627,17 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         if (key_text.len > 0) {
             // class field 이름 'constructor' 금지 — static/non-static 모두 (ECMAScript 15.7.1)
             if (std.mem.eql(u8, key_text, "constructor")) {
-                self.addError(key_node.span, "Class field cannot be named 'constructor'");
+                try self.addError(key_node.span, "Class field cannot be named 'constructor'");
             }
             if ((flags & 0x01) != 0 and std.mem.eql(u8, key_text, "prototype")) {
-                self.addError(key_node.span, "Static class field cannot be named 'prototype'");
+                try self.addError(key_node.span, "Static class field cannot be named 'prototype'");
             }
         }
         // private field '#constructor' 금지
         if (key_node.tag == .private_identifier) {
             const pn = self.ast.source[key_node.span.start..key_node.span.end];
             if (std.mem.eql(u8, pn, "#constructor")) {
-                self.addError(key_node.span, "Class member cannot be named '#constructor'");
+                try self.addError(key_node.span, "Class member cannot be named '#constructor'");
             }
         }
     }
@@ -647,7 +647,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
 
     // 프로퍼티 (= 이니셜라이저) — class field에서 arguments 사용 금지
     var init_val = NodeIndex.none;
-    if (self.eat(.eq)) {
+    if (try self.eat(.eq)) {
         const saved_in_class_field = self.in_class_field;
         const saved_new_target = self.allow_new_target;
         const saved_super_property = self.allow_super_property;
@@ -660,7 +660,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.allow_super_property = saved_super_property;
     }
     // class field 끝에서 ASI 규칙 적용: 같은 줄에 다른 멤버가 오면 에러
-    self.expectSemicolon();
+    try self.expectSemicolon();
 
     // property_definition / accessor_property:
     // extra = [key, init_val, flags, deco_start, deco_len]

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -38,7 +38,7 @@ fn parseExpressionOrRest(self: *Parser) ParseError2!NodeIndex {
     const scratch_top = self.saveScratch();
     try self.scratch.append(first);
     var had_trailing_comma = false;
-    while (self.eat(.comma)) {
+    while (try self.eat(.comma)) {
         if (self.current() == .r_paren) {
             had_trailing_comma = true;
             break;
@@ -78,7 +78,7 @@ pub fn parseExpression(self: *Parser) ParseError2!NodeIndex {
     // 콤마 연산자 → sequence expression
     const scratch_top = self.saveScratch();
     try self.scratch.append(first);
-    while (self.eat(.comma)) {
+    while (try self.eat(.comma)) {
         // trailing comma: 콤마 뒤에 )가 오면 arrow function 파라미터 trailing comma
         if (self.current() == .r_paren) break;
         const elem = try parseAssignmentExpression(self);
@@ -126,19 +126,19 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
     // async arrow function 감지 (2가지 형태)
     if (self.current() == .kw_async) {
         const async_span = self.currentSpan();
-        const peek = self.peekNext();
+        const peek = try self.peekNext();
 
         if (!peek.has_newline_before) {
             // 형태 1: async x => body (단순 식별자)
             if (peek.kind == .identifier or (peek.kind.isKeyword() and !peek.kind.isReservedKeyword())) {
                 const saved = self.saveState();
-                self.advance(); // skip 'async'
+                try self.advance(); // skip 'async'
                 const id_span = self.currentSpan();
-                self.advance(); // skip identifier
+                try self.advance(); // skip identifier
                 if (self.current() == .arrow and !self.scanner.token.has_newline_before) {
                     // ECMAScript 14.2.1: strict mode에서 eval/arguments를 arrow 파라미터로 사용 금지
-                    self.checkStrictBinding(id_span);
-                    self.advance(); // skip =>
+                    try self.checkStrictBinding(id_span);
+                    try self.advance(); // skip =>
                     const param = try self.ast.addNode(.{
                         .tag = .binding_identifier,
                         .span = id_span,
@@ -158,14 +158,14 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
             // async () => {} — 빈 파라미터도 포함
             if (peek.kind == .l_paren) {
                 const saved = self.saveState();
-                self.advance(); // skip 'async'
+                try self.advance(); // skip 'async'
 
                 // () 빈 파라미터 체크
-                if (self.current() == .l_paren and self.peekNextKind() == .r_paren) {
-                    self.advance(); // skip (
-                    self.advance(); // skip )
+                if (self.current() == .l_paren and try self.peekNextKind() == .r_paren) {
+                    try self.advance(); // skip (
+                    try self.advance(); // skip )
                     if (self.current() == .arrow and !self.scanner.token.has_newline_before) {
-                        self.advance(); // skip =>
+                        try self.advance(); // skip =>
                         const body = try parseArrowBody(self, true, .none);
                         return try self.ast.addNode(.{
                             .tag = .arrow_function_expression,
@@ -178,10 +178,10 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
                     // 괄호를 expression으로 파싱 (parenthesized_expression)
                     const params_expr = try parseConditionalExpression(self);
                     if (self.current() == .arrow and !self.scanner.token.has_newline_before) {
-                        self.coverExpressionToArrowParams(params_expr);
+                        try self.coverExpressionToArrowParams(params_expr);
                         // async arrow: 파라미터에 'await' 식별자 사용 금지
-                        self.checkAsyncArrowParamsForAwait(params_expr);
-                        self.advance(); // skip =>
+                        try self.checkAsyncArrowParamsForAwait(params_expr);
+                        try self.advance(); // skip =>
                         const body = try parseArrowBody(self, true, params_expr);
                         return try self.ast.addNode(.{
                             .tag = .arrow_function_expression,
@@ -200,12 +200,12 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
         const id_span = self.currentSpan();
         const saved = self.saveState();
 
-        self.advance(); // skip identifier
+        try self.advance(); // skip identifier
         if (self.current() == .arrow and !self.scanner.token.has_newline_before) {
             // identifier => body
             // ECMAScript 14.2.1: strict mode에서 eval/arguments를 arrow 파라미터로 사용 금지
-            self.checkStrictBinding(id_span);
-            self.advance(); // skip =>
+            try self.checkStrictBinding(id_span);
+            try self.advance(); // skip =>
             const param = try self.ast.addNode(.{
                 .tag = .binding_identifier,
                 .span = id_span,
@@ -225,13 +225,13 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
     }
 
     // () => body — 빈 파라미터 arrow function
-    if (self.current() == .l_paren and self.peekNextKind() == .r_paren) {
+    if (self.current() == .l_paren and try self.peekNextKind() == .r_paren) {
         const arrow_start = self.currentSpan().start;
         const saved = self.saveState();
-        self.advance(); // skip (
-        self.advance(); // skip )
+        try self.advance(); // skip (
+        try self.advance(); // skip )
         if (self.current() == .arrow and !self.scanner.token.has_newline_before) {
-            self.advance(); // skip =>
+            try self.advance(); // skip =>
             const body = try parseArrowBody(self, false, .none);
             return try self.ast.addNode(.{
                 .tag = .arrow_function_expression,
@@ -247,13 +247,13 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .kw_yield and self.ctx.in_generator) {
         // formal parameter 안에서 yield expression 금지 (ECMAScript 14.1.2)
         if (self.in_formal_parameters) {
-            self.addError(self.currentSpan(), "'yield' expression is not allowed in formal parameters");
+            try self.addError(self.currentSpan(), "'yield' expression is not allowed in formal parameters");
         }
         const yield_start = self.currentSpan().start;
-        self.advance();
+        try self.advance();
         // yield* delegate — * 전에 줄바꿈이 있으면 delegate 아님
         var yield_flags: u16 = 0;
-        if (!self.scanner.token.has_newline_before and self.eat(.star)) {
+        if (!self.scanner.token.has_newline_before and try self.eat(.star)) {
             yield_flags = 1; // delegate
         }
         var operand = NodeIndex.none;
@@ -291,9 +291,9 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
         self.isValidArrowParamForm(left))
     {
         // arrow 파라미터 cover grammar 검증 (ECMAScript: ArrowFormalParameters)
-        self.coverExpressionToArrowParams(left);
+        try self.coverExpressionToArrowParams(left);
         const left_start = self.ast.getNode(left).span.start;
-        self.advance(); // skip =>
+        try self.advance(); // skip =>
         const body = try parseArrowBody(self, false, left);
 
         return try self.ast.addNode(.{
@@ -306,10 +306,10 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
     if (self.current().isAssignment()) {
         // cover grammar: expression → assignment target 검증 (ECMAScript 13.15.1)
         // 구조적 유효성 + rest-init + escaped keyword + strict eval/arguments를 단일 walk로 검증
-        _ = self.coverExpressionToAssignmentTarget(left, true);
+        _ = try self.coverExpressionToAssignmentTarget(left, true);
         const left_start = self.ast.getNode(left).span.start;
         const flags: u16 = @intFromEnum(self.current());
-        self.advance();
+        try self.advance();
         const right = try parseAssignmentExpression(self);
         return try self.ast.addNode(.{
             .tag = .assignment_expression,
@@ -324,7 +324,7 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
 fn parseConditionalExpression(self: *Parser) ParseError2!NodeIndex {
     const expr = try parseBinaryExpression(self, 0);
 
-    if (self.eat(.question)) {
+    if (try self.eat(.question)) {
         const expr_start = self.ast.getNode(expr).span.start;
         // ECMAScript: ConditionalExpression[In] →
         //   ... ? AssignmentExpression[+In] : AssignmentExpression[?In]
@@ -332,7 +332,7 @@ fn parseConditionalExpression(self: *Parser) ParseError2!NodeIndex {
         const cond_saved = self.enterAllowInContext(true);
         const consequent = try parseAssignmentExpression(self);
         self.restoreContext(cond_saved); // alternate는 원래 context로 복원
-        self.expect(.colon);
+        try self.expect(.colon);
         const alternate = try parseAssignmentExpression(self);
         return try self.ast.addNode(.{
             .tag = .conditional_expression,
@@ -352,7 +352,7 @@ fn parseBinaryExpression(self: *Parser, min_prec: u8) ParseError2!NodeIndex {
     // bare #field가 `in` 연산자 없이 사용되면 SyntaxError.
     if (!left.isNone() and self.ast.getNode(left).tag == .private_identifier) {
         if (self.current() != .kw_in or !self.ctx.allow_in) {
-            self.addError(self.ast.getNode(left).span, "Private name '#' is not valid outside of `in` expression");
+            try self.addError(self.ast.getNode(left).span, "Private name '#' is not valid outside of `in` expression");
         }
     }
 
@@ -373,7 +373,7 @@ fn parseBinaryExpression(self: *Parser, min_prec: u8) ParseError2!NodeIndex {
         if (self.current() == .star2 and !left.isNone()) {
             const left_tag = self.ast.getNode(left).tag;
             if (left_tag == .unary_expression) {
-                self.addError(self.currentSpan(), "Unary expression cannot be the left operand of '**'");
+                try self.addError(self.currentSpan(), "Unary expression cannot be the left operand of '**'");
             }
         }
 
@@ -384,17 +384,17 @@ fn parseBinaryExpression(self: *Parser, min_prec: u8) ParseError2!NodeIndex {
         // ?? 와 &&/|| 혼합 감지 (ECMAScript: 괄호 없이 혼합 금지)
         if (op_kind == .question2) {
             if (has_logical_or_and) {
-                self.addError(self.currentSpan(), "Cannot mix '??' with '&&' or '||' without parentheses");
+                try self.addError(self.currentSpan(), "Cannot mix '??' with '&&' or '||' without parentheses");
             }
             has_coalesce = true;
         } else if (op_kind == .amp2 or op_kind == .pipe2) {
             if (has_coalesce) {
-                self.addError(self.currentSpan(), "Cannot mix '??' with '&&' or '||' without parentheses");
+                try self.addError(self.currentSpan(), "Cannot mix '??' with '&&' or '||' without parentheses");
             }
             has_logical_or_and = true;
         }
 
-        self.advance();
+        try self.advance();
 
         // ** (star2)는 우결합: prec - 1로 재귀하여 같은 우선순위를 오른쪽에 허용
         const next_prec = if (op_kind == .star2) prec - 1 else prec;
@@ -405,7 +405,7 @@ fn parseBinaryExpression(self: *Parser, min_prec: u8) ParseError2!NodeIndex {
         // 예: `#field in #field in this` → 내부 `#field in #field`의 RHS `#field`이 bare → 에러
         if (op_kind == .kw_in and !right.isNone()) {
             if (self.ast.getNode(right).tag == .private_identifier) {
-                self.addError(self.ast.getNode(right).span, "Private name '#' is not valid as right-hand side of `in` expression");
+                try self.addError(self.ast.getNode(right).span, "Private name '#' is not valid as right-hand side of `in` expression");
             }
         }
 
@@ -416,7 +416,7 @@ fn parseBinaryExpression(self: *Parser, min_prec: u8) ParseError2!NodeIndex {
             if (right_node.tag == .logical_expression) {
                 const right_op: Kind = @enumFromInt(right_node.data.binary.flags);
                 if (right_op == .amp2 or right_op == .pipe2) {
-                    self.addError(right_node.span, "Cannot mix '??' with '&&' or '||' without parentheses");
+                    try self.addError(right_node.span, "Cannot mix '??' with '&&' or '||' without parentheses");
                 }
             }
         }
@@ -439,7 +439,7 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
         .bang, .tilde, .minus, .plus, .kw_typeof, .kw_void, .kw_delete => {
             const start = self.currentSpan().start;
             const is_delete = kind == .kw_delete;
-            self.advance();
+            try self.advance();
             const operand = try parseUnaryExpression(self);
             // strict mode: delete identifier → SyntaxError (ECMAScript 12.5.3.1)
             // delete of private field → always SyntaxError (ECMAScript 13.5.1.1)
@@ -462,7 +462,7 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
                         const right_idx = del_node.data.binary.right;
                         if (!right_idx.isNone() and @intFromEnum(right_idx) < self.ast.nodes.items.len) {
                             if (self.ast.getNode(right_idx).tag == .private_identifier) {
-                                self.addError(del_node.span, "Private fields cannot be deleted");
+                                try self.addError(del_node.span, "Private fields cannot be deleted");
                             }
                         }
                     }
@@ -474,7 +474,7 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
                 while (!target.isNone()) {
                     const t = self.ast.getNode(target);
                     if (t.tag == .identifier_reference) {
-                        self.addError(t.span, "Deleting an identifier is not allowed in strict mode");
+                        try self.addError(t.span, "Deleting an identifier is not allowed in strict mode");
                         break;
                     } else if (t.tag == .parenthesized_expression) {
                         target = t.data.unary.operand;
@@ -489,10 +489,10 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
         },
         .plus2, .minus2 => {
             const start = self.currentSpan().start;
-            self.advance();
+            try self.advance();
             const operand = try parseUnaryExpression(self);
             // ++/-- operand는 유효한 assignment target이어야 함
-            _ = self.coverExpressionToAssignmentTarget(operand, true);
+            _ = try self.coverExpressionToAssignmentTarget(operand, true);
             return try self.ast.addNode(.{
                 .tag = .update_expression,
                 .span = .{ .start = start, .end = self.currentSpan().start },
@@ -503,11 +503,11 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
             // static initializer에서 await 사용 금지 (ECMAScript 15.7.14)
             // module mode에서 await expression으로 파싱되기 전에 체크해야 함
             if (self.in_static_initializer) {
-                self.addError(self.currentSpan(), "'await' is not allowed in class static initializer");
+                try self.addError(self.currentSpan(), "'await' is not allowed in class static initializer");
             }
             // formal parameter 안에서 await expression 금지 (ECMAScript 14.1.2)
             if (self.in_formal_parameters and self.ctx.in_async) {
-                self.addError(self.currentSpan(), "'await' expression is not allowed in formal parameters");
+                try self.addError(self.currentSpan(), "'await' expression is not allowed in formal parameters");
             }
             // async 함수 안에서는 항상 await_expression.
             // module top-level(함수 밖)에서는 top-level await.
@@ -515,7 +515,7 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
             // ECMAScript: FunctionBody[~Yield, ~Await] → await은 keyword가 아님.
             if (self.ctx.in_async or (self.is_module and !self.ctx.in_function)) {
                 const start = self.currentSpan().start;
-                self.advance();
+                try self.advance();
                 const operand = try parseUnaryExpression(self);
                 return try self.ast.addNode(.{
                     .tag = .await_expression,
@@ -525,7 +525,7 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
             }
             // module 안 일반 함수에서 await 사용 → strict mode 위반 에러
             if (self.is_module and self.ctx.in_function and !self.ctx.in_async) {
-                self.addError(self.currentSpan(), "'await' is not allowed in non-async function in module code");
+                try self.addError(self.currentSpan(), "'await' is not allowed in non-async function in module code");
             }
             // async 밖 + script mode에서는 식별자로 파싱
             return parsePostfixExpression(self);
@@ -545,10 +545,10 @@ fn parsePostfixExpression(self: *Parser) ParseError2!NodeIndex {
         !self.scanner.token.has_newline_before)
     {
         // ++/-- operand는 유효한 assignment target이어야 함
-        _ = self.coverExpressionToAssignmentTarget(expr, true);
+        _ = try self.coverExpressionToAssignmentTarget(expr, true);
         const expr_start = self.ast.getNode(expr).span.start;
         const kind = self.current();
-        self.advance();
+        try self.advance();
         expr = try self.ast.addNode(.{
             .tag = .update_expression,
             .span = .{ .start = expr_start, .end = self.currentSpan().start },
@@ -559,7 +559,7 @@ fn parsePostfixExpression(self: *Parser) ParseError2!NodeIndex {
     // TS: non-null assertion (expr!)
     if (self.current() == .bang and !self.scanner.token.has_newline_before) {
         const expr_start = self.ast.getNode(expr).span.start;
-        self.advance();
+        try self.advance();
         expr = try self.ast.addNode(.{
             .tag = .ts_non_null_expression,
             .span = .{ .start = expr_start, .end = self.currentSpan().start },
@@ -571,7 +571,7 @@ fn parsePostfixExpression(self: *Parser) ParseError2!NodeIndex {
     while (self.current() == .kw_as or self.current() == .kw_satisfies) {
         const expr_start = self.ast.getNode(expr).span.start;
         const is_satisfies = self.current() == .kw_satisfies;
-        self.advance();
+        try self.advance();
         const ty = try self.parseType();
         expr = try self.ast.addNode(.{
             .tag = if (is_satisfies) .ts_satisfies_expression else .ts_as_expression,
@@ -593,10 +593,10 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
             .l_paren => {
                 // super() 호출은 constructor에서만 허용
                 if (self.ast.getNode(expr).tag == .super_expression and !self.allow_super_call) {
-                    self.addError(self.ast.getNode(expr).span, "'super()' is only allowed in a class constructor");
+                    try self.addError(self.ast.getNode(expr).span, "'super()' is only allowed in a class constructor");
                 }
                 // 함수 호출
-                self.advance();
+                try self.advance();
                 const arg_list = try parseArgumentList(self);
                 expr = try self.ast.addNode(.{
                     .tag = .call_expression,
@@ -606,13 +606,13 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
             },
             .dot => {
                 // 멤버 접근: a.b
-                self.advance();
+                try self.advance();
                 const prop = try parseIdentifierName(self);
                 // super.#private → SyntaxError (ECMAScript: SuperProperty doesn't include PrivateName)
                 if (!prop.isNone() and self.ast.getNode(prop).tag == .private_identifier) {
                     const obj_node = self.ast.getNode(expr);
                     if (obj_node.tag == .super_expression) {
-                        self.addError(self.ast.getNode(prop).span, "Private field access on super is not allowed");
+                        try self.addError(self.ast.getNode(prop).span, "Private field access on super is not allowed");
                     }
                 }
                 expr = try self.ast.addNode(.{
@@ -626,11 +626,11 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
             },
             .l_bracket => {
                 // 계산된 멤버 접근: a[b] — `in` 연산자 허용 (ECMAScript: [+In])
-                self.advance();
+                try self.advance();
                 const cm_saved = self.enterAllowInContext(true);
                 const prop = try parseExpression(self);
                 self.restoreContext(cm_saved);
-                self.expect(.r_bracket);
+                try self.expect(.r_bracket);
                 expr = try self.ast.addNode(.{
                     .tag = .computed_member_expression,
                     .span = .{ .start = expr_start, .end = self.currentSpan().start },
@@ -639,14 +639,14 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
             },
             .question_dot => {
                 // optional chaining: a?.b, a?.[b], a?.()
-                self.advance(); // skip ?.
+                try self.advance(); // skip ?.
                 if (self.current() == .l_bracket) {
                     // a?.[expr] — `in` 연산자 허용 (ECMAScript: [+In])
-                    self.advance();
+                    try self.advance();
                     const oc_saved = self.enterAllowInContext(true);
                     const prop = try parseExpression(self);
                     self.restoreContext(oc_saved);
-                    self.expect(.r_bracket);
+                    try self.expect(.r_bracket);
                     expr = try self.ast.addNode(.{
                         .tag = .computed_member_expression,
                         .span = .{ .start = expr_start, .end = self.currentSpan().start },
@@ -654,7 +654,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                     });
                 } else if (self.current() == .l_paren) {
                     // a?.()
-                    self.advance();
+                    try self.advance();
                     const arg_list = try parseArgumentList(self);
                     expr = try self.ast.addNode(.{
                         .tag = .call_expression,
@@ -676,7 +676,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
             .no_substitution_template, .template_head => {
                 // tagged template 금지: a?.b`template` (ECMAScript 12.3.1.1)
                 if (after_optional_chain) {
-                    self.addError(self.currentSpan(), "Tagged template cannot be used in optional chain");
+                    try self.addError(self.currentSpan(), "Tagged template cannot be used in optional chain");
                 }
                 // tagged template: expr`text` 또는 expr`text${...}...`
                 // tagged template에서는 잘못된 이스케이프 허용 (cooked가 undefined)
@@ -684,7 +684,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                     try parseTemplateLiteral(self, true)
                 else blk: {
                     const tmpl_span = self.currentSpan();
-                    self.advance();
+                    try self.advance();
                     break :blk try self.ast.addNode(.{
                         .tag = .template_literal,
                         .span = tmpl_span,
@@ -718,20 +718,20 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
         // - import_expression (import(...)) → 에러
         // - call_expression (import.source/defer(...)) → 에러
         // 미리 에러를 보고하되, import.meta인 경우만 통과시킴
-        const next = self.peekNextKind();
+        const next = try self.peekNextKind();
         if (next != .dot) {
             // import( → 동적 import는 new 불가
-            self.addError(import_span, "'import' cannot be used with 'new'");
+            try self.addError(import_span, "'import' cannot be used with 'new'");
         }
         // import. → parsePrimaryExpression에서 처리
         // 결과를 확인하여 import.source/defer면 에러
     }
     if (self.current() == .kw_new) {
         const span = self.currentSpan();
-        self.advance(); // skip 'new'
+        try self.advance(); // skip 'new'
         const callee = try parseNewCallee(self);
         if (self.current() == .l_paren) {
-            self.advance();
+            try self.advance();
             const arg_list = try parseArgumentList(self);
             return try self.ast.addNode(.{
                 .tag = .new_expression,
@@ -753,14 +753,14 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
     if (!expr.isNone()) {
         const result_tag = self.ast.getNode(expr).tag;
         if (result_tag == .import_expression) {
-            self.addError(self.ast.getNode(expr).span, "'import' cannot be used with 'new'");
+            try self.addError(self.ast.getNode(expr).span, "'import' cannot be used with 'new'");
         }
     }
     while (true) {
         const expr_start = self.ast.getNode(expr).span.start;
         switch (self.current()) {
             .dot => {
-                self.advance();
+                try self.advance();
                 const prop = try parseIdentifierName(self);
                 expr = try self.ast.addNode(.{
                     .tag = .static_member_expression,
@@ -769,9 +769,9 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
                 });
             },
             .l_bracket => {
-                self.advance();
+                try self.advance();
                 const prop = try parseExpression(self);
-                self.expect(.r_bracket);
+                try self.expect(.r_bracket);
                 expr = try self.ast.addNode(.{
                     .tag = .computed_member_expression,
                     .span = .{ .start = expr_start, .end = self.currentSpan().start },
@@ -799,10 +799,10 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                         "'arguments' is not allowed in class static initializer"
                     else
                         "'arguments' is not allowed in class field initializer";
-                    self.addError(span, msg);
+                    try self.addError(span, msg);
                 }
             }
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .identifier_reference,
                 .span = span,
@@ -812,9 +812,9 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
         .decimal, .float, .hex, .octal, .binary, .positive_exponential, .negative_exponential => {
             // strict mode에서 legacy octal 숫자 금지 (ECMAScript 12.8.3.1)
             if (self.scanner.token.has_legacy_octal and self.is_strict_mode) {
-                self.addError(span, "Octal literals are not allowed in strict mode");
+                try self.addError(span, "Octal literals are not allowed in strict mode");
             }
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .numeric_literal,
                 .span = span,
@@ -822,7 +822,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             });
         },
         .decimal_bigint, .binary_bigint, .octal_bigint, .hex_bigint => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .bigint_literal,
                 .span = span,
@@ -832,9 +832,9 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
         .string_literal => {
             // strict mode에서 legacy octal escape 금지 (ECMAScript 12.8.4.1)
             if (self.scanner.token.has_legacy_octal and self.is_strict_mode) {
-                self.addError(span, "Octal escape sequences are not allowed in strict mode");
+                try self.addError(span, "Octal escape sequences are not allowed in strict mode");
             }
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .string_literal,
                 .span = span,
@@ -842,7 +842,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             });
         },
         .kw_true, .kw_false => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .boolean_literal,
                 .span = span,
@@ -850,7 +850,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             });
         },
         .kw_null => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .null_literal,
                 .span = span,
@@ -858,7 +858,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             });
         },
         .kw_this => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .this_expression,
                 .span = span,
@@ -868,19 +868,19 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
         .kw_new => {
             // new expression: new Callee(args)
             // new는 중첩 가능: new new Foo()()
-            self.advance(); // skip 'new'
+            try self.advance(); // skip 'new'
 
             // new.target — 메타 프로퍼티 (함수 안에서만 유효)
             if (self.current() == .dot) {
-                const peek = self.peekNextKind();
+                const peek = try self.peekNextKind();
                 if (peek == .kw_target) {
-                    self.advance(); // skip '.'
+                    try self.advance(); // skip '.'
                     const target_span = self.currentSpan();
-                    self.advance(); // skip 'target'
+                    try self.advance(); // skip 'target'
                     // ECMAScript 15.1.1: new.target은 함수 본문 안에서만 허용
                     // arrow function은 외부의 allow_new_target을 상속
                     if (!self.allow_new_target) {
-                        self.addError(.{ .start = span.start, .end = target_span.end }, "'new.target' is not allowed outside of functions");
+                        try self.addError(.{ .start = span.start, .end = target_span.end }, "'new.target' is not allowed outside of functions");
                     }
                     return try self.ast.addNode(.{
                         .tag = .meta_property,
@@ -895,7 +895,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
 
             // 인자: (args) — 있으면 소비, 없으면 인자 없는 new (new Foo)
             if (self.current() == .l_paren) {
-                self.advance(); // skip (
+                try self.advance(); // skip (
                 const arg_list = try parseArgumentList(self);
                 return try self.ast.addNode(.{
                     .tag = .new_expression,
@@ -917,9 +917,9 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             // allow_super_property는 메서드 진입 시 true, 일반 함수 진입 시 false로 리셋
             // arrow function은 외부의 allow_super_property를 상속
             if (!self.allow_super_property and !self.allow_super_call) {
-                self.addError(span, "'super' is not allowed outside of a method");
+                try self.addError(span, "'super' is not allowed outside of a method");
             }
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .super_expression,
                 .span = span,
@@ -929,11 +929,11 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
         .l_paren => {
             // 괄호 표현식 또는 arrow function 파라미터 리스트.
             // 괄호 안에서는 `in` 연산자가 항상 허용된다 (ECMAScript: [+In] 컨텍스트).
-            self.advance(); // skip (
+            try self.advance(); // skip (
 
             // 빈 괄호: () → arrow function의 빈 파라미터 리스트
             if (self.current() == .r_paren) {
-                self.advance(); // skip )
+                try self.advance(); // skip )
                 return try self.ast.addNode(.{
                     .tag = .parenthesized_expression,
                     .span = .{ .start = span.start, .end = self.currentSpan().start },
@@ -946,7 +946,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             const paren_saved = self.enterAllowInContext(true);
             const expr = try parseExpressionOrRest(self);
             self.restoreContext(paren_saved);
-            self.expect(.r_paren);
+            try self.expect(.r_paren);
             return try self.ast.addNode(.{
                 .tag = .parenthesized_expression,
                 .span = .{ .start = span.start, .end = self.currentSpan().start },
@@ -965,16 +965,16 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             const decorators = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
             self.restoreScratch(scratch_top);
             if (self.current() != .kw_class) {
-                self.addError(self.currentSpan(), "Class expected after decorator");
+                try self.addError(self.currentSpan(), "Class expected after decorator");
             }
             return self.parseClassWithDecorators(.class_expression, decorators);
         },
         .kw_function => return self.parseFunctionExpression(),
         .l_angle => return self.parseJSXElement(),
         .kw_import => {
-            self.advance(); // skip 'import'
+            try self.advance(); // skip 'import'
             if (self.current() == .dot) {
-                self.advance(); // skip '.'
+                try self.advance(); // skip '.'
                 const prop_span = self.currentSpan();
                 const prop_name = try parseIdentifierName(self);
                 _ = prop_name;
@@ -984,7 +984,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                 const prop_text = self.ast.source[prop_span.start..prop_span.end];
                 if (std.mem.eql(u8, prop_text, "meta")) {
                     if (!self.is_module) {
-                        self.addError(.{ .start = span.start, .end = prop_span.end }, "'import.meta' is only allowed in module code");
+                        try self.addError(.{ .start = span.start, .end = prop_span.end }, "'import.meta' is only allowed in module code");
                     }
                     return try self.ast.addNode(.{
                         .tag = .meta_property,
@@ -998,7 +998,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                 const is_source = std.mem.eql(u8, prop_text, "source");
                 const is_defer = std.mem.eql(u8, prop_text, "defer");
                 if (!is_source and !is_defer) {
-                    self.addError(.{ .start = span.start, .end = prop_span.end }, "Expected 'import.meta', 'import.source', or 'import.defer'");
+                    try self.addError(.{ .start = span.start, .end = prop_span.end }, "Expected 'import.meta', 'import.source', or 'import.defer'");
                     return try self.ast.addNode(.{
                         .tag = .meta_property,
                         .span = .{ .start = span.start, .end = prop_span.end },
@@ -1012,7 +1012,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                 }
 
                 // import.source/defer without () → 에러
-                self.addError(.{ .start = span.start, .end = prop_span.end }, "'import.source'/'import.defer' requires arguments");
+                try self.addError(.{ .start = span.start, .end = prop_span.end }, "'import.source'/'import.defer' requires arguments");
                 return try self.ast.addNode(.{
                     .tag = .meta_property,
                     .span = .{ .start = span.start, .end = prop_span.end },
@@ -1026,9 +1026,9 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             // 보간 없는 템플릿 리터럴: `text`
             // untagged template에서 잘못된 이스케이프는 SyntaxError (ECMAScript 13.2.8.1)
             if (self.scanner.token.has_invalid_escape) {
-                self.addError(span, "Invalid escape sequence in template literal");
+                try self.addError(span, "Invalid escape sequence in template literal");
             }
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .template_literal,
                 .span = span,
@@ -1039,12 +1039,12 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             // 보간 있는 템플릿 리터럴: `text${expr}...`
             // untagged template에서 잘못된 이스케이프는 SyntaxError
             if (self.scanner.token.has_invalid_escape) {
-                self.addError(span, "Invalid escape sequence in template literal");
+                try self.addError(span, "Invalid escape sequence in template literal");
             }
             return parseTemplateLiteral(self, false);
         },
         .regexp_literal => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .regexp_literal,
                 .span = span,
@@ -1072,7 +1072,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             // 멤버 표현식(this.#foo, obj.#foo)이 아닌 독립적인 #identifier를
             // primary expression으로 파싱하면, 이후 parseBinaryExpression에서
             // `in` 연산자와 자연스럽게 결합된다.
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .private_identifier,
                 .span = span,
@@ -1081,14 +1081,14 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
         },
         .kw_async => {
             // async function expression 또는 async arrow
-            const peek = self.peekNext();
+            const peek = try self.peekNext();
             if (peek.kind == .kw_function and !peek.has_newline_before) {
                 // async function expression
-                self.advance(); // skip 'async'
+                try self.advance(); // skip 'async'
                 return self.parseFunctionExpressionWithFlags(ast_mod.FunctionFlags.is_async);
             }
             // async를 일반 식별자로 취급 (async arrow는 parseAssignmentExpression에서 처리)
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .identifier_reference,
                 .span = span,
@@ -1099,10 +1099,10 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             // escaped strict reserved → strict mode에서 에러, non-strict에서 identifier
             if (self.current() == .escaped_strict_reserved) {
                 if (self.is_strict_mode) {
-                    self.addError(span, "Escaped reserved word cannot be used as identifier in strict mode");
+                    try self.addError(span, "Escaped reserved word cannot be used as identifier in strict mode");
                 }
-                _ = self.checkYieldAwaitUse(span, "identifier");
-                self.advance();
+                _ = try self.checkYieldAwaitUse(span, "identifier");
+                try self.advance();
                 return try self.ast.addNode(.{
                     .tag = .identifier_reference,
                     .span = span,
@@ -1115,11 +1115,11 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                 (!self.current().isReservedKeyword() or self.current() == .kw_await or self.current() == .kw_yield))
             {
                 if (self.is_strict_mode and self.current().isStrictModeReserved()) {
-                    self.addError(span, "Reserved word in strict mode cannot be used as identifier");
+                    try self.addError(span, "Reserved word in strict mode cannot be used as identifier");
                 } else {
-                    _ = self.checkYieldAwaitUse(span, "identifier");
+                    _ = try self.checkYieldAwaitUse(span, "identifier");
                 }
-                self.advance();
+                try self.advance();
                 return try self.ast.addNode(.{
                     .tag = .identifier_reference,
                     .span = span,
@@ -1127,8 +1127,8 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                 });
             }
             // 에러 복구: 알 수 없는 토큰 → 에러 노드 생성 후 건너뜀
-            self.addError(span, "Expression expected");
-            self.advance();
+            try self.addError(span, "Expression expected");
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .invalid,
                 .span = span,
@@ -1150,7 +1150,7 @@ fn parseTemplateLiteral(self: *Parser, is_tagged: bool) ParseError2!NodeIndex {
         .span = self.currentSpan(),
         .data = .{ .none = 0 },
     }));
-    self.advance(); // skip template_head
+    try self.advance(); // skip template_head
 
     while (true) {
         // expression inside ${} — `in` 연산자 항상 허용 (ECMAScript: TemplateMiddleList[+In])
@@ -1163,29 +1163,29 @@ fn parseTemplateLiteral(self: *Parser, is_tagged: bool) ParseError2!NodeIndex {
         if (self.current() == .template_middle) {
             // untagged template에서 잘못된 이스케이프는 SyntaxError
             if (!is_tagged and self.scanner.token.has_invalid_escape) {
-                self.addError(self.currentSpan(), "Invalid escape sequence in template literal");
+                try self.addError(self.currentSpan(), "Invalid escape sequence in template literal");
             }
             try self.scratch.append(try self.ast.addNode(.{
                 .tag = .template_element,
                 .span = self.currentSpan(),
                 .data = .{ .none = 0 },
             }));
-            self.advance();
+            try self.advance();
         } else if (self.current() == .template_tail) {
             // untagged template에서 잘못된 이스케이프는 SyntaxError
             if (!is_tagged and self.scanner.token.has_invalid_escape) {
-                self.addError(self.currentSpan(), "Invalid escape sequence in template literal");
+                try self.addError(self.currentSpan(), "Invalid escape sequence in template literal");
             }
             try self.scratch.append(try self.ast.addNode(.{
                 .tag = .template_element,
                 .span = self.currentSpan(),
                 .data = .{ .none = 0 },
             }));
-            self.advance();
+            try self.advance();
             break;
         } else {
             // 에러 복구: 닫히지 않은 템플릿
-            self.addError(self.currentSpan(), "Expected template continuation");
+            try self.addError(self.currentSpan(), "Expected template continuation");
             break;
         }
     }
@@ -1202,7 +1202,7 @@ fn parseTemplateLiteral(self: *Parser, is_tagged: bool) ParseError2!NodeIndex {
 
 fn parseArrayExpression(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip [
+    try self.advance(); // skip [
 
     var elements = std.ArrayList(NodeIndex).init(self.allocator);
     defer elements.deinit();
@@ -1216,12 +1216,12 @@ fn parseArrayExpression(self: *Parser) ParseError2!NodeIndex {
                 .span = hole_span,
                 .data = .{ .none = 0 },
             }));
-            self.advance();
+            try self.advance();
             continue;
         }
         const elem = try parseSpreadOrAssignment(self);
         try elements.append(elem);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
         // spread 뒤에 trailing comma가 있고 바로 ]가 오면 플래그를 설정.
         // 이 정보는 coverArrayExpressionToTarget에서 rest trailing comma 에러에 사용된다.
         if (!elem.isNone() and self.ast.getNode(elem).tag == .spread_element and self.current() == .r_bracket) {
@@ -1230,7 +1230,7 @@ fn parseArrayExpression(self: *Parser) ParseError2!NodeIndex {
     }
 
     const end = self.currentSpan().end;
-    self.expect(.r_bracket);
+    try self.expect(.r_bracket);
 
     const list = try self.ast.addNodeList(elements.items);
     return try self.ast.addNode(.{
@@ -1248,7 +1248,7 @@ pub fn parseIdentifierName(self: *Parser) ParseError2!NodeIndex {
         self.current() == .escaped_strict_reserved or self.current().isKeyword())
     {
         // IdentifierName: 예약어도 property name으로 사용 가능 (escaped 포함)
-        self.advance();
+        try self.advance();
         return try self.ast.addNode(.{
             .tag = .identifier_reference,
             .span = span,
@@ -1256,15 +1256,15 @@ pub fn parseIdentifierName(self: *Parser) ParseError2!NodeIndex {
         });
     }
     if (self.current() == .private_identifier) {
-        self.advance();
+        try self.advance();
         return try self.ast.addNode(.{
             .tag = .private_identifier,
             .span = span,
             .data = .{ .string_ref = span },
         });
     }
-    self.addError(span, "Identifier expected");
-    self.advance();
+    try self.addError(span, "Identifier expected");
+    try self.advance();
     return try self.ast.addNode(.{ .tag = .invalid, .span = span, .data = .{ .none = 0 } });
 }
 
@@ -1278,9 +1278,9 @@ pub fn parseModuleExportName(self: *Parser) ParseError2!NodeIndex {
         // lone surrogate 검사: \uD800-\uDFFF가 쌍을 이루지 않으면 에러
         const str_content = self.ast.source[span.start + 1 .. if (span.end > 0) span.end - 1 else span.end];
         if (containsLoneSurrogate(str_content)) {
-            self.addError(span, "String literal contains lone surrogate");
+            try self.addError(span, "String literal contains lone surrogate");
         }
-        self.advance();
+        try self.advance();
         return try self.ast.addNode(.{
             .tag = .string_literal,
             .span = span,
@@ -1368,9 +1368,9 @@ fn parseArgumentList(self: *Parser) ParseError2!NodeList {
     while (self.current() != .r_paren and self.current() != .eof) {
         const arg = try parseSpreadOrAssignment(self);
         try self.scratch.append(arg);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
     return list;
@@ -1382,7 +1382,7 @@ fn parseSpreadOrAssignment(self: *Parser) ParseError2!NodeIndex {
     defer self.restoreContext(arg_saved);
     if (self.current() == .dot3) {
         const start = self.currentSpan().start;
-        self.advance(); // skip ...
+        try self.advance(); // skip ...
         const arg = try parseAssignmentExpression(self);
         return try self.ast.addNode(.{
             .tag = .spread_element,
@@ -1398,7 +1398,7 @@ pub fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
     switch (self.current()) {
         .identifier, .escaped_keyword, .escaped_strict_reserved => {
             // property key: 예약어도 사용 가능 (obj.let, class { yield() {} })
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .identifier_reference,
                 .span = span,
@@ -1407,7 +1407,7 @@ pub fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
         },
         .private_identifier => {
             // #private 필드/메서드
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .private_identifier,
                 .span = span,
@@ -1415,7 +1415,7 @@ pub fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
             });
         },
         .string_literal => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .string_literal,
                 .span = span,
@@ -1423,7 +1423,7 @@ pub fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
             });
         },
         .decimal, .float, .hex, .octal, .binary, .positive_exponential, .negative_exponential => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .numeric_literal,
                 .span = span,
@@ -1431,7 +1431,7 @@ pub fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
             });
         },
         .decimal_bigint, .binary_bigint, .octal_bigint, .hex_bigint => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .bigint_literal,
                 .span = span,
@@ -1440,11 +1440,11 @@ pub fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
         },
         .l_bracket => {
             // computed property: [expr] — `in` 연산자 허용 (ECMAScript: ComputedPropertyName[+In])
-            self.advance();
+            try self.advance();
             const cpk_saved = self.enterAllowInContext(true);
             const expr = try parseAssignmentExpression(self);
             self.restoreContext(cpk_saved);
-            self.expect(.r_bracket);
+            try self.expect(.r_bracket);
             return try self.ast.addNode(.{
                 .tag = .computed_property_key,
                 .span = .{ .start = span.start, .end = self.currentSpan().start },
@@ -1454,15 +1454,15 @@ pub fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
         else => {
             // 다른 키워드도 프로퍼티 키로 허용 (class, return 등)
             if (self.current().isKeyword()) {
-                self.advance();
+                try self.advance();
                 return try self.ast.addNode(.{
                     .tag = .identifier_reference,
                     .span = span,
                     .data = .{ .string_ref = span },
                 });
             }
-            self.addError(span, "Property key expected");
-            self.advance();
+            try self.addError(span, "Property key expected");
+            try self.advance();
             return try self.ast.addNode(.{ .tag = .invalid, .span = span, .data = .{ .none = 0 } });
         },
     }

--- a/src/parser/jsx.zig
+++ b/src/parser/jsx.zig
@@ -16,11 +16,11 @@ const ParseError2 = @import("parser.zig").ParseError2;
 /// <Tag ...>children</Tag> 또는 <Tag ... /> 또는 <>...</>
 pub fn parseJSXElement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.scanner.nextInsideJSXElement(); // '<' 이후 JSX 모드
+    try self.scanner.nextInsideJSXElement(); // '<' 이후 JSX 모드
 
     // Fragment: <>
     if (self.current() == .r_angle) {
-        self.scanner.nextJSXChild(); // '>' 이후 children 모드
+        try self.scanner.nextJSXChild(); // '>' 이후 children 모드
         return parseJSXFragment(self, start);
     }
 
@@ -38,9 +38,9 @@ pub fn parseJSXElement(self: *Parser) ParseError2!NodeIndex {
 
     // Self-closing: />
     if (self.current() == .slash) {
-        self.scanner.nextInsideJSXElement(); // skip /
+        try self.scanner.nextInsideJSXElement(); // skip /
         // expect >
-        self.scanner.next(); // back to normal mode after >
+        try self.scanner.next(); // back to normal mode after >
 
         // 항상 5 fields: [tag, attrs_start, attrs_len, children_start, children_len]
         // self-closing은 children_len=0으로 통일하여 transformer에서 heuristic 불필요
@@ -58,29 +58,29 @@ pub fn parseJSXElement(self: *Parser) ParseError2!NodeIndex {
     }
 
     // > children </tag>
-    self.scanner.nextJSXChild(); // '>' 이후 children 모드
+    try self.scanner.nextJSXChild(); // '>' 이후 children 모드
 
     // Children
     const children_top = self.saveScratch();
     while (self.current() != .eof) {
         if (self.current() == .l_angle) {
             // 다음 토큰이 / 이면 닫는 태그 (JSX 모드로 peek)
-            if (self.peekNextKindJSX() == .slash) break;
+            if (try self.peekNextKindJSX() == .slash) break;
             // 중첩 JSX element
             const child = try parseJSXElement(self);
             try self.scratch.append(child);
         } else if (self.current() == .l_curly) {
             // JSX expression: {expr}
-            self.advance(); // skip {
+            try self.advance(); // skip {
             const expr = try self.parseExpression();
-            self.expect(.r_curly);
+            try self.expect(.r_curly);
             const container = try self.ast.addNode(.{
                 .tag = .jsx_expression_container,
                 .span = .{ .start = 0, .end = self.currentSpan().start },
                 .data = .{ .unary = .{ .operand = expr, .flags = 0 } },
             });
             try self.scratch.append(container);
-            self.scanner.nextJSXChild(); // '{expr}' 이후 다시 children 모드
+            try self.scanner.nextJSXChild(); // '{expr}' 이후 다시 children 모드
         } else if (self.current() == .jsx_text) {
             const text_span = self.currentSpan();
             try self.scratch.append(try self.ast.addNode(.{
@@ -88,7 +88,7 @@ pub fn parseJSXElement(self: *Parser) ParseError2!NodeIndex {
                 .span = text_span,
                 .data = .{ .string_ref = text_span },
             }));
-            self.scanner.nextJSXChild();
+            try self.scanner.nextJSXChild();
         } else {
             break;
         }
@@ -97,14 +97,14 @@ pub fn parseJSXElement(self: *Parser) ParseError2!NodeIndex {
     self.restoreScratch(children_top);
 
     // Closing tag: </TagName>
-    self.scanner.nextInsideJSXElement(); // skip <
-    self.scanner.nextInsideJSXElement(); // skip /
+    try self.scanner.nextInsideJSXElement(); // skip <
+    try self.scanner.nextInsideJSXElement(); // skip /
     // skip tag name
     if (self.current() == .jsx_identifier or self.current() == .identifier) {
-        self.scanner.nextInsideJSXElement();
+        try self.scanner.nextInsideJSXElement();
     }
     // expect >
-    self.scanner.next(); // back to normal mode
+    try self.scanner.next(); // back to normal mode
 
     const extra_start = try self.ast.addExtra(@intFromEnum(tag_name));
     _ = try self.ast.addExtra(attrs.start);
@@ -125,20 +125,20 @@ fn parseJSXFragment(self: *Parser, start: u32) ParseError2!NodeIndex {
     while (self.current() != .eof) {
         if (self.current() == .l_angle) {
             // JSX 모드로 peek (normal 모드에서는 /가 regex로 해석될 수 있음)
-            if (self.peekNextKindJSX() == .slash) break;
+            if (try self.peekNextKindJSX() == .slash) break;
             const child = try parseJSXElement(self);
             try self.scratch.append(child);
         } else if (self.current() == .l_curly) {
-            self.advance();
+            try self.advance();
             const expr = try self.parseExpression();
-            self.expect(.r_curly);
+            try self.expect(.r_curly);
             const container = try self.ast.addNode(.{
                 .tag = .jsx_expression_container,
                 .span = .{ .start = 0, .end = self.currentSpan().start },
                 .data = .{ .unary = .{ .operand = expr, .flags = 0 } },
             });
             try self.scratch.append(container);
-            self.scanner.nextJSXChild();
+            try self.scanner.nextJSXChild();
         } else if (self.current() == .jsx_text) {
             const text_span = self.currentSpan();
             try self.scratch.append(try self.ast.addNode(.{
@@ -146,7 +146,7 @@ fn parseJSXFragment(self: *Parser, start: u32) ParseError2!NodeIndex {
                 .span = text_span,
                 .data = .{ .string_ref = text_span },
             }));
-            self.scanner.nextJSXChild();
+            try self.scanner.nextJSXChild();
         } else {
             break;
         }
@@ -155,9 +155,9 @@ fn parseJSXFragment(self: *Parser, start: u32) ParseError2!NodeIndex {
     self.restoreScratch(children_top);
 
     // </>
-    self.scanner.nextInsideJSXElement(); // <
-    self.scanner.nextInsideJSXElement(); // /
-    self.scanner.next(); // >
+    try self.scanner.nextInsideJSXElement(); // <
+    try self.scanner.nextInsideJSXElement(); // /
+    try self.scanner.next(); // >
 
     return try self.ast.addNode(.{
         .tag = .jsx_fragment,
@@ -169,14 +169,14 @@ fn parseJSXFragment(self: *Parser, start: u32) ParseError2!NodeIndex {
 fn parseJSXTagName(self: *Parser) ParseError2!NodeIndex {
     const span = self.currentSpan();
     if (self.current() == .jsx_identifier or self.current() == .identifier) {
-        self.scanner.nextInsideJSXElement();
+        try self.scanner.nextInsideJSXElement();
         return try self.ast.addNode(.{
             .tag = .jsx_identifier,
             .span = span,
             .data = .{ .string_ref = span },
         });
     }
-    self.addError(span, "JSX tag name expected");
+    try self.addError(span, "JSX tag name expected");
     return NodeIndex.none;
 }
 
@@ -185,24 +185,24 @@ fn parseJSXAttribute(self: *Parser) ParseError2!NodeIndex {
 
     // spread attribute: {...expr}
     if (self.current() == .l_curly) {
-        self.advance();
+        try self.advance();
         if (self.current() == .dot3) {
-            self.advance();
+            try self.advance();
             const expr = try self.parseAssignmentExpression();
-            self.expect(.r_curly);
+            try self.expect(.r_curly);
             return try self.ast.addNode(.{
                 .tag = .jsx_spread_attribute,
                 .span = .{ .start = start, .end = self.currentSpan().start },
                 .data = .{ .unary = .{ .operand = expr, .flags = 0 } },
             });
         }
-        self.addError(self.currentSpan(), "Spread expected");
+        try self.addError(self.currentSpan(), "Spread expected");
         return NodeIndex.none;
     }
 
     // name="value" or name={expr}
     const name_span = self.currentSpan();
-    self.scanner.nextInsideJSXElement(); // skip attribute name
+    try self.scanner.nextInsideJSXElement(); // skip attribute name
 
     const name = try self.ast.addNode(.{
         .tag = .jsx_identifier,
@@ -212,19 +212,19 @@ fn parseJSXAttribute(self: *Parser) ParseError2!NodeIndex {
 
     var value = NodeIndex.none;
     if (self.current() == .eq) {
-        self.scanner.nextInsideJSXElement(); // skip =
+        try self.scanner.nextInsideJSXElement(); // skip =
         if (self.current() == .string_literal) {
             const val_span = self.currentSpan();
-            self.scanner.nextInsideJSXElement();
+            try self.scanner.nextInsideJSXElement();
             value = try self.ast.addNode(.{
                 .tag = .string_literal,
                 .span = val_span,
                 .data = .{ .string_ref = val_span },
             });
         } else if (self.current() == .l_curly) {
-            self.advance();
+            try self.advance();
             value = try self.parseAssignmentExpression();
-            self.expect(.r_curly);
+            try self.expect(.r_curly);
         }
     }
 

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -23,18 +23,18 @@ const ParseError2 = @import("parser.zig").ParseError2;
 /// `(` 를 소비하고, 1~2개 인자를 파싱하고, `)` 를 기대한다.
 /// import() 내부에서는 `in` 연산자를 허용 (+In context).
 pub fn parseImportCallArgs(self: *Parser, start: u32) ParseError2!NodeIndex {
-    self.expect(.l_paren);
+    try self.expect(.l_paren);
     const saved_ctx = self.enterAllowInContext(true);
     defer self.restoreContext(saved_ctx);
     const arg = try self.parseAssignmentExpression();
     // 두 번째 인자 (import attributes/options) — 있으면 파싱하고 무시
-    if (self.eat(.comma)) {
+    if (try self.eat(.comma)) {
         if (self.current() != .r_paren) {
             _ = try self.parseAssignmentExpression();
-            _ = self.eat(.comma); // trailing comma
+            _ = try self.eat(.comma); // trailing comma
         }
     }
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     return try self.ast.addNode(.{
         .tag = .import_expression,
         .span = .{ .start = start, .end = self.currentSpan().start },
@@ -46,11 +46,11 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     // ECMAScript 15.2: import 선언은 module의 top-level에서만 허용
     if (!self.is_module) {
-        self.addError(self.currentSpan(), "'import' declaration is only allowed in module code");
+        try self.addError(self.currentSpan(), "'import' declaration is only allowed in module code");
     } else if (!self.ctx.is_top_level) {
-        self.addError(self.currentSpan(), "'import' declaration must be at the top level");
+        try self.addError(self.currentSpan(), "'import' declaration must be at the top level");
     }
-    self.advance(); // skip 'import'
+    try self.advance(); // skip 'import'
 
     // import defer / import source — Stage 3 proposals
     // defer/source를 스킵하고 나머지는 일반 import로 처리
@@ -60,16 +60,16 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
             std.mem.eql(u8, self.ast.source[self.currentSpan().start..self.currentSpan().end], "source")))
     {
         has_phase_modifier = true;
-        self.advance(); // skip defer/source
+        try self.advance(); // skip defer/source
     }
 
     // import "module" — side-effect import
     if (self.current() == .string_literal) {
         if (has_phase_modifier) {
-            self.addError(self.currentSpan(), "'import defer/source' requires a binding");
+            try self.addError(self.currentSpan(), "'import defer/source' requires a binding");
         }
         const source_node = try parseModuleSource(self);
-        _ = self.eat(.semicolon);
+        _ = try self.eat(.semicolon);
         return try self.ast.addNode(.{
             .tag = .import_declaration,
             .span = .{ .start = start, .end = self.currentSpan().start },
@@ -81,16 +81,16 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .l_paren) {
         // import 키워드는 이미 advance()됨. parsePrimaryExpression에 위임하기 위해
         // 수동으로 import expression 생성.
-        self.expect(.l_paren);
+        try self.expect(.l_paren);
         const arg = try self.parseAssignmentExpression();
-        self.expect(.r_paren);
+        try self.expect(.r_paren);
         const import_expr = try self.ast.addNode(.{
             .tag = .import_expression,
             .span = .{ .start = start, .end = self.currentSpan().start },
             .data = .{ .unary = .{ .operand = arg, .flags = 0 } },
         });
         // 후속 .then() 등의 member/call 체이닝 처리
-        _ = self.eat(.semicolon);
+        _ = try self.eat(.semicolon);
         return try self.ast.addNode(.{
             .tag = .expression_statement,
             .span = .{ .start = start, .end = self.currentSpan().start },
@@ -104,10 +104,10 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     // default import: import foo from "module"
     var has_default = false;
     if (self.current() == .identifier) {
-        const next = self.peekNextKind();
+        const next = try self.peekNextKind();
         if (next == .comma or next == .kw_from) {
             const spec_span = self.currentSpan();
-            self.advance();
+            try self.advance();
             const spec = try self.ast.addNode(.{
                 .tag = .import_default_specifier,
                 .span = spec_span,
@@ -116,14 +116,14 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
             try self.scratch.append(spec);
             has_default = true;
 
-            if (self.eat(.comma)) {
+            if (try self.eat(.comma)) {
                 // import default, { ... } from "module"
                 // import default, * as ns from "module"
             } else {
                 // import default from "module"
-                self.expect(.kw_from);
+                try self.expect(.kw_from);
                 const source_node = try parseModuleSource(self);
-                _ = self.eat(.semicolon);
+                _ = try self.eat(.semicolon);
 
                 const specifiers = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
                 self.restoreScratch(scratch_top);
@@ -142,10 +142,10 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
 
     // namespace import: import * as ns from "module"
     if (self.current() == .star) {
-        self.advance(); // skip *
-        self.expect(.kw_as);
+        try self.advance(); // skip *
+        try self.expect(.kw_as);
         const local_span = self.currentSpan();
-        self.expect(.identifier);
+        try self.expect(.identifier);
         const spec = try self.ast.addNode(.{
             .tag = .import_namespace_specifier,
             .span = local_span,
@@ -156,18 +156,18 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
 
     // named imports: import { a, b as c } from "module"
     if (self.current() == .l_curly) {
-        self.advance(); // skip {
+        try self.advance(); // skip {
         while (self.current() != .r_curly and self.current() != .eof) {
             const spec = try parseImportSpecifier(self);
             try self.scratch.append(spec);
-            if (!self.eat(.comma)) break;
+            if (!try self.eat(.comma)) break;
         }
-        self.expect(.r_curly);
+        try self.expect(.r_curly);
     }
 
-    self.expect(.kw_from);
+    try self.expect(.kw_from);
     const source_node = try parseModuleSource(self);
-    _ = self.eat(.semicolon);
+    _ = try self.eat(.semicolon);
 
     const specifiers = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -192,14 +192,14 @@ fn parseImportSpecifier(self: *Parser) ParseError2!NodeIndex {
     // import { "☿" as Ami } from ... (OK)
     // import { "☿" } from ... (Error — string cannot be used as binding)
     var local = imported;
-    if (self.eat(.kw_as)) {
+    if (try self.eat(.kw_as)) {
         // `as` 뒤는 반드시 BindingIdentifier (string literal 불가)
         local = try self.parseIdentifierName();
     } else if (!imported.isNone() and @intFromEnum(imported) < self.ast.nodes.items.len and
         self.ast.getNode(imported).tag == .string_literal)
     {
         // string literal without `as` — binding 이름이 없으므로 에러
-        self.addError(self.ast.getNode(imported).span, "String literal in import specifier requires 'as' binding");
+        try self.addError(self.ast.getNode(imported).span, "String literal in import specifier requires 'as' binding");
     }
 
     return try self.ast.addNode(.{
@@ -213,14 +213,14 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     // ECMAScript 15.2: export 선언은 module의 top-level에서만 허용
     if (!self.is_module) {
-        self.addError(self.currentSpan(), "'export' declaration is only allowed in module code");
+        try self.addError(self.currentSpan(), "'export' declaration is only allowed in module code");
     } else if (!self.ctx.is_top_level) {
-        self.addError(self.currentSpan(), "'export' declaration must be at the top level");
+        try self.addError(self.currentSpan(), "'export' declaration must be at the top level");
     }
-    self.advance(); // skip 'export'
+    try self.advance(); // skip 'export'
 
     // export default
-    if (self.eat(.kw_default)) {
+    if (try self.eat(.kw_default)) {
         const decl = switch (self.current()) {
             // export default function / export default function* — 이름 선택적
             .kw_function => blk: {
@@ -228,7 +228,7 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
                 // anonymous function declaration은 호출 불가 (IIFE가 아님)
                 // export default function() {}() → SyntaxError
                 if (self.current() == .l_paren) {
-                    self.addError(self.currentSpan(), "Anonymous function declaration cannot be invoked");
+                    try self.addError(self.currentSpan(), "Anonymous function declaration cannot be invoked");
                 }
                 break :blk fn_decl;
             },
@@ -236,17 +236,17 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
             else => blk: {
                 // export default async function / export default async function* — 이름 선택적
                 if (self.current() == .kw_async) {
-                    const peek = self.peekNext();
+                    const peek = try self.peekNext();
                     if (peek.kind == .kw_function and !peek.has_newline_before) {
                         const fn_decl = try self.parseAsyncFunctionDeclarationDefaultExport();
                         if (self.current() == .l_paren) {
-                            self.addError(self.currentSpan(), "Anonymous function declaration cannot be invoked");
+                            try self.addError(self.currentSpan(), "Anonymous function declaration cannot be invoked");
                         }
                         break :blk fn_decl;
                     }
                 }
                 const expr = try self.parseAssignmentExpression();
-                self.expectSemicolon();
+                try self.expectSemicolon();
                 break :blk expr;
             },
         };
@@ -259,14 +259,14 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
 
     // export * from "module" / export * as ns from "module"
     if (self.current() == .star) {
-        self.advance(); // skip *
+        try self.advance(); // skip *
         var exported_name = NodeIndex.none;
-        if (self.eat(.kw_as)) {
+        if (try self.eat(.kw_as)) {
             exported_name = try self.parseModuleExportName();
         }
-        self.expect(.kw_from);
+        try self.expect(.kw_from);
         const source_node = try parseModuleSource(self);
-        self.expectSemicolon();
+        try self.expectSemicolon();
 
         return try self.ast.addNode(.{
             .tag = .export_all_declaration,
@@ -277,22 +277,22 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
 
     // export { a, b } / export { a } from "module"
     if (self.current() == .l_curly) {
-        self.advance(); // skip {
+        try self.advance(); // skip {
 
         const scratch_top = self.saveScratch();
         while (self.current() != .r_curly and self.current() != .eof) {
             const spec = try parseExportSpecifier(self);
             try self.scratch.append(spec);
-            if (!self.eat(.comma)) break;
+            if (!try self.eat(.comma)) break;
         }
-        self.expect(.r_curly);
+        try self.expect(.r_curly);
 
         // re-export: export { a } from "module"
         var source_node = NodeIndex.none;
-        if (self.eat(.kw_from)) {
+        if (try self.eat(.kw_from)) {
             source_node = try parseModuleSource(self);
         }
-        self.expectSemicolon();
+        try self.expectSemicolon();
 
         // export NamedExports ; (without `from`) →
         // local 이름에 string literal 사용 불가
@@ -307,7 +307,7 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
                     if (!local_idx.isNone() and @intFromEnum(local_idx) < self.ast.nodes.items.len) {
                         const local_node = self.ast.getNode(local_idx);
                         if (local_node.tag == .string_literal) {
-                            self.addError(local_node.span, "String literal cannot be used as local binding in export");
+                            try self.addError(local_node.span, "String literal cannot be used as local binding in export");
                         }
                     }
                 }
@@ -354,7 +354,7 @@ fn parseExportSpecifier(self: *Parser) ParseError2!NodeIndex {
     const local = try self.parseModuleExportName();
 
     var exported = local;
-    if (self.eat(.kw_as)) {
+    if (try self.eat(.kw_as)) {
         exported = try self.parseModuleExportName();
     }
 
@@ -368,32 +368,32 @@ fn parseExportSpecifier(self: *Parser) ParseError2!NodeIndex {
 fn parseModuleSource(self: *Parser) ParseError2!NodeIndex {
     const span = self.currentSpan();
     if (self.current() == .string_literal) {
-        self.advance();
+        try self.advance();
         // import attributes: with { type: 'json' } 또는 assert { type: 'json' }
-        skipImportAttributes(self);
+        try skipImportAttributes(self);
         return try self.ast.addNode(.{
             .tag = .string_literal,
             .span = span,
             .data = .{ .string_ref = span },
         });
     }
-    self.addError(span, "Module source string expected");
+    try self.addError(span, "Module source string expected");
     return NodeIndex.none;
 }
 
 /// import attributes (with/assert { ... })를 파싱한다.
 /// AST에 저장하지 않고 소비만 한다 (트랜스포머에서 필요 시 추가).
 /// 중복 키 검사도 수행한다 (ECMAScript: WithClauseToAttributes 중복 에러).
-fn skipImportAttributes(self: *Parser) void {
+fn skipImportAttributes(self: *Parser) !void {
     // with { ... }: 줄바꿈 허용 (ECMAScript: AttributesKeyword = with)
     // assert { ... }: 줄바꿈 불허 (ECMAScript: [no LineTerminator here] assert)
     const is_with = self.current() == .kw_with;
     const is_assert = self.current() == .kw_assert and !self.scanner.token.has_newline_before;
     if (!is_with and !is_assert) return;
 
-    self.advance(); // skip with/assert
+    try self.advance(); // skip with/assert
     if (self.current() == .l_curly) {
-        self.advance(); // skip {
+        try self.advance(); // skip {
 
         // 중복 키 검사를 위한 키 수집 (최대 16개, 초과 시 검사 생략)
         var keys: [16][]const u8 = undefined;
@@ -404,7 +404,7 @@ fn skipImportAttributes(self: *Parser) void {
             // key: identifier 또는 string literal
             const key_span = self.currentSpan();
             const key_text = self.ast.source[key_span.start..key_span.end];
-            self.advance(); // key
+            try self.advance(); // key
 
             // 중복 키 검사
             if (key_count < 16) {
@@ -417,7 +417,7 @@ fn skipImportAttributes(self: *Parser) void {
 
                 for (0..key_count) |i| {
                     if (std.mem.eql(u8, keys[i], effective_key)) {
-                        self.addError(key_span, "Duplicate import attribute key");
+                        try self.addError(key_span, "Duplicate import attribute key");
                         break;
                     }
                 }
@@ -426,13 +426,13 @@ fn skipImportAttributes(self: *Parser) void {
                 key_count += 1;
             }
 
-            _ = self.eat(.colon);
+            _ = try self.eat(.colon);
             if (self.current() != .r_curly and self.current() != .eof) {
-                self.advance(); // value
+                try self.advance(); // value
             }
-            _ = self.eat(.comma);
+            _ = try self.eat(.comma);
         }
-        _ = self.eat(.r_curly);
+        _ = try self.eat(.r_curly);
     }
 }
 

--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -17,7 +17,7 @@ const ParseError2 = @import("parser.zig").ParseError2;
 
 pub fn parseObjectExpression(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip {
+    try self.advance(); // skip {
 
     var props = std.ArrayList(NodeIndex).init(self.allocator);
     defer props.deinit();
@@ -25,7 +25,7 @@ pub fn parseObjectExpression(self: *Parser) ParseError2!NodeIndex {
     while (self.current() != .r_curly and self.current() != .eof) {
         const prop = try parseObjectProperty(self);
         try props.append(prop);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
 
     const end = self.currentSpan().end;
@@ -34,7 +34,7 @@ pub fn parseObjectExpression(self: *Parser) ParseError2!NodeIndex {
     // prev_token_kind를 `.r_paren`으로 설정하면 scanSlash()가 division으로 판별한다.
     // 예: `{valueOf: fn} / 1` — object literal 뒤 division
     self.scanner.prev_token_kind = .r_paren;
-    self.expect(.r_curly);
+    try self.expect(.r_curly);
 
     const list = try self.ast.addNodeList(props.items);
     return try self.ast.addNode(.{
@@ -49,7 +49,7 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
 
     // spread: ...expr
     if (self.current() == .dot3) {
-        self.advance();
+        try self.advance();
         const expr = try self.parseAssignmentExpression();
         return try self.ast.addNode(.{
             .tag = .spread_element,
@@ -60,10 +60,10 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
 
     // get/set 메서드 shorthand: { get prop() {}, set prop(v) {} }
     if (self.current() == .kw_get or self.current() == .kw_set) {
-        const peek = self.peekNextKind();
+        const peek = try self.peekNextKind();
         if (peek != .colon and peek != .l_paren and peek != .comma and peek != .r_curly) {
             const method_flags: u16 = if (self.current() == .kw_get) 0x02 else 0x04;
-            self.advance(); // skip get/set
+            try self.advance(); // skip get/set
             const key = try self.parsePropertyKey();
             return parseObjectMethodBody(self, start, key, method_flags);
         }
@@ -71,14 +71,14 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
 
     // async 메서드 shorthand: { async foo() {} }
     if (self.current() == .kw_async) {
-        const peek = self.peekNext();
+        const peek = try self.peekNext();
         if (peek.kind != .colon and peek.kind != .comma and
             peek.kind != .r_curly and !peek.has_newline_before)
         {
             var method_flags: u16 = 0x08; // async
-            self.advance(); // skip 'async'
+            try self.advance(); // skip 'async'
             // async generator: { async *foo() {} }
-            if (self.eat(.star)) method_flags |= 0x10;
+            if (try self.eat(.star)) method_flags |= 0x10;
             const key = try self.parsePropertyKey();
             return parseObjectMethodBody(self, start, key, method_flags);
         }
@@ -86,7 +86,7 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
 
     // generator 메서드: { *foo() {} }
     if (self.current() == .star) {
-        self.advance(); // skip '*'
+        try self.advance(); // skip '*'
         const key = try self.parsePropertyKey();
         return parseObjectMethodBody(self, start, key, 0x10); // generator
     }
@@ -96,7 +96,7 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
 
     // object literal에서 private identifier는 키로 사용 불가
     if (!key.isNone() and self.ast.getNode(key).tag == .private_identifier) {
-        self.addError(self.ast.getNode(key).span, "Private identifier is not allowed as object property key");
+        try self.addError(self.ast.getNode(key).span, "Private identifier is not allowed as object property key");
     }
 
     // 메서드 shorthand: { foo() {} }
@@ -107,9 +107,9 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
     // key: value
     var value = NodeIndex.none;
     var prop_flags: u16 = 0;
-    if (self.eat(.colon)) {
+    if (try self.eat(.colon)) {
         value = try self.parseAssignmentExpression();
-    } else if (self.eat(.eq)) {
+    } else if (try self.eat(.eq)) {
         // shorthand with default: { x = 1 }  (destructuring default)
         // CoverInitializedName — destructuring 변환에서 소비되지 않으면 에러
         value = try self.parseAssignmentExpression();
@@ -130,19 +130,19 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
                         else
                             kw.isReservedKeyword() or kw.isLiteralKeyword();
                         if (is_context_reserved) {
-                            self.addError(key_node.span, "Reserved word cannot be used as shorthand property");
+                            try self.addError(key_node.span, "Reserved word cannot be used as shorthand property");
                         } else if (self.is_strict_mode and kw.isStrictModeReserved()) {
-                            self.addError(key_node.span, "Reserved word in strict mode cannot be used as shorthand property");
+                            try self.addError(key_node.span, "Reserved word in strict mode cannot be used as shorthand property");
                         } else if (kw == .kw_yield and self.ctx.in_generator) {
-                            self.addError(key_node.span, "'yield' cannot be used as shorthand property in generator");
+                            try self.addError(key_node.span, "'yield' cannot be used as shorthand property in generator");
                         } else if (kw == .kw_await and (self.ctx.in_async or self.is_module)) {
-                            self.addError(key_node.span, "'await' cannot be used as shorthand property in async/module");
+                            try self.addError(key_node.span, "'await' cannot be used as shorthand property in async/module");
                         }
                     }
                 },
                 // non-identifier keys (numeric, bigint, string, computed) 는 shorthand 불가
                 .numeric_literal, .bigint_literal, .string_literal, .computed_property_key => {
-                    self.addError(key_node.span, "Expected ':' after property key");
+                    try self.addError(key_node.span, "Expected ':' after property key");
                 },
                 else => {},
             }
@@ -165,27 +165,27 @@ pub fn parseObjectMethodBody(self: *Parser, start: u32, key: NodeIndex, flags: u
     // ECMAScript 12.3.7: 객체 리터럴 메서드에서도 super.prop 허용
     self.allow_super_property = true;
 
-    self.expect(.l_paren);
+    try self.expect(.l_paren);
     self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const param = try self.parseBindingIdentifier();
         try self.scratch.append(param);
-        self.checkRestParameterLast(param);
-        if (!self.eat(.comma)) break;
+        try self.checkRestParameterLast(param);
+        if (!try self.eat(.comma)) break;
     }
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     self.in_formal_parameters = false;
 
     // TS 리턴 타입
     _ = try self.tryParseReturnType();
     self.has_simple_params = self.checkSimpleParams(scratch_top);
-    self.checkDuplicateParams(scratch_top);
+    try self.checkDuplicateParams(scratch_top);
     const body = try self.parseFunctionBodyExpr();
 
     // retroactive strict mode checks for object methods
     if (self.is_strict_mode and !saved_ctx.is_strict_mode) {
-        self.checkStrictParamNames(scratch_top);
+        try self.checkStrictParamNames(scratch_top);
     }
 
     self.restoreFunctionContext(saved_ctx);

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -220,14 +220,14 @@ pub const Parser = struct {
     }
 
     /// 다음 토큰으로 전진. 여는/닫는 괄호를 자동 추적한다.
-    pub fn advance(self: *Parser) void {
+    pub fn advance(self: *Parser) !void {
         const kind = self.current();
         // 여는 괄호면 스택에 push
         if (kind == .l_paren or kind == .l_bracket or kind == .l_curly) {
-            self.bracket_stack.append(.{
+            try self.bracket_stack.append(.{
                 .kind = kind,
                 .span = self.currentSpan(),
-            }) catch @panic("OOM: bracket stack");
+            });
         } else if (kind == .r_paren or kind == .r_bracket or kind == .r_curly) {
             // 닫는 괄호면 스택에서 매칭되는 여는 괄호만 pop.
             // 매칭 안 되면 pop하지 않는다 — 에러 복구 시 스택 오염 방지.
@@ -243,13 +243,13 @@ pub const Parser = struct {
                 _ = self.bracket_stack.pop();
             }
         }
-        self.scanner.next();
+        try self.scanner.next();
     }
 
     /// 현재 토큰이 expected이면 소비하고 true, 아니면 false.
-    pub fn eat(self: *Parser, expected: Kind) bool {
+    pub fn eat(self: *Parser, expected: Kind) !bool {
         if (self.current() == expected) {
-            self.advance();
+            try self.advance();
             return true;
         }
         return false;
@@ -257,10 +257,10 @@ pub const Parser = struct {
 
     /// 현재 토큰이 expected이면 소비, 아니면 "Expected X but found Y" 에러 추가.
     /// 닫는 괄호를 기대하는 경우, 매칭되는 여는 괄호 위치도 표시한다.
-    pub fn expect(self: *Parser, expected: Kind) void {
-        if (!self.eat(expected)) {
+    pub fn expect(self: *Parser, expected: Kind) !void {
+        if (!try self.eat(expected)) {
             const opening = self.findMatchingOpenBracket(expected);
-            self.errors.append(.{
+            try self.errors.append(.{
                 .span = self.currentSpan(),
                 .message = expected.symbol(),
                 .found = self.current().symbol(),
@@ -271,7 +271,7 @@ pub const Parser = struct {
                     .l_curly => "opening '{' is here",
                     else => null,
                 } else null,
-            }) catch @panic("OOM: parser error list");
+            });
         }
     }
 
@@ -280,24 +280,24 @@ pub const Parser = struct {
     /// - 현재 토큰 앞에 개행이 있으면 OK (ASI)
     /// - 현재 토큰이 } 또는 EOF이면 OK (ASI)
     /// - 그 외: "Expected ';' but found X" + 힌트
-    pub fn expectSemicolon(self: *Parser) void {
-        if (self.eat(.semicolon)) return;
+    pub fn expectSemicolon(self: *Parser) !void {
+        if (try self.eat(.semicolon)) return;
         if (self.scanner.token.has_newline_before) return;
         if (self.current() == .r_curly or self.current() == .eof) return;
-        self.errors.append(.{
+        try self.errors.append(.{
             .span = self.currentSpan(),
             .message = ";",
             .found = self.current().symbol(),
             .hint = "Try inserting a semicolon here",
-        }) catch @panic("OOM: parser error list");
+        });
     }
 
     /// 에러를 추가한다. 기존 호출부 하위 호환 — found/hint 등은 null.
-    pub fn addError(self: *Parser, span: Span, expected: []const u8) void {
-        self.errors.append(.{
+    pub fn addError(self: *Parser, span: Span, expected: []const u8) !void {
+        try self.errors.append(.{
             .span = span,
             .message = expected,
-        }) catch @panic("OOM: parser error list");
+        });
     }
 
     /// 닫는 괄호에 매칭되는 여는 괄호를 bracket_stack에서 찾는다.
@@ -337,9 +337,9 @@ pub const Parser = struct {
 
     /// rest parameter가 마지막이 아니면 에러.
     /// spread_element 뒤에 comma가 오면 rest가 마지막이 아닌 것.
-    pub fn checkRestParameterLast(self: *Parser, param: NodeIndex) void {
+    pub fn checkRestParameterLast(self: *Parser, param: NodeIndex) ParseError2!void {
         if (!param.isNone() and self.ast.getNode(param).tag == .spread_element and self.current() == .comma) {
-            self.addError(self.currentSpan(), "Rest parameter must be last formal parameter");
+            try self.addError(self.currentSpan(), "Rest parameter must be last formal parameter");
         }
     }
 
@@ -350,11 +350,11 @@ pub const Parser = struct {
 
     /// strict mode에서 eval/arguments를 바인딩 이름으로 사용하면 에러.
     /// escaped 형태 (\u0065val → "eval")도 검증한다.
-    pub fn checkStrictBinding(self: *Parser, span: Span) void {
+    pub fn checkStrictBinding(self: *Parser, span: Span) ParseError2!void {
         if (!self.is_strict_mode) return;
         const text = self.resolveIdentifierText(span);
         if (std.mem.eql(u8, text, "eval") or std.mem.eql(u8, text, "arguments")) {
-            self.addError(span, "Assignment to 'eval' or 'arguments' is not allowed in strict mode");
+            try self.addError(span, "Assignment to 'eval' or 'arguments' is not allowed in strict mode");
         }
     }
 
@@ -368,12 +368,12 @@ pub const Parser = struct {
 
     /// binding pattern에서 rest element가 assignment_pattern(= initializer)이면 에러.
     /// parseArrayPattern, parseObjectPattern, parseBindingPattern의 rest 처리에서 공통 사용.
-    pub fn checkBindingRestInit(self: *Parser, rest_arg: NodeIndex) void {
+    pub fn checkBindingRestInit(self: *Parser, rest_arg: NodeIndex) ParseError2!void {
         if (rest_arg.isNone()) return;
         const rest_node = self.ast.getNode(rest_arg);
         // binding 위치에서는 assignment_pattern, cover grammar에서는 assignment_expression
         if (rest_node.tag == .assignment_pattern or rest_node.tag == .assignment_expression) {
-            self.addError(rest_node.span, rest_init_error);
+            try self.addError(rest_node.span, rest_init_error);
         }
     }
 
@@ -381,7 +381,7 @@ pub const Parser = struct {
     /// 소스에 `\`가 있고, 디코딩하면 reserved keyword이면 에러.
     /// strict mode에서는 escaped strict mode reserved도 에러.
     /// cover grammar 함수 내부 + parseObjectProperty에서 사용.
-    pub fn checkIdentifierEscapedKeyword(self: *Parser, span: Span) void {
+    pub fn checkIdentifierEscapedKeyword(self: *Parser, span: Span) ParseError2!void {
         // escape가 없으면 검사 불필요
         const raw = self.ast.source[span.start..span.end];
         if (std.mem.indexOfScalar(u8, raw, '\\') == null) return;
@@ -393,7 +393,7 @@ pub const Parser = struct {
             if (kw.isReservedKeyword() or kw.isLiteralKeyword() or
                 (self.is_strict_mode and kw.isStrictModeReserved()))
             {
-                self.addError(span, "Keywords cannot contain escape characters");
+                try self.addError(span, "Keywords cannot contain escape characters");
             }
         }
     }
@@ -436,16 +436,16 @@ pub const Parser = struct {
     /// 태그를 변환하고 (setTag) 검증도 수행한다.
     /// 반환값: true면 valid assignment target, false면 에러를 이미 추가했거나 invalid.
     /// is_top이 true면 최상위 호출 (invalid일 때 "Invalid assignment target" 에러 추가).
-    pub fn coverExpressionToAssignmentTarget(self: *Parser, idx: NodeIndex, is_top: bool) bool {
+    pub fn coverExpressionToAssignmentTarget(self: *Parser, idx: NodeIndex, is_top: bool) ParseError2!bool {
         if (idx.isNone()) return false;
         const node = self.ast.getNode(idx);
         return switch (node.tag) {
             // 1) identifier — valid target. 태그를 assignment_target_identifier로 변환.
             .identifier_reference => {
                 // escaped keyword 검증: v\u0061r → "var"이면 에러
-                self.checkIdentifierEscapedKeyword(node.span);
+                try self.checkIdentifierEscapedKeyword(node.span);
                 // strict mode: eval/arguments에 할당 금지 (checkStrictBinding 내부에서 strict 체크)
-                self.checkStrictBinding(node.span);
+                try self.checkStrictBinding(node.span);
                 self.ast.setTag(idx, .assignment_target_identifier);
                 return true;
             },
@@ -455,21 +455,21 @@ pub const Parser = struct {
             .static_member_expression, .computed_member_expression => {
                 if (node.data.binary.flags == 0) return true; // normal
                 // optional chaining (a?.b, a?.[b])은 assignment target이 아님
-                if (is_top) self.addError(node.span, "Invalid assignment target");
+                if (is_top) try self.addError(node.span, "Invalid assignment target");
                 return false;
             },
 
             // 3) array destructuring — 태그를 array_assignment_target으로 변환 + 자식 재귀
             .array_expression => {
                 self.ast.setTag(idx, .array_assignment_target);
-                self.coverArrayExpressionToTarget(node);
+                try self.coverArrayExpressionToTarget(node);
                 return true;
             },
 
             // 4) object destructuring — 태그를 object_assignment_target으로 변환 + 자식 재귀
             .object_expression => {
                 self.ast.setTag(idx, .object_assignment_target);
-                self.coverObjectExpressionToTarget(node);
+                try self.coverObjectExpressionToTarget(node);
                 // CoverInitializedName이 destructuring으로 정상 소비됨
                 self.has_cover_init_name = false;
                 return true;
@@ -479,17 +479,17 @@ pub const Parser = struct {
             .parenthesized_expression => {
                 const inner = node.data.unary.operand;
                 if (inner.isNone()) {
-                    if (is_top) self.addError(node.span, "Invalid assignment target");
+                    if (is_top) try self.addError(node.span, "Invalid assignment target");
                     return false;
                 }
                 const inner_tag = self.ast.getNode(inner).tag;
                 // ({x}) = 1, ([x]) = 1 → parenthesized destructuring 금지
                 if (inner_tag == .array_expression or inner_tag == .object_expression) {
-                    self.addError(node.span, "Invalid assignment target");
+                    try self.addError(node.span, "Invalid assignment target");
                     return false;
                 }
                 // (x) = 1 → 내부가 simple target이면 OK
-                return self.coverExpressionToAssignmentTarget(inner, is_top);
+                return try self.coverExpressionToAssignmentTarget(inner, is_top);
             },
 
             // 6) 이미 변환된 assignment target 태그는 유지
@@ -502,12 +502,12 @@ pub const Parser = struct {
             //    is_top 여부와 무관하게 항상 에러. else 분기는 is_top=false일 때 에러를 내지 않으므로
             //    destructuring 내부([import.meta] = arr)에서 잘못 통과하는 것을 방지.
             .meta_property => {
-                self.addError(node.span, "Invalid assignment target");
+                try self.addError(node.span, "Invalid assignment target");
                 return false;
             },
 
             else => {
-                if (is_top) self.addError(node.span, "Invalid assignment target");
+                if (is_top) try self.addError(node.span, "Invalid assignment target");
                 return false;
             },
         };
@@ -516,19 +516,19 @@ pub const Parser = struct {
     /// spread element의 operand를 검증하는 cover grammar 헬퍼.
     /// rest에 initializer가 있으면 에러를 내고, operand를 재귀 검증한다.
     /// coverArrayExpressionToTarget과 coverObjectExpressionToTarget에서 공통 사용.
-    pub fn coverSpreadElementToTarget(self: *Parser, spread_idx: NodeIndex, operand_idx: NodeIndex) void {
+    pub fn coverSpreadElementToTarget(self: *Parser, spread_idx: NodeIndex, operand_idx: NodeIndex) ParseError2!void {
         const operand = self.ast.getNode(operand_idx);
         if (operand.tag == .assignment_expression) {
-            self.addError(operand.span, rest_init_error);
+            try self.addError(operand.span, rest_init_error);
         }
         // spread_element → assignment_target_rest로 변환
         self.ast.setTag(spread_idx, .assignment_target_rest);
-        _ = self.coverExpressionToAssignmentTarget(operand_idx, true);
+        _ = try self.coverExpressionToAssignmentTarget(operand_idx, true);
     }
 
     /// array expression 내부를 assignment target으로 검증 (coverExpressionToAssignmentTarget 헬퍼).
     /// 각 요소의 spread rest-init 금지 + nested pattern 재귀 검증.
-    pub fn coverArrayExpressionToTarget(self: *Parser, node: Node) void {
+    pub fn coverArrayExpressionToTarget(self: *Parser, node: Node) ParseError2!void {
         const list = node.data.list;
         var i: u32 = 0;
         while (i < list.len) : (i += 1) {
@@ -540,23 +540,23 @@ pub const Parser = struct {
                 .spread_element => {
                     // rest는 마지막 요소여야 함: [...x, y] → SyntaxError
                     if (i + 1 < list.len) {
-                        self.addError(elem.span, "Rest element must be last element");
+                        try self.addError(elem.span, "Rest element must be last element");
                     }
                     // rest 뒤 trailing comma 금지: [...x,] → SyntaxError
                     // parseArrayExpression에서 spread_trailing_comma로 마킹됨
                     if ((elem.data.unary.flags & spread_trailing_comma) != 0) {
-                        self.addError(elem.span, "Rest element may not have a trailing comma");
+                        try self.addError(elem.span, "Rest element may not have a trailing comma");
                     }
-                    self.coverSpreadElementToTarget(elem_idx, elem.data.unary.operand);
+                    try self.coverSpreadElementToTarget(elem_idx, elem.data.unary.operand);
                 },
                 .assignment_expression => {
                     // [x = 1] → assignment_target_with_default로 변환
                     self.ast.setTag(elem_idx, .assignment_target_with_default);
-                    _ = self.coverExpressionToAssignmentTarget(elem.data.binary.left, true);
+                    _ = try self.coverExpressionToAssignmentTarget(elem.data.binary.left, true);
                 },
                 else => {
                     // identifier, nested array/object/member 등 → 재귀 검증
-                    _ = self.coverExpressionToAssignmentTarget(elem_idx, true);
+                    _ = try self.coverExpressionToAssignmentTarget(elem_idx, true);
                 },
             }
         }
@@ -564,7 +564,7 @@ pub const Parser = struct {
 
     /// object expression 내부를 assignment target으로 검증 (coverExpressionToAssignmentTarget 헬퍼).
     /// 각 프로퍼티의 shorthand escaped keyword + strict eval/arguments + spread rest-init + nested value 재귀 검증.
-    pub fn coverObjectExpressionToTarget(self: *Parser, node: Node) void {
+    pub fn coverObjectExpressionToTarget(self: *Parser, node: Node) ParseError2!void {
         const list = node.data.list;
         var i: u32 = 0;
         while (i < list.len) : (i += 1) {
@@ -577,8 +577,8 @@ pub const Parser = struct {
                     // shorthand without value: { eval } — right가 none인 경우
                     // parseObjectProperty에서 shorthand는 value를 생성하지 않으므로 right=none
                     const key_span = self.ast.getNode(elem.data.binary.left).span;
-                    self.checkIdentifierEscapedKeyword(key_span);
-                    self.checkStrictBinding(key_span);
+                    try self.checkIdentifierEscapedKeyword(key_span);
+                    try self.checkStrictBinding(key_span);
                     self.ast.setTag(elem_idx, .assignment_target_property_identifier);
                 } else if (!elem.data.binary.left.isNone() and !elem.data.binary.right.isNone()) {
                     // shorthand 검증: key와 value가 같은 span이면 shorthand
@@ -586,16 +586,16 @@ pub const Parser = struct {
                     const val_node = self.ast.getNode(elem.data.binary.right);
                     const is_shorthand = key_span.start == val_node.span.start and key_span.end == val_node.span.end;
                     if (is_shorthand) {
-                        self.checkIdentifierEscapedKeyword(key_span);
+                        try self.checkIdentifierEscapedKeyword(key_span);
                         // strict mode: shorthand에서 eval/arguments 할당 금지
-                        self.checkStrictBinding(key_span);
+                        try self.checkStrictBinding(key_span);
                         // shorthand → assignment_target_property_identifier
                         self.ast.setTag(elem_idx, .assignment_target_property_identifier);
                     } else if (is_shorthand_default) {
                         // shorthand with default: { eval = 0 } — key가 target, value가 default
                         // key의 eval/arguments 검증이 필요 (strict mode)
-                        self.checkIdentifierEscapedKeyword(key_span);
-                        self.checkStrictBinding(key_span);
+                        try self.checkIdentifierEscapedKeyword(key_span);
+                        try self.checkStrictBinding(key_span);
                         self.ast.setTag(elem_idx, .assignment_target_property_identifier);
                         // value(default)는 assignment target이 아니므로 검증하지 않음
                     } else {
@@ -605,30 +605,30 @@ pub const Parser = struct {
                         // { key: target = default } → target을 검증, default는 검증하지 않음
                         if (val_node.tag == .assignment_expression) {
                             self.ast.setTag(elem.data.binary.right, .assignment_target_with_default);
-                            _ = self.coverExpressionToAssignmentTarget(val_node.data.binary.left, true);
+                            _ = try self.coverExpressionToAssignmentTarget(val_node.data.binary.left, true);
                         } else {
                             // value를 재귀 검증 (nested pattern일 수 있음)
-                            _ = self.coverExpressionToAssignmentTarget(elem.data.binary.right, true);
+                            _ = try self.coverExpressionToAssignmentTarget(elem.data.binary.right, true);
                         }
                     }
                 }
             } else if (elem.tag == .spread_element) {
                 // rest는 마지막 요소여야 함: {...x, y} → SyntaxError
                 if (i + 1 < list.len) {
-                    self.addError(elem.span, "Rest element must be last element");
+                    try self.addError(elem.span, "Rest element must be last element");
                 }
                 // object rest: {...x} = obj
-                self.coverSpreadElementToTarget(elem_idx, elem.data.unary.operand);
+                try self.coverSpreadElementToTarget(elem_idx, elem.data.unary.operand);
             } else if (elem.tag == .method_definition) {
                 // method/getter/setter/async/generator는 destructuring target이 아님
-                self.addError(elem.span, "Invalid assignment target");
+                try self.addError(elem.span, "Invalid assignment target");
             }
         }
     }
 
     /// cover grammar 표현식에서 바인딩 이름의 span을 재귀 수집하여 중복 검사한다.
     /// 중복 발견 시 즉시 에러를 추가한다.
-    pub fn collectCoverParamNames(self: *Parser, idx: NodeIndex) void {
+    pub fn collectCoverParamNames(self: *Parser, idx: NodeIndex) ParseError2!void {
         if (idx.isNone()) return;
         const node = self.ast.getNode(idx);
         switch (node.tag) {
@@ -639,19 +639,19 @@ pub const Parser = struct {
                 for (self.param_name_spans.items) |prev_span| {
                     const prev_name = self.ast.source[prev_span.start..prev_span.end];
                     if (std.mem.eql(u8, name, prev_name)) {
-                        self.addError(node.span, "Duplicate parameter name");
+                        try self.addError(node.span, "Duplicate parameter name");
                         return;
                     }
                 }
-                self.param_name_spans.append(node.span) catch @panic("OOM: param_name_spans");
+                try self.param_name_spans.append(node.span);
             },
-            .parenthesized_expression => self.collectCoverParamNames(node.data.unary.operand),
+            .parenthesized_expression => try self.collectCoverParamNames(node.data.unary.operand),
             .sequence_expression => {
                 const list = node.data.list;
                 var i: u32 = 0;
                 while (i < list.len) : (i += 1) {
                     const elem_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
-                    self.collectCoverParamNames(elem_idx);
+                    try self.collectCoverParamNames(elem_idx);
                 }
             },
             .object_expression, .array_expression, .object_assignment_target, .array_assignment_target => {
@@ -659,13 +659,13 @@ pub const Parser = struct {
                 var i: u32 = 0;
                 while (i < list.len) : (i += 1) {
                     const elem_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
-                    self.collectCoverParamNames(elem_idx);
+                    try self.collectCoverParamNames(elem_idx);
                 }
             },
             .object_property, .assignment_target_property_identifier, .assignment_target_property_property => {
                 // shorthand: left=key(identifier_reference), right=none → key is the binding
                 if (node.data.binary.right.isNone()) {
-                    self.collectCoverParamNames(node.data.binary.left);
+                    try self.collectCoverParamNames(node.data.binary.left);
                 } else {
                     // long-form { key: value } → value is the binding
                     // BUT: for shorthand { x } where key==value (same span), also walk left
@@ -673,23 +673,23 @@ pub const Parser = struct {
                     const val_span = self.ast.getNode(node.data.binary.right).span;
                     if (key_span.start == val_span.start and key_span.end == val_span.end) {
                         // shorthand with value = same as key (e.g., {x} parsed with both key and value)
-                        self.collectCoverParamNames(node.data.binary.right);
+                        try self.collectCoverParamNames(node.data.binary.right);
                     } else {
-                        self.collectCoverParamNames(node.data.binary.right);
+                        try self.collectCoverParamNames(node.data.binary.right);
                     }
                 }
             },
             .binding_property => {
-                self.collectCoverParamNames(node.data.binary.right);
+                try self.collectCoverParamNames(node.data.binary.right);
             },
             .assignment_expression, .assignment_pattern, .assignment_target_with_default => {
                 // default value: left = binding, right = default_value
-                self.collectCoverParamNames(node.data.binary.left);
+                try self.collectCoverParamNames(node.data.binary.left);
                 // default value 내부의 yield/await 검사 (이름 수집하지 않고 검사만)
-                self.checkCoverParamDefaultForYieldAwait(node.data.binary.right);
+                try self.checkCoverParamDefaultForYieldAwait(node.data.binary.right);
             },
             .spread_element, .assignment_target_rest, .binding_rest_element, .rest_element => {
-                self.collectCoverParamNames(node.data.unary.operand);
+                try self.collectCoverParamNames(node.data.unary.operand);
             },
             else => {},
         }
@@ -710,7 +710,7 @@ pub const Parser = struct {
     /// async arrow 파라미터에서 'await' 식별자 사용을 금지한다.
     /// async arrow의 파라미터는 async context 진입 전에 파싱되므로 await가 identifier로 파싱된다.
     /// 이 함수는 cover grammar 변환 후 호출하여 identifier 이름이 "await"인 경우를 검출한다.
-    pub fn checkAsyncArrowParamsForAwait(self: *Parser, idx: NodeIndex) void {
+    pub fn checkAsyncArrowParamsForAwait(self: *Parser, idx: NodeIndex) ParseError2!void {
         if (idx.isNone()) return;
         if (@intFromEnum(idx) >= self.ast.nodes.items.len) return;
         const node = self.ast.getNode(idx);
@@ -718,11 +718,11 @@ pub const Parser = struct {
             .identifier_reference, .binding_identifier, .assignment_target_identifier => {
                 const name = self.ast.source[node.span.start..node.span.end];
                 if (std.mem.eql(u8, name, "await")) {
-                    self.addError(node.span, "'await' is not allowed in async arrow function parameters");
+                    try self.addError(node.span, "'await' is not allowed in async arrow function parameters");
                 }
             },
             .parenthesized_expression, .spread_element, .assignment_target_rest => {
-                self.checkAsyncArrowParamsForAwait(node.data.unary.operand);
+                try self.checkAsyncArrowParamsForAwait(node.data.unary.operand);
             },
             .sequence_expression,
             .array_expression,
@@ -734,7 +734,7 @@ pub const Parser = struct {
                 var i: u32 = 0;
                 while (i < list.len) : (i += 1) {
                     const elem_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
-                    self.checkAsyncArrowParamsForAwait(elem_idx);
+                    try self.checkAsyncArrowParamsForAwait(elem_idx);
                 }
             },
             .assignment_expression,
@@ -745,12 +745,12 @@ pub const Parser = struct {
             .assignment_target_property_property,
             .binding_property,
             => {
-                self.checkAsyncArrowParamsForAwait(node.data.binary.left);
-                self.checkAsyncArrowParamsForAwait(node.data.binary.right);
+                try self.checkAsyncArrowParamsForAwait(node.data.binary.left);
+                try self.checkAsyncArrowParamsForAwait(node.data.binary.right);
             },
             // 중첩 arrow의 파라미터에도 await 사용 금지
             .arrow_function_expression => {
-                self.checkAsyncArrowParamsForAwait(node.data.binary.left);
+                try self.checkAsyncArrowParamsForAwait(node.data.binary.left);
             },
             else => {},
         }
@@ -758,23 +758,23 @@ pub const Parser = struct {
 
     /// arrow 파라미터 default value 내부에 yield/await가 있는지 검사한다.
     /// 이름 수집은 하지 않고 yield/await expression만 검출한다.
-    pub fn checkCoverParamDefaultForYieldAwait(self: *Parser, idx: NodeIndex) void {
+    pub fn checkCoverParamDefaultForYieldAwait(self: *Parser, idx: NodeIndex) ParseError2!void {
         if (idx.isNone()) return;
         if (@intFromEnum(idx) >= self.ast.nodes.items.len) return;
         const node = self.ast.getNode(idx);
         switch (node.tag) {
             .yield_expression => {
-                self.addError(node.span, "'yield' is not allowed in arrow function parameters");
+                try self.addError(node.span, "'yield' is not allowed in arrow function parameters");
             },
             .await_expression => {
-                self.addError(node.span, "'await' is not allowed in arrow function parameters");
+                try self.addError(node.span, "'await' is not allowed in arrow function parameters");
             },
             // unary node — operand만 검사
             .parenthesized_expression,
             .spread_element,
             .unary_expression,
             .update_expression,
-            => self.checkCoverParamDefaultForYieldAwait(node.data.unary.operand),
+            => try self.checkCoverParamDefaultForYieldAwait(node.data.unary.operand),
             // list node — 각 요소 검사
             .sequence_expression,
             .array_expression,
@@ -784,7 +784,7 @@ pub const Parser = struct {
                 var i: u32 = 0;
                 while (i < list.len) : (i += 1) {
                     const elem_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
-                    self.checkCoverParamDefaultForYieldAwait(elem_idx);
+                    try self.checkCoverParamDefaultForYieldAwait(elem_idx);
                 }
             },
             // binary node — 양쪽 자식 검사
@@ -793,13 +793,13 @@ pub const Parser = struct {
             .logical_expression,
             .object_property,
             => {
-                self.checkCoverParamDefaultForYieldAwait(node.data.binary.left);
-                self.checkCoverParamDefaultForYieldAwait(node.data.binary.right);
+                try self.checkCoverParamDefaultForYieldAwait(node.data.binary.left);
+                try self.checkCoverParamDefaultForYieldAwait(node.data.binary.right);
             },
             // conditional은 ternary이지만 binary data 사용 (condition=left, consequent/alternate 조합=right)
             .conditional_expression => {
-                self.checkCoverParamDefaultForYieldAwait(node.data.binary.left);
-                self.checkCoverParamDefaultForYieldAwait(node.data.binary.right);
+                try self.checkCoverParamDefaultForYieldAwait(node.data.binary.left);
+                try self.checkCoverParamDefaultForYieldAwait(node.data.binary.right);
             },
             // 리프 노드 (identifier, literal 등)나 기타 — 더 이상 탐색 불필요
             else => {},
@@ -811,12 +811,12 @@ pub const Parser = struct {
     /// coverExpressionToAssignmentTarget을 위임한다.
     ///
     /// 기존 checkRestInitInArrowParams를 대체한다.
-    pub fn coverExpressionToArrowParams(self: *Parser, idx: NodeIndex) void {
+    pub fn coverExpressionToArrowParams(self: *Parser, idx: NodeIndex) ParseError2!void {
         if (idx.isNone()) return;
         const node = self.ast.getNode(idx);
         if (node.tag == .parenthesized_expression) {
             // (expr) → 내부를 다시 풀기
-            self.coverExpressionToArrowParams(node.data.unary.operand);
+            try self.coverExpressionToArrowParams(node.data.unary.operand);
         } else if (node.tag == .sequence_expression) {
             // (a, b, c) → 각 요소를 개별 검증
             const list = node.data.list;
@@ -827,65 +827,65 @@ pub const Parser = struct {
                 if (elem.tag == .spread_element) {
                     // rest 파라미터: 마지막 요소여야 하고 initializer 금지, trailing comma 금지
                     if (i + 1 < list.len) {
-                        self.addError(elem.span, "Rest element must be last element");
+                        try self.addError(elem.span, "Rest element must be last element");
                     }
                     if ((elem.data.unary.flags & spread_trailing_comma) != 0) {
-                        self.addError(elem.span, "Rest element may not have a trailing comma");
+                        try self.addError(elem.span, "Rest element may not have a trailing comma");
                     }
-                    self.checkBindingRestInit(elem.data.unary.operand);
+                    try self.checkBindingRestInit(elem.data.unary.operand);
                     // rest의 operand도 valid assignment target이어야 함
-                    _ = self.coverExpressionToAssignmentTarget(elem.data.unary.operand, false);
+                    _ = try self.coverExpressionToAssignmentTarget(elem.data.unary.operand, false);
                 } else {
-                    _ = self.coverExpressionToAssignmentTarget(elem_idx, false);
+                    _ = try self.coverExpressionToAssignmentTarget(elem_idx, false);
                 }
             }
         } else if (node.tag == .spread_element) {
             // 단일 rest 파라미터: (...x) → initializer 금지 + trailing comma 금지
             if ((node.data.unary.flags & spread_trailing_comma) != 0) {
-                self.addError(node.span, "Rest element may not have a trailing comma");
+                try self.addError(node.span, "Rest element may not have a trailing comma");
             }
-            self.checkBindingRestInit(node.data.unary.operand);
-            _ = self.coverExpressionToAssignmentTarget(node.data.unary.operand, false);
+            try self.checkBindingRestInit(node.data.unary.operand);
+            _ = try self.coverExpressionToAssignmentTarget(node.data.unary.operand, false);
         } else {
             // 단일 expression → 직접 검증
-            _ = self.coverExpressionToAssignmentTarget(idx, false);
+            _ = try self.coverExpressionToAssignmentTarget(idx, false);
         }
         // arrow 파라미터 중복 검사: (x, {x}) => 1 등
         // cover grammar 변환 후에 수행 (변환된 태그도 처리하므로)
         self.param_name_spans.clearRetainingCapacity();
-        self.collectCoverParamNames(idx);
+        try self.collectCoverParamNames(idx);
     }
 
     /// 키워드를 바인딩 위치에서 사용할 때의 검증.
     /// ECMAScript 12.1.1: reserved keyword, strict mode reserved, contextual keywords.
     /// escaped 형태 (\u0061wait 등)도 동일하게 검증한다.
-    pub fn checkKeywordBinding(self: *Parser) void {
+    pub fn checkKeywordBinding(self: *Parser) ParseError2!void {
         // await는 조건부 예약어 — async/module에서만 금지, script에서는 식별자로 사용 가능
         // yield도 조건부 — generator/strict에서만 금지
         // 둘 다 checkYieldAwaitUse에서 처리
         if (self.current() == .kw_await or self.current() == .kw_yield) {
-            _ = self.checkYieldAwaitUse(self.currentSpan(), "identifier");
+            _ = try self.checkYieldAwaitUse(self.currentSpan(), "identifier");
         } else if (self.current().isReservedKeyword() or self.current().isLiteralKeyword()) {
-            self.addError(self.currentSpan(), "Reserved word cannot be used as identifier");
+            try self.addError(self.currentSpan(), "Reserved word cannot be used as identifier");
         } else if (self.is_strict_mode and self.current().isStrictModeReserved()) {
-            self.addError(self.currentSpan(), "Reserved word in strict mode cannot be used as identifier");
+            try self.addError(self.currentSpan(), "Reserved word in strict mode cannot be used as identifier");
         } else if (self.current() == .escaped_keyword) {
             // escaped reserved keyword는 식별자로 사용 불가 (예: \u0061wait in script)
             // 단, escaped await는 script mode의 non-async에서는 허용
             const is_escaped_await = self.isEscapedKeyword("await");
             if (is_escaped_await) {
                 if (self.is_module or self.ctx.in_async) {
-                    self.addError(self.currentSpan(), "'await' cannot be used as identifier in this context");
+                    try self.addError(self.currentSpan(), "'await' cannot be used as identifier in this context");
                 }
             } else {
-                self.addError(self.currentSpan(), "Keywords cannot contain escape characters");
+                try self.addError(self.currentSpan(), "Keywords cannot contain escape characters");
             }
         } else if (self.current() == .escaped_strict_reserved) {
             // escaped strict reserved는 strict mode에서 금지
             // yield/await 컨텍스트 에러가 우선
-            const had_error = self.checkYieldAwaitUse(self.currentSpan(), "identifier");
+            const had_error = try self.checkYieldAwaitUse(self.currentSpan(), "identifier");
             if (!had_error and self.is_strict_mode) {
-                self.addError(self.currentSpan(), "Keywords cannot contain escape characters");
+                try self.addError(self.currentSpan(), "Keywords cannot contain escape characters");
             }
         }
     }
@@ -894,7 +894,7 @@ pub const Parser = struct {
     /// ECMAScript 13.1.1: yield는 [Yield] 또는 strict mode에서, await는 [Await] 또는 module에서 금지.
     /// context_noun: "identifier", "label" 등 — 에러 메시지에 사용 (comptime 문자열 연결).
     /// 에러를 추가했으면 true, 아니면 false를 반환한다.
-    pub fn checkYieldAwaitUse(self: *Parser, span: Span, comptime context_noun: []const u8) bool {
+    pub fn checkYieldAwaitUse(self: *Parser, span: Span, comptime context_noun: []const u8) ParseError2!bool {
         // yield/await는 escaped 형태(yi\u0065ld)도 동일 규칙 적용 (ECMAScript 12.1.1)
         // await는 reserved keyword이므로 escaped_keyword로 분류됨 → 여기서는 yield만 처리
         const is_yield = self.current() == .kw_yield or
@@ -903,18 +903,18 @@ pub const Parser = struct {
 
         if (is_yield) {
             if (self.ctx.in_generator) {
-                self.addError(span, "'yield' cannot be used as " ++ context_noun ++ " in generator");
+                try self.addError(span, "'yield' cannot be used as " ++ context_noun ++ " in generator");
                 return true;
             } else if (self.is_strict_mode) {
-                self.addError(span, "'yield' cannot be used as " ++ context_noun ++ " in strict mode");
+                try self.addError(span, "'yield' cannot be used as " ++ context_noun ++ " in strict mode");
                 return true;
             }
         } else if (is_await) {
             if (self.ctx.in_async) {
-                self.addError(span, "'await' cannot be used as " ++ context_noun ++ " in async function");
+                try self.addError(span, "'await' cannot be used as " ++ context_noun ++ " in async function");
                 return true;
             } else if (self.is_module) {
-                self.addError(span, "'await' cannot be used as " ++ context_noun ++ " in module code");
+                try self.addError(span, "'await' cannot be used as " ++ context_noun ++ " in module code");
                 return true;
             }
         }
@@ -1019,14 +1019,14 @@ pub const Parser = struct {
         // ECMAScript 14.7.5: It is a Syntax Error if IsLabelledFunction(Statement) is true.
         // 반복문의 body가 labelled function이면 에러 (중첩 label도 재귀 검사).
         // Annex B의 labelled function 예외는 반복문 body에서 적용되지 않는다.
-        self.checkLabelledFunction(body);
+        try self.checkLabelledFunction(body);
 
         return body;
     }
 
     /// IsLabelledFunction 검사: labeled statement을 재귀적으로 따라가서
     /// 최종 body가 function declaration이면 에러를 발생시킨다.
-    pub fn checkLabelledFunction(self: *Parser, idx: NodeIndex) void {
+    pub fn checkLabelledFunction(self: *Parser, idx: NodeIndex) ParseError2!void {
         if (idx.isNone()) return;
         const node = self.ast.getNode(idx);
         if (node.tag == .labeled_statement) {
@@ -1034,10 +1034,10 @@ pub const Parser = struct {
             const inner = node.data.binary.right;
             const inner_node = self.ast.getNode(inner);
             if (inner_node.tag == .function_declaration) {
-                self.addError(inner_node.span, "Labelled function declaration is not allowed in loop body");
+                try self.addError(inner_node.span, "Labelled function declaration is not allowed in loop body");
             } else if (inner_node.tag == .labeled_statement) {
                 // 중첩 label: label1: label2: function f() {}
-                self.checkLabelledFunction(inner);
+                try self.checkLabelledFunction(inner);
             }
         }
     }
@@ -1091,7 +1091,7 @@ pub const Parser = struct {
     /// ECMAScript 15.4.1/15.5.1: generator/async generator는 항상 에러
     /// strict mode에서도 항상 에러
     /// sloppy mode + simple params인 일반 function만 허용
-    pub fn checkDuplicateParams(self: *Parser, scratch_top: usize) void {
+    pub fn checkDuplicateParams(self: *Parser, scratch_top: usize) ParseError2!void {
         const must_check = self.is_strict_mode or !self.has_simple_params or
             self.ctx.in_generator or self.ctx.in_async;
         if (!must_check) return;
@@ -1105,7 +1105,7 @@ pub const Parser = struct {
             // 이 파라미터에서 나오는 모든 바인딩 이름을 수집한다.
             // 단순 식별자(a)는 1개, destructuring([a,b])은 여러 개.
             const names_before = self.param_name_spans.items.len;
-            self.collectBoundNames(param_idx);
+            try self.collectBoundNames(param_idx);
             // collectBoundNames 이후 재참조: append 시 재할당이 일어날 수 있으므로
             // names_before 이후 범위를 수집 완료 후에 인덱스로 순회한다.
             const names_after = self.param_name_spans.items.len;
@@ -1119,7 +1119,7 @@ pub const Parser = struct {
                 for (self.param_name_spans.items[0..j]) |prev_span| {
                     const prev_name = self.ast.source[prev_span.start..prev_span.end];
                     if (std.mem.eql(u8, name, prev_name)) {
-                        self.addError(name_span, "Duplicate parameter name");
+                        try self.addError(name_span, "Duplicate parameter name");
                         break;
                     }
                 }
@@ -1141,25 +1141,25 @@ pub const Parser = struct {
     ///   - object_pattern ({a, b: c})            → 각 property 재귀
     ///   - binding_property ({key: value})       → right(value) 재귀
     ///   - elision / invalid                    → 무시
-    pub fn collectBoundNames(self: *Parser, idx: NodeIndex) void {
+    pub fn collectBoundNames(self: *Parser, idx: NodeIndex) ParseError2!void {
         if (idx.isNone()) return;
         const node = self.ast.getNode(idx);
         switch (node.tag) {
             // 단말 노드: 이름 1개 추가
             .binding_identifier => {
-                self.param_name_spans.append(node.span) catch @panic("OOM: param_name_spans");
+                try self.param_name_spans.append(node.span);
             },
             // x = default → 왼쪽이 실제 바인딩
             .assignment_pattern => {
-                self.collectBoundNames(node.data.binary.left);
+                try self.collectBoundNames(node.data.binary.left);
             },
             // TS parameter property (public x) → operand가 실제 바인딩
             .formal_parameter => {
-                self.collectBoundNames(node.data.unary.operand);
+                try self.collectBoundNames(node.data.unary.operand);
             },
             // ...rest → operand가 실제 바인딩 (배열/객체 패턴 포함)
             .spread_element, .rest_element, .binding_rest_element => {
-                self.collectBoundNames(node.data.unary.operand);
+                try self.collectBoundNames(node.data.unary.operand);
             },
             // [a, b, [c, d]] → 각 element를 재귀적으로 처리
             .array_pattern => {
@@ -1167,7 +1167,7 @@ pub const Parser = struct {
                 var i: u32 = 0;
                 while (i < list.len) : (i += 1) {
                     const elem_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
-                    self.collectBoundNames(elem_idx);
+                    try self.collectBoundNames(elem_idx);
                 }
             },
             // {a, b: c, ...rest} → 각 property를 재귀적으로 처리
@@ -1176,13 +1176,13 @@ pub const Parser = struct {
                 var i: u32 = 0;
                 while (i < list.len) : (i += 1) {
                     const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
-                    self.collectBoundNames(prop_idx);
+                    try self.collectBoundNames(prop_idx);
                 }
             },
             // {key: value} → right(value)가 실제 바인딩 패턴
             // shorthand {a} 도 binding_property: left=key(binding_identifier), right=value(binding_identifier)
             .binding_property => {
-                self.collectBoundNames(node.data.binary.right);
+                try self.collectBoundNames(node.data.binary.right);
             },
             // elision, invalid 등 — 바인딩 없음, 무시
             else => {},
@@ -1212,29 +1212,29 @@ pub const Parser = struct {
 
     /// "use strict" directive가 발견된 후 함수 이름이 eval/arguments인지 소급 검증.
     /// ECMAScript 14.1.2: strict mode에서 eval/arguments를 바인딩 이름으로 사용 금지.
-    pub fn checkStrictFunctionName(self: *Parser, name_idx: NodeIndex) void {
+    pub fn checkStrictFunctionName(self: *Parser, name_idx: NodeIndex) ParseError2!void {
         if (name_idx.isNone()) return;
         const node = self.ast.getNode(name_idx);
         if (node.tag != .binding_identifier) return;
-        self.checkStrictBinding(node.span);
+        try self.checkStrictBinding(node.span);
     }
 
     /// "use strict" directive가 발견된 후 파라미터 이름을 소급 검증.
     /// ECMAScript 14.1.2: strict mode에서 eval/arguments + 중복 파라미터 금지.
     /// destructuring 패턴 안의 이름도 재귀적으로 검사한다.
-    pub fn checkStrictParamNames(self: *Parser, scratch_top: usize) void {
+    pub fn checkStrictParamNames(self: *Parser, scratch_top: usize) ParseError2!void {
         const params = self.scratch.items[scratch_top..];
         for (params) |param_idx| {
             // collectBoundNames로 destructuring 안의 이름도 포함하여 모두 검사
             self.param_name_spans.clearRetainingCapacity();
-            self.collectBoundNames(param_idx);
+            try self.collectBoundNames(param_idx);
             for (self.param_name_spans.items) |name_span| {
-                self.checkStrictBinding(name_span);
+                try self.checkStrictBinding(name_span);
             }
         }
         self.param_name_spans.clearRetainingCapacity();
         // 중복 파라미터도 소급 검사 (simple params + sloppy에서는 허용이지만 strict에서는 금지)
-        self.checkDuplicateParams(scratch_top);
+        try self.checkDuplicateParams(scratch_top);
     }
 
     /// 함수 선언의 본문을 파싱한다 (닫는 `}` 뒤의 `/`는 regexp로 토큰화).
@@ -1250,7 +1250,7 @@ pub const Parser = struct {
 
     pub fn parseFunctionBodyInner(self: *Parser, in_expression: bool) ParseError2!NodeIndex {
         const start = self.currentSpan().start;
-        self.expect(.l_curly);
+        try self.expect(.l_curly);
 
         var stmts = std.ArrayList(NodeIndex).init(self.allocator);
         defer stmts.deinit();
@@ -1269,12 +1269,12 @@ pub const Parser = struct {
                     // ECMAScript 14.1.2: function with non-simple parameter list
                     // shall not contain a Use Strict Directive
                     if (!self.has_simple_params) {
-                        self.addError(self.currentSpan(), "\"use strict\" not allowed in function with non-simple parameters");
+                        try self.addError(self.currentSpan(), "\"use strict\" not allowed in function with non-simple parameters");
                     }
                     self.is_strict_mode = true;
                     // "use strict" 이전에 octal escape가 있었으면 retroactive 에러
                     if (has_prologue_octal) {
-                        self.addError(prologue_octal_span, "Octal escape sequences are not allowed in strict mode");
+                        try self.addError(prologue_octal_span, "Octal escape sequences are not allowed in strict mode");
                     }
                 } else if (self.current() == .string_literal) {
                     // directive prologue의 문자열 — octal escape 추적
@@ -1300,7 +1300,7 @@ pub const Parser = struct {
         if (in_expression) {
             self.scanner.prev_token_kind = .r_paren;
         }
-        self.expect(.r_curly);
+        try self.expect(.r_curly);
 
         const list = try self.ast.addNodeList(stmts.items);
         return try self.ast.addNode(.{
@@ -1424,10 +1424,10 @@ pub const Parser = struct {
     }
 
     /// 다음 토큰의 Kind와 줄바꿈 여부를 미리 본다 (현재 토큰을 소비하지 않음).
-    pub fn peekNext(self: *Parser) PeekResult {
+    pub fn peekNext(self: *Parser) !PeekResult {
         const saved = self.saveState();
 
-        self.scanner.next();
+        try self.scanner.next();
         const result = PeekResult{
             .kind = self.scanner.token.kind,
             .has_newline_before = self.scanner.token.has_newline_before,
@@ -1438,16 +1438,16 @@ pub const Parser = struct {
     }
 
     /// peekNext의 Kind만 반환하는 편의 함수.
-    pub fn peekNextKind(self: *Parser) Kind {
-        return self.peekNext().kind;
+    pub fn peekNextKind(self: *Parser) !Kind {
+        return (try self.peekNext()).kind;
     }
 
     /// JSX element 모드에서 다음 토큰의 Kind를 미리 본다 (현재 토큰을 소비하지 않음).
     /// JSX children 파싱 중 '<' 다음이 '/'인지 판별할 때 사용.
     /// normal 모드에서는 '/'가 regex로 해석될 수 있으므로 JSX 전용 peek이 필요하다.
-    pub fn peekNextKindJSX(self: *Parser) Kind {
+    pub fn peekNextKindJSX(self: *Parser) !Kind {
         const saved = self.saveState();
-        self.scanner.nextInsideJSXElement();
+        try self.scanner.nextInsideJSXElement();
         const peek_kind = self.scanner.token.kind;
         self.restoreState(saved);
         return peek_kind;
@@ -1589,7 +1589,7 @@ pub const Parser = struct {
 // ============================================================
 
 test "Parser: empty program" {
-    var scanner = Scanner.init(std.testing.allocator, "");
+    var scanner = try Scanner.init(std.testing.allocator, "");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1600,7 +1600,7 @@ test "Parser: empty program" {
 }
 
 test "Parser: variable declaration" {
-    var scanner = Scanner.init(std.testing.allocator, "const x = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "const x = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1612,7 +1612,7 @@ test "Parser: variable declaration" {
 }
 
 test "Parser: binary expression" {
-    var scanner = Scanner.init(std.testing.allocator, "1 + 2 * 3;");
+    var scanner = try Scanner.init(std.testing.allocator, "1 + 2 * 3;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1624,7 +1624,7 @@ test "Parser: binary expression" {
 }
 
 test "Parser: if statement" {
-    var scanner = Scanner.init(std.testing.allocator, "function f(x) { if (x) { return 1; } else { return 2; } }");
+    var scanner = try Scanner.init(std.testing.allocator, "function f(x) { if (x) { return 1; } else { return 2; } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1634,7 +1634,7 @@ test "Parser: if statement" {
 }
 
 test "Parser: function declaration" {
-    var scanner = Scanner.init(std.testing.allocator, "function add(a, b) { return a + b; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function add(a, b) { return a + b; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1644,7 +1644,7 @@ test "Parser: function declaration" {
 }
 
 test "Parser: call expression" {
-    var scanner = Scanner.init(std.testing.allocator, "foo(1, 2, 3);");
+    var scanner = try Scanner.init(std.testing.allocator, "foo(1, 2, 3);");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1654,7 +1654,7 @@ test "Parser: call expression" {
 }
 
 test "Parser: member access" {
-    var scanner = Scanner.init(std.testing.allocator, "a.b.c;");
+    var scanner = try Scanner.init(std.testing.allocator, "a.b.c;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1664,7 +1664,7 @@ test "Parser: member access" {
 }
 
 test "Parser: array and object literals" {
-    var scanner = Scanner.init(std.testing.allocator, "[1, 2, 3];");
+    var scanner = try Scanner.init(std.testing.allocator, "[1, 2, 3];");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1674,7 +1674,7 @@ test "Parser: array and object literals" {
 }
 
 test "Parser: error recovery" {
-    var scanner = Scanner.init(std.testing.allocator, "@@@;");
+    var scanner = try Scanner.init(std.testing.allocator, "@@@;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1684,7 +1684,7 @@ test "Parser: error recovery" {
 }
 
 test "Parser: do-while statement" {
-    var scanner = Scanner.init(std.testing.allocator, "do { x++; } while (x < 10);");
+    var scanner = try Scanner.init(std.testing.allocator, "do { x++; } while (x < 10);");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1694,7 +1694,7 @@ test "Parser: do-while statement" {
 }
 
 test "Parser: for-in statement" {
-    var scanner = Scanner.init(std.testing.allocator, "for (var key in obj) { }");
+    var scanner = try Scanner.init(std.testing.allocator, "for (var key in obj) { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1704,7 +1704,7 @@ test "Parser: for-in statement" {
 }
 
 test "Parser: for-of statement" {
-    var scanner = Scanner.init(std.testing.allocator, "for (const item of arr) { }");
+    var scanner = try Scanner.init(std.testing.allocator, "for (const item of arr) { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1714,7 +1714,7 @@ test "Parser: for-of statement" {
 }
 
 test "Parser: switch statement" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\function f(x) {
         \\  switch (x) {
         \\    case 1: break;
@@ -1732,7 +1732,7 @@ test "Parser: switch statement" {
 }
 
 test "Parser: for with empty parts" {
-    var scanner = Scanner.init(std.testing.allocator, "for (;;) { }");
+    var scanner = try Scanner.init(std.testing.allocator, "for (;;) { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1745,7 +1745,7 @@ test "Parser: switch with var in case body (scratch nesting)" {
     // 이 테스트는 scratch save/restore가 올바르게 동작하는지 검증한다.
     // case 본문에 var 선언이 있으면 scratch를 중첩 사용하게 되는데,
     // save/restore 없이 clearRetainingCapacity를 쓰면 이전 case가 사라진다.
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\switch (x) {
         \\  case 1:
         \\    var a = 1;
@@ -1767,7 +1767,7 @@ test "Parser: switch with var in case body (scratch nesting)" {
 
 test "Parser: nested call in var initializer (scratch nesting)" {
     // var x = foo(bar(1, 2), 3); — 중첩 호출에서 scratch가 안전한지 검증
-    var scanner = Scanner.init(std.testing.allocator, "var x = foo(bar(1, 2), 3);");
+    var scanner = try Scanner.init(std.testing.allocator, "var x = foo(bar(1, 2), 3);");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1777,7 +1777,7 @@ test "Parser: nested call in var initializer (scratch nesting)" {
 }
 
 test "Parser: try-catch" {
-    var scanner = Scanner.init(std.testing.allocator, "try { foo(); } catch (e) { bar(); }");
+    var scanner = try Scanner.init(std.testing.allocator, "try { foo(); } catch (e) { bar(); }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1787,7 +1787,7 @@ test "Parser: try-catch" {
 }
 
 test "Parser: try-finally" {
-    var scanner = Scanner.init(std.testing.allocator, "try { foo(); } finally { cleanup(); }");
+    var scanner = try Scanner.init(std.testing.allocator, "try { foo(); } finally { cleanup(); }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1797,7 +1797,7 @@ test "Parser: try-finally" {
 }
 
 test "Parser: try-catch-finally" {
-    var scanner = Scanner.init(std.testing.allocator, "try { foo(); } catch (e) { bar(); } finally { cleanup(); }");
+    var scanner = try Scanner.init(std.testing.allocator, "try { foo(); } catch (e) { bar(); } finally { cleanup(); }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1807,7 +1807,7 @@ test "Parser: try-catch-finally" {
 }
 
 test "Parser: try without catch or finally is error" {
-    var scanner = Scanner.init(std.testing.allocator, "try { foo(); }");
+    var scanner = try Scanner.init(std.testing.allocator, "try { foo(); }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1817,7 +1817,7 @@ test "Parser: try without catch or finally is error" {
 }
 
 test "Parser: optional catch binding (ES2019)" {
-    var scanner = Scanner.init(std.testing.allocator, "try { foo(); } catch { bar(); }");
+    var scanner = try Scanner.init(std.testing.allocator, "try { foo(); } catch { bar(); }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1827,7 +1827,7 @@ test "Parser: optional catch binding (ES2019)" {
 }
 
 test "Parser: arrow function (simple)" {
-    var scanner = Scanner.init(std.testing.allocator, "const f = x => x + 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "const f = x => x + 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1837,7 +1837,7 @@ test "Parser: arrow function (simple)" {
 }
 
 test "Parser: arrow function (parenthesized)" {
-    var scanner = Scanner.init(std.testing.allocator, "const f = (a, b) => a + b;");
+    var scanner = try Scanner.init(std.testing.allocator, "const f = (a, b) => a + b;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1847,7 +1847,7 @@ test "Parser: arrow function (parenthesized)" {
 }
 
 test "Parser: arrow function with block body" {
-    var scanner = Scanner.init(std.testing.allocator, "const f = (x) => { return x * 2; };");
+    var scanner = try Scanner.init(std.testing.allocator, "const f = (x) => { return x * 2; };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1857,7 +1857,7 @@ test "Parser: arrow function with block body" {
 }
 
 test "Parser: spread in array" {
-    var scanner = Scanner.init(std.testing.allocator, "[1, ...arr, 2];");
+    var scanner = try Scanner.init(std.testing.allocator, "[1, ...arr, 2];");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1867,7 +1867,7 @@ test "Parser: spread in array" {
 }
 
 test "Parser: spread in call" {
-    var scanner = Scanner.init(std.testing.allocator, "foo(...args);");
+    var scanner = try Scanner.init(std.testing.allocator, "foo(...args);");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1877,7 +1877,7 @@ test "Parser: spread in call" {
 }
 
 test "Parser: class declaration" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\class Foo {
         \\  constructor(x) { this.x = x; }
         \\  getX() { return this.x; }
@@ -1892,7 +1892,7 @@ test "Parser: class declaration" {
 }
 
 test "Parser: class with extends" {
-    var scanner = Scanner.init(std.testing.allocator, "class Bar extends Foo { }");
+    var scanner = try Scanner.init(std.testing.allocator, "class Bar extends Foo { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1902,7 +1902,7 @@ test "Parser: class with extends" {
 }
 
 test "Parser: class with static method and property" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\class Config {
         \\  static defaultValue = 42;
         \\  static create() { return 1; }
@@ -1917,7 +1917,7 @@ test "Parser: class with static method and property" {
 }
 
 test "Parser: class expression" {
-    var scanner = Scanner.init(std.testing.allocator, "const Foo = class { bar() { } };");
+    var scanner = try Scanner.init(std.testing.allocator, "const Foo = class { bar() { } };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1927,7 +1927,7 @@ test "Parser: class expression" {
 }
 
 test "Parser: function expression" {
-    var scanner = Scanner.init(std.testing.allocator, "const f = function(x) { return x; };");
+    var scanner = try Scanner.init(std.testing.allocator, "const f = function(x) { return x; };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1937,7 +1937,7 @@ test "Parser: function expression" {
 }
 
 test "Parser: array destructuring" {
-    var scanner = Scanner.init(std.testing.allocator, "const [a, b, c] = arr;");
+    var scanner = try Scanner.init(std.testing.allocator, "const [a, b, c] = arr;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1947,7 +1947,7 @@ test "Parser: array destructuring" {
 }
 
 test "Parser: object destructuring" {
-    var scanner = Scanner.init(std.testing.allocator, "const { x, y } = obj;");
+    var scanner = try Scanner.init(std.testing.allocator, "const { x, y } = obj;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1957,7 +1957,7 @@ test "Parser: object destructuring" {
 }
 
 test "Parser: destructuring with default values" {
-    var scanner = Scanner.init(std.testing.allocator, "const [a = 1, b = 2] = arr;");
+    var scanner = try Scanner.init(std.testing.allocator, "const [a = 1, b = 2] = arr;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1967,7 +1967,7 @@ test "Parser: destructuring with default values" {
 }
 
 test "Parser: nested destructuring" {
-    var scanner = Scanner.init(std.testing.allocator, "const { a: { b } } = obj;");
+    var scanner = try Scanner.init(std.testing.allocator, "const { a: { b } } = obj;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1977,7 +1977,7 @@ test "Parser: nested destructuring" {
 }
 
 test "Parser: destructuring with rest" {
-    var scanner = Scanner.init(std.testing.allocator, "const [first, ...rest] = arr;");
+    var scanner = try Scanner.init(std.testing.allocator, "const [first, ...rest] = arr;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1987,7 +1987,7 @@ test "Parser: destructuring with rest" {
 }
 
 test "Parser: function with destructuring params" {
-    var scanner = Scanner.init(std.testing.allocator, "function foo({ x, y }, [a, b]) { }");
+    var scanner = try Scanner.init(std.testing.allocator, "function foo({ x, y }, [a, b]) { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1999,7 +1999,7 @@ test "Parser: function with destructuring params" {
 test "Parser: duplicate param in array destructuring (strict)" {
     // strict mode에서 function f(a, [a, b]) {} 는 에러: a가 두 번 바인딩됨.
     // array_pattern 안의 이름을 collectBoundNames로 수집해야 잡을 수 있음.
-    var scanner = Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [a, b]) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [a, b]) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2010,7 +2010,7 @@ test "Parser: duplicate param in array destructuring (strict)" {
 
 test "Parser: duplicate param in object destructuring (strict)" {
     // strict mode에서 function f(a, {a}) {} 는 에러: a가 두 번 바인딩됨.
-    var scanner = Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, {a}) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, {a}) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2021,7 +2021,7 @@ test "Parser: duplicate param in object destructuring (strict)" {
 
 test "Parser: no duplicate in different destructuring names (strict)" {
     // 이름이 다르면 에러 없음
-    var scanner = Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [b, c]) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [b, c]) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2032,7 +2032,7 @@ test "Parser: no duplicate in different destructuring names (strict)" {
 
 test "Parser: duplicate param nested destructuring (strict)" {
     // 중첩 destructuring: function f(a, [{a}]) {} → a가 중복
-    var scanner = Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [{a}]) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [{a}]) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2043,7 +2043,7 @@ test "Parser: duplicate param nested destructuring (strict)" {
 
 test "Parser: duplicate param with default value in array (strict)" {
     // default value: function f(a, [a = 1]) {} → a가 중복
-    var scanner = Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [a = 1]) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [a = 1]) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2054,7 +2054,7 @@ test "Parser: duplicate param with default value in array (strict)" {
 
 test "Parser: duplicate param with rest in array (strict)" {
     // rest element: function f(a, [...a]) {} → a가 중복
-    var scanner = Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [...a]) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "\"use strict\"; function f(a, [...a]) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2066,7 +2066,7 @@ test "Parser: duplicate param with rest in array (strict)" {
 test "Parser: duplicate param within same destructuring (generator)" {
     // generator 함수에서도 destructuring 내 중복은 에러
     // function* f([a, a]) {} → a가 중복 (generator는 항상 중복 검사)
-    var scanner = Scanner.init(std.testing.allocator, "function* f([a, a]) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "function* f([a, a]) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2080,7 +2080,7 @@ test "Parser: duplicate param within same destructuring (generator)" {
 // ============================================================
 
 test "Parser: import side-effect" {
-    var scanner = Scanner.init(std.testing.allocator, "import 'module';");
+    var scanner = try Scanner.init(std.testing.allocator, "import 'module';");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2091,7 +2091,7 @@ test "Parser: import side-effect" {
 }
 
 test "Parser: import default" {
-    var scanner = Scanner.init(std.testing.allocator, "import foo from 'module';");
+    var scanner = try Scanner.init(std.testing.allocator, "import foo from 'module';");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2102,7 +2102,7 @@ test "Parser: import default" {
 }
 
 test "Parser: import named" {
-    var scanner = Scanner.init(std.testing.allocator, "import { a, b as c } from 'module';");
+    var scanner = try Scanner.init(std.testing.allocator, "import { a, b as c } from 'module';");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2113,7 +2113,7 @@ test "Parser: import named" {
 }
 
 test "Parser: import namespace" {
-    var scanner = Scanner.init(std.testing.allocator, "import * as ns from 'module';");
+    var scanner = try Scanner.init(std.testing.allocator, "import * as ns from 'module';");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2124,7 +2124,7 @@ test "Parser: import namespace" {
 }
 
 test "Parser: import default + named" {
-    var scanner = Scanner.init(std.testing.allocator, "import React, { useState } from 'react';");
+    var scanner = try Scanner.init(std.testing.allocator, "import React, { useState } from 'react';");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2135,7 +2135,7 @@ test "Parser: import default + named" {
 }
 
 test "Parser: export default" {
-    var scanner = Scanner.init(std.testing.allocator, "export default 42;");
+    var scanner = try Scanner.init(std.testing.allocator, "export default 42;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2146,7 +2146,7 @@ test "Parser: export default" {
 }
 
 test "Parser: export named" {
-    var scanner = Scanner.init(std.testing.allocator, "export { a, b as c };");
+    var scanner = try Scanner.init(std.testing.allocator, "export { a, b as c };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2157,7 +2157,7 @@ test "Parser: export named" {
 }
 
 test "Parser: export declaration" {
-    var scanner = Scanner.init(std.testing.allocator, "export const x = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "export const x = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2168,7 +2168,7 @@ test "Parser: export declaration" {
 }
 
 test "Parser: export all re-export" {
-    var scanner = Scanner.init(std.testing.allocator, "export * from 'module';");
+    var scanner = try Scanner.init(std.testing.allocator, "export * from 'module';");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2179,7 +2179,7 @@ test "Parser: export all re-export" {
 }
 
 test "Parser: export named re-export" {
-    var scanner = Scanner.init(std.testing.allocator, "export { foo } from 'module';");
+    var scanner = try Scanner.init(std.testing.allocator, "export { foo } from 'module';");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2190,7 +2190,7 @@ test "Parser: export named re-export" {
 }
 
 test "Parser: export default function" {
-    var scanner = Scanner.init(std.testing.allocator, "export default function foo() { }");
+    var scanner = try Scanner.init(std.testing.allocator, "export default function foo() { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2201,7 +2201,7 @@ test "Parser: export default function" {
 }
 
 test "Parser: dynamic import expression" {
-    var scanner = Scanner.init(std.testing.allocator, "const m = import('module');");
+    var scanner = try Scanner.init(std.testing.allocator, "const m = import('module');");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2211,7 +2211,7 @@ test "Parser: dynamic import expression" {
 }
 
 test "Parser: async function declaration" {
-    var scanner = Scanner.init(std.testing.allocator, "async function fetchData() { return await fetch(); }");
+    var scanner = try Scanner.init(std.testing.allocator, "async function fetchData() { return await fetch(); }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2221,7 +2221,7 @@ test "Parser: async function declaration" {
 }
 
 test "Parser: generator function" {
-    var scanner = Scanner.init(std.testing.allocator, "function* gen() { yield 1; yield 2; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function* gen() { yield 1; yield 2; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2231,7 +2231,7 @@ test "Parser: generator function" {
 }
 
 test "Parser: yield delegate" {
-    var scanner = Scanner.init(std.testing.allocator, "function* gen() { yield* other(); }");
+    var scanner = try Scanner.init(std.testing.allocator, "function* gen() { yield* other(); }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2241,7 +2241,7 @@ test "Parser: yield delegate" {
 }
 
 test "Parser: async arrow function" {
-    var scanner = Scanner.init(std.testing.allocator, "const f = async () => { await fetch(); };");
+    var scanner = try Scanner.init(std.testing.allocator, "const f = async () => { await fetch(); };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2251,7 +2251,7 @@ test "Parser: async arrow function" {
 }
 
 test "Parser: class with private field and method" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\class Counter {
         \\  #count = 0;
         \\  #increment() { this.#count++; }
@@ -2267,7 +2267,7 @@ test "Parser: class with private field and method" {
 }
 
 test "Parser: private field access" {
-    var scanner = Scanner.init(std.testing.allocator, "this.#name;");
+    var scanner = try Scanner.init(std.testing.allocator, "this.#name;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2279,7 +2279,7 @@ test "Parser: private field access" {
 test "Parser: assignment destructuring (array)" {
     // 배열 대입 구조분해 — 현재 array_expression + assignment로 파싱됨
     // semantic analysis에서 assignment target으로 변환 예정
-    var scanner = Scanner.init(std.testing.allocator, "[a, b] = [1, 2];");
+    var scanner = try Scanner.init(std.testing.allocator, "[a, b] = [1, 2];");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2289,7 +2289,7 @@ test "Parser: assignment destructuring (array)" {
 }
 
 test "Parser: assignment destructuring (object)" {
-    var scanner = Scanner.init(std.testing.allocator, "({ x, y } = obj);");
+    var scanner = try Scanner.init(std.testing.allocator, "({ x, y } = obj);");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2299,7 +2299,7 @@ test "Parser: assignment destructuring (object)" {
 }
 
 test "Parser: import.meta" {
-    var scanner = Scanner.init(std.testing.allocator, "const url = import.meta.url;");
+    var scanner = try Scanner.init(std.testing.allocator, "const url = import.meta.url;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2310,7 +2310,7 @@ test "Parser: import.meta" {
 }
 
 test "Parser: array elision [, , x]" {
-    var scanner = Scanner.init(std.testing.allocator, "const [, , x] = arr;");
+    var scanner = try Scanner.init(std.testing.allocator, "const [, , x] = arr;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2324,7 +2324,7 @@ test "Parser: array elision [, , x]" {
 // ============================================================
 
 test "Parser: TS variable with type annotation" {
-    var scanner = Scanner.init(std.testing.allocator, "const x: number = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "const x: number = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2334,7 +2334,7 @@ test "Parser: TS variable with type annotation" {
 }
 
 test "Parser: TS function with typed params and return" {
-    var scanner = Scanner.init(std.testing.allocator, "function add(a: number, b: number): number { return a + b; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function add(a: number, b: number): number { return a + b; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2344,7 +2344,7 @@ test "Parser: TS function with typed params and return" {
 }
 
 test "Parser: TS union type" {
-    var scanner = Scanner.init(std.testing.allocator, "const x: string | number = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "const x: string | number = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2354,7 +2354,7 @@ test "Parser: TS union type" {
 }
 
 test "Parser: TS array type" {
-    var scanner = Scanner.init(std.testing.allocator, "const arr: number[] = [];");
+    var scanner = try Scanner.init(std.testing.allocator, "const arr: number[] = [];");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2364,7 +2364,7 @@ test "Parser: TS array type" {
 }
 
 test "Parser: TS generic type" {
-    var scanner = Scanner.init(std.testing.allocator, "const arr: Array<string> = [];");
+    var scanner = try Scanner.init(std.testing.allocator, "const arr: Array<string> = [];");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2374,7 +2374,7 @@ test "Parser: TS generic type" {
 }
 
 test "Parser: TS as expression" {
-    var scanner = Scanner.init(std.testing.allocator, "const x = value as string;");
+    var scanner = try Scanner.init(std.testing.allocator, "const x = value as string;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2384,7 +2384,7 @@ test "Parser: TS as expression" {
 }
 
 test "Parser: TS non-null assertion" {
-    var scanner = Scanner.init(std.testing.allocator, "const x = value!;");
+    var scanner = try Scanner.init(std.testing.allocator, "const x = value!;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2394,7 +2394,7 @@ test "Parser: TS non-null assertion" {
 }
 
 test "Parser: TS object type literal" {
-    var scanner = Scanner.init(std.testing.allocator, "const obj: { x: number; y: string } = { x: 1, y: 'a' };");
+    var scanner = try Scanner.init(std.testing.allocator, "const obj: { x: number; y: string } = { x: 1, y: 'a' };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2404,7 +2404,7 @@ test "Parser: TS object type literal" {
 }
 
 test "Parser: TS tuple type" {
-    var scanner = Scanner.init(std.testing.allocator, "const t: [string, number] = ['a', 1];");
+    var scanner = try Scanner.init(std.testing.allocator, "const t: [string, number] = ['a', 1];");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2414,7 +2414,7 @@ test "Parser: TS tuple type" {
 }
 
 test "Parser: TS typeof and keyof" {
-    var scanner = Scanner.init(std.testing.allocator, "const k: keyof typeof obj = 'x';");
+    var scanner = try Scanner.init(std.testing.allocator, "const k: keyof typeof obj = 'x';");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2428,7 +2428,7 @@ test "Parser: TS typeof and keyof" {
 // ============================================================
 
 test "Parser: TS type alias" {
-    var scanner = Scanner.init(std.testing.allocator, "type StringOrNumber = string | number;");
+    var scanner = try Scanner.init(std.testing.allocator, "type StringOrNumber = string | number;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2438,7 +2438,7 @@ test "Parser: TS type alias" {
 }
 
 test "Parser: TS generic type alias" {
-    var scanner = Scanner.init(std.testing.allocator, "type Result<T, E> = { ok: T } | { err: E };");
+    var scanner = try Scanner.init(std.testing.allocator, "type Result<T, E> = { ok: T } | { err: E };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2448,7 +2448,7 @@ test "Parser: TS generic type alias" {
 }
 
 test "Parser: TS interface" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\interface User {
         \\  name: string;
         \\  age: number;
@@ -2464,7 +2464,7 @@ test "Parser: TS interface" {
 
 test "Parser: TS interface extends" {
     // interface Admin extends User — 단일 extends를 NodeList(len=1)로 저장
-    var scanner = Scanner.init(std.testing.allocator, "interface Admin extends User { role: string; }");
+    var scanner = try Scanner.init(std.testing.allocator, "interface Admin extends User { role: string; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2487,7 +2487,7 @@ test "Parser: TS interface extends" {
 
 test "Parser: TS interface multiple extends" {
     // interface Foo extends Bar, Baz — 다중 extends를 NodeList로 정확히 저장
-    var scanner = Scanner.init(std.testing.allocator, "interface Foo extends Bar, Baz { }");
+    var scanner = try Scanner.init(std.testing.allocator, "interface Foo extends Bar, Baz { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2516,7 +2516,7 @@ test "Parser: TS interface multiple extends" {
 
 test "Parser: TS interface no extends" {
     // extends 없는 경우 extends_len = 0
-    var scanner = Scanner.init(std.testing.allocator, "interface Empty { }");
+    var scanner = try Scanner.init(std.testing.allocator, "interface Empty { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2535,7 +2535,7 @@ test "Parser: TS interface no extends" {
 }
 
 test "Parser: TS enum" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\enum Color {
         \\  Red,
         \\  Green = 10,
@@ -2551,7 +2551,7 @@ test "Parser: TS enum" {
 }
 
 test "Parser: TS namespace" {
-    var scanner = Scanner.init(std.testing.allocator, "namespace Utils { const x = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "namespace Utils { const x = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2561,7 +2561,7 @@ test "Parser: TS namespace" {
 }
 
 test "Parser: TS declare" {
-    var scanner = Scanner.init(std.testing.allocator, "declare const VERSION: string;");
+    var scanner = try Scanner.init(std.testing.allocator, "declare const VERSION: string;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2571,7 +2571,7 @@ test "Parser: TS declare" {
 }
 
 test "Parser: TS abstract class" {
-    var scanner = Scanner.init(std.testing.allocator, "abstract class Shape { abstract area(): number; }");
+    var scanner = try Scanner.init(std.testing.allocator, "abstract class Shape { abstract area(): number; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2581,7 +2581,7 @@ test "Parser: TS abstract class" {
 }
 
 test "Parser: TS generic type parameter with constraint and default" {
-    var scanner = Scanner.init(std.testing.allocator, "type Foo<T extends string = 'hello'> = T;");
+    var scanner = try Scanner.init(std.testing.allocator, "type Foo<T extends string = 'hello'> = T;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2591,7 +2591,7 @@ test "Parser: TS generic type parameter with constraint and default" {
 }
 
 test "Parser: TS parameter property" {
-    var scanner = Scanner.init(std.testing.allocator, "class Foo { constructor(public x: number, private y: string) { } }");
+    var scanner = try Scanner.init(std.testing.allocator, "class Foo { constructor(public x: number, private y: string) { } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2601,7 +2601,7 @@ test "Parser: TS parameter property" {
 }
 
 test "Parser: decorator on class" {
-    var scanner = Scanner.init(std.testing.allocator, "@Component class Foo { }");
+    var scanner = try Scanner.init(std.testing.allocator, "@Component class Foo { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2611,7 +2611,7 @@ test "Parser: decorator on class" {
 }
 
 test "Parser: decorator with arguments" {
-    var scanner = Scanner.init(std.testing.allocator, "@Injectable() class Service { }");
+    var scanner = try Scanner.init(std.testing.allocator, "@Injectable() class Service { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2621,7 +2621,7 @@ test "Parser: decorator with arguments" {
 }
 
 test "Parser: decorator on class member" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\class Foo {
         \\  @log
         \\  public greet(): void { }
@@ -2636,7 +2636,7 @@ test "Parser: decorator on class member" {
 }
 
 test "Parser: class implements" {
-    var scanner = Scanner.init(std.testing.allocator, "class Foo implements Bar, Baz { }");
+    var scanner = try Scanner.init(std.testing.allocator, "class Foo implements Bar, Baz { }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2646,7 +2646,7 @@ test "Parser: class implements" {
 }
 
 test "Parser: static readonly member" {
-    var scanner = Scanner.init(std.testing.allocator, "class Foo { static readonly MAX = 100; }");
+    var scanner = try Scanner.init(std.testing.allocator, "class Foo { static readonly MAX = 100; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2656,7 +2656,7 @@ test "Parser: static readonly member" {
 }
 
 test "Parser: class with generics" {
-    var scanner = Scanner.init(std.testing.allocator, "class Box<T> { value: T; }");
+    var scanner = try Scanner.init(std.testing.allocator, "class Box<T> { value: T; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2670,7 +2670,7 @@ test "Parser: class with generics" {
 // ============================================================
 
 test "Parser: JSX self-closing element" {
-    var scanner = Scanner.init(std.testing.allocator, "const x = <br />;");
+    var scanner = try Scanner.init(std.testing.allocator, "const x = <br />;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2680,7 +2680,7 @@ test "Parser: JSX self-closing element" {
 }
 
 test "Parser: JSX element with children" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\const x = <div>hello</div>;
     );
     defer scanner.deinit();
@@ -2692,7 +2692,7 @@ test "Parser: JSX element with children" {
 }
 
 test "Parser: JSX with attributes" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\const x = <div className="foo" id="bar" />;
     );
     defer scanner.deinit();
@@ -2704,7 +2704,7 @@ test "Parser: JSX with attributes" {
 }
 
 test "Parser: JSX with expression" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\const x = <span>{name}</span>;
     );
     defer scanner.deinit();
@@ -2719,7 +2719,7 @@ test "Parser: function call with division in args" {
     // arrow lookahead가 prev_token_kind를 복구하지 않으면
     // / 가 regex로 해석되어 실패하던 버그 테스트
     const source = "truncate(x / y)";
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2733,7 +2733,7 @@ test "Parser: function call with division in args" {
 // ================================================================
 
 test "Parser: return outside function is error" {
-    var scanner = Scanner.init(std.testing.allocator, "return 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "return 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2744,7 +2744,7 @@ test "Parser: return outside function is error" {
 }
 
 test "Parser: return inside function is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "function f() { return 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function f() { return 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2754,7 +2754,7 @@ test "Parser: return inside function is valid" {
 }
 
 test "Parser: return inside arrow function is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "const f = () => { return 1; };");
+    var scanner = try Scanner.init(std.testing.allocator, "const f = () => { return 1; };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2764,7 +2764,7 @@ test "Parser: return inside arrow function is valid" {
 }
 
 test "Parser: break outside loop/switch is error" {
-    var scanner = Scanner.init(std.testing.allocator, "break;");
+    var scanner = try Scanner.init(std.testing.allocator, "break;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2775,7 +2775,7 @@ test "Parser: break outside loop/switch is error" {
 }
 
 test "Parser: break inside loop is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "while (true) { break; }");
+    var scanner = try Scanner.init(std.testing.allocator, "while (true) { break; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2785,7 +2785,7 @@ test "Parser: break inside loop is valid" {
 }
 
 test "Parser: break inside switch is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "function f(x) { switch (x) { case 1: break; } }");
+    var scanner = try Scanner.init(std.testing.allocator, "function f(x) { switch (x) { case 1: break; } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2795,7 +2795,7 @@ test "Parser: break inside switch is valid" {
 }
 
 test "Parser: continue outside loop is error" {
-    var scanner = Scanner.init(std.testing.allocator, "continue;");
+    var scanner = try Scanner.init(std.testing.allocator, "continue;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2806,7 +2806,7 @@ test "Parser: continue outside loop is error" {
 }
 
 test "Parser: continue inside for loop is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "for (var i = 0; i < 10; i++) { continue; }");
+    var scanner = try Scanner.init(std.testing.allocator, "for (var i = 0; i < 10; i++) { continue; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2817,7 +2817,7 @@ test "Parser: continue inside for loop is valid" {
 
 test "Parser: break in nested function inside loop is error" {
     // 함수 경계에서 loop 컨텍스트가 리셋되므로, 내부 함수의 break는 에러
-    var scanner = Scanner.init(std.testing.allocator, "while (true) { function f() { break; } }");
+    var scanner = try Scanner.init(std.testing.allocator, "while (true) { function f() { break; } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2828,7 +2828,7 @@ test "Parser: break in nested function inside loop is error" {
 }
 
 test "Parser: with statement in strict mode is error" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\"use strict";
         \\with (obj) { x; }
     );
@@ -2842,7 +2842,7 @@ test "Parser: with statement in strict mode is error" {
 }
 
 test "Parser: with statement in non-strict mode is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "with (obj) { x; }");
+    var scanner = try Scanner.init(std.testing.allocator, "with (obj) { x; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2853,7 +2853,7 @@ test "Parser: with statement in non-strict mode is valid" {
 
 test "Parser: use strict in function body" {
     // 함수 내부 "use strict"가 strict mode를 설정하는지 확인
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\function f() {
         \\  "use strict";
         \\  with (obj) { x; }
@@ -2869,7 +2869,7 @@ test "Parser: use strict in function body" {
 }
 
 test "Parser: module mode is always strict" {
-    var scanner = Scanner.init(std.testing.allocator, "with (obj) { x; }");
+    var scanner = try Scanner.init(std.testing.allocator, "with (obj) { x; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2885,7 +2885,7 @@ test "Parser: module mode is always strict" {
 // ================================================================
 
 test "Parser: reserved word as variable name is error" {
-    var scanner = Scanner.init(std.testing.allocator, "var var = 123;");
+    var scanner = try Scanner.init(std.testing.allocator, "var var = 123;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2895,7 +2895,7 @@ test "Parser: reserved word as variable name is error" {
 }
 
 test "Parser: strict mode reserved word as binding in strict mode is error" {
-    var scanner = Scanner.init(std.testing.allocator,
+    var scanner = try Scanner.init(std.testing.allocator,
         \\"use strict";
         \\var implements = 1;
     );
@@ -2908,7 +2908,7 @@ test "Parser: strict mode reserved word as binding in strict mode is error" {
 }
 
 test "Parser: strict mode reserved word as binding in non-strict is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "var implements = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "var implements = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2918,7 +2918,7 @@ test "Parser: strict mode reserved word as binding in non-strict is valid" {
 }
 
 test "Parser: let as variable name is valid in non-strict" {
-    var scanner = Scanner.init(std.testing.allocator, "var let = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "var let = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2932,7 +2932,7 @@ test "Parser: let as variable name is valid in non-strict" {
 // ============================================================
 
 test "Parser: ++this is invalid assignment target" {
-    var scanner = Scanner.init(std.testing.allocator, "++this;");
+    var scanner = try Scanner.init(std.testing.allocator, "++this;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2942,7 +2942,7 @@ test "Parser: ++this is invalid assignment target" {
 }
 
 test "Parser: delete identifier in strict mode is error" {
-    var scanner = Scanner.init(std.testing.allocator, "\"use strict\"; delete x;");
+    var scanner = try Scanner.init(std.testing.allocator, "\"use strict\"; delete x;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2952,7 +2952,7 @@ test "Parser: delete identifier in strict mode is error" {
 }
 
 test "Parser: const without initializer is error" {
-    var scanner = Scanner.init(std.testing.allocator, "const x;");
+    var scanner = try Scanner.init(std.testing.allocator, "const x;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2962,7 +2962,7 @@ test "Parser: const without initializer is error" {
 }
 
 test "Parser: for-of const without init is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "for (const x of [1]) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "for (const x of [1]) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2973,7 +2973,7 @@ test "Parser: for-of const without init is valid" {
 
 test "Parser: import/export only at module top-level" {
     // import in function body — error even in module
-    var scanner = Scanner.init(std.testing.allocator, "function f() { import 'x'; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function f() { import 'x'; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -2984,7 +2984,7 @@ test "Parser: import/export only at module top-level" {
 }
 
 test "Parser: function in loop body is error" {
-    var scanner = Scanner.init(std.testing.allocator, "for (;;) function f() {}");
+    var scanner = try Scanner.init(std.testing.allocator, "for (;;) function f() {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2994,7 +2994,7 @@ test "Parser: function in loop body is error" {
 }
 
 test "Parser: yield is identifier outside generator" {
-    var scanner = Scanner.init(std.testing.allocator, "var yield = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "var yield = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3004,7 +3004,7 @@ test "Parser: yield is identifier outside generator" {
 }
 
 test "Parser: await is identifier in script mode" {
-    var scanner = Scanner.init(std.testing.allocator, "var await = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "var await = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3014,7 +3014,7 @@ test "Parser: await is identifier in script mode" {
 }
 
 test "Parser: await is reserved in module mode" {
-    var scanner = Scanner.init(std.testing.allocator, "var await = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "var await = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     parser.is_module = true;
@@ -3025,7 +3025,7 @@ test "Parser: await is reserved in module mode" {
 }
 
 test "Parser: super outside method is error" {
-    var scanner = Scanner.init(std.testing.allocator, "super.x;");
+    var scanner = try Scanner.init(std.testing.allocator, "super.x;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3035,7 +3035,7 @@ test "Parser: super outside method is error" {
 }
 
 test "Parser: new.target outside function is error" {
-    var scanner = Scanner.init(std.testing.allocator, "new.target;");
+    var scanner = try Scanner.init(std.testing.allocator, "new.target;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3045,7 +3045,7 @@ test "Parser: new.target outside function is error" {
 }
 
 test "Parser: object shorthand reserved word is error" {
-    var scanner = Scanner.init(std.testing.allocator, "({true});");
+    var scanner = try Scanner.init(std.testing.allocator, "({true});");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3055,7 +3055,7 @@ test "Parser: object shorthand reserved word is error" {
 }
 
 test "Parser: optional chaining is not assignment target" {
-    var scanner = Scanner.init(std.testing.allocator, "x?.y = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "x?.y = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3065,7 +3065,7 @@ test "Parser: optional chaining is not assignment target" {
 }
 
 test "Parser: parenthesized destructuring is not assignment target" {
-    var scanner = Scanner.init(std.testing.allocator, "({}) = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "({}) = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3077,7 +3077,7 @@ test "Parser: parenthesized destructuring is not assignment target" {
 test "Parser: arguments in class field initializer is error" {
     // class field에서 arguments 직접 사용 — SyntaxError
     {
-        var scanner = Scanner.init(std.testing.allocator, "var C = class { x = arguments; };");
+        var scanner = try Scanner.init(std.testing.allocator, "var C = class { x = arguments; };");
         defer scanner.deinit();
         var parser = Parser.init(std.testing.allocator, &scanner);
         defer parser.deinit();
@@ -3087,7 +3087,7 @@ test "Parser: arguments in class field initializer is error" {
     }
     // arrow function 안에서 arguments 사용 — arrow는 자체 arguments가 없으므로 SyntaxError
     {
-        var scanner = Scanner.init(std.testing.allocator, "class C { x = () => arguments; }");
+        var scanner = try Scanner.init(std.testing.allocator, "class C { x = () => arguments; }");
         defer scanner.deinit();
         var parser = Parser.init(std.testing.allocator, &scanner);
         defer parser.deinit();
@@ -3097,7 +3097,7 @@ test "Parser: arguments in class field initializer is error" {
     }
     // 일반 function 안에서 arguments 사용 — 자체 arguments 바인딩이 있으므로 OK
     {
-        var scanner = Scanner.init(std.testing.allocator, "class C { x = function() { return arguments; }; }");
+        var scanner = try Scanner.init(std.testing.allocator, "class C { x = function() { return arguments; }; }");
         defer scanner.deinit();
         var parser = Parser.init(std.testing.allocator, &scanner);
         defer parser.deinit();
@@ -3113,7 +3113,7 @@ test "Parser: arguments in class field initializer is error" {
 
 test "CoverGrammar: rest element with initializer in array destructuring" {
     // [...x = 1] = arr → rest에 initializer 금지
-    var scanner = Scanner.init(std.testing.allocator, "[...x = 1] = arr;");
+    var scanner = try Scanner.init(std.testing.allocator, "[...x = 1] = arr;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3133,7 +3133,7 @@ test "CoverGrammar: rest element with initializer in array destructuring" {
 
 test "CoverGrammar: valid array destructuring" {
     // [a, b, ...c] = arr → 에러 없음
-    var scanner = Scanner.init(std.testing.allocator, "[a, b, ...c] = arr;");
+    var scanner = try Scanner.init(std.testing.allocator, "[a, b, ...c] = arr;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3144,7 +3144,7 @@ test "CoverGrammar: valid array destructuring" {
 
 test "CoverGrammar: valid object destructuring" {
     // ({ a, b: c } = obj) → 에러 없음
-    var scanner = Scanner.init(std.testing.allocator, "({ a, b: c } = obj);");
+    var scanner = try Scanner.init(std.testing.allocator, "({ a, b: c } = obj);");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3155,7 +3155,7 @@ test "CoverGrammar: valid object destructuring" {
 
 test "CoverGrammar: strict mode eval assignment" {
     // "use strict"; eval = 1 → 에러
-    var scanner = Scanner.init(std.testing.allocator, "\"use strict\"; eval = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "\"use strict\"; eval = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3166,7 +3166,7 @@ test "CoverGrammar: strict mode eval assignment" {
 
 test "CoverGrammar: parenthesized destructuring is invalid" {
     // ([x]) = 1 → parenthesized destructuring 금지
-    var scanner = Scanner.init(std.testing.allocator, "([x]) = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "([x]) = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3177,7 +3177,7 @@ test "CoverGrammar: parenthesized destructuring is invalid" {
 
 test "CoverGrammar: for-in with rest-init is error" {
     // for ([...x = 1] in obj) {} → rest-init 금지
-    var scanner = Scanner.init(std.testing.allocator, "for ([...x = 1] in obj) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "for ([...x = 1] in obj) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3195,7 +3195,7 @@ test "CoverGrammar: for-in with rest-init is error" {
 
 test "CoverGrammar: arrow params rest-init is error" {
     // ([...x = 1]) => {} → rest-init 금지
-    var scanner = Scanner.init(std.testing.allocator, "([...x = 1]) => {};");
+    var scanner = try Scanner.init(std.testing.allocator, "([...x = 1]) => {};");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3237,7 +3237,7 @@ const ErrorCheck = struct {
 
 /// 테스트 헬퍼: 소스를 파싱하고 조건에 맞는 에러가 있는지 검증한다.
 fn expectParseError(source: []const u8, check: ErrorCheck) !void {
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3270,7 +3270,7 @@ fn expectParseError(source: []const u8, check: ErrorCheck) !void {
 
 /// 테스트 헬퍼: 소스를 파싱하고 에러가 없는지 검증한다.
 fn expectNoParseError(source: []const u8) !void {
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3343,7 +3343,7 @@ test "ErrorMsg: addError backward compat (no found/hint)" {
 }
 
 test "ErrorMsg: multiple errors all have proper fields" {
-    var scanner = Scanner.init(std.testing.allocator, "function( { ) }");
+    var scanner = try Scanner.init(std.testing.allocator, "function( { ) }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3357,7 +3357,7 @@ test "ErrorMsg: multiple errors all have proper fields" {
 
 test "ErrorMsg: nested brackets track correctly" {
     // 중첩 괄호: `if ([1, (2` → 에러에 related_span이 하나 이상 존재
-    var scanner = Scanner.init(std.testing.allocator, "if ([1, (2");
+    var scanner = try Scanner.init(std.testing.allocator, "if ([1, (2");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -3397,7 +3397,7 @@ test "ErrorMsg: valid code has no errors (regression)" {
 // ================================================================
 
 test "Diagnostic: parser errors have kind=parse" {
-    var scanner = Scanner.init(std.testing.allocator, "var 123bad;");
+    var scanner = try Scanner.init(std.testing.allocator, "var 123bad;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -20,7 +20,7 @@ const ParseError2 = @import("parser.zig").ParseError2;
 
 /// 소스 전체를 파싱하여 AST를 반환한다.
 pub fn parse(self: *Parser) !NodeIndex {
-    self.advance(); // 첫 토큰 로드
+    try self.advance(); // 첫 토큰 로드
 
     // module 모드면 항상 strict (D054)
     if (self.is_module) {
@@ -29,7 +29,7 @@ pub fn parse(self: *Parser) !NodeIndex {
 
     // hashbang (#! ...) 건너뛰기
     if (self.current() == .hashbang_comment) {
-        self.advance();
+        try self.advance();
     }
 
     var stmts = std.ArrayList(NodeIndex).init(self.allocator);
@@ -68,48 +68,48 @@ pub fn parse(self: *Parser) !NodeIndex {
 pub fn parseStatementChecked(self: *Parser, comptime is_loop_body: bool) ParseError2!NodeIndex {
     switch (self.current()) {
         .kw_const => {
-            self.addError(self.currentSpan(), "Lexical declaration is not allowed in statement position");
+            try self.addError(self.currentSpan(), "Lexical declaration is not allowed in statement position");
         },
         .kw_let => {
             if (self.is_strict_mode) {
-                self.addError(self.currentSpan(), "Lexical declaration is not allowed in statement position");
-            } else if (isLetDeclarationStart(self)) {
+                try self.addError(self.currentSpan(), "Lexical declaration is not allowed in statement position");
+            } else if (try isLetDeclarationStart(self)) {
                 // sloppy mode에서도 `let`이 LexicalDeclaration으로 해석되면 에러
                 // isLetDeclarationStart: 줄바꿈 없이 identifier/[/{, 또는 줄바꿈 있어도 [
-                self.addError(self.currentSpan(), "Lexical declaration is not allowed in statement position");
+                try self.addError(self.currentSpan(), "Lexical declaration is not allowed in statement position");
             }
         },
         .kw_class => {
             // class declaration은 statement position에서 항상 금지 (Annex B에 class 예외 없음)
-            self.addError(self.currentSpan(), "Class declaration is not allowed in statement position");
+            try self.addError(self.currentSpan(), "Class declaration is not allowed in statement position");
         },
         .kw_function => {
-            if (self.peekNextKind() == .star) {
+            if (try self.peekNextKind() == .star) {
                 // generator는 항상 금지
-                self.addError(self.currentSpan(), "Generator declaration is not allowed in statement position");
+                try self.addError(self.currentSpan(), "Generator declaration is not allowed in statement position");
             } else if (is_loop_body or self.in_labelled_fn_check) {
                 // loop/with body에서 function은 항상 금지 (ECMAScript 13.7.4, Annex B 미적용)
                 // labelled function이 if/with body를 통해 전파된 경우도 금지
-                self.addError(self.currentSpan(), "Function declaration is not allowed in statement position");
+                try self.addError(self.currentSpan(), "Function declaration is not allowed in statement position");
             } else if (self.is_strict_mode) {
                 // if/else/labeled body에서는 strict mode에서만 금지
-                self.addError(self.currentSpan(), "Function declaration is not allowed in statement position in strict mode");
+                try self.addError(self.currentSpan(), "Function declaration is not allowed in statement position in strict mode");
             }
         },
         .kw_async => {
-            const peek = self.peekNext();
+            const peek = try self.peekNext();
             if (peek.kind == .kw_function and !peek.has_newline_before) {
-                self.addError(self.currentSpan(), "Async function declaration is not allowed in statement position");
+                try self.addError(self.currentSpan(), "Async function declaration is not allowed in statement position");
             }
         },
         .kw_export => {
-            self.addError(self.currentSpan(), "'export' is not allowed in statement position");
+            try self.addError(self.currentSpan(), "'export' is not allowed in statement position");
         },
         .kw_import => {
             // import()와 import.meta는 expression이므로 제외
-            const peek = self.peekNextKind();
+            const peek = try self.peekNextKind();
             if (peek != .l_paren and peek != .dot) {
-                self.addError(self.currentSpan(), "'import' is not allowed in statement position");
+                try self.addError(self.currentSpan(), "'import' is not allowed in statement position");
             }
         },
         else => {},
@@ -125,22 +125,22 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
         // ECMAScript: sloppy mode에서 `let`은 LexicalDeclaration으로 취급되려면
         // 뒤에 줄바꿈 없이 BindingIdentifier, `[`, `{`가 와야 한다.
         // 그렇지 않으면 식별자로 취급하여 expression statement로 파싱한다.
-        .kw_let => if (self.is_strict_mode or isLetDeclarationStart(self))
+        .kw_let => if (self.is_strict_mode or try isLetDeclarationStart(self))
             parseVariableDeclaration(self)
         else
             parseExpressionStatement(self),
-        .kw_const => if (self.peekNextKind() == .kw_enum)
+        .kw_const => if (try self.peekNextKind() == .kw_enum)
             self.parseConstEnum()
         else
             parseVariableDeclaration(self),
         // using declaration (TC39 Stage 3: Explicit Resource Management)
         // `using x = getResource()` — parsed like const
-        .kw_using => if (isUsingDeclarationStart(self))
+        .kw_using => if (try isUsingDeclarationStart(self))
             parseVariableDeclaration(self)
         else
             parseExpressionOrLabeledStatement(self),
         // await using declaration: `await using x = getResource()`
-        .kw_await => if (isAwaitUsingDeclarationStart(self))
+        .kw_await => if (try isAwaitUsingDeclarationStart(self))
             parseAwaitUsingDeclaration(self)
         else
             parseExpressionOrLabeledStatement(self),
@@ -159,7 +159,7 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
         .kw_function => self.parseFunctionDeclaration(),
         .kw_class => self.parseClassDeclaration(),
         .kw_import => blk: {
-            const next = self.peekNextKind();
+            const next = try self.peekNextKind();
             break :blk if (next == .l_paren or next == .dot)
                 parseExpressionStatement(self)
             else
@@ -182,7 +182,7 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
 
 pub fn parseBlockStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.expect(.l_curly);
+    try self.expect(.l_curly);
 
     // 블록 안에서는 top-level이 아님 (import/export 금지)
     const block_saved = self.ctx;
@@ -199,7 +199,7 @@ pub fn parseBlockStatement(self: *Parser) ParseError2!NodeIndex {
     self.ctx = block_saved;
 
     const end = self.currentSpan().end;
-    self.expect(.r_curly);
+    try self.expect(.r_curly);
 
     const list = try self.ast.addNodeList(stmts.items);
     return try self.ast.addNode(.{
@@ -211,7 +211,7 @@ pub fn parseBlockStatement(self: *Parser) ParseError2!NodeIndex {
 
 fn parseEmptyStatement(self: *Parser) ParseError2!NodeIndex {
     const span = self.currentSpan();
-    self.advance(); // skip ;
+    try self.advance(); // skip ;
     return try self.ast.addNode(.{
         .tag = .empty_statement,
         .span = span,
@@ -225,11 +225,11 @@ pub fn parseExpressionStatement(self: *Parser) ParseError2!NodeIndex {
     const expr = try self.parseExpression();
     // CoverInitializedName ({ x = 1 }) 이 destructuring으로 소비되지 않았으면 에러
     if (self.has_cover_init_name) {
-        self.addError(.{ .start = start, .end = self.currentSpan().start }, "Invalid shorthand property initializer");
+        try self.addError(.{ .start = start, .end = self.currentSpan().start }, "Invalid shorthand property initializer");
         self.has_cover_init_name = false;
     }
     const end = self.currentSpan().end;
-    self.expectSemicolon(); // ASI 규칙 적용: 개행/}/EOF 있으면 삽입, 아니면 에러
+    try self.expectSemicolon(); // ASI 규칙 적용: 개행/}/EOF 있으면 삽입, 아니면 에러
     return try self.ast.addNode(.{
         .tag = .expression_statement,
         .span = .{ .start = start, .end = end },
@@ -241,8 +241,8 @@ pub fn parseExpressionStatement(self: *Parser) ParseError2!NodeIndex {
 /// ECMAScript: sloppy mode에서 `let`이 LexicalDeclaration의 시작인지 판별한다.
 /// `let` 뒤에 줄바꿈 없이 BindingIdentifier, `[`, `{`가 오면 LexicalDeclaration이다.
 /// 그 외에는 `let`을 식별자로 취급한다 (expression statement).
-fn isLetDeclarationStart(self: *Parser) bool {
-    const next = self.peekNext();
+fn isLetDeclarationStart(self: *Parser) ParseError2!bool {
+    const next = try self.peekNext();
     if (next.has_newline_before) {
         // `let` 뒤에 줄바꿈이 있으면, 일반적으로 ASI가 적용되어 `let`은 식별자.
         // 예외 1: `let [` → ExpressionStatement lookahead 제한으로 항상 LexicalDeclaration.
@@ -262,17 +262,17 @@ fn isLetDeclarationStart(self: *Parser) bool {
 }
 
 /// `using` 뒤에 줄바꿈 없이 identifier가 오면 UsingDeclaration으로 해석한다.
-fn isUsingDeclarationStart(self: *Parser) bool {
-    const next = self.peekNext();
+fn isUsingDeclarationStart(self: *Parser) ParseError2!bool {
+    const next = try self.peekNext();
     if (next.has_newline_before) return false;
     return next.kind == .identifier or
         (next.kind.isKeyword() and !next.kind.isReservedKeyword() and !next.kind.isLiteralKeyword());
 }
 
 /// `await` + `using` + identifier (줄바꿈 없이) → AwaitUsingDeclaration
-fn isAwaitUsingDeclarationStart(self: *Parser) bool {
+fn isAwaitUsingDeclarationStart(self: *Parser) ParseError2!bool {
     if (!self.ctx.in_async) return false;
-    const next = self.peekNext();
+    const next = try self.peekNext();
     if (next.has_newline_before or next.kind != .kw_using) return false;
     // await using 뒤에 identifier가 와야 함 — 더 앞은 볼 수 없으므로 true 반환
     return true;
@@ -280,7 +280,7 @@ fn isAwaitUsingDeclarationStart(self: *Parser) bool {
 
 /// `await using x = expr;` 선언을 파싱한다.
 fn parseAwaitUsingDeclaration(self: *Parser) ParseError2!NodeIndex {
-    self.advance(); // skip 'await'
+    try self.advance(); // skip 'await'
     return parseVariableDeclaration(self); // 'using'부터 parseVariableDeclaration 진행
 }
 
@@ -293,25 +293,25 @@ fn parseExpressionOrLabeledStatement(self: *Parser) ParseError2!NodeIndex {
         self.current() == .kw_await or self.current() == .kw_yield or
         (self.current().isKeyword() and !self.current().isReservedKeyword() and !self.current().isLiteralKeyword()))
     {
-        const peek = self.peekNext();
+        const peek = try self.peekNext();
         if (peek.kind == .colon) {
             // yield/await를 label로 사용하면 generator/async에서 에러
-            _ = self.checkYieldAwaitUse(self.currentSpan(), "label");
+            _ = try self.checkYieldAwaitUse(self.currentSpan(), "label");
             if (self.current() == .escaped_keyword) {
                 // escaped `await` is only reserved in module/async context
                 const esc_text = self.resolveIdentifierText(self.currentSpan());
                 const is_escaped_await = std.mem.eql(u8, esc_text, "await");
                 if (is_escaped_await) {
                     if (self.is_module or self.ctx.in_async) {
-                        self.addError(self.currentSpan(), "Escaped reserved word cannot be used as label");
+                        try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as label");
                     }
                 } else {
-                    self.addError(self.currentSpan(), "Escaped reserved word cannot be used as label");
+                    try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as label");
                 }
             } else if (self.current() == .escaped_strict_reserved and self.is_strict_mode) {
-                self.addError(self.currentSpan(), "Escaped reserved word cannot be used as label in strict mode");
+                try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as label in strict mode");
             } else if (self.is_strict_mode and self.current().isStrictModeReserved()) {
-                self.addError(self.currentSpan(), "Reserved word in strict mode cannot be used as label");
+                try self.addError(self.currentSpan(), "Reserved word in strict mode cannot be used as label");
             }
             return parseLabeledStatement(self);
         }
@@ -328,8 +328,8 @@ fn parseLabeledStatement(self: *Parser) ParseError2!NodeIndex {
         .span = self.currentSpan(),
         .data = .{ .string_ref = self.currentSpan() },
     });
-    self.advance(); // skip label
-    self.advance(); // skip ':'
+    try self.advance(); // skip label
+    try self.advance(); // skip ':'
     const body = try parseStatementChecked(self, false);
     return try self.ast.addNode(.{
         .tag = .labeled_statement,
@@ -342,13 +342,13 @@ fn parseLabeledStatement(self: *Parser) ParseError2!NodeIndex {
 /// strict mode에서는 SyntaxError (D054)
 fn parseWithStatement(self: *Parser) ParseError2!NodeIndex {
     if (self.is_strict_mode) {
-        self.addError(self.currentSpan(), "'with' is not allowed in strict mode");
+        try self.addError(self.currentSpan(), "'with' is not allowed in strict mode");
     }
     const start = self.currentSpan().start;
-    self.advance(); // skip 'with'
-    self.expect(.l_paren);
+    try self.advance(); // skip 'with'
+    try self.expect(.l_paren);
     const obj = try self.parseExpression();
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     // with body에서 function declaration은 항상 금지 (Annex B에 with 예외 없음)
     // IsLabelledFunction(Statement) 체크도 필요
     const saved_labelled = self.in_labelled_fn_check;
@@ -371,12 +371,12 @@ fn parseVariableDeclaration(self: *Parser) ParseError2!NodeIndex {
         .kw_using => 2, // using은 const처럼 동작 (block-scoped, immutable)
         else => 0,
     };
-    self.advance(); // skip var/let/const/using
+    try self.advance(); // skip var/let/const/using
 
     // let/const 선언에서 바인딩 이름 'let'은 금지 (ECMAScript 14.3.1.1)
     // 'let let = 1' → SyntaxError (non-strict에서도)
     if (kind_flags != 0 and self.current() == .kw_let) {
-        self.addError(self.currentSpan(), "'let' is not allowed as variable name in lexical declaration");
+        try self.addError(self.currentSpan(), "'let' is not allowed as variable name in lexical declaration");
     }
 
     const scratch_top = self.saveScratch();
@@ -390,12 +390,12 @@ fn parseVariableDeclaration(self: *Parser) ParseError2!NodeIndex {
             if (decl_node.tag == .variable_declarator) {
                 const init_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[decl_node.data.extra + 2]);
                 if (init_idx.isNone()) {
-                    self.addError(decl_node.span, "Const declarations must be initialized");
+                    try self.addError(decl_node.span, "Const declarations must be initialized");
                 }
             }
         }
         try self.scratch.append(decl);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
 
     const end = self.currentSpan().end;
@@ -404,7 +404,7 @@ fn parseVariableDeclaration(self: *Parser) ParseError2!NodeIndex {
     if (self.for_loop_init) {
         // for(var x = 0; ...) — 세미콜론은 parseForStatement에서 expect
     } else {
-        self.expectSemicolon();
+        try self.expectSemicolon();
     }
 
     const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
@@ -436,7 +436,7 @@ fn parseVariableDeclarator(self: *Parser) ParseError2!NodeIndex {
     // 이니셜라이저 — `in` 연산자를 복원한다 (ECMAScript: Initializer[+In]).
     // for 초기화절에서 allow_in=false여도, 이니셜라이저 안에서는 `in`이 연산자로 동작해야 한다.
     var init_expr = NodeIndex.none;
-    if (self.eat(.eq)) {
+    if (try self.eat(.eq)) {
         const init_saved = self.enterAllowInContext(true);
         init_expr = try self.parseAssignmentExpression();
         self.restoreContext(init_saved);
@@ -457,10 +457,10 @@ fn parseVariableDeclarator(self: *Parser) ParseError2!NodeIndex {
 fn parseReturnStatement(self: *Parser) ParseError2!NodeIndex {
     // return은 함수 안에서만 허용
     if (!self.ctx.in_function) {
-        self.addError(self.currentSpan(), "'return' outside of function");
+        try self.addError(self.currentSpan(), "'return' outside of function");
     }
     const start = self.currentSpan().start;
-    self.advance(); // skip 'return'
+    try self.advance(); // skip 'return'
 
     var arg = NodeIndex.none;
     if (self.current() != .semicolon and self.current() != .eof and
@@ -470,7 +470,7 @@ fn parseReturnStatement(self: *Parser) ParseError2!NodeIndex {
     }
 
     const end = self.currentSpan().end;
-    _ = self.eat(.semicolon);
+    _ = try self.eat(.semicolon);
 
     return try self.ast.addNode(.{
         .tag = .return_statement,
@@ -481,17 +481,17 @@ fn parseReturnStatement(self: *Parser) ParseError2!NodeIndex {
 
 fn parseIfStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'if'
-    self.expect(.l_paren);
+    try self.advance(); // skip 'if'
+    try self.expect(.l_paren);
     const test_expr = try self.parseExpression();
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     // ECMAScript 13.6.1: IsLabelledFunction(Statement) → SyntaxError
     const saved_labelled = self.in_labelled_fn_check;
     self.in_labelled_fn_check = true;
     const consequent = try parseStatementChecked(self, false);
 
     var alternate = NodeIndex.none;
-    if (self.eat(.kw_else)) {
+    if (try self.eat(.kw_else)) {
         alternate = try parseStatementChecked(self, false);
     }
     self.in_labelled_fn_check = saved_labelled;
@@ -505,10 +505,10 @@ fn parseIfStatement(self: *Parser) ParseError2!NodeIndex {
 
 fn parseWhileStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'while'
-    self.expect(.l_paren);
+    try self.advance(); // skip 'while'
+    try self.expect(.l_paren);
     const test_expr = try self.parseExpression();
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     const body = try self.parseLoopBody();
 
     return try self.ast.addNode(.{
@@ -520,13 +520,13 @@ fn parseWhileStatement(self: *Parser) ParseError2!NodeIndex {
 
 fn parseDoWhileStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'do'
+    try self.advance(); // skip 'do'
     const body = try self.parseLoopBody();
-    self.expect(.kw_while);
-    self.expect(.l_paren);
+    try self.expect(.kw_while);
+    try self.expect(.l_paren);
     const test_expr = try self.parseExpression();
-    self.expect(.r_paren);
-    _ = self.eat(.semicolon);
+    try self.expect(.r_paren);
+    _ = try self.eat(.semicolon);
 
     return try self.ast.addNode(.{
         .tag = .do_while_statement,
@@ -537,20 +537,20 @@ fn parseDoWhileStatement(self: *Parser) ParseError2!NodeIndex {
 
 fn parseForStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'for'
+    try self.advance(); // skip 'for'
 
     // for await (...) — async iteration
     // for-await-of: `for await (x of iterable)` — async iteration
     // await 플래그는 for-of에서 `async` 식별자 사용 허용 여부에 영향
-    const is_await = self.eat(.kw_await);
+    const is_await = try self.eat(.kw_await);
 
-    self.expect(.l_paren);
+    try self.expect(.l_paren);
 
     // for문의 init 부분 파싱
     // for(init; ...) or for(left in/of right)
     if (self.current() == .semicolon) {
         // for(; ...) — 빈 init
-        self.advance();
+        try self.advance();
         return parseForRest(self, start, NodeIndex.none);
     }
 
@@ -570,7 +570,7 @@ fn parseForStatement(self: *Parser) ParseError2!NodeIndex {
     //   단, `for (let of = 1;;)` 같은 경우는 isLetDeclarationStart가 true → 선언 경로.
     //   `kw_of` 뒤에 `=`이 오면 isLetDeclarationStart가 true (keyword + not reserved).
     const is_let_as_identifier = self.current() == .kw_let and !self.is_strict_mode and
-        (!isLetDeclarationStart(self) or self.peekNextKind() == .kw_of);
+        (!try isLetDeclarationStart(self) or try self.peekNextKind() == .kw_of);
 
     if ((self.current() == .kw_var or self.current() == .kw_let or self.current() == .kw_const) and !is_let_as_identifier) {
         const init_expr = try parseVariableDeclaration(self);
@@ -579,13 +579,13 @@ fn parseForStatement(self: *Parser) ParseError2!NodeIndex {
         // parseVariableDeclaration이 세미콜론을 소비했으면 for(;;)
         // 'in' 또는 'of'가 보이면 for-in/for-of
         if (self.current() == .kw_in or self.current() == .kw_of) {
-            validateForInOfDeclaration(self, init_expr);
+            try validateForInOfDeclaration(self, init_expr);
             if (self.current() == .kw_in) {
                 return parseForIn(self, start, init_expr);
             }
             return parseForOf(self, start, init_expr);
         }
-        self.expect(.semicolon); // for 헤더의 첫 번째 세미콜론 (ASI 금지, 7.9.2)
+        try self.expect(.semicolon); // for 헤더의 첫 번째 세미콜론 (ASI 금지, 7.9.2)
         return parseForRest(self, start, init_expr);
     }
 
@@ -598,7 +598,7 @@ fn parseForStatement(self: *Parser) ParseError2!NodeIndex {
     self.restoreContext(for_saved);
     self.for_loop_init = saved_for_loop_init;
     if (self.current() == .kw_in) {
-        _ = self.coverExpressionToAssignmentTarget(init_expr, true);
+        _ = try self.coverExpressionToAssignmentTarget(init_expr, true);
         return parseForIn(self, start, init_expr);
     }
     if (self.current() == .kw_of) {
@@ -610,18 +610,18 @@ fn parseForStatement(self: *Parser) ParseError2!NodeIndex {
         if (init_node.tag == .identifier_reference) {
             const text = self.ast.source[init_node.span.start..init_node.span.end];
             if (std.mem.eql(u8, text, "async") and !is_await) {
-                self.addError(init_node.span, "'async' is not allowed as identifier in for-of left-hand side");
+                try self.addError(init_node.span, "'async' is not allowed as identifier in for-of left-hand side");
             }
             // for (let of []) — 'let' 키워드가 for-of의 LHS로 사용되면 에러
             // ECMAScript 14.7.5: [lookahead ≠ let] LeftHandSideExpression of
             if (std.mem.eql(u8, text, "let")) {
-                self.addError(init_node.span, "'let' is not allowed as identifier in for-of left-hand side");
+                try self.addError(init_node.span, "'let' is not allowed as identifier in for-of left-hand side");
             }
         }
-        _ = self.coverExpressionToAssignmentTarget(init_expr, true);
+        _ = try self.coverExpressionToAssignmentTarget(init_expr, true);
         return parseForOf(self, start, init_expr);
     }
-    self.expect(.semicolon); // for 헤더의 첫 번째 세미콜론 (ASI 금지, 7.9.2)
+    try self.expect(.semicolon); // for 헤더의 첫 번째 세미콜론 (ASI 금지, 7.9.2)
     return parseForRest(self, start, init_expr);
 }
 
@@ -629,7 +629,7 @@ fn parseForStatement(self: *Parser) ParseError2!NodeIndex {
 /// - 단일 바인딩만 허용 (ECMAScript 14.7.5.1)
 /// - initializer 금지 (for-of는 항상, for-in은 strict + let/const)
 /// - Annex B.3.5: sloppy mode의 var + for-in은 initializer 허용
-fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) void {
+fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) ParseError2!void {
     if (init_expr.isNone()) return;
     const init_node = self.ast.getNode(init_expr);
     if (init_node.tag != .variable_declaration) return;
@@ -640,7 +640,7 @@ fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) void {
     const decl_len = extras[init_node.data.extra + 2];
 
     if (decl_len > 1) {
-        self.addError(init_node.span, "Only a single variable declaration is allowed in a for-in/for-of statement");
+        try self.addError(init_node.span, "Only a single variable declaration is allowed in a for-in/for-of statement");
     }
     if (decl_len == 0) return;
 
@@ -657,7 +657,7 @@ fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) void {
     const is_var = kind_flags == 0;
     const is_for_in = self.current() == .kw_in;
     if (is_for_in and is_var and !self.is_strict_mode) return; // Annex B.3.5
-    self.addError(decl_node.span, "For-in/for-of loop variable declaration may not have an initializer");
+    try self.addError(decl_node.span, "For-in/for-of loop variable declaration may not have an initializer");
 }
 
 /// for(init; test; update) body — 나머지 파싱
@@ -666,13 +666,13 @@ fn parseForRest(self: *Parser, start: u32, init_expr: NodeIndex) ParseError2!Nod
     if (self.current() != .semicolon) {
         test_expr = try self.parseExpression();
     }
-    self.expect(.semicolon); // for 헤더의 두 번째 세미콜론 (ASI 금지, 7.9.2)
+    try self.expect(.semicolon); // for 헤더의 두 번째 세미콜론 (ASI 금지, 7.9.2)
 
     var update_expr = NodeIndex.none;
     if (self.current() != .r_paren) {
         update_expr = try self.parseExpression();
     }
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     const body = try self.parseLoopBody();
 
     const extra_start = try self.ast.addExtra(@intFromEnum(init_expr));
@@ -689,9 +689,9 @@ fn parseForRest(self: *Parser, start: u32, init_expr: NodeIndex) ParseError2!Nod
 
 /// for(left in right) body
 fn parseForIn(self: *Parser, start: u32, left: NodeIndex) ParseError2!NodeIndex {
-    self.advance(); // skip 'in'
+    try self.advance(); // skip 'in'
     const right = try self.parseExpression();
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     const body = try self.parseLoopBody();
 
     return try self.ast.addNode(.{
@@ -703,9 +703,9 @@ fn parseForIn(self: *Parser, start: u32, left: NodeIndex) ParseError2!NodeIndex 
 
 /// for(left of right) body
 fn parseForOf(self: *Parser, start: u32, left: NodeIndex) ParseError2!NodeIndex {
-    self.advance(); // skip 'of'
+    try self.advance(); // skip 'of'
     const right = try self.parseAssignmentExpression();
-    self.expect(.r_paren);
+    try self.expect(.r_paren);
     const body = try self.parseLoopBody();
 
     return try self.ast.addNode(.{
@@ -719,7 +719,7 @@ fn parseForOf(self: *Parser, start: u32, left: NodeIndex) ParseError2!NodeIndex 
 fn parseSimpleStatement(self: *Parser, tag: Tag) ParseError2!NodeIndex {
     const keyword_span = self.currentSpan();
     const start = keyword_span.start;
-    self.advance(); // skip break/continue/debugger
+    try self.advance(); // skip break/continue/debugger
 
     // break/continue 뒤에 줄바꿈 없이 identifier가 오면 label로 소비
     var label = NodeIndex.none;
@@ -731,21 +731,21 @@ fn parseSimpleStatement(self: *Parser, tag: Tag) ParseError2!NodeIndex {
             .span = self.currentSpan(),
             .data = .{ .string_ref = self.currentSpan() },
         });
-        self.advance();
+        try self.advance();
     }
 
     // continue → label 유무와 관계없이 loop 안에서만 허용
     if (tag == .continue_statement and !self.in_loop) {
-        self.addError(keyword_span, "'continue' outside of loop");
+        try self.addError(keyword_span, "'continue' outside of loop");
     }
     // break → label이 없을 때만 loop 또는 switch 필요
     // label이 있는 break는 labelled statement 안에서 유효 (loop/switch 불필요)
     if (tag == .break_statement and label.isNone() and !self.in_loop and !self.in_switch) {
-        self.addError(keyword_span, "'break' outside of loop or switch");
+        try self.addError(keyword_span, "'break' outside of loop or switch");
     }
 
     const end = self.currentSpan().end;
-    _ = self.eat(.semicolon);
+    _ = try self.eat(.semicolon);
     return try self.ast.addNode(.{
         .tag = tag,
         .span = .{ .start = start, .end = end },
@@ -755,11 +755,11 @@ fn parseSimpleStatement(self: *Parser, tag: Tag) ParseError2!NodeIndex {
 
 fn parseSwitchStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'switch'
-    self.expect(.l_paren);
+    try self.advance(); // skip 'switch'
+    try self.expect(.l_paren);
     const discriminant = try self.parseExpression();
-    self.expect(.r_paren);
-    self.expect(.l_curly);
+    try self.expect(.r_paren);
+    try self.expect(.l_curly);
 
     const saved_ctx = self.ctx;
     const saved_in_switch = self.in_switch;
@@ -776,7 +776,7 @@ fn parseSwitchStatement(self: *Parser) ParseError2!NodeIndex {
         const case_node = try parseSwitchCase(self);
         if (is_default) {
             if (has_default) {
-                self.addError(default_span, "Only one default clause is allowed in a switch statement");
+                try self.addError(default_span, "Only one default clause is allowed in a switch statement");
             }
             has_default = true;
         }
@@ -787,7 +787,7 @@ fn parseSwitchStatement(self: *Parser) ParseError2!NodeIndex {
     self.in_switch = saved_in_switch;
 
     const end = self.currentSpan().end;
-    self.expect(.r_curly);
+    try self.expect(.r_curly);
 
     const cases = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -806,15 +806,15 @@ fn parseSwitchCase(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
 
     var test_expr = NodeIndex.none;
-    if (self.eat(.kw_case)) {
+    if (try self.eat(.kw_case)) {
         test_expr = try self.parseExpression();
-        self.expect(.colon);
-    } else if (self.eat(.kw_default)) {
-        self.expect(.colon);
+        try self.expect(.colon);
+    } else if (try self.eat(.kw_default)) {
+        try self.expect(.colon);
     } else {
         const err_span = self.currentSpan();
-        self.addError(err_span, "Case or default expected");
-        self.advance();
+        try self.addError(err_span, "Case or default expected");
+        try self.advance();
         return try self.ast.addNode(.{ .tag = .invalid, .span = err_span, .data = .{ .none = 0 } });
     }
 
@@ -842,14 +842,14 @@ fn parseSwitchCase(self: *Parser) ParseError2!NodeIndex {
 
 fn parseThrowStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'throw'
+    try self.advance(); // skip 'throw'
     // ECMAScript 14.14: throw [no LineTerminator here] Expression
     if (self.scanner.token.has_newline_before) {
-        self.addError(.{ .start = start, .end = self.currentSpan().start }, "No line break is allowed after 'throw'");
+        try self.addError(.{ .start = start, .end = self.currentSpan().start }, "No line break is allowed after 'throw'");
     }
     const arg = try self.parseExpression();
     const end = self.currentSpan().end;
-    _ = self.eat(.semicolon);
+    _ = try self.eat(.semicolon);
     return try self.ast.addNode(.{
         .tag = .throw_statement,
         .span = .{ .start = start, .end = end },
@@ -859,7 +859,7 @@ fn parseThrowStatement(self: *Parser) ParseError2!NodeIndex {
 
 fn parseTryStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'try'
+    try self.advance(); // skip 'try'
 
     const block = try parseBlockStatement(self);
 
@@ -871,13 +871,13 @@ fn parseTryStatement(self: *Parser) ParseError2!NodeIndex {
 
     // finally 절 (선택적)
     var finalizer = NodeIndex.none;
-    if (self.eat(.kw_finally)) {
+    if (try self.eat(.kw_finally)) {
         finalizer = try parseBlockStatement(self);
     }
 
     // catch도 finally도 없으면 에러
     if (handler.isNone() and finalizer.isNone()) {
-        self.addError(.{ .start = start, .end = self.currentSpan().start }, "Catch or finally expected");
+        try self.addError(.{ .start = start, .end = self.currentSpan().start }, "Catch or finally expected");
     }
 
     return try self.ast.addNode(.{
@@ -889,13 +889,13 @@ fn parseTryStatement(self: *Parser) ParseError2!NodeIndex {
 
 fn parseCatchClause(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'catch'
+    try self.advance(); // skip 'catch'
 
     // catch 파라미터 (선택적 — ES2019 optional catch binding)
     var param = NodeIndex.none;
-    if (self.eat(.l_paren)) {
+    if (try self.eat(.l_paren)) {
         param = try self.parseBindingIdentifier();
-        self.expect(.r_paren);
+        try self.expect(.r_paren);
     }
 
     const body = try parseBlockStatement(self);

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -23,7 +23,7 @@ const ParseError2 = @import("parser.zig").ParseError2;
 /// type Foo = Type;
 pub fn parseTsTypeAliasDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'type'
+    try self.advance(); // skip 'type'
 
     const name = try self.parseSimpleIdentifier();
 
@@ -33,9 +33,9 @@ pub fn parseTsTypeAliasDeclaration(self: *Parser) ParseError2!NodeIndex {
         type_params = try parseTsTypeParameterDeclaration(self);
     }
 
-    self.expect(.eq);
+    try self.expect(.eq);
     const ty = try parseType(self);
-    _ = self.eat(.semicolon);
+    _ = try self.eat(.semicolon);
 
     const extra_start = try self.ast.addExtra(@intFromEnum(name));
     _ = try self.ast.addExtra(@intFromEnum(type_params));
@@ -53,7 +53,7 @@ pub fn parseTsTypeAliasDeclaration(self: *Parser) ParseError2!NodeIndex {
 /// extra = [name, type_params, extends_start, extends_len, body]
 pub fn parseTsInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'interface'
+    try self.advance(); // skip 'interface'
 
     const name = try self.parseSimpleIdentifier();
 
@@ -67,10 +67,10 @@ pub fn parseTsInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
     // NodeList(start, len)로 저장하여 다중 extends를 지원한다.
     // extends 없으면 extends_list.len = 0.
     const scratch_top = self.saveScratch();
-    if (self.eat(.kw_extends)) {
+    if (try self.eat(.kw_extends)) {
         const first = try parseType(self);
         try self.scratch.append(first);
-        while (self.eat(.comma)) {
+        while (try self.eat(.comma)) {
             const next = try parseType(self);
             try self.scratch.append(next);
         }
@@ -99,7 +99,7 @@ pub fn parseTsInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
 /// const enum Foo { A, B, C }
 /// const enum은 일반 enum과 동일하게 파싱하되, flags=1로 표시.
 pub fn parseConstEnum(self: *Parser) ParseError2!NodeIndex {
-    self.advance(); // skip 'const'
+    try self.advance(); // skip 'const'
     return parseTsEnumDeclarationWithFlags(self, 1);
 }
 
@@ -112,20 +112,20 @@ pub fn parseTsEnumDeclaration(self: *Parser) ParseError2!NodeIndex {
 /// extra = [name, members_start, members_len, flags]
 fn parseTsEnumDeclarationWithFlags(self: *Parser, flags: u32) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'enum'
+    try self.advance(); // skip 'enum'
 
     const name = try self.parseSimpleIdentifier();
-    self.expect(.l_curly);
+    try self.expect(.l_curly);
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
         const member = try parseTsEnumMember(self);
         try self.scratch.append(member);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
 
     const end = self.currentSpan().end;
-    self.expect(.r_curly);
+    try self.expect(.r_curly);
 
     const members = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -146,7 +146,7 @@ fn parseTsEnumMember(self: *Parser) ParseError2!NodeIndex {
     const name = try self.parsePropertyKey();
 
     var init_val = NodeIndex.none;
-    if (self.eat(.eq)) {
+    if (try self.eat(.eq)) {
         init_val = try self.parseAssignmentExpression();
     }
 
@@ -160,7 +160,7 @@ fn parseTsEnumMember(self: *Parser) ParseError2!NodeIndex {
 /// namespace Foo { ... } / module "name" { ... }
 pub fn parseTsModuleDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip 'namespace' or 'module'
+    try self.advance(); // skip 'namespace' or 'module'
     return parseTsModuleBody(self, start);
 }
 
@@ -169,7 +169,7 @@ fn parseTsModuleBody(self: *Parser, start: u32) ParseError2!NodeIndex {
     const name = try self.parseSimpleIdentifier();
 
     // 중첩: namespace A.B.C { }
-    if (self.eat(.dot)) {
+    if (try self.eat(.dot)) {
         const inner = try parseTsModuleBody(self, start);
         return try self.ast.addNode(.{
             .tag = .ts_module_declaration,
@@ -189,7 +189,7 @@ fn parseTsModuleBody(self: *Parser, start: u32) ParseError2!NodeIndex {
 
 /// declare var/let/const/function/class/...
 pub fn parseTsDeclareStatement(self: *Parser) ParseError2!NodeIndex {
-    self.advance(); // skip 'declare'
+    try self.advance(); // skip 'declare'
     // declare 뒤의 선언은 ambient context (const 이니셜라이저 불필요 등)
     const saved = self.ctx;
     self.ctx.in_ambient = true;
@@ -200,7 +200,7 @@ pub fn parseTsDeclareStatement(self: *Parser) ParseError2!NodeIndex {
 
 /// abstract class Foo { }
 pub fn parseTsAbstractClass(self: *Parser) ParseError2!NodeIndex {
-    self.advance(); // skip 'abstract'
+    try self.advance(); // skip 'abstract'
     return self.parseClassDeclaration();
 }
 
@@ -220,7 +220,7 @@ pub fn parseDecoratedStatement(self: *Parser) ParseError2!NodeIndex {
         .kw_export => self.parseExportDeclaration(),
         .kw_abstract => parseTsAbstractClass(self),
         else => {
-            self.addError(self.currentSpan(), "Class or export expected after decorator");
+            try self.addError(self.currentSpan(), "Class or export expected after decorator");
             return self.parseExpressionStatement();
         },
     };
@@ -229,7 +229,7 @@ pub fn parseDecoratedStatement(self: *Parser) ParseError2!NodeIndex {
 /// @expr — 단일 데코레이터 파싱
 pub fn parseDecorator(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip @
+    try self.advance(); // skip @
     const expr = try self.parseCallExpression();
 
     return try self.ast.addNode(.{
@@ -246,15 +246,15 @@ pub fn parseDecorator(self: *Parser) ParseError2!NodeIndex {
 /// <T, U extends V = W>
 pub fn parseTsTypeParameterDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip <
+    try self.advance(); // skip <
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_angle and self.current() != .eof) {
         const param = try parseTsTypeParameter(self);
         try self.scratch.append(param);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
-    self.expect(.r_angle);
+    try self.expect(.r_angle);
 
     const params = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -272,13 +272,13 @@ fn parseTsTypeParameter(self: *Parser) ParseError2!NodeIndex {
 
     // T extends U
     var constraint = NodeIndex.none;
-    if (self.eat(.kw_extends)) {
+    if (try self.eat(.kw_extends)) {
         constraint = try parseType(self);
     }
 
     // T = DefaultType
     var default_type = NodeIndex.none;
-    if (self.eat(.eq)) {
+    if (try self.eat(.eq)) {
         default_type = try parseType(self);
     }
 
@@ -303,14 +303,14 @@ pub fn tryParseTypeAnnotation(self: *Parser) ParseError2!NodeIndex {
     // 타입 어노테이션이 아닌 colon인 경우 구분 필요:
     // object literal `{ key: value }`, ternary `? : `, switch `case:` 등
     // 여기서는 binding pattern/variable declarator 컨텍스트에서만 호출되므로 안전
-    self.advance(); // skip ':'
+    try self.advance(); // skip ':'
     return parseType(self);
 }
 
 /// 리턴 타입 어노테이션 (`: Type`). 함수 선언에서 사용.
 pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() != .colon) return NodeIndex.none;
-    self.advance();
+    try self.advance();
     return parseType(self);
 }
 
@@ -321,7 +321,7 @@ pub fn parseType(self: *Parser) ParseError2!NodeIndex {
     // 유니온: A | B | C
     while (self.current() == .pipe) {
         const start = self.ast.getNode(left).span.start;
-        self.advance(); // skip |
+        try self.advance(); // skip |
         const right = try parseIntersectionType(self);
         left = try self.ast.addNode(.{
             .tag = .ts_union_type,
@@ -339,7 +339,7 @@ fn parseIntersectionType(self: *Parser) ParseError2!NodeIndex {
     // 인터섹션: A & B & C
     while (self.current() == .amp) {
         const start = self.ast.getNode(left).span.start;
-        self.advance(); // skip &
+        try self.advance(); // skip &
         const right = try parsePostfixType(self);
         left = try self.ast.addNode(.{
             .tag = .ts_intersection_type,
@@ -356,10 +356,10 @@ fn parsePostfixType(self: *Parser) ParseError2!NodeIndex {
 
     while (self.current() == .l_bracket) {
         const start = self.ast.getNode(base).span.start;
-        if (self.peekNextKind() == .r_bracket) {
+        if (try self.peekNextKind() == .r_bracket) {
             // 배열 타입: T[]
-            self.advance(); // [
-            self.advance(); // ]
+            try self.advance(); // [
+            try self.advance(); // ]
             base = try self.ast.addNode(.{
                 .tag = .ts_array_type,
                 .span = .{ .start = start, .end = self.currentSpan().start },
@@ -367,9 +367,9 @@ fn parsePostfixType(self: *Parser) ParseError2!NodeIndex {
             });
         } else {
             // 인덱스 접근 타입: T[K]
-            self.advance(); // [
+            try self.advance(); // [
             const index_type = try parseType(self);
-            self.expect(.r_bracket);
+            try self.expect(.r_bracket);
             base = try self.ast.addNode(.{
                 .tag = .ts_indexed_access_type,
                 .span = .{ .start = start, .end = self.currentSpan().start },
@@ -400,7 +400,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
             else => .ts_type_reference, // 다른 TS 키워드는 타입 참조로
         };
         if (tag != .ts_type_reference) {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = tag,
                 .span = span,
@@ -412,7 +412,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
     switch (self.current()) {
         // void
         .kw_void => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .ts_void_keyword,
                 .span = span,
@@ -421,7 +421,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         },
         // null
         .kw_null => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .ts_null_keyword,
                 .span = span,
@@ -430,7 +430,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         },
         // this
         .kw_this => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .ts_this_type,
                 .span = span,
@@ -439,7 +439,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         },
         // 리터럴 타입 (true, false, 숫자, 문자열)
         .kw_true, .kw_false => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .ts_literal_type,
                 .span = span,
@@ -447,7 +447,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
             });
         },
         .decimal, .float, .hex, .string_literal => {
-            self.advance();
+            try self.advance();
             return try self.ast.addNode(.{
                 .tag = .ts_literal_type,
                 .span = span,
@@ -464,7 +464,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         .l_bracket => return parseTupleType(self),
         // typeof T
         .kw_typeof => {
-            self.advance();
+            try self.advance();
             const operand = try parseType(self);
             return try self.ast.addNode(.{
                 .tag = .ts_type_query,
@@ -474,7 +474,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         },
         // keyof T
         .kw_keyof => {
-            self.advance();
+            try self.advance();
             const operand = try parseType(self);
             return try self.ast.addNode(.{
                 .tag = .ts_type_operator,
@@ -487,8 +487,8 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
             if (self.current().isKeyword()) {
                 return parseTypeReference(self);
             }
-            self.addError(span, "Type expected");
-            self.advance();
+            try self.addError(span, "Type expected");
+            try self.advance();
             return try self.ast.addNode(.{ .tag = .invalid, .span = span, .data = .{ .none = 0 } });
         },
     }
@@ -497,13 +497,13 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
 fn parseTypeReference(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     const name_span = self.currentSpan();
-    self.advance(); // type name
+    try self.advance(); // type name
 
     // Foo.Bar 형태
     var name_end = name_span.end;
-    while (self.eat(.dot)) {
+    while (try self.eat(.dot)) {
         name_end = self.currentSpan().end;
-        self.advance(); // Bar
+        try self.advance(); // Bar
     }
 
     // 제네릭: Foo<T, U>
@@ -525,15 +525,15 @@ fn parseTypeReference(self: *Parser) ParseError2!NodeIndex {
 
 fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip <
+    try self.advance(); // skip <
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_angle and self.current() != .eof) {
         const ty = try parseType(self);
         try self.scratch.append(ty);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
-    self.expect(.r_angle);
+    try self.expect(.r_angle);
 
     const types = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -547,13 +547,13 @@ fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
 
 fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip (
+    try self.advance(); // skip (
 
     // 빈 괄호 + => → 함수 타입 () => R
     if (self.current() == .r_paren) {
-        self.advance();
+        try self.advance();
         if (self.current() == .arrow) {
-            self.advance();
+            try self.advance();
             const return_type = try parseType(self);
             return try self.ast.addNode(.{
                 .tag = .ts_function_type,
@@ -568,9 +568,9 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     // 파라미터가 있는 경우 — 단순히 첫 번째 타입을 파싱하고 ) 뒤에 =>가 있으면 함수 타입
     const inner = try parseType(self);
     if (self.current() == .r_paren) {
-        self.advance();
+        try self.advance();
         if (self.current() == .arrow) {
-            self.advance();
+            try self.advance();
             const return_type = try parseType(self);
             return try self.ast.addNode(.{
                 .tag = .ts_function_type,
@@ -579,7 +579,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
             });
         }
     } else {
-        self.expect(.r_paren);
+        try self.expect(.r_paren);
     }
 
     // 괄호 타입: (Type)
@@ -592,20 +592,20 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
 
 fn parseObjectType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip {
+    try self.advance(); // skip {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
         const member = try parseTypeMember(self);
         try self.scratch.append(member);
         // ; 또는 , 로 구분
-        if (!self.eat(.semicolon) and !self.eat(.comma)) {
+        if (!try self.eat(.semicolon) and !try self.eat(.comma)) {
             if (self.current() != .r_curly) break;
         }
     }
 
     const end = self.currentSpan().end;
-    self.expect(.r_curly);
+    try self.expect(.r_curly);
 
     const members = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -621,8 +621,8 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     // 간단: key: Type 또는 key?: Type
     const key = try self.parsePropertyKey();
-    _ = self.eat(.question); // optional
-    self.expect(.colon);
+    _ = try self.eat(.question); // optional
+    try self.expect(.colon);
     const value_type = try parseType(self);
 
     return try self.ast.addNode(.{
@@ -634,17 +634,17 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
 
 fn parseTupleType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    self.advance(); // skip [
+    try self.advance(); // skip [
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_bracket and self.current() != .eof) {
         const ty = try parseType(self);
         try self.scratch.append(ty);
-        if (!self.eat(.comma)) break;
+        if (!try self.eat(.comma)) break;
     }
 
     const end = self.currentSpan().end;
-    self.expect(.r_bracket);
+    try self.expect(.r_bracket);
 
     const types = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1765,7 +1765,7 @@ const Parser = @import("../parser/parser.zig").Parser;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 
 test "SemanticAnalyzer: var declaration creates symbol" {
-    var scanner = Scanner.init(std.testing.allocator, "var x = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "var x = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1781,7 +1781,7 @@ test "SemanticAnalyzer: var declaration creates symbol" {
 }
 
 test "SemanticAnalyzer: let redeclaration is error" {
-    var scanner = Scanner.init(std.testing.allocator, "let x = 1; let x = 2;");
+    var scanner = try Scanner.init(std.testing.allocator, "let x = 1; let x = 2;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1795,7 +1795,7 @@ test "SemanticAnalyzer: let redeclaration is error" {
 }
 
 test "SemanticAnalyzer: var redeclaration is allowed" {
-    var scanner = Scanner.init(std.testing.allocator, "var x = 1; var x = 2;");
+    var scanner = try Scanner.init(std.testing.allocator, "var x = 1; var x = 2;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1809,7 +1809,7 @@ test "SemanticAnalyzer: var redeclaration is allowed" {
 }
 
 test "SemanticAnalyzer: function declaration creates symbol" {
-    var scanner = Scanner.init(std.testing.allocator, "function foo() {}");
+    var scanner = try Scanner.init(std.testing.allocator, "function foo() {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1824,7 +1824,7 @@ test "SemanticAnalyzer: function declaration creates symbol" {
 }
 
 test "SemanticAnalyzer: scopes are created" {
-    var scanner = Scanner.init(std.testing.allocator, "{ let x = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "{ let x = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1840,7 +1840,7 @@ test "SemanticAnalyzer: scopes are created" {
 }
 
 test "SemanticAnalyzer: let and var conflict is error" {
-    var scanner = Scanner.init(std.testing.allocator, "let x = 1; var x = 2;");
+    var scanner = try Scanner.init(std.testing.allocator, "let x = 1; var x = 2;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1854,7 +1854,7 @@ test "SemanticAnalyzer: let and var conflict is error" {
 }
 
 test "SemanticAnalyzer: const redeclaration is error" {
-    var scanner = Scanner.init(std.testing.allocator, "const x = 1; const x = 2;");
+    var scanner = try Scanner.init(std.testing.allocator, "const x = 1; const x = 2;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1872,7 +1872,7 @@ test "SemanticAnalyzer: const redeclaration is error" {
 // ============================================================
 
 test "SemanticAnalyzer: declared private name is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "class C { #x = 1; foo() { this.#x; } }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { #x = 1; foo() { this.#x; } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1886,7 +1886,7 @@ test "SemanticAnalyzer: declared private name is valid" {
 }
 
 test "SemanticAnalyzer: undeclared private name is error" {
-    var scanner = Scanner.init(std.testing.allocator, "class C { foo() { this.#x; } }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { foo() { this.#x; } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1900,7 +1900,7 @@ test "SemanticAnalyzer: undeclared private name is error" {
 }
 
 test "SemanticAnalyzer: private name outside class is error" {
-    var scanner = Scanner.init(std.testing.allocator, "this.#x;");
+    var scanner = try Scanner.init(std.testing.allocator, "this.#x;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1914,7 +1914,7 @@ test "SemanticAnalyzer: private name outside class is error" {
 }
 
 test "SemanticAnalyzer: private method is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "class C { #foo() {} bar() { this.#foo(); } }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { #foo() {} bar() { this.#foo(); } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1929,7 +1929,7 @@ test "SemanticAnalyzer: private method is valid" {
 
 test "SemanticAnalyzer: nested class private name" {
     // 내부 class에서 외부 class의 private name 접근은 불가
-    var scanner = Scanner.init(std.testing.allocator, "class Outer { #x; foo() { class Inner { bar() { this.#y; } } } }");
+    var scanner = try Scanner.init(std.testing.allocator, "class Outer { #x; foo() { class Inner { bar() { this.#y; } } } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1944,7 +1944,7 @@ test "SemanticAnalyzer: nested class private name" {
 }
 
 test "SemanticAnalyzer: inner class can access outer private name" {
-    var scanner = Scanner.init(std.testing.allocator, "class Outer { #x; foo() { class Inner { bar() { this.#x; } } } }");
+    var scanner = try Scanner.init(std.testing.allocator, "class Outer { #x; foo() { class Inner { bar() { this.#x; } } } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1960,7 +1960,7 @@ test "SemanticAnalyzer: inner class can access outer private name" {
 
 test "SemanticAnalyzer: duplicate private method is error" {
     // 같은 이름의 private method 두 번 선언 → 에러
-    var scanner = Scanner.init(std.testing.allocator, "class C { #m() {} #m() {} }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { #m() {} #m() {} }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1975,7 +1975,7 @@ test "SemanticAnalyzer: duplicate private method is error" {
 
 test "SemanticAnalyzer: duplicate private field is error" {
     // 같은 이름의 private field 두 번 선언 → 에러
-    var scanner = Scanner.init(std.testing.allocator, "class C { #x; #x; }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { #x; #x; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -1990,7 +1990,7 @@ test "SemanticAnalyzer: duplicate private field is error" {
 
 test "SemanticAnalyzer: private getter+setter pair is valid" {
     // getter와 setter 쌍은 중복이 아님
-    var scanner = Scanner.init(std.testing.allocator, "class C { get #x() { return 1; } set #x(v) {} }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { get #x() { return 1; } set #x(v) {} }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2005,7 +2005,7 @@ test "SemanticAnalyzer: private getter+setter pair is valid" {
 
 test "SemanticAnalyzer: private method+getter duplicate is error" {
     // method와 getter는 쌍이 아님 → 에러
-    var scanner = Scanner.init(std.testing.allocator, "class C { #m() {} get #m() { return 1; } }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { #m() {} get #m() { return 1; } }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2021,7 +2021,7 @@ test "SemanticAnalyzer: private method+getter duplicate is error" {
 test "SemanticAnalyzer: private name in object literal method is error" {
     // 객체 리터럴에서 private name 메서드는 SyntaxError
     // 이 테스트는 method_definition key 순회 + private_identifier 검출이 동작하는지 확인
-    var scanner = Scanner.init(std.testing.allocator, "var o = { #m() {} };");
+    var scanner = try Scanner.init(std.testing.allocator, "var o = { #m() {} };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2041,7 +2041,7 @@ test "SemanticAnalyzer: private name in object literal method is error" {
 
 test "SemanticAnalyzer: call expression args are visited" {
     // 함수 호출 인자 내부의 함수 표현식이 스코프를 생성하는지 확인
-    var scanner = Scanner.init(std.testing.allocator, "f(function() { let x = 1; });");
+    var scanner = try Scanner.init(std.testing.allocator, "f(function() { let x = 1; });");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2058,7 +2058,7 @@ test "SemanticAnalyzer: call expression args are visited" {
 
 test "SemanticAnalyzer: template literal expressions are visited" {
     // 템플릿 리터럴 내부 표현식이 순회되는지 확인
-    var scanner = Scanner.init(std.testing.allocator, "let x = `${function() { let y = 1; }()}`;");
+    var scanner = try Scanner.init(std.testing.allocator, "let x = `${function() { let y = 1; }()}`;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2079,7 +2079,7 @@ test "SemanticAnalyzer: template literal expressions are visited" {
 test "SemanticAnalyzer: var in nested block is same function scope" {
     // var x = 1; { var x = 2; }
     // var는 함수 스코프에서 호이스팅되므로 같은 스코프에 이미 있어도 재선언 허용
-    var scanner = Scanner.init(std.testing.allocator, "var x = 1; { var x = 2; }");
+    var scanner = try Scanner.init(std.testing.allocator, "var x = 1; { var x = 2; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2095,7 +2095,7 @@ test "SemanticAnalyzer: var in nested block is same function scope" {
 test "SemanticAnalyzer: let in nested block is separate scope" {
     // let x = 1; { let x = 2; }
     // 내부 블록의 let x는 별도 블록 스코프에 선언되므로 충돌 없음
-    var scanner = Scanner.init(std.testing.allocator, "let x = 1; { let x = 2; }");
+    var scanner = try Scanner.init(std.testing.allocator, "let x = 1; { let x = 2; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2111,7 +2111,7 @@ test "SemanticAnalyzer: let in nested block is separate scope" {
 test "SemanticAnalyzer: var hoisting in function" {
     // function f() { return x; var x = 1; }
     // var는 함수 최상단으로 호이스팅되므로 return x; 이후에 선언되어도 에러 없음
-    var scanner = Scanner.init(std.testing.allocator, "function f() { return x; var x = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function f() { return x; var x = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2131,7 +2131,7 @@ test "SemanticAnalyzer: var hoisting in function" {
 test "SemanticAnalyzer: same let name in different functions is valid" {
     // function f() { let x = 1; } function g() { let x = 2; }
     // 서로 다른 함수 스코프이므로 충돌 없음
-    var scanner = Scanner.init(std.testing.allocator, "function f() { let x = 1; } function g() { let x = 2; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function f() { let x = 1; } function g() { let x = 2; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2147,7 +2147,7 @@ test "SemanticAnalyzer: same let name in different functions is valid" {
 test "SemanticAnalyzer: parameter and let redeclaration is error" {
     // function f(x) { let x = 1; }
     // 파라미터 x와 let x는 같은 함수 스코프 — 충돌
-    var scanner = Scanner.init(std.testing.allocator, "function f(x) { let x = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function f(x) { let x = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2163,7 +2163,7 @@ test "SemanticAnalyzer: parameter and let redeclaration is error" {
 test "SemanticAnalyzer: parameter and var redeclaration is valid" {
     // function f(x) { var x = 1; }
     // 파라미터 x와 var x는 공존 가능 (ECMAScript 허용)
-    var scanner = Scanner.init(std.testing.allocator, "function f(x) { var x = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function f(x) { var x = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2183,7 +2183,7 @@ test "SemanticAnalyzer: parameter and var redeclaration is valid" {
 test "SemanticAnalyzer: for loop with let is valid" {
     // for(let i=0; i<10; i++) { let j = i; }
     // for 문이 블록 스코프를 생성하고 let i는 그 스코프에 선언됨
-    var scanner = Scanner.init(std.testing.allocator, "for(let i=0; i<10; i++) { let j = i; }");
+    var scanner = try Scanner.init(std.testing.allocator, "for(let i=0; i<10; i++) { let j = i; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2199,7 +2199,7 @@ test "SemanticAnalyzer: for loop with let is valid" {
 test "SemanticAnalyzer: same let name in separate for loops is valid" {
     // for(let i=0;;){} for(let i=0;;){}
     // 각 for 문이 별도 블록 스코프를 생성하므로 충돌 없음
-    var scanner = Scanner.init(std.testing.allocator, "for(let i=0; i<1; i++){} for(let i=0; i<2; i++){}");
+    var scanner = try Scanner.init(std.testing.allocator, "for(let i=0; i<1; i++){} for(let i=0; i<2; i++){}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2219,7 +2219,7 @@ test "SemanticAnalyzer: same let name in separate for loops is valid" {
 test "SemanticAnalyzer: import binding redeclared with let is error" {
     // import { x } from 'a'; let x = 1;
     // import 바인딩은 모든 재선언과 충돌
-    var scanner = Scanner.init(std.testing.allocator, "import { x } from 'a'; let x = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "import { x } from 'a'; let x = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2235,7 +2235,7 @@ test "SemanticAnalyzer: import binding redeclared with let is error" {
 test "SemanticAnalyzer: import binding redeclared with var is error" {
     // import { x } from 'a'; var x = 1;
     // import 바인딩은 var 재선언과도 충돌
-    var scanner = Scanner.init(std.testing.allocator, "import { x } from 'a'; var x = 1;");
+    var scanner = try Scanner.init(std.testing.allocator, "import { x } from 'a'; var x = 1;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2255,7 +2255,7 @@ test "SemanticAnalyzer: import binding redeclared with var is error" {
 test "SemanticAnalyzer: catch binding shadowed by let is error" {
     // try {} catch(e) { let e = 1; }
     // catch 파라미터 e와 같은 catch body 블록의 let e는 충돌
-    var scanner = Scanner.init(std.testing.allocator, "try {} catch(e) { let e = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "try {} catch(e) { let e = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2271,7 +2271,7 @@ test "SemanticAnalyzer: catch binding shadowed by let is error" {
 test "SemanticAnalyzer: catch binding shadowed by var is valid" {
     // try {} catch(e) { var e = 1; }
     // var는 catch 바깥으로 호이스팅되므로 catch 파라미터와 충돌하지 않음
-    var scanner = Scanner.init(std.testing.allocator, "try {} catch(e) { var e = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "try {} catch(e) { var e = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2291,7 +2291,7 @@ test "SemanticAnalyzer: catch binding shadowed by var is valid" {
 test "SemanticAnalyzer: duplicate let in switch block is error" {
     // switch (x) { case 1: let y = 1; break; case 2: let y = 2; break; }
     // switch body는 하나의 블록 스코프 — 같은 이름의 let은 충돌
-    var scanner = Scanner.init(std.testing.allocator, "switch (x) { case 1: let y = 1; break; case 2: let y = 2; break; }");
+    var scanner = try Scanner.init(std.testing.allocator, "switch (x) { case 1: let y = 1; break; case 2: let y = 2; break; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2307,7 +2307,7 @@ test "SemanticAnalyzer: duplicate let in switch block is error" {
 test "SemanticAnalyzer: duplicate var in switch block is valid" {
     // switch (x) { case 1: var y = 1; break; case 2: var y = 2; break; }
     // var는 함수 스코프로 호이스팅되므로 switch block 내 중복 선언 허용
-    var scanner = Scanner.init(std.testing.allocator, "switch (x) { case 1: var y = 1; break; case 2: var y = 2; break; }");
+    var scanner = try Scanner.init(std.testing.allocator, "switch (x) { case 1: var y = 1; break; case 2: var y = 2; break; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2327,7 +2327,7 @@ test "SemanticAnalyzer: duplicate var in switch block is valid" {
 test "SemanticAnalyzer: let inside generator is valid" {
     // function* g() { let x = 1; }
     // generator 내부는 별도 함수 스코프 — let 선언 에러 없음
-    var scanner = Scanner.init(std.testing.allocator, "function* g() { let x = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "function* g() { let x = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2343,7 +2343,7 @@ test "SemanticAnalyzer: let inside generator is valid" {
 test "SemanticAnalyzer: let inside async function is valid" {
     // async function f() { let x = 1; }
     // async 함수 내부는 별도 함수 스코프 — let 선언 에러 없음
-    var scanner = Scanner.init(std.testing.allocator, "async function f() { let x = 1; }");
+    var scanner = try Scanner.init(std.testing.allocator, "async function f() { let x = 1; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2359,7 +2359,7 @@ test "SemanticAnalyzer: let inside async function is valid" {
 test "SemanticAnalyzer: generator duplicate params is error" {
     // function* g(a, a) {}
     // generator는 UniqueFormalParameters 적용 — 중복 파라미터 에러
-    var scanner = Scanner.init(std.testing.allocator, "function* g(a, a) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "function* g(a, a) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2375,7 +2375,7 @@ test "SemanticAnalyzer: generator duplicate params is error" {
 test "SemanticAnalyzer: async function duplicate params is error" {
     // async function f(a, a) {}
     // async function은 UniqueFormalParameters 적용 — 중복 파라미터 에러
-    var scanner = Scanner.init(std.testing.allocator, "async function f(a, a) {}");
+    var scanner = try Scanner.init(std.testing.allocator, "async function f(a, a) {}");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2395,7 +2395,7 @@ test "SemanticAnalyzer: async function duplicate params is error" {
 test "SemanticAnalyzer: named class expression is valid" {
     // let C = class C { constructor() {} }
     // 클래스 표현식의 이름은 자체 스코프에만 등록 — 에러 없음
-    var scanner = Scanner.init(std.testing.allocator, "let C = class C { constructor() {} }");
+    var scanner = try Scanner.init(std.testing.allocator, "let C = class C { constructor() {} }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2411,7 +2411,7 @@ test "SemanticAnalyzer: named class expression is valid" {
 test "SemanticAnalyzer: static and instance private field with same name is error" {
     // class C { #x = 1; static #x = 2; }
     // ECMAScript: static/instance 동시 선언 불가 — checker에서 검증
-    var scanner = Scanner.init(std.testing.allocator, "class C { #x = 1; static #x = 2; }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { #x = 1; static #x = 2; }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2429,7 +2429,7 @@ test "SemanticAnalyzer: static and instance private field with same name is erro
 // ============================================================
 
 test "SemanticAnalyzer: errors have kind=semantic" {
-    var scanner = Scanner.init(std.testing.allocator, "let x = 1; let x = 2;");
+    var scanner = try Scanner.init(std.testing.allocator, "let x = 1; let x = 2;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2444,7 +2444,7 @@ test "SemanticAnalyzer: errors have kind=semantic" {
 }
 
 test "SemanticAnalyzer: redeclaration error message contains identifier name" {
-    var scanner = Scanner.init(std.testing.allocator, "let foo = 1; let foo = 2;");
+    var scanner = try Scanner.init(std.testing.allocator, "let foo = 1; let foo = 2;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2459,7 +2459,7 @@ test "SemanticAnalyzer: redeclaration error message contains identifier name" {
 }
 
 test "SemanticAnalyzer: duplicate export name is semantic error" {
-    var scanner = Scanner.init(std.testing.allocator, "export const a = 1; export const a = 2;");
+    var scanner = try Scanner.init(std.testing.allocator, "export const a = 1; export const a = 2;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -2484,7 +2484,7 @@ test "SemanticAnalyzer: valid code has no semantic errors" {
         "var x = 1; var x = 2;", // var은 재선언 허용
     };
     for (cases) |src| {
-        var scanner = Scanner.init(std.testing.allocator, src);
+        var scanner = try Scanner.init(std.testing.allocator, src);
         defer scanner.deinit();
         var parser = Parser.init(std.testing.allocator, &scanner);
         defer parser.deinit();
@@ -2505,7 +2505,7 @@ test "SemanticAnalyzer: valid code has no semantic errors" {
 /// 테스트 헬퍼: 소스 코드를 파싱+분석하여 특정 이름의 심볼 reference_count를 반환.
 /// 같은 이름의 심볼이 여러 개이면 배열 순서대로(선언 순) 반환.
 fn getRefCounts(source: []const u8, target_name: []const u8, out: *[8]u32) usize {
-    var scanner = Scanner.init(std.testing.allocator, source);
+    var scanner = Scanner.init(std.testing.allocator, source) catch return 0;
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -489,7 +489,7 @@ const Parser = @import("../parser/parser.zig").Parser;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 
 test "checker: duplicate constructor is error" {
-    var scanner = Scanner.init(std.testing.allocator, "class C { constructor() {} constructor() {} }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { constructor() {} constructor() {} }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -515,7 +515,7 @@ test "checker: duplicate constructor is error" {
 }
 
 test "checker: single constructor is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "class C { constructor() {} foo() {} }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { constructor() {} foo() {} }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -536,7 +536,7 @@ test "checker: single constructor is valid" {
 }
 
 test "checker: static/instance private name conflict is error" {
-    var scanner = Scanner.init(std.testing.allocator, "class C { set #f(v) {} static get #f() {} }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { set #f(v) {} static get #f() {} }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -560,7 +560,7 @@ test "checker: static/instance private name conflict is error" {
 }
 
 test "checker: same static private getter+setter is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "class C { static get #f() {} static set #f(v) {} }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { static get #f() {} static set #f(v) {} }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -581,7 +581,7 @@ test "checker: same static private getter+setter is valid" {
 }
 
 test "checker: duplicate __proto__ is error" {
-    var scanner = Scanner.init(std.testing.allocator, "var o = { __proto__: null, __proto__: null };");
+    var scanner = try Scanner.init(std.testing.allocator, "var o = { __proto__: null, __proto__: null };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -605,7 +605,7 @@ test "checker: duplicate __proto__ is error" {
 }
 
 test "checker: single __proto__ is valid" {
-    var scanner = Scanner.init(std.testing.allocator, "var o = { __proto__: null, x: 1 };");
+    var scanner = try Scanner.init(std.testing.allocator, "var o = { __proto__: null, x: 1 };");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -626,7 +626,7 @@ test "checker: single __proto__ is valid" {
 }
 
 test "checker: duplicate arrow params is error" {
-    var scanner = Scanner.init(std.testing.allocator, "var f = (x, x) => x;");
+    var scanner = try Scanner.init(std.testing.allocator, "var f = (x, x) => x;");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();
@@ -641,7 +641,7 @@ test "checker: duplicate arrow params is error" {
 }
 
 test "checker: duplicate method params is error" {
-    var scanner = Scanner.init(std.testing.allocator, "class C { foo(a, a) {} }");
+    var scanner = try Scanner.init(std.testing.allocator, "class C { foo(a, a) {} }");
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
     defer parser.deinit();

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -150,7 +150,9 @@ pub fn parseMetadata(source: []const u8) TestMetadata {
 /// - is_negative_parse == false → 에러 없이 파싱 완료되면 pass
 pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata, verbose: bool) TestResult {
     // Scanner → Parser로 파싱
-    var scanner = Scanner.init(allocator, source);
+    var scanner = Scanner.init(allocator, source) catch {
+        return .skip; // OOM은 인프라 문제 → skip
+    };
     defer scanner.deinit();
 
     var parser = Parser.init(allocator, &scanner);

--- a/src/test_fixtures.zig
+++ b/src/test_fixtures.zig
@@ -51,7 +51,7 @@ const TestResult = struct {
 fn runFixture(allocator: std.mem.Allocator, source: []const u8, cg_options: CodegenOptions) !TestResult {
     // Scanner: 렉서. source를 받아 토큰으로 변환한다.
     const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = Scanner.init(allocator, source);
+    scanner_ptr.* = try Scanner.init(allocator, source);
 
     // Parser: 토큰 스트림을 AST로 변환한다.
     const parser_ptr = try allocator.create(Parser);

--- a/src/test_regression.zig
+++ b/src/test_regression.zig
@@ -43,7 +43,7 @@ const TestResult = struct {
 // E2E 헬퍼: source → (파싱 + 변환 + 코드젠) → 출력 문자열
 fn e2e(allocator: std.mem.Allocator, source: []const u8) !TestResult {
     const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = Scanner.init(allocator, source);
+    scanner_ptr.* = try Scanner.init(allocator, source);
 
     const parser_ptr = try allocator.create(Parser);
     parser_ptr.* = Parser.init(allocator, scanner_ptr);
@@ -89,7 +89,7 @@ const ParseResult = struct {
 
 fn parseOnly(allocator: std.mem.Allocator, source: []const u8) !ParseResult {
     var result = ParseResult{
-        .scanner = Scanner.init(allocator, source),
+        .scanner = try Scanner.init(allocator, source),
         .parser_inst = undefined,
         .allocator = allocator,
     };
@@ -263,7 +263,7 @@ test "regression: import.UNKNOWN is a syntax error (558be92)" {
 // fix(parser): import.meta is valid in module code (558be92)
 // 검증: import.meta는 module mode에서 정상 파싱되어야 함.
 test "regression: import.meta still parses OK in module mode (558be92)" {
-    var scanner = Scanner.init(std.testing.allocator, "var x = import.meta;");
+    var scanner = try Scanner.init(std.testing.allocator, "var x = import.meta;");
     defer scanner.deinit();
     var parser_inst = Parser.init(std.testing.allocator, &scanner);
     defer parser_inst.deinit();

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1209,7 +1209,7 @@ const TestResult = struct {
 /// 테스트 헬퍼: 소스 코드를 파싱 → transformer 실행.
 fn parseAndTransform(allocator: std.mem.Allocator, source: []const u8) !TestResult {
     const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = Scanner.init(allocator, source);
+    scanner_ptr.* = try Scanner.init(allocator, source);
 
     const parser_ptr = try allocator.create(Parser);
     parser_ptr.* = Parser.init(allocator, scanner_ptr);


### PR DESCRIPTION
## Summary
- Scanner의 `@panic("OOM")` 5개를 `error.OutOfMemory` 전파로 변경
- Parser의 `@panic("OOM")` 8개를 `error.OutOfMemory` 전파로 변경
- 모든 호출자(main, test262, codegen, semantic, transformer)에서 `try` 추가
- OOM 시 panic 대신 에러를 반환하여 watch 모드/dev 서버에서 프로세스 생존 가능

## Changes
**Scanner (15 함수 시그니처 변경):**
- `init()` → `!Scanner`, `next()` → `!void`, `nextInsideJSXElement()` → `!void`
- 내부 함수(recordNewline, handleNewline, skipWhitespace 등) → error union

**Parser (~410 call site에 try 추가):**
- `advance()`, `eat()`, `expect()`, `expectSemicolon()`, `addError()` → error union
- `collectCoverParamNames()`, `collectBoundNames()` → `ParseError2!void`

## Test plan
- [x] `zig build test` 통과
- [x] `echo "const x: number = 1;" | zig build run -- -` 동작 확인
- [x] `grep -r '@panic("OOM")' src/lexer/ src/parser/` → 0건

## Dependencies
- PR #202 (Arena allocator) 위에 빌드됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)