### PR TITLE
feat(flow): 함수 타입 파라미터 + extends 바운드 + shorthand 함수 타입

### DIFF
--- a/packages/integration/tests/flow-rn.test.ts
+++ b/packages/integration/tests/flow-rn.test.ts
@@ -34,17 +34,37 @@ async function expectFail(file: string) {
   expect(hasError).toBe(true);
 }
 
-describe("Flow RN: passing files (20/50)", () => {
+describe("Flow RN: passing files (43/50)", () => {
   test("__flowtests__/ReactNativeTypes-flowtest.js", () =>
     expectPass("__flowtests__/ReactNativeTypes-flowtest.js"));
   test("ActionSheetIOS/NativeActionSheetManager.js", () =>
     expectPass("ActionSheetIOS/NativeActionSheetManager.js"));
   test("Alert/NativeAlertManager.js", () => expectPass("Alert/NativeAlertManager.js"));
   test("Alert/RCTAlertManager.js", () => expectPass("Alert/RCTAlertManager.js"));
+  test("Alert/RCTAlertManager.android.js", () => expectPass("Alert/RCTAlertManager.android.js"));
+  test("Alert/RCTAlertManager.ios.js", () => expectPass("Alert/RCTAlertManager.ios.js"));
   test("Animated/Animated.js", () => expectPass("Animated/Animated.js"));
   test("Animated/AnimatedExports.js", () => expectPass("Animated/AnimatedExports.js"));
+  test("Animated/AnimatedImplementation.js", () =>
+    expectPass("Animated/AnimatedImplementation.js"));
+  test("Animated/AnimatedMock.js", () => expectPass("Animated/AnimatedMock.js"));
   test("Animated/AnimatedPlatformConfig.js", () =>
     expectPass("Animated/AnimatedPlatformConfig.js"));
+  test("Animated/Easing.js", () => expectPass("Animated/Easing.js"));
+  test("Animated/NativeAnimatedAllowlist.js", () =>
+    expectPass("Animated/NativeAnimatedAllowlist.js"));
+  test("Animated/NativeAnimatedModule.js", () => expectPass("Animated/NativeAnimatedModule.js"));
+  test("Animated/NativeAnimatedTurboModule.js", () =>
+    expectPass("Animated/NativeAnimatedTurboModule.js"));
+  test("Animated/SpringConfig.js", () => expectPass("Animated/SpringConfig.js"));
+  test("Animated/animations/Animation.js", () => expectPass("Animated/animations/Animation.js"));
+  test("Animated/animations/DecayAnimation.js", () =>
+    expectPass("Animated/animations/DecayAnimation.js"));
+  test("Animated/animations/SpringAnimation.js", () =>
+    expectPass("Animated/animations/SpringAnimation.js"));
+  test("Animated/animations/TimingAnimation.js", () =>
+    expectPass("Animated/animations/TimingAnimation.js"));
+  test("Animated/bezier.js", () => expectPass("Animated/bezier.js"));
   test("Animated/components/AnimatedFlatList.js", () =>
     expectPass("Animated/components/AnimatedFlatList.js"));
   test("Animated/components/AnimatedImage.js", () =>
@@ -55,63 +75,43 @@ describe("Flow RN: passing files (20/50)", () => {
     expectPass("Animated/components/AnimatedText.js"));
   test("Animated/components/AnimatedView.js", () =>
     expectPass("Animated/components/AnimatedView.js"));
-  test("Animated/NativeAnimatedAllowlist.js", () =>
-    expectPass("Animated/NativeAnimatedAllowlist.js"));
-  test("Animated/NativeAnimatedModule.js", () => expectPass("Animated/NativeAnimatedModule.js"));
-  test("Animated/NativeAnimatedTurboModule.js", () =>
-    expectPass("Animated/NativeAnimatedTurboModule.js"));
+  test("Animated/nodes/AnimatedAddition.js", () =>
+    expectPass("Animated/nodes/AnimatedAddition.js"));
+  test("Animated/nodes/AnimatedColor.js", () => expectPass("Animated/nodes/AnimatedColor.js"));
+  test("Animated/nodes/AnimatedDiffClamp.js", () =>
+    expectPass("Animated/nodes/AnimatedDiffClamp.js"));
+  test("Animated/nodes/AnimatedDivision.js", () =>
+    expectPass("Animated/nodes/AnimatedDivision.js"));
+  test("Animated/nodes/AnimatedModulo.js", () => expectPass("Animated/nodes/AnimatedModulo.js"));
+  test("Animated/nodes/AnimatedMultiplication.js", () =>
+    expectPass("Animated/nodes/AnimatedMultiplication.js"));
+  test("Animated/nodes/AnimatedNode.js", () => expectPass("Animated/nodes/AnimatedNode.js"));
+  test("Animated/nodes/AnimatedProps.js", () => expectPass("Animated/nodes/AnimatedProps.js"));
+  test("Animated/nodes/AnimatedStyle.js", () => expectPass("Animated/nodes/AnimatedStyle.js"));
+  test("Animated/nodes/AnimatedSubtraction.js", () =>
+    expectPass("Animated/nodes/AnimatedSubtraction.js"));
   test("Animated/nodes/AnimatedTracking.js", () =>
     expectPass("Animated/nodes/AnimatedTracking.js"));
+  test("Animated/nodes/AnimatedTransform.js", () =>
+    expectPass("Animated/nodes/AnimatedTransform.js"));
+  test("Animated/nodes/AnimatedValue.js", () => expectPass("Animated/nodes/AnimatedValue.js"));
+  test("Animated/nodes/AnimatedValueXY.js", () => expectPass("Animated/nodes/AnimatedValueXY.js"));
   test("Animated/nodes/AnimatedWithChildren.js", () =>
     expectPass("Animated/nodes/AnimatedWithChildren.js"));
   test("Animated/shouldUseTurboAnimatedModule.js", () =>
     expectPass("Animated/shouldUseTurboAnimatedModule.js"));
-  test("Animated/SpringConfig.js", () => expectPass("Animated/SpringConfig.js"));
   test("Animated/useAnimatedColor.js", () => expectPass("Animated/useAnimatedColor.js"));
 });
 
-describe("Flow RN: failing files (30/50) — fix하면 expectPass로 전환", () => {
+describe("Flow RN: failing files (7/50) — fix하면 expectPass로 전환", () => {
   test("ActionSheetIOS/ActionSheetIOS.js", () => expectFail("ActionSheetIOS/ActionSheetIOS.js"));
   test("Alert/Alert.js", () => expectFail("Alert/Alert.js"));
-  test("Alert/RCTAlertManager.android.js", () => expectFail("Alert/RCTAlertManager.android.js"));
-  test("Alert/RCTAlertManager.ios.js", () => expectFail("Alert/RCTAlertManager.ios.js"));
   test("Animated/AnimatedEvent.js", () => expectFail("Animated/AnimatedEvent.js"));
-  test("Animated/AnimatedImplementation.js", () =>
-    expectFail("Animated/AnimatedImplementation.js"));
-  test("Animated/AnimatedMock.js", () => expectFail("Animated/AnimatedMock.js"));
-  test("Animated/animations/Animation.js", () => expectFail("Animated/animations/Animation.js"));
-  test("Animated/animations/DecayAnimation.js", () =>
-    expectFail("Animated/animations/DecayAnimation.js"));
-  test("Animated/animations/SpringAnimation.js", () =>
-    expectFail("Animated/animations/SpringAnimation.js"));
-  test("Animated/animations/TimingAnimation.js", () =>
-    expectFail("Animated/animations/TimingAnimation.js"));
-  test("Animated/bezier.js", () => expectFail("Animated/bezier.js"));
   test("Animated/components/AnimatedScrollView.js", () =>
     expectFail("Animated/components/AnimatedScrollView.js"));
   test("Animated/createAnimatedComponent.js", () =>
     expectFail("Animated/createAnimatedComponent.js"));
-  test("Animated/Easing.js", () => expectFail("Animated/Easing.js"));
-  test("Animated/nodes/AnimatedAddition.js", () =>
-    expectFail("Animated/nodes/AnimatedAddition.js"));
-  test("Animated/nodes/AnimatedColor.js", () => expectFail("Animated/nodes/AnimatedColor.js"));
-  test("Animated/nodes/AnimatedDiffClamp.js", () =>
-    expectFail("Animated/nodes/AnimatedDiffClamp.js"));
-  test("Animated/nodes/AnimatedDivision.js", () =>
-    expectFail("Animated/nodes/AnimatedDivision.js"));
   test("Animated/nodes/AnimatedInterpolation.js", () =>
     expectFail("Animated/nodes/AnimatedInterpolation.js"));
-  test("Animated/nodes/AnimatedModulo.js", () => expectFail("Animated/nodes/AnimatedModulo.js"));
-  test("Animated/nodes/AnimatedMultiplication.js", () =>
-    expectFail("Animated/nodes/AnimatedMultiplication.js"));
-  test("Animated/nodes/AnimatedNode.js", () => expectFail("Animated/nodes/AnimatedNode.js"));
   test("Animated/nodes/AnimatedObject.js", () => expectFail("Animated/nodes/AnimatedObject.js"));
-  test("Animated/nodes/AnimatedProps.js", () => expectFail("Animated/nodes/AnimatedProps.js"));
-  test("Animated/nodes/AnimatedStyle.js", () => expectFail("Animated/nodes/AnimatedStyle.js"));
-  test("Animated/nodes/AnimatedSubtraction.js", () =>
-    expectFail("Animated/nodes/AnimatedSubtraction.js"));
-  test("Animated/nodes/AnimatedTransform.js", () =>
-    expectFail("Animated/nodes/AnimatedTransform.js"));
-  test("Animated/nodes/AnimatedValue.js", () => expectFail("Animated/nodes/AnimatedValue.js"));
-  test("Animated/nodes/AnimatedValueXY.js", () => expectFail("Animated/nodes/AnimatedValueXY.js"));
 });

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -49,6 +49,10 @@ pub fn tryParseTypeAnnotation(self: *Parser) ParseError2!NodeIndex {
 pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() != .colon) return NodeIndex.none;
     try self.advance();
+    // 반환 타입에서는 shorthand 함수 타입 금지: (): any => {} 에서 =>는 arrow body
+    const saved_flag = self.flow_in_return_type;
+    self.flow_in_return_type = true;
+    defer self.flow_in_return_type = saved_flag;
     const ty = try parseType(self);
     // %checks — Flow type guard predicate. 타입 스트리핑에서는 무시.
     // `%`는 .percent 토큰, `checks`는 identifier.
@@ -77,7 +81,21 @@ pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
 /// Flow 타입을 파싱한다.
 /// Babel: flowParseType → flowParseUnionType
 pub fn parseType(self: *Parser) ParseError2!NodeIndex {
-    return parseUnionType(self);
+    const t = try parseUnionType(self);
+
+    // shorthand 함수 타입: Type => ReturnType (괄호 없는 단일 파라미터)
+    // 반환 타입 컨텍스트에서는 금지 — (): any => {} 에서 =>는 arrow function body
+    if (self.current() == .arrow and !self.flow_in_return_type) {
+        try self.advance();
+        _ = try parseType(self);
+        return try self.ast.addNode(.{
+            .tag = .flow_literal_type,
+            .span = self.ast.getNode(t).span,
+            .data = .{ .none = 0 },
+        });
+    }
+
+    return t;
 }
 
 // ================================================================
@@ -473,9 +491,12 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
 
     try self.advance(); // type param name
 
-    // constraint: T: Type (Flow는 extends 대신 : 사용)
+    // constraint: T: Type (Flow 클래식) 또는 T extends Type (Flow 최신, RN 0.76+)
     var constraint = NodeIndex.none;
     if (self.current() == .colon) {
+        try self.advance();
+        constraint = try parseType(self);
+    } else if (self.current() == .kw_extends) {
         try self.advance();
         constraint = try parseType(self);
     }
@@ -578,6 +599,8 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
 }
 
 /// 함수 타입 파라미터 리스트: name: Type, name?: Type, ...rest: Type
+/// Flow는 `(t: number) => void` 형태에서 `t`가 파라미터 이름.
+/// 이름이 없는 `(number) => void` 형태도 허용 (positional).
 fn parseFunctionTypeParamList(self: *Parser) ParseError2!ast_mod.NodeList {
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
@@ -588,7 +611,40 @@ fn parseFunctionTypeParamList(self: *Parser) ParseError2!ast_mod.NodeList {
             try self.advance();
         }
 
-        // name: Type 또는 Type (이름 없는 파라미터도 Flow에서 허용)
+        // name: Type 또는 name?: Type — 이름 뒤에 : 또는 ?: 가 오면 named param
+        if (self.current() == .identifier) {
+            const next = try self.peekNextKind();
+            if (next == .colon) {
+                // name: Type
+                try self.advance(); // skip name
+                try self.advance(); // skip :
+                const param_type = try parseType(self);
+                try self.scratch.append(self.allocator, param_type);
+                if (!try self.eat(.comma)) break;
+                if (try self.ensureLoopProgress(loop_guard_pos)) break;
+                continue;
+            } else if (next == .question) {
+                // name?: Type (optional)
+                try self.advance(); // skip name
+                try self.advance(); // skip ?
+                if (try self.eat(.colon)) {
+                    const param_type = try parseType(self);
+                    try self.scratch.append(self.allocator, param_type);
+                } else {
+                    // name? without colon — treat as type
+                    try self.scratch.append(self.allocator, try self.ast.addNode(.{
+                        .tag = .flow_literal_type,
+                        .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
+                        .data = .{ .none = 0 },
+                    }));
+                }
+                if (!try self.eat(.comma)) break;
+                if (try self.ensureLoopProgress(loop_guard_pos)) break;
+                continue;
+            }
+        }
+
+        // positional: Type (이름 없는 파라미터)
         const param_type = try parseType(self);
         try self.scratch.append(self.allocator, param_type);
 

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -154,6 +154,9 @@ pub const Parser = struct {
     has_cover_init_name: bool = false,
     /// formal parameter 파싱 중인지 (yield/await expression 금지).
     in_formal_parameters: bool = false,
+    /// Flow 반환 타입 파싱 중 — shorthand 함수 타입 `Type => Type` 금지.
+    /// (): any => {} 에서 any 뒤 =>가 arrow body인지 shorthand인지 구분.
+    flow_in_return_type: bool = false,
     /// enum 멤버 초기값 파싱 중인지.
     /// true이면 await/yield를 키워드가 아닌 식별자로 취급한다.
     /// (enum 내에서 다른 멤버를 참조: `enum X { await = 1, y = await }`)

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2747,3 +2747,43 @@ test "JSX spread + regular attributes" {
         \\}
     , ".tsx");
 }
+
+// ============================================================
+// Flow 함수 타입 파라미터
+// ============================================================
+
+test "Flow: function type with named params" {
+    try expectNoParseErrorFlow("type F = (t: number) => number;");
+}
+
+test "Flow: function type with optional param" {
+    try expectNoParseErrorFlow("type F = (callback?: ?Function) => void;");
+}
+
+test "Flow: function type with multiple params" {
+    try expectNoParseErrorFlow("type F = (id: number, value: string) => void;");
+}
+
+test "Flow: shorthand function type with identifier" {
+    try expectNoParseErrorFlow("type F = AnimatedNode => number;");
+}
+
+test "Flow: shorthand function type with keyword type" {
+    try expectNoParseErrorFlow("type F = string => void;");
+}
+
+test "Flow: return type any does not trigger shorthand" {
+    try expectNoParseErrorFlowJSX(
+        \\const App = (props: {count: number}): any => {
+        \\  return <span>{props.count}</span>;
+        \\};
+    );
+}
+
+test "Flow: generic extends constraint" {
+    try expectNoParseErrorFlow(
+        \\class C {
+        \\  foo<T extends number | string>(x: T): T { return x; }
+        \\}
+    );
+}


### PR DESCRIPTION
## Summary
Flow 파서 미지원 구문 3건을 추가하여 RN 호환성을 43/50으로 개선합니다.

### 1. 함수 타입 named 파라미터
- `(t: number) => number` — name: Type 패턴 인식
- `(callback?: ?EndCallback) => void` — optional 파라미터
- `(id: number, value: string) => void` — 다중 파라미터

### 2. 제네릭 extends 바운드
- `<T extends number | string>` — Flow 최신 문법 (RN 0.76+)
- 기존 `<T: Bound>` (Flow 클래식)과 병행 지원

### 3. Shorthand 함수 타입
- `AnimatedNode => T` — 괄호 없는 단일 파라미터 함수 타입
- `flow_in_return_type` 플래그로 반환 타입 컨텍스트에서 arrow function body와 구분
  - `(): any => {}` — any 뒤 =>는 arrow body (shorthand 아님)
  - `type F = string => void` — shorthand 함수 타입 (OK)

## RN 호환성
**20/50 → 43/50 통과 (+23개)**

실패 7개 잔여 원인: conditional type, type guard, 특수 함수 타입 패턴

## Test plan
- [x] `zig build test` 전체 통과
- [x] 파서 테스트 7개 추가
- [x] `flow-rn.test.ts` 43 expectPass + 7 expectFail로 업데이트
- [ ] CI Build & Test
- [ ] CI Integration Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)