### PR TITLE
feat(linker): --global-identifier 예약 전역 식별자 (롤리팝 호환)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -104,6 +104,9 @@ pub const BundleOptions = struct {
     /// 번들 시작 시 즉시 실행 폴리필 (--polyfill). 절대 경로 목록.
     /// 파일 내용을 IIFE로 감싸서 런타임 헬퍼 앞에 인라인. 모듈 그래프에 미포함.
     polyfills: []const []const u8 = &.{},
+    /// 예약 전역 식별자 (--global-identifier). scope hoisting 시 이 이름을 모듈 변수로
+    /// 사용하지 않도록 리네이밍. RN의 polyfillGlobal()로 등록되는 이름 충돌 방지.
+    global_identifiers: []const []const u8 = &.{},
     /// --keep-names: minify 시 함수/클래스의 .name 프로퍼티 보존
     keep_names: bool = false,
     /// 플러그인 배열 (resolveId, load, transform, renderChunk, generateBundle 훅)
@@ -472,7 +475,7 @@ pub const Bundler = struct {
         // code_splitting=true일 때는 글로벌 computeRenames를 건너뛴다.
         // 각 청크가 독립된 네임스페이스이므로 emitChunks에서 per-chunk로 처리.
         var linker: ?Linker = if (self.options.scope_hoist or self.options.dev_mode) blk: {
-            var l = Linker.init(self.allocator, graph.modules.items, self.options.format);
+            var l = Linker.initWithGlobalIdentifiers(self.allocator, graph.modules.items, self.options.format, self.options.global_identifiers);
             try l.link();
             if (!self.options.dev_mode and !self.options.code_splitting) {
                 try l.computeRenames();

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -171,8 +171,12 @@ pub const Linker = struct {
 
     /// 자동 수집된 예약 글로벌 이름. 모든 모듈의 unresolved references를 합친 것.
     /// scope hoisting 시 모듈 top-level 변수가 이 이름을 shadowing하면 리네임.
-    /// Rolldown 방식: 하드코딩 목록 대신 실제 사용된 글로벌만 예약.
     reserved_globals: std.StringHashMap(void),
+
+    /// 외부에서 전달된 예약 전역 식별자 (--global-identifier).
+    /// RN의 polyfillGlobal()로 등록되는 이름(Performance, EventCounts 등)을
+    /// 모듈 변수로 사용하지 않도록 리네이밍.
+    global_identifiers: []const []const u8 = &.{},
 
     /// computeMangling 완료 후 true. buildMetadataForAst에서 nested mangling 수행 여부 결정.
     nested_mangling_enabled: bool = false,
@@ -200,6 +204,10 @@ pub const Linker = struct {
     };
 
     pub fn init(allocator: std.mem.Allocator, modules: []const Module, format: types.Format) Linker {
+        return initWithGlobalIdentifiers(allocator, modules, format, &.{});
+    }
+
+    pub fn initWithGlobalIdentifiers(allocator: std.mem.Allocator, modules: []const Module, format: types.Format, global_identifiers: []const []const u8) Linker {
         return .{
             .allocator = allocator,
             .modules = modules,
@@ -210,6 +218,7 @@ pub const Linker = struct {
             .canonical_names = std.StringHashMap([]const u8).init(allocator),
             .canonical_names_used = std.StringHashMap(void).init(allocator),
             .reserved_globals = std.StringHashMap(void).init(allocator),
+            .global_identifiers = global_identifiers,
         };
     }
 
@@ -427,6 +436,10 @@ pub const Linker = struct {
             while (it.next()) |entry| {
                 try self.reserved_globals.put(entry.key_ptr.*, {});
             }
+        }
+        // 외부 전달된 전역 식별자도 예약 (--global-identifier, RN polyfillGlobal 등)
+        for (self.global_identifiers) |name| {
+            try self.reserved_globals.put(name, {});
         }
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -76,6 +76,8 @@ const CliOptions = struct {
     /// --polyfill=<path>: 번들 시작 시 즉시 실행되는 폴리필 스크립트.
     /// 파일 내용을 읽어 IIFE로 감싸서 런타임 헬퍼 앞에 인라인. 모듈 그래프에 포함되지 않음.
     polyfill_list: std.ArrayList([]const u8) = .empty,
+    /// --global-identifier=<name>: 예약 전역 식별자. scope hoisting 시 리네이밍 대상.
+    global_identifier_list: std.ArrayList([]const u8) = .empty,
     keep_names: bool = false,
     plugin_paths: std.ArrayList([]const u8) = .empty,
     proxy_list: std.ArrayList(lib.server.DevServer.ProxyRule) = .empty,
@@ -130,6 +132,7 @@ const CliOptions = struct {
         self.run_before_main_list.deinit(alloc);
         for (self.polyfill_list.items) |p| alloc.free(p);
         self.polyfill_list.deinit(alloc);
+        self.global_identifier_list.deinit(alloc);
         self.plugin_paths.deinit(alloc);
         self.proxy_list.deinit(alloc);
         self.resolve_extensions_list.deinit(alloc);
@@ -472,6 +475,11 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             else
                 &opts.polyfill_list;
             try target_list.append(allocator, abs);
+        } else if (std.mem.startsWith(u8, arg, "--global-identifier=")) {
+            const name = arg["--global-identifier=".len..];
+            if (name.len > 0) {
+                try opts.global_identifier_list.append(allocator, name);
+            }
         } else if (std.mem.startsWith(u8, arg, "--legal-comments=")) {
             const val = arg["--legal-comments=".len..];
             opts.legal_comments = CliOptions.LegalCommentsEnum.fromString(val) orelse {
@@ -1045,6 +1053,7 @@ pub fn main() !void {
             .inject = opts.inject_list.items,
             .run_before_main = opts.run_before_main_list.items,
             .polyfills = opts.polyfill_list.items,
+            .global_identifiers = opts.global_identifier_list.items,
             .keep_names = opts.keep_names,
             .plugins = plugin_list.items,
             .flow = opts.flow,


### PR DESCRIPTION
## Summary
scope hoisting 시 지정된 이름을 모듈 변수로 사용하지 않도록 리네이밍.
RN의 `polyfillGlobal()`로 등록되는 이름과 모듈 변수의 충돌 방지.

`Performance` 모듈의 hoisted var `Performance`가 `polyfillGlobal("Performance", ...)`과 
충돌하여 Hermes에서 `Illegal constructor` 에러 발생 → `Performance$1`로 리네이밍하여 해결.

## 설계
Linker의 `reserved_globals`에 외부 전달된 이름 추가.
`computeRenames`에서 충돌 감지 → `$N` suffix로 리네이밍.
기존 unresolved references 예약과 동일한 메커니즘.

```bash
zts --bundle index.js --global-identifier=Performance --global-identifier=EventCounts
```

## Test plan
- [x] Performance → Performance$1 리네이밍 확인
- [x] 기존 테스트 75개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)