### PR TITLE
fix(parser): TS non-null assertion 체이닝 수정 (foo()!.bar)

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -584,16 +584,8 @@ fn parsePostfixExpression(self: *Parser) ParseError2!NodeIndex {
         }
     }
 
-    // TS: non-null assertion (expr!)
-    if (self.current() == .bang and !self.scanner.token.has_newline_before) {
-        const expr_start = self.ast.getNode(expr).span.start;
-        try self.advance();
-        expr = try self.ast.addNode(.{
-            .tag = .ts_non_null_expression,
-            .span = .{ .start = expr_start, .end = self.currentSpan().start },
-            .data = .{ .unary = .{ .operand = expr, .flags = 0 } },
-        });
-    }
+    // TS non-null assertion (expr!) — parseCallExpression 내부에서 처리
+    // (체이닝 지원: foo()!.bar!.baz)
 
     // TS: as Type / satisfies Type (체이닝 가능: x as A as B)
     while (self.current() == .kw_as or self.current() == .kw_satisfies) {
@@ -772,6 +764,18 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                         .data = .{ .extra = te },
                     });
                 }
+            },
+            .bang => {
+                // TS non-null assertion: expr!
+                // `!` 뒤에 `.`, `[`, `(` 가 오면 체이닝 (foo()!.bar)
+                // 줄바꿈 뒤의 `!`는 논리 NOT으로 해석해야 하므로 제외
+                if (self.scanner.token.has_newline_before) break;
+                try self.advance();
+                expr = try self.ast.addNode(.{
+                    .tag = .ts_non_null_expression,
+                    .span = .{ .start = expr_start, .end = self.currentSpan().start },
+                    .data = .{ .unary = .{ .operand = expr, .flags = 0 } },
+                });
             },
             else => break,
         }


### PR DESCRIPTION
## Summary
- `foo()!.bar`, `foo()!.bar!.baz` 등 non-null assertion 뒤 property access가 파싱 실패하던 버그 수정
- `!` 처리를 `parsePostfixExpression` → `parseCallExpression` while 루프로 이동
- 줄바꿈 뒤 `!`는 논리 NOT으로 정상 유지

## Test plan
- [x] `zig build test` — 전체 유닛 테스트 통과
- [x] `bun run test:integration` — 6/6 통과
- [x] `bun run test:e2e` — 4/4 통과
- [x] 수동 검증 7개 케이스: 기본, 체이닝, 이중 체이닝, call, computed, 줄바꿈
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)