### PR TITLE
fix(parser): override param + class index signature + 제네릭 타입 — 적합성 57.4%

### DIFF
--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -16,20 +16,23 @@ const Parser = @import("parser.zig").Parser;
 const ParseError2 = @import("parser.zig").ParseError2;
 
 pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
-    // TS parameter property: public x, private x, protected x, readonly x
-    // flags 비트: 0x01=public, 0x02=private, 0x04=protected, 0x08=readonly
-    // readonly는 contextual keyword (identifier로 토큰화됨)
+    // TS parameter property: public x, private x, protected x, readonly x, override x
+    // flags 비트: 0x01=public, 0x02=private, 0x04=protected, 0x08=readonly, 0x10=override
+    // readonly와 override는 contextual keyword (identifier로 토큰화됨)
     const is_readonly = self.isContextual("readonly");
+    const is_override = self.isContextual("override");
     if (self.current() == .kw_public or self.current() == .kw_private or
-        self.current() == .kw_protected or is_readonly)
+        self.current() == .kw_protected or is_readonly or is_override)
     {
         const modifier_span = self.currentSpan();
         const next = try self.peekNextKind();
         // modifier 뒤에 식별자가 오면 parameter property
-        // readonly는 이제 identifier로 토큰화되므로 next == .identifier에 포함됨
+        // readonly/override는 identifier로 토큰화되므로 next == .identifier에 포함됨
         if (next == .identifier or next == .l_bracket or next == .l_curly) {
             var modifier_flags: u16 = if (is_readonly)
                 0x08
+            else if (is_override)
+                0x10
             else switch (self.current()) {
                 .kw_public => 0x01,
                 .kw_private => 0x02,
@@ -38,9 +41,12 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
             };
             try self.advance(); // skip first modifier
 
-            // 두 번째 modifier: public readonly x
+            // 두 번째 modifier: public readonly x, override readonly x
             if (self.isContextual("readonly")) {
                 modifier_flags |= 0x08;
+                try self.advance();
+            } else if (self.isContextual("override")) {
+                modifier_flags |= 0x10;
                 try self.advance();
             }
 

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -587,6 +587,30 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         flags |= 0x10; // generator flag
     }
 
+    // TS 인덱스 시그니처: [key: string]: any — class body에서만 유효, 타입 스트리핑 대상
+    // 클래스에서는 computed property [expr]와 구분해야 하므로, [identifier :] 패턴을 엄격히 확인.
+    // 타입 리터럴의 isIndexSignature()는 identifier 뒤를 확인하지 않아 여기서는 사용 불가.
+    if (self.current() == .l_bracket) {
+        const saved = self.saveState();
+        try self.advance(); // skip [
+        if (self.current() == .identifier or self.current() == .kw_this) {
+            try self.advance(); // skip identifier
+            if (self.current() == .colon) {
+                // [identifier : 패턴 확인 → 인덱스 시그니처
+                self.restoreState(saved);
+                // parseIndexSignature가 [ 부터 파싱
+                const idx_sig = try self.parseIndexSignature(start, false);
+                _ = idx_sig;
+                // 세미콜론 소비 (optional)
+                _ = try self.eat(.semicolon);
+                // index signature는 TS 전용이므로 스트리핑 — 빈 노드 반환
+                return NodeIndex.none;
+            }
+        }
+        // 인덱스 시그니처가 아님 → 원래 위치로 복구
+        self.restoreState(saved);
+    }
+
     // 키
     const key = try self.parsePropertyKey();
 

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1764,6 +1764,10 @@ pub const Parser = struct {
         return ts.parseType(self);
     }
 
+    pub fn parseIndexSignature(self: *Parser, start: u32, is_readonly: bool) ParseError2!NodeIndex {
+        return ts.parseIndexSignature(self, start, is_readonly);
+    }
+
     pub fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
         return ts.parseTypeArguments(self);
     }

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -911,8 +911,10 @@ fn parseTypeReference(self: *Parser) ParseError2!NodeIndex {
     }
 
     // 제네릭: Foo<T, U> — << (shift_left) 도 중첩 제네릭 시작
+    // 줄바꿈 후 <는 제네릭이 아닌 다음 멤버의 시작일 수 있음
+    // 예: { <A>(): c.d \n <E>(): g.h } — \n 뒤의 <는 새 콜 시그니처
     var type_args = NodeIndex.none;
-    if (self.isAtOpeningAngleBracket()) {
+    if (self.isAtOpeningAngleBracket() and !self.scanner.token.has_newline_before) {
         type_args = try parseTypeArguments(self);
     }
 
@@ -1424,7 +1426,7 @@ fn isIndexSignature(self: *Parser) ParseError2!bool {
 }
 
 /// 인덱스 시그니처 파싱: [key: string]: Type
-fn parseIndexSignature(self: *Parser, start: u32, is_readonly: bool) ParseError2!NodeIndex {
+pub fn parseIndexSignature(self: *Parser, start: u32, is_readonly: bool) ParseError2!NodeIndex {
     try self.advance(); // skip [
     // 파라미터: key: Type
     const param_start = self.currentSpan().start;


### PR DESCRIPTION
## Summary
적합성 파싱 에러 5건 추가 수정. 56.5% → 57.4% (+10건), 에러 76 → 64건.

- **override parameter property** (2건): `constructor(override x)`, `constructor(override readonly x)` — binding.zig에서 `override` modifier 인식
- **class index signature** (2건): `class Foo { [key: string]: any }` — declaration.zig에서 `[identifier :` 패턴 감지 → `parseIndexSignature` 호출
- **타입 리터럴 제네릭 ASI** (1건): `c.d\n<E extends F>()` — 줄바꿈 뒤 `<`를 제네릭이 아닌 비교로 처리

## Test plan
- [x] `zig build test` — 유닛 테스트 전체 통과
- [x] Test262: 50,504/50,504 (100.0%)
- [x] 스모크 99/99, baseline 98/98 MATCH
- [x] 적합성 57.4% (637/1110), 에러 64건

🤖 Generated with [Claude Code](https://claude.com/claude-code)