### PR TITLE
feat(bundler): 브라우저 호환성 — deconflict 자동 수집 + import.meta polyfill + auto define

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -148,15 +148,6 @@ pub const Bundler = struct {
         self.resolve_cache.deinit();
     }
 
-    /// bundler Platform → codegen Platform 변환.
-    fn codgenPlatform(self: *const Bundler) EmitOptions.CgPlatform {
-        return switch (self.options.platform) {
-            .browser => .browser,
-            .node => .node,
-            .neutral => .neutral,
-        };
-    }
-
     /// 번들 파이프라인 실행: resolve → graph → emit.
     /// graph는 함수 내에서 생성+해제. &self.resolve_cache 포인터는 self가 살아있는 동안 유효.
     pub fn bundle(self: *Bundler) !BundleResult {
@@ -204,7 +195,6 @@ pub const Bundler = struct {
 
         if (self.options.dev_mode) {
             // Dev mode: 모듈 래핑 + HMR 런타임 주입 + per-module codes + 소스맵 동시 생성
-            const cg_platform = self.codgenPlatform();
             const dev_result = try emitter.emitDevBundle(
                 self.allocator,
                 &graph,
@@ -216,7 +206,7 @@ pub const Bundler = struct {
                     .root_dir = self.options.root_dir,
                     .react_refresh = self.options.react_refresh,
                     .define = self.options.define,
-                    .platform = cg_platform,
+                    .platform = self.options.platform,
                 },
                 if (linker) |*l| l else null,
             );
@@ -239,7 +229,7 @@ pub const Bundler = struct {
                 self.allocator,
                 graph.modules.items,
                 &chunk_graph,
-                .{ .format = self.options.format, .minify = self.options.minify, .define = self.options.define, .platform = self.codgenPlatform() },
+                .{ .format = self.options.format, .minify = self.options.minify, .define = self.options.define, .platform = self.options.platform },
                 if (linker) |*l| l else null,
             );
             errdefer if (outputs) |outs| {
@@ -257,7 +247,7 @@ pub const Bundler = struct {
             output = try emitter.emitWithTreeShaking(
                 self.allocator,
                 &graph,
-                .{ .format = self.options.format, .minify = self.options.minify, .define = self.options.define, .platform = self.codgenPlatform() },
+                .{ .format = self.options.format, .minify = self.options.minify, .define = self.options.define, .platform = self.options.platform },
                 if (linker) |*l| l else null,
                 if (shaker) |*s| s else null,
             );

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -141,9 +141,7 @@ pub const EmitOptions = struct {
     /// define 글로벌 치환 (--define:KEY=VALUE)
     define: []const @import("../transformer/transformer.zig").DefineEntry = &.{},
     /// 타겟 플랫폼. import.meta polyfill 방식을 결정한다.
-    platform: CgPlatform = .browser,
-
-    pub const CgPlatform = @import("../codegen/codegen.zig").Platform;
+    platform: @import("../codegen/codegen.zig").Platform = .browser,
 
     pub const Format = enum {
         esm,

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -281,10 +281,6 @@ pub const Linker = struct {
         }
     }
 
-    /// name_to_owners에서 충돌하는 이름을 찾아 리네임을 계산한다.
-    /// exec_index가 가장 낮은 소유자가 원본 이름 유지, 나머지는 $1, $2, ...
-    /// skip_max_module_index가 true이면 module_index == maxInt(u32)인 항목(cross-chunk
-    /// import 점유 마커)은 rename 대상에서 제외한다.
     /// 후보 이름이 사용 가능한지 확인.
     /// 예약어/글로벌, 다른 모듈의 top-level 이름, 해당 모듈의 중첩 스코프 바인딩과 충돌하면 불가.
     fn isCandidateAvailable(
@@ -317,6 +313,10 @@ pub const Linker = struct {
         return candidate;
     }
 
+    /// name_to_owners에서 충돌하는 이름을 찾아 리네임을 계산한다.
+    /// exec_index가 가장 낮은 소유자가 원본 이름 유지, 나머지는 $1, $2, ...
+    /// skip_max_module_index가 true이면 module_index == maxInt(u32)인 항목(cross-chunk
+    /// import 점유 마커)은 rename 대상에서 제외한다.
     fn calculateRenames(
         self: *Linker,
         name_to_owners: *NameToOwnersMap,

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -19,11 +19,8 @@ const ResolveError = resolver_mod.ResolveError;
 const types = @import("types.zig");
 const ImportKind = types.ImportKind;
 
-pub const Platform = enum {
-    browser,
-    node,
-    neutral,
-};
+/// 타겟 플랫폼. codegen.Platform을 번들러 전체에서 공유.
+pub const Platform = @import("../codegen/codegen.zig").Platform;
 
 /// Node.js 빌트인 모듈 목록 (node: 프리픽스 없이).
 /// platform=node일 때 자동 external로 처리.

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -68,6 +68,10 @@ pub const CodegenOptions = struct {
     platform: Platform = .browser,
 };
 
+// import.meta polyfill 상수 (emitMetaProperty + emitStaticMember에서 공유)
+const IMPORT_META_URL_NODE = "require(\"url\").pathToFileURL(__filename).href";
+const IMPORT_META_NODE_OBJECT = "{url:" ++ IMPORT_META_URL_NODE ++ ",dirname:__dirname,filename:__filename}";
+
 const SourceMapBuilder = @import("sourcemap.zig").SourceMapBuilder;
 const Mapping = @import("sourcemap.zig").Mapping;
 
@@ -899,7 +903,7 @@ pub const Codegen = struct {
                     if (self.options.platform == .node) {
                         // Node.js CJS polyfill
                         if (std.mem.eql(u8, prop_text, "url")) {
-                            try self.write("require(\"url\").pathToFileURL(__filename).href");
+                            try self.write(IMPORT_META_URL_NODE);
                             return;
                         } else if (std.mem.eql(u8, prop_text, "dirname")) {
                             try self.write("__dirname");
@@ -1038,7 +1042,7 @@ pub const Codegen = struct {
         if (std.mem.eql(u8, text, "import.meta")) {
             if (self.options.module_format == .cjs or self.options.replace_import_meta) {
                 if (self.options.platform == .node) {
-                    try self.write("{url:require(\"url\").pathToFileURL(__filename).href,dirname:__dirname,filename:__filename}");
+                    try self.write(IMPORT_META_NODE_OBJECT);
                 } else {
                     try self.write("{}");
                 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -421,9 +421,10 @@ pub fn main() !void {
         }
     }
 
-    // --platform=browser이면 process.env.NODE_ENV를 자동 define (esbuild 호환).
+    // --bundle + --platform=browser이면 process.env.NODE_ENV를 자동 define (esbuild 호환).
+    // 트랜스파일 모드에서는 적용하지 않음 (esbuild와 동일).
     // 사용자가 이미 --define:process.env.NODE_ENV=... 를 지정한 경우 덮어쓰지 않음.
-    if (platform == .browser) {
+    if (is_bundle and platform == .browser) {
         var has_node_env = false;
         for (define_list.items) |d| {
             if (std.mem.eql(u8, d.key, "process.env.NODE_ENV")) {
@@ -626,11 +627,6 @@ pub fn main() !void {
     }
 
     // 트랜스파일 옵션 구성
-    const cg_platform: lib.codegen.codegen.Platform = switch (platform) {
-        .browser => .browser,
-        .node => .node,
-        .neutral => .neutral,
-    };
     const options = TranspileOptions{
         .module_format = module_format,
         .minify = minify,
@@ -639,7 +635,7 @@ pub fn main() !void {
         .sourcemap = sourcemap,
         .ascii_only = ascii_only,
         .define = define_list.items,
-        .platform = cg_platform,
+        .platform = platform,
     };
 
     const is_stdin = std.mem.eql(u8, input_path_str, "-");


### PR DESCRIPTION
## Summary

### 1. deconflict 글로벌 자동 수집
- esbuild 방식: semantic analyzer의 unbound 심볼 자동 수집 → 예약 이름
- rolldown 방식: 중첩 스코프 바인딩 확인 → shadowing 방지
- **effect 패키지 window 충돌 해결**

### 2. import.meta polyfill
- ESM: 그대로 유지
- CJS+node: `import.meta.url` → `require("url").pathToFileURL(__filename).href`
- CJS+node: `import.meta.dirname` → `__dirname`, `.filename` → `__filename`
- CJS+browser: 빈 문자열

### 3. --platform=browser auto define
- `process.env.NODE_ENV` → `"production"` 자동 치환 (esbuild 호환)
- 사용자 `--define` 우선

### 4. __toESM __copyProps 수정
- 이미 설정된 프로퍼티 건너뛰기 (debug 패키지 "Cannot redefine property" 해결)

## Test plan
- [x] `zig build test` 통과
- [x] 스모크 테스트 **47/47** 통과 + **47/47** 출력 일치
- [x] effect 브라우저 번들 실행 정상 (window 충돌 해결)
- [x] jotai 브라우저 번들 실행 정상 (import.meta 해결)
- [x] import.meta CJS polyfill 검증 (url, dirname, filename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)