### PR TITLE
fix(flow): RN 호환 Flow 파싱 2차 개선 (에러 146→60)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -358,6 +358,8 @@ pub const Node = struct {
         flow_type_cast_expression,
         /// {| key: Type |} — Flow exact object type
         flow_exact_object_type,
+        /// match (expr) { ... } — Flow match expression
+        flow_match_expression,
 
         // ==============================================================
         // TypeScript Expressions

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -550,6 +550,13 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         }
     }
 
+    // Flow: class body variance — static +prop 또는 static -prop, 또는 +prop / -prop (non-static)
+    // Flow에서 `+`는 covariant(read-only), `-`는 contravariant(write-only) 프로퍼티를 의미한다.
+    // static 키워드 소비 후, 프로퍼티 키 파싱 전에 variance marker를 건너뛴다.
+    if (self.is_flow and (self.current() == .plus or self.current() == .minus)) {
+        try self.advance(); // skip variance marker
+    }
+
     // static 뒤의 TS modifier도 소비 (static readonly x 등)
     // 주의: 첫 번째 루프와 동일하게 멤버 이름으로 사용되는 경우를 처리
     while (self.current() == .kw_public or self.current() == .kw_private or

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -21,6 +21,7 @@ const Kind = token_mod.Kind;
 const Span = token_mod.Span;
 const Parser = @import("parser.zig").Parser;
 const ParseError2 = @import("parser.zig").ParseError2;
+const flow = @import("flow.zig");
 
 /// TypeScript의 canFollowTypeArgumentsInExpression 대응 (esbuild tsCanFollowTypeArgumentsInExpression).
 /// `f<Type>` 다음에 올 수 있는 토큰인지 판별한다.
@@ -1179,6 +1180,19 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
         (self.current().isKeyword() and !self.current().isReservedKeyword() and
             !self.current().isLiteralKeyword() and self.current() != .kw_async))
     {
+        // Flow match expression: match (expr) { Pattern => expr, ... }
+        // match는 예약어가 아닌 contextual keyword이므로 식별자로 파싱되기 전에 감지한다.
+        // 타입 스트리핑 전용이므로 balanced brace counting으로 전체를 소비한다.
+        if (self.is_flow and self.current() == .identifier) {
+            const text = self.resolveIdentifierText(span);
+            if (std.mem.eql(u8, text, "match")) {
+                const next_kind = try self.peekNextKind();
+                if (next_kind == .l_paren) {
+                    return try flow.parseMatchExpression(self);
+                }
+            }
+        }
+
         if (self.current() == .identifier) {
             if (self.in_class_field or self.in_static_initializer) {
                 const text = self.resolveIdentifierText(span);

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -545,6 +545,11 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
         try self.advance();
     }
 
+    // Flow const type parameter: <const T: {...}> — const modifier를 건너뛴다.
+    if (self.current() == .kw_const) {
+        try self.advance(); // skip 'const'
+    }
+
     try self.advance(); // type param name
 
     // constraint: T: Type (Flow 클래식) 또는 T extends Type (Flow 최신, RN 0.76+)
@@ -601,6 +606,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     // 패턴도 감지해야 한다.
     const is_likely_fn = blk: {
         if (self.current() == .dot3) break :blk true;
+        // Flow: positional params — object/tuple 타입이 첫 param으로 올 수 있음
         if (self.current() == .l_curly or self.current() == .l_bracket) break :blk true;
         if (self.current() == .identifier) {
             const next = try self.peekNextKind();
@@ -1188,5 +1194,50 @@ pub fn parseFlowInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
         .tag = .flow_interface_declaration,
         .span = .{ .start = start, .end = self.currentSpan().start },
         .data = .{ .extra = extra },
+    });
+}
+
+// ================================================================
+// Flow Match Expression
+// ================================================================
+
+/// Flow match expression: match (expr) { Pattern => expr, ... }
+/// match는 contextual keyword이므로 예약어가 아니다.
+/// 타입 스트리핑 전용이므로 내부를 개별 파싱하지 않고
+/// balanced brace counting으로 전체를 소비한 뒤 단일 노드를 생성한다.
+pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
+    const start = self.currentSpan().start;
+    try self.advance(); // skip 'match'
+
+    // match (expr) — 괄호 안의 discriminant를 소비
+    try self.expect(.l_paren);
+    var paren_depth: u32 = 1;
+    while (paren_depth > 0 and self.current() != .eof) {
+        switch (self.current()) {
+            .l_paren => paren_depth += 1,
+            .r_paren => paren_depth -= 1,
+            else => {},
+        }
+        if (paren_depth > 0) try self.advance();
+    }
+    try self.expect(.r_paren);
+
+    // match body { ... } — balanced brace counting으로 전체를 소비
+    try self.expect(.l_curly);
+    var brace_depth: u32 = 1;
+    while (brace_depth > 0 and self.current() != .eof) {
+        switch (self.current()) {
+            .l_curly => brace_depth += 1,
+            .r_curly => brace_depth -= 1,
+            else => {},
+        }
+        if (brace_depth > 0) try self.advance();
+    }
+    try self.expect(.r_curly);
+
+    return try self.ast.addNode(.{
+        .tag = .flow_match_expression,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .none = 0 },
     });
 }

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1989,6 +1989,30 @@ pub const Parser = struct {
             }
             // (a?: Type) — optional parameter
             if (self.current() == .question) return true;
+            // (a, b: Type) => ... — 첫 번째 파라미터에 타입이 없고 뒤에 타입이 있는 경우.
+            // `,` 뒤의 파라미터에서 `identifier :` 패턴을 찾으면 typed arrow로 판별.
+            // 예: (background, useForeground: boolean) => {}
+            //     (acc, edge: Edge) => {}
+            if (self.current() == .comma) {
+                while (self.current() == .comma) {
+                    try self.advance(); // skip ,
+                    // rest parameter with type
+                    if (self.current() == .dot3) return true;
+                    // destructuring with type
+                    if (self.current() == .l_curly or self.current() == .l_bracket) return true;
+                    if (self.current() == .identifier or self.current().isKeyword() or self.current() == .escaped_keyword) {
+                        try self.advance(); // skip identifier
+                        if (self.current() == .colon or self.current() == .question) return true;
+                        if (self.current() == .r_paren) {
+                            try self.advance();
+                            return self.current() == .colon and !self.in_ternary_consequent;
+                        }
+                        // 이 파라미터에도 타입이 없으면 다음 파라미터 확인
+                    } else {
+                        break;
+                    }
+                }
+            }
             return false;
         }
 


### PR DESCRIPTION
## Summary
- `static +PROP`: Flow class body covariant/contravariant property 지원
- `<const T: {...}>`: Flow generic의 const type parameter 지원
- `match (expr) { ... }`: Flow match expression 파싱 (balanced brace skip)
- `(a, b: Type) => {}`: 첫 파라미터에 타입 없는 typed arrow function 감지 개선

**결과**: 에러 파일 13 → 6, 에러 수 146 → 60, 모듈 577 → 582

## Test plan
- [x] `zig build test` 통과
- [x] RN ExampleApp 번들링 에러 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)