### PR TITLE
refactor(codegen): require rewrite 공통 헬퍼 추출 + 코드 품질 개선

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1561,10 +1561,40 @@ pub const Codegen = struct {
         try self.writeByte(')');
     }
 
+    /// string_literal 노드에서 specifier를 추출하고 require_rewrites 맵에서 조회.
+    /// 매칭되면 변수명 반환, 아니면 null. 출력은 하지 않음.
+    fn resolveRequireRewrite(self: *Codegen, source: ast_mod.NodeIndex) ?[]const u8 {
+        const meta = self.options.linking_metadata orelse return null;
+        if (meta.require_rewrites.count() == 0 or source.isNone()) return null;
+
+        const node = self.ast.getNode(source);
+        if (node.tag != .string_literal) return null;
+
+        const raw = self.ast.source[node.data.string_ref.start..node.data.string_ref.end];
+        const specifier = if (raw.len >= 2 and (raw[0] == '"' or raw[0] == '\''))
+            raw[1 .. raw.len - 1]
+        else
+            raw;
+
+        return meta.require_rewrites.get(specifier);
+    }
+
+    /// require_xxx()를 출력. 성공 시 true.
+    fn emitRequireRewriteOrCall(self: *Codegen, source: ast_mod.NodeIndex) !bool {
+        if (self.resolveRequireRewrite(source)) |req_var| {
+            try self.write(req_var);
+            try self.write("()");
+            return true;
+        }
+        try self.write("require(");
+        try self.emitNode(source);
+        try self.writeByte(')');
+        return false;
+    }
+
     /// CJS require('specifier') → require_xxx() 치환. 성공 시 true.
     fn tryRewriteRequire(self: *Codegen, callee: ast_mod.NodeIndex, args_start: u32, args_len: u32) !bool {
-        const meta = self.options.linking_metadata orelse return false;
-        if (meta.require_rewrites.count() == 0 or callee.isNone() or args_len != 1) return false;
+        if (callee.isNone() or args_len != 1) return false;
 
         const callee_node = self.ast.getNode(callee);
         if (callee_node.tag != .identifier_reference) return false;
@@ -1574,22 +1604,13 @@ pub const Codegen = struct {
 
         if (args_start >= self.ast.extra_data.items.len) return false;
         const arg_idx: ast_mod.NodeIndex = @enumFromInt(self.ast.extra_data.items[args_start]);
-        if (arg_idx.isNone()) return false;
 
-        const arg_node = self.ast.getNode(arg_idx);
-        if (arg_node.tag != .string_literal) return false;
-
-        // 따옴표 제거: "path" 또는 'path' → path
-        const raw = self.ast.source[arg_node.data.string_ref.start..arg_node.data.string_ref.end];
-        const specifier = if (raw.len >= 2 and (raw[0] == '"' or raw[0] == '\''))
-            raw[1 .. raw.len - 1]
-        else
-            raw;
-
-        const req_var = meta.require_rewrites.get(specifier) orelse return false;
-        try self.write(req_var);
-        try self.write("()");
-        return true;
+        if (self.resolveRequireRewrite(arg_idx)) |req_var| {
+            try self.write(req_var);
+            try self.write("()");
+            return true;
+        }
+        return false;
     }
 
     fn emitNew(self: *Codegen, node: Node) !void {
@@ -2049,12 +2070,8 @@ pub const Codegen = struct {
     /// CJS: import * as bar from './bar' → const bar=require('./bar');
     fn emitImportCJS(self: *Codegen, source: NodeIndex, specs_start: u32, specs_len: u32) !void {
         if (specs_len == 0) {
-            // side-effect import: import './bar' → require('./bar');
-            if (try self.tryEmitRequireRewrite(source)) |_| {} else {
-                try self.write("require(");
-                try self.emitNode(source);
-                try self.writeByte(')');
-            }
+            // side-effect import: import './bar' → require_bar(); or require('./bar');
+            _ = try self.emitRequireRewriteOrCall(source);
             try self.writeByte(';');
             return;
         }
@@ -2110,42 +2127,14 @@ pub const Codegen = struct {
             try self.writeByte('}');
         }
 
-        // require_rewrites 맵에 있으면 require_xxx()로 치환, 없으면 require("specifier")
         try self.writeByte('=');
-        if (try self.tryEmitRequireRewrite(source)) |_| {} else {
-            try self.write("require(");
-            try self.emitNode(source);
-            try self.writeByte(')');
-        }
+        _ = try self.emitRequireRewriteOrCall(source);
 
         if (has_default and !has_namespace and named_count == 0) {
             try self.write(".default");
         }
 
         try self.writeByte(';');
-    }
-
-    /// source node에서 specifier를 추출하여 require_rewrites 맵에서 찾으면
-    /// require_xxx()를 출력하고 true를 반환. 없으면 아무것도 출력하지 않고 null 반환.
-    fn tryEmitRequireRewrite(self: *Codegen, source: NodeIndex) !?void {
-        const meta = self.options.linking_metadata orelse return null;
-        if (meta.require_rewrites.count() == 0) return null;
-        if (source.isNone()) return null;
-
-        const source_node = self.ast.getNode(source);
-        if (source_node.tag != .string_literal) return null;
-
-        // 따옴표 제거: "path" 또는 'path' → path
-        const raw = self.ast.source[source_node.data.string_ref.start..source_node.data.string_ref.end];
-        const specifier = if (raw.len >= 2 and (raw[0] == '"' or raw[0] == '\''))
-            raw[1 .. raw.len - 1]
-        else
-            raw;
-
-        const req_var = meta.require_rewrites.get(specifier) orelse return null;
-        try self.write(req_var);
-        try self.write("()");
-        return {};
     }
 
     /// import specifier의 imported + rename separator + local 출력.

--- a/tests/integration/tests/es5-rn.test.ts
+++ b/tests/integration/tests/es5-rn.test.ts
@@ -210,7 +210,19 @@ describe("RN 번들: Metro vs ZTS 모듈 수 비교", () => {
   test("번들 내 미변환 require() 호출 검출", async () => {
     // __commonJS 래퍼 안에서 ESM import가 require()로 변환될 때
     // require_xxx()로 치환되어야 함. raw require("specifier")가 남아있으면 런타임 에러.
-    const outFile = resolve(EXAMPLE_APP, "zts-hermes.js");
+    // 이전 ��스트(Hermes 구문 검증)에 의존하지 않고 자체 번들 생성
+    const outFile = resolve(EXAMPLE_APP, "zts-require-check.js");
+    const zts = Bun.spawnSync([
+      ZTS_BIN,
+      "--bundle",
+      resolve(EXAMPLE_APP, "index.js"),
+      "--platform=react-native",
+      "--rn-platform=ios",
+      "--flow",
+      "-o",
+      outFile,
+    ]);
+    expect(zts.exitCode).toBe(0);
     const output = await Bun.file(outFile).text();
 
     // 번들 내 raw require("...") 패턴 검출 (require_ 접두사가 아닌 것만)


### PR DESCRIPTION
## Summary
- `/simplify` 리뷰 결과 반영
- `resolveRequireRewrite()`: specifier 추출 + 맵 조회 공통 헬퍼 추출 (tryRewriteRequire와 중복 제거)
- `emitRequireRewriteOrCall()`: require_xxx() 또는 require("spec") 출력 통합
- `!?void` → `!bool` 반환 타입 정리, `if |_| {} else {}` 비관용적 패턴 제거
- es5-rn.test.ts: 미변환 require 테스트의 이전 테스트 순서 의존성 제거

## Test plan
- [x] `zig build test` 전체 통과
- [x] `cd tests/integration && bun test tests/bundle-smoke.test.ts` 37 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)