### PR TITLE
fix(flow): nullable return type + ternary typed arrow (에러 41→1)

### DIFF
--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -639,9 +639,10 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     }
 
     // `) =>` → single positional param function type
+    // return type context에서는 `=>` 가 arrow function body이므로 function type으로 해석하지 않는다.
     if (self.current() == .r_paren) {
         try self.advance();
-        if (self.current() == .arrow) {
+        if (self.current() == .arrow and !self.flow_in_return_type) {
             try self.advance();
             _ = try parseType(self);
         }

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1967,10 +1967,16 @@ pub const Parser = struct {
         // (): Type => ... — 빈 파라미터 + 리턴 타입
         if (self.current() == .r_paren) {
             try self.advance();
-            // ): 이면 typed arrow (리턴 타입 어노테이션)
-            // ternary consequent 안에서는 `:` 가 ternary separator일 수 있으므로 여기서 판단하지 않는다.
-            // parseConditionalExpression의 speculative reinterpret에서 처리한다.
-            return self.current() == .colon and !self.in_ternary_consequent;
+            if (self.current() != .colon) return false;
+            // ternary consequent 안에서는 `:` 가 ternary separator일 수 있다.
+            if (!self.in_ternary_consequent) return true;
+            // Flow: `:` 뒤에 type keyword가 오면 return type annotation 확정.
+            // void, number 등은 expression start로 사용되지 않으므로 ternary `:` 와 구분 가능.
+            if (self.is_flow) {
+                const after = try self.peekNextKind();
+                if (after == .kw_void or after == .kw_typeof) return true;
+            }
+            return false;
         }
 
         // (...rest: Type) => ... — rest parameter with type

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2840,6 +2840,22 @@ test "Flow: typed arrow in multi-param" {
     try expectNoParseErrorFlow("const f = (a, b, c: string) => c;");
 }
 
+test "Flow: nullable return type with arrow" {
+    // ?(T) return type이 function type이 아닌 nullable paren type으로 해석되어야 함
+    try expectNoParseErrorFlow(
+        \\class C {
+        \\  _getItem = (data: Array<ItemT>, index: number): ?(ItemT | string) => {
+        \\    return data[index];
+        \\  };
+        \\}
+    );
+}
+
+test "Flow: typed arrow in ternary consequent" {
+    // (): void => {} — 삼항 안에서 typed empty-param arrow
+    try expectNoParseErrorFlow("const x = true ? (): void => { return; } : null;");
+}
+
 test "Flow: type guard predicate" {
     try expectNoParseErrorFlow(
         \\function isObj(value: mixed): value is {[string]: unknown} {


### PR DESCRIPTION
## Summary
- `parseParenOrFunctionType`: return type context에서 `(T) =>` 가 function type으로 오인되는 버그 수정 (`flow_in_return_type` 체크)
- `isTypedArrowFunction`: ternary consequent에서 `(): void => {}` 감지 (`:` 뒤 type keyword lookahead)
- 테스트 2개 추가: nullable return type, ternary typed arrow

**결과**: 에러 41 → 1, 에러 파일 3 → 1 (Platform.ios.js 번들러 에러 1건 잔여)

## Test plan
- [x] `zig build test` 통과 (신규 테스트 포함)
- [x] RN ExampleApp 번들링 에러 1건으로 감소

🤖 Generated with [Claude Code](https://claude.com/claude-code)