### PR TITLE
fix(codegen): namespace export 초기값 없으면 스킵

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2553,16 +2553,15 @@ pub const Codegen = struct {
             const d_extras = self.ast.extra_data.items[de .. de + 3];
             const name_idx: NodeIndex = @enumFromInt(d_extras[0]);
             const init_idx: NodeIndex = @enumFromInt(d_extras[2]);
+            // init이 없으면 할당할 값이 없으므로 스킵 (esbuild 호환)
+            if (init_idx.isNone()) continue;
             const var_name_node = self.ast.getNode(name_idx);
             const var_name = self.ast.getText(var_name_node.span);
-            // ns.prop = init; (init 없으면 ns.prop = void 0; — undefined 초기화)
             try self.write(ns_name);
             try self.writeByte('.');
             try self.write(var_name);
-            if (!init_idx.isNone()) {
-                try self.writeByte('=');
-                try self.emitNode(init_idx);
-            }
+            try self.writeByte('=');
+            try self.emitNode(init_idx);
             try self.writeByte(';');
         }
     }


### PR DESCRIPTION
## Summary
- `namespace Foo { export let x }` → `ns.x;` 의미 없는 출력 제거
- 초기값 없는 namespace export는 할당할 게 없으므로 스킵 (esbuild 호환)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `namespace Foo { export let x } export let x` → 빈 IIFE body

🤖 Generated with [Claude Code](https://claude.com/claude-code)