### PR TITLE
fix(parser): 삼항 연산자 + 화살표 expression body 파싱 (#446)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -4616,3 +4616,43 @@ test "useDefineForClassFields=false: no-init fields removed" {
     // class body에 y, w가 없어야 함 (method만 있음)
     try std.testing.expect(std.mem.indexOf(u8, r.output, ";y") == null);
 }
+
+// ============================================================
+// 삼항 연산자 + 화살표 함수 (#446)
+// ============================================================
+
+test "ternary with arrow function body containing parens" {
+    // d3-array cumsum 패턴: ? v => (expr) : v => (expr)
+    // 파서가 에러 없이 파싱해야 함
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var scanner = try Scanner.init(allocator, "const f = true ? v => (v + 1) : v => (v - 1);");
+    var parser = Parser.init(allocator, &scanner);
+    parser.is_module = true;
+    scanner.is_module = true;
+    _ = try parser.parse();
+    try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
+}
+
+test "ternary with arrow function — d3 cumsum pattern" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const source =
+        \\function cumsum(values, valueof) {
+        \\  var sum = 0, index = 0;
+        \\  return Float64Array.from(values, valueof === undefined
+        \\    ? v => (sum += +v || 0)
+        \\    : v => (sum += +valueof(v, index++, values) || 0));
+        \\}
+    ;
+    var scanner = try Scanner.init(allocator, source);
+    var parser = Parser.init(allocator, &scanner);
+    parser.is_module = true;
+    scanner.is_module = true;
+    _ = try parser.parse();
+    try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
+}

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -196,8 +196,14 @@ pub fn parseArrowBody(self: *Parser, is_async: bool, param_idx: NodeIndex) Parse
     self.has_simple_params = self.isSimpleArrowParams(param_idx);
     const body = if (self.current() == .l_curly)
         try self.parseFunctionBodyExpr()
-    else
-        try parseAssignmentExpression(self);
+    else blk: {
+        // expression body에서는 외부 ternary context를 유지해야 함.
+        // enterFunctionContext가 in_ternary_consequent를 false로 리셋하지만,
+        // 화살표 expression body에서 `:` 를 만나면 외부 삼항의 separator일 수 있음.
+        // `a ? v => (expr) : v => (expr2)` — `:` 는 외부 삼항의 separator.
+        self.in_ternary_consequent = saved_ctx.in_ternary_consequent;
+        break :blk try parseAssignmentExpression(self);
+    };
     self.restoreFunctionContext(saved_ctx);
     return body;
 }


### PR DESCRIPTION
## Summary
\`a ? v => (expr) : v => (expr2)\` 에서 화살표 expression body 뒤의 \`:\`를 TS typed arrow return type으로 오인하는 파서 버그 수정.

## 근본 원인
\`enterFunctionContext\`가 \`in_ternary_consequent\`를 false로 리셋하여, 화살표 expression body에서 외부 삼항의 \`:\` 컨텍스트가 유실.

## 수정
\`parseArrowBody\`에서 expression body일 때 \`in_ternary_consequent\`를 외부 값으로 복원.

## Test plan
- [x] \`true ? v => (v+1) : v => (v-1)\` 파싱 에러 0개
- [x] d3-array cumsum 패턴 파싱 정상
- [x] d3 번들: scaleLinear, range, cumsum 모두 function
- [x] 유닛 테스트 전체 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)