### PR TITLE
feat(server): thread-per-connection + watch → full-reload (HMR 4/6단계)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -41,9 +41,15 @@ const WsClients = struct {
     fn broadcast(self: *WsClients, data: []const u8) void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        for (self.items[0..self.len]) |writer| {
-            // WebSocket text frame: FIN + opcode=text, then length, then payload
-            writeWsFrame(writer, data) catch {};
+        var i: usize = 0;
+        while (i < self.len) {
+            writeWsFrame(self.items[i], data) catch {
+                // 전송 실패 → dead client 제거 (swap-remove)
+                self.len -= 1;
+                self.items[i] = self.items[self.len];
+                continue;
+            };
+            i += 1;
         }
     }
 };
@@ -166,7 +172,7 @@ pub const DevServer = struct {
                 getLog().print("zts: accept failed: {}\n", .{err}) catch {};
                 continue;
             };
-            const thread = std.Thread.spawn(.{}, handleConnection, .{ self, connection }) catch {
+            const thread = std.Thread.spawn(.{ .stack_size = 64 * 1024 }, handleConnection, .{ self, connection }) catch {
                 connection.stream.close();
                 continue;
             };
@@ -268,6 +274,7 @@ pub const DevServer = struct {
         getLog().print("  [ws] client disconnected\n", .{}) catch {};
     }
 
+    // TODO: entry 파일만 감시. 번들러 모듈 그래프의 모든 import 파일을 감시해야 함 (5단계)
     fn watchLoop(self: *DevServer) void {
         getLog().print("  [watch] watching for changes...\n", .{}) catch {};
 


### PR DESCRIPTION
## Summary
- `std.Thread.spawn` + `detach`로 connection-per-thread 전환 → WS + HTTP 동시 처리
- `WsClients` 구조체: mutex 보호 클라이언트 목록 + broadcast 함수
- `watchLoop`: entry 파일 mtime 폴링 → 변경 시 `{"type":"full-reload"}` broadcast
- `writeWsFrame`: raw writer로 WS text frame 인코딩 (broadcast에서 사용)

## Test plan
- [x] `zig build test` — 유닛 테스트 통과
- [x] `bun run test:integration` — 6/6 통과
- [x] WS 연결 중 HTTP 요청 동시 처리 확인 (블로킹 없음)
- [x] 파일 변경 → `full-reload` broadcast → WS 클라이언트 수신 확인
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)