### PR TITLE
feat(es2015): shorthand property → full form

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3766,3 +3766,23 @@ test "ES2015: template no transform on esnext" {
     defer r.deinit();
     try std.testing.expectEqualStrings("const x=`hello`;", r.output);
 }
+
+// --- ES2015: shorthand property ---
+
+test "ES2015: shorthand property expansion" {
+    var r = try e2eTarget(std.testing.allocator, "var o={x,y};", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var o={x:x,y:y};", r.output);
+}
+
+test "ES2015: mixed shorthand and full property" {
+    var r = try e2eTarget(std.testing.allocator, "var o={x:1,y};", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var o={x:1,y:y};", r.output);
+}
+
+test "ES2015: shorthand no transform on esnext" {
+    var r = try e2eTarget(std.testing.allocator, "var o={x,y};", .esnext);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var o={x,y};", r.output);
+}

--- a/src/transformer/es2015_shorthand.zig
+++ b/src/transformer/es2015_shorthand.zig
@@ -2,7 +2,10 @@
 //!
 //! --target < es2015 일 때 활성화.
 //! { x, y } → { x: x, y: y }
-//! { method() {} } → { method: function() {} }
+//! { method() {} } → method는 object_property가 아닌 method_definition이므로 여기서 미처리.
+//!
+//! object_property에서 binary.right가 none이면 shorthand.
+//! key의 identifier를 복제하여 value로 채워넣는다.
 //!
 //! 스펙:
 //! - https://tc39.es/ecma262/#sec-object-initialiser (ES2015)
@@ -10,17 +13,37 @@
 //! 참고:
 //! - SWC: crates/swc_ecma_compat_es2015/src/shorthand_property.rs (~41줄)
 
-const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
-const Tag = Node.Tag;
-const token_mod = @import("../lexer/token.zig");
-const Span = token_mod.Span;
 
-pub fn ES2015Shorthand(comptime _: type) type {
+pub fn ES2015Shorthand(comptime Transformer: type) type {
     return struct {
-        // TODO: lowerShorthandProperty
+        /// shorthand property를 full form으로 확장한다.
+        /// { x } → { x: x }
+        ///
+        /// key(identifier_reference)를 복제해서 value로 설정.
+        pub fn expandShorthand(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const new_key = try self.visitNode(node.data.binary.left);
+
+            // key를 복제하여 value로 사용
+            const key_node = self.new_ast.getNode(new_key);
+            const new_value = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = key_node.span,
+                .data = .{ .string_ref = key_node.data.string_ref },
+            });
+
+            return self.new_ast.addNode(.{
+                .tag = .object_property,
+                .span = node.span,
+                .data = .{ .binary = .{
+                    .left = new_key,
+                    .right = new_value,
+                    .flags = node.data.binary.flags,
+                } },
+            });
+        }
     };
 }
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -31,6 +31,7 @@ const es2020 = @import("es2020.zig");
 const es2021 = @import("es2021.zig");
 const es2022 = @import("es2022.zig");
 const es2015_template = @import("es2015_template.zig");
+const es2015_shorthand = @import("es2015_shorthand.zig");
 const es_helpers = @import("es_helpers.zig");
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 
@@ -2394,6 +2395,10 @@ pub const Transformer = struct {
 
     /// object_property: binary = { left=key, right=value, flags }
     fn visitObjectProperty(self: *Transformer, node: Node) Error!NodeIndex {
+        // ES2015: shorthand property 확장 ({ x } → { x: x })
+        if (self.options.target.needsES2015() and node.data.binary.right.isNone()) {
+            return es2015_shorthand.ES2015Shorthand(Transformer).expandShorthand(self, node);
+        }
         const new_key = try self.visitNode(node.data.binary.left);
         const new_value = try self.visitNode(node.data.binary.right);
         return self.new_ast.addNode(.{


### PR DESCRIPTION
## Summary
- `--target=es5`에서 shorthand property를 full form으로 확장
- `{ x, y }` → `{ x: x, y: y }`
- key identifier를 복제하여 value로 설정

## Test plan
- [x] `zig build test` 전체 통과
- [x] 3개 유닛 테스트 (shorthand, mixed, esnext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)