### PR TITLE
fix(transformer): export default class + ES5 + CJS에서 빈 값 출력 수정

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -895,6 +895,29 @@ test "Codegen CJS: export named function" {
     try std.testing.expectEqualStrings("function foo(){}exports.foo=foo;", r.output);
 }
 
+test "Codegen CJS + ES5: export default class" {
+    // export default class Foo { } → ES5 function + module.exports=Foo;
+    var r = try e2eFull(std.testing.allocator, "export default class Foo { constructor() {} }", .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) }, .{ .minify_whitespace = true, .module_format = .cjs }, ".ts");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "module.exports=Foo;") != null);
+    // module.exports=; (빈 값) 금지
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "module.exports=;"), null);
+}
+
+test "Codegen CJS + ES5: export default anonymous class" {
+    var r = try e2eFull(std.testing.allocator, "export default class { constructor() {} }", .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) }, .{ .minify_whitespace = true, .module_format = .cjs }, ".ts");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "module.exports=_Class;") != null);
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "module.exports=;"), null);
+}
+
+test "Codegen CJS + ES5: export default class with extends" {
+    var r = try e2eFull(std.testing.allocator, "export default class CustomEvent extends Event { constructor(type) { super(type); } }", .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) }, .{ .minify_whitespace = true, .module_format = .cjs }, ".ts");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "module.exports=CustomEvent;") != null);
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "module.exports=;"), null);
+}
+
 // ============================================================
 // E2E Tests: Formatted output
 // ============================================================

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -674,7 +674,7 @@ pub const Transformer = struct {
             .formal_parameter => self.visitFormalParameter(node),
             .import_declaration => self.visitImportDeclaration(node),
             .export_named_declaration => self.visitExportNamedDeclaration(node),
-            .export_default_declaration => self.visitUnaryNode(node),
+            .export_default_declaration => self.visitExportDefaultDeclaration(node),
             .export_all_declaration => self.visitBinaryNode(node),
             .catch_clause => {
                 if (self.options.unsupported.optional_catch_binding) {
@@ -836,6 +836,39 @@ pub const Transformer = struct {
                 self.new_symbol_ids.items[new_i] = self.old_symbol_ids[old_i];
             }
         }
+    }
+
+    /// export default class/function → ES5 lowering 시 operand가 .none이 되는 케이스 처리.
+    /// lowerClassDeclaration이 pending_nodes에 function 등을 넣고 .none을 반환하므로,
+    /// 클래스/함수 이름(또는 익명의 합성 이름 _Class)의 identifier reference를 operand로 사용.
+    fn visitExportDefaultDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
+        const operand_idx = node.data.unary.operand;
+        const new_operand = try self.visitNode(operand_idx);
+
+        if (new_operand.isNone()) {
+            const operand_node = self.old_ast.getNode(operand_idx);
+            if (operand_node.tag == .class_declaration or operand_node.tag == .function_declaration) {
+                const name_idx: NodeIndex = @enumFromInt(self.old_ast.extra_data.items[operand_node.data.extra]);
+                // named class/function → 원본 이름 사용
+                // anonymous class → lowerClassDeclaration이 "_Class"로 합성 (addString)
+                const name_span = if (!name_idx.isNone())
+                    self.old_ast.getNode(name_idx).data.string_ref
+                else
+                    try self.new_ast.addString("_Class");
+                const name_ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
+                return self.new_ast.addNode(.{
+                    .tag = node.tag,
+                    .span = node.span,
+                    .data = .{ .unary = .{ .operand = name_ref, .flags = node.data.unary.flags } },
+                });
+            }
+        }
+
+        return self.new_ast.addNode(.{
+            .tag = node.tag,
+            .span = node.span,
+            .data = .{ .unary = .{ .operand = new_operand, .flags = node.data.unary.flags } },
+        });
     }
 
     /// 단항 노드: operand를 재귀 방문 후 복사.


### PR DESCRIPTION
## Summary
- `export default class Foo extends Event { ... }` + ES5 타겟 + CJS → `module.exports=;` (빈 값) 버그 수정
- `lowerClassDeclaration`이 class를 function으로 분해 후 `.none` 반환 시, 클래스 이름의 identifier reference로 operand 대체
- 익명 클래스(`export default class { }`)도 합성 이름 `_Class`로 처리
- `es_helpers.makeIdentifierRefFromSpan` 헬퍼 재사용

## Test plan
- [x] 회귀 테스트 3개 추가 (named, anonymous, extends)
- [x] `zig build test` 전체 통과
- [ ] RN 앱에서 `export default class` 포함 번들 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)