### PR TITLE
fix(bundler): namespace 변수명 progressive 충돌 방지

### DIFF
--- a/packages/integration/tests/bundle-smoke.test.ts
+++ b/packages/integration/tests/bundle-smoke.test.ts
@@ -248,4 +248,76 @@ describe("번들 스모크 테스트", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("ok");
   });
+
+  test("namespace 변수명 progressive 충돌 방지 (z_ns export 존재 시 z_ns2)", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import * as z from "./lib"; console.log(z.foo(), z.z_ns, Object.keys(z).sort().join(","));`,
+      "lib.ts": `export function foo() { return "ok"; } export const z_ns = 42;`,
+    });
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("ok 42 foo,z_ns");
+  });
+
+  test("namespace 변수명 이중 충돌 (z_ns + z_ns2 export 존재 시 z_ns3)", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import * as z from "./lib"; console.log(z.foo(), z.z_ns, z.z_ns2, Object.keys(z).sort().join(","));`,
+      "lib.ts": `export function foo() { return "ok"; } export const z_ns = 1; export const z_ns2 = 2;`,
+    });
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("ok 1 2 foo,z_ns,z_ns2");
+  });
+
+  test("namespace import 빈 모듈", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import * as empty from "./lib"; console.log(Object.keys(empty).length);`,
+      "lib.ts": `// empty`,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("0");
+  });
+
+  test("namespace import를 함수 인자로 전달", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import * as lib from "./lib"; function inspect(obj: any) { return Object.keys(obj).join(","); } console.log(inspect(lib));`,
+      "lib.ts": `export const a = 1; export const b = 2;`,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("a,b");
+  });
+
+  test("namespace를 변수에 대입", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import * as lib from "./lib"; const ref = lib; console.log(ref.foo());`,
+      "lib.ts": `export function foo() { return "ok"; }`,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("ok");
+  });
+
+  test("namespace를 typeof로 사용", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import * as lib from "./lib"; console.log(typeof lib);`,
+      "lib.ts": `export const a = 1;`,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("object");
+  });
+
+  test("namespace를 spread로 사용", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import * as lib from "./lib"; const copy = { ...lib }; console.log(copy.a, copy.b);`,
+      "lib.ts": `export const a = 1; export const b = 2;`,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("1 2");
+  });
 });

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1545,11 +1545,33 @@ pub const Linker = struct {
 
         if (ns_inline_list) |list| {
             const obj_str = try self.buildInlineObjectStr(target_mod_idx, 0);
+            // 충돌 방지: export 이름과 겹치지 않는 변수명 생성
+            const ns_var_name = try self.makeUniqueNsVarName(var_name, &seen);
             try list.append(self.allocator, .{
                 .symbol_id = symbol_id,
                 .object_literal = obj_str,
-                .var_name = try std.mem.concat(self.allocator, u8, &.{ var_name, "_ns" }),
+                .var_name = ns_var_name,
             });
+        }
+    }
+
+    /// namespace preamble 변수명을 export 이름과 충돌하지 않도록 생성.
+    /// "z" → "z_ns", 충돌 시 "z_ns2", "z_ns3", ...
+    fn makeUniqueNsVarName(self: *const Linker, base: []const u8, exports: *const std.StringHashMap(void)) std.mem.Allocator.Error![]const u8 {
+        // 첫 시도: base_ns
+        const first = try std.mem.concat(self.allocator, u8, &.{ base, "_ns" });
+        if (!exports.contains(first)) return first;
+        self.allocator.free(first);
+
+        // 충돌 시 progressive suffix: base_ns2, base_ns3, ...
+        // export 수가 유한하므로 반드시 종료
+        var suffix: u32 = 2;
+        while (true) : (suffix += 1) {
+            var buf: [16]u8 = undefined;
+            const num_str = std.fmt.bufPrint(&buf, "{d}", .{suffix}) catch unreachable;
+            const candidate = try std.mem.concat(self.allocator, u8, &.{ base, "_ns", num_str });
+            if (!exports.contains(candidate)) return candidate;
+            self.allocator.free(candidate);
         }
     }
 


### PR DESCRIPTION
## Summary
`_ns` suffix가 기존 export 이름과 충돌할 때 `_ns2`, `_ns3`, ... 순서로 고유 이름을 탐색.

## Before / After
```ts
// lib.ts
export function foo() { return 'foo'; }
export const z_ns = 42;  // _ns와 충돌!

// Before: var z_ns = {...} → SyntaxError: Identifier 'z_ns' has already been declared
// After:  var z_ns2 = {...} → 정상 동작
```

## Test plan
- [x] `z_ns` 단일 충돌 → `z_ns2` 생성
- [x] `z_ns` + `z_ns2` 이중 충돌 → `z_ns3` 생성
- [x] 기존 테스트 19/19 pass
- [x] 유닛 테스트 전체 pass, 메모리 누수 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)