### PR TITLE
feat(core): Arena allocator Stage 2-3 완료

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,14 +127,12 @@ Arena allocator ─────────┬──→ 번들러 (파일별 are
 
 #### 추천 구현 순서
 1. ✅ **Test262 마무리 + regexp validator** — 23,384건 100% 통과 (실패 0건)
-2. **Arena allocator 설계 + 도입** — 번들러 전 필수 (1~3단계). 나중에 넣을수록 변경 범위 커짐
-   - 1단계: Parser에 Arena 적용 (allocator 교체, 하루 소요)
-   - 2단계: Semantic Analyzer에 적용 (스코프/심볼)
-   - 3단계: Transformer/Codegen에 적용 (Phase별 Arena 분리)
+2. ✅ **Arena allocator 설계 + 도입** — 1~3단계 완료
+   - ✅ 1단계: transpileFile에서 파일당 Arena 1개 생성, 모든 모듈(Scanner/Parser/Semantic/Transformer/Codegen)에 전달
+   - ✅ 2~3단계: Phase별 Arena 분리 불필요 — Scanner의 comments/line_offsets를 Codegen이 참조하므로 파일당 Arena 1개가 최적
+   - ✅ @panic("OOM") 전량 제거, 에러 전파로 교체
+   - ✅ test262 runner에 arena + reset 패턴 적용 (번들러 파일별 Arena 패턴 검증)
    - 4단계: 번들러 파일별 Arena (번들러 구현 시 같이)
-   - Arena = 소유권 경계. 각 모듈은 할당만, 해제는 호출자가 Arena 단위로
-   - `std.heap.ArenaAllocator` 사용, `std.mem.Allocator` 인터페이스 동일하므로 기존 코드 변경 최소
-   - **@panic("OOM") 정리**: 현재 44개의 `@panic("OOM")` (parser 6, lexer 5, analyzer 24, checker 9). Arena 도입 시 ArrayList append가 사라지면서 자연스럽게 해결. 번들러에서 파일별 에러 복구하려면 panic 대신 에러 전파 필요
 3. **ES 다운레벨링** (ES2024→ES2016 점진적, ES2015 이후, ES5) — 트랜스포머 visitor 추가. 독립적이라 언제든 가능하지만 AST 안정화 후가 이상적
    - 1차 ES2024→ES2020 (~200줄, 1~2일): `??`, `?.`, `??=`/`||=`/`&&=`, class public field
    - 2차 ES2019→ES2016 (~500줄, 3~5일): async/await→generator+Promise, rest/spread properties

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1743,44 +1743,13 @@ const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const Transformer = @import("../transformer/transformer.zig").Transformer;
 
-/// end-to-end 헬퍼: 소스 → 파싱 → 변환 → codegen → JS 문자열
-fn generateJS(allocator: std.mem.Allocator, source: []const u8) !struct { output: []const u8, scanner: *Scanner, parser: *Parser, codegen_inst: *Codegen, transformed_ast: Ast } {
-    const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = try Scanner.init(allocator, source);
-
-    const parser_ptr = try allocator.create(Parser);
-    parser_ptr.* = Parser.init(allocator, scanner_ptr);
-    _ = try parser_ptr.parse();
-
-    var t = Transformer.init(allocator, &parser_ptr.ast, .{});
-    const root = try t.transform();
-    t.scratch.deinit(allocator);
-
-    const cg = try allocator.create(Codegen);
-    cg.* = Codegen.init(allocator, &t.new_ast);
-    // new_ast는 cg가 참조하므로 여기서 해제하면 안 됨
-    // transformed_ast를 반환하여 caller가 관리
-
-    const output = try cg.generate(root);
-    return .{ .output = output, .scanner = scanner_ptr, .parser = parser_ptr, .codegen_inst = cg, .transformed_ast = t.new_ast };
-}
-
+/// Arena 기반 테스트 결과. deinit()으로 모든 메모리를 일괄 해제.
 const TestResult = struct {
     output: []const u8,
-    scanner: *Scanner,
-    parser: *Parser,
-    codegen_inst: *Codegen,
-    transformed_ast: Ast,
-    allocator: std.mem.Allocator,
+    arena: std.heap.ArenaAllocator,
 
     fn deinit(self: *TestResult) void {
-        self.codegen_inst.deinit();
-        self.allocator.destroy(self.codegen_inst);
-        self.transformed_ast.deinit();
-        self.parser.deinit();
-        self.allocator.destroy(self.parser);
-        self.scanner.deinit();
-        self.allocator.destroy(self.scanner);
+        self.arena.deinit();
     }
 };
 
@@ -1796,30 +1765,24 @@ fn e2eCJS(allocator: std.mem.Allocator, source: []const u8) !TestResult {
 const TransformOptions = @import("../transformer/transformer.zig").TransformOptions;
 
 /// 풀 옵션 e2e. transform + codegen 옵션 모두 전달.
-fn e2eFull(allocator: std.mem.Allocator, source: []const u8, t_options: TransformOptions, cg_options: CodegenOptions) !TestResult {
-    const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = try Scanner.init(allocator, source);
+/// Arena로 전체 파이프라인을 실행. output은 arena 메모리를 가리키므로
+/// TestResult.deinit() 전에 사용해야 한다.
+fn e2eFull(backing_allocator: std.mem.Allocator, source: []const u8, t_options: TransformOptions, cg_options: CodegenOptions) !TestResult {
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
+    const allocator = arena.allocator();
 
-    const parser_ptr = try allocator.create(Parser);
-    parser_ptr.* = Parser.init(allocator, scanner_ptr);
-    _ = try parser_ptr.parse();
+    var scanner = try Scanner.init(allocator, source);
+    var parser = Parser.init(allocator, &scanner);
+    _ = try parser.parse();
 
-    var t = Transformer.init(allocator, &parser_ptr.ast, t_options);
+    var t = Transformer.init(allocator, &parser.ast, t_options);
     const root = try t.transform();
-    t.scratch.deinit(allocator);
 
-    const cg = try allocator.create(Codegen);
-    cg.* = Codegen.initWithOptions(allocator, &t.new_ast, cg_options);
-
+    var cg = Codegen.initWithOptions(allocator, &t.new_ast, cg_options);
     const output = try cg.generate(root);
-    return .{
-        .output = output,
-        .scanner = scanner_ptr,
-        .parser = parser_ptr,
-        .codegen_inst = cg,
-        .transformed_ast = t.new_ast,
-        .allocator = allocator,
-    };
+
+    return .{ .output = output, .arena = arena };
 }
 
 fn e2eWithOptions(allocator: std.mem.Allocator, source: []const u8, cg_options: CodegenOptions) !TestResult {

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -149,14 +149,18 @@ pub fn parseMetadata(source: []const u8) TestMetadata {
 /// - is_negative_parse == true → 파서/렉서가 에러를 발생시키면 pass
 /// - is_negative_parse == false → 에러 없이 파싱 완료되면 pass
 pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata, verbose: bool) TestResult {
+    // 파일당 Arena: Scanner/Parser/Analyzer 모두 arena에서 할당.
+    // 함수 종료 시 arena.deinit()으로 일괄 해제.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
     // Scanner → Parser로 파싱
-    var scanner = Scanner.init(allocator, source) catch {
+    var scanner = Scanner.init(arena_alloc, source) catch {
         return .skip; // OOM은 인프라 문제 → skip
     };
-    defer scanner.deinit();
 
-    var parser = Parser.init(allocator, &scanner);
-    defer parser.deinit();
+    var parser = Parser.init(arena_alloc, &scanner);
 
     // module 모드 설정 — module은 항상 strict mode (D054)
     if (meta.is_module) {
@@ -177,8 +181,7 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
     // Semantic analysis (D038): 파서 에러가 없을 때만 실행
     var semantic_error_count: usize = 0;
     if (scanner.token.kind != .syntax_error and parser.errors.items.len == 0) {
-        var analyzer = SemanticAnalyzer.init(allocator, &parser.ast);
-        defer analyzer.deinit(); // deinit이 에러 메시지 메모리도 해제
+        var analyzer = SemanticAnalyzer.init(arena_alloc, &parser.ast);
         analyzer.is_strict_mode = parser.is_strict_mode;
         analyzer.is_module = parser.is_module;
         analyzer.analyze() catch {

--- a/src/test_fixtures.zig
+++ b/src/test_fixtures.zig
@@ -19,63 +19,38 @@ const Transformer = @import("transformer/transformer.zig").Transformer;
 const Codegen = @import("codegen/codegen.zig").Codegen;
 const CodegenOptions = @import("codegen/codegen.zig").CodegenOptions;
 const ModuleFormat = @import("codegen/codegen.zig").ModuleFormat;
-const Ast = @import("parser/ast.zig").Ast;
 
 // ============================================================
 // E2E 헬퍼
 // ============================================================
 
-/// 테스트 결과를 들고 있는 구조체.
-/// deinit()을 호출하여 모든 메모리를 해제한다.
+/// Arena 기반 테스트 결과. deinit()으로 모든 메모리를 일괄 해제.
 const TestResult = struct {
     output: []const u8,
-    scanner: *Scanner,
-    parser_inst: *Parser,
-    codegen_inst: *Codegen,
-    transformed_ast: Ast,
-    allocator: std.mem.Allocator,
+    arena: std.heap.ArenaAllocator,
 
     fn deinit(self: *TestResult) void {
-        self.codegen_inst.deinit();
-        self.allocator.destroy(self.codegen_inst);
-        self.transformed_ast.deinit();
-        self.parser_inst.deinit();
-        self.allocator.destroy(self.parser_inst);
-        self.scanner.deinit();
-        self.allocator.destroy(self.scanner);
+        self.arena.deinit();
     }
 };
 
 /// source를 파싱 → 변환 → 코드젠하여 minify된 JS 문자열을 반환한다.
-/// cg_options: CodegenOptions를 통해 ESM/CJS 등 옵션을 전달할 수 있다.
-fn runFixture(allocator: std.mem.Allocator, source: []const u8, cg_options: CodegenOptions) !TestResult {
-    // Scanner: 렉서. source를 받아 토큰으로 변환한다.
-    const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = try Scanner.init(allocator, source);
+fn runFixture(backing_allocator: std.mem.Allocator, source: []const u8, cg_options: CodegenOptions) !TestResult {
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
+    const allocator = arena.allocator();
 
-    // Parser: 토큰 스트림을 AST로 변환한다.
-    const parser_ptr = try allocator.create(Parser);
-    parser_ptr.* = Parser.init(allocator, scanner_ptr);
-    _ = try parser_ptr.parse();
+    var scanner = try Scanner.init(allocator, source);
+    var parser = Parser.init(allocator, &scanner);
+    _ = try parser.parse();
 
-    // Transformer: TS-전용 노드(타입, interface 등)를 제거하고 새 AST를 만든다.
-    var t = Transformer.init(allocator, &parser_ptr.ast, .{});
+    var t = Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
-    t.scratch.deinit(allocator);
 
-    // Codegen: 변환된 AST를 JS 문자열로 출력한다.
-    const cg = try allocator.create(Codegen);
-    cg.* = Codegen.initWithOptions(allocator, &t.new_ast, cg_options);
+    var cg = Codegen.initWithOptions(allocator, &t.new_ast, cg_options);
     const output = try cg.generate(root);
 
-    return .{
-        .output = output,
-        .scanner = scanner_ptr,
-        .parser_inst = parser_ptr,
-        .codegen_inst = cg,
-        .transformed_ast = t.new_ast,
-        .allocator = allocator,
-    };
+    return .{ .output = output, .arena = arena };
 }
 
 /// ESM 모드로 변환 (기본값)

--- a/src/test_regression.zig
+++ b/src/test_regression.zig
@@ -15,56 +15,38 @@ const Transformer = @import("transformer/transformer.zig").Transformer;
 const TransformOptions = @import("transformer/transformer.zig").TransformOptions;
 const Codegen = @import("codegen/codegen.zig").Codegen;
 const CodegenOptions = @import("codegen/codegen.zig").CodegenOptions;
-const Ast = @import("parser/ast.zig").Ast;
 
 // ============================================================
 // E2E 헬퍼: 파싱 → 변환 → 코드젠 전체 파이프라인
 // ============================================================
 
+/// Arena 기반 테스트 결과. deinit()으로 모든 메모리를 일괄 해제.
 const TestResult = struct {
     output: []const u8,
-    scanner: *Scanner,
-    parser_inst: *Parser,
-    codegen_inst: *Codegen,
-    transformed_ast: Ast,
-    allocator: std.mem.Allocator,
+    arena: std.heap.ArenaAllocator,
 
     fn deinit(self: *TestResult) void {
-        self.codegen_inst.deinit();
-        self.allocator.destroy(self.codegen_inst);
-        self.transformed_ast.deinit();
-        self.parser_inst.deinit();
-        self.allocator.destroy(self.parser_inst);
-        self.scanner.deinit();
-        self.allocator.destroy(self.scanner);
+        self.arena.deinit();
     }
 };
 
 // E2E 헬퍼: source → (파싱 + 변환 + 코드젠) → 출력 문자열
-fn e2e(allocator: std.mem.Allocator, source: []const u8) !TestResult {
-    const scanner_ptr = try allocator.create(Scanner);
-    scanner_ptr.* = try Scanner.init(allocator, source);
+fn e2e(backing_allocator: std.mem.Allocator, source: []const u8) !TestResult {
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
+    const allocator = arena.allocator();
 
-    const parser_ptr = try allocator.create(Parser);
-    parser_ptr.* = Parser.init(allocator, scanner_ptr);
-    _ = try parser_ptr.parse();
+    var scanner = try Scanner.init(allocator, source);
+    var parser = Parser.init(allocator, &scanner);
+    _ = try parser.parse();
 
-    var t = Transformer.init(allocator, &parser_ptr.ast, .{});
+    var t = Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
-    t.scratch.deinit(allocator);
 
-    const cg = try allocator.create(Codegen);
-    cg.* = Codegen.initWithOptions(allocator, &t.new_ast, .{ .minify = true });
+    var cg = Codegen.initWithOptions(allocator, &t.new_ast, .{ .minify = true });
     const output = try cg.generate(root);
 
-    return .{
-        .output = output,
-        .scanner = scanner_ptr,
-        .parser_inst = parser_ptr,
-        .codegen_inst = cg,
-        .transformed_ast = t.new_ast,
-        .allocator = allocator,
-    };
+    return .{ .output = output, .arena = arena };
 }
 
 // 파서만 실행하는 헬퍼 (에러 개수만 확인할 때 사용)


### PR DESCRIPTION
## Summary
- test262 runner에 파일당 Arena 적용 (23k+ 테스트에 bulk dealloc)
- codegen/test_fixtures/test_regression의 e2e 헬퍼를 Arena 기반으로 단순화
- TestResult: 7개 필드 (scanner, parser, codegen, transformed_ast, allocator 등) → 2개 (output + arena)
- CLAUDE.md: Arena Stage 2-3 완료 표시 (Phase별 분리 불필요 — 파일당 Arena 1개가 최적)

## Test plan
- [x] `zig build test` 전체 통과
- [x] 77줄 삭제, 수동 create/destroy/deinit 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)