### PR TITLE
feat(parser): add Flow import typeof support

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2428,3 +2428,27 @@ test "Flow: export opaque type stripped" {
     defer r.deinit();
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
+
+test "Flow: import type stripped" {
+    var r = try e2eFlowModule(std.testing.allocator, "import type { Foo } from 'bar';\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: import typeof default stripped" {
+    var r = try e2eFlowModule(std.testing.allocator, "import typeof Foo from 'bar';\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: import typeof namespace stripped" {
+    var r = try e2eFlowModule(std.testing.allocator, "import typeof * as ns from 'bar';\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: export type re-export stripped" {
+    var r = try e2eFlowModule(std.testing.allocator, "export type { Foo } from 'bar';\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -56,12 +56,25 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     }
     try self.advance(); // skip 'import'
 
-    // TS: import type — type-only import (완전 제거)
+    // TS/Flow: import type — type-only import (완전 제거)
     // import type Foo from 'bar'
     // import type { Foo } from 'bar'
     // import type * as ns from 'bar'
+    // Flow: import typeof — type-only import (완전 제거)
+    // import typeof Foo from 'bar'
+    // import typeof * as ns from 'bar'
     var is_type_only = false;
-    if (self.current() == .identifier and self.isContextual("type")) {
+
+    // Flow: import typeof — typeof는 키워드(.kw_typeof)이므로 별도 감지
+    if (self.is_flow and self.current() == .kw_typeof) {
+        const next = try self.peekNextKind();
+        if (next == .star or next == .identifier or next == .l_curly) {
+            is_type_only = true;
+            try self.advance(); // skip 'typeof'
+        }
+    }
+
+    if (!is_type_only and self.current() == .identifier and self.isContextual("type")) {
         const next = try self.peekNextKind();
         // import type { ... } / import type * / import type Foo from
         // 주의: import type from 'bar'는 'type'이라는 이름의 default import


### PR DESCRIPTION
## Summary
- `import typeof` 파싱 추가 (Flow 전용): `import typeof Foo from 'bar'`, `import typeof * as ns from 'bar'`
- `import type`은 기존 TS 구현 재사용 — 추가 코드 불필요
- `export type { ... }` re-export도 기존 TS 구현 재사용

## Changes
| 파일 | 변경 |
|------|------|
| `module.zig` | `import typeof` 감지 (`.kw_typeof` + Flow 모드 체크) |
| `codegen_test.zig` | 테스트 4개 추가 |

## Test plan
- [x] `zig build test` 전체 통과
- [x] `import type { Foo }` 스트리핑
- [x] `import typeof Foo` 스트리핑
- [x] `import typeof * as ns` 스트리핑
- [x] `export type { Foo }` 스트리핑

🤖 Generated with [Claude Code](https://claude.com/claude-code)