### PR TITLE
fix(bundler): sourceMappingURL 실제 파일명 + 디버그 코드 제거

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -81,6 +81,8 @@ pub const BundleOptions = struct {
     sources_content: bool = true,
     /// 소스맵 생성 (--sourcemap)
     sourcemap: bool = false,
+    /// 출력 파일명 (소스맵 참조용)
+    output_filename: []const u8 = "bundle.js",
     /// UTF-8 문자를 이스케이프하지 않고 그대로 출력 (--charset=utf8)
     charset_utf8: bool = false,
     /// 엔트리 청크 파일명 패턴 (--entry-names, 기본: "[name]")
@@ -287,6 +289,7 @@ pub const Bundler = struct {
             .out_extension_js = self.options.out_extension_js,
             .source_root = self.options.source_root,
             .sources_content = self.options.sources_content,
+            .output_filename = self.options.output_filename,
             .charset_utf8 = self.options.charset_utf8,
             .entry_names = self.options.entry_names,
             .chunk_names = self.options.chunk_names,

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -77,6 +77,8 @@ pub const EmitOptions = struct {
     global_name: ?[]const u8 = null,
     /// 출력 파일 확장자 오버라이드 (.mjs, .cjs 등)
     out_extension_js: ?[]const u8 = null,
+    /// 출력 파일명 (소스맵 참조용, 예: "out.js")
+    output_filename: []const u8 = "bundle.js",
     /// 소스맵 sourceRoot 필드
     source_root: ?[]const u8 = null,
     /// 소스맵에 sourcesContent 포함 여부
@@ -438,13 +440,15 @@ pub fn emitWithTreeShaking(
                 mapping.generated_line += prologue_lines;
             }
         }
-        const json = try sm.generateJSON("bundle.js");
+        const json = try sm.generateJSON(options.output_filename);
         sourcemap_json = try allocator.dupe(u8, json);
     }
 
     // 소스맵 참조 추가
     if (sourcemap_json != null) {
-        try output.appendSlice(allocator, "//# sourceMappingURL=bundle.js.map\n");
+        try output.appendSlice(allocator, "//# sourceMappingURL=");
+        try output.appendSlice(allocator, options.output_filename);
+        try output.appendSlice(allocator, ".map\n");
     }
 
     return .{
@@ -634,13 +638,15 @@ pub fn emitDevBundle(
     // 소스맵 JSON 생성
     var sourcemap_json: ?[]const u8 = null;
     if (bundle_sm) |*sm| {
-        const json = try sm.generateJSON("bundle.js");
+        const json = try sm.generateJSON(options.output_filename);
         sourcemap_json = try allocator.dupe(u8, json);
     }
 
     // 소스맵 참조 추가
     if (sourcemap_json != null) {
-        try output.appendSlice(allocator, "//# sourceMappingURL=/bundle.js.map\n");
+        try output.appendSlice(allocator, "//# sourceMappingURL=/");
+        try output.appendSlice(allocator, options.output_filename);
+        try output.appendSlice(allocator, ".map\n");
     }
 
     return .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -1090,6 +1090,7 @@ pub fn main() !void {
             .resolve_extensions = opts.resolve_extensions_list.items,
             .main_fields = opts.main_fields_list.items,
             .sourcemap = opts.sourcemap,
+            .output_filename = if (opts.output_file) |of| std.fs.path.basename(of) else "bundle.js",
         };
 
         // config 파일 옵션 적용 — 첫 번째 플러그인의 config만 사용 (CLI가 우선)


### PR DESCRIPTION
## Summary
- `sourceMappingURL=bundle.js.map` 하드코딩 → 실제 출력 파일명 사용 (`app.js` → `app.js.map`)
- `EmitOptions`/`BundleOptions`에 `output_filename` 필드 추가
- App.tsx 디버그 코드 제거 (console.log, 빨간 박스)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `-o app.js --sourcemap` → `sourceMappingURL=app.js.map` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)