### PR TITLE
fix(benchmark): 소수점 표시로 0KB 표기 문제 수정

### DIFF
--- a/packages/benchmark/smoke.ts
+++ b/packages/benchmark/smoke.ts
@@ -984,7 +984,9 @@ for (const p of filteredProjects) {
 
 // Summary table
 function fmtSize(size: number): string {
-  return size > 0 ? `${Math.round(size / 1024)}KB` : "-";
+  if (size <= 0) return "-";
+  const kb = size / 1024;
+  return kb >= 10 ? `${Math.round(kb)}KB` : `${kb.toFixed(1)}KB`;
 }
 function fmtStatus(build: boolean): string {
   return build ? "OK" : "FAIL";


### PR DESCRIPTION
## Summary
- `fmtSize`에서 10KB 미만 번들 크기를 소수점 1자리까지 표시하도록 변경
- 기존 `Math.round`로 0KB로 표시되던 작은 번들(solid-js 0.3KB, type-fest 0.1KB 등)이 정확하게 표시됨

## Test plan
- [x] smoke 테스트 전체 129/129 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)