### PR TITLE
feat(parser,transformer): 파서 증분 + 미사용 import 제거 — 적합성 51.8%

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -116,6 +116,9 @@ fn transpileFile(
         .drop_debugger = options.drop_debugger,
         .define = options.define,
     });
+    // unused import 제거를 위해 semantic 데이터를 transformer에 전달
+    transformer.old_symbol_ids = analyzer.symbol_ids.items;
+    transformer.symbols = analyzer.symbols.items;
     const root = transformer.transform() catch |err| {
         try stderr.print("zts: transform error in '{s}': {}\n", .{ file_path, err });
         return;

--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -101,7 +101,7 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
             // ECMAScript 12.1.1: await는 Module goal에서만 Syntax Error.
             // 다른 reserved keyword의 escaped 형태는 항상 사용 불가.
             const is_escaped_await = self.isEscapedKeyword("await");
-            if (!is_escaped_await or self.is_module or self.ctx.in_async) {
+            if (!is_escaped_await or (self.is_module and !self.in_namespace) or self.ctx.in_async) {
                 try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier");
             }
             const span = self.currentSpan();
@@ -191,7 +191,7 @@ pub fn parseBindingName(self: *Parser) ParseError2!NodeIndex {
             // ECMAScript 12.1.1: await는 Module goal에서만 Syntax Error.
             // 다른 reserved keyword의 escaped 형태는 항상 사용 불가.
             const is_escaped_await = self.isEscapedKeyword("await");
-            if (!is_escaped_await or self.is_module or self.ctx.in_async) {
+            if (!is_escaped_await or (self.is_module and !self.in_namespace) or self.ctx.in_async) {
                 try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as identifier");
             }
             const span = self.currentSpan();
@@ -366,7 +366,7 @@ pub fn parseBindingProperty(self: *Parser) ParseError2!NodeIndex {
     // - yield: generator 밖에서 식별자 가능
     const is_shorthand_eligible = self.current() == .identifier or
         (self.current().isKeyword() and !self.current().isReservedKeyword()) or
-        (self.current() == .kw_await and !self.ctx.in_async and (!self.is_module or self.ctx.in_function)) or
+        (self.current() == .kw_await and !self.ctx.in_async and (!self.is_module or self.in_namespace or self.ctx.in_function)) or
         (self.current() == .kw_yield and !self.ctx.in_generator and !self.is_strict_mode);
     if (is_shorthand_eligible) {
         const id_span = self.currentSpan();

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -30,6 +30,16 @@ fn parseFunctionBodyOrOverload(self: *Parser) ParseError2!NodeIndex {
         _ = try self.eat(.semicolon);
         return NodeIndex.none;
     }
+    // ambient context (declare)에서는 body가 없어도 됨 — ASI로 처리
+    // 예: `declare function fn()\n function scope() {}`
+    if (self.ctx.in_ambient and self.current() != .l_curly) {
+        return NodeIndex.none;
+    }
+    // TS function overload + ASI: 줄바꿈 뒤에 body가 아닌 것이 오면 overload
+    // 예: `function fn(): void\n function fn(x: number): void {}`
+    if (self.scanner.token.has_newline_before and self.current() != .l_curly) {
+        return NodeIndex.none;
+    }
     return self.parseFunctionBody();
 }
 
@@ -329,7 +339,7 @@ pub fn parseClassWithDecorators(self: *Parser, tag: Tag, decorators: NodeList) P
     var name = NodeIndex.none;
     if (self.current() == .identifier or
         (self.current() == .kw_yield and !self.ctx.in_generator) or
-        (self.current() == .kw_await and !self.ctx.in_async and !self.is_module) or
+        (self.current() == .kw_await and !self.ctx.in_async and (!self.is_module or self.in_namespace)) or
         self.current() == .escaped_keyword or self.current() == .escaped_strict_reserved)
     {
         name = try self.parseBindingIdentifier();

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -557,7 +557,7 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
             // module top-level(함수 밖)에서는 top-level await.
             // module 안 일반 함수 body에서는 await을 식별자로 취급 → strict mode 에러.
             // ECMAScript: FunctionBody[~Yield, ~Await] → await은 keyword가 아님.
-            if (self.ctx.in_async or (self.is_module and !self.ctx.in_function)) {
+            if (self.ctx.in_async or (self.is_module and !self.in_namespace and !self.ctx.in_function)) {
                 const start = self.currentSpan().start;
                 try self.advance();
                 const operand = try parseUnaryExpression(self);
@@ -568,7 +568,7 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
                 });
             }
             // module 안 일반 함수에서 await 사용 → strict mode 위반 에러
-            if (self.is_module and self.ctx.in_function and !self.ctx.in_async) {
+            if (self.is_module and !self.in_namespace and self.ctx.in_function and !self.ctx.in_async) {
                 try self.addError(self.currentSpan(), "'await' is not allowed in non-async function in module code");
             }
             // async 밖 + script mode에서는 식별자로 파싱

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -46,7 +46,8 @@ pub fn parseImportCallArgs(self: *Parser, start: u32) ParseError2!NodeIndex {
 pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     // ECMAScript 15.2: import 선언은 module의 top-level에서만 허용
-    if (!self.is_module) {
+    // namespace body 안에서도 import 허용 (in_namespace)
+    if (!self.is_module and !self.in_namespace) {
         try self.addError(self.currentSpan(), "'import' declaration is only allowed in module code");
     } else if (!self.ctx.is_top_level) {
         try self.addError(self.currentSpan(), "'import' declaration must be at the top level");
@@ -342,7 +343,8 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
     // function 파서에서 확인해야 하므로 여기서 미리 저장한다.
     const had_no_side_effects = self.scanner.token.has_no_side_effects_comment;
     // ECMAScript 15.2: export 선언은 module의 top-level에서만 허용
-    if (!self.is_module) {
+    // namespace body 안에서도 export 허용 (in_namespace)
+    if (!self.is_module and !self.in_namespace) {
         try self.addError(self.currentSpan(), "'export' declaration is only allowed in module code");
     } else if (!self.ctx.is_top_level) {
         try self.addError(self.currentSpan(), "'export' declaration must be at the top level");

--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -138,7 +138,7 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
                             try self.addError(key_node.span, "Reserved word in strict mode cannot be used as shorthand property");
                         } else if (kw == .kw_yield and self.ctx.in_generator) {
                             try self.addError(key_node.span, "'yield' cannot be used as shorthand property in generator");
-                        } else if (kw == .kw_await and (self.ctx.in_async or self.is_module)) {
+                        } else if (kw == .kw_await and (self.ctx.in_async or (self.is_module and !self.in_namespace))) {
                             try self.addError(key_node.span, "'await' cannot be used as shorthand property in async/module");
                         }
                     }

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -77,6 +77,10 @@ pub const Parser = struct {
     /// 파싱 시작 시 한 번 결정되는 불변 설정이므로 Context에 포함하지 않음.
     is_module: bool = false,
 
+    /// namespace body 안인지. export/import를 허용하되 await를 키워드로 취급하지 않음.
+    /// is_module과 분리: namespace는 export/import를 허용하지만 module code가 아님.
+    in_namespace: bool = false,
+
     /// JSX 모드 (TSX). true이면 <는 JSX 엘리먼트 시작으로 우선 해석.
     /// false이면 <T>()=>{}가 제네릭 arrow로 해석.
     is_jsx: bool = false,
@@ -1013,7 +1017,7 @@ pub const Parser = struct {
             // 단, escaped await는 script mode의 non-async에서는 허용
             const is_escaped_await = self.isEscapedKeyword("await");
             if (is_escaped_await) {
-                if (self.is_module or self.ctx.in_async) {
+                if ((self.is_module and !self.in_namespace) or self.ctx.in_async) {
                     try self.addError(self.currentSpan(), "'await' cannot be used as identifier in this context");
                 }
             } else {
@@ -1052,7 +1056,9 @@ pub const Parser = struct {
             if (self.ctx.in_async) {
                 try self.addError(span, "'await' cannot be used as " ++ context_noun ++ " in async function");
                 return true;
-            } else if (self.is_module) {
+            } else if (self.is_module and !self.in_namespace) {
+                // namespace body 안에서는 await를 식별자로 허용
+                // (namespace는 IIFE로 변환되므로 top-level module code가 아님)
                 try self.addError(span, "'await' cannot be used as " ++ context_noun ++ " in module code");
                 return true;
             }

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -347,7 +347,7 @@ fn parseExpressionOrLabeledStatement(self: *Parser) ParseError2!NodeIndex {
                 const esc_text = self.resolveIdentifierText(self.currentSpan());
                 const is_escaped_await = std.mem.eql(u8, esc_text, "await");
                 if (is_escaped_await) {
-                    if (self.is_module or self.ctx.in_async) {
+                    if ((self.is_module and !self.in_namespace) or self.ctx.in_async) {
                         try self.addError(self.currentSpan(), "Escaped reserved word cannot be used as label");
                     }
                 } else {

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -195,8 +195,10 @@ fn parseTsModuleBody(self: *Parser, start: u32) ParseError2!NodeIndex {
             .data = .{ .none = 0 },
         });
         try self.advance();
-        // body 없는 shorthand: declare module 'X';
-        if (self.current() == .semicolon or self.current() == .eof) {
+        // body 없는 shorthand: declare module 'X'; 또는 ASI
+        if (self.current() == .semicolon or self.current() == .eof or
+            (self.scanner.token.has_newline_before and self.current() != .l_curly))
+        {
             _ = try self.eat(.semicolon);
             return try self.ast.addNode(.{
                 .tag = .ts_module_declaration,
@@ -227,12 +229,16 @@ fn parseTsModuleBody(self: *Parser, start: u32) ParseError2!NodeIndex {
     // namespace body에서는 export/import 허용 (모듈과 동일한 컨텍스트)
     // parseBlockStatement는 내부에서 is_top_level=false로 설정하므로
     // 여기서 직접 블록을 파싱하여 is_top_level=true를 유지한다
+    // in_namespace 설정: namespace body 안에서는 await를 식별자로 사용 가능
+    // (namespace는 IIFE로 변환되므로 top-level module code가 아님)
     const saved_module = self.is_module;
+    const saved_namespace = self.in_namespace;
     const saved_ctx = self.ctx;
-    self.is_module = true;
+    self.in_namespace = true;
     self.ctx.is_top_level = true;
     const body = try parseNamespaceBlock(self);
     self.is_module = saved_module;
+    self.in_namespace = saved_namespace;
     self.ctx = saved_ctx;
 
     return try self.ast.addNode(.{
@@ -322,6 +328,35 @@ pub fn parseDecorator(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip @
     const expr = try self.parseCallExpression();
+
+    // TS decorator with type arguments: @x<Type> property
+    // parseCallExpression의 speculative parse는 `<Type>` 뒤에 `(`이 올 때만 성공하므로
+    // decorator에서는 `<Type>` 뒤에 식별자가 올 수 있으므로 여기서 별도 처리
+    if (self.isAtOpeningAngleBracket()) {
+        const saved_scanner = self.saveState();
+        const saved_nodes_len = self.ast.nodes.items.len;
+        const saved_extra_len = self.ast.extra_data.items.len;
+        const saved_scratch = self.saveScratch();
+        const saved_errors_len = self.errors.items.len;
+
+        const type_args_ok = ta_blk: {
+            _ = self.parseTypeArguments() catch {
+                break :ta_blk false;
+            };
+            break :ta_blk true;
+        };
+
+        // 타입 인자 노드는 스트리핑 — AST에서 제거
+        self.ast.nodes.items.len = saved_nodes_len;
+        self.ast.extra_data.items.len = saved_extra_len;
+        self.restoreScratch(saved_scratch);
+        self.errors.shrinkRetainingCapacity(saved_errors_len);
+        if (!type_args_ok) {
+            // 파싱 실패 시 상태 복원
+            self.restoreState(saved_scanner);
+        }
+        // 성공 시 scanner는 type args 이후를 가리킴 (expr은 type args 없이 유지)
+    }
 
     return try self.ast.addNode(.{
         .tag = .decorator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -22,6 +22,7 @@ const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
 const Span = @import("../lexer/token.zig").Span;
+const Symbol = @import("../semantic/symbol.zig").Symbol;
 
 /// define 치환 엔트리. key=식별자 텍스트, value=치환 문자열.
 pub const DefineEntry = struct {
@@ -76,6 +77,10 @@ pub const Transformer = struct {
     old_symbol_ids: []const ?u32 = &.{},
     /// 새 AST 기준 symbol_ids. new_ast에 노드 추가 시 자동 전파.
     new_symbol_ids: std.ArrayList(?u32) = .empty,
+
+    /// semantic analyzer의 심볼 테이블 (unused import 판별용).
+    /// 비어 있으면 unused import 제거 비활성.
+    symbols: []const Symbol = &.{},
 
     /// define value의 string_table Span 캐시. options.define과 동일 인덱스.
     /// transform() 시작 시 한 번 빌드하여, tryDefineReplace에서 addString 중복 호출을 방지.
@@ -1168,11 +1173,61 @@ pub const Transformer = struct {
     ///   side-effect import (import "module")은 specs_len=0.
     fn visitImportDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
-        const new_specs = try self.visitExtraList(self.readU32(e, 0), self.readU32(e, 1));
+        const specs_start = self.readU32(e, 0);
+        const specs_len = self.readU32(e, 1);
+
+        // Unused import 제거: 모든 specifier의 reference_count가 0이면 import 전체를 제거.
+        // side-effect import (import 'foo')는 specifier가 없으므로 제거하지 않음.
+        if (self.symbols.len > 0 and self.old_symbol_ids.len > 0 and specs_len > 0) {
+            const all_unused = self.areAllSpecifiersUnused(specs_start, specs_len);
+            if (all_unused) return .none;
+        }
+
+        const new_specs = try self.visitExtraList(specs_start, specs_len);
         const new_source = try self.visitNode(self.readNodeIdx(e, 2));
         return self.addExtraNode(.import_declaration, node.span, &.{
             new_specs.start, new_specs.len, @intFromEnum(new_source),
         });
+    }
+
+    /// import의 모든 specifier가 미사용인지 확인한다.
+    /// type-only specifier(이미 스트리핑됨)와 reference_count==0인 specifier만 있으면 true.
+    fn areAllSpecifiersUnused(self: *Transformer, specs_start: u32, specs_len: u32) bool {
+        var i: u32 = 0;
+        while (i < specs_len) : (i += 1) {
+            const spec_idx_raw = self.old_ast.extra_data.items[specs_start + i];
+            const spec_idx: NodeIndex = @enumFromInt(spec_idx_raw);
+            if (spec_idx.isNone()) continue;
+            const spec_node = self.old_ast.getNode(spec_idx);
+
+            // type-only specifier (flags & 1 != 0) → 이미 스트리핑됨, 무시
+            if (spec_node.tag == .import_specifier and spec_node.data.binary.flags & 1 != 0) continue;
+            if (spec_node.tag == .export_specifier) continue; // 방어적: export specifier는 여기 없지만
+
+            // 심볼 ID를 찾을 노드 인덱스 결정
+            const sym_node_idx: u32 = switch (spec_node.tag) {
+                // import_specifier: binary.right가 local name 노드
+                .import_specifier => blk: {
+                    const local_idx = spec_node.data.binary.right;
+                    break :blk if (!local_idx.isNone()) @intFromEnum(local_idx) else @intFromEnum(spec_idx);
+                },
+                // import_default_specifier, import_namespace_specifier: spec 노드 자체가 심볼
+                else => @intFromEnum(spec_idx),
+            };
+
+            // symbol_ids에서 심볼 ID 조회
+            if (sym_node_idx < self.old_symbol_ids.len) {
+                if (self.old_symbol_ids[sym_node_idx]) |sym_id| {
+                    if (sym_id < self.symbols.len) {
+                        if (self.symbols[sym_id].reference_count > 0) return false;
+                        continue; // 미사용 — 다음 specifier 확인
+                    }
+                }
+            }
+            // symbol_id를 찾지 못하면 보수적으로 유지 (사용 중으로 간주)
+            return false;
+        }
+        return true;
     }
 
     /// export_named_declaration: extra_data = [declaration, specifiers_start, specifiers_len, source]


### PR DESCRIPTION
## Summary
- 파서 4건 + 미사용 import 제거, 적합성 **50.7% → 51.8%** (pass 563→575)

## Test plan
- [x] `zig build test` — 0 failures
- [x] `bun run smoke.ts` — 99/99, 98/98 match

🤖 Generated with [Claude Code](https://claude.com/claude-code)