### PR TITLE
refactor(codegen): /simplify — IIFE 닫는 패턴 헬퍼 추출

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1975,11 +1975,7 @@ pub const Codegen = struct {
             try self.write("\";");
         }
 
-        try self.write("})(");
-        try self.write(name_text);
-        try self.write(" || (");
-        try self.write(name_text);
-        try self.write(" = {}));");
+        try self.emitIIFEClosing(name_text);
     }
 
     // ================================================================
@@ -2009,11 +2005,7 @@ pub const Codegen = struct {
             try self.write(") => {");
             // 내부 namespace를 재귀 출력
             try self.emitNamespaceIIFE(body_node);
-            try self.write("})(");
-            try self.write(name_text);
-            try self.write(" || (");
-            try self.write(name_text);
-            try self.write(" = {}));");
+            try self.emitIIFEClosing(name_text);
             return;
         }
 
@@ -2062,6 +2054,11 @@ pub const Codegen = struct {
             }
         }
 
+        try self.emitIIFEClosing(name_text);
+    }
+
+    /// enum/namespace IIFE 닫는 부분: })(name || (name = {}));
+    fn emitIIFEClosing(self: *Codegen, name_text: []const u8) !void {
         try self.write("})(");
         try self.write(name_text);
         try self.write(" || (");


### PR DESCRIPTION
## Summary
enum/namespace/중첩 namespace 3곳에서 동일한 IIFE 닫는 패턴(5줄)을 `emitIIFEClosing()` 헬퍼로 추출. -10줄.

## Test plan
- [x] zig build test 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)