### PR TITLE
fix(transformer,codegen): destructuring default parameter + tryRewriteRequire 크래시 수정

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1565,7 +1565,7 @@ pub const Codegen = struct {
         const callee_node = self.ast.getNode(callee);
         if (callee_node.tag != .identifier_reference) return false;
 
-        const callee_text = self.ast.source[callee_node.data.string_ref.start..callee_node.data.string_ref.end];
+        const callee_text = self.ast.getText(callee_node.data.string_ref);
         if (!std.mem.eql(u8, callee_text, "require")) return false;
 
         if (args_start >= self.ast.extra_data.items.len) return false;

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -1484,6 +1484,21 @@ test "ES5: class static async method → state machine" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "yield") == null);
 }
 
+test "ES5: destructuring default parameter with spread (AnimatedImplementation pattern)" {
+    var r = try e2eTarget(std.testing.allocator, "function foo() { return {...x}; }\nfunction bar({a = 1, b = true} = {}) { return a; }", .es5);
+    defer r.deinit();
+    // spread + destructuring default parameter → 크래시 없이 출력
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "void 0") != null);
+}
+
+test "ES5: destructuring default parameter in function" {
+    var r = try e2eTarget(std.testing.allocator, "function loop(animation, {iterations = -1, reset = true} = {}) { return iterations; }", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "void 0") != null);
+    // destructuring은 var {iterations, reset} = _ref 형태로 분해
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "yield") == null);
+}
+
 test "ES5: generator with destructuring var hoisting" {
     var r = try e2eTarget(std.testing.allocator, "function* gen() { var {x, y} = yield getObj(); return x; }", .es5);
     defer r.deinit();

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -88,13 +88,18 @@ pub fn ES2015Params(comptime Transformer: type) type {
                     const default_idx: NodeIndex = @enumFromInt(extras[pe + 2]);
 
                     if (!default_idx.isNone()) {
-                        // default parameter: x = val → x; body에 x = x === void 0 ? val : x 삽입
-                        const new_pattern = try self.visitNode(pattern_idx);
-                        try self.scratch.append(self.allocator, new_pattern);
-
-                        const new_default = try self.visitNode(default_idx);
-                        const default_stmt = try buildDefaultCheck(self, new_pattern, new_default, span);
-                        try body_stmts.append(self.allocator, default_stmt);
+                        const pat_node = self.old_ast.getNode(pattern_idx);
+                        if (pat_node.tag == .object_pattern or pat_node.tag == .array_pattern) {
+                            // destructuring + default → temp 변수 경유
+                            const result = try buildDestructuringDefault(self, pattern_idx, default_idx, &body_stmts, span);
+                            try self.scratch.append(self.allocator, result);
+                        } else {
+                            const new_pattern = try self.visitNode(pattern_idx);
+                            try self.scratch.append(self.allocator, new_pattern);
+                            const new_default = try self.visitNode(default_idx);
+                            const default_stmt = try buildDefaultCheck(self, new_pattern, new_default, span);
+                            try body_stmts.append(self.allocator, default_stmt);
+                        }
                         param_index += 1;
                         continue;
                     }
@@ -102,12 +107,17 @@ pub fn ES2015Params(comptime Transformer: type) type {
 
                 if (param.tag == .assignment_pattern) {
                     // assignment_pattern: binary { left=pattern, right=default }
-                    const new_pattern = try self.visitNode(param.data.binary.left);
-                    try self.scratch.append(self.allocator, new_pattern);
-
-                    const new_default = try self.visitNode(param.data.binary.right);
-                    const default_stmt = try buildDefaultCheck(self, new_pattern, new_default, span);
-                    try body_stmts.append(self.allocator, default_stmt);
+                    const pattern_node = self.old_ast.getNode(param.data.binary.left);
+                    if (pattern_node.tag == .object_pattern or pattern_node.tag == .array_pattern) {
+                        const result = try buildDestructuringDefault(self, param.data.binary.left, param.data.binary.right, &body_stmts, span);
+                        try self.scratch.append(self.allocator, result);
+                    } else {
+                        const new_pattern = try self.visitNode(param.data.binary.left);
+                        try self.scratch.append(self.allocator, new_pattern);
+                        const new_default = try self.visitNode(param.data.binary.right);
+                        const default_stmt = try buildDefaultCheck(self, new_pattern, new_default, span);
+                        try body_stmts.append(self.allocator, default_stmt);
+                    }
                     param_index += 1;
                     continue;
                 }
@@ -132,6 +142,37 @@ pub fn ES2015Params(comptime Transformer: type) type {
             new_params: NodeList,
             body_stmts: std.ArrayList(NodeIndex),
         };
+
+        /// destructuring + default parameter → temp 변수 경유.
+        /// ({a = 1} = {}) → (_ref); body에 _ref = _ref === void 0 ? {} : _ref; var {a} = _ref;
+        fn buildDestructuringDefault(
+            self: *Transformer,
+            pattern_idx: NodeIndex,
+            default_idx: NodeIndex,
+            body_stmts: *std.ArrayList(NodeIndex),
+            span: Span,
+        ) Transformer.Error!NodeIndex {
+            const temp_span = try es_helpers.makeTempVarSpan(self);
+            const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
+
+            const new_default = try self.visitNode(default_idx);
+            const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, span);
+            const default_stmt = try buildDefaultCheck(self, temp_ref, new_default, span);
+            try body_stmts.append(self.allocator, default_stmt);
+
+            // var {a} = _ref
+            const new_pattern = try self.visitNode(pattern_idx);
+            const temp_ref2 = try es_helpers.makeTempVarRef(self, temp_span, span);
+            const destruct_decl = try es_helpers.makeVarDeclaration(
+                self,
+                &.{try es_helpers.makeDeclarator(self, new_pattern, temp_ref2, span)},
+                0,
+                span,
+            );
+            try body_stmts.append(self.allocator, destruct_decl);
+
+            return temp_binding;
+        }
 
         /// x = x === void 0 ? default_value : x
         /// → expression_statement 생성


### PR DESCRIPTION
## Summary
- `copyIdentifier`가 `object_pattern`의 `data.list`를 `data.string_ref`로 잘못 해석하여 identifier span 오염 → destructuring default parameter에서 temp 변수 사용
- `tryRewriteRequire`에서 `ast.source[]` 직접 접근 → `ast.getText()` 사용 (string_table 호환)
- RN AnimatedImplementation.js + KeyboardAvoidingView.js 번들 크래시 해결

## Test plan
- [x] `function foo() { return {...x}; } function bar({a=1}={}) { return a; }` → 크래시 없이 ES5 변환
- [x] RN ExampleApp `--target=es5 --flow` 번들 (698KB) panic 0개
- [x] 기존 테스트 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)