### PR TITLE
fix(es2015): assignment destructuring + spread in new 누락 수정

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3865,6 +3865,12 @@ test "ES2015: spread no transform on esnext" {
     try std.testing.expectEqualStrings("f(...arr);", r.output);
 }
 
+test "ES2015: spread in new expression" {
+    var r = try e2eTarget(std.testing.allocator, "new Foo(...args);", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Foo.bind.apply") != null);
+}
+
 // --- ES2015: arrow function ---
 
 test "ES2015: arrow expression body" {
@@ -3959,6 +3965,22 @@ test "ES2015: destructuring no transform on esnext" {
     var r = try e2eTarget(std.testing.allocator, "var {a,b}=obj;", .esnext);
     defer r.deinit();
     try std.testing.expectEqualStrings("var {a:a,b:b}=obj;", r.output);
+}
+
+test "ES2015: assignment object destructuring" {
+    var r = try e2eTarget(std.testing.allocator, "({a,b}=obj);", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_a=obj") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "a=_a.a") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "b=_a.b") != null);
+}
+
+test "ES2015: assignment array destructuring" {
+    var r = try e2eTarget(std.testing.allocator, "([x,y]=arr);", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_a=arr") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "x=_a[0]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "y=_a[1]") != null);
 }
 
 // --- ES2015: let/const → var ---

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -108,6 +108,128 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             });
         }
 
+        /// assignment destructuring을 sequence expression으로 변환.
+        /// ({a, b} = obj) → (_ref = obj, a = _ref.a, b = _ref.b, _ref)
+        pub fn lowerDestructuringAssignment(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const span = node.span;
+            const left_idx = node.data.binary.left;
+            const right_idx = node.data.binary.right;
+
+            const left_node = self.old_ast.getNode(left_idx);
+            const new_right = try self.visitNode(right_idx);
+            const temp_span = try es_helpers.makeTempVarSpan(self);
+
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+            // _ref = obj
+            const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
+            const init_assign = try self.new_ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = temp_ref, .right = new_right, .flags = 0 } },
+            });
+            try self.scratch.append(self.allocator, init_assign);
+
+            // 각 property/element를 assignment로 변환
+            if (left_node.tag == .object_assignment_target) {
+                try emitObjectAssignments(self, left_node, temp_span, span);
+            } else if (left_node.tag == .array_assignment_target) {
+                try emitArrayAssignments(self, left_node, temp_span, span);
+            }
+
+            // 마지막에 _ref 반환
+            try self.scratch.append(self.allocator, try es_helpers.makeTempVarRef(self, temp_span, temp_span));
+
+            // sequence expression
+            const seq_list = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+            return self.new_ast.addNode(.{
+                .tag = .sequence_expression,
+                .span = span,
+                .data = .{ .list = seq_list },
+            });
+        }
+
+        /// object_assignment_target의 각 property를 assignment로 변환.
+        fn emitObjectAssignments(self: *Transformer, target: Node, ref_span: Span, span: Span) Transformer.Error!void {
+            const members = self.old_ast.extra_data.items[target.data.list.start .. target.data.list.start + target.data.list.len];
+            for (members) |raw_idx| {
+                const prop = self.old_ast.getNode(@enumFromInt(raw_idx));
+
+                if (prop.tag == .assignment_target_rest) continue; // rest 미지원
+
+                const key_idx = prop.data.binary.left;
+                if (key_idx.isNone()) continue;
+
+                // _ref.key
+                const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
+                const new_key = try self.visitNode(key_idx);
+                const me = try self.new_ast.addExtras(&.{ @intFromEnum(ref), @intFromEnum(new_key), 0 });
+                const access = try self.new_ast.addNode(.{
+                    .tag = .static_member_expression,
+                    .span = span,
+                    .data = .{ .extra = me },
+                });
+
+                // target = _ref.key
+                const target_node = if (prop.tag == .assignment_target_property_identifier) blk: {
+                    // shorthand {a} → a = _ref.a
+                    const key_node = self.old_ast.getNode(key_idx);
+                    break :blk try self.new_ast.addNode(.{
+                        .tag = .identifier_reference,
+                        .span = key_node.span,
+                        .data = .{ .string_ref = key_node.data.string_ref },
+                    });
+                } else blk: {
+                    // long-form {a: b} → b = _ref.a
+                    break :blk try self.visitNode(prop.data.binary.right);
+                };
+
+                const assign = try self.new_ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = target_node, .right = access, .flags = 0 } },
+                });
+                try self.scratch.append(self.allocator, assign);
+            }
+        }
+
+        /// array_assignment_target의 각 element를 assignment로 변환.
+        fn emitArrayAssignments(self: *Transformer, target: Node, ref_span: Span, span: Span) Transformer.Error!void {
+            const members = self.old_ast.extra_data.items[target.data.list.start .. target.data.list.start + target.data.list.len];
+            for (members, 0..) |raw_idx, idx| {
+                const elem = self.old_ast.getNode(@enumFromInt(raw_idx));
+                if (elem.tag == .elision) continue;
+                if (elem.tag == .assignment_target_rest) continue;
+
+                // _ref[idx]
+                const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
+                var idx_buf: [16]u8 = undefined;
+                const idx_str = std.fmt.bufPrint(&idx_buf, "{d}", .{idx}) catch "0";
+                const idx_span = try self.new_ast.addString(idx_str);
+                const idx_node = try self.new_ast.addNode(.{
+                    .tag = .numeric_literal,
+                    .span = idx_span,
+                    .data = .{ .none = 0 },
+                });
+                const access_extra = try self.new_ast.addExtras(&.{ @intFromEnum(ref), @intFromEnum(idx_node), 0 });
+                const access = try self.new_ast.addNode(.{
+                    .tag = .computed_member_expression,
+                    .span = span,
+                    .data = .{ .extra = access_extra },
+                });
+
+                // target = _ref[idx]
+                const target_node = try self.visitNode(@enumFromInt(raw_idx));
+                const assign = try self.new_ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = target_node, .right = access, .flags = 0 } },
+                });
+                try self.scratch.append(self.allocator, assign);
+            }
+        }
+
         /// object_pattern 또는 array_pattern을 개별 declarator로 분해.
         /// ref_span은 임시 변수의 span (_ref).
         fn emitPatternDeclarators(self: *Transformer, pattern: Node, ref_span: Span, span: Span) Transformer.Error!void {

--- a/src/transformer/es2015_spread.zig
+++ b/src/transformer/es2015_spread.zig
@@ -108,6 +108,117 @@ pub fn ES2015Spread(comptime Transformer: type) type {
             });
         }
 
+        /// new Foo(...args) → new (Foo.bind.apply(Foo, [null].concat(args)))()
+        pub fn lowerSpreadNew(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const extras = self.old_ast.extra_data.items;
+            const e = node.data.extra;
+            const span = node.span;
+
+            const callee_idx: NodeIndex = @enumFromInt(extras[e]);
+            const args_start = extras[e + 1];
+            const args_len = extras[e + 2];
+            const old_args = extras[args_start .. args_start + args_len];
+
+            const new_callee = try self.visitNode(callee_idx);
+
+            // [null].concat(args) — null을 첫 인자로 추가 (bind의 this)
+            const null_span = try self.new_ast.addString("null");
+            const null_node = try self.new_ast.addNode(.{
+                .tag = .null_literal,
+                .span = null_span,
+                .data = .{ .none = 0 },
+            });
+            const null_arr_list = try self.new_ast.addNodeList(&.{null_node});
+            const null_arr = try self.new_ast.addNode(.{
+                .tag = .array_expression,
+                .span = span,
+                .data = .{ .list = null_arr_list },
+            });
+
+            // args 조합
+            const combined_args = try buildSpreadArgs(self, old_args, span);
+
+            // [null].concat(combined_args)
+            const concat_span = try self.new_ast.addString("concat");
+            const concat_prop = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = concat_span,
+                .data = .{ .string_ref = concat_span },
+            });
+            const concat_me = try self.new_ast.addExtras(&.{
+                @intFromEnum(null_arr), @intFromEnum(concat_prop), 0,
+            });
+            const concat_member = try self.new_ast.addNode(.{
+                .tag = .static_member_expression,
+                .span = span,
+                .data = .{ .extra = concat_me },
+            });
+            const concat_call_args = try self.new_ast.addNodeList(&.{combined_args});
+            const concat_call_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(concat_member), concat_call_args.start, concat_call_args.len, 0,
+            });
+            const null_concat = try self.new_ast.addNode(.{
+                .tag = .call_expression,
+                .span = span,
+                .data = .{ .extra = concat_call_extra },
+            });
+
+            // Foo.bind
+            const bind_span = try self.new_ast.addString("bind");
+            const bind_prop = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = bind_span,
+                .data = .{ .string_ref = bind_span },
+            });
+            const bind_me = try self.new_ast.addExtras(&.{
+                @intFromEnum(new_callee), @intFromEnum(bind_prop), 0,
+            });
+            const bind_member = try self.new_ast.addNode(.{
+                .tag = .static_member_expression,
+                .span = span,
+                .data = .{ .extra = bind_me },
+            });
+
+            // Foo.bind.apply
+            const apply_span = try self.new_ast.addString("apply");
+            const apply_prop = try self.new_ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = apply_span,
+                .data = .{ .string_ref = apply_span },
+            });
+            const apply_me = try self.new_ast.addExtras(&.{
+                @intFromEnum(bind_member), @intFromEnum(apply_prop), 0,
+            });
+            const apply_member = try self.new_ast.addNode(.{
+                .tag = .static_member_expression,
+                .span = span,
+                .data = .{ .extra = apply_me },
+            });
+
+            // Foo.bind.apply(Foo, [null].concat(args))
+            const callee_ref2 = try self.visitNode(callee_idx);
+            const apply_args = try self.new_ast.addNodeList(&.{ callee_ref2, null_concat });
+            const apply_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(apply_member), apply_args.start, apply_args.len, 0,
+            });
+            const bind_apply_call = try self.new_ast.addNode(.{
+                .tag = .call_expression,
+                .span = span,
+                .data = .{ .extra = apply_extra },
+            });
+
+            // new (Foo.bind.apply(Foo, [null].concat(args)))()
+            const empty_new_args = try self.new_ast.addNodeList(&.{});
+            const new_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(bind_apply_call), empty_new_args.start, empty_new_args.len, 0,
+            });
+            return self.new_ast.addNode(.{
+                .tag = .new_expression,
+                .span = span,
+                .data = .{ .extra = new_extra },
+            });
+        }
+
         /// array_expression에 spread가 있는지 확인.
         pub fn hasSpreadInArray(self: *const Transformer, node: Node) bool {
             const members = self.old_ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -473,6 +473,16 @@ pub const Transformer = struct {
                         return es2021.ES2021(Transformer).lowerLogicalAssignment(self, node, .amp2);
                     }
                 }
+                // ES2015: assignment destructuring → sequence expression
+                if (self.options.target.needsES2015()) {
+                    const left_idx = node.data.binary.left;
+                    if (!left_idx.isNone()) {
+                        const left_node = self.old_ast.getNode(left_idx);
+                        if (left_node.tag == .object_assignment_target or left_node.tag == .array_assignment_target) {
+                            return es2015_destructuring.ES2015Destructuring(Transformer).lowerDestructuringAssignment(self, node);
+                        }
+                    }
+                }
                 return self.visitBinaryNode(node);
             },
             .while_statement,
@@ -575,7 +585,14 @@ pub const Transformer = struct {
                 }
                 return self.visitCallExpression(node);
             },
-            .new_expression => self.visitNewExpression(node),
+            .new_expression => {
+                if (self.options.target.needsES2015()) {
+                    if (es2015_spread.ES2015Spread(Transformer).hasSpreadArg(self, node)) {
+                        return es2015_spread.ES2015Spread(Transformer).lowerSpreadNew(self, node);
+                    }
+                }
+                return self.visitNewExpression(node);
+            },
             .tagged_template_expression => self.visitTaggedTemplate(node),
             .method_definition => self.visitMethodDefinition(node),
             .property_definition => self.visitPropertyDefinition(node),


### PR DESCRIPTION
## Summary
기존 ES2015 변환에서 누락된 2가지 케이스 추가:

1. **assignment destructuring**:
   - `({a, b} = obj)` → `(_a = obj, a = _a.a, b = _a.b, _a)`
   - `([x, y] = arr)` → `(_a = arr, x = _a[0], y = _a[1], _a)`

2. **spread in new expression**:
   - `new Foo(...args)` → `new (Foo.bind.apply(Foo, [null].concat(args)))()`

## Test plan
- [x] `zig build test` 전체 통과
- [x] 3개 유닛 테스트 (spread in new, assignment object/array)

🤖 Generated with [Claude Code](https://claude.com/claude-code)