### PR TITLE
fix(transformer): 표현식 super class ES5 변환 누락 (React.Component 등)

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2307,6 +2307,14 @@ test "ES2015: class expression with extends" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "(function(") != null);
 }
 
+test "ES2015: class expression extends member expression" {
+    var r = try e2eTarget(std.testing.allocator, "const F=class extends a.B{constructor(){super();}};", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ")(a.B)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.call(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super(") == null);
+}
+
 // --- class private field ---
 
 test "ES2015: class private field WeakMap" {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -278,10 +278,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // super class
             const has_super = !super_idx.isNone();
             var super_span: ?Span = null;
+            var expr_super_node: NodeIndex = .none;
             if (has_super) {
                 const super_node = self.old_ast.getNode(super_idx);
                 if (super_node.tag == .identifier_reference or super_node.tag == .binding_identifier) {
                     super_span = super_node.data.string_ref;
+                } else {
+                    expr_super_node = try self.visitNode(super_idx);
+                    super_span = try self.new_ast.addString("_super");
                 }
             }
 
@@ -459,7 +463,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             // (function(_super) { ... })(ParentClass) 또는 (function() { ... })()
             return if (has_super and super_span != null) blk: {
-                break :blk try es_helpers.makeCallExpr(self, paren, &.{try self.makeIdentifierRefWithSymbol(super_span.?, super_idx)}, span);
+                const parent_arg = if (!expr_super_node.isNone())
+                    expr_super_node
+                else
+                    try self.makeIdentifierRefWithSymbol(super_span.?, super_idx);
+                break :blk try es_helpers.makeCallExpr(self, paren, &.{parent_arg}, span);
             } else es_helpers.makeCallExpr(self, paren, &.{}, span);
         }
 


### PR DESCRIPTION
## Summary
`class Foo extends a.B { constructor() { super() } }` 에서 super class가 member expression일 때 ES5 IIFE 변환이 누락되는 버그 수정.

기존에는 `identifier_reference`만 처리하고 표현식은 `TODO: IIFE 패턴`으로 무시 → `super()` 미변환 + `__extends` 누락 → `SyntaxError: 'super' keyword unexpected here`

**영향 범위:** `React.Component`, `React.PureComponent`, `EventTarget`, `eventTargetShim.EventTarget` 등 member expression으로 참조하는 모든 부모 클래스.

**Before:**
```js
// super class 무시 → IIFE 인자 없음
var AbortSignal = (function() {
    function AbortSignal() { super(); }  // ❌ SyntaxError
    return AbortSignal;
})();
```

**After:**
```js
var AbortSignal = (function(_super) {
    function AbortSignal() { _super.call(this); }  // ✅
    __extends(AbortSignal, _super);
    return AbortSignal;
})(eventTargetShim.EventTarget);
```

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/es5-rn.test.ts` (from tests/integration/) — 17개 통과
- [x] ES5 번들에서 `super()` 0건 잔존 확인
- [x] Node.js ES5 번들 실행: ReferenceError/SyntaxError 없음
- [x] 유닛 테스트 추가: member expression extends IIFE 변환

🤖 Generated with [Claude Code](https://claude.com/claude-code)