### PR TITLE
fix(emitter): --run-before-main 모듈을 엔트리 직전에 강제 호출

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -290,6 +290,7 @@ pub const Bundler = struct {
             .keep_names = self.options.keep_names,
             .plugins = self.options.plugins,
             .polyfills = &.{}, // 호출자가 loadPolyfills()로 설정
+            .run_before_main = self.options.run_before_main,
         };
     }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -106,6 +106,9 @@ pub const EmitOptions = struct {
     /// 번들 시작 시 즉시 실행 폴리필. 각 항목은 { .name, .content }.
     /// IIFE로 감싸서 런타임 헬퍼 앞에 인라인. 파일 I/O는 bundler에서 완료.
     polyfills: []const PolyfillEntry = &.{},
+    /// 엔트리 모듈 직전에 실행할 모듈 경로 (--run-before-main).
+    /// 해당 모듈의 require_xxx() / init_xxx() 호출을 엔트리 코드 앞에 삽입.
+    run_before_main: []const []const u8 = &.{},
 
     pub const PolyfillEntry = struct {
         name: []const u8,
@@ -284,6 +287,30 @@ pub fn emitWithTreeShaking(
         collected_helpers = @bitCast(@as(u16, @bitCast(collected_helpers)) | @as(u16, @bitCast(results[i].helpers)));
 
         const code = results[i].code orelse continue;
+
+        // --run-before-main: 엔트리 모듈 직전에 해당 모듈의 require/init 호출 삽입.
+        // inject로 그래프에 포함은 되지만, import_records에 없어서 linker가 preamble을 생성하지 않음.
+        // 여기서 엔트리 직전에 강제 호출하여 side-effect 실행을 보장.
+        const is_entry = if (entry_idx) |ei| @intFromEnum(m.index) == ei else false;
+        if (is_entry and options.run_before_main.len > 0) {
+            for (options.run_before_main) |rbm_path| {
+                // 그래프에서 해당 모듈을 찾아 require_xxx() 또는 init_xxx() 호출 생성
+                for (graph.modules.items) |*rbm| {
+                    if (std.mem.eql(u8, rbm.path, rbm_path)) {
+                        const call_name = if (rbm.wrap_kind == .cjs)
+                            types.makeRequireVarName(allocator, rbm.path) catch null
+                        else
+                            types.makeInitVarName(allocator, rbm.path) catch null;
+                        if (call_name) |name| {
+                            defer allocator.free(name);
+                            try module_output.appendSlice(allocator, name);
+                            try module_output.appendSlice(allocator, "();\n");
+                        }
+                        break;
+                    }
+                }
+            }
+        }
 
         if (!options.minify_whitespace) {
             try module_output.appendSlice(allocator, "// --- ");

--- a/tests/integration/tests/polyfill-rbm.test.ts
+++ b/tests/integration/tests/polyfill-rbm.test.ts
@@ -131,6 +131,34 @@ describe("--run-before-main", () => {
     expect(initPos).toBeLessThan(entryPos);
   });
 
+  test("run-before-main 모듈의 require/init 호출이 엔트리 직전에 삽입된다", async () => {
+    fixture = await createFixture(fixtures);
+    const outFile = join(fixture.dir, "out.js");
+
+    const result = await runZtsInDir(fixture.dir, [
+      "--bundle",
+      "entry.js",
+      `-o`,
+      outFile,
+      `--run-before-main=${join(fixture.dir, "init-core.js")}`,
+    ]);
+    expect(result.exitCode).toBe(0);
+
+    const bundle = readFileSync(outFile, "utf-8");
+    const lines = bundle.split("\n");
+
+    // 엔트리 코드(__ENTRY_RAN__) 직전에 require_init_core() 또는 init_init_core() 호출이 있어야 함
+    const entryLineIdx = lines.findLastIndex((l) => l.includes("__ENTRY_RAN__"));
+    expect(entryLineIdx).toBeGreaterThan(0);
+
+    // 엔트리 이전 20줄 이내에 init-core 모듈의 호출(require_xxx() 또는 init_xxx())이 있어야 함
+    const precedingLines = lines.slice(Math.max(0, entryLineIdx - 20), entryLineIdx).join("\n");
+    const hasCall = /(?:require|init)_[a-zA-Z0-9_]*init[_-]core[a-zA-Z0-9_]*\(\)/.test(
+      precedingLines,
+    );
+    expect(hasCall).toBe(true);
+  });
+
   test("존재하지 않는 run-before-main 경로는 에러 메시지를 출력한다", async () => {
     fixture = await createFixture(fixtures);
 


### PR DESCRIPTION
## Summary
- inject로 그래프에 포함되어도 `import_records`에 없으면 linker가 preamble을 생성하지 않는 문제 수정
- emitter Phase 3에서 엔트리 모듈 출력 직전에 `require_xxx()`/`init_xxx()` 호출을 강제 삽입
- `InitializeCore.js`가 엔트리 전에 반드시 실행되도록 보장

## Test plan
- [x] 새 테스트 추가: require/init 호출이 엔트리 직전에 삽입되는지 regex로 검증
- [x] 기존 테스트 74개 + 신규 1개 = 75개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)