### PR TITLE
feat(bundler): add emitter for single file bundle generation

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1,0 +1,275 @@
+//! ZTS Bundler — Emitter
+//!
+//! 모듈 그래프의 모듈들을 exec_index 순서로 변환+코드젠하여
+//! 단일 파일 번들로 출력한다.
+//!
+//! 책임:
+//!   - exec_index 순서 정렬
+//!   - 각 모듈: Transformer → Codegen
+//!   - 포맷별 래핑 (ESM/CJS/IIFE)
+//!   - import/export 처리는 linker(별도 PR)에서 담당
+//!
+//! 설계:
+//!   - Rollup 방식: emitter(finaliser)와 linker 분리 (유지보수 우선)
+//!   - D058: exec_index 순서 = ESM 실행 순서
+
+const std = @import("std");
+const types = @import("types.zig");
+const ModuleIndex = types.ModuleIndex;
+const ModuleType = types.ModuleType;
+const Module = @import("module.zig").Module;
+const ModuleGraph = @import("graph.zig").ModuleGraph;
+const Ast = @import("../parser/ast.zig").Ast;
+const Transformer = @import("../transformer/transformer.zig").Transformer;
+const Codegen = @import("../codegen/codegen.zig").Codegen;
+const CodegenOptions = @import("../codegen/codegen.zig").CodegenOptions;
+
+pub const EmitOptions = struct {
+    format: Format = .esm,
+    minify: bool = false,
+
+    pub const Format = enum {
+        esm,
+        cjs,
+        iife,
+    };
+};
+
+pub const OutputFile = struct {
+    path: []const u8,
+    contents: []const u8,
+};
+
+/// 모듈 그래프를 단일 번들로 출력한다.
+/// 반환된 contents는 allocator 소유 (caller가 free).
+pub fn emit(
+    allocator: std.mem.Allocator,
+    graph: *const ModuleGraph,
+    options: EmitOptions,
+) ![]const u8 {
+    // 1. JS 모듈만 필터 + exec_index 순으로 정렬
+    var sorted: std.ArrayList(*const Module) = .empty;
+    defer sorted.deinit(allocator);
+
+    for (graph.modules.items) |*m| {
+        if (m.module_type == .javascript and m.ast != null) {
+            try sorted.append(allocator, m);
+        }
+    }
+
+    std.mem.sort(*const Module, sorted.items, {}, struct {
+        fn lessThan(_: void, a: *const Module, b: *const Module) bool {
+            return a.exec_index < b.exec_index;
+        }
+    }.lessThan);
+
+    // 2. 각 모듈을 변환 + 코드젠
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(allocator);
+
+    // 포맷별 prologue
+    switch (options.format) {
+        .iife => try output.appendSlice(allocator, "(function() {\n"),
+        .cjs => try output.appendSlice(allocator, "'use strict';\n"),
+        .esm => {},
+    }
+
+    for (sorted.items) |m| {
+        const code = try emitModule(allocator, m, options) orelse continue;
+        defer allocator.free(code);
+
+        if (!options.minify) {
+            // 모듈 경계 주석 (디버깅용)
+            try output.appendSlice(allocator, "// --- ");
+            try output.appendSlice(allocator, std.fs.path.basename(m.path));
+            try output.appendSlice(allocator, " ---\n");
+        }
+
+        try output.appendSlice(allocator, code);
+        if (!options.minify) {
+            try output.append(allocator, '\n');
+        }
+    }
+
+    // 포맷별 epilogue
+    switch (options.format) {
+        .iife => try output.appendSlice(allocator, "})();\n"),
+        .cjs, .esm => {},
+    }
+
+    return output.toOwnedSlice(allocator);
+}
+
+/// 단일 모듈을 Transformer → Codegen 파이프라인으로 처리.
+/// 모듈별 arena에 AST가 보존되어 있으므로 재파싱 불필요.
+fn emitModule(
+    allocator: std.mem.Allocator,
+    module: *const Module,
+    options: EmitOptions,
+) !?[]const u8 {
+    const ast = &(module.ast orelse return null);
+
+    // 변환용 arena (Transformer/Codegen 내부 메모리)
+    var emit_arena = std.heap.ArenaAllocator.init(allocator);
+    defer emit_arena.deinit();
+    const arena_alloc = emit_arena.allocator();
+
+    // Transformer: TS 타입 스트리핑 등
+    var transformer = Transformer.init(arena_alloc, ast, .{});
+    const root = try transformer.transform();
+
+    // Codegen: AST → JS 문자열
+    var cg = Codegen.initWithOptions(arena_alloc, &transformer.new_ast, .{
+        .minify = options.minify,
+        .module_format = switch (options.format) {
+            .cjs => .cjs,
+            else => .esm,
+        },
+    });
+    const code = try cg.generate(root);
+
+    // arena 해제 전에 복사 (caller 소유)
+    return try allocator.dupe(u8, code);
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+const resolve_cache_mod = @import("resolve_cache.zig");
+
+fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        dir.makePath(parent) catch {};
+    }
+    dir.writeFile(.{ .sub_path = path, .data = data }) catch |err| return err;
+}
+
+fn buildGraph(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !struct { graph: ModuleGraph, cache: resolve_cache_mod.ResolveCache } {
+    const dp = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dp);
+    const entry = try std.fs.path.resolve(allocator, &.{ dp, entry_name });
+    defer allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(allocator, .browser, &.{});
+    var graph = ModuleGraph.init(allocator, &cache);
+    try graph.build(&.{entry});
+    return .{ .graph = graph, .cache = cache };
+}
+
+test "emitter: single module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x: number = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const output = try emit(std.testing.allocator, &result.graph, .{});
+    defer std.testing.allocator.free(output);
+
+    // TS 타입 스트리핑: "const x: number = 1;" → "const x = 1;"
+    try std.testing.expect(std.mem.indexOf(u8, output, "const x = 1;") != null);
+}
+
+test "emitter: two modules exec order" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';\nconst a = 1;");
+    try writeFile(tmp.dir, "b.ts", "const b = 2;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "a.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const output = try emit(std.testing.allocator, &result.graph, .{});
+    defer std.testing.allocator.free(output);
+
+    // b.ts가 a.ts보다 먼저 출력 (exec_index 순서)
+    const b_pos = std.mem.indexOf(u8, output, "const b = 2;") orelse return error.TestUnexpectedResult;
+    const a_pos = std.mem.indexOf(u8, output, "const a = 1;") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(b_pos < a_pos);
+}
+
+test "emitter: minified output" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x: number = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const output = try emit(std.testing.allocator, &result.graph, .{ .minify = true });
+    defer std.testing.allocator.free(output);
+
+    // minify: 모듈 경계 주석 없음
+    try std.testing.expect(std.mem.indexOf(u8, output, "// ---") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "const x=1;") != null);
+}
+
+test "emitter: IIFE format" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const output = try emit(std.testing.allocator, &result.graph, .{ .format = .iife });
+    defer std.testing.allocator.free(output);
+
+    try std.testing.expect(std.mem.startsWith(u8, output, "(function() {\n"));
+    try std.testing.expect(std.mem.endsWith(u8, output, "})();\n"));
+}
+
+test "emitter: CJS format" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const output = try emit(std.testing.allocator, &result.graph, .{ .format = .cjs });
+    defer std.testing.allocator.free(output);
+
+    try std.testing.expect(std.mem.startsWith(u8, output, "'use strict';\n"));
+}
+
+test "emitter: empty graph" {
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .browser, &.{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    const output = try emit(std.testing.allocator, &graph, .{});
+    defer std.testing.allocator.free(output);
+
+    try std.testing.expectEqual(@as(usize, 0), output.len);
+}
+
+test "emitter: chain A → B → C order" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';\nconst a = 'a';");
+    try writeFile(tmp.dir, "b.ts", "import './c';\nconst b = 'b';");
+    try writeFile(tmp.dir, "c.ts", "const c = 'c';");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "a.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const output = try emit(std.testing.allocator, &result.graph, .{});
+    defer std.testing.allocator.free(output);
+
+    // C → B → A 순서
+    const c_pos = std.mem.indexOf(u8, output, "const c = 'c';") orelse return error.TestUnexpectedResult;
+    const b_pos = std.mem.indexOf(u8, output, "const b = 'b';") orelse return error.TestUnexpectedResult;
+    const a_pos = std.mem.indexOf(u8, output, "const a = 'a';") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(c_pos < b_pos);
+    try std.testing.expect(b_pos < a_pos);
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -21,6 +21,7 @@ pub const package_json = @import("package_json.zig");
 pub const resolve_cache = @import("resolve_cache.zig");
 pub const module = @import("module.zig");
 pub const graph = @import("graph.zig");
+pub const emitter = @import("emitter.zig");
 
 // 공개 타입 re-export
 pub const ModuleIndex = types.ModuleIndex;
@@ -44,4 +45,5 @@ test {
     _ = resolve_cache;
     _ = module;
     _ = graph;
+    _ = emitter;
 }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -37,7 +37,8 @@ pub const Module = struct {
 
     module_type: ModuleType,
     side_effects: bool,
-    /// DFS 후위 순서 = ESM 실행 순서 (D058, D076)
+    /// DFS 후위 순서 = ESM 실행 순서 (D058, D076).
+    /// maxInt = 미방문 (DFS에서 할당되지 않음).
     exec_index: u32,
     /// 순환 참조 그룹 ID. 0 = 순환 없음 (D065)
     cycle_group: u32,
@@ -65,7 +66,7 @@ pub const Module = struct {
             .dynamic_imports = .empty,
             .module_type = .unknown,
             .side_effects = true,
-            .exec_index = 0,
+            .exec_index = std.math.maxInt(u32),
             .cycle_group = 0,
             .state = .reserved,
         };
@@ -114,7 +115,7 @@ pub const Module = struct {
 test "Module: init defaults" {
     const m = Module.init(@enumFromInt(0), "src/index.ts");
     try std.testing.expectEqual(Module.State.reserved, m.state);
-    try std.testing.expectEqual(@as(u32, 0), m.exec_index);
+    try std.testing.expectEqual(std.math.maxInt(u32), m.exec_index);
     try std.testing.expectEqual(@as(u32, 0), m.cycle_group);
     try std.testing.expect(m.side_effects);
     try std.testing.expect(m.ast == null);

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -355,6 +355,18 @@ fn createFile(dir: std.fs.Dir, path: []const u8) !void {
     file.close();
 }
 
+/// 테스트용 헬퍼: 경로 끝 부분 비교 (구분자 독립 — Windows `\` + Unix `/` 모두 처리).
+fn pathEndsWith(path: []const u8, expected_suffix: []const u8) bool {
+    if (path.len < expected_suffix.len) return false;
+    const tail = path[path.len - expected_suffix.len ..];
+    for (tail, expected_suffix) |a, b| {
+        const na = if (a == '\\') @as(u8, '/') else a;
+        const nb = if (b == '\\') @as(u8, '/') else b;
+        if (na != nb) return false;
+    }
+    return true;
+}
+
 /// 테스트용 헬퍼: tmpDir에 파일 생성 + 내용 쓰기 (부모 디렉토리 자동 생성)
 fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
     if (std.fs.path.dirname(path)) |parent| {
@@ -375,7 +387,7 @@ test "resolve: exact file" {
     const result = try resolver.resolve(dir_path, "./foo.ts");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "foo.ts"));
+    try std.testing.expect(pathEndsWith(result.path, "foo.ts"));
     try std.testing.expectEqual(ModuleType.javascript, result.module_type);
 }
 
@@ -391,7 +403,7 @@ test "resolve: extension search (.ts)" {
     const result = try resolver.resolve(dir_path, "./bar");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "bar.ts"));
+    try std.testing.expect(pathEndsWith(result.path, "bar.ts"));
 }
 
 test "resolve: extension search (.tsx before .js)" {
@@ -408,7 +420,7 @@ test "resolve: extension search (.tsx before .js)" {
     defer std.testing.allocator.free(result.path);
 
     // .ts → .tsx → .js 순서이므로 .tsx가 먼저
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "comp.tsx"));
+    try std.testing.expect(pathEndsWith(result.path, "comp.tsx"));
 }
 
 test "resolve: TS extension mapping (.js → .ts)" {
@@ -424,7 +436,7 @@ test "resolve: TS extension mapping (.js → .ts)" {
     const result = try resolver.resolve(dir_path, "./util.js");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "util.ts"));
+    try std.testing.expect(pathEndsWith(result.path, "util.ts"));
 }
 
 test "resolve: TS extension mapping (.jsx → .tsx)" {
@@ -439,7 +451,7 @@ test "resolve: TS extension mapping (.jsx → .tsx)" {
     const result = try resolver.resolve(dir_path, "./App.jsx");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "App.tsx"));
+    try std.testing.expect(pathEndsWith(result.path, "App.tsx"));
 }
 
 test "resolve: directory index (./dir → ./dir/index.ts)" {
@@ -454,7 +466,7 @@ test "resolve: directory index (./dir → ./dir/index.ts)" {
     const result = try resolver.resolve(dir_path, "./components");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "components/index.ts"));
+    try std.testing.expect(pathEndsWith(result.path, "components/index.ts"));
 }
 
 test "resolve: directory index (.tsx)" {
@@ -469,7 +481,7 @@ test "resolve: directory index (.tsx)" {
     const result = try resolver.resolve(dir_path, "./pages");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "pages/index.tsx"));
+    try std.testing.expect(pathEndsWith(result.path, "pages/index.tsx"));
 }
 
 test "resolve: parent directory (../)" {
@@ -485,7 +497,7 @@ test "resolve: parent directory (../)" {
     const result = try resolver.resolve(sub_path, "../shared");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "shared.ts"));
+    try std.testing.expect(pathEndsWith(result.path, "shared.ts"));
 }
 
 test "resolve: module not found" {
@@ -513,7 +525,7 @@ test "resolve: bare specifier with main field" {
     const result = try resolver.resolve(dir_path, "my-lib");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "my-lib/lib/index.js"));
+    try std.testing.expect(pathEndsWith(result.path, "my-lib/lib/index.js"));
 }
 
 test "resolve: bare specifier with module field" {
@@ -531,7 +543,7 @@ test "resolve: bare specifier with module field" {
     defer std.testing.allocator.free(result.path);
 
     // module 필드가 main보다 우선
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "esm-pkg/esm/index.js"));
+    try std.testing.expect(pathEndsWith(result.path, "esm-pkg/esm/index.js"));
 }
 
 test "resolve: bare specifier with exports field" {
@@ -549,7 +561,7 @@ test "resolve: bare specifier with exports field" {
     defer std.testing.allocator.free(result.path);
 
     // 기본 conditions에 "import"가 포함되어 esm.js 선택
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "exp-pkg/esm.js"));
+    try std.testing.expect(pathEndsWith(result.path, "exp-pkg/esm.js"));
 }
 
 test "resolve: bare specifier with index fallback" {
@@ -565,7 +577,7 @@ test "resolve: bare specifier with index fallback" {
     const result = try resolver.resolve(dir_path, "simple");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "simple/index.js"));
+    try std.testing.expect(pathEndsWith(result.path, "simple/index.js"));
 }
 
 test "resolve: bare specifier walk up directories" {
@@ -583,7 +595,7 @@ test "resolve: bare specifier walk up directories" {
     const result = try resolver.resolve(deep_path, "top-pkg");
     defer std.testing.allocator.free(result.path);
 
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "top-pkg/index.js"));
+    try std.testing.expect(pathEndsWith(result.path, "top-pkg/index.js"));
 }
 
 test "resolve: bare specifier not found" {
@@ -661,7 +673,7 @@ test "resolve: extension search priority (.ts > .tsx > .js)" {
     defer std.testing.allocator.free(result.path);
 
     // .ts가 가장 먼저
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "mod.ts"));
+    try std.testing.expect(pathEndsWith(result.path, "mod.ts"));
 }
 
 test "resolve: exact .js file exists (no TS mapping)" {
@@ -678,5 +690,5 @@ test "resolve: exact .js file exists (no TS mapping)" {
     defer std.testing.allocator.free(result.path);
 
     // 정확한 .js가 있으면 TS 매핑하지 않음
-    try std.testing.expect(std.mem.endsWith(u8, result.path, "lib.js"));
+    try std.testing.expect(pathEndsWith(result.path, "lib.js"));
 }


### PR DESCRIPTION
## Summary
- exec_index 순서로 모듈 변환+코드젠 → 단일 번들 출력
- 포맷별 래핑: ESM, CJS (`'use strict'`), IIFE (`(function() { ... })()`)
- import/export 처리는 linker(별도 PR)에서 담당 (Rollup 방식 C, 유지보수 우선)
- 모듈별 emit arena로 Transformer/Codegen 메모리 관리

## 리뷰 반영
- `errdefer output.deinit(allocator)` — OOM 시 output 버퍼 누수 방지
- `transform()`/`generate()` 에러 전파 — silent swallow 제거
- `exec_index` 기본값 `maxInt(u32)` — 미방문 모듈이 정상 모듈과 구분됨
- `pathEndsWith` — Windows `\` + Unix `/` 경로 구분자 정규화

## Test plan
- [x] `zig build test` 전체 통과 (누수 0)
- [x] 7개 유닛 테스트: 단일, exec 순서, minify, IIFE, CJS, 빈 그래프, A→B→C 체인

🤖 Generated with [Claude Code](https://claude.com/claude-code)