### PR TITLE
docs: CLAUDE.md 번들러 성능 로드맵 실측 기반 업데이트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,41 +250,36 @@ Per-File Arena (단일 할당자, 파일 처리 후 한 번에 해제)
 | 6a-ex | exports 조건 해석 Node.js 스펙 준수 (tslib CJS→ESM 해결) | ✅ |
 | 6b. Dev server | HTTP+WS, Live Reload, HMR, React Fast Refresh, CSS 핫 리로드 | ✅ |
 | Test262 | 50,504건 100% 통과 | ✅ |
-| Smoke | 125개 패키지, avg 0.74x, ❌ 0개 | ✅ |
+| Smoke | 125개 패키지, avg 0.94x, ❌ 0개 | ✅ |
+| 7-2. emit 병렬화 | 모듈별 transform+codegen 스레드 풀 실행 | ✅ |
+| 7-3. resolve 병렬화 | 배치 내 resolve 스레드 풀 + ResolveCache Mutex | ✅ |
+| 7-fix. fixpoint oscillation | 미사용 모듈 제거를 fixpoint 후로 이동 (100회→2회) | ✅ |
 
-### 🔜 다음 우선순위: 번들러 성능 — esbuild 수준 달성
-현재 1102모듈 대형 번들 기준: ZTS 1502ms vs esbuild 77ms (20배 차이).
-목표: ~120-180ms (esbuild의 1.5-2.3배).
+### 번들러 성능 현황 (3242모듈, 2026-03-29 실측)
+ZTS 279ms vs esbuild 182ms (**1.5배**).
 
-**Phase 7-1: StmtInfo를 파서/semantic에서 구축 (Part 시스템)**
-- 현재: 파싱 후 tree_shaker.analyze()에서 stmt_info.build()로 전체 AST 재순회 → 723ms
-- 목표: semantic analyzer에서 파싱 중 per-statement declared/referenced 심볼을 구축
-  - analyzer.symbol_ids + scope 정보를 활용해 Part 데이터를 파싱 시점에 채움
-  - stmt_info.build() 완전 제거, tree-shake 단계는 이미 구축된 데이터로 즉시 시작
-- 참고: esbuild Part 시스템, bun ast.zig Part 구조체
-- 예상: tree-shake 723ms → ~10ms
+| 단계 | ZTS | esbuild | 배율 | 비고 |
+|------|-----|---------|------|------|
+| scan (resolve+parse) | 240ms | 125ms | 1.9x | 배치 구조 한계 |
+| tree-shake | 51ms | 1ms | 51x | fixpoint+stmtinfo+crossBFS |
+| link | 16ms | 54ms | 0.3x | ZTS가 빠름 |
+| emit | 15ms | 32ms | 0.5x | ZTS가 빠름 |
+| **총합** | **279ms** | **182ms** | **1.5x** | |
 
-**Phase 7-2: emit 병렬화 (모듈별 transform+codegen을 스레드 풀)**
-- 현재: emitter에서 모듈을 순차적으로 transform+codegen → 164ms
-- 목표: 각 모듈의 transform+codegen을 독립적으로 스레드 풀에서 병렬 실행
-  - 모듈별 Arena가 이미 독립적이므로 스레드 안전
-  - linker rename 결과를 읽기 전용으로 참조, 최종 출력만 메인 스레드에서 합침
-- 참고: bun generateChunksInParallel (Part 범위별 병렬)
-- 예상: 164ms → ~40ms (4코어 기준)
+### 🔜 다음 우선순위
 
-**Phase 7-3: resolve 파이프라인 (Zig 0.16 async/await 또는 esbuild 방식)**
-- 현재: parse(병렬) → resolve(순차) 배치 구조 → resolve 194ms
-- 목표: parse+resolve를 하나의 워커 단위로 통합, 채널 기반 파이프라인
-  - resolve_cache에 Mutex 추가, 스레드 풀에서 resolve 호출
-  - 메인 스레드는 결과 수신 → addModule → 즉시 새 워커 스폰 (배치 경계 제거)
-  - Zig 0.16 async/await 지원 시 rolldown join_all 방식도 검토
-- 참고: esbuild goroutine+channel, bun ParseTask 2단계 (io_pool + worker_pool)
-- 예상: graph 414ms → ~100ms
+**scan 파이프라인화 (배치 경계 제거)**
+- 현재: parse 배치 → resolve 배치 → parse 배치 (배치 경계에서 대기 발생)
+- 목표: Bun/esbuild처럼 모듈 발견 즉시 다음 파싱 시작 (태스크 큐 기반 파이프라인)
+  - Bun: io_pool + worker_pool 2단계 ParseTask
+  - esbuild: goroutine + channel
+  - ZTS: 스레드 풀 + atomic 큐로 구현 가능 (Zig 0.16 async 불필요)
+- 예상: scan 240ms → ~130ms
 
-**Phase 7-4: link 최적화**
-- 현재: computeRenames + scope hoisting → 87ms
-- 목표: canonical_names 구축 최적화, 불필요한 순회 제거
-- 예상: 87ms → ~30ms
+**tree-shake 알고리즘 개선**
+- 현재: fixpoint 2회 + stmtinfo 15ms + crossBFS 25ms = 51ms
+- esbuild는 Part 시스템으로 단일 패스 1ms
+- 점진적 개선: stmtinfo 병렬화, used_exports를 BitSet으로 교체 등
 
 ### ⏳ 진행 중 / 미완료
 - **ES 다운레벨링**: ES2022~ES2015 ✅ (--target=es5 지원)
@@ -305,23 +300,24 @@ Per-File Arena (단일 할당자, 파일 처리 후 한 번에 해제)
 AST 안정화 ──────────────┬──→ WASM 공개 AST API
                          └──→ .d.ts (isolatedDeclarations)
 
-번들러 성능 ─────────────┬──→ 7-1: Part 시스템 (semantic에서 StmtInfo 구축)
-                         ├──→ 7-2: emit 병렬화 (7-1과 독립)
-                         ├──→ 7-3: resolve 파이프라인 (Zig 0.16 async 또는 Mutex)
-                         └──→ 7-4: link 최적화 (독립)
+번들러 성능 ─────────────┬──→ scan 파이프라인화 (배치 경계 제거)
+                         └──→ tree-shake 알고리즘 개선 (stmtinfo/crossBFS)
 
 독립 (아무 때나): ES 다운레벨링, Flow, SIMD, 미니파이어
 ```
 
-### 성능 최적화 도입 시기
-| 최적화 | 추천 시점 | 이유 |
-|--------|-----------|------|
-| Arena allocator | ✅ 완료 | 번들러에 필수 |
-| SIMD | 번들러 MVP 후 | 렉서만 건드려서 언제든 동일 비용 |
-| 멀티스레드 parse+finalize | ✅ 완료 | finalize를 parseModule에 통합, parse_arena 소유 |
+### 성능 최적화 현황
+| 최적화 | 상태 | 효과 |
+|--------|------|------|
+| Arena allocator | ✅ 완료 | 번들러 기반 |
+| mimalloc | ✅ 완료 | c_allocator 대비 8% 추가 개선 |
+| 멀티스레드 parse+finalize | ✅ 완료 | finalize를 parseModule에 통합 |
 | tree-shaker 역인덱스 | ✅ 완료 | stmt_info O(N log S) + sym→stmt 역인덱스 |
-| 비동기 resolve 병렬화 | Zig 0.16 async/await 지원 후 | 현재 resolve 95ms (모듈당 0.15ms)로 급하지 않음. Zig 0.16에서 async/await 복귀 예정 → rolldown 방식(join_all 패턴)으로 파일 내 import 병렬 resolve 가능. 그때 esbuild 방식(파일 단위 파이프라인)과 비교하여 결정 |
-| 프로파일링 | 번들러 MVP 후 | 실제 워크로드 필요 |
+| emit 병렬화 | ✅ 완료 | 74ms → 15ms (-80%) |
+| resolve 병렬화 | ✅ 완료 | 191ms → 134ms (-30%, 캐시 히트율 높아 제한적) |
+| fixpoint oscillation 수정 | ✅ 완료 | 100회 → 2회 수렴, tree-shake 238ms → 51ms |
+| scan 파이프라인화 | 🔜 | 배치 경계 제거 → 240ms → ~130ms 예상 |
+| SIMD | 미착수 | 렉서 공백/식별자/문자열 스캔 가속 |
 
 ## Commands
 ```bash


### PR DESCRIPTION
## Summary
Phase 7 실측 결과를 반영하여 CLAUDE.md의 번들러 성능 섹션 업데이트.

- 3242모듈 기준 ZTS 279ms vs esbuild 182ms (1.5x)
- 완료된 최적화: emit 병렬화, resolve 병렬화, fixpoint oscillation 수정
- 다음 우선순위: scan 파이프라인화, tree-shake 알고리즘 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)