### PR TITLE
fix(linker): ESM 래핑 모듈 namespace import exports_xxx rename 버그 수정

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -8365,9 +8365,9 @@ test "ESM wrap: CJS wrapper imports scope-hoisted ESM — no raw require" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require('./util.js')") == null);
 }
 
-test "ESM wrap: namespace import of __esm module — exports_xxx.prop access" {
-    // import * as ns from './esm-mod' → ns가 exports_xxx로 rename되어
-    // ns.prop → exports_xxx.prop 형태로 접근. 직접 변수 치환 방지.
+test "ESM wrap: namespace import of __esm module — canonical name direct rewrite" {
+    // import * as ns from './esm-mod' → ns.prop → canonical name 직접 치환.
+    // exports_xxx rename은 변수 덮어쓰기 버그를 유발하므로 사용하지 않음.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",
@@ -8394,10 +8394,11 @@ test "ESM wrap: namespace import of __esm module — exports_xxx.prop access" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // namespace import가 exports_xxx로 rename되어야 함 (직접 'greet' 치환 금지)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports_utils") != null);
-    // raw 'greet()' 호출이 남아있으면 안 됨 (exports_utils.greet() 형태여야)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports_utils.greet") != null);
+    // namespace import가 canonical name으로 직접 치환되어야 함
+    // utils.greet() → greet() (호이스팅된 function 참조)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "greet()") != null);
+    // exports_xxx로 rename되지 않아야 함 (변수 덮어쓰기 버그 방지)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports_utils.greet") == null);
 }
 
 test "ESM wrap: skip_cjs_exports — no exports.x in __esm wrapper" {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -967,24 +967,9 @@ pub const Linker = struct {
                 }
 
                 // namespace import: esbuild 방식 — ns.prop → canonical_name 직접 치환.
-                // __esm 타겟: 직접 치환 불가 (변수가 래퍼 안에만 존재).
-                // → ns를 exports_xxx로 rename하여 exports_xxx.prop 형태로 접근.
+                // __esm 타겟도 동일: rolldown 방식으로 변수가 래퍼 밖에 호이스팅되므로
+                // canonical name으로 직접 치환 가능. exports_xxx rename은 변수 덮어쓰기 버그 유발.
                 if (ib.kind == .namespace) {
-                    if (canonical_mod < self.modules.len and self.modules[canonical_mod].wrap_kind == .esm) {
-                        const exports_var = try types.makeExportsVarName(self.allocator, self.modules[canonical_mod].path);
-                        // ns 변수를 exports_xxx로 rename → ns.prop → exports_xxx.prop
-                        if (module_scope.get(ib.local_name)) |sym_idx| {
-                            try renames.put(@intCast(sym_idx), exports_var);
-                            try owned_nested_renames.append(self.allocator, exports_var);
-                            if (m.wrap_kind == .esm) {
-                                try export_getter_overrides.put(self.allocator, ib.local_name, exports_var);
-                            }
-                        } else {
-                            self.allocator.free(exports_var);
-                        }
-                        continue;
-                    }
-
                     const ns_sym_id = module_scope.get(ib.local_name) orelse continue;
                     const effective_syms = override_symbol_ids orelse sem.symbol_ids;
 


### PR DESCRIPTION
## Summary
- `import * as ns from './esm-module'`에서 `ns`를 `exports_xxx`로 rename하던 로직 제거
- scope-hoisted 모듈과 동일하게 `registerNamespaceRewrites`로 `ns.prop` → canonical name 직접 치환
- ESM 래핑 모듈의 변수가 rolldown 방식으로 호이스팅되므로 직접 치환이 안전

## 배경
`exports_xxx` rename은 다른 소비자 모듈이 같은 이름으로 재할당하면 원본 exports 객체가 손실되는 버그 유발. RN 번들에서 112번 재할당 관찰됨.

## Test plan
- [x] `zig build test` 2199개 유닛 테스트 통과
- [x] `bun test tests/bundle-smoke.test.ts` 99개 통합 테스트 통과
- [x] 기존 테스트를 새 동작에 맞게 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)