### PR TITLE
fix(codegen): __esm body CJS import __toESM 래핑

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2207,7 +2207,14 @@ pub const Codegen = struct {
         }
 
         try self.writeByte('=');
+
+        // __esm body에서 default/namespace import: __toESM(require_xxx()) 래핑 필요.
+        // CJS module.exports = fn 에서 .default가 없으므로 __toESM이 래핑해준다.
+        // named import ({a,b}=require_xxx())는 CJS exports에 직접 접근하므로 불필요.
+        const wrap_toesm = self.options.esm_var_assign_only and (has_default or has_namespace) and named_count == 0;
+        if (wrap_toesm) try self.write("__toESM(");
         _ = try self.emitRequireRewriteOrCall(source);
+        if (wrap_toesm) try self.writeByte(')');
 
         if (has_default and !has_namespace and named_count == 0) {
             try self.write(".default");


### PR DESCRIPTION
## Summary
- __esm body에서 CJS default/namespace import 시 `__toESM` 래핑 누락 수정
- `invariant$4=require_invariant_browser().default` → `invariant$4=__toESM(require_invariant_browser()).default`
- CJS `module.exports = fn` 패턴에서 `.default` 프로퍼티가 없으므로 `__toESM`이 필요

### 원인
이전 PR (#669)에서 __esm 모듈의 CJS import를 preamble이 아닌 body codegen에 위임했으나,
preamble의 `writeCjsImport`가 하던 `__toESM` 래핑이 body codegen에는 없었음

## Test plan
- [x] `zig build test` 통과
- [x] 통합 테스트 2414 pass, 0 fail
- [x] RN 번들에서 `invariant$4=__toESM(require_invariant_browser()).default` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)