### PR TITLE
feat(bundler): add linker for cross-module symbol binding

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1,0 +1,417 @@
+//! ZTS Bundler — Linker
+//!
+//! 크로스 모듈 심볼 바인딩: 각 import를 대응하는 export에 연결한다.
+//! re-export 체인을 따라가서 canonical export를 찾는다.
+//!
+//! 설계:
+//!   - D059: Rolldown식 스코프 호이스팅
+//!   - 메타데이터 방식: AST 수정 없이 codegen에서 치환
+//!
+//! 참고:
+//!   - references/rolldown/crates/rolldown/src/stages/link_stage/bind_imports_and_exports.rs
+//!   - references/esbuild/internal/linker/linker.go
+
+const std = @import("std");
+const types = @import("types.zig");
+const ModuleIndex = types.ModuleIndex;
+const BundlerDiagnostic = types.BundlerDiagnostic;
+const Module = @import("module.zig").Module;
+const ImportBinding = @import("binding_scanner.zig").ImportBinding;
+const ExportBinding = @import("binding_scanner.zig").ExportBinding;
+const Span = @import("../lexer/token.zig").Span;
+
+/// 크로스 모듈 심볼 참조. 어떤 모듈의 어떤 export를 가리키는지.
+pub const SymbolRef = struct {
+    module_index: ModuleIndex,
+    /// 해당 모듈의 export 이름 (e.g. "x", "default")
+    export_name: []const u8,
+};
+
+/// 해석된 import 바인딩. linker가 codegen에 전달.
+pub const ResolvedBinding = struct {
+    /// importer 모듈에서 사용하는 로컬 이름
+    local_name: []const u8,
+    /// 로컬 바인딩의 소스 위치 (rename 키)
+    local_span: Span,
+    /// 최종적으로 가리키는 export (re-export 체인 해결 후)
+    canonical: SymbolRef,
+};
+
+pub const Linker = struct {
+    allocator: std.mem.Allocator,
+    modules: []const Module,
+
+    /// 모듈별 export 맵: "module_index\x00exported_name" → ExportEntry
+    export_map: std.StringHashMap(ExportEntry),
+
+    /// import→export 바인딩 결과: (module_index, local_span_key) → ResolvedBinding
+    resolved_bindings: std.AutoHashMap(BindingKey, ResolvedBinding),
+
+    diagnostics: std.ArrayList(BundlerDiagnostic),
+
+    const ExportEntry = struct {
+        binding: ExportBinding,
+        module_index: ModuleIndex,
+    };
+
+    const BindingKey = struct {
+        module_index: u32,
+        span_key: u64,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, modules: []const Module) Linker {
+        return .{
+            .allocator = allocator,
+            .modules = modules,
+            .export_map = std.StringHashMap(ExportEntry).init(allocator),
+            .resolved_bindings = std.AutoHashMap(BindingKey, ResolvedBinding).init(allocator),
+            .diagnostics = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Linker) void {
+        // export_map의 키는 allocator로 할당됨
+        var eit = self.export_map.keyIterator();
+        while (eit.next()) |key| {
+            self.allocator.free(key.*);
+        }
+        self.export_map.deinit();
+        self.resolved_bindings.deinit();
+        self.diagnostics.deinit(self.allocator);
+    }
+
+    /// 링킹 실행: export 맵 구축 → import 바인딩 해결.
+    pub fn link(self: *Linker) !void {
+        try self.buildExportMap();
+        try self.resolveImports();
+    }
+
+    /// 모든 모듈의 export를 수집하여 export_map에 등록.
+    fn buildExportMap(self: *Linker) !void {
+        for (self.modules, 0..) |m, i| {
+            const mod_idx: ModuleIndex = @enumFromInt(@as(u32, @intCast(i)));
+            for (m.export_bindings) |eb| {
+                if (std.mem.eql(u8, eb.exported_name, "*")) continue;
+                const key = try makeExportKey(self.allocator, @intCast(i), eb.exported_name);
+                try self.export_map.put(key, .{
+                    .binding = eb,
+                    .module_index = mod_idx,
+                });
+            }
+        }
+    }
+
+    /// 모든 모듈의 import 바인딩을 해석하여 canonical export에 연결.
+    fn resolveImports(self: *Linker) !void {
+        for (self.modules, 0..) |m, i| {
+            for (m.import_bindings) |ib| {
+                if (ib.kind == .namespace) continue; // namespace import는 별도 처리 (후순위)
+
+                const source_record = if (ib.import_record_index < m.import_records.len)
+                    m.import_records[ib.import_record_index]
+                else
+                    continue;
+
+                if (source_record.resolved.isNone()) continue; // external 또는 미해석
+
+                // re-export 체인을 따라가서 canonical export 찾기
+                const canonical = self.resolveExportChain(
+                    source_record.resolved,
+                    ib.imported_name,
+                    0,
+                ) orelse {
+                    // export를 찾을 수 없음
+                    self.addDiag(
+                        .missing_export,
+                        .@"error",
+                        m.path,
+                        ib.local_span,
+                        .link,
+                        "Imported name not found in module",
+                        ib.imported_name,
+                    );
+                    continue;
+                };
+
+                const bk = BindingKey{
+                    .module_index = @intCast(i),
+                    .span_key = spanKey(ib.local_span),
+                };
+                try self.resolved_bindings.put(bk, .{
+                    .local_name = ib.local_name,
+                    .local_span = ib.local_span,
+                    .canonical = canonical,
+                });
+            }
+        }
+    }
+
+    /// re-export 체인을 따라가서 canonical export를 찾는다.
+    /// 깊이 제한 100 (순환 re-export 방지).
+    fn resolveExportChain(
+        self: *const Linker,
+        module_idx: ModuleIndex,
+        name: []const u8,
+        depth: u32,
+    ) ?SymbolRef {
+        if (depth > 100) return null; // 순환 방지
+
+        const mod_i = @intFromEnum(module_idx);
+        if (mod_i >= self.modules.len) return null;
+
+        // 1. 직접 export 확인
+        var key_buf: [256]u8 = undefined;
+        const key = makeExportKeyBuf(&key_buf, @intCast(mod_i), name);
+        if (self.export_map.get(key)) |entry| {
+            if (entry.binding.kind == .re_export) {
+                // re-export: 소스 모듈로 재귀
+                if (entry.binding.import_record_index) |rec_idx| {
+                    const m = self.modules[mod_i];
+                    if (rec_idx < m.import_records.len) {
+                        const source_mod = m.import_records[rec_idx].resolved;
+                        if (!source_mod.isNone()) {
+                            // re-export에서 exported_name이 local_name과 같으면
+                            // 소스 모듈에서도 같은 이름으로 export됨
+                            return self.resolveExportChain(source_mod, entry.binding.local_name, depth + 1);
+                        }
+                    }
+                }
+                return null;
+            }
+            // local export: 이 모듈의 심볼
+            return .{
+                .module_index = module_idx,
+                .export_name = name,
+            };
+        }
+
+        // 2. export * 확인 (re_export_all)
+        const m = self.modules[mod_i];
+        for (m.export_bindings) |eb| {
+            if (eb.kind != .re_export_all) continue;
+            if (eb.import_record_index) |rec_idx| {
+                if (rec_idx < m.import_records.len) {
+                    const source_mod = m.import_records[rec_idx].resolved;
+                    if (!source_mod.isNone()) {
+                        if (self.resolveExportChain(source_mod, name, depth + 1)) |result| {
+                            return result;
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// 특정 모듈+import에 대한 resolved binding 조회.
+    pub fn getResolvedBinding(self: *const Linker, module_index: u32, span: Span) ?ResolvedBinding {
+        const bk = BindingKey{
+            .module_index = module_index,
+            .span_key = spanKey(span),
+        };
+        return self.resolved_bindings.get(bk);
+    }
+
+    fn addDiag(
+        self: *Linker,
+        code: BundlerDiagnostic.ErrorCode,
+        severity: BundlerDiagnostic.Severity,
+        file_path: []const u8,
+        span: Span,
+        step: BundlerDiagnostic.Step,
+        message: []const u8,
+        suggestion: ?[]const u8,
+    ) void {
+        self.diagnostics.append(self.allocator, .{
+            .code = code,
+            .severity = severity,
+            .message = message,
+            .file_path = file_path,
+            .span = span,
+            .step = step,
+            .suggestion = suggestion,
+        }) catch {};
+    }
+
+    fn spanKey(span: Span) u64 {
+        return @as(u64, span.start) << 32 | span.end;
+    }
+
+    /// export 맵 키 생성 (할당). "module_index\x00name"
+    fn makeExportKey(allocator: std.mem.Allocator, module_index: u32, name: []const u8) ![]const u8 {
+        var buf = try allocator.alloc(u8, 4 + 1 + name.len);
+        @memcpy(buf[0..4], std.mem.asBytes(&module_index));
+        buf[4] = 0;
+        @memcpy(buf[5..], name);
+        return buf;
+    }
+
+    /// export 맵 키 생성 (스택 버퍼, 조회용).
+    fn makeExportKeyBuf(buf: *[256]u8, module_index: u32, name: []const u8) []const u8 {
+        const total = 5 + name.len;
+        if (total > 256) return "";
+        @memcpy(buf[0..4], std.mem.asBytes(&module_index));
+        buf[4] = 0;
+        @memcpy(buf[5 .. 5 + name.len], name);
+        return buf[0..total];
+    }
+};
+
+// ============================================================
+// Tests
+// ============================================================
+
+const resolve_cache_mod = @import("resolve_cache.zig");
+const ModuleGraph = @import("graph.zig").ModuleGraph;
+
+fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        dir.makePath(parent) catch {};
+    }
+    try dir.writeFile(.{ .sub_path = path, .data = data });
+}
+
+fn dirPath(tmp: *std.testing.TmpDir) ![]const u8 {
+    return try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+}
+
+fn buildAndLink(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !struct {
+    linker: Linker,
+    graph: ModuleGraph,
+    cache: resolve_cache_mod.ResolveCache,
+} {
+    const dp = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dp);
+    const entry = try std.fs.path.resolve(allocator, &.{ dp, entry_name });
+    defer allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(allocator, .browser, &.{});
+    var graph = ModuleGraph.init(allocator, &cache);
+    try graph.build(&.{entry});
+
+    var linker = Linker.init(allocator, graph.modules.items);
+    try linker.link();
+
+    return .{ .linker = linker, .graph = graph, .cache = cache };
+}
+
+test "linker: direct import resolves to export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b'; console.log(x);");
+    try writeFile(tmp.dir, "b.ts", "export const x = 42;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    // a.ts의 import x가 b.ts의 export x에 연결
+    const a = r.graph.modules.items[0];
+    try std.testing.expect(a.import_bindings.len > 0);
+    const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
+    try std.testing.expect(binding != null);
+    try std.testing.expectEqualStrings("x", binding.?.canonical.export_name);
+    // canonical이 b.ts(index 1)를 가리킴
+    try std.testing.expectEqual(@as(u32, 1), @intFromEnum(binding.?.canonical.module_index));
+}
+
+test "linker: re-export chain resolved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b';");
+    try writeFile(tmp.dir, "b.ts", "export { x } from './c';");
+    try writeFile(tmp.dir, "c.ts", "export const x = 1;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    const a = r.graph.modules.items[0];
+    const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
+    try std.testing.expect(binding != null);
+    // chain: a→b→c, canonical은 c(index 2)
+    try std.testing.expectEqual(@as(u32, 2), @intFromEnum(binding.?.canonical.module_index));
+}
+
+test "linker: missing export produces diagnostic" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import { missing } from './b';");
+    try writeFile(tmp.dir, "b.ts", "export const x = 1;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    // missing export → diagnostic
+    var has_missing = false;
+    for (r.linker.diagnostics.items) |d| {
+        if (d.code == .missing_export) has_missing = true;
+    }
+    try std.testing.expect(has_missing);
+}
+
+test "linker: export * resolves through re-export all" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b';");
+    try writeFile(tmp.dir, "b.ts", "export * from './c';");
+    try writeFile(tmp.dir, "c.ts", "export const x = 99;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    const a = r.graph.modules.items[0];
+    const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
+    try std.testing.expect(binding != null);
+    // export * → c.ts(index 2)
+    try std.testing.expectEqual(@as(u32, 2), @intFromEnum(binding.?.canonical.module_index));
+}
+
+test "linker: default import resolves" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import myDefault from './b';");
+    try writeFile(tmp.dir, "b.ts", "export default 42;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    const a = r.graph.modules.items[0];
+    const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
+    try std.testing.expect(binding != null);
+    try std.testing.expectEqualStrings("default", binding.?.canonical.export_name);
+}
+
+test "linker: external import not resolved (no binding)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import { x } from 'react';");
+
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "a.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .browser, &.{"react"});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+    try graph.build(&.{entry});
+
+    var linker = Linker.init(std.testing.allocator, graph.modules.items);
+    defer linker.deinit();
+    try linker.link();
+
+    // external → resolved binding 없음, diagnostic도 없음
+    try std.testing.expectEqual(@as(usize, 0), linker.resolved_bindings.count());
+    try std.testing.expectEqual(@as(usize, 0), linker.diagnostics.items.len);
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -23,6 +23,7 @@ pub const module = @import("module.zig");
 pub const graph = @import("graph.zig");
 pub const emitter = @import("emitter.zig");
 pub const binding_scanner = @import("binding_scanner.zig");
+pub const linker = @import("linker.zig");
 pub const bundler_core = @import("bundler.zig");
 
 // 공개 타입 re-export
@@ -52,5 +53,6 @@ test {
     _ = graph;
     _ = emitter;
     _ = binding_scanner;
+    _ = linker;
     _ = bundler_core;
 }


### PR DESCRIPTION
## Summary
- `linker.zig`: 크로스 모듈 심볼 바인딩
- import → export 연결, re-export 체인 해결 (깊이 100 제한)
- `export *` 해결: re_export_all을 통한 간접 export 탐색
- missing_export diagnostic 생성

## /simplify 리뷰 반영
- **[Critical 수정]** export_map 키를 `name_hash` (해시 충돌 위험) → `StringHashMap` 기반 (정확한 이름 비교)로 변경
- deinit에서 export_map 키 해제

## Test plan
- [x] `zig build test` 전체 통과 (누수 0)
- [x] 6개 유닛 테스트: 직접 import, re-export 체인, missing export, export *, default import, external

🤖 Generated with [Claude Code](https://claude.com/claude-code)