### PR TITLE
fix(bundler): namespace 객체에서 bare default 키워드 출력 방지

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1559,7 +1559,13 @@ pub const Linker = struct {
     pub fn resolveToLocalName(self: *const Linker, ref: SymbolRef) []const u8 {
         const cmod: u32 = @intCast(@intFromEnum(ref.module_index));
         const local = self.getExportLocalName(cmod, ref.export_name) orelse ref.export_name;
-        return self.getCanonicalName(cmod, local) orelse local;
+        const canonical = self.getCanonicalName(cmod, local) orelse local;
+        // "default"는 JS 예약어 — 식별자로 사용 불가.
+        // codegen이 생성하는 합성 변수명(_default)의 canonical name으로 대체.
+        if (std.mem.eql(u8, canonical, "default")) {
+            return self.getCanonicalName(cmod, "_default") orelse "_default";
+        }
+        return canonical;
     }
 
     /// ESM namespace import를 위한 namespace 객체 preamble 생성.
@@ -1749,9 +1755,16 @@ pub const Linker = struct {
                 break :blk eb.local_name;
             } else self.getCanonicalName(@intCast(mod_i), eb.local_name) orelse eb.local_name;
 
+            // "default"는 JS 예약어 — 값 위치에 식별자로 사용 불가.
+            // codegen이 생성하는 합성 변수명(_default)의 canonical name으로 대체.
+            const safe_local = if (std.mem.eql(u8, actual_local, "default"))
+                self.getCanonicalName(@intCast(mod_i), "_default") orelse "_default"
+            else
+                actual_local;
+
             try exports.append(self.allocator, .{
                 .exported = eb.exported_name,
-                .local = actual_local,
+                .local = safe_local,
                 .owned = actual_local.len > 0 and actual_local[0] == '{',
             });
         }


### PR DESCRIPTION
## Summary
- namespace 인라인 객체에서 export의 local name이 `default`인 경우, JS 예약어가 식별자 위치에 출력되어 SyntaxError 발생
- codegen 합성 변수명(`_default`)의 canonical name으로 대체

## Test plan
- [x] eventemitter3 `import *` — 2개 export, undefined 0개 (esbuild와 일치)
- [x] 유닛 테스트 전체 통과
- [x] 스모크 테스트 129/129 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)