### PR TITLE
feat: ES 다운레벨링 전체 파일 구조 + ES2019 optional catch binding

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3538,6 +3538,26 @@ test "ES2016: **= no transform on es2016" {
     try std.testing.expectEqualStrings("a**=b;", r.output);
 }
 
+// --- catch binding (ES2019) ---
+
+test "ES2019: optional catch binding" {
+    var r = try e2eTarget(std.testing.allocator, "try { x; } catch { y; }", .es2018);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("try{x;}catch(_unused){y;}", r.output);
+}
+
+test "ES2019: catch with binding preserved" {
+    var r = try e2eTarget(std.testing.allocator, "try { x; } catch (e) { y; }", .es2018);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("try{x;}catch(e){y;}", r.output);
+}
+
+test "ES2019: optional catch no transform on es2019" {
+    var r = try e2eTarget(std.testing.allocator, "try { x; } catch { y; }", .es2019);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("try{x;}catch{y;}", r.output);
+}
+
 // --- ES2022: class static block ---
 
 test "ES2022: static block to IIFE" {

--- a/src/transformer/es2015.zig
+++ b/src/transformer/es2015.zig
@@ -1,0 +1,25 @@
+//! ES2015 (ES6) 다운레벨링
+//!
+//! --target < es2015 일 때 활성화.
+//! arrow function → function + bind
+//! class → function + prototype
+//! let/const → var + IIFE (TDZ 에뮬레이션)
+//! template literal → string concatenation
+//! destructuring → 임시 변수
+//! for-of → for loop
+//! default parameters → 조건부 할당
+//! computed property → 변수 + 대괄호
+//! spread → Function.prototype.apply
+//! generator → 상태 머신
+//!
+//! 스펙:
+//! - https://tc39.es/ecma262/ (ES2015 / ES6)
+//! - https://262.ecma-international.org/6.0/
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower.go (~3000줄)
+//! - oxc: crates/oxc_transformer/src/es2015/ (arrow, class, template literal 등)
+//! - Babel: @babel/preset-env (ES2015 플러그인 ~20개)
+//! - SWC: crates/swc_ecma_compat_es2015/
+//!
+//! TODO: 구현 예정 (~6000줄, 가장 큰 단일 작업)

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -1,0 +1,15 @@
+//! ES2017 다운레벨링: async/await → generator + Promise
+//!
+//! --target < es2017 일 때 활성화.
+//! async function f() { await x; } → function f() { return __async(function*() { yield x; }); }
+//!
+//! 스펙:
+//! - async functions: https://tc39.es/ecma262/#sec-async-function-definitions (ES2017, TC39 Stage 4: 2016-11)
+//!                     https://github.com/tc39/ecmascript-asyncawait
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower.go (lowerAsync)
+//! - oxc: crates/oxc_transformer/src/es2017/
+//! - Babel: @babel/plugin-transform-async-to-generator
+//!
+//! TODO: 구현 예정 (~1000줄, 런타임 헬퍼 __async 필요)

--- a/src/transformer/es2018.zig
+++ b/src/transformer/es2018.zig
@@ -1,0 +1,18 @@
+//! ES2018 다운레벨링: object rest/spread properties + async generator
+//!
+//! --target < es2018 일 때 활성화.
+//! { ...obj } → Object.assign({}, obj)
+//! { a, ...rest } = obj → (destructuring rest 풀기)
+//! async function* f() {} → (async generator 변환)
+//!
+//! 스펙:
+//! - object rest/spread: https://tc39.es/ecma262/#sec-object-initializer (ES2018, TC39 Stage 4: 2018-01)
+//!                        https://github.com/tc39/proposal-object-rest-spread
+//! - async iteration: https://tc39.es/ecma262/#sec-for-in-and-for-of-statements (ES2018)
+//!                     https://github.com/tc39/proposal-async-iteration
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower.go (lowerObjectSpread)
+//! - oxc: crates/oxc_transformer/src/es2018/
+//!
+//! TODO: 구현 예정 (~300줄)

--- a/src/transformer/es2019.zig
+++ b/src/transformer/es2019.zig
@@ -1,0 +1,57 @@
+//! ES2019 다운레벨링: optional catch binding
+//!
+//! --target < es2019 일 때 활성화.
+//! try { } catch { } → try { } catch (_unused) { }
+//!
+//! 스펙:
+//! - optional catch binding: https://tc39.es/ecma262/#sec-try-statement (ES2019, TC39 Stage 4: 2018-05)
+//!                            https://github.com/tc39/proposal-optional-catch-binding
+//!
+//! 참고:
+//! - esbuild: internal/js_parser/js_parser_lower.go
+//! - oxc: crates/oxc_transformer/src/es2019/
+
+const std = @import("std");
+const ast_mod = @import("../parser/ast.zig");
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const token_mod = @import("../lexer/token.zig");
+const Span = token_mod.Span;
+
+pub fn ES2019(comptime Transformer: type) type {
+    return struct {
+        /// `catch { }` → `catch (_unused) { }`
+        /// catch_clause의 binding이 없으면 합성 binding을 추가.
+        /// `catch { }` → `catch (_unused) { }`
+        pub fn lowerOptionalCatchBinding(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            // catch_clause: binary = { left=param, right=body }
+            const param = node.data.binary.left;
+            const body = node.data.binary.right;
+
+            // 이미 binding이 있으면 통상 방문
+            if (!param.isNone()) {
+                const new_param = try self.visitNode(param);
+                const new_body = try self.visitNode(body);
+                return self.new_ast.addNode(.{
+                    .tag = .catch_clause,
+                    .span = node.span,
+                    .data = .{ .binary = .{ .left = new_param, .right = new_body, .flags = 0 } },
+                });
+            }
+
+            // binding 없음 → _unused 합성
+            const unused_span = try self.new_ast.addString("_unused");
+            const unused_binding = try self.new_ast.addNode(.{
+                .tag = .binding_identifier,
+                .span = unused_span,
+                .data = .{ .string_ref = unused_span },
+            });
+            const new_body = try self.visitNode(body);
+            return self.new_ast.addNode(.{
+                .tag = .catch_clause,
+                .span = node.span,
+                .data = .{ .binary = .{ .left = unused_binding, .right = new_body, .flags = 0 } },
+            });
+        }
+    };
+}

--- a/src/transformer/es2024.zig
+++ b/src/transformer/es2024.zig
@@ -1,0 +1,14 @@
+//! ES2024 다운레벨링
+//!
+//! --target < es2024 일 때 활성화.
+//!
+//! 현재 변환 대상:
+//! - (없음 — ES2024 신규 문법은 대부분 런타임 API이므로 구문 변환 불필요)
+//!
+//! 스펙:
+//! - https://tc39.es/ecma262/ (ES2024)
+//! - Array.groupBy, Promise.withResolvers 등은 polyfill 영역
+//!
+//! 참고:
+//! - esbuild: ES2024 구문 변환 없음
+//! - oxc: crates/oxc_transformer/src/es2024/ (비어 있음)

--- a/src/transformer/mod.zig
+++ b/src/transformer/mod.zig
@@ -18,17 +18,27 @@ pub const DefineEntry = transformer.DefineEntry;
 pub const TransformOptions = transformer.TransformOptions;
 
 /// ES 다운레벨링 모듈 (절충안 구조: 파일 분리 + 단일 패스)
+pub const es2015 = @import("es2015.zig");
 pub const es2016 = @import("es2016.zig");
+pub const es2017 = @import("es2017.zig");
+pub const es2018 = @import("es2018.zig");
+pub const es2019 = @import("es2019.zig");
 pub const es2020 = @import("es2020.zig");
 pub const es2021 = @import("es2021.zig");
 pub const es2022 = @import("es2022.zig");
+pub const es2024 = @import("es2024.zig");
 pub const es_helpers = @import("es_helpers.zig");
 
 test {
     _ = transformer;
+    _ = es2015;
     _ = es2016;
+    _ = es2017;
+    _ = es2018;
+    _ = es2019;
     _ = es2020;
     _ = es2021;
     _ = es2022;
+    _ = es2024;
     _ = es_helpers;
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -24,6 +24,7 @@ const Ast = ast_mod.Ast;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es2016 = @import("es2016.zig");
+const es2019 = @import("es2019.zig");
 const es2020 = @import("es2020.zig");
 const es2021 = @import("es2021.zig");
 const es2022 = @import("es2022.zig");
@@ -91,6 +92,10 @@ pub const TransformOptions = struct {
         /// 해당 타겟에서 class static block 변환이 필요한지
         pub fn needsClassStaticBlock(self: Target) bool {
             return @intFromEnum(self) < @intFromEnum(Target.es2022);
+        }
+        /// 해당 타겟에서 optional catch binding 변환이 필요한지
+        pub fn needsOptionalCatchBinding(self: Target) bool {
+            return @intFromEnum(self) < @intFromEnum(Target.es2019);
         }
     };
 };
@@ -445,8 +450,12 @@ pub const Transformer = struct {
             .import_declaration => self.visitImportDeclaration(node),
             .export_named_declaration => self.visitExportNamedDeclaration(node),
             .export_default_declaration => self.visitUnaryNode(node),
-            .export_all_declaration,
-            .catch_clause,
+            .export_all_declaration, .catch_clause => {
+                if (self.options.target.needsOptionalCatchBinding()) {
+                    return es2019.ES2019(Transformer).lowerOptionalCatchBinding(self, node);
+                }
+                return self.visitBinaryNode(node);
+            },
             .binding_property,
             .assignment_pattern,
             => self.visitBinaryNode(node),


### PR DESCRIPTION
## Summary
- 모든 ES 버전 파일 생성 (es2015~es2024)
- ES2019: `catch {}` → `catch (_unused) {}` 구현
- 유닛 테스트 3개

## Test plan
- [x] `zig build test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)