### PR TITLE
fix(bundler): Rolldown 방식 CJS→ESM Interop 도입

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -7961,7 +7961,8 @@ test "CJS: __toESM wraps default import from CJS" {
 
     try std.testing.expect(!result.hasErrors());
     // default import는 __toESM으로 래핑되어야 함
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib(), 1)") != null);
+    // .ts importer → Babel 모드 (isNodeMode 없음)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
 }
 
 test "CJS: __toESM not applied to named imports" {
@@ -7979,9 +7980,8 @@ test "CJS: __toESM not applied to named imports" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // named import의 preamble에는 __toESM이 적용되지 않음 (require_lib().value 형태)
-    // __toESM 런타임 헬퍼 자체는 존재하지만, preamble에서는 사용하지 않음
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib(), 1)") == null);
+    // named import에는 __toESM 미적용 (require_lib().value 형태)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_lib().value") != null);
 }
 
@@ -8154,8 +8154,8 @@ test "CJS: namespace import from CJS uses __toESM" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // namespace import도 __toESM으로 래핑
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib(), 1)") != null);
+    // namespace import도 __toESM으로 래핑 (.ts → Babel 모드)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
 }
 
 test "CJS: multiple ESM modules importing same CJS module" {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -275,13 +275,29 @@ pub const ModuleGraph = struct {
         };
 
         var parser = Parser.init(arena_alloc, &scanner);
-        parser.configureForBundler(std.fs.path.extension(module.path));
+        const ext = std.fs.path.extension(module.path);
+        parser.configureForBundler(ext);
+
+        // 모듈 정의 형식 결정 (Rolldown ModuleDefFormat)
+        module.def_format = if (std.mem.eql(u8, ext, ".mjs"))
+            .esm_mjs
+        else if (std.mem.eql(u8, ext, ".mts"))
+            .esm_mts
+        else if (std.mem.eql(u8, ext, ".cjs"))
+            .cjs
+        else if (std.mem.eql(u8, ext, ".cts"))
+            .cts
+        else if (module.is_module_field or self.isPackageTypeModule(module.path))
+            .esm_package_json
+        else
+            .unknown;
+
         // .js/.jsx: package.json "type" 또는 Unambiguous 모드로 module/script 결정
         // .mjs/.mts/.ts/.tsx: 이미 확정 module, 변경 없음
         if (!parser.is_module) {
             parser.is_module = true;
             scanner.is_module = true;
-            if (!module.is_module_field and !self.isPackageTypeModule(module.path)) {
+            if (module.def_format == .unknown) {
                 parser.is_unambiguous = true;
             }
         }
@@ -636,18 +652,16 @@ pub const ModuleGraph = struct {
 
     /// node_modules 내 .js 파일이 ESM/CJS 신호 없으면 CJS로 간주.
     /// Node.js 규칙: package.json "type": "module"이 없으면 .js는 CJS.
-    fn isImplicitCjs(self: *ModuleGraph, module: *const Module) bool {
+    fn isImplicitCjs(_: *ModuleGraph, module: *const Module) bool {
         // node_modules 밖이면 ESM으로 간주 (사용자 코드)
         const nm = "node_modules" ++ std.fs.path.sep_str;
         if (std.mem.indexOf(u8, module.path, nm) == null) return false;
-        const ext = std.fs.path.extension(module.path);
-        // .cjs/.cts는 항상 CJS (type 필드 무관)
-        if (std.mem.eql(u8, ext, ".cjs") or std.mem.eql(u8, ext, ".cts")) return true;
-        // .mjs/.mts는 항상 ESM
-        if (std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".mts")) return false;
-        // package.json "type": "module"이면 ESM
-        if (self.isPackageTypeModule(module.path)) return false;
-        return true;
+        // def_format이 파싱 시점에 이미 결정됨 — 디스크 I/O 불필요
+        return switch (module.def_format) {
+            .cjs, .cts, .cjs_package_json => true,
+            .esm_mjs, .esm_mts, .esm_package_json => false,
+            .unknown => true, // node_modules 내 .js는 기본 CJS
+        };
     }
 
     /// 모듈 경로에서 가장 가까운 package.json의 "type" 필드가 "module"인지 확인.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -816,7 +816,8 @@ pub const Linker = struct {
                 // CJS 모듈에서 import하는 경우: preamble에서 require_xxx() 호출 생성
                 if (canonical_mod < self.modules.len and self.modules[canonical_mod].wrap_kind == .cjs) {
                     const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
-                    try appendCjsImportPreamble(&cjs_preamble_buf, self.allocator, ib.local_name, ib.imported_name, req_var, ib.kind == .namespace);
+                    const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
+                    try appendCjsImportPreamble(&cjs_preamble_buf, self.allocator, ib.local_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
                     continue;
                 }
 
@@ -849,7 +850,8 @@ pub const Linker = struct {
                     const cjs_mod: u32 = @intCast(@intFromEnum(rb.canonical.module_index));
                     if (cjs_mod < self.modules.len and self.modules[cjs_mod].wrap_kind == .cjs) {
                         const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, cjs_mod);
-                        try appendCjsImportPreamble(&cjs_preamble_buf, self.allocator, ib.local_name, ib.imported_name, req_var, false);
+                        const interop_mode2: types.Interop = if (m.def_format.isEsm()) .node else .babel;
+                        try appendCjsImportPreamble(&cjs_preamble_buf, self.allocator, ib.local_name, ib.imported_name, req_var, false, interop_mode2);
                         continue;
                     }
                 }
@@ -1952,18 +1954,22 @@ fn appendCjsImportPreamble(
     imported_name: []const u8,
     req_var: []const u8,
     is_namespace: bool,
+    interop: types.Interop,
 ) !void {
     try buf.appendSlice(allocator, "var ");
     try buf.appendSlice(allocator, local_name);
-    // isNodeMode=1: --platform=node에서 __esModule=true인 CJS도 default: mod를 설정 (esbuild 호환)
+    // Rolldown Interop: node → __toESM(req(), 1), babel → __toESM(req())
+    const toesm_suffix: []const u8 = if (interop == .node) "(), 1)" else "())";
     if (is_namespace) {
         try buf.appendSlice(allocator, " = __toESM(");
         try buf.appendSlice(allocator, req_var);
-        try buf.appendSlice(allocator, "(), 1);\n");
+        try buf.appendSlice(allocator, toesm_suffix);
+        try buf.appendSlice(allocator, ";\n");
     } else if (std.mem.eql(u8, imported_name, "default")) {
         try buf.appendSlice(allocator, " = __toESM(");
         try buf.appendSlice(allocator, req_var);
-        try buf.appendSlice(allocator, "(), 1).default;\n");
+        try buf.appendSlice(allocator, toesm_suffix);
+        try buf.appendSlice(allocator, ".default;\n");
     } else {
         try buf.appendSlice(allocator, " = ");
         try buf.appendSlice(allocator, req_var);

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -71,6 +71,8 @@ pub const Module = struct {
     exports_kind: types.ExportsKind = .none,
     /// 모듈 래핑 방식 (CJS → __commonJS 팩토리 함수)
     wrap_kind: types.WrapKind = .none,
+    /// 모듈 정의 형식 (확장자/package.json 기반, Rolldown ModuleDefFormat)
+    def_format: types.ModuleDefFormat = .unknown,
     /// Top-Level Await 사용 여부. TLA 모듈을 static import하는 모듈도 전이적으로 true.
     uses_top_level_await: bool = false,
     side_effects: bool,
@@ -97,6 +99,13 @@ pub const Module = struct {
         /// import 추출 완료, 사용 가능
         ready,
     };
+
+    /// CJS importee에 대한 interop 모드 결정 (Rolldown 방식).
+    /// importer(self)가 ESM 정의 형식이면 Node 모드, 아니면 Babel 모드.
+    pub fn interop(self: *const Module, importee: *const Module) ?types.Interop {
+        if (importee.exports_kind != .commonjs) return null;
+        return if (self.def_format.isEsm()) .node else .babel;
+    }
 
     pub fn init(index: ModuleIndex, path: []const u8) Module {
         return .{

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -63,6 +63,43 @@ pub const WrapKind = enum {
     cjs,
 };
 
+/// CJS → ESM interop 모드 (Rolldown Interop).
+/// importer의 모듈 정의 형식에 따라 __toESM 호출 방식이 결정됨.
+pub const Interop = enum {
+    /// __toESM(require_foo()) — __esModule 플래그 존중
+    babel,
+    /// __toESM(require_foo(), 1) — Node.js ESM 명세 호환 (항상 default: mod 설정)
+    node,
+};
+
+/// 모듈 정의 형식 (Rolldown ModuleDefFormat).
+/// 파일 확장자 또는 package.json "type" 필드로 결정.
+/// CJS → ESM interop 시 Node 모드 활성화 여부에 사용.
+pub const ModuleDefFormat = enum {
+    /// 형식 미확정
+    unknown,
+    /// .cjs 확장자
+    cjs,
+    /// .cts 확장자
+    cts,
+    /// package.json "type": "commonjs"
+    cjs_package_json,
+    /// .mjs 확장자
+    esm_mjs,
+    /// .mts 확장자
+    esm_mts,
+    /// package.json "type": "module"
+    esm_package_json,
+
+    pub fn isEsm(self: ModuleDefFormat) bool {
+        return self == .esm_mjs or self == .esm_mts or self == .esm_package_json;
+    }
+
+    pub fn isCommonjs(self: ModuleDefFormat) bool {
+        return self == .cjs or self == .cts or self == .cjs_package_json;
+    }
+};
+
 // ============================================================
 // 청크 인덱스 (Code Splitting)
 // ============================================================


### PR DESCRIPTION
## Summary
- CJS import의 `__toESM` 호출 시 `isNodeMode`를 importer의 모듈 정의 형식에 따라 결정
- Rolldown의 `Interop` enum + `ModuleDefFormat` 패턴 도입

## Changes
- **types.zig**: `Interop` enum (`babel`/`node`), `ModuleDefFormat` enum (7가지 형식)
- **module.zig**: `def_format` 필드 + `interop()` 메서드
- **graph.zig**: 파싱 시 확장자/package.json으로 `def_format` 결정
- **linker.zig**: `appendCjsImportPreamble`에 `node_mode` 파라미터

## 동작
| importer | importee | 결과 |
|----------|----------|------|
| `.js`/`.ts` (Unknown) | CJS | `__toESM(req())` — `__esModule` 존중 |
| `.mjs`/`.mts` (ESM) | CJS | `__toESM(req(), 1)` — Node.js ESM 호환 |

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] 스모크 테스트 127/129 통과 (tslib tree-shaking, cookie 패키지 문제는 기존)
- [x] CJS+`__esModule` 패키지에서 불필요한 `default` export 제거 확인
- [x] `.mjs` importer에서 Node 모드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)