### PR TITLE
refactor: /simplify 리뷰 — 중복 제거 + 안전성 개선

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1506,14 +1506,8 @@ pub const Linker = struct {
                                     .export_name = name,
                                 };
                             }
-                            if (self.resolveExportChain(source_mod, entry.binding.local_name, depth + 1)) |result| {
+                            if (self.resolveOrCjsFallback(source_mod, entry.binding.local_name, depth + 1)) |result| {
                                 return result;
-                            }
-                            // CJS 모듈은 정적 export가 없어 resolveExportChain이 null.
-                            // CJS 모듈 자체를 반환 — 소비자가 require_xxx()로 접근.
-                            const src_idx = @intFromEnum(source_mod);
-                            if (src_idx < self.modules.len and self.modules[src_idx].wrap_kind == .cjs) {
-                                return .{ .module_index = source_mod, .export_name = entry.binding.local_name };
                             }
                         }
                     }
@@ -1556,21 +1550,25 @@ pub const Linker = struct {
                 if (rec_idx < m.import_records.len) {
                     const source_mod = m.import_records[rec_idx].resolved;
                     if (!source_mod.isNone()) {
-                        if (self.resolveExportChain(source_mod, name, depth + 1)) |result| {
+                        if (self.resolveOrCjsFallback(source_mod, name, depth + 1)) |result| {
                             return result;
-                        }
-                        // CJS 모듈은 정적 export가 없으므로 resolveExportChain이 null을 반환한다.
-                        // 이 경우 CJS 모듈 자체를 반환하여, 소비자 측에서 require_xxx().name 형태의
-                        // CJS preamble을 생성하도록 한다. (esbuild의 __reExport 패턴과 동일한 효과)
-                        const src_idx = @intFromEnum(source_mod);
-                        if (src_idx < self.modules.len and self.modules[src_idx].wrap_kind == .cjs) {
-                            return .{ .module_index = source_mod, .export_name = name };
                         }
                     }
                 }
             }
         }
 
+        return null;
+    }
+
+    /// resolveExportChain + CJS fallback. CJS 모듈은 정적 export가 없으므로
+    /// resolve 실패 시 CJS 모듈 자체를 반환하여 소비자가 require_xxx()로 접근.
+    fn resolveOrCjsFallback(self: *const Linker, source_mod: ModuleIndex, name: []const u8, depth: u32) ?SymbolRef {
+        if (self.resolveExportChain(source_mod, name, depth)) |result| return result;
+        const src_idx = @intFromEnum(source_mod);
+        if (src_idx < self.modules.len and self.modules[src_idx].wrap_kind == .cjs) {
+            return .{ .module_index = source_mod, .export_name = name };
+        }
         return null;
     }
 

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -219,46 +219,38 @@ pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
         const member = ast.nodes.items[@intFromEnum(mi)];
 
         switch (member.tag) {
-            .static_block => return true, // static block은 항상 side-effect
+            .static_block => return true,
             .property_definition, .accessor_property => {
                 const me = member.data.extra;
                 if (me + 4 >= ast.extra_data.items.len) return true;
-                // computed key가 불순이면 side-effect
-                const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[me]);
-                if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
-                    const key_node = ast.nodes.items[@intFromEnum(key_idx)];
-                    if (key_node.tag == .computed_property_key) {
-                        if (!isExprPure(ast, key_node.data.unary.operand)) return true;
-                    }
-                }
+                if (computedKeyHasSideEffects(ast, me)) return true;
                 // static field의 불순 초기화: static flag (bit 0)
-                const flags = ast.extra_data.items[me + 2];
-                const is_static = (flags & 1) != 0;
-                if (is_static) {
+                if ((ast.extra_data.items[me + 2] & 1) != 0) {
                     const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[me + 1]);
                     if (!isExprPure(ast, init_idx)) return true;
                 }
-                // member decorator
-                const m_deco_len = ast.extra_data.items[me + 4];
-                if (m_deco_len > 0) return true;
+                if (ast.extra_data.items[me + 4] > 0) return true; // decorator
             },
             .method_definition => {
                 const me = member.data.extra;
                 if (me + 6 >= ast.extra_data.items.len) return true;
-                // computed key 검사
-                const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[me]);
-                if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
-                    const key_node = ast.nodes.items[@intFromEnum(key_idx)];
-                    if (key_node.tag == .computed_property_key) {
-                        if (!isExprPure(ast, key_node.data.unary.operand)) return true;
-                    }
-                }
-                // method decorator
-                const m_deco_len = ast.extra_data.items[me + 6];
-                if (m_deco_len > 0) return true;
+                if (computedKeyHasSideEffects(ast, me)) return true;
+                if (ast.extra_data.items[me + 6] > 0) return true; // decorator
             },
             else => {},
         }
+    }
+    return false;
+}
+
+/// class member의 computed key가 불순인지 검사. extra_data[extra_offset]에서 key NodeIndex를 읽는다.
+fn computedKeyHasSideEffects(ast: *const Ast, extra_offset: u32) bool {
+    if (extra_offset >= ast.extra_data.items.len) return true;
+    const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_offset]);
+    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return false;
+    const key_node = ast.nodes.items[@intFromEnum(key_idx)];
+    if (key_node.tag == .computed_property_key) {
+        return !isExprPure(ast, key_node.data.unary.operand);
     }
     return false;
 }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -579,20 +579,18 @@ pub const TreeShaker = struct {
 
         // namespace barrel re-export: canonical이 namespace import를 가리키면
         // 소스 모듈의 모든 export를 시드해야 함 (import * as z; export { z } 패턴)
-        if (canon_mod < self.modules.len) {
-            const canon_local = self.linker.getExportLocalName(@intCast(canon_mod), canonical.export_name) orelse canonical.export_name;
-            for (self.modules[canon_mod].import_bindings) |cib| {
-                if (cib.kind == .namespace and std.mem.eql(u8, cib.local_name, canon_local)) {
-                    if (cib.import_record_index < self.modules[canon_mod].import_records.len) {
-                        const ns_src = @intFromEnum(self.modules[canon_mod].import_records[cib.import_record_index].resolved);
-                        if (ns_src < self.modules.len) {
-                            try self.markAllExportsUsed(@intCast(ns_src));
-                            self.included.set(ns_src);
-                            try self.seedAllStmts(@intCast(ns_src), queue, module_stmt_infos, reachable_stmts);
-                        }
+        const canon_local = self.linker.getExportLocalName(@intCast(canon_mod), canonical.export_name) orelse canonical.export_name;
+        for (self.modules[canon_mod].import_bindings) |cib| {
+            if (cib.kind == .namespace and std.mem.eql(u8, cib.local_name, canon_local)) {
+                if (cib.import_record_index < self.modules[canon_mod].import_records.len) {
+                    const ns_src = @intFromEnum(self.modules[canon_mod].import_records[cib.import_record_index].resolved);
+                    if (ns_src < self.modules.len) {
+                        try self.markAllExportsUsed(@intCast(ns_src));
+                        self.included.set(ns_src);
+                        try self.seedAllStmts(@intCast(ns_src), queue, module_stmt_infos, reachable_stmts);
                     }
-                    break;
                 }
+                break;
             }
         }
 

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -767,20 +767,20 @@ pub const Codegen = struct {
     /// else 분기의 if_statement가 상수 조건 DCE로 아무것도 출력하지 않는지 재귀 확인.
     /// `else if (false) { ... }` → dead, `else if (false) { ... } else if (false) { ... }` → dead
     fn isDeadIfNode(self: *Codegen, node_idx: NodeIndex) bool {
+        return self.isDeadIfNodeDepth(node_idx, 0);
+    }
+
+    fn isDeadIfNodeDepth(self: *Codegen, node_idx: NodeIndex, depth: u32) bool {
+        if (depth >= 128) return false;
         if (self.options.linking_metadata == null) return false;
         if (node_idx.isNone() or @intFromEnum(node_idx) >= self.ast.nodes.items.len) return false;
         const n = self.ast.getNode(node_idx);
         if (n.tag != .if_statement) return false;
         const t = n.data.ternary;
         const known = self.evalBooleanCondition(t.a) orelse return false;
-        if (known) {
-            // if (true) → then 분기를 출력하므로 dead가 아님
-            return false;
-        }
-        // if (false) { ... } → else 분기가 없으면 dead
+        if (known) return false;
         if (t.c.isNone()) return true;
-        // if (false) { ... } else <alt> → alt도 dead인지 재귀 확인
-        return self.isDeadIfNode(t.c);
+        return self.isDeadIfNodeDepth(t.c, depth + 1);
     }
 
     /// 조건 노드가 컴파일 타임 boolean으로 확정되면 값을 반환한다.


### PR DESCRIPTION
## Summary
- purity.zig: computed key 검사 중복 → `computedKeyHasSideEffects()` 헬퍼
- linker.zig: CJS fallback 중복 → `resolveOrCjsFallback()` 헬퍼
- tree_shaker.zig: 불필요한 bounds 가드 제거
- codegen.zig: `isDeadIfNode()` 재귀 깊이 128 제한

동작 변경 없음 (리팩터링만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)