### PR TITLE
fix(codegen): CJS re-export에서 default 예약어 식별자 출력 버그 수정

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2162,6 +2162,8 @@ pub const Codegen = struct {
     }
 
     /// CJS: export const x = 1 → const x=1;exports.x=x;
+    /// CJS: export { foo } → exports.foo=foo;
+    /// CJS: export { foo, default as Bar } from './bar' → exports.foo=require("./bar").foo;exports.Bar=require("./bar").default;
     fn emitExportNamedCJS(self: *Codegen, decl: NodeIndex, specs_start: u32, specs_len: u32, source: NodeIndex) !void {
         if (!decl.isNone() and @intFromEnum(decl) < self.ast.nodes.items.len) {
             // export const x = 1 → const x=1; + exports.x=x;
@@ -2169,16 +2171,28 @@ pub const Codegen = struct {
             // 선언에서 이름 추출하여 exports.name = name
             try self.emitCJSExportBinding(decl);
         } else {
-            // export { foo, bar } → exports.foo=foo;exports.bar=bar;
-            _ = source;
+            const has_source = !source.isNone() and @intFromEnum(source) < self.ast.nodes.items.len;
             const spec_indices = self.ast.extra_data.items[specs_start .. specs_start + specs_len];
             for (spec_indices) |raw_idx| {
                 const spec = self.ast.getNode(@enumFromInt(raw_idx));
-                const spec_text = self.ast.source[spec.span.start..spec.span.end];
+                if (spec.tag != .export_specifier) continue;
+
+                // export_specifier: { left=local/imported, right=exported }
+                // alias 없으면 exported == local (파서가 동일 인덱스 할당)
+                const local_idx = spec.data.binary.left;
+                const exported_idx = spec.data.binary.right;
+                const exported_text = self.ast.getText(self.ast.getNode(exported_idx).span);
+                const local_text = self.ast.getText(self.ast.getNode(local_idx).span);
+
                 try self.write("exports.");
-                try self.write(spec_text);
+                try self.write(exported_text);
                 try self.writeByte('=');
-                try self.write(spec_text);
+                if (has_source) {
+                    try self.write("require(");
+                    try self.emitNode(source);
+                    try self.write(").");
+                }
+                try self.write(local_text);
                 try self.writeByte(';');
             }
         }

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -865,6 +865,30 @@ test "Codegen CJS: export all" {
     try std.testing.expectEqualStrings("Object.assign(exports,require(\"./bar\"));", r.output);
 }
 
+test "Codegen CJS: re-export named" {
+    var r = try e2eCJS(std.testing.allocator, "export { foo } from './bar';");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("exports.foo=require(\"./bar\").foo;", r.output);
+}
+
+test "Codegen CJS: re-export default" {
+    var r = try e2eCJS(std.testing.allocator, "export { default } from './foo';");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("exports.default=require(\"./foo\").default;", r.output);
+}
+
+test "Codegen CJS: re-export default as named" {
+    var r = try e2eCJS(std.testing.allocator, "export { default as Foo } from './bar';");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("exports.Foo=require(\"./bar\").default;", r.output);
+}
+
+test "Codegen CJS: re-export named as default" {
+    var r = try e2eCJS(std.testing.allocator, "export { foo as default } from './bar';");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("exports.default=require(\"./bar\").foo;", r.output);
+}
+
 test "Codegen CJS: export named function" {
     var r = try e2eCJS(std.testing.allocator, "export function foo() {}");
     defer r.deinit();


### PR DESCRIPTION
## Summary
- `export { default } from './foo'` → `exports.default=default;` (예약어를 식별자로 사용) 버그 수정
- re-export 시 `require(source).name` 형태로 올바르게 변환
- specifier의 `binary.left`(local) / `binary.right`(exported)를 정확히 분리
- `ast.getText` 헬퍼 사용, 중복 코드 제거

## Test plan
- [x] 4개 회귀 테스트 (`expectEqualStrings`로 정확한 출력 검증)
- [x] `zig build test` 전체 통과
- [ ] RN 앱에서 `export { default } from` 포함 번들 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)