### PR TITLE
fix: dev 모드에서 __DEV__=true + NODE_ENV=development

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -507,17 +507,18 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             if (std.mem.eql(u8, d.key, "process.env.NODE_ENV")) has_node_env = true;
             if (std.mem.eql(u8, d.key, "__DEV__")) has_dev = true;
         }
+        const is_dev = opts.is_serve or opts.watch;
         if (!has_node_env) {
             try opts.define_list.append(allocator, .{
                 .key = "process.env.NODE_ENV",
-                .value = "\"production\"",
+                .value = if (is_dev) "\"development\"" else "\"production\"",
             });
         }
-        // RN만: __DEV__를 자동 define (Metro 호환). production → false.
+        // RN만: __DEV__를 자동 define (Metro 호환).
         if (!has_dev and opts.platform == .react_native) {
             try opts.define_list.append(allocator, .{
                 .key = "__DEV__",
-                .value = "false",
+                .value = if (is_dev) "true" else "false",
             });
         }
     }


### PR DESCRIPTION
## Summary
- `--serve`/`--watch` 시 `__DEV__=true`, `process.env.NODE_ENV="development"`
- 기본(릴리즈): `__DEV__=false`, `process.env.NODE_ENV="production"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)