### PR TITLE
fix(parser): 적합성 파싱 에러 7건 수정 — 56.5%

### DIFF
--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -103,8 +103,8 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
         try self.addError(self.ast.getNode(key).span, "Private identifier is not allowed as object property key");
     }
 
-    // 메서드 shorthand: { foo() {} }
-    if (self.current() == .l_paren) {
+    // 메서드 shorthand: { foo() {} } 또는 { foo<T>() {} }
+    if (self.current() == .l_paren or self.isAtOpeningAngleBracket()) {
         return parseObjectMethodBody(self, start, key, 0);
     }
 
@@ -168,6 +168,11 @@ pub fn parseObjectMethodBody(self: *Parser, start: u32, key: NodeIndex, flags: u
     const saved_ctx = self.enterFunctionContext((flags & 0x08) != 0, (flags & 0x10) != 0);
     // ECMAScript 12.3.7: 객체 리터럴 메서드에서도 super.prop 허용
     self.allow_super_property = true;
+
+    // TS 제네릭 파라미터: { foo<T>() {} }
+    if (self.isAtOpeningAngleBracket()) {
+        _ = try self.parseTsTypeParameterDeclaration();
+    }
 
     try self.expect(.l_paren);
     self.in_formal_parameters = true;

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -623,6 +623,13 @@ pub const Parser = struct {
             .object_assignment_target,
             => true,
 
+            // 6b) TS as/satisfies expression — 내부 expression을 assignment target으로 검증
+            // (z as any) = 1 → z가 valid target이면 OK (esbuild/TS 호환)
+            .ts_as_expression, .ts_satisfies_expression => {
+                const inner = node.data.binary.left;
+                return try self.coverExpressionToAssignmentTarget(inner, is_top);
+            },
+
             // 7) meta_property (import.meta, new.target) — 절대로 assignment target이 될 수 없음.
             //    is_top 여부와 무관하게 항상 에러. else 분기는 is_top=false일 때 에러를 내지 않으므로
             //    destructuring 내부([import.meta] = arr)에서 잘못 통과하는 것을 방지.

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -1168,11 +1168,38 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
     }
 
     // 2. 컨스트럭트 시그니처: new ( 또는 new <
+    //    named construct signature: new bar<T>(): R (esbuild 호환)
     if (self.current() == .kw_new) {
         const next = try self.peekNextKind();
         if (next == .l_paren or next == .l_angle) {
             try self.advance(); // skip 'new'
             return parseSignatureMember(self, start, true);
+        }
+        // new identifier( 또는 new identifier< → named construct signature
+        // `new` 뒤에 이름이 오는 패턴. new를 건너뛰고 이름 + 시그니처로 파싱.
+        if (next == .identifier or next == .escaped_keyword) {
+            try self.advance(); // skip 'new'
+            const key = try self.parsePropertyKey();
+            _ = try self.eat(.question); // optional
+            var type_params = NodeIndex.none;
+            if (self.isAtOpeningAngleBracket()) {
+                type_params = try parseTsTypeParameterDeclaration(self);
+            }
+            try self.expect(.l_paren);
+            const params = try parseTypeMemberParamList(self);
+            const return_type = try tryParseReturnType(self);
+            const extra = try self.ast.addExtras(&.{
+                @intFromEnum(key),
+                @intFromEnum(type_params),
+                params.start,
+                params.len,
+                @intFromEnum(return_type),
+            });
+            return try self.ast.addNode(.{
+                .tag = .ts_method_signature,
+                .span = .{ .start = start, .end = self.currentSpan().start },
+                .data = .{ .extra = extra },
+            });
         }
     }
 
@@ -1651,10 +1678,16 @@ fn parseMappedType(self: *Parser) ParseError2!NodeIndex {
 }
 
 /// import("module").Type — import type (oxc parse_ts_import_type)
+/// import("module", { assert: { type: "json" } }).Type — import attributes (TS 5.3+)
 fn parseImportType(self: *Parser, start: u32) ParseError2!NodeIndex {
     try self.advance(); // skip 'import'
     try self.expect(.l_paren);
     const module_type = try parseType(self);
+    // import attributes: import("module", { assert: { ... } })
+    // 2번째 인자는 옵션 객체. 타입 스트리핑에서 제거되므로 파싱만 하고 버린다.
+    if (try self.eat(.comma)) {
+        _ = try parseType(self);
+    }
     try self.expect(.r_paren);
     // 선택적 .member 접근
     var result = try self.ast.addNode(.{


### PR DESCRIPTION
## Summary
esbuild 적합성 파싱 에러 10건 중 7건 수정. 적합성 55.9% → 56.5%.

- **import type attributes** (2건): `typeof import('fs', { assert: { type: 'json' } })` — 2번째 인자 파싱
- **named construct signature** (2건): `interface { new bar<const T>(): T }` — new 뒤 이름 + 제네릭
- **객체 리터럴 제네릭 메서드** (1건): `{ bar<T>() {} }` — `isAtOpeningAngleBracket` 체크
- **as/satisfies assignment** (2건): `(z as any) = 1` — cover grammar에서 unwrap

스킵 3건: `number!`는 유효하지 않은 TS, TSX 케이스는 입력 불완전, 1건은 이미 통과

## Test plan
- [x] `zig build test` — 유닛 테스트 전체 통과
- [x] Test262: 50,504/50,504 (100.0%)
- [x] 스모크 99/99, baseline 98/98 MATCH
- [x] 적합성 56.5% (627/1110), 에러 76건

🤖 Generated with [Claude Code](https://claude.com/claude-code)