### PR TITLE
fix(bundler): .js Unambiguous 파싱 + scope hoisting 리네임 충돌 방지

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,9 @@
       "name": "@zts/benchmark",
       "version": "0.1.0",
       "dependencies": {
+        "lodash-es": "^4.17.23",
         "valibot": "^1.3.1",
+        "vue": "^3.5.31",
       },
       "devDependencies": {
         "@rspack/cli": "^1.3.0",
@@ -44,6 +46,14 @@
     },
   },
   "packages": {
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.5.7", "", {}, "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="],
@@ -458,6 +468,24 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.31", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.31", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.31", "", { "dependencies": { "@vue/compiler-core": "3.5.31", "@vue/shared": "3.5.31" } }, "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.31", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.31", "@vue/compiler-dom": "3.5.31", "@vue/compiler-ssr": "3.5.31", "@vue/shared": "3.5.31", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.31", "", { "dependencies": { "@vue/compiler-dom": "3.5.31", "@vue/shared": "3.5.31" } }, "sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.31", "", { "dependencies": { "@vue/shared": "3.5.31" } }, "sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.31", "", { "dependencies": { "@vue/reactivity": "3.5.31", "@vue/shared": "3.5.31" } }, "sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.31", "", { "dependencies": { "@vue/reactivity": "3.5.31", "@vue/runtime-core": "3.5.31", "@vue/shared": "3.5.31", "csstype": "^3.2.3" } }, "sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.31", "", { "dependencies": { "@vue/compiler-ssr": "3.5.31", "@vue/shared": "3.5.31" }, "peerDependencies": { "vue": "3.5.31" } }, "sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA=="],
+
+    "@vue/shared": ["@vue/shared@3.5.31", "", {}, "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw=="],
+
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 
     "@webassemblyjs/floating-point-hex-parser": ["@webassemblyjs/floating-point-hex-parser@1.13.2", "", {}, "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="],
@@ -642,6 +670,8 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
     "debounce": ["debounce@1.2.1", "", {}, "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="],
 
     "debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -678,6 +708,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "envinfo": ["envinfo@7.21.0", "", { "bin": { "envinfo": "dist/cli.js" } }, "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
@@ -701,6 +733,8 @@
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -876,7 +910,11 @@
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
+    "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
+
     "lowercase-keys": ["lowercase-keys@3.0.0", "", {}, "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -913,6 +951,8 @@
     "ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "multicast-dns": ["multicast-dns@7.2.5", "", { "dependencies": { "dns-packet": "^5.2.2", "thunky": "^1.0.2" }, "bin": { "multicast-dns": "cli.js" } }, "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
@@ -981,6 +1021,8 @@
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
@@ -1082,6 +1124,8 @@
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "spdy": ["spdy@4.0.2", "", { "dependencies": { "debug": "^4.1.0", "handle-thing": "^2.0.0", "http-deceiver": "^1.2.7", "select-hose": "^2.0.0", "spdy-transport": "^3.0.0" } }, "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA=="],
@@ -1161,6 +1205,8 @@
     "valibot": ["valibot@1.3.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vue": ["vue@3.5.31", "", { "dependencies": { "@vue/compiler-dom": "3.5.31", "@vue/compiler-sfc": "3.5.31", "@vue/runtime-dom": "3.5.31", "@vue/server-renderer": "3.5.31", "@vue/shared": "3.5.31" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q=="],
 
     "watchpack": ["watchpack@2.5.1", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg=="],
 

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -8,7 +8,9 @@
     "bench:bundle": "bun run bench.ts --bundle"
   },
   "dependencies": {
-    "valibot": "^1.3.1"
+    "lodash-es": "^4.17.23",
+    "valibot": "^1.3.1",
+    "vue": "^3.5.31"
   },
   "devDependencies": {
     "@rspack/cli": "^1.3.0",

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -275,19 +275,16 @@ pub const ModuleGraph = struct {
         };
 
         var parser = Parser.init(arena_alloc, &scanner);
-        parser.configureFromExtension(std.fs.path.extension(module.path));
-        // package.json "type": "module"이면 .js 파일도 ESM으로 파싱해야 한다.
-        // configureFromExtension은 .js를 is_module=false로 두므로,
-        // 파싱 전에 package.json type 필드를 확인하여 오버라이드한다.
-        // (이전에는 파싱 후 determineExportsKind에서만 확인했으나,
-        //  파서가 import/export를 module 모드에서만 허용하므로 파싱 전에 필요)
-        if (!parser.is_module and (module.is_module_field or self.isPackageTypeModule(module.path))) {
+        parser.configureForBundler(std.fs.path.extension(module.path));
+        // .js/.jsx: package.json "type" 또는 Unambiguous 모드로 module/script 결정
+        // .mjs/.mts/.ts/.tsx: 이미 확정 module, 변경 없음
+        if (!parser.is_module) {
             parser.is_module = true;
             scanner.is_module = true;
+            if (!module.is_module_field and !self.isPackageTypeModule(module.path)) {
+                parser.is_unambiguous = true;
+            }
         }
-        // 번들러에서는 모든 모듈을 확정적 Module로 파싱 (import로 연결되므로)
-        // Unambiguous 모드 비활성화 — await는 항상 키워드, strict 항상 적용
-        parser.is_unambiguous = false;
         _ = parser.parse() catch {
             self.addDiag(.parse_error, .@"error", module.path, Span.EMPTY, .parse, "Parse failed", null);
             module.state = .ready;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -155,6 +155,8 @@ pub const Linker = struct {
     /// 이름 충돌 해결 결과: (module_index, export_name) → canonical_name.
     /// 충돌 없으면 원본 이름 유지 (엔트리 없음).
     canonical_names: std.StringHashMap([]const u8),
+    /// canonical_names 값의 역방향 조회용. 리네임 후보가 기존 할당과 충돌하는지 O(1) 확인.
+    canonical_names_used: std.StringHashMap(void),
 
     /// 자동 수집된 예약 글로벌 이름. 모든 모듈의 unresolved references를 합친 것.
     /// scope hoisting 시 모듈 top-level 변수가 이 이름을 shadowing하면 리네임.
@@ -191,6 +193,7 @@ pub const Linker = struct {
             .resolved_bindings = std.AutoHashMap(BindingKey, ResolvedBinding).init(allocator),
             .diagnostics = .empty,
             .canonical_names = std.StringHashMap([]const u8).init(allocator),
+            .canonical_names_used = std.StringHashMap(void).init(allocator),
             .reserved_globals = std.StringHashMap(void).init(allocator),
         };
     }
@@ -209,6 +212,7 @@ pub const Linker = struct {
             self.allocator.free(entry.value_ptr.*);
         }
         self.canonical_names.deinit();
+        self.canonical_names_used.deinit();
         self.reserved_globals.deinit();
         self.diagnostics.deinit(self.allocator);
     }
@@ -295,6 +299,10 @@ pub const Linker = struct {
         if (self.isReservedOrGlobal(candidate)) return false;
         if (name_to_owners.contains(candidate)) return false;
         if (self.hasNestedBinding(module_index, candidate)) return false;
+        // canonical_names에 이미 이 이름으로 리네임된 다른 모듈이 있으면 충돌.
+        // resolveNestedShadowConflicts에서 target을 리네임할 때,
+        // calculateRenames가 이미 할당한 이름과 겹치지 않도록 확인.
+        if (self.isCanonicalNameTaken(candidate)) return false;
         return true;
     }
 
@@ -339,11 +347,7 @@ pub const Linker = struct {
                     var suffix: u32 = 1;
                     const candidate = try self.findAvailableCandidate(name, owner.module_index, &suffix, name_to_owners);
                     const key = try makeExportKey(self.allocator, owner.module_index, name);
-                    if (self.canonical_names.fetchRemove(key)) |old| {
-                        self.allocator.free(old.key);
-                        self.allocator.free(old.value);
-                    }
-                    try self.canonical_names.put(key, candidate);
+                    try self.putCanonicalName(key, candidate);
                 }
                 continue;
             }
@@ -369,12 +373,7 @@ pub const Linker = struct {
                 const candidate = try self.findAvailableCandidate(name, owner.module_index, &suffix, name_to_owners);
 
                 const key = try makeExportKey(self.allocator, owner.module_index, name);
-                // M4 수정: 중복 키 시 이전 키/값 해제
-                if (self.canonical_names.fetchRemove(key)) |old| {
-                    self.allocator.free(old.key);
-                    self.allocator.free(old.value);
-                }
-                try self.canonical_names.put(key, candidate);
+                try self.putCanonicalName(key, candidate);
                 suffix += 1;
             }
         }
@@ -441,11 +440,7 @@ pub const Linker = struct {
                     // 새 이름: target_name$N (기존 이름 충돌 없는 것)
                     var suffix: u32 = 1;
                     const candidate = try self.findAvailableCandidate(target_name, cmod, &suffix, name_to_owners);
-                    if (self.canonical_names.fetchRemove(key)) |old| {
-                        self.allocator.free(old.key);
-                        self.allocator.free(old.value);
-                    }
-                    try self.canonical_names.put(key, candidate);
+                    try self.putCanonicalName(key, candidate);
                 }
             }
         }
@@ -569,6 +564,22 @@ pub const Linker = struct {
                 }
             }
         }
+    }
+
+    /// 다른 모듈의 리네임 대상으로 이미 할당된 이름인지 O(1) 확인.
+    fn isCanonicalNameTaken(self: *const Linker, name: []const u8) bool {
+        return self.canonical_names_used.contains(name);
+    }
+
+    /// canonical_names에 put하면서 역방향 맵도 동기화.
+    fn putCanonicalName(self: *Linker, key: []const u8, value: []const u8) !void {
+        if (self.canonical_names.fetchRemove(key)) |old| {
+            _ = self.canonical_names_used.fetchRemove(old.value);
+            self.allocator.free(old.key);
+            self.allocator.free(old.value);
+        }
+        try self.canonical_names.put(key, value);
+        try self.canonical_names_used.put(value, {});
     }
 
     /// 모듈의 중첩 스코프(비-모듈 스코프)에 해당 이름이 존재하는지 확인.
@@ -1799,6 +1810,7 @@ pub const Linker = struct {
             self.allocator.free(entry.value_ptr.*);
         }
         self.canonical_names.clearRetainingCapacity();
+        self.canonical_names_used.clearRetainingCapacity();
     }
 
     /// 특정 모듈들만 대상으로 이름 충돌을 감지하고 리네임을 계산한다.

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -247,16 +247,24 @@ pub const Parser = struct {
     /// - .mts/.mjs → 확정적 Module (is_module=true)
     /// - .ts/.tsx → Unambiguous (is_module=true 낙관적 파싱 + 에러 지연)
     /// - .js/.jsx/.cts/.cjs → Script (is_module=false)
+    /// CLI용: .ts/.tsx는 Unambiguous 모드 (import/export 유무로 module/script 파싱 후 확정)
     pub fn configureFromExtension(self: *Parser, ext: []const u8) void {
+        self.applyExtension(ext, true);
+    }
+
+    /// 번들러용: .ts/.tsx를 확정 module로 파싱 (await 키워드, strict mode 항상 적용)
+    pub fn configureForBundler(self: *Parser, ext: []const u8) void {
+        self.applyExtension(ext, false);
+    }
+
+    fn applyExtension(self: *Parser, ext: []const u8, ts_unambiguous: bool) void {
         if (std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".mjs")) {
-            // 확정적 Module — import/export 없어도 module
             self.is_module = true;
             self.scanner.is_module = true;
         } else if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx")) {
-            // Unambiguous — 낙관적으로 module로 파싱, 파싱 후 확정
             self.is_module = true;
             self.scanner.is_module = true;
-            self.is_unambiguous = true;
+            self.is_unambiguous = ts_unambiguous;
         }
         if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx") or
             std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".cts"))


### PR DESCRIPTION
## Summary
- 번들러에서 `.js/.jsx` 파일을 Unambiguous 모드로 파싱 (oxc 방식) — import/export 유무로 module/script 자동 결정
- scope hoisting 리네임 시 `canonical_names`에 이미 할당된 이름과 충돌하는 문제 수정
- `[warning] Parse completed with errors` 해결

## Changes
- `parser.configureForBundler()` API 분리 — `.ts/.tsx`는 확정 module, `.js/.jsx`는 Unambiguous
- `canonical_names_used` 역방향 HashSet으로 O(1) 충돌 확인
- `putCanonicalName` 헬퍼로 3곳의 put+fetchRemove 중복 패턴 통합

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] 통합 테스트 2,291개 통과
- [x] 스모크 테스트 129/129 통과
- [x] vue `import *` 171개 export 정상 (이전 0개)
- [x] vue ref/computed/reactive 기능 테스트 통과
- [x] lodash-es 전체 번들 정상

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)