### PR TITLE
feat: load 훅 loader 필드 — text/css/json 자동 래핑 (esbuild 호환)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -15,7 +15,7 @@
  *         load(id) {
  *           if (!id.endsWith('.css')) return null;
  *           const css = fs.readFileSync(id, 'utf8');
- *           return `export default ${JSON.stringify(css)};`;
+ *           return { contents: css, loader: 'text' };
  *         }
  *       }
  *     ]
@@ -30,8 +30,21 @@ export interface ResolveResult {
   path: string;
 }
 
+export type Loader =
+  | "js"
+  | "ts"
+  | "json"
+  | "text"
+  | "css"
+  | "file"
+  | "dataurl"
+  | "binary"
+  | "copy"
+  | "empty";
+
 export interface LoadResult {
   contents: string;
+  loader?: Loader;
 }
 
 export interface OutputFile {

--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -292,6 +292,15 @@ pub const SubprocessPlugin = struct {
 
         if (parsed.result) |result| {
             if (result.contents) |contents| {
+                // loader에 따라 JS 모듈로 래핑 (esbuild 호환)
+                const loader_str = result.loader orelse "js";
+                if (std.mem.eql(u8, loader_str, "text") or std.mem.eql(u8, loader_str, "css")) {
+                    const escaped = escapeJsonString(allocator, contents) catch return error.OutOfMemory;
+                    defer allocator.free(escaped);
+                    return std.fmt.allocPrint(allocator, "export default \"{s}\";", .{escaped}) catch return error.OutOfMemory;
+                } else if (std.mem.eql(u8, loader_str, "json")) {
+                    return std.fmt.allocPrint(allocator, "export default {s};", .{contents}) catch return error.OutOfMemory;
+                }
                 return allocator.dupe(u8, contents) catch return error.OutOfMemory;
             }
         }
@@ -451,6 +460,7 @@ const HookResponse = struct {
     const HookResult = struct {
         path: ?[]const u8 = null,
         contents: ?[]const u8 = null,
+        loader: ?[]const u8 = null,
     };
 };
 


### PR DESCRIPTION
## Summary
load 훅에서 `{ contents, loader }` 반환 시 번들러가 자동 래핑:
- `loader: "text"/"css"` → `export default "escaped";`
- `loader: "json"` → `export default {...};`
- `loader: "js"` (기본값) → 그대로 JS 모듈

## Before/After
```typescript
// Before: 플러그인이 직접 래핑해야 함
return \`export default \${JSON.stringify(css)};\`;

// After: loader만 지정
return { contents: css, loader: 'text' };
```

## Test plan
- [x] `zig build test` 전체 통과
- [x] E2E: `{ contents: css, loader: 'text' }` → `export default "..."` 자동 래핑

🤖 Generated with [Claude Code](https://claude.com/claude-code)