### PR TITLE
fix(codegen): CJS 래핑 모듈의 ESM import→require 변환 시 require_xxx() 치환 누락

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,14 @@ zig build test     # 유닛 테스트
 zig build test262  # Test262 러너 테스트
 ```
 
+### 통합 테스트 (Bun)
+```bash
+cd tests/integration && bun test              # 전체 통합 테스트
+cd tests/integration && bun test tests/bundle-smoke.test.ts   # 번들 스모크
+cd tests/integration && bun test tests/es5-rn.test.ts         # RN ES5 + Hermes
+```
+**주의**: 통합 테스트는 반드시 `tests/integration/` 디렉토리에서 실행해야 한다. 프로젝트 루트에서 실행하면 경로 해석 문제로 대부분 실패한다.
+
 ## ZTS CLI 옵션 (현재 지원)
 
 ### 트랜스파일

--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -7972,6 +7972,89 @@ test "CJS: esm_with_dynamic_fallback module required — wrapped in __commonJS (
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_hybrid") != null);
 }
 
+test "CJS: ESM import inside __commonJS wrapper rewritten to require_xxx()" {
+    // ESM 모듈이 require()로 소비되어 __commonJS 래핑될 때,
+    // 내부 import 문이 require("specifier")로 변환되는데,
+    // 이 변환된 require()도 require_xxx()로 치환되어야 한다.
+    // (emitImportCJS에서 require_rewrites 맵 미참조 버그 수정 검증)
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "const lib = require('./esm-lib.js');\nconsole.log(lib);");
+    // esm-lib.js: ESM import 사용, require()로 소비되어 CJS 래핑됨
+    try writeFile(tmp.dir, "esm-lib.js",
+        \\import helper from './helper.cjs';
+        \\export function greet() { return helper(); }
+    );
+    try writeFile(tmp.dir, "helper.cjs", "module.exports = function() { return 'hello'; };");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // esm-lib.js의 import helper from './helper.cjs'가
+    // require_helper()로 변환되어야 함 (require("./helper.cjs")가 아님)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_helper") != null);
+    // 번들 내에 raw require("./helper.cjs")가 남아있으면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./helper.cjs\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require('./helper.cjs')") == null);
+}
+
+test "CJS: side-effect import inside __commonJS wrapper rewritten to require_xxx()" {
+    // side-effect import (import './foo') 도 require_xxx()로 변환되어야 함
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "const lib = require('./side-lib.js');\nconsole.log(lib);");
+    try writeFile(tmp.dir, "side-lib.js",
+        \\import './setup.cjs';
+        \\export const value = 42;
+    );
+    try writeFile(tmp.dir, "setup.cjs", "global.__SETUP = true;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // side-effect import도 require_setup()으로 변환
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_setup") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./setup.cjs\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require('./setup.cjs')") == null);
+}
+
+test "CJS: named import inside __commonJS wrapper rewritten to require_xxx()" {
+    // import { foo } from './bar' → const {foo}=require_bar(); (require("./bar") 아님)
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "const lib = require('./named-lib.js');\nconsole.log(lib);");
+    try writeFile(tmp.dir, "named-lib.js",
+        \\import { value } from './util.cjs';
+        \\export function compute() { return value * 2; }
+    );
+    try writeFile(tmp.dir, "util.cjs", "exports.value = 21;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_util") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./util.cjs\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require('./util.cjs')") == null);
+}
+
 // ============================================================
 // Top-Level Await (TLA) Tests
 // ============================================================

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2050,9 +2050,12 @@ pub const Codegen = struct {
     fn emitImportCJS(self: *Codegen, source: NodeIndex, specs_start: u32, specs_len: u32) !void {
         if (specs_len == 0) {
             // side-effect import: import './bar' → require('./bar');
-            try self.write("require(");
-            try self.emitNode(source);
-            try self.write(");");
+            if (try self.tryEmitRequireRewrite(source)) |_| {} else {
+                try self.write("require(");
+                try self.emitNode(source);
+                try self.writeByte(')');
+            }
+            try self.writeByte(';');
             return;
         }
 
@@ -2107,15 +2110,42 @@ pub const Codegen = struct {
             try self.writeByte('}');
         }
 
-        try self.write("=require(");
-        try self.emitNode(source);
-        try self.writeByte(')');
+        // require_rewrites 맵에 있으면 require_xxx()로 치환, 없으면 require("specifier")
+        try self.writeByte('=');
+        if (try self.tryEmitRequireRewrite(source)) |_| {} else {
+            try self.write("require(");
+            try self.emitNode(source);
+            try self.writeByte(')');
+        }
 
         if (has_default and !has_namespace and named_count == 0) {
             try self.write(".default");
         }
 
         try self.writeByte(';');
+    }
+
+    /// source node에서 specifier를 추출하여 require_rewrites 맵에서 찾으면
+    /// require_xxx()를 출력하고 true를 반환. 없으면 아무것도 출력하지 않고 null 반환.
+    fn tryEmitRequireRewrite(self: *Codegen, source: NodeIndex) !?void {
+        const meta = self.options.linking_metadata orelse return null;
+        if (meta.require_rewrites.count() == 0) return null;
+        if (source.isNone()) return null;
+
+        const source_node = self.ast.getNode(source);
+        if (source_node.tag != .string_literal) return null;
+
+        // 따옴표 제거: "path" 또는 'path' → path
+        const raw = self.ast.source[source_node.data.string_ref.start..source_node.data.string_ref.end];
+        const specifier = if (raw.len >= 2 and (raw[0] == '"' or raw[0] == '\''))
+            raw[1 .. raw.len - 1]
+        else
+            raw;
+
+        const req_var = meta.require_rewrites.get(specifier) orelse return null;
+        try self.write(req_var);
+        try self.write("()");
+        return {};
     }
 
     /// import specifier의 imported + rename separator + local 출력.

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -458,4 +458,69 @@ describe("번들 스모크 테스트", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("created,flat");
   });
+
+  test("CJS 래핑된 ESM 모듈의 import가 require_xxx()로 변환 — 번들 출력 검증", async () => {
+    // ESM 모듈이 require()로 소비되어 __commonJS 래핑될 때,
+    // 내부 import 문의 require()가 require_xxx()로 치환되어야 함.
+    // raw require("specifier")가 남아있으면 런타임에서 require 미정의 에러 발생.
+    const fixture = await createFixture({
+      "index.ts": `const lib = require('./esm-lib.js'); console.log(lib.greet());`,
+      "esm-lib.js": `
+        import * as helper from './helper.cjs';
+        export function greet() { return helper.default(); }
+      `,
+      "helper.cjs": `module.exports = function() { return 'hello-from-cjs'; };`,
+    });
+    cleanup = fixture.cleanup;
+    const outFile = join(fixture.dir, "out.js");
+    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile]);
+    expect(bundle.exitCode).toBe(0);
+
+    const output = await Bun.file(outFile).text();
+    // default import: require_helper()로 변환되어야 함
+    expect(output).toContain("require_helper()");
+    // raw require("./helper.cjs")가 남아있으면 안 됨
+    expect(output).not.toContain('require("./helper.cjs")');
+    expect(output).not.toContain("require('./helper.cjs')");
+  });
+
+  test("CJS 래핑된 ESM 모듈의 named import — 번들 출력 검증", async () => {
+    const fixture = await createFixture({
+      "index.ts": `const lib = require('./consumer.js'); console.log(lib.compute());`,
+      "consumer.js": `
+        import { multiply } from './math.cjs';
+        export function compute() { return multiply(6, 7); }
+      `,
+      "math.cjs": `exports.multiply = function(a, b) { return a * b; };`,
+    });
+    cleanup = fixture.cleanup;
+    const outFile = join(fixture.dir, "out.js");
+    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile]);
+    expect(bundle.exitCode).toBe(0);
+
+    const output = await Bun.file(outFile).text();
+    expect(output).toContain("require_math()");
+    expect(output).not.toContain('require("./math.cjs")');
+    expect(output).not.toContain("require('./math.cjs')");
+  });
+
+  test("CJS 래핑된 ESM 모듈의 side-effect import — 번들 출력 검증", async () => {
+    const fixture = await createFixture({
+      "index.ts": `const lib = require('./app.js'); console.log(lib.value);`,
+      "app.js": `
+        import './setup.cjs';
+        export const value = globalThis.__SETUP_DONE;
+      `,
+      "setup.cjs": `globalThis.__SETUP_DONE = 'setup-ok';`,
+    });
+    cleanup = fixture.cleanup;
+    const outFile = join(fixture.dir, "out.js");
+    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile]);
+    expect(bundle.exitCode).toBe(0);
+
+    const output = await Bun.file(outFile).text();
+    expect(output).toContain("require_setup()");
+    expect(output).not.toContain('require("./setup.cjs")');
+    expect(output).not.toContain("require('./setup.cjs')");
+  });
 });

--- a/tests/integration/tests/es5-rn.test.ts
+++ b/tests/integration/tests/es5-rn.test.ts
@@ -206,6 +206,28 @@ describe("RN 번들: Metro vs ZTS 모듈 수 비교", () => {
     console.log(`hermesc errors: ${errorCount}`);
     expect(errorCount).toBe(0);
   }, 60_000);
+
+  test("번들 내 미변환 require() 호출 검출", async () => {
+    // __commonJS 래퍼 안에서 ESM import가 require()로 변환될 때
+    // require_xxx()로 치환되어야 함. raw require("specifier")가 남아있으면 런타임 에러.
+    const outFile = resolve(EXAMPLE_APP, "zts-hermes.js");
+    const output = await Bun.file(outFile).text();
+
+    // 번들 내 raw require("...") 패턴 검출 (require_ 접두사가 아닌 것만)
+    // __commonJS 런타임 정의 내의 require는 제외
+    const rawRequires = output.match(/(?<!_)require\s*\(\s*["'][^"']+["']\s*\)/g) || [];
+
+    // 현재 알려진 미해결 케이스 수 기록 (점진적 개선 추적)
+    console.log(`Raw require() calls remaining: ${rawRequires.length}`);
+    if (rawRequires.length > 0) {
+      // 처음 5개 출력 (디버깅용)
+      console.log("Examples:", rawRequires.slice(0, 5));
+    }
+
+    // scope hoisted esm_with_dynamic_fallback 내 require()는 아직 미해결이므로
+    // 현재 기준선보다 악화되지 않는 것만 검증 (기준선은 점진적으로 낮춤)
+    expect(rawRequires.length).toBeLessThanOrEqual(280);
+  }, 60_000);
 });
 
 describe("RN ES5 다운레벨링: 기존 flow-rn fixtures", () => {


### PR DESCRIPTION
## Summary
- `emitImportCJS()`에서 ESM `import`를 `require()`로 변환할 때 linker의 `require_rewrites` 맵을 참조하지 않아 raw `require("specifier")`가 그대로 출력되는 버그 수정
- `tryEmitRequireRewrite()` 헬퍼 추가: source node에서 specifier 추출 → 맵 조회 → `require_xxx()` 출력
- RN 번들 기준 미변환 require() 호출 665개 → 278개로 감소 (58% 개선)
- CLAUDE.md에 통합 테스트 실행 방법 추가 (`tests/integration/`에서 실행 필수)

## Test plan
- [x] `zig build test` 전체 통과 (유닛 테스트 3개 추가: default/named/side-effect import)
- [x] `cd tests/integration && bun test tests/bundle-smoke.test.ts` 통과 (통합 테스트 3개 추가)
- [x] `cd tests/integration && bun test tests/es5-rn.test.ts` RN 번들 미변환 require 기준선 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)