### PR TITLE
fix(bundler): export_bindings 필터 — export * re-export 경유 모듈 보호

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -329,8 +329,7 @@ pub fn emitWithTreeShaking(
                 if (!s.isExportUsed(mod_idx, eb.exported_name)) continue;
 
                 // StmtInfo 도달성: 모든 importer에서 이 export의 import가 dead이면 제외.
-                // TODO: isImportLiveInModule false negative 해결 후 활성화 (arktype flatMorph 등)
-                if (false and eb.kind == .local and m.importers.items.len > 0 and
+                if (eb.kind == .local and m.importers.items.len > 0 and
                     !std.mem.eql(u8, eb.exported_name, "default"))
                 {
                     const is_dead = is_dead: {
@@ -339,6 +338,16 @@ pub fn emitWithTreeShaking(
                             const imp_i = @intFromEnum(importer_idx);
                             if (imp_i >= graph.modules.items.len) break :is_dead false;
                             const importer = &graph.modules.items[imp_i];
+                            // export * re-export 경유 모듈은 보수적으로 live
+                            for (importer.export_bindings) |ieb| {
+                                if (ieb.kind == .re_export_all) {
+                                    if (ieb.import_record_index) |rec_idx| {
+                                        if (rec_idx < importer.import_records.len and
+                                            importer.import_records[rec_idx].resolved == m.index)
+                                            break :is_dead false;
+                                    }
+                                }
+                            }
                             for (importer.import_bindings) |ib| {
                                 if (ib.import_record_index >= importer.import_records.len) continue;
                                 if (importer.import_records[ib.import_record_index].resolved != m.index) continue;

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -338,3 +338,84 @@ test "stmt_info: unused import not reachable" {
     try std.testing.expect(!reachable.isSet(1)); // import y (unused)
     try std.testing.expect(reachable.isSet(2)); // used
 }
+
+test "stmt_info: arrow function body references tracked" {
+    // arktype flatMorph 패턴: import 심볼이 arrow function body에서 참조됨
+    const alloc = std.testing.allocator;
+    var r = try buildTestInfos(alloc,
+        \\import { x } from './mod';
+        \\export const fn1 = (a) => x + a;
+        \\export const fn2 = () => 1;
+    );
+    defer r.infos.deinit();
+    defer r.arena.deinit();
+
+    // fn1은 x를 참조해야 함
+    const fn1_stmt = r.infos.stmts[1];
+    var has_x_ref = false;
+    for (fn1_stmt.referenced_symbols) |sym| {
+        // x의 심볼 인덱스와 매칭되는지
+        if (r.infos.stmts[0].declared_symbols.len > 0) {
+            if (sym == r.infos.stmts[0].declared_symbols[0]) {
+                has_x_ref = true;
+            }
+        }
+    }
+    try std.testing.expect(has_x_ref); // fn1은 x를 참조
+
+    // fn1을 seed로 BFS → import x도 reachable
+    const fn1_sym = fn1_stmt.declared_symbols[0];
+    var reachable = try r.infos.computeReachable(alloc, &.{fn1_sym});
+    defer reachable.deinit();
+
+    try std.testing.expect(reachable.isSet(0)); // import x (fn1이 참조)
+    try std.testing.expect(reachable.isSet(1)); // fn1 (seed)
+    try std.testing.expect(!reachable.isSet(2)); // fn2 (미도달)
+}
+
+test "stmt_info: multi-statement module with arrow closures (arktype pattern)" {
+    // arktype records.js 패턴: 22개 statement, import가 arrow body에서 참조
+    const alloc = std.testing.allocator;
+    var r = try buildTestInfos(alloc,
+        \\import { noSuggest } from './errors';
+        \\import { flatMorph } from './flatMorph';
+        \\export const entriesOf = Object.entries;
+        \\export const fromEntries = (entries) => Object.fromEntries(entries);
+        \\export const keysOf = (o) => Object.keys(o);
+        \\export const isKeyOf = (k, o) => k in o;
+        \\export const hasKey = (o, k) => k in o;
+        \\export const hasDefinedKey = (o, k) => o[k] !== undefined;
+        \\export const splitByKeys = (o, leftKeys) => {
+        \\    const l = {};
+        \\    const r = {};
+        \\    let k;
+        \\    for (k in o) {
+        \\        if (k in leftKeys) l[k] = o[k];
+        \\        else r[k] = o[k];
+        \\    }
+        \\    return [l, r];
+        \\};
+        \\export const invert = (t) => flatMorph(t, (k, v) => [v, k]);
+    );
+    defer r.infos.deinit();
+    defer r.arena.deinit();
+
+    // "invert" statement가 flatMorph를 참조하는지 확인
+    // flatMorph는 stmt 1 (import)에서 선언
+    const flatMorph_sym = r.infos.stmts[1].declared_symbols[0];
+
+    // invert는 마지막 statement
+    const last_stmt = r.infos.stmts[r.infos.stmts.len - 1];
+    var has_ref = false;
+    for (last_stmt.referenced_symbols) |sym| {
+        if (sym == flatMorph_sym) has_ref = true;
+    }
+    try std.testing.expect(has_ref); // invert는 flatMorph를 참조해야 함
+
+    // invert를 seed로 BFS → flatMorph import도 reachable
+    if (last_stmt.declared_symbols.len > 0) {
+        var reachable = try r.infos.computeReachable(alloc, &.{last_stmt.declared_symbols[0]});
+        defer reachable.deinit();
+        try std.testing.expect(reachable.isSet(1)); // flatMorph import reachable
+    }
+}


### PR DESCRIPTION
## Summary
- `export * from './mod'` re-export 경유 모듈이 import_bindings에 없어 dead로 오판되는 문제 수정
- arktype `flatMorph` 런타임 에러 해결
- export_bindings 필터 활성화 → pathe --platform=node 3.2KB 달성

## 원인
`@ark/util/index.js`가 `export * from "./flatMorph.js"`로 re-export.
export_bindings 필터에서 importer의 `import_bindings`만 확인 → re-export_all 경유 모듈 누락 → dead 오판.

## 수정
importer의 `export_bindings`에서 `re_export_all`이 이 모듈을 가리키면 보수적으로 live 처리.

## 결과
| 패키지 | 이전 | 현재 |
|--------|------|------|
| pathe --platform=node | 13KB (❌ 3.79x) | **3KB (✅ 0.87x)** |
| arktype | FAIL | **OK (259KB)** |
| smoke ❌ | 3개 | **2개** (svelte, three) |
| Average | 0.91x | **0.87x** |

## Test plan
- [x] `zig build test` — 전체 통과 (유닛 테스트 2개 추가)
- [x] `bun test` — 2291/2291 통과
- [x] `bun run smoke.ts` — regression 없음

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)