### PR TITLE
feat(transformer): as/satisfies 괄호 unwrap — 적합성 49.5%

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -242,7 +242,22 @@ pub const Transformer = struct {
             .return_statement,
             .throw_statement,
             .spread_element,
-            .parenthesized_expression,
+            => self.visitUnaryNode(node),
+            .parenthesized_expression => {
+                // (expr as T) → expr: TS expression이면 괄호 불필요
+                const inner = node.data.unary.operand;
+                if (!inner.isNone()) {
+                    const inner_tag = self.old_ast.getNode(inner).tag;
+                    if (inner_tag == .ts_as_expression or
+                        inner_tag == .ts_satisfies_expression or
+                        inner_tag == .ts_non_null_expression or
+                        inner_tag == .ts_type_assertion)
+                    {
+                        return self.visitNode(inner);
+                    }
+                }
+                return self.visitUnaryNode(node);
+            },
             .await_expression,
             .yield_expression,
             .rest_element,


### PR DESCRIPTION
## Summary
- `(expr as T)` → `expr`: TS expression이 parenthesized_expression 안에 있으면 괄호 제거
- 적합성 **49.3% → 49.5%** (pass 547→549)

## Test plan
- [x] `zig build test` — 0 failures
- [x] `bun run smoke.ts` — 99/99, 98/98 match

🤖 Generated with [Claude Code](https://claude.com/claude-code)