### PR TITLE
docs: 플러그인 2단계 완료 반영 + shutdown 버그 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ zts - < input.ts                # stdin 입력
 zts --bundle <entry.ts>                          # 번들 → stdout
 zts --bundle <entry.ts> -o out.js                # 번들 → 파일
 zts --bundle <entry.ts> --splitting --outdir dist  # 코드 스플리팅
+zts --bundle <entry.ts> --plugin zts.config.js     # JS 플러그인
 ```
 
 ### 공통 옵션
@@ -83,6 +84,7 @@ zts --bundle <entry.ts> --splitting --outdir dist  # 코드 스플리팅
 --legal-comments=<mode>      라이센스 주석 처리 (none, inline, eof, linked, external)
 --inject:<path>              모든 엔트리에 자동 import (반복 가능)
 --keep-names                 minify 시 함수/클래스 .name 프로퍼티 보존
+--plugin <path>                  JS 플러그인 (subprocess JSON IPC)
 -w, --watch                      파일 변경 감시
 -p, --project <path>             tsconfig.json 경로
 ```

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -81,20 +81,17 @@ CJS 래핑 등
 
 ## 구현 전략 — 3단계
 
-### 1단계: Zig Builtin 플러그인 (난이도 L, 3~5일)
-- 플러그인 인터페이스를 Zig 함수 포인터로 정의
-- JSON/Text/Asset 로더를 Zig builtin 플러그인으로 구현 (최고 성능)
-- resolveId 훅으로 alias, virtual module 지원
-- 파이프라인 단방향 구조(resolver → graph → emitter)라 훅 삽입 용이
-- N-API 불필요, 즉시 가능
+### 1단계: Zig Builtin 플러그인 ✅ 완료 (PR #521)
+- Plugin struct (context + 5개 훅 함수 포인터) + PluginRunner
+- 파이프라인 5곳에 훅 삽입 (resolver → graph → emitter → bundler)
+- context: ?*anyopaque로 subprocess 플러그인 상태 전달 지원 (PR #522)
 
-### 2단계: JS 플러그인 — subprocess 방식 (난이도 M, 1주)
-- esbuild와 동일한 아키텍처: 별도 Node.js 프로세스를 spawn하고 stdin/stdout JSON 메시지로 통신
-- N-API 불필요 — child_process + JSON 프로토콜만으로 동작
-- "문자열 in, 문자열 out" — Zig와 JS가 AST를 공유하지 않음
-- 플러그인 필터(예: `filter: /\.css$/`)로 호출 대상을 제한하여 IPC 오버헤드 최소화
-- 성능: 호출당 ~50~200μs (특정 확장자만 처리하면 전체 영향 10ms 이하)
-- 사용자가 PostCSS, Lightning CSS, Babel 등을 JS 플러그인으로 사용 가능
+### 2단계: JS 플러그인 — subprocess 방식 ✅ 완료 (PR #523, #524, #525)
+- SubprocessPlugin: Node.js child process spawn + stdin/stdout JSON IPC
+- @zts/core npm 패키지: definePlugin(), build.onResolve/onLoad/onTransform
+- CLI: `--plugin <path>` 옵션으로 JS 플러그인 파일 지정
+- suffix 기반 필터 매칭 (.css, .svg 등)으로 IPC 호출 최소화
+- **제한사항**: 현재 load 훅은 JS 모듈 파싱 경로에서만 동작. 비-JS 확장자(.css 등)를 JS로 변환하려면 graph.zig의 module_type 결정 로직 확장 필요.
 
 ```
 ZTS (Zig 바이너리)

--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -41,8 +41,12 @@ pub const FilterMap = struct {
 pub const SubprocessPlugin = struct {
     child: std.process.Child,
     stdin_file: std.fs.File,
-    /// buffered reader로 줄바꿈 경계를 정확히 처리
-    stdout_reader: std.io.BufferedReader(4096, std.fs.File.Reader),
+    stdout_file: std.fs.File,
+    /// 줄바꿈 경계를 정확히 처리하기 위한 내부 버퍼.
+    /// read()가 다음 메시지 데이터까지 읽었을 때, 잔여 데이터를 보관.
+    read_buf: [8192]u8 = undefined,
+    read_buf_len: usize = 0,
+    read_buf_pos: usize = 0,
     next_id: u32 = 1,
     filters: FilterMap = .{},
     allocator: std.mem.Allocator,
@@ -55,9 +59,9 @@ pub const SubprocessPlugin = struct {
             &.{ "node", config_path },
             allocator,
         );
-        child.stdin_behavior = .pipe;
-        child.stdout_behavior = .pipe;
-        child.stderr_behavior = .inherit;
+        child.stdin_behavior = .Pipe;
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Inherit;
 
         try child.spawn();
 
@@ -68,7 +72,7 @@ pub const SubprocessPlugin = struct {
         self.* = .{
             .child = child,
             .stdin_file = stdin_file,
-            .stdout_reader = std.io.bufferedReader(stdout_file.reader()),
+            .stdout_file = stdout_file,
             .allocator = allocator,
             .filter_arena = std.heap.ArenaAllocator.init(allocator),
         };
@@ -114,7 +118,10 @@ pub const SubprocessPlugin = struct {
     /// 프로세스 종료.
     pub fn shutdown(self: *SubprocessPlugin) void {
         self.sendRaw("{\"type\":\"shutdown\"}\n") catch {};
-        self.stdin_file.close();
+        // stdin을 닫아서 Node.js에게 EOF 신호 전달.
+        // child.wait()가 내부에서 stdin/stdout을 정리하므로 별도 close 불필요.
+        self.child.stdin = null;
+        self.child.stdout = null;
         _ = self.child.wait() catch {};
         self.filter_arena.deinit();
         self.allocator.destroy(self);
@@ -136,12 +143,35 @@ pub const SubprocessPlugin = struct {
         try self.sendRaw(request);
     }
 
-    /// stdout에서 한 줄 읽기. heap 할당, caller가 free.
+    /// stdout에서 한 줄 읽기 (줄바꿈 경계 정확 처리). heap 할당, caller가 free.
     fn readLine(self: *SubprocessPlugin, allocator: std.mem.Allocator) ![]u8 {
-        return self.stdout_reader.reader().readUntilDelimiterAlloc(allocator, '\n', 1024 * 1024) catch |err| switch (err) {
-            error.EndOfStream => return error.EndOfStream,
-            else => return error.PluginFailed,
-        };
+        var line: std.ArrayList(u8) = .empty;
+        errdefer line.deinit(allocator);
+
+        while (true) {
+            // 내부 버퍼에 데이터가 있으면 줄바꿈 검색
+            if (self.read_buf_pos < self.read_buf_len) {
+                const remaining = self.read_buf[self.read_buf_pos..self.read_buf_len];
+                if (std.mem.indexOfScalar(u8, remaining, '\n')) |nl_pos| {
+                    try line.appendSlice(allocator, remaining[0..nl_pos]);
+                    self.read_buf_pos += nl_pos + 1; // 줄바꿈 건너뜀
+                    return line.toOwnedSlice(allocator);
+                }
+                // 줄바꿈 없으면 남은 전부 복사
+                try line.appendSlice(allocator, remaining);
+                self.read_buf_pos = 0;
+                self.read_buf_len = 0;
+            }
+
+            // 버퍼 리필
+            const n = self.stdout_file.read(&self.read_buf) catch return error.PluginFailed;
+            if (n == 0) {
+                if (line.items.len > 0) return line.toOwnedSlice(allocator);
+                return error.EndOfStream;
+            }
+            self.read_buf_len = n;
+            self.read_buf_pos = 0;
+        }
     }
 
     // ===== 훅 구현 =====


### PR DESCRIPTION
## Summary
- CLAUDE.md: `--plugin <path>` CLI 옵션 문서화
- PLUGINS.md: 1단계/2단계 완료 상태 반영 + load 훅 제한사항 기록
- subprocess_plugin: shutdown double-close panic 수정
- subprocess_plugin: StdIo enum PascalCase 수정 (exe 빌드 호환)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `zig build` exe 빌드 성공
- [x] E2E 테스트: --plugin으로 Node.js 프로세스 spawn + 번들 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)