### PR TITLE
fix(tree-shaker): namespace import 시 named re-export 소스 모듈 include

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -399,22 +399,43 @@ pub const TreeShaker = struct {
 
     fn markAllExportsUsed(self: *TreeShaker, module_index: u32) !void {
         if (module_index >= self.modules.len) return;
+        // 순환 방지: 이미 처리한 모듈은 skip
+        if (self.isExportUsed(module_index, "*")) return;
+        try self.markExportUsed(module_index, "*"); // sentinel
+
         const m = self.modules[module_index];
         for (m.export_bindings) |eb| {
-            if (eb.kind == .re_export_all) {
-                // export * from './dep' → dep 모듈의 모든 export도 마킹 + include
+            if (std.mem.eql(u8, eb.exported_name, "*")) continue;
+
+            if (eb.kind == .re_export_all or eb.kind == .re_export) {
+                // re-export (named + all): 소스 모듈도 include + 재귀
                 if (eb.import_record_index) |rec_idx| {
                     if (rec_idx < m.import_records.len) {
                         const source_mod = @intFromEnum(m.import_records[rec_idx].resolved);
                         if (source_mod < self.modules.len) {
                             if (!self.included.isSet(source_mod)) self.included.set(source_mod);
-                            try self.markAllExportsUsed(@intCast(source_mod));
+                            if (eb.kind == .re_export_all) {
+                                try self.markAllExportsUsed(@intCast(source_mod));
+                            } else {
+                                // named re-export: canonical 모듈도 include
+                                if (self.linker.resolveExportChain(
+                                    m.import_records[rec_idx].resolved,
+                                    eb.local_name,
+                                    0,
+                                )) |canonical| {
+                                    const canon_idx = @intFromEnum(canonical.module_index);
+                                    if (canon_idx < self.modules.len) {
+                                        if (!self.included.isSet(canon_idx)) self.included.set(canon_idx);
+                                        try self.markExportUsed(@intCast(canon_idx), canonical.export_name);
+                                    }
+                                }
+                            }
                         }
                     }
                 }
-                continue;
+                if (eb.kind == .re_export_all) continue;
             }
-            if (std.mem.eql(u8, eb.exported_name, "*")) continue;
+
             try self.markExportUsed(module_index, eb.exported_name);
         }
     }


### PR DESCRIPTION
## Summary
- namespace import (`import * as X`)에서 named re-export (`export { Y } from './mod'`)의 소스 모듈이 tree-shaking으로 제거되는 버그 수정
- `markAllExportsUsed()`에서 `re_export` kind도 canonical 모듈을 include하고 export 마킹
- `"*"` sentinel로 순환 참조 방지

## 배경
zod 번들링 시 `JSONSchemaGenerator is not defined` 에러. `core/index.js`가 `export { JSONSchemaGenerator } from './json-schema-generator.js'`로 re-export하는데, namespace import 시 tree-shaker가 `json-schema-generator.js`를 제거.

## 현재 상태
- zod 번들 생성: 255KB (esbuild: 504KB) — tree-shaking이 더 공격적
- zod 런타임: 아직 실행 안 됨 — namespace preamble의 scope hoisting 충돌 문제 남아있음
- 이 PR은 tree-shaker 수정만 포함. namespace preamble 충돌은 후속 이슈로 분리 필요

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] 통합 테스트 6/6 통과
- [x] preact, date-fns, uuid 스모크 테스트 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)