### PR TITLE
feat(bundler): computeCrossChunkLinks — cross-chunk dependency tracking

### DIFF
--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -515,7 +515,8 @@ pub fn computeCrossChunkLinks(
 
         for (chunk.modules.items) |mod_idx| {
             const mi = @intFromEnum(mod_idx);
-            if (mi >= modules.len) continue;
+            // 청크에 포함된 모듈은 반드시 modules 배열 내에 있어야 함
+            std.debug.assert(mi < modules.len);
             const m = &modules[mi];
 
             // 정적 의존성 → cross_chunk_imports


### PR DESCRIPTION
## Summary
Code splitting PR3: 청크 간 의존성 계산.

- 각 청크의 모듈이 다른 청크 모듈에 의존하면 `cross_chunk_imports`에 기록
- 동적 import는 `cross_chunk_dynamic_imports`에 별도 기록
- 중복 제거 (같은 대상 청크 한 번만)

## Test plan
- [x] 같은 청크 내 의존성 → 빈 리스트
- [x] 정적 크로스 청크 import
- [x] 동적 크로스 청크 import
- [x] 중복 제거 (여러 모듈 → 같은 청크)
- [x] 양방향 의존
- [x] 기존 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)