### PR TITLE
fix(transformer): generator dead code 제거

### DIFF
--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -369,8 +369,10 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // then body
             try collectBodyOperations(self, then_body, ops, next_label);
 
-            // goto end
-            try ops.append(self.allocator, .{ .code = .break_op, .arg = .{ .label = end_label } });
+            // goto end (then body가 return/break로 끝나면 생략 — dead code 방지)
+            if (ops.items.len == 0 or (ops.items[ops.items.len - 1].code != .return_op and ops.items[ops.items.len - 1].code != .break_op)) {
+                try ops.append(self.allocator, .{ .code = .break_op, .arg = .{ .label = end_label } });
+            }
 
             // else label
             if (!else_body.isNone()) {


### PR DESCRIPTION
## Summary
generator for+conditional return 변환 시 `return [2]` 뒤에 unreachable `return [3, N]` dead code 제거.

collectIfOperations에서 then body가 return_op/break_op로 끝나면 goto end를 생략.

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `bun run smoke.ts` — 129/129, 128/128

🤖 Generated with [Claude Code](https://claude.com/claude-code)