### PR TITLE
fix(bundler): Node 서브패스 external + __copyProps var→let + cheerio

### DIFF
--- a/packages/benchmark/smoke.ts
+++ b/packages/benchmark/smoke.ts
@@ -505,10 +505,14 @@ const projects: ProjectConfig[] = [
     pkg: "hookable",
     entry: `import { createHooks } from 'hookable';\nconst hooks = createHooks();\nconsole.log(typeof hooks.hook);`,
   },
+  // minimatch: "type":"module" .js를 ESM으로 인식 못함 — 별도 이슈
+  {
+    name: "cheerio",
+    pkg: "cheerio",
+    entry: `import { load } from 'cheerio';\nconst doc = load('<h1>Hello</h1>');\nconsole.log(doc('h1').text());`,
+  },
   // --- 제외 패키지 (ISSUES.md 참조) ---
-  // zx: Node 내장 서브패스(stream/web) 미해석 — resolver 수정 필요
-  // cheerio: 번들 OK, 실행 시 출력 없음 — 조사 필요
-  // minimatch: "type":"module" .js를 ESM으로 인식 못함 — graph.zig 수정 필요
+  // zx: ESM 번들에 CJS require 혼입 — CJS interop 개선 필요
 ];
 
 // ============================================================

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -32,11 +32,11 @@ const TOESM_RUNTIME =
     \\var __getProtoOf = Object.getPrototypeOf;
     \\var __defProp = Object.defineProperty;
     \\var __hasOwn = Object.prototype.hasOwnProperty;
-    \\var __copyProps = (to, from) => { for (var key in from) if (__hasOwn.call(from, key) && !__hasOwn.call(to, key)) __defProp(to, key, { get: () => from[key], enumerable: true }); return to; };
+    \\var __copyProps = (to, from) => { for (let key in from) if (__hasOwn.call(from, key) && !__hasOwn.call(to, key)) __defProp(to, key, { get: () => from[key], enumerable: true }); return to; };
     \\var __toESM = (mod, isNodeMode, target) => (target = mod != null ? Object.create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target, mod));
     \\
 ;
-const TOESM_RUNTIME_MIN = "var __getProtoOf=Object.getPrototypeOf;var __defProp=Object.defineProperty;var __hasOwn=Object.prototype.hasOwnProperty;var __copyProps=(to,from)=>{for(var key in from)if(__hasOwn.call(from,key)&&!__hasOwn.call(to,key))__defProp(to,key,{get:()=>from[key],enumerable:true});return to};var __toESM=(mod,isNodeMode,target)=>(target=mod!=null?Object.create(__getProtoOf(mod)):{},__copyProps(isNodeMode||!mod||!mod.__esModule?__defProp(target,\"default\",{value:mod,enumerable:true}):target,mod));";
+const TOESM_RUNTIME_MIN = "var __getProtoOf=Object.getPrototypeOf;var __defProp=Object.defineProperty;var __hasOwn=Object.prototype.hasOwnProperty;var __copyProps=(to,from)=>{for(let key in from)if(__hasOwn.call(from,key)&&!__hasOwn.call(to,key))__defProp(to,key,{get:()=>from[key],enumerable:true});return to};var __toESM=(mod,isNodeMode,target)=>(target=mod!=null?Object.create(__getProtoOf(mod)):{},__copyProps(isNodeMode||!mod||!mod.__esModule?__defProp(target,\"default\",{value:mod,enumerable:true}):target,mod));";
 /// HMR 런타임: 모듈 레지스트리 + __zts_require + import.meta.hot API.
 /// dev mode 번들 상단에 주입된다.
 ///

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -169,10 +169,15 @@ pub const ResolveCache = struct {
             return true;
         }
 
-        // platform=node이면 node 빌트인 자동 external
+        // platform=node이면 node 빌트인 자동 external (서브패스 포함)
+        // "fs", "fs/promises", "stream/web" 등
         if (self.platform == .node) {
+            const base = if (std.mem.indexOf(u8, specifier, "/")) |slash|
+                specifier[0..slash]
+            else
+                specifier;
             for (node_builtins) |builtin| {
-                if (std.mem.eql(u8, specifier, builtin)) return true;
+                if (std.mem.eql(u8, base, builtin)) return true;
             }
         }
 


### PR DESCRIPTION
## Summary
1. **Node 서브패스 external**: `fs/promises`, `stream/web` 등 자동 external 처리
2. **__copyProps var→let**: getter closure가 마지막 key만 캡처하는 버그 수정 (cheerio 해결)
3. **스모크 테스트 60개**: cheerio 추가

## Test plan
- [x] `zig build test` 통과
- [x] 스모크 60/60 + 출력 60/60 일치
- [x] cheerio: `load("<h1>Hello</h1>")("h1").text()` → `Hello`

🤖 Generated with [Claude Code](https://claude.com/claude-code)