### PR TITLE
refactor(transformer): makeParenExpr 헬퍼 추출

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -219,7 +219,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 @intFromEnum(iife_body), 0,                    none,
             });
             const wrapper_fn = try self.new_ast.addNode(.{ .tag = .function_expression, .span = span, .data = .{ .extra = wrapper_extra } });
-            const paren = try self.new_ast.addNode(.{ .tag = .parenthesized_expression, .span = span, .data = .{ .unary = .{ .operand = wrapper_fn, .flags = 0 } } });
+            const paren = try es_helpers.makeParenExpr(self, wrapper_fn, span);
 
             // (function(_super) { ... })(ParentClass) 또는 (function() { ... })()
             const iife_call = if (has_super and super_span != null) blk: {
@@ -466,7 +466,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             } else try self.new_ast.addNodeList(&.{});
             const wrapper_extra = try self.new_ast.addExtras(&.{ none, wrapper_params.start, wrapper_params.len, @intFromEnum(iife_body), 0, none });
             const wrapper_fn = try self.new_ast.addNode(.{ .tag = .function_expression, .span = span, .data = .{ .extra = wrapper_extra } });
-            const paren = try self.new_ast.addNode(.{ .tag = .parenthesized_expression, .span = span, .data = .{ .unary = .{ .operand = wrapper_fn, .flags = 0 } } });
+            const paren = try es_helpers.makeParenExpr(self, wrapper_fn, span);
 
             // (function(_super) { ... })(ParentClass) 또는 (function() { ... })()
             return if (has_super and super_span != null) blk: {

--- a/src/transformer/es2015_computed.zig
+++ b/src/transformer/es2015_computed.zig
@@ -172,11 +172,7 @@ pub fn ES2015Computed(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .list = seq_list },
             });
-            return self.new_ast.addNode(.{
-                .tag = .parenthesized_expression,
-                .span = span,
-                .data = .{ .unary = .{ .operand = seq, .flags = 0 } },
-            });
+            return es_helpers.makeParenExpr(self, seq, span);
         }
     };
 }

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1187,11 +1187,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 .data = .{ .binary = .{ .left = lhs, .right = rhs, .flags = 0 } },
             });
             const expr = if (self.new_ast.getNode(lhs).tag == .object_pattern)
-                try self.new_ast.addNode(.{
-                    .tag = .parenthesized_expression,
-                    .span = span,
-                    .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
-                })
+                try es_helpers.makeParenExpr(self, assign, span)
             else
                 assign;
             return es_helpers.makeExprStmt(self, expr, span);
@@ -1498,11 +1494,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // parenthesized_expression: 내부 재귀
             if (node.tag == .parenthesized_expression) {
                 const inner = try visitExprWithYieldExtraction(self, node.data.unary.operand, ops, next_label);
-                return self.new_ast.addNode(.{
-                    .tag = .parenthesized_expression,
-                    .span = node.span,
-                    .data = .{ .unary = .{ .operand = inner, .flags = 0 } },
-                });
+                return es_helpers.makeParenExpr(self, inner, node.span);
             }
 
             // logical/binary expression: 양쪽 재귀
@@ -1799,11 +1791,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
         /// negate=true이면 조건을 !로 반전.
         fn buildConditionalBreak(self: *Transformer, label: u32, cond: NodeIndex, negate: bool, span: Span) Transformer.Error!NodeIndex {
             const final_cond = if (negate) blk: {
-                const paren_cond = try self.new_ast.addNode(.{
-                    .tag = .parenthesized_expression,
-                    .span = span,
-                    .data = .{ .unary = .{ .operand = cond, .flags = 0 } },
-                });
+                const paren_cond = try es_helpers.makeParenExpr(self, cond, span);
                 break :blk try self.new_ast.addNode(.{
                     .tag = .unary_expression,
                     .span = span,

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -31,11 +31,7 @@ pub fn ES2017(comptime Transformer: type) type {
                 .span = node.span,
                 .data = .{ .unary = .{ .operand = new_operand, .flags = 0 } },
             });
-            return self.new_ast.addNode(.{
-                .tag = .parenthesized_expression,
-                .span = node.span,
-                .data = .{ .unary = .{ .operand = yield_node, .flags = 0 } },
-            });
+            return es_helpers.makeParenExpr(self, yield_node, node.span);
         }
 
         /// async function foo() { ... } → function foo() { return __async(function*() { ... }); }

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -70,11 +70,7 @@ pub fn ES2020(comptime Transformer: type) type {
                         .flags = @intFromEnum(token_mod.Kind.eq),
                     } },
                 });
-                const paren_assign = try self.new_ast.addNode(.{
-                    .tag = .parenthesized_expression,
-                    .span = node.span,
-                    .data = .{ .unary = .{ .operand = assign_node, .flags = 0 } },
-                });
+                const paren_assign = try helpers.makeParenExpr(self, assign_node, node.span);
                 const neq_null = try self.new_ast.addNode(.{
                     .tag = .binary_expression,
                     .span = node.span,
@@ -136,11 +132,7 @@ pub fn ES2020(comptime Transformer: type) type {
                         .flags = @intFromEnum(token_mod.Kind.eq),
                     } },
                 });
-                null_check_base = try self.new_ast.addNode(.{
-                    .tag = .parenthesized_expression,
-                    .span = node.span,
-                    .data = .{ .unary = .{ .operand = assign_node, .flags = 0 } },
-                });
+                null_check_base = try helpers.makeParenExpr(self, assign_node, node.span);
                 chain_base = try helpers.makeTempVarRef(self, temp_span, node.span);
             }
 
@@ -154,11 +146,7 @@ pub fn ES2020(comptime Transformer: type) type {
             });
             // 괄호로 감싸서 binary expression 안에서 우선순위 보장
             // 예: a?.b !== c?.d → (a == null ? void 0 : a.b) !== (c == null ? void 0 : c.d)
-            return self.new_ast.addNode(.{
-                .tag = .parenthesized_expression,
-                .span = node.span,
-                .data = .{ .unary = .{ .operand = cond, .flags = 0 } },
-            });
+            return helpers.makeParenExpr(self, cond, node.span);
         }
 
         fn hasOptionalFlag(self: *const Transformer, node: Node) bool {

--- a/src/transformer/es2021.zig
+++ b/src/transformer/es2021.zig
@@ -19,6 +19,7 @@ const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const es_helpers = @import("es_helpers.zig");
 
 pub fn ES2021(comptime Transformer: type) type {
     return struct {
@@ -39,11 +40,7 @@ pub fn ES2021(comptime Transformer: type) type {
                     .flags = @intFromEnum(token_mod.Kind.eq),
                 } },
             });
-            const paren_assign = try self.new_ast.addNode(.{
-                .tag = .parenthesized_expression,
-                .span = node.span,
-                .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
-            });
+            const paren_assign = try es_helpers.makeParenExpr(self, assign, node.span);
 
             if (self.options.unsupported.nullish_coalescing) {
                 const left_copy2 = try self.new_ast.addNode(self.new_ast.getNode(new_left));
@@ -97,11 +94,7 @@ pub fn ES2021(comptime Transformer: type) type {
                     .flags = @intFromEnum(token_mod.Kind.eq),
                 } },
             });
-            const paren_assign = try self.new_ast.addNode(.{
-                .tag = .parenthesized_expression,
-                .span = node.span,
-                .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
-            });
+            const paren_assign = try es_helpers.makeParenExpr(self, assign, node.span);
             return self.new_ast.addNode(.{
                 .tag = .logical_expression,
                 .span = node.span,

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -479,11 +479,7 @@ pub fn ES2022(comptime Transformer: type) type {
             });
 
             // 괄호로 감싸기: (arrow)
-            const paren_arrow = try self.new_ast.addNode(.{
-                .tag = .parenthesized_expression,
-                .span = span,
-                .data = .{ .unary = .{ .operand = arrow, .flags = 0 } },
-            });
+            const paren_arrow = try es_helpers.makeParenExpr(self, arrow, span);
 
             // call_expression: extra = [callee, args_start, args_len, flags]
             const empty_args = try self.new_ast.addNodeList(&.{});

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -68,6 +68,15 @@ pub fn makeVoidZero(self: anytype, span: Span) !NodeIndex {
     });
 }
 
+/// 식을 괄호로 감싼 parenthesized_expression 생성.
+pub fn makeParenExpr(self: anytype, inner: NodeIndex, span: Span) !NodeIndex {
+    return self.new_ast.addNode(.{
+        .tag = .parenthesized_expression,
+        .span = span,
+        .data = .{ .unary = .{ .operand = inner, .flags = 0 } },
+    });
+}
+
 /// 이름 문자열로 identifier_reference 노드 생성.
 /// addString + addNode를 한 번에 수행.
 pub fn makeIdentifierRef(self: anytype, name: []const u8) !NodeIndex {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1215,11 +1215,7 @@ pub const Transformer = struct {
 
         // (function(_m){...})(discriminant)
         // function expression을 parenthesized로 감싸서 IIFE 형태로 만듦
-        const paren_fn = try self.new_ast.addNode(.{
-            .tag = .parenthesized_expression,
-            .span = span,
-            .data = .{ .unary = .{ .operand = fn_expr, .flags = 0 } },
-        });
+        const paren_fn = try es_helpers.makeParenExpr(self, fn_expr, span);
         // call_expression extra: [callee, args_start, args_len, flags]
         const args_list = try self.new_ast.addNodeList(&.{new_discriminant});
         const call_extra = try self.new_ast.addExtras(&.{


### PR DESCRIPTION
## Summary
- `parenthesized_expression` 인라인 생성 패턴이 8개 파일 14곳에 중복
- `es_helpers.makeParenExpr(self, inner, span)` 헬퍼로 통합
- 순수 리팩터링, 동작 변경 없음 (-38줄)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun test tests/downlevel.test.ts` 105개 통과
- [x] `bun test tests/bundle-smoke.test.ts` 99개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)