### PR TITLE
feat(bundler): tree-shaker 2단계 — export 수준 DCE

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -9998,3 +9998,65 @@ test "Interop: .mjs importer uses Node mode, .ts uses Babel mode" {
     // .mjs importer → Node 모드 (isNodeMode=1)
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib(), 1)") != null);
 }
+
+test "TreeShaking: export-level DCE — tslib pattern (export default object)" {
+    // tslib 패턴: 33개 named export + export default { ... } 객체
+    // __awaiter만 import하면 나머지 + default 객체 모두 제거
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { __awaiter } from './tslib';
+        \\console.log(__awaiter);
+    );
+    try writeFile(tmp.dir, "tslib.ts",
+        \\export function __extends() { return 1; }
+        \\export function __awaiter() { return 2; }
+        \\export function __rest() { return 3; }
+        \\export function __decorate() { return 4; }
+        \\export default { __extends, __awaiter, __rest, __decorate };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // __awaiter 포함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__awaiter") != null);
+    // 미사용 함수 제거 (함수 body가 출력에 없어야 함)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function __extends") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function __rest") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function __decorate") == null);
+}
+
+test "TreeShaking: export-level DCE — var with ternary init removed" {
+    // tslib 패턴: var __createBinding = Object.create ? fn1 : fn2
+    // 미사용 시 제거
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './lib';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export var ternaryVar = Object.create ? function() { return 1; } : function() { return 2; };
+        \\export function used() { return 42; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function used") != null);
+    // ternary 초기화 변수 제거
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ternaryVar") == null);
+}

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -327,6 +327,11 @@ pub fn emitWithTreeShaking(
                 if (eb.kind == .re_export_all) continue;
                 if (s.isExportUsed(mod_idx, eb.exported_name)) {
                     names_buf.append(allocator, eb.local_name) catch break :blk null;
+                    // exported_name도 추가: statement_shaker가 export default를
+                    // "default"로 등록하므로 local_name(_default 등)과 매칭되지 않을 수 있음
+                    if (!std.mem.eql(u8, eb.exported_name, eb.local_name)) {
+                        names_buf.append(allocator, eb.exported_name) catch break :blk null;
+                    }
                 }
             }
             // cross-module: 이 모듈을 import하는 모듈의 named binding도 포함

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -26,6 +26,7 @@ pub const binding_scanner = @import("binding_scanner.zig");
 pub const linker = @import("linker.zig");
 pub const tree_shaker = @import("tree_shaker.zig");
 pub const statement_shaker = @import("statement_shaker.zig");
+pub const purity = @import("purity.zig");
 pub const chunk = @import("chunk.zig");
 pub const bundler_core = @import("bundler.zig");
 
@@ -66,6 +67,7 @@ test {
     _ = binding_scanner;
     _ = linker;
     _ = tree_shaker;
+    _ = purity;
     _ = chunk;
     _ = bundler_core;
 }

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -1,0 +1,163 @@
+//! ZTS Bundler — Expression Purity Analysis
+//!
+//! tree_shaker(모듈 수준)와 statement_shaker(문 수준) 양쪽에서 공유하는
+//! 표현식 순수성 판정 로직. 순수 표현식은 side effect가 없어 안전하게 제거 가능.
+//!
+//! 판정 기준 (esbuild/rolldown 동일):
+//!   - 리터럴, 식별자 참조, 함수/arrow 표현식 → 순수
+//!   - 객체/배열 리터럴 → 원소가 모두 순수이면 순수 (computed key, spread 제외)
+//!   - 삼항/이항/논리/단항 → 재귀 검사 (delete 제외)
+//!   - 멤버 접근 → 순수 (getter side effect는 실전에서 극히 드물어 무시, esbuild 동일)
+//!   - @__PURE__ call/new → 순수
+//!   - 나머지 → 보수적으로 불순
+
+const std = @import("std");
+const Ast = @import("../parser/ast.zig").Ast;
+const Node = @import("../parser/ast.zig").Node;
+const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const CallFlags = @import("../parser/ast.zig").CallFlags;
+const Token = @import("../lexer/token.zig");
+
+/// 재귀 깊이 제한. 초과 시 보수적으로 불순 처리.
+const max_depth: u32 = 128;
+
+/// NodeIndex를 받아 순수성을 판정한다.
+pub fn isExprPure(ast: *const Ast, idx: NodeIndex) bool {
+    return isExprPureDepth(ast, idx, 0);
+}
+
+fn isExprPureDepth(ast: *const Ast, idx: NodeIndex, depth: u32) bool {
+    if (depth >= max_depth) return false;
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return true;
+    return isNodePureDepth(ast, ast.nodes.items[@intFromEnum(idx)], depth);
+}
+
+/// Node를 받아 순수성을 판정한다.
+pub fn isNodePure(ast: *const Ast, node: Node) bool {
+    return isNodePureDepth(ast, node, 0);
+}
+
+fn isNodePureDepth(ast: *const Ast, node: Node, depth: u32) bool {
+    if (depth >= max_depth) return false;
+    const d = depth + 1;
+    return switch (node.tag) {
+        .boolean_literal,
+        .null_literal,
+        .numeric_literal,
+        .string_literal,
+        .bigint_literal,
+        .regexp_literal,
+        => true,
+
+        .identifier_reference => true,
+
+        .function_expression,
+        .arrow_function_expression,
+        => true,
+
+        // class expression — extends/static 초기화에 side effect 가능
+        .class_expression => false,
+
+        .object_expression => isObjectPure(ast, node, d),
+        .array_expression => isArrayPure(ast, node, d),
+
+        .call_expression, .new_expression => {
+            if (ast.hasExtra(node.data.extra, 3)) {
+                return (ast.readExtra(node.data.extra, 3) & CallFlags.is_pure) != 0;
+            }
+            return false;
+        },
+
+        .parenthesized_expression => isExprPureDepth(ast, node.data.unary.operand, d),
+
+        .conditional_expression => {
+            const t = node.data.ternary;
+            return isExprPureDepth(ast, t.a, d) and isExprPureDepth(ast, t.b, d) and isExprPureDepth(ast, t.c, d);
+        },
+
+        .binary_expression, .logical_expression => {
+            return isExprPureDepth(ast, node.data.binary.left, d) and
+                isExprPureDepth(ast, node.data.binary.right, d);
+        },
+
+        .unary_expression => {
+            const e = node.data.extra;
+            if (!ast.hasExtra(e, 1)) return false;
+            const op_kind: u8 = @truncate(ast.readExtra(e, 1) & 0xFF);
+            if (op_kind == @intFromEnum(Token.Kind.kw_delete)) return false;
+            return isExprPureDepth(ast, @enumFromInt(ast.readExtra(e, 0)), d);
+        },
+
+        // 멤버 접근 — getter side effect는 무시 (esbuild 동일)
+        .static_member_expression, .computed_member_expression => true,
+
+        else => false,
+    };
+}
+
+fn isObjectPure(ast: *const Ast, node: Node, depth: u32) bool {
+    const list = node.data.list;
+    if (list.len == 0) return true;
+    if (list.start + list.len > ast.extra_data.items.len) return false;
+    const indices = ast.extra_data.items[list.start .. list.start + list.len];
+    for (indices) |raw_idx| {
+        const prop_idx: NodeIndex = @enumFromInt(raw_idx);
+        if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) continue;
+        const prop = ast.nodes.items[@intFromEnum(prop_idx)];
+        if (prop.tag != .object_property) return false;
+        const key_idx = prop.data.binary.left;
+        if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
+            if (ast.nodes.items[@intFromEnum(key_idx)].tag == .computed_property_key) return false;
+        }
+        if (!isExprPureDepth(ast, prop.data.binary.right, depth)) return false;
+    }
+    return true;
+}
+
+fn isArrayPure(ast: *const Ast, node: Node, depth: u32) bool {
+    const list = node.data.list;
+    if (list.len == 0) return true;
+    if (list.start + list.len > ast.extra_data.items.len) return false;
+    const indices = ast.extra_data.items[list.start .. list.start + list.len];
+    for (indices) |raw_idx| {
+        const elem_idx: NodeIndex = @enumFromInt(raw_idx);
+        if (elem_idx.isNone() or @intFromEnum(elem_idx) >= ast.nodes.items.len) continue;
+        const elem = ast.nodes.items[@intFromEnum(elem_idx)];
+        if (elem.tag == .spread_element) return false;
+        if (!isNodePureDepth(ast, elem, depth)) return false;
+    }
+    return true;
+}
+
+/// variable declaration의 순수성 판정.
+/// 모든 declarator의 초기값이 순수이면 순수.
+pub fn isVarDeclPure(ast: *const Ast, node: Node) bool {
+    const e = node.data.extra;
+    if (e + 2 >= ast.extra_data.items.len) return false;
+    const list_start = ast.extra_data.items[e + 1];
+    const list_len = ast.extra_data.items[e + 2];
+    if (list_len == 0) return true;
+    if (list_start + list_len > ast.extra_data.items.len) return false;
+    const decls = ast.extra_data.items[list_start .. list_start + list_len];
+    for (decls) |raw| {
+        const idx: NodeIndex = @enumFromInt(raw);
+        if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) continue;
+        const decl = ast.nodes.items[@intFromEnum(idx)];
+        if (decl.tag != .variable_declarator) return false;
+        const de = decl.data.extra;
+        if (de + 2 >= ast.extra_data.items.len) return false;
+        const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[de + 2]);
+        if (init_idx.isNone()) continue;
+        if (!isExprPure(ast, init_idx)) return false;
+    }
+    return true;
+}
+
+/// class declaration/expression의 side effect 판정.
+/// extends 절이 없으면 순수 (esbuild보다 정밀, rolldown 동일).
+pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
+    const e = node.data.extra;
+    if (e + 1 >= ast.extra_data.items.len) return true;
+    const super_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
+    return !super_idx.isNone();
+}

--- a/src/bundler/statement_shaker.zig
+++ b/src/bundler/statement_shaker.zig
@@ -13,6 +13,7 @@ const Ast = @import("../parser/ast.zig").Ast;
 const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Span = @import("../lexer/token.zig").Span;
+const purity = @import("purity.zig");
 
 const StmtInfo = struct {
     node_idx: u32,
@@ -334,8 +335,8 @@ fn extractArrayPatternNames(
 fn hasSideEffects(ast: *const Ast, node: Node) bool {
     switch (node.tag) {
         .function_declaration => return false,
-        .class_declaration => return classHasSideEffects(ast, node),
-        .variable_declaration => return varDeclHasSideEffects(ast, node),
+        .class_declaration => return purity.classHasSideEffects(ast, node),
+        .variable_declaration => return !purity.isVarDeclPure(ast, node),
         .export_named_declaration => {
             const e = node.data.extra;
             if (e + 3 < ast.extra_data.items.len) {
@@ -343,92 +344,26 @@ fn hasSideEffects(ast: *const Ast, node: Node) bool {
                 if (!decl_idx.isNone() and @intFromEnum(decl_idx) < ast.nodes.items.len) {
                     return hasSideEffects(ast, ast.nodes.items[@intFromEnum(decl_idx)]);
                 }
-                // inner declaration이 없는 export { ... } → linker가 skip_nodes로 처리
                 return false;
             }
             return true;
         },
         .export_default_declaration => {
-            // linker가 export default → var _default = X 변환하므로
-            // rename된 이름이 다른 모듈에서 참조될 수 있음 → 항상 보존
-            return true;
+            // "default"는 extractDeclaredNames에서 등록됨.
+            // used_export_names에 "default"가 없으면 seed 안 됨 → 자동 제거.
+            const inner_idx = node.data.unary.operand;
+            if (inner_idx.isNone() or @intFromEnum(inner_idx) >= ast.nodes.items.len) return true;
+            const inner = ast.nodes.items[@intFromEnum(inner_idx)];
+            return switch (inner.tag) {
+                .function_declaration => false,
+                .class_declaration => purity.classHasSideEffects(ast, inner),
+                else => !purity.isNodePure(ast, inner),
+            };
         },
         // import/export 문은 linker skip_nodes와 충돌 방지를 위해 건드리지 않음
         .import_declaration, .export_all_declaration => return true,
         else => return true,
     }
-}
-
-/// variable declaration의 side effects 판정.
-/// 초기값이 없거나 리터럴이면 side-effect-free.
-fn varDeclHasSideEffects(ast: *const Ast, node: Node) bool {
-    const e = node.data.extra;
-    if (e + 2 >= ast.extra_data.items.len) return true;
-    const list_start = ast.extra_data.items[e + 1];
-    const list_len = ast.extra_data.items[e + 2];
-    if (list_len == 0) return false;
-
-    var i: u32 = 0;
-    while (i < list_len) : (i += 1) {
-        const idx = list_start + i;
-        if (idx >= ast.extra_data.items.len) return true;
-        const decl_idx: NodeIndex = @enumFromInt(ast.extra_data.items[idx]);
-        if (decl_idx.isNone()) continue;
-        const decl_ni = @intFromEnum(decl_idx);
-        if (decl_ni >= ast.nodes.items.len) return true;
-        const decl_node = ast.nodes.items[decl_ni];
-        if (decl_node.tag != .variable_declarator) return true;
-
-        // variable_declarator: extra [name, type_ann, init_expr]
-        const de = decl_node.data.extra;
-        if (de + 2 >= ast.extra_data.items.len) return true;
-        const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[de + 2]);
-        if (init_idx.isNone()) continue; // 초기값 없음 → safe
-
-        const init_ni = @intFromEnum(init_idx);
-        if (init_ni >= ast.nodes.items.len) return true;
-        const init_node = ast.nodes.items[init_ni];
-        if (!isExprSideEffectFree(ast, init_node)) return true;
-    }
-    return false;
-}
-
-/// 초기값 표현식이 side-effect-free인지 판정.
-/// 리터럴, 함수 표현식, @__PURE__ 호출이 safe.
-fn isExprSideEffectFree(ast: *const Ast, node: Node) bool {
-    return switch (node.tag) {
-        .numeric_literal,
-        .string_literal,
-        .boolean_literal,
-        .null_literal,
-        .bigint_literal,
-        .regexp_literal,
-        .function_expression,
-        .arrow_function_expression,
-        .identifier_reference,
-        => true,
-        // @__PURE__ 어노테이션이 있는 호출은 side-effect-free
-        .call_expression, .new_expression => {
-            const e = node.data.extra;
-            if (ast.hasExtra(e, 3)) {
-                const flags = ast.readExtra(e, 3);
-                return (flags & 0x01) != 0; // CallFlags.is_pure
-            }
-            return false;
-        },
-        else => false,
-    };
-}
-
-/// class declaration의 side effects 판정.
-/// extends 절이 없으면 side-effect-free (순수 프로토타입 정의).
-fn classHasSideEffects(ast: *const Ast, node: Node) bool {
-    // extra = [name, super_class, body, ...]
-    const e = node.data.extra;
-    if (e + 1 >= ast.extra_data.items.len) return true;
-    const super_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
-    // extends 절이 있으면 side-effectful (super 표현식 평가)
-    return !super_idx.isNone();
 }
 
 /// 모든 AST 노드를 순회하면서 identifier_reference를 찾고,
@@ -670,8 +605,8 @@ test "statement shaker: assignment_target_identifier tracked (++x pattern)" {
     try std.testing.expectEqual(@as(u32, 1), skipped);
 }
 
-test "statement shaker: export default always preserved" {
-    // zod 패턴: export default function 은 linker rename 때문에 항상 보존
+test "statement shaker: export default function removed when unused" {
+    // export default function은 side-effect-free → "default" 미사용 시 제거
     const alloc = std.testing.allocator;
     var r = try parseAndGetRoot(alloc,
         \\export default function config() { return {}; }
@@ -682,11 +617,31 @@ test "statement shaker: export default always preserved" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    // used_exports가 비어있어도 export default는 보존
+    // used_exports 비어있음 → export default + unused 모두 제거
     try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
 
-    // export default → side-effectful (항상 보존)
-    // unused만 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 2), skipped);
+}
+
+test "statement shaker: export default preserved when used" {
+    // "default"가 used_exports에 있으면 보존
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\export default function config() { return {}; }
+        \\function unused() { return 2; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    const names: [1][]const u8 = .{"default"};
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+
+    // export default config → 보존, unused만 제거
     var skipped: u32 = 0;
     var it = skip.iterator(.{});
     while (it.next()) |_| skipped += 1;
@@ -843,6 +798,98 @@ test "statement shaker: identifier_reference initializer is side-effect-free" {
     var it = skip.iterator(.{});
     while (it.next()) |_| skipped += 1;
     try std.testing.expect(skipped >= 2);
+}
+
+test "statement shaker: tslib pattern — export default object removes unused" {
+    // tslib 핵심 패턴: export default { __extends, __awaiter, ... }
+    // "default" 미사용 시 export default 객체 제거 → 미참조 함수도 제거
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\function __extends() { return 1; }
+        \\function __awaiter() { return 2; }
+        \\function __rest() { return 3; }
+        \\export default { __extends, __awaiter, __rest };
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    // __awaiter만 사용 → __extends, __rest, export default 제거
+    const names: [1][]const u8 = .{"__awaiter"};
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    // __extends(1) + __rest(1) + export default(1) = 3개 제거
+    try std.testing.expectEqual(@as(u32, 3), skipped);
+}
+
+test "statement shaker: conditional init is side-effect-free" {
+    // tslib 패턴: var __createBinding = Object.create ? (function(){}) : (function(){})
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\var __createBinding = Object.create ? function(o) {} : function(o) {};
+        \\function used() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    const names: [1][]const u8 = .{"used"};
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+
+    // __createBinding: ternary(member, fn, fn) → side-effect-free → 미사용 → 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
+test "statement shaker: typeof binary is side-effect-free" {
+    // tslib 패턴: var _Sup = typeof SuppressedError === "function" ? SuppressedError : function() {}
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\var _Sup = typeof SuppressedError === "function" ? SuppressedError : function() {};
+        \\function used() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    const names: [1][]const u8 = .{"used"};
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+
+    // typeof ... === "function" ? ... : ... → side-effect-free → 미사용 → 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
+test "statement shaker: export default class extends is side-effectful" {
+    // extends 절 있는 class expression → side-effectful → 항상 보존
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\export default class extends Base {}
+        \\function unused() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+
+    // export default class extends Base → side-effectful → 보존
+    // unused만 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
 }
 
 test "statement shaker module compiles" {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -24,7 +24,7 @@ const Linker = @import("linker.zig").Linker;
 const Ast = @import("../parser/ast.zig").Ast;
 const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
-const CallFlags = @import("../parser/ast.zig").CallFlags;
+const purity = @import("purity.zig");
 
 pub const TreeShaker = struct {
     allocator: std.mem.Allocator,
@@ -235,128 +235,46 @@ pub const TreeShaker = struct {
 
     fn isStatementPure(ast: *const Ast, stmt: Node) bool {
         return switch (stmt.tag) {
-            // import/export 선언 — side effect 없음 (import 대상 모듈의 side effect는 별도 추적)
             .import_declaration,
             .export_all_declaration,
             => true,
 
-            // export named — 내부에 declaration이 있으면 그것도 검사
             .export_named_declaration => {
-                // extra: [declaration, specifiers_start, specifiers_len, source]
                 if (!ast.hasExtra(stmt.data.extra, 0)) return true;
                 const decl_idx = ast.readExtraNode(stmt.data.extra, 0);
-                if (decl_idx.isNone()) return true; // export { x } 또는 re-export
+                if (decl_idx.isNone()) return true;
                 if (@intFromEnum(decl_idx) >= ast.nodes.items.len) return true;
                 const decl = ast.nodes.items[@intFromEnum(decl_idx)];
                 return isStatementPure(ast, decl);
             },
 
-            // export default — 내부 expression/declaration 검사
             .export_default_declaration => {
-                // unary: operand = declaration 또는 expression
-                return isExpressionPure(ast, stmt.data.unary.operand);
+                const inner_idx = stmt.data.unary.operand;
+                if (inner_idx.isNone() or @intFromEnum(inner_idx) >= ast.nodes.items.len) return false;
+                const inner = ast.nodes.items[@intFromEnum(inner_idx)];
+                return switch (inner.tag) {
+                    .function_declaration => true,
+                    .class_declaration => !purity.classHasSideEffects(ast, inner),
+                    else => purity.isExprPure(ast, inner_idx),
+                };
             },
 
-            // 함수 선언 — 선언만, 호출 아님
             .function_declaration => true,
+            .class_declaration => !purity.classHasSideEffects(ast, stmt),
 
-            // class 선언 — extends나 static 초기화에 side effect 가능 → 보수적으로 불순
-            .class_declaration => false,
-
-            // TS 타입 선언 — 런타임에 존재하지 않음
             .ts_interface_declaration,
             .ts_type_alias_declaration,
             => true,
 
-            // TS enum/namespace — 런타임에 IIFE로 변환됨 → 불순
             .ts_enum_declaration,
             .ts_module_declaration,
             => false,
 
-            // 변수 선언 — 초기값에 따라 다름
-            .variable_declaration => isVarDeclPure(ast, stmt),
-
-            // expression statement — 내부 expression이 순수하면 OK
-            .expression_statement => isExpressionPure(ast, stmt.data.unary.operand),
+            .variable_declaration => purity.isVarDeclPure(ast, stmt),
+            .expression_statement => purity.isExprPure(ast, stmt.data.unary.operand),
 
             .empty_statement => true,
 
-            else => false,
-        };
-    }
-
-    fn isVarDeclPure(ast: *const Ast, stmt: Node) bool {
-        // variable_declaration: extra = [kind_flags, list.start, list.len]
-        const e = stmt.data.extra;
-        if (!ast.hasExtra(e, 2)) return false;
-        const list_start = ast.readExtra(e, 1);
-        const list_len = ast.readExtra(e, 2);
-        if (list_len == 0) return true;
-        if (list_start + list_len > ast.extra_data.items.len) return false;
-        const decls = ast.extra_data.items[list_start .. list_start + list_len];
-        for (decls) |raw| {
-            const idx: NodeIndex = @enumFromInt(raw);
-            if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) continue;
-            const decl = ast.nodes.items[@intFromEnum(idx)];
-            if (decl.tag != .variable_declarator) return false;
-            // variable_declarator: extra = [name, type_ann, init_expr]
-            const init_val = ast.readExtraNode(decl.data.extra, 2);
-            if (init_val.isNone()) continue;
-            if (!isExpressionPure(ast, init_val)) return false;
-        }
-        return true;
-    }
-
-    fn isExpressionPure(ast: *const Ast, idx: NodeIndex) bool {
-        if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return true;
-        const node = ast.nodes.items[@intFromEnum(idx)];
-        return switch (node.tag) {
-            // 리터럴 — 항상 순수
-            .boolean_literal,
-            .null_literal,
-            .numeric_literal,
-            .string_literal,
-            .bigint_literal,
-            .regexp_literal,
-            => true,
-
-            // template literal — 표현식 포함 가능 → 보수적으로 불순
-            .template_literal => false,
-
-            // 식별자 참조 — 읽기만, side effect 없음
-            .identifier_reference => true,
-
-            // 함수/arrow expression — 선언만, 호출 아님
-            .function_expression,
-            .arrow_function_expression,
-            => true,
-
-            // class expression — extends/static 초기화에 side effect 가능 → 보수적으로 불순
-            .class_expression => false,
-
-            // 배열/객체 리터럴 — 원소에 call 등 side effect 가능 → 보수적으로 불순
-            .array_expression, .object_expression => false,
-
-            // @__PURE__ call — 순수
-            .call_expression => {
-                if (ast.hasExtra(node.data.extra, 3)) {
-                    return (ast.readExtra(node.data.extra, 3) & CallFlags.is_pure) != 0;
-                }
-                return false;
-            },
-
-            // @__PURE__ new — 순수
-            .new_expression => {
-                if (ast.hasExtra(node.data.extra, 3)) {
-                    return (ast.readExtra(node.data.extra, 3) & CallFlags.is_pure) != 0;
-                }
-                return false;
-            },
-
-            // 괄호 expression — 내부가 순수하면 OK
-            .parenthesized_expression => isExpressionPure(ast, node.data.unary.operand),
-
-            // 나머지 — 보수적으로 불순
             else => false,
         };
     }


### PR DESCRIPTION
## Summary
- **export_default_declaration 순수성 검사**: 미사용 `export default { ... }` 객체 제거 가능
- **isExprPure 확장**: object/array/conditional/binary/unary/member expression 순수성 분석
- **purity.zig 공유 모듈**: tree_shaker + statement_shaker 중복 제거, 재귀 깊이 128 제한
- **tslib 번들**: 15,960B → 793B (95% 감소, esbuild 847B 이하)

## 변경 파일
| 파일 | 변경 |
|---|---|
| `purity.zig` | 신규 — 공유 순수성 분석 (isExprPure, isVarDeclPure, classHasSideEffects) |
| `statement_shaker.zig` | export default 제거 가능 + purity.zig 위임 |
| `tree_shaker.zig` | isExpressionPure/isVarDeclPure → purity.zig 위임 |
| `emitter.zig` | used_names에 exported_name 추가 (default 매칭) |
| `mod.zig` | purity.zig 등록 |
| `bundler.zig` | 통합 테스트 2개 추가 |

## Test plan
- [x] `zig build test` — 유닛 테스트 1,600+ 전체 통과
- [x] `bun test` (integration) — 2,291개 전체 통과
- [x] `bun run smoke.ts` — 111개 패키지 regression 없음 (107/111 일치 유지)
- [x] tslib 수동 검증: `import { __awaiter }` → 793B, `node` 런타임 정상

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)