### PR TITLE
fix(transformer): optional chaining 복제 노드 symbol_id 누락 수정

### DIFF
--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -121,6 +121,8 @@ pub fn ES2020(comptime Transformer: type) type {
             if (simple) {
                 null_check_base = visited_base;
                 chain_base = try self.new_ast.addNode(self.new_ast.getNode(visited_base));
+                // symbol_id 전파: 복제된 노드에도 rename이 적용되도록
+                self.copyNewSymbolId(visited_base, chain_base);
             } else {
                 const temp_span = try helpers.makeTempVarSpan(self);
                 const temp_ref1 = try helpers.makeTempVarRef(self, temp_span, node.span);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -887,6 +887,27 @@ pub const Transformer = struct {
         }
     }
 
+    /// new_ast 내에서 노드 간 symbol_id 복사 (new → new).
+    /// 노드 복제 시 symbol_id가 누락되지 않도록 사용.
+    pub fn copyNewSymbolId(self: *Transformer, src_new_idx: NodeIndex, dst_new_idx: NodeIndex) void {
+        if (self.old_symbol_ids.len == 0) return;
+        if (src_new_idx.isNone() or dst_new_idx.isNone()) return;
+
+        const src_i = @intFromEnum(src_new_idx);
+        const dst_i = @intFromEnum(dst_new_idx);
+
+        // dst를 new_symbol_ids 크기만큼 확장
+        while (self.new_symbol_ids.items.len <= dst_i) {
+            self.new_symbol_ids.append(self.allocator, null) catch return;
+        }
+
+        if (src_i < self.new_symbol_ids.items.len) {
+            if (self.new_symbol_ids.items[src_i]) |sid| {
+                self.new_symbol_ids.items[dst_i] = sid;
+            }
+        }
+    }
+
     /// export default class/function → ES5 lowering 시 operand가 .none이 되는 케이스 처리.
     /// lowerClassDeclaration이 pending_nodes에 function 등을 넣고 .none을 반환하므로,
     /// 클래스/함수 이름(또는 익명의 합성 이름 _Class)의 identifier reference를 operand로 사용.


### PR DESCRIPTION
## Summary
- `X?.now` → `X == null ? void 0 : X.now` ES5 lowering에서 두 번째 `X` 참조가 `addNode` 직접 호출로 생성되어 symbol_id 누락
- 번들에서 rename 시 `_default$14 == null ? void 0 : NativePerformance.now` 처럼 한쪽만 rename → `TypeError: Cannot read property 'now' of undefined`
- `copyNewSymbolId(new→new)` 메서드 추가하여 복제된 노드에 symbol_id 전파

## Test plan
- [x] `zig build test` 유닛 테스트 전체 통과
- [x] `bun test tests/es5-rn.test.ts` RN ES5 통합 테스트 통과 (15/15)
- [x] `bun test tests/bundle-smoke.test.ts` 번들 스모크 테스트 통과 (48/48)
- [x] RN 번들에서 `_default$14 == null ? void 0 : _default$14.now` 올바른 rename 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)