### PR TITLE
fix(bundler): wire binding scanner into graph.parseModule

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -26,6 +26,7 @@ const BundlerDiagnostic = types.BundlerDiagnostic;
 const Module = @import("module.zig").Module;
 const ResolveCache = @import("resolve_cache.zig").ResolveCache;
 const import_scanner = @import("import_scanner.zig");
+const binding_scanner_mod = @import("binding_scanner.zig");
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
@@ -55,8 +56,10 @@ pub const ModuleGraph = struct {
 
     pub fn deinit(self: *ModuleGraph) void {
         for (self.modules.items) |*m| {
-            // import_records는 graph allocator 소유. source/ast는 module.parse_arena 소유.
+            // import_records, import_bindings, export_bindings는 graph allocator 소유.
             if (m.import_records.len > 0) self.allocator.free(m.import_records);
+            if (m.import_bindings.len > 0) self.allocator.free(m.import_bindings);
+            if (m.export_bindings.len > 0) self.allocator.free(m.export_bindings);
             m.deinit(self.allocator); // parse_arena.deinit() + dependencies/importers 해제
         }
         self.modules.deinit(self.allocator);
@@ -194,6 +197,11 @@ pub const ModuleGraph = struct {
             return;
         };
         module.import_records = records;
+
+        // Import/Export 바인딩 상세 추출 — linker에서 사용
+        module.import_bindings = binding_scanner_mod.extractImportBindings(self.allocator, &parser.ast, records) catch &.{};
+        module.export_bindings = binding_scanner_mod.extractExportBindings(self.allocator, &parser.ast, records) catch &.{};
+
         module.ast = parser.ast;
         module.state = .ready;
     }
@@ -732,4 +740,38 @@ test "graph: semantic exported_names tracks default export" {
 
     const sem = graph.modules.items[0].semantic.?;
     try std.testing.expect(sem.exported_names.get("default") != null);
+}
+
+test "graph: import/export bindings preserved after build" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b';\nexport const y = x + 1;");
+    try writeFile(tmp.dir, "b.ts", "export const x = 42;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "a.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .browser, &.{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    // a.ts: import_bindings에 x가 있어야 함
+    const a = graph.modules.items[0];
+    try std.testing.expect(a.import_bindings.len > 0);
+    try std.testing.expectEqualStrings("x", a.import_bindings[0].local_name);
+    try std.testing.expectEqualStrings("x", a.import_bindings[0].imported_name);
+
+    // a.ts: export_bindings에 y가 있어야 함
+    try std.testing.expect(a.export_bindings.len > 0);
+    try std.testing.expectEqualStrings("y", a.export_bindings[0].exported_name);
+
+    // b.ts: export_bindings에 x가 있어야 함
+    const b = graph.modules.items[1];
+    try std.testing.expect(b.export_bindings.len > 0);
+    try std.testing.expectEqualStrings("x", b.export_bindings[0].exported_name);
 }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -17,6 +17,9 @@ const Ast = @import("../parser/ast.zig").Ast;
 const Span = @import("../lexer/token.zig").Span;
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Scope = @import("../semantic/scope.zig").Scope;
+const binding_scanner = @import("binding_scanner.zig");
+pub const ImportBinding = binding_scanner.ImportBinding;
+pub const ExportBinding = binding_scanner.ExportBinding;
 
 /// Semantic analyzer 결과. parse_arena가 소유하는 데이터의 참조.
 /// linker가 import→export 연결 + 이름 충돌 해결에 사용.
@@ -43,6 +46,10 @@ pub const Module = struct {
     parse_arena: ?std.heap.ArenaAllocator,
     /// semantic analyzer 결과. parse_arena가 소유. linker에서 사용.
     semantic: ?ModuleSemanticData,
+    /// import 바인딩 상세. graph allocator 소유 (소스 텍스트 참조).
+    import_bindings: []ImportBinding = &.{},
+    /// export 바인딩 상세. graph allocator 소유 (소스 텍스트 참조).
+    export_bindings: []ExportBinding = &.{},
 
     /// 내가 import하는 모듈들 (순방향)
     dependencies: std.ArrayList(ModuleIndex),


### PR DESCRIPTION
## Summary
- PR #222에서 누락된 연결: binding_scanner를 graph.parseModule에서 호출
- `Module`에 `import_bindings`, `export_bindings` 필드 추가
- `graph.deinit`에서 bindings 해제 (graph allocator 소유)

## Test plan
- [x] `zig build test` 전체 통과 (누수 0)
- [x] 1개 테스트: import/export bindings 보존 확인 (a.ts imports x from b.ts, exports y)

🤖 Generated with [Claude Code](https://claude.com/claude-code)