### PR TITLE
feat(es2015): arrow function → function expression

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3864,3 +3864,41 @@ test "ES2015: spread no transform on esnext" {
     defer r.deinit();
     try std.testing.expectEqualStrings("f(...arr);", r.output);
 }
+
+// --- ES2015: arrow function ---
+
+test "ES2015: arrow expression body" {
+    var r = try e2eTarget(std.testing.allocator, "var f=()=>42;", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=function(){return 42;};", r.output);
+}
+
+test "ES2015: arrow with param" {
+    var r = try e2eTarget(std.testing.allocator, "var f=x=>x+1;", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=function(x){return x + 1;};", r.output);
+}
+
+test "ES2015: arrow with parens param" {
+    var r = try e2eTarget(std.testing.allocator, "var f=(x)=>x+1;", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=function(x){return x + 1;};", r.output);
+}
+
+test "ES2015: arrow block body" {
+    var r = try e2eTarget(std.testing.allocator, "var f=(x)=>{return x;};", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=function(x){return x;};", r.output);
+}
+
+test "ES2015: arrow multiple params" {
+    var r = try e2eTarget(std.testing.allocator, "var f=(a,b)=>a+b;", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=function(a,b){return a + b;};", r.output);
+}
+
+test "ES2015: arrow no transform on esnext" {
+    var r = try e2eTarget(std.testing.allocator, "var f=()=>42;", .esnext);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=()=>42;", r.output);
+}

--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -1,31 +1,136 @@
 //! ES2015 다운레벨링: arrow function
 //!
 //! --target < es2015 일 때 활성화.
-//! () => expr → function() { return expr; }
-//! () => { stmts } → function() { stmts }
-//! this 참조 → var _this = this; ... _this
-//! arguments 참조 → var _arguments = arguments;
+//! () => expr       → function() { return expr; }
+//! () => { stmts }  → function() { stmts }
+//! (x) => x + 1     → function(x) { return x + 1; }
+//! x => x + 1       → function(x) { return x + 1; }
+//!
+//! 파서에서 arrow의 params 슬롯은 세 가지 형태:
+//!   1. NodeIndex.none → 빈 파라미터 (() => ...)
+//!   2. binding_identifier → 단일 파라미터 (x => ...)
+//!   3. formal_parameters(list) → 괄호 형태 ((x, y) => ...)
+//!
+//! this/arguments 캡처:
+//!   현재 미구현. 완전한 구현 시 외부 함수에서 var _this = this 삽입 필요.
 //!
 //! 스펙:
 //! - https://tc39.es/ecma262/#sec-arrow-function-definitions (ES2015)
 //!
 //! 참고:
 //! - SWC: crates/swc_ecma_compat_es2015/src/arrow.rs (~253줄)
-//! - oxc: crates/oxc_transformer/src/common/arrow_function_converter.rs
-//! - esbuild: pkg/js_parser/js_parser_lower.go
+//! - ZTS ES2017: es2017.zig lowerAsyncArrow
 
-const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
+const NodeList = ast_mod.NodeList;
 const Tag = Node.Tag;
-const token_mod = @import("../lexer/token.zig");
-const Span = token_mod.Span;
 
-pub fn ES2015Arrow(comptime _: type) type {
+pub fn ES2015Arrow(comptime Transformer: type) type {
     return struct {
-        // TODO: lowerArrowFunction
-        // TODO: captureThis
+        /// arrow_function_expression → function_expression 변환.
+        pub fn lowerArrowFunction(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const extras = self.old_ast.extra_data.items;
+            const e = node.data.extra;
+            if (e + 2 >= extras.len) return NodeIndex.none;
+
+            const params_idx: NodeIndex = @enumFromInt(extras[e]);
+            const body_idx: NodeIndex = @enumFromInt(extras[e + 1]);
+            const flags = extras[e + 2];
+
+            // params 슬롯의 형태:
+            //   1. none → () => ... (빈 파라미터)
+            //   2. formal_parameters(list) → <T>(x, y) => ... (TS 제네릭 arrow)
+            //   3. binding_identifier → x => ... (단일 파라미터, 괄호 없음)
+            //   4. parenthesized_expression → (x) => ... (cover grammar)
+            //      내부: identifier_reference (단일) 또는 sequence_expression (복수)
+            const param_list: NodeList = if (params_idx.isNone())
+                try self.new_ast.addNodeList(&.{})
+            else blk: {
+                const params_node = self.old_ast.getNode(params_idx);
+                switch (params_node.tag) {
+                    .formal_parameters => {
+                        break :blk try self.visitExtraList(
+                            params_node.data.list.start,
+                            params_node.data.list.len,
+                        );
+                    },
+                    .parenthesized_expression => {
+                        // cover grammar: (x) 또는 (a, b, ...rest)
+                        const inner_idx = params_node.data.unary.operand;
+                        if (inner_idx.isNone()) {
+                            break :blk try self.new_ast.addNodeList(&.{});
+                        }
+                        const inner = self.old_ast.getNode(inner_idx);
+                        if (inner.tag == .sequence_expression) {
+                            // (a, b, c) → sequence_expression의 list에서 추출
+                            break :blk try self.visitExtraList(
+                                inner.data.list.start,
+                                inner.data.list.len,
+                            );
+                        } else {
+                            // (x) → 단일 파라미터
+                            const new_param = try self.visitNode(inner_idx);
+                            break :blk try self.new_ast.addNodeList(
+                                if (!new_param.isNone()) &.{new_param} else &.{},
+                            );
+                        }
+                    },
+                    else => {
+                        // x => ... — 단일 binding_identifier
+                        const new_param = try self.visitNode(params_idx);
+                        break :blk try self.new_ast.addNodeList(
+                            if (!new_param.isNone()) &.{new_param} else &.{},
+                        );
+                    },
+                }
+            };
+
+            const new_body = try self.visitNode(body_idx);
+
+            // expression body → { return expr; }
+            const func_body = blk: {
+                if (new_body.isNone()) break :blk new_body;
+                const body_node = self.new_ast.getNode(new_body);
+                if (body_node.tag != .block_statement and body_node.tag != .function_body) {
+                    const ret = try self.new_ast.addNode(.{
+                        .tag = .return_statement,
+                        .span = node.span,
+                        .data = .{ .unary = .{ .operand = new_body, .flags = 0 } },
+                    });
+                    const list = try self.new_ast.addNodeList(&.{ret});
+                    break :blk try self.new_ast.addNode(.{
+                        .tag = .block_statement,
+                        .span = node.span,
+                        .data = .{ .list = list },
+                    });
+                }
+                break :blk new_body;
+            };
+
+            // function_expression: extra = [name, params_start, params_len, body, flags, return_type]
+            const func_flags: u32 = if (flags & ast_mod.ArrowFlags.is_async != 0)
+                ast_mod.FunctionFlags.is_async
+            else
+                0;
+
+            const none = @intFromEnum(NodeIndex.none);
+            const new_extra = try self.new_ast.addExtras(&.{
+                none, // name (anonymous)
+                param_list.start,
+                param_list.len,
+                @intFromEnum(func_body),
+                func_flags,
+                none, // return_type
+            });
+
+            return self.new_ast.addNode(.{
+                .tag = .function_expression,
+                .span = node.span,
+                .data = .{ .extra = new_extra },
+            });
+        }
     };
 }
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -35,6 +35,7 @@ const es2015_shorthand = @import("es2015_shorthand.zig");
 const es2015_computed = @import("es2015_computed.zig");
 const es2015_params = @import("es2015_params.zig");
 const es2015_spread = @import("es2015_spread.zig");
+const es2015_arrow = @import("es2015_arrow.zig");
 const es_helpers = @import("es_helpers.zig");
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 
@@ -533,6 +534,9 @@ pub const Transformer = struct {
                     if (e + 2 < extras.len and (extras[e + 2] & ast_mod.ArrowFlags.is_async) != 0) {
                         return es2017_mod.ES2017(Transformer).lowerAsyncArrow(self, node);
                     }
+                }
+                if (self.options.target.needsES2015()) {
+                    return es2015_arrow.ES2015Arrow(Transformer).lowerArrowFunction(self, node);
                 }
                 return self.visitArrowFunction(node);
             },


### PR DESCRIPTION
## Summary
- `--target=es5`에서 arrow function을 function expression으로 변환
- expression body → `{ return expr; }` 블록 래핑
- 파서의 세 가지 params 형태 처리: none, binding_identifier, parenthesized_expression(cover grammar), formal_parameters(TS)
- this/arguments 캡처는 후순위 (현재 미구현)

## Test plan
- [x] `zig build test` 전체 통과
- [x] 6개 유닛 테스트 (empty, single param, parens, block body, multiple, esnext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)