### PR TITLE
refactor: execIndexLessThan → bundleOrderLessThan rename

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -147,7 +147,7 @@ pub fn emitWithTreeShaking(
         }
     }
 
-    std.mem.sort(*const Module, sorted.items, {}, Module.execIndexLessThan);
+    std.mem.sort(*const Module, sorted.items, {}, Module.bundleOrderLessThan);
 
     // 2. 각 모듈을 변환 + 코드젠
     var output: std.ArrayList(u8) = .empty;
@@ -373,7 +373,7 @@ pub fn emitDevBundle(
         }
     }
 
-    std.mem.sort(*const Module, sorted.items, {}, Module.execIndexLessThan);
+    std.mem.sort(*const Module, sorted.items, {}, Module.bundleOrderLessThan);
 
     // 2. 출력 빌드
     var output: std.ArrayList(u8) = .empty;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -134,10 +134,10 @@ pub const Module = struct {
     /// 래핑된 모듈(__esm/__commonJS)을 scope-hoisted 모듈보다 먼저 배치.
     /// var init_xxx = __esm(...) 선언이 init_xxx() 호출보다 앞에 와야 하므로,
     /// 같은 그룹 내에서는 exec_index 오름차순.
-    pub fn execIndexLessThan(_: void, a: *const Module, b: *const Module) bool {
-        const a_wrapped: u1 = if (a.wrap_kind == .none) 1 else 0;
-        const b_wrapped: u1 = if (b.wrap_kind == .none) 1 else 0;
-        if (a_wrapped != b_wrapped) return a_wrapped < b_wrapped;
+    pub fn bundleOrderLessThan(_: void, a: *const Module, b: *const Module) bool {
+        const a_wrapped = a.wrap_kind != .none;
+        const b_wrapped = b.wrap_kind != .none;
+        if (a_wrapped != b_wrapped) return a_wrapped;
         return a.exec_index < b.exec_index;
     }
 


### PR DESCRIPTION
## Summary
- 함수명을 실제 동작에 맞게 변경 (wrap_kind + exec_index 기반 정렬)
- `u1` 정수 매핑 → `bool` 직접 비교로 가독성 개선
- 변수명 `a_wrapped`가 실제 의미와 반대였던 혼란 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)