### PR TITLE
feat: ES2022 다운레벨링 — class static block → IIFE

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3537,3 +3537,36 @@ test "ES2016: **= no transform on es2016" {
     defer r.deinit();
     try std.testing.expectEqualStrings("a**=b;", r.output);
 }
+
+// --- ES2022: class static block ---
+
+test "ES2022: static block to IIFE" {
+    var r = try e2eTarget(std.testing.allocator, "class Foo { static { console.log(\"init\"); } }", .es2021);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("class Foo{}(()=>{console.log(\"init\");})();", r.output);
+}
+
+test "ES2022: static block no transform on es2022" {
+    // static_block은 writeNodeSpan으로 소스를 그대로 복사하므로 공백이 유지됨
+    var r = try e2eTarget(std.testing.allocator, "class Foo{static{console.log(\"init\")}}", .es2022);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("class Foo{static{console.log(\"init\")}}", r.output);
+}
+
+test "ES2022: static block no transform on esnext" {
+    var r = try e2eTarget(std.testing.allocator, "class Foo{static{console.log(\"init\")}}", .esnext);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("class Foo{static{console.log(\"init\")}}", r.output);
+}
+
+test "ES2022: multiple static blocks" {
+    var r = try e2eTarget(std.testing.allocator, "class Foo { static { a(); } method() {} static { b(); } }", .es2021);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("class Foo{method(){}}(()=>{a();})();(()=>{b();})();", r.output);
+}
+
+test "ES2022: static block with methods preserved" {
+    var r = try e2eTarget(std.testing.allocator, "class Foo { method() { return 1; } static { init(); } }", .es2021);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("class Foo{method(){return 1;}}(()=>{init();})();", r.output);
+}

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -1,0 +1,158 @@
+//! ES2022 다운레벨링: class static block
+//!
+//! --target < es2022 일 때 활성화.
+//! class Foo { static { console.log("init"); } }
+//! → class Foo {} (() => { console.log("init"); })();
+//!
+//! 제한사항: static block 내부의 `this` (클래스 자체 참조)는 아직 클래스 이름으로
+//! 치환하지 않음. `this.x = 1` 같은 패턴이 있으면 런타임에 잘못된 `this`를 참조.
+//! TODO: body 순회하여 this_expression → ClassName 참조로 교체 (esbuild 방식)
+//!
+//! 스펙:
+//! - class static block: https://tc39.es/ecma262/#sec-static-blocks (ES2022, TC39 Stage 4)
+//!                        https://github.com/tc39/proposal-class-static-block
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower_class.go (lowerAllStaticFields)
+//! - oxc: crates/oxc_transformer/src/es2022/
+
+const std = @import("std");
+const ast_mod = @import("../parser/ast.zig");
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const NodeList = ast_mod.NodeList;
+const Tag = Node.Tag;
+const token_mod = @import("../lexer/token.zig");
+const Span = token_mod.Span;
+
+pub fn ES2022(comptime Transformer: type) type {
+    return struct {
+        /// 클래스 바디에서 static block을 제거하고, IIFE로 변환하여 pending_nodes에 추가한다.
+        /// 반환값: static block이 있었으면 true, 없었으면 false.
+        ///
+        /// 동작:
+        ///   1. 원본 class_body의 멤버를 순회
+        ///   2. static_block이 아닌 멤버 → 그대로 방문하여 새 body에 추가
+        ///   3. static_block → body에서 제거하고 IIFE로 변환, static_blocks에 수집
+        ///   4. 호출자가 class 노드를 pending_nodes에 넣고, static_blocks의 IIFE를 그 뒤에 추가
+        pub fn lowerStaticBlocks(
+            self: *Transformer,
+            body_idx: NodeIndex,
+            new_body_out: *NodeIndex,
+            static_block_iifes: *std.ArrayList(NodeIndex),
+        ) Transformer.Error!bool {
+            const body_node = self.old_ast.getNode(body_idx);
+            const body_members = self.old_ast.extra_data.items[body_node.data.list.start .. body_node.data.list.start + body_node.data.list.len];
+
+            // 먼저 static block이 있는지 빠르게 확인
+            var has_static_block = false;
+            for (body_members) |raw_idx| {
+                const member = self.old_ast.getNode(@enumFromInt(raw_idx));
+                if (member.tag == .static_block) {
+                    has_static_block = true;
+                    break;
+                }
+            }
+
+            if (!has_static_block) return false;
+
+            // static block이 있으면: 멤버를 분류하여 새 body를 생성
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+            // pending_nodes save/restore: 중첩 호출에 안전
+            const pending_top = self.pending_nodes.items.len;
+            defer self.pending_nodes.shrinkRetainingCapacity(pending_top);
+
+            for (body_members) |raw_idx| {
+                const member = self.old_ast.getNode(@enumFromInt(raw_idx));
+                if (member.tag == .static_block) {
+                    // static block → IIFE로 변환
+                    const iife = try buildStaticBlockIIFE(self, member);
+                    try static_block_iifes.append(self.allocator, iife);
+                } else {
+                    // 일반 멤버 → 그대로 방문
+                    const new_member = try self.visitNode(@enumFromInt(raw_idx));
+
+                    // pending_nodes 드레인
+                    if (self.pending_nodes.items.len > pending_top) {
+                        try self.scratch.appendSlice(self.allocator, self.pending_nodes.items[pending_top..]);
+                        self.pending_nodes.shrinkRetainingCapacity(pending_top);
+                    }
+
+                    if (!new_member.isNone()) {
+                        try self.scratch.append(self.allocator, new_member);
+                    }
+                }
+            }
+
+            // 새 class_body 노드 생성
+            const new_list = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+            new_body_out.* = try self.new_ast.addNode(.{
+                .tag = .class_body,
+                .span = body_node.span,
+                .data = .{ .list = new_list },
+            });
+
+            return true;
+        }
+
+        /// static block의 body를 IIFE `(() => { ...body... })()`로 변환.
+        /// static block: unary node, operand = block_statement (function_body)
+        pub fn buildStaticBlockIIFE(self: *Transformer, static_block_node: Node) Transformer.Error!NodeIndex {
+            // static block의 body를 방문
+            const new_body = try self.visitNode(static_block_node.data.unary.operand);
+
+            const span = static_block_node.span;
+
+            // 빈 formal_parameters 노드 생성
+            const empty_params_list = try self.new_ast.addNodeList(&.{});
+            const params = try self.new_ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = empty_params_list },
+            });
+
+            // arrow_function_expression: extra = [params, body, flags]
+            // flags = 0 (non-async)
+            const arrow_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(params),
+                @intFromEnum(new_body),
+                0, // flags
+            });
+            const arrow = try self.new_ast.addNode(.{
+                .tag = .arrow_function_expression,
+                .span = span,
+                .data = .{ .extra = arrow_extra },
+            });
+
+            // 괄호로 감싸기: (arrow)
+            const paren_arrow = try self.new_ast.addNode(.{
+                .tag = .parenthesized_expression,
+                .span = span,
+                .data = .{ .unary = .{ .operand = arrow, .flags = 0 } },
+            });
+
+            // call_expression: extra = [callee, args_start, args_len, flags]
+            const empty_args = try self.new_ast.addNodeList(&.{});
+            const call = try self.new_ast.addExtras(&.{
+                @intFromEnum(paren_arrow),
+                empty_args.start,
+                empty_args.len,
+                0, // flags
+            });
+            const call_node = try self.new_ast.addNode(.{
+                .tag = .call_expression,
+                .span = span,
+                .data = .{ .extra = call },
+            });
+
+            // expression_statement로 감싸기
+            return self.new_ast.addNode(.{
+                .tag = .expression_statement,
+                .span = span,
+                .data = .{ .unary = .{ .operand = call_node, .flags = 0 } },
+            });
+        }
+    };
+}

--- a/src/transformer/mod.zig
+++ b/src/transformer/mod.zig
@@ -21,6 +21,7 @@ pub const TransformOptions = transformer.TransformOptions;
 pub const es2016 = @import("es2016.zig");
 pub const es2020 = @import("es2020.zig");
 pub const es2021 = @import("es2021.zig");
+pub const es2022 = @import("es2022.zig");
 pub const es_helpers = @import("es_helpers.zig");
 
 test {
@@ -28,5 +29,6 @@ test {
     _ = es2016;
     _ = es2020;
     _ = es2021;
+    _ = es2022;
     _ = es_helpers;
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -26,6 +26,7 @@ const Span = token_mod.Span;
 const es2016 = @import("es2016.zig");
 const es2020 = @import("es2020.zig");
 const es2021 = @import("es2021.zig");
+const es2022 = @import("es2022.zig");
 const es_helpers = @import("es_helpers.zig");
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 
@@ -86,6 +87,10 @@ pub const TransformOptions = struct {
         /// 해당 타겟에서 logical assignment (??=, ||=, &&=) 변환이 필요한지
         pub fn needsLogicalAssignment(self: Target) bool {
             return @intFromEnum(self) < @intFromEnum(Target.es2021);
+        }
+        /// 해당 타겟에서 class static block 변환이 필요한지
+        pub fn needsClassStaticBlock(self: Target) bool {
+            return @intFromEnum(self) < @intFromEnum(Target.es2022);
         }
     };
 };
@@ -1122,6 +1127,38 @@ pub const Transformer = struct {
         if (self.options.use_define_for_class_fields and !self.options.experimental_decorators) {
             const new_name = try self.visitNode(self.readNodeIdx(e, 0));
             const new_super = try self.visitNode(self.readNodeIdx(e, 1));
+
+            // ES2022 다운레벨링: static block → IIFE (target < es2022)
+            if (self.options.target.needsClassStaticBlock()) {
+                var new_body: NodeIndex = .none;
+                var static_block_iifes: std.ArrayList(NodeIndex) = .empty;
+                defer static_block_iifes.deinit(self.allocator);
+
+                const had_static_blocks = try es2022.ES2022(Transformer).lowerStaticBlocks(
+                    self,
+                    self.readNodeIdx(e, 2),
+                    &new_body,
+                    &static_block_iifes,
+                );
+
+                if (had_static_blocks) {
+                    const new_decos = try self.visitExtraList(self.readU32(e, 6), self.readU32(e, 7));
+                    const none = @intFromEnum(NodeIndex.none);
+                    const class_result = try self.addExtraNode(node.tag, node.span, &.{
+                        @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
+                        none,                   0,                       0,
+                        new_decos.start,        new_decos.len,
+                    });
+
+                    // class 노드를 pending_nodes에 넣고, static block IIFE를 그 뒤에 추가
+                    try self.pending_nodes.append(self.allocator, class_result);
+                    for (static_block_iifes.items) |iife| {
+                        try self.pending_nodes.append(self.allocator, iife);
+                    }
+                    return .none;
+                }
+            }
+
             const new_body = try self.visitNode(self.readNodeIdx(e, 2));
             const new_decos = try self.visitExtraList(self.readU32(e, 6), self.readU32(e, 7));
             const none = @intFromEnum(NodeIndex.none);
@@ -1173,12 +1210,17 @@ pub const Transformer = struct {
         var existing_constructor: ?NodeIndex = null;
         var existing_constructor_pos: ?usize = null;
 
+        // ES2022 다운레벨링: static block → IIFE (target < es2022)
+        var static_block_iifes: std.ArrayList(NodeIndex) = .empty;
+        defer static_block_iifes.deinit(self.allocator);
+
         var ctx = ClassMemberContext{
             .class_members = &class_members,
             .field_assignments = &field_assignments,
             .member_decorators = &member_decorators,
             .existing_constructor = &existing_constructor,
             .existing_constructor_pos = &existing_constructor_pos,
+            .static_block_iifes = if (self.options.target.needsClassStaticBlock()) &static_block_iifes else null,
         };
         for (body_members) |raw_idx| {
             try self.classifyClassMember(raw_idx, &ctx);
@@ -1288,6 +1330,7 @@ pub const Transformer = struct {
                     old_deco_start,
                     old_deco_len,
                     member_decorators.items,
+                    static_block_iifes.items,
                 );
             }
         }
@@ -1299,6 +1342,21 @@ pub const Transformer = struct {
             NodeList{ .start = 0, .len = 0 };
 
         const none = @intFromEnum(NodeIndex.none);
+
+        // ES2022: static block이 있으면 class를 pending에 넣고 IIFE를 뒤에 추가
+        if (static_block_iifes.items.len > 0) {
+            const class_result = try self.addExtraNode(node.tag, node.span, &.{
+                @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
+                none,                   0,                       0,
+                new_decos.start,        new_decos.len,
+            });
+            try self.pending_nodes.append(self.allocator, class_result);
+            for (static_block_iifes.items) |iife| {
+                try self.pending_nodes.append(self.allocator, iife);
+            }
+            return .none;
+        }
+
         return self.addExtraNode(node.tag, node.span, &.{
             @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
             none,                   0,                       0,
@@ -1318,6 +1376,8 @@ pub const Transformer = struct {
         member_decorators: *std.ArrayList(MemberDecoratorInfo),
         existing_constructor: *?NodeIndex,
         existing_constructor_pos: *?usize,
+        /// ES2022 다운레벨링: static block → IIFE (target < es2022 일 때 사용)
+        static_block_iifes: ?*std.ArrayList(NodeIndex) = null,
     };
 
     fn classifyClassMember(
@@ -1336,6 +1396,13 @@ pub const Transformer = struct {
         // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
         if (member.tag == .method_definition) {
             try self.classifyMethodDefinition(member, ctx.class_members, ctx.member_decorators, ctx.existing_constructor, ctx.existing_constructor_pos);
+            return;
+        }
+
+        // ES2022 다운레벨링: static block → IIFE (target < es2022)
+        if (member.tag == .static_block and ctx.static_block_iifes != null) {
+            const iife = try es2022.ES2022(Transformer).buildStaticBlockIIFE(self, member);
+            try ctx.static_block_iifes.?.append(self.allocator, iife);
             return;
         }
 
@@ -1772,6 +1839,7 @@ pub const Transformer = struct {
         old_deco_start: u32,
         old_deco_len: u32,
         member_decos: []const MemberDecoratorInfo,
+        static_block_iifes: []const NodeIndex,
     ) Error!NodeIndex {
         const none = @intFromEnum(NodeIndex.none);
         const decorate_span = try self.new_ast.addString("__decorateClass");
@@ -1823,6 +1891,11 @@ pub const Transformer = struct {
             const class_deco_stmt = try self.buildDecorateClassCall(decorate_span, name_span, old_deco_start, old_deco_len);
             try self.pending_nodes.append(self.allocator, class_deco_stmt);
 
+            // ES2022: static block IIFE를 decorator 호출 뒤에 추가
+            for (static_block_iifes) |iife| {
+                try self.pending_nodes.append(self.allocator, iife);
+            }
+
             // visitClass의 반환값은 .none (let 선언 + decorator 호출이 pending_nodes에 있음)
             return .none;
         }
@@ -1847,10 +1920,29 @@ pub const Transformer = struct {
                 try self.pending_nodes.append(self.allocator, call_stmt);
             }
 
+            // ES2022: static block IIFE를 decorator 호출 뒤에 추가
+            for (static_block_iifes) |iife| {
+                try self.pending_nodes.append(self.allocator, iife);
+            }
+
             return .none;
         }
 
         // decorator가 없는 경우
+        // ES2022: static block이 있으면 class를 pending에 넣고 IIFE를 뒤에 추가
+        if (static_block_iifes.len > 0) {
+            const class_result = try self.addExtraNode(node.tag, node.span, &.{
+                @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
+                none,                   0,                       0,
+                empty_list.start,       empty_list.len,
+            });
+            try self.pending_nodes.append(self.allocator, class_result);
+            for (static_block_iifes) |iife| {
+                try self.pending_nodes.append(self.allocator, iife);
+            }
+            return .none;
+        }
+
         return self.addExtraNode(node.tag, node.span, &.{
             @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
             none,                   0,                       0,


### PR DESCRIPTION
## Summary
- `static { ... }` → `(() => { ... })()` (target < es2022)
- fast path + slow path (assign semantics, decorators) 모두 지원
- es2022.zig + 유닛 테스트 5개

## Test plan
- [x] `zig build test` 전체 통과
- [x] static block → IIFE (es2021 타겟)
- [x] esnext/es2022 → 변환 없음
- [x] 복수 static block, 메서드 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)