### PR TITLE
fix: /simplify — catch_clause dispatch 분리

### DIFF
--- a/src/transformer/es2019.zig
+++ b/src/transformer/es2019.zig
@@ -21,8 +21,6 @@ const Span = token_mod.Span;
 pub fn ES2019(comptime Transformer: type) type {
     return struct {
         /// `catch { }` → `catch (_unused) { }`
-        /// catch_clause의 binding이 없으면 합성 binding을 추가.
-        /// `catch { }` → `catch (_unused) { }`
         pub fn lowerOptionalCatchBinding(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             // catch_clause: binary = { left=param, right=body }
             const param = node.data.binary.left;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -450,7 +450,8 @@ pub const Transformer = struct {
             .import_declaration => self.visitImportDeclaration(node),
             .export_named_declaration => self.visitExportNamedDeclaration(node),
             .export_default_declaration => self.visitUnaryNode(node),
-            .export_all_declaration, .catch_clause => {
+            .export_all_declaration => self.visitBinaryNode(node),
+            .catch_clause => {
                 if (self.options.target.needsOptionalCatchBinding()) {
                     return es2019.ES2019(Transformer).lowerOptionalCatchBinding(self, node);
                 }


### PR DESCRIPTION
export_all_declaration이 catch binding 체크를 잘못 받던 버그 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)