### PR TITLE
feat(bundler): 필터 매칭 확장 + virtual module 지원

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -77,10 +77,15 @@ class PluginHost {
     }
   }
 
+  matchesFilter(filter, target) {
+    if (!filter) return true;
+    return target.startsWith(filter) || target.endsWith(filter) || target.includes(filter);
+  }
+
   async runFirstHook(hookName, msg) {
     for (const entry of this.hooks[hookName]) {
       const target = msg.specifier || msg.path || msg.moduleId || "";
-      if (entry.filter && !target.endsWith(entry.filter)) continue;
+      if (!this.matchesFilter(entry.filter, target)) continue;
 
       try {
         const args = this.buildArgs(hookName, msg);
@@ -101,7 +106,7 @@ class PluginHost {
 
     for (const entry of this.hooks[hookName]) {
       const target = msg.moduleId || "";
-      if (entry.filter && !target.endsWith(entry.filter)) continue;
+      if (!this.matchesFilter(entry.filter, target)) continue;
 
       try {
         const args = { ...this.buildArgs(hookName, msg), code: currentCode };

--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -31,12 +31,15 @@ pub const FilterMap = struct {
     has_load: bool = false,
     has_transform: bool = false,
 
-    /// target이 필터 목록의 어떤 suffix로든 끝나면 true.
+    /// target이 필터 목록의 어떤 패턴에든 매칭되면 true.
+    /// suffix, prefix, contains 매칭 지원 (예: ".css", "virtual:", "\0").
     /// 필터가 비어있으면 모든 대상에 적용 (esbuild 호환).
     pub fn matchesAny(filters: []const []const u8, target: []const u8) bool {
         if (filters.len == 0) return true;
         for (filters) |f| {
-            if (std.mem.endsWith(u8, target, f)) return true;
+            if (std.mem.endsWith(u8, target, f) or
+                std.mem.startsWith(u8, target, f) or
+                std.mem.indexOf(u8, target, f) != null) return true;
         }
         return false;
     }


### PR DESCRIPTION
## Summary
- FilterMap: suffix 외에 prefix, contains 매칭 추가 (`virtual:`, `\0` prefix 지원)
- `@zts/core`: `matchesFilter()` — startsWith/endsWith/includes 통합
- Virtual module 패턴 동작 확인: `resolveId(\0virtual:env)` → `load(JS export)`

## Test plan
- [x] `zig build test` 전체 통과
- [x] E2E: virtual module (`import { NODE_ENV } from 'virtual:env'`) 번들 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)