### PR TITLE
feat(transformer): __callSuper + Reflect.construct로 네이티브 클래스 extends 지원

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -86,6 +86,23 @@ pub const CLASS_CALL_CHECK_RUNTIME =
 ;
 pub const CLASS_CALL_CHECK_RUNTIME_MIN = "var __classCallCheck=(instance,Constructor)=>{if(!(instance instanceof Constructor))throw new TypeError(\"Cannot call a class as a function\")};";
 
+/// __callSuper: super() 호출을 Reflect.construct로 래핑 (SWC _call_super 호환).
+/// 네이티브 ES6 클래스(Error, Map 등)를 extends할 때 .call()이 불가하므로
+/// Reflect.construct를 사용하여 올바른 내부 슬롯을 가진 인스턴스를 생성.
+/// 트랜스파일된 클래스에는 fallback으로 .apply()를 사용.
+pub const CALL_SUPER_RUNTIME =
+    \\var __callSuper = function(_this, Parent, args) {
+    \\  if (typeof Reflect !== "undefined" && typeof Reflect.construct === "function") {
+    \\    return Reflect.construct(Parent, args || [], _this.constructor);
+    \\  }
+    \\  var result = Parent.apply(_this, args);
+    \\  if (result && (typeof result === "object" || typeof result === "function")) return result;
+    \\  return _this;
+    \\};
+    \\
+;
+pub const CALL_SUPER_RUNTIME_MIN = "var __callSuper=function(_this,Parent,args){if(typeof Reflect!==\"undefined\"&&typeof Reflect.construct===\"function\")return Reflect.construct(Parent,args||[],_this.constructor);var result=Parent.apply(_this,args);if(result&&(typeof result===\"object\"||typeof result===\"function\"))return result;return _this};";
+
 /// __async: async/await → generator 변환 시 주입 (esbuild 호환).
 /// generator-to-Promise wrapper. this/arguments를 fn.apply로 보존.
 ///
@@ -311,6 +328,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
     if (helpers.class_call_check) {
         try buf.appendSlice(allocator, if (minify) CLASS_CALL_CHECK_RUNTIME_MIN else CLASS_CALL_CHECK_RUNTIME);
+    }
+    if (helpers.call_super) {
+        try buf.appendSlice(allocator, if (minify) CALL_SUPER_RUNTIME_MIN else CALL_SUPER_RUNTIME);
     }
 }
 

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2220,16 +2220,18 @@ test "ES2015: generator try/catch/finally with yield" {
 test "ES2015: class extends with super()" {
     var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(x){super(x);this.x=x;}}", .es5);
     defer r.deinit();
-    // super(x) → _super.call(this,x) — IIFE 매개변수를 사용하여 스코프 격리
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.call(this,x)") != null);
+    // super(x) → var _this=__callSuper(this,_super,[x]) + _this.x=x + return _this
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super,[x])") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_this.x=x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return _this") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__extends(C,_super)") != null);
 }
 
 test "ES2015: class extends default constructor" {
     var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){}}", .es5);
     defer r.deinit();
-    // 기본 생성자 → _super.apply(this,arguments) — IIFE 매개변수 사용
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.apply(this,arguments)") != null);
+    // 기본 생성자 → return __callSuper(this,_super,arguments) — implicit forwarding
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super,arguments)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__extends(C,_super)") != null);
 }
 
@@ -2283,8 +2285,8 @@ test "ES2015: class extends member expression (e.g. React.Component)" {
     // _super 매개변수 + __extends 호출
     try std.testing.expect(std.mem.indexOf(u8, r.output, "(function(_super)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__extends(Foo,_super)") != null);
-    // super() → _super.call(this) 변환
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.call(this)") != null);
+    // super() → __callSuper(this,_super,arguments) 변환
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super,[])") != null);
     // 원본 super 키워드가 남아있으면 안 됨
     try std.testing.expect(std.mem.indexOf(u8, r.output, "super(") == null);
 }
@@ -2316,7 +2318,7 @@ test "ES2015: class expression extends member expression" {
     var r = try e2eTarget(std.testing.allocator, "const F=class extends a.B{constructor(){super();}};", .es5);
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, ")(a.B)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.call(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super,[])") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "super(") == null);
 }
 

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -491,7 +491,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return self.old_ast.getNode(callee).tag == .super_expression;
         }
 
-        /// super(args) → Parent.call(this, args)
+        /// super(args) → __callSuper(this, _super, [args])
+        /// Reflect.construct를 사용하여 네이티브 클래스 extends도 지원.
+        /// super() 호출 후 this → _this 별칭을 활성화하여
+        /// __callSuper가 반환하는 새 객체를 올바르게 참조.
         /// call_expression: extra = [callee, args_start, args_len, flags]
         pub fn lowerSuperCall(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const super_class_span = self.current_super_class orelse return self.visitCallExpression(node);
@@ -501,24 +504,19 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const args_len = extras[e + 2];
             const span = node.span;
 
-            // Parent.call
-            const parent_ref = try es_helpers.makeIdentifierRefFromSpan(self, super_class_span);
-            const call_prop = try es_helpers.makeIdentifierRef(self, "call");
-            const callee = try es_helpers.makeStaticMember(self, parent_ref, call_prop, span);
+            const callee = try es_helpers.makeIdentifierRef(self, "__callSuper");
 
-            // args: [this, ...original_args]
+            // super() 이전이므로 원래 this 사용 — 아직 alias 활성화 전
             const this_node = try self.new_ast.addNode(.{
                 .tag = .this_expression,
                 .span = span,
                 .data = .{ .none = 0 },
             });
 
+            const parent_ref = try es_helpers.makeIdentifierRefFromSpan(self, super_class_span);
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
-            try self.scratch.append(self.allocator, this_node);
-
-            // 원래 인자들을 visit하여 추가
             const old_args = self.old_ast.extra_data.items[args_start .. args_start + args_len];
             for (old_args) |raw_idx| {
                 const new_arg = try self.visitNode(@enumFromInt(raw_idx));
@@ -527,15 +525,29 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 }
             }
 
-            const new_args = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
-            const new_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(callee), new_args.start, new_args.len, 0,
-            });
-            return self.new_ast.addNode(.{
-                .tag = .call_expression,
+            const elems = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+            const args_array = try self.new_ast.addNode(.{
+                .tag = .array_expression,
                 .span = span,
-                .data = .{ .extra = new_extra },
+                .data = .{ .list = elems },
             });
+
+            const call = try es_helpers.makeCallExpr(self, callee, &.{ this_node, parent_ref, args_array }, span);
+
+            // _this = __callSuper(this, _super, [args])
+            // 대입식으로 반환하여 super()가 if/else 등 어디에 있든 동작.
+            // var _this 선언과 return _this는 postProcessSuperCallBody에서 추가.
+            const this_ref = try es_helpers.makeIdentifierRef(self, "_this");
+            const assign = try self.new_ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = this_ref, .right = call, .flags = 0 } },
+            });
+
+            self.super_call_this_alias = true;
+            self.runtime_helpers.call_super = true;
+
+            return assign;
         }
 
         /// call_expression의 callee가 super.method (static_member_expression + super) 인지 확인.
@@ -1031,8 +1043,20 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const params_len = ctor_extras[me + 2];
             const body_idx: NodeIndex = @enumFromInt(ctor_extras[me + 3]);
 
+            // super_call_this_alias save/restore (lowerSuperCall이 설정)
+            const saved_super_alias = self.super_call_this_alias;
+            self.super_call_this_alias = false;
+            defer self.super_call_this_alias = saved_super_alias;
+
             const new_params = try self.visitExtraList(params_start, params_len);
-            const new_body = try visitMethodBody(self, body_idx, span);
+            var new_body = try visitMethodBody(self, body_idx, span);
+
+            // super() 호출이 있었으면 body 후처리:
+            // 1. super() expression_statement → var _this = __callSuper(...)
+            // 2. body 끝에 return _this 추가
+            if (self.super_call_this_alias) {
+                new_body = try postProcessSuperCallBody(self, new_body, span);
+            }
 
             const none = @intFromEnum(NodeIndex.none);
             const func_extra = try self.new_ast.addExtras(&.{
@@ -1047,6 +1071,45 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .tag = .function_declaration,
                 .span = span,
                 .data = .{ .extra = func_extra },
+            });
+        }
+
+        /// super() 호출이 있는 constructor body를 후처리:
+        /// 1. body 앞에 var _this; 선언 추가
+        /// 2. body 끝에 return _this; 추가
+        /// lowerSuperCall이 _this = __callSuper(...) 대입식을 생성하므로,
+        /// super()가 if/else 등 어디에 있든 정상 동작한다.
+        fn postProcessSuperCallBody(self: *Transformer, body: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            const body_node = self.new_ast.getNode(body);
+            if (body_node.tag != .block_statement) return body;
+
+            const stmts_list = body_node.data.list;
+            const stmts = self.new_ast.extra_data.items[stmts_list.start .. stmts_list.start + stmts_list.len];
+
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+            // var _this; (초기화 없는 선언)
+            try self.scratch.append(self.allocator, try self.buildVarDecl("_this", .none, span));
+
+            // 기존 body statements
+            for (stmts) |raw_idx| {
+                try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+            }
+
+            // return _this;
+            const this_ref = try es_helpers.makeIdentifierRef(self, "_this");
+            try self.scratch.append(self.allocator, try self.new_ast.addNode(.{
+                .tag = .return_statement,
+                .span = span,
+                .data = .{ .unary = .{ .operand = this_ref, .flags = 0 } },
+            }));
+
+            const new_list = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+            return self.new_ast.addNode(.{
+                .tag = .block_statement,
+                .span = span,
+                .data = .{ .list = new_list },
             });
         }
 
@@ -1078,39 +1141,25 @@ pub fn ES2015Class(comptime Transformer: type) type {
         }
 
         /// extends가 있고 constructor가 없을 때 기본 constructor 생성:
-        /// function Child() { return Parent.apply(this, arguments) || this; }
+        /// function Child() { return __callSuper(this, _super, arguments); }
         fn buildDefaultSuperConstructor(self: *Transformer, name: NodeIndex, super_class_span: Span, span: Span) Transformer.Error!NodeIndex {
-            // Parent.apply(this, arguments)
-            const parent_ref = try es_helpers.makeIdentifierRefFromSpan(self, super_class_span);
-            const apply_prop = try es_helpers.makeIdentifierRef(self, "apply");
-            const callee = try es_helpers.makeStaticMember(self, parent_ref, apply_prop, span);
-
-            // args: [this, arguments]
+            // __callSuper(this, _super, arguments)
+            const call_super_ref = try es_helpers.makeIdentifierRef(self, "__callSuper");
             const this_node = try self.new_ast.addNode(.{
                 .tag = .this_expression,
                 .span = span,
                 .data = .{ .none = 0 },
             });
+            const parent_ref = try es_helpers.makeIdentifierRefFromSpan(self, super_class_span);
             const args_ref = try es_helpers.makeIdentifierRef(self, "arguments");
-            const apply_call = try es_helpers.makeCallExpr(self, callee, &.{ this_node, args_ref }, span);
+            const call_super = try es_helpers.makeCallExpr(self, call_super_ref, &.{ this_node, parent_ref, args_ref }, span);
 
-            // Parent.apply(this, arguments) || this
-            const this2 = try self.new_ast.addNode(.{
-                .tag = .this_expression,
-                .span = span,
-                .data = .{ .none = 0 },
-            });
-            const or_expr = try self.new_ast.addNode(.{
-                .tag = .logical_expression,
-                .span = span,
-                .data = .{ .binary = .{ .left = apply_call, .right = this2, .flags = @intFromEnum(token_mod.Kind.pipe2) } },
-            });
+            self.runtime_helpers.call_super = true;
 
-            // return Parent.apply(this, arguments) || this;
             const ret_stmt = try self.new_ast.addNode(.{
                 .tag = .return_statement,
                 .span = span,
-                .data = .{ .unary = .{ .operand = or_expr, .flags = 0 } },
+                .data = .{ .unary = .{ .operand = call_super, .flags = 0 } },
             });
 
             const body_list = try self.new_ast.addNodeList(&.{ret_stmt});

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -103,7 +103,9 @@ pub const RuntimeHelpers = packed struct(u16) {
     class_private_method_get: bool = false,
     /// __classCallCheck: class를 new 없이 호출 방지 (ES2015 스펙)
     class_call_check: bool = false,
-    _padding: u5 = 0,
+    /// __callSuper: Reflect.construct 기반 super() 호출 (네이티브 클래스 extends 지원)
+    call_super: bool = false,
+    _padding: u4 = 0,
 };
 
 /// AST-to-AST 변환기.
@@ -199,6 +201,11 @@ pub const Transformer = struct {
 
     /// 현재 함수 스코프에서 arrow body가 arguments를 사용하여 var _arguments = arguments 삽입이 필요한지.
     needs_arguments_var: bool = false,
+
+    /// ES2015 class constructor에서 super() 호출 후 this → _this 별칭이 필요한지.
+    /// __callSuper가 Reflect.construct를 사용하면 새 객체를 반환하므로,
+    /// super() 이후의 this 참조를 _this로 교체해야 한다.
+    super_call_this_alias: bool = false,
 
     /// 런타임 헬퍼 사용 추적.
     /// 각 변환이 헬퍼를 사용하면 해당 비트를 설정한다.
@@ -754,12 +761,11 @@ pub const Transformer = struct {
                 // ES2015 arrow this 캡처: arrow body 안의 this → _this
                 if (self.options.unsupported.arrow and self.arrow_this_depth > 0) {
                     self.needs_this_var = true;
-                    const this_span = try self.new_ast.addString("_this");
-                    return self.new_ast.addNode(.{
-                        .tag = .identifier_reference,
-                        .span = this_span,
-                        .data = .{ .string_ref = this_span },
-                    });
+                    return es_helpers.makeIdentifierRef(self, "_this");
+                }
+                // ES2015 class super() 후 this → _this
+                if (self.super_call_this_alias) {
+                    return es_helpers.makeIdentifierRef(self, "_this");
                 }
                 return self.copyNodeDirect(node);
             },
@@ -1535,9 +1541,11 @@ pub const Transformer = struct {
         const saved_arrow_depth = self.arrow_this_depth;
         const saved_needs_this = self.needs_this_var;
         const saved_needs_args = self.needs_arguments_var;
+        const saved_super_alias = self.super_call_this_alias;
         self.arrow_this_depth = 0;
         self.needs_this_var = false;
         self.needs_arguments_var = false;
+        self.super_call_this_alias = false;
 
         // 임시 변수 카운터 저장 (함수 스코프 내 사용된 임시 변수 호이스팅용)
         const saved_temp_counter = self.temp_var_counter;
@@ -1629,6 +1637,7 @@ pub const Transformer = struct {
         self.arrow_this_depth = saved_arrow_depth;
         self.needs_this_var = saved_needs_this;
         self.needs_arguments_var = saved_needs_args;
+        self.super_call_this_alias = saved_super_alias;
 
         // React Fast Refresh: Hook 시그니처 감지 + _s() 호출 삽입
         // 함수 이름을 old_ast에서 추출 (new_name은 아직 extra에 추가 전이므로)

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1174,6 +1174,87 @@ export class C extends Mid {
     expect(result.runOutput).toBe("c>mid>base");
   });
 
+  test("ES5 __callSuper: extends Error에서 Reflect.construct로 올바른 인스턴스 생성", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `class AppError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "AppError";
+  }
+}
+const e = new AppError("test");
+console.log(e instanceof Error && e.message === "test" && e.name === "AppError");`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("true");
+  });
+
+  test("ES5 __callSuper: super() 인자 없을 때 빈 배열 전달", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `class Base { args: any[]; constructor(...a: any[]) { this.args = a; } }
+class Child extends Base { constructor() { super(); } }
+console.log(new Child().args.length);`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("0");
+  });
+
+  test("ES5 __callSuper: super() 후 this → _this 별칭이 중첩 함수에 누출되지 않음", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `class Base { x = 0; }
+class Child extends Base {
+  fn: () => string;
+  constructor() {
+    super();
+    this.fn = function() { return typeof this; };
+  }
+}
+const c = new Child();
+console.log(c.fn.call(undefined));`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("undefined");
+  });
+
+  test("ES5 __callSuper: conditional branch 안의 super()도 정상 동작", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `class Base { v: number; constructor(v: number) { this.v = v; } }
+class Child extends Base {
+  constructor(x: boolean) {
+    if (x) { super(1); } else { super(2); }
+    this.v *= 10;
+  }
+}
+console.log(new Child(true).v + ":" + new Child(false).v);`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("10:20");
+  });
+
   test("ES5 class getter/setter가 configurable: true로 정의되어 이후 재정의 가능", async () => {
     // abort-controller 패턴: class getter 정의 후 Object.defineProperties로 enumerable 추가.
     // configurable: true가 없으면 TypeError: property is not configurable 발생.


### PR DESCRIPTION
## Summary
- `__callSuper` 런타임 헬퍼 추가 (Reflect.construct 우선 + .apply() fallback)
- `super()` → `_this = __callSuper(this, _super, [args])` 대입식으로 변환
- super() 이후 `this` → `_this` 별칭 자동 치환 + `var _this;` 선언 + `return _this` 추가
- conditional branch 안의 super()도 정상 동작 (top-level 스캔 대신 대입식 패턴 사용)
- `visitFunction`에서 `super_call_this_alias` save/restore (중첩 함수 누출 방지)

## 변경 전/후
```javascript
// 변경 전: 네이티브 클래스 extends 불가
var Foo = (function(_super) {
    function Foo(msg) { _super.call(this, msg); this.name = "Foo"; }
    // Error.call(this) → 내부 슬롯 미생성
})(Error);

// 변경 후: Reflect.construct로 올바른 인스턴스 생성
var Foo = (function(_super) {
    function Foo(msg) {
        var _this;
        _this = __callSuper(this, _super, [msg]);
        _this.name = "Foo";
        return _this;
    }
})(Error);
```

## Test plan
- [x] 유닛 테스트: __callSuper 패턴, _this 치환, default constructor 검증
- [x] 통합 테스트: extends Error, 빈 인자 super(), 중첩 함수 this 누출, conditional branch super()
- [x] /simplify 리뷰 반영: arguments→[] 버그, visitFunction save/restore, 중복 코드 통합, 불필요한 주석 제거

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)