### PR TITLE
fix(flow): match expression → if-else IIFE 변환

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -768,7 +768,8 @@ pub const Codegen = struct {
 
             .formal_parameter => try self.emitFormalParam(node),
 
-            // Flow match expression: 원본 텍스트 그대로 출력 (런타임 기능)
+            // Flow match expression — transformer에서 if-else IIFE로 변환됨
+            // 변환되지 않은 경우 (non-bundle 등) span 텍스트 그대로 출력
             .flow_match_expression => try self.writeNodeSpan(node),
 
             // JSX → React.createElement

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1193,14 +1193,78 @@ pub fn parseFlowInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
 /// match는 contextual keyword이므로 예약어가 아니다.
 /// 타입 스트리핑 전용이므로 내부를 개별 파싱하지 않고
 /// balanced brace counting으로 전체를 소비한 뒤 단일 노드를 생성한다.
+/// Flow match expression: match (expr) { Pattern => body, ... }
+/// discriminant와 arms를 파싱하여 flow_match_expression 노드 생성.
+/// codegen에서 if-else chain IIFE로 변환.
 pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip 'match'
-    try skipBalancedParens(self); // match (expr)
-    try skipBalancedBraces(self); // match body { ... }
+
+    // discriminant: (expr)
+    try self.expect(.l_paren);
+    const discriminant = try self.parseAssignmentExpression();
+    try self.expect(.r_paren);
+
+    // match body: { arm1, arm2, ... }
+    try self.expect(.l_curly);
+    const scratch_top = self.saveScratch();
+
+    while (self.current() != .r_curly and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
+
+        // pattern 파싱 — `_ =>` wildcard는 arrow function으로 해석되므로 별도 처리
+        const pattern = blk: {
+            // `_` wildcard: `_ =>` 패턴이면 식별자만 파싱하고 `=>` 는 caller에서 소비
+            if (self.current() == .identifier) {
+                const text = self.ast.source[self.currentSpan().start..self.currentSpan().end];
+                if (std.mem.eql(u8, text, "_")) {
+                    const s = self.currentSpan();
+                    try self.advance();
+                    break :blk try self.ast.addNode(.{
+                        .tag = .identifier_reference,
+                        .span = s,
+                        .data = .{ .string_ref = s },
+                    });
+                }
+            }
+            break :blk try self.parseAssignmentExpression();
+        };
+        try self.expect(.arrow);
+
+        // body: { ... } (block) 또는 expression
+        var body: NodeIndex = undefined;
+        if (self.current() == .l_curly) {
+            body = try self.parseBlockStatement();
+        } else {
+            body = try self.parseAssignmentExpression();
+            _ = try self.eat(.comma);
+        }
+
+        // arm: binary { left=pattern, right=body }
+        const arm = try self.ast.addNode(.{
+            .tag = .flow_match_expression, // arm도 같은 태그 재사용 (구분은 위치로)
+            .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
+            .data = .{ .binary = .{ .left = pattern, .right = body, .flags = 0 } },
+        });
+        try self.scratch.append(self.allocator, arm);
+
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
+    }
+    try self.expect(.r_curly);
+
+    const arms = self.scratch.items[scratch_top..];
+    const arms_list = try self.ast.addNodeList(arms);
+    self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    // flow_match_expression: extra = [discriminant, arms_start, arms_len]
+    const extra = try self.ast.addExtras(&.{
+        @intFromEnum(discriminant),
+        arms_list.start,
+        arms_list.len,
+    });
     return try self.ast.addNode(.{
         .tag = .flow_match_expression,
         .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .none = 0 },
+        .data = .{ .extra = extra },
     });
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -365,6 +365,8 @@ pub const Transformer = struct {
             .flow_type_cast_expression,
             => self.visitTsExpression(node),
 
+            .flow_match_expression => self.visitFlowMatch(node),
+
             // === 리스트 노드: 자식을 하나씩 방문하며 복사 ===
             .program,
             .block_statement,
@@ -1040,6 +1042,132 @@ pub const Transformer = struct {
     /// 예: `x as number` → `x` (operand만 반환)
     /// 예: `x!` → `x` (non-null assertion 제거)
     /// 예: `<number>x` → `x` (type assertion 제거)
+    /// Flow match expression → (function(_m){if(_m===P){B}else if...})(expr)
+    fn visitFlowMatch(self: *Transformer, node: Node) Error!NodeIndex {
+        const span = node.span;
+        const extras = self.old_ast.extra_data.items;
+        const e = node.data.extra;
+        const discriminant_idx: NodeIndex = @enumFromInt(extras[e]);
+        const arms_start = extras[e + 1];
+        const arms_len = extras[e + 2];
+
+        const new_discriminant = try self.visitNode(discriminant_idx);
+
+        // 임시 변수 _m
+        const match_var = try es_helpers.makeTempVarSpan(self);
+        const match_param = try es_helpers.makeBindingIdentifier(self, match_var);
+
+        // arms → if-else chain 구성 (뒤에서부터)
+        const arm_indices = extras[arms_start .. arms_start + arms_len];
+        var else_branch: NodeIndex = .none;
+
+        var i: usize = arm_indices.len;
+        while (i > 0) {
+            i -= 1;
+            const arm = self.old_ast.getNode(@enumFromInt(arm_indices[i]));
+            const pattern = arm.data.binary.left;
+            const body_idx = arm.data.binary.right;
+            const new_body_raw = try self.visitNode(body_idx);
+            // body를 { return body; } 또는 block 그대로 사용
+            const body_node = self.new_ast.getNode(new_body_raw);
+            const new_body = if (body_node.tag == .block_statement)
+                new_body_raw
+            else blk: {
+                // expression → { return expr; }
+                const return_stmt = try self.new_ast.addNode(.{
+                    .tag = .return_statement,
+                    .span = span,
+                    .data = .{ .unary = .{ .operand = new_body_raw, .flags = 0 } },
+                });
+                const stmts = try self.new_ast.addNodeList(&.{return_stmt});
+                break :blk try self.new_ast.addNode(.{
+                    .tag = .block_statement,
+                    .span = span,
+                    .data = .{ .list = stmts },
+                });
+            };
+
+            // wildcard `_` 감지
+            const pat_node = self.old_ast.getNode(pattern);
+            const is_wildcard = blk: {
+                if (pat_node.tag == .identifier_reference) {
+                    const text = self.old_ast.source[pat_node.span.start..pat_node.span.end];
+                    break :blk std.mem.eql(u8, text, "_");
+                }
+                break :blk false;
+            };
+
+            if (is_wildcard) {
+                else_branch = new_body;
+            } else {
+                const new_pattern = try self.visitNode(pattern);
+                const match_ref = try es_helpers.makeTempVarRef(self, match_var, match_var);
+                // _m === pattern
+                const test_expr = try self.new_ast.addNode(.{
+                    .tag = .binary_expression,
+                    .span = span,
+                    .data = .{ .binary = .{
+                        .left = match_ref,
+                        .right = new_pattern,
+                        .flags = @intFromEnum(token_mod.Kind.eq3),
+                    } },
+                });
+                else_branch = try self.new_ast.addNode(.{
+                    .tag = .if_statement,
+                    .span = span,
+                    .data = .{ .ternary = .{ .a = test_expr, .b = new_body, .c = else_branch } },
+                });
+            }
+        }
+
+        // function(_m) { if-chain }
+        const body_list = if (!else_branch.isNone())
+            try self.new_ast.addNodeList(&.{else_branch})
+        else
+            @import("../parser/ast.zig").NodeList{ .start = 0, .len = 0 };
+        const fn_body = try self.new_ast.addNode(.{
+            .tag = .block_statement,
+            .span = span,
+            .data = .{ .list = body_list },
+        });
+        // function extra: [name, params_start, params_len, body, flags, return_type]
+        const fn_params_list = try self.new_ast.addNodeList(&.{match_param});
+        const fn_extra = try self.new_ast.addExtras(&.{
+            @intFromEnum(NodeIndex.none), // name (anonymous)
+            fn_params_list.start,
+            fn_params_list.len,
+            @intFromEnum(fn_body),
+            0, // flags
+            @intFromEnum(NodeIndex.none), // return type
+        });
+        const fn_expr = try self.new_ast.addNode(.{
+            .tag = .function_expression,
+            .span = span,
+            .data = .{ .extra = fn_extra },
+        });
+
+        // (function(_m){...})(discriminant)
+        // function expression을 parenthesized로 감싸서 IIFE 형태로 만듦
+        const paren_fn = try self.new_ast.addNode(.{
+            .tag = .parenthesized_expression,
+            .span = span,
+            .data = .{ .unary = .{ .operand = fn_expr, .flags = 0 } },
+        });
+        // call_expression extra: [callee, args_start, args_len, flags]
+        const args_list = try self.new_ast.addNodeList(&.{new_discriminant});
+        const call_extra = try self.new_ast.addExtras(&.{
+            @intFromEnum(paren_fn),
+            args_list.start,
+            args_list.len,
+            0, // flags
+        });
+        return self.new_ast.addNode(.{
+            .tag = .call_expression,
+            .span = span,
+            .data = .{ .extra = call_extra },
+        });
+    }
+
     fn visitTsExpression(self: *Transformer, node: Node) Error!NodeIndex {
         if (!self.options.strip_types) {
             return self.copyNodeDirect(node);


### PR DESCRIPTION
## Summary
- Flow `match (expr) { Pattern => body }` → `(function(_m){if(_m===P){return B}...})(expr)` 변환
- 파서: match arms 개별 파싱 (discriminant + pattern/body pairs)
- transformer: `visitFlowMatch`로 if-else chain IIFE 생성
- wildcard `_` → else branch

**hermesc**: match expression 에러 해결. non-terminated string 1건 잔여 (별도 이슈).

## Test plan
- [x] `zig build test` 통과
- [x] `node /tmp/match-out4.js` → "b" 올바른 출력
- [x] hermesc 검증: match 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)