### PR TITLE
test: TSC 스냅샷 업데이트 (new Foo()() → new Foo())

### DIFF
--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -1087,7 +1087,7 @@ function B3() {
 class K extends B1() {
 	namae;
 }
-class C extends (new B2()().anon) {
+class C extends (new B2().anon) {
 	name;
 }
 let b3Number = B3();
@@ -3876,7 +3876,7 @@ exports[`TSC: classes genericSetterInClassType 1`] = `
 	}
 	set y(v) {
 	}
-}var c = new C()();c.y = c.y;class Box {
+}var c = new C();c.y = c.y;class Box {
 	#value;
 	get value() {
 		return this.#value;
@@ -3884,7 +3884,7 @@ exports[`TSC: classes genericSetterInClassType 1`] = `
 	set value(value) {
 		this.#value = value;
 	}
-}new Box()().value = 3;})(Generic || (Generic = {}));
+}new Box().value = 3;})(Generic || (Generic = {}));
 "
 `;
 
@@ -4137,7 +4137,7 @@ class D {
 	y;
 }
 var d = new D();
-var d2 = new D()();
+var d2 = new D();
 var r2 = D;
 "
 `;
@@ -6382,7 +6382,7 @@ exports[`TSC: classes privateNamesConstructorChain-2 1`] = `
 	#foo = 3;
 	static #bar = 5;
 	accessChildProps() {
-		new Child()().#foo;
+		new Child().#foo;
 		// OK (\`#foo\` was added when \`Parent\`'s constructor was called on \`child\`)
 Child.#bar;
 	}
@@ -6394,7 +6394,7 @@ class Child extends Parent {
 #bar = "bar";
 }
 // OK
-new Parent()().accessChildProps();
+new Parent().accessChildProps();
 "
 `;
 
@@ -8599,7 +8599,7 @@ class MyMap {
 	constructor(Map_) {
 		this.Map_ = Map_;
 	}
-	store = new this.Map_()();
+	store = new this.Map_();
 }
 "
 `;
@@ -9553,7 +9553,7 @@ C.a;
 C.a = 1;
 C[2];
 C[2] = 42;
-const c = new C()();
+const c = new C();
 c.foo(1);
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -6873,15 +6873,15 @@ class MyPromise {
 	constructor(executor) {
 	}
 }
-new MyPromise()((resolve) => resolve());
+new MyPromise((resolve) => resolve());
 // no error
-new MyPromise()((resolve) => resolve());
+new MyPromise((resolve) => resolve());
 // no error
-new MyPromise()((resolve) => resolve());
+new MyPromise((resolve) => resolve());
 // error, \`any\` arguments cannot be omitted
-new MyPromise()((resolve) => resolve());
+new MyPromise((resolve) => resolve());
 // error, \`unknown\` arguments cannot be omitted
-new MyPromise()((resolve) => resolve());
+new MyPromise((resolve) => resolve());
 // error, \`never\` arguments cannot be omitted
 // Multiple parameters
 function a(x,y,z) {
@@ -7488,12 +7488,12 @@ var s;
 new fn1({});
 // Error
 // Generic and non - generic overload where generic overload is the only candidate when called with type arguments
-var d = new fn2()(0, undefined);
+var d = new fn2(0, undefined);
 var d;
 // Generic and non - generic overload where generic overload is the only candidate when called without type arguments
 var s = new fn2(0, "");
 // Generic and non - generic overload where non - generic overload is the only candidate when called with type arguments
-new fn2()("", 0);
+new fn2("", 0);
 // Error
 // Generic and non - generic overload where non - generic overload is the only candidate when called without type arguments
 new fn2("", 0);
@@ -7504,26 +7504,26 @@ var s = new fn3("", 3, "");
 var n = new fn3(5, 5, 5);
 var n;
 // Generic overloads with differing arity called with type arguments matching each overload type parameter count
-var s = new fn3()(4);
-var s = new fn3()("", "", "");
-var n = new fn3()("", "", 3);
+var s = new fn3(4);
+var s = new fn3("", "", "");
+var n = new fn3("", "", 3);
 // Generic overloads with differing arity called with type argument count that doesn't match any overload
-new fn3()();
+new fn3();
 // Error
 // Generic overloads with constraints called with type arguments that satisfy the constraints
-new fn4()("", 3);
-new fn4()(3, "");
+new fn4("", 3);
+new fn4(3, "");
 // Error
-new fn4()("", 3);
+new fn4("", 3);
 // Error
-new fn4()(3, "");
+new fn4(3, "");
 // Generic overloads with constraints called without type arguments but with types that satisfy the constraints
 new fn4("", 3);
 new fn4(3, "");
 new fn4(3, undefined);
 new fn4("", null);
 // Generic overloads with constraints called with type arguments that do not satisfy the constraints
-new fn4()(null, null);
+new fn4(null, null);
 // Error
 // Generic overloads with constraints called without type arguments but with types that do not satisfy the constraints
 new fn4(true, null);
@@ -7630,59 +7630,59 @@ var arr;
 exports[`TSC: expressions typeArgumentInferenceConstructSignatures 1`] = `
 "// Generic call with no parameters
 new noParams();
-new noParams()();
-new noParams()();
+new noParams();
+new noParams();
 // Generic call with parameters but none use type parameter type
 new noGenericParams("");
-new noGenericParams()("");
-new noGenericParams()("");
+new noGenericParams("");
+new noGenericParams("");
 // Generic call with multiple type parameters and only one used in parameter type annotation
 new someGenerics1(3, 4);
-new someGenerics1()(3, 4);
+new someGenerics1(3, 4);
 // Error
-new someGenerics1()(3, 4);
+new someGenerics1(3, 4);
 // Generic call with argument of function type whose parameter is of type parameter type
 new someGenerics2a((n) => n);
-new someGenerics2a()((n) => n);
-new someGenerics2a()((n) => n.substr(0));
+new someGenerics2a((n) => n);
+new someGenerics2a((n) => n.substr(0));
 new someGenerics2b((n, x) => n);
-new someGenerics2b()((n, t) => n);
-new someGenerics2b()((n,t) => n.substr(t * t));
+new someGenerics2b((n, t) => n);
+new someGenerics2b((n,t) => n.substr(t * t));
 // Generic call with argument of function type whose parameter is not of type parameter type but body/return type uses type parameter
 new someGenerics3(() => "");
-new someGenerics3()(() => undefined);
-new someGenerics3()(() => 3);
+new someGenerics3(() => undefined);
+new someGenerics3(() => 3);
 // 2 parameter generic call with argument 1 of type parameter type and argument 2 of function type whose parameter is of type parameter type
 new someGenerics4(4, () => null);
-new someGenerics4()("", () => 3);
-new someGenerics4()("", (x) => "");
+new someGenerics4("", () => 3);
+new someGenerics4("", (x) => "");
 // Error
-new someGenerics4()(null, null);
+new someGenerics4(null, null);
 // 2 parameter generic call with argument 2 of type parameter type and argument 1 of function type whose parameter is of type parameter type
 new someGenerics5(4, () => null);
-new someGenerics5()("", () => 3);
-new someGenerics5()("", (x) => "");
+new someGenerics5("", () => 3);
+new someGenerics5("", (x) => "");
 // Error
-new someGenerics5()(null, null);
+new someGenerics5(null, null);
 // Generic call with multiple arguments of function types that each have parameters of the same generic type
 new someGenerics6((n) => n, (n) => n, (n) => n);
-new someGenerics6()((n) => n, (n) => n, (n) => n);
-new someGenerics6()((n) => n, (n) => n, (n) => n);
+new someGenerics6((n) => n, (n) => n, (n) => n);
+new someGenerics6((n) => n, (n) => n, (n) => n);
 // Error
-new someGenerics6()((n) => n, (n) => n, (n) => n);
+new someGenerics6((n) => n, (n) => n, (n) => n);
 // Generic call with multiple arguments of function types that each have parameters of different generic type
 new someGenerics7((n) => n, (n) => n, (n) => n);
-new someGenerics7()((n) => n, (n) => n, (n) => n);
-new someGenerics7()((n) => n, (n) => n, (n) => n);
+new someGenerics7((n) => n, (n) => n, (n) => n);
+new someGenerics7((n) => n, (n) => n, (n) => n);
 // Generic call with argument of generic function type
 var x = new someGenerics8(someGenerics7);
-new x()(null, null, null);
+new x(null, null, null);
 // Generic call with multiple parameters of generic type passed arguments with no best common type
 var a9a = new someGenerics9("", 0, []);
-var a9b = new someGenerics9()({ a: 0 }, { b: "" }, null);
+var a9b = new someGenerics9({ a: 0 }, { b: "" }, null);
 // Generic call with multiple parameters of generic type passed arguments with multiple best common types
 var a9e = new someGenerics9(undefined, { x: 6, z: window }, { x: 6, y: "" });
-var a9f = new someGenerics9()(undefined, { x: 6, z: window }, { x: 6, y: "" });
+var a9f = new someGenerics9(undefined, { x: 6, z: window }, { x: 6, y: "" });
 // Generic call with multiple parameters of generic type passed arguments with a single best common type
 var a9d = new someGenerics9({ x: 3 }, { x: 6 }, { x: 6 });
 // Generic call with multiple parameters of generic type where one argument is of type 'any'


### PR DESCRIPTION
## Summary
- `new` 표현식 codegen 수정으로 인한 스냅샷 업데이트
- `new Foo()()` → `new Foo()`: 불필요한 이중 호출 제거 반영
- 9개 TSC 스냅샷 테스트 수정 (classes 6개, expressions 3개)

## Test plan
- [x] TSC 스냅샷 테스트 2177개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)