### PR TITLE
feat: --serve + --plugin 연동 — dev server 플러그인 지원

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -863,10 +863,29 @@ pub fn main() !void {
             };
         } else null;
 
+        // Subprocess 플러그인 spawn (--serve + --plugin)
+        var serve_subprocess_list: std.ArrayList(*SubprocessPlugin) = .empty;
+        defer {
+            for (serve_subprocess_list.items) |sp| sp.shutdown();
+            serve_subprocess_list.deinit(allocator);
+        }
+        var serve_plugin_list: std.ArrayList(plugin_mod.Plugin) = .empty;
+        defer serve_plugin_list.deinit(allocator);
+
+        for (opts.plugin_paths.items) |config_path| {
+            const sp = SubprocessPlugin.spawn(allocator, config_path) catch |err| {
+                try stderr.print("zts: plugin '{s}' spawn failed: {}\n", .{ config_path, err });
+                return;
+            };
+            try serve_subprocess_list.append(allocator, sp);
+            try serve_plugin_list.append(allocator, sp.toPlugin());
+        }
+
         var dev_server = lib.server.DevServer.init(allocator, .{
             .root_dir = serve_dir,
             .port = opts.serve_port,
             .entry_point = entry,
+            .plugins = serve_plugin_list.items,
         }) catch |err| {
             try stderr.print("Error: failed to start dev server: {}\n", .{err});
             return;

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -3,7 +3,9 @@ const http = std.http;
 const mime = @import("mime.zig");
 const lib = @import("../root.zig");
 const Bundler = lib.bundler.Bundler;
+const BundleOptions = lib.bundler.BundleOptions;
 const BundleResult = lib.bundler.BundleResult;
+const plugin_mod = lib.bundler.plugin;
 
 fn getLog() std.fs.File.DeprecatedWriter {
     return std.fs.File.stderr().deprecatedWriter();
@@ -98,7 +100,7 @@ pub const DevServer = struct {
     entry_point: ?[]const u8,
     abs_entry: ?[]const u8,
     ws_clients: WsClients = .{},
-    /// 마지막 번들의 소스맵 (캐시). /bundle.js.map 요청 시 반환. mutex로 보호.
+    plugins: []const plugin_mod.Plugin = &.{},
     sourcemap_cache: struct {
         mutex: std.Thread.Mutex = .{},
         data: ?[]const u8 = null,
@@ -108,6 +110,7 @@ pub const DevServer = struct {
         root_dir: []const u8 = ".",
         port: u16 = 3000,
         entry_point: ?[]const u8 = null,
+        plugins: []const plugin_mod.Plugin = &.{},
     };
 
     const max_file_size: u64 = 50 * 1024 * 1024;
@@ -147,6 +150,7 @@ pub const DevServer = struct {
             .tcp_server = null,
             .entry_point = options.entry_point,
             .abs_entry = abs_entry,
+            .plugins = options.plugins,
         };
     }
 
@@ -298,7 +302,7 @@ pub const DevServer = struct {
         const abs_entry = self.abs_entry orelse return;
 
         // 초기 번들 → 모듈 경로 수집
-        var watch_paths = collectModulePaths(self.allocator, abs_entry) orelse return;
+        var watch_paths = collectModulePaths(self.allocator, abs_entry, self.plugins) orelse return;
         defer freeWatchPaths(self.allocator, &watch_paths);
 
         // root_dir의 CSS 파일을 watch 대상에 추가
@@ -394,7 +398,7 @@ pub const DevServer = struct {
             if (has_css and !has_non_css) continue;
 
             // 재번들 시도 → 에러면 에러 오버레이, 성공이면 HMR update (폴백: full-reload)
-            const rebuild_result = tryRebuild(self.allocator, abs_entry);
+            const rebuild_result = tryRebuild(self.allocator, abs_entry, self.plugins);
             switch (rebuild_result) {
                 .success => |result| {
                     defer {
@@ -449,12 +453,13 @@ pub const DevServer = struct {
         fatal, // 번들러 자체 실패
     };
 
-    fn tryRebuild(allocator: std.mem.Allocator, abs_entry: []const u8) RebuildResult {
+    fn tryRebuild(allocator: std.mem.Allocator, abs_entry: []const u8, plugins: []const plugin_mod.Plugin) RebuildResult {
         var bundler = Bundler.init(allocator, .{
             .entry_points = &.{abs_entry},
             .platform = .browser,
             .dev_mode = true,
             .react_refresh = true,
+            .plugins = plugins,
         });
         defer bundler.deinit();
 
@@ -545,12 +550,13 @@ pub const DevServer = struct {
         return allocator.dupe(u8, msg.items) catch return null;
     }
 
-    fn collectModulePaths(allocator: std.mem.Allocator, abs_entry: []const u8) ?[]const []const u8 {
+    fn collectModulePaths(allocator: std.mem.Allocator, abs_entry: []const u8, plugins: []const plugin_mod.Plugin) ?[]const []const u8 {
         var bundler = Bundler.init(allocator, .{
             .entry_points = &.{abs_entry},
             .platform = .browser,
             .dev_mode = true,
             .react_refresh = true,
+            .plugins = plugins,
         });
         defer bundler.deinit();
 


### PR DESCRIPTION
## Summary
- DevServer.Options에 `plugins` 필드 추가
- `tryRebuild()`/`collectModulePaths()`에 plugins 전달하여 Bundler에 주입
- main.zig `--serve` 블록에서 SubprocessPlugin spawn + DevServer에 전달
- `--serve --bundle entry.ts --plugin plugin.js` 사용 가능

## Test plan
- [x] `zig build test` 전체 통과
- [x] 기존 dev server 동작에 영향 없음 (plugins 기본값 `&.{}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)