### PR TITLE
fix: __DEV__ 자동 define + define boolean 치환 수정

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -497,21 +497,27 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
         opts.bundle_format = .iife;
     }
 
-    // --bundle + --platform=browser이면 process.env.NODE_ENV를 자동 define (esbuild 호환).
+    // --bundle + --platform=browser/react-native이면 자동 define (esbuild 호환).
     // 트랜스파일 모드에서는 적용하지 않음 (esbuild와 동일).
-    // 사용자가 이미 --define:process.env.NODE_ENV=... 를 지정한 경우 덮어쓰지 않음.
+    // 사용자가 이미 동일 키를 --define: 로 지정한 경우 덮어쓰지 않음.
     if (opts.is_bundle and opts.platform.isBrowserLike()) {
         var has_node_env = false;
+        var has_dev = false;
         for (opts.define_list.items) |d| {
-            if (std.mem.eql(u8, d.key, "process.env.NODE_ENV")) {
-                has_node_env = true;
-                break;
-            }
+            if (std.mem.eql(u8, d.key, "process.env.NODE_ENV")) has_node_env = true;
+            if (std.mem.eql(u8, d.key, "__DEV__")) has_dev = true;
         }
         if (!has_node_env) {
             try opts.define_list.append(allocator, .{
                 .key = "process.env.NODE_ENV",
                 .value = "\"production\"",
+            });
+        }
+        // RN: __DEV__를 자동 define (Metro 호환). production → false.
+        if (!has_dev) {
+            try opts.define_list.append(allocator, .{
+                .key = "__DEV__",
+                .value = "false",
             });
         }
     }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1268,10 +1268,12 @@ pub const Transformer = struct {
 
         for (self.options.define, 0..) |entry, i| {
             if (std.mem.eql(u8, text, entry.key)) {
-                // transform() 시작 시 캐싱된 string_table Span 사용 (addString 중복 방지)
                 const value_span = self.define_spans[i];
+                // 값이 따옴표로 시작하면 string_literal, 아니면 identifier_reference.
+                // "production" → string_literal, false/true/숫자 → identifier_reference.
+                const is_string = entry.value.len >= 2 and (entry.value[0] == '"' or entry.value[0] == '\'');
                 return self.new_ast.addNode(.{
-                    .tag = .string_literal,
+                    .tag = if (is_string) .string_literal else .identifier_reference,
                     .span = value_span,
                     .data = .{ .string_ref = value_span },
                 });


### PR DESCRIPTION
## Summary
- `--platform=react-native`에서 `__DEV__=false` 자동 define (Metro 호환)
- define 치환 타입 수정: `false`/`true`/숫자는 `identifier_reference`로, 문자열은 `string_literal`로
- 이전: 모든 값을 `string_literal`로 치환 → `false`→`"als"` 오류

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun run test:hermes` — 0 error, 13 pass
- [x] RN 번들 `__DEV__` 0개 (전부 `false`로 치환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)