### PR TITLE
feat(tree-shaker): activate auto-pure module detection

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -201,8 +201,8 @@ test "Bundler: single file bundle" {
 test "Bundler: two files bundled in order" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.ts", "import './b';\nconst a = 1;");
-    try writeFile(tmp.dir, "b.ts", "const b = 2;");
+    try writeFile(tmp.dir, "a.ts", "import './b';\nconst a = 1;\nconsole.log(a);");
+    try writeFile(tmp.dir, "b.ts", "const b = 2;\nconsole.log(b);");
 
     const entry = try absPath(&tmp, "a.ts");
     defer std.testing.allocator.free(entry);
@@ -216,8 +216,8 @@ test "Bundler: two files bundled in order" {
     defer result.deinit(std.testing.allocator);
 
     // b.ts가 a.ts보다 먼저 (exec_index 순서)
-    const b_pos = std.mem.indexOf(u8, result.output, "const b = 2;") orelse return error.TestUnexpectedResult;
-    const a_pos = std.mem.indexOf(u8, result.output, "const a = 1;") orelse return error.TestUnexpectedResult;
+    const b_pos = std.mem.indexOf(u8, result.output, "console.log(b);") orelse return error.TestUnexpectedResult;
+    const a_pos = std.mem.indexOf(u8, result.output, "console.log(a);") orelse return error.TestUnexpectedResult;
     try std.testing.expect(b_pos < a_pos);
 }
 
@@ -411,7 +411,7 @@ test "Linker integration: export keyword stripped (non-entry)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "a.ts", "import './b';");
-    try writeFile(tmp.dir, "b.ts", "export const y = 99;");
+    try writeFile(tmp.dir, "b.ts", "export const y = 99;\nconsole.log(y);");
 
     const entry = try absPath(&tmp, "a.ts");
     defer std.testing.allocator.free(entry);
@@ -5896,7 +5896,7 @@ test "DynamicImport: static path in import()" {
         \\const lazy = import('./lazy');
         \\lazy.then(m => console.log(m));
     );
-    try writeFile(tmp.dir, "lazy.ts", "export const data = 'lazy-loaded';");
+    try writeFile(tmp.dir, "lazy.ts", "export const data = 'lazy-loaded';\nconsole.log(data);");
 
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
@@ -6358,9 +6358,8 @@ test "TreeShaking: unused side_effects=false module excluded from bundle" {
     try std.testing.expect(!result.hasErrors());
     // x는 출력에 존재
     try std.testing.expect(std.mem.indexOf(u8, result.output, "42") != null);
-    // c.ts는 side_effects=true가 기본이므로 포함됨 (side_effects 기본값)
-    // 이 테스트는 기본 동작 확인: side_effects=true면 포함
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "dead_code") != null);
+    // c.ts는 pure code만 있으므로 auto-pure 감지로 side_effects=false → 제외됨
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "dead_code") == null);
 }
 
 test "TreeShaking: tree_shaking=false preserves all modules" {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -79,10 +79,18 @@ pub const TreeShaker = struct {
             }
         }
 
-        // TODO: 자동 순수 판별 활성화 — 별도 PR에서 기존 테스트 업데이트 후 활성화
-        // isModulePure/isStatementPure/isExpressionPure 분석 함수는 준비 완료.
-        // 활성화하면 `const x = 1`만 있는 모듈이 side_effects=false → 미사용 시 제거.
-        // 기존 테스트 200개+ 중 상당수가 side_effects=true를 전제하므로 일괄 수정 필요.
+        // 자동 순수 판별: 진입점이 아닌 모듈의 top-level이 모두 순수하면 side_effects=false
+        // (rolldown/esbuild 동작: package.json sideEffects 없어도 자동 감지)
+        for (self.modules, 0..) |m, i| {
+            if (!m.side_effects) continue;
+            if (self.entry_set.isSet(i)) continue;
+            if (m.ast) |ast| {
+                if (isModulePure(&ast)) {
+                    const mutable_modules: [*]Module = @constCast(self.modules.ptr);
+                    mutable_modules[i].side_effects = false;
+                }
+            }
+        }
 
         for (self.modules, 0..) |m, i| {
             if (self.entry_set.isSet(i) or m.side_effects) {


### PR DESCRIPTION
## Summary
자동 순수 판별 활성화 — esbuild/rolldown 동작과 동일.

package.json sideEffects 없이도 모듈의 top-level 문장을 분석하여 side_effects=false를 자동 설정합니다.

### 순수로 판별되는 문장
- `export const x = 1` (리터럴 초기값)
- `export function f() {}` (함수 선언)
- `import/export` 선언
- `export const val = /* @__PURE__ */ create()` (@__PURE__ call)
- TS type/interface 선언

### 불순으로 판별되는 문장 (보수적)
- `console.log()` (일반 call)
- `class Foo {}` (extends/static 초기화 가능)
- `enum Color {}` (런타임 IIFE)
- array/object 리터럴 (원소에 call 가능)
- template literal (표현식 포함 가능)

### 우선순위
package.json sideEffects > 자동 감지 (rolldown 패턴)

## Test plan
- [x] 기존 테스트 4개 수정 (side effect 추가 또는 기대값 수정)
- [x] 전체 테스트 통과
- [x] pre-push hook 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)