### PR TITLE
feat(bundler): 번들 모드 소스맵 생성 지원

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -79,6 +79,8 @@ pub const BundleOptions = struct {
     source_root: ?[]const u8 = null,
     /// 소스맵에 sourcesContent 포함 여부 (--sources-content=false로 제외)
     sources_content: bool = true,
+    /// 소스맵 생성 (--sourcemap)
+    sourcemap: bool = false,
     /// UTF-8 문자를 이스케이프하지 않고 그대로 출력 (--charset=utf8)
     charset_utf8: bool = false,
     /// 엔트리 청크 파일명 패턴 (--entry-names, 기본: "[name]")
@@ -387,13 +389,14 @@ pub const Bundler = struct {
         // emit (IIFE 포맷)
         var emit_opts = self.makeEmitOptions();
         emit_opts.format = .iife;
-        const worker_output = try emitter.emitWithTreeShaking(
+        const worker_result = try emitter.emitWithTreeShaking(
             arena_alloc,
             &worker_graph,
             emit_opts,
             &worker_linker,
             null,
         );
+        const worker_output = worker_result.output;
 
         // content hash로 파일명 생성
         const hash = std.hash.Crc32.hash(worker_output);
@@ -588,17 +591,34 @@ pub const Bundler = struct {
 
             // output은 빈 문자열 — code splitting 시 outputs를 사용
             output = try self.allocator.dupe(u8, "");
-        } else {
-            // 기존 단일 파일 경로
+        } else if (self.options.sourcemap) {
+            // 소스맵 요청 시: emitDevBundle 사용 (소스맵 생성 지원)
+            // TODO: emitWithTreeShaking에 소스맵 생성 통합
             var emit_opts = self.makeEmitOptions();
             emit_opts.polyfills = polyfill_entries.items;
-            output = try emitter.emitWithTreeShaking(
+            emit_opts.sourcemap = true;
+            const dev_result = try emitter.emitDevBundle(
+                self.allocator,
+                &graph,
+                emit_opts,
+                if (linker) |*l| l else null,
+            );
+            output = dev_result.output;
+            dev_sourcemap = dev_result.sourcemap;
+            // module_codes는 non-dev에서 불필요 → 즉시 해제
+            emitter.DevBundleResult.deinitCodes(dev_result.module_codes, self.allocator);
+        } else {
+            // 기존 단일 파일 경로 (tree shaking 포함, 소스맵 없음)
+            var emit_opts = self.makeEmitOptions();
+            emit_opts.polyfills = polyfill_entries.items;
+            const emit_result = try emitter.emitWithTreeShaking(
                 self.allocator,
                 &graph,
                 emit_opts,
                 if (linker) |*l| l else null,
                 if (shaker) |*s| s else null,
             );
+            output = emit_result.output;
         }
         errdefer self.allocator.free(output);
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -123,14 +123,26 @@ pub const OutputFile = struct {
     contents: []const u8,
 };
 
+/// 번들 출력 결과. output + 소스맵.
+pub const EmitResult = struct {
+    /// 번들 코드. allocator 소유.
+    output: []const u8,
+    /// 소스맵 JSON (V3). null이면 소스맵 미생성. allocator 소유.
+    sourcemap: ?[]const u8 = null,
+
+    pub fn deinit(self: *const EmitResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.output);
+        if (self.sourcemap) |sm| allocator.free(sm);
+    }
+};
+
 /// 모듈 그래프를 단일 번들로 출력한다.
-/// 반환된 contents는 allocator 소유 (caller가 free).
 pub fn emit(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
     options: EmitOptions,
     linker: ?*const Linker,
-) ![]const u8 {
+) !EmitResult {
     return emitWithTreeShaking(allocator, graph, options, linker, null);
 }
 
@@ -141,7 +153,7 @@ pub fn emitWithTreeShaking(
     options: EmitOptions,
     linker: ?*const Linker,
     shaker: ?*const TreeShaker,
-) ![]const u8 {
+) !EmitResult {
     // 1. JS/JSON 모듈 필터 + exec_index 순으로 정렬
     var sorted: std.ArrayList(*const Module) = .empty;
     defer sorted.deinit(allocator);
@@ -249,7 +261,7 @@ pub fn emitWithTreeShaking(
     }
 
     // Phase 2: emitModule 병렬 실행 (2개 이상이면 스레드 풀, 아니면 순차)
-    var results = try allocator.alloc(EmitResult, sorted.items.len);
+    var results = try allocator.alloc(ModuleEmitResult, sorted.items.len);
     defer {
         for (results) |r| {
             if (r.code) |c| allocator.free(c);
@@ -380,7 +392,10 @@ pub fn emitWithTreeShaking(
         try output.append(allocator, '\n');
     }
 
-    return output.toOwnedSlice(allocator);
+    return .{
+        .output = try output.toOwnedSlice(allocator),
+        .sourcemap = null, // TODO: emitModule에서 매핑 반환 후 소스맵 생성 지원
+    };
 }
 
 /// Dev mode 번들 출력.
@@ -1523,7 +1538,7 @@ fn computeAllUsedNames(
 }
 
 /// 스레드 풀에서 실행되는 emitModule 래퍼.
-const EmitResult = struct {
+const ModuleEmitResult = struct {
     code: ?[]const u8 = null,
     helpers: RuntimeHelpers = .{},
 };
@@ -1565,7 +1580,7 @@ fn emitModuleThread(
     is_entry: bool,
     used_names: ?[]const []const u8,
     shaker: ?*const TreeShaker,
-    result: *EmitResult,
+    result: *ModuleEmitResult,
 ) void {
     result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers) catch null;
 }

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -30,8 +30,9 @@ test "emitter: single module" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{}, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // TS 타입 스트리핑: "const x: number = 1;" → "const x = 1;"
     try std.testing.expect(std.mem.indexOf(u8, output, "const x = 1;") != null);
@@ -47,8 +48,9 @@ test "emitter: two modules exec order" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{}, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // b.ts가 a.ts보다 먼저 출력 (exec_index 순서)
     const b_pos = std.mem.indexOf(u8, output, "const b = 2;") orelse return error.TestUnexpectedResult;
@@ -65,8 +67,9 @@ test "emitter: minified output" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{ .minify_whitespace = true }, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .minify_whitespace = true }, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // minify: 모듈 경계 주석 없음
     try std.testing.expect(std.mem.indexOf(u8, output, "// ---") == null);
@@ -82,8 +85,9 @@ test "emitter: IIFE format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{ .format = .iife }, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .format = .iife }, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     try std.testing.expect(std.mem.startsWith(u8, output, "(function() {\n"));
     try std.testing.expect(std.mem.endsWith(u8, output, "})();\n"));
@@ -98,8 +102,9 @@ test "emitter: CJS format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{ .format = .cjs }, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .format = .cjs }, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     try std.testing.expect(std.mem.startsWith(u8, output, "\"use strict\";\n"));
 }
@@ -110,8 +115,9 @@ test "emitter: empty graph" {
     var graph = ModuleGraph.init(std.testing.allocator, &cache);
     defer graph.deinit();
 
-    const output = try emit(std.testing.allocator, &graph, .{}, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &graph, .{}, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     try std.testing.expectEqual(@as(usize, 0), output.len);
 }
@@ -127,8 +133,9 @@ test "emitter: chain A → B → C order" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{}, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // C → B → A 순서
     const c_pos = std.mem.indexOf(u8, output, "const c = \"c\";") orelse return error.TestUnexpectedResult;
@@ -151,8 +158,9 @@ test "emitter: TS enum and interface stripping" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{}, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // interface 제거됨
     try std.testing.expect(std.mem.indexOf(u8, output, "interface") == null);
@@ -846,11 +854,12 @@ test "banner/footer — basic ESM" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
         .banner_js = "/* banner */",
         .footer_js = "/* footer */",
     }, null);
-    defer std.testing.allocator.free(output);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // banner가 맨 앞에 위치
     try std.testing.expect(std.mem.startsWith(u8, output, "/* banner */\n"));
@@ -867,12 +876,13 @@ test "banner/footer — IIFE format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
         .format = .iife,
         .banner_js = "// license header",
         .footer_js = "// end",
     }, null);
-    defer std.testing.allocator.free(output);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // banner → IIFE prologue → code → IIFE epilogue → footer
     try std.testing.expect(std.mem.startsWith(u8, output, "// license header\n(function() {\n"));
@@ -888,11 +898,12 @@ test "banner/footer — CJS format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
         .format = .cjs,
         .banner_js = "/* CJS banner */",
     }, null);
-    defer std.testing.allocator.free(output);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // banner가 "use strict" 앞에 위치
     try std.testing.expect(std.mem.startsWith(u8, output, "/* CJS banner */\n\"use strict\";\n"));
@@ -911,11 +922,12 @@ test "globalName — IIFE wrapping" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
         .format = .iife,
         .global_name = "MyLib",
     }, null);
-    defer std.testing.allocator.free(output);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // prologue: "var MyLib = (function() {\n"
     try std.testing.expect(std.mem.startsWith(u8, output, "var MyLib = (function() {\n"));
@@ -932,11 +944,12 @@ test "globalName — dotted name warning" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
         .format = .iife,
         .global_name = "MyApp.Utils",
     }, null);
-    defer std.testing.allocator.free(output);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // 경고 주석이 포함되어야 함
     try std.testing.expect(std.mem.indexOf(u8, output, "[ZTS WARNING] Dotted globalName") != null);
@@ -953,11 +966,12 @@ test "globalName — ignored for non-IIFE" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
         .format = .esm,
         .global_name = "MyLib",
     }, null);
-    defer std.testing.allocator.free(output);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // ESM에서는 globalName이 무시됨
     try std.testing.expect(std.mem.indexOf(u8, output, "var MyLib") == null);
@@ -972,13 +986,14 @@ test "globalName — with banner/footer" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
         .format = .iife,
         .global_name = "MyLib",
         .banner_js = "/* license */",
         .footer_js = "/* end */",
     }, null);
-    defer std.testing.allocator.free(output);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // banner → globalName prologue → code → epilogue → footer
     try std.testing.expect(std.mem.startsWith(u8, output, "/* license */\nvar MyLib = (function() {\n"));
@@ -1002,8 +1017,9 @@ test "JSON module — ESM format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{ .format = .esm }, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .format = .esm }, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // JSON ESM: object 내용이 번들에 포함됨
     try std.testing.expect(std.mem.indexOf(u8, output, "\"key\"") != null);
@@ -1027,8 +1043,9 @@ test "JSON module — CJS format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const output = try emit(std.testing.allocator, &result.graph, .{ .format = .cjs }, null);
-    defer std.testing.allocator.free(output);
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .format = .cjs }, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
 
     // JSON 내용이 출력에 포함됨
     try std.testing.expect(std.mem.indexOf(u8, output, "\"key\"") != null);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1089,6 +1089,7 @@ pub fn main() !void {
             .jsx_in_js = opts.jsx_in_js,
             .resolve_extensions = opts.resolve_extensions_list.items,
             .main_fields = opts.main_fields_list.items,
+            .sourcemap = opts.sourcemap,
         };
 
         // config 파일 옵션 적용 — 첫 번째 플러그인의 config만 사용 (CLI가 우선)
@@ -1189,6 +1190,15 @@ pub fn main() !void {
                 try stdout.print("Bundled → {s} ({d} bytes)\n", .{ out_path, result.output.len });
             }
             try writeAssetOutputs(allocator, result.asset_outputs, std.fs.path.dirname(out_path) orelse ".");
+
+            // 소스맵 파일 출력
+            if (result.sourcemap) |sm_json| {
+                const map_path = try std.fmt.allocPrint(allocator, "{s}.map", .{out_path});
+                defer allocator.free(map_path);
+                std.fs.cwd().writeFile(.{ .sub_path = map_path, .data = sm_json }) catch |err| {
+                    try stderr.print("zts: cannot write '{s}': {}\n", .{ map_path, err });
+                };
+            }
         } else {
             // --watch-json: stdout은 NDJSON 전용이므로 raw 번들 출력 억제
             if (!opts.watch_json) {


### PR DESCRIPTION
## Summary
- `--sourcemap` 옵션이 번들 모드에서 무시되던 문제 수정
- `emitWithTreeShaking` 반환 타입을 `EmitResult`(output + sourcemap) 구조체로 변경
- `BundleOptions`에 `sourcemap: bool` 필드 추가
- 소스맵 요청 시 `emitDevBundle` 경로 사용 (소스맵 생성 지원)
- `main.zig`에서 번들 `.map` 파일 출력
- `module_codes` 메모리 릭 수정 (`deinitCodes` 후 중복 free 제거)

## TODO
- [ ] `emitWithTreeShaking` 자체에 소스맵 생성 통합 (현재는 소스맵 요청 시 tree-shaking 미적용)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun test tests/bundle-smoke.test.ts` 99개 통과
- [x] `--sourcemap`으로 번들 시 `.map` 파일 + `sourceMappingURL` 정상 생성
- [x] 메모리 릭 없음 (debug allocator 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)