### PR TITLE
feat(parser): 증분 수정 배치 — 적합성 29.0%

### DIFF
--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -75,7 +75,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     // import defer / import source — Stage 3 proposals
     // defer/source를 스킵하고 나머지는 일반 import로 처리
     var has_phase_modifier = false;
-    if (self.current() == .kw_defer or self.isContextual("source")) {
+    if (self.current() == .kw_defer or self.current() == .kw_source or self.isContextual("source")) {
         has_phase_modifier = true;
         try self.advance(); // skip defer/source
     }
@@ -343,10 +343,15 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
                     _ = try self.parseTsInterfaceDeclaration();
                     break :blk NodeIndex.none;
                 }
-                // export default abstract class Foo {} — abstract 키워드 처리
+                // export default abstract class Foo {}
+                // export default abstract (abstract를 식별자 표현식으로)
                 if (self.current() == .identifier and self.isContextual("abstract")) {
-                    try self.advance(); // skip 'abstract'
-                    break :blk try self.parseClassDeclaration();
+                    const peek = try self.peekNext();
+                    if (peek.kind == .kw_class and !peek.has_newline_before) {
+                        try self.advance(); // skip 'abstract'
+                        break :blk try self.parseClassDeclaration();
+                    }
+                    // abstract 단독 → 식별자 expression (fallthrough)
                 }
                 // export default async function / export default async function* — 이름 선택적
                 if (self.current() == .kw_async) {
@@ -465,6 +470,24 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
             .span = .{ .start = start, .end = self.currentSpan().start },
             .data = .{ .extra = extra_start },
         });
+    }
+
+    // TS: export as namespace ns — 타입 전용 (완전 제거)
+    if (self.current() == .identifier and self.isContextual("as")) {
+        try self.advance(); // skip 'as'
+        if (self.current() == .identifier and self.isContextual("namespace")) {
+            try self.advance(); // skip 'namespace'
+            _ = try self.parseSimpleIdentifier(); // skip name
+            _ = try self.eat(.semicolon);
+            return NodeIndex.none;
+        }
+    }
+
+    // TS: export = expr — export assignment (타입 전용)
+    if (try self.eat(.eq)) {
+        _ = try self.parseAssignmentExpression();
+        _ = try self.eat(.semicolon);
+        return NodeIndex.none;
     }
 
     // export var/let/const/function/class

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1724,7 +1724,15 @@ pub const Parser = struct {
         // ?는 ternary와 모호하므로 : 만 감지
         if (self.current() == .identifier or self.current().isKeyword() or self.current() == .escaped_keyword) {
             try self.advance(); // skip identifier
-            return self.current() == .colon;
+            if (self.current() == .colon) return true;
+            // (a): Type => ... — 단일 파라미터 + 리턴 타입
+            if (self.current() == .r_paren) {
+                try self.advance();
+                return self.current() == .colon;
+            }
+            // (a?: Type) — optional parameter
+            if (self.current() == .question) return true;
+            return false;
         }
 
         // ({}: Type) 또는 ([]: Type) — destructuring with type

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -259,6 +259,12 @@ fn parseNamespaceBlock(self: *Parser) ParseError2!NodeIndex {
 /// declare var/let/const/function/class/...
 pub fn parseTsDeclareStatement(self: *Parser) ParseError2!NodeIndex {
     try self.advance(); // skip 'declare'
+    // declare global { ... } — 글로벌 augmentation (타입 전용, 완전 제거)
+    if (self.current() == .identifier and self.isContextual("global")) {
+        try self.advance(); // skip 'global'
+        _ = try self.parseBlockStatement();
+        return NodeIndex.none;
+    }
     // declare 뒤의 선언은 ambient context (const 이니셜라이저 불필요 등)
     const saved = self.ctx;
     self.ctx.in_ambient = true;
@@ -1088,16 +1094,15 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
         }
     }
 
-    // readonly 수정자 (프로퍼티/인덱스 시그니처에서만 유효)
+    // readonly/accessor 수정자 (프로퍼티/인덱스 시그니처에서만 유효)
     var is_readonly = false;
-    if (self.current() == .identifier and self.isContextual("readonly")) {
-        // readonly 다음이 [ 이면 인덱스 시그니처, 아니면 프로퍼티
+    if (self.current() == .identifier and
+        (self.isContextual("readonly") or self.isContextual("accessor")))
+    {
         const next = try self.peekNextKind();
-        if (next != .l_paren and next != .l_angle and next != .colon and next != .comma and
-            next != .semicolon and next != .r_curly and next != .question)
-        {
+        if (isFollowedByTypeMemberName(next)) {
             is_readonly = true;
-            try self.advance(); // skip 'readonly'
+            try self.advance(); // skip 'readonly'/'accessor'
         }
     }
 


### PR DESCRIPTION
## Summary
- 7개 증분 수정으로 적합성 **28.4% → 29.0%** (pass 315→322, 에러 233→211)

## 변경
- `(a): void => {}`: typed arrow 감지 — 단일 파라미터 + `)` + `:` 패턴
- `export as namespace ns`: 타입 전용 완전 제거
- `export = expr`: TS export assignment 제거
- `import source foo`: `kw_source` 토큰 감지 수정
- `export default abstract`: `class` 없으면 identifier expression fallthrough
- `declare global { }`: 글로벌 augmentation 제거
- `accessor` in interface: `readonly`와 동일한 수정자로 처리

## Test plan
- [x] `zig build test` — 0 failures
- [x] `bun run smoke.ts` — 99/99, 98/98 match
- [x] 적합성 29.0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)