### PR TITLE
fix(emitter): named fn expr base name 매칭 수정

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -2365,7 +2365,10 @@ fn emitEsmWrappedModule(
     // 외부 스코프의 X 변수를 덮어쓰는 비표준 동작을 보임.
     // "= function NAME(" → "= function(" 으로 변환하여 이름 충돌 방지.
     for (hoisted_var_names.items) |hv_name| {
-        const needle = try std.fmt.allocPrint(arena_alloc, "= function {s}(", .{hv_name});
+        // 리네이밍된 이름(Performance$1)에서 base name(Performance)을 추출하여 검색.
+        // body_code는 리네이밍 전 원본 이름을 사용하므로 base name으로 매칭해야 함.
+        const base_name = if (std.mem.indexOfScalar(u8, hv_name, '$')) |dollar| hv_name[0..dollar] else hv_name;
+        const needle = try std.fmt.allocPrint(arena_alloc, "= function {s}(", .{base_name});
         const replacement = "= function(";
         var pos: usize = 0;
         while (std.mem.indexOf(u8, body_code[pos..], needle)) |rel| {


### PR DESCRIPTION
## Summary
hoisted var가 `Performance$1`로 리네이밍되면 `= function Performance$1(`을 찾지만
body_code는 원본 `= function Performance(`을 사용하여 매칭 실패.
`$` 앞의 base name으로 검색하여 정확히 매칭.

## Test plan
- [x] `Performance_public = function()` (이름 제거) + `"default": () => Performance$1` (리네이밍) 동시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)