### PR TITLE
fix(bundler): exports 조건 해석을 Node.js 스펙 순서로 변경

### DIFF
--- a/src/bundler/package_json.zig
+++ b/src/bundler/package_json.zig
@@ -225,10 +225,18 @@ fn resolveConditions(value: std.json.Value, conditions: []const []const u8) ?[]c
     switch (value) {
         .string => |s| return s,
         .object => |obj| {
-            // JSON 소스 순서를 유지하므로 conditions 순서로 탐색
-            for (conditions) |cond| {
-                if (obj.get(cond)) |v| {
-                    return resolveConditions(v, conditions);
+            // Node.js 스펙: exports 객체의 key 순서로 탐색하고,
+            // 각 key가 conditions set에 포함되는지 확인한다.
+            // (이전: conditions 배열 순서로 탐색 → tslib import.node 오매칭)
+            for (obj.keys()) |key| {
+                if (std.mem.eql(u8, key, "default")) continue; // default는 마지막
+                for (conditions) |cond| {
+                    if (std.mem.eql(u8, key, cond)) {
+                        if (resolveConditions(obj.get(key).?, conditions)) |result| {
+                            return result;
+                        }
+                        break;
+                    }
                 }
             }
             // "default"는 항상 마지막 폴백 (Node.js 스펙)


### PR DESCRIPTION
## Summary
- exports 객체의 **key 순서**로 condition을 탐색하도록 수정 (Node.js 스펙 준수)
- 이전: conditions 배열 순서 → tslib `import.node`가 `module`보다 먼저 매칭
- 이후: exports key 순서 → `module` condition이 먼저 매칭되어 ESM 사용

## 변경 파일
- `src/bundler/package_json.zig` — `resolveConditions` 탐색 순서 수정 (12줄)

## 결과
- **tslib** `--platform=node`: 22KB FAIL → **1KB OK** (esbuild 1KB와 동등)

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `bun test` (integration) — 2291/2291 통과
- [x] `bun run smoke.ts` — tslib FAIL→OK, regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)