### PR TITLE
fix(codegen): CJS import { X as Y } → { X: Y } 변환

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2103,14 +2103,28 @@ pub const Codegen = struct {
                 }
             }
         } else if (named_count > 0) {
-            // import { foo, bar } from './bar' → const {foo,bar}=require('./bar');
+            // import { foo, bar as baz } from './bar' → const {foo,bar:baz}=require('./bar');
+            // ESM의 `as` rename을 CJS destructuring의 `:` rename으로 변환
             try self.writeByte('{');
             var first = true;
             for (spec_indices) |raw_idx| {
-                const spec = self.ast.getNode(@enumFromInt(raw_idx));
+                const spec_idx: NodeIndex = @enumFromInt(raw_idx);
+                const spec = self.ast.getNode(spec_idx);
                 if (spec.tag == .import_specifier) {
                     if (!first) try self.writeByte(',');
-                    try self.writeNodeSpan(spec);
+                    const imported = spec.data.binary.left;
+                    const local = spec.data.binary.right;
+                    try self.emitNode(imported);
+                    if (!local.isNone() and @intFromEnum(local) != @intFromEnum(imported)) {
+                        const imp_node = self.ast.getNode(imported);
+                        const loc_node = self.ast.getNode(local);
+                        const imp_text = self.ast.source[imp_node.span.start..imp_node.span.end];
+                        const loc_text = self.ast.source[loc_node.span.start..loc_node.span.end];
+                        if (!std.mem.eql(u8, imp_text, loc_text)) {
+                            try self.writeByte(':');
+                            try self.emitNode(local);
+                        }
+                    }
                     first = false;
                 }
             }

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -841,10 +841,30 @@ test "Codegen: non-null assertion stripped" {
 // ============================================================
 
 test "Codegen CJS: import named" {
-    // CJS named import uses writeNodeSpan which preserves trailing space from source
     var r = try e2eCJS(std.testing.allocator, "import { foo } from './bar';");
     defer r.deinit();
-    try std.testing.expectEqualStrings("const {foo }=require(\"./bar\");", r.output);
+    try std.testing.expectEqualStrings("const {foo}=require(\"./bar\");", r.output);
+}
+
+test "Codegen CJS: import named with rename" {
+    // ESM `as` → CJS `:` 변환: import { X as Y } → const {X:Y}=require(...)
+    var r = try e2eCJS(std.testing.allocator, "import { Commands as ViewCommands } from './view';");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const {Commands:ViewCommands}=require(\"./view\");", r.output);
+}
+
+test "Codegen CJS: import named multiple with rename" {
+    // 여러 named import 중 일부만 rename
+    var r = try e2eCJS(std.testing.allocator, "import { foo, bar as baz, qux } from './mod';");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const {foo,bar:baz,qux}=require(\"./mod\");", r.output);
+}
+
+test "Codegen CJS: import named same name" {
+    // imported == local (rename 없음) — `:` 출력하지 않음
+    var r = try e2eCJS(std.testing.allocator, "import { foo as foo } from './bar';");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const {foo}=require(\"./bar\");", r.output);
 }
 
 test "Codegen CJS: import default" {


### PR DESCRIPTION
## Summary
- ESM→CJS 변환에서 `import { Commands as ViewCommands }` → `const {Commands:ViewCommands}=require(...)` 
- 기존에는 원본 텍스트를 그대로 출력하여 `const {Commands as ViewCommands}` 로 잘못 생성
- Hermes에서 `'}' expected at end of object binding pattern` 에러 발생

## Test plan
- [x] `zig build test` 통과
- [x] 신규 테스트: rename, multiple rename, same-name rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)