### PR TITLE
fix: flow comment — has_flow_pragma 동기화 + /*:: */ 블록 스킵

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -546,6 +546,7 @@ pub const ModuleGraph = struct {
         if (!parser.is_ts) {
             if (self.flow) {
                 parser.is_flow = true;
+                scanner.has_flow_pragma = true; // flow comment 활성화
             } else {
                 parser.configureFlowFromPath(module.path);
             }

--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -930,10 +930,16 @@ pub const Scanner = struct {
         // Flow comment 감지: /*:: (블록) 또는 /*: (인라인 타입)
         if (self.has_flow_pragma and self.current < self.source.len and self.source[self.current] == ':') {
             if (self.current + 1 < self.source.len and self.source[self.current + 1] == ':') {
-                // /*:: — 블록 flow comment. 내용을 코드로 파싱.
-                self.current += 2; // skip '::'
-                self.in_flow_comment = true;
-                return false; // 주석 처리 종료 — 이후 next()가 내부 코드를 스캔
+                // /*:: — 블록 flow comment. 내용은 전부 type-only 선언이므로
+                // 스트리핑 대상 → 파싱하지 않고 */ 까지 통째로 스킵.
+                while (self.current + 1 < self.source.len) {
+                    if (self.source[self.current] == '*' and self.source[self.current + 1] == '/') {
+                        self.current += 2; // skip */
+                        break;
+                    }
+                    self.current += 1;
+                }
+                return false;
             }
             // /*: — 인라인 flow comment (: Type */). colon부터 코드로 파싱.
             self.in_flow_comment = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -535,6 +535,7 @@ fn transpileFile(
     if (!parser.is_ts) {
         if (options.flow) {
             parser.is_flow = true;
+            scanner.has_flow_pragma = true; // flow comment (/*:: */, /*: */) 활성화
         } else {
             parser.configureFlowFromPath(file_path);
         }

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -289,9 +289,11 @@ pub const Parser = struct {
         if (self.is_ts) return; // TS와 Flow는 상호 배타
         if (std.mem.endsWith(u8, file_path, ".js.flow")) {
             self.is_flow = true;
+            self.scanner.has_flow_pragma = true; // flow comment 활성화
         } else if (std.mem.endsWith(u8, file_path, ".jsx.flow")) {
             self.is_flow = true;
             self.is_jsx = true;
+            self.scanner.has_flow_pragma = true;
         }
     }
 


### PR DESCRIPTION
## Summary
- `--flow` CLI / `.js.flow` 확장자에서 `scanner.has_flow_pragma` 설정 누락 수정
- `/*:: */` 블록 flow comment: 파싱 대신 통째로 스킵 (script 모드 import 에러 방지)
- Metro babel-register.js (CJS + flow comment) 정상 동작 확인
- 410/410 Metro @flow 파일 파싱 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)