### PR TITLE
fix(transformer): ES5 class getter/setter에 configurable: true 추가

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2247,6 +2247,8 @@ test "ES2015: class getter/setter paired" {
     defer r.deinit();
     // 하나의 Object.defineProperty로 합쳐져야 함
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty") != null);
+    // configurable: true — ES6 class getter/setter는 스펙상 configurable
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "configurable:true") != null);
     // "get:" 와 "set:" 가 같은 호출 안에 있어야 함
     try std.testing.expect(std.mem.indexOf(u8, r.output, "get:function()") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "set:function(x)") != null);

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1374,11 +1374,27 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     }
                 }
 
-                // descriptor object: { get: fn, set: fn } 또는 { get: fn }
+                // configurable: true — ES6 class getter/setter는 스펙상 configurable.
+                // ES5 Object.defineProperty의 기본값은 false이므로 명시 필요.
+                // 이를 누락하면 이후 Object.defineProperties로 재정의 시 TypeError 발생.
+                const config_key = try es_helpers.makeIdentifierRef(self, "configurable");
+                const true_span = try self.new_ast.addString("true");
+                const config_val = try self.new_ast.addNode(.{
+                    .tag = .boolean_literal,
+                    .span = true_span,
+                    .data = .{ .none = 0 },
+                });
+                const config_prop = try self.new_ast.addNode(.{
+                    .tag = .object_property,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = config_key, .right = config_val, .flags = 0 } },
+                });
+
+                // descriptor object: { configurable: true, get: fn, set: fn } 또는 { configurable: true, get: fn }
                 const obj_list = if (paired_prop) |pp|
-                    try self.new_ast.addNodeList(&.{ prop1, pp })
+                    try self.new_ast.addNodeList(&.{ config_prop, prop1, pp })
                 else
-                    try self.new_ast.addNodeList(&.{prop1});
+                    try self.new_ast.addNodeList(&.{ config_prop, prop1 });
                 const desc_obj = try self.new_ast.addNode(.{
                     .tag = .object_expression,
                     .span = span,

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1174,6 +1174,27 @@ export class C extends Mid {
     expect(result.runOutput).toBe("c>mid>base");
   });
 
+  test("ES5 class getter/setter가 configurable: true로 정의되어 이후 재정의 가능", async () => {
+    // abort-controller 패턴: class getter 정의 후 Object.defineProperties로 enumerable 추가.
+    // configurable: true가 없으면 TypeError: property is not configurable 발생.
+    const result = await bundleAndRun(
+      {
+        "index.ts": `import { Sig } from "./signal";
+Object.defineProperties(Sig.prototype, { aborted: { enumerable: true } });
+console.log(new Sig().aborted);`,
+        "signal.ts": `export class Sig {
+  get aborted(): boolean { return false; }
+}`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("false");
+  });
+
   test("export * from 이 __esm 래퍼에서 소스 모듈의 named export를 전파한다", async () => {
     const result = await bundleAndRun({
       "index.ts": `import { greet, add } from "./proxy"; console.log(greet("world") + ":" + add(1, 2));`,


### PR DESCRIPTION
## Summary
- ES5 class 변환 시 getter/setter의 `Object.defineProperty` descriptor에 `configurable: true` 추가
- ES6 class getter/setter는 스펙상 configurable이지만, `Object.defineProperty` 기본값은 `false`
- `abort-controller` 등 getter 정의 후 `Object.defineProperties`로 `enumerable` 추가하는 패턴에서 `TypeError: property is not configurable` 발생

## 변경 전/후
```javascript
// 변경 전 (버그)
Object.defineProperty(Sig.prototype, "aborted", { get: function() { ... } });
// configurable 기본값 false → 이후 재정의 불가

// 변경 후
Object.defineProperty(Sig.prototype, "aborted", { configurable: true, get: function() { ... } });
// 이후 Object.defineProperties로 enumerable 추가 가능
```

## Test plan
- [x] 유닛 테스트: getter/setter descriptor에 `configurable:true` 포함 확인
- [x] 통합 테스트: getter 정의 후 `Object.defineProperties` 재정의 시나리오 검증
- [x] bungae ExampleApp 번들에서 abort-controller 코드 `configurable: true` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)