### PR TITLE
refactor(flow): match 주석 정리 + 통합 테스트

### DIFF
--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1189,13 +1189,8 @@ pub fn parseFlowInterfaceDeclaration(self: *Parser) ParseError2!NodeIndex {
 // Flow Match Expression
 // ================================================================
 
-/// Flow match expression: match (expr) { Pattern => expr, ... }
-/// match는 contextual keyword이므로 예약어가 아니다.
-/// 타입 스트리핑 전용이므로 내부를 개별 파싱하지 않고
-/// balanced brace counting으로 전체를 소비한 뒤 단일 노드를 생성한다.
 /// Flow match expression: match (expr) { Pattern => body, ... }
-/// discriminant와 arms를 파싱하여 flow_match_expression 노드 생성.
-/// codegen에서 if-else chain IIFE로 변환.
+/// discriminant와 arms를 재귀 파싱. transformer에서 if-else IIFE로 변환.
 pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip 'match'
@@ -1232,7 +1227,7 @@ pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
         try self.expect(.arrow);
 
         // body: { ... } (block) 또는 expression
-        var body: NodeIndex = undefined;
+        var body: NodeIndex = .none;
         if (self.current() == .l_curly) {
             body = try self.parseBlockStatement();
         } else {

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -902,6 +902,28 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("empty");
     });
 
+    test("flow match expression", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.js": `// @flow
+            function classify(x) {
+              return match (x) {
+                1 => "one",
+                2 => "two",
+                _ => "other",
+              };
+            }
+            console.log([classify(1), classify(2), classify(3)].join(","));
+          `,
+        },
+        "index.js",
+        ["--flow"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("one,two,other");
+    });
+
     test("async for-of with await", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary
- stale 주석 제거 (balanced brace counting → 재귀 파싱)
- `var body = undefined` → `.none` 초기화
- flow match expression 통합 테스트 추가 (`classify(1,2,3)` → `"one,two,other"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)