### PR TITLE
feat(bundler): add --resolve-extensions + --main-fields CLI options

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -101,6 +101,10 @@ pub const BundleOptions = struct {
     plugins: []const plugin_mod.Plugin = &.{},
     /// Flow 모드 강제 활성화 (--flow). @flow pragma 없이도 .js/.jsx를 Flow로 파싱.
     flow: bool = false,
+    /// 커스텀 확장자 탐색 순서 (--resolve-extensions). 비어있으면 기본값 사용.
+    resolve_extensions: []const []const u8 = &.{},
+    /// package.json 필드 해석 순서 (--main-fields). 비어있으면 기본 (module → main).
+    main_fields: []const []const u8 = &.{},
 
     pub const AliasEntry = types.AliasEntry;
 };
@@ -216,6 +220,8 @@ pub const Bundler = struct {
                 .custom_conditions = options.conditions,
                 .preserve_symlinks = options.preserve_symlinks,
                 .alias = options.alias,
+                .resolve_extensions = options.resolve_extensions,
+                .main_fields = options.main_fields,
             }),
         };
     }

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -111,6 +111,8 @@ pub const ResolveCache = struct {
         custom_conditions: []const []const u8 = &.{},
         preserve_symlinks: bool = false,
         alias: []const resolver_mod.AliasEntry = &.{},
+        resolve_extensions: []const []const u8 = &.{},
+        main_fields: []const []const u8 = &.{},
     };
 
     pub fn init(
@@ -125,6 +127,8 @@ pub const ResolveCache = struct {
         var r = Resolver.init(allocator);
         r.preserve_symlinks = preserve_symlinks;
         r.alias = alias;
+        r.custom_extensions = options.resolve_extensions;
+        r.main_fields = options.main_fields;
         const has_custom = custom_conditions.len > 0;
         const cond_import = if (has_custom)
             buildConditions(allocator, baseConditionsFor(platform, .static_import), custom_conditions) catch baseConditionsFor(platform, .static_import)

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -41,6 +41,17 @@ pub const ResolveError = error{
     OutOfMemory,
 };
 
+/// JSON object에서 문자열 필드를 읽는다. package.json의 임의 필드 조회용.
+fn getJsonStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    if (obj.get(key)) |val| {
+        switch (val) {
+            .string => |s| return s,
+            else => return null,
+        }
+    }
+    return null;
+}
+
 /// 기본 확장자 탐색 순서.
 /// TypeScript 확장자가 먼저 (TS 프로젝트에서 .ts가 .js보다 우선).
 /// .mts/.cts는 ESM/CJS 모듈 전용 TypeScript 확장자.
@@ -73,6 +84,12 @@ pub const Resolver = struct {
     /// 정확 매칭: "react" → "preact/compat"
     /// 접두사 매칭: "react/hooks" → "preact/compat/hooks"
     alias: []const AliasEntry = &.{},
+    /// 커스텀 확장자 탐색 순서 (--resolve-extensions). 비어있으면 default_extensions 사용.
+    /// RN 예: .ios.ts, .ios.tsx, .native.ts, .native.tsx, .ts, .tsx, .js, .jsx, .json
+    custom_extensions: []const []const u8 = &.{},
+    /// package.json 필드 해석 순서 (--main-fields). 비어있으면 기본 순서 (module → main).
+    /// RN 예: react-native, browser, main, module
+    main_fields: []const []const u8 = &.{},
 
     pub fn init(allocator: std.mem.Allocator) Resolver {
         return .{ .allocator = allocator };
@@ -151,8 +168,10 @@ pub const Resolver = struct {
     }
 
     /// 확장자를 하나씩 붙여서 존재하는 파일을 찾는다.
+    /// custom_extensions가 설정되어 있으면 그것을 사용, 아니면 default_extensions.
     fn tryExtensions(self: *Resolver, base: []const u8) ResolveError!?ResolveResult {
-        for (default_extensions) |ext| {
+        const extensions = if (self.custom_extensions.len > 0) self.custom_extensions else default_extensions;
+        for (extensions) |ext| {
             const path = std.mem.concat(self.allocator, u8, &.{ base, ext }) catch
                 return error.OutOfMemory;
             defer self.allocator.free(path);
@@ -196,13 +215,24 @@ pub const Resolver = struct {
         // 예: fp-ts/function/package.json → { "main": "../lib/function.js", "module": "../es6/function.js" }
         if (try self.tryDirectoryPackageJson(path)) |result| return result;
 
-        for (index_files) |index_name| {
-            const index_path = std.fs.path.resolve(self.allocator, &.{ path, index_name }) catch
-                return error.OutOfMemory;
-            defer self.allocator.free(index_path);
-
-            if (self.fileExists(index_path)) {
-                return self.makeResult(index_path);
+        // custom_extensions가 있으면 "index" + 각 확장자로 탐색
+        const extensions = if (self.custom_extensions.len > 0) self.custom_extensions else default_extensions;
+        if (self.custom_extensions.len > 0) {
+            for (extensions) |ext| {
+                const index_name = std.mem.concat(self.allocator, u8, &.{ "index", ext }) catch
+                    return error.OutOfMemory;
+                defer self.allocator.free(index_name);
+                const index_path = std.fs.path.resolve(self.allocator, &.{ path, index_name }) catch
+                    return error.OutOfMemory;
+                defer self.allocator.free(index_path);
+                if (self.fileExists(index_path)) return self.makeResult(index_path);
+            }
+        } else {
+            for (index_files) |index_name| {
+                const index_path = std.fs.path.resolve(self.allocator, &.{ path, index_name }) catch
+                    return error.OutOfMemory;
+                defer self.allocator.free(index_path);
+                if (self.fileExists(index_path)) return self.makeResult(index_path);
             }
         }
         return null;
@@ -219,25 +249,42 @@ pub const Resolver = struct {
 
         const pkg = &parsed.pkg;
 
-        // module 필드 우선 (ESM)
-        if (pkg.module) |mod| {
-            const abs_path = std.fs.path.resolve(self.allocator, &.{ dir_path, mod }) catch
-                return error.OutOfMemory;
-            defer self.allocator.free(abs_path);
-            if (self.fileExists(abs_path)) {
-                var result = (try self.makeResult(abs_path)) orelse return null;
-                result.is_module_field = true;
-                return result;
+        if (self.main_fields.len > 0) {
+            const obj = parsed.parsed.value.object;
+            for (self.main_fields) |field| {
+                if (getJsonStr(obj, field)) |value| {
+                    const abs_path = std.fs.path.resolve(self.allocator, &.{ dir_path, value }) catch
+                        return error.OutOfMemory;
+                    defer self.allocator.free(abs_path);
+                    if (self.fileExists(abs_path)) {
+                        var result = (try self.makeResult(abs_path)) orelse return null;
+                        result.is_module_field = std.mem.eql(u8, field, "module");
+                        return result;
+                    }
+                    if (try self.tryExtensions(abs_path)) |result| return result;
+                }
             }
-        }
+        } else {
+            // module 필드 우선 (ESM)
+            if (pkg.module) |mod| {
+                const abs_path = std.fs.path.resolve(self.allocator, &.{ dir_path, mod }) catch
+                    return error.OutOfMemory;
+                defer self.allocator.free(abs_path);
+                if (self.fileExists(abs_path)) {
+                    var result = (try self.makeResult(abs_path)) orelse return null;
+                    result.is_module_field = true;
+                    return result;
+                }
+            }
 
-        // main 필드
-        if (pkg.main) |main| {
-            const abs_path = std.fs.path.resolve(self.allocator, &.{ dir_path, main }) catch
-                return error.OutOfMemory;
-            defer self.allocator.free(abs_path);
-            if (self.fileExists(abs_path)) return self.makeResult(abs_path);
-            if (try self.tryExtensions(abs_path)) |result| return result;
+            // main 필드
+            if (pkg.main) |main| {
+                const abs_path = std.fs.path.resolve(self.allocator, &.{ dir_path, main }) catch
+                    return error.OutOfMemory;
+                defer self.allocator.free(abs_path);
+                if (self.fileExists(abs_path)) return self.makeResult(abs_path);
+                if (try self.tryExtensions(abs_path)) |result| return result;
+            }
         }
 
         return null;
@@ -334,26 +381,44 @@ pub const Resolver = struct {
             return null;
         }
 
-        // 2. module 필드 (ESM 엔트리, exports 없을 때)
-        if (pkg.module) |mod| {
-            const abs_path = std.fs.path.resolve(self.allocator, &.{ pkg_dir_path, mod }) catch
-                return error.OutOfMemory;
-            defer self.allocator.free(abs_path);
-            if (self.fileExists(abs_path)) {
-                var result = (try self.makeResult(abs_path)) orelse return null;
-                result.is_module_field = true;
-                return result;
+        // main_fields가 설정되면 지정된 순서로 필드 탐색
+        if (self.main_fields.len > 0) {
+            const obj = parsed.parsed.value.object;
+            for (self.main_fields) |field| {
+                if (getJsonStr(obj, field)) |value| {
+                    const abs_path = std.fs.path.resolve(self.allocator, &.{ pkg_dir_path, value }) catch
+                        return error.OutOfMemory;
+                    defer self.allocator.free(abs_path);
+                    if (self.fileExists(abs_path)) {
+                        var result = (try self.makeResult(abs_path)) orelse return null;
+                        result.is_module_field = std.mem.eql(u8, field, "module");
+                        return result;
+                    }
+                    if (try self.tryExtensions(abs_path)) |result| return result;
+                }
             }
-        }
+        } else {
+            // 기본 순서: module → main
+            // 2. module 필드 (ESM 엔트리, exports 없을 때)
+            if (pkg.module) |mod| {
+                const abs_path = std.fs.path.resolve(self.allocator, &.{ pkg_dir_path, mod }) catch
+                    return error.OutOfMemory;
+                defer self.allocator.free(abs_path);
+                if (self.fileExists(abs_path)) {
+                    var result = (try self.makeResult(abs_path)) orelse return null;
+                    result.is_module_field = true;
+                    return result;
+                }
+            }
 
-        // 3. main 필드 (CJS 엔트리)
-        if (pkg.main) |main| {
-            const abs_path = std.fs.path.resolve(self.allocator, &.{ pkg_dir_path, main }) catch
-                return error.OutOfMemory;
-            defer self.allocator.free(abs_path);
-            if (self.fileExists(abs_path)) return self.makeResult(abs_path);
-            // main에 확장자가 없을 수 있음
-            if (try self.tryExtensions(abs_path)) |result| return result;
+            // 3. main 필드 (CJS 엔트리)
+            if (pkg.main) |main| {
+                const abs_path = std.fs.path.resolve(self.allocator, &.{ pkg_dir_path, main }) catch
+                    return error.OutOfMemory;
+                defer self.allocator.free(abs_path);
+                if (self.fileExists(abs_path)) return self.makeResult(abs_path);
+                if (try self.tryExtensions(abs_path)) |result| return result;
+            }
         }
 
         // 4. index 파일 폴백

--- a/src/main.zig
+++ b/src/main.zig
@@ -74,6 +74,10 @@ const CliOptions = struct {
     proxy_list: std.ArrayList(lib.server.DevServer.ProxyRule) = .empty,
     /// Flow 모드 강제 활성화. @flow pragma 없이도 .js/.jsx를 Flow로 파싱한다.
     flow: bool = false,
+    /// 커스텀 확장자 탐색 순서 (--resolve-extensions=.ios.ts,.ts,...)
+    resolve_extensions_list: std.ArrayList([]const u8) = .empty,
+    /// package.json 필드 해석 순서 (--main-fields=react-native,browser,main)
+    main_fields_list: std.ArrayList([]const u8) = .empty,
 
     const AliasEntry = BundleOptions.AliasEntry;
     const LoaderOverride = @import("zts_lib").bundler.types.LoaderOverride;
@@ -193,6 +197,18 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             opts.watch = true;
         } else if (std.mem.eql(u8, arg, "--flow")) {
             opts.flow = true;
+        } else if (std.mem.startsWith(u8, arg, "--resolve-extensions=")) {
+            const val = arg["--resolve-extensions=".len..];
+            var it = std.mem.splitScalar(u8, val, ',');
+            while (it.next()) |ext| {
+                if (ext.len > 0) try opts.resolve_extensions_list.append(allocator, ext);
+            }
+        } else if (std.mem.startsWith(u8, arg, "--main-fields=")) {
+            const val = arg["--main-fields=".len..];
+            var it = std.mem.splitScalar(u8, val, ',');
+            while (it.next()) |field| {
+                if (field.len > 0) try opts.main_fields_list.append(allocator, field);
+            }
         } else if (std.mem.eql(u8, arg, "--timing")) {
             opts.timing = true;
         } else if (std.mem.eql(u8, arg, "--bundle")) {
@@ -1065,6 +1081,8 @@ pub fn main() !void {
             .keep_names = opts.keep_names,
             .plugins = plugin_list.items,
             .flow = opts.flow,
+            .resolve_extensions = opts.resolve_extensions_list.items,
+            .main_fields = opts.main_fields_list.items,
         };
 
         // config 파일 옵션 적용 — 첫 번째 플러그인의 config만 사용 (CLI가 우선)
@@ -1737,6 +1755,10 @@ fn printUsage(writer: anytype) !void {
         \\
         \\Flow options:
         \\  --flow                            Enable Flow type stripping (auto-detected via @flow pragma)
+        \\
+        \\Resolve options:
+        \\  --resolve-extensions=<exts>       Comma-separated extension order (e.g. .ios.ts,.ts,.js)
+        \\  --main-fields=<fields>            Comma-separated package.json field order (e.g. react-native,browser,main)
         \\
     , .{});
 }


### PR DESCRIPTION
## Summary
RN 플랫폼 확장자 및 package.json 필드 순서를 범용 옵션으로 지원.

- `--resolve-extensions=.ios.ts,.native.ts,.ts,.js` — 확장자 탐색 순서 오버라이드
- `--main-fields=react-native,browser,main,module` — package.json 필드 해석 순서 오버라이드
- 전파 경로: CLI → BundleOptions → ResolveCache → Resolver

## RN 사용 예시
```bash
zts --bundle entry.js \
  --resolve-extensions=.ios.ts,.ios.tsx,.ios.js,.native.ts,.native.tsx,.native.js,.ts,.tsx,.js,.json \
  --main-fields=react-native,browser,main,module \
  --conditions=react-native,import,require,default \
  --flow
```

## Test plan
- [x] `zig build test` 전체 통과
- [x] CLI 파싱 동작
- [x] resolver에서 custom_extensions 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)