### PR TITLE
refactor: es_helpers 빌더 + linker 분해 + 정렬 통합 + CLI 파싱

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -110,11 +110,7 @@ pub fn emitWithTreeShaking(
         }
     }
 
-    std.mem.sort(*const Module, sorted.items, {}, struct {
-        fn lessThan(_: void, a: *const Module, b: *const Module) bool {
-            return a.exec_index < b.exec_index;
-        }
-    }.lessThan);
+    std.mem.sort(*const Module, sorted.items, {}, Module.execIndexLessThan);
 
     // 2. 각 모듈을 변환 + 코드젠
     var output: std.ArrayList(u8) = .empty;
@@ -351,11 +347,7 @@ pub fn emitDevBundle(
         }
     }
 
-    std.mem.sort(*const Module, sorted.items, {}, struct {
-        fn lessThan(_: void, a: *const Module, b: *const Module) bool {
-            return a.exec_index < b.exec_index;
-        }
-    }.lessThan);
+    std.mem.sort(*const Module, sorted.items, {}, Module.execIndexLessThan);
 
     // 2. 출력 빌드
     var output: std.ArrayList(u8) = .empty;
@@ -718,11 +710,7 @@ pub fn emitChunks(
                     try chunk_output.appendSlice(allocator, "import{");
                 }
                 // 결정론적 출력을 위해 심볼명 정렬
-                std.mem.sort([]const u8, symbols.?.items, {}, struct {
-                    fn lessThan(_: void, a: []const u8, b: []const u8) bool {
-                        return std.mem.order(u8, a, b) == .lt;
-                    }
-                }.lessThan);
+                std.mem.sort([]const u8, symbols.?.items, {}, types.stringLessThan);
                 for (symbols.?.items, 0..) |name, si| {
                     const total = name_total_count.get(name) orelse 1;
                     const seen_gop = try name_seen_count.getOrPut(allocator, name);
@@ -852,11 +840,7 @@ pub fn emitChunks(
             while (eit.next()) |entry| {
                 try export_names.append(allocator, entry.key_ptr.*);
             }
-            std.mem.sort([]const u8, export_names.items, {}, struct {
-                fn lessThan(_: void, a: []const u8, b: []const u8) bool {
-                    return std.mem.order(u8, a, b) == .lt;
-                }
-            }.lessThan);
+            std.mem.sort([]const u8, export_names.items, {}, types.stringLessThan);
 
             if (!options.minify_whitespace) {
                 try chunk_output.appendSlice(allocator, "export { ");

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -458,26 +458,33 @@ pub const Linker = struct {
         }
     }
 
-    /// minify 활성화 시, scope hoisting 후 모든 top-level 이름을 짧은 이름으로 교체.
-    /// computeRenames 이후에 호출해야 함 (충돌 해결 완료 상태).
-    pub fn computeMangling(self: *Linker) !void {
-        const Mangler = @import("../codegen/mangler.zig");
+    const NameEntry = struct {
+        name: []const u8,
+        total_refs: u32,
+    };
 
-        // ================================================================
-        // Top-level 심볼을 빈도순 Base54로 mangling (cross-module)
-        // ================================================================
+    /// mangling 후보 수집 결과. computeMangling()에서 사용.
+    const ManglingCandidates = struct {
+        /// mangling 제외 대상 (export/import binding 이름)
+        exported: std.StringHashMap(void),
+        /// 빈도순 정렬된 mangling 후보 목록
+        entries: std.ArrayListUnmanaged(NameEntry),
 
-        // 1. 모든 모듈의 top-level 심볼의 reference_count 합산
-        const NameEntry = struct {
-            name: []const u8,
-            total_refs: u32,
-        };
+        fn deinit(mc: *ManglingCandidates, allocator: std.mem.Allocator) void {
+            mc.exported.deinit();
+            mc.entries.deinit(allocator);
+        }
+    };
+
+    /// 모든 모듈의 top-level 심볼을 수집하고 reference_count 빈도순으로 정렬.
+    /// mangling 제외 대상(export/import binding)도 함께 수집한다.
+    fn collectManglingCandidates(self: *const Linker) !ManglingCandidates {
         var name_refs = std.StringHashMap(u32).init(self.allocator);
         defer name_refs.deinit();
 
         // export/import binding 이름 수집 (mangling 제외 대상)
         var exported = std.StringHashMap(void).init(self.allocator);
-        defer exported.deinit();
+        errdefer exported.deinit();
         for (self.modules) |m| {
             for (m.export_bindings) |eb| {
                 try exported.put(eb.exported_name, {});
@@ -509,9 +516,9 @@ pub const Linker = struct {
             }
         }
 
-        // 2. 빈도순 정렬
+        // 빈도순 정렬
         var entries: std.ArrayListUnmanaged(NameEntry) = .empty;
-        defer entries.deinit(self.allocator);
+        errdefer entries.deinit(self.allocator);
         {
             var it = name_refs.iterator();
             while (it.next()) |entry| {
@@ -528,7 +535,23 @@ pub const Linker = struct {
             }
         }.cmp);
 
-        // 3. 빈도순으로 Base54 이름 할당
+        return .{ .exported = exported, .entries = entries };
+    }
+
+    /// minify 활성화 시, scope hoisting 후 모든 top-level 이름을 짧은 이름으로 교체.
+    /// computeRenames 이후에 호출해야 함 (충돌 해결 완료 상태).
+    pub fn computeMangling(self: *Linker) !void {
+        const Mangler = @import("../codegen/mangler.zig");
+
+        // ================================================================
+        // Top-level 심볼을 빈도순 Base54로 mangling (cross-module)
+        // ================================================================
+
+        // 1. mangling 후보 수집 + 빈도순 정렬
+        var candidates = try self.collectManglingCandidates();
+        defer candidates.deinit(self.allocator);
+
+        // 2. 빈도순으로 Base54 이름 할당
         // 기존에 사용 중인 이름 수집 (충돌 방지)
         var all_names = std.StringHashMap(void).init(self.allocator);
         defer all_names.deinit();
@@ -557,11 +580,11 @@ pub const Linker = struct {
 
         var name_counter: u32 = 0;
         var name_buf: [8]u8 = undefined;
-        for (entries.items) |entry| {
+        for (candidates.entries.items) |entry| {
             var new_name = Mangler.nextBase54Name(&name_counter, &name_buf);
             while (all_names.contains(new_name) or
                 used_names.contains(new_name) or
-                exported.contains(new_name))
+                candidates.exported.contains(new_name))
             {
                 new_name = Mangler.nextBase54Name(&name_counter, &name_buf);
             }
@@ -573,7 +596,7 @@ pub const Linker = struct {
             }
         }
 
-        // 4. canonical_names 업데이트 — 기존 rename된 이름도 mangling
+        // 3. canonical_names 업데이트 — 기존 rename된 이름도 mangling
         var update_list: std.ArrayList(struct { key: []const u8, val: []const u8 }) = .empty;
         defer update_list.deinit(self.allocator);
 
@@ -594,7 +617,7 @@ pub const Linker = struct {
             }
         }
 
-        // 5. 아직 canonical_names에 없는 이름도 추가 (충돌 없던 이름)
+        // 4. 아직 canonical_names에 없는 이름도 추가 (충돌 없던 이름)
         for (self.modules, 0..) |m, i| {
             const sem = m.semantic orelse continue;
             if (sem.scope_maps.len == 0) continue;
@@ -1059,63 +1082,75 @@ pub const Linker = struct {
         }
 
         // 3. 엔트리 포인트 final exports
-        var final_exports: ?[]const u8 = null;
-        if (is_entry and m.export_bindings.len > 0) {
-            var buf: std.ArrayList(u8) = .empty;
-            defer buf.deinit(self.allocator);
-            try buf.appendSlice(self.allocator, "export {");
-            var first = true;
-            for (m.export_bindings) |eb| {
-                if (eb.kind == .re_export_all) continue;
-                if (std.mem.eql(u8, eb.exported_name, "*")) continue;
-                if (!first) try buf.appendSlice(self.allocator, ",");
-                first = false;
-                const actual_name = self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
-                try buf.append(self.allocator, ' ');
-                try buf.appendSlice(self.allocator, actual_name);
-                if (!std.mem.eql(u8, actual_name, eb.exported_name)) {
-                    try buf.appendSlice(self.allocator, " as ");
-                    try buf.appendSlice(self.allocator, eb.exported_name);
-                }
-            }
-            try buf.appendSlice(self.allocator, " };\n");
-            if (!first) {
-                final_exports = try self.allocator.dupe(u8, buf.items);
-            }
-        }
-
-        // ns_member_rewrites 소유권 이동
-        const ns_rewrites: LinkingMetadata.NsMemberRewrites = if (ns_rewrite_list.items.len > 0) blk: {
-            break :blk .{ .entries = try self.allocator.dupe(LinkingMetadata.NsMemberRewrites.Entry, ns_rewrite_list.items) };
-        } else .{};
-        ns_rewrite_list.deinit(self.allocator);
-
-        const ns_inlines: LinkingMetadata.NsInlineObjects = if (ns_inline_list.items.len > 0) blk: {
-            break :blk .{ .entries = try self.allocator.dupe(LinkingMetadata.NsInlineObjects.Entry, ns_inline_list.items) };
-        } else .{};
-        ns_inline_list.deinit(self.allocator);
-
-        // namespace 변수 선언을 preamble에 추가: var gql = {parse: parse, ...};
-        var ns_preamble_buf: std.ArrayList(u8) = .empty;
-        defer ns_preamble_buf.deinit(self.allocator);
-        for (ns_inlines.entries) |entry| {
-            try ns_preamble_buf.appendSlice(self.allocator, "var ");
-            try ns_preamble_buf.appendSlice(self.allocator, entry.var_name);
-            try ns_preamble_buf.appendSlice(self.allocator, " = ");
-            try ns_preamble_buf.appendSlice(self.allocator, entry.object_literal);
-            try ns_preamble_buf.appendSlice(self.allocator, ";\n");
-        }
-        const combined_preamble: ?[]const u8 = if (ns_preamble_buf.items.len > 0) blk: {
-            // ns preamble이 있으면 cjs preamble과 합침
-            const combined = try std.mem.concat(self.allocator, u8, &.{
-                cjs_import_preamble orelse "",
-                ns_preamble_buf.items,
-            });
-            if (cjs_import_preamble) |p| self.allocator.free(p);
-            break :blk combined;
-        } else cjs_import_preamble;
+        const final_exports = try self.buildFinalExports(is_entry, module_index, m.export_bindings);
 
         // 크로스-모듈 상수 인라인: import binding의 canonical export가 상수이면 매핑
+        const const_values = try self.buildCrossModuleConstValues(m, sem);
+
+        // ns_member_rewrites / ns_inline_objects 소유권 이동 + namespace preamble 생성.
+        // finalizeNamespaceData가 리스트를 소비(deinit)하므로, 이후 에러 시
+        // errdefer가 이미 해제된 리스트에 접근하지 않도록 마지막에 호출한다.
+        const ns_result = try finalizeNamespaceData(self.allocator, &ns_rewrite_list, &ns_inline_list, cjs_import_preamble);
+        const ns_rewrites = ns_result.rewrites;
+        const ns_inlines = ns_result.inlines;
+        const combined_preamble = ns_result.combined_preamble;
+
+        return .{
+            .skip_nodes = skip_nodes,
+            .renames = renames,
+            .final_exports = final_exports,
+            .symbol_ids = sem.symbol_ids,
+            .cjs_import_preamble = combined_preamble,
+            .default_export_name = default_export_name,
+            .ns_member_rewrites = ns_rewrites,
+            .ns_inline_objects = ns_inlines,
+            .const_values = const_values,
+            .owned_rename_values = owned_nested_renames,
+            .allocator = self.allocator,
+        };
+    }
+
+    /// 엔트리 포인트의 최종 export 문을 생성한다. (e.g. "export { x, y$1 as y };\n")
+    /// is_entry가 false이거나 export가 없으면 null 반환.
+    fn buildFinalExports(
+        self: *const Linker,
+        is_entry: bool,
+        module_index: u32,
+        export_bindings: []const ExportBinding,
+    ) !?[]const u8 {
+        if (!is_entry or export_bindings.len == 0) return null;
+
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(self.allocator);
+        try buf.appendSlice(self.allocator, "export {");
+        var first = true;
+        for (export_bindings) |eb| {
+            if (eb.kind == .re_export_all) continue;
+            if (std.mem.eql(u8, eb.exported_name, "*")) continue;
+            if (!first) try buf.appendSlice(self.allocator, ",");
+            first = false;
+            const actual_name = self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
+            try buf.append(self.allocator, ' ');
+            try buf.appendSlice(self.allocator, actual_name);
+            if (!std.mem.eql(u8, actual_name, eb.exported_name)) {
+                try buf.appendSlice(self.allocator, " as ");
+                try buf.appendSlice(self.allocator, eb.exported_name);
+            }
+        }
+        try buf.appendSlice(self.allocator, " };\n");
+        if (!first) {
+            return try self.allocator.dupe(u8, buf.items);
+        }
+        return null;
+    }
+
+    /// 크로스-모듈 상수 인라인 맵을 생성한다.
+    /// import binding의 canonical export가 상수이면 symbol_id → ConstValue 매핑을 반환.
+    fn buildCrossModuleConstValues(
+        self: *const Linker,
+        m: Module,
+        sem: @import("module.zig").ModuleSemanticData,
+    ) !std.AutoHashMapUnmanaged(u32, @import("../semantic/symbol.zig").ConstValue) {
         var const_values: std.AutoHashMapUnmanaged(u32, @import("../semantic/symbol.zig").ConstValue) = .{};
         for (m.import_bindings) |ib| {
             if (ib.import_record_index >= m.import_records.len) continue;
@@ -1146,19 +1181,57 @@ pub const Linker = struct {
                 }
             }
         }
+        return const_values;
+    }
+
+    /// namespace 리스트의 소유권을 이동하고, namespace preamble을 CJS preamble과 합친다.
+    /// ns_rewrite_list와 ns_inline_list는 이 함수 호출 후 deinit된다.
+    fn finalizeNamespaceData(
+        allocator: std.mem.Allocator,
+        ns_rewrite_list: *std.ArrayList(LinkingMetadata.NsMemberRewrites.Entry),
+        ns_inline_list: *std.ArrayList(LinkingMetadata.NsInlineObjects.Entry),
+        cjs_import_preamble: ?[]const u8,
+    ) !struct {
+        rewrites: LinkingMetadata.NsMemberRewrites,
+        inlines: LinkingMetadata.NsInlineObjects,
+        combined_preamble: ?[]const u8,
+    } {
+        const ns_rewrites: LinkingMetadata.NsMemberRewrites = if (ns_rewrite_list.items.len > 0)
+            .{ .entries = try allocator.dupe(LinkingMetadata.NsMemberRewrites.Entry, ns_rewrite_list.items) }
+        else
+            .{};
+        ns_rewrite_list.deinit(allocator);
+
+        const ns_inlines: LinkingMetadata.NsInlineObjects = if (ns_inline_list.items.len > 0)
+            .{ .entries = try allocator.dupe(LinkingMetadata.NsInlineObjects.Entry, ns_inline_list.items) }
+        else
+            .{};
+        ns_inline_list.deinit(allocator);
+
+        // namespace 변수 선언을 preamble에 추가: var gql = {parse: parse, ...};
+        var ns_preamble_buf: std.ArrayList(u8) = .empty;
+        defer ns_preamble_buf.deinit(allocator);
+        for (ns_inlines.entries) |entry| {
+            try ns_preamble_buf.appendSlice(allocator, "var ");
+            try ns_preamble_buf.appendSlice(allocator, entry.var_name);
+            try ns_preamble_buf.appendSlice(allocator, " = ");
+            try ns_preamble_buf.appendSlice(allocator, entry.object_literal);
+            try ns_preamble_buf.appendSlice(allocator, ";\n");
+        }
+        const combined_preamble: ?[]const u8 = if (ns_preamble_buf.items.len > 0) blk: {
+            // ns preamble이 있으면 cjs preamble과 합침
+            const combined = try std.mem.concat(allocator, u8, &.{
+                cjs_import_preamble orelse "",
+                ns_preamble_buf.items,
+            });
+            if (cjs_import_preamble) |p| allocator.free(p);
+            break :blk combined;
+        } else cjs_import_preamble;
 
         return .{
-            .skip_nodes = skip_nodes,
-            .renames = renames,
-            .final_exports = final_exports,
-            .symbol_ids = sem.symbol_ids,
-            .cjs_import_preamble = combined_preamble,
-            .default_export_name = default_export_name,
-            .ns_member_rewrites = ns_rewrites,
-            .ns_inline_objects = ns_inlines,
-            .const_values = const_values,
-            .owned_rename_values = owned_nested_renames,
-            .allocator = self.allocator,
+            .rewrites = ns_rewrites,
+            .inlines = ns_inlines,
+            .combined_preamble = combined_preamble,
         };
     }
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -110,6 +110,12 @@ pub const Module = struct {
         return if (self.def_format.isEsm()) .node else .babel;
     }
 
+    /// exec_index 기준 오름차순 comparator. *const Module 정렬에 사용.
+    /// emitter, chunk 등에서 모듈을 ESM 실행 순서로 정렬할 때 공유.
+    pub fn execIndexLessThan(_: void, a: *const Module, b: *const Module) bool {
+        return a.exec_index < b.exec_index;
+    }
+
     pub fn init(index: ModuleIndex, path: []const u8) Module {
         return .{
             .index = index,

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -221,6 +221,16 @@ pub const BundlerDiagnostic = struct {
 // 공유 유틸리티
 // ============================================================
 
+// ============================================================
+// 공유 비교자 (Comparators)
+// ============================================================
+
+/// []const u8 문자열을 사전순으로 비교하는 comparator.
+/// 결정론적 출력을 위한 정렬에 사용 (cross-chunk import/export 이름 등).
+pub fn stringLessThan(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.order(u8, a, b) == .lt;
+}
+
 /// 모듈 경로에서 require_xxx 변수명을 생성한다.
 /// "lib/foo-bar.cjs" → "require_foo_bar"
 pub fn makeRequireVarName(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,225 @@ const runner = lib.test262.runner;
 const Bundler = lib.bundler.Bundler;
 const emitter = lib.bundler.emitter;
 
+/// CLI 인자를 파싱한 결과를 담는 구조체.
+/// main()에서 개별 변수 30여 개로 흩어져 있던 옵션을 하나로 모은다.
+const CliOptions = struct {
+    input_file: ?[]const u8 = null,
+    output_file: ?[]const u8 = null,
+    output_dir: ?[]const u8 = null,
+    minify_whitespace: bool = false,
+    minify_identifiers: bool = false,
+    minify_syntax: bool = false,
+    module_format: lib.codegen.codegen.ModuleFormat = .esm,
+    drop_console: bool = false,
+    drop_debugger: bool = false,
+    sourcemap: bool = false,
+    ascii_only: bool = false,
+    quote_style: lib.codegen.QuoteStyle = .double,
+    watch: bool = false,
+    is_test262: bool = false,
+    is_tokenize: bool = false,
+    is_bundle: bool = false,
+    is_serve: bool = false,
+    serve_port: u16 = 3000,
+    splitting: bool = false,
+    external_list: std.ArrayList([]const u8) = .empty,
+    define_list: std.ArrayList(DefineEntry) = .empty,
+    platform: lib.bundler.Platform = .browser,
+    bundle_format: lib.bundler.emitter.EmitOptions.Format = .esm,
+    bundle_format_explicit: bool = false,
+    test262_dir: ?[]const u8 = null,
+    project_path: ?[]const u8 = null,
+    use_define_for_class_fields: ?bool = null,
+    experimental_decorators: ?bool = null,
+    target: lib.transformer.TransformOptions.Target = .esnext,
+    conditions_list: std.ArrayList([]const u8) = .empty,
+
+    fn deinit(self: *CliOptions, alloc: std.mem.Allocator) void {
+        self.external_list.deinit(alloc);
+        self.define_list.deinit(alloc);
+        self.conditions_list.deinit(alloc);
+    }
+};
+
+/// CLI 인자를 파싱하여 CliOptions를 반환한다.
+/// --help 출력이나 파싱 에러로 프로그램을 종료해야 하면 null을 반환한다.
+fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?CliOptions {
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    const stderr = std.fs.File.stderr().deprecatedWriter();
+
+    if (args.len < 2) {
+        try printUsage(stdout);
+        return null;
+    }
+
+    var opts = CliOptions{};
+
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--test262")) {
+            opts.is_test262 = true;
+            if (i + 1 < args.len) {
+                i += 1;
+                opts.test262_dir = args[i];
+            }
+        } else if (std.mem.eql(u8, arg, "--tokenize")) {
+            opts.is_tokenize = true;
+        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--out-file")) {
+            if (i + 1 < args.len) {
+                i += 1;
+                opts.output_file = args[i];
+            }
+        } else if (std.mem.eql(u8, arg, "--outdir")) {
+            if (i + 1 < args.len) {
+                i += 1;
+                opts.output_dir = args[i];
+            }
+        } else if (std.mem.eql(u8, arg, "--minify")) {
+            opts.minify_whitespace = true;
+            opts.minify_identifiers = true;
+            opts.minify_syntax = true;
+        } else if (std.mem.eql(u8, arg, "--minify-whitespace")) {
+            opts.minify_whitespace = true;
+        } else if (std.mem.eql(u8, arg, "--minify-identifiers")) {
+            opts.minify_identifiers = true;
+        } else if (std.mem.eql(u8, arg, "--minify-syntax")) {
+            opts.minify_syntax = true;
+        } else if (std.mem.eql(u8, arg, "--format=cjs")) {
+            opts.module_format = .cjs;
+            opts.bundle_format = .cjs;
+            opts.bundle_format_explicit = true;
+        } else if (std.mem.eql(u8, arg, "--format=esm")) {
+            opts.module_format = .esm;
+            opts.bundle_format = .esm;
+            opts.bundle_format_explicit = true;
+        } else if (std.mem.eql(u8, arg, "--drop=console")) {
+            opts.drop_console = true;
+        } else if (std.mem.eql(u8, arg, "--drop=debugger")) {
+            opts.drop_debugger = true;
+        } else if (std.mem.startsWith(u8, arg, "--define:")) {
+            // --define:KEY=VALUE (esbuild 호환 문법)
+            const kv = arg["--define:".len..];
+            if (std.mem.indexOf(u8, kv, "=")) |eq_pos| {
+                try opts.define_list.append(allocator, .{
+                    .key = kv[0..eq_pos],
+                    .value = kv[eq_pos + 1 ..],
+                });
+            } else {
+                try stderr.print("zts: --define requires KEY=VALUE format: {s}\n", .{arg});
+                return null;
+            }
+        } else if (std.mem.eql(u8, arg, "--ascii-only")) {
+            opts.ascii_only = true;
+        } else if (std.mem.startsWith(u8, arg, "--quotes=")) {
+            const val = arg["--quotes=".len..];
+            if (std.mem.eql(u8, val, "double")) {
+                opts.quote_style = .double;
+            } else if (std.mem.eql(u8, val, "single")) {
+                opts.quote_style = .single;
+            } else if (std.mem.eql(u8, val, "preserve")) {
+                opts.quote_style = .preserve;
+            } else {
+                try stderr.print("zts: invalid --quotes value: {s} (expected: double, single, preserve)\n", .{val});
+                return null;
+            }
+        } else if (std.mem.eql(u8, arg, "--sourcemap")) {
+            opts.sourcemap = true;
+        } else if (std.mem.eql(u8, arg, "--project") or std.mem.eql(u8, arg, "-p")) {
+            if (i + 1 < args.len) {
+                i += 1;
+                opts.project_path = args[i];
+            }
+        } else if (std.mem.eql(u8, arg, "--watch") or std.mem.eql(u8, arg, "-w")) {
+            opts.watch = true;
+        } else if (std.mem.eql(u8, arg, "--bundle")) {
+            opts.is_bundle = true;
+        } else if (std.mem.eql(u8, arg, "--serve")) {
+            opts.is_serve = true;
+        } else if (std.mem.eql(u8, arg, "--port")) {
+            if (i + 1 < args.len) {
+                i += 1;
+                opts.serve_port = std.fmt.parseInt(u16, args[i], 10) catch {
+                    try stderr.print("zts: invalid port number: {s}\n", .{args[i]});
+                    return null;
+                };
+            }
+        } else if (std.mem.eql(u8, arg, "--splitting")) {
+            opts.splitting = true;
+        } else if (std.mem.eql(u8, arg, "--external")) {
+            if (i + 1 < args.len) {
+                i += 1;
+                try opts.external_list.append(allocator, args[i]);
+            }
+        } else if (std.mem.startsWith(u8, arg, "--conditions=")) {
+            const val = arg["--conditions=".len..];
+            // 쉼표로 분리된 조건 목록 (esbuild 호환: --conditions=production,development)
+            var it = std.mem.splitScalar(u8, val, ',');
+            while (it.next()) |cond| {
+                if (cond.len > 0) try opts.conditions_list.append(allocator, cond);
+            }
+        } else if (std.mem.eql(u8, arg, "--platform=node")) {
+            opts.platform = .node;
+        } else if (std.mem.eql(u8, arg, "--platform=browser")) {
+            opts.platform = .browser;
+        } else if (std.mem.eql(u8, arg, "--platform=neutral")) {
+            opts.platform = .neutral;
+        } else if (std.mem.eql(u8, arg, "--format=iife")) {
+            opts.bundle_format = .iife;
+            opts.bundle_format_explicit = true;
+        } else if (std.mem.eql(u8, arg, "--experimental-decorators")) {
+            opts.experimental_decorators = true;
+        } else if (std.mem.eql(u8, arg, "--use-define-for-class-fields=false")) {
+            opts.use_define_for_class_fields = false;
+        } else if (std.mem.eql(u8, arg, "--use-define-for-class-fields=true")) {
+            opts.use_define_for_class_fields = true;
+        } else if (std.mem.startsWith(u8, arg, "--target=")) {
+            const val = arg["--target=".len..];
+            opts.target = std.meta.stringToEnum(lib.transformer.TransformOptions.Target, val) orelse {
+                try stderr.print("zts: unknown target '{s}'\n", .{val});
+                return null;
+            };
+        } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            try printUsage(stdout);
+            return null;
+        } else if (arg[0] != '-' or (arg.len == 1 and arg[0] == '-')) {
+            opts.input_file = arg;
+        } else {
+            try stderr.print("zts: unknown option: {s}\n", .{arg});
+            return null;
+        }
+    }
+
+    // --bundle + --platform=browser + --format 미지정이면 IIFE로 기본 설정 (esbuild 호환).
+    // 브라우저 <script> 태그에서 로드할 때 top-level 선언이 글로벌을 오염시키지 않도록
+    // 번들 전체를 IIFE로 래핑한다. ESM 출력이 필요하면 --format=esm을 명시해야 한다.
+    if (opts.is_bundle and opts.platform == .browser and !opts.bundle_format_explicit) {
+        opts.bundle_format = .iife;
+    }
+
+    // --bundle + --platform=browser이면 process.env.NODE_ENV를 자동 define (esbuild 호환).
+    // 트랜스파일 모드에서는 적용하지 않음 (esbuild와 동일).
+    // 사용자가 이미 --define:process.env.NODE_ENV=... 를 지정한 경우 덮어쓰지 않음.
+    if (opts.is_bundle and opts.platform == .browser) {
+        var has_node_env = false;
+        for (opts.define_list.items) |d| {
+            if (std.mem.eql(u8, d.key, "process.env.NODE_ENV")) {
+                has_node_env = true;
+                break;
+            }
+        }
+        if (!has_node_env) {
+            try opts.define_list.append(allocator, .{
+                .key = "process.env.NODE_ENV",
+                .value = "\"production\"",
+            });
+        }
+    }
+
+    return opts;
+}
+
 /// 트랜스파일 옵션을 담는 구조체.
 /// CLI에서 파싱한 옵션들을 transpileFile / walkAndTranspile에 전달한다.
 const DefineEntry = lib.transformer.DefineEntry;
@@ -324,212 +543,12 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    if (args.len < 2) {
-        try printUsage(stdout);
-        return;
-    }
-
-    // 옵션 파싱
-    var input_file: ?[]const u8 = null;
-    var output_file: ?[]const u8 = null;
-    var output_dir: ?[]const u8 = null;
-    var minify_whitespace = false;
-    var minify_identifiers = false;
-    var minify_syntax = false;
-    var module_format: lib.codegen.codegen.ModuleFormat = .esm;
-    var drop_console = false;
-    var drop_debugger = false;
-    var sourcemap = false;
-    var ascii_only = false;
-    var quote_style: lib.codegen.QuoteStyle = .double;
-    var watch = false;
-    var is_test262 = false;
-    var is_tokenize = false;
-    var is_bundle = false;
-    var is_serve = false;
-    var serve_port: u16 = 3000;
-    var splitting = false;
-    var external_list: std.ArrayList([]const u8) = .empty;
-    defer external_list.deinit(allocator);
-    var define_list: std.ArrayList(DefineEntry) = .empty;
-    defer define_list.deinit(allocator);
-    var platform: lib.bundler.Platform = .browser;
-    var bundle_format: lib.bundler.emitter.EmitOptions.Format = .esm;
-    var bundle_format_explicit = false; // 사용자가 --format을 명시했는지 추적
-    var test262_dir: ?[]const u8 = null;
-    var project_path: ?[]const u8 = null;
-    var use_define_for_class_fields: ?bool = null; // null = CLI에서 미지정 → tsconfig 따름
-    var experimental_decorators: ?bool = null; // null = CLI에서 미지정 → tsconfig 따름
-    const Target = lib.transformer.TransformOptions.Target;
-    var target: Target = .esnext;
-    var conditions_list: std.ArrayList([]const u8) = .empty;
-    defer conditions_list.deinit(allocator);
-
-    var i: usize = 1;
-    while (i < args.len) : (i += 1) {
-        const arg = args[i];
-        if (std.mem.eql(u8, arg, "--test262")) {
-            is_test262 = true;
-            if (i + 1 < args.len) {
-                i += 1;
-                test262_dir = args[i];
-            }
-        } else if (std.mem.eql(u8, arg, "--tokenize")) {
-            is_tokenize = true;
-        } else if (std.mem.eql(u8, arg, "-o") or std.mem.eql(u8, arg, "--out-file")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                output_file = args[i];
-            }
-        } else if (std.mem.eql(u8, arg, "--outdir")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                output_dir = args[i];
-            }
-        } else if (std.mem.eql(u8, arg, "--minify")) {
-            minify_whitespace = true;
-            minify_identifiers = true;
-            minify_syntax = true;
-        } else if (std.mem.eql(u8, arg, "--minify-whitespace")) {
-            minify_whitespace = true;
-        } else if (std.mem.eql(u8, arg, "--minify-identifiers")) {
-            minify_identifiers = true;
-        } else if (std.mem.eql(u8, arg, "--minify-syntax")) {
-            minify_syntax = true;
-        } else if (std.mem.eql(u8, arg, "--format=cjs")) {
-            module_format = .cjs;
-            bundle_format = .cjs;
-            bundle_format_explicit = true;
-        } else if (std.mem.eql(u8, arg, "--format=esm")) {
-            module_format = .esm;
-            bundle_format = .esm;
-            bundle_format_explicit = true;
-        } else if (std.mem.eql(u8, arg, "--drop=console")) {
-            drop_console = true;
-        } else if (std.mem.eql(u8, arg, "--drop=debugger")) {
-            drop_debugger = true;
-        } else if (std.mem.startsWith(u8, arg, "--define:")) {
-            // --define:KEY=VALUE (esbuild 호환 문법)
-            const kv = arg["--define:".len..];
-            if (std.mem.indexOf(u8, kv, "=")) |eq_pos| {
-                try define_list.append(allocator, .{
-                    .key = kv[0..eq_pos],
-                    .value = kv[eq_pos + 1 ..],
-                });
-            } else {
-                try stderr.print("zts: --define requires KEY=VALUE format: {s}\n", .{arg});
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "--ascii-only")) {
-            ascii_only = true;
-        } else if (std.mem.startsWith(u8, arg, "--quotes=")) {
-            const val = arg["--quotes=".len..];
-            if (std.mem.eql(u8, val, "double")) {
-                quote_style = .double;
-            } else if (std.mem.eql(u8, val, "single")) {
-                quote_style = .single;
-            } else if (std.mem.eql(u8, val, "preserve")) {
-                quote_style = .preserve;
-            } else {
-                try stderr.print("zts: invalid --quotes value: {s} (expected: double, single, preserve)\n", .{val});
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "--sourcemap")) {
-            sourcemap = true;
-        } else if (std.mem.eql(u8, arg, "--project") or std.mem.eql(u8, arg, "-p")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                project_path = args[i];
-            }
-        } else if (std.mem.eql(u8, arg, "--watch") or std.mem.eql(u8, arg, "-w")) {
-            watch = true;
-        } else if (std.mem.eql(u8, arg, "--bundle")) {
-            is_bundle = true;
-        } else if (std.mem.eql(u8, arg, "--serve")) {
-            is_serve = true;
-        } else if (std.mem.eql(u8, arg, "--port")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                serve_port = std.fmt.parseInt(u16, args[i], 10) catch {
-                    try stderr.print("zts: invalid port number: {s}\n", .{args[i]});
-                    return;
-                };
-            }
-        } else if (std.mem.eql(u8, arg, "--splitting")) {
-            splitting = true;
-        } else if (std.mem.eql(u8, arg, "--external")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                try external_list.append(allocator, args[i]);
-            }
-        } else if (std.mem.startsWith(u8, arg, "--conditions=")) {
-            const val = arg["--conditions=".len..];
-            // 쉼표로 분리된 조건 목록 (esbuild 호환: --conditions=production,development)
-            var it = std.mem.splitScalar(u8, val, ',');
-            while (it.next()) |cond| {
-                if (cond.len > 0) try conditions_list.append(allocator, cond);
-            }
-        } else if (std.mem.eql(u8, arg, "--platform=node")) {
-            platform = .node;
-        } else if (std.mem.eql(u8, arg, "--platform=browser")) {
-            platform = .browser;
-        } else if (std.mem.eql(u8, arg, "--platform=neutral")) {
-            platform = .neutral;
-        } else if (std.mem.eql(u8, arg, "--format=iife")) {
-            bundle_format = .iife;
-            bundle_format_explicit = true;
-        } else if (std.mem.eql(u8, arg, "--experimental-decorators")) {
-            experimental_decorators = true;
-        } else if (std.mem.eql(u8, arg, "--use-define-for-class-fields=false")) {
-            use_define_for_class_fields = false;
-        } else if (std.mem.eql(u8, arg, "--use-define-for-class-fields=true")) {
-            use_define_for_class_fields = true;
-        } else if (std.mem.startsWith(u8, arg, "--target=")) {
-            const val = arg["--target=".len..];
-            target = std.meta.stringToEnum(Target, val) orelse {
-                try stderr.print("zts: unknown target '{s}'\n", .{val});
-                return;
-            };
-        } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
-            try printUsage(stdout);
-            return;
-        } else if (arg[0] != '-' or (arg.len == 1 and arg[0] == '-')) {
-            input_file = arg;
-        } else {
-            try stderr.print("zts: unknown option: {s}\n", .{arg});
-            return;
-        }
-    }
-
-    // --bundle + --platform=browser + --format 미지정이면 IIFE로 기본 설정 (esbuild 호환).
-    // 브라우저 <script> 태그에서 로드할 때 top-level 선언이 글로벌을 오염시키지 않도록
-    // 번들 전체를 IIFE로 래핑한다. ESM 출력이 필요하면 --format=esm을 명시해야 한다.
-    if (is_bundle and platform == .browser and !bundle_format_explicit) {
-        bundle_format = .iife;
-    }
-
-    // --bundle + --platform=browser이면 process.env.NODE_ENV를 자동 define (esbuild 호환).
-    // 트랜스파일 모드에서는 적용하지 않음 (esbuild와 동일).
-    // 사용자가 이미 --define:process.env.NODE_ENV=... 를 지정한 경우 덮어쓰지 않음.
-    if (is_bundle and platform == .browser) {
-        var has_node_env = false;
-        for (define_list.items) |d| {
-            if (std.mem.eql(u8, d.key, "process.env.NODE_ENV")) {
-                has_node_env = true;
-                break;
-            }
-        }
-        if (!has_node_env) {
-            try define_list.append(allocator, .{
-                .key = "process.env.NODE_ENV",
-                .value = "\"production\"",
-            });
-        }
-    }
+    var opts = try parseCliArguments(args, allocator) orelse return;
+    defer opts.deinit(allocator);
 
     // --test262
-    if (is_test262) {
-        const dir_path = test262_dir orelse {
+    if (opts.is_test262) {
+        const dir_path = opts.test262_dir orelse {
             try stderr.print("Error: --test262 requires a directory path\n", .{});
             return;
         };
@@ -542,8 +561,8 @@ pub fn main() !void {
     }
 
     // --tokenize
-    if (is_tokenize) {
-        const file_path = input_file orelse {
+    if (opts.is_tokenize) {
+        const file_path = opts.input_file orelse {
             try stderr.print("Error: --tokenize requires a file path\n", .{});
             return;
         };
@@ -568,14 +587,14 @@ pub fn main() !void {
     }
 
     // --serve (정적 서버 또는 --bundle과 조합하여 번들 서빙)
-    if (is_serve) {
+    if (opts.is_serve) {
         // --serve --bundle entry.ts → entry의 디렉토리를 root로 사용
-        const serve_dir: []const u8 = if (is_bundle and input_file != null) blk: {
-            break :blk std.fs.path.dirname(input_file.?) orelse ".";
-        } else input_file orelse ".";
+        const serve_dir: []const u8 = if (opts.is_bundle and opts.input_file != null) blk: {
+            break :blk std.fs.path.dirname(opts.input_file.?) orelse ".";
+        } else opts.input_file orelse ".";
 
-        const entry: ?[]const u8 = if (is_bundle) blk: {
-            break :blk input_file orelse {
+        const entry: ?[]const u8 = if (opts.is_bundle) blk: {
+            break :blk opts.input_file orelse {
                 try stderr.print("Error: --serve --bundle requires an entry file path\n", .{});
                 return;
             };
@@ -583,7 +602,7 @@ pub fn main() !void {
 
         var dev_server = lib.server.DevServer.init(allocator, .{
             .root_dir = serve_dir,
-            .port = serve_port,
+            .port = opts.serve_port,
             .entry_point = entry,
         }) catch |err| {
             try stderr.print("Error: failed to start dev server: {}\n", .{err});
@@ -598,8 +617,8 @@ pub fn main() !void {
     }
 
     // --bundle
-    if (is_bundle) {
-        const entry_file = input_file orelse {
+    if (opts.is_bundle) {
+        const entry_file = opts.input_file orelse {
             try stderr.print("Error: --bundle requires an entry file path\n", .{});
             return;
         };
@@ -610,25 +629,25 @@ pub fn main() !void {
         defer allocator.free(abs_entry);
 
         // --splitting은 --outdir 필수
-        if (splitting and output_dir == null) {
+        if (opts.splitting and opts.output_dir == null) {
             try stderr.print("Error: --splitting requires --outdir\n", .{});
             return;
         }
 
         var bundler = Bundler.init(allocator, .{
             .entry_points = &.{abs_entry},
-            .format = bundle_format,
-            .platform = platform,
-            .external = external_list.items,
-            .minify_whitespace = minify_whitespace,
-            .minify_identifiers = minify_identifiers,
-            .minify_syntax = minify_syntax,
-            .code_splitting = splitting,
-            .define = define_list.items,
-            .experimental_decorators = experimental_decorators orelse false,
-            .use_define_for_class_fields = use_define_for_class_fields orelse true,
-            .target = target,
-            .conditions = conditions_list.items,
+            .format = opts.bundle_format,
+            .platform = opts.platform,
+            .external = opts.external_list.items,
+            .minify_whitespace = opts.minify_whitespace,
+            .minify_identifiers = opts.minify_identifiers,
+            .minify_syntax = opts.minify_syntax,
+            .code_splitting = opts.splitting,
+            .define = opts.define_list.items,
+            .experimental_decorators = opts.experimental_decorators orelse false,
+            .use_define_for_class_fields = opts.use_define_for_class_fields orelse true,
+            .target = opts.target,
+            .conditions = opts.conditions_list.items,
         });
         defer bundler.deinit();
 
@@ -653,7 +672,7 @@ pub fn main() !void {
         // 출력
         if (result.outputs) |outputs| {
             // Code splitting: 다중 파일 출력 → --outdir 필수
-            const out_dir = output_dir orelse ".";
+            const out_dir = opts.output_dir orelse ".";
             std.fs.cwd().makePath(out_dir) catch {};
             for (outputs) |o| {
                 const full_path = try std.fs.path.join(allocator, &.{ out_dir, o.path });
@@ -664,7 +683,7 @@ pub fn main() !void {
                 try stdout.print("  {s} ({d} bytes)\n", .{ full_path, o.contents.len });
             }
             try stdout.print("Bundled → {d} chunks in {s}/\n", .{ outputs.len, out_dir });
-        } else if (output_file) |out_path| {
+        } else if (opts.output_file) |out_path| {
             // 단일 파일 출력
             if (std.fs.path.dirname(out_path)) |dir| {
                 std.fs.cwd().makePath(dir) catch {};
@@ -680,14 +699,14 @@ pub fn main() !void {
     }
 
     // 입력 경로가 디렉토리인지 확인
-    const input_path_str = input_file orelse {
+    const input_path_str = opts.input_file orelse {
         try printUsage(stdout);
         return;
     };
 
     // tsconfig.json 로드.
     // 우선순위: --project 경로 > 입력이 디렉토리면 그 디렉토리 > 입력 파일의 부모 디렉토리
-    const tsconfig_dir: []const u8 = if (project_path) |pp|
+    const tsconfig_dir: []const u8 = if (opts.project_path) |pp|
         pp
     else if (!std.mem.eql(u8, input_path_str, "-"))
         // 파일이면 dirname, 디렉토리면 그대로
@@ -701,26 +720,26 @@ pub fn main() !void {
     // tsconfig 값을 기본값으로 사용하되, CLI 옵션이 우선한다.
     // CLI에서 명시적으로 설정하지 않은 옵션만 tsconfig에서 가져온다.
     // module_format: tsconfig의 module이 "commonjs"이면 cjs 사용
-    if (module_format == .esm) { // CLI에서 --format=cjs를 안 했으면
+    if (opts.module_format == .esm) { // CLI에서 --format=cjs를 안 했으면
         if (tsconfig.module) |mod| {
             if (std.ascii.eqlIgnoreCase(mod, "commonjs")) {
-                module_format = .cjs;
+                opts.module_format = .cjs;
             }
         }
     }
     // sourcemap: tsconfig에서 true이면 적용 (CLI --sourcemap이 이미 true면 그대로)
-    if (!sourcemap and tsconfig.source_map) {
-        sourcemap = true;
+    if (!opts.sourcemap and tsconfig.source_map) {
+        opts.sourcemap = true;
     }
     // output_dir: tsconfig의 outDir를 기본값으로 사용
-    if (output_dir == null) {
+    if (opts.output_dir == null) {
         if (tsconfig.out_dir) |od| {
-            output_dir = od;
+            opts.output_dir = od;
         }
     }
     // experimentalDecorators: CLI 미지정이면 tsconfig에서 가져옴
-    if (experimental_decorators == null and tsconfig.experimental_decorators) {
-        experimental_decorators = true;
+    if (opts.experimental_decorators == null and tsconfig.experimental_decorators) {
+        opts.experimental_decorators = true;
     }
     // useDefineForClassFields: CLI 미지정이면 tsconfig에서 가져옴 (tsconfig 파싱 필요 — 아래 참고)
     // 주의: tsconfig에 useDefineForClassFields가 없고 experimentalDecorators=true이면
@@ -730,20 +749,20 @@ pub fn main() !void {
 
     // 트랜스파일 옵션 구성
     const options = TranspileOptions{
-        .module_format = module_format,
-        .minify_whitespace = minify_whitespace,
-        .minify_identifiers = minify_identifiers,
-        .minify_syntax = minify_syntax,
-        .drop_console = drop_console,
-        .drop_debugger = drop_debugger,
-        .sourcemap = sourcemap,
-        .ascii_only = ascii_only,
-        .quote_style = quote_style,
-        .define = define_list.items,
-        .platform = platform,
-        .use_define_for_class_fields = use_define_for_class_fields orelse true,
-        .experimental_decorators = experimental_decorators orelse false,
-        .target = target,
+        .module_format = opts.module_format,
+        .minify_whitespace = opts.minify_whitespace,
+        .minify_identifiers = opts.minify_identifiers,
+        .minify_syntax = opts.minify_syntax,
+        .drop_console = opts.drop_console,
+        .drop_debugger = opts.drop_debugger,
+        .sourcemap = opts.sourcemap,
+        .ascii_only = opts.ascii_only,
+        .quote_style = opts.quote_style,
+        .define = opts.define_list.items,
+        .platform = opts.platform,
+        .use_define_for_class_fields = opts.use_define_for_class_fields orelse true,
+        .experimental_decorators = opts.experimental_decorators orelse false,
+        .target = opts.target,
     };
 
     const is_stdin = std.mem.eql(u8, input_path_str, "-");
@@ -760,24 +779,24 @@ pub fn main() !void {
             };
             dir.close();
             // 디렉토리 확인됨 — 아래 디렉토리 처리로 이동
-            const out_dir = output_dir orelse {
+            const out_dir = opts.output_dir orelse {
                 try stderr.print("zts: --outdir is required when input is a directory\n", .{});
                 return;
             };
             try walkAndTranspile(allocator, input_path_str, out_dir, options);
-            if (watch) {
+            if (opts.watch) {
                 try watchDirectory(allocator, input_path_str, out_dir, options, stderr);
             }
             return;
         };
 
         if (stat.kind == .directory) {
-            const out_dir = output_dir orelse {
+            const out_dir = opts.output_dir orelse {
                 try stderr.print("zts: --outdir is required when input is a directory\n", .{});
                 return;
             };
             try walkAndTranspile(allocator, input_path_str, out_dir, options);
-            if (watch) {
+            if (opts.watch) {
                 try watchDirectory(allocator, input_path_str, out_dir, options, stderr);
             }
             return;
@@ -793,11 +812,11 @@ pub fn main() !void {
             return;
         };
         defer allocator.free(source);
-        try transpileFile(allocator, file_path, source, output_file, options);
+        try transpileFile(allocator, file_path, source, opts.output_file, options);
     } else {
-        try transpileFile(allocator, file_path, null, output_file, options);
-        if (watch) {
-            try watchFile(allocator, file_path, output_file, options, stderr);
+        try transpileFile(allocator, file_path, null, opts.output_file, options);
+        if (opts.watch) {
+            try watchFile(allocator, file_path, opts.output_file, options, stderr);
         }
     }
 }

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -194,11 +194,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const name_node = if (!new_name.isNone())
                 new_name
             else
-                try self.new_ast.addNode(.{
-                    .tag = .binding_identifier,
-                    .span = name_span,
-                    .data = .{ .string_ref = name_span },
-                });
+                try es_helpers.makeBindingIdentifier(self, name_span);
 
             // super class
             const has_super = !super_idx.isNone();

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -113,14 +113,10 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     // 먼저 init을 임시 변수에 저장
                     const new_init = try self.visitNode(init_idx);
                     const temp_span = try es_helpers.makeTempVarSpan(self);
-                    const temp_binding = try self.new_ast.addNode(.{
-                        .tag = .binding_identifier,
-                        .span = temp_span,
-                        .data = .{ .string_ref = temp_span },
-                    });
+                    const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
 
                     // var _ref = init
-                    const ref_decl = try makeDeclarator(self, temp_binding, new_init, span);
+                    const ref_decl = try es_helpers.makeDeclarator(self, temp_binding, new_init, span);
                     try self.scratch.append(self.allocator, ref_decl);
 
                     // 패턴을 개별 declarator로 분해
@@ -385,7 +381,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         .span = key_node.span,
                         .data = .{ .string_ref = key_node.data.string_ref },
                     });
-                    const decl = try makeDeclarator(self, binding, member_access, span);
+                    const decl = try es_helpers.makeDeclarator(self, binding, member_access, span);
                     try self.scratch.append(self.allocator, decl);
                 } else {
                     const value_node = self.old_ast.getNode(value_idx);
@@ -394,23 +390,19 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         const binding = try self.visitNode(value_node.data.binary.left);
                         const default_val = try self.visitNode(value_node.data.binary.right);
                         const defaulted = try buildDefaulted(self, member_access, default_val, ref_span, key_idx, span);
-                        const decl = try makeDeclarator(self, binding, defaulted, span);
+                        const decl = try es_helpers.makeDeclarator(self, binding, defaulted, span);
                         try self.scratch.append(self.allocator, decl);
                     } else if (value_node.tag == .object_pattern or value_node.tag == .array_pattern) {
                         // nested: { a: { b } } → var _ref2 = _ref.a; var b = _ref2.b
                         const nested_span = try es_helpers.makeTempVarSpan(self);
-                        const nested_binding = try self.new_ast.addNode(.{
-                            .tag = .binding_identifier,
-                            .span = nested_span,
-                            .data = .{ .string_ref = nested_span },
-                        });
-                        const nested_decl = try makeDeclarator(self, nested_binding, member_access, span);
+                        const nested_binding = try es_helpers.makeBindingIdentifier(self, nested_span);
+                        const nested_decl = try es_helpers.makeDeclarator(self, nested_binding, member_access, span);
                         try self.scratch.append(self.allocator, nested_decl);
                         try emitPatternDeclarators(self, value_node, nested_span, span);
                     } else {
                         // long-form: { a: b } → var b = _ref.a
                         const binding = try self.visitNode(value_idx);
-                        const decl = try makeDeclarator(self, binding, member_access, span);
+                        const decl = try es_helpers.makeDeclarator(self, binding, member_access, span);
                         try self.scratch.append(self.allocator, decl);
                     }
                 }
@@ -431,7 +423,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     // ...rest → var rest = _ref.slice(N)
                     const rest_binding = try self.visitNode(elem.data.unary.operand);
                     const rest_init = try buildArraySlice(self, ref_span, idx, span);
-                    const rest_decl = try makeDeclarator(self, rest_binding, rest_init, span);
+                    const rest_decl = try es_helpers.makeDeclarator(self, rest_binding, rest_init, span);
                     try self.scratch.append(self.allocator, rest_decl);
                     continue;
                 }
@@ -455,23 +447,19 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         .span = span,
                         .data = .{ .ternary = .{ .a = eq_check, .b = default_val, .c = elem_access2 } },
                     });
-                    const decl = try makeDeclarator(self, binding, conditional, span);
+                    const decl = try es_helpers.makeDeclarator(self, binding, conditional, span);
                     try self.scratch.append(self.allocator, decl);
                 } else if (elem.tag == .object_pattern or elem.tag == .array_pattern) {
                     // nested: [[a, b]] → var _ref2 = _ref[0]; var a = _ref2[0]; ...
                     const nested_span = try es_helpers.makeTempVarSpan(self);
-                    const nested_binding = try self.new_ast.addNode(.{
-                        .tag = .binding_identifier,
-                        .span = nested_span,
-                        .data = .{ .string_ref = nested_span },
-                    });
-                    const nested_decl = try makeDeclarator(self, nested_binding, elem_access, span);
+                    const nested_binding = try es_helpers.makeBindingIdentifier(self, nested_span);
+                    const nested_decl = try es_helpers.makeDeclarator(self, nested_binding, elem_access, span);
                     try self.scratch.append(self.allocator, nested_decl);
                     try emitPatternDeclarators(self, elem, nested_span, span);
                 } else {
                     // 단순: [x] → var x = _ref[0]
                     const binding = try self.visitNode(@enumFromInt(raw_idx));
-                    const decl = try makeDeclarator(self, binding, elem_access, span);
+                    const decl = try es_helpers.makeDeclarator(self, binding, elem_access, span);
                     try self.scratch.append(self.allocator, decl);
                 }
             }
@@ -493,18 +481,6 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 .tag = .conditional_expression,
                 .span = span,
                 .data = .{ .ternary = .{ .a = eq_check, .b = default_val, .c = access2 } },
-            });
-        }
-
-        /// variable_declarator 노드 생성 헬퍼
-        fn makeDeclarator(self: *Transformer, binding: NodeIndex, init: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const de = try self.new_ast.addExtras(&.{
-                @intFromEnum(binding), @intFromEnum(NodeIndex.none), @intFromEnum(init),
-            });
-            return self.new_ast.addNode(.{
-                .tag = .variable_declarator,
-                .span = span,
-                .data = .{ .extra = de },
             });
         }
 
@@ -579,7 +555,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             // __rest(_ref, [...])
             const call = try es_helpers.makeCallExpr(self, rest_callee, &.{ ref, arr_node }, span);
 
-            return makeDeclarator(self, binding, call, span);
+            return es_helpers.makeDeclarator(self, binding, call, span);
         }
     };
 }

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -41,58 +41,21 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
 
             // --- init: var _a = 0, _b = arr ---
             // _a = 0
-            const idx_binding = try makeBinding(self, idx_span);
-            const zero_span = try self.new_ast.addString("0");
-            const zero = try self.new_ast.addNode(.{
-                .tag = .numeric_literal,
-                .span = zero_span,
-                .data = .{ .none = 0 },
-            });
-            const idx_decl_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(idx_binding), @intFromEnum(NodeIndex.none), @intFromEnum(zero),
-            });
-            const idx_decl = try self.new_ast.addNode(.{
-                .tag = .variable_declarator,
-                .span = span,
-                .data = .{ .extra = idx_decl_extra },
-            });
+            const idx_binding = try es_helpers.makeBindingIdentifier(self, idx_span);
+            const zero = try es_helpers.makeNumericLiteral(self, 0);
+            const idx_decl = try es_helpers.makeDeclarator(self, idx_binding, zero, span);
 
             // _b = arr
-            const arr_binding = try makeBinding(self, arr_span);
-            const arr_decl_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(arr_binding), @intFromEnum(NodeIndex.none), @intFromEnum(new_right),
-            });
-            const arr_decl = try self.new_ast.addNode(.{
-                .tag = .variable_declarator,
-                .span = span,
-                .data = .{ .extra = arr_decl_extra },
-            });
+            const arr_binding = try es_helpers.makeBindingIdentifier(self, arr_span);
+            const arr_decl = try es_helpers.makeDeclarator(self, arr_binding, new_right, span);
 
-            const init_list = try self.new_ast.addNodeList(&.{ idx_decl, arr_decl });
-            const init_extra = try self.new_ast.addExtras(&.{ 0, init_list.start, init_list.len }); // 0 = var
-            const init = try self.new_ast.addNode(.{
-                .tag = .variable_declaration,
-                .span = span,
-                .data = .{ .extra = init_extra },
-            });
+            const init = try es_helpers.makeVarDeclaration(self, &.{ idx_decl, arr_decl }, 0, span);
 
             // --- test: _a < _b.length ---
             const idx_ref = try es_helpers.makeTempVarRef(self, idx_span, idx_span);
-            const length_span = try self.new_ast.addString("length");
-            const length_prop = try self.new_ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = length_span,
-                .data = .{ .string_ref = length_span },
-            });
+            const length_prop = try es_helpers.makeIdentifierRef(self, "length");
             const arr_ref_test = try es_helpers.makeTempVarRef(self, arr_span, arr_span);
-            const member_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(arr_ref_test), @intFromEnum(length_prop), 0,
-            });
-            const arr_length = try self.new_ast.addNode(.{
-                .tag = .static_member_expression,
-                .span = span,
-                .data = .{ .extra = member_extra },
-            });
+            const arr_length = try es_helpers.makeStaticMember(self, arr_ref_test, length_prop, span);
             const test_expr = try self.new_ast.addNode(.{
                 .tag = .binary_expression,
                 .span = span,
@@ -153,15 +116,6 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
             });
         }
 
-        /// binding_identifier 노드 생성
-        fn makeBinding(self: *Transformer, name_span: Span) Transformer.Error!NodeIndex {
-            return self.new_ast.addNode(.{
-                .tag = .binding_identifier,
-                .span = name_span,
-                .data = .{ .string_ref = name_span },
-            });
-        }
-
         /// for-of의 left를 기반으로 `var x = elem` 문 생성.
         /// left가 variable_declaration이면 해당 패턴을 재사용.
         /// left가 expression이면 assignment로 변환.
@@ -185,23 +139,8 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                 const binding_name = try self.visitNode(@enumFromInt(extras[first_decl.data.extra]));
 
                 // var x = elem
-                const decl_extra = try self.new_ast.addExtras(&.{
-                    @intFromEnum(binding_name),
-                    @intFromEnum(NodeIndex.none),
-                    @intFromEnum(elem),
-                });
-                const declarator = try self.new_ast.addNode(.{
-                    .tag = .variable_declarator,
-                    .span = span,
-                    .data = .{ .extra = decl_extra },
-                });
-                const decl_list = try self.new_ast.addNodeList(&.{declarator});
-                const var_extra = try self.new_ast.addExtras(&.{ 0, decl_list.start, decl_list.len }); // 0 = var
-                return self.new_ast.addNode(.{
-                    .tag = .variable_declaration,
-                    .span = span,
-                    .data = .{ .extra = var_extra },
-                });
+                const declarator = try es_helpers.makeDeclarator(self, binding_name, elem, span);
+                return es_helpers.makeVarDeclaration(self, &.{declarator}, 0, span);
             } else {
                 // for (x of ...) → x = _b[_a]
                 const new_left = try self.visitNode(left);

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -178,25 +178,10 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 defer self.scratch.shrinkRetainingCapacity(scratch_top2);
 
                 for (hoisted_vars.items) |binding| {
-                    const decl_extra = try self.new_ast.addExtras(&.{
-                        @intFromEnum(binding),
-                        @intFromEnum(NodeIndex.none),
-                        @intFromEnum(NodeIndex.none),
-                    });
-                    const declarator = try self.new_ast.addNode(.{
-                        .tag = .variable_declarator,
-                        .span = span,
-                        .data = .{ .extra = decl_extra },
-                    });
+                    const declarator = try es_helpers.makeDeclarator(self, binding, .none, span);
                     try self.scratch.append(self.allocator, declarator);
                 }
-                const decl_list = try self.new_ast.addNodeList(self.scratch.items[scratch_top2..]);
-                const var_decl_extra = try self.new_ast.addExtras(&.{ 0, decl_list.start, decl_list.len });
-                var_decl_node = try self.new_ast.addNode(.{
-                    .tag = .variable_declaration,
-                    .span = span,
-                    .data = .{ .extra = var_decl_extra },
-                });
+                var_decl_node = try es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top2..], 0, span);
             }
 
             return .{ .body = switch_node, .var_decl = var_decl_node };
@@ -1366,7 +1351,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             // _state 파라미터
             const state_span = try self.new_ast.addString("_state");
-            const state_param = try self.new_ast.addNode(.{ .tag = .binding_identifier, .span = state_span, .data = .{ .string_ref = state_span } });
+            const state_param = try es_helpers.makeBindingIdentifier(self, state_span);
 
             // function body: switch_body를 block으로 감싸기
             const body_list = try self.new_ast.addNodeList(&.{switch_body});

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -190,94 +190,25 @@ pub fn ES2015Params(comptime Transformer: type) type {
             });
 
             // [].slice
-            const slice_span = try self.new_ast.addString("slice");
-            const slice_prop = try self.new_ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = slice_span,
-                .data = .{ .string_ref = slice_span },
-            });
-            const member_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(empty_arr), @intFromEnum(slice_prop), 0,
-            });
-            const slice_member = try self.new_ast.addNode(.{
-                .tag = .static_member_expression,
-                .span = span,
-                .data = .{ .extra = member_extra },
-            });
+            const slice_prop = try es_helpers.makeIdentifierRef(self, "slice");
+            const slice_member = try es_helpers.makeStaticMember(self, empty_arr, slice_prop, span);
 
             // [].slice.call
-            const call_span = try self.new_ast.addString("call");
-            const call_prop = try self.new_ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = call_span,
-                .data = .{ .string_ref = call_span },
-            });
-            const call_member_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(slice_member), @intFromEnum(call_prop), 0,
-            });
-            const slice_call = try self.new_ast.addNode(.{
-                .tag = .static_member_expression,
-                .span = span,
-                .data = .{ .extra = call_member_extra },
-            });
+            const call_prop = try es_helpers.makeIdentifierRef(self, "call");
+            const slice_call = try es_helpers.makeStaticMember(self, slice_member, call_prop, span);
 
             // arguments
-            const args_span = try self.new_ast.addString("arguments");
-            const args_ref = try self.new_ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = args_span,
-                .data = .{ .string_ref = args_span },
-            });
+            const args_ref = try es_helpers.makeIdentifierRef(self, "arguments");
 
             // start_index number
-            var idx_buf: [16]u8 = undefined;
-            const idx_str = std.fmt.bufPrint(&idx_buf, "{d}", .{start_index}) catch "0";
-            const idx_span = try self.new_ast.addString(idx_str);
-            const idx_node = try self.new_ast.addNode(.{
-                .tag = .numeric_literal,
-                .span = idx_span,
-                .data = .{ .none = 0 },
-            });
+            const idx_node = try es_helpers.makeNumericLiteral(self, @intCast(start_index));
 
             // [].slice.call(arguments, N)
-            const call_args = try self.new_ast.addNodeList(&.{ args_ref, idx_node });
-            const call_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(slice_call),
-                call_args.start,
-                call_args.len,
-                0,
-            });
-            const call_node = try self.new_ast.addNode(.{
-                .tag = .call_expression,
-                .span = span,
-                .data = .{ .extra = call_extra },
-            });
+            const call_node = try es_helpers.makeCallExpr(self, slice_call, &.{ args_ref, idx_node }, span);
 
             // var rest = [].slice.call(arguments, N)
-            const declarator_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(binding),
-                @intFromEnum(NodeIndex.none),
-                @intFromEnum(call_node),
-            });
-            const declarator = try self.new_ast.addNode(.{
-                .tag = .variable_declarator,
-                .span = span,
-                .data = .{ .extra = declarator_extra },
-            });
-
-            // variable_declaration: extra = [kind_flags, list_start, list_len]
-            // kind_flags: 0 = var
-            const decl_list = try self.new_ast.addNodeList(&.{declarator});
-            const var_extra = try self.new_ast.addExtras(&.{
-                0, // var
-                decl_list.start,
-                decl_list.len,
-            });
-            return self.new_ast.addNode(.{
-                .tag = .variable_declaration,
-                .span = span,
-                .data = .{ .extra = var_extra },
-            });
+            const declarator = try es_helpers.makeDeclarator(self, binding, call_node, span);
+            return es_helpers.makeVarDeclaration(self, &.{declarator}, 0, span);
         }
 
         /// identifier 노드를 복제한다 (같은 이름의 새 노드).

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -143,6 +143,41 @@ pub fn makeEqNull(self: anytype, base: NodeIndex, span: Span) !NodeIndex {
     });
 }
 
+/// binding_identifier 노드 생성 (변수 바인딩용).
+/// span은 이미 addString된 이름 span.
+pub fn makeBindingIdentifier(self: anytype, name_span: Span) !NodeIndex {
+    return self.new_ast.addNode(.{
+        .tag = .binding_identifier,
+        .span = name_span,
+        .data = .{ .string_ref = name_span },
+    });
+}
+
+/// variable_declarator 노드 생성 (binding + optional init).
+/// extra = [binding, type_annotation(none), init]
+pub fn makeDeclarator(self: anytype, binding: NodeIndex, init: NodeIndex, span: Span) !NodeIndex {
+    const de = try self.new_ast.addExtras(&.{
+        @intFromEnum(binding), @intFromEnum(NodeIndex.none), @intFromEnum(init),
+    });
+    return self.new_ast.addNode(.{
+        .tag = .variable_declarator,
+        .span = span,
+        .data = .{ .extra = de },
+    });
+}
+
+/// variable_declaration 노드 생성 (var 키워드, declarators 배열).
+/// kind_flags: 0 = var, 1 = let, 2 = const
+pub fn makeVarDeclaration(self: anytype, declarators: []const NodeIndex, kind_flags: u32, span: Span) !NodeIndex {
+    const decl_list = try self.new_ast.addNodeList(declarators);
+    const var_extra = try self.new_ast.addExtras(&.{ kind_flags, decl_list.start, decl_list.len });
+    return self.new_ast.addNode(.{
+        .tag = .variable_declaration,
+        .span = span,
+        .data = .{ .extra = var_extra },
+    });
+}
+
 /// expression을 expression_statement로 감싸기.
 pub fn makeExprStmt(self: anytype, expr: NodeIndex, span: Span) !NodeIndex {
     return self.new_ast.addNode(.{


### PR DESCRIPTION
## Summary
- **es_helpers.zig**: `makeBindingIdentifier`, `makeDeclarator`, `makeVarDeclaration` 추가. es2015_destructuring/for_of/params/generator/class에서 중복 패턴 제거
- **linker.zig**: `buildMetadataForAst()`에서 `buildFinalExports`, `buildCrossModuleConstValues`, `finalizeNamespaceData` 추출. `computeMangling()`에서 `collectManglingCandidates` 추출
- **types.zig/module.zig**: `stringLessThan`, `execIndexLessThan` 공유 comparator. emitter.zig 4개 인라인 comparator 교체
- **main.zig**: `CliOptions` struct + `parseCliArguments()` 함수 추출 (~170줄)

11 files changed, 528 insertions(+), 574 deletions(-) (순감소 46줄)

## Test plan
- [x] `zig build` 통과
- [x] `zig build test` 전체 통과
- [x] `zig fmt` 통과
- [x] `oxlint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)