### PR TITLE
feat(es2015): default/rest parameters → body 문 삽입

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3812,3 +3812,29 @@ test "ES2015: computed no transform on esnext" {
     defer r.deinit();
     try std.testing.expectEqualStrings("var o={[k]:v};", r.output);
 }
+
+// --- ES2015: default/rest parameters ---
+
+test "ES2015: default parameter" {
+    var r = try e2eTarget(std.testing.allocator, "function f(x=1){return x;}", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function f(x){x=x===void 0?1:x;return x;}", r.output);
+}
+
+test "ES2015: rest parameter" {
+    var r = try e2eTarget(std.testing.allocator, "function f(a,...rest){return rest;}", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function f(a){var rest=[].slice.call(arguments,1);return rest;}", r.output);
+}
+
+test "ES2015: default + rest combined" {
+    var r = try e2eTarget(std.testing.allocator, "function f(x=1,...rest){}", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function f(x){x=x===void 0?1:x;var rest=[].slice.call(arguments,1);}", r.output);
+}
+
+test "ES2015: params no transform on esnext" {
+    var r = try e2eTarget(std.testing.allocator, "function f(x=1,...rest){}", .esnext);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function f(x=1,...rest){}", r.output);
+}

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -1,8 +1,14 @@
 //! ES2015 다운레벨링: default parameters + rest parameters
 //!
 //! --target < es2015 일 때 활성화.
-//! function f(x = 1) {} → function f(x) { x = x === void 0 ? 1 : x; }
-//! function f(...args) {} → function f() { var args = [].slice.call(arguments); }
+//!
+//! Default parameters:
+//!   function f(x = 1) {} → function f(x) { x = x === void 0 ? 1 : x; }
+//!
+//! Rest parameters:
+//!   function f(a, ...rest) {} → function f(a) { var rest = [].slice.call(arguments, 1); }
+//!
+//! 두 변환 모두 파라미터 목록을 수정하고 함수 바디 앞에 문을 삽입한다.
 //!
 //! 스펙:
 //! - https://tc39.es/ecma262/#sec-function-definitions (ES2015, default/rest)
@@ -15,14 +21,278 @@ const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
+const NodeList = ast_mod.NodeList;
 const Tag = Node.Tag;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const es_helpers = @import("es_helpers.zig");
 
-pub fn ES2015Params(comptime _: type) type {
+pub fn ES2015Params(comptime Transformer: type) type {
     return struct {
-        // TODO: lowerDefaultParams
-        // TODO: lowerRestParams
+        /// 파라미터 목록에서 default/rest 파라미터가 있는지 검사한다.
+        pub fn hasDefaultOrRest(self: *const Transformer, params_start: u32, params_len: u32) bool {
+            const old_params = self.old_ast.extra_data.items[params_start .. params_start + params_len];
+            for (old_params) |raw_idx| {
+                const param = self.old_ast.getNode(@enumFromInt(raw_idx));
+                if (param.tag == .spread_element or param.tag == .rest_element) return true;
+                if (param.tag == .formal_parameter and param.data.unary.flags == 0) {
+                    // extra 레이아웃: [pattern, type_ann, default_value, ...]
+                    const extras = self.old_ast.extra_data.items;
+                    const pe = param.data.extra;
+                    if (pe + 2 < extras.len) {
+                        const default_val: NodeIndex = @enumFromInt(extras[pe + 2]);
+                        if (!default_val.isNone()) return true;
+                    }
+                }
+                // assignment_pattern도 default를 의미
+                if (param.tag == .assignment_pattern) return true;
+            }
+            return false;
+        }
+
+        /// default/rest 파라미터를 변환한다.
+        /// 파라미터 목록에서 default와 rest를 제거하고,
+        /// 함수 바디 앞에 초기화 문을 삽입한다.
+        ///
+        /// 반환: { new_params, body_prepend_stmts }
+        pub fn lowerParams(
+            self: *Transformer,
+            params_start: u32,
+            params_len: u32,
+            span: Span,
+        ) Transformer.Error!LowerResult {
+            const old_params = self.old_ast.extra_data.items[params_start .. params_start + params_len];
+
+            const param_scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(param_scratch_top);
+
+            var body_stmts: std.ArrayList(NodeIndex) = .empty;
+
+            var param_index: usize = 0; // arguments index tracking
+
+            for (old_params) |raw_idx| {
+                const param = self.old_ast.getNode(@enumFromInt(raw_idx));
+
+                if (param.tag == .spread_element or param.tag == .rest_element) {
+                    // rest parameter: ...args → var args = [].slice.call(arguments, N)
+                    const rest_binding = try self.visitNode(param.data.unary.operand);
+                    const rest_stmt = try buildRestSlice(self, rest_binding, param_index, span);
+                    try body_stmts.append(self.allocator, rest_stmt);
+                    // rest를 params에 넣지 않음
+                    continue;
+                }
+
+                if (param.tag == .formal_parameter and param.data.unary.flags == 0) {
+                    const pe = param.data.extra;
+                    const extras = self.old_ast.extra_data.items;
+                    const pattern_idx: NodeIndex = @enumFromInt(extras[pe]);
+                    const default_idx: NodeIndex = if (pe + 2 < extras.len)
+                        @enumFromInt(extras[pe + 2])
+                    else
+                        .none;
+
+                    if (!default_idx.isNone()) {
+                        // default parameter: x = val → x; body에 x = x === void 0 ? val : x 삽입
+                        const new_pattern = try self.visitNode(pattern_idx);
+                        try self.scratch.append(self.allocator, new_pattern);
+
+                        const new_default = try self.visitNode(default_idx);
+                        const default_stmt = try buildDefaultCheck(self, new_pattern, new_default, span);
+                        try body_stmts.append(self.allocator, default_stmt);
+                        param_index += 1;
+                        continue;
+                    }
+                }
+
+                if (param.tag == .assignment_pattern) {
+                    // assignment_pattern: binary { left=pattern, right=default }
+                    const new_pattern = try self.visitNode(param.data.binary.left);
+                    try self.scratch.append(self.allocator, new_pattern);
+
+                    const new_default = try self.visitNode(param.data.binary.right);
+                    const default_stmt = try buildDefaultCheck(self, new_pattern, new_default, span);
+                    try body_stmts.append(self.allocator, default_stmt);
+                    param_index += 1;
+                    continue;
+                }
+
+                // 일반 파라미터: 그대로 방문
+                const new_param = try self.visitNode(@enumFromInt(raw_idx));
+                if (!new_param.isNone()) {
+                    try self.scratch.append(self.allocator, new_param);
+                }
+                param_index += 1;
+            }
+
+            const new_params = try self.new_ast.addNodeList(self.scratch.items[param_scratch_top..]);
+
+            return .{
+                .new_params = new_params,
+                .body_stmts = body_stmts,
+            };
+        }
+
+        pub const LowerResult = struct {
+            new_params: NodeList,
+            body_stmts: std.ArrayList(NodeIndex),
+        };
+
+        /// x = x === void 0 ? default_value : x
+        /// → expression_statement 생성
+        fn buildDefaultCheck(self: *Transformer, pattern: NodeIndex, default_val: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            // void 0
+            const void_zero = try es_helpers.makeVoidZero(self, span);
+
+            // x === void 0
+            const pattern_ref = try copyIdentifier(self, pattern);
+            const eq_check = try self.new_ast.addNode(.{
+                .tag = .binary_expression,
+                .span = span,
+                .data = .{ .binary = .{
+                    .left = pattern_ref,
+                    .right = void_zero,
+                    .flags = @intFromEnum(token_mod.Kind.eq3),
+                } },
+            });
+
+            // x === void 0 ? default_value : x
+            const pattern_ref2 = try copyIdentifier(self, pattern);
+            const conditional = try self.new_ast.addNode(.{
+                .tag = .conditional_expression,
+                .span = span,
+                .data = .{ .ternary = .{
+                    .a = eq_check,
+                    .b = default_val,
+                    .c = pattern_ref2,
+                } },
+            });
+
+            // x = (conditional)
+            const pattern_ref3 = try copyIdentifier(self, pattern);
+            const assign = try self.new_ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = pattern_ref3, .right = conditional, .flags = 0 } },
+            });
+
+            // expression_statement
+            return self.new_ast.addNode(.{
+                .tag = .expression_statement,
+                .span = span,
+                .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+            });
+        }
+
+        /// var rest = [].slice.call(arguments, N)
+        fn buildRestSlice(self: *Transformer, binding: NodeIndex, start_index: usize, span: Span) Transformer.Error!NodeIndex {
+            // [] (empty array)
+            const empty_arr_list = try self.new_ast.addNodeList(&.{});
+            const empty_arr = try self.new_ast.addNode(.{
+                .tag = .array_expression,
+                .span = span,
+                .data = .{ .list = empty_arr_list },
+            });
+
+            // [].slice
+            const slice_span = try self.new_ast.addString("slice");
+            const slice_prop = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = slice_span,
+                .data = .{ .string_ref = slice_span },
+            });
+            const member_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(empty_arr), @intFromEnum(slice_prop), 0,
+            });
+            const slice_member = try self.new_ast.addNode(.{
+                .tag = .static_member_expression,
+                .span = span,
+                .data = .{ .extra = member_extra },
+            });
+
+            // [].slice.call
+            const call_span = try self.new_ast.addString("call");
+            const call_prop = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = call_span,
+                .data = .{ .string_ref = call_span },
+            });
+            const call_member_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(slice_member), @intFromEnum(call_prop), 0,
+            });
+            const slice_call = try self.new_ast.addNode(.{
+                .tag = .static_member_expression,
+                .span = span,
+                .data = .{ .extra = call_member_extra },
+            });
+
+            // arguments
+            const args_span = try self.new_ast.addString("arguments");
+            const args_ref = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = args_span,
+                .data = .{ .string_ref = args_span },
+            });
+
+            // start_index number
+            var idx_buf: [16]u8 = undefined;
+            const idx_str = std.fmt.bufPrint(&idx_buf, "{d}", .{start_index}) catch "0";
+            const idx_span = try self.new_ast.addString(idx_str);
+            const idx_node = try self.new_ast.addNode(.{
+                .tag = .numeric_literal,
+                .span = idx_span,
+                .data = .{ .none = 0 },
+            });
+
+            // [].slice.call(arguments, N)
+            const call_args = try self.new_ast.addNodeList(&.{ args_ref, idx_node });
+            const call_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(slice_call),
+                call_args.start,
+                call_args.len,
+                0,
+            });
+            const call_node = try self.new_ast.addNode(.{
+                .tag = .call_expression,
+                .span = span,
+                .data = .{ .extra = call_extra },
+            });
+
+            // var rest = [].slice.call(arguments, N)
+            const declarator_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(binding),
+                @intFromEnum(NodeIndex.none),
+                @intFromEnum(call_node),
+            });
+            const declarator = try self.new_ast.addNode(.{
+                .tag = .variable_declarator,
+                .span = span,
+                .data = .{ .extra = declarator_extra },
+            });
+
+            // variable_declaration: extra = [kind_flags, list_start, list_len]
+            // kind_flags: 0 = var
+            const decl_list = try self.new_ast.addNodeList(&.{declarator});
+            const var_extra = try self.new_ast.addExtras(&.{
+                0, // var
+                decl_list.start,
+                decl_list.len,
+            });
+            return self.new_ast.addNode(.{
+                .tag = .variable_declaration,
+                .span = span,
+                .data = .{ .extra = var_extra },
+            });
+        }
+
+        /// identifier 노드를 복제한다 (같은 이름의 새 노드).
+        fn copyIdentifier(self: *Transformer, node_idx: NodeIndex) Transformer.Error!NodeIndex {
+            const node = self.new_ast.getNode(node_idx);
+            return self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = node.span,
+                .data = .{ .string_ref = node.data.string_ref },
+            });
+        }
     };
 }
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -33,6 +33,7 @@ const es2022 = @import("es2022.zig");
 const es2015_template = @import("es2015_template.zig");
 const es2015_shorthand = @import("es2015_shorthand.zig");
 const es2015_computed = @import("es2015_computed.zig");
+const es2015_params = @import("es2015_params.zig");
 const es_helpers = @import("es_helpers.zig");
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 
@@ -1113,7 +1114,26 @@ pub const Transformer = struct {
         const scratch_top = self.scratch.items.len;
         defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
-        const pp = try self.visitParamsCollectProperties(old_params);
+        // ES2015: default/rest params → 파라미터 축소 + 바디 문 삽입
+        var es2015_body_stmts: ?std.ArrayList(NodeIndex) = null;
+        defer if (es2015_body_stmts) |*s| s.deinit(self.allocator);
+
+        const pp = if (self.options.target.needsES2015() and
+            es2015_params.ES2015Params(Transformer).hasDefaultOrRest(self, params_start, params_len))
+        blk: {
+            const lower_result = try es2015_params.ES2015Params(Transformer).lowerParams(
+                self,
+                params_start,
+                params_len,
+                node.span,
+            );
+            es2015_body_stmts = lower_result.body_stmts;
+            break :blk ParamPropertyResult{
+                .new_params = lower_result.new_params,
+                .prop_names = undefined,
+                .prop_count = 0,
+            };
+        } else try self.visitParamsCollectProperties(old_params);
 
         // 바디 방문
         const old_body_idx = self.readNodeIdx(e, 3);
@@ -1122,6 +1142,13 @@ pub const Transformer = struct {
         // parameter property가 있으면 바디 앞에 this.x = x 문 삽입
         if (pp.prop_count > 0 and !new_body.isNone()) {
             new_body = try self.insertParameterPropertyAssignments(new_body, pp.prop_names[0..pp.prop_count]);
+        }
+
+        // ES2015 default/rest 바디 문 삽입
+        if (es2015_body_stmts) |stmts| {
+            if (stmts.items.len > 0 and !new_body.isNone()) {
+                new_body = try self.prependStatementsToBody(new_body, stmts.items);
+            }
         }
 
         // React Fast Refresh: Hook 시그니처 감지 + _s() 호출 삽입
@@ -1229,6 +1256,34 @@ pub const Transformer = struct {
         }
 
         // 기존 바디 문들을 추가
+        const old_stmts = self.new_ast.extra_data.items[old_list.start .. old_list.start + old_list.len];
+        for (old_stmts) |raw_idx| {
+            try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+        }
+
+        const new_list = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+        return self.new_ast.addNode(.{
+            .tag = .block_statement,
+            .span = body.span,
+            .data = .{ .list = new_list },
+        });
+    }
+
+    /// block_statement 바디 앞에 문들을 삽입한다 (범용 버전).
+    fn prependStatementsToBody(self: *Transformer, body_idx: NodeIndex, stmts: []const NodeIndex) Error!NodeIndex {
+        const body = self.new_ast.getNode(body_idx);
+        if (body.tag != .block_statement) return body_idx;
+
+        const old_list = body.data.list;
+        const scratch_top = self.scratch.items.len;
+        defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+        // prepend 문들
+        for (stmts) |stmt| {
+            try self.scratch.append(self.allocator, stmt);
+        }
+
+        // 기존 바디 문들
         const old_stmts = self.new_ast.extra_data.items[old_list.start .. old_list.start + old_list.len];
         for (old_stmts) |raw_idx| {
             try self.scratch.append(self.allocator, @enumFromInt(raw_idx));


### PR DESCRIPTION
## Summary
- `--target=es5`에서 default/rest parameters를 변환
- default: `f(x = 1)` → `f(x) { x = x === void 0 ? 1 : x; }`
- rest: `f(a, ...rest)` → `f(a) { var rest = [].slice.call(arguments, 1); }`
- 조합도 정상 동작
- `prependStatementsToBody` 범용 헬퍼 추가

## Test plan
- [x] `zig build test` 전체 통과
- [x] 4개 유닛 테스트 (default, rest, combined, esnext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)