### PR TITLE
fix: free plugin_paths and proxy_list in CliOptions.deinit

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -101,6 +101,8 @@ const CliOptions = struct {
         self.loader_list.deinit(alloc);
         for (self.inject_list.items) |p| alloc.free(p);
         self.inject_list.deinit(alloc);
+        self.plugin_paths.deinit(alloc);
+        self.proxy_list.deinit(alloc);
         self.resolve_extensions_list.deinit(alloc);
         self.main_fields_list.deinit(alloc);
     }


### PR DESCRIPTION
## Summary
- Debug 빌드에서 `--plugin`, `--proxy` 옵션 사용 시 GPA memory leak 경고 수정
- `CliOptions.deinit`에 `plugin_paths.deinit()`와 `proxy_list.deinit()` 추가 (2줄)

## Test plan
- [x] `zig build test` 통과
- [x] `--plugin` 사용 시 `error(gpa): memory address leaked` 메시지 사라짐 확인
- [x] `--proxy`, `--external`, `--inject`, `--define` 등 다양한 옵션 조합에서 leak 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)