### PR TITLE
fix(bundler): fix 7 review issues (3 critical, 4 medium)

### DIFF
--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -17,9 +17,12 @@ const Ast = @import("../parser/ast.zig").Ast;
 
 pub const Module = struct {
     index: ModuleIndex,
+    /// 절대 파일 경로. graph의 path_to_module 키와 동일한 메모리를 참조 (빌림, Module이 해제하지 않음).
     path: []const u8,
+    /// 소스 코드. graph의 arena에서 할당 (빌림, Module이 해제하지 않음).
     source: []const u8,
     ast: ?Ast,
+    /// import_scanner가 추출한 레코드. graph의 arena에서 할당 (빌림).
     import_records: []ImportRecord,
 
     /// 내가 import하는 모듈들 (순방향)
@@ -72,8 +75,12 @@ pub const Module = struct {
         dep_index: ModuleIndex,
         all_modules: []Module,
     ) !void {
+        if (dep_index.isNone()) return;
+        const idx = @intFromEnum(dep_index);
+        if (idx >= all_modules.len) return;
+
         try self.dependencies.append(allocator, dep_index);
-        var dep = &all_modules[@intFromEnum(dep_index)];
+        var dep = &all_modules[idx];
         try dep.importers.append(allocator, self.index);
     }
 

--- a/src/bundler/package_json.zig
+++ b/src/bundler/package_json.zig
@@ -94,25 +94,33 @@ pub fn parsePackageJson(allocator: std.mem.Allocator, dir: std.fs.Dir) !ParsedPa
 /// exports 필드에서 조건에 맞는 경로를 찾는다.
 /// subpath: "." (패키지 루트) 또는 "./utils" 등
 /// conditions: ["import", "default"] 등 (D064)
+/// exports 필드에서 조건에 맞는 경로를 찾는다.
+/// 와일드카드 치환이 필요한 경우 allocator로 새 문자열을 할당.
+/// 반환된 문자열이 allocated인지 여부는 caller가 판별해야 함 — allocated_result로 반환.
+pub const ExportsResult = struct {
+    path: []const u8,
+    allocated: bool,
+};
+
 pub fn resolveExports(
+    allocator: std.mem.Allocator,
     exports: std.json.Value,
     subpath: []const u8,
     conditions: []const []const u8,
-) ?[]const u8 {
+) ?ExportsResult {
     switch (exports) {
-        // "exports": "./index.js"
         .string => |s| {
-            if (std.mem.eql(u8, subpath, ".")) return s;
+            if (std.mem.eql(u8, subpath, ".")) return .{ .path = s, .allocated = false };
             return null;
         },
         .object => |obj| {
-            // 키가 "."으로 시작하는지로 서브패스 맵 vs 조건 객체 구분
             if (isSubpathMap(obj)) {
-                return resolveSubpathMap(obj, subpath, conditions);
+                return resolveSubpathMap(allocator, obj, subpath, conditions);
             }
-            // 조건 객체: { "import": ..., "require": ..., "default": ... }
             if (std.mem.eql(u8, subpath, ".")) {
-                return resolveConditions(exports, conditions);
+                if (resolveConditions(exports, conditions)) |path| {
+                    return .{ .path = path, .allocated = false };
+                }
             }
             return null;
         },
@@ -123,13 +131,16 @@ pub fn resolveExports(
 /// 서브패스 맵에서 매칭되는 엔트리를 찾는다.
 /// 정확한 매칭 먼저, 와일드카드 매칭 나중.
 fn resolveSubpathMap(
+    allocator: std.mem.Allocator,
     obj: std.json.ObjectMap,
     subpath: []const u8,
     conditions: []const []const u8,
-) ?[]const u8 {
+) ?ExportsResult {
     // 1. 정확한 매칭
     if (obj.get(subpath)) |value| {
-        return resolveConditions(value, conditions);
+        if (resolveConditions(value, conditions)) |path| {
+            return .{ .path = path, .allocated = false };
+        }
     }
 
     // 2. 와일드카드 매칭 (./* 패턴)
@@ -144,18 +155,17 @@ fn resolveSubpathMap(
                 std.mem.startsWith(u8, subpath, prefix) and
                 std.mem.endsWith(u8, subpath, suffix))
             {
-                // 와일드카드가 매칭한 부분 추출
                 const matched = subpath[prefix.len .. subpath.len - suffix.len];
                 const resolved = resolveConditions(entry.value_ptr.*, conditions) orelse continue;
 
                 // 결과에서 * 를 매칭된 부분으로 치환
-                if (std.mem.indexOf(u8, resolved, "*")) |_| {
-                    // 정적 분석에서는 * 치환 불가 (동적 문자열 생성 필요)
-                    // 하지만 대부분의 경우 패턴이 단순하므로 매칭만 확인
-                    _ = matched;
-                    return resolved;
+                if (std.mem.indexOf(u8, resolved, "*")) |res_star| {
+                    const before = resolved[0..res_star];
+                    const after = resolved[res_star + 1 ..];
+                    const substituted = std.mem.concat(allocator, u8, &.{ before, matched, after }) catch return null;
+                    return .{ .path = substituted, .allocated = true };
                 }
-                return resolved;
+                return .{ .path = resolved, .allocated = false };
             }
         }
     }
@@ -276,8 +286,8 @@ test "resolveExports: string shorthand" {
     defer parsed.deinit();
 
     const exports = parsed.value.object.get("exports").?;
-    const result = resolveExports(exports, ".", &.{"import"});
-    try std.testing.expectEqualStrings("./index.js", result.?);
+    const result = resolveExports(std.testing.allocator, exports, ".", &.{"import"});
+    try std.testing.expectEqualStrings("./index.js", result.?.path);
 }
 
 test "resolveExports: condition object" {
@@ -290,16 +300,14 @@ test "resolveExports: condition object" {
     const exports = parsed.value.object.get("exports").?;
 
     // import 조건 매칭
-    const esm = resolveExports(exports, ".", &.{"import"});
-    try std.testing.expectEqualStrings("./esm.js", esm.?);
+    const esm = resolveExports(std.testing.allocator, exports, ".", &.{"import"});
+    try std.testing.expectEqualStrings("./esm.js", esm.?.path);
 
-    // require 조건 매칭
-    const cjs = resolveExports(exports, ".", &.{"require"});
-    try std.testing.expectEqualStrings("./cjs.js", cjs.?);
+    const cjs = resolveExports(std.testing.allocator, exports, ".", &.{"require"});
+    try std.testing.expectEqualStrings("./cjs.js", cjs.?.path);
 
-    // 없는 조건 → default 폴백
-    const fallback = resolveExports(exports, ".", &.{"browser"});
-    try std.testing.expectEqualStrings("./index.js", fallback.?);
+    const fallback = resolveExports(std.testing.allocator, exports, ".", &.{"browser"});
+    try std.testing.expectEqualStrings("./index.js", fallback.?.path);
 }
 
 test "resolveExports: subpath map" {
@@ -311,13 +319,13 @@ test "resolveExports: subpath map" {
 
     const exports = parsed.value.object.get("exports").?;
 
-    const root = resolveExports(exports, ".", &.{"import"});
-    try std.testing.expectEqualStrings("./index.js", root.?);
+    const root = resolveExports(std.testing.allocator, exports, ".", &.{"import"});
+    try std.testing.expectEqualStrings("./index.js", root.?.path);
 
-    const utils = resolveExports(exports, "./utils", &.{"import"});
-    try std.testing.expectEqualStrings("./src/utils.js", utils.?);
+    const utils = resolveExports(std.testing.allocator, exports, "./utils", &.{"import"});
+    try std.testing.expectEqualStrings("./src/utils.js", utils.?.path);
 
-    const missing = resolveExports(exports, "./nonexistent", &.{"import"});
+    const missing = resolveExports(std.testing.allocator, exports, "./nonexistent", &.{"import"});
     try std.testing.expect(missing == null);
 }
 
@@ -330,11 +338,11 @@ test "resolveExports: nested conditions in subpath" {
 
     const exports = parsed.value.object.get("exports").?;
 
-    const esm = resolveExports(exports, ".", &.{"import"});
-    try std.testing.expectEqualStrings("./esm.js", esm.?);
+    const esm = resolveExports(std.testing.allocator, exports, ".", &.{"import"});
+    try std.testing.expectEqualStrings("./esm.js", esm.?.path);
 
-    const cjs = resolveExports(exports, ".", &.{"require"});
-    try std.testing.expectEqualStrings("./cjs.js", cjs.?);
+    const cjs = resolveExports(std.testing.allocator, exports, ".", &.{"require"});
+    try std.testing.expectEqualStrings("./cjs.js", cjs.?.path);
 }
 
 test "resolveExports: wildcard pattern" {
@@ -346,8 +354,11 @@ test "resolveExports: wildcard pattern" {
 
     const exports = parsed.value.object.get("exports").?;
 
-    const result = resolveExports(exports, "./utils", &.{"import"});
-    try std.testing.expectEqualStrings("./src/*.js", result.?);
+    const result = resolveExports(std.testing.allocator, exports, "./utils", &.{"import"});
+    try std.testing.expect(result != null);
+    defer if (result.?.allocated) std.testing.allocator.free(result.?.path);
+    // 와일드카드 치환: ./* → ./utils, ./src/*.js → ./src/utils.js
+    try std.testing.expectEqualStrings("./src/utils.js", result.?.path);
 }
 
 test "resolveExports: no match returns null" {
@@ -358,7 +369,7 @@ test "resolveExports: no match returns null" {
     defer parsed.deinit();
 
     const exports = parsed.value.object.get("exports").?;
-    const result = resolveExports(exports, ".", &.{"import"});
+    const result = resolveExports(std.testing.allocator, exports, ".", &.{"import"});
     try std.testing.expect(result == null);
 }
 

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -94,8 +94,9 @@ pub const ResolveCache = struct {
 
         if (self.cache.get(cache_key)) |cached| {
             return switch (cached) {
+                // 캐시 히트: caller 소유 복사본 반환 (Critical #2 수정)
                 .resolved => |r| ResolveResult{
-                    .path = r.path,
+                    .path = self.allocator.dupe(u8, r.path) catch return error.OutOfMemory,
                     .module_type = r.module_type,
                 },
                 .external => null,
@@ -106,29 +107,35 @@ pub const ResolveCache = struct {
         // 3. 실제 resolve
         const result = self.resolver.resolve(source_dir, specifier) catch |err| switch (err) {
             error.ModuleNotFound => {
-                // 캐시에 not_found 저장
-                const key_owned = self.allocator.dupe(u8, cache_key) catch return error.OutOfMemory;
-                self.cache.put(key_owned, .not_found) catch return error.OutOfMemory;
+                try self.putCache(cache_key, .not_found);
                 return error.ModuleNotFound;
             },
             else => return err,
         };
 
-        // 4. 캐시에 저장
+        // 4. 캐시에 저장 (캐시가 path를 소유, caller에게는 별도 복사본)
+        const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
+        try self.putCache(cache_key, .{ .resolved = .{
+            .path = cache_path,
+            .module_type = result.module_type,
+        } });
+
+        // result.path는 resolver가 할당한 것 — caller 소유로 그대로 반환
+        return result;
+    }
+
+    /// 캐시에 엔트리 저장. 기존 키가 있으면 이전 키/값 해제 (Critical #1 수정).
+    fn putCache(self: *ResolveCache, cache_key: []const u8, value: CachedResult) !void {
+        // 기존 엔트리가 있으면 해제
+        if (self.cache.fetchRemove(cache_key)) |old| {
+            self.allocator.free(old.key);
+            switch (old.value) {
+                .resolved => |r| self.allocator.free(r.path),
+                else => {},
+            }
+        }
         const key_owned = self.allocator.dupe(u8, cache_key) catch return error.OutOfMemory;
-        const path_owned = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
-        // resolve가 반환한 원본 path는 해제
-        self.allocator.free(result.path);
-
-        self.cache.put(key_owned, .{ .resolved = .{
-            .path = path_owned,
-            .module_type = result.module_type,
-        } }) catch return error.OutOfMemory;
-
-        return ResolveResult{
-            .path = path_owned,
-            .module_type = result.module_type,
-        };
+        self.cache.put(key_owned, value) catch return error.OutOfMemory;
     }
 
     /// specifier가 external인지 판별.
@@ -262,18 +269,21 @@ test "resolve: cache hit" {
     var cache = ResolveCache.init(std.testing.allocator, .browser, &.{});
     defer cache.deinit();
 
-    // 첫 번째 호출 (캐시 미스)
+    // 첫 번째 호출 (캐시 미스) — caller 소유
     const result1 = try cache.resolve(dir_path, "./foo", .static_import);
     try std.testing.expect(result1 != null);
+    defer std.testing.allocator.free(result1.?.path);
     try std.testing.expect(std.mem.endsWith(u8, result1.?.path, "foo.ts"));
 
-    // 두 번째 호출 (캐시 히트)
+    // 두 번째 호출 (캐시 히트) — 별도 할당, caller 소유
     const result2 = try cache.resolve(dir_path, "./foo", .static_import);
     try std.testing.expect(result2 != null);
+    defer std.testing.allocator.free(result2.?.path);
     try std.testing.expect(std.mem.endsWith(u8, result2.?.path, "foo.ts"));
 
-    // 같은 포인터 (캐시에서 반환)
-    try std.testing.expectEqual(result1.?.path.ptr, result2.?.path.ptr);
+    // 내용은 같지만 포인터는 다름 (각각 독립 할당)
+    try std.testing.expectEqualStrings(result1.?.path, result2.?.path);
+    try std.testing.expect(result1.?.path.ptr != result2.?.path.ptr);
 }
 
 test "resolve: not found cached" {

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -200,21 +200,18 @@ pub const Resolver = struct {
 
         // 1. exports 필드 (D064)
         // subpath: "." 또는 "/sub" → exports 매칭용 "." 또는 "./sub"
-        const exports_subpath = if (std.mem.eql(u8, subpath, "."))
-            subpath
+        // subpath: "." → 그대로, "/sub" → "./sub"
+        const allocated_subpath: ?[]const u8 = if (std.mem.eql(u8, subpath, "."))
+            null
         else
-            // "/sub" → "./sub" (앞에 "." 붙임)
-            blk: {
-                const buf = std.mem.concat(self.allocator, u8, &.{ ".", subpath }) catch
-                    return error.OutOfMemory;
-                break :blk buf;
-            };
-        const should_free_subpath = !std.mem.eql(u8, subpath, ".");
-        defer if (should_free_subpath) self.allocator.free(exports_subpath);
+            std.mem.concat(self.allocator, u8, &.{ ".", subpath }) catch return error.OutOfMemory;
+        defer if (allocated_subpath) |buf| self.allocator.free(buf);
+        const exports_subpath = allocated_subpath orelse subpath;
 
         if (pkg.exports) |exports| {
-            if (pkg_json.resolveExports(exports, exports_subpath, self.conditions)) |rel_path| {
-                const abs_path = std.fs.path.resolve(self.allocator, &.{ pkg_dir_path, rel_path }) catch
+            if (pkg_json.resolveExports(self.allocator, exports, exports_subpath, self.conditions)) |exports_result| {
+                defer if (exports_result.allocated) self.allocator.free(exports_result.path);
+                const abs_path = std.fs.path.resolve(self.allocator, &.{ pkg_dir_path, exports_result.path }) catch
                     return error.OutOfMemory;
                 defer self.allocator.free(abs_path);
 
@@ -287,7 +284,13 @@ pub const Resolver = struct {
 pub fn isRelativeOrAbsolute(specifier: []const u8) bool {
     if (specifier.len == 0) return false;
     if (specifier[0] == '/') return true;
-    if (specifier.len >= 2 and specifier[0] == '.' and (specifier[1] == '/' or specifier[1] == '.')) return true;
+    // "./" — 현재 디렉토리 상대
+    if (specifier.len >= 2 and specifier[0] == '.' and specifier[1] == '/') return true;
+    // "../" — 상위 디렉토리 상대. ".." 뒤에 / 또는 끝이어야 함 ("..foo"는 bare specifier)
+    if (specifier.len >= 2 and specifier[0] == '.' and specifier[1] == '.') {
+        if (specifier.len == 2) return true; // ".." 그 자체
+        if (specifier[2] == '/') return true; // "../..."
+    }
     return false;
 }
 


### PR DESCRIPTION
## Summary

통합 코드 리뷰에서 발견된 7개 이슈 수정.

### Critical (3개)
1. **resolve_cache 메모리 누수**: `put` 시 기존 키/값 미해제 → `putCache` 헬퍼로 `fetchRemove` 후 해제
2. **resolve_cache 소유권 불일치**: 캐시 히트 시 캐시 내부 포인터 반환 → caller 소유 `dupe` 복사본 반환
3. **package_json 와일드카드 미치환**: `./src/*.js` 그대로 반환 → `matched` 부분으로 `*` 치환 (`./src/utils.js`)

### Medium (4개)
4. **module addDependency 방어**: `dep_index.isNone()` + bounds check 추가
5. **module 소유권 문서화**: path/source/import_records는 graph의 arena에서 빌림 명시
6. **resolver exports_subpath**: bool flag 대신 `?[]const u8` optional 기반으로 개선
7. **resolver isRelativeOrAbsolute**: `"..foo"` → bare specifier로 올바르게 판별

## Test plan
- [x] `zig build test` 전체 통과
- [x] 와일드카드 테스트: `./src/*.js` → `./src/utils.js` 치환 확인
- [x] 캐시 히트 테스트: 포인터 다름 (독립 할당) 확인
- [x] 기존 모든 테스트 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)