### PR TITLE
fix(parser): 적합성 에러 7건 해결 — ternary arrow + return type + for-in

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -103,6 +103,8 @@ pub const Codegen = struct {
     next_comment_idx: usize = 0,
     /// for문 init 위치에서 variable_declaration 출력 시 세미콜론 생략
     in_for_init: bool = false,
+    /// for-in var initializer hoisting: emitVariableDeclarator에서 init 스킵
+    skip_var_init: bool = false,
     /// namespace IIFE 내부에서 export된 변수의 참조를 ns.name으로 치환하기 위한 상태.
     /// emitNamespaceIIFE에서 설정되고, emitNode의 identifier 출력에서 참조.
     ns_prefix: ?[]const u8 = null,
@@ -776,16 +778,82 @@ pub const Codegen = struct {
 
     fn emitForInOf(self: *Codegen, node: Node, keyword: []const u8) !void {
         const t = node.data.ternary;
+
+        // for-in var initializer hoisting (esbuild 호환):
+        // `for (var x = expr in y)` → `x = expr;\nfor (var x in y)`
+        // TS에서 `for (var x = Array<number> in y)` 같은 패턴에서 타입 인자가
+        // 스트리핑되어 initializer가 남을 수 있다. 이를 별도 문장으로 hoisting.
+        if (try self.tryHoistForInVarInit(t.a)) {
+            try self.writeNewline();
+            try self.writeIndent();
+        }
+
         if (self.options.minify) try self.write("for(") else try self.write("for (");
         self.in_for_init = true;
-        defer self.in_for_init = false;
+        self.skip_var_init = try self.shouldSkipVarInit(t.a);
         try self.emitNode(t.a);
+        self.in_for_init = false;
+        self.skip_var_init = false;
         try self.writeByte(' ');
         try self.write(keyword);
         try self.writeByte(' ');
         try self.emitNode(t.b);
         try self.writeByte(')');
         try self.emitNode(t.c);
+    }
+
+    /// for-in var initializer가 있으면 `name = init;`를 hoisting 출력.
+    /// 출력했으면 true, 아니면 false.
+    fn tryHoistForInVarInit(self: *Codegen, left: NodeIndex) !bool {
+        if (left.isNone()) return false;
+        const left_node = self.ast.getNode(left);
+        if (left_node.tag != .variable_declaration) return false;
+
+        const extras = self.ast.extra_data.items;
+        const e = left_node.data.extra;
+        const list_start = extras[e + 1];
+        const list_len = extras[e + 2];
+        if (list_len == 0) return false;
+
+        const first_decl: NodeIndex = @enumFromInt(extras[list_start]);
+        if (first_decl.isNone()) return false;
+        const decl_node = self.ast.getNode(first_decl);
+        if (decl_node.tag != .variable_declarator) return false;
+
+        const name: NodeIndex = @enumFromInt(extras[decl_node.data.extra]);
+        const init_val: NodeIndex = @enumFromInt(extras[decl_node.data.extra + 2]);
+        if (init_val.isNone()) return false;
+
+        // name = init;
+        try self.emitNode(name);
+        try self.writeSpace();
+        try self.writeByte('=');
+        try self.writeSpace();
+        try self.emitNode(init_val);
+        try self.writeByte(';');
+        return true;
+    }
+
+    /// for-in left가 initializer를 가진 var declaration인지 확인.
+    /// hoisting된 경우 emitVariableDeclarator에서 init를 스킵하기 위함.
+    fn shouldSkipVarInit(self: *Codegen, left: NodeIndex) !bool {
+        if (left.isNone()) return false;
+        const left_node = self.ast.getNode(left);
+        if (left_node.tag != .variable_declaration) return false;
+
+        const extras = self.ast.extra_data.items;
+        const e = left_node.data.extra;
+        const list_start = extras[e + 1];
+        const list_len = extras[e + 2];
+        if (list_len == 0) return false;
+
+        const first_decl: NodeIndex = @enumFromInt(extras[list_start]);
+        if (first_decl.isNone()) return false;
+        const decl_node = self.ast.getNode(first_decl);
+        if (decl_node.tag != .variable_declarator) return false;
+
+        const init_val: NodeIndex = @enumFromInt(extras[decl_node.data.extra + 2]);
+        return !init_val.isNone();
     }
 
     fn emitSwitch(self: *Codegen, node: Node) !void {
@@ -1510,7 +1578,8 @@ pub const Codegen = struct {
         const init_val: NodeIndex = @enumFromInt(extras[2]);
 
         try self.emitNode(name);
-        if (!init_val.isNone()) {
+        // skip_var_init: for-in hoisting으로 init가 별도 문장에 출력된 경우 스킵
+        if (!init_val.isNone() and !self.skip_var_init) {
             try self.writeSpace();
             try self.writeByte('=');
             try self.writeSpace();

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -401,7 +401,20 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
         });
     }
 
-    const left = try parseConditionalExpression(self);
+    var left = try parseConditionalExpression(self);
+
+    // TS typed arrow with return type after ternary alternate:
+    // `a ? b : (e = f) : T => g` — the alternate `(e = f)` followed by `: T =>` is a typed arrow.
+    // Only try this when NOT inside a ternary consequent (to avoid consuming
+    // the outer ternary's `:` separator in nested ternaries).
+    if (self.current() == .colon and !self.in_ternary_consequent and !left.isNone()) {
+        const left_node = self.ast.getNode(left);
+        if (left_node.tag == .parenthesized_expression) {
+            if (try tryReinterpretAsTypedArrow(self, left)) |arrow| {
+                return arrow;
+            }
+        }
+    }
 
     // => 를 만나면 arrow function (괄호 형태)
     // left가 parenthesized_expression이면 파라미터 리스트로 취급
@@ -453,8 +466,30 @@ fn parseConditionalExpression(self: *Parser) ParseError2!NodeIndex {
         //   ... ? AssignmentExpression[+In] : AssignmentExpression[?In]
         // consequent는 항상 `in` 허용, alternate는 외부 context 유지
         const cond_saved = self.enterAllowInContext(true);
-        const consequent = try parseAssignmentExpression(self);
+        // ternary consequent에서 `(x): T =>` 패턴의 typed arrow 감지를 억제한다.
+        // `:` 가 return type annotation인지 ternary separator인지 모호하기 때문.
+        // 대신 아래 tryReinterpretAsTypedArrow에서 speculative하게 시도한다.
+        const saved_in_ternary = self.in_ternary_consequent;
+        self.in_ternary_consequent = true;
+        var consequent = try parseAssignmentExpression(self);
+        self.in_ternary_consequent = saved_in_ternary;
         self.restoreContext(cond_saved); // alternate는 원래 context로 복원
+
+        // TS typed arrow in ternary consequent:
+        // `a ? (b = c) : T => d : (e = f)` → `a ? ((b = c): T => d) : (e = f)`
+        // The first `:` is a return type annotation for the typed arrow, not the ternary separator.
+        // After parsing the consequent as a parenthesized expression and seeing `:`,
+        // speculatively try `: Type => body` to see if it forms a typed arrow.
+        // If successful, the arrow becomes the consequent; the next `:` is the ternary separator.
+        if (self.current() == .colon and !consequent.isNone()) {
+            const cons_node = self.ast.getNode(consequent);
+            if (cons_node.tag == .parenthesized_expression) {
+                if (try tryReinterpretAsTypedArrow(self, consequent)) |arrow| {
+                    consequent = arrow;
+                }
+            }
+        }
+
         try self.expect(.colon);
         const alternate = try parseAssignmentExpression(self);
         return try self.ast.addNode(.{
@@ -465,6 +500,59 @@ fn parseConditionalExpression(self: *Parser) ParseError2!NodeIndex {
     }
 
     return expr;
+}
+
+/// Speculatively try to reinterpret a parenthesized expression followed by `: Type =>`
+/// as a typed arrow function. Used in ternary consequent position where `:` is ambiguous
+/// between return type annotation and ternary separator.
+/// Returns the arrow node on success, null on failure (state fully restored).
+fn tryReinterpretAsTypedArrow(self: *Parser, paren_expr: NodeIndex) ParseError2!?NodeIndex {
+    const saved = self.saveState();
+    const errors_before = self.errors.items.len;
+
+    // Consume `:` (speculatively — might be return type or ternary separator)
+    try self.advance(); // skip :
+
+    // Parse the return type. Use disallow_conditional_types to prevent the type
+    // parser from consuming `?` that belongs to an outer ternary.
+    const ctx_saved = self.ctx;
+    self.ctx.disallow_conditional_types = true;
+    const type_node = try self.parseType();
+    _ = type_node;
+    self.ctx = ctx_saved;
+
+    // Check for `=>` — if present, this is a typed arrow function
+    if (self.current() != .arrow or self.scanner.token.has_newline_before) {
+        // Not a typed arrow — restore and let the caller treat `:` as ternary separator
+        self.errors.shrinkRetainingCapacity(errors_before);
+        self.restoreState(saved);
+        return null;
+    }
+
+    // Confirmed typed arrow! Determine params from the parenthesized expression.
+    const paren_node = self.ast.getNode(paren_expr);
+    const arrow_start = paren_node.span.start;
+
+    // Empty parens `()` are stored with data.none = 0 (no inner expression).
+    // Non-empty parens `(expr)` store data.unary.operand = inner expression node index.
+    // data.none reads the same bytes as unary.operand via extern union — 0 means empty
+    // because node index 0 is always the program root, never a valid sub-expression.
+    const is_empty_paren = (paren_node.data.none == 0);
+    const params: NodeIndex = if (is_empty_paren) .none else paren_expr;
+
+    if (!is_empty_paren) {
+        try self.coverExpressionToArrowParams(paren_expr);
+    }
+
+    try self.advance(); // skip =>
+    const body = try parseArrowBody(self, false, params);
+
+    const ae = try self.ast.addExtras(&.{ @intFromEnum(params), @intFromEnum(body), 0 });
+    return try self.ast.addNode(.{
+        .tag = .arrow_function_expression,
+        .span = .{ .start = arrow_start, .end = self.currentSpan().start },
+        .data = .{ .extra = ae },
+    });
 }
 
 /// 이항 연산자를 precedence climbing으로 파싱.

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -156,6 +156,10 @@ pub const Parser = struct {
     /// if/with/labeled body에서 labelled function statement 금지 체크 중인지.
     /// IsLabelledFunction(Statement) is true → SyntaxError
     in_labelled_fn_check: bool = false,
+    /// ternary의 consequent 파싱 중인지.
+    /// true이면 `(identifier) :` 패턴을 typed arrow로 해석하지 않는다 — `:` 가
+    /// ternary separator일 수 있기 때문. `(identifier: Type)` 등 확실한 패턴은 여전히 허용.
+    in_ternary_consequent: bool = false,
 
     // ================================================================
     // Context packed struct 정의
@@ -216,6 +220,7 @@ pub const Parser = struct {
         allow_super_call: bool,
         allow_super_property: bool,
         in_formal_parameters: bool,
+        in_ternary_consequent: bool,
     };
 
     pub fn init(allocator: std.mem.Allocator, scanner: *Scanner) Parser {
@@ -1213,6 +1218,7 @@ pub const Parser = struct {
             .allow_super_call = self.allow_super_call,
             .allow_super_property = self.allow_super_property,
             .in_formal_parameters = self.in_formal_parameters,
+            .in_ternary_consequent = self.in_ternary_consequent,
         };
         self.ctx = self.ctx.enterFunction(is_async, is_generator);
         // Parser 필드 리셋 — 함수 경계에서 초기 상태로
@@ -1226,6 +1232,7 @@ pub const Parser = struct {
         self.in_static_initializer = false;
         self.allow_new_target = true; // 일반 함수에서는 new.target 허용
         self.in_formal_parameters = false;
+        self.in_ternary_consequent = false; // 함수 본문은 새로운 expression 컨텍스트
         return saved;
     }
 
@@ -1243,6 +1250,7 @@ pub const Parser = struct {
         self.allow_super_call = saved.allow_super_call;
         self.allow_super_property = saved.allow_super_property;
         self.in_formal_parameters = saved.in_formal_parameters;
+        self.in_ternary_consequent = saved.in_ternary_consequent;
     }
 
     /// Context(u8)를 복원한다 (enterAllowInContext 등과 쌍).
@@ -1891,7 +1899,9 @@ pub const Parser = struct {
         if (self.current() == .r_paren) {
             try self.advance();
             // ): 이면 typed arrow (리턴 타입 어노테이션)
-            return self.current() == .colon;
+            // ternary consequent 안에서는 `:` 가 ternary separator일 수 있으므로 여기서 판단하지 않는다.
+            // parseConditionalExpression의 speculative reinterpret에서 처리한다.
+            return self.current() == .colon and !self.in_ternary_consequent;
         }
 
         // (...rest: Type) => ... — rest parameter with type
@@ -1903,9 +1913,10 @@ pub const Parser = struct {
             try self.advance(); // skip identifier
             if (self.current() == .colon) return true;
             // (a): Type => ... — 단일 파라미터 + 리턴 타입
+            // ternary consequent 안에서는 `:` 가 ternary separator일 수 있으므로 여기서 판단하지 않는다.
             if (self.current() == .r_paren) {
                 try self.advance();
-                return self.current() == .colon;
+                return self.current() == .colon and !self.in_ternary_consequent;
             }
             // (a?: Type) — optional parameter
             if (self.current() == .question) return true;

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -788,12 +788,19 @@ fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) ParseError2!v
     // BindingPattern (array/object destructuring)은 Annex B에서도 항상 금지
     const is_var = kind_flags == 0;
     const is_for_in = self.current() == .kw_in;
-    if (is_for_in and is_var and !self.is_strict_mode) {
-        // BindingIdentifier인지 확인 — destructuring이면 허용 불가
-        const binding_name: NodeIndex = @enumFromInt(extras[decl_node.data.extra]);
-        if (!binding_name.isNone()) {
-            const binding_node = self.ast.getNode(binding_name);
-            if (binding_node.tag == .binding_identifier) return; // Annex B.3.5 허용
+    if (is_for_in and is_var) {
+        // TS 모드에서는 for-in var initializer를 허용 (esbuild 호환).
+        // TS에서 `for (var x = Array<number> in y)` 같은 패턴에서 타입 인자가
+        // 스트리핑되어 initializer가 남을 수 있다. codegen에서 hoisting 처리.
+        if (self.is_ts) return;
+
+        if (!self.is_strict_mode) {
+            // BindingIdentifier인지 확인 — destructuring이면 허용 불가
+            const binding_name: NodeIndex = @enumFromInt(extras[decl_node.data.extra]);
+            if (!binding_name.isNone()) {
+                const binding_node = self.ast.getNode(binding_name);
+                if (binding_node.tag == .binding_identifier) return; // Annex B.3.5 허용
+            }
         }
     }
     try self.addError(decl_node.span, "For-in/for-of loop variable declaration may not have an initializer");

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -1178,7 +1178,36 @@ fn tryParseFunctionTypeWithBacktracking(self: *Parser, start: u32) ParseError2!?
     }
 
     // 함수 타입 파라미터 패턴 (identifier:, identifier?, this:, [...], {...})
-    if (isFunctionTypeParam(self)) {
+    // identifier:/identifier? 와 this:/this? 는 모호성 없이 함수 타입 파라미터 확정.
+    // [...] 과 {...} 는 괄호 타입 내부의 튜플/오브젝트 타입일 수도 있으므로
+    // backtracking으로 시도해야 한다.
+    // 예: ({y: z}) — 괄호로 감싼 오브젝트 타입 (함수 파라미터가 아님)
+    //     ({y}: T) => R — destructuring 함수 파라미터
+    if (self.current() == .l_bracket or self.current() == .l_curly) {
+        // 모호한 경우: backtracking으로 함수 타입 시도.
+        // parseFunctionTypeParams 내부의 expect(.arrow)가 에러를 추가하고 계속
+        // 진행하므로, 에러 카운트로 성공/실패를 판단한다.
+        const inner_saved = self.saveState();
+        const inner_nodes = self.ast.nodes.items.len;
+        const inner_extras = self.ast.extra_data.items.len;
+        const inner_errors = self.errors.items.len;
+        const result = try parseFunctionTypeParams(self, start);
+        if (self.errors.items.len > inner_errors) {
+            // 에러 발생 — 함수 타입이 아님, 복원하여 괄호 타입으로 폴백
+            self.ast.nodes.items.len = inner_nodes;
+            self.ast.extra_data.items.len = inner_extras;
+            self.errors.shrinkRetainingCapacity(inner_errors);
+            self.restoreState(inner_saved);
+            // 외부 saved로도 복원
+            self.ast.nodes.items.len = nodes_before;
+            self.ast.extra_data.items.len = extras_before;
+            self.errors.shrinkRetainingCapacity(errors_before);
+            self.restoreState(saved);
+            return null;
+        }
+        return result;
+    } else if (isFunctionTypeParam(self)) {
+        // identifier:/identifier? 또는 this:/this? — 모호성 없음, 함수 타입 확정
         const result = try parseFunctionTypeParams(self, start);
         return result;
     }


### PR DESCRIPTION
## Summary
- ternary + typed arrow 백트래킹: `a ? (b=c) : T => d : (e=f)` 5가지 패턴 (5건)
- return type `({y: z})` 파싱 — function type param 백트래킹 분기 (2건)  
- `for (var x = Array<number> in y)` — for-in var init 호이스트 (3건 → codegen)

## Results
- 적합성 에러 10→3건 (-7), Pass 818→820 (+2), 적합성 73.7%→73.9%
- Unit 전체 통과

## Test plan
- [x] `zig build test` 전체 통과
- [x] `x = a ? (b=c) : T => d : (e=f)` → `x = a ? (b = c) => d : e = f;`
- [x] `x = a ? b - (c) : d => e` → `x = a ? b - c : (d) => e;`
- [x] `let x: () => {} | ({y: z});` → `let x;`
- [x] `for (var x = Array<number> in y);` → `x = Array;\nfor (var x in y);`

🤖 Generated with [Claude Code](https://claude.com/claude-code)