### PR TITLE
fix(linker): scope hoisted 모듈의 require() 미변환 + buildRequireRewrites 공통 헬퍼

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -8055,6 +8055,38 @@ test "CJS: named import inside __commonJS wrapper rewritten to require_xxx()" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require('./util.cjs')") == null);
 }
 
+test "CJS: scope hoisted esm_with_dynamic_fallback — internal require() rewritten" {
+    // ESM+CJS 혼합 모듈이 import로 소비되어 scope hoisting될 때,
+    // 내부 require() 호출이 require_xxx()로 변환되어야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // entry가 import로 소비 → hybrid.js는 ESM으로 승격 (scope hoisted)
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { greet } from './hybrid.js';
+        \\console.log(greet());
+    );
+    // hybrid.js: ESM(export) + CJS(require) → esm_with_dynamic_fallback, import로 소비 → scope hoisted
+    try writeFile(tmp.dir, "hybrid.js",
+        \\const dep = require('./dep.cjs');
+        \\export function greet() { return dep(); }
+    );
+    try writeFile(tmp.dir, "dep.cjs", "module.exports = function() { return 'hi'; };");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // scope hoisted 모듈 내부 require('./dep.cjs') → require_dep()
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_dep") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./dep.cjs\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require('./dep.cjs')") == null);
+}
+
 // ============================================================
 // Top-Level Await (TLA) Tests
 // ============================================================

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -798,29 +798,13 @@ pub const Linker = struct {
         // 단, 내부 require() 호출은 번들된 require_xxx()로 치환해야 함.
         if (m.wrap_kind == .cjs) {
             const node_count = new_ast.nodes.items.len;
-            var require_rewrites: std.StringHashMapUnmanaged([]const u8) = .{};
-            for (m.import_records) |rec| {
-                if (rec.resolved.isNone()) continue;
-                const target = @intFromEnum(rec.resolved);
-                if (target >= self.modules.len) continue;
-                // 번들된 모듈을 가리키는 require() → require_xxx()로 치환
-                // __commonJS로 래핑되는 모듈만 대상 (CJS, JSON 모두 wrap_kind=.cjs)
-                if (self.modules[target].wrap_kind == .cjs) {
-                    // 동일 specifier의 기존 값이 있으면 해제 (중복 require 방지)
-                    if (require_rewrites.get(rec.specifier)) |old| {
-                        self.allocator.free(old);
-                    }
-                    const var_name = try types.makeRequireVarName(self.allocator, self.modules[target].path);
-                    try require_rewrites.put(self.allocator, rec.specifier, var_name);
-                }
-            }
             return .{
                 .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, node_count),
                 .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
                 .final_exports = null,
                 .symbol_ids = if (m.semantic) |sem| sem.symbol_ids else &.{},
                 .cjs_import_preamble = null,
-                .require_rewrites = require_rewrites,
+                .require_rewrites = try self.buildRequireRewrites(&m),
                 .allocator = self.allocator,
             };
         }
@@ -1098,12 +1082,17 @@ pub const Linker = struct {
         const ns_inlines = ns_result.inlines;
         const combined_preamble = ns_result.combined_preamble;
 
+        // ESM+CJS 혼합 모듈(esm_with_dynamic_fallback)이 scope hoisting될 때
+        // 내부 require() 호출도 require_xxx()로 치환해야 함.
+        const require_rewrites = try self.buildRequireRewrites(&m);
+
         return .{
             .skip_nodes = skip_nodes,
             .renames = renames,
             .final_exports = final_exports,
             .symbol_ids = sem.symbol_ids,
             .cjs_import_preamble = combined_preamble,
+            .require_rewrites = require_rewrites,
             .default_export_name = default_export_name,
             .ns_member_rewrites = ns_rewrites,
             .ns_inline_objects = ns_inlines,
@@ -1111,6 +1100,25 @@ pub const Linker = struct {
             .owned_rename_values = owned_nested_renames,
             .allocator = self.allocator,
         };
+    }
+
+    /// 모듈의 import_records에서 require() → CJS 모듈 대상의 specifier → require_xxx() 맵 구축.
+    /// CJS 래핑 모듈과 scope hoisted ESM+CJS 혼합 모듈 모두에서 사용.
+    fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHashMapUnmanaged([]const u8) {
+        var require_rewrites: std.StringHashMapUnmanaged([]const u8) = .{};
+        for (m.import_records) |rec| {
+            if (rec.resolved.isNone()) continue;
+            const target = @intFromEnum(rec.resolved);
+            if (target >= self.modules.len) continue;
+            if (self.modules[target].wrap_kind == .cjs) {
+                if (require_rewrites.get(rec.specifier)) |old| {
+                    self.allocator.free(old);
+                }
+                const var_name = try types.makeRequireVarName(self.allocator, self.modules[target].path);
+                try require_rewrites.put(self.allocator, rec.specifier, var_name);
+            }
+        }
+        return require_rewrites;
     }
 
     /// 엔트리 포인트의 최종 export 문을 생성한다. (e.g. "export { x, y$1 as y };\n")

--- a/tests/integration/tests/es5-rn.test.ts
+++ b/tests/integration/tests/es5-rn.test.ts
@@ -238,7 +238,7 @@ describe("RN 번들: Metro vs ZTS 모듈 수 비교", () => {
 
     // scope hoisted esm_with_dynamic_fallback 내 require()는 아직 미해결이므로
     // 현재 기준선보다 악화되지 않는 것만 검증 (기준선은 점진적으로 낮춤)
-    expect(rawRequires.length).toBeLessThanOrEqual(280);
+    expect(rawRequires.length).toBeLessThanOrEqual(230);
   }, 60_000);
 });
 


### PR DESCRIPTION
## Summary
- scope hoisted `esm_with_dynamic_fallback` 모듈 내부의 `require()` 호출이 `require_xxx()`로 변환되지 않는 버그 수정
- `buildRequireRewrites()` 공통 헬퍼 추출: CJS 래핑 경로 + scope hoisting 경로 모두에서 사용
- RN 번들 미변환 require(): **278 → 230** (추가 48개 해결), 전체 **665 → 230** (65% 개선)
- 남은 230개는 CJS 래핑 모듈이 scope hoisted ESM 모듈을 import하는 경우 — 구조적 리팩터링 필요 (별도 이슈)

## Test plan
- [x] `zig build test` 전체 통과 (유닛 테스트 1개 추가)
- [x] `cd tests/integration && bun test tests/bundle-smoke.test.ts` 37 pass / 0 fail
- [x] es5-rn.test.ts 기준선 280 → 230으로 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)