### PR TITLE
fix(codegen,tree-shaking): smoke FAIL 6개 수정 — unary DCE + else 누락 + re-export 전파

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -696,6 +696,9 @@ pub const TreeShaker = struct {
     }
 
     /// 모듈의 모든 statement를 BFS 큐에 추가.
+    /// export * / export { x } from 're-export 대상 모듈도 재귀적으로 시드한다.
+    /// (namespace escape 등으로 모듈 전체가 live인 경우, re-export 체인의
+    ///  하위 모듈 statement도 reachable이어야 DCE에서 살아남는다.)
     fn seedAllStmts(
         self: *TreeShaker,
         mod_idx: u32,
@@ -704,12 +707,35 @@ pub const TreeShaker = struct {
         reachable_stmts: []?std.DynamicBitSet,
     ) std.mem.Allocator.Error!void {
         if (mod_idx >= module_stmt_infos.len) return;
+        // 순환 export * 방지: opaque_visited로 이미 처리한 모듈 skip
+        if (self.opaque_visited) |ov| {
+            if (ov.isSet(mod_idx)) return;
+        }
+        if (self.opaque_visited) |*ov| ov.set(mod_idx);
+
         const infos = module_stmt_infos[mod_idx] orelse return;
         if (reachable_stmts[mod_idx] == null) {
             reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
         }
         for (infos.stmts, 0..) |_, si| {
             try self.enqueue(mod_idx, @intCast(si), reachable_stmts, queue);
+        }
+
+        // re-export 체인 전파: export * / named re-export 대상 모듈도 시드.
+        if (mod_idx >= self.modules.len) return;
+        const m = self.modules[mod_idx];
+        for (m.export_bindings) |eb| {
+            if (eb.kind != .re_export and eb.kind != .re_export_all) continue;
+            const rec_idx = eb.import_record_index orelse continue;
+            if (rec_idx >= m.import_records.len) continue;
+            const src = @intFromEnum(m.import_records[rec_idx].resolved);
+            if (src >= self.modules.len) continue;
+            if (eb.kind == .re_export_all) {
+                self.included.set(src);
+                try self.seedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
+            } else {
+                try self.seedExport(src, eb.local_name, queue, module_stmt_infos, reachable_stmts);
+            }
         }
     }
 

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -748,6 +748,8 @@ pub const Codegen = struct {
         try self.writeByte(')');
         try self.emitNode(t.b);
         if (!t.c.isNone()) {
+            // else 분기가 DCE로 완전히 제거되는 if문이면 else 키워드 자체를 생략
+            if (self.isDeadIfNode(t.c)) return;
             if (self.options.minify) {
                 const next_node = self.ast.getNode(t.c);
                 if (next_node.tag == .block_statement) {
@@ -760,6 +762,25 @@ pub const Codegen = struct {
             }
             try self.emitNode(t.c);
         }
+    }
+
+    /// else 분기의 if_statement가 상수 조건 DCE로 아무것도 출력하지 않는지 재귀 확인.
+    /// `else if (false) { ... }` → dead, `else if (false) { ... } else if (false) { ... }` → dead
+    fn isDeadIfNode(self: *Codegen, node_idx: NodeIndex) bool {
+        if (self.options.linking_metadata == null) return false;
+        if (node_idx.isNone() or @intFromEnum(node_idx) >= self.ast.nodes.items.len) return false;
+        const n = self.ast.getNode(node_idx);
+        if (n.tag != .if_statement) return false;
+        const t = n.data.ternary;
+        const known = self.evalBooleanCondition(t.a) orelse return false;
+        if (known) {
+            // if (true) → then 분기를 출력하므로 dead가 아님
+            return false;
+        }
+        // if (false) { ... } → else 분기가 없으면 dead
+        if (t.c.isNone()) return true;
+        // if (false) { ... } else <alt> → alt도 dead인지 재귀 확인
+        return self.isDeadIfNode(t.c);
     }
 
     /// 조건 노드가 컴파일 타임 boolean으로 확정되면 값을 반환한다.
@@ -800,12 +821,14 @@ pub const Codegen = struct {
                 return null;
             },
             .unary_expression => {
-                const operand_idx = cond.data.unary.operand;
-                if (!operand_idx.isNone() and @intFromEnum(operand_idx) < self.ast.nodes.items.len) {
-                    const op_text = self.ast.source[cond.span.start..cond.span.end];
-                    if (op_text.len > 0 and op_text[0] == '!') {
-                        if (self.evalBooleanConditionDepth(operand_idx, depth + 1)) |v| return !v;
-                    }
+                // unary_expression은 extra 저장: extra_data[e] = operand, extra_data[e+1] = operator
+                const e = cond.data.extra;
+                const extras = self.ast.extra_data.items;
+                if (e + 1 >= extras.len) return null;
+                const operand_idx: NodeIndex = @enumFromInt(extras[e]);
+                const op: Kind = @enumFromInt(@as(u8, @truncate(extras[e + 1])));
+                if (op == .bang) {
+                    if (self.evalBooleanConditionDepth(operand_idx, depth + 1)) |v| return !v;
                 }
                 return null;
             },


### PR DESCRIPTION
## Summary
3가지 독립 버그 수정:

1. **evalBooleanConditionDepth unary_expression**: `.data.unary.operand`(잘못된 union) → `.data.extra` + `extra_data`
2. **emitIf else DCE**: `else if (false) {}` → `} else }` 문법 에러 → `isDeadIfNode()` 재귀 검사
3. **seedAllStmts re-export 전파**: `export *` / `export { x } from` 대상 재귀 시드

## 결과
| 패키지 | 이전 | 이후 |
|--------|------|------|
| supports-color | FAIL | **OK** ✅ |
| immer | FAIL | **OK** ✅ |
| vue | FAIL | **OK** ✅ |
| cheerio | FAIL | **OK** ✅ |
| zod | FAIL | **OK** ✅ |
| zlib | FAIL | **OK** ✅ |
| smoke FAIL | 9개 | **3개** (effect, typebox: 잔여, cookie: esbuild도 실패) |

## Test plan
- [x] `zig build test` 전체 통과
- [x] smoke 125개: avg 0.73x, ❌ 0개

🤖 Generated with [Claude Code](https://claude.com/claude-code)