### PR TITLE
fix(tree-shaking): class body side-effect 분석 — static block, computed key, impure static field

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -10162,6 +10162,83 @@ test "TreeShaking: re-export chain — only used export included (three.module.j
     try std.testing.expect(std.mem.indexOf(u8, result.output, "class Scene") == null);
 }
 
+test "TreeShaking: class with static block preserved — side-effect in body" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './classes';
+        \\console.log(used);
+    );
+    try writeFile(tmp.dir, "classes.ts",
+        \\export class X { static { console.log("init"); } }
+        \\export const used = 1;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // static block이 있으므로 X가 보존되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class X") != null);
+}
+
+test "TreeShaking: class with impure static field preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './classes';
+        \\console.log(used);
+    );
+    try writeFile(tmp.dir, "classes.ts",
+        \\export class X { static foo = init(); }
+        \\function init() { return 1; }
+        \\export const used = 1;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // static foo = init() → impure → X 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class X") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "init") != null);
+}
+
+test "TreeShaking: class with pure static field removed" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './classes';
+        \\console.log(used);
+    );
+    try writeFile(tmp.dir, "classes.ts",
+        \\export class X { static foo = 42; }
+        \\export const used = 1;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // static foo = 42 → pure → X 제거
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class X") == null);
+}
+
 test "TreeShaking: export default identifier — import preserved (yargs y18n pattern)" {
     // yargs 패턴: export default someVar → import { x } → x가 번들에 포함
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -188,14 +188,77 @@ pub fn stmtHasSideEffects(ast: *const Ast, node: Node) bool {
 }
 
 /// class declaration/expression의 side effect 판정.
-/// esbuild/rolldown 동일: extends 절이 순수 표현식이면 side-effect 없음.
-/// 미사용 class는 extends가 있어도 제거 가능 — 실제 사용 시 referenced_symbols로
-/// extends 대상이 자연스럽게 포함됨.
+/// esbuild ClassCanBeRemovedIfUnused 동일: extends + body 멤버 전체 검사.
+/// 미사용 class는 순수하면 제거 가능 — 실제 사용 시 referenced_symbols로 포함됨.
 pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
     const e = node.data.extra;
-    if (e + 1 >= ast.extra_data.items.len) return true;
+    if (e + 7 >= ast.extra_data.items.len) return true;
+
+    // extends 절이 불순이면 side-effect
     const super_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
-    // extends 절이 없거나 순수 표현식이면 side-effect 없음
-    // identifier, member expression, conditional 등 모두 처리 (esbuild 동일)
-    return !isExprPure(ast, super_idx);
+    if (!isExprPure(ast, super_idx)) return true;
+
+    // decorator가 있으면 side-effect
+    const deco_len = ast.extra_data.items[e + 7];
+    if (deco_len > 0) return true;
+
+    // class body 멤버 순회
+    const body_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 2]);
+    if (body_idx.isNone()) return false;
+    if (@intFromEnum(body_idx) >= ast.nodes.items.len) return true;
+
+    const body_node = ast.nodes.items[@intFromEnum(body_idx)];
+    if (body_node.tag != .class_body) return true;
+
+    const members = body_node.data.list;
+    if (members.start + members.len > ast.extra_data.items.len) return true;
+
+    for (ast.extra_data.items[members.start .. members.start + members.len]) |raw_idx| {
+        const mi: NodeIndex = @enumFromInt(raw_idx);
+        if (mi.isNone() or @intFromEnum(mi) >= ast.nodes.items.len) continue;
+        const member = ast.nodes.items[@intFromEnum(mi)];
+
+        switch (member.tag) {
+            .static_block => return true, // static block은 항상 side-effect
+            .property_definition, .accessor_property => {
+                const me = member.data.extra;
+                if (me + 4 >= ast.extra_data.items.len) return true;
+                // computed key가 불순이면 side-effect
+                const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[me]);
+                if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
+                    const key_node = ast.nodes.items[@intFromEnum(key_idx)];
+                    if (key_node.tag == .computed_property_key) {
+                        if (!isExprPure(ast, key_node.data.unary.operand)) return true;
+                    }
+                }
+                // static field의 불순 초기화: static flag (bit 0)
+                const flags = ast.extra_data.items[me + 2];
+                const is_static = (flags & 1) != 0;
+                if (is_static) {
+                    const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[me + 1]);
+                    if (!isExprPure(ast, init_idx)) return true;
+                }
+                // member decorator
+                const m_deco_len = ast.extra_data.items[me + 4];
+                if (m_deco_len > 0) return true;
+            },
+            .method_definition => {
+                const me = member.data.extra;
+                if (me + 6 >= ast.extra_data.items.len) return true;
+                // computed key 검사
+                const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[me]);
+                if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
+                    const key_node = ast.nodes.items[@intFromEnum(key_idx)];
+                    if (key_node.tag == .computed_property_key) {
+                        if (!isExprPure(ast, key_node.data.unary.operand)) return true;
+                    }
+                }
+                // method decorator
+                const m_deco_len = ast.extra_data.items[me + 6];
+                if (m_deco_len > 0) return true;
+            },
+            else => {},
+        }
+    }
+    return false;
 }

--- a/src/bundler/statement_shaker.zig
+++ b/src/bundler/statement_shaker.zig
@@ -979,6 +979,87 @@ test "statement shaker: side-effect on class symbol preserved" {
     try std.testing.expectEqual(@as(u32, 1), skipped);
 }
 
+test "statement shaker: class with static block is side-effectful" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\class X { static { console.log("effect"); } }
+        \\function unused() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+
+    // static block → side-effect → X 보존, unused만 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
+test "statement shaker: class with computed key call is side-effectful" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\function key() { return "foo"; }
+        \\class X { static [key()] = 1; }
+        \\function unused() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+
+    // computed key fn() → side-effect → X와 key 보존, unused만 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
+test "statement shaker: class with impure static field is side-effectful" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\class X { static foo = init(); }
+        \\function unused() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+
+    // static foo = init() → side-effect → X 보존, unused만 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
+test "statement shaker: class with pure static field is removable" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\class X { static foo = 42; }
+        \\function unused() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+
+    // static foo = 42 → 순수 리터럴 → X + unused 모두 제거
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 2), skipped);
+}
+
 test "statement shaker module compiles" {
     _ = @import("statement_shaker.zig");
 }


### PR DESCRIPTION
## Summary
- `classHasSideEffects()`에서 class body 멤버도 분석하도록 확장 (esbuild `ClassCanBeRemovedIfUnused` 동일)
- static block, computed key call, impure static field initializer, decorator를 side-effect로 판정
- 순수 리터럴 static field는 제거 가능

## 검사 항목
| 케이스 | 판정 |
|--------|------|
| `static { console.log() }` | side-effect ✓ |
| `static [fn()] = 1` | side-effect ✓ |
| `static foo = init()` | side-effect ✓ |
| `static foo = 42` | 순수 → 제거 가능 ✓ |
| `@decorator class X {}` | side-effect ✓ |

## Test plan
- [x] `zig build test` 전체 통과
- [x] smoke test 125개 패키지 — ❌ 0개, avg 0.72x
- [x] three.js 번들 260KB, 실행 결과 3.74 정상

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)