### PR TITLE
feat(bundler): add Bundler orchestrator with public API

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1,0 +1,301 @@
+//! ZTS Bundler — Orchestrator
+//!
+//! 번들러의 최상위 공개 API. ResolveCache → ModuleGraph → Emitter 파이프라인을 조율.
+//!
+//! 사용법:
+//!   var bundler = Bundler.init(allocator, .{
+//!       .entry_points = &.{"src/index.ts"},
+//!       .format = .esm,
+//!   });
+//!   defer bundler.deinit();
+//!   const result = try bundler.bundle();
+//!   defer result.deinit(allocator);
+
+const std = @import("std");
+const types = @import("types.zig");
+const BundlerDiagnostic = types.BundlerDiagnostic;
+const ModuleGraph = @import("graph.zig").ModuleGraph;
+const ResolveCache = @import("resolve_cache.zig").ResolveCache;
+const Platform = @import("resolve_cache.zig").Platform;
+const emitter = @import("emitter.zig");
+const EmitOptions = emitter.EmitOptions;
+
+pub const BundleOptions = struct {
+    entry_points: []const []const u8,
+    format: EmitOptions.Format = .esm,
+    platform: Platform = .browser,
+    external: []const []const u8 = &.{},
+    minify: bool = false,
+};
+
+pub const BundleResult = struct {
+    /// 번들 출력 내용 (단일 파일). allocator 소유.
+    output: []const u8,
+    /// 빌드 중 발생한 진단 메시지들. deep copy — 내부 문자열도 allocator 소유.
+    diagnostics: ?[]OwnedDiagnostic,
+
+    /// 문자열 필드를 소유하는 diagnostic (graph 해제 후에도 유효).
+    pub const OwnedDiagnostic = struct {
+        code: BundlerDiagnostic.ErrorCode,
+        severity: BundlerDiagnostic.Severity,
+        message: []const u8,
+        file_path: []const u8,
+        step: BundlerDiagnostic.Step,
+        suggestion: ?[]const u8,
+    };
+
+    pub fn deinit(self: *const BundleResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.output);
+        if (self.diagnostics) |diags| {
+            for (diags) |d| {
+                allocator.free(d.file_path);
+                if (d.suggestion) |s| allocator.free(s);
+                // message는 string literal (comptime) → free 불필요
+            }
+            allocator.free(diags);
+        }
+    }
+
+    pub fn hasErrors(self: *const BundleResult) bool {
+        const diags = self.diagnostics orelse return false;
+        for (diags) |d| {
+            if (d.severity == .@"error") return true;
+        }
+        return false;
+    }
+
+    pub fn getDiagnostics(self: *const BundleResult) []const OwnedDiagnostic {
+        return self.diagnostics orelse &[_]OwnedDiagnostic{};
+    }
+};
+
+pub const Bundler = struct {
+    allocator: std.mem.Allocator,
+    options: BundleOptions,
+    resolve_cache: ResolveCache,
+
+    pub fn init(allocator: std.mem.Allocator, options: BundleOptions) Bundler {
+        return .{
+            .allocator = allocator,
+            .options = options,
+            .resolve_cache = ResolveCache.init(allocator, options.platform, options.external),
+        };
+    }
+
+    pub fn deinit(self: *Bundler) void {
+        self.resolve_cache.deinit();
+    }
+
+    /// 번들 파이프라인 실행: resolve → graph → emit.
+    /// graph는 함수 내에서 생성+해제. &self.resolve_cache 포인터는 self가 살아있는 동안 유효.
+    pub fn bundle(self: *Bundler) !BundleResult {
+        // 1. 모듈 그래프 구축
+        // graph가 &self.resolve_cache를 참조 — self가 move되지 않으므로 포인터 안전.
+        var graph = ModuleGraph.init(self.allocator, &self.resolve_cache);
+        defer graph.deinit();
+
+        try graph.build(self.options.entry_points);
+
+        // 2. 번들 출력 생성
+        const output = try emitter.emit(self.allocator, &graph, .{
+            .format = self.options.format,
+            .minify = self.options.minify,
+        });
+        errdefer self.allocator.free(output);
+
+        // 3. 진단 메시지 deep copy (graph.deinit 후에도 문자열 유효하도록)
+        const diagnostics: ?[]BundleResult.OwnedDiagnostic = if (graph.diagnostics.items.len > 0) blk: {
+            const diags = try self.allocator.alloc(BundleResult.OwnedDiagnostic, graph.diagnostics.items.len);
+            errdefer self.allocator.free(diags);
+            for (graph.diagnostics.items, 0..) |d, i| {
+                diags[i] = .{
+                    .code = d.code,
+                    .severity = d.severity,
+                    .message = d.message, // string literal — 복사 불필요
+                    .file_path = try self.allocator.dupe(u8, d.file_path),
+                    .step = d.step,
+                    .suggestion = if (d.suggestion) |s| try self.allocator.dupe(u8, s) else null,
+                };
+            }
+            break :blk diags;
+        } else null;
+
+        return .{
+            .output = output,
+            .diagnostics = diagnostics,
+        };
+    }
+};
+
+// ============================================================
+// Tests
+// ============================================================
+
+fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        dir.makePath(parent) catch {};
+    }
+    dir.writeFile(.{ .sub_path = path, .data = data }) catch |err| return err;
+}
+
+fn absPath(tmp: *std.testing.TmpDir, rel: []const u8) ![]const u8 {
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    return try std.fs.path.resolve(std.testing.allocator, &.{ dp, rel });
+}
+
+test "Bundler: single file bundle" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x: number = 42;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const x = 42;") != null);
+    try std.testing.expect(!result.hasErrors());
+}
+
+test "Bundler: two files bundled in order" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';\nconst a = 1;");
+    try writeFile(tmp.dir, "b.ts", "const b = 2;");
+
+    const entry = try absPath(&tmp, "a.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // b.ts가 a.ts보다 먼저 (exec_index 순서)
+    const b_pos = std.mem.indexOf(u8, result.output, "const b = 2;") orelse return error.TestUnexpectedResult;
+    const a_pos = std.mem.indexOf(u8, result.output, "const a = 1;") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(b_pos < a_pos);
+}
+
+test "Bundler: external module excluded" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "import 'react';\nconst x = 1;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // react는 external → 에러 없이 번들 생성
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const x = 1;") != null);
+}
+
+test "Bundler: minified output" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x: number = 1;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const x=1;") != null);
+    // minify: 모듈 경계 주석 없음
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "// ---") == null);
+}
+
+test "Bundler: unresolved import produces error diagnostic" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "import './nonexistent';");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.hasErrors());
+    const diags = result.getDiagnostics();
+    try std.testing.expect(diags.len > 0);
+    try std.testing.expectEqual(types.BundlerDiagnostic.ErrorCode.unresolved_import, diags[0].code);
+}
+
+test "Bundler: circular dependency produces warning" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';");
+    try writeFile(tmp.dir, "b.ts", "import './a';");
+
+    const entry = try absPath(&tmp, "a.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // 순환은 경고 (에러 아님) → 번들 생성은 성공
+    try std.testing.expect(!result.hasErrors());
+    var has_circular = false;
+    for (result.getDiagnostics()) |d| {
+        if (d.code == .circular_dependency) has_circular = true;
+    }
+    try std.testing.expect(has_circular);
+}
+
+test "Bundler: IIFE format" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .iife,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(std.mem.startsWith(u8, result.output, "(function() {\n"));
+    try std.testing.expect(std.mem.endsWith(u8, result.output, "})();\n"));
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -22,6 +22,7 @@ pub const resolve_cache = @import("resolve_cache.zig");
 pub const module = @import("module.zig");
 pub const graph = @import("graph.zig");
 pub const emitter = @import("emitter.zig");
+pub const bundler_core = @import("bundler.zig");
 
 // 공개 타입 re-export
 pub const ModuleIndex = types.ModuleIndex;
@@ -36,6 +37,9 @@ pub const ResolveCache = resolve_cache.ResolveCache;
 pub const Platform = resolve_cache.Platform;
 pub const Module = module.Module;
 pub const ModuleGraph = graph.ModuleGraph;
+pub const Bundler = bundler_core.Bundler;
+pub const BundleOptions = bundler_core.BundleOptions;
+pub const BundleResult = bundler_core.BundleResult;
 
 test {
     _ = types;
@@ -46,4 +50,5 @@ test {
     _ = module;
     _ = graph;
     _ = emitter;
+    _ = bundler_core;
 }


### PR DESCRIPTION
## Summary
- `Bundler` 구조체: 번들러 최상위 공개 API
- `Bundler.init(allocator, options)` → `bundle()` → `BundleResult`
- `BundleOptions`: entry_points, format (esm/cjs/iife), platform, external, minify
- `BundleResult`: output(번들 내용) + diagnostics (deep copy, graph 해제 후에도 유효)

## 리뷰 반영
- **[Critical 수정]** diagnostic 문자열 deep copy: `file_path`, `suggestion`을 `allocator.dupe`로 복사. graph.deinit 후 dangling pointer 방지
- **[Medium 수정]** diagnostics를 `?[]OwnedDiagnostic` optional 타입으로 변경. 빈 경우 null, 해제 시 명확한 소유권
- **포인터 안전**: graph는 bundle() 스택에 생성, `&self.resolve_cache`는 `*Bundler`로 안정
- **errdefer**: output 할당 후 diagnostics deep copy 실패 시 output 해제

## Test plan
- [x] `zig build test` 전체 통과 (누수 0)
- [x] 7개 유닛 테스트: 단일, exec 순서, external, minify, unresolved, circular, IIFE

🤖 Generated with [Claude Code](https://claude.com/claude-code)