### PR TITLE
feat: renderChunk/generateBundle subprocess 훅 + config watch 재시작

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -45,6 +45,8 @@ class PluginHost {
       resolveId: this.plugins.some((p) => p.resolveId),
       load: this.plugins.some((p) => p.load),
       transform: this.plugins.some((p) => p.transform),
+      renderChunk: this.plugins.some((p) => p.renderChunk),
+      generateBundle: this.plugins.some((p) => p.generateBundle),
     };
   }
 
@@ -68,6 +70,10 @@ class PluginHost {
         return this.runLoad(msg);
       case "transform":
         return this.runTransform(msg);
+      case "renderChunk":
+        return this.runRenderChunk(msg);
+      case "generateBundle":
+        return this.runGenerateBundle(msg);
       case "shutdown":
         process.exit(0);
       default:
@@ -131,6 +137,45 @@ class PluginHost {
 
     if (changed) {
       return { id: msg.id, result: { contents: currentCode }, error: null };
+    }
+    return { id: msg.id, result: null, error: null };
+  }
+
+  // renderChunk: chain 모드 — 청크 코드 후처리
+  async runRenderChunk(msg) {
+    let currentCode = msg.code;
+    let changed = false;
+
+    for (const plugin of this.plugins) {
+      if (!plugin.renderChunk) continue;
+      try {
+        const result = await plugin.renderChunk(currentCode, msg.chunkName);
+        if (result == null) continue;
+        const code = typeof result === "string" ? result : result.contents;
+        if (code != null) {
+          currentCode = code;
+          changed = true;
+        }
+      } catch (err) {
+        return { id: msg.id, result: null, error: `[${plugin.name || "plugin"}] ${err}` };
+      }
+    }
+
+    if (changed) {
+      return { id: msg.id, result: { contents: currentCode }, error: null };
+    }
+    return { id: msg.id, result: null, error: null };
+  }
+
+  // generateBundle: 모든 플러그인에 알림
+  async runGenerateBundle(msg) {
+    for (const plugin of this.plugins) {
+      if (!plugin.generateBundle) continue;
+      try {
+        await plugin.generateBundle(msg.outputs || []);
+      } catch (err) {
+        return { id: msg.id, result: null, error: `[${plugin.name || "plugin"}] ${err}` };
+      }
     }
     return { id: msg.id, result: null, error: null };
   }

--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -30,6 +30,8 @@ pub const FilterMap = struct {
     has_resolve: bool = false,
     has_load: bool = false,
     has_transform: bool = false,
+    has_render_chunk: bool = false,
+    has_generate_bundle: bool = false,
 
     /// target이 필터의 suffix 또는 prefix에 매칭되면 true.
     /// suffix: ".css", ".svg" / prefix: "virtual:", "\0"
@@ -125,6 +127,8 @@ pub const SubprocessPlugin = struct {
             .has_resolve = init_resp.hooks.resolveId orelse (resolve_f.len > 0),
             .has_load = init_resp.hooks.load orelse (load_f.len > 0),
             .has_transform = init_resp.hooks.transform orelse (transform_f.len > 0),
+            .has_render_chunk = init_resp.hooks.renderChunk orelse false,
+            .has_generate_bundle = init_resp.hooks.generateBundle orelse false,
         };
         if (init_resp.name) |name| {
             self.plugin_name = name;
@@ -149,8 +153,8 @@ pub const SubprocessPlugin = struct {
             .resolveId = subprocessResolveId,
             .load = subprocessLoad,
             .transform = subprocessTransform,
-            .renderChunk = null,
-            .generateBundle = null,
+            .renderChunk = subprocessRenderChunk,
+            .generateBundle = subprocessGenerateBundle,
         };
     }
 
@@ -331,6 +335,64 @@ pub const SubprocessPlugin = struct {
         return null;
     }
 
+    fn subprocessRenderChunk(ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, allocator: std.mem.Allocator) PluginError!?[]const u8 {
+        const self = getSelf(ctx);
+        if (!self.filters.has_render_chunk) return null;
+
+        const escaped_code = escapeJsonString(allocator, code) catch return error.OutOfMemory;
+        defer allocator.free(escaped_code);
+        const escaped_name = escapeJsonString(allocator, chunk_name) catch return error.OutOfMemory;
+        defer allocator.free(escaped_name);
+
+        const fields = std.fmt.allocPrint(allocator, "\"code\":\"{s}\",\"chunkName\":\"{s}\"", .{
+            escaped_code, escaped_name,
+        }) catch return error.OutOfMemory;
+        defer allocator.free(fields);
+
+        const response = self.sendAndReceive(allocator, "renderChunk", fields) catch {
+            self.reportError("renderChunk", chunk_name, null);
+            return error.PluginFailed;
+        };
+        defer allocator.free(response);
+        const parsed = std.json.parseFromSliceLeaky(HookResponse, allocator, response, .{
+            .ignore_unknown_fields = true,
+        }) catch return error.PluginFailed;
+
+        if (parsed.@"error") |err_msg| {
+            self.reportError("renderChunk", chunk_name, err_msg);
+            return error.PluginFailed;
+        }
+
+        if (parsed.result) |result| {
+            if (result.contents) |contents| {
+                return allocator.dupe(u8, contents) catch return error.OutOfMemory;
+            }
+        }
+        return null;
+    }
+
+    fn subprocessGenerateBundle(ctx: ?*anyopaque, output_files: []const OutputFile) void {
+        const self = getSelf(ctx);
+        if (!self.filters.has_generate_bundle) return;
+
+        // 출력 파일 목록을 JSON 배열로 전송
+        var fields_buf: std.ArrayList(u8) = .empty;
+        defer fields_buf.deinit(self.allocator);
+
+        fields_buf.appendSlice(self.allocator, "\"outputs\":[") catch return;
+        for (output_files, 0..) |f, i| {
+            if (i > 0) fields_buf.append(self.allocator, ',') catch return;
+            fields_buf.appendSlice(self.allocator, "{\"path\":\"") catch return;
+            const escaped = escapeJsonString(self.allocator, f.path) catch return;
+            defer self.allocator.free(escaped);
+            fields_buf.appendSlice(self.allocator, escaped) catch return;
+            fields_buf.appendSlice(self.allocator, "\"}") catch return;
+        }
+        fields_buf.append(self.allocator, ']') catch return;
+
+        _ = self.sendAndReceive(self.allocator, "generateBundle", fields_buf.items) catch return;
+    }
+
     inline fn getSelf(ctx: ?*anyopaque) *SubprocessPlugin {
         return @ptrCast(@alignCast(ctx.?));
     }
@@ -376,6 +438,8 @@ const InitResponse = struct {
         resolveId: ?bool = null,
         load: ?bool = null,
         transform: ?bool = null,
+        renderChunk: ?bool = null,
+        generateBundle: ?bool = null,
     };
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -995,7 +995,7 @@ pub fn main() !void {
         }
 
         // BundleOptions를 변수로 추출 — 초기 번들과 watch 재번들에서 재사용
-        const bundle_opts: BundleOptions = .{
+        var bundle_opts: BundleOptions = .{
             .entry_points = &.{abs_entry},
             .format = opts.bundle_format,
             .platform = opts.platform,
@@ -1138,6 +1138,15 @@ pub fn main() !void {
                 }
             }
 
+            // config 파일도 감시 대상에 추가
+            for (opts.plugin_paths.items) |config_path| {
+                const abs_config = std.fs.cwd().realpathAlloc(allocator, config_path) catch continue;
+                const config_mt = getFileMtime(abs_config) catch 0;
+                mtime_map.put(abs_config, config_mt) catch {
+                    allocator.free(abs_config);
+                };
+            }
+
             try stderr.print("[watch] Watching {d} files for changes...\n", .{mtime_map.count()});
 
             while (true) {
@@ -1145,6 +1154,7 @@ pub fn main() !void {
 
                 // mtime 변경 확인
                 var changed = false;
+                var config_changed = false;
                 var mit = mtime_map.iterator();
                 while (mit.next()) |entry| {
                     const current_mtime = getFileMtime(entry.key_ptr.*) catch continue;
@@ -1152,12 +1162,40 @@ pub fn main() !void {
                         try stderr.print("[watch] Changed: {s}\n", .{entry.key_ptr.*});
                         entry.value_ptr.* = current_mtime;
                         changed = true;
+                        // config 파일이 변경되었는지 확인
+                        for (opts.plugin_paths.items) |config_path| {
+                            const abs_config = std.fs.cwd().realpathAlloc(allocator, config_path) catch continue;
+                            defer allocator.free(abs_config);
+                            if (std.mem.eql(u8, entry.key_ptr.*, abs_config)) {
+                                config_changed = true;
+                                break;
+                            }
+                        }
                     }
                 }
 
                 if (!changed) continue;
 
-                // 재번들 (플러그인은 그대로 유지, 새 Bundler 인스턴스 생성)
+                // config 변경 시 플러그인 프로세스 재시작
+                if (config_changed) {
+                    try stderr.print("[watch] Config changed, restarting plugins...\n", .{});
+                    for (subprocess_list.items) |sp| sp.shutdown();
+                    subprocess_list.clearRetainingCapacity();
+                    plugin_list.clearRetainingCapacity();
+
+                    for (opts.plugin_paths.items) |config_path| {
+                        const sp = SubprocessPlugin.spawn(allocator, config_path) catch |err| {
+                            try stderr.print("[watch] Plugin restart failed: {}\n", .{err});
+                            continue;
+                        };
+                        try subprocess_list.append(allocator, sp);
+                        try plugin_list.append(allocator, sp.toPlugin());
+                    }
+                    // bundle_opts의 plugins를 갱신
+                    bundle_opts.plugins = plugin_list.items;
+                }
+
+                // 재번들
                 var rebundler = Bundler.init(allocator, bundle_opts);
                 defer rebundler.deinit();
 


### PR DESCRIPTION
## Summary
1. **renderChunk** subprocess IPC — 청크 코드 후처리 (chain 모드)
2. **generateBundle** subprocess IPC — 번들 완료 알림 (출력 파일 목록)
3. **@zts/core** renderChunk/generateBundle 핸들러
4. **watch 모드 config 감지** — zts.config.js 수정 시 플러그인 프로세스 자동 재시작

## Test plan
- [x] `zig build test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)