### PR TITLE
feat(es2015): for-of → index-based for loop

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3902,3 +3902,27 @@ test "ES2015: arrow no transform on esnext" {
     defer r.deinit();
     try std.testing.expectEqualStrings("var f=()=>42;", r.output);
 }
+
+// --- ES2015: for-of ---
+
+test "ES2015: for-of with const" {
+    var r = try e2eTarget(std.testing.allocator, "for(const x of arr){f(x);}", .es5);
+    defer r.deinit();
+    // _a=index, _b=array
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _a") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_b.length") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var x=_b[_a]") != null);
+}
+
+test "ES2015: for-of with expression left" {
+    var r = try e2eTarget(std.testing.allocator, "for(x of arr){}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "x=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "for(") != null);
+}
+
+test "ES2015: for-of no transform on esnext" {
+    var r = try e2eTarget(std.testing.allocator, "for(const x of arr){}", .esnext);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("for(const x of arr){}", r.output);
+}

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -1,27 +1,222 @@
 //! ES2015 다운레벨링: for-of loop
 //!
 //! --target < es2015 일 때 활성화.
-//! for (const x of arr) { } → for (var _i = 0; _i < arr.length; _i++) { var x = arr[_i]; }
-//! for (const x of iterable) { } → iterator protocol 사용 (try/catch/finally)
+//!
+//! for (const x of arr) { body }
+//! → for (var _i = 0, _arr = arr; _i < _arr.length; _i++) { var x = _arr[_i]; body }
+//!
+//! 배열 기반 변환 (esbuild 호환). 임의 iterable은 미지원.
+//! iterable이 부작용을 가질 수 있으므로 임시 변수에 저장.
 //!
 //! 스펙:
 //! - https://tc39.es/ecma262/#sec-for-in-and-for-of-statements (ES2015)
 //!
 //! 참고:
 //! - SWC: crates/swc_ecma_compat_es2015/src/for_of.rs (~724줄)
-//! - esbuild: pkg/js_parser/js_parser_lower.go
+//! - esbuild: for-of 다운레벨링 미지원 (for-await만)
 
-const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const Tag = Node.Tag;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const es_helpers = @import("es_helpers.zig");
 
-pub fn ES2015ForOf(comptime _: type) type {
+pub fn ES2015ForOf(comptime Transformer: type) type {
     return struct {
-        // TODO: lowerForOfStatement
+        /// for (const x of arr) { body }
+        /// → for (var _a = 0, _b = arr; _a < _b.length; _a++) { var x = _b[_a]; body }
+        pub fn lowerForOfStatement(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const span = node.span;
+            const left = node.data.ternary.a; // loop variable (variable_declaration or expression)
+            const right = node.data.ternary.b; // iterable
+            const body = node.data.ternary.c; // body
+
+            // 임시 변수: _a (index), _b (array)
+            const idx_span = try es_helpers.makeTempVarSpan(self);
+            const arr_span = try es_helpers.makeTempVarSpan(self);
+
+            const new_right = try self.visitNode(right);
+
+            // --- init: var _a = 0, _b = arr ---
+            // _a = 0
+            const idx_binding = try makeBinding(self, idx_span, span);
+            const zero_span = try self.new_ast.addString("0");
+            const zero = try self.new_ast.addNode(.{
+                .tag = .numeric_literal,
+                .span = zero_span,
+                .data = .{ .none = 0 },
+            });
+            const idx_decl_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(idx_binding), @intFromEnum(NodeIndex.none), @intFromEnum(zero),
+            });
+            const idx_decl = try self.new_ast.addNode(.{
+                .tag = .variable_declarator,
+                .span = span,
+                .data = .{ .extra = idx_decl_extra },
+            });
+
+            // _b = arr
+            const arr_binding = try makeBinding(self, arr_span, span);
+            const arr_decl_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(arr_binding), @intFromEnum(NodeIndex.none), @intFromEnum(new_right),
+            });
+            const arr_decl = try self.new_ast.addNode(.{
+                .tag = .variable_declarator,
+                .span = span,
+                .data = .{ .extra = arr_decl_extra },
+            });
+
+            const init_list = try self.new_ast.addNodeList(&.{ idx_decl, arr_decl });
+            const init_extra = try self.new_ast.addExtras(&.{ 0, init_list.start, init_list.len }); // 0 = var
+            const init = try self.new_ast.addNode(.{
+                .tag = .variable_declaration,
+                .span = span,
+                .data = .{ .extra = init_extra },
+            });
+
+            // --- test: _a < _b.length ---
+            const idx_ref = try es_helpers.makeTempVarRef(self, idx_span, idx_span);
+            const length_span = try self.new_ast.addString("length");
+            const length_prop = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = length_span,
+                .data = .{ .string_ref = length_span },
+            });
+            const arr_ref_test = try es_helpers.makeTempVarRef(self, arr_span, arr_span);
+            const member_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(arr_ref_test), @intFromEnum(length_prop), 0,
+            });
+            const arr_length = try self.new_ast.addNode(.{
+                .tag = .static_member_expression,
+                .span = span,
+                .data = .{ .extra = member_extra },
+            });
+            const test_expr = try self.new_ast.addNode(.{
+                .tag = .binary_expression,
+                .span = span,
+                .data = .{ .binary = .{
+                    .left = idx_ref,
+                    .right = arr_length,
+                    .flags = @intFromEnum(token_mod.Kind.l_angle),
+                } },
+            });
+
+            // --- update: _a++ ---
+            const idx_ref_update = try es_helpers.makeTempVarRef(self, idx_span, idx_span);
+            const update_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(idx_ref_update),
+                @intFromEnum(token_mod.Kind.plus2) | (ast_mod.UnaryFlags.postfix),
+            });
+            const update_expr = try self.new_ast.addNode(.{
+                .tag = .unary_expression,
+                .span = span,
+                .data = .{ .extra = update_extra },
+            });
+
+            // --- body: var x = _b[_a]; original_body ---
+            const new_body = try self.visitNode(body);
+
+            // _b[_a]
+            const arr_ref_body = try es_helpers.makeTempVarRef(self, arr_span, arr_span);
+            const idx_ref_body = try es_helpers.makeTempVarRef(self, idx_span, idx_span);
+            const elem_access_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(arr_ref_body), @intFromEnum(idx_ref_body), 0,
+            });
+            const elem_access = try self.new_ast.addNode(.{
+                .tag = .computed_member_expression,
+                .span = span,
+                .data = .{ .extra = elem_access_extra },
+            });
+
+            // var x = _b[_a] (or assignment if left is expression)
+            const elem_assign = try buildLoopVarAssign(self, left, elem_access, span);
+
+            // prepend to body
+            const final_body = if (!new_body.isNone())
+                try self.prependStatementsToBody(new_body, &.{elem_assign})
+            else
+                new_body;
+
+            // --- for_statement: extra = [init, test, update, body] ---
+            const for_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(init),
+                @intFromEnum(test_expr),
+                @intFromEnum(update_expr),
+                @intFromEnum(final_body),
+            });
+            return self.new_ast.addNode(.{
+                .tag = .for_statement,
+                .span = span,
+                .data = .{ .extra = for_extra },
+            });
+        }
+
+        /// binding_identifier 노드 생성
+        fn makeBinding(self: *Transformer, name_span: Span, _: Span) Transformer.Error!NodeIndex {
+            return self.new_ast.addNode(.{
+                .tag = .binding_identifier,
+                .span = name_span,
+                .data = .{ .string_ref = name_span },
+            });
+        }
+
+        /// for-of의 left를 기반으로 `var x = elem` 문 생성.
+        /// left가 variable_declaration이면 해당 패턴을 재사용.
+        /// left가 expression이면 assignment로 변환.
+        fn buildLoopVarAssign(self: *Transformer, left: NodeIndex, elem: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            if (left.isNone()) return NodeIndex.none;
+            const left_node = self.old_ast.getNode(left);
+
+            if (left_node.tag == .variable_declaration) {
+                // for (const/let/var x of ...) → var x = _b[_a]
+                const extras = self.old_ast.extra_data.items;
+                const le = left_node.data.extra;
+                const list_start = extras[le + 1];
+                const list_len = extras[le + 2];
+                if (list_len == 0) return NodeIndex.none;
+
+                // 첫 번째 declarator의 binding name 추출
+                const first_decl_idx: NodeIndex = @enumFromInt(extras[list_start]);
+                const first_decl = self.old_ast.getNode(first_decl_idx);
+                if (first_decl.tag != .variable_declarator) return NodeIndex.none;
+
+                const binding_name = try self.visitNode(@enumFromInt(extras[first_decl.data.extra]));
+
+                // var x = elem
+                const decl_extra = try self.new_ast.addExtras(&.{
+                    @intFromEnum(binding_name),
+                    @intFromEnum(NodeIndex.none),
+                    @intFromEnum(elem),
+                });
+                const declarator = try self.new_ast.addNode(.{
+                    .tag = .variable_declarator,
+                    .span = span,
+                    .data = .{ .extra = decl_extra },
+                });
+                const decl_list = try self.new_ast.addNodeList(&.{declarator});
+                const var_extra = try self.new_ast.addExtras(&.{ 0, decl_list.start, decl_list.len }); // 0 = var
+                return self.new_ast.addNode(.{
+                    .tag = .variable_declaration,
+                    .span = span,
+                    .data = .{ .extra = var_extra },
+                });
+            } else {
+                // for (x of ...) → x = _b[_a]
+                const new_left = try self.visitNode(left);
+                const assign = try self.new_ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = new_left, .right = elem, .flags = 0 } },
+                });
+                return self.new_ast.addNode(.{
+                    .tag = .expression_statement,
+                    .span = span,
+                    .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+                });
+            }
+        }
     };
 }
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -36,6 +36,7 @@ const es2015_computed = @import("es2015_computed.zig");
 const es2015_params = @import("es2015_params.zig");
 const es2015_spread = @import("es2015_spread.zig");
 const es2015_arrow = @import("es2015_arrow.zig");
+const es2015_for_of = @import("es2015_for_of.zig");
 const es_helpers = @import("es_helpers.zig");
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 
@@ -504,10 +505,15 @@ pub const Transformer = struct {
             .if_statement,
             .conditional_expression,
             .for_in_statement,
-            .for_of_statement,
             .for_await_of_statement,
             .try_statement,
             => self.visitTernaryNode(node),
+            .for_of_statement => {
+                if (self.options.target.needsES2015()) {
+                    return es2015_for_of.ES2015ForOf(Transformer).lowerForOfStatement(self, node);
+                }
+                return self.visitTernaryNode(node);
+            },
 
             // === extra 기반 노드: 별도 처리 ===
             .variable_declaration => self.visitVariableDeclaration(node),
@@ -1290,7 +1296,7 @@ pub const Transformer = struct {
     }
 
     /// block_statement 바디 앞에 문들을 삽입한다 (범용 버전).
-    fn prependStatementsToBody(self: *Transformer, body_idx: NodeIndex, stmts: []const NodeIndex) Error!NodeIndex {
+    pub fn prependStatementsToBody(self: *Transformer, body_idx: NodeIndex, stmts: []const NodeIndex) Error!NodeIndex {
         const body = self.new_ast.getNode(body_idx);
         if (body.tag != .block_statement) return body_idx;
 


### PR DESCRIPTION
## Summary
- `--target=es5`에서 for-of를 인덱스 기반 for 루프로 변환
- `for (const x of arr) { body }` → `for (var _a = 0, _b = arr; _a < _b.length; ++_a) { var x = _b[_a]; body }`
- expression left (`for (x of arr)`)도 지원
- iterable을 임시 변수에 저장하여 부작용 방지

## Test plan
- [x] `zig build test` 전체 통과
- [x] 3개 유닛 테스트 (const, expression left, esnext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)