### PR TITLE
feat(parser): add Flow as expression — flow_as_expression 독립 태그

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2500,3 +2500,21 @@ test "Flow: declare export type stripped" {
     defer r.deinit();
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
+
+test "Flow: as type cast stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let x = {} as Foo;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x={};", r.output);
+}
+
+test "Flow: chained as cast stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let x = y as Foo as Bar;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=y;", r.output);
+}
+
+test "Flow: parenthesized as cast stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let x = (y as Foo);");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=y;", r.output);
+}

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -352,6 +352,8 @@ pub const Node = struct {
         flow_opaque_type,
         /// interface Foo extends Bar { ... } — Flow interface declaration
         flow_interface_declaration,
+        /// expr as Type — Flow type cast expression
+        flow_as_expression,
 
         // ==============================================================
         // TypeScript Expressions

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -791,19 +791,25 @@ fn parsePostfixExpression(self: *Parser) ParseError2!NodeIndex {
     // TS non-null assertion (expr!) — parseCallExpression 내부에서 처리
     // (체이닝 지원: foo()!.bar!.baz)
 
-    // TS: as Type / satisfies Type (체이닝 가능: x as A as B)
+    // TS/Flow: as Type / satisfies Type (체이닝 가능: x as A as B)
+    // Flow는 as만 지원 (satisfies 없음)
     // ASI: `bar\nas(null)` → 줄바꿈 뒤의 as는 타입 캐스트가 아니라 함수 호출
-    // esbuild: as/satisfies 앞에 줄바꿈이 있으면 ASI 적용
     while (self.current() == .identifier and !self.scanner.token.has_newline_before) {
         const text = self.tokenText();
         const is_as = std.mem.eql(u8, text, "as");
-        const is_satisfies = !is_as and std.mem.eql(u8, text, "satisfies");
+        const is_satisfies = !is_as and !self.is_flow and std.mem.eql(u8, text, "satisfies");
         if (!is_as and !is_satisfies) break;
         const expr_start = self.ast.getNode(expr).span.start;
         try self.advance();
         const ty = try self.parseType();
+        const tag: @import("ast.zig").Node.Tag = if (is_satisfies)
+            .ts_satisfies_expression
+        else if (self.is_flow)
+            .flow_as_expression
+        else
+            .ts_as_expression;
         expr = try self.ast.addNode(.{
-            .tag = if (is_satisfies) .ts_satisfies_expression else .ts_as_expression,
+            .tag = tag,
             .span = .{ .start = expr_start, .end = self.currentSpan().start },
             .data = .{ .binary = .{ .left = expr, .right = ty, .flags = 0 } },
         });

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -401,6 +401,7 @@ pub const Transformer = struct {
             .ts_non_null_expression,
             .ts_type_assertion,
             .ts_instantiation_expression,
+            .flow_as_expression,
             => self.visitTsExpression(node),
 
             // === 리스트 노드: 자식을 하나씩 방문하며 복사 ===
@@ -467,7 +468,8 @@ pub const Transformer = struct {
                     if (inner_tag == .ts_as_expression or
                         inner_tag == .ts_satisfies_expression or
                         inner_tag == .ts_non_null_expression or
-                        inner_tag == .ts_type_assertion)
+                        inner_tag == .ts_type_assertion or
+                        inner_tag == .flow_as_expression)
                     {
                         return self.visitNode(inner);
                     }


### PR DESCRIPTION
## Summary
- `flow_as_expression` AST 태그 추가 (ts_as_expression 재사용 안 함)
- Flow 모드에서 `satisfies` 키워드 비활성화
- transformer에서 `flow_as_expression` → 값만 보존 (타입 제거)
- 괄호 벗기기 (`(x as T)` → `x`)에 flow 태그 추가
- 테스트 3개

🤖 Generated with [Claude Code](https://claude.com/claude-code)