### PR TITLE
fix: /simplify — %checks 텍스트 검증 + exact object 루프 가드

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1355,8 +1355,8 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             // Flow TypeCast: (expr: Type) — 괄호 안에서 expression 뒤에 `: Type`이 오면
             if (self.is_flow and self.current() == .colon) {
                 try self.advance(); // skip ':'
-                const cast_type = try self.parseType();
-                _ = cast_type;
+                // 타입을 파싱하여 스캐너 위치를 진행시킴 (AST 노드는 스트리핑됨)
+                _ = try self.parseType();
                 try self.expect(.r_paren);
                 return try self.ast.addNode(.{
                     .tag = .flow_type_cast_expression,

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -55,7 +55,13 @@ pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .percent) {
         const next = try self.peekNextKind();
         if (next == .identifier) {
+            // %checks만 유효 — %foo 같은 임의 identifier는 무시
+            const saved = self.saveState();
             try self.advance(); // skip '%'
+            if (!std.mem.eql(u8, self.tokenText(), "checks")) {
+                self.restoreState(saved);
+                return ty;
+            }
             try self.advance(); // skip 'checks'
             // %checks(expr) 형태도 가능
             if (self.current() == .l_paren) {
@@ -617,6 +623,7 @@ fn parseExactObjectType(self: *Parser) ParseError2!NodeIndex {
     // |} 를 찾을 때까지 토큰 소비. 중첩된 {| |} 도 추적.
     var depth: u32 = 1;
     while (depth > 0 and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
         if (self.current() == .l_curly) {
             // {| 중첩 감지
             if (try self.peekNextKind() == .pipe) {
@@ -636,6 +643,7 @@ fn parseExactObjectType(self: *Parser) ParseError2!NodeIndex {
             }
         }
         try self.advance();
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
     return try self.ast.addNode(.{


### PR DESCRIPTION
simplify 리뷰 반영. %checks 오탐 방지, parseExactObjectType 무한 루프 방지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)