### PR TITLE
fix(bundler): export *에서 default export 제외 (ESM 스펙 준수)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1803,7 +1803,11 @@ pub const Linker = struct {
             });
         }
 
-        // export * 재귀 — export * as ns는 이미 첫 루프에서 인라인 객체로 처리됨
+        // export * 재귀 — export * as ns는 이미 첫 루프에서 인라인 객체로 처리됨.
+        // ESM 스펙: export *는 "default"를 제외 (ECMAScript 15.2.3.5).
+        // seen에 "default"를 추가하여 하위 모듈의 default export가 수집되지 않도록 함.
+        // 직접 선언된 export { default }는 위 첫 루프에서 이미 수집됨.
+        try seen.put("default", {});
         for (m.export_bindings) |eb| {
             if (eb.kind != .re_export_all) continue;
             if (!std.mem.eql(u8, eb.exported_name, "*")) continue; // export * as ns는 skip


### PR DESCRIPTION
## Summary
ECMAScript 15.2.3.5 — `export *`는 `default`를 제외해야 함.

## Changes
- `collectExportsRecursive`에서 `export *` 재귀 진입 전에 seen에 `"default"` 추가
- 직접 선언된 `export { default }`는 영향 없음 (첫 루프에서 이미 수집)

## Comparison (date-fns)
| 번들러 | exports | hasDefault |
|--------|---------|------------|
| ZTS (before) | 251 | true |
| ZTS (after) | 250 | false |
| esbuild | 250 | false |
| rolldown | 250 | false |

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] date-fns 250개 (esbuild/rolldown 동일)
- [x] graphql 215, mobx 68, neverthrow 13 — 모두 esbuild 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)