### PR TITLE
fix(bundler): CJS require_rewrites 메모리 릭 수정

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -613,6 +613,10 @@ pub const Linker = struct {
                 // 번들된 모듈을 가리키는 require() → require_xxx()로 치환
                 // __commonJS로 래핑되는 모듈만 대상 (CJS, JSON 모두 wrap_kind=.cjs)
                 if (self.modules[target].wrap_kind == .cjs) {
+                    // 동일 specifier의 기존 값이 있으면 해제 (중복 require 방지)
+                    if (require_rewrites.get(rec.specifier)) |old| {
+                        self.allocator.free(old);
+                    }
                     const var_name = try types.makeRequireVarName(self.allocator, self.modules[target].path);
                     try require_rewrites.put(self.allocator, rec.specifier, var_name);
                 }


### PR DESCRIPTION
## Summary
- CJS 모듈에서 동일 specifier를 여러 번 require할 때 `require_rewrites.put`이 기존 값을 덮어쓰면서 이전 `makeRequireVarName` 결과가 해제되지 않던 메모리 릭 수정
- express 번들 시 9개 릭 → 0개

## Test plan
- [x] `zig build test` 통과
- [x] 12/12 스모크 테스트 통과
- [x] express 번들 후 GPA 메모리 릭 0개 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)