### PR TITLE
fix(codegen): ES2015 shorthand 확장 시 object property key rename 버그 수정

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1405,7 +1405,14 @@ pub const Codegen = struct {
                 try self.emitNode(key);
             }
         } else {
-            try self.emitNode(key);
+            // ES2015 shorthand 확장으로 key가 identifier_reference가 되면
+            // scope hoisting rename이 적용되므로 원본 span으로 출력하여 방지.
+            const key_node = self.ast.getNode(key);
+            if (key_node.tag == .identifier_reference) {
+                try self.writeSpan(key_node.data.string_ref);
+            } else {
+                try self.emitNode(key);
+            }
             if (self.options.minify_whitespace) {
                 try self.writeByte(':');
             } else {

--- a/src/transformer/es2015_shorthand.zig
+++ b/src/transformer/es2015_shorthand.zig
@@ -33,6 +33,9 @@ pub fn ES2015Shorthand(comptime Transformer: type) type {
                 .span = key_node.span,
                 .data = .{ .string_ref = key_node.data.string_ref },
             });
+            // scope hoisting rename이 value에도 적용되도록 symbol_id 복사.
+            // key는 프로퍼티 이름이므로 rename 불필요하나, value는 변수 참조이므로 필요.
+            self.copyNewSymbolId(new_key, new_value);
 
             return self.new_ast.addNode(.{
                 .tag = .object_property,

--- a/src/transformer/es2016.zig
+++ b/src/transformer/es2016.zig
@@ -36,6 +36,7 @@ pub fn ES2016(comptime Transformer: type) type {
 
             // Math.pow(a, b) — left를 복사해서 callee의 인자로 사용
             const left_copy = try self.new_ast.addNode(self.new_ast.getNode(new_left));
+            self.copyNewSymbolId(new_left, left_copy);
             const pow_call = try buildMathPowCall(self, node.span, left_copy, new_right);
 
             // a = Math.pow(a, b)

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -43,6 +43,7 @@ pub fn ES2020(comptime Transformer: type) type {
 
             if (simple) {
                 const left_copy = try self.new_ast.addNode(self.new_ast.getNode(new_left));
+                self.copyNewSymbolId(new_left, left_copy);
                 const neq_null = try self.new_ast.addNode(.{
                     .tag = .binary_expression,
                     .span = node.span,

--- a/src/transformer/es2021.zig
+++ b/src/transformer/es2021.zig
@@ -28,6 +28,7 @@ pub fn ES2021(comptime Transformer: type) type {
             const new_left = try self.visitNode(node.data.binary.left);
             const new_right = try self.visitNode(node.data.binary.right);
             const left_copy1 = try self.new_ast.addNode(self.new_ast.getNode(new_left));
+            self.copyNewSymbolId(new_left, left_copy1);
 
             const assign = try self.new_ast.addNode(.{
                 .tag = .assignment_expression,
@@ -46,6 +47,7 @@ pub fn ES2021(comptime Transformer: type) type {
 
             if (self.options.unsupported.nullish_coalescing) {
                 const left_copy2 = try self.new_ast.addNode(self.new_ast.getNode(new_left));
+                self.copyNewSymbolId(new_left, left_copy2);
                 const null_span = try self.new_ast.addString("null");
                 const null_node = try self.new_ast.addNode(.{
                     .tag = .null_literal,
@@ -84,6 +86,7 @@ pub fn ES2021(comptime Transformer: type) type {
             const new_left = try self.visitNode(node.data.binary.left);
             const new_right = try self.visitNode(node.data.binary.right);
             const left_copy = try self.new_ast.addNode(self.new_ast.getNode(new_left));
+            self.copyNewSymbolId(new_left, left_copy);
 
             const assign = try self.new_ast.addNode(.{
                 .tag = .assignment_expression,


### PR DESCRIPTION
## Summary
- `--target=es5` + scope hoisting 조합에서 shorthand property `{ serialize }` → `{ serialize$1: serialize }` (키/값 반전) 출력되는 버그 수정
- 번개(bungae) dev server로 RN 앱 실행 시 `ReferenceError: Property 'serialize' doesn't exist` 런타임 에러 유발
- 동일한 `copyNewSymbolId` 누락 패턴을 es2016/es2020/es2021 트랜스포머에서도 일괄 수정

## 원인
1. **codegen**: non-shorthand path에서 `emitNode(key)` 호출 시 identifier_reference key에 scope hoisting rename이 적용됨 (프로퍼티 이름은 원본이어야 함)
2. **es2015_shorthand**: 확장된 value 노드에 `copyNewSymbolId` 미호출로 symbol_id 전파 누락 → rename 미적용

## Test plan
- [x] `zig build test` — 유닛 테스트 통과
- [x] `bun test tests/bundle-smoke.test.ts` — 60 pass
- [x] `bun test tests/es5-rn.test.ts` — 17 pass
- [x] 번개 ExampleApp 번들링 → DOMCollection.js `{ serialize: serialize$1, test: test$1 }` 정상 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)