### PR TITLE
fix(codegen): JSX classic 모드에서 번들러 리네이밍된 React 변수 반영

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -169,6 +169,10 @@ pub const Codegen = struct {
     jsx_used_jsxs: bool = false,
     jsx_used_jsxDEV: bool = false,
     jsx_used_fragment: bool = false,
+    /// classic JSX: 번들러 리네이밍이 반영된 factory/fragment 문자열.
+    /// 초기화 시 한 번만 계산 (모듈당 O(N) → O(1) per JSX element).
+    resolved_jsx_factory: ?[]const u8 = null,
+    resolved_jsx_fragment: ?[]const u8 = null,
 
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
@@ -189,6 +193,8 @@ pub const Codegen = struct {
             .sm_builder = sm,
             .gen_line = 0,
             .gen_col = 0,
+            .resolved_jsx_factory = resolveJSXRename(ast, options.linking_metadata, options.jsx_factory, allocator),
+            .resolved_jsx_fragment = resolveJSXRename(ast, options.linking_metadata, options.jsx_fragment, allocator),
         };
     }
 
@@ -2576,7 +2582,7 @@ pub const Codegen = struct {
         switch (self.options.jsx_runtime) {
             .classic => {
                 try self.write("/* @__PURE__ */ ");
-                try self.write(self.options.jsx_factory);
+                try self.emitJSXFactoryWithRename(self.options.jsx_factory);
                 try self.writeByte('(');
                 try self.emitJSXTagName(tag_name_idx);
                 try self.emitJSXAttrsClassic(attrs_start, attrs_len);
@@ -2637,9 +2643,9 @@ pub const Codegen = struct {
         switch (self.options.jsx_runtime) {
             .classic => {
                 try self.write("/* @__PURE__ */ ");
-                try self.write(self.options.jsx_factory);
+                try self.emitJSXFactoryWithRename(self.options.jsx_factory);
                 try self.writeByte('(');
-                try self.write(self.options.jsx_fragment);
+                try self.emitJSXFactoryWithRename(self.options.jsx_fragment);
                 if (self.options.minify_whitespace) try self.write(",null") else try self.write(", null");
                 try self.emitJSXChildrenClassic(list.start, list.len);
                 try self.writeByte(')');
@@ -2673,6 +2679,34 @@ pub const Codegen = struct {
                 try self.writeByte(')');
             },
         }
+    }
+
+    fn emitJSXFactoryWithRename(self: *Codegen, factory: []const u8) !void {
+        if (factory.ptr == self.options.jsx_factory.ptr) {
+            try self.write(self.resolved_jsx_factory orelse factory);
+        } else {
+            try self.write(self.resolved_jsx_fragment orelse factory);
+        }
+    }
+
+    /// 초기화 시 한 번만 호출: jsx_factory/fragment의 prefix를 리네이밍된 이름으로 교체.
+    fn resolveJSXRename(ast: *const Ast, meta_opt: ?*const LinkingMetadata, factory: []const u8, allocator: std.mem.Allocator) ?[]const u8 {
+        const meta = meta_opt orelse return null;
+        const dot_pos = std.mem.indexOf(u8, factory, ".") orelse return null;
+        const prefix = factory[0..dot_pos];
+        const suffix = factory[dot_pos..];
+
+        for (meta.symbol_ids, 0..) |maybe_sid, node_i| {
+            const sid = maybe_sid orelse continue;
+            const new_name = meta.renames.get(sid) orelse continue;
+            const node_idx: NodeIndex = @enumFromInt(node_i);
+            const node = ast.getNode(node_idx);
+            if (node.tag != .identifier_reference and node.tag != .binding_identifier) continue;
+            if (std.mem.eql(u8, ast.getText(node.data.string_ref), prefix)) {
+                return std.fmt.allocPrint(allocator, "{s}{s}", .{ new_name, suffix }) catch null;
+            }
+        }
+        return null;
     }
 
     /// tag name 출력: 소문자면 문자열("div"), 그 외 식별자(MyComp)


### PR DESCRIPTION
## Summary
- `jsx_factory`("React.createElement")와 `jsx_fragment`("React.Fragment")가 문자열 그대로 출력되어 번들러의 변수 리네이밍(React→React$90)을 무시하던 문제 수정
- `emitJSXFactoryWithRename` 함수 추가: prefix를 `linking_metadata.renames`에서 조회하여 리네이밍된 이름으로 출력
- RN dev 모드에서 `Unexpected ref object` / `Cannot add new property 'current'` 에러 해결

## 변경 전/후
```javascript
// 변경 전: 다른 모듈의 React를 참조
React.createElement(View, { ref: appContainerRootViewRef })

// 변경 후: 올바른 모듈의 React$90 참조
React$90.createElement(View, { ref: appContainerRootViewRef })
```

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] 통합 테스트 95개 통과
- [x] dev 모드 RN 번들에서 `React$90.createElement` 사용 확인

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)