### PR TITLE
feat(bundler): 플러그인 인프라 1단계 — Plugin struct + 파이프라인 훅

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -12,6 +12,7 @@
 //!   defer result.deinit(allocator);
 
 const std = @import("std");
+const plugin_mod = @import("plugin.zig");
 const types = @import("types.zig");
 const BundlerDiagnostic = types.BundlerDiagnostic;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
@@ -96,6 +97,8 @@ pub const BundleOptions = struct {
     inject: []const []const u8 = &.{},
     /// --keep-names: minify 시 함수/클래스의 .name 프로퍼티 보존
     keep_names: bool = false,
+    /// 플러그인 배열 (resolveId, load, transform, renderChunk, generateBundle 훅)
+    plugins: []const plugin_mod.Plugin = &.{},
 
     pub const AliasEntry = types.AliasEntry;
 };
@@ -243,6 +246,7 @@ pub const Bundler = struct {
             .asset_names = self.options.asset_names,
             .legal_comments = self.options.legal_comments,
             .keep_names = self.options.keep_names,
+            .plugins = self.options.plugins,
         };
     }
 
@@ -265,6 +269,7 @@ pub const Bundler = struct {
         graph.public_path = self.options.public_path;
         graph.asset_names = self.options.asset_names;
         graph.inject_files = self.options.inject;
+        graph.plugins = self.options.plugins;
         defer graph.deinit();
 
         try graph.build(self.options.entry_points);
@@ -484,6 +489,16 @@ pub const Bundler = struct {
             try generateMetafileJson(self.allocator, &graph, output, outputs)
         else
             null;
+
+        // 8. Plugin: generateBundle 훅 — 번들 완료 후 모든 플러그인에 알림
+        if (self.options.plugins.len > 0) {
+            const runner = plugin_mod.PluginRunner.init(self.options.plugins);
+            const gen_outputs: []const emitter.OutputFile = if (outputs) |outs|
+                outs
+            else
+                &.{.{ .path = "bundle.js", .contents = output }};
+            runner.runGenerateBundle(gen_outputs);
+        }
 
         return .{
             .output = output,

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -38,6 +38,7 @@ const TreeShaker = @import("tree_shaker.zig").TreeShaker;
 const statement_shaker = @import("statement_shaker.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const ExportBinding = @import("binding_scanner.zig").ExportBinding;
+const plugin_mod = @import("plugin.zig");
 
 pub const EmitOptions = struct {
     format: Format = .esm,
@@ -90,6 +91,8 @@ pub const EmitOptions = struct {
     legal_comments: types.LegalComments = .default,
     /// --keep-names: minify 시 함수/클래스 .name 프로퍼티 보존
     keep_names: bool = false,
+    /// 플러그인 배열. bundler에서 전파.
+    plugins: []const plugin_mod.Plugin = &.{},
 
     pub const Format = enum {
         esm,
@@ -271,6 +274,20 @@ pub fn emitWithTreeShaking(
 
     // 모듈 코드 합류
     try output.appendSlice(allocator, module_output.items);
+
+    // Plugin: renderChunk 훅 — 단일 파일 모드에서도 적용
+    if (options.plugins.len > 0) {
+        const runner = plugin_mod.PluginRunner.init(options.plugins);
+        const rc_result = runner.runRenderChunk(output.items, "bundle", allocator) catch |err| switch (err) {
+            error.PluginFailed => null,
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        if (rc_result) |result| {
+            output.clearRetainingCapacity();
+            try output.appendSlice(allocator, result);
+            allocator.free(result);
+        }
+    }
 
     // 포맷별 epilogue
     switch (options.format) {
@@ -913,6 +930,22 @@ pub fn emitChunks(
                 try chunk_output.appendSlice(allocator, " };\n");
             } else {
                 try chunk_output.appendSlice(allocator, "};");
+            }
+        }
+
+        // Plugin: renderChunk 훅 — 청크 완성 후, footer 전
+        if (options.plugins.len > 0) {
+            const runner = plugin_mod.PluginRunner.init(options.plugins);
+            var rc_stem_buf: [128]u8 = undefined;
+            const rc_chunk_name = chunkPlaceholderStem(chunk, &rc_stem_buf, options);
+            const chunk_rc_result = runner.runRenderChunk(chunk_output.items, rc_chunk_name, allocator) catch |err| switch (err) {
+                error.PluginFailed => null,
+                error.OutOfMemory => return error.OutOfMemory,
+            };
+            if (chunk_rc_result) |result| {
+                chunk_output.clearRetainingCapacity();
+                try chunk_output.appendSlice(allocator, result);
+                allocator.free(result);
             }
         }
 
@@ -1614,7 +1647,21 @@ pub fn emitModule(
         // keepNames: codegen이 rename된 함수/클래스를 수집
         .keep_names = options.keep_names,
     });
-    const code = try cg.generate(root);
+    var code = try cg.generate(root);
+
+    // Plugin: transform 훅 — codegen 직후, CJS 래핑 전
+    // 플러그인 결과를 arena로 복사하여 emit_arena와 같은 생명주기 보장
+    if (options.plugins.len > 0) {
+        const runner = plugin_mod.PluginRunner.init(options.plugins);
+        const transform_result = runner.runTransform(code, module.path, allocator) catch |err| switch (err) {
+            error.PluginFailed => null,
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        if (transform_result) |result| {
+            code = try arena_alloc.dupe(u8, result);
+            allocator.free(result);
+        }
+    }
 
     // keepNames: codegen이 generate() 내에서 직접 __name() 호출을 buf에 append.
     // entries가 있으면 런타임 헬퍼 플래그만 설정.

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -36,6 +36,7 @@ const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
 const Span = @import("../lexer/token.zig").Span;
 const pkg_json = @import("package_json.zig");
 const mime = @import("../server/mime.zig");
+const plugin_mod = @import("plugin.zig");
 
 pub const ModuleGraph = struct {
     allocator: std.mem.Allocator,
@@ -67,6 +68,8 @@ pub const ModuleGraph = struct {
     entry_dir: []const u8 = "",
     /// --inject 파일 목록. build()에서 모든 엔트리의 의존성으로 추가.
     inject_files: []const []const u8 = &.{},
+    /// 플러그인 배열. bundler에서 전파.
+    plugins: []const plugin_mod.Plugin = &.{},
 
     pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGraph {
         return .{
@@ -486,11 +489,24 @@ pub const ModuleGraph = struct {
         module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
         const arena_alloc = module.parse_arena.?.allocator();
 
-        // 파일 읽기 (arena — module.source가 참조)
-        const source = std.fs.cwd().readFileAlloc(arena_alloc, module.path, 100 * 1024 * 1024) catch {
-            self.addDiag(.read_error, .@"error", module.path, Span.EMPTY, .resolve, "Cannot read file", null);
-            module.state = .ready;
-            return;
+        // Plugin: load 훅 — virtual module 지원을 위해 파일 I/O 전에 플러그인에게 기회를 줌
+        const source: []const u8 = blk: {
+            if (self.plugins.len > 0) {
+                const runner = plugin_mod.PluginRunner.init(self.plugins);
+                const load_result = runner.runLoad(module.path, arena_alloc) catch |err| switch (err) {
+                    error.PluginFailed => null,
+                    error.OutOfMemory => {
+                        module.state = .ready;
+                        return;
+                    },
+                };
+                if (load_result) |plugin_source| break :blk plugin_source;
+            }
+            break :blk std.fs.cwd().readFileAlloc(arena_alloc, module.path, 100 * 1024 * 1024) catch {
+                self.addDiag(.read_error, .@"error", module.path, Span.EMPTY, .resolve, "Cannot read file", null);
+                module.state = .ready;
+                return;
+            };
         };
         module.source = source;
 
@@ -713,7 +729,27 @@ pub const ModuleGraph = struct {
         const source_dir = std.fs.path.dirname(module_path) orelse ".";
         const records = self.modules.items[mod_idx].import_records;
 
+        // Plugin: resolveId 훅용 runner를 루프 밖에서 한 번만 생성
+        const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
+            plugin_mod.PluginRunner.init(self.plugins)
+        else
+            null;
+
         for (records, 0..) |record, rec_i| {
+            // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
+            if (plugin_runner) |runner| {
+                if (runner.runResolveId(record.specifier, module_path, self.allocator)) |plugin_result| {
+                    try self.applyResolveResult(mod_idx, rec_i, record, plugin_result, false);
+                    continue;
+                } else |err| switch (err) {
+                    error.PluginFailed => {
+                        try self.applyResolveResult(mod_idx, rec_i, record, null, true);
+                        continue;
+                    },
+                    error.OutOfMemory => return error.OutOfMemory,
+                }
+            }
+
             const resolved = self.resolve_cache.resolve(
                 source_dir,
                 record.specifier,

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -31,6 +31,7 @@ pub const stmt_info = @import("stmt_info.zig");
 pub const chunk = @import("chunk.zig");
 pub const runtime_helpers = @import("runtime_helpers.zig");
 pub const bundler_core = @import("bundler.zig");
+pub const plugin = @import("plugin.zig");
 
 // 공개 타입 re-export
 pub const ModuleIndex = types.ModuleIndex;
@@ -56,6 +57,8 @@ pub const ChunkGraph = chunk.ChunkGraph;
 pub const Bundler = bundler_core.Bundler;
 pub const BundleOptions = bundler_core.BundleOptions;
 pub const BundleResult = bundler_core.BundleResult;
+pub const Plugin = plugin.Plugin;
+pub const PluginRunner = plugin.PluginRunner;
 
 test {
     _ = types;
@@ -74,6 +77,7 @@ test {
     _ = chunk;
     _ = runtime_helpers;
     _ = bundler_core;
+    _ = plugin;
 
     // test files
     _ = @import("bundler_test.zig");
@@ -91,4 +95,5 @@ test {
     _ = @import("resolve_cache_test.zig");
     _ = @import("types_test.zig");
     _ = @import("module_test.zig");
+    _ = @import("plugin_test.zig");
 }

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -1,0 +1,153 @@
+//! ZTS Bundler — Plugin System
+//!
+//! Rollup 호환 플러그인 인터페이스 (resolveId, load, transform, renderChunk, generateBundle).
+//! Builtin 플러그인은 Zig 함수 포인터로 구현하여 최고 성능.
+//!
+//! 훅 실행 순서:
+//!   - resolveId/load: 첫 번째 non-null 반환 플러그인이 승리 (first 모드)
+//!   - transform/renderChunk: 순차 체이닝 (이전 플러그인 출력 → 다음 플러그인 입력)
+//!   - generateBundle: 모두 실행
+
+const std = @import("std");
+const resolver_mod = @import("resolver.zig");
+const ResolveResult = resolver_mod.ResolveResult;
+const OutputFile = @import("emitter.zig").OutputFile;
+
+/// 플러그인 훅에서 반환할 수 있는 에러 타입.
+/// anyerror를 쓰지 않고 specific error set으로 제한하여
+/// 호출부에서 switch로 명시적 처리 가능.
+pub const PluginError = error{
+    PluginFailed,
+    OutOfMemory,
+};
+
+/// Rollup 호환 플러그인 인터페이스.
+/// 각 훅은 optional 함수 포인터 — null이면 해당 훅을 구현하지 않음.
+pub const Plugin = struct {
+    name: []const u8,
+
+    /// 모듈 경로 해석 커스텀 (alias, virtual module).
+    /// non-null 반환 시 기본 resolver를 건너뜀.
+    resolveId: ?*const fn (specifier: []const u8, importer: ?[]const u8, allocator: std.mem.Allocator) PluginError!?ResolveResult = null,
+
+    /// 모듈 내용 로딩 (virtual module, 커스텀 로더).
+    /// non-null 반환 시 파일 시스템 읽기를 건너뜀.
+    load: ?*const fn (path: []const u8, allocator: std.mem.Allocator) PluginError!?[]const u8 = null,
+
+    /// 코드 변환 (codegen 직후, CJS 래핑 전).
+    /// non-null 반환 시 원본 코드를 반환값으로 교체.
+    transform: ?*const fn (code: []const u8, id: []const u8, allocator: std.mem.Allocator) PluginError!?[]const u8 = null,
+
+    /// 청크 코드 후처리 (청크 완성 후, footer 전).
+    /// non-null 반환 시 청크 코드를 반환값으로 교체.
+    renderChunk: ?*const fn (code: []const u8, chunk_name: []const u8, allocator: std.mem.Allocator) PluginError!?[]const u8 = null,
+
+    /// 번들 생성 완료 알림. 모든 플러그인에 호출됨.
+    generateBundle: ?*const fn (output_files: []const OutputFile) void = null,
+};
+
+/// 플러그인 배열을 순회하며 훅을 실행하는 유틸리티.
+/// stateless — plugins 슬라이스 참조만 보유.
+pub const PluginRunner = struct {
+    plugins: []const Plugin,
+
+    pub fn init(plugins: []const Plugin) PluginRunner {
+        return .{ .plugins = plugins };
+    }
+
+    /// plugins가 비어있으면 true (no-op 최적화용)
+    pub fn isEmpty(self: *const PluginRunner) bool {
+        return self.plugins.len == 0;
+    }
+
+    /// resolveId: first 모드 — 첫 번째 non-null 반환값 사용.
+    /// 모든 플러그인이 null을 반환하면 null (기본 resolver 사용).
+    pub fn runResolveId(
+        self: *const PluginRunner,
+        specifier: []const u8,
+        importer: ?[]const u8,
+        allocator: std.mem.Allocator,
+    ) PluginError!?ResolveResult {
+        for (self.plugins) |p| {
+            if (p.resolveId) |hook| {
+                if (try hook(specifier, importer, allocator)) |result| {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// load: first 모드 — 첫 번째 non-null 반환값 사용.
+    /// 모든 플러그인이 null을 반환하면 null (파일 시스템에서 읽기).
+    pub fn runLoad(
+        self: *const PluginRunner,
+        path: []const u8,
+        allocator: std.mem.Allocator,
+    ) PluginError!?[]const u8 {
+        for (self.plugins) |p| {
+            if (p.load) |hook| {
+                if (try hook(path, allocator)) |result| {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// transform: 순차 체이닝 — 이전 플러그인 출력이 다음 플러그인 입력.
+    /// 체이닝 중간 결과는 free. 최종 결과는 allocator 소유.
+    /// 아무 플러그인도 변환하지 않으면 null 반환.
+    pub fn runTransform(
+        self: *const PluginRunner,
+        code: []const u8,
+        id: []const u8,
+        allocator: std.mem.Allocator,
+    ) PluginError!?[]const u8 {
+        var current: ?[]const u8 = null;
+        for (self.plugins) |p| {
+            if (p.transform) |hook| {
+                const input = current orelse code;
+                if (try hook(input, id, allocator)) |result| {
+                    // 이전 체이닝 결과가 있으면 해제 (원본 code는 caller 소유이므로 건드리지 않음)
+                    if (current) |prev| allocator.free(prev);
+                    current = result;
+                }
+            }
+        }
+        return current;
+    }
+
+    /// renderChunk: 순차 체이닝 — 이전 플러그인 출력이 다음 플러그인 입력.
+    /// 아무 플러그인도 변환하지 않으면 null 반환.
+    pub fn runRenderChunk(
+        self: *const PluginRunner,
+        code: []const u8,
+        chunk_name: []const u8,
+        allocator: std.mem.Allocator,
+    ) PluginError!?[]const u8 {
+        var current: ?[]const u8 = null;
+        for (self.plugins) |p| {
+            if (p.renderChunk) |hook| {
+                const input = current orelse code;
+                if (try hook(input, chunk_name, allocator)) |result| {
+                    if (current) |prev| allocator.free(prev);
+                    current = result;
+                }
+            }
+        }
+        return current;
+    }
+
+    /// generateBundle: 모든 플러그인 실행. 반환값 없음.
+    pub fn runGenerateBundle(
+        self: *const PluginRunner,
+        output_files: []const OutputFile,
+    ) void {
+        for (self.plugins) |p| {
+            if (p.generateBundle) |hook| {
+                hook(output_files);
+            }
+        }
+    }
+};

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -1,0 +1,249 @@
+//! 플러그인 시스템 테스트
+//!
+//! - 단위 테스트: PluginRunner의 각 훅 실행 로직 검증
+//! - 통합 테스트: Bundler.bundle()을 통한 end-to-end 검증
+
+const std = @import("std");
+const Bundler = @import("bundler.zig").Bundler;
+const plugin_mod = @import("plugin.zig");
+const Plugin = plugin_mod.Plugin;
+const PluginRunner = plugin_mod.PluginRunner;
+const ResolveResult = @import("resolver.zig").ResolveResult;
+const OutputFile = @import("emitter.zig").OutputFile;
+const test_helpers = @import("test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+
+// ============================================================
+// 단위 테스트: PluginRunner
+// ============================================================
+
+test "PluginRunner: empty plugins is no-op" {
+    const runner = PluginRunner.init(&.{});
+    try std.testing.expect(runner.isEmpty());
+
+    const resolve_result = try runner.runResolveId("foo", null, std.testing.allocator);
+    try std.testing.expect(resolve_result == null);
+
+    const load_result = try runner.runLoad("foo.ts", std.testing.allocator);
+    try std.testing.expect(load_result == null);
+
+    const transform_result = try runner.runTransform("code", "id", std.testing.allocator);
+    try std.testing.expect(transform_result == null);
+
+    const render_result = try runner.runRenderChunk("code", "chunk", std.testing.allocator);
+    try std.testing.expect(render_result == null);
+
+    runner.runGenerateBundle(&.{});
+}
+
+// --- resolveId 훅 테스트 ---
+
+fn testResolveIdHook(specifier: []const u8, _: ?[]const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?ResolveResult {
+    if (std.mem.eql(u8, specifier, "virtual:config")) {
+        return .{
+            .path = try allocator.dupe(u8, "/virtual/config.js"),
+            .module_type = .javascript,
+        };
+    }
+    return null;
+}
+
+test "PluginRunner: resolveId first mode" {
+    const plugins = [_]Plugin{
+        .{ .name = "test-resolve", .resolveId = testResolveIdHook },
+    };
+    const runner = PluginRunner.init(&plugins);
+
+    // 매칭되는 specifier → non-null
+    const result = try runner.runResolveId("virtual:config", null, std.testing.allocator);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqualStrings("/virtual/config.js", result.?.path);
+    std.testing.allocator.free(result.?.path);
+
+    // 매칭 안 되는 specifier → null (기본 resolver 사용)
+    const result2 = try runner.runResolveId("./normal", null, std.testing.allocator);
+    try std.testing.expect(result2 == null);
+}
+
+// --- load 훅 테스트 ---
+
+fn testLoadHook(path: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    if (std.mem.endsWith(u8, path, ".custom")) {
+        return try allocator.dupe(u8, "export default 'custom-loaded';");
+    }
+    return null;
+}
+
+test "PluginRunner: load first mode" {
+    const plugins = [_]Plugin{
+        .{ .name = "test-load", .load = testLoadHook },
+    };
+    const runner = PluginRunner.init(&plugins);
+
+    const result = try runner.runLoad("module.custom", std.testing.allocator);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqualStrings("export default 'custom-loaded';", result.?);
+    std.testing.allocator.free(result.?);
+
+    // 매칭 안 되는 확장자 → null (파일 시스템에서 읽기)
+    const result2 = try runner.runLoad("module.ts", std.testing.allocator);
+    try std.testing.expect(result2 == null);
+}
+
+// --- transform 훅 테스트 (체이닝) ---
+
+fn testTransformHookA(code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    return std.mem.concat(allocator, u8, &.{ "/* A */", code }) catch return error.OutOfMemory;
+}
+
+fn testTransformHookB(code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    return std.mem.concat(allocator, u8, &.{ "/* B */", code }) catch return error.OutOfMemory;
+}
+
+test "PluginRunner: transform chaining" {
+    const plugins = [_]Plugin{
+        .{ .name = "transform-a", .transform = testTransformHookA },
+        .{ .name = "transform-b", .transform = testTransformHookB },
+    };
+    const runner = PluginRunner.init(&plugins);
+
+    const result = try runner.runTransform("original", "test.js", std.testing.allocator);
+    try std.testing.expect(result != null);
+    // B가 A의 결과를 받으므로: "/* B *//* A */original"
+    try std.testing.expectEqualStrings("/* B *//* A */original", result.?);
+    std.testing.allocator.free(result.?);
+}
+
+// --- renderChunk 훅 테스트 ---
+
+fn testRenderChunkHook(code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    return std.mem.concat(allocator, u8, &.{ "/* rendered */\n", code }) catch return error.OutOfMemory;
+}
+
+test "PluginRunner: renderChunk chaining" {
+    const plugins = [_]Plugin{
+        .{ .name = "test-render", .renderChunk = testRenderChunkHook },
+    };
+    const runner = PluginRunner.init(&plugins);
+
+    const result = try runner.runRenderChunk("chunk code", "main", std.testing.allocator);
+    try std.testing.expect(result != null);
+    try std.testing.expect(std.mem.startsWith(u8, result.?, "/* rendered */\n"));
+    std.testing.allocator.free(result.?);
+}
+
+// --- generateBundle 훅 테스트 ---
+
+var generate_bundle_called: bool = false;
+
+fn testGenerateBundleHook(_: []const OutputFile) void {
+    generate_bundle_called = true;
+}
+
+test "PluginRunner: generateBundle all executed" {
+    generate_bundle_called = false;
+    const plugins = [_]Plugin{
+        .{ .name = "test-generate", .generateBundle = testGenerateBundleHook },
+    };
+    const runner = PluginRunner.init(&plugins);
+
+    runner.runGenerateBundle(&.{.{ .path = "out.js", .contents = "code" }});
+    try std.testing.expect(generate_bundle_called);
+}
+
+// ============================================================
+// 통합 테스트: Bundler.bundle()을 통한 플러그인 훅 실행 검증
+// ============================================================
+
+// --- transform 훅 통합 테스트 ---
+
+fn integrationTransformHook(code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    return std.mem.concat(allocator, u8, &.{ "/* PLUGIN_TRANSFORM */\n", code }) catch return error.OutOfMemory;
+}
+
+test "Plugin integration: transform hook modifies output" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x: number = 42;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{
+        .{ .name = "test-transform", .transform = integrationTransformHook },
+    };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .plugins = &plugins,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // transform 훅이 삽입한 마커가 출력에 포함되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "/* PLUGIN_TRANSFORM */") != null);
+    try std.testing.expect(!result.hasErrors());
+}
+
+// --- generateBundle 훅 통합 테스트 ---
+
+var integration_generate_called: bool = false;
+var integration_generate_output_len: usize = 0;
+
+fn integrationGenerateBundleHook(outputs: []const OutputFile) void {
+    integration_generate_called = true;
+    integration_generate_output_len = outputs.len;
+}
+
+test "Plugin integration: generateBundle hook is called" {
+    integration_generate_called = false;
+    integration_generate_output_len = 0;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{
+        .{ .name = "test-generate", .generateBundle = integrationGenerateBundleHook },
+    };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .plugins = &plugins,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(integration_generate_called);
+    try std.testing.expect(integration_generate_output_len > 0);
+}
+
+// --- plugins 없이 기존 동작 유지 테스트 ---
+
+test "Plugin integration: no plugins preserves existing behavior" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x: number = 42;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const x = 42;") != null);
+    try std.testing.expect(!result.hasErrors());
+}

--- a/src/bundler/test_helpers.zig
+++ b/src/bundler/test_helpers.zig
@@ -7,3 +7,10 @@ pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {
     }
     try dir.writeFile(.{ .sub_path = path, .data = data });
 }
+
+/// 테스트용 헬퍼: tmpDir 상대 경로를 절대 경로로 변환 (caller가 free 해야 함)
+pub fn absPath(tmp: *std.testing.TmpDir, rel: []const u8) ![]const u8 {
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    return try std.fs.path.resolve(std.testing.allocator, &.{ dp, rel });
+}


### PR DESCRIPTION
## Summary
- Rollup 호환 5개 훅(`resolveId`, `load`, `transform`, `renderChunk`, `generateBundle`)을 Zig 함수 포인터로 정의
- `PluginRunner` 유틸리티: first 모드(resolveId/load), 순차 체이닝(transform/renderChunk), 전체 실행(generateBundle)
- 번들러 파이프라인 4곳에 훅 삽입 (resolver → graph → emitter → bundler)
- 단위 테스트 6개 + 통합 테스트 3개 = 총 9개 테스트

## Test plan
- [x] `zig build test` 전체 통과 (기존 테스트 regression 없음)
- [x] PluginRunner 단위 테스트: empty/resolveId/load/transform chaining/renderChunk/generateBundle
- [x] 통합 테스트: transform 훅 마커 삽입, generateBundle 호출 확인, plugins 없이 기존 동작 유지
- [x] `/simplify` 리뷰 완료: UB 제거, OOM 전파, absPath 중복 제거, clearRetainingCapacity 최적화

🤖 Generated with [Claude Code](https://claude.com/claude-code)