### PR TITLE
fix(test): ES5 RN 번들 테스트 yield 오탐 수정

### DIFF
--- a/tests/integration/tests/es5-rn.test.ts
+++ b/tests/integration/tests/es5-rn.test.ts
@@ -108,9 +108,12 @@ describe("RN ES5: ExampleApp 번들 테스트", () => {
     expect(bundle.stderr.toString()).not.toContain("panic");
 
     const output = await Bun.file(resolve(EXAMPLE_APP, "out-es5.js")).text();
-    // yield/function*이 남아있으면 안 됨
-    expect(output).not.toContain("yield ");
+    // generator 구문이 남아있으면 안 됨
     expect(output).not.toContain("function*");
+    expect(output).not.toMatch(/\bfunction\s*\*/);
+    // yield 키워드 체크: 문자열 리터럴 내 "yield" 오탐 방지를 위해
+    // 세미콜론/줄바꿈/공백 뒤에 오는 실제 yield 키워드만 감지
+    expect(output).not.toMatch(/(?:^|[;,=({\n])\s*yield[\s;]/m);
     // ES5 출력 크기 (100KB+)
     expect(output.length).toBeGreaterThan(100_000);
   });


### PR DESCRIPTION
## Summary
- React 소스의 문자열 리터럴 `"yield unexpected results"`를 yield 키워드로 오인하던 테스트 수정
- `toContain("yield ")` → 문/식 시작 위치의 yield만 감지하는 정규식으로 교체
- `function*` 체크도 정규식으로 강화

## Test plan
- [x] `bun run test:integration` 2394 pass / 3 fail (기존 4 fail → 3 fail)
- [x] ES5 번들 출력에 실제 yield 키워드 0개 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)