### PR TITLE
test+fix: config 자동 감지 테스트 + /simplify 반영

### DIFF
--- a/packages/integration/tests/helpers.ts
+++ b/packages/integration/tests/helpers.ts
@@ -45,6 +45,19 @@ export async function runZts(
   return runCmd([ZTS_BIN, ...args]);
 }
 
+export async function runZtsInDir(
+  dir: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = spawn({ cmd: [ZTS_BIN, ...args], stdout: "pipe", stderr: "pipe", cwd: dir });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
 export async function bundleAndRun(
   files: Record<string, string>,
   entry: string = "index.ts",

--- a/packages/integration/tests/plugin.test.ts
+++ b/packages/integration/tests/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { createFixture, runZts, ZTS_BIN } from "./helpers";
+import { createFixture, runZts, runZtsInDir, ZTS_BIN } from "./helpers";
 import { join, resolve } from "node:path";
 
 const CORE_PATH = resolve(import.meta.dir, "../../../packages/core/index.js");
@@ -408,6 +408,114 @@ describe("Plugin: subprocess", () => {
 
       proc.kill();
       await proc.exited;
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+describe("Plugin: auto config detection", () => {
+  test("zts.config.js is auto-detected without --plugin", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import css from './style.css';\nconsole.log(css);`,
+      "style.css": "body { color: auto; }",
+      "package.json": '{"type": "module"}',
+      "zts.config.js": `
+        import { defineConfig } from '${CORE_PATH}';
+        defineConfig({ plugins: [{
+          name: 'auto-css',
+          async load(id) {
+            if (!id.endsWith('.css')) return null;
+            const fs = await import('node:fs');
+            const css = await fs.promises.readFile(id, 'utf8');
+            return 'export default ' + JSON.stringify(css) + ';';
+          }
+        }] });
+      `,
+    });
+
+    try {
+      // --plugin 없이 실행 — zts.config.js 자동 감지
+      const result = await runZtsInDir(dir, ["--bundle", "entry.ts"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain("Using config: zts.config.js");
+      expect(result.stdout).toContain("body { color: auto; }");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("zts.config.ts is auto-detected", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `const x: number = 42;\nconsole.log(x);`,
+      "package.json": '{"type": "module"}',
+      "zts.config.ts": `
+        import { defineConfig } from '${CORE_PATH}';
+        defineConfig({ plugins: [{
+          name: 'ts-banner',
+          transform(code: string, id: string) {
+            if (!id.endsWith('.ts') || id.includes('zts.config')) return null;
+            return '/* TS-CONFIG */\\n' + code;
+          }
+        }] });
+      `,
+    });
+
+    try {
+      const result = await runZtsInDir(dir, ["--bundle", "entry.ts"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain("Using config: zts.config.ts");
+      expect(result.stdout).toContain("/* TS-CONFIG */");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("explicit --plugin overrides auto-detection", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `const x = 1;\nconsole.log(x);`,
+      "package.json": '{"type": "module"}',
+      "zts.config.js": `
+        import { defineConfig } from '${CORE_PATH}';
+        defineConfig({ plugins: [{
+          name: 'should-not-load',
+          transform(code) { return '/* AUTO */\\n' + code; }
+        }] });
+      `,
+      "custom.js": `
+        import { defineConfig } from '${CORE_PATH}';
+        defineConfig({ plugins: [{
+          name: 'custom',
+          transform(code) { return '/* CUSTOM */\\n' + code; }
+        }] });
+      `,
+    });
+
+    try {
+      // --plugin 명시 → 자동 감지 안 함
+      const result = await runZtsInDir(dir, ["--bundle", "entry.ts", "--plugin", "custom.js"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("/* CUSTOM */");
+      expect(result.stdout).not.toContain("/* AUTO */");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("no config file does not cause error", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `const x = 42;\nconsole.log(x);`,
+    });
+
+    try {
+      const result = await runZtsInDir(dir, ["--bundle", "entry.ts"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain("Using config");
+      expect(result.stdout).toContain("const x = 42");
     } finally {
       await cleanup();
     }

--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -338,9 +338,13 @@ pub const SubprocessPlugin = struct {
 
 const JsRuntime = enum { bun, node };
 
+var cached_runtime: ?JsRuntime = null;
+
 fn detectRuntime() JsRuntime {
-    if (canExec("bun")) return .bun;
-    return .node;
+    if (cached_runtime) |r| return r;
+    const r: JsRuntime = if (canExec("bun")) .bun else .node;
+    cached_runtime = r;
+    return r;
 }
 
 fn canExec(name: []const u8) bool {
@@ -474,4 +478,19 @@ test "escapeJsonString: windows path backslash" {
     const result = try escapeJsonString(std.testing.allocator, "C:\\Users\\test\\file.ts");
     defer std.testing.allocator.free(result);
     try std.testing.expectEqualStrings("C:\\\\Users\\\\test\\\\file.ts", result);
+}
+
+test "detectRuntime: returns bun or node" {
+    const runtime = detectRuntime();
+    // 어떤 런타임이든 유효해야 함
+    try std.testing.expect(runtime == .bun or runtime == .node);
+}
+
+test "canExec: valid command returns true" {
+    // 'true'는 POSIX 필수 유틸리티, 항상 exit 0
+    try std.testing.expect(canExec("true"));
+}
+
+test "canExec: invalid command returns false" {
+    try std.testing.expect(!canExec("nonexistent_binary_zts_test_12345"));
 }


### PR DESCRIPTION
## Summary
**테스트 7개 추가:**
- Zig: detectRuntime, canExec(true/nonexistent) 3개
- 통합: zts.config.js 자동 감지, zts.config.ts 자동 감지, --plugin 우선, config 없음 4개

**/simplify 수정 2건:**
- detectRuntime() 결과 캐싱 (다중 --plugin 시 bun --version 중복 실행 방지)
- canExec("echo") → canExec("true") (POSIX 필수 유틸리티)

## Test plan
- [x] `zig build test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)