### PR TITLE
fix: CSS load 예시 수정 — export default 래핑

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -6,6 +6,7 @@
  *
  * 사용법:
  *   import { defineConfig } from '@zts/core';
+ *   import fs from 'node:fs';
  *
  *   export default defineConfig({
  *     plugins: [
@@ -13,7 +14,8 @@
  *         name: 'css-loader',
  *         load(id) {
  *           if (!id.endsWith('.css')) return null;
- *           return fs.readFileSync(id, 'utf8');
+ *           const css = fs.readFileSync(id, 'utf8');
+ *           return `export default ${JSON.stringify(css)};`;
  *         }
  *       }
  *     ]


### PR DESCRIPTION
@zts/core 사용법 주석에서 raw CSS 반환 → `export default JSON.stringify(css)` 래핑으로 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)