### PR TITLE
fix(emitter): __export default 예약어 SyntaxError + hermesc CI

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1775,7 +1775,12 @@ pub fn emitModule(
                         try wrapped.appendSlice(allocator, eb.exported_name);
                     }
                     try wrapped.appendSlice(allocator, ": () => ");
-                    try wrapped.appendSlice(allocator, eb.local_name);
+                    // local_name이 JS 예약어(default 등)이면 linker가 생성한 합성 변수명 사용
+                    const local = if (std.mem.eql(u8, eb.local_name, "default"))
+                        (if (metadata) |md| md.default_export_name else "_default")
+                    else
+                        eb.local_name;
+                    try wrapped.appendSlice(allocator, local);
                     try wrapped.appendSlice(allocator, ",\n");
                 }
             }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "scripts": {
     "test": "bun test",
+    "test:hermes": "bun test tests/es5-rn.test.ts --filter 'Hermes'",
+    "test:smoke": "bun test tests/bundle-smoke.test.ts",
+    "test:rn": "bun test tests/es5-rn.test.ts",
     "build:zts": "cd ../.. && zig build -Doptimize=ReleaseFast"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- `__export()` 생성 시 `() => default` → `() => _default`로 수정 (JS 예약어 SyntaxError)
- `package.json`에 `test:hermes`, `test:smoke`, `test:rn` 스크립트 추가

## 검증 결과
- **hermesc errors: 0**
- **raw require(): 0**
- **13 pass / 0 fail** (`bun run test:hermes`)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `cd tests/integration && bun run test:hermes` — hermesc 0 error
- [x] `cd tests/integration && bun run test:smoke` — 37 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)