### PR TITLE
refactor(flow): parseMatchExpression 중복 제거

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1181,15 +1181,10 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             !self.current().isLiteralKeyword() and self.current() != .kw_async))
     {
         // Flow match expression: match (expr) { Pattern => expr, ... }
-        // match는 예약어가 아닌 contextual keyword이므로 식별자로 파싱되기 전에 감지한다.
-        // 타입 스트리핑 전용이므로 balanced brace counting으로 전체를 소비한다.
-        if (self.is_flow and self.current() == .identifier) {
-            const text = self.resolveIdentifierText(span);
-            if (std.mem.eql(u8, text, "match")) {
-                const next_kind = try self.peekNextKind();
-                if (next_kind == .l_paren) {
-                    return try flow.parseMatchExpression(self);
-                }
+        if (self.is_flow and self.isContextual("match")) {
+            const next_kind = try self.peekNextKind();
+            if (next_kind == .l_paren) {
+                return try flow.parseMatchExpression(self);
             }
         }
 

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1208,33 +1208,8 @@ pub fn parseFlowInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
 pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip 'match'
-
-    // match (expr) — 괄호 안의 discriminant를 소비
-    try self.expect(.l_paren);
-    var paren_depth: u32 = 1;
-    while (paren_depth > 0 and self.current() != .eof) {
-        switch (self.current()) {
-            .l_paren => paren_depth += 1,
-            .r_paren => paren_depth -= 1,
-            else => {},
-        }
-        if (paren_depth > 0) try self.advance();
-    }
-    try self.expect(.r_paren);
-
-    // match body { ... } — balanced brace counting으로 전체를 소비
-    try self.expect(.l_curly);
-    var brace_depth: u32 = 1;
-    while (brace_depth > 0 and self.current() != .eof) {
-        switch (self.current()) {
-            .l_curly => brace_depth += 1,
-            .r_curly => brace_depth -= 1,
-            else => {},
-        }
-        if (brace_depth > 0) try self.advance();
-    }
-    try self.expect(.r_curly);
-
+    try skipBalancedParens(self); // match (expr)
+    try skipBalancedBraces(self); // match body { ... }
     return try self.ast.addNode(.{
         .tag = .flow_match_expression,
         .span = .{ .start = start, .end = self.currentSpan().start },


### PR DESCRIPTION
## Summary
- `parseMatchExpression`: inline balanced counting → `skipBalancedParens`/`skipBalancedBraces` 재사용 (36줄→6줄)
- match 감지: `resolveIdentifierText` + string compare → `isContextual("match")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)