### PR TITLE
feat(parser): 제네릭 > 토큰 분할 — 적합성 28.4%

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2560,6 +2560,28 @@ test "Codegen: JSX fragment" {
 }
 
 // ============================================================
+// E2E Tests: Token splitting (>> → > + >, >= → > + = etc.)
+// ============================================================
+
+test "Codegen: nested generic >> splits correctly" {
+    var r = try e2e(std.testing.allocator, "let x: Array<Array<number>>");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x;", r.output);
+}
+
+test "Codegen: arrow with >= split (): A<T>=> 0" {
+    var r = try e2e(std.testing.allocator, "(): A<T>=> 0");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("()=>0;", r.output);
+}
+
+test "Codegen: triple nested generic >>>" {
+    var r = try e2e(std.testing.allocator, "let x: A<B<C<number>>>");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x;", r.output);
+}
+
+// ============================================================
 // E2E Tests: Namespace with export
 // ============================================================
 

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1667,7 +1667,7 @@ fn parseTSTypeAssertion(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip <
     _ = try self.parseType();
-    try self.expect(.r_angle);
+    try self.expectClosingAngleBracket();
     // oxc: parse_unary_expression_or_higher — <T>-x, <T>await foo() 등 지원
     const expr = try parseUnaryExpression(self);
     return try self.ast.addNode(.{

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -293,6 +293,32 @@ pub const Parser = struct {
         }
     }
 
+    /// 제네릭 닫는 꺾쇠 `>` 를 기대한다. (oxc re_lex_ts_r_angle 대응)
+    /// `>>`, `>>>`, `>=`, `>>=`, `>>>=` 를 `>` + 나머지로 분할한다.
+    /// 예: `Array<Map<K,V>>` 에서 `>>` → `>` + `>`
+    /// 예: `(): A<T>=> 0` 에서 `>=` → `>` + `=`
+    pub fn expectClosingAngleBracket(self: *Parser) !void {
+        if (self.current() == .r_angle) {
+            try self.advance();
+        } else if (self.isAtClosingAngleBracket()) {
+            // 토큰의 첫 바이트(>)만 소비하고 나머지는 다음 렉싱에서 처리
+            self.scanner.prev_token_kind = .r_angle;
+            self.scanner.current = self.scanner.token.span.start + 1;
+            try self.advance();
+        } else {
+            try self.expect(.r_angle);
+        }
+    }
+
+    /// 현재 토큰이 `>` 또는 `>`로 시작하는 복합 토큰인지 확인한다.
+    /// 타입 인수/파라미터 루프의 종료 조건으로 사용.
+    pub fn isAtClosingAngleBracket(self: *const Parser) bool {
+        return switch (self.current()) {
+            .r_angle, .shift_right, .shift_right3, .gt_eq, .shift_right_eq, .shift_right3_eq => true,
+            else => false,
+        };
+    }
+
     /// ASI (Automatic Semicolon Insertion) 규칙으로 세미콜론을 처리한다.
     /// - 세미콜론이 있으면 소비
     /// - 현재 토큰 앞에 개행이 있으면 OK (ASI)
@@ -3861,4 +3887,49 @@ test "CoverGrammar: literal keywords parsed as boolean_literal not identifier" {
     try expectNoParseError("const b = false;");
     try expectNoParseError("const c = null;");
     try expectNoParseError("const obj = { true: 1, false: 2, null: 3 };");
+}
+
+// ================================================================
+// 제네릭 토큰 분할 테스트 (>> → > + >, >= → > + = 등)
+// ================================================================
+
+test "TokenSplit: nested generic >> splits to > + >" {
+    // Array<Array<number>> — >> 가 > > 로 분할되어야 함
+    try expectNoParseError("let x: Array<Array<number>>");
+}
+
+test "TokenSplit: triple nested generic >>> splits correctly" {
+    // A<B<C<number>>> — >>> 가 > > > 로 분할
+    try expectNoParseError("let x: A<B<C<number>>>");
+}
+
+test "TokenSplit: >= splits to > + = in arrow return type" {
+    // (): A<T>=> 0 — >= 가 > = 로 분할, arrow function으로 파싱
+    try expectNoParseError("(): A<T>=> 0");
+}
+
+test "TokenSplit: nested generic in return type" {
+    try expectNoParseError("let x: () => A<B<T>>");
+}
+
+test "TokenSplit: type assertion with nested generic" {
+    // <Array<number>>expr — >> 분할 후 type assertion
+    try expectNoParseError("let x = <Array<number>>y");
+}
+
+test "TokenSplit: generic type arguments with nested generics" {
+    try expectNoParseError("type Foo = Map<string, Array<number>>");
+    try expectNoParseError("type Bar = Promise<Map<string, Set<number>>>");
+}
+
+test "TokenSplit: generic function return type with nested generic" {
+    try expectNoParseError("function foo(): Array<Array<number>> { return []; }");
+}
+
+test "TokenSplit: interface with nested generic members" {
+    try expectNoParseError("interface Foo { bar: Map<string, Array<number>> }");
+}
+
+test "TokenSplit: type alias with conditional + nested generic" {
+    try expectNoParseError("type Foo<T> = T extends Array<Array<number>> ? T : never");
 }

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -319,7 +319,7 @@ pub fn parseTsTypeParameterDeclaration(self: *Parser) ParseError2!NodeIndex {
     try self.advance(); // skip <
 
     const scratch_top = self.saveScratch();
-    while (self.current() != .r_angle and self.current() != .eof) {
+    while (!self.isAtClosingAngleBracket() and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
         const param = try parseTsTypeParameter(self);
         try self.scratch.append(self.allocator, param);
@@ -327,7 +327,7 @@ pub fn parseTsTypeParameterDeclaration(self: *Parser) ParseError2!NodeIndex {
 
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
-    try self.expect(.r_angle);
+    try self.expectClosingAngleBracket();
 
     const params = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
@@ -840,7 +840,7 @@ pub fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
     try self.advance(); // skip <
 
     const scratch_top = self.saveScratch();
-    while (self.current() != .r_angle and self.current() != .eof) {
+    while (!self.isAtClosingAngleBracket() and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
         const ty = try parseType(self);
         try self.scratch.append(self.allocator, ty);
@@ -848,7 +848,7 @@ pub fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
 
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
-    try self.expect(.r_angle);
+    try self.expectClosingAngleBracket();
 
     const types = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);


### PR DESCRIPTION
## Summary
- `>>`, `>=`, `>>>` 등 복합 토큰을 `>` + 나머지로 분할 (oxc `re_lex_ts_r_angle` 대응)
- 적합성 **27.2% → 28.4%** (pass 302→315, 에러 246→233)

## 구현
- `expectClosingAngleBracket`: 복합 토큰 감지 → 스캐너 위치 1바이트만 소비 후 되감기
- `isAtClosingAngleBracket`: 루프 종료 조건 (토큰 리스트 공유)
- `prev_token_kind = .r_angle` 보존 (regex/division 오판 방지)
- `parseTypeArguments`, `parseTsTypeParameterDeclaration`, `parseTSTypeAssertion`에서 사용

## 지원 케이스
| 입력 | 토큰 | 분할 |
|------|------|------|
| `Array<Array<number>>` | `>>` | `>` + `>` |
| `A<B<C<number>>>` | `>>>` | `>` + `>>` |
| `(): A<T>=> 0` | `>=` | `>` + `=` |
| `<Array<number>>y` | `>>` | `>` + `>` |

## Test plan
- [x] `zig build test` — 0 failures (파서 9개 + e2e 3개 신규 테스트)
- [x] `bun run smoke.ts` — 99/99, 98/98 match
- [x] 적합성 28.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)