### PR TITLE
fix(bundler): shared spanKey + larger export key buffer

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -68,7 +68,7 @@ pub fn extractImportBindings(
     var source_to_record = std.AutoHashMap(u64, u32).init(allocator);
     defer source_to_record.deinit();
     for (import_records, 0..) |rec, i| {
-        const key = spanKey(rec.span);
+        const key = types.spanKey(rec.span);
         try source_to_record.put(key, @intCast(i));
     }
 
@@ -86,7 +86,7 @@ pub fn extractImportBindings(
 
         // source span으로 ImportRecord 인덱스 찾기
         const source_node = ast.getNode(source_idx);
-        const rec_idx = source_to_record.get(spanKey(source_node.span)) orelse continue;
+        const rec_idx = source_to_record.get(types.spanKey(source_node.span)) orelse continue;
 
         if (specs_len == 0) continue; // side-effect import
 
@@ -162,7 +162,7 @@ pub fn extractExportBindings(
     var source_to_record = std.AutoHashMap(u64, u32).init(allocator);
     defer source_to_record.deinit();
     for (import_records, 0..) |rec, i| {
-        const key = spanKey(rec.span);
+        const key = types.spanKey(rec.span);
         try source_to_record.put(key, @intCast(i));
     }
 
@@ -199,7 +199,7 @@ pub fn extractExportBindings(
                 const has_source = !source_idx.isNone();
                 const rec_idx: ?u32 = if (has_source) blk: {
                     const src_node = ast.getNode(source_idx);
-                    break :blk source_to_record.get(spanKey(src_node.span));
+                    break :blk source_to_record.get(types.spanKey(src_node.span));
                 } else null;
 
                 if (specs_len > 0) {
@@ -248,7 +248,7 @@ pub fn extractExportBindings(
                 const source_idx = node.data.binary.right;
                 if (source_idx.isNone()) continue;
                 const src_node = ast.getNode(source_idx);
-                const rec_idx = source_to_record.get(spanKey(src_node.span));
+                const rec_idx = source_to_record.get(types.spanKey(src_node.span));
 
                 try bindings.append(allocator, .{
                     .exported_name = "*",
@@ -330,10 +330,6 @@ fn extractDeclExportNames(allocator: std.mem.Allocator, ast: *const Ast, decl: N
     }
 
     return names.toOwnedSlice(allocator);
-}
-
-fn spanKey(span: Span) u64 {
-    return @as(u64, span.start) << 32 | span.end;
 }
 
 // ============================================================

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -135,7 +135,7 @@ pub const Linker = struct {
 
                 const bk = BindingKey{
                     .module_index = @intCast(i),
-                    .span_key = spanKey(ib.local_span),
+                    .span_key = types.spanKey(ib.local_span),
                 };
                 try self.resolved_bindings.put(bk, .{
                     .local_name = ib.local_name,
@@ -160,7 +160,7 @@ pub const Linker = struct {
         if (mod_i >= self.modules.len) return null;
 
         // 1. 직접 export 확인
-        var key_buf: [256]u8 = undefined;
+        var key_buf: [4096]u8 = undefined;
         const key = makeExportKeyBuf(&key_buf, @intCast(mod_i), name);
         if (self.export_map.get(key)) |entry| {
             if (entry.binding.kind == .re_export) {
@@ -208,7 +208,7 @@ pub const Linker = struct {
     pub fn getResolvedBinding(self: *const Linker, module_index: u32, span: Span) ?ResolvedBinding {
         const bk = BindingKey{
             .module_index = module_index,
-            .span_key = spanKey(span),
+            .span_key = types.spanKey(span),
         };
         return self.resolved_bindings.get(bk);
     }
@@ -234,10 +234,6 @@ pub const Linker = struct {
         }) catch {};
     }
 
-    fn spanKey(span: Span) u64 {
-        return @as(u64, span.start) << 32 | span.end;
-    }
-
     /// export 맵 키 생성 (할당). "module_index\x00name"
     fn makeExportKey(allocator: std.mem.Allocator, module_index: u32, name: []const u8) ![]const u8 {
         var buf = try allocator.alloc(u8, 4 + 1 + name.len);
@@ -248,9 +244,9 @@ pub const Linker = struct {
     }
 
     /// export 맵 키 생성 (스택 버퍼, 조회용).
-    fn makeExportKeyBuf(buf: *[256]u8, module_index: u32, name: []const u8) []const u8 {
+    fn makeExportKeyBuf(buf: *[4096]u8, module_index: u32, name: []const u8) []const u8 {
         const total = 5 + name.len;
-        if (total > 256) return "";
+        if (total > 4096) return "";
         @memcpy(buf[0..4], std.mem.asBytes(&module_index));
         buf[4] = 0;
         @memcpy(buf[5 .. 5 + name.len], name);

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -169,6 +169,20 @@ test "ModuleType: fromExtension" {
     try std.testing.expectEqual(ModuleType.unknown, ModuleType.fromExtension(".wasm"));
 }
 
+// ============================================================
+// 공유 유틸리티
+// ============================================================
+
+/// Span을 u64 키로 변환. 번들러 전역에서 식별자/노드를 고유 식별하는 데 사용.
+/// binding_scanner, linker 등에서 동일 함수를 공유하여 키 불일치 방지.
+pub fn spanKey(span: Span) u64 {
+    return @as(u64, span.start) << 32 | span.end;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
 test "ImportRecord: default resolved is none" {
     const record = ImportRecord{
         .specifier = "./foo",


### PR DESCRIPTION
## /simplify 반영
- **[HIGH]** spanKey 중복 제거: `types.spanKey()` 공유 함수로 추출. linker, binding_scanner에서 참조.
- **[HIGH]** makeExportKeyBuf 버퍼 256→4096 (긴 export 이름도 지원)

🤖 Generated with [Claude Code](https://claude.com/claude-code)