### PR TITLE
fix(transformer): catch 파라미터 var 호이스팅 누락 수정

### DIFF
--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -916,6 +916,18 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                     try collectHoistedVarFromNode(self, node.data.binary.right, hoisted);
                 } else if (node.tag == .for_in_statement or node.tag == .for_of_statement) {
                     try collectHoistedVarFromNode(self, node.data.ternary.c, hoisted);
+                } else if (node.tag == .try_statement) {
+                    // try body + catch body + finally body 재귀
+                    try collectHoistedVarFromNode(self, node.data.ternary.a, hoisted);
+                    if (!node.data.ternary.b.isNone()) {
+                        const catch_node = self.old_ast.getNode(node.data.ternary.b);
+                        // catch 파라미터를 var로 호이스팅 (state machine에서 접근 가능하도록)
+                        if (!catch_node.data.binary.left.isNone()) {
+                            try collectBindingIdentifiers(self, catch_node.data.binary.left, hoisted);
+                        }
+                        try collectHoistedVarFromNode(self, catch_node.data.binary.right, hoisted);
+                    }
+                    try collectHoistedVarFromNode(self, node.data.ternary.c, hoisted);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `collectHoistedVars`에서 `try_statement`의 catch 파라미터를 `var`로 호이스팅하지 않아 Bun strict mode에서 `ReferenceError: e is not defined` 발생
- try/catch/finally body도 재귀 순회하도록 추가

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/downlevel.test.ts` — 85/85 통과 (0 fail)
- [x] `catch (e: any) { return await ... }` Bun에서 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)