### PR TITLE
fix(flow): JSX+Flow <T>() => body generic arrow 감지 (에러 0)

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -2029,15 +2029,22 @@ fn isTsxGenericArrowAfterAsync(self: *Parser) ParseError2!bool {
     return try checkTsxGenericArrowTypeParam(self);
 }
 
-/// `<` 다음 위치에서 `[const] Ident (,|=|extends|:)` 패턴을 확인.
-/// Flow는 `:` 로 constraint를 표기하므로 (예: `<T: {...}>(x) => ...`) colon도 허용.
+/// `<` 다음 위치에서 generic arrow function의 type parameter 패턴을 확인.
+/// `[const] Ident (,|=|extends|:)` 또는 Flow에서 `Ident > (` (단일 무제약 param).
 fn checkTsxGenericArrowTypeParam(self: *Parser) ParseError2!bool {
     if (self.current() == .kw_const) try self.advance();
     if (self.current() != .identifier and !self.current().isKeyword()) return false;
     try self.advance();
     const kind = self.current();
-    return kind == .comma or kind == .eq or kind == .kw_extends or
-        (self.is_flow and kind == .colon);
+    if (kind == .comma or kind == .eq or kind == .kw_extends) return true;
+    if (self.is_flow and kind == .colon) return true;
+    // Flow: <T>(...) => body — `>` 뒤에 `(` 가 오면 generic arrow로 판별.
+    // TSX에서는 <T> 가 JSX element일 수 있으므로, Flow 모드에서만 허용.
+    if (self.is_flow and kind == .r_angle) {
+        const after = try self.peekNextKind();
+        return after == .l_paren;
+    }
+    return false;
 }
 
 /// TS 제네릭 arrow function 파싱 시도: <T>() => body, <const T>() => body

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2854,6 +2854,15 @@ test "Flow: nullable return type with arrow" {
 test "Flow: typed arrow in ternary consequent" {
     // (): void => {} — 삼항 안에서 typed empty-param arrow
     try expectNoParseErrorFlow("const x = true ? (): void => { return; } : null;");
+    // typeof도 type keyword로 감지
+    try expectNoParseErrorFlow("const x = true ? (): typeof a => { return a; } : null;");
+}
+
+test "Flow: single type param generic arrow in JSX mode" {
+    // <T>() => body — JSX+Flow에서 <T> 뒤에 ( 가 오면 generic arrow로 판별
+    try expectNoParseErrorFlow("const f = <T>(x: T): T => x;");
+    // object method
+    try expectNoParseErrorFlow("const obj = { select: <T>(spec: T): T => spec };");
 }
 
 test "Flow: type guard predicate" {


### PR DESCRIPTION
## Summary
- `checkTsxGenericArrowTypeParam`에서 Flow 모드일 때 `<T>` (단일 무제약 param) 뒤에 `(`가 오면 generic arrow로 판별
- 기존에는 `<T,>` (trailing comma) 또는 `<T: X>` (constraint)만 감지

**결과**: RN ExampleApp 번들 에러 1 → **0**

## Test plan
- [x] `zig build test` 통과
- [x] RN ExampleApp 번들 에러 0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)