### PR TITLE
feat(bundler): auto-detect and bundle Web Workers

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -258,6 +258,112 @@ pub const Bundler = struct {
         };
     }
 
+    /// 출력 코드에서 Worker의 new URL("specifier", ...) 패턴을 worker 파일명 문자열로 교체.
+    /// 코드를 한 번만 스캔하면서 모든 new URL( 패턴을 매칭 (다중 worker 순서 독립).
+    fn rewriteWorkerURLs(self: *Bundler, code: []u8, graph: *ModuleGraph, worker_map: *std.StringHashMap([]const u8)) ![]const u8 {
+        // specifier → worker filename 매핑 구축
+        var spec_to_filename = std.StringHashMap([]const u8).init(self.allocator);
+        defer spec_to_filename.deinit();
+        for (graph.worker_entries.items) |we| {
+            const filename = worker_map.get(we.resolved_path) orelse continue;
+            const mod = &graph.modules.items[@intFromEnum(we.source_module)];
+            if (we.record_index >= mod.import_records.len) continue;
+            try spec_to_filename.put(mod.import_records[we.record_index].specifier, filename);
+        }
+
+        var result: std.ArrayListUnmanaged(u8) = .empty;
+        defer result.deinit(self.allocator);
+        try result.ensureTotalCapacity(self.allocator, code.len);
+
+        const needle = "new URL(";
+        var pos: usize = 0;
+        while (std.mem.indexOf(u8, code[pos..], needle)) |rel| {
+            const abs_start = pos + rel;
+            const after = abs_start + needle.len;
+            // new URL("specifier", ...) — 따옴표 시작 확인
+            if (after < code.len and code[after] == '"') {
+                // specifier 끝 따옴표 찾기
+                if (std.mem.indexOf(u8, code[after + 1 ..], "\"")) |quote_end| {
+                    const spec = code[after + 1 .. after + 1 + quote_end];
+                    // 닫는 괄호 찾기
+                    if (std.mem.indexOf(u8, code[abs_start..], ")")) |paren_end| {
+                        const replace_end = abs_start + paren_end + 1;
+                        if (spec_to_filename.get(spec)) |filename| {
+                            try result.appendSlice(self.allocator, code[pos..abs_start]);
+                            try result.append(self.allocator, '"');
+                            try result.appendSlice(self.allocator, "./");
+                            try result.appendSlice(self.allocator, filename);
+                            try result.append(self.allocator, '"');
+                            pos = replace_end;
+                            continue;
+                        }
+                    }
+                }
+            }
+            // 매칭 안 되면 needle 지나서 계속
+            try result.appendSlice(self.allocator, code[pos .. abs_start + needle.len]);
+            pos = abs_start + needle.len;
+        }
+        try result.appendSlice(self.allocator, code[pos..]);
+
+        self.allocator.free(code);
+        return try result.toOwnedSlice(self.allocator);
+    }
+
+    const WorkerBuildResult = struct {
+        filename: []const u8,
+        contents: []const u8,
+    };
+
+    /// Worker 파일을 독립 IIFE 번들로 빌드한다.
+    fn buildWorker(self: *Bundler, worker_path: []const u8) !WorkerBuildResult {
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena.deinit();
+        const arena_alloc = arena.allocator();
+
+        // worker용 resolve cache (부모와 공유하지 않음)
+        var worker_resolve_cache = ResolveCache.init(arena_alloc, .{ .platform = self.resolve_cache.platform });
+
+        var worker_graph = ModuleGraph.init(arena_alloc, &worker_resolve_cache);
+        worker_graph.loader_overrides = self.options.loader_overrides;
+        worker_graph.public_path = self.options.public_path;
+        worker_graph.plugins = self.options.plugins;
+        worker_graph.flow = self.options.flow;
+        defer worker_graph.deinit();
+
+        const entry_path = try arena_alloc.dupe(u8, worker_path);
+        const entry_arr: [1][]const u8 = .{entry_path};
+        try worker_graph.build(&entry_arr);
+
+        // 링킹
+        var worker_linker = Linker.init(arena_alloc, worker_graph.modules.items);
+        try worker_linker.link();
+        try worker_linker.computeRenames();
+        if (self.options.minify_identifiers) {
+            try worker_linker.computeMangling();
+        }
+        defer worker_linker.deinit();
+
+        // emit (IIFE 포맷)
+        var emit_opts = self.makeEmitOptions();
+        emit_opts.format = .iife;
+        const worker_output = try emitter.emitWithTreeShaking(
+            arena_alloc,
+            &worker_graph,
+            emit_opts,
+            &worker_linker,
+            null,
+        );
+
+        // content hash로 파일명 생성
+        const hash = std.hash.Crc32.hash(worker_output);
+        const basename = std.fs.path.stem(std.fs.path.basename(worker_path));
+        const filename = try std.fmt.allocPrint(self.allocator, "{s}-{x:0>8}.js", .{ basename, hash });
+        const contents = try self.allocator.dupe(u8, worker_output);
+
+        return .{ .filename = filename, .contents = contents };
+    }
+
     /// 번들 파이프라인 실행: resolve → graph → emit.
     /// graph는 함수 내에서 생성+해제. &self.resolve_cache 포인터는 self가 살아있는 동안 유효.
     pub fn bundle(self: *Bundler) !BundleResult {
@@ -282,6 +388,30 @@ pub const Bundler = struct {
         defer graph.deinit();
 
         try graph.build(self.options.entry_points);
+
+        // Worker 별도 빌드: new Worker(new URL(...)) 패턴에서 수집된 worker 경로를 독립 IIFE로 빌드
+        var worker_output_map = std.StringHashMap([]const u8).init(self.allocator);
+        defer {
+            var it = worker_output_map.valueIterator();
+            while (it.next()) |v| self.allocator.free(v.*);
+            worker_output_map.deinit();
+        }
+        var worker_output_files: std.ArrayList(OutputFile) = .empty;
+        defer worker_output_files.deinit(self.allocator);
+
+        for (graph.worker_entries.items) |we| {
+            // 같은 worker 파일이 여러 곳에서 참조되면 한 번만 빌드
+            if (worker_output_map.contains(we.resolved_path)) continue;
+
+            const worker_result = self.buildWorker(we.resolved_path) catch {
+                continue;
+            };
+            try worker_output_map.put(we.resolved_path, worker_result.filename);
+            try worker_output_files.append(self.allocator, .{
+                .path = try self.allocator.dupe(u8, worker_result.filename),
+                .contents = worker_result.contents,
+            });
+        }
 
         if (timer) |*t| {
             t_graph = t.read();
@@ -389,6 +519,11 @@ pub const Bundler = struct {
             );
         }
         errdefer self.allocator.free(output);
+
+        // Worker URL 교체: 출력 코드에서 new URL("./worker.ts", "") → "./worker-[hash].js"
+        if (graph.worker_entries.items.len > 0 and output.len > 0) {
+            output = try self.rewriteWorkerURLs(@constCast(output), &graph, &worker_output_map);
+        }
 
         if (timer) |*t| {
             t_emit = t.read();
@@ -509,6 +644,21 @@ pub const Bundler = struct {
             runner.runGenerateBundle(gen_outputs);
         }
 
+        // Worker 출력 파일을 asset_outputs에 합침
+        const final_asset_outputs: ?[]OutputFile = if (worker_output_files.items.len > 0 or asset_outputs != null) blk: {
+            const existing = if (asset_outputs) |a| a.len else 0;
+            const total = existing + worker_output_files.items.len;
+            const merged = try self.allocator.alloc(OutputFile, total);
+            if (asset_outputs) |a| {
+                @memcpy(merged[0..a.len], a);
+                self.allocator.free(a);
+            }
+            for (worker_output_files.items, 0..) |wf, i| {
+                merged[existing + i] = wf;
+            }
+            break :blk merged;
+        } else asset_outputs;
+
         return .{
             .output = output,
             .sourcemap = dev_sourcemap,
@@ -516,7 +666,7 @@ pub const Bundler = struct {
             .diagnostics = diagnostics,
             .module_paths = module_paths,
             .module_dev_codes = module_dev_codes,
-            .asset_outputs = asset_outputs,
+            .asset_outputs = final_asset_outputs,
             .metafile_json = metafile_json,
         };
     }

--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -11355,3 +11355,180 @@ test "Batch D: inject — inject file included in metafile inputs" {
     // inject 파일도 metafile inputs에 포함
     try std.testing.expect(std.mem.indexOf(u8, result.metafile_json.?, "shim.js") != null);
 }
+
+// ============================================================
+// Web Worker auto-bundling
+// ============================================================
+
+test "Worker: new Worker(new URL) produces separate IIFE bundle" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\const w = new Worker(new URL('./worker.ts', import.meta.url));
+        \\w.postMessage('hi');
+    );
+    try writeFile(tmp.dir, "worker.ts",
+        \\self.onmessage = (e) => self.postMessage('pong');
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    // 메인 번들에 worker URL이 교체됨 (new URL 대신 문자열)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(\"./worker-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".js\")") != null);
+    // new URL이 사라짐
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new URL(") == null);
+
+    // worker 번들이 asset_outputs에 포함
+    try std.testing.expect(result.asset_outputs != null);
+    const assets = result.asset_outputs.?;
+    try std.testing.expect(assets.len >= 1);
+
+    // worker 번들이 IIFE로 래핑
+    var found_worker = false;
+    for (assets) |a| {
+        if (std.mem.startsWith(u8, a.path, "worker-")) {
+            found_worker = true;
+            try std.testing.expect(std.mem.indexOf(u8, a.contents, "self.onmessage") != null);
+            try std.testing.expect(std.mem.startsWith(u8, a.contents, "(function() {"));
+        }
+    }
+    try std.testing.expect(found_worker);
+}
+
+test "Worker: no Worker pattern means no extra assets" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1; console.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // worker가 없으면 asset_outputs가 null
+    try std.testing.expect(result.asset_outputs == null);
+}
+
+test "Worker: multiple workers produce separate bundles" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\const w1 = new Worker(new URL('./worker-a.ts', import.meta.url));
+        \\const w2 = new Worker(new URL('./worker-b.ts', import.meta.url));
+        \\w1.postMessage('a');
+        \\w2.postMessage('b');
+    );
+    try writeFile(tmp.dir, "worker-a.ts", "self.onmessage = (e) => self.postMessage('a');");
+    try writeFile(tmp.dir, "worker-b.ts", "self.onmessage = (e) => self.postMessage('b');");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    // 두 worker URL이 모두 교체됨
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(\"./worker-a-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(\"./worker-b-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new URL(") == null);
+
+    // 2개 worker 번들이 asset_outputs에 포함
+    try std.testing.expect(result.asset_outputs != null);
+    try std.testing.expect(result.asset_outputs.?.len >= 2);
+
+    var found_a = false;
+    var found_b = false;
+    for (result.asset_outputs.?) |a| {
+        if (std.mem.startsWith(u8, a.path, "worker-a-")) found_a = true;
+        if (std.mem.startsWith(u8, a.path, "worker-b-")) found_b = true;
+    }
+    try std.testing.expect(found_a);
+    try std.testing.expect(found_b);
+}
+
+test "Worker: duplicate references to same worker build only once" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\const w1 = new Worker(new URL('./worker.ts', import.meta.url));
+        \\const w2 = new Worker(new URL('./worker.ts', import.meta.url));
+        \\w1.postMessage('first');
+        \\w2.postMessage('second');
+    );
+    try writeFile(tmp.dir, "worker.ts", "self.onmessage = (e) => self.postMessage('ok');");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    // 두 참조 모두 같은 파일명으로 교체
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(\"./worker-") != null);
+    // new URL은 전부 사라짐
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new URL(") == null);
+
+    // asset_outputs에 worker 번들 1개만 (중복 빌드 방지)
+    try std.testing.expect(result.asset_outputs != null);
+    var worker_count: usize = 0;
+    for (result.asset_outputs.?) |a| {
+        if (std.mem.startsWith(u8, a.path, "worker-")) worker_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), worker_count);
+}
+
+test "Worker: SharedWorker is also detected" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\const sw = new SharedWorker(new URL('./shared.ts', import.meta.url));
+        \\sw.port.postMessage('hi');
+    );
+    try writeFile(tmp.dir, "shared.ts", "self.onconnect = (e) => {};");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new SharedWorker(\"./shared-") != null);
+    try std.testing.expect(result.asset_outputs != null);
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -72,6 +72,18 @@ pub const ModuleGraph = struct {
     plugins: []const plugin_mod.Plugin = &.{},
     /// Flow 모드 강제 활성화 (--flow). bundler에서 전파.
     flow: bool = false,
+    /// Worker 엔트리: new Worker(new URL(...)) 패턴에서 수집된 worker 파일 경로.
+    /// 메인 그래프에는 모듈로 추가하지 않고, bundler에서 별도 빌드한다.
+    worker_entries: std.ArrayList(WorkerEntry) = .empty,
+
+    pub const WorkerEntry = struct {
+        /// resolve된 worker 파일 절대 경로
+        resolved_path: []const u8,
+        /// worker를 참조하는 모듈 인덱스
+        source_module: ModuleIndex,
+        /// 해당 모듈의 import_records 내 인덱스
+        record_index: u32,
+    };
 
     pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGraph {
         return .{
@@ -100,6 +112,10 @@ pub const ModuleGraph = struct {
         while (se_it.next()) |se| se.deinit(self.allocator);
         self.side_effects_cache.deinit();
         self.diagnostics.deinit(self.allocator);
+        for (self.worker_entries.items) |we| {
+            self.allocator.free(we.resolved_path);
+        }
+        self.worker_entries.deinit(self.allocator);
     }
 
     /// 확장자에 대한 로더를 결정한다.
@@ -339,6 +355,11 @@ pub const ModuleGraph = struct {
         is_error: bool,
     ) !void {
         if (is_error) {
+            // Worker resolve 실패 → 경고만 (메인 빌드 중단하지 않음)
+            if (record.kind == .worker) {
+                self.addDiag(.unresolved_import, .warning, self.modules.items[mod_idx].path, record.span, .resolve, "Cannot resolve worker module", record.specifier);
+                return;
+            }
             // ModuleNotFound — browser에서 Node 빌트인은 빈 CJS로 대체
             if (self.resolve_cache.platform == .browser and resolve_cache_mod.isNodeBuiltin(record.specifier)) {
                 const dep_idx = try self.addDisabledModule(record.specifier);
@@ -357,6 +378,17 @@ pub const ModuleGraph = struct {
 
         if (resolved) |r| {
             defer self.allocator.free(r.path);
+
+            // Worker: 메인 그래프에 모듈로 추가하지 않고 경로만 수집
+            if (record.kind == .worker) {
+                const path_dupe = try self.allocator.dupe(u8, r.path);
+                try self.worker_entries.append(self.allocator, .{
+                    .resolved_path = path_dupe,
+                    .source_module = @enumFromInt(mod_idx),
+                    .record_index = @intCast(rec_i),
+                });
+                return;
+            }
 
             if (r.disabled) {
                 const dep_idx = try self.addDisabledModule(record.specifier);

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -90,6 +90,11 @@ pub fn extractImportsWithCjsDetection(allocator: std.mem.Allocator, ast: *const 
                     try records.append(allocator, record);
                 }
             },
+            .new_expression => {
+                if (tryExtractWorkerNew(ast, node)) |record| {
+                    try records.append(allocator, record);
+                }
+            },
             .assignment_expression => {
                 if (!has_module_exports and isModuleExportsAssign(ast, node)) {
                     has_module_exports = true;
@@ -283,6 +288,102 @@ fn getStringLiteralText(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
     if (node.tag != .string_literal) return null;
 
     return stripQuotes(ast.source[node.span.start..node.span.end]);
+}
+
+/// new Worker(new URL('./worker.ts', import.meta.url)) 패턴 감지.
+/// new_expression extra: [callee, args_start, args_len, flags]
+fn tryExtractWorkerNew(ast: *const Ast, node: Node) ?ImportRecord {
+    const e = node.data.extra;
+    if (!ast.hasExtra(e, 2)) return null;
+
+    // callee가 "Worker" 또는 "SharedWorker"인지 확인
+    const callee_idx = ast.readExtraNode(e, 0);
+    if (callee_idx.isNone()) return null;
+    const callee_ni = @intFromEnum(callee_idx);
+    if (callee_ni >= ast.nodes.items.len) return null;
+    const callee = ast.nodes.items[callee_ni];
+    if (callee.tag != .identifier_reference) return null;
+    const callee_text = ast.getText(callee.span);
+    if (!std.mem.eql(u8, callee_text, "Worker") and !std.mem.eql(u8, callee_text, "SharedWorker")) return null;
+
+    // 인수가 1개 이상인지
+    const args_len = ast.readExtra(e, 2);
+    if (args_len < 1) return null;
+
+    // 첫 번째 인수: new URL(...)인지 확인
+    const args_start = ast.readExtra(e, 1);
+    if (args_start >= ast.extra_data.items.len) return null;
+    const url_new_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    if (url_new_idx.isNone()) return null;
+    const url_ni = @intFromEnum(url_new_idx);
+    if (url_ni >= ast.nodes.items.len) return null;
+    const url_new = ast.nodes.items[url_ni];
+    if (url_new.tag != .new_expression) return null;
+
+    // new URL의 callee가 "URL"인지
+    const ue = url_new.data.extra;
+    if (!ast.hasExtra(ue, 2)) return null;
+    const url_callee_idx = ast.readExtraNode(ue, 0);
+    if (url_callee_idx.isNone()) return null;
+    const uc_ni = @intFromEnum(url_callee_idx);
+    if (uc_ni >= ast.nodes.items.len) return null;
+    const url_callee = ast.nodes.items[uc_ni];
+    if (url_callee.tag != .identifier_reference) return null;
+    if (!std.mem.eql(u8, ast.getText(url_callee.span), "URL")) return null;
+
+    // new URL의 인수가 2개인지
+    const url_args_len = ast.readExtra(ue, 2);
+    if (url_args_len < 2) return null;
+
+    const url_args_start = ast.readExtra(ue, 1);
+    if (url_args_start + 1 >= ast.extra_data.items.len) return null;
+
+    // 첫 번째 인수: string_literal (worker 경로)
+    const spec_idx: NodeIndex = @enumFromInt(ast.extra_data.items[url_args_start]);
+    const specifier = getStringLiteralText(ast, spec_idx) orelse return null;
+    const spec_node = ast.getNode(spec_idx);
+
+    // 두 번째 인수: import.meta.url 패턴 확인
+    const meta_url_idx: NodeIndex = @enumFromInt(ast.extra_data.items[url_args_start + 1]);
+    if (!isImportMetaUrl(ast, meta_url_idx)) return null;
+
+    return .{
+        .specifier = specifier,
+        .kind = .worker,
+        .span = spec_node.span,
+        .url_span = url_new.span, // new URL(...) 전체 범위
+    };
+}
+
+/// static_member_expression(object=meta_property "import.meta", property="url")인지 확인.
+fn isImportMetaUrl(ast: *const Ast, idx: NodeIndex) bool {
+    if (idx.isNone()) return false;
+    const ni = @intFromEnum(idx);
+    if (ni >= ast.nodes.items.len) return false;
+    const node = ast.nodes.items[ni];
+    if (node.tag != .static_member_expression) return false;
+
+    const me = node.data.extra;
+    if (!ast.hasExtra(me, 1)) return false;
+
+    // object: meta_property (import.meta)
+    const obj_idx = ast.readExtraNode(me, 0);
+    if (obj_idx.isNone()) return false;
+    const obj_ni = @intFromEnum(obj_idx);
+    if (obj_ni >= ast.nodes.items.len) return false;
+    const obj = ast.nodes.items[obj_ni];
+    if (obj.tag != .meta_property) return false;
+    if (!std.mem.eql(u8, ast.getText(obj.span), "import.meta")) return false;
+
+    // property: "url"
+    const prop_idx = ast.readExtraNode(me, 1);
+    if (prop_idx.isNone()) return false;
+    const prop_ni = @intFromEnum(prop_idx);
+    if (prop_ni >= ast.nodes.items.len) return false;
+    const prop = ast.nodes.items[prop_ni];
+    if (!std.mem.eql(u8, ast.getText(prop.span), "url")) return false;
+
+    return true;
 }
 
 /// 따옴표(`'`, `"`)를 벗긴다. 최소 2글자 이상이어야 함.

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -49,6 +49,8 @@ pub const ImportKind = enum {
     side_effect,
     /// require("./foo") (CJS)
     require,
+    /// new Worker(new URL('./worker.ts', import.meta.url))
+    worker,
 };
 
 // ============================================================
@@ -290,6 +292,8 @@ pub const ImportRecord = struct {
     kind: ImportKind,
     /// 소스 코드에서의 위치 (에러 메시지용)
     span: Span,
+    /// worker: new URL(...) 전체 범위 (리라이트 대상)
+    url_span: ?Span = null,
     /// resolve 완료 후 채워지는 모듈 인덱스
     resolved: ModuleIndex = .none,
     /// --external로 명시적으로 제외된 모듈 (resolve 실패와 구분)


### PR DESCRIPTION
## Summary
- `new Worker(new URL('./worker.ts', import.meta.url))` 패턴 자동 감지 → 별도 IIFE 번들 생성
- Vite/Webpack 5와 동일한 DX. esbuild는 미지원이라 ZTS가 앞서는 기능
- Worker/SharedWorker 모두 지원
- 중복 참조 시 1회만 빌드 (중복 빌드 방지)
- 별도 옵션 불필요 (자동 감지)

### 동작 예시
```
입력: new Worker(new URL('./worker.ts', import.meta.url))
출력: new Worker("./worker-7186d514.js")     ← 메인 번들
      worker-7186d514.js                     ← IIFE 별도 파일
```

### 변경 파일
| 파일 | 변경 |
|------|------|
| `types.zig` | `ImportKind.worker` + `ImportRecord.url_span` |
| `import_scanner.zig` | `tryExtractWorkerNew()` + `isImportMetaUrl()` 패턴 매칭 |
| `graph.zig` | `WorkerEntry` 수집, worker resolve 분리, deinit |
| `bundler.zig` | `buildWorker()` 독립 IIFE 빌드 + `rewriteWorkerURLs()` 순서 독립 치환 |
| `bundler_test.zig` | 5개 테스트 |

### 테스트 (5개)
| 테스트 | 검증 |
|--------|------|
| 단일 worker | IIFE 번들 + URL 교체 + asset_outputs |
| worker 없음 | asset_outputs == null |
| 다중 worker | 별도 번들 2개 + URL 모두 교체 |
| 중복 참조 | 같은 worker 2번 → 빌드 1회, asset 1개 |
| SharedWorker | `new SharedWorker(new URL(...))` 감지 |

## Test plan
- [x] `zig build test` 전체 통과 (1979 tests)
- [x] CLI: `-o` 옵션으로 main.js + worker-*.js 별도 파일 출력 확인
- [x] 다중 worker, 중복 참조 CLI 테스트 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)