### PR TITLE
feat(server): SPA 폴백 (historyApiFallback)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -471,10 +471,18 @@ pub const DevServer = struct {
 
         self.serveStaticFile(request, rel_path) catch |err| switch (err) {
             error.FileNotFound => {
-                try request.respond("404 Not Found", .{
-                    .status = .not_found,
-                    .extra_headers = &cors_headers,
-                });
+                // SPA 폴백: 확장자 없는 경로 → index.html (React Router 등)
+                if (self.entry_point != null and std.fs.path.extension(rel_path).len == 0) {
+                    self.serveStaticFile(request, "index.html") catch |e2| switch (e2) {
+                        error.FileNotFound => try self.serveAutoHtml(request),
+                        else => return e2,
+                    };
+                } else {
+                    try request.respond("404 Not Found", .{
+                        .status = .not_found,
+                        .extra_headers = &cors_headers,
+                    });
+                }
             },
             else => return err,
         };


### PR DESCRIPTION
## Summary
- 확장자 없는 경로에서 파일 못 찾으면 index.html로 폴백 (SPA 라우팅 지원)
- `/about`, `/users/123` → auto HTML 반환
- `/missing.js` → 404 유지 (확장자 있는 파일은 폴백 안 함)

## Test plan
- [x] `zig build test` — 통과
- [x] `bun run test:e2e` — 5/5 통과
- [x] `bun run test:integration` — 6/6 통과
- [x] 수동: `/about`, `/users/123` → 200, `/missing.js` → 404
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)