### PR TITLE
fix(codegen): destructuring 문자열 키를 bracket notation으로 출력

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2017,6 +2017,30 @@ test "ES2015: destructuring with computed key" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "var") != null);
 }
 
+test "ES2015: destructuring with string key uses bracket notation" {
+    // 하이픈 포함 문자열 키: _ref["aria-busy"] (bracket), _ref.ariaBusy (dot) 아님
+    var r = try e2eTarget(std.testing.allocator,
+        \\var {"aria-busy":busy,"aria-checked":checked}=obj;
+    , .es5);
+    defer r.deinit();
+    // bracket notation 사용 확인
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "[\"aria-busy\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "[\"aria-checked\"]") != null);
+    // dot notation이 아닌지 확인
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, ".\"aria-busy\""), null);
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, ".\"aria-checked\""), null);
+}
+
+test "ES2015: destructuring with string key and default uses bracket notation" {
+    // 문자열 키 + 기본값: _ref["aria-busy"] === void 0 ? false : _ref["aria-busy"]
+    var r = try e2eTarget(std.testing.allocator,
+        \\var {"aria-busy":busy=false}=obj;
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "[\"aria-busy\"]") != null);
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, ".\"aria-busy\""), null);
+}
+
 test "ES2015: for-of with destructuring" {
     var r = try e2eTarget(std.testing.allocator, "for(const [k,v] of arr){}", .es5);
     defer r.deinit();

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -193,13 +193,12 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 const key_idx = prop.data.binary.left;
                 if (key_idx.isNone()) continue;
 
-                // _ref.key
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
+                const key_node = self.old_ast.getNode(key_idx);
                 const new_key = try self.visitNode(key_idx);
-                const access = try es_helpers.makeStaticMember(self, ref, new_key, span);
+                const access = try es_helpers.makeMemberFromKey(self, ref, new_key, key_node.tag, span);
 
                 if (prop.tag == .assignment_target_property_identifier) {
-                    const key_node = self.old_ast.getNode(key_idx);
                     const target_node = try self.new_ast.addNode(.{
                         .tag = .identifier_reference,
                         .span = key_node.span,
@@ -211,7 +210,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     const is_shorthand_default = (prop.data.binary.flags & 0x01) != 0;
                     const rhs = if (is_shorthand_default and !prop.data.binary.right.isNone()) blk: {
                         const default_val = try self.visitNode(prop.data.binary.right);
-                        break :blk try buildDefaulted(self, access, default_val, ref_span, key_idx, span);
+                        break :blk try buildDefaulted(self, access, default_val, ref_span, key_idx, key_node.tag, span);
                     } else access;
 
                     const assign = try self.new_ast.addNode(.{
@@ -228,7 +227,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     if (right_node.tag == .assignment_target_with_default) {
                         const target_node = try self.visitNode(right_node.data.binary.left);
                         const default_val = try self.visitNode(right_node.data.binary.right);
-                        const rhs = try buildDefaulted(self, access, default_val, ref_span, key_idx, span);
+                        const rhs = try buildDefaulted(self, access, default_val, ref_span, key_idx, key_node.tag, span);
                         const assign = try self.new_ast.addNode(.{
                             .tag = .assignment_expression,
                             .span = span,
@@ -356,21 +355,15 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 const key_idx = prop.data.binary.left;
                 const value_idx = prop.data.binary.right;
 
-                // _ref.key (static member access)
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
                 const key_node = self.old_ast.getNode(key_idx);
 
                 const member_access = if (key_node.tag == .computed_property_key) blk: {
                     const inner = try self.visitNode(key_node.data.unary.operand);
-                    const me = try self.new_ast.addExtras(&.{ @intFromEnum(ref), @intFromEnum(inner), 0 });
-                    break :blk try self.new_ast.addNode(.{
-                        .tag = .computed_member_expression,
-                        .span = span,
-                        .data = .{ .extra = me },
-                    });
+                    break :blk try es_helpers.makeComputedMember(self, ref, inner, span);
                 } else blk: {
                     const new_key = try self.visitNode(key_idx);
-                    break :blk try es_helpers.makeStaticMember(self, ref, new_key, span);
+                    break :blk try es_helpers.makeMemberFromKey(self, ref, new_key, key_node.tag, span);
                 };
 
                 // value 처리: shorthand vs long-form, default value
@@ -389,7 +382,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         // default: { a = 1 } → var a = _ref.a === void 0 ? 1 : _ref.a
                         const binding = try self.visitNode(value_node.data.binary.left);
                         const default_val = try self.visitNode(value_node.data.binary.right);
-                        const defaulted = try buildDefaulted(self, member_access, default_val, ref_span, key_idx, span);
+                        const defaulted = try buildDefaulted(self, member_access, default_val, ref_span, key_idx, key_node.tag, span);
                         const decl = try es_helpers.makeDeclarator(self, binding, defaulted, span);
                         try self.scratch.append(self.allocator, decl);
                     } else if (value_node.tag == .object_pattern or value_node.tag == .array_pattern) {
@@ -465,18 +458,18 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             }
         }
 
-        /// _ref.key === void 0 ? default : _ref.key
-        fn buildDefaulted(self: *Transformer, access: NodeIndex, default_val: NodeIndex, ref_span: Span, key_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+        /// _ref.key === void 0 ? default : _ref.key (또는 _ref["key"])
+        fn buildDefaulted(self: *Transformer, access: NodeIndex, default_val: NodeIndex, ref_span: Span, key_idx: NodeIndex, key_tag: Node.Tag, span: Span) Transformer.Error!NodeIndex {
             const void_zero = try es_helpers.makeVoidZero(self, span);
             const eq_check = try self.new_ast.addNode(.{
                 .tag = .binary_expression,
                 .span = span,
                 .data = .{ .binary = .{ .left = access, .right = void_zero, .flags = @intFromEnum(token_mod.Kind.eq3) } },
             });
-            // _ref.key 다시 생성 (access는 이미 eq_check에서 소비)
+            // access는 이미 eq_check에서 소비되었으므로 다시 생성
             const ref2 = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
             const new_key = try self.visitNode(key_idx);
-            const access2 = try es_helpers.makeStaticMember(self, ref2, new_key, span);
+            const access2 = try es_helpers.makeMemberFromKey(self, ref2, new_key, key_tag, span);
             return self.new_ast.addNode(.{
                 .tag = .conditional_expression,
                 .span = span,
@@ -488,14 +481,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         fn makeArrayAccess(self: *Transformer, ref_span: Span, idx: usize, span: Span) Transformer.Error!NodeIndex {
             const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
             const idx_node = try es_helpers.makeNumericLiteral(self, @intCast(idx));
-            const access_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(ref), @intFromEnum(idx_node), 0,
-            });
-            return self.new_ast.addNode(.{
-                .tag = .computed_member_expression,
-                .span = span,
-                .data = .{ .extra = access_extra },
-            });
+            return es_helpers.makeComputedMember(self, ref, idx_node, span);
         }
 
         /// _ref.slice(N) 호출 생성 (array rest 변환용).

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -98,6 +98,28 @@ pub fn makeStaticMember(self: anytype, obj: NodeIndex, prop: NodeIndex, span: Sp
     });
 }
 
+/// obj[prop] computed member expression 생성.
+/// 문자열 키("aria-busy")나 숫자 키처럼 dot notation이 불가능한 경우 사용.
+/// extra = [object, property, flags=0]
+pub fn makeComputedMember(self: anytype, obj: NodeIndex, prop: NodeIndex, span: Span) !NodeIndex {
+    const me = try self.new_ast.addExtras(&.{ @intFromEnum(obj), @intFromEnum(prop), 0 });
+    return self.new_ast.addNode(.{
+        .tag = .computed_member_expression,
+        .span = span,
+        .data = .{ .extra = me },
+    });
+}
+
+/// 프로퍼티 키의 타입에 따라 static(dot) 또는 computed(bracket) member expression 생성.
+/// string_literal, numeric_literal → bracket notation (_ref["aria-busy"], _ref[0])
+/// 그 외 (identifier 등) → dot notation (_ref.key)
+pub fn makeMemberFromKey(self: anytype, obj: NodeIndex, prop: NodeIndex, key_tag: ast_mod.Node.Tag, span: Span) !NodeIndex {
+    return switch (key_tag) {
+        .string_literal, .numeric_literal => makeComputedMember(self, obj, prop, span),
+        else => makeStaticMember(self, obj, prop, span),
+    };
+}
+
 /// callee(args...) call expression 생성.
 /// extra = [callee, args_start, args_len, flags=0]
 pub fn makeCallExpr(self: anytype, callee: NodeIndex, args: []const NodeIndex, span: Span) !NodeIndex {


### PR DESCRIPTION
## Summary
- `"aria-busy"` 같은 하이픈 포함 문자열 키가 `_a."aria-busy"` (dot notation)로 출력되던 버그 수정 → `_a["aria-busy"]` (bracket notation)
- `es_helpers`에 `makeComputedMember`, `makeMemberFromKey` 헬퍼 추가하여 키 타입에 따라 dot/bracket 자동 분기
- 기존 인라인 `computed_member_expression` 생성 코드를 헬퍼로 통합 (`makeArrayAccess`, `computed_property_key` 브랜치)
- `buildDefaulted`에 `key_tag` 파라미터 추가로 중복 `getNode` 호출 제거

## Test plan
- [x] 회귀 테스트 2개 추가 (문자열 키 bracket notation, 문자열 키 + 기본값)
- [x] `zig build test` 전체 통과
- [ ] RN 앱에서 `aria-*` destructuring 포함 번들 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)