### PR TITLE
fix(transformer): dev 모드 번들링 크래시 수정 (extra_data dangling pointer)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1085,16 +1085,20 @@ pub fn ES2015Class(comptime Transformer: type) type {
             if (body_node.tag != .block_statement) return body;
 
             const stmts_list = body_node.data.list;
-            const stmts = self.new_ast.extra_data.items[stmts_list.start .. stmts_list.start + stmts_list.len];
+            // extra_data.items slice를 먼저 캡처하면, buildVarDecl 등이 extra_data를
+            // grow시켜 재할당하면 dangling pointer가 됨.
+            // 따라서 인덱스만 저장하고, 사용할 때 다시 접근한다.
+            const stmts_start = stmts_list.start;
+            const stmts_len = stmts_list.len;
 
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
-            // var _this; (초기화 없는 선언)
+            // var _this; (초기화 없는 선언) — extra_data grow 가능
             try self.scratch.append(self.allocator, try self.buildVarDecl("_this", .none, span));
 
-            // 기존 body statements
-            for (stmts) |raw_idx| {
+            // 기존 body statements — extra_data grow 후 다시 접근
+            for (self.new_ast.extra_data.items[stmts_start .. stmts_start + stmts_len]) |raw_idx| {
                 try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
             }
 


### PR DESCRIPTION
## Summary
- `postProcessSuperCallBody`에서 `extra_data.items` slice를 캡처한 후 `buildVarDecl`이 `extra_data`를 grow시켜 재할당하면 dangling pointer 발생
- dev 모드 RN 번들링(`--target=es5 --define:__DEV__=true`)에서 `index out of bounds: 0xAAAAAAAA` 크래시 유발
- slice 대신 인덱스(start, len)만 저장하고 사용 시점에 `extra_data.items`를 다시 접근하도록 수정

## 재현
```bash
zts --bundle index.js --platform=react-native --target=es5 --define:__DEV__=true
# → thread panic: index out of bounds: index 2863311530 (0xAAAAAAAA)
```

## Test plan
- [x] dev 모드 RN 번들링 성공 확인 (7346978 bytes)
- [x] 유닛 테스트 전체 통과
- [x] production 모드 번들링 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)