### PR TITLE
fix(bundler): JSX 옵션 번들러 전달 + RN automatic 기본값

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -119,6 +119,14 @@ pub const BundleOptions = struct {
     flow: bool = false,
     /// .js 파일에서도 JSX 파싱 활성화 (--platform=react-native 프리셋).
     jsx_in_js: bool = false,
+    /// JSX 런타임 모드 (--jsx=classic|automatic|automatic-dev)
+    jsx_runtime: @import("../codegen/codegen.zig").JsxRuntime = .classic,
+    /// classic 모드 JSX factory (--jsx-factory)
+    jsx_factory: []const u8 = "React.createElement",
+    /// classic 모드 Fragment factory (--jsx-fragment)
+    jsx_fragment: []const u8 = "React.Fragment",
+    /// automatic 모드 import source (--jsx-import-source)
+    jsx_import_source: []const u8 = "react",
     /// 커스텀 확장자 탐색 순서 (--resolve-extensions). 비어있으면 기본값 사용.
     resolve_extensions: []const []const u8 = &.{},
     /// package.json 필드 해석 순서 (--main-fields). 비어있으면 기본 (module → main).
@@ -296,6 +304,10 @@ pub const Bundler = struct {
             .asset_names = self.options.asset_names,
             .legal_comments = self.options.legal_comments,
             .keep_names = self.options.keep_names,
+            .jsx_runtime = self.options.jsx_runtime,
+            .jsx_factory = self.options.jsx_factory,
+            .jsx_fragment = self.options.jsx_fragment,
+            .jsx_import_source = self.options.jsx_import_source,
             .plugins = self.options.plugins,
             .polyfills = &.{}, // 호출자가 loadPolyfills()로 설정
             .run_before_main = self.options.run_before_main,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1015,6 +1015,10 @@ pub fn main() !void {
             }
             opts.flow = true;
             opts.jsx_in_js = true; // RN의 .js 파일은 Flow + JSX 혼용
+            // Metro는 automatic JSX transform 사용 — 사용자가 명시하지 않았으면 자동 설정
+            if (opts.jsx_runtime == .classic) {
+                opts.jsx_runtime = .automatic;
+            }
 
             // RN 에셋 기본 로더: Metro assetExts 호환.
             // 사용자 --loader 오버라이드가 loader_list 앞에 이미 있으므로
@@ -1087,6 +1091,10 @@ pub fn main() !void {
             .plugins = plugin_list.items,
             .flow = opts.flow,
             .jsx_in_js = opts.jsx_in_js,
+            .jsx_runtime = opts.jsx_runtime,
+            .jsx_factory = opts.jsx_factory,
+            .jsx_fragment = opts.jsx_fragment,
+            .jsx_import_source = opts.jsx_import_source,
             .resolve_extensions = opts.resolve_extensions_list.items,
             .main_fields = opts.main_fields_list.items,
             .sourcemap = opts.sourcemap,


### PR DESCRIPTION
## Summary
- `BundleOptions`에 `jsx_runtime`/`jsx_factory`/`jsx_fragment`/`jsx_import_source` 필드 추가
- `makeEmitOptions`에서 JSX 옵션을 `EmitOptions`로 전달
- `main.zig`에서 CLI/tsconfig JSX 옵션을 `BundleOptions`에 전달
- `--platform=react-native` 시 JSX를 `automatic`으로 자동 설정 (Metro 호환)

## 배경
번들 모드에서 JSX 옵션이 전달되지 않아 항상 `classic`(`React.createElement`)으로 변환됨.
RN에서 `import React` 없이 JSX를 사용하면 런타임 에러 발생.

## Test plan
- [x] `zig build` 빌드 성공
- [x] `bun test tests/bundle-smoke.test.ts` 99개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)