### PR TITLE
feat(server): WebSocket HMR 채널 (HMR 3/6단계)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -117,7 +117,6 @@ pub const DevServer = struct {
                 },
             };
 
-            // WebSocket upgrade 체크
             switch (request.upgradeRequested()) {
                 .websocket => |opt_key| {
                     const key = opt_key orelse {
@@ -160,11 +159,9 @@ pub const DevServer = struct {
         }
     }
 
-    fn handleWebSocket(self: *DevServer, ws: *http.Server.WebSocket) void {
-        _ = self;
+    fn handleWebSocket(_: *DevServer, ws: *http.Server.WebSocket) void {
         getLog().print("  [ws] client connected\n", .{}) catch {};
 
-        // 연결 후 connected 메시지 전송
         ws.writeMessage("{\"type\":\"connected\"}", .text) catch {
             getLog().print("  [ws] failed to send connected message\n", .{}) catch {};
             return;


### PR DESCRIPTION
## Summary
- `std.http.Server.WebSocket` 기반 HMR WebSocket 서버
- `/__hmr` 경로에서 WebSocket upgrade → 양방향 메시지 통신
- auto HTML에 HMR 클라이언트 스크립트 주입 (자동 재연결 포함)
- JSON 프로토콜: `{"type":"connected"}`, `{"type":"full-reload"}`

## Test plan
- [x] `zig build test` — 유닛 테스트 통과
- [x] `bun run test:integration` — 6/6 통과
- [x] Bun WebSocket 클라이언트로 실제 연결 검증 (OPEN → connected 메시지 → CLOSED)
- [x] auto HTML에 `__hmr` 스크립트 포함 확인
- [x] 비-HMR 경로 WebSocket upgrade 거부 확인
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)