### PR TITLE
feat(bundler): add foundational types for module bundler

### DIFF
--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -1,0 +1,28 @@
+//! ZTS Bundler
+//!
+//! 여러 JS/TS 파일을 하나의 번들로 합치는 모듈 번들러.
+//! Phase 6 — resolver, 모듈 그래프, 스코프 호이스팅, tree-shaking, code splitting.
+//!
+//! 설계:
+//!   - D056: 품질 먼저 → 속도 추가 (Rolldown 전략)
+//!   - D057: 모듈 그래프가 모든 기능의 기반
+//!   - D081: 3계층 resolver (resolver + cache + plugin)
+//!
+//! 사용법:
+//!   const bundler = @import("bundler/mod.zig");
+//!   // (Phase B1 완성 후)
+//!   // var b = bundler.Bundler.init(allocator, options);
+//!   // const result = try b.bundle();
+
+pub const types = @import("types.zig");
+
+// 공개 타입 re-export
+pub const ModuleIndex = types.ModuleIndex;
+pub const ImportKind = types.ImportKind;
+pub const ModuleType = types.ModuleType;
+pub const ImportRecord = types.ImportRecord;
+pub const BundlerDiagnostic = types.BundlerDiagnostic;
+
+test {
+    _ = types;
+}

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -1,0 +1,191 @@
+//! ZTS Bundler — 공유 타입 정의
+//!
+//! 번들러의 모든 모듈이 공유하는 기본 타입.
+//! D066 (에러 핸들링), D070 (모듈 ID), D073 (모듈 타입), D079 (import 추출) 설계 반영.
+
+const std = @import("std");
+const Span = @import("../lexer/token.zig").Span;
+
+// ============================================================
+// 모듈 ID (D070)
+// ============================================================
+
+/// 모듈 그래프에서 모듈을 식별하는 인덱스.
+/// NodeIndex, SymbolId, ScopeId와 동일한 u32 enum 패턴.
+pub const ModuleIndex = enum(u32) {
+    none = std.math.maxInt(u32),
+    _,
+
+    pub fn isNone(self: ModuleIndex) bool {
+        return self == .none;
+    }
+};
+
+// ============================================================
+// Import 종류
+// ============================================================
+
+/// import문의 종류. 모듈 그래프 엣지 분류에 사용.
+pub const ImportKind = enum {
+    /// import x from "./foo" / import { a } from "./foo"
+    static_import,
+    /// import("./foo")
+    dynamic_import,
+    /// export { x } from "./foo" / export * from "./foo"
+    re_export,
+    /// import "./foo" (specifier만, 바인딩 없음)
+    side_effect,
+    /// require("./foo") (CJS)
+    require,
+};
+
+// ============================================================
+// 모듈 타입 (D073)
+// ============================================================
+
+/// 파일 확장자 또는 설정에 의해 결정되는 모듈 타입.
+/// ParserAndGenerator 패턴(rspack)의 기반.
+pub const ModuleType = enum {
+    javascript,
+    json,
+    css,
+    asset,
+    unknown,
+
+    /// 파일 확장자로부터 모듈 타입을 추론한다.
+    pub fn fromExtension(ext: []const u8) ModuleType {
+        if (std.mem.eql(u8, ext, ".ts") or
+            std.mem.eql(u8, ext, ".tsx") or
+            std.mem.eql(u8, ext, ".js") or
+            std.mem.eql(u8, ext, ".jsx") or
+            std.mem.eql(u8, ext, ".mjs") or
+            std.mem.eql(u8, ext, ".mts") or
+            std.mem.eql(u8, ext, ".cjs") or
+            std.mem.eql(u8, ext, ".cts"))
+        {
+            return .javascript;
+        }
+        if (std.mem.eql(u8, ext, ".json")) return .json;
+        if (std.mem.eql(u8, ext, ".css")) return .css;
+        return .unknown;
+    }
+};
+
+// ============================================================
+// Import 레코드 (D079)
+// ============================================================
+
+/// AST에서 추출한 단일 import/export 정보.
+/// import_scanner가 AST 순회로 수집하고, 모듈 그래프가 resolve에 사용.
+pub const ImportRecord = struct {
+    /// 원본 import 경로 (예: "./foo", "react", "../utils")
+    specifier: []const u8,
+    /// import 종류
+    kind: ImportKind,
+    /// 소스 코드에서의 위치 (에러 메시지용)
+    span: Span,
+    /// resolve 완료 후 채워지는 모듈 인덱스
+    resolved: ModuleIndex = .none,
+};
+
+// ============================================================
+// 번들러 진단 정보 (D066)
+// ============================================================
+
+/// 번들러 에러/경고.
+/// esbuild의 suggestion + Bun의 step enum 설계.
+pub const BundlerDiagnostic = struct {
+    /// 에러 코드 (프로그래밍적 처리용)
+    code: ErrorCode,
+    /// 심각도
+    severity: Severity,
+    /// 에러 메시지
+    message: []const u8,
+    /// 에러가 발생한 파일 경로
+    file_path: []const u8,
+    /// 소스 코드에서의 위치
+    span: Span,
+    /// 어느 단계에서 발생했는지 (Bun ParseTask.Error.Step 참고)
+    step: Step,
+    /// 해결 제안 (예: "Did you mean './foo.js'?")
+    suggestion: ?[]const u8 = null,
+
+    pub const ErrorCode = enum {
+        /// import 경로를 resolve할 수 없음
+        unresolved_import,
+        /// export 이름을 찾을 수 없음
+        missing_export,
+        /// 순환 참조 감지
+        circular_dependency,
+        /// 파일 파싱 실패
+        parse_error,
+        /// 파일 읽기 실패
+        read_error,
+        /// JSON 파싱 실패
+        json_parse_error,
+    };
+
+    pub const Severity = enum {
+        @"error",
+        warning,
+        info,
+    };
+
+    pub const Step = enum {
+        resolve,
+        parse,
+        transform,
+        link,
+        emit,
+    };
+};
+
+// ============================================================
+// Tests
+// ============================================================
+
+test "ModuleIndex: none sentinel" {
+    try std.testing.expect(ModuleIndex.none.isNone());
+    const idx: ModuleIndex = @enumFromInt(0);
+    try std.testing.expect(!idx.isNone());
+}
+
+test "ModuleIndex: size is 4 bytes" {
+    try std.testing.expectEqual(@as(usize, 4), @sizeOf(ModuleIndex));
+}
+
+test "ModuleType: fromExtension" {
+    try std.testing.expectEqual(ModuleType.javascript, ModuleType.fromExtension(".ts"));
+    try std.testing.expectEqual(ModuleType.javascript, ModuleType.fromExtension(".tsx"));
+    try std.testing.expectEqual(ModuleType.javascript, ModuleType.fromExtension(".js"));
+    try std.testing.expectEqual(ModuleType.javascript, ModuleType.fromExtension(".jsx"));
+    try std.testing.expectEqual(ModuleType.javascript, ModuleType.fromExtension(".mjs"));
+    try std.testing.expectEqual(ModuleType.javascript, ModuleType.fromExtension(".mts"));
+    try std.testing.expectEqual(ModuleType.javascript, ModuleType.fromExtension(".cjs"));
+    try std.testing.expectEqual(ModuleType.javascript, ModuleType.fromExtension(".cts"));
+    try std.testing.expectEqual(ModuleType.json, ModuleType.fromExtension(".json"));
+    try std.testing.expectEqual(ModuleType.css, ModuleType.fromExtension(".css"));
+    try std.testing.expectEqual(ModuleType.unknown, ModuleType.fromExtension(".png"));
+    try std.testing.expectEqual(ModuleType.unknown, ModuleType.fromExtension(".wasm"));
+}
+
+test "ImportRecord: default resolved is none" {
+    const record = ImportRecord{
+        .specifier = "./foo",
+        .kind = .static_import,
+        .span = Span.EMPTY,
+    };
+    try std.testing.expect(record.resolved.isNone());
+}
+
+test "BundlerDiagnostic: default suggestion is null" {
+    const diag = BundlerDiagnostic{
+        .code = .unresolved_import,
+        .severity = .@"error",
+        .message = "Module not found",
+        .file_path = "src/index.ts",
+        .span = Span.EMPTY,
+        .step = .resolve,
+    };
+    try std.testing.expect(diag.suggestion == null);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -13,6 +13,7 @@ pub const codegen = @import("codegen/mod.zig");
 pub const config = @import("config.zig");
 pub const regexp = @import("regexp/mod.zig");
 pub const test262 = @import("test262/mod.zig");
+pub const bundler = @import("bundler/mod.zig");
 
 test {
     _ = lexer;
@@ -22,5 +23,6 @@ test {
     _ = codegen;
     _ = config;
     _ = test262;
+    _ = bundler;
     _ = @import("test_arena.zig");
 }


### PR DESCRIPTION
## Summary
- 번들러 Phase B1 시작 — 기본 타입 정의
- `ModuleIndex`: u32 enum (D070, NodeIndex/SymbolId와 일관)
- `ImportKind`: static/dynamic/re_export/side_effect/require
- `ModuleType`: javascript/json/css/asset/unknown (D073, rspack ParserAndGenerator 기반)
- `ImportRecord`: AST에서 추출한 import 정보 (D079)
- `BundlerDiagnostic`: esbuild suggestion + Bun step enum (D066)
- `src/bundler/mod.zig` + `src/bundler/types.zig` 생성
- `src/root.zig`에 bundler 모듈 등록

## Test plan
- [x] `zig build test` 전체 통과
- [x] ModuleIndex, ModuleType, ImportRecord, BundlerDiagnostic 유닛 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)