### PR TITLE
fix(parser): /simplify — tsIsBinaryOperator 중복 + dead code + kw_await 누락

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -59,21 +59,13 @@ fn canFollowTypeArgumentsInExpression(self: *const Parser) bool {
 /// TypeScript 컴파일러의 isBinaryOperator 대응.
 /// 현재 토큰이 이항 연산자인지 판별한다.
 fn tsIsBinaryOperator(self: *const Parser, kind: Kind) bool {
-    return switch (kind) {
-        .kw_in => self.ctx.allow_in,
-        .question2, .pipe2, .amp2 => true,
-        .pipe, .caret, .amp => true,
-        .eq2, .neq, .eq3, .neq2 => true,
-        .l_angle, .r_angle, .lt_eq, .gt_eq, .kw_instanceof => true,
-        .shift_left, .shift_right, .shift_right3 => true,
-        .plus, .minus => true,
-        .star, .slash, .percent, .star2 => true,
-        .identifier => blk: {
-            const text = self.tokenText();
-            break :blk std.mem.eql(u8, text, "as") or std.mem.eql(u8, text, "satisfies");
-        },
-        else => false,
-    };
+    if (kind == .kw_in) return self.ctx.allow_in;
+    if (getBinaryPrecedence(kind) > 0) return true;
+    if (kind == .identifier) {
+        const text = self.tokenText();
+        return std.mem.eql(u8, text, "as") or std.mem.eql(u8, text, "satisfies");
+    }
+    return false;
 }
 
 /// TypeScript 컴파일러의 isStartOfExpression 대응.
@@ -87,11 +79,7 @@ fn tsIsStartOfExpression(self: *const Parser, kind: Kind) bool {
         .l_angle => true,
         .private_identifier => true,
         .at => true,
-        .identifier => blk: {
-            const text = self.tokenText();
-            break :blk std.mem.eql(u8, text, "await") or std.mem.eql(u8, text, "yield") or
-                tsIsBinaryOperator(self, kind);
-        },
+        .kw_await, .kw_yield => true,
         else => tsIsBinaryOperator(self, kind),
     };
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -741,14 +741,11 @@ pub const Transformer = struct {
         if (node.data.binary.flags == 1) return .none;
         const new_name = try self.visitNode(node.data.binary.left);
         const new_body = try self.visitNode(node.data.binary.right);
-        // 내부가 타입만 있어 전부 스트리핑된 namespace → 런타임 코드 불필요
+        // 타입만 있어 전부 스트리핑됐거나, 빈 블록인 namespace → strip
         if (new_body.isNone()) return .none;
-        // 빈 namespace는 런타임 코드 불필요 → strip (esbuild 호환)
-        if (!new_body.isNone()) {
-            const body_node = self.new_ast.getNode(new_body);
-            if ((body_node.tag == .block_statement or body_node.tag == .ts_module_block) and body_node.data.list.len == 0) {
-                return .none;
-            }
+        const body_node = self.new_ast.getNode(new_body);
+        if ((body_node.tag == .block_statement or body_node.tag == .ts_module_block) and body_node.data.list.len == 0) {
+            return .none;
         }
         return self.new_ast.addNode(.{
             .tag = .ts_module_declaration,


### PR DESCRIPTION
## Summary
- `tsIsBinaryOperator`: 12개 연산자 매치 → `getBinaryPrecedence` 재사용 (drift 방지)
- `tsIsStartOfExpression`: `.identifier` dead code 제거, `kw_await`/`kw_yield` 추가 (`f<T> await x` 오파싱 버그 수정)
- transformer `visitNamespaceDeclaration`: 항상 true인 if 가드 제거

## Test plan
- [x] `zig build test` — 전체 통과
- [x] 적합성 818 pass, 10 error (변동 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)