### PR TITLE
fix(parser): add progress guards to prevent OOM on malformed input

### DIFF
--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -259,6 +259,7 @@ pub fn parseArrayPattern(self: *Parser) ParseError2!NodeIndex {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_bracket and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         if (self.current() == .comma) {
             // elision (빈 슬롯) — placeholder 노드 추가
             const hole_span = self.currentSpan();
@@ -292,6 +293,8 @@ pub fn parseArrayPattern(self: *Parser) ParseError2!NodeIndex {
         _ = try self.tryParseTypeAnnotation();
         if (!elem.isNone()) try self.scratch.append(self.allocator, elem);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     const end = self.currentSpan().end;
@@ -313,6 +316,7 @@ pub fn parseObjectPattern(self: *Parser) ParseError2!NodeIndex {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         if (self.current() == .dot3) {
             // rest element: ...pattern
             const rest_start = self.currentSpan().start;
@@ -331,6 +335,8 @@ pub fn parseObjectPattern(self: *Parser) ParseError2!NodeIndex {
         const prop = try parseBindingProperty(self);
         if (!prop.isNone()) try self.scratch.append(self.allocator, prop);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     const end = self.currentSpan().end;

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -53,10 +53,13 @@ fn parseFunctionDeclarationWithFlags(self: *Parser, extra_flags: u32) ParseError
     self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const param = try self.parseBindingIdentifier();
         try self.scratch.append(self.allocator, param);
         try self.checkRestParameterLast(param);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     try self.expect(.r_paren);
     self.in_formal_parameters = false;
@@ -152,10 +155,13 @@ fn parseFunctionDeclarationWithFlagsOptionalName(self: *Parser, extra_flags: u32
     self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const param = try self.parseBindingIdentifier();
         try self.scratch.append(self.allocator, param);
         try self.checkRestParameterLast(param);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     try self.expect(.r_paren);
     self.in_formal_parameters = false;
@@ -224,10 +230,13 @@ pub fn parseFunctionExpressionWithFlags(self: *Parser, extra_flags: u32) ParseEr
     self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const param = try self.parseBindingIdentifier();
         try self.scratch.append(self.allocator, param);
         try self.checkRestParameterLast(param);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     try self.expect(.r_paren);
     self.in_formal_parameters = false;
@@ -356,6 +365,7 @@ fn parseClassBody(self: *Parser) ParseError2!NodeIndex {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         // 세미콜론 스킵 (클래스 본문에서 허용)
         if (self.current() == .semicolon) {
             try self.advance();
@@ -363,6 +373,8 @@ fn parseClassBody(self: *Parser) ParseError2!NodeIndex {
         }
         const member = try parseClassMember(self);
         if (!member.isNone()) try self.scratch.append(self.allocator, member);
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     self.in_class = saved_in_class;
@@ -528,10 +540,13 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.in_formal_parameters = true;
         const param_top = self.saveScratch();
         while (self.current() != .r_paren and self.current() != .eof) {
+            const loop_guard_pos = self.scanner.token.span.start;
             const param = try self.parseBindingIdentifier();
             try self.scratch.append(self.allocator, param);
             try self.checkRestParameterLast(param);
             if (!try self.eat(.comma)) break;
+
+            if (try self.ensureLoopProgress(loop_guard_pos)) break;
         }
         try self.expect(.r_paren);
         self.in_formal_parameters = false;

--- a/src/parser/jsx.zig
+++ b/src/parser/jsx.zig
@@ -19,6 +19,7 @@ const Kind = @import("../lexer/token.zig").Kind;
 fn parseJSXChildren(self: *Parser) ParseError2!ast_mod.NodeList {
     const children_top = self.saveScratch();
     while (self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         if (self.current() == .l_angle) {
             if (try self.peekNextKindJSX() == .slash) break;
             const child = try parseJSXElement(self);
@@ -53,6 +54,8 @@ fn parseJSXChildren(self: *Parser) ParseError2!ast_mod.NodeList {
         } else {
             break;
         }
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     const children = try self.ast.addNodeList(self.scratch.items[children_top..]);
     self.restoreScratch(children_top);
@@ -76,8 +79,11 @@ pub fn parseJSXElement(self: *Parser) ParseError2!NodeIndex {
     // Attributes
     const scratch_top = self.saveScratch();
     while (self.current() != .r_angle and self.current() != .slash and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const attr = try parseJSXAttribute(self);
         try self.scratch.append(self.allocator, attr);
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     const attrs = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -164,9 +164,12 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .l_curly) {
         try self.advance(); // skip {
         while (self.current() != .r_curly and self.current() != .eof) {
+            const loop_guard_pos = self.scanner.token.span.start;
             const spec = try parseImportSpecifier(self);
             try self.scratch.append(self.allocator, spec);
             if (!try self.eat(.comma)) break;
+
+            if (try self.ensureLoopProgress(loop_guard_pos)) break;
         }
         try self.expect(.r_curly);
     }
@@ -304,9 +307,12 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
 
         const scratch_top = self.saveScratch();
         while (self.current() != .r_curly and self.current() != .eof) {
+            const loop_guard_pos = self.scanner.token.span.start;
             const spec = try parseExportSpecifier(self);
             try self.scratch.append(self.allocator, spec);
             if (!try self.eat(.comma)) break;
+
+            if (try self.ensureLoopProgress(loop_guard_pos)) break;
         }
         try self.expect(.r_curly);
 
@@ -424,6 +430,7 @@ fn skipImportAttributes(self: *Parser) !void {
         var key_count: usize = 0;
 
         while (self.current() != .r_curly and self.current() != .eof) {
+            const loop_guard_pos = self.scanner.token.span.start;
             // key: identifier 또는 string literal
             const key_span = self.currentSpan();
             const key_text = self.ast.source[key_span.start..key_span.end];
@@ -454,6 +461,8 @@ fn skipImportAttributes(self: *Parser) !void {
                 try self.advance(); // value
             }
             _ = try self.eat(.comma);
+
+            if (try self.ensureLoopProgress(loop_guard_pos)) break;
         }
         _ = try self.eat(.r_curly);
     }

--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -23,9 +23,12 @@ pub fn parseObjectExpression(self: *Parser) ParseError2!NodeIndex {
     defer props.deinit(self.allocator);
 
     while (self.current() != .r_curly and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const prop = try parseObjectProperty(self);
         try props.append(self.allocator, prop);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     const end = self.currentSpan().end;
@@ -169,10 +172,13 @@ pub fn parseObjectMethodBody(self: *Parser, start: u32, key: NodeIndex, flags: u
     self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const param = try self.parseBindingIdentifier();
         try self.scratch.append(self.allocator, param);
         try self.checkRestParameterLast(param);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     try self.expect(.r_paren);
     self.in_formal_parameters = false;

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -257,6 +257,7 @@ pub const Parser = struct {
 
     /// 현재 토큰이 expected이면 소비, 아니면 "Expected X but found Y" 에러 추가.
     /// 닫는 괄호를 기대하는 경우, 매칭되는 여는 괄호 위치도 표시한다.
+    /// 에러 시 토큰을 advance하지 않음 — 각 루프의 progress guard가 무한 루프를 방지.
     pub fn expect(self: *Parser, expected: Kind) !void {
         if (!try self.eat(expected)) {
             const opening = self.findMatchingOpenBracket(expected);
@@ -290,6 +291,17 @@ pub const Parser = struct {
             .found = self.current().symbol(),
             .hint = "Try inserting a semicolon here",
         });
+    }
+
+    /// 루프 progress guard: 토큰이 진행되지 않았으면 강제 advance.
+    /// EOF에 도달하여 루프를 탈출해야 하면 true 반환.
+    /// 사용법: `if (try self.ensureLoopProgress(saved_pos)) break;`
+    pub fn ensureLoopProgress(self: *Parser, saved_pos: u32) !bool {
+        if (self.scanner.token.span.start == saved_pos) {
+            if (self.current() == .eof) return true;
+            try self.advance();
+        }
+        return false;
     }
 
     /// 에러를 추가한다. 기존 호출부 하위 호환 — found/hint 등은 null.
@@ -1263,6 +1275,7 @@ pub const Parser = struct {
         var prologue_octal_span: Span = Span.EMPTY;
 
         while (self.current() != .r_curly and self.current() != .eof) {
+            const loop_guard_pos = self.scanner.token.span.start;
             if (in_directive_prologue) {
                 if (self.isUseStrictDirective()) {
                     // non-simple parameters + "use strict" → 에러
@@ -1289,6 +1302,7 @@ pub const Parser = struct {
 
             const stmt = try self.parseStatement();
             if (!stmt.isNone()) try stmts.append(self.allocator, stmt);
+            if (try self.ensureLoopProgress(loop_guard_pos)) break;
         }
 
         const end = self.currentSpan().end;

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -39,6 +39,8 @@ pub fn parse(self: *Parser) !NodeIndex {
     var in_directive_prologue = true;
 
     while (self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
+
         if (in_directive_prologue) {
             if (self.isUseStrictDirective()) {
                 self.is_strict_mode = true;
@@ -52,6 +54,8 @@ pub fn parse(self: *Parser) !NodeIndex {
         if (!stmt.isNone()) {
             try stmts.append(self.allocator, stmt);
         }
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     const list = try self.ast.addNodeList(stmts.items);
@@ -192,8 +196,12 @@ pub fn parseBlockStatement(self: *Parser) ParseError2!NodeIndex {
     defer stmts.deinit(self.allocator);
 
     while (self.current() != .r_curly and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
+
         const stmt = try parseStatement(self);
         if (!stmt.isNone()) try stmts.append(self.allocator, stmt);
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     self.ctx = block_saved;
@@ -770,6 +778,8 @@ fn parseSwitchStatement(self: *Parser) ParseError2!NodeIndex {
     const scratch_top = self.saveScratch();
     var has_default = false;
     while (self.current() != .r_curly and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
+
         // duplicate default 검출 (ECMAScript 14.12.1)
         const is_default = self.current() == .kw_default;
         const default_span = self.currentSpan();
@@ -781,6 +791,8 @@ fn parseSwitchStatement(self: *Parser) ParseError2!NodeIndex {
             has_default = true;
         }
         try self.scratch.append(self.allocator, case_node);
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     self.restoreContext(saved_ctx);
@@ -823,8 +835,12 @@ fn parseSwitchCase(self: *Parser) ParseError2!NodeIndex {
     while (self.current() != .kw_case and self.current() != .kw_default and
         self.current() != .r_curly and self.current() != .eof)
     {
+        const loop_guard_pos = self.scanner.token.span.start;
+
         const stmt = try parseStatement(self);
         if (!stmt.isNone()) try self.scratch.append(self.allocator, stmt);
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     const body = try self.ast.addNodeList(self.scratch.items[body_top..]);

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -119,9 +119,12 @@ fn parseTsEnumDeclarationWithFlags(self: *Parser, flags: u32) ParseError2!NodeIn
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const member = try parseTsEnumMember(self);
         try self.scratch.append(self.allocator, member);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     const end = self.currentSpan().end;
@@ -267,9 +270,12 @@ pub fn parseTsTypeParameterDeclaration(self: *Parser) ParseError2!NodeIndex {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_angle and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const param = try parseTsTypeParameter(self);
         try self.scratch.append(self.allocator, param);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     try self.expect(.r_angle);
 
@@ -546,9 +552,12 @@ fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_angle and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const ty = try parseType(self);
         try self.scratch.append(self.allocator, ty);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     try self.expect(.r_angle);
 
@@ -613,12 +622,15 @@ fn parseObjectType(self: *Parser) ParseError2!NodeIndex {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const member = try parseTypeMember(self);
         try self.scratch.append(self.allocator, member);
         // ; 또는 , 로 구분
         if (!try self.eat(.semicolon) and !try self.eat(.comma)) {
             if (self.current() != .r_curly) break;
         }
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     const end = self.currentSpan().end;
@@ -655,9 +667,12 @@ fn parseTupleType(self: *Parser) ParseError2!NodeIndex {
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_bracket and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         const ty = try parseType(self);
         try self.scratch.append(self.allocator, ty);
         if (!try self.eat(.comma)) break;
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     const end = self.currentSpan().end;


### PR DESCRIPTION
## Summary

파서 에러 복구 시 토큰이 진행되지 않아 무한 루프 → OOM(signal 9)이 발생하는 문제를 방지합니다.

8개 파서 파일의 23개 while 루프에 **progress guard**를 추가하여, 루프 반복에서 토큰이 진행되지 않으면 강제로 advance하거나 break합니다.

## 문제

파서가 구문 오류를 만나면 에러를 기록하고 계속 파싱합니다 (에러 복구). 그런데 일부 루프에서 에러 복구 후 토큰을 소비하지 않으면 같은 위치에서 무한 반복 → 메모리 소진 → OOM(signal 9 SIGKILL)이 발생합니다.

이전 PR에서 발견된 사례:
- JSX `{expr}` expression container → `expect(.r_curly)` 문제 (이미 수정)
- 객체 메서드 shorthand → extra_data 레이아웃 불일치 (이미 수정)

이번 PR은 **모든 위험한 루프에 일괄적으로 안전망을 추가**합니다.

## 해결 방법: Progress Guard 패턴

```zig
while (condition) {
    const loop_guard_pos = self.scanner.token.span.start;
    // ... 기존 루프 본문 ...
    // 루프 끝에서 토큰 위치 변화 확인
    if (self.scanner.token.span.start == loop_guard_pos) {
        if (self.current() == .eof) break;
        try self.advance(); // 강제 진행
    }
}
```

## 수정된 루프 (23개, 8개 파일)

| 파일 | 루프 수 | 대상 |
|------|--------|------|
| `statement.zig` | 4 | 프로그램 본문, 블록문, switch cases, switch case body |
| `declaration.zig` | 5 | 함수 파라미터 ×3, 클래스 메서드 파라미터, 클래스 본문 |
| `object.zig` | 2 | 객체 프로퍼티, 객체 메서드 파라미터 |
| `jsx.zig` | 2 | JSX children, JSX attributes |
| `module.zig` | 3 | import specifiers, export specifiers, import attributes |
| `ts.zig` | 5 | enum members, type parameters, type arguments, object type members, tuple elements |
| `binding.zig` | 2 | 배열 바인딩 패턴, 객체 바인딩 패턴 |

## expression.zig 제외 이유

expression.zig의 루프들(`parseCallExpression`, array elements, argument list 등)은 이미 `!eat(.comma) break` 또는 `else => break` 패턴으로 보호되어 있습니다. progress guard를 추가하면 정상 파싱 흐름을 방해하여 22개 기존 테스트가 실패합니다.

## expect() 미수정 결정

esbuild/Bun처럼 `expect()` 에러 시 토큰 advance를 시도했으나 27개 기존 테스트가 실패하여 되돌렸습니다. 많은 파서 코드가 `expect()` 실패 후 현재 토큰에 머무는 동작에 의존하고 있어서, 이를 변경하면 대규모 리팩터링이 필요합니다. 대신 루프 레벨의 progress guard로 방어합니다.

## Test plan
- [x] `zig build test` — 전체 865개 테스트 통과
- [x] pre-push hook (zig fmt + zig build test) 통과
- [x] 기존 테스트 0개 실패 (regression 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)