### PR TITLE
docs: ES 다운레벨링 TC39 스펙 링크 추가

### DIFF
--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -3,6 +3,16 @@
 //! --target < es2020 일 때 활성화.
 //! ?? → a != null ? a : b
 //! ?. → a == null ? void 0 : a.b
+//!
+//! 스펙:
+//! - ?? : https://tc39.es/ecma262/#sec-nullish-coalescing-operator (ES2020, TC39 Stage 4: 2020-01)
+//!         https://github.com/tc39/proposal-nullish-coalescing
+//! - ?. : https://tc39.es/ecma262/#sec-optional-chains (ES2020, TC39 Stage 4: 2020-01)
+//!         https://github.com/tc39/proposal-optional-chaining
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower.go (lowerNullishCoalescing, lowerOptionalChain)
+//! - oxc: crates/oxc_transformer/src/es2020/
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");

--- a/src/transformer/es2021.zig
+++ b/src/transformer/es2021.zig
@@ -4,6 +4,14 @@
 //! ??= → a ?? (a = b) (또는 target < es2020이면 a != null ? a : (a = b))
 //! ||= → a || (a = b)
 //! &&= → a && (a = b)
+//!
+//! 스펙:
+//! - ??= / ||= / &&= : https://tc39.es/ecma262/#sec-assignment-operators (ES2021, TC39 Stage 4: 2020-07)
+//!                      https://github.com/tc39/proposal-logical-assignment
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower.go (lowerAssign)
+//! - oxc: crates/oxc_transformer/src/es2021/
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -1,6 +1,10 @@
 //! ES 다운레벨링 공통 헬퍼
 //!
 //! 임시 변수 생성, void 0, null 비교 등 여러 ES 버전 변환에서 공유하는 유틸리티.
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower_class.go (privateTempRef 패턴)
+//! - `== null` vs `=== null`: JS에서 `x == null`은 null과 undefined 모두 체크 (loose equality)
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");


### PR DESCRIPTION
## Summary
각 ES 다운레벨링 파일 상단에 TC39 스펙 문서 링크 추가:
- es2020.zig: proposal-nullish-coalescing, proposal-optional-chaining
- es2021.zig: proposal-logical-assignment
- es_helpers.zig: == null 동작 설명

🤖 Generated with [Claude Code](https://claude.com/claude-code)