### PR TITLE
feat(parser): add Flow TypeCast, exact object, %checks

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2567,6 +2567,40 @@ test "Flow: consecutive flow comments" {
 }
 
 // ================================================================
+// Flow TypeCast, Exact Object, %checks
+// ================================================================
+
+test "Flow: TypeCast (expr: Type) stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let x = (null: any);");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=null;", r.output);
+}
+
+test "Flow: TypeCast object (expr: Type) stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let x = (obj: Foo);");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=obj;", r.output);
+}
+
+test "Flow: exact object type {| |} stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let x: {| name: string |} = {};");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x={};", r.output);
+}
+
+test "Flow: empty exact object type {||} stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let x: {||} = {};");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x={};", r.output);
+}
+
+test "Flow: %checks predicate stripped" {
+    var r = try e2eFlow(std.testing.allocator, "function f(x: mixed): boolean %checks { return true; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function f(x){return true;}", r.output);
+}
+
+// ================================================================
 // Flow Metro Smoke Test — Metro RN 실제 패턴 통합 테스트
 // ================================================================
 

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -354,6 +354,10 @@ pub const Node = struct {
         flow_interface_declaration,
         /// expr as Type — Flow type cast expression
         flow_as_expression,
+        /// (expr: Type) — Flow TypeCast expression
+        flow_type_cast_expression,
+        /// {| key: Type |} — Flow exact object type
+        flow_exact_object_type,
 
         // ==============================================================
         // TypeScript Expressions

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1351,6 +1351,20 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             const paren_saved = self.enterAllowInContext(true);
             const expr = try parseExpressionOrRest(self);
             self.restoreContext(paren_saved);
+
+            // Flow TypeCast: (expr: Type) — 괄호 안에서 expression 뒤에 `: Type`이 오면
+            if (self.is_flow and self.current() == .colon) {
+                try self.advance(); // skip ':'
+                const cast_type = try self.parseType();
+                _ = cast_type;
+                try self.expect(.r_paren);
+                return try self.ast.addNode(.{
+                    .tag = .flow_type_cast_expression,
+                    .span = .{ .start = span.start, .end = self.currentSpan().start },
+                    .data = .{ .unary = .{ .operand = expr, .flags = 0 } },
+                });
+            }
+
             try self.expect(.r_paren);
             return try self.ast.addNode(.{
                 .tag = .parenthesized_expression,

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -45,11 +45,27 @@ pub fn tryParseTypeAnnotation(self: *Parser) ParseError2!NodeIndex {
 }
 
 /// 리턴 타입 어노테이션 (`: Type`). 함수 선언에서 사용.
-/// Flow는 TS의 type predicate 대신 %checks를 사용하지만, 여기서는 타입만 파싱.
+/// Flow의 `%checks` predicate도 여기서 소비한다 (타입 뒤에 붙을 수 있음).
 pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() != .colon) return NodeIndex.none;
     try self.advance();
-    return parseType(self);
+    const ty = try parseType(self);
+    // %checks — Flow type guard predicate. 타입 스트리핑에서는 무시.
+    // `%`는 .percent 토큰, `checks`는 identifier.
+    if (self.current() == .percent) {
+        const next = try self.peekNextKind();
+        if (next == .identifier) {
+            try self.advance(); // skip '%'
+            try self.advance(); // skip 'checks'
+            // %checks(expr) 형태도 가능
+            if (self.current() == .l_paren) {
+                try self.advance(); // skip '('
+                _ = try self.parseAssignmentExpression();
+                try self.expect(.r_paren);
+            }
+        }
+    }
+    return ty;
 }
 
 /// Flow 타입을 파싱한다.
@@ -247,8 +263,13 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         .identifier => return parseTypeReference(self),
         // 괄호 타입: (Type) 또는 함수 타입: (a: Type) => Type
         .l_paren => return parseParenOrFunctionType(self),
-        // 객체 타입 리터럴: { key: Type, ... }
-        .l_curly => return parseObjectType(self),
+        // exact object type: {| key: Type |} 또는 일반 object type: { key: Type }
+        .l_curly => {
+            if (try self.peekNextKind() == .pipe) {
+                return parseExactObjectType(self);
+            }
+            return parseObjectType(self);
+        },
         // 제네릭 함수 타입: <T>(x: T) => R
         .l_angle => {
             const type_params = try parseTypeParameterDeclaration(self);
@@ -581,6 +602,44 @@ fn parseObjectType(self: *Parser) ParseError2!NodeIndex {
     try self.expect(.r_curly);
     return try self.ast.addNode(.{
         .tag = .flow_literal_type,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .none = 0 },
+    });
+}
+
+/// Exact object type: {| key: Type, ... |}
+/// balanced brace+pipe counting으로 전체를 소비. {| 뒤의 |} 까지.
+fn parseExactObjectType(self: *Parser) ParseError2!NodeIndex {
+    const start = self.currentSpan().start;
+    try self.advance(); // skip '{'
+    try self.advance(); // skip '|'
+
+    // |} 를 찾을 때까지 토큰 소비. 중첩된 {| |} 도 추적.
+    var depth: u32 = 1;
+    while (depth > 0 and self.current() != .eof) {
+        if (self.current() == .l_curly) {
+            // {| 중첩 감지
+            if (try self.peekNextKind() == .pipe) {
+                depth += 1;
+                try self.advance(); // skip '{'
+                try self.advance(); // skip '|'
+                continue;
+            }
+        }
+        if (self.current() == .pipe) {
+            if (try self.peekNextKind() == .r_curly) {
+                depth -= 1;
+                try self.advance(); // skip '|'
+                try self.advance(); // skip '}'
+                if (depth == 0) break;
+                continue;
+            }
+        }
+        try self.advance();
+    }
+
+    return try self.ast.addNode(.{
+        .tag = .flow_exact_object_type,
         .span = .{ .start = start, .end = self.currentSpan().start },
         .data = .{ .none = 0 },
     });

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -402,6 +402,7 @@ pub const Transformer = struct {
             .ts_type_assertion,
             .ts_instantiation_expression,
             .flow_as_expression,
+            .flow_type_cast_expression,
             => self.visitTsExpression(node),
 
             // === 리스트 노드: 자식을 하나씩 방문하며 복사 ===
@@ -469,7 +470,8 @@ pub const Transformer = struct {
                         inner_tag == .ts_satisfies_expression or
                         inner_tag == .ts_non_null_expression or
                         inner_tag == .ts_type_assertion or
-                        inner_tag == .flow_as_expression)
+                        inner_tag == .flow_as_expression or
+                        inner_tag == .flow_type_cast_expression)
                     {
                         return self.visitNode(inner);
                     }
@@ -3223,6 +3225,7 @@ pub const Transformer = struct {
             .flow_type_alias_declaration,
             .flow_opaque_type,
             .flow_interface_declaration,
+            .flow_exact_object_type,
             => true,
             else => false,
         };


### PR DESCRIPTION
## Summary
- `(expr: Type)` TypeCast — 괄호 안 colon 뒤 타입을 감지, 값만 보존
- `{| key: Type |}` Exact object type — balanced `{|` `|}` counting
- `%checks` predicate — 리턴 타입 뒤에서 소비, `%checks(expr)` 형태도 지원
- 테스트 5개 추가

## Test plan
- [x] `(null: any)` → `null`
- [x] `(obj: Foo)` → `obj`
- [x] `{| name: string |}` 스트리핑
- [x] `{||}` 빈 exact object 스트리핑
- [x] `%checks` predicate 스트리핑

🤖 Generated with [Claude Code](https://claude.com/claude-code)