### PR TITLE
fix(parser): new X<T>() type argument 이중 호출 버그 수정

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1078,6 +1078,33 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
     return expr;
 }
 
+/// new X<T>() 에서 type argument <T>를 speculatively 파싱하여 skip한다.
+/// call expression 체인의 l_angle 분기와 동일한 패턴.
+/// 실패하면 상태를 복원하여 < 를 비교 연산자로 처리하도록 한다.
+fn trySkipNewExprTypeArgs(self: *Parser) void {
+    if (!self.isAtOpeningAngleBracket()) return;
+    const saved_scanner = self.saveState();
+    const saved_nodes_len = self.ast.nodes.items.len;
+    const saved_extra_len = self.ast.extra_data.items.len;
+    const saved_scratch = self.saveScratch();
+    const saved_errors_len = self.errors.items.len;
+
+    const type_args_ok = blk: {
+        _ = self.parseTypeArgumentsInExpression() catch {
+            break :blk false;
+        };
+        if (self.errors.items.len > saved_errors_len) break :blk false;
+        break :blk (self.current() == .l_paren);
+    };
+
+    const scanner_after = if (type_args_ok) self.saveState() else saved_scanner;
+    self.ast.nodes.items.len = saved_nodes_len;
+    self.ast.extra_data.items.len = saved_extra_len;
+    self.restoreScratch(saved_scratch);
+    self.errors.shrinkRetainingCapacity(saved_errors_len);
+    self.restoreState(scanner_after);
+}
+
 /// new 표현식의 callee를 파싱한다.
 /// new는 중첩 가능하므로 new를 만나면 재귀한다.
 /// member access (.prop, [expr])만 허용하고 호출 ()은 상위에서 처리.
@@ -1103,6 +1130,7 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
         try self.advance(); // skip 'new'
         const callee = try parseNewCallee(self);
+        trySkipNewExprTypeArgs(self);
         if (self.current() == .l_paren) {
             try self.advance();
             const arg_list = try parseArgumentList(self);
@@ -1293,6 +1321,9 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
 
             // callee: 재귀적으로 new 또는 primary + member chain
             const callee = try parseNewCallee(self);
+
+            // TS/Flow: new X<T>() — type argument를 speculatively 파싱하여 skip
+            trySkipNewExprTypeArgs(self);
 
             // 인자: (args) — 있으면 소비, 없으면 인자 없는 new (new Foo)
             if (self.current() == .l_paren) {

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -782,4 +782,20 @@ describe("__esm 실행 순서 보장", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("a b");
   });
+
+  test("new expression with type arguments — new X<T>() 이중 호출 방지", async () => {
+    // new WeakSet<{...}>() 같은 TS/Flow 제네릭이 new WeakSet()()로 잘못 변환되지 않아야 함
+    const result = await bundleAndRun({
+      "index.ts": `
+        const s = new Set<number>();
+        const m = new Map<string, number>();
+        s.add(1); s.add(2);
+        m.set("a", 10);
+        console.log(s.size, m.get("a"));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("2 10");
+  });
 });


### PR DESCRIPTION
## Summary
- `new WeakSet<{...}>()` 같은 TS/Flow 제네릭 new 표현식이 `new WeakSet()()` (이중 호출)로 잘못 변환되는 버그 수정
- `trySkipNewExprTypeArgs` 헬퍼 추출로 `parsePrimaryExpression`과 `parseNewCallee` 양쪽에서 공유

## Test plan
- [x] 유닛 테스트 통과
- [x] 통합 테스트 47개 통과 (신규 1개 포함)
- [x] RN es5-rn 15개 통과
- [x] `new Set<T>()`, `new Map<K,V>()`, `new WeakSet<{...}>()`, `new Foo<T>(args)` 모두 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)