### PR TITLE
fix(parser): JS 모드 destructuring default 파서 버그 4개 수정 (minimatch 해결)

### DIFF
--- a/packages/benchmark/smoke.ts
+++ b/packages/benchmark/smoke.ts
@@ -505,7 +505,11 @@ const projects: ProjectConfig[] = [
     pkg: "hookable",
     entry: `import { createHooks } from 'hookable';\nconst hooks = createHooks();\nconsole.log(typeof hooks.hook);`,
   },
-  // minimatch: "type":"module" .js를 ESM으로 인식 못함 — 별도 이슈
+  {
+    name: "minimatch",
+    pkg: "minimatch",
+    entry: `import { minimatch } from 'minimatch';\nconsole.log(minimatch('foo.js', '*.js'));`,
+  },
   {
     name: "cheerio",
     pkg: "cheerio",

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1268,8 +1268,21 @@ pub const Codegen = struct {
         }
         // shorthand: right가 none이면 {key} 형태 — 콜론 생략
         if (!node.data.binary.right.isNone()) {
-            try self.writeByte(':');
-            try self.emitNode(node.data.binary.right);
+            // shorthand_with_default: { x = val } → x:x=val
+            // cover grammar에서 assignment_target_property_identifier로 변환된 경우,
+            // right가 default value이고 key가 binding name이다.
+            // 출력: key:key=default (TS 모드의 binding_property와 동일한 형태)
+            const shorthand_with_default: u16 = 0x01; // Parser.shorthand_with_default과 동일
+            const is_shorthand_default = (node.data.binary.flags & shorthand_with_default) != 0;
+            if (is_shorthand_default and node.tag == .assignment_target_property_identifier) {
+                try self.writeByte(':');
+                try self.writeSpan(key_node.span);
+                try self.writeByte('=');
+                try self.emitNode(node.data.binary.right);
+            } else {
+                try self.writeByte(':');
+                try self.emitNode(node.data.binary.right);
+            }
         }
     }
 

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -920,8 +920,10 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
 
     // contextual keyword도 expression 위치에서 식별자로 유효.
     // async는 제외 — async function/arrow에서 특수 처리 (아래 switch에서).
+    // literal keyword (true, false, null)는 제외 — 아래 switch에서 boolean_literal/null_literal로 처리.
     if (self.current() == .identifier or
-        (self.current().isKeyword() and !self.current().isReservedKeyword() and self.current() != .kw_async))
+        (self.current().isKeyword() and !self.current().isReservedKeyword() and
+            !self.current().isLiteralKeyword() and self.current() != .kw_async))
     {
         if (self.current() == .identifier) {
             if (self.in_class_field or self.in_static_initializer) {

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -707,22 +707,33 @@ pub const Parser = struct {
                     try self.collectCoverParamNames(elem_idx);
                 }
             },
-            .object_property, .assignment_target_property_identifier, .assignment_target_property_property => {
-                // shorthand: left=key(identifier_reference), right=none → key is the binding
+            .assignment_target_property_identifier => {
+                // shorthand property (identifier): { x }, { x = default }
+                // left = key(identifier_reference) = 바인딩, right = default value 또는 none
+                // 항상 left(key)에서 바인딩 이름을 수집한다. right는 default value이므로 수집하지 않는다.
+                try self.collectCoverParamNames(node.data.binary.left);
+            },
+            .object_property => {
+                // cover grammar 변환 전의 object property.
+                // shorthand_with_default({ x = val }): left=key(바인딩), right=default value
+                // shorthand({ x }): right=none, left=key(바인딩)
+                // long-form({ key: value }): left=key, right=value(바인딩)
+                const is_shorthand_default = (node.data.binary.flags & shorthand_with_default) != 0;
                 if (node.data.binary.right.isNone()) {
+                    // shorthand: { x } — key가 바인딩
+                    try self.collectCoverParamNames(node.data.binary.left);
+                } else if (is_shorthand_default) {
+                    // shorthand with default: { x = val } — key가 바인딩, value는 default
                     try self.collectCoverParamNames(node.data.binary.left);
                 } else {
-                    // long-form { key: value } → value is the binding
-                    // BUT: for shorthand { x } where key==value (same span), also walk left
-                    const key_span = if (!node.data.binary.left.isNone()) self.ast.getNode(node.data.binary.left).span else node.span;
-                    const val_span = self.ast.getNode(node.data.binary.right).span;
-                    if (key_span.start == val_span.start and key_span.end == val_span.end) {
-                        // shorthand with value = same as key (e.g., {x} parsed with both key and value)
-                        try self.collectCoverParamNames(node.data.binary.right);
-                    } else {
-                        try self.collectCoverParamNames(node.data.binary.right);
-                    }
+                    // long-form: { key: value } — value가 바인딩
+                    try self.collectCoverParamNames(node.data.binary.right);
                 }
+            },
+            .assignment_target_property_property => {
+                // long-form property: { key: target } 또는 { key: target = default }
+                // right(value)에서 바인딩 이름을 수집한다.
+                try self.collectCoverParamNames(node.data.binary.right);
             },
             .binding_property => {
                 try self.collectCoverParamNames(node.data.binary.right);
@@ -868,7 +879,9 @@ pub const Parser = struct {
         const node = self.ast.getNode(idx);
         if (node.tag == .parenthesized_expression) {
             // (expr) → 내부를 다시 풀기
-            try self.coverExpressionToArrowParams(node.data.unary.operand);
+            // return으로 종료: 재귀 호출 내부에서 collectCoverParamNames가 실행되므로
+            // 여기서 다시 실행하면 중복 에러가 발생한다.
+            return self.coverExpressionToArrowParams(node.data.unary.operand);
         } else if (node.tag == .sequence_expression) {
             // (a, b, c) → 각 요소를 개별 검증
             const list = node.data.list;
@@ -3787,4 +3800,44 @@ test "Parser: static_member_expression text matches source exactly" {
     // define 매칭에 사용되는 getNodeText가 정확한 텍스트를 반환하는지 검증
     // 공백이 포함되지 않아야 함
     try std.testing.expectEqualStrings("process.env.NODE_ENV", max_span_text);
+}
+
+// ============================================================
+// Destructuring default values in arrow params (cover grammar)
+// ============================================================
+
+test "CoverGrammar: arrow param destructuring with boolean defaults" {
+    // { x = false, y = false } — false/true/null은 default value이지 param name이 아님
+    try expectNoParseError("const f = (s, { x = false, y = false } = {}) => s;");
+    try expectNoParseError("const f = (s, { x = true, y = true } = {}) => s;");
+    try expectNoParseError("const f = (s, { x = null, y = null } = {}) => s;");
+}
+
+test "CoverGrammar: arrow param destructuring with identifier defaults" {
+    // { x = a, y = a } — a는 default value 참조이지 param name이 아님
+    try expectNoParseError("const f = (s, { x = a, y = a } = {}) => s;");
+    try expectNoParseError("const f = ({ x = foo, y = foo } = {}) => s;");
+}
+
+test "CoverGrammar: arrow param destructuring with number defaults" {
+    try expectNoParseError("const f = (s, { x = 1, y = 2 } = {}) => s;");
+}
+
+test "CoverGrammar: actual duplicate param names are still detected" {
+    // 실제 중복 파라미터는 에러가 나야 함
+    try expectParseError("const f = (x, { x } = {}) => s;", .{ .message = "Duplicate parameter name" });
+}
+
+test "CoverGrammar: arrow param single destructuring with defaults" {
+    // 단일 파라미터 (sequence가 아닌 경우)
+    try expectNoParseError("const f = ({ x = false, y = false } = {}) => s;");
+    try expectNoParseError("const f = ({ x = false, y = false }) => s;");
+}
+
+test "CoverGrammar: literal keywords parsed as boolean_literal not identifier" {
+    // true/false/null이 expression 위치에서 올바른 리터럴 노드로 파싱되는지 검증
+    try expectNoParseError("const a = true;");
+    try expectNoParseError("const b = false;");
+    try expectNoParseError("const c = null;");
+    try expectNoParseError("const obj = { true: 1, false: 2, null: 3 };");
 }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1467,8 +1467,15 @@ pub const SemanticAnalyzer = struct {
                 // binary: { left = key, right = value }
                 try self.declareBindingPattern(node.data.binary.right);
             },
-            .assignment_target_property_identifier, .assignment_target_property_property => {
-                // cover grammar 변환된 프로퍼티
+            .assignment_target_property_identifier => {
+                // shorthand property: { x } 또는 { x = default }
+                // left = key(바인딩), right = default value 또는 none
+                // 항상 left(key)에서 바인딩을 추출한다. right는 default value.
+                try self.declareBindingPattern(node.data.binary.left);
+            },
+            .assignment_target_property_property => {
+                // long-form property: { key: value }
+                // right(value)에서 바인딩을 추출한다.
                 try self.declareBindingPattern(node.data.binary.right);
             },
             .assignment_pattern, .assignment_expression, .assignment_target_with_default => {

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -468,12 +468,30 @@ fn collectArrowParamNames(
             // left = binding, right = default value
             try collectArrowParamNames(ast, node.data.binary.left, seen, errors, allocator);
         },
+        .assignment_target_property_identifier => {
+            // shorthand property: { x } 또는 { x = default }
+            // left = key(바인딩), right = default value 또는 none
+            // 항상 left(key)에서 바인딩 이름을 수집한다.
+            try collectArrowParamNames(ast, node.data.binary.left, seen, errors, allocator);
+        },
+        .object_property => {
+            // cover grammar 변환 전의 object property.
+            // shorthand_with_default({ x = val }): left=key(바인딩), right=default
+            // shorthand({ x }): right=none, left=key(바인딩)
+            // long-form({ key: value }): left=key, right=value(바인딩)
+            const shorthand_with_default: u16 = 0x01; // Parser.shorthand_with_default과 동일
+            const is_shorthand_default = (node.data.binary.flags & shorthand_with_default) != 0;
+            if (node.data.binary.right.isNone() or is_shorthand_default) {
+                try collectArrowParamNames(ast, node.data.binary.left, seen, errors, allocator);
+            } else {
+                try collectArrowParamNames(ast, node.data.binary.right, seen, errors, allocator);
+            }
+        },
         .binding_property,
-        .object_property,
-        .assignment_target_property_identifier,
         .assignment_target_property_property,
         => {
-            // binary: { left = key, right = value }
+            // long-form property: { key: value }
+            // right(value)에서 바인딩 이름을 수집한다.
             try collectArrowParamNames(ast, node.data.binary.right, seen, errors, allocator);
         },
         .spread_element, .binding_rest_element, .rest_element, .assignment_target_rest => {
@@ -655,4 +673,30 @@ test "checker: duplicate method params is error" {
     try ana.analyze();
 
     try std.testing.expect(ana.errors.items.len > 0);
+}
+
+test "checker: destructuring default values are not param names" {
+    // { x = false, y = false } — false는 default value이지 param name이 아님
+    // 파서 + semantic 모두 에러 없어야 함
+    const cases = [_][]const u8{
+        "const f = (s, { x = false, y = false } = {}) => s;",
+        "const f = (s, { x = true, y = true } = {}) => s;",
+        "const f = (s, { x = null, y = null } = {}) => s;",
+        "const f = (s, { x = a, y = a } = {}) => s;",
+        "const f = ({ x = foo, y = foo } = {}) => x;",
+    };
+    for (cases) |src| {
+        var scanner = try Scanner.init(std.testing.allocator, src);
+        defer scanner.deinit();
+        var parser = Parser.init(std.testing.allocator, &scanner);
+        defer parser.deinit();
+        _ = try parser.parse();
+        try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
+
+        const SemanticAnalyzer = @import("analyzer.zig").SemanticAnalyzer;
+        var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+        defer ana.deinit();
+        try ana.analyze();
+        try std.testing.expectEqual(@as(usize, 0), ana.errors.items.len);
+    }
 }


### PR DESCRIPTION
## Summary
JS 모드(.js/.mjs)에서 `{ x = false, y = false }` destructuring default가 잘못 파싱되는 버그 4개 수정.

### Root Causes
1. `parsePrimaryExpression`: `false`/`true`/`null`이 `identifier_reference`로 잘못 파싱 — `isLiteralKeyword()` 체크 추가
2. `collectCoverParamNames`: shorthand-with-default의 default value를 파라미터 이름으로 수집 — left/right 분기 수정
3. `semantic/checker.zig` + `analyzer.zig`: 동일한 left/right 혼동 수정
4. `codegen.zig`: `{ x:false }` → `{ x:x=false }` 올바른 출력

## Test plan
- [x] `zig build test` 통과
- [x] minimatch 번들+실행: `minimatch('foo.js', '*.js')` → `true`
- [x] 스모크 **61/61** + 출력 **61/61** 일치
- [x] 테스트 7개 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)