### PR TITLE
fix: 복수 private field 클래스 패닉 수정 (dangling slice)

### DIFF
--- a/packages/integration/tests/downlevel.test.ts
+++ b/packages/integration/tests/downlevel.test.ts
@@ -469,8 +469,22 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("1 20");
     });
 
-    // TODO: 복수 private field 클래스에서 codegen 패닉 (collectTopLevelDeclNames index OOB)
-    // test("multiple class with private fields", ...)
+    test("multiple class with private fields", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class A { #v = 1; get() { return this.#v; } }
+            class B { #v = 2; get() { return this.#v; } }
+            console.log(new A().get(), new B().get());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 2");
+    });
   });
 
   // ===== ES2016 (target=es2015) =====

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -806,21 +806,25 @@ pub fn ES2015Class(comptime Transformer: type) type {
         /// function_declaration의 body 앞에 문들을 삽입
         fn prependToFunctionBody(self: *Transformer, func_idx: NodeIndex, stmts: []const NodeIndex) Transformer.Error!NodeIndex {
             const func = self.new_ast.getNode(func_idx);
-            const func_extras = self.new_ast.extra_data.items;
             const fe = func.data.extra;
 
-            // function: extra = [name, params_start, params_len, body, flags, return_type]
-            const body_idx: NodeIndex = @enumFromInt(func_extras[fe + 3]);
+            // extra_data 슬라이스는 prependStatementsToBody 호출 시 재할당될 수 있으므로
+            // 필요한 값을 미리 로컬에 복사
+            const saved_name = self.new_ast.extra_data.items[fe];
+            const saved_params_start = self.new_ast.extra_data.items[fe + 1];
+            const saved_params_len = self.new_ast.extra_data.items[fe + 2];
+            const saved_flags = self.new_ast.extra_data.items[fe + 4];
+            const body_idx: NodeIndex = @enumFromInt(self.new_ast.extra_data.items[fe + 3]);
+
             const new_body = try self.prependStatementsToBody(body_idx, stmts);
 
-            // function 노드를 새 body로 재생성
             const none = @intFromEnum(NodeIndex.none);
             const new_extra = try self.new_ast.addExtras(&.{
-                func_extras[fe], // name
-                func_extras[fe + 1], // params_start
-                func_extras[fe + 2], // params_len
+                saved_name,
+                saved_params_start,
+                saved_params_len,
                 @intFromEnum(new_body),
-                func_extras[fe + 4], // flags
+                saved_flags,
                 none,
             });
             return self.new_ast.addNode(.{


### PR DESCRIPTION
## Summary
prependToFunctionBody에서 \`extra_data.items\` 슬라이스를 캡처한 후 \`prependStatementsToBody\`를 호출하면 extra_data ArrayList가 재할당되어 캡처된 슬라이스가 dangling pointer가 되는 버그 수정.

**재현**: 두 개 이상의 클래스에 각각 private field + 메서드가 있을 때 codegen에서 index OOB 패닉.

**수정**: 필요한 extra_data 값을 미리 로컬 변수에 복사한 후 호출.

## Test plan
- [x] `zig build test` 1516/1516 통과
- [x] 통합 테스트 44/44 통과 (multiple class with private fields 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)