### PR TITLE
refactor: symbol_id 전파 헬퍼 통합 + while-loop 최적화

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -176,7 +176,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             // --- static fields → ClassName.field = value ---
             for (cm.static_fields.items) |field| {
-                const class_ref = try makeClassNameRef(self, name_span, name_idx, span);
+                const class_ref = try self.makeIdentifierRefWithSymbol(name_span, name_idx);
                 const static_assign = try buildFieldAssign(self, class_ref, field.key, field.init, span);
                 try self.pending_nodes.append(self.allocator, static_assign);
             }
@@ -347,7 +347,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             // 5. static fields
             for (cm.static_fields.items) |field| {
-                const class_ref = try makeClassNameRef(self, name_span, name_idx, span);
+                const class_ref = try self.makeIdentifierRefWithSymbol(name_span, name_idx);
                 const static_assign = try buildFieldAssign(self, class_ref, field.key, field.init, span);
                 try self.scratch.append(self.allocator, static_assign);
             }
@@ -358,7 +358,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
 
             // 7. return ClassName;
-            const return_ref = try makeClassNameRef(self, name_span, name_idx, span);
+            const return_ref = try self.makeIdentifierRefWithSymbol(name_span, name_idx);
             const return_stmt = try self.new_ast.addNode(.{
                 .tag = .return_statement,
                 .span = span,
@@ -680,18 +680,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return std.mem.eql(u8, ta, tb);
         }
 
-        /// span + symbol_id를 가진 클래스 이름 identifier_reference 생성.
-        /// class_name_old_idx: 원본 AST의 binding_identifier 노드 인덱스 (symbol_id 전파용).
-        fn makeClassNameRef(self: *Transformer, class_name_span: Span, class_name_old_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            _ = span;
-            const ref = try es_helpers.makeIdentifierRefFromSpan(self, class_name_span);
-            self.propagateSymbolId(class_name_old_idx, ref);
-            return ref;
-        }
-
         /// ClassName.prototype static_member_expression 생성.
         fn buildPrototypeRef(self: *Transformer, class_name_span: Span, class_name_old_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const class_ref = try makeClassNameRef(self, class_name_span, class_name_old_idx, span);
+            const class_ref = try self.makeIdentifierRefWithSymbol(class_name_span, class_name_old_idx);
             const proto_prop = try es_helpers.makeIdentifierRef(self, "prototype");
             return es_helpers.makeStaticMember(self, class_ref, proto_prop, span);
         }
@@ -1064,8 +1055,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
         /// child_old_idx, parent_old_idx: 원본 AST 노드 인덱스 (symbol_id 전파용).
         fn buildExtendsCall(self: *Transformer, child_span: Span, parent_span: Span, child_old_idx: NodeIndex, parent_old_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const extends_ref = try es_helpers.makeIdentifierRef(self, "__extends");
-            const child_ref = try makeClassNameRef(self, child_span, child_old_idx, span);
-            const parent_ref = try makeClassNameRef(self, parent_span, parent_old_idx, span);
+            const child_ref = try self.makeIdentifierRefWithSymbol(child_span, child_old_idx);
+            const parent_ref = try self.makeIdentifierRefWithSymbol(parent_span, parent_old_idx);
             const call = try es_helpers.makeCallExpr(self, extends_ref, &.{ child_ref, parent_ref }, span);
 
             return self.new_ast.addNode(.{
@@ -1232,7 +1223,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
         /// target.methodName = func_expr (expression_statement)
         fn buildMethodAssignment(self: *Transformer, info: MethodInfo, class_name_span: Span, class_name_old_idx: NodeIndex, key_idx: NodeIndex, func_expr: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const target = if (info.is_static)
-                try makeClassNameRef(self, class_name_span, class_name_old_idx, span)
+                try self.makeIdentifierRefWithSymbol(class_name_span, class_name_old_idx)
             else
                 try buildPrototypeRef(self, class_name_span, class_name_old_idx, span);
             const member_access = try es_helpers.makeMemberFromKeyIdx(self, target, key_idx, span);
@@ -1310,7 +1301,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
                 // target
                 const target = if (info.is_static)
-                    try makeClassNameRef(self, class_name_span, class_name_old_idx, span)
+                    try self.makeIdentifierRefWithSymbol(class_name_span, class_name_old_idx)
                 else
                     try buildPrototypeRef(self, class_name_span, class_name_old_idx, span);
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -864,6 +864,14 @@ pub const Transformer = struct {
         return self.new_ast.getNode(name_idx).data.string_ref;
     }
 
+    /// new_symbol_ids를 target_idx까지 null로 확장.
+    fn ensureNewSymbolIds(self: *Transformer, target_idx: usize) void {
+        if (self.new_symbol_ids.items.len <= target_idx) {
+            const needed = target_idx + 1 - self.new_symbol_ids.items.len;
+            self.new_symbol_ids.appendNTimes(self.allocator, null, needed) catch return;
+        }
+    }
+
     /// 원본 → 새 노드의 symbol_id 전파.
     pub fn propagateSymbolId(self: *Transformer, old_idx: NodeIndex, new_idx: NodeIndex) void {
         if (self.old_symbol_ids.len == 0) return; // 전파 비활성
@@ -872,10 +880,7 @@ pub const Transformer = struct {
         const old_i = @intFromEnum(old_idx);
         const new_i = @intFromEnum(new_idx);
 
-        // new_symbol_ids를 new_ast 노드 수만큼 확장
-        while (self.new_symbol_ids.items.len <= new_i) {
-            self.new_symbol_ids.append(self.allocator, null) catch return;
-        }
+        self.ensureNewSymbolIds(new_i);
 
         if (old_i < self.old_symbol_ids.len) {
             // ts_as_expression 등 wrapper 노드가 내부 노드와 같은 new_idx를 반환하면
@@ -896,16 +901,21 @@ pub const Transformer = struct {
         const src_i = @intFromEnum(src_new_idx);
         const dst_i = @intFromEnum(dst_new_idx);
 
-        // dst를 new_symbol_ids 크기만큼 확장
-        while (self.new_symbol_ids.items.len <= dst_i) {
-            self.new_symbol_ids.append(self.allocator, null) catch return;
-        }
+        self.ensureNewSymbolIds(dst_i);
 
         if (src_i < self.new_symbol_ids.items.len) {
             if (self.new_symbol_ids.items[src_i]) |sid| {
                 self.new_symbol_ids.items[dst_i] = sid;
             }
         }
+    }
+
+    /// span + old_idx로 identifier_reference 생성 + symbol_id 전파.
+    /// ES5 class lowering, decorator 등에서 renamed 이름이 반영되도록 사용.
+    pub fn makeIdentifierRefWithSymbol(self: *Transformer, name_span: Span, old_idx: NodeIndex) Error!NodeIndex {
+        const ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
+        self.propagateSymbolId(old_idx, ref);
+        return ref;
     }
 
     /// export default class/function → ES5 lowering 시 operand가 .none이 되는 케이스 처리.
@@ -925,11 +935,7 @@ pub const Transformer = struct {
                     self.old_ast.getNode(name_idx).data.string_ref
                 else
                     try self.new_ast.addString("_Class");
-                const name_ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
-                // symbol_id 전파: rename된 이름이 export default 참조에도 반영되도록
-                if (!name_idx.isNone()) {
-                    self.propagateSymbolId(name_idx, name_ref);
-                }
+                const name_ref = try self.makeIdentifierRefWithSymbol(name_span, name_idx);
                 return self.new_ast.addNode(.{
                     .tag = node.tag,
                     .span = node.span,
@@ -2979,12 +2985,7 @@ pub const Transformer = struct {
         });
 
         // arg2: Foo.prototype (instance) or Foo (static)
-        const class_ref = try self.new_ast.addNode(.{
-            .tag = .identifier_reference,
-            .span = class_name_span,
-            .data = .{ .string_ref = class_name_span },
-        });
-        self.propagateSymbolId(class_name_old_idx, class_ref);
+        const class_ref = try self.makeIdentifierRefWithSymbol(class_name_span, class_name_old_idx);
         const target = if (!md.is_static) blk: {
             const proto_span = try self.new_ast.addString("prototype");
             const proto_id = try self.new_ast.addNode(.{
@@ -3085,12 +3086,7 @@ pub const Transformer = struct {
         });
 
         // arg2: Foo
-        const class_ref = try self.new_ast.addNode(.{
-            .tag = .identifier_reference,
-            .span = class_name_span,
-            .data = .{ .string_ref = class_name_span },
-        });
-        self.propagateSymbolId(class_name_old_idx, class_ref);
+        const class_ref = try self.makeIdentifierRefWithSymbol(class_name_span, class_name_old_idx);
 
         const args = try self.new_ast.addNodeList(&.{ deco_array, class_ref });
         const call = try self.addExtraNode(.call_expression, zero_span, &.{
@@ -3098,12 +3094,7 @@ pub const Transformer = struct {
         });
 
         // Foo = __decorateClass([dec], Foo)
-        const lhs = try self.new_ast.addNode(.{
-            .tag = .identifier_reference,
-            .span = class_name_span,
-            .data = .{ .string_ref = class_name_span },
-        });
-        self.propagateSymbolId(class_name_old_idx, lhs);
+        const lhs = try self.makeIdentifierRefWithSymbol(class_name_span, class_name_old_idx);
         const assign = try self.new_ast.addNode(.{
             .tag = .assignment_expression,
             .span = zero_span,


### PR DESCRIPTION
## Summary
- `makeClassNameRef`(es2015_class 로컬) → `makeIdentifierRefWithSymbol`(Transformer 메서드)로 승격
- decorator 코드의 inline `addNode + propagateSymbolId` 3곳 → `makeIdentifierRefWithSymbol`로 통합
- `propagateSymbolId`/`copyNewSymbolId`의 while-loop append → `ensureNewSymbolIds` + `appendNTimes` 최적화
- `makeClassNameRef`의 미사용 `span` 파라미터 제거 (9곳 단순화)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun test tests/bundle-smoke.test.ts` 52/52
- [x] `bun test tests/es5-rn.test.ts` 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)