### PR TITLE
fix(semantic): jsx_member_expression left side symbol 등록

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -987,6 +987,10 @@ pub const SemanticAnalyzer = struct {
                     self.resolveIdentifier(name, @intFromEnum(idx));
                 }
             },
+            // JSX member expression: <Foo.Bar> → left(Foo)를 재귀 방문하여 symbol 등록
+            .jsx_member_expression => {
+                try self.visitNode(node.data.binary.left);
+            },
 
             // ---- 일반 표현식 순회 (private name 참조 등을 위해) ----
             .assignment_expression => {


### PR DESCRIPTION
## Summary
- `<Animated.View>` 같은 JSX member expression에서 `Animated`가 semantic analyzer에서 방문되지 않아 `symbol_ids`에 등록되지 않는 버그 수정
- 번들러가 `Animated` → `Animated$4`로 rename해도 codegen이 원본 이름을 사용하여 `TouchableOpacity` render에서 undefined 컴포넌트 참조 발생
- `jsx_member_expression` case 추가: left child를 재귀 방문하여 symbol 등록

## Test plan
- [x] `zig build test` 통과
- [x] 기존 JSX rename 통합 테스트 통과
- [x] RN 번들에서 `Animated$4.View` 정상 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)