### PR TITLE
feat(parser,transformer): declare 스트리핑 + 빈 namespace 제거 — 적합성 33.4%

### DIFF
--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -265,12 +265,13 @@ pub fn parseTsDeclareStatement(self: *Parser) ParseError2!NodeIndex {
         _ = try parseNamespaceBlock(self);
         return NodeIndex.none;
     }
-    // declare 뒤의 선언은 ambient context (const 이니셜라이저 불필요 등)
+    // declare 뒤의 선언은 ambient context — 런타임 코드 없음 (완전 제거)
+    // 파싱은 완료하되 (구문 검증) 결과는 버린다
     const saved = self.ctx;
     self.ctx.in_ambient = true;
-    const result = try self.parseStatement();
+    _ = try self.parseStatement();
     self.ctx = saved;
-    return result;
+    return NodeIndex.none;
 }
 
 /// abstract class Foo { }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -699,6 +699,13 @@ pub const Transformer = struct {
         if (node.data.binary.flags == 1) return .none;
         const new_name = try self.visitNode(node.data.binary.left);
         const new_body = try self.visitNode(node.data.binary.right);
+        // 빈 namespace는 런타임 코드 불필요 → strip (esbuild 호환)
+        if (!new_body.isNone()) {
+            const body_node = self.new_ast.getNode(new_body);
+            if (body_node.tag == .block_statement and body_node.data.list.len == 0) {
+                return .none;
+            }
+        }
         return self.new_ast.addNode(.{
             .tag = .ts_module_declaration,
             .span = node.span,


### PR DESCRIPTION
## Summary
- `declare` 문 완전 제거 + 빈 namespace 제거
- 적합성 **29.2% → 33.4%** (pass 324→371, +47)

## 변경
- `parseTsDeclareStatement`: 파싱 후 `NodeIndex.none` 반환 (declare class/function/var/enum 모두)
- `visitNamespaceDeclaration`: body가 빈 block이면 `.none` 반환

## Test plan
- [x] `zig build test` — 0 failures
- [x] `bun run smoke.ts` — 99/99, 98/98 match
- [x] 적합성 33.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)