### PR TITLE
feat: ES2016 다운레벨링 — ** → Math.pow

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3505,3 +3505,35 @@ test "ES2021: ||= no transform on es2021" {
     defer r.deinit();
     try std.testing.expectEqualStrings("a||=b;", r.output);
 }
+
+// --- ** (exponentiation) ---
+
+test "ES2016: ** to Math.pow" {
+    var r = try e2eTarget(std.testing.allocator, "const x = a ** b;", .es2015);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const x=Math.pow(a,b);", r.output);
+}
+
+test "ES2016: **= to Math.pow assignment" {
+    var r = try e2eTarget(std.testing.allocator, "a **= b;", .es2015);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("a=Math.pow(a,b);", r.output);
+}
+
+test "ES2016: ** no transform on es2016" {
+    var r = try e2eTarget(std.testing.allocator, "const x = a ** b;", .es2016);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const x=a**b;", r.output);
+}
+
+test "ES2016: ** no transform on esnext" {
+    var r = try e2eTarget(std.testing.allocator, "const x = a ** b;", .esnext);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const x=a**b;", r.output);
+}
+
+test "ES2016: **= no transform on es2016" {
+    var r = try e2eTarget(std.testing.allocator, "a **= b;", .es2016);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("a**=b;", r.output);
+}

--- a/src/transformer/es2016.zig
+++ b/src/transformer/es2016.zig
@@ -1,0 +1,96 @@
+//! ES2016 다운레벨링: ** (exponentiation operator)
+//!
+//! --target < es2016 일 때 활성화.
+//! a ** b    → Math.pow(a, b)
+//! a **= b   → a = Math.pow(a, b)
+//!
+//! 스펙:
+//! - ** : https://tc39.es/ecma262/#sec-exp-operator (ES2016, TC39 Stage 4)
+//!         https://github.com/tc39/proposal-exponentiation-operator
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower.go (lowerExponentiationOperator)
+//! - oxc: crates/oxc_transformer/src/es2016/
+
+const std = @import("std");
+const ast_mod = @import("../parser/ast.zig");
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const token_mod = @import("../lexer/token.zig");
+const Span = token_mod.Span;
+
+pub fn ES2016(comptime Transformer: type) type {
+    return struct {
+        /// `a ** b` → `Math.pow(a, b)`
+        pub fn lowerExponentiation(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const new_left = try self.visitNode(node.data.binary.left);
+            const new_right = try self.visitNode(node.data.binary.right);
+
+            return buildMathPowCall(self, node.span, new_left, new_right);
+        }
+
+        /// `a **= b` → `a = Math.pow(a, b)`
+        pub fn lowerExponentiationAssignment(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const new_left = try self.visitNode(node.data.binary.left);
+            const new_right = try self.visitNode(node.data.binary.right);
+
+            // Math.pow(a, b) — left를 복사해서 callee의 인자로 사용
+            const left_copy = try self.new_ast.addNode(self.new_ast.getNode(new_left));
+            const pow_call = try buildMathPowCall(self, node.span, left_copy, new_right);
+
+            // a = Math.pow(a, b)
+            return self.new_ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = node.span,
+                .data = .{ .binary = .{
+                    .left = new_left,
+                    .right = pow_call,
+                    .flags = @intFromEnum(token_mod.Kind.eq),
+                } },
+            });
+        }
+
+        /// Math.pow(left, right) 호출 노드를 생성.
+        fn buildMathPowCall(self: *Transformer, span: Span, left: NodeIndex, right: NodeIndex) Transformer.Error!NodeIndex {
+            // "Math" 식별자
+            const math_span = try self.new_ast.addString("Math");
+            const math_node = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = math_span,
+                .data = .{ .string_ref = math_span },
+            });
+
+            // "pow" 식별자
+            const pow_span = try self.new_ast.addString("pow");
+            const pow_node = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = pow_span,
+                .data = .{ .string_ref = pow_span },
+            });
+
+            // Math.pow (static member expression) — extra = [object, property, flags]
+            const member_extra = try self.new_ast.addExtras(&.{ @intFromEnum(math_node), @intFromEnum(pow_node), 0 });
+            const callee = try self.new_ast.addNode(.{
+                .tag = .static_member_expression,
+                .span = span,
+                .data = .{ .extra = member_extra },
+            });
+
+            // 인자 리스트: (left, right)
+            const args = try self.new_ast.addNodeList(&.{ left, right });
+
+            // call_expression: extra = [callee, args_start, args_len, flags]
+            const call_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(callee),
+                args.start,
+                args.len,
+                0,
+            });
+            return self.new_ast.addNode(.{
+                .tag = .call_expression,
+                .span = span,
+                .data = .{ .extra = call_extra },
+            });
+        }
+    };
+}

--- a/src/transformer/mod.zig
+++ b/src/transformer/mod.zig
@@ -18,12 +18,14 @@ pub const DefineEntry = transformer.DefineEntry;
 pub const TransformOptions = transformer.TransformOptions;
 
 /// ES 다운레벨링 모듈 (절충안 구조: 파일 분리 + 단일 패스)
+pub const es2016 = @import("es2016.zig");
 pub const es2020 = @import("es2020.zig");
 pub const es2021 = @import("es2021.zig");
 pub const es_helpers = @import("es_helpers.zig");
 
 test {
     _ = transformer;
+    _ = es2016;
     _ = es2020;
     _ = es2021;
     _ = es_helpers;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -23,6 +23,7 @@ const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const es2016 = @import("es2016.zig");
 const es2020 = @import("es2020.zig");
 const es2021 = @import("es2021.zig");
 const es_helpers = @import("es_helpers.zig");
@@ -70,6 +71,10 @@ pub const TransformOptions = struct {
         es2024,
         esnext,
 
+        /// 해당 타겟에서 exponentiation operator (**) 변환이 필요한지
+        pub fn needsExponentiation(self: Target) bool {
+            return @intFromEnum(self) < @intFromEnum(Target.es2016);
+        }
         /// 해당 타겟에서 nullish coalescing (??) 변환이 필요한지
         pub fn needsNullishCoalescing(self: Target) bool {
             return @intFromEnum(self) < @intFromEnum(Target.es2020);
@@ -328,6 +333,13 @@ pub const Transformer = struct {
             .binary_expression,
             .logical_expression,
             => {
+                // ES 다운레벨링: ** → Math.pow (target < es2016)
+                if (self.options.target.needsExponentiation() and node.tag == .binary_expression) {
+                    const op: token_mod.Kind = @enumFromInt(node.data.binary.flags);
+                    if (op == .star2) {
+                        return es2016.ES2016(Transformer).lowerExponentiation(self, node);
+                    }
+                }
                 // ES 다운레벨링: ?? → ternary
                 if (self.options.target.needsNullishCoalescing() and node.tag == .logical_expression) {
                     const op: token_mod.Kind = @enumFromInt(node.data.binary.flags);
@@ -338,6 +350,13 @@ pub const Transformer = struct {
                 return self.visitBinaryNode(node);
             },
             .assignment_expression => {
+                // ES 다운레벨링: **= → a = Math.pow(a, b) (es2016)
+                if (self.options.target.needsExponentiation()) {
+                    const op: token_mod.Kind = @enumFromInt(node.data.binary.flags);
+                    if (op == .star2_eq) {
+                        return es2016.ES2016(Transformer).lowerExponentiationAssignment(self, node);
+                    }
+                }
                 // ES 다운레벨링: ??=, ||=, &&= (es2021)
                 if (self.options.target.needsLogicalAssignment()) {
                     const op: token_mod.Kind = @enumFromInt(node.data.binary.flags);


### PR DESCRIPTION
## Summary
- `a ** b` → `Math.pow(a, b)` (target < es2016)
- `a **= b` → `a = Math.pow(a, b)`
- es2016.zig + TC39 스펙 링크 + 유닛 테스트 4개

## Test plan
- [x] `zig build test` 전체 통과
- [x] `a ** b` → `Math.pow(a, b)` (es2015 타겟)
- [x] esnext/es2016 → 변환 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)