### PR TITLE
fix: import x = require 이름 누락 + 데코레이터 공백 — 적합성 68.9%

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1245,12 +1245,12 @@ pub const Codegen = struct {
         const deco_start = self.ast.extra_data.items[e + 6];
         const deco_len = self.ast.extra_data.items[e + 7];
 
-        // decorator 출력: @log\n@validate\nclass Foo {}
+        // decorator 출력: @log @validate class Foo {} (esbuild 호환: 공백 구분)
         if (deco_len > 0) {
             const deco_indices = self.ast.extra_data.items[deco_start .. deco_start + deco_len];
             for (deco_indices) |raw_idx| {
                 try self.emitNode(@enumFromInt(raw_idx));
-                try self.writeByte('\n');
+                try self.writeByte(' ');
             }
         }
 

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -157,7 +157,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
                 .data = .{ .binary = .{ .left = try self.ast.addNode(.{
                     .tag = .identifier_reference,
                     .span = name_span,
-                    .data = .{ .none = 0 },
+                    .data = .{ .string_ref = name_span },
                 }), .right = value, .flags = 0 } },
             });
         }


### PR DESCRIPTION
## Summary
1. **import x = require('y')**: identifier_reference 노드의 data가 `none`이어서 이름이 빈 문자열로 출력되던 버그 수정 (`string_ref`로 변경)
2. **데코레이터 구분자**: 줄바꿈 → 공백 (esbuild 호환: `@x @y class Foo {}`)

## 적합성
66.6% → **68.9%** (Pass 739 → 765, **+26건**)

## Test plan
- [x] zig build test 통과
- [x] pre-push 훅 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)