### PR TITLE
fix(transformer): Flow component 파라미터를 props destructuring으로 변환

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -3799,6 +3799,64 @@ test "Flow: class with typed methods does not crash transformer" {
 }
 
 // ============================================================
+// Flow: component declaration → props destructuring
+// ============================================================
+
+test "Flow: component params → object destructuring" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\component View(ref, ...props: any) {
+        \\  return null;
+        \\}
+    );
+    defer r.deinit();
+    // component View(ref, ...props) → function View({ ref:ref, ...props })
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function View(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "ref:ref") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...props") != null);
+    // 별도 함수 파라미터가 아닌 단일 destructuring 파라미터여야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function View(ref,") == null);
+}
+
+test "Flow: component param with type annotation stripped" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\component Foo(name: string, count: number) {
+        \\  return null;
+        \\}
+    );
+    defer r.deinit();
+    // 타입 어노테이션이 제거되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "string") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "number") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "name:name") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "count:count") != null);
+}
+
+test "Flow: component param with default value" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\component Foo(x: number = 42) {
+        \\  return x;
+        \\}
+    );
+    defer r.deinit();
+    // default가 보존되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "42") != null);
+    // 타입 어노테이션은 제거
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "number") == null);
+}
+
+test "Flow: component param with complex type annotation" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\component Bar(cb: (x: string) => void = defaultCb) {
+        \\  return null;
+        \\}
+    );
+    defer r.deinit();
+    // 함수 타입 어노테이션 제거, default 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "defaultCb") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=> void") == null);
+}
+
+// ============================================================
 // Private Method (#method → WeakSet + standalone function)
 // ============================================================
 

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -985,25 +985,71 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
         _ = try parseTypeParameterDeclaration(self);
     }
 
-    // 파라미터 파싱: component의 파라미터를 일반 함수 파라미터로 변환
-    // component 파라미터: ref?, propName: Type, ...rest: Type
-    // → 함수 파라미터: ref, propName, ...rest (타입 제거)
+    // component 파라미터를 단일 객체 destructuring 파라미터로 변환.
+    // component View(ref?, ...props: ViewProps) { ... }
+    // → function View({ ref, ...props }) { ... }
+    // React가 component를 View(props) 하나의 인자로 호출하므로,
+    // component 파라미터는 props 객체의 프로퍼티를 나타낸다.
     try self.expect(.l_paren);
-    self.in_formal_parameters = true;
     const scratch_top = self.saveScratch();
+    const param_start_span = self.currentSpan();
     while (self.current() != .r_paren and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
-        const param = try self.parseBindingIdentifier();
-        try self.scratch.append(self.allocator, param);
-        try self.checkRestParameterLast(param);
+
+        // rest: ...props: Type → binding_rest_element
+        if (self.current() == .dot3) {
+            try self.advance();
+            const rest_name = try self.parseSimpleIdentifier();
+            if (self.current() == .colon) {
+                try self.advance();
+                _ = try parseType(self);
+            }
+            try self.scratch.append(self.allocator, try self.ast.addNode(.{
+                .tag = .binding_rest_element,
+                .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
+                .data = .{ .unary = .{ .operand = rest_name, .flags = 0 } },
+            }));
+        } else {
+            // propName: Type = default → binding_property
+            const prop_name = try self.parseSimpleIdentifier();
+            _ = try self.eat(.question);
+            if (self.current() == .colon) {
+                try self.advance();
+                _ = try parseType(self);
+            }
+
+            const right_node = if (try self.eat(.eq)) blk: {
+                const default_val = try self.parseAssignmentExpression();
+                break :blk try self.ast.addNode(.{
+                    .tag = .assignment_pattern,
+                    .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
+                    .data = .{ .binary = .{ .left = prop_name, .right = default_val, .flags = 0 } },
+                });
+            } else prop_name;
+
+            try self.scratch.append(self.allocator, try self.ast.addNode(.{
+                .tag = .binding_property,
+                .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
+                .data = .{ .binary = .{ .left = prop_name, .right = right_node, .flags = 0 } },
+            }));
+        }
+
         if (!try self.eat(.comma)) break;
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
-    const param_items = self.scratch.items[scratch_top..];
-    const params = try self.ast.addNodeList(param_items);
+    const prop_items = self.scratch.items[scratch_top..];
+    const prop_list = try self.ast.addNodeList(prop_items);
     self.restoreScratch(scratch_top);
-    self.in_formal_parameters = false;
     try self.expect(.r_paren);
+
+    // object_pattern 노드 생성: { ref, ...props }
+    const obj_pattern = try self.ast.addNode(.{
+        .tag = .object_pattern,
+        .span = .{ .start = param_start_span.start, .end = self.currentSpan().start },
+        .data = .{ .list = prop_list },
+    });
+    // 단일 파라미터로 래핑
+    const params = try self.ast.addNodeList(&.{obj_pattern});
 
     try trySkipRendersClause(self);
 

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -296,7 +296,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
         /// object_pattern 또는 array_pattern을 개별 declarator로 분해.
         /// ref_span은 임시 변수의 span (_ref).
-        fn emitPatternDeclarators(self: *Transformer, pattern: Node, ref_span: Span, span: Span) Transformer.Error!void {
+        pub fn emitPatternDeclarators(self: *Transformer, pattern: Node, ref_span: Span, span: Span) Transformer.Error!void {
             if (pattern.tag == .object_pattern) {
                 try emitObjectPatternDeclarators(self, pattern, ref_span, span);
             } else if (pattern.tag == .array_pattern) {

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -35,14 +35,18 @@ pub fn ES2015Params(comptime Transformer: type) type {
             for (old_params) |raw_idx| {
                 const param = self.old_ast.getNode(@enumFromInt(raw_idx));
                 if (param.tag == .spread_element or param.tag == .rest_element) return true;
+                // destructuring 파라미터도 ES5 변환 필요
+                if (param.tag == .object_pattern or param.tag == .array_pattern) return true;
                 if (param.tag == .formal_parameter) {
-                    // extra = [pattern, type_ann, default, flags, deco_start, deco_len]
                     const extras = self.old_ast.extra_data.items;
                     const pe = param.data.extra;
                     const default_val: NodeIndex = @enumFromInt(extras[pe + 2]);
                     if (!default_val.isNone()) return true;
+                    // formal_parameter 안의 destructuring 패턴도 체크
+                    const pattern_idx: NodeIndex = @enumFromInt(extras[pe]);
+                    const pattern_node = self.old_ast.getNode(pattern_idx);
+                    if (pattern_node.tag == .object_pattern or pattern_node.tag == .array_pattern) return true;
                 }
-                // assignment_pattern도 default를 의미
                 if (param.tag == .assignment_pattern) return true;
             }
             return false;
@@ -122,6 +126,22 @@ pub fn ES2015Params(comptime Transformer: type) type {
                     continue;
                 }
 
+                // destructuring 파라미터 (default 없음): temp 변수 경유
+                // function View({ ref, ...props }) → function View(_param) { var {ref, ...props} = _param; }
+                const param_node = self.old_ast.getNode(@enumFromInt(raw_idx));
+                const pattern_idx_raw = if (param_node.tag == .formal_parameter)
+                    self.old_ast.extra_data.items[param_node.data.extra]
+                else
+                    raw_idx;
+                const pattern_node = self.old_ast.getNode(@enumFromInt(pattern_idx_raw));
+
+                if (pattern_node.tag == .object_pattern or pattern_node.tag == .array_pattern) {
+                    const result = try buildDestructuringParam(self, @enumFromInt(pattern_idx_raw), &body_stmts, span);
+                    try self.scratch.append(self.allocator, result);
+                    param_index += 1;
+                    continue;
+                }
+
                 // 일반 파라미터: 그대로 방문
                 const new_param = try self.visitNode(@enumFromInt(raw_idx));
                 if (!new_param.isNone()) {
@@ -170,6 +190,33 @@ pub fn ES2015Params(comptime Transformer: type) type {
                 span,
             );
             try body_stmts.append(self.allocator, destruct_decl);
+
+            return temp_binding;
+        }
+
+        /// destructuring parameter (default 없음) → temp 변수 경유.
+        /// ({ ref, ...props }) → (_param); body에 var ref = _param.ref, props = __rest(_param, ["ref"]);
+        fn buildDestructuringParam(
+            self: *Transformer,
+            pattern_idx: NodeIndex,
+            body_stmts: *std.ArrayList(NodeIndex),
+            span: Span,
+        ) Transformer.Error!NodeIndex {
+            const temp_span = try es_helpers.makeTempVarSpan(self);
+            const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
+
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+            const pattern = self.old_ast.getNode(pattern_idx);
+            const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(Transformer);
+            try es2015_destruct.emitPatternDeclarators(self, pattern, temp_span, span);
+
+            const declarators = self.scratch.items[scratch_top..];
+            if (declarators.len > 0) {
+                const decl = try es_helpers.makeVarDeclaration(self, declarators, 0, span);
+                try body_stmts.append(self.allocator, decl);
+            }
 
             return temp_binding;
         }

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1255,6 +1255,36 @@ console.log(new Child(true).v + ":" + new Child(false).v);`,
     expect(result.runOutput).toBe("10:20");
   });
 
+  test("ES5 destructuring 파라미터: function({ ref, ...props }) 올바른 변환", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `function test({ ref, ...props }: any) { return ref + ":" + props.x; }
+console.log(test({ ref: "hello", x: 42 }));`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("hello:42");
+  });
+
+  test("ES5 destructuring 파라미터 + 기본값: function({ a = 1 }) 변환", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `function test({ a = 10, b }: any) { return a + b; }
+console.log(test({ b: 5 }));`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("15");
+  });
+
   test("ES5 class getter/setter가 configurable: true로 정의되어 이후 재정의 가능", async () => {
     // abort-controller 패턴: class getter 정의 후 Object.defineProperties로 enumerable 추가.
     // configurable: true가 없으면 TypeError: property is not configurable 발생.


### PR DESCRIPTION
## Summary
- Flow `component View(ref, ...props)` 구문의 파라미터가 별도 함수 인자로 변환되던 버그 수정
- React가 `View(props)` 하나의 인자로 호출 → `ref`에 props 객체 전체가 전달 → ref.hasOwnProperty("current") 실패
- dev 모드에서 `Object.freeze(element.props)` + frozen props가 ref로 사용 → "Cannot add new property 'current'" 크래시

## 변경 사항
1. **flow.zig**: component 파라미터를 object_pattern으로 변환
   - `component View(ref, ...props)` → `function View({ ref, ...props })`
2. **es2015_params.zig**: destructuring 파라미터를 ES5 lowering 대상에 포함
   - `hasDefaultOrRest`에 object_pattern/array_pattern 체크 추가
   - `buildDestructuringParam`: temp 변수 경유 + `emitPatternDeclarators`로 ES5 변환
3. **es2015_destructuring.zig**: `emitPatternDeclarators`를 pub으로 변경 (es2015_params에서 호출)

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] dev 모드 RN 번들: `function View$56(_a) { var ref = _a.ref, props = __rest(_a, ["ref"]); }` 확인
- [x] `component View(ref, ...props)` → ES5 변환 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)