### PR TITLE
feat(bundler): symbol_ids + codegen metadata + transformer propagation

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -265,6 +265,7 @@ pub const Linker = struct {
                 .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, 0),
                 .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
                 .final_exports = null,
+                .symbol_ids = &.{},
                 .allocator = self.allocator,
             };
         }
@@ -275,6 +276,7 @@ pub const Linker = struct {
                 .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, 0),
                 .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
                 .final_exports = null,
+                .symbol_ids = &.{},
                 .allocator = self.allocator,
             };
         };

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -70,6 +70,11 @@ pub const Transformer = struct {
     /// visitExtraList가 각 자식 방문 후 이 버퍼를 드레인하여 리스트에 삽입한다.
     pending_nodes: std.ArrayList(NodeIndex),
 
+    /// 원본 AST의 symbol_ids (semantic analyzer가 생성). null이면 전파 안 함.
+    old_symbol_ids: []const ?u32 = &.{},
+    /// 새 AST 기준 symbol_ids. new_ast에 노드 추가 시 자동 전파.
+    new_symbol_ids: std.ArrayList(?u32) = .empty,
+
     pub fn init(allocator: std.mem.Allocator, old_ast: *const Ast, options: TransformOptions) Transformer {
         return .{
             .old_ast = old_ast,
@@ -116,7 +121,13 @@ pub const Transformer = struct {
 
     fn visitNode(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
         if (idx.isNone()) return .none;
+        const new_idx = try self.visitNodeInner(idx);
+        // symbol_id 전파: 원본 node_idx → 새 node_idx
+        self.propagateSymbolId(idx, new_idx);
+        return new_idx;
+    }
 
+    fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
         const node = self.old_ast.getNode(idx);
 
         // --------------------------------------------------------
@@ -331,6 +342,31 @@ pub const Transformer = struct {
     /// 노드를 그대로 새 AST에 복사한다 (자식 없는 리프 노드용).
     fn copyNodeDirect(self: *Transformer, node: Node) Error!NodeIndex {
         return self.new_ast.addNode(node);
+    }
+
+    /// visitNode의 래퍼: 원본 node_idx의 symbol_id를 새 node_idx로 전파.
+    fn visitNodeWithSymbol(self: *Transformer, old_idx: NodeIndex) Error!NodeIndex {
+        const new_idx = try self.visitNode(old_idx);
+        self.propagateSymbolId(old_idx, new_idx);
+        return new_idx;
+    }
+
+    /// 원본 → 새 노드의 symbol_id 전파.
+    fn propagateSymbolId(self: *Transformer, old_idx: NodeIndex, new_idx: NodeIndex) void {
+        if (self.old_symbol_ids.len == 0) return; // 전파 비활성
+        if (new_idx.isNone()) return;
+
+        const old_i = @intFromEnum(old_idx);
+        const new_i = @intFromEnum(new_idx);
+
+        // new_symbol_ids를 new_ast 노드 수만큼 확장
+        while (self.new_symbol_ids.items.len <= new_i) {
+            self.new_symbol_ids.append(self.allocator, null) catch return;
+        }
+
+        if (old_i < self.old_symbol_ids.len) {
+            self.new_symbol_ids.items[new_i] = self.old_symbol_ids[old_i];
+        }
     }
 
     /// 단항 노드: operand를 재귀 방문 후 복사.


### PR DESCRIPTION
## Summary

linker PR #5 전체: symbol_id 기반 식별자 리네임 인프라.

### 변경 사항
1. **semantic analyzer**: `symbol_ids` 배열 (노드 인덱스 → 심볼 인덱스)
2. **linker**: `LinkingMetadata` + `buildMetadata()` (skip_nodes + renames + final_exports)
3. **codegen**: `linking_metadata` 옵션 (skip + symbol_id 기반 리네임)
4. **transformer**: `propagateSymbolId` — new_ast에 symbol_ids 전파
5. **module/graph**: `ModuleSemanticData.symbol_ids` 필드

### /simplify 반영
- **[Critical]** Transformer가 new_ast를 만들 때 symbol_ids 무효화 → `propagateSymbolId`로 해결
- **[High]** buildMetadata 초기 리턴에 symbol_ids 필드 누락 → 추가
- 성능: old_symbol_ids.len == 0이면 전파 비활성 (비번들 모드 비용 0)

## Test plan
- [x] `zig build test` 전체 통과 (누수 0)
- [x] 기존 모든 테스트 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)