### PR TITLE
fix(emitter): CJS 엔트리 자동 호출 (#707)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -344,6 +344,22 @@ pub fn emitWithTreeShaking(
         }
     }
 
+    // CJS 엔트리 자동 호출: __commonJS로 래핑된 엔트리 모듈은 require_xxx()를 호출해야 실행됨.
+    // esbuild와 동일하게 번들 끝(IIFE epilogue 직전)에 require_xxx() 삽입.
+    if (entry_idx) |ei| {
+        const entry_module = for (sorted.items) |m| {
+            if (@intFromEnum(m.index) == ei) break m;
+        } else null;
+        if (entry_module) |em| {
+            if (em.wrap_kind == .cjs) {
+                const call_name = try types.makeRequireVarName(allocator, em.path);
+                defer allocator.free(call_name);
+                try output.appendSlice(allocator, call_name);
+                try output.appendSlice(allocator, "();\n");
+            }
+        }
+    }
+
     // 포맷별 epilogue
     switch (options.format) {
         .iife => try output.appendSlice(allocator, "})();\n"),

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1036,4 +1036,14 @@ describe("_default 합성 변수 충돌 방지", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("v0,v1,v2,v3,v4");
   });
+
+  test("CJS 엔트리 모듈이 IIFE 번들에서 자동 호출된다 (#707)", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `const a = require("./a"); console.log(a.default);`,
+      "a.ts": `export default "hello";`,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("hello");
+  });
 });


### PR DESCRIPTION
## Summary
- CJS 엔트리 모듈(`__commonJS` 래핑)이 IIFE/ESM 번들에서 `require_xxx()` 호출 없이 실행되지 않던 버그 수정
- IIFE epilogue 직전에 CJS 엔트리의 `require_xxx()` 자동 삽입
- esbuild 동작과 동일하게 변경

## Test plan
- [x] CJS 엔트리 자동 호출 통합 테스트 추가 및 통과
- [x] 기존 57개 bundle-smoke 테스트 모두 통과

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)