### PR TITLE
feat(bundler): --platform=react-native ESM 모듈 lazy loading (Metro 호환)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1153,6 +1153,20 @@ pub const ModuleGraph = struct {
                 }
             }
         }
+
+        // Pass 3: React Native — Metro 호환 lazy loading.
+        // Metro는 모든 모듈을 factory로 감싸 require() 시점에만 실행.
+        // scope-hoisted ESM 모듈의 top-level 코드(TurboModule.getEnforcing 등)가
+        // 번들 초기화 시 즉시 실행되면 아직 등록되지 않은 native 모듈에서 크래시.
+        // 엔트리를 제외한 모든 ESM 모듈을 __esm 래핑하여 lazy loading을 보장한다.
+        if (self.resolve_cache.platform == .react_native) {
+            for (self.modules.items, 0..) |*m, i| {
+                if (i == 0) continue; // 엔트리 모듈은 scope-hoisted 유지
+                if (m.wrap_kind == .none and (m.exports_kind == .esm or m.exports_kind == .esm_with_dynamic_fallback)) {
+                    m.wrap_kind = .esm;
+                }
+            }
+        }
     }
 
     /// node_modules 내 .js 파일이 ESM/CJS 신호 없으면 CJS로 간주.


### PR DESCRIPTION
## Summary
- Metro는 모든 모듈을 factory로 감싸 `require()` 시점에만 실행 (lazy loading)
- ZTS scope-hoisting은 ESM 모듈의 top-level 코드를 즉시 실행 → `TurboModuleRegistry.getEnforcing` 등이 native 모듈 등록 전에 호출되어 크래시
- `--platform=react-native`에서 엔트리를 제외한 모든 ESM 모듈을 `__esm` 래핑하여 Metro 호환 lazy loading 보장
- 번들 크기 약 10% 증가 (래핑 오버헤드) — Metro도 동일한 오버헤드 존재

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun test tests/es5-rn.test.ts` 15/15 통과
- [x] `bun test tests/bundle-smoke.test.ts` 52/52 통과
- [x] `getEnforcing("SegmentFetcher")`가 `__esm` init 내부로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)