### PR TITLE
feat(server): CSS 핫 리로드 — link tag swap (페이지 새로고침 없이)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ Arena allocator ─────────┬──→ 번들러 (파일별 are
        8. ✅ SPA 폴백 — PR #269
        9. ✅ import.meta.hot API (모듈 래핑 + accept/dispose + 모듈 단위 교체) — PR #270, #271
        10. ✅ React Fast Refresh ($RefreshReg$ 주입 + 런타임 통합) — PR #273, #274
-       11. CSS 핫 리로드 (link tag swap, 페이지 새로고침 없이)
+       11. ✅ CSS 핫 리로드 (link tag swap) — PR #275
      - **추가 의사결정 (D059-D060):**
        - D059. 동시성: `std.Thread.spawn` per-connection (esbuild goroutine과 유사)
        - dev server 전용이라 OS 스레드 10-20개면 충분
@@ -328,7 +328,7 @@ Phase B1: 기반 (✅ 완료)          Phase B2: 핵심 (✅ 대부분 완료) P
 ✅ Tree-shaking (모듈 수준)         ├ ✅ 모듈 그래프 파일 감시
   ├ export 사용 추적                 ├ ✅ 에러 오버레이 + 소스맵
   ├ @__PURE__ / @__NO_SIDE_EFFECTS__├ ✅ import.meta.hot + Fast Refresh
-  ├ sideEffects 필드                 └ CSS 핫 리로드
+  ├ sideEffects 필드                 └ ✅ CSS 핫 리로드
   ├ sideEffects 필드
   └ cross-module 전파
 ```
@@ -570,7 +570,7 @@ HMR API 비교:
 핵심 HMR (큰 작업):
   9. ✅ import.meta.hot API — PR #270 (모듈 래핑 dev 번들), PR #271 (모듈 단위 WS update)
   10. ✅ React Fast Refresh — PR #273 ($RefreshReg$ 주입), PR #274 (런타임 통합 + hot.accept)
-  11. CSS 핫 리로드 — link tag swap (페이지 새로고침 없이)
+  11. ✅ CSS 핫 리로드 — PR #275 (link tag swap + CSS 파일 감시)
 ```
 
 ###### 아키텍처

--- a/packages/e2e/tests/smoke.test.ts
+++ b/packages/e2e/tests/smoke.test.ts
@@ -191,12 +191,12 @@ test.describe("Dev Server E2E", () => {
           }
         };
         ws.onerror = () => resolve("error");
-        setTimeout(() => resolve("timeout"), 8000);
+        setTimeout(() => resolve("timeout"), 12000);
       });
     }, TEST_PORT);
 
-    // watch가 감지할 수 있도록 잠시 대기 후 CSS 변경
-    await new Promise((r) => setTimeout(r, 1000));
+    // watch가 감지할 수 있도록 잠시 대기 후 CSS 변경 (CI 환경에서 mtime polling 간격 고려)
+    await new Promise((r) => setTimeout(r, 1500));
     await writeFile(join(fixtureDir, "style.css"), "body { background: red; }");
 
     const result = await updatePromise;

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -124,7 +124,7 @@ pub const DevServer = struct {
     };
 
     pub fn init(allocator: std.mem.Allocator, options: Options) !DevServer {
-        const root_dir = std.fs.cwd().openDir(options.root_dir, .{}) catch |err| {
+        const root_dir = std.fs.cwd().openDir(options.root_dir, .{ .iterate = true }) catch |err| {
             getLog().print("zts: cannot open directory '{s}': {}\n", .{ options.root_dir, err }) catch {};
             return err;
         };


### PR DESCRIPTION
## Summary
- **CSS 파일 감시**: `collectCssFiles`로 root_dir에서 `.css` 파일 재귀 탐색 + mtime 감시
- **css-update WS 메시지**: CSS 변경 시 `{"type":"css-update","file":"/style.css"}` 전송
- **JS 재빌드 스킵**: CSS만 변경된 경우 번들 재빌드 없이 WS 전송만
- **클라이언트 link tag swap**: `<link>` 태그의 `href`에 `?t=timestamp` 추가하여 브라우저가 CSS 새로 로드
- **E2E 테스트**: CSS 변경 → `css-update` 메시지 수신 확인

## HMR 로드맵 완성
```
  1-8.  ✅ 기반 인프라 (HTTP/WS/Live Reload/에러 오버레이/SPA/소스맵)
  9.    ✅ import.meta.hot API
  10.   ✅ React Fast Refresh
  11.   ✅ CSS 핫 리로드 ← 이번 PR
```

## Test plan
- [x] `zig build test` 전체 통과
- [x] E2E 8개 전체 통과 (새로 추가: CSS 변경 → css-update 수신)
- [x] CSS만 변경 시 JS 재빌드 안 함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)