### PR TITLE
fix(linker): barrel re-export 패턴 export chain 소스 모듈까지 추적

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1367,7 +1367,22 @@ pub const Linker = struct {
                 }
                 return null;
             }
-            // local export: 이 모듈의 심볼
+            // local export: 이 모듈의 심볼이지만, barrel re-export 패턴인지 확인.
+            // `import { X } from './a'; export { X }` 는 binding_scanner에서 .local로
+            // 분류되지만 실제로는 import binding이므로 소스 모듈로 따라가야 한다.
+            const m_local = self.modules[mod_i];
+            for (m_local.import_bindings) |ib| {
+                if (std.mem.eql(u8, ib.local_name, entry.binding.local_name)) {
+                    // 이 로컬 이름은 import binding → 소스 모듈의 export를 따라간다
+                    if (ib.import_record_index < m_local.import_records.len) {
+                        const source_mod = m_local.import_records[ib.import_record_index].resolved;
+                        if (!source_mod.isNone()) {
+                            return self.resolveExportChain(source_mod, ib.imported_name, depth + 1);
+                        }
+                    }
+                    break;
+                }
+            }
             return .{
                 .module_index = module_idx,
                 .export_name = name,

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -386,6 +386,17 @@ pub const TreeShaker = struct {
                         newly_included = true;
                     }
                 }
+                // barrel re-export 중간 모듈도 포함: import 대상 모듈이 canonical과
+                // 다르면 경유 모듈(barrel)도 포함시키고 해당 export를 사용됨으로 마킹.
+                // 예: entry → mid(barrel) → leaf 에서 mid도 포함되어야 함.
+                // mid의 export "x"도 사용됨으로 마킹해야 fixpoint에서 제거되지 않음.
+                if (canon_idx != target_mod) {
+                    try self.markExportUsed(@intCast(target_mod), ib.imported_name);
+                    if (!self.included.isSet(target_mod)) {
+                        self.included.set(target_mod);
+                        newly_included = true;
+                    }
+                }
             } else if (ib.kind == .namespace) {
                 try self.markAllExportsUsed(@intCast(target_mod));
                 if (!self.included.isSet(target_mod)) {


### PR DESCRIPTION
## Summary
- `import { X } from './a'; export { X }` 패턴(barrel re-export)에서 `resolveExportChain`이 중간 모듈에서 멈추는 버그 수정
- `.local` export의 로컬 이름이 import binding이면 소스 모듈로 따라가도록 `resolveExportChain` 개선
- tree-shaker에서 barrel 중간 모듈도 포함+export 사용 마킹하여 fixpoint에서 제거 방지
- hono 등 barrel file(index.js)로 re-export하는 라이브러리 번들 실행 에러 해결

## Test plan
- [x] `zig build test` 통과 (기존 tree-shaker 테스트 포함)
- [x] hono 스모크 테스트: `new Hono().get("/")` 번들+실행 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)