### PR TITLE
feat(server): on-the-fly 번들 서빙 (HMR 2/6단계)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -393,12 +393,24 @@ pub fn main() !void {
         return;
     }
 
-    // --serve
+    // --serve (정적 서버 또는 --bundle과 조합하여 번들 서빙)
     if (is_serve) {
-        const serve_dir = input_file orelse ".";
+        // --serve --bundle entry.ts → entry의 디렉토리를 root로 사용
+        const serve_dir: []const u8 = if (is_bundle and input_file != null) blk: {
+            break :blk std.fs.path.dirname(input_file.?) orelse ".";
+        } else input_file orelse ".";
+
+        const entry: ?[]const u8 = if (is_bundle) blk: {
+            break :blk input_file orelse {
+                try stderr.print("Error: --serve --bundle requires an entry file path\n", .{});
+                return;
+            };
+        } else null;
+
         var dev_server = lib.server.DevServer.init(allocator, .{
             .root_dir = serve_dir,
             .port = serve_port,
+            .entry_point = entry,
         }) catch |err| {
             try stderr.print("Error: failed to start dev server: {}\n", .{err});
             return;
@@ -874,6 +886,7 @@ fn printUsage(writer: anytype) !void {
         \\
         \\Dev server:
         \\  --serve [dir]                    Start static file server (default: .)
+        \\  --serve --bundle <entry.ts>      Bundle and serve entry point
         \\  --port <number>                  Server port (default: 3000)
         \\
         \\Bundle options:

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const http = std.http;
 const mime = @import("mime.zig");
+const lib = @import("../root.zig");
+const Bundler = lib.bundler.Bundler;
 
 fn getLog() std.fs.File.DeprecatedWriter {
     return std.fs.File.stderr().deprecatedWriter();
@@ -12,13 +14,17 @@ pub const DevServer = struct {
     root_path: []const u8,
     port: u16,
     tcp_server: ?std.net.Server,
+    /// 번들 엔트리 포인트 (절대 경로). null이면 정적 파일 서버 전용.
+    entry_point: ?[]const u8,
 
     pub const Options = struct {
         root_dir: []const u8 = ".",
         port: u16 = 3000,
+        entry_point: ?[]const u8 = null,
     };
 
     const max_file_size: u64 = 50 * 1024 * 1024;
+    const bundle_path = "/bundle.js";
 
     pub fn init(allocator: std.mem.Allocator, options: Options) !DevServer {
         const root_dir = std.fs.cwd().openDir(options.root_dir, .{}) catch |err| {
@@ -32,6 +38,7 @@ pub const DevServer = struct {
             .root_path = options.root_dir,
             .port = options.port,
             .tcp_server = null,
+            .entry_point = options.entry_point,
         };
     }
 
@@ -49,10 +56,14 @@ pub const DevServer = struct {
             return err;
         };
 
-        getLog().print("\n  zts dev server\n\n  Local: http://localhost:{d}/\n  Root:  {s}\n\n", .{
-            self.port,
-            self.root_path,
-        }) catch {};
+        const w = getLog();
+        w.print("\n  zts dev server\n\n", .{}) catch {};
+        w.print("  Local: http://localhost:{d}/\n", .{self.port}) catch {};
+        w.print("  Root:  {s}\n", .{self.root_path}) catch {};
+        if (self.entry_point) |ep| {
+            w.print("  Entry: {s}\n", .{ep}) catch {};
+        }
+        w.print("\n", .{}) catch {};
 
         self.acceptLoop();
     }
@@ -121,6 +132,31 @@ pub const DevServer = struct {
             return;
         };
 
+        // entry_point가 있을 때: /bundle.js → on-the-fly 번들링
+        if (self.entry_point != null) {
+            if (std.mem.eql(u8, raw_path, bundle_path)) {
+                self.serveBundle(request) catch |err| {
+                    getLog().print("zts: bundle failed: {}\n", .{err}) catch {};
+                    try request.respond("500 Bundle Error", .{
+                        .status = .internal_server_error,
+                        .extra_headers = &cors_headers,
+                    });
+                };
+                return;
+            }
+
+            // / → entry가 있으면 자동 HTML (index.html이 없을 때)
+            if (std.mem.eql(u8, rel_path, "index.html")) {
+                if (self.root_dir.openFile("index.html", .{})) |f| {
+                    f.close();
+                    // index.html이 있으면 정적 서빙으로 폴스루
+                } else |_| {
+                    try self.serveAutoHtml(request);
+                    return;
+                }
+            }
+        }
+
         self.serveStaticFile(request, rel_path) catch |err| switch (err) {
             error.FileNotFound => {
                 try request.respond("404 Not Found", .{
@@ -130,6 +166,80 @@ pub const DevServer = struct {
             },
             else => return err,
         };
+    }
+
+    fn serveBundle(self: *DevServer, request: *http.Server.Request) !void {
+        const entry = self.entry_point orelse unreachable;
+        const abs_entry = try std.fs.cwd().realpathAlloc(self.allocator, entry);
+        defer self.allocator.free(abs_entry);
+
+        var bundler = Bundler.init(self.allocator, .{
+            .entry_points = &.{abs_entry},
+            .platform = .browser,
+        });
+        defer bundler.deinit();
+
+        const result = try bundler.bundle();
+        defer result.deinit(self.allocator);
+
+        if (result.hasErrors()) {
+            const diags = result.getDiagnostics();
+            var msg: std.ArrayList(u8) = .empty;
+            defer msg.deinit(self.allocator);
+            const w = msg.writer(self.allocator);
+            try w.print("// ZTS Bundle Error\n", .{});
+            for (diags) |d| {
+                try w.print("// [{s}] {s}: {s}\n", .{
+                    @tagName(d.severity),
+                    d.file_path,
+                    d.message,
+                });
+            }
+            try w.print("console.error('ZTS: bundle failed, see server logs');\n", .{});
+
+            const js_headers = cors_headers ++ [_]http.Header{
+                .{ .name = "Content-Type", .value = "application/javascript; charset=utf-8" },
+            };
+            try request.respond(msg.items, .{
+                .status = .internal_server_error,
+                .extra_headers = &js_headers,
+            });
+
+            getLog().print("  500 {s} (bundle errors)\n", .{entry}) catch {};
+            return;
+        }
+
+        const js_headers = cors_headers ++ [_]http.Header{
+            .{ .name = "Content-Type", .value = "application/javascript; charset=utf-8" },
+        };
+        try request.respond(result.output, .{
+            .extra_headers = &js_headers,
+        });
+
+        getLog().print("  200 {s} (bundled)\n", .{bundle_path}) catch {};
+    }
+
+    fn serveAutoHtml(self: *DevServer, request: *http.Server.Request) !void {
+        _ = self;
+        const html =
+            \\<!DOCTYPE html>
+            \\<html>
+            \\<head><meta charset="utf-8"><title>ZTS Dev Server</title></head>
+            \\<body>
+            \\<div id="root"></div>
+            \\<script type="module" src="/bundle.js"></script>
+            \\</body>
+            \\</html>
+        ;
+
+        const headers = cors_headers ++ [_]http.Header{
+            .{ .name = "Content-Type", .value = "text/html; charset=utf-8" },
+        };
+        try request.respond(html, .{
+            .extra_headers = &headers,
+        });
+
+        getLog().print("  200 / (auto html)\n", .{}) catch {};
     }
 
     fn serveStaticFile(self: *DevServer, request: *http.Server.Request, rel_path: []const u8) !void {


### PR DESCRIPTION
## Summary
- DevServer에 번들러 통합: `--serve --bundle entry.ts`로 on-the-fly 번들 서빙
- `/bundle.js` 요청 → Bundler.bundle() 실행 → TS 타입 스트리핑된 JS 응답
- `/` 요청 → index.html 없으면 자동 HTML 생성 (`<script src="/bundle.js">`)
- 번들 에러 시 500 + JS 에러 메시지 (console.error)
- 정적 파일 서빙은 기존대로 동작

## Test plan
- [x] `zig build test` — 유닛 테스트 통과
- [x] `bun run test:integration` — 기존 통합 테스트 6/6 통과
- [x] 수동 검증: auto HTML / bundle.js (TS→JS) / 정적 파일 / 404
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)