### PR TITLE
fix(tree-shaking): class extends 순수 식별자 side-effect-free 처리

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -10063,6 +10063,105 @@ test "TreeShaking: export-level DCE — var with ternary init removed" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "ternaryVar") == null);
 }
 
+test "TreeShaking: class extends identifier — unused child removed (three.js pattern)" {
+    // three.js 핵심 패턴: Object3D → Light → AmbientLight 상속 체인.
+    // Vector3만 사용하면 AmbientLight 등 미사용 클래스는 제거되어야 함.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { B } from './classes';
+        \\console.log(new B());
+    );
+    try writeFile(tmp.dir, "classes.ts",
+        \\export class Base {}
+        \\export class A extends Base {}
+        \\export class B extends Base {}
+        \\export class C extends A {}
+        \\Base.DEFAULT_UP = 123;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // B와 Base는 포함, Base.DEFAULT_UP도 포함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class Base") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class B ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DEFAULT_UP") != null);
+    // A와 C는 미사용이므로 제거
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class A ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class C ") == null);
+}
+
+test "TreeShaking: class extends call expr — kept as side-effect" {
+    // extends fn()은 side-effect → 미사용이어도 보존
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './classes';
+        \\console.log(used);
+    );
+    try writeFile(tmp.dir, "classes.ts",
+        \\export const used = 1;
+        \\function mixin() { return class {}; }
+        \\export class X extends mixin() {}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // extends mixin()은 side-effect이므로 X가 보존되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "mixin") != null);
+}
+
+test "TreeShaking: re-export chain — only used export included (three.module.js pattern)" {
+    // three.module.js 패턴: core에서 많은 심볼을 import, 일부만 re-export
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { Vector3 } from './facade';
+        \\console.log(new Vector3());
+    );
+    try writeFile(tmp.dir, "facade.ts",
+        \\export { Vector3, AmbientLight, Scene } from './core';
+    );
+    try writeFile(tmp.dir, "core.ts",
+        \\export class EventDispatcher {}
+        \\export class Object3D extends EventDispatcher {}
+        \\export class Vector3 {}
+        \\export class Light extends Object3D {}
+        \\export class AmbientLight extends Light {}
+        \\export class Scene extends Object3D {}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // Vector3만 포함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Vector3") != null);
+    // AmbientLight, Light, Scene은 미사용이므로 제거
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "AmbientLight") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class Light") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class Scene") == null);
+}
+
 test "TreeShaking: export default identifier — import preserved (yargs y18n pattern)" {
     // yargs 패턴: export default someVar → import { x } → x가 번들에 포함
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -188,10 +188,14 @@ pub fn stmtHasSideEffects(ast: *const Ast, node: Node) bool {
 }
 
 /// class declaration/expression의 side effect 판정.
-/// extends 절이 없으면 순수 (esbuild보다 정밀, rolldown 동일).
+/// esbuild/rolldown 동일: extends 절이 순수 표현식이면 side-effect 없음.
+/// 미사용 class는 extends가 있어도 제거 가능 — 실제 사용 시 referenced_symbols로
+/// extends 대상이 자연스럽게 포함됨.
 pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
     const e = node.data.extra;
     if (e + 1 >= ast.extra_data.items.len) return true;
     const super_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
-    return !super_idx.isNone();
+    // extends 절이 없거나 순수 표현식이면 side-effect 없음
+    // identifier, member expression, conditional 등 모두 처리 (esbuild 동일)
+    return !isExprPure(ast, super_idx);
 }

--- a/src/bundler/statement_shaker.zig
+++ b/src/bundler/statement_shaker.zig
@@ -646,7 +646,8 @@ test "statement shaker: export specifier-only is side-effect-free" {
     try std.testing.expect(skipped >= 1); // unused + export 문
 }
 
-test "statement shaker: class extends is side-effectful" {
+test "statement shaker: class extends identifier is removable" {
+    // esbuild/rolldown 동일: extends가 순수 식별자이면 side-effect 없음 → 미사용 시 제거
     const alloc = std.testing.allocator;
     var r = try parseAndGetRoot(alloc,
         \\class Derived extends Base {}
@@ -659,11 +660,11 @@ test "statement shaker: class extends is side-effectful" {
 
     try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
 
-    // class extends → side-effectful → 보존, unused만 제거
+    // class extends identifier → 순수 → Derived + unused 모두 제거
     var skipped: u32 = 0;
     var it = skip.iterator(.{});
     while (it.next()) |_| skipped += 1;
-    try std.testing.expectEqual(@as(u32, 1), skipped);
+    try std.testing.expectEqual(@as(u32, 2), skipped);
 }
 
 test "statement shaker: class without extends is removable" {
@@ -843,8 +844,8 @@ test "statement shaker: typeof binary is side-effect-free" {
     try std.testing.expectEqual(@as(u32, 1), skipped);
 }
 
-test "statement shaker: export default class extends is side-effectful" {
-    // extends 절 있는 class expression → side-effectful → 항상 보존
+test "statement shaker: export default class extends identifier is removable" {
+    // esbuild/rolldown 동일: extends가 순수 식별자이면 side-effect 없음
     const alloc = std.testing.allocator;
     var r = try parseAndGetRoot(alloc,
         \\export default class extends Base {}
@@ -857,8 +858,121 @@ test "statement shaker: export default class extends is side-effectful" {
 
     try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
 
-    // export default class extends Base → side-effectful → 보존
-    // unused만 제거
+    // export default class extends Base → 순수 식별자 → 미사용 시 제거 가능
+    // 둘 다 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 2), skipped);
+}
+
+test "statement shaker: class extends call expression is side-effectful" {
+    // extends fn() → side-effect (함수 호출) → 보존
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\class X extends getBase() {}
+        \\function unused() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+
+    // extends getBase() → 불순 → X 보존, unused만 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
+test "statement shaker: class extends member expression is removable" {
+    // extends a.b → member expression은 순수 (esbuild 동일) → 미사용 시 제거
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\class X extends ns.Base {}
+        \\function unused() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+
+    // extends ns.Base → 순수 member expression → X + unused 모두 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 2), skipped);
+}
+
+test "statement shaker: class inheritance chain — unused children removable" {
+    // three.js 패턴: Object3D → Light → AmbientLight 상속 체인.
+    // AmbientLight가 미사용이면 extends가 있어도 제거되어야 함.
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\class Base {}
+        \\class Child extends Base {}
+        \\class Unused extends Base {}
+        \\class GrandChild extends Child {}
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    const names: [1][]const u8 = .{"Child"};
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+
+    // Child → used, Base → Child의 의존. Unused, GrandChild → 미사용 → 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 2), skipped);
+}
+
+test "statement shaker: used class with extends preserves parent" {
+    // 사용되는 클래스의 extends 대상(부모)은 의존성으로 보존되어야 함
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\class Parent {}
+        \\class Used extends Parent {}
+        \\class Unused extends Parent {}
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    const names: [1][]const u8 = .{"Used"};
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+
+    // Parent → Used의 의존으로 보존, Used → used, Unused → 미사용 → 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
+test "statement shaker: side-effect on class symbol preserved" {
+    // Base.DEFAULT_UP = ... (side-effect) — Base가 used이면 보존되어야 함
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\class Base {}
+        \\Base.DEFAULT_UP = 123;
+        \\class Unused extends Base {}
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    const names: [1][]const u8 = .{"Base"};
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+
+    // Base → used, Base.DEFAULT_UP → side-effect → 보존, Unused → 미사용 → 제거
     var skipped: u32 = 0;
     var it = skip.iterator(.{});
     while (it.next()) |_| skipped += 1;


### PR DESCRIPTION
## Summary
- `classHasSideEffects()`에서 extends 절이 순수 표현식(identifier, member expr)이면 side-effect 없음으로 처리
- 기존 `isExprPure()` 재사용으로 코드 간결화
- 회귀 테스트 8개 추가 (statement_shaker 5개, bundler 통합 3개)

## 결과

| 패키지 | 이전 | 이후 |
|--------|------|------|
| three | 1.90x ❌ | **0.61x** ✅ |
| svelte | 14.74x ❌ | **0.69x** ✅ |
| 전체 평균 | 0.87x | **0.72x** |
| ❌ 패키지 | 2개 | **0개** |

## Test plan
- [x] `zig build test` 전체 통과
- [x] smoke test 125개 패키지 — ❌ 0개
- [x] `class extends Identifier` 미사용 시 제거 확인
- [x] `class extends fn()` 보존 확인
- [x] `class extends a.b` (member expr) 미사용 시 제거 확인
- [x] 상속 체인 (Base→Child→Unused) 미사용 자식 제거 확인
- [x] 사용 클래스의 부모 보존 확인
- [x] `Base.DEFAULT_UP = 123` side-effect 보존 확인
- [x] re-export 체인 (three.module.js 패턴) 미사용 export 제거 확인

## 후속
- class body side-effect 미분석 (static block, computed key, impure static field): #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)