### PR TITLE
fix(linker): CJS preamble 변수 scope 충돌 수정 (hermesc 9→1)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -265,12 +265,27 @@ pub const Linker = struct {
             const sym_name = scope_entry.key_ptr.*;
             if (std.mem.eql(u8, sym_name, "default")) continue;
 
-            // import binding은 다른 모듈의 심볼을 참조하므로 충돌 대상 아님.
-            // namespace import도 인라인(ns.prop → prop)되어 preamble 변수가 생성되지 않으므로
-            // 충돌 대상이 아님.
+            // import binding은 일반적으로 인라인되어 변수가 생성되지 않으므로 충돌 대상 아님.
+            // 단, CJS 모듈을 import하면 preamble에서 `var X = require_xxx().X`로 변수가 생성되므로
+            // 충돌 대상에 포함해야 한다.
             const sym_idx = scope_entry.value_ptr.*;
             if (sym_idx < sem.symbols.len and sem.symbols[sym_idx].decl_flags.is_import) {
-                continue;
+                // CJS preamble 변수가 생성되는 경우에만 충돌 대상에 포함
+                const generates_preamble = blk: {
+                    for (m.import_bindings) |ib| {
+                        if (!std.mem.eql(u8, ib.local_name, sym_name)) continue;
+                        if (ib.import_record_index >= m.import_records.len) break :blk false;
+                        const rec = m.import_records[ib.import_record_index];
+                        // unresolved import → require() preamble
+                        if (rec.resolved.isNone()) break :blk true;
+                        // CJS 모듈 import → require_xxx() preamble
+                        const cmod = @intFromEnum(rec.resolved);
+                        if (cmod < self.modules.len and self.modules[cmod].wrap_kind == .cjs) break :blk true;
+                        break :blk false;
+                    }
+                    break :blk false;
+                };
+                if (!generates_preamble) continue;
             }
 
             const entry = try name_to_owners.getOrPut(sym_name);

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -433,4 +433,29 @@ describe("번들 스모크 테스트", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("1,3,6");
   });
+
+  test("CJS import 변수명 scope 충돌 해결", async () => {
+    // 두 모듈이 같은 이름(StyleSheet)을 top-level에 선언할 때
+    // CJS preamble 변수와 ESM export가 충돌하지 않아야 함
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          import { StyleSheet } from "./styles";
+          import { render } from "./renderer";
+          console.log(StyleSheet.create({}) + "," + render());
+        `,
+        "styles.ts": `
+          export const StyleSheet = { create(s: any) { return "created"; } };
+        `,
+        "renderer.ts": `
+          const StyleSheet = { flatten(s: any) { return "flat"; } };
+          export function render() { return StyleSheet.flatten({}); }
+        `,
+      },
+      "index.ts",
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("created,flat");
+  });
 });

--- a/tests/integration/tests/es5-rn.test.ts
+++ b/tests/integration/tests/es5-rn.test.ts
@@ -197,8 +197,8 @@ describe("RN 번들: Metro vs ZTS 모듈 수 비교", () => {
     }
     const errorCount = (stderr.match(/error:/g) || []).length;
     console.log(`hermesc errors: ${errorCount}`);
-    // 번들러 scope hoisting 변수 충돌 (Identifier already declared) — 별도 이슈
-    expect(errorCount).toBeLessThanOrEqual(9);
+    // ExceptionsManager self-reference 1건 잔여 — 별도 이슈
+    expect(errorCount).toBeLessThanOrEqual(1);
   }, 60_000);
 });
 


### PR DESCRIPTION
## Summary
- `collectModuleNames`에서 CJS import preamble 변수도 `name_to_owners`에 포함
- 기존: `is_import` 플래그로 스킵 → `var StyleSheet`과 `const StyleSheet` 충돌
- 수정: CJS 모듈 import 시 preamble 변수가 생성되면 충돌 감지 대상에 포함
- `calculateRenames`에서 자동으로 `StyleSheet$1` 등 suffix 추가

**hermesc 에러**: 9 → 1 (ExceptionsManager self-reference 1건 잔여)

## Test plan
- [x] `zig build test` 통과
- [x] hermesc 검증: 9 → 1 에러
- [x] 통합 테스트: CJS import 변수명 scope 충돌 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)