### PR TITLE
feat(parser): 증분 수정 5건 — 적합성 48.2%

### DIFF
--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -493,8 +493,14 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
                 .data = .{ .unary = .{ .operand = body, .flags = 0 } },
             });
         }
-        // static 뒤에 (나 = 가 오면 static은 메서드/프로퍼티 이름
-        if (next != .l_paren and next != .eq and next != .semicolon) {
+        // static 뒤에 (, =, ;, } 가 오거나 줄바꿈이 있으면 static은 메서드/프로퍼티 이름
+        // 예: class C { static } — "static"이라는 이름의 필드
+        // 예: class C { static = 1 } — "static"이라는 이름의 필드 (초기화)
+        // 예: class C { static\n } — ASI로 "static" 필드
+        if (next != .l_paren and next != .eq and next != .semicolon and
+            next != .r_curly and next != .eof and
+            !(try self.peekNext()).has_newline_before)
+        {
             flags |= 0x01; // static modifier
             try self.advance();
         }

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -729,8 +729,46 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                             .data = .{ .extra = me },
                         });
                     }
-                } else if (self.current() == .l_paren) {
-                    // a?.()
+                } else if (self.current() == .l_paren or self.isAtOpeningAngleBracket()) {
+                    // a?.() or a?.<Type>()
+                    // TS type arguments: speculatively parse, skip if followed by (
+                    if (self.isAtOpeningAngleBracket()) {
+                        const saved_scanner = self.saveState();
+                        const saved_nodes_len = self.ast.nodes.items.len;
+                        const saved_extra_len = self.ast.extra_data.items.len;
+                        const saved_scratch = self.saveScratch();
+                        const saved_errors_len = self.errors.items.len;
+
+                        const type_args_ok = ta_blk: {
+                            _ = self.parseTypeArguments() catch {
+                                break :ta_blk false;
+                            };
+                            break :ta_blk (self.current() == .l_paren);
+                        };
+
+                        const scanner_after = if (type_args_ok) self.saveState() else saved_scanner;
+                        self.ast.nodes.items.len = saved_nodes_len;
+                        self.ast.extra_data.items.len = saved_extra_len;
+                        self.restoreScratch(saved_scratch);
+                        self.errors.shrinkRetainingCapacity(saved_errors_len);
+                        self.restoreState(scanner_after);
+                        if (!type_args_ok) {
+                            // type args failed, fall through to a?.b (identifier)
+                            const prop = try parseIdentifierName(self);
+                            {
+                                const prop_end = if (!prop.isNone()) self.ast.getNode(prop).span.end else self.currentSpan().start;
+                                const me = try self.ast.addExtras(&.{ @intFromEnum(expr), @intFromEnum(prop), 1 }); // 1 = optional
+                                expr = try self.ast.addNode(.{
+                                    .tag = .static_member_expression,
+                                    .span = .{ .start = expr_start, .end = prop_end },
+                                    .data = .{ .extra = me },
+                                });
+                            }
+                            after_optional_chain = true;
+                            continue;
+                        }
+                    }
+                    // Now at '(' — parse call
                     try self.advance();
                     const arg_list = try parseArgumentList(self);
                     var oc_flags: u32 = ast_mod.CallFlags.optional_chain;

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1700,6 +1700,10 @@ pub const Parser = struct {
         return ts.parseTsAbstractClass(self);
     }
 
+    pub fn parseTsNamespaceBlock(self: *Parser) ParseError2!NodeIndex {
+        return ts.parseNamespaceBlock(self);
+    }
+
     pub fn parseDecoratedStatement(self: *Parser) ParseError2!NodeIndex {
         return ts.parseDecoratedStatement(self);
     }

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -202,6 +202,14 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
                 break :blk self.parseTsDeclareStatement();
             } else if (std.mem.eql(u8, text, "abstract")) {
                 break :blk self.parseTsAbstractClass();
+            } else if (std.mem.eql(u8, text, "global")) {
+                // global { } inside namespace/module — global augmentation
+                const next = try self.peekNextKind();
+                if (next == .l_curly) {
+                    try self.advance(); // skip 'global'
+                    _ = try self.parseTsNamespaceBlock();
+                    break :blk NodeIndex.none;
+                }
             }
             // 위 조건에 매치되지 않으면 expression 또는 labeled statement로 파싱
             break :blk parseExpressionOrLabeledStatement(self);
@@ -475,6 +483,15 @@ fn parseVariableDeclarator(self: *Parser) ParseError2!NodeIndex {
 
     // TS 타입 어노테이션 (: Type)
     const type_ann = try self.tryParseTypeAnnotation();
+
+    // TS definite assignment assertion AFTER type: let x: number! = y
+    // (다른 형태인 x!: Type 는 위에서 이미 처리)
+    // 줄바꿈 후 !는 ASI 경계이므로 definite assignment가 아님
+    if (self.current() == .bang and !self.scanner.token.has_newline_before and
+        !type_ann.isNone() and !name.isNone() and self.ast.getNode(name).tag == .binding_identifier)
+    {
+        _ = try self.eat(.bang);
+    }
 
     // 이니셜라이저 — `in` 연산자를 복원한다 (ECMAScript: Initializer[+In]).
     // for 초기화절에서 allow_in=false여도, 이니셜라이저 안에서는 `in`이 연산자로 동작해야 한다.

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -232,7 +232,7 @@ fn parseTsModuleBody(self: *Parser, start: u32) ParseError2!NodeIndex {
 }
 
 /// namespace body 블록 파싱 — parseBlockStatement와 동일하되 is_top_level을 유지
-fn parseNamespaceBlock(self: *Parser) ParseError2!NodeIndex {
+pub fn parseNamespaceBlock(self: *Parser) ParseError2!NodeIndex {
     const block_start = self.currentSpan().start;
     try self.expect(.l_curly);
 
@@ -1115,9 +1115,10 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
     }
 
     // static 수정자 (interface에서 static accessor x 등)
-    if (self.current() == .identifier and self.isContextual("static")) {
+    // static은 kw_static 토큰이므로 별도 체크 필요
+    if (self.current() == .kw_static or (self.current() == .identifier and self.isContextual("static"))) {
         const next = try self.peekNextKind();
-        if (isFollowedByTypeMemberName(next)) {
+        if (isFollowedByTypeMemberName(next) or next == .kw_accessor) {
             try self.advance(); // skip 'static'
         }
     }


### PR DESCRIPTION
## Summary
- 파서 증분 수정 5건, 적합성 **47.3% → 48.2%** (에러 192→181)

## 수정
1. `class Foo { static }` — static 단독 프로퍼티 이름
2. `interface { static accessor x }` — kw_static 토큰 + accessor 연쇄
3. `let x: number! = y` — 타입 뒤 `!` definite assignment
4. `declare module M { global { } }` — namespace 내 global 블록
5. `f?.<number>()` — optional chaining + 타입 인수

## Test plan
- [x] `zig build test` — 0 failures
- [x] `bun run smoke.ts` — 99/99, 98/98 match

🤖 Generated with [Claude Code](https://claude.com/claude-code)