### PR TITLE
feat(parser): 증분 수정 4건 + /simplify — 적합성 40.5%

### DIFF
--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -66,6 +66,7 @@ fn parseFunctionDeclarationWithFlags(self: *Parser, extra_flags: u32) ParseError
 
     try self.expect(.l_paren);
     self.in_formal_parameters = true;
+    try self.trySkipThisParameter();
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
@@ -176,6 +177,7 @@ fn parseFunctionDeclarationWithFlagsOptionalName(self: *Parser, extra_flags: u32
 
     try self.expect(.l_paren);
     self.in_formal_parameters = true;
+    try self.trySkipThisParameter();
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
@@ -257,6 +259,7 @@ pub fn parseFunctionExpressionWithFlags(self: *Parser, extra_flags: u32) ParseEr
 
     try self.expect(.l_paren);
     self.in_formal_parameters = true;
+    try self.trySkipThisParameter();
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
@@ -591,6 +594,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.allow_super_property = true;
         try self.expect(.l_paren);
         self.in_formal_parameters = true;
+        try self.trySkipThisParameter();
         const param_top = self.saveScratch();
         while (self.current() != .r_paren and self.current() != .eof) {
             const loop_guard_pos = self.scanner.token.span.start;

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -177,8 +177,13 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
                 const saved = self.saveState();
                 try self.advance(); // skip 'async'
 
-                // () 빈 파라미터 체크
-                if (self.current() == .l_paren and try self.peekNextKind() == .r_paren) {
+                // TS typed arrow 먼저 시도: async (a: Type): ReturnType => body
+                // 빈 파라미터 + 리턴 타입 (async (): void => {})도 isTypedArrowFunction이 감지
+                if (try self.isTypedArrowFunction()) {
+                    if (try self.parseTypedArrowParams(async_span.start, true)) |arrow| return arrow;
+                    self.restoreState(saved);
+                } else if (self.current() == .l_paren and try self.peekNextKind() == .r_paren) {
+                    // () 빈 파라미터 체크 (타입 없는 경우)
                     try self.advance(); // skip (
                     try self.advance(); // skip )
                     if (self.current() == .arrow and !self.scanner.token.has_newline_before) {
@@ -193,10 +198,6 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
                             });
                         }
                     }
-                    self.restoreState(saved);
-                } else if (try self.isTypedArrowFunction()) {
-                    // async (a: Type) => body — TS typed async arrow
-                    if (try self.parseTypedArrowParams(async_span.start, true)) |arrow| return arrow;
                     self.restoreState(saved);
                 } else {
                     // 괄호를 expression으로 파싱 (parenthesized_expression)

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -268,8 +268,28 @@ fn parseImportSpecifier(self: *Parser) ParseError2!NodeIndex {
             const saved = self.saveState();
             try self.advance(); // tentatively skip 'type'
             if (self.isContextual("as")) {
-                // "import { type as alias }" — 'type'은 값 이름, modifier 아님
-                self.restoreState(saved);
+                // "import { type as }" → type modifier, 'as'가 imported name
+                // "import { type as as foo }" → type modifier, 'as' imported, 'foo' local
+                // "import { type as alias }" → 'type'은 값 이름, 'alias'는 로컬 바인딩
+                const after_as = try self.peekNextKind();
+                if (after_as == .r_curly or after_as == .comma) {
+                    // "import { type as }" — 'as'가 imported name, type modifier 확정
+                    is_type_only = 1;
+                } else if (after_as == .identifier or after_as.isKeyword()) {
+                    // 다음 토큰 텍스트를 확인: "type as as foo" vs "type as alias"
+                    const saved2 = self.saveState();
+                    try self.advance(); // skip 'as'
+                    if (self.isContextual("as")) {
+                        // "type as as foo" — type modifier, 'as' imported, 'as' keyword, 'foo' local
+                        self.restoreState(saved2);
+                        is_type_only = 1;
+                    } else {
+                        // "type as alias" — 'type'은 값 이름, modifier 아님
+                        self.restoreState(saved);
+                    }
+                } else {
+                    self.restoreState(saved);
+                }
             } else {
                 is_type_only = 1;
                 // 'type' modifier 확정 — 이미 advance됨

--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -170,6 +170,7 @@ pub fn parseObjectMethodBody(self: *Parser, start: u32, key: NodeIndex, flags: u
 
     try self.expect(.l_paren);
     self.in_formal_parameters = true;
+    try self.trySkipThisParameter();
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1685,6 +1685,21 @@ pub const Parser = struct {
         return ts.tryParseTypeAnnotation(self);
     }
 
+    /// TS `this: Type` 파라미터 스킵. 함수의 첫 번째 파라미터가 `this`이면
+    /// `this` + `: Type` + 선택적 `,`를 소비하고 파라미터 리스트에 추가하지 않는다.
+    /// TS this parameter: `this: Type` → 스킵 (런타임에 불필요).
+    /// `this:` 패턴만 감지 — bare `this`는 일반 파라미터로 처리.
+    pub fn trySkipThisParameter(self: *Parser) ParseError2!void {
+        if (self.current() == .kw_this) {
+            const next = try self.peekNextKind();
+            if (next == .colon) {
+                try self.advance(); // skip 'this'
+                _ = try self.tryParseTypeAnnotation(); // skip ': Type'
+                _ = try self.eat(.comma);
+            }
+        }
+    }
+
     pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
         return ts.tryParseReturnType(self);
     }
@@ -1750,6 +1765,7 @@ pub const Parser = struct {
 
         try self.advance(); // skip (
         self.in_formal_parameters = true;
+        try self.trySkipThisParameter();
         const scratch_top = self.saveScratch();
 
         while (self.current() != .r_paren and self.current() != .eof) {

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -467,6 +467,11 @@ fn parseVariableDeclarator(self: *Parser) ParseError2!NodeIndex {
     // variable declarator에서 `=`는 initializer이므로 여기서 소비하면 안 됨.
     const name = try self.parseBindingName();
 
+    // TS definite assignment assertion: let x!: Type (simple identifier만, destructuring 제외)
+    if (self.current() == .bang and !name.isNone() and self.ast.getNode(name).tag == .binding_identifier) {
+        _ = try self.eat(.bang);
+    }
+
     // TS 타입 어노테이션 (: Type)
     const type_ann = try self.tryParseTypeAnnotation();
 


### PR DESCRIPTION
## Summary
- 파서 증분 수정 4건 + /simplify 리뷰 반영
- 에러 208→201, 적합성 40.5% 유지, smoke 99/99

## 파서 수정
1. **var a!: string** — definite assignment `!` (binding_identifier에서만)
2. **import { type as }** — type-only import specifier 감지/제거
3. **async (): void => {}** — async typed arrow 리턴 타입
4. **function foo(this: any)** — this 파라미터 스킵 (trySkipThisParameter)

## /simplify 수정
- trySkipThisParameter: `this:` 패턴만 감지 (bare `this` 허용 안 함)
- `!` eating: simple identifier에서만 (destructuring 제외)

## Test plan
- [x] `zig build test` — 0 failures
- [x] `bun run smoke.ts` — 99/99, 98/98 match

🤖 Generated with [Claude Code](https://claude.com/claude-code)