### PR TITLE
feat(es2015): let/const → var

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3726,39 +3726,39 @@ test "ES2022: multiple static blocks with this" {
 // --- ES2015: template literal ---
 
 test "ES2015: no-substitution template" {
-    var r = try e2eTarget(std.testing.allocator, "const x=`hello`;", .es5);
+    var r = try e2eTarget(std.testing.allocator, "var x=`hello`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("const x=\"hello\";", r.output);
+    try std.testing.expectEqualStrings("var x=\"hello\";", r.output);
 }
 
 test "ES2015: template with substitution" {
-    var r = try e2eTarget(std.testing.allocator, "const x=`a${b}c`;", .es5);
+    var r = try e2eTarget(std.testing.allocator, "var x=`a${b}c`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("const x=\"a\" + b + \"c\";", r.output);
+    try std.testing.expectEqualStrings("var x=\"a\" + b + \"c\";", r.output);
 }
 
 test "ES2015: template empty head" {
-    var r = try e2eTarget(std.testing.allocator, "const x=`${a}`;", .es5);
+    var r = try e2eTarget(std.testing.allocator, "var x=`${a}`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("const x=\"\" + a;", r.output);
+    try std.testing.expectEqualStrings("var x=\"\" + a;", r.output);
 }
 
 test "ES2015: template multiple substitutions" {
-    var r = try e2eTarget(std.testing.allocator, "const x=`${a}${b}`;", .es5);
+    var r = try e2eTarget(std.testing.allocator, "var x=`${a}${b}`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("const x=\"\" + a + b;", r.output);
+    try std.testing.expectEqualStrings("var x=\"\" + a + b;", r.output);
 }
 
 test "ES2015: template with text between substitutions" {
-    var r = try e2eTarget(std.testing.allocator, "const x=`a${b}c${d}e`;", .es5);
+    var r = try e2eTarget(std.testing.allocator, "var x=`a${b}c${d}e`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("const x=\"a\" + b + \"c\" + d + \"e\";", r.output);
+    try std.testing.expectEqualStrings("var x=\"a\" + b + \"c\" + d + \"e\";", r.output);
 }
 
 test "ES2015: empty template" {
-    var r = try e2eTarget(std.testing.allocator, "const x=``;", .es5);
+    var r = try e2eTarget(std.testing.allocator, "var x=``;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("const x=\"\";", r.output);
+    try std.testing.expectEqualStrings("var x=\"\";", r.output);
 }
 
 test "ES2015: template no transform on esnext" {
@@ -3959,4 +3959,30 @@ test "ES2015: destructuring no transform on esnext" {
     var r = try e2eTarget(std.testing.allocator, "var {a,b}=obj;", .esnext);
     defer r.deinit();
     try std.testing.expectEqualStrings("var {a:a,b:b}=obj;", r.output);
+}
+
+// --- ES2015: let/const → var ---
+
+test "ES2015: let to var" {
+    var r = try e2eTarget(std.testing.allocator, "let x=1;", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var x=1;", r.output);
+}
+
+test "ES2015: const to var" {
+    var r = try e2eTarget(std.testing.allocator, "const y=2;", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var y=2;", r.output);
+}
+
+test "ES2015: var stays var" {
+    var r = try e2eTarget(std.testing.allocator, "var z=3;", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=3;", r.output);
+}
+
+test "ES2015: let/const no transform on esnext" {
+    var r = try e2eTarget(std.testing.allocator, "let x=1;const y=2;", .esnext);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;const y=2;", r.output);
 }

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -1,36 +1,31 @@
 //! ES2015 다운레벨링: let/const → var
 //!
 //! --target < es2015 일 때 활성화.
-//! let x = 1 → var x = 1
+//! let x = 1  → var x = 1
 //! const y = 2 → var y = 2
-//! for (let i = 0; ...) → TDZ 에뮬레이션 (IIFE 래핑 필요 시)
+//!
+//! kind_flags: 0=var, 1=let, 2=const
+//! let/const의 kind_flags를 0(var)으로 변경하는 단순 변환.
 //!
 //! TDZ (Temporal Dead Zone) 에뮬레이션:
-//! - 루프 내 클로저가 let 변수를 캡처하는 경우 IIFE로 감싸야 함
-//! - 단순 선언은 var로 교체만 하면 됨
+//!   현재 미구현. 루프 내 클로저가 let 변수를 캡처하는 경우
+//!   IIFE로 감싸야 하지만, 대부분의 코드에서는 불필요.
+//!   SWC는 ~1400줄, esbuild는 지원하지만 여기서는 v1으로 키워드만 변환.
 //!
 //! 스펙:
 //! - https://tc39.es/ecma262/#sec-let-and-const-declarations (ES2015)
 //!
 //! 참고:
 //! - SWC: crates/swc_ecma_compat_es2015/src/block_scoping/ (~1404줄)
-//! - esbuild: pkg/js_parser/js_parser_lower.go
 
-const std = @import("std");
-const ast_mod = @import("../parser/ast.zig");
-const Node = ast_mod.Node;
-const NodeIndex = ast_mod.NodeIndex;
-const Tag = Node.Tag;
-const token_mod = @import("../lexer/token.zig");
-const Span = token_mod.Span;
-
-pub fn ES2015BlockScoping(comptime _: type) type {
-    return struct {
-        // TODO: lowerLetConst
-        // TODO: wrapLoopBodyForTDZ
-    };
+/// let(1) 또는 const(2)이면 var(0)으로 변환.
+pub fn lowerKindFlags(kind_flags: u32) u32 {
+    return if (kind_flags == 1 or kind_flags == 2) 0 else kind_flags;
 }
 
 test "ES2015 block scoping module compiles" {
-    _ = ES2015BlockScoping;
+    const std = @import("std");
+    try std.testing.expectEqual(@as(u32, 0), lowerKindFlags(0)); // var → var
+    try std.testing.expectEqual(@as(u32, 0), lowerKindFlags(1)); // let → var
+    try std.testing.expectEqual(@as(u32, 0), lowerKindFlags(2)); // const → var
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -38,6 +38,7 @@ const es2015_spread = @import("es2015_spread.zig");
 const es2015_arrow = @import("es2015_arrow.zig");
 const es2015_for_of = @import("es2015_for_of.zig");
 const es2015_destructuring = @import("es2015_destructuring.zig");
+const es2015_block_scoping = @import("es2015_block_scoping.zig");
 const es_helpers = @import("es_helpers.zig");
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 
@@ -1101,8 +1102,12 @@ pub const Transformer = struct {
             }
         }
         const e = node.data.extra;
+        const kind_flags = if (self.options.target.needsES2015())
+            es2015_block_scoping.lowerKindFlags(self.readU32(e, 0))
+        else
+            self.readU32(e, 0);
         const new_list = try self.visitExtraList(self.readU32(e, 1), self.readU32(e, 2));
-        return self.addExtraNode(.variable_declaration, node.span, &.{ self.readU32(e, 0), new_list.start, new_list.len });
+        return self.addExtraNode(.variable_declaration, node.span, &.{ kind_flags, new_list.start, new_list.len });
     }
 
     /// variable_declarator: extra_data = [name, type_ann, init]


### PR DESCRIPTION
## Summary
- `--target=es5`에서 let/const를 var로 변환
- kind_flags (0=var, 1=let, 2=const)를 0으로 변경하는 단순 변환
- TDZ 에뮬레이션은 후순위

## Test plan
- [x] `zig build test` 전체 통과
- [x] 4개 유닛 테스트 (let→var, const→var, var 유지, esnext)
- [x] 기존 template 테스트 입력을 var로 수정 (const→var 변환과 겹치지 않게)

🤖 Generated with [Claude Code](https://claude.com/claude-code)