### PR TITLE
fix(parser): contextual keyword를 expression/statement에서 식별자 허용

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -883,11 +883,12 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
 fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
     const span = self.currentSpan();
 
-    switch (self.current()) {
-        .identifier => {
-            // class field/static initializer에서 arguments 사용 금지
-            // ECMAScript 15.7.1 (class field), 15.7.14 (static block)
-            // 이 컨텍스트들은 자체 arguments 바인딩이 없다.
+    // contextual keyword도 expression 위치에서 식별자로 유효.
+    // async는 제외 — async function/arrow에서 특수 처리 (아래 switch에서).
+    if (self.current() == .identifier or
+        (self.current().isKeyword() and !self.current().isReservedKeyword() and self.current() != .kw_async))
+    {
+        if (self.current() == .identifier) {
             if (self.in_class_field or self.in_static_initializer) {
                 const text = self.resolveIdentifierText(span);
                 if (std.mem.eql(u8, text, "arguments")) {
@@ -898,13 +899,16 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                     try self.addError(span, msg);
                 }
             }
-            try self.advance();
-            return try self.ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = span,
-                .data = .{ .string_ref = span },
-            });
-        },
+        }
+        try self.advance();
+        return try self.ast.addNode(.{
+            .tag = .identifier_reference,
+            .span = span,
+            .data = .{ .string_ref = span },
+        });
+    }
+
+    switch (self.current()) {
         .decimal, .float, .hex, .octal, .binary, .positive_exponential, .negative_exponential => {
             // strict mode에서 legacy octal 숫자 금지 (ECMAScript 12.8.3.1)
             if (self.scanner.token.has_legacy_octal and self.is_strict_mode) {

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -176,7 +176,15 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
         .kw_type => self.parseTsTypeAliasDeclaration(),
         .kw_interface => self.parseTsInterfaceDeclaration(),
         .kw_enum => self.parseTsEnumDeclaration(),
-        .kw_namespace => self.parseTsModuleDeclaration(),
+        .kw_namespace => blk: {
+            // namespace Name { } → TS module declaration
+            // namespace = 2 → expression statement (변수로 사용)
+            const next = try self.peekNextKind();
+            if (next == .identifier or next == .l_curly or next == .string_literal) {
+                break :blk self.parseTsModuleDeclaration();
+            }
+            break :blk self.parseExpressionStatement();
+        },
         .kw_module => blk: {
             // module.exports = ... (CJS) → expression statement
             // module Foo { } (TS namespace) → TS module declaration


### PR DESCRIPTION
## Summary
- contextual keyword(namespace/get/set 등)를 expression + statement 위치에서 식별자로 허용
- uuid v35.js 파싱 경고 해결

## 변경
1. **parsePrimaryExpression**: contextual keyword → identifier_reference (async 제외)
2. **parseStatement**: `kw_namespace` 뒤에 identifier/{/string 아니면 expression statement 폴백

## Test plan
- [x] 전체 테스트 통과
- [x] uuid 경고 0 ✅
- [x] preact ✅ date-fns ✅ uuid ✅ zod ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)