### PR TITLE
fix(transformer): ES5 타겟에서 async/await → state machine 직접 변환

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -273,7 +273,7 @@ pub fn emitWithTreeShaking(
     }
 
     // ES2015 런타임 헬퍼 주입: transformer가 실제 사용한 헬퍼만 주입
-    try rt.appendRuntimeHelpers(&output, allocator, collected_helpers, options.minify_whitespace);
+    try rt.appendRuntimeHelpers(&output, allocator, collected_helpers, options.minify_whitespace, options.unsupported.arrow);
 
     // 모듈 코드 합류
     try output.appendSlice(allocator, module_output.items);

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -776,14 +776,14 @@ test "CodeSplitting: static import not rewritten" {
 test "appendRuntimeHelpers: no helpers → empty" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try appendRuntimeHelpers(&buf, std.testing.allocator, .{}, false);
+    try appendRuntimeHelpers(&buf, std.testing.allocator, .{}, false, false);
     try std.testing.expectEqual(@as(usize, 0), buf.items.len);
 }
 
 test "appendRuntimeHelpers: extends only" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .extends = true }, false);
+    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .extends = true }, false, false);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "var __extends") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "__generator") == null);
 }
@@ -791,7 +791,7 @@ test "appendRuntimeHelpers: extends only" {
 test "appendRuntimeHelpers: generator only" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .generator = true }, false);
+    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .generator = true }, false, false);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "var __generator") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "__extends") == null);
 }
@@ -799,14 +799,14 @@ test "appendRuntimeHelpers: generator only" {
 test "appendRuntimeHelpers: rest only" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .rest = true }, false);
+    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .rest = true }, false, false);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "var __rest") != null);
 }
 
 test "appendRuntimeHelpers: multiple helpers" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .extends = true, .generator = true, .rest = true }, false);
+    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .extends = true, .generator = true, .rest = true }, false, false);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "var __extends") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "var __generator") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "var __rest") != null);
@@ -815,7 +815,7 @@ test "appendRuntimeHelpers: multiple helpers" {
 test "appendRuntimeHelpers: minified" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .generator = true }, true);
+    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .generator = true }, true, false);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "var __generator=function") != null);
     // minified에는 줄바꿈이 없어야 함
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\n") == null);
@@ -825,7 +825,7 @@ test "appendRuntimeHelpers: generator runtime is valid JS" {
     // __generator가 올바른 JS인지 기본 구조 검증
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .generator = true }, false);
+    try appendRuntimeHelpers(&buf, std.testing.allocator, .{ .generator = true }, false, false);
     // 핵심 구조 요소 존재 확인
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "label: 0") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "Symbol.iterator") != null);

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -78,6 +78,28 @@ pub const ASYNC_RUNTIME =
 ;
 pub const ASYNC_RUNTIME_MIN = "var __async=(fn)=>function(...args){return new Promise((resolve,reject)=>{var gen=fn.apply(this,args);function step(key,arg){try{var info=gen[key](arg);var value=info.value}catch(error){reject(error);return}if(info.done)resolve(value);else Promise.resolve(value).then(val=>step(\"next\",val),err=>step(\"throw\",err))}step(\"next\")})};";
 
+/// __async ES5 호환: arrow function, rest params 없이 동일 동작.
+pub const ASYNC_RUNTIME_ES5 =
+    \\var __async = function(fn) {
+    \\  return function() {
+    \\    var args = Array.prototype.slice.call(arguments);
+    \\    var self = this;
+    \\    return new Promise(function(resolve, reject) {
+    \\      var gen = fn.apply(self, args);
+    \\      function step(key, arg) {
+    \\        try { var info = gen[key](arg); var value = info.value; }
+    \\        catch (error) { reject(error); return; }
+    \\        if (info.done) resolve(value);
+    \\        else Promise.resolve(value).then(function(val) { step("next", val); }, function(err) { step("throw", err); });
+    \\      }
+    \\      step("next");
+    \\    });
+    \\  };
+    \\};
+    \\
+;
+pub const ASYNC_RUNTIME_ES5_MIN = "var __async=function(fn){return function(){var args=Array.prototype.slice.call(arguments);var self=this;return new Promise(function(resolve,reject){var gen=fn.apply(self,args);function step(key,arg){try{var info=gen[key](arg);var value=info.value}catch(error){reject(error);return}if(info.done)resolve(value);else Promise.resolve(value).then(function(val){step(\"next\",val)},function(err){step(\"throw\",err)})}step(\"next\")})}};";
+
 /// __extends: class 상속 prototype chain (ES2015). TypeScript __extends 호환.
 pub const EXTENDS_RUNTIME = "var __extends = function(d, b) {\n  for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];\n  function __() { this.constructor = d; }\n  d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());\n};\n";
 pub const EXTENDS_RUNTIME_MIN = "var __extends=function(d,b){for(var p in b)if(Object.prototype.hasOwnProperty.call(b,p))d[p]=b[p];function __(){this.constructor=d}d.prototype=b===null?Object.create(b):(__.prototype=b.prototype,new __())};";
@@ -202,7 +224,7 @@ pub const HMR_RUNTIME_LINES = blk: {
 
 /// 런타임 헬퍼 문자열을 ArrayList에 주입한다.
 /// standalone 트랜스파일(main.zig)에서도 사용할 수 있도록 pub으로 노출.
-pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, helpers: RuntimeHelpers, minify: bool) !void {
+pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, helpers: RuntimeHelpers, minify: bool, es5_compat: bool) !void {
     if (helpers.extends) {
         try buf.appendSlice(allocator, if (minify) EXTENDS_RUNTIME_MIN else EXTENDS_RUNTIME);
     }
@@ -213,7 +235,11 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
         try buf.appendSlice(allocator, if (minify) REST_RUNTIME_MIN else REST_RUNTIME);
     }
     if (helpers.async_helper) {
-        try buf.appendSlice(allocator, if (minify) ASYNC_RUNTIME_MIN else ASYNC_RUNTIME);
+        if (es5_compat) {
+            try buf.appendSlice(allocator, if (minify) ASYNC_RUNTIME_ES5_MIN else ASYNC_RUNTIME_ES5);
+        } else {
+            try buf.appendSlice(allocator, if (minify) ASYNC_RUNTIME_MIN else ASYNC_RUNTIME);
+        }
     }
     if (helpers.to_binary) {
         try buf.appendSlice(allocator, if (minify) TO_BINARY_RUNTIME_MIN else TO_BINARY_RUNTIME);

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -1280,6 +1280,63 @@ test "ES2017: non-async function unchanged" {
     try std.testing.expectEqualStrings("export function foo(){return 1;}", r.output);
 }
 
+// --- ES5: async → state machine (async_await + generator 둘 다 unsupported) ---
+
+/// ES5 async state machine 변환의 공통 검증.
+/// function*/yield 없고, __async/__generator가 있어야 함.
+fn expectAsyncStateMachine(output: []const u8) !void {
+    try std.testing.expect(std.mem.indexOf(u8, output, "__async") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "__generator") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "function*") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "yield") == null);
+}
+
+test "ES5: async function → __async + __generator state machine" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo() { return await bar(); }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_state") != null);
+}
+
+test "ES5: async function with multiple awaits" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo() { var x = await a(); await b(x); return x; }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_state.sent()") != null);
+}
+
+test "ES5: async arrow block body → state machine" {
+    var r = try e2eTarget(std.testing.allocator, "var f = async () => { await x; };", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+}
+
+test "ES5: async arrow expression body → state machine" {
+    var r = try e2eTarget(std.testing.allocator, "var f = async () => await x;", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+}
+
+test "ES5: async function with if/await" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo(x) { if (x) { await a(); } await b(); }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+}
+
+test "ES5: __async runtime ES5 compatibility" {
+    const rt = @import("../bundler/runtime_helpers.zig");
+    // ES5 런타임 상수에 arrow function / rest params가 없어야 함
+    try std.testing.expect(std.mem.indexOf(u8, rt.ASYNC_RUNTIME_ES5, "=>") == null);
+    try std.testing.expect(std.mem.indexOf(u8, rt.ASYNC_RUNTIME_ES5, "...") == null);
+    try std.testing.expect(std.mem.indexOf(u8, rt.ASYNC_RUNTIME_ES5_MIN, "=>") == null);
+    try std.testing.expect(std.mem.indexOf(u8, rt.ASYNC_RUNTIME_ES5_MIN, "...") == null);
+    // ES5 타겟에서 es5_compat가 설정되는지 확인
+    var r = try e2eTarget(std.testing.allocator, "async function foo() { await bar(); }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+}
+
 // --- ES2018: object spread ---
 
 test "ES2018: spread only" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -788,7 +788,7 @@ fn transpileFile(
     const rh = transformer.runtime_helpers;
     const output = if (@as(u16, @bitCast(rh)) != 0) blk: {
         var helper_buf: std.ArrayList(u8) = .empty;
-        emitter.appendRuntimeHelpers(&helper_buf, arena_alloc, rh, options.minify_whitespace) catch |err| {
+        emitter.appendRuntimeHelpers(&helper_buf, arena_alloc, rh, options.minify_whitespace, transformer.runtime_es5_compat) catch |err| {
             try stderr.print("zts: helper injection error: {}\n", .{err});
             break :blk raw_output;
         };

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -97,22 +97,16 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 .data = .{ .unary = .{ .operand = gen_call, .flags = 0 } },
             });
 
-            // var 선언을 __generator 밖에 배치 (함수 스코프에서 한 번만 선언)
-            const new_body = if (sm_result.var_decl.isNone()) blk: {
-                const body_list = try self.new_ast.addNodeList(&.{ret_stmt});
-                break :blk try self.new_ast.addNode(.{
-                    .tag = .block_statement,
-                    .span = span,
-                    .data = .{ .list = body_list },
-                });
-            } else blk: {
-                const body_list = try self.new_ast.addNodeList(&.{ sm_result.var_decl, ret_stmt });
-                break :blk try self.new_ast.addNode(.{
-                    .tag = .block_statement,
-                    .span = span,
-                    .data = .{ .list = body_list },
-                });
-            };
+            // hoisted var 선언을 __generator 밖에 배치
+            const body_list = if (sm_result.var_decl.isNone())
+                try self.new_ast.addNodeList(&.{ret_stmt})
+            else
+                try self.new_ast.addNodeList(&.{ sm_result.var_decl, ret_stmt });
+            const new_body = try self.new_ast.addNode(.{
+                .tag = .block_statement,
+                .span = span,
+                .data = .{ .list = body_list },
+            });
 
             // 일반 function으로 변환 (generator 플래그 제거)
             const new_flags = flags & ~@as(u32, ast_mod.FunctionFlags.is_generator);
@@ -132,17 +126,22 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             });
         }
 
-        const StateMachineResult = struct {
+        pub const StateMachineResult = struct {
             body: NodeIndex, // switch 문 (또는 switch를 포함하는 block)
             var_decl: NodeIndex, // 호이스팅된 var 선언 (없으면 .none)
         };
 
         /// generator body를 switch 문 기반 상태 머신으로 변환.
-        fn buildStateMachine(self: *Transformer, body_idx: NodeIndex, span: Span) Transformer.Error!StateMachineResult {
+        /// es2017 결합 변환에서도 호출 (async body의 await를 yield처럼 처리).
+        pub fn buildStateMachine(self: *Transformer, body_idx: NodeIndex, span: Span) Transformer.Error!StateMachineResult {
             if (body_idx.isNone()) return .{ .body = .none, .var_decl = .none };
 
             const body = self.old_ast.getNode(body_idx);
-            if (body.tag != .block_statement and body.tag != .function_body) return .{ .body = .none, .var_decl = .none };
+
+            // expression body (arrow function): implicit return으로 처리
+            if (body.tag != .block_statement and body.tag != .function_body) {
+                return buildExpressionBodyStateMachine(self, body_idx, body, span);
+            }
 
             const stmts = self.old_ast.extra_data.items[body.data.list.start .. body.data.list.start + body.data.list.len];
 
@@ -194,15 +193,15 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             switch (stmt.tag) {
                 .expression_statement => {
-                    // expression_statement 안의 yield 감지
+                    // expression_statement 안의 yield/await 감지
                     const expr_idx = stmt.data.unary.operand;
                     const expr = self.old_ast.getNode(expr_idx);
 
-                    if (expr.tag == .yield_expression) {
+                    if (expr.tag == .yield_expression or expr.tag == .await_expression) {
                         const value_idx = expr.data.unary.operand;
-                        const is_delegate = (expr.data.unary.flags & 1) != 0;
+                        const is_delegate = if (expr.tag == .yield_expression) (expr.data.unary.flags & 1) != 0 else false;
                         const new_value = if (!value_idx.isNone()) try self.visitNode(value_idx) else NodeIndex.none;
-                        // yield* → [5, iter], yield → [4, value]
+                        // yield* → [5, iter], yield/await → [4, value]
                         const opcode: OpCode = if (is_delegate) .yield_star else .yield_op;
                         try ops.append(self.allocator, .{ .code = opcode, .arg = .{ .node = new_value } });
                         next_label.* += 1;
@@ -211,10 +210,10 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                         const sent_stmt = try buildSentExprStmt(self, stmt.span);
                         try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = sent_stmt } });
                     } else if (expr.tag == .assignment_expression) {
-                        // x = yield value 패턴 감지
+                        // x = yield value / x = await value 패턴 감지
                         const right_idx = expr.data.binary.right;
                         const right = self.old_ast.getNode(right_idx);
-                        if (right.tag == .yield_expression) {
+                        if (right.tag == .yield_expression or right.tag == .await_expression) {
                             const yield_value_idx = right.data.unary.operand;
                             const new_yield_value = if (!yield_value_idx.isNone()) try self.visitNode(yield_value_idx) else NodeIndex.none;
                             try ops.append(self.allocator, .{ .code = .yield_op, .arg = .{ .node = new_yield_value } });
@@ -242,8 +241,26 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 },
                 .return_statement => {
                     const value_idx = stmt.data.unary.operand;
-                    const new_value = if (!value_idx.isNone()) try self.visitNode(value_idx) else NodeIndex.none;
-                    try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = new_value } });
+                    if (!value_idx.isNone()) {
+                        const value_node = self.old_ast.getNode(value_idx);
+                        if (value_node.tag == .yield_expression or value_node.tag == .await_expression) {
+                            // return yield/await x → yield x + return _state.sent()
+                            const inner_value = value_node.data.unary.operand;
+                            const new_inner = if (!inner_value.isNone()) try self.visitNode(inner_value) else NodeIndex.none;
+                            const is_delegate = if (value_node.tag == .yield_expression) (value_node.data.unary.flags & 1) != 0 else false;
+                            const opcode: OpCode = if (is_delegate) .yield_star else .yield_op;
+                            try ops.append(self.allocator, .{ .code = opcode, .arg = .{ .node = new_inner } });
+                            next_label.* += 1;
+                            try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
+                            const sent = try buildSentCall(self, stmt.span);
+                            try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = sent } });
+                        } else {
+                            const new_value = try self.visitNode(value_idx);
+                            try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = new_value } });
+                        }
+                    } else {
+                        try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = NodeIndex.none } });
+                    }
                 },
                 .variable_declaration => {
                     // 모든 var는 호이스팅됨. init를 assignment로 변환.
@@ -933,8 +950,8 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 if (init_idx.isNone()) continue;
 
                 const init_node = self.old_ast.getNode(init_idx);
-                if (init_node.tag == .yield_expression) {
-                    // var x = yield value → yield value + x = _state.sent()
+                if (init_node.tag == .yield_expression or init_node.tag == .await_expression) {
+                    // var x = yield/await value → yield value + x = _state.sent()
                     const yield_val = init_node.data.unary.operand;
                     const new_val = if (!yield_val.isNone()) try self.visitNode(yield_val) else NodeIndex.none;
                     try ops.append(self.allocator, .{ .code = .yield_op, .arg = .{ .node = new_val } });
@@ -970,7 +987,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
         fn containsYield(self: *const Transformer, idx: NodeIndex) bool {
             if (idx.isNone()) return false;
             const node = self.old_ast.getNode(idx);
-            if (node.tag == .yield_expression) return true;
+            if (node.tag == .yield_expression or node.tag == .await_expression) return true;
             // labeled break/continue: generator label stack에 등록된 label 참조 시 처리 필요
             if ((node.tag == .break_statement or node.tag == .continue_statement) and
                 !node.data.unary.operand.isNone() and self.generator_label_stack.items.len > 0)
@@ -1137,6 +1154,35 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 },
                 else => false,
             };
+        }
+
+        /// expression body (arrow function 등)를 state machine으로 변환.
+        /// expression을 implicit return으로 처리.
+        fn buildExpressionBodyStateMachine(self: *Transformer, body_idx: NodeIndex, body: Node, span: Span) Transformer.Error!StateMachineResult {
+            // expression body는 최대 3개 연산 (yield + nop + return)
+            var ops_buf: [3]Operation = undefined;
+            var ops_len: usize = 0;
+
+            if (body.tag == .await_expression or body.tag == .yield_expression) {
+                // return await/yield x → yield x + return _state.sent()
+                const inner_value = body.data.unary.operand;
+                const new_inner = if (!inner_value.isNone()) try self.visitNode(inner_value) else NodeIndex.none;
+                const is_delegate = if (body.tag == .yield_expression) (body.data.unary.flags & 1) != 0 else false;
+                const opcode: OpCode = if (is_delegate) .yield_star else .yield_op;
+                ops_buf[0] = .{ .code = opcode, .arg = .{ .node = new_inner } };
+                ops_buf[1] = .{ .code = .nop, .arg = .{ .none = {} } };
+                const sent = try buildSentCall(self, span);
+                ops_buf[2] = .{ .code = .return_op, .arg = .{ .node = sent } };
+                ops_len = 3;
+            } else {
+                // 일반 expression: return expr
+                const new_value = try self.visitNode(body_idx);
+                ops_buf[0] = .{ .code = .return_op, .arg = .{ .node = new_value } };
+                ops_len = 1;
+            }
+
+            const switch_node = try buildSwitchFromOps(self, ops_buf[0..ops_len], span);
+            return .{ .body = switch_node, .var_decl = .none };
         }
 
         /// 연산 리스트를 switch case로 변환.
@@ -1345,8 +1391,9 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             return es_helpers.makeIdentifierRef(self, "_state");
         }
 
-        /// __generator(function(_state) { switch_body }) 호출 생성.
-        fn buildGeneratorHelperCall(self: *Transformer, switch_body: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+        /// __generator(function(_state) { ... }) 호출 생성.
+        /// es2017 결합 변환에서도 호출.
+        pub fn buildGeneratorHelperCall(self: *Transformer, switch_body: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             self.runtime_helpers.generator = true;
 
             // _state 파라미터

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -14,6 +14,7 @@
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const es_helpers = @import("es_helpers.zig");
+const es2015_generator = @import("es2015_generator.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const token_mod = @import("../lexer/token.zig");
@@ -125,6 +126,112 @@ pub fn ES2017(comptime Transformer: type) type {
             });
         }
 
+        /// async function → __async(__generator(function(_state) { switch... })).call(this)
+        /// async_await + generator 둘 다 unsupported일 때 호출.
+        /// body를 pre-visit하지 않고 원본 body에서 직접 state machine 생성.
+        /// await_expression은 es2015_generator의 collectOperations에서 yield처럼 처리됨.
+        pub fn lowerAsyncToStateMachine(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const GenMod = es2015_generator.ES2015Generator(Transformer);
+            const extras = self.old_ast.extra_data.items;
+            const e = node.data.extra;
+            const span = node.span;
+
+            const name_idx: NodeIndex = @enumFromInt(extras[e]);
+            const params_start = extras[e + 1];
+            const params_len = extras[e + 2];
+            const body_idx: NodeIndex = @enumFromInt(extras[e + 3]);
+            const flags = extras[e + 4];
+
+            const new_name = try self.visitNode(name_idx);
+            const new_params = try self.visitExtraList(params_start, params_len);
+
+            const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+            if (sm_result.body.isNone()) return .none;
+
+            const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
+            const async_call = try buildAsyncHelperCall(self, gen_call, span);
+
+            const return_stmt = try self.new_ast.addNode(.{
+                .tag = .return_statement,
+                .span = span,
+                .data = .{ .unary = .{ .operand = async_call, .flags = 0 } },
+            });
+
+            // hoisted var 선언을 __generator 밖에 배치
+            const body_list = if (sm_result.var_decl.isNone())
+                try self.new_ast.addNodeList(&.{return_stmt})
+            else
+                try self.new_ast.addNodeList(&.{ sm_result.var_decl, return_stmt });
+            const wrapper_body = try self.new_ast.addNode(.{
+                .tag = .block_statement,
+                .span = span,
+                .data = .{ .list = body_list },
+            });
+
+            // 일반 function으로 변환 (async + generator 플래그 모두 제거)
+            const new_flags = flags & ~(ast_mod.FunctionFlags.is_async | @as(u32, ast_mod.FunctionFlags.is_generator));
+            const new_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(new_name),
+                new_params.start,
+                new_params.len,
+                @intFromEnum(wrapper_body),
+                new_flags,
+                @intFromEnum(NodeIndex.none),
+            });
+            return self.new_ast.addNode(.{
+                .tag = node.tag,
+                .span = span,
+                .data = .{ .extra = new_extra },
+            });
+        }
+
+        /// async arrow → () => __async(__generator(function(_state) { switch... }).call(this))
+        /// async_await + generator 둘 다 unsupported일 때 호출.
+        pub fn lowerAsyncArrowToStateMachine(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const GenMod = es2015_generator.ES2015Generator(Transformer);
+            const extras = self.old_ast.extra_data.items;
+            const e = node.data.extra;
+            const span = node.span;
+
+            const params_idx: NodeIndex = @enumFromInt(extras[e]);
+            const body_idx: NodeIndex = @enumFromInt(extras[e + 1]);
+            const flags = extras[e + 2];
+
+            const new_params = try self.visitNode(params_idx);
+
+            const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+            if (sm_result.body.isNone()) return .none;
+
+            const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
+            const async_call = try buildAsyncHelperCall(self, gen_call, span);
+
+            // hoisted vars가 있으면 block body, 없으면 expression body
+            const final_body = if (sm_result.var_decl.isNone()) async_call else blk: {
+                const return_stmt = try self.new_ast.addNode(.{
+                    .tag = .return_statement,
+                    .span = span,
+                    .data = .{ .unary = .{ .operand = async_call, .flags = 0 } },
+                });
+                const body_list = try self.new_ast.addNodeList(&.{ sm_result.var_decl, return_stmt });
+                break :blk try self.new_ast.addNode(.{
+                    .tag = .block_statement,
+                    .span = span,
+                    .data = .{ .list = body_list },
+                });
+            };
+            const new_flags = flags & ~@as(u32, ast_mod.ArrowFlags.is_async);
+            const new_extra = try self.new_ast.addExtras(&.{
+                @intFromEnum(new_params),
+                @intFromEnum(final_body),
+                new_flags,
+            });
+            return self.new_ast.addNode(.{
+                .tag = .arrow_function_expression,
+                .span = span,
+                .data = .{ .extra = new_extra },
+            });
+        }
+
         fn buildGeneratorWrapper(self: *Transformer, body: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const empty_params = try self.new_ast.addNodeList(&.{});
             const gen_extra = try self.new_ast.addExtras(&.{
@@ -142,43 +249,15 @@ pub fn ES2017(comptime Transformer: type) type {
             });
         }
 
-        /// __async(function*() { ... })() — 즉시 호출.
-        /// __async는 래퍼 함수를 반환하므로 ()로 즉시 실행해야 Promise를 얻음.
+        /// __async(gen).call(this) — this 바인딩 보존.
         fn buildAsyncHelperCall(self: *Transformer, gen_func: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const async_span = try self.new_ast.addString("__async");
-            const async_ref = try self.new_ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = async_span,
-                .data = .{ .string_ref = async_span },
-            });
-            const args = try self.new_ast.addNodeList(&.{gen_func});
-            const inner_call_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(async_ref),
-                args.start,
-                args.len,
-                0,
-            });
-            const inner_call = try self.new_ast.addNode(.{
-                .tag = .call_expression,
-                .span = span,
-                .data = .{ .extra = inner_call_extra },
-            });
-            // __async(gen).call(this) — this 바인딩 보존
+            self.runtime_helpers.async_helper = true;
+            const async_ref = try es_helpers.makeIdentifierRef(self, "__async");
+            const inner_call = try es_helpers.makeCallExpr(self, async_ref, &.{gen_func}, span);
             const call_prop = try es_helpers.makeIdentifierRef(self, "call");
             const member = try es_helpers.makeStaticMember(self, inner_call, call_prop, span);
             const this_ref = try es_helpers.makeIdentifierRef(self, "this");
-            const this_args = try self.new_ast.addNodeList(&.{this_ref});
-            const outer_call_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(member),
-                this_args.start,
-                this_args.len,
-                0,
-            });
-            return self.new_ast.addNode(.{
-                .tag = .call_expression,
-                .span = span,
-                .data = .{ .extra = outer_call_extra },
-            });
+            return es_helpers.makeCallExpr(self, member, &.{this_ref}, span);
         }
     };
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -190,6 +190,10 @@ pub const Transformer = struct {
     /// 번들러 emitter가 이 비트맵을 읽어 필요한 헬퍼만 출력에 주입한다.
     runtime_helpers: RuntimeHelpers = .{},
 
+    /// 런타임 헬퍼를 ES5 문법으로 출력 (arrow, rest params 제거).
+    /// unsupported.arrow일 때 자동 설정.
+    runtime_es5_compat: bool = false,
+
     /// React Fast Refresh: 감지된 컴포넌트 등록 목록.
     /// transform 완료 후 프로그램 끝에 $RefreshReg$ 호출로 주입.
     refresh_registrations: std.ArrayList(RefreshRegistration) = .empty,
@@ -232,7 +236,7 @@ pub const Transformer = struct {
         var opts = options;
         if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
 
-        return .{
+        var self: Transformer = .{
             .old_ast = old_ast,
             .new_ast = Ast.init(allocator, old_ast.source),
             .options = opts,
@@ -240,6 +244,8 @@ pub const Transformer = struct {
             .scratch = .empty,
             .pending_nodes = .empty,
         };
+        if (opts.unsupported.arrow) self.runtime_es5_compat = true;
+        return self;
     }
 
     pub fn deinit(self: *Transformer) void {
@@ -591,6 +597,10 @@ pub const Transformer = struct {
                     const extras = self.old_ast.extra_data.items;
                     const e = node.data.extra;
                     if (e + 4 < extras.len and (extras[e + 4] & ast_mod.FunctionFlags.is_async) != 0) {
+                        // async + generator 둘 다 unsupported → 직접 state machine 생성
+                        if (self.options.unsupported.generator) {
+                            return es2017_mod.ES2017(Transformer).lowerAsyncToStateMachine(self, node);
+                        }
                         return es2017_mod.ES2017(Transformer).lowerAsyncFunction(self, node);
                     }
                 }
@@ -611,6 +621,10 @@ pub const Transformer = struct {
                     const extras = self.old_ast.extra_data.items;
                     const e = node.data.extra;
                     if (e + 2 < extras.len and (extras[e + 2] & ast_mod.ArrowFlags.is_async) != 0) {
+                        // async + generator 둘 다 unsupported → 직접 state machine 생성
+                        if (self.options.unsupported.generator) {
+                            return es2017_mod.ES2017(Transformer).lowerAsyncArrowToStateMachine(self, node);
+                        }
                         return es2017_mod.ES2017(Transformer).lowerAsyncArrow(self, node);
                     }
                 }


### PR DESCRIPTION
## Summary
- ES5 타겟에서 async function이 `function*` + `yield`로만 변환되고 state machine으로 재변환되지 않는 버그 수정
- `async_await + generator` 둘 다 unsupported일 때 중간 generator를 거치지 않고 직접 `__async(__generator(function(_state) { switch... }))` 형태로 변환
- `__async` 런타임 헬퍼 ES5 호환 버전 추가 (arrow function, rest params 제거)
- `buildAsyncHelperCall`에서 `runtime_helpers.async_helper` 플래그 설정 누락 수정

## Test plan
- [x] ES5 타겟 async function → state machine 변환 테스트 (function*/yield 제거 확인)
- [x] ES5 타겟 async arrow (block body + expression body) 변환 테스트
- [x] ES5 타겟 if/await 조합 테스트
- [x] `__async` 런타임 ES5 호환성 테스트 (arrow/rest 없음 확인)
- [x] ES2016 타겟은 기존 동작 유지 (function* + yield 출력)
- [x] 기존 generator 다운레벨링 테스트 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)