### PR TITLE
fix: /simplify 미검토 PR 통합 리뷰 반영

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -79,7 +79,7 @@ class PluginHost {
 
   matchesFilter(filter, target) {
     if (!filter) return true;
-    return target.startsWith(filter) || target.endsWith(filter) || target.includes(filter);
+    return target.endsWith(filter) || target.startsWith(filter);
   }
 
   async runFirstHook(hookName, msg) {
@@ -160,7 +160,15 @@ export function definePlugin(nameOrSetup, maybeSetup) {
 
   const rl = createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY });
 
-  rl.on("line", async (line) => {
+  // 큐 기반 직렬화 — async 콜백이 완료될 때까지 다음 메시지를 대기
+  // Zig 측 mutex가 직렬화를 보장하지만, JS 측에서도 명시적으로 보장
+  let processing = false;
+  const queue = [];
+
+  async function processNext() {
+    if (processing || queue.length === 0) return;
+    processing = true;
+    const line = queue.shift();
     try {
       const msg = JSON.parse(line);
       const response = await host.handleMessage(msg);
@@ -168,5 +176,12 @@ export function definePlugin(nameOrSetup, maybeSetup) {
     } catch (err) {
       process.stdout.write(`${JSON.stringify({ id: 0, result: null, error: String(err) })}\n`);
     }
+    processing = false;
+    processNext();
+  }
+
+  rl.on("line", (line) => {
+    queue.push(line);
+    processNext();
   });
 }

--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -31,15 +31,13 @@ pub const FilterMap = struct {
     has_load: bool = false,
     has_transform: bool = false,
 
-    /// target이 필터 목록의 어떤 패턴에든 매칭되면 true.
-    /// suffix, prefix, contains 매칭 지원 (예: ".css", "virtual:", "\0").
+    /// target이 필터의 suffix 또는 prefix에 매칭되면 true.
+    /// suffix: ".css", ".svg" / prefix: "virtual:", "\0"
     /// 필터가 비어있으면 모든 대상에 적용 (esbuild 호환).
     pub fn matchesAny(filters: []const []const u8, target: []const u8) bool {
         if (filters.len == 0) return true;
         for (filters) |f| {
-            if (std.mem.endsWith(u8, target, f) or
-                std.mem.startsWith(u8, target, f) or
-                std.mem.indexOf(u8, target, f) != null) return true;
+            if (std.mem.endsWith(u8, target, f) or std.mem.startsWith(u8, target, f)) return true;
         }
         return false;
     }
@@ -145,8 +143,10 @@ pub const SubprocessPlugin = struct {
     /// 프로세스 종료.
     pub fn shutdown(self: *SubprocessPlugin) void {
         self.sendRaw("{\"type\":\"shutdown\"}\n") catch {};
-        // stdin을 닫아서 Node.js에게 EOF 신호 전달.
-        // child.wait()가 내부에서 stdin/stdout을 정리하므로 별도 close 불필요.
+        // stdin close → Node.js에 EOF 전달 → 프로세스 종료 유도
+        self.stdin_file.close();
+        self.stdout_file.close();
+        // child.wait()가 이미 닫힌 fd를 다시 닫지 않도록 null 설정
         self.child.stdin = null;
         self.child.stdout = null;
         _ = self.child.wait() catch {};


### PR DESCRIPTION
## Summary
미검토 PR 6개(#524~#530)를 통합 리뷰하여 발견된 이슈 수정:

1. **matchesFilter/matchesAny 과잉 매칭** — `includes` 제거, suffix/prefix만 유지 (`.css`가 `.css-backup` 매칭하던 문제)
2. **readline async 경합 조건** — 큐 기반 직렬화 추가 (Zig mutex 외에 JS 측에서도 보장)
3. **shutdown fd leak** — stdin_file/stdout_file 명시적 close 후 child null 설정

## Test plan
- [x] `zig build test` 전체 통과
- [x] E2E: CSS 플러그인 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)