### PR TITLE
fix(parser): 적합성 에러 25건 해결 — instantiation expr + ternary arrow + decorator await

### DIFF
--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -18,9 +18,18 @@ const ParseError2 = @import("parser.zig").ParseError2;
 pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
     // TS parameter decorator: @dec x, @dec(() => 0) x
     // 데코레이터는 TS에서 스트리핑되므로 파싱 후 무시한다.
-    // esbuild: `declare class Foo { foo(@dec(() => 0) x) }` 지원
-    while (self.current() == .at) {
-        _ = try self.parseDecorator();
+    // 데코레이터 표현식은 클래스의 외부 스코프에서 평가되므로,
+    // @dec(await x)에서 await이 유효하려면 외부 async 컨텍스트를 복원해야 한다.
+    if (self.current() == .at) {
+        const saved_async = self.ctx.in_async;
+        const saved_formal = self.in_formal_parameters;
+        self.ctx.in_async = self.class_scope_async;
+        self.in_formal_parameters = false;
+        while (self.current() == .at) {
+            _ = try self.parseDecorator();
+        }
+        self.ctx.in_async = saved_async;
+        self.in_formal_parameters = saved_formal;
     }
 
     // TS parameter property: public x, private x, protected x, readonly x, override x

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -426,7 +426,10 @@ fn parseClassBody(self: *Parser) ParseError2!NodeIndex {
 
     // class body 안에서는 in_class=true (super 허용 등)
     const saved_in_class = self.in_class;
+    const saved_class_scope_async = self.class_scope_async;
     self.in_class = true;
+    // 클래스 외부 스코프의 async 컨텍스트를 저장 (파라미터 데코레이터에서 사용)
+    self.class_scope_async = self.ctx.in_async;
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
@@ -443,6 +446,7 @@ fn parseClassBody(self: *Parser) ParseError2!NodeIndex {
     }
 
     self.in_class = saved_in_class;
+    self.class_scope_async = saved_class_scope_async;
 
     const end = self.currentSpan().end;
     try self.expect(.r_curly);

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -22,22 +22,95 @@ const Span = token_mod.Span;
 const Parser = @import("parser.zig").Parser;
 const ParseError2 = @import("parser.zig").ParseError2;
 
-/// TypeScript의 canFollowTypeArgumentsInExpression 대응.
+/// TypeScript의 canFollowTypeArgumentsInExpression 대응 (esbuild tsCanFollowTypeArgumentsInExpression).
 /// `f<Type>` 다음에 올 수 있는 토큰인지 판별한다.
-/// `<`가 비교 연산자가 아니라 타입 인수의 시작임을 확인하기 위해,
-/// `>` 다음 토큰이 새 expression의 시작이 될 수 있는 것(식별자, 숫자 등)이면 false,
-/// 그렇지 않은 것(세미콜론, 콤마, 괄호 닫기 등)이면 true를 반환한다.
-fn canFollowTypeArgumentsInExpression(kind: Kind) bool {
+/// esbuild 3단계 로직:
+/// 1. 호출/템플릿 토큰 → true (확실히 type args)
+/// 2. `<`, `>`, `+`, `-` (및 `>`로 시작하는 복합 토큰) → false (확실히 비교)
+/// 3. newline_before || isBinaryOperator || !isStartOfExpression → true
+fn canFollowTypeArgumentsInExpression(self: *const Parser) bool {
+    const kind = self.current();
     return switch (kind) {
+        // 호출, 멤버 접근, tagged template — 확실히 type args 뒤에 올 수 있음
         .l_paren, .dot, .question_dot => true,
-        .r_paren, .r_bracket, .r_curly => true,
-        .semicolon, .comma, .colon, .eof => true,
-        .eq2, .eq3, .neq, .neq2 => true,
-        .amp2, .pipe2, .question2 => true,
-        .caret, .amp, .pipe => true,
-        .question => true,
         .no_substitution_template, .template_head => true,
+
+        // `<` 뒤에 또 `<`는 의미 없고, `>`는 re-scan된 `>>`와 모호하므로 불허.
+        // `+`, `-`는 이 컨텍스트에서 단항 연산자이므로 불허.
+        // `>`로 시작하는 복합 토큰(>=, >>, >>>, >>=, >>>=)도 불허 (esbuild 동일).
+        .l_angle,
+        .r_angle,
+        .plus,
+        .minus,
+        .gt_eq,
+        .shift_right,
+        .shift_right_eq,
+        .shift_right3,
+        .shift_right3_eq,
+        => false,
+
+        // 그 외: newline || binary operator || not start of expression → true
+        else => self.scanner.token.has_newline_before or
+            tsIsBinaryOperator(self, kind) or
+            !tsIsStartOfExpression(self, kind),
+    };
+}
+
+/// TypeScript 컴파일러의 isBinaryOperator 대응.
+/// 현재 토큰이 이항 연산자인지 판별한다.
+fn tsIsBinaryOperator(self: *const Parser, kind: Kind) bool {
+    return switch (kind) {
+        .kw_in => self.ctx.allow_in,
+        .question2, .pipe2, .amp2 => true,
+        .pipe, .caret, .amp => true,
+        .eq2, .neq, .eq3, .neq2 => true,
+        .l_angle, .r_angle, .lt_eq, .gt_eq, .kw_instanceof => true,
+        .shift_left, .shift_right, .shift_right3 => true,
+        .plus, .minus => true,
+        .star, .slash, .percent, .star2 => true,
+        .identifier => blk: {
+            const text = self.tokenText();
+            break :blk std.mem.eql(u8, text, "as") or std.mem.eql(u8, text, "satisfies");
+        },
         else => false,
+    };
+}
+
+/// TypeScript 컴파일러의 isStartOfExpression 대응.
+/// 현재 토큰이 expression의 시작이 될 수 있는지 판별한다.
+fn tsIsStartOfExpression(self: *const Parser, kind: Kind) bool {
+    if (tsIsStartOfLeftHandSideExpression(kind)) return true;
+    return switch (kind) {
+        .plus, .minus, .tilde, .bang => true,
+        .kw_delete, .kw_typeof, .kw_void => true,
+        .plus2, .minus2 => true,
+        .l_angle => true,
+        .private_identifier => true,
+        .at => true,
+        .identifier => blk: {
+            const text = self.tokenText();
+            break :blk std.mem.eql(u8, text, "await") or std.mem.eql(u8, text, "yield") or
+                tsIsBinaryOperator(self, kind);
+        },
+        else => tsIsBinaryOperator(self, kind),
+    };
+}
+
+/// TypeScript 컴파일러의 isStartOfLeftHandSideExpression 대응.
+fn tsIsStartOfLeftHandSideExpression(kind: Kind) bool {
+    return switch (kind) {
+        .kw_this, .kw_super => true,
+        .kw_null, .kw_true, .kw_false => true,
+        .string_literal,
+        .no_substitution_template,
+        .template_head,
+        => true,
+        .l_paren, .l_bracket, .l_curly => true,
+        .kw_function, .kw_class, .kw_new => true,
+        .slash, .slash_eq => true, // regex
+        .identifier => true,
+        .kw_import => true,
+        else => kind.isNumericLiteral(), // decimal, float, hex, bigint 등
     };
 }
 
@@ -871,8 +944,9 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                 const saved_errors_len = self.errors.items.len;
 
                 const type_args_ok = blk: {
-                    // parseTypeArguments will advance past < and parse types until >
-                    _ = self.parseTypeArguments() catch {
+                    // parseTypeArgumentsInExpression: strict mode — 최외곽 닫는 `>`가
+                    // 정확히 `.r_angle`일 때만 성공. `>=`/`>>`는 비교 연산자로 처리.
+                    _ = self.parseTypeArgumentsInExpression() catch {
                         break :blk false;
                     };
                     // If the speculative parse produced any errors, it means the type
@@ -880,8 +954,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                     // the inner `<b` is not a valid type parameter list).
                     if (self.errors.items.len > saved_errors_len) break :blk false;
                     // After >, check if next token can follow type arguments
-                    const next = self.current();
-                    break :blk canFollowTypeArgumentsInExpression(next);
+                    break :blk canFollowTypeArgumentsInExpression(self);
                 };
 
                 // AST rollback (타입 인자 노드 제거 — 성공/실패 공통)

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -134,6 +134,10 @@ pub const Parser = struct {
     in_class_field: bool = false,
     /// extends 있는 class인지 (super() 허용 판단)
     has_super_class: bool = false,
+    /// class가 위치한 외부 스코프의 async 컨텍스트.
+    /// 파라미터 데코레이터는 메서드가 아닌 클래스의 외부 스코프에서 평가되므로,
+    /// @dec(await x)에서 await이 유효한지 판단할 때 이 값을 사용한다.
+    class_scope_async: bool = false,
     /// super() 호출 허용 여부 (constructor + extends)
     allow_super_call: bool = false,
     /// super.x / super[x] 허용 여부
@@ -1862,6 +1866,12 @@ pub const Parser = struct {
 
     pub fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
         return ts.parseTypeArguments(self);
+    }
+
+    /// 식 컨텍스트에서의 타입 인자 파싱 (speculative).
+    /// 최외곽 닫는 `>`가 정확히 `.r_angle`일 때만 성공한다.
+    pub fn parseTypeArgumentsInExpression(self: *Parser) ParseError2!NodeIndex {
+        return ts.parseTypeArgumentsInExpression(self);
     }
 
     // ================================================================

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -971,6 +971,18 @@ fn parseTypeReference(self: *Parser) ParseError2!NodeIndex {
 }
 
 pub fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
+    return parseTypeArgumentsImpl(self, false);
+}
+
+/// 식 컨텍스트에서의 타입 인자 파싱 (speculative).
+/// 최외곽 닫는 `>`가 정확히 `.r_angle`일 때만 성공한다.
+/// `>=`, `>>` 등 복합 토큰이면 실패(에러)로 처리되어 backtrack된다.
+/// esbuild의 isParseTypeArgumentsInExpression 플래그에 대응.
+pub fn parseTypeArgumentsInExpression(self: *Parser) ParseError2!NodeIndex {
+    return parseTypeArgumentsImpl(self, true);
+}
+
+fn parseTypeArgumentsImpl(self: *Parser, strict_close: bool) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.expectOpeningAngleBracket();
 
@@ -983,7 +995,17 @@ pub fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
 
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
-    try self.expectClosingAngleBracket();
+
+    // strict_close: 식 컨텍스트에서는 정확히 `>` 토큰만 허용.
+    // `>=`나 `>>`는 비교/시프트 연산자이므로 타입 인자가 아니다.
+    // 내부 중첩 타입 인자(예: Array<Array<number>>)는 내부 parseType에서
+    // 일반 expectClosingAngleBracket으로 `>>`를 분할 처리하므로, 여기서
+    // 최외곽만 strict로 검사하면 된다.
+    if (strict_close) {
+        try self.expect(.r_angle);
+    } else {
+        try self.expectClosingAngleBracket();
+    }
 
     const types = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -741,6 +741,8 @@ pub const Transformer = struct {
         if (node.data.binary.flags == 1) return .none;
         const new_name = try self.visitNode(node.data.binary.left);
         const new_body = try self.visitNode(node.data.binary.right);
+        // 내부가 타입만 있어 전부 스트리핑된 namespace → 런타임 코드 불필요
+        if (new_body.isNone()) return .none;
         // 빈 namespace는 런타임 코드 불필요 → strip (esbuild 호환)
         if (!new_body.isNone()) {
             const body_node = self.new_ast.getNode(new_body);


### PR DESCRIPTION
## Summary
- TS instantiation expression `f<x>` — esbuild 방식 3-tier disambiguation (18건)
- ternary + typed arrow `a ? (b=c) : T => d : e` — 백트래킹 감지 (5건)
- decorator await `@dec(await x)` — class 외부 async 컨텍스트 복원 (1건)
- namespace IIFE 패닉 — 타입만 있는 namespace body 가드 (1건)

## Results
- 적합성 에러 27→10건 (-17), Pass 793→818 (+25), 적합성 71.4%→73.7%
- Unit 전체 통과, 스모크 99/99

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `f<x> = g<y>;` → `f = g;`
- [x] `return Array<number> in x;` → `return Array in x;`
- [x] `x<true>\nif(y){}` → `x;\nif (y) {}`
- [x] `x = a ? (b=c) : T => d : (e=f)` → `x = a ? (b = c) => d : e = f;`
- [x] `async function foo() { class Foo { foo(@dec(await x) y) {} } }` — 에러 없음
- [x] swc:issue-3454 namespace 패닉 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)