### PR TITLE
fix(bundler): ESM→CJS re-export 체인 default export 해석 실패 수정

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -296,11 +296,24 @@ pub fn extractExportBindings(
                         if (name.len > 0) local_name = name;
                     }
                 }
+                // export { X }와 동일: local_name이 import binding이면 re_export로 분류
+                // (export default EventEmitter where EventEmitter is imported)
+                var kind: ExportBinding.Kind = .local;
+                var final_rec_idx: ?u32 = null;
+                var final_local_name = local_name;
+                if (import_by_name.get(local_name)) |ib| {
+                    if (ib.kind != .namespace) {
+                        kind = .re_export;
+                        final_rec_idx = ib.import_record_index;
+                        final_local_name = ib.imported_name;
+                    }
+                }
                 try bindings.append(allocator, .{
                     .exported_name = "default",
-                    .local_name = local_name,
+                    .local_name = final_local_name,
                     .local_span = node.span,
-                    .kind = .local,
+                    .kind = kind,
+                    .import_record_index = final_rec_idx,
                 });
             },
             .export_all_declaration => {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1506,7 +1506,15 @@ pub const Linker = struct {
                                     .export_name = name,
                                 };
                             }
-                            return self.resolveExportChain(source_mod, entry.binding.local_name, depth + 1);
+                            if (self.resolveExportChain(source_mod, entry.binding.local_name, depth + 1)) |result| {
+                                return result;
+                            }
+                            // CJS 모듈은 정적 export가 없어 resolveExportChain이 null.
+                            // CJS 모듈 자체를 반환 — 소비자가 require_xxx()로 접근.
+                            const src_idx = @intFromEnum(source_mod);
+                            if (src_idx < self.modules.len and self.modules[src_idx].wrap_kind == .cjs) {
+                                return .{ .module_index = source_mod, .export_name = entry.binding.local_name };
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- `export default ImportedVar` 패턴에서 ImportedVar가 CJS 모듈 import일 때 resolve 실패 수정
- binding_scanner: `export default X`도 `export { X }`와 동일하게 import binding이면 `.re_export` 분류
- linker: `.re_export` 분기에서 CJS 모듈 도달 시 CJS 자체 반환 (기존 `export *` 패턴과 동일)

## 원인
```
// index.mjs (ESM wrapper)
import EventEmitter from './index.js'  // CJS
export default EventEmitter
```
1. `export default EventEmitter`가 `.local`로 분류 → `resolveExportChain`이 `.re_export` 대신 fallback 경로
2. `.re_export` 경로에서도 CJS 모듈 도달 시 null 반환 → index.mjs가 tree-shaking 대상 → 번들에서 제거

## Test plan
- [x] `zig build test` 전체 통과
- [x] 통합 테스트 33/33 통과 (namespace 충돌 포함)
- [x] eventemitter3 번들+실행 정상 (이전: `EE is not defined`)
- [x] smoke test: ❌ 0개, avg 0.72x

🤖 Generated with [Claude Code](https://claude.com/claude-code)