### PR TITLE
fix(bundler): subprocess plugin JSON 파싱 메모리릭 수정

### DIFF
--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -285,7 +285,9 @@ pub const SubprocessPlugin = struct {
             return error.PluginFailed;
         };
         defer allocator.free(response);
-        const parsed = std.json.parseFromSliceLeaky(HookResponse, allocator, response, .{
+        var json_arena = std.heap.ArenaAllocator.init(allocator);
+        defer json_arena.deinit();
+        const parsed = std.json.parseFromSliceLeaky(HookResponse, json_arena.allocator(), response, .{
             .ignore_unknown_fields = true,
         }) catch return error.PluginFailed;
 
@@ -321,7 +323,9 @@ pub const SubprocessPlugin = struct {
             return error.PluginFailed;
         };
         defer allocator.free(response);
-        const parsed = std.json.parseFromSliceLeaky(HookResponse, allocator, response, .{
+        var json_arena = std.heap.ArenaAllocator.init(allocator);
+        defer json_arena.deinit();
+        const parsed = std.json.parseFromSliceLeaky(HookResponse, json_arena.allocator(), response, .{
             .ignore_unknown_fields = true,
         }) catch return error.PluginFailed;
 
@@ -367,7 +371,9 @@ pub const SubprocessPlugin = struct {
             return error.PluginFailed;
         };
         defer allocator.free(response);
-        const parsed = std.json.parseFromSliceLeaky(HookResponse, allocator, response, .{
+        var json_arena = std.heap.ArenaAllocator.init(allocator);
+        defer json_arena.deinit();
+        const parsed = std.json.parseFromSliceLeaky(HookResponse, json_arena.allocator(), response, .{
             .ignore_unknown_fields = true,
         }) catch return error.PluginFailed;
 
@@ -403,7 +409,9 @@ pub const SubprocessPlugin = struct {
             return error.PluginFailed;
         };
         defer allocator.free(response);
-        const parsed = std.json.parseFromSliceLeaky(HookResponse, allocator, response, .{
+        var json_arena = std.heap.ArenaAllocator.init(allocator);
+        defer json_arena.deinit();
+        const parsed = std.json.parseFromSliceLeaky(HookResponse, json_arena.allocator(), response, .{
             .ignore_unknown_fields = true,
         }) catch return error.PluginFailed;
 


### PR DESCRIPTION
## Summary
- `parseFromSliceLeaky`가 caller allocator에 문자열을 할당하지만 해제하지 않아 IPC 훅 호출마다 메모리 누수
- 4개 훅(resolveId, load, transform, renderChunk)에서 임시 `ArenaAllocator`로 JSON 파싱
- 필요한 결과만 `dupe`하여 반환, arena는 즉시 해제

## Test plan
- [x] `zig build test` 전체 통과
- [x] 에셋 플러그인 번들 시 debug allocator에서 메모리릭 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)