### PR TITLE
fix(transformer): ES5 class async method가 state machine으로 변환되지 않는 버그 수정

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -1458,6 +1458,32 @@ test "ES5: multiple awaits in array literal use temp vars" {
         std.mem.indexOf(u8, r.output, "= _state.sent()") != null);
 }
 
+test "ES5: class async method → state machine (RN KeyboardAvoidingView pattern)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  async bar(x) {
+        \\    if (x && (await check())) { return 0; }
+        \\    const y = await compute(x);
+        \\    return y;
+        \\  }
+        \\}
+    , .es5);
+    defer r.deinit();
+    // class async method도 state machine으로 변환되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__generator") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "yield") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function*") == null);
+    // async 키워드가 메서드 선언에 남아있으면 안 됨 (async function은 __async 헬퍼 제외)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "async function") == null);
+}
+
+test "ES5: class static async method → state machine" {
+    var r = try e2eTarget(std.testing.allocator, "class Foo { static async fetch() { return await getData(); } }", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__generator") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "yield") == null);
+}
+
 test "ES5: generator with destructuring var hoisting" {
     var r = try e2eTarget(std.testing.allocator, "function* gen() { var {x, y} = yield getObj(); return x; }", .es5);
     defer r.deinit();

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1072,12 +1072,41 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             // function expression 생성
             const new_params = try self.visitExtraList(params_start, params_len);
-            const new_body = try visitMethodBody(self, body_idx, span);
 
+            const is_async = flags & 0x08 != 0;
+            const is_generator = flags & 0x10 != 0;
+
+            // async method + generator 다운레벨링: class lowering이 먼저 실행되어
+            // method_definition → function_expression으로 변환되므로,
+            // 여기서 직접 async → state machine 변환을 수행해야 함.
+            // (new_ast에 생성된 function_expression은 transformer가 재방문하지 않음)
+            if (is_async and self.options.unsupported.async_await) {
+                const ES2017 = @import("es2017.zig").ES2017(@TypeOf(self.*));
+                const GenMod = @import("es2015_generator.zig").ES2015Generator(@TypeOf(self.*));
+
+                if (self.options.unsupported.generator) {
+                    // async + generator 둘 다 unsupported → __async(__generator(state machine))
+                    // buildStateMachine이 old_ast에서 body를 읽고 내부에서 visitNode 수행
+                    const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+                    if (!sm_result.body.isNone()) {
+                        const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
+                        const async_call = try ES2017.buildAsyncHelperCall(self, gen_call, span);
+                        const func_expr = try buildWrappedFunc(self, async_call, sm_result.var_decl, new_params, span);
+                        return buildMethodAssignment(self, info, class_name_span, key_idx, func_expr, span);
+                    }
+                }
+                // async만 unsupported → __async(function*() { ... })
+                const gen_wrapper = try ES2017.buildGeneratorWrapper(self, try visitMethodBody(self, body_idx, span), span);
+                const async_call = try ES2017.buildAsyncHelperCall(self, gen_wrapper, span);
+                const func_expr = try buildWrappedFunc(self, async_call, .none, new_params, span);
+                return buildMethodAssignment(self, info, class_name_span, key_idx, func_expr, span);
+            }
+
+            const new_body = try visitMethodBody(self, body_idx, span);
             const func_flags: u32 = blk: {
                 var f: u32 = 0;
-                if (flags & 0x08 != 0) f |= 0x01; // async
-                if (flags & 0x10 != 0) f |= 0x02; // generator
+                if (is_async) f |= 0x01;
+                if (is_generator) f |= 0x02;
                 break :blk f;
             };
 
@@ -1096,22 +1125,54 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .data = .{ .extra = func_extra },
             });
 
-            // ClassName 또는 ClassName.prototype
+            return buildMethodAssignment(self, info, class_name_span, key_idx, func_expr, span);
+        }
+
+        /// return call_expr 를 body로 하는 function expression 생성.
+        /// var_decl이 있으면 body 앞에 추가 (hoisted vars).
+        fn buildWrappedFunc(self: *Transformer, call_expr: NodeIndex, var_decl: NodeIndex, params: ast_mod.NodeList, span: Span) Transformer.Error!NodeIndex {
+            const return_stmt = try self.new_ast.addNode(.{
+                .tag = .return_statement,
+                .span = span,
+                .data = .{ .unary = .{ .operand = call_expr, .flags = 0 } },
+            });
+            const body_list = if (var_decl.isNone())
+                try self.new_ast.addNodeList(&.{return_stmt})
+            else
+                try self.new_ast.addNodeList(&.{ var_decl, return_stmt });
+            const wrapper_body = try self.new_ast.addNode(.{
+                .tag = .block_statement,
+                .span = span,
+                .data = .{ .list = body_list },
+            });
+            const none = @intFromEnum(NodeIndex.none);
+            const func_extra = try self.new_ast.addExtras(&.{
+                none,
+                params.start,
+                params.len,
+                @intFromEnum(wrapper_body),
+                0,
+                none,
+            });
+            return self.new_ast.addNode(.{
+                .tag = .function_expression,
+                .span = span,
+                .data = .{ .extra = func_extra },
+            });
+        }
+
+        /// target.methodName = func_expr (expression_statement)
+        fn buildMethodAssignment(self: *Transformer, info: MethodInfo, class_name_span: Span, key_idx: NodeIndex, func_expr: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const target = if (info.is_static)
                 try es_helpers.makeIdentifierRefFromSpan(self, class_name_span)
             else
                 try buildPrototypeRef(self, class_name_span, span);
-
             const member_access = try es_helpers.makeMemberFromKeyIdx(self, target, key_idx, span);
-
-            // target.methodName = function() {}
             const assign = try self.new_ast.addNode(.{
                 .tag = .assignment_expression,
                 .span = span,
                 .data = .{ .binary = .{ .left = member_access, .right = func_expr, .flags = 0 } },
             });
-
-            // expression_statement
             return self.new_ast.addNode(.{
                 .tag = .expression_statement,
                 .span = span,

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1095,9 +1095,14 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 .spread_element,
                 .rest_element,
                 .parenthesized_expression,
-                .unary_expression,
-                .update_expression,
                 => containsYield(self, node.data.unary.operand),
+                .unary_expression, .update_expression => {
+                    // extra = [operand, operator_and_flags]
+                    const extras = self.old_ast.extra_data.items;
+                    const e = node.data.extra;
+                    if (e >= extras.len) return false;
+                    return containsYield(self, @enumFromInt(extras[e]));
+                },
                 .assignment_expression,
                 .binary_expression,
                 .logical_expression,
@@ -1278,17 +1283,18 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 next_label.* += 1;
                 try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
                 // temp 변수에 _state.sent() 결과 저장
+                // temp_span을 node.span 대신 사용 — 번들러에서 다른 모듈의 source span과 충돌 방지
                 const temp_span = try es_helpers.makeTempVarSpan(self);
-                const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, node.span);
-                const sent_call = try buildSentCall(self, node.span);
+                const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
+                const sent_call = try buildSentCall(self, temp_span);
                 const assign = try self.new_ast.addNode(.{
                     .tag = .assignment_expression,
-                    .span = node.span,
+                    .span = temp_span,
                     .data = .{ .binary = .{ .left = temp_ref, .right = sent_call, .flags = 0 } },
                 });
-                const assign_stmt = try es_helpers.makeExprStmt(self, assign, node.span);
+                const assign_stmt = try es_helpers.makeExprStmt(self, assign, temp_span);
                 try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = assign_stmt } });
-                return es_helpers.makeTempVarRef(self, temp_span, node.span);
+                return es_helpers.makeTempVarRef(self, temp_span, temp_span);
             }
 
             // yield를 포함하지 않으면 일반 visit
@@ -1329,13 +1335,20 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 });
             }
 
-            // unary/update expression (!, ~, typeof, ++x 등): operand 재귀
+            // unary/update expression: extra = [operand, operator_and_flags]
             if (node.tag == .unary_expression or node.tag == .update_expression) {
-                const new_operand = try visitExprWithYieldExtraction(self, node.data.unary.operand, ops, next_label);
+                const extras = self.old_ast.extra_data.items;
+                const e = node.data.extra;
+                const operand_idx: NodeIndex = @enumFromInt(extras[e]);
+                const new_operand = try visitExprWithYieldExtraction(self, operand_idx, ops, next_label);
+                const new_extra = try self.new_ast.addExtras(&.{
+                    @intFromEnum(new_operand),
+                    extras[e + 1], // operator_and_flags
+                });
                 return self.new_ast.addNode(.{
                     .tag = node.tag,
                     .span = node.span,
-                    .data = .{ .unary = .{ .operand = new_operand, .flags = node.data.unary.flags } },
+                    .data = .{ .extra = new_extra },
                 });
             }
 

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -232,7 +232,7 @@ pub fn ES2017(comptime Transformer: type) type {
             });
         }
 
-        fn buildGeneratorWrapper(self: *Transformer, body: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+        pub fn buildGeneratorWrapper(self: *Transformer, body: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const empty_params = try self.new_ast.addNodeList(&.{});
             const gen_extra = try self.new_ast.addExtras(&.{
                 @intFromEnum(NodeIndex.none), // name
@@ -250,7 +250,7 @@ pub fn ES2017(comptime Transformer: type) type {
         }
 
         /// __async(gen).call(this) — this 바인딩 보존.
-        fn buildAsyncHelperCall(self: *Transformer, gen_func: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+        pub fn buildAsyncHelperCall(self: *Transformer, gen_func: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             self.runtime_helpers.async_helper = true;
             const async_ref = try es_helpers.makeIdentifierRef(self, "__async");
             const inner_call = try es_helpers.makeCallExpr(self, async_ref, &.{gen_func}, span);


### PR DESCRIPTION
## Summary
- class lowering → function_expression 변환 후 async→state machine이 적용되지 않는 버그
- `buildPrototypeAssignment`에서 async method 감지 시 직접 `__async(__generator(...))` 변환 수행
- RN `KeyboardAvoidingView._relativeKeyboardHeight` 실제 패턴으로 재현 및 수정 확인

## Test plan
- [x] `class Foo { async bar(x) { if (x && (await check())) { return 0; } ... } }` → yield/function* 없음
- [x] `class Foo { static async fetch() { return await getData(); } }` → static method도 정상
- [x] RN `KeyboardAvoidingView.js` 실제 파일 트랜스파일 — yield 0개 확인
- [x] 기존 테스트 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)