### PR TITLE
fix(bundler): 플러그인 load 훅 비-JS 확장자 지원 + IPC 버그 수정

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -463,6 +463,32 @@ pub const ModuleGraph = struct {
         var module = &self.modules.items[mod_idx];
         module.state = .parsing;
 
+        // Plugin: load 훅 — 모든 module_type 분기 전에 플러그인에게 기회를 줌.
+        // 플러그인이 내용을 반환하면 JS 모듈로 전환 (예: .css → JS export).
+        if (self.plugins.len > 0) {
+            const runner = plugin_mod.PluginRunner.init(self.plugins);
+            // 임시 allocator로 load 결과만 확인 (성공 시 arena를 생성)
+            var tmp_arena = std.heap.ArenaAllocator.init(self.allocator);
+            const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
+                error.PluginFailed => null,
+                error.OutOfMemory => {
+                    tmp_arena.deinit();
+                    module.state = .ready;
+                    return;
+                },
+            };
+            if (load_result) |plugin_source| {
+                // 플러그인이 내용을 반환 → JS 모듈로 전환하여 아래 파싱 경로를 탐
+                module.module_type = .javascript;
+                module.parse_arena = tmp_arena;
+                module.source = plugin_source;
+                // module_type 분기를 건너뛰고 JS 파싱 경로로 직접 이동
+                // (아래 "모듈별 Arena" 블록은 parse_arena가 이미 설정되어 있으므로 건너뜀)
+            } else {
+                tmp_arena.deinit();
+            }
+        }
+
         // JSON 모듈: 파싱 불필요, CJS로 래핑만
         if (module.module_type == .json) {
             module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
@@ -486,32 +512,24 @@ pub const ModuleGraph = struct {
         }
 
         // 모듈별 Arena: Scanner/Parser/AST 메모리를 소유 (D061)
-        module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+        // 플러그인 load 훅에서 이미 설정된 경우 건너뜀
+        if (module.parse_arena == null) {
+            module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+        }
         const arena_alloc = module.parse_arena.?.allocator();
 
-        // Plugin: load 훅 — virtual module 지원을 위해 파일 I/O 전에 플러그인에게 기회를 줌
-        const source: []const u8 = blk: {
-            if (self.plugins.len > 0) {
-                const runner = plugin_mod.PluginRunner.init(self.plugins);
-                const load_result = runner.runLoad(module.path, arena_alloc) catch |err| switch (err) {
-                    error.PluginFailed => null,
-                    error.OutOfMemory => {
-                        module.state = .ready;
-                        return;
-                    },
-                };
-                if (load_result) |plugin_source| break :blk plugin_source;
-            }
-            break :blk std.fs.cwd().readFileAlloc(arena_alloc, module.path, 100 * 1024 * 1024) catch {
+        // 파일 시스템에서 읽기 (플러그인이 source를 이미 설정한 경우 건너뜀)
+        if (module.source.len == 0) {
+            const source = std.fs.cwd().readFileAlloc(arena_alloc, module.path, 100 * 1024 * 1024) catch {
                 self.addDiag(.read_error, .@"error", module.path, Span.EMPTY, .resolve, "Cannot read file", null);
                 module.state = .ready;
                 return;
             };
-        };
-        module.source = source;
+            module.source = source;
+        }
 
         // Scanner + Parser (arena 할당)
-        var scanner = Scanner.init(arena_alloc, source) catch {
+        var scanner = Scanner.init(arena_alloc, module.source) catch {
             self.addDiag(.parse_error, .@"error", module.path, Span.EMPTY, .parse, "Scanner initialization failed", null);
             module.state = .ready;
             return;
@@ -564,8 +582,8 @@ pub const ModuleGraph = struct {
                 if (arena_alloc.alloc([]const u8, legal_count)) |buf| {
                     var li: usize = 0;
                     for (parser.scanner.comments.items) |c| {
-                        if (c.is_legal and c.start < source.len and c.end <= source.len) {
-                            buf[li] = source[c.start..c.end];
+                        if (c.is_legal and c.start < module.source.len and c.end <= module.source.len) {
+                            buf[li] = module.source[c.start..c.end];
                             li += 1;
                         }
                     }
@@ -738,16 +756,16 @@ pub const ModuleGraph = struct {
         for (records, 0..) |record, rec_i| {
             // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
             if (plugin_runner) |runner| {
-                if (runner.runResolveId(record.specifier, module_path, self.allocator)) |plugin_result| {
+                const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
+                    error.PluginFailed => null,
+                    error.OutOfMemory => return error.OutOfMemory,
+                };
+                // non-null이면 플러그인이 resolve 완료 → 기본 resolver 건너뜀
+                if (resolve_result) |plugin_result| {
                     try self.applyResolveResult(mod_idx, rec_i, record, plugin_result, false);
                     continue;
-                } else |err| switch (err) {
-                    error.PluginFailed => {
-                        try self.applyResolveResult(mod_idx, rec_i, record, null, true);
-                        continue;
-                    },
-                    error.OutOfMemory => return error.OutOfMemory,
                 }
+                // null이면 기본 resolver로 fall through
             }
 
             const resolved = self.resolve_cache.resolve(

--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -48,6 +48,8 @@ pub const SubprocessPlugin = struct {
     read_buf_len: usize = 0,
     read_buf_pos: usize = 0,
     next_id: u32 = 1,
+    /// 멀티스레드 parseModule에서 동시 IPC 접근 방지
+    ipc_mutex: std.Thread.Mutex = .{},
     filters: FilterMap = .{},
     allocator: std.mem.Allocator,
     /// 핸드셰이크에서 수신한 필터 문자열 저장용
@@ -86,14 +88,13 @@ pub const SubprocessPlugin = struct {
     fn handshake(self: *SubprocessPlugin) !void {
         try self.sendRaw("{\"id\":0,\"type\":\"init\"}\n");
 
-        const response = self.readLine(self.allocator) catch return error.PluginFailed;
-        defer self.allocator.free(response);
-
+        // filter_arena에 응답을 할당 — parseFromSliceLeaky가 문자열을 참조하므로 arena와 같은 수명 필요
         const arena_alloc = self.filter_arena.allocator();
-        const parsed = std.json.parseFromSlice(InitResponse, arena_alloc, response, .{
+        const response = self.readLine(arena_alloc) catch return error.PluginFailed;
+
+        const init_resp = std.json.parseFromSliceLeaky(InitResponse, arena_alloc, response, .{
             .ignore_unknown_fields = true,
         }) catch return error.PluginFailed;
-        const init_resp = parsed.value;
 
         self.filters = .{
             .resolve_filters = init_resp.filters.resolveId orelse &.{},
@@ -133,14 +134,18 @@ pub const SubprocessPlugin = struct {
         try self.stdin_file.writeAll(data);
     }
 
-    /// JSON 요청 전송
-    fn sendJsonRequest(self: *SubprocessPlugin, allocator: std.mem.Allocator, msg_type: []const u8, fields: []const u8) !void {
+    /// JSON 요청 전송 + 응답 읽기 (mutex로 보호). caller가 응답을 free.
+    fn sendAndReceive(self: *SubprocessPlugin, allocator: std.mem.Allocator, msg_type: []const u8, fields: []const u8) ![]u8 {
+        self.ipc_mutex.lock();
+        defer self.ipc_mutex.unlock();
+
         const id = self.next_id;
         self.next_id += 1;
 
         const request = try std.fmt.allocPrint(allocator, "{{\"id\":{d},\"type\":\"{s}\",{s}}}\n", .{ id, msg_type, fields });
         defer allocator.free(request);
         try self.sendRaw(request);
+        return self.readLine(allocator);
     }
 
     /// stdout에서 한 줄 읽기 (줄바꿈 경계 정확 처리). heap 할당, caller가 free.
@@ -190,9 +195,7 @@ pub const SubprocessPlugin = struct {
         }) catch return error.OutOfMemory;
         defer allocator.free(fields);
 
-        self.sendJsonRequest(allocator, "resolveId", fields) catch return error.PluginFailed;
-
-        const response = self.readLine(allocator) catch return error.PluginFailed;
+        const response = self.sendAndReceive(allocator, "resolveId", fields) catch return error.PluginFailed;
         defer allocator.free(response);
         const parsed = std.json.parseFromSliceLeaky(HookResponse, allocator, response, .{
             .ignore_unknown_fields = true,
@@ -221,9 +224,7 @@ pub const SubprocessPlugin = struct {
         const fields = std.fmt.allocPrint(allocator, "\"path\":\"{s}\"", .{escaped_path}) catch return error.OutOfMemory;
         defer allocator.free(fields);
 
-        self.sendJsonRequest(allocator, "load", fields) catch return error.PluginFailed;
-
-        const response = self.readLine(allocator) catch return error.PluginFailed;
+        const response = self.sendAndReceive(allocator, "load", fields) catch return error.PluginFailed;
         defer allocator.free(response);
         const parsed = std.json.parseFromSliceLeaky(HookResponse, allocator, response, .{
             .ignore_unknown_fields = true,
@@ -253,9 +254,7 @@ pub const SubprocessPlugin = struct {
         }) catch return error.OutOfMemory;
         defer allocator.free(fields);
 
-        self.sendJsonRequest(allocator, "transform", fields) catch return error.PluginFailed;
-
-        const response = self.readLine(allocator) catch return error.PluginFailed;
+        const response = self.sendAndReceive(allocator, "transform", fields) catch return error.PluginFailed;
         defer allocator.free(response);
         const parsed = std.json.parseFromSliceLeaky(HookResponse, allocator, response, .{
             .ignore_unknown_fields = true,


### PR DESCRIPTION
## Summary
- load 훅을 module_type 분기 전으로 이동 — `.css` 등 비-JS 파일도 플러그인이 JS로 변환 가능
- resolveId 훅 null 반환 시 기본 resolver로 fall through (기존: external로 잘못 처리)
- 핸드셰이크 필터 문자열 dangling pointer 수정 (parseFromSliceLeaky + arena 할당)
- IPC mutex 추가 (멀티스레드 parseModule 안전)

## Test plan
- [x] `zig build test` 전체 통과
- [x] E2E: CSS 플러그인으로 `.css` → JS export 변환 번들 생성 확인
- [x] `zig build` exe 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)