### PR TITLE
feat(e2e): 브라우저 E2E 10→31개 확장

### DIFF
--- a/packages/e2e/tests/browser-smoke.test.ts
+++ b/packages/e2e/tests/browser-smoke.test.ts
@@ -126,6 +126,7 @@ const cases: BrowserSmokeCase[] = [
     pkg: "vue",
     entry: `import { ref } from 'vue';\nconsole.log(ref(0).value);`,
     expected: "0",
+    extraArgs: ['--define:process.env.NODE_ENV="production"'],
   },
   {
     name: "svelte",
@@ -138,6 +139,7 @@ const cases: BrowserSmokeCase[] = [
     pkg: "react",
     entry: `import React from 'react';\nconsole.log(typeof React.createElement);`,
     expected: "function",
+    extraArgs: ['--define:process.env.NODE_ENV="production"'],
   },
   {
     name: "graphql",


### PR DESCRIPTION
## Summary
- 브라우저 E2E 10→31개 확장 (Node 전용 제외 가능한 모든 패키지)
- uuid, rxjs, tiny-invariant, tanstack-query, neverthrow, yaml, semver, hono, chalk, drizzle-orm, react-dom, zod, superjson, date-fns, d3, pako, solid-js, vue, svelte, react, graphql
- process.env.NODE_ENV 참조 패키지에 --define 추가

## 제외 사유
- effect: scope hoisting window 글로벌 충돌
- jotai/valtio/fp-ts: import.meta outside module

## Test plan
- [x] Playwright 29/31 통과 (vue/react는 PR #314 머지 후 통과 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)