### PR TITLE
fix(emitter): __esm 모듈 정렬 — scope-hoisted 호출 전 선언 보장

### DIFF
--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -130,8 +130,14 @@ pub const Module = struct {
         return if (self.def_format.isEsm()) .node else .babel;
     }
 
-    /// exec_index 기준 오름차순 comparator.
+    /// 번들 출력 순서 comparator.
+    /// 래핑된 모듈(__esm/__commonJS)을 scope-hoisted 모듈보다 먼저 배치.
+    /// var init_xxx = __esm(...) 선언이 init_xxx() 호출보다 앞에 와야 하므로,
+    /// 같은 그룹 내에서는 exec_index 오름차순.
     pub fn execIndexLessThan(_: void, a: *const Module, b: *const Module) bool {
+        const a_wrapped: u1 = if (a.wrap_kind == .none) 1 else 0;
+        const b_wrapped: u1 = if (b.wrap_kind == .none) 1 else 0;
+        if (a_wrapped != b_wrapped) return a_wrapped < b_wrapped;
         return a.exec_index < b.exec_index;
     }
 

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -798,4 +798,33 @@ describe("__esm 실행 순서 보장", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("2 10");
   });
+
+  test("__esm 모듈 정의가 scope-hoisted 호출보다 먼저 위치해야 함", async () => {
+    // scope-hoisted 모듈이 __esm 모듈의 init_xxx()를 호출할 때,
+    // var init_xxx = __esm({...}) 할당이 호출 지점보다 앞에 있어야 함
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+        import { result } from "./consumer.js";
+        console.log(result);
+      `,
+        "consumer.js": `
+        const lib = require("./lib.js");
+        export const result = lib.getValue();
+      `,
+        "lib.js": `
+        import { helper } from "./helper.js";
+        export function getValue() { return helper(); }
+      `,
+        "helper.js": `
+        export function helper() { return "ok"; }
+      `,
+      },
+      "index.ts",
+      ["--format=cjs"],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("ok");
+  });
 });


### PR DESCRIPTION
## Summary
- `var init_xxx = __esm({...})` 할당이 `init_xxx()` 호출보다 뒤에 위치하여 undefined 에러 발생하던 버그 수정
- 래핑된 모듈(__esm/__commonJS)을 scope-hoisted 모듈보다 먼저 배치하도록 정렬 기준 변경

## Test plan
- [x] 통합 테스트 48개 통과 (신규 1개 포함)
- [x] RN es5-rn 15개 통과
- [x] 실제 RN 번들에서 `init_RendererProxy` 정의가 모든 scope-hoisted 호출보다 먼저 위치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)