### PR TITLE
fix(watch): --watch-json 초기 빌드 NDJSON 프로토콜 준수

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ zts --bundle <entry.ts> --plugin zts.config.js     # JS 플러그인
 번개(bungae) 같은 외부 도구가 stdout을 파싱하여 HMR 메시지를 생성하는 용도.
 
 ```jsonl
-{"type":"ready","files":2592}
+{"type":"ready","files":2592,"bytes":123456}
 {"type":"rebuild","success":true,"changed":["/src/app.tsx"],"modules":["/src/app.tsx","/src/util.ts"],"bytes":123456}
 {"type":"rebuild","success":false,"error":"ModuleNotFound"}
 ```

--- a/packages/integration/tests/watch-json.test.ts
+++ b/packages/integration/tests/watch-json.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { createFixture, ZTS_BIN } from "./helpers";
 import { join } from "node:path";
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
 
 /**
@@ -28,21 +28,31 @@ async function waitForNdjsonLines(
   timeoutMs = 10000,
 ): Promise<Record<string, unknown>[]> {
   const deadline = Date.now() + timeoutMs;
+  let lastContent = "";
   while (Date.now() < deadline) {
-    if (existsSync(jsonOutPath)) {
+    try {
       const content = readFileSync(jsonOutPath, "utf8").trim();
+      lastContent = content;
       if (content) {
-        const lines = content.split("\n").filter(Boolean);
-        if (lines.length >= minLines) {
-          return lines.map((l) => JSON.parse(l));
+        const parsed: Record<string, unknown>[] = [];
+        for (const line of content.split("\n").filter(Boolean)) {
+          try {
+            parsed.push(JSON.parse(line));
+          } catch {
+            break; // partial line — 다음 폴링에서 재시도
+          }
+        }
+        if (parsed.length >= minLines) {
+          return parsed;
         }
       }
+    } catch {
+      // 파일이 아직 없음 — 다음 폴링에서 재시도
     }
     await new Promise((r) => setTimeout(r, 200));
   }
-  const content = existsSync(jsonOutPath) ? readFileSync(jsonOutPath, "utf8") : "(file not found)";
   throw new Error(
-    `Timeout waiting for ${minLines} NDJSON line(s). Content: ${JSON.stringify(content)}`,
+    `Timeout waiting for ${minLines} NDJSON line(s). Content: ${JSON.stringify(lastContent)}`,
   );
 }
 
@@ -53,8 +63,11 @@ function killAndWait(proc: ChildProcess): Promise<void> {
       resolve();
       return;
     }
-    proc.on("exit", () => resolve());
-    setTimeout(resolve, 2000);
+    const fallback = setTimeout(resolve, 2000);
+    proc.on("exit", () => {
+      clearTimeout(fallback);
+      resolve();
+    });
     proc.kill();
   });
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1252,7 +1252,7 @@ pub fn main() !void {
 
         // 출력
         // --watch-json 모드에서는 stdout이 NDJSON 전용이므로
-        // 상태 메시지는 stderr로, raw 번들 출력은 억제
+        // 상태 메시지와 raw 번들 출력은 억제
         var initial_bytes: usize = 0;
         if (result.outputs) |outputs| {
             // Code splitting: 다중 파일 출력 → --outdir 필수


### PR DESCRIPTION
## Summary
- `--watch-json` 모드에서 초기 빌드 시 인간용 메시지(`Bundled → ...`)와 raw 번들 내용이 stdout으로 출력되어 NDJSON 프로토콜을 깨뜨리는 버그 수정
- `ready` 이벤트에 `bytes` 필드 추가하여 초기 빌드 결과를 전달: `{"type":"ready","files":N,"bytes":M}`
- `--watch-json` 통합 테스트 5개 추가 (ready 이벤트, NDJSON 순수성, rebuild 이벤트, raw 출력 억제, code splitting)

## Test plan
- [x] `bun test packages/integration/tests/watch-json.test.ts` — 5개 테스트 통과
- [x] `zig build` — 빌드 성공
- [x] `zig build test` — 유닛 테스트 통과
- [x] 수동 테스트: `zts --bundle entry.ts -o out.js --watch-json` → NDJSON ready 이벤트 출력 + 파일 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)