### PR TITLE
feat(parser): add Flow declare + interface — flow.zig 독립 구현

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2458,3 +2458,45 @@ test "Flow: import typeof named stripped" {
     defer r.deinit();
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
+
+test "Flow: declare function stripped" {
+    var r = try e2eFlow(std.testing.allocator, "declare function foo(x: number): string;\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: declare var stripped" {
+    var r = try e2eFlow(std.testing.allocator, "declare var x: number;\nlet y = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let y=1;", r.output);
+}
+
+test "Flow: declare class stripped" {
+    var r = try e2eFlow(std.testing.allocator, "declare class Foo { bar(): void; }\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: declare module.exports stripped" {
+    var r = try e2eFlow(std.testing.allocator, "declare module.exports: typeof EventEmitter;\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: interface declaration stripped" {
+    var r = try e2eFlow(std.testing.allocator, "interface Foo { x: number; y: string; }\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: interface extends stripped" {
+    var r = try e2eFlow(std.testing.allocator, "interface Foo extends Bar, Baz { x: number; }\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: declare export type stripped" {
+    var r = try e2eFlowModule(std.testing.allocator, "declare export type ID = string;\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -350,6 +350,8 @@ pub const Node = struct {
         flow_type_alias_declaration,
         /// opaque type Foo = Type — Flow opaque type (supertype constraint 포함 가능)
         flow_opaque_type,
+        /// interface Foo extends Bar { ... } — Flow interface declaration
+        flow_interface_declaration,
 
         // ==============================================================
         // TypeScript Expressions

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -692,3 +692,140 @@ pub fn parseFlowOpaqueType(self: *Parser) ParseError2!NodeIndex {
         .data = .{ .extra = extra },
     });
 }
+
+// ================================================================
+// Flow Declare Statement
+// ================================================================
+
+/// declare class/function/var/type/opaque type/module/module.exports/export
+/// 타입 스트리핑에서는 전체를 제거하므로 내부를 파싱한 뒤 NodeIndex.none을 반환한다.
+pub fn parseFlowDeclareStatement(self: *Parser) ParseError2!NodeIndex {
+    try self.advance(); // skip 'declare'
+
+    // declare module.exports: Type — Flow CJS 모듈 타입 선언
+    if (self.current() == .identifier and self.isContextual("module")) {
+        const next = try self.peekNextKind();
+        if (next == .dot) {
+            // declare module.exports: Type;
+            try self.advance(); // skip 'module'
+            try self.advance(); // skip '.'
+            try self.advance(); // skip 'exports'
+            if (self.current() == .colon) {
+                try self.advance();
+                _ = try parseType(self);
+            }
+            _ = try self.eat(.semicolon);
+            return NodeIndex.none;
+        }
+        // declare module "name" { ... } — ambient module
+        if (next == .string_literal or next == .identifier) {
+            try self.advance(); // skip 'module'
+            try self.advance(); // skip name
+            if (self.current() == .l_curly) {
+                // balanced brace skip
+                try self.advance(); // skip '{'
+                var depth: u32 = 1;
+                while (depth > 0 and self.current() != .eof) {
+                    switch (self.current()) {
+                        .l_curly => depth += 1,
+                        .r_curly => depth -= 1,
+                        else => {},
+                    }
+                    if (depth > 0) try self.advance();
+                }
+                try self.expect(.r_curly);
+            }
+            return NodeIndex.none;
+        }
+    }
+
+    // declare export — Flow 전용 (declare export type, declare export class 등)
+    if (self.current() == .kw_export) {
+        try self.advance(); // skip 'export'
+        // declare export default — skip to semicolon
+        if (try self.eat(.kw_default)) {
+            _ = try parseType(self);
+            _ = try self.eat(.semicolon);
+            return NodeIndex.none;
+        }
+    }
+
+    // declare opaque type — opaque 키워드 후 type
+    if (self.current() == .identifier and self.isContextual("opaque")) {
+        _ = try parseFlowOpaqueType(self);
+        return NodeIndex.none;
+    }
+
+    // declare type/class/function/var/interface — 공통 처리
+    // 내부 선언을 파싱 (AST 노드 생성됨)하지만 반환값은 .none (전체 제거)
+    const saved_ambient = self.ctx;
+    self.ctx.in_ambient = true;
+    _ = try self.parseStatement();
+    self.ctx = saved_ambient;
+    return NodeIndex.none;
+}
+
+// ================================================================
+// Flow Interface Declaration
+// ================================================================
+
+/// interface Foo extends Bar { ... }
+pub fn parseFlowInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
+    const start = self.currentSpan().start;
+    try self.advance(); // skip 'interface'
+
+    const name = try self.parseSimpleIdentifier();
+
+    // 선택적 타입 파라미터: interface Foo<T>
+    var type_params = NodeIndex.none;
+    if (self.isAtOpeningAngleBracket()) {
+        type_params = try parseTypeParameterDeclaration(self);
+    }
+
+    // extends 절: interface Foo extends Bar, Baz
+    var extends_start: u32 = 0;
+    var extends_len: u32 = 0;
+    if (try self.eat(.kw_extends)) {
+        const scratch_top = self.saveScratch();
+        const first = try parseType(self);
+        try self.scratch.append(self.allocator, first);
+        while (try self.eat(.comma)) {
+            const next_type = try parseType(self);
+            try self.scratch.append(self.allocator, next_type);
+        }
+        const items = self.scratch.items[scratch_top..];
+        const list = try self.ast.addNodeList(items);
+        self.scratch.shrinkRetainingCapacity(scratch_top);
+        extends_start = list.start;
+        extends_len = list.len;
+    }
+
+    // body: { ... } — balanced brace skip (타입 스트리핑이므로 내부 구조 불필요)
+    const body_start = self.currentSpan().start;
+    if (self.current() == .l_curly) {
+        try self.advance();
+        var depth: u32 = 1;
+        while (depth > 0 and self.current() != .eof) {
+            switch (self.current()) {
+                .l_curly => depth += 1,
+                .r_curly => depth -= 1,
+                else => {},
+            }
+            if (depth > 0) try self.advance();
+        }
+        try self.expect(.r_curly);
+    }
+    _ = body_start;
+
+    const extra = try self.ast.addExtras(&.{
+        @intFromEnum(name),
+        @intFromEnum(type_params),
+        extends_start,
+        extends_len,
+    });
+    return try self.ast.addNode(.{
+        .tag = .flow_interface_declaration,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .extra = extra },
+    });
+}

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1888,6 +1888,14 @@ pub const Parser = struct {
         return flow.parseFlowOpaqueType(self);
     }
 
+    pub fn parseFlowDeclareStatement(self: *Parser) ParseError2!NodeIndex {
+        return flow.parseFlowDeclareStatement(self);
+    }
+
+    pub fn parseFlowInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
+        return flow.parseFlowInterfaceDeclaration(self);
+    }
+
     pub fn tryParseTypeAnnotation(self: *Parser) ParseError2!NodeIndex {
         if (self.is_flow) return flow.tryParseTypeAnnotation(self);
         return ts.tryParseTypeAnnotation(self);

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -215,8 +215,7 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
                 {
                     break :blk self.parseTsModuleDeclaration();
                 }
-            } else if (!self.is_flow and std.mem.eql(u8, text, "declare")) {
-                // declare — TS 전용 (Flow의 declare는 후속 PR에서 별도 구현)
+            } else if (std.mem.eql(u8, text, "declare")) {
                 const next_decl = try self.peekNext();
                 if (!next_decl.has_newline_before and switch (next_decl.kind) {
                     .semicolon,
@@ -241,6 +240,9 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
                     => false,
                     else => true,
                 }) {
+                    if (self.is_flow) {
+                        break :blk self.parseFlowDeclareStatement();
+                    }
                     break :blk self.parseTsDeclareStatement();
                 }
             } else if (!self.is_flow and std.mem.eql(u8, text, "abstract")) {
@@ -268,6 +270,9 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
             const next_iface = try self.peekNext();
             if (next_iface.has_newline_before) {
                 break :blk_iface parseExpressionOrLabeledStatement(self);
+            }
+            if (self.is_flow) {
+                break :blk_iface self.parseFlowInterfaceDeclaration();
             }
             break :blk_iface self.parseTsInterfaceDeclaration();
         },

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3220,6 +3220,7 @@ pub const Transformer = struct {
             .flow_this_parameter,
             .flow_type_alias_declaration,
             .flow_opaque_type,
+            .flow_interface_declaration,
             => true,
             else => false,
         };


### PR DESCRIPTION
## Summary
- `parseFlowDeclareStatement()`: declare class/function/var/type/opaque/module/module.exports/export
- `parseFlowInterfaceDeclaration()`: interface Foo extends Bar { ... }
- flow_ 태그 독립 사용 (ts_ 핸들러 재사용 안 함)
- 테스트 7개 추가

## Test plan
- [x] declare function/var/class 스트리핑
- [x] declare module.exports 스트리핑
- [x] declare export type 스트리핑
- [x] interface + extends 스트리핑

🤖 Generated with [Claude Code](https://claude.com/claude-code)