### PR TITLE
fix(bundler): iterative DFS + add 8 missing tests from final review

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -307,3 +307,47 @@ test "Bundler: IIFE format" {
     try std.testing.expect(std.mem.startsWith(u8, result.output, "(function() {\n"));
     try std.testing.expect(std.mem.endsWith(u8, result.output, "})();\n"));
 }
+
+test "Bundler: CJS format" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .cjs,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(std.mem.startsWith(u8, result.output, "'use strict';\n"));
+}
+
+test "Bundler: multiple entry points" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "e1.ts", "const a = 1;");
+    try writeFile(tmp.dir, "e2.ts", "const b = 2;");
+
+    const entry1 = try absPath(&tmp, "e1.ts");
+    defer std.testing.allocator.free(entry1);
+    const entry2 = try absPath(&tmp, "e2.ts");
+    defer std.testing.allocator.free(entry2);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{ entry1, entry2 },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const a = 1;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const b = 2;") != null);
+}

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -273,3 +273,27 @@ test "emitter: chain A → B → C order" {
     try std.testing.expect(c_pos < b_pos);
     try std.testing.expect(b_pos < a_pos);
 }
+
+test "emitter: TS enum and interface stripping" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts",
+        \\interface Foo { x: number; }
+        \\enum Color { Red, Green, Blue }
+        \\const x: Foo = { x: 1 };
+    );
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "a.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const output = try emit(std.testing.allocator, &result.graph, .{});
+    defer std.testing.allocator.free(output);
+
+    // interface 제거됨
+    try std.testing.expect(std.mem.indexOf(u8, output, "interface") == null);
+    // enum → IIFE 변환
+    try std.testing.expect(std.mem.indexOf(u8, output, "Color") != null);
+    // 일반 코드 유지
+    try std.testing.expect(std.mem.indexOf(u8, output, "const x") != null);
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -219,44 +219,69 @@ pub const ModuleGraph = struct {
         }
     }
 
-    /// Phase 2: DFS 후위 순서 순회. exec_index 부여 + 순환 감지 (D065, D076).
-    /// modules 배열은 Phase 1에서 확정되어 더 이상 변경되지 않음.
-    fn dfs(self: *ModuleGraph, idx: ModuleIndex, visited: *std.DynamicBitSet, in_stack: *std.DynamicBitSet) !void {
-        const mod_idx = @intFromEnum(idx);
-        if (mod_idx >= self.modules.items.len) return;
+    /// Phase 2: 반복 DFS 후위 순서 순회. exec_index 부여 + 순환 감지 (D065, D076).
+    /// 재귀 대신 명시적 스택 사용 — 깊은 모듈 체인에서도 스택 오버플로 없음.
+    fn dfs(self: *ModuleGraph, start_idx: ModuleIndex, visited: *std.DynamicBitSet, in_stack: *std.DynamicBitSet) !void {
+        const DfsEntry = struct {
+            idx: u32,
+            post: bool, // true = 후처리 (exec_index 부여), false = 전처리 (의존성 push)
+        };
 
-        if (visited.isSet(mod_idx)) return;
+        var stack: std.ArrayList(DfsEntry) = .empty;
+        defer stack.deinit(self.allocator);
 
-        // 순환 감지 (D065)
-        if (in_stack.isSet(mod_idx)) {
-            self.cycle_counter += 1;
-            self.modules.items[mod_idx].cycle_group = self.cycle_counter;
-            self.addDiag(
-                .circular_dependency,
-                .warning,
-                self.modules.items[mod_idx].path,
-                Span.EMPTY,
-                .link,
-                "Circular dependency detected",
-                null,
-            );
-            return;
+        const start = @intFromEnum(start_idx);
+        if (start >= self.modules.items.len) return;
+        if (visited.isSet(start)) return;
+
+        try stack.append(self.allocator, .{ .idx = start, .post = false });
+
+        while (stack.items.len > 0) {
+            const entry = stack.pop() orelse break;
+
+            if (entry.post) {
+                // 후처리: exec_index 부여 + in_stack 해제
+                in_stack.unset(entry.idx);
+                visited.set(entry.idx);
+                self.modules.items[entry.idx].exec_index = self.exec_counter;
+                self.exec_counter += 1;
+                continue;
+            }
+
+            if (visited.isSet(entry.idx)) continue;
+
+            // 순환 감지 (D065)
+            if (in_stack.isSet(entry.idx)) {
+                self.cycle_counter += 1;
+                self.modules.items[entry.idx].cycle_group = self.cycle_counter;
+                self.addDiag(
+                    .circular_dependency,
+                    .warning,
+                    self.modules.items[entry.idx].path,
+                    Span.EMPTY,
+                    .link,
+                    "Circular dependency detected",
+                    null,
+                );
+                continue;
+            }
+
+            in_stack.set(entry.idx);
+
+            // 후처리를 먼저 push (LIFO이므로 나중에 실행)
+            try stack.append(self.allocator, .{ .idx = entry.idx, .post = true });
+
+            // 의존성을 역순으로 push (원래 순서대로 방문하기 위해)
+            const deps = self.modules.items[entry.idx].dependencies.items;
+            var j: usize = deps.len;
+            while (j > 0) {
+                j -= 1;
+                const dep = @intFromEnum(deps[j]);
+                if (dep < self.modules.items.len and !visited.isSet(dep)) {
+                    try stack.append(self.allocator, .{ .idx = dep, .post = false });
+                }
+            }
         }
-
-        in_stack.set(mod_idx);
-
-        // 의존성 순회 (Phase 1에서 이미 resolve 완료)
-        const deps = self.modules.items[mod_idx].dependencies.items;
-        for (deps) |dep_idx| {
-            try self.dfs(dep_idx, visited, in_stack);
-        }
-
-        in_stack.unset(mod_idx);
-        visited.set(mod_idx);
-
-        // 후위 순서로 exec_index 부여 (D058)
-        self.modules.items[mod_idx].exec_index = self.exec_counter;
-        self.exec_counter += 1;
     }
 
     fn addDiag(
@@ -536,4 +561,79 @@ test "graph: re-export adds dependency" {
 
     try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
     try std.testing.expectEqual(@as(usize, 1), graph.modules.items[0].dependencies.items.len);
+}
+
+test "graph: multiple entry points" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry1.ts", "const a = 1;");
+    try writeFile(tmp.dir, "entry2.ts", "const b = 2;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const e1 = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "entry1.ts" });
+    defer std.testing.allocator.free(e1);
+    const e2 = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "entry2.ts" });
+    defer std.testing.allocator.free(e2);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .browser, &.{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{ e1, e2 });
+
+    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
+    // 둘 다 exec_index가 할당됨 (maxInt 아님)
+    try std.testing.expect(graph.modules.items[0].exec_index != std.math.maxInt(u32));
+    try std.testing.expect(graph.modules.items[1].exec_index != std.math.maxInt(u32));
+}
+
+test "graph: dynamic import stored in dynamic_imports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "const m = import('./lazy');");
+    try writeFile(tmp.dir, "lazy.ts", "export const x = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "a.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .browser, &.{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
+    // 동적 import는 dynamic_imports에, dependencies에는 없음
+    try std.testing.expectEqual(@as(usize, 0), graph.modules.items[0].dependencies.items.len);
+    try std.testing.expectEqual(@as(usize, 1), graph.modules.items[0].dynamic_imports.items.len);
+}
+
+test "graph: JSON module — no AST, in graph" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './data.json';");
+    try writeFile(tmp.dir, "data.json", "{\"key\":\"value\"}");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "a.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .browser, &.{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
+    // JSON 모듈은 AST 없음 (파싱 안 함)
+    const json_mod = graph.modules.items[1];
+    try std.testing.expect(json_mod.ast == null);
+    try std.testing.expectEqual(types.ModuleType.json, json_mod.module_type);
 }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -154,3 +154,21 @@ test "Module: state transitions" {
     m.state = .ready;
     try std.testing.expectEqual(Module.State.ready, m.state);
 }
+
+test "Module: addDependency with none index — no-op" {
+    const alloc = std.testing.allocator;
+    var modules: [1]Module = .{Module.init(@enumFromInt(0), "a.ts")};
+    defer modules[0].deinit(alloc);
+
+    try modules[0].addDependency(alloc, .none, &modules);
+    try std.testing.expectEqual(@as(usize, 0), modules[0].dependencies.items.len);
+}
+
+test "Module: addDependency with out-of-bounds index — no-op" {
+    const alloc = std.testing.allocator;
+    var modules: [1]Module = .{Module.init(@enumFromInt(0), "a.ts")};
+    defer modules[0].deinit(alloc);
+
+    try modules[0].addDependency(alloc, @enumFromInt(99), &modules);
+    try std.testing.expectEqual(@as(usize, 0), modules[0].dependencies.items.len);
+}


### PR DESCRIPTION
## Summary

/simplify 최종 리뷰에서 발견된 Critical 1개 + 테스트 부족 수정.

### 코드 수정
- **[Critical] 재귀 DFS → 반복 DFS** (graph.zig): 명시적 스택 + post flag로 후위 순서 유지. 깊은 모듈 체인에서 스택 오버플로 방지.

### 테스트 추가 (8개)
| 심각도 | 파일 | 테스트 |
|--------|------|--------|
| Critical | graph.zig | 복수 진입점 |
| Critical | emitter.zig | TS enum + interface 번들 |
| Medium | graph.zig | 동적 import → dynamic_imports |
| Medium | graph.zig | JSON 모듈 (AST null) |
| Medium | module.zig | addDependency(.none) no-op |
| Medium | module.zig | addDependency(out-of-bounds) no-op |
| Medium | bundler.zig | CJS 포맷 |
| Medium | bundler.zig | 복수 진입점 |

## Test plan
- [x] `zig build test` 전체 통과 (누수 0)
- [x] 기존 모든 테스트 유지 + 8개 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)