### PR TITLE
fix(codegen): export default class ES5 rename 시 var 덮어쓰기 버그 수정

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2428,6 +2428,13 @@ pub const Codegen = struct {
                     const def_name = self.options.linking_metadata.?.default_export_name;
                     const is_self_ref = blk: {
                         if (inner_node.tag == .identifier_reference) {
+                            const md = self.options.linking_metadata.?;
+                            // rename된 이름으로 비교 (ES5 lowering 시 원본 span과 def_name이 다를 수 있음)
+                            if (self.resolveSymbolId(inner, md)) |sid| {
+                                if (md.renames.get(sid)) |renamed| {
+                                    break :blk std.mem.eql(u8, renamed, def_name);
+                                }
+                            }
                             const ref_text = self.ast.source[inner_node.span.start..inner_node.span.end];
                             break :blk std.mem.eql(u8, ref_text, def_name);
                         }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -905,6 +905,10 @@ pub const Transformer = struct {
                 else
                     try self.new_ast.addString("_Class");
                 const name_ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
+                // symbol_id 전파: rename된 이름이 export default 참조에도 반영되도록
+                if (!name_idx.isNone()) {
+                    self.propagateSymbolId(name_idx, name_ref);
+                }
                 return self.new_ast.addNode(.{
                     .tag = node.tag,
                     .span = node.span,


### PR DESCRIPTION
## Summary
- `export default class DOMException extends Error` + ES5 lowering + 이름 충돌로 rename 시 `var DOMException$1 = DOMException;`이 생성되어 함수 선언을 `undefined`로 덮어쓰는 버그 수정
- `visitExportDefaultDeclaration`에서 원본 AST span으로 생성한 identifier에 `propagateSymbolId` 추가
- codegen의 self-reference 감지에서 `symbol_id → renames` 테이블 조회로 renamed 이름과 정확히 비교

## Test plan
- [x] `zig build test` 유닛 테스트 전체 통과 (2170/2170)
- [x] `bun test tests/es5-rn.test.ts` RN ES5 통합 테스트 통과 (15/15)
- [x] `bun test tests/bundle-smoke.test.ts` 번들 스모크 테스트 통과 (48/48)
- [x] 실제 RN 번들에서 DOMException 관련 `var DOMException$1 = DOMException;` 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)