### PR TITLE
fix(tree-shaking): namespace barrel re-export 소스 모듈 시드 누락 수정

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -576,6 +576,26 @@ pub const TreeShaker = struct {
 
         try self.markExportUsed(@intCast(canon_mod), canonical.export_name);
         self.included.set(canon_mod);
+
+        // namespace barrel re-export: canonical이 namespace import를 가리키면
+        // 소스 모듈의 모든 export를 시드해야 함 (import * as z; export { z } 패턴)
+        if (canon_mod < self.modules.len) {
+            const canon_local = self.linker.getExportLocalName(@intCast(canon_mod), canonical.export_name) orelse canonical.export_name;
+            for (self.modules[canon_mod].import_bindings) |cib| {
+                if (cib.kind == .namespace and std.mem.eql(u8, cib.local_name, canon_local)) {
+                    if (cib.import_record_index < self.modules[canon_mod].import_records.len) {
+                        const ns_src = @intFromEnum(self.modules[canon_mod].import_records[cib.import_record_index].resolved);
+                        if (ns_src < self.modules.len) {
+                            try self.markAllExportsUsed(@intCast(ns_src));
+                            self.included.set(ns_src);
+                            try self.seedAllStmts(@intCast(ns_src), queue, module_stmt_infos, reachable_stmts);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
         if (canon_mod != target_mod and target_mod < self.modules.len) {
             try self.markExportUsed(@intCast(target_mod), imported_name);
             self.included.set(target_mod);


### PR DESCRIPTION
## Summary
- `import * as z from './inner'; export { z }` 패턴에서 inner.ts의 export가 tree-shaking으로 제거되는 버그 수정
- `seedExport()`에서 canonical이 namespace import를 가리킬 때 소스 모듈을 직접 시드

## 원인
`seedExport(pkg, "z")` → `resolveExportChain`이 pkg 자체를 반환 (namespace import) → pkg의 z 선언 statement만 시드 → **inner.ts가 시드되지 않음** → foo/bar가 BFS에서 unreachable → tree-shaking 제거

## Test plan
- [x] `zig build test` 전체 통과
- [x] 통합 테스트 `namespace import 변수명 충돌 방지` 통과
- [x] smoke test: svelte 0.69x ✅, three 0.61x ✅, ❌ 0개

🤖 Generated with [Claude Code](https://claude.com/claude-code)