### PR TITLE
fix(transformer): ES5 class computed key bracket notation 수정

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2105,6 +2105,29 @@ test "ES2015: class with computed method" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "prototype") != null);
 }
 
+test "ES2015: class with computed method uses bracket notation" {
+    // [Symbol.iterator]() → prototype[Symbol.iterator] = function() (dot 없이)
+    var r = try e2eTarget(std.testing.allocator, "class F{[Symbol.iterator](){return this;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "prototype[Symbol.iterator]") != null);
+    // prototype.[Symbol.iterator] (잘못된 dot notation) 금지
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "prototype.["), null);
+}
+
+test "ES2015: static computed field uses bracket notation" {
+    var r = try e2eTarget(std.testing.allocator, "var k='x';class F{static [k]=1;}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "F[k]=1") != null);
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "F.[k]"), null);
+}
+
+test "ES2015: instance computed field uses bracket notation" {
+    var r = try e2eTarget(std.testing.allocator, "var k='tag';class F{[k]='foo';}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "this[k]") != null);
+    try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "this.[k]"), null);
+}
+
 test "ES2015: class with multiple fields" {
     var r = try e2eTarget(std.testing.allocator, "class F{a=1;b='hi';c=true;}", .es5);
     defer r.deinit();

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -819,11 +819,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
         }
 
-        /// obj.key = init expression_statement 생성.
+        /// obj.key = init 또는 obj[computedKey] = init expression_statement 생성.
         /// instance field: obj = this, static field: obj = ClassName identifier.
         fn buildFieldAssign(self: *Transformer, obj: NodeIndex, key_idx: NodeIndex, init_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const new_key = try self.visitNode(key_idx);
-            const member = try es_helpers.makeStaticMember(self, obj, new_key, span);
+            const member = try es_helpers.makeMemberFromKeyIdx(self, obj, key_idx, span);
             const new_init = try self.visitNode(init_idx);
             const assign = try self.new_ast.addNode(.{
                 .tag = .assignment_expression,
@@ -1103,9 +1102,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             else
                 try buildPrototypeRef(self, class_name_span, span);
 
-            // target.methodName
-            const new_key = try self.visitNode(key_idx);
-            const member_access = try es_helpers.makeStaticMember(self, target, new_key, span);
+            const member_access = try es_helpers.makeMemberFromKeyIdx(self, target, key_idx, span);
 
             // target.methodName = function() {}
             const assign = try self.new_ast.addNode(.{

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -358,13 +358,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
                 const key_node = self.old_ast.getNode(key_idx);
 
-                const member_access = if (key_node.tag == .computed_property_key) blk: {
-                    const inner = try self.visitNode(key_node.data.unary.operand);
-                    break :blk try es_helpers.makeComputedMember(self, ref, inner, span);
-                } else blk: {
-                    const new_key = try self.visitNode(key_idx);
-                    break :blk try es_helpers.makeMemberFromKey(self, ref, new_key, key_node.tag, span);
-                };
+                const member_access = try es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
 
                 // value 처리: shorthand vs long-form, default value
                 if (value_idx.isNone() or @intFromEnum(value_idx) == @intFromEnum(key_idx)) {

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -120,6 +120,21 @@ pub fn makeMemberFromKey(self: anytype, obj: NodeIndex, prop: NodeIndex, key_tag
     };
 }
 
+/// old_ast의 key_idx로부터 obj.key 또는 obj[key] member expression 생성.
+/// computed_property_key → 내부 표현식을 unwrap하여 bracket notation.
+/// string_literal, numeric_literal → bracket notation.
+/// 그 외 (identifier) → dot notation.
+pub fn makeMemberFromKeyIdx(self: anytype, obj: NodeIndex, key_idx: NodeIndex, span: Span) !NodeIndex {
+    const key_node = self.old_ast.getNode(key_idx);
+    if (key_node.tag == .computed_property_key) {
+        const inner = try self.visitNode(key_node.data.unary.operand);
+        return makeComputedMember(self, obj, inner, span);
+    } else {
+        const new_key = try self.visitNode(key_idx);
+        return makeMemberFromKey(self, obj, new_key, key_node.tag, span);
+    }
+}
+
 /// callee(args...) call expression 생성.
 /// extra = [callee, args_start, args_len, flags=0]
 pub fn makeCallExpr(self: anytype, callee: NodeIndex, args: []const NodeIndex, span: Span) !NodeIndex {


### PR DESCRIPTION
## Summary
- `[Symbol.iterator]()` 같은 computed key가 `prototype.[Symbol.iterator]` (잘못된 dot+bracket)로 출력되던 버그 수정
- `es_helpers.makeMemberFromKeyIdx` 헬퍼 추가: computed_property_key unwrap + dot/bracket 자동 분기
- 3곳(es2015_class 2곳, es2015_destructuring 1곳)의 6줄 중복 패턴을 1줄 호출로 통합

## Test plan
- [x] 회귀 테스트 3개 추가 (computed method, static/instance computed field)
- [x] `zig build test` 전체 통과
- [ ] RN 앱에서 `[Symbol.iterator]` computed method 포함 번들 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)