### PR TITLE
fix(transformer): yield 추출 temp 변수 + member expression 크래시 + expression 핸들러 추가

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -1425,6 +1425,39 @@ test "ES5: generator with yield in return expression" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "yield") == null);
 }
 
+test "ES5: await in object literal" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo() { return {x: await a, y: await b}; }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+}
+
+test "ES5: await in template literal" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo() { return `hello ${await name()}`; }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+}
+
+test "ES5: await in spread element" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo() { return bar(...await getArgs()); }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+}
+
+test "ES5: await in member expression (a.b.method(await x))" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo() { if (a.b && (await a.c())) { run(); } }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+}
+
+test "ES5: multiple awaits in array literal use temp vars" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo() { return [await a, await b]; }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+    // 각 yield 결과가 temp 변수에 저장되어야 함 (직접 _state.sent() 중복 호출 방지)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=_state.sent()") != null or
+        std.mem.indexOf(u8, r.output, "= _state.sent()") != null);
+}
+
 test "ES5: generator with destructuring var hoisting" {
     var r = try e2eTarget(std.testing.allocator, "function* gen() { var {x, y} = yield getObj(); return x; }", .es5);
     defer r.deinit();

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1077,7 +1077,9 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 .block_statement,
                 .function_body,
                 .array_expression,
+                .object_expression,
                 .sequence_expression,
+                .template_literal,
                 .formal_parameters,
                 .class_body,
                 => {
@@ -1099,7 +1101,17 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 .assignment_expression,
                 .binary_expression,
                 .logical_expression,
+                .object_property,
                 => containsYield(self, node.data.binary.left) or containsYield(self, node.data.binary.right),
+                // extra = [child0, child1, flags] — child 2개만 재귀
+                .static_member_expression,
+                .computed_member_expression,
+                .tagged_template_expression,
+                => {
+                    const extras = self.old_ast.extra_data.items;
+                    const e = node.data.extra;
+                    return containsYield(self, @enumFromInt(extras[e])) or containsYield(self, @enumFromInt(extras[e + 1]));
+                },
                 .conditional_expression,
                 .if_statement,
                 .for_in_statement,
@@ -1252,10 +1264,10 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             if (expr_idx.isNone()) return .none;
             const node = self.old_ast.getNode(expr_idx);
 
-            // yield/await → yield operation 추출 + _state.sent() 반환
+            // yield/await → yield operation 추출 + temp 변수에 결과 저장
+            // 하나의 expression에 여러 yield가 있으면 각 결과를 temp에 저장해야 함
             if (node.tag == .yield_expression or node.tag == .await_expression) {
                 const value_idx = node.data.unary.operand;
-                // operand에도 yield/await가 중첩될 수 있음 (await(await x))
                 const new_value = if (!value_idx.isNone())
                     try visitExprWithYieldExtraction(self, value_idx, ops, next_label)
                 else
@@ -1265,7 +1277,18 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 try ops.append(self.allocator, .{ .code = opcode, .arg = .{ .node = new_value } });
                 next_label.* += 1;
                 try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
-                return buildSentCall(self, node.span);
+                // temp 변수에 _state.sent() 결과 저장
+                const temp_span = try es_helpers.makeTempVarSpan(self);
+                const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, node.span);
+                const sent_call = try buildSentCall(self, node.span);
+                const assign = try self.new_ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = node.span,
+                    .data = .{ .binary = .{ .left = temp_ref, .right = sent_call, .flags = 0 } },
+                });
+                const assign_stmt = try es_helpers.makeExprStmt(self, assign, node.span);
+                try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = assign_stmt } });
+                return es_helpers.makeTempVarRef(self, temp_span, node.span);
             }
 
             // yield를 포함하지 않으면 일반 visit
@@ -1327,14 +1350,23 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 });
             }
 
-            // member expression: object.property
-            if (node.tag == .static_member_expression or node.tag == .computed_member_expression) {
-                const new_object = try visitExprWithYieldExtraction(self, node.data.binary.left, ops, next_label);
-                const new_prop = try visitExprWithYieldExtraction(self, node.data.binary.right, ops, next_label);
+            // extra = [child0, child1, flags] — member expression, tagged template
+            if (node.tag == .static_member_expression or node.tag == .computed_member_expression or
+                node.tag == .tagged_template_expression)
+            {
+                const extras = self.old_ast.extra_data.items;
+                const e = node.data.extra;
+                const new_child0 = try visitExprWithYieldExtraction(self, @enumFromInt(extras[e]), ops, next_label);
+                const new_child1 = try visitExprWithYieldExtraction(self, @enumFromInt(extras[e + 1]), ops, next_label);
+                const new_extra = try self.new_ast.addExtras(&.{
+                    @intFromEnum(new_child0),
+                    @intFromEnum(new_child1),
+                    extras[e + 2],
+                });
                 return self.new_ast.addNode(.{
                     .tag = node.tag,
                     .span = node.span,
-                    .data = .{ .binary = .{ .left = new_object, .right = new_prop, .flags = node.data.binary.flags } },
+                    .data = .{ .extra = new_extra },
                 });
             }
 
@@ -1369,7 +1401,50 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 });
             }
 
-            // 미지원 expression 타입: visitNode fallback (yield가 남을 수 있음)
+            // list 기반: array, object, sequence, template literal
+            if (node.tag == .array_expression or node.tag == .object_expression or
+                node.tag == .sequence_expression or node.tag == .template_literal)
+            {
+                const scratch_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                const elements = self.old_ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
+                for (elements) |raw_idx| {
+                    const new_elem = try visitExprWithYieldExtraction(self, @enumFromInt(raw_idx), ops, next_label);
+                    try self.scratch.append(self.allocator, new_elem);
+                }
+                const new_list = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+                return self.new_ast.addNode(.{
+                    .tag = node.tag,
+                    .span = node.span,
+                    .data = .{ .list = new_list },
+                });
+            }
+
+            // object_property: binary (key: value)
+            if (node.tag == .object_property) {
+                const new_key = try visitExprWithYieldExtraction(self, node.data.binary.left, ops, next_label);
+                const new_value = if (!node.data.binary.right.isNone())
+                    try visitExprWithYieldExtraction(self, node.data.binary.right, ops, next_label)
+                else
+                    NodeIndex.none;
+                return self.new_ast.addNode(.{
+                    .tag = .object_property,
+                    .span = node.span,
+                    .data = .{ .binary = .{ .left = new_key, .right = new_value, .flags = node.data.binary.flags } },
+                });
+            }
+
+            // spread_element: unary
+            if (node.tag == .spread_element) {
+                const new_operand = try visitExprWithYieldExtraction(self, node.data.unary.operand, ops, next_label);
+                return self.new_ast.addNode(.{
+                    .tag = .spread_element,
+                    .span = node.span,
+                    .data = .{ .unary = .{ .operand = new_operand, .flags = node.data.unary.flags } },
+                });
+            }
+
+            // 그 외: visitNode fallback (yield가 남을 수 있음)
             if (std.debug.runtime_safety) {
                 std.log.warn("visitExprWithYieldExtraction: unhandled tag {}", .{node.tag});
             }


### PR DESCRIPTION
## Summary
- 다중 yield가 하나의 expression에 있을 때 `_state.sent()` 중복 호출로 마지막 값만 반환되던 버그 수정 → temp 변수 저장
- `static_member_expression`/`computed_member_expression`을 binary가 아닌 extra 기반으로 올바르게 접근 (index out of bounds 크래시 수정)
- `visitExprWithYieldExtraction`에 array/object/sequence/template/spread/tagged_template/member expression 핸들러 추가
- `containsYield`에도 동일한 노드 타입 지원 추가

## Test plan
- [x] `[await a, await b]` → temp 변수 `_a`, `_b` 사용 확인
- [x] `{x: await a, y: await b}` → object literal 내 await
- [x] `` `hello ${await name()}` `` → template literal 내 await
- [x] `bar(...await getArgs())` → spread 내 await
- [x] `a.b && (await a.c())` → member expression 내 await (크래시 수정 확인)
- [x] 기존 테스트 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)