### PR TITLE
fix: /simplify 리뷰 반영 — 해시 이중 조회, absPath 중복, catch unreachable

### DIFF
--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -1,12 +1,8 @@
 const std = @import("std");
 const IncrementalBundler = @import("incremental.zig").IncrementalBundler;
-const writeFile = @import("test_helpers.zig").writeFile;
-
-fn absPath(tmp: *std.testing.TmpDir, rel: []const u8) ![]const u8 {
-    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
-    defer std.testing.allocator.free(dp);
-    return try std.fs.path.resolve(std.testing.allocator, &.{ dp, rel });
-}
+const test_helpers = @import("test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
 
 test "IncrementalBundler: first build is full rebuild" {
     var tmp = std.testing.tmpDir(.{});

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -587,7 +587,7 @@ pub const DevServer = struct {
         if (modules.len == 0) return null;
 
         var msg: std.ArrayList(u8) = .empty;
-        defer msg.deinit(allocator);
+        errdefer msg.deinit(allocator);
         const w = msg.writer(allocator);
 
         w.print("{{\"type\":\"update\",\"modules\":[", .{}) catch return null;
@@ -600,7 +600,7 @@ pub const DevServer = struct {
             w.print("\"}}", .{}) catch return null;
         }
         w.print("]}}", .{}) catch return null;
-        return allocator.dupe(u8, msg.items) catch return null;
+        return msg.toOwnedSlice(allocator) catch return null;
     }
 
     /// root_dir에서 .css 파일을 재귀 탐색하여 절대 경로 목록에 추가.
@@ -1006,9 +1006,9 @@ test "collectCssFiles: .css만 수집하고 .js는 제외" {
     defer tmp.cleanup();
 
     // .css 파일 2개 + .js 파일 1개 생성
-    tmp.dir.writeFile(.{ .sub_path = "a.css", .data = "" }) catch unreachable;
-    tmp.dir.writeFile(.{ .sub_path = "b.css", .data = "" }) catch unreachable;
-    tmp.dir.writeFile(.{ .sub_path = "c.js", .data = "" }) catch unreachable;
+    tmp.dir.writeFile(.{ .sub_path = "a.css", .data = "" }) catch return error.TestUnexpectedResult;
+    tmp.dir.writeFile(.{ .sub_path = "b.css", .data = "" }) catch return error.TestUnexpectedResult;
+    tmp.dir.writeFile(.{ .sub_path = "c.js", .data = "" }) catch return error.TestUnexpectedResult;
 
     var out: std.ArrayList([]const u8) = .empty;
     defer {
@@ -1035,11 +1035,11 @@ test "collectCssFiles: node_modules 내 .css 제외" {
     defer tmp.cleanup();
 
     // 일반 .css
-    tmp.dir.writeFile(.{ .sub_path = "style.css", .data = "" }) catch unreachable;
+    tmp.dir.writeFile(.{ .sub_path = "style.css", .data = "" }) catch return error.TestUnexpectedResult;
 
     // node_modules/ 하위 .css — 제외되어야 함
-    tmp.dir.makePath("node_modules/pkg") catch unreachable;
-    tmp.dir.writeFile(.{ .sub_path = "node_modules/pkg/lib.css", .data = "" }) catch unreachable;
+    tmp.dir.makePath("node_modules/pkg") catch return error.TestUnexpectedResult;
+    tmp.dir.writeFile(.{ .sub_path = "node_modules/pkg/lib.css", .data = "" }) catch return error.TestUnexpectedResult;
 
     var out: std.ArrayList([]const u8) = .empty;
     defer {
@@ -1061,11 +1061,11 @@ test "collectCssFiles: 숨김 폴더(.git) 내 .css 제외" {
     var tmp = std.testing.tmpDir(.{ .iterate = true });
     defer tmp.cleanup();
 
-    tmp.dir.writeFile(.{ .sub_path = "main.css", .data = "" }) catch unreachable;
+    tmp.dir.writeFile(.{ .sub_path = "main.css", .data = "" }) catch return error.TestUnexpectedResult;
 
     // .git/ 하위 .css — 숨김 폴더이므로 제외되어야 함
-    tmp.dir.makePath(".git/hooks") catch unreachable;
-    tmp.dir.writeFile(.{ .sub_path = ".git/hooks/style.css", .data = "" }) catch unreachable;
+    tmp.dir.makePath(".git/hooks") catch return error.TestUnexpectedResult;
+    tmp.dir.writeFile(.{ .sub_path = ".git/hooks/style.css", .data = "" }) catch return error.TestUnexpectedResult;
 
     var out: std.ArrayList([]const u8) = .empty;
     defer {

--- a/src/server/file_watcher.zig
+++ b/src/server/file_watcher.zig
@@ -334,22 +334,22 @@ const InotifyBackend = struct {
             const name = std.mem.sliceTo(name_ptr[0..event.len], 0);
             if (name.len == 0) continue;
 
-            // wd → 디렉토리 경로, 디렉토리 + 파일명 → 절대 경로
             const dir_path = self.wd_dirs.get(event.wd) orelse continue;
 
-            // 감시 대상 파일인지 확인 (디렉토리 내 모든 파일이 아닌 등록된 파일만)
-            // 절대 경로를 구성하여 watched_files에서 조회
+            // 디렉토리 + "/" + 파일명 → 절대 경로 (memcpy, bufPrint 오버헤드 회피)
             var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-            const full_path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ dir_path, name }) catch continue;
+            if (dir_path.len + 1 + name.len > path_buf.len) continue;
+            @memcpy(path_buf[0..dir_path.len], dir_path);
+            path_buf[dir_path.len] = '/';
+            @memcpy(path_buf[dir_path.len + 1 ..][0..name.len], name);
+            const full_path = path_buf[0 .. dir_path.len + 1 + name.len];
 
-            if (!self.watched_files.contains(full_path)) continue;
+            // getKey 1회로 존재 확인 + 소유 키 획득 (contains+getKey 이중 조회 제거)
+            const watched_path = self.watched_files.getKey(full_path) orelse continue;
 
             const is_delete = event.mask & std.os.linux.IN.DELETE != 0;
             const is_moved_from = event.mask & std.os.linux.IN.MOVED_FROM != 0;
             const kind: ChangeKind = if (is_delete or is_moved_from) .deleted else .modified;
-
-            // path는 watched_files의 키를 가리키므로 안전
-            const watched_path = self.watched_files.getKey(full_path) orelse continue;
             try self.result_buf.append(allocator, .{ .path = watched_path, .kind = kind });
         }
 


### PR DESCRIPTION
## Summary
- inotify `waitForChanges`: `contains`+`getKey` 이중 조회 → `getKey` 1회로 통합
- inotify: `bufPrint` → `memcpy` 조합 (핫패스 포맷터 오버헤드 제거)
- `incremental_test`: 로컬 `absPath` 삭제 → `test_helpers.absPath` import
- `dev_server` 테스트: `catch unreachable` → `catch return error` (OOM 안전)
- `buildHmrUpdateFromModules`: `dupe` → `toOwnedSlice` (불필요한 복사 제거)

## Test plan
- [x] `zig build test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)