### PR TITLE
fix(bundler): prevent crash on .none NodeIndex in transformer/codegen

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -11531,3 +11531,76 @@ test "Worker: SharedWorker is also detected" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "new SharedWorker(\"./shared-") != null);
     try std.testing.expect(result.asset_outputs != null);
 }
+
+// ============================================================
+// None-node crash prevention: parse errors must not crash transformer/codegen
+// Previously, modules with parse errors had incomplete ASTs containing
+// .none (0xFFFFFFFF) node indices, causing index-out-of-bounds panics.
+// ============================================================
+
+test "Bundle: Flow file with parse errors does not crash" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Entry imports a Flow file with import typeof (requires --flow or @flow pragma)
+    try writeFile(tmp.dir, "entry.js",
+        \\const x = require('./lib');
+        \\console.log(x);
+    );
+    // Flow file with @flow pragma and import typeof — Flow type-only import
+    try writeFile(tmp.dir, "lib.js",
+        \\// @flow
+        \\import typeof * as API from './api';
+        \\module.exports = { value: 42 };
+    );
+    try writeFile(tmp.dir, "api.js",
+        \\module.exports = {};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .flow = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // Should not crash — either succeeds or reports errors gracefully
+    try std.testing.expect(result.output.len > 0 or result.hasErrors());
+}
+
+test "Bundle: module with syntax errors does not crash transformer" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Entry file is valid
+    try writeFile(tmp.dir, "entry.js",
+        \\const x = require('./broken');
+        \\console.log(x);
+    );
+    // Broken file with intentional syntax error
+    try writeFile(tmp.dir, "broken.js",
+        \\export const x = {
+        \\  a: 1,
+        \\  ...  // incomplete spread — parse error
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // Should not crash — broken module is skipped, bundle still produced
+    try std.testing.expect(result.output.len > 0 or result.hasErrors());
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -804,7 +804,14 @@ pub const ModuleGraph = struct {
         };
 
         if (parser.errors.items.len > 0) {
-            self.addDiag(.parse_error, .warning, module.path, Span.EMPTY, .parse, "Parse completed with errors", null);
+            // 파싱 에러가 있으면 AST가 불완전 → transformer/codegen 크래시 방지
+            // 에러 메시지를 기록하고 이 모듈을 스킵
+            for (parser.errors.items) |err| {
+                const msg = if (err.message.len > 0) err.message else "Parse error";
+                self.addDiag(.parse_error, .@"error", module.path, err.span, .parse, msg, null);
+            }
+            module.state = .ready;
+            return;
         }
 
         // Legal comments 수집 (eof/linked/external 모드용)

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -792,11 +792,15 @@ pub const Codegen = struct {
     fn emitProgram(self: *Codegen, node: Node) !void {
         const list = node.data.list;
         const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-        for (indices, 0..) |raw_idx, i| {
-            if (i > 0) try self.writeNewline();
-            try self.emitNode(@enumFromInt(raw_idx));
+        var emitted = false;
+        for (indices) |raw_idx| {
+            const node_idx: NodeIndex = @enumFromInt(raw_idx);
+            if (node_idx.isNone()) continue;
+            if (emitted) try self.writeNewline();
+            try self.emitNode(node_idx);
+            emitted = true;
         }
-        if (indices.len > 0) try self.writeNewline();
+        if (emitted) try self.writeNewline();
         // 파일 끝에 남은 주석들 출력
         try self.emitComments(null);
     }
@@ -1353,6 +1357,7 @@ pub const Codegen = struct {
     fn emitObjectProperty(self: *Codegen, node: Node) !void {
         const key = node.data.binary.left;
         const value = node.data.binary.right;
+        if (key.isNone()) return;
         if (value.isNone()) {
             // shorthand: { x } — key만 출력.
             // 단, scope hoisting으로 식별자가 리네임된 경우 shorthand를 풀어야 함:
@@ -1383,6 +1388,7 @@ pub const Codegen = struct {
     /// 식별자 노드가 scope hoisting에 의해 리네임되는지 확인.
     /// linking_metadata.renames 또는 ns_prefix 치환 대상이면 true.
     fn identifierHasRename(self: *Codegen, idx: NodeIndex) bool {
+        if (idx.isNone()) return false;
         const key_node = self.ast.getNode(idx);
         // linking_metadata renames 확인
         if (self.options.linking_metadata) |meta| {
@@ -3242,9 +3248,13 @@ pub const Codegen = struct {
     fn emitNodeList(self: *Codegen, start: u32, len: u32, sep: []const u8) !void {
         if (len == 0) return;
         const indices = self.ast.extra_data.items[start .. start + len];
-        for (indices, 0..) |raw_idx, i| {
-            if (i > 0) try self.write(sep);
-            try self.emitNode(@enumFromInt(raw_idx));
+        var first = true;
+        for (indices) |raw_idx| {
+            const node_idx: NodeIndex = @enumFromInt(raw_idx);
+            if (node_idx.isNone()) continue;
+            if (!first) try self.write(sep);
+            first = false;
+            try self.emitNode(node_idx);
         }
     }
 };

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -3195,3 +3195,63 @@ test "JSX classic: component uppercase" {
     // App은 문자열이 아닌 식별자
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"App\"") == null);
 }
+
+// ============================================================
+// None-node safety: transformer/codegen must not crash on .none NodeIndex
+// These tests ensure Flow type stripping produces valid AST without
+// index-out-of-bounds panics (previously crashed with index 4294967295).
+// ============================================================
+
+test "Flow: import typeof does not crash" {
+    // import typeof * as Foo from './bar' — Flow type-only import, should be stripped
+    var r = try e2eFlowModule(std.testing.allocator,
+        \\import typeof * as Foo from './bar';
+        \\console.log("hello");
+    );
+    defer r.deinit();
+    // import typeof should be removed, only console.log remains
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "import") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log") != null);
+}
+
+test "Flow: import typeof named does not crash" {
+    var r = try e2eFlowModule(std.testing.allocator,
+        \\import typeof { Foo, Bar } from './baz';
+        \\export const x = 1;
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "import") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "x=1") != null);
+}
+
+test "Flow: type alias with object type does not crash codegen" {
+    var r = try e2eFlowModule(std.testing.allocator,
+        \\type Props = { name: string, age: number };
+        \\const x = 42;
+    );
+    defer r.deinit();
+    // Flow type alias should be stripped
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Props") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "42") != null);
+}
+
+test "Flow: mixed import type and value import does not crash" {
+    var r = try e2eFlowModule(std.testing.allocator,
+        \\import typeof * as API from './api';
+        \\import { useState } from 'react';
+        \\const x = useState(0);
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "useState") != null);
+}
+
+test "Flow: class with typed methods does not crash transformer" {
+    var r = try e2eFlowModule(std.testing.allocator,
+        \\class Foo {
+        \\  bar(x: string): number { return 1; }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "class Foo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "bar") != null);
+}

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1430,7 +1430,9 @@ pub const Transformer = struct {
         };
 
         for (old_params) |raw_idx| {
-            const param_node = self.old_ast.getNode(@enumFromInt(raw_idx));
+            const param_idx: NodeIndex = @enumFromInt(raw_idx);
+            if (param_idx.isNone()) continue;
+            const param_node = self.old_ast.getNode(param_idx);
             // formal_parameter: extra = [pattern, type_ann, default, flags, deco_start, deco_len]
             // flags != 0 → parameter property (public/private/protected/readonly/override)
             if (param_node.tag == .formal_parameter and self.old_ast.extra_data.items[param_node.data.extra + 3] != 0) {
@@ -1942,7 +1944,9 @@ pub const Transformer = struct {
         raw_idx: u32,
         ctx: *ClassMemberContext,
     ) Error!void {
-        const member = self.old_ast.getNode(@enumFromInt(raw_idx));
+        const member_idx: NodeIndex = @enumFromInt(raw_idx);
+        if (member_idx.isNone()) return;
+        const member = self.old_ast.getNode(member_idx);
 
         // property_definition: extra = [key, init_val, flags, deco_start, deco_len]
         if (member.tag == .property_definition) {
@@ -2170,7 +2174,9 @@ pub const Transformer = struct {
     /// decorator 노드에서 expression 부분을 visit하여 반환.
     /// decorator 태그이면 operand(expression)를, 아니면 노드 자체를 visit.
     pub fn visitDecoratorExpression(self: *Transformer, raw_idx: u32) Error!NodeIndex {
-        const deco_node = self.old_ast.getNode(@enumFromInt(raw_idx));
+        const deco_idx: NodeIndex = @enumFromInt(raw_idx);
+        if (deco_idx.isNone()) return .none;
+        const deco_node = self.old_ast.getNode(deco_idx);
         return if (deco_node.tag == .decorator)
             self.visitNode(deco_node.data.unary.operand)
         else
@@ -2244,7 +2250,9 @@ pub const Transformer = struct {
         const zero_span = Span{ .start = 0, .end = 0 };
         const old_params = self.old_ast.extra_data.items[params_start .. params_start + params_len];
         for (old_params, 0..) |raw_idx, param_index| {
-            const param = self.old_ast.getNode(@enumFromInt(raw_idx));
+            const p_idx: NodeIndex = @enumFromInt(raw_idx);
+            if (p_idx.isNone()) continue;
+            const param = self.old_ast.getNode(p_idx);
             if (param.tag != .formal_parameter) continue;
             const pe = param.data.extra;
             const pdeco_start = self.old_ast.extra_data.items[pe + 4];


### PR DESCRIPTION
## Summary

- React Native 번들링 시 SIGBUS (exit 138) 크래시 수정
- Flow 타입 노드 (`import typeof` 등) 스트리핑 후 남는 `.none` (0xFFFFFFFF) 인덱스가 transformer/codegen에서 index out of bounds 패닉을 유발하던 문제 해결

## Changes

### graph.zig
- 파싱 에러가 있는 모듈은 transformer/codegen을 스킵하고 에러 메시지를 기록
- 기존: 에러를 warning으로 기록하고 불완전한 AST를 그대로 전달 → 크래시

### codegen.zig
- `emitNodeList`: `.none` 노드를 스킵하고 separator가 잘못 삽입되지 않도록 수정
- `emitProgram`: `.none` 노드에 대해 불필요한 newline 삽입 방지
- `emitObjectProperty`: key가 `.none`이면 early return
- `identifierHasRename`: `.none` 인덱스 체크 추가

### transformer.zig
- `visitParamsCollectProperties`: `.none` 파라미터 스킵
- `visitDecoratorExpression`: `.none` 데코레이터 스킵
- 파라미터 데코레이터 추출: `.none` 파라미터 스킵

## Test plan

- [x] codegen 테스트 5개 추가 (Flow import typeof, named typeof, type alias, mixed import, class with typed methods)
- [x] bundler 테스트 2개 추가 (Flow file with parse errors, module with syntax errors)
- [x] 기존 테스트 2014/2017 통과 (기존 실패 3개는 변경 전과 동일)
- [x] ExampleApp react-native 번들링 크래시 없이 192KB 번들 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)