### PR TITLE
fix(codegen): __esm import destructuring rename 키 불일치 수정

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2243,17 +2243,32 @@ pub const Codegen = struct {
 
     /// import specifier의 imported + rename separator + local 출력.
     /// ESM은 " as ", CJS는 ":" 를 separator로 사용한다.
+    /// imported 쪽은 항상 원본 이름을 사용 (exports 객체의 프로퍼티 키).
+    /// local 쪽은 rename 적용 (로컬 변수명).
     fn emitImportSpecifierRename(self: *Codegen, spec_node: Node, sep: []const u8) !void {
         const imported = spec_node.data.binary.left;
         const local = spec_node.data.binary.right;
-        try self.emitNode(imported);
-        if (!local.isNone() and @intFromEnum(local) != @intFromEnum(imported)) {
+        // imported: 항상 원본 이름 (exports 객체 키 = rename 전 이름)
+        try self.writeSpan(self.ast.getNode(imported).span);
+        // local이 rename 되었거나 원본 imported와 다른 경우 → separator + local 출력
+        const needs_rename = blk: {
+            if (local.isNone() or @intFromEnum(local) == @intFromEnum(imported)) break :blk false;
+            // 원본 텍스트가 다르면 항상 rename 필요 (import { foo as bar })
             const imp_text = self.ast.source[self.ast.getNode(imported).span.start..self.ast.getNode(imported).span.end];
             const loc_text = self.ast.source[self.ast.getNode(local).span.start..self.ast.getNode(local).span.end];
-            if (!std.mem.eql(u8, imp_text, loc_text)) {
-                try self.write(sep);
-                try self.emitNode(local);
+            if (!std.mem.eql(u8, imp_text, loc_text)) break :blk true;
+            // 원본 텍스트가 같아도 linker가 rename했으면 separator 필요
+            // (e.g., import { Foo } → {Foo: Foo$1})
+            if (self.options.linking_metadata) |meta| {
+                if (self.resolveSymbolId(local, meta)) |sid| {
+                    if (meta.renames.get(sid)) |_| break :blk true;
+                }
             }
+            break :blk false;
+        };
+        if (needs_rename) {
+            try self.write(sep);
+            try self.emitNode(local);
         }
     }
 

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -919,4 +919,39 @@ describe("__esm 실행 순서 보장", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("42,conflict");
   });
+
+  test("ES5 __esm import destructuring rename — 키는 원본 이름 사용", async () => {
+    // __esm 모듈에서 import destructuring 시 exports 객체의 키는 원본 이름,
+    // 로컬 변수는 renamed 이름이어야 함.
+    // ({Base:Base$1}=...) ← 올바름, ({Base$1}=...) ← 잘못됨 (프로퍼티 없음)
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+        import { getChild } from "./consumer";
+        console.log(getChild());
+      `,
+        "consumer.ts": `
+        const m = require("./child");
+        export function getChild() { return m.Child.value(); }
+      `,
+        "child.ts": `
+        import { Base } from "./base";
+        export class Child extends Base {
+          static value() { return "child"; }
+        }
+      `,
+        "base.ts": `
+        export class Base {}
+      `,
+        "conflict.ts": `
+        export class Base { x = 1; }
+      `,
+      },
+      "index.ts",
+      ["--target=es5", "--format=cjs"],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("child");
+  });
 });


### PR DESCRIPTION
## Summary
- `__esm` 모듈에서 `import { PerformanceEntry }` 같은 named import가 rename될 때 `({PerformanceEntry$1}=exports)` 형태로 생성되어 exports 객체에 해당 키가 없어 `undefined` 반환
- `imported` 키는 항상 원본 이름(`writeSpan`), local이 rename된 경우 `({PerformanceEntry:PerformanceEntry$1}=exports)` 형태로 명시적 할당
- 회귀 테스트 추가

## Test plan
- [x] `zig build test` 유닛 테스트 전체 통과
- [x] `bun test tests/es5-rn.test.ts` RN ES5 통합 테스트 통과 (15/15)
- [x] `bun test tests/bundle-smoke.test.ts` 번들 스모크 테스트 통과 (52/52)
- [x] RN 번들에서 `({PerformanceEntry:PerformanceEntry$1}=...)` 올바른 destructuring 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)