### PR TITLE
feat(bundler): CJS→WrapESM 참조 변환 + ESM 모듈 CJS codegen

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1631,7 +1631,9 @@ pub fn emitModule(
         .minify_whitespace = options.minify_whitespace,
         // scope-hoisted 모듈은 항상 ESM codegen 사용 (bare declarations).
         // __commonJS 래핑 모듈만 CJS codegen (module.exports = ...).
-        .module_format = if (module.wrap_kind == .cjs) .cjs else .esm,
+        // 래핑 모듈(CJS/ESM)은 CJS codegen: import→require, export→exports.x
+        // __esm 래핑 모듈: import→require로 변환하여 require_rewrites 적용 가능
+        .module_format = if (module.wrap_kind.isWrapped()) .cjs else .esm,
         .linking_metadata = if (metadata) |*m| m else null,
         // 번들 모드에서 ESM이 아니면 import.meta → {} 치환 (esbuild 호환)
         // Node.js는 import.meta를 보면 ESM으로 재파싱하려 해서 에러 발생

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1110,12 +1110,26 @@ pub const Linker = struct {
             if (rec.resolved.isNone()) continue;
             const target = @intFromEnum(rec.resolved);
             if (target >= self.modules.len) continue;
-            if (self.modules[target].wrap_kind == .cjs) {
+            const target_mod = &self.modules[target];
+
+            if (target_mod.wrap_kind == .cjs) {
+                // CJS 타겟: require("spec") → require_xxx()
                 if (require_rewrites.get(rec.specifier)) |old| {
                     self.allocator.free(old);
                 }
-                const var_name = try types.makeRequireVarName(self.allocator, self.modules[target].path);
+                const var_name = try types.makeRequireVarName(self.allocator, target_mod.path);
                 try require_rewrites.put(self.allocator, rec.specifier, var_name);
+            } else if (target_mod.wrap_kind == .esm) {
+                // ESM 타겟: require("spec") → (init_xxx(), __toCommonJS(exports_xxx))
+                if (require_rewrites.get(rec.specifier)) |old| {
+                    self.allocator.free(old);
+                }
+                const init_name = try types.makeInitVarName(self.allocator, target_mod.path);
+                defer self.allocator.free(init_name);
+                const exports_name = try types.makeExportsVarName(self.allocator, target_mod.path);
+                defer self.allocator.free(exports_name);
+                const call_expr = try std.fmt.allocPrint(self.allocator, "({s}(), __toCommonJS({s}))", .{ init_name, exports_name });
+                try require_rewrites.put(self.allocator, rec.specifier, call_expr);
             }
         }
         return require_rewrites;

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1579,11 +1579,20 @@ pub const Codegen = struct {
         return meta.require_rewrites.get(specifier);
     }
 
-    /// require_xxx()를 출력. 성공 시 true.
+    /// rewrite 값을 출력한다. 값이 완전한 표현식('('로 시작)이면 그대로,
+    /// 변수명이면 "()"를 붙여 호출한다.
+    fn emitRewriteValue(self: *Codegen, req_var: []const u8) !void {
+        try self.write(req_var);
+        // (init_xxx(), __toCommonJS(...)) 같은 완전한 표현식은 ()를 붙이지 않음
+        if (req_var.len == 0 or req_var[0] != '(') {
+            try self.write("()");
+        }
+    }
+
+    /// require_xxx() 또는 (init_xxx(), __toCommonJS(...))를 출력. 성공 시 true.
     fn emitRequireRewriteOrCall(self: *Codegen, source: ast_mod.NodeIndex) !bool {
         if (self.resolveRequireRewrite(source)) |req_var| {
-            try self.write(req_var);
-            try self.write("()");
+            try self.emitRewriteValue(req_var);
             return true;
         }
         try self.write("require(");
@@ -1606,8 +1615,7 @@ pub const Codegen = struct {
         const arg_idx: ast_mod.NodeIndex = @enumFromInt(self.ast.extra_data.items[args_start]);
 
         if (self.resolveRequireRewrite(arg_idx)) |req_var| {
-            try self.write(req_var);
-            try self.write("()");
+            try self.emitRewriteValue(req_var);
             return true;
         }
         return false;


### PR DESCRIPTION
## Summary
- `buildRequireRewrites()`에 WrapESM 타겟 지원: `require("spec")` → `(init_xxx(), __toCommonJS(exports_xxx))`
- `emitRewriteValue()`: 완전한 표현식(`(` 시작)이면 `()` 미추가
- WrapESM 모듈도 CJS codegen 사용: import→require 변환하여 require_rewrites 적용
- ESM import 선언이 `__esm` 래퍼 안에 남던 문제 해결

## 진행 상황 (#645)
- [x] WrapKind.esm + 런타임 헬퍼 (#646)
- [x] CJS→WrapESM 참조 변환 (이 PR)
- [ ] CJS→scope hoisted ESM 참조 변환 (230개 남음)

## Test plan
- [x] `zig build test` 전체 통과
- [x] RN 번들 미변환 `require()`: ESM import 선언 → 0개

🤖 Generated with [Claude Code](https://claude.com/claude-code)