### PR TITLE
feat(runtime): configurable_exports 옵션 추가 (RN 자동 활성화)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -131,7 +131,10 @@ pub const BundleOptions = struct {
     resolve_extensions: []const []const u8 = &.{},
     /// package.json 필드 해석 순서 (--main-fields). 비어있으면 기본 (module → main).
     main_fields: []const []const u8 = &.{},
-    /// 증분 빌드용 모듈 파싱 캐시. null이면 매번 전체 파싱.
+    /// Object.defineProperty에 configurable: true 추가 (RN/Hermes 호환).
+    /// --platform=react-native에서 자동 활성화.
+    configurable_exports: bool = false,
+    /// 증분 빌드용 모�� 파싱 캐시. null이면 매번 전체 파싱.
     /// IncrementalBundler가 소유하고 빌드 간 보존한다.
     module_store: ?*@import("module_store.zig").PersistentModuleStore = null,
 
@@ -311,6 +314,7 @@ pub const Bundler = struct {
             .plugins = self.options.plugins,
             .polyfills = &.{}, // 호출자가 loadPolyfills()로 설정
             .run_before_main = self.options.run_before_main,
+            .configurable_exports = self.options.configurable_exports,
         };
     }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -111,6 +111,8 @@ pub const EmitOptions = struct {
     /// 엔트리 모듈 직전에 실행할 모듈 경로 (--run-before-main).
     /// 해당 모듈의 require_xxx() / init_xxx() 호출을 엔트리 코드 앞에 삽입.
     run_before_main: []const []const u8 = &.{},
+    /// Object.defineProperty에 configurable: true 추가 (RN/Hermes 호환).
+    configurable_exports: bool = false,
 
     pub const PolyfillEntry = struct {
         name: []const u8,
@@ -2157,10 +2159,10 @@ fn emitBundleRuntimeHelpers(
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
         // __toESM, __copyProps, __defProp은 CJS/ESM 양쪽에서 공유
-        try rt.appendCjsRuntime(output, allocator, options.minify_whitespace);
+        try rt.appendCjsRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
     }
     if (needs_esm_wrap_runtime) {
-        try rt.appendEsmWrapRuntime(output, allocator, options.minify_whitespace);
+        try rt.appendEsmWrapRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
     }
     if (options.experimental_decorators) {
         try rt.appendDecoratorRuntime(output, allocator, options.minify_whitespace);
@@ -2191,10 +2193,10 @@ fn emitChunkRuntimeHelpers(
         }
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
-        try rt.appendCjsRuntime(output, allocator, options.minify_whitespace);
+        try rt.appendCjsRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
     }
     if (needs_esm_wrap_runtime) {
-        try rt.appendEsmWrapRuntime(output, allocator, options.minify_whitespace);
+        try rt.appendEsmWrapRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
     }
     if (options.experimental_decorators) {
         try rt.appendDecoratorRuntime(output, allocator, options.minify_whitespace);

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -25,11 +25,23 @@ pub const TOESM_RUNTIME =
     \\var __getProtoOf = Object.getPrototypeOf;
     \\var __defProp = Object.defineProperty;
     \\var __hasOwn = Object.prototype.hasOwnProperty;
+    \\var __copyProps = (to, from) => { Object.keys(from).forEach(key => { if (!__hasOwn.call(to, key)) __defProp(to, key, { get: () => from[key], enumerable: true }); }); return to; };
+    \\var __toESM = (mod, isNodeMode, target) => (target = mod != null ? Object.create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target, mod));
+    \\
+;
+pub const TOESM_RUNTIME_MIN = "var __getProtoOf=Object.getPrototypeOf;var __defProp=Object.defineProperty;var __hasOwn=Object.prototype.hasOwnProperty;var __copyProps=(to,from)=>{Object.keys(from).forEach(key=>{if(!__hasOwn.call(to,key))__defProp(to,key,{get:()=>from[key],enumerable:true})});return to};var __toESM=(mod,isNodeMode,target)=>(target=mod!=null?Object.create(__getProtoOf(mod)):{},__copyProps(isNodeMode||!mod||!mod.__esModule?__defProp(target,\"default\",{value:mod,enumerable:true}):target,mod));";
+
+/// __toESM configurable 버전: RN/Hermes 호환을 위해 configurable: true 추가.
+/// --platform=react-native에서 자동 활성화.
+pub const TOESM_RUNTIME_CONFIGURABLE =
+    \\var __getProtoOf = Object.getPrototypeOf;
+    \\var __defProp = Object.defineProperty;
+    \\var __hasOwn = Object.prototype.hasOwnProperty;
     \\var __copyProps = (to, from) => { Object.keys(from).forEach(key => { if (!__hasOwn.call(to, key)) __defProp(to, key, { get: () => from[key], enumerable: true, configurable: true }); }); return to; };
     \\var __toESM = (mod, isNodeMode, target) => (target = mod != null ? Object.create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true, configurable: true }) : target, mod));
     \\
 ;
-pub const TOESM_RUNTIME_MIN = "var __getProtoOf=Object.getPrototypeOf;var __defProp=Object.defineProperty;var __hasOwn=Object.prototype.hasOwnProperty;var __copyProps=(to,from)=>{Object.keys(from).forEach(key=>{if(!__hasOwn.call(to,key))__defProp(to,key,{get:()=>from[key],enumerable:true,configurable:true})});return to};var __toESM=(mod,isNodeMode,target)=>(target=mod!=null?Object.create(__getProtoOf(mod)):{},__copyProps(isNodeMode||!mod||!mod.__esModule?__defProp(target,\"default\",{value:mod,enumerable:true,configurable:true}):target,mod));";
+pub const TOESM_RUNTIME_CONFIGURABLE_MIN = "var __getProtoOf=Object.getPrototypeOf;var __defProp=Object.defineProperty;var __hasOwn=Object.prototype.hasOwnProperty;var __copyProps=(to,from)=>{Object.keys(from).forEach(key=>{if(!__hasOwn.call(to,key))__defProp(to,key,{get:()=>from[key],enumerable:true,configurable:true})});return to};var __toESM=(mod,isNodeMode,target)=>(target=mod!=null?Object.create(__getProtoOf(mod)):{},__copyProps(isNodeMode||!mod||!mod.__esModule?__defProp(target,\"default\",{value:mod,enumerable:true,configurable:true}):target,mod));";
 
 /// __esm: ESM 모듈의 지연 초기화 팩토리 (esbuild 호환).
 /// ESM 모듈이 require()로 소비될 때 사용. 한 번만 실행되고 결과를 캐시.
@@ -40,15 +52,23 @@ pub const ESM_RUNTIME_MIN = "var __esm=(fn,res)=>function __init(){return fn&&(r
 /// __export: ESM namespace 객체에 live getter 등록 (esbuild 호환).
 /// var foo_exports = {}; __export(foo_exports, { greet: () => greet });
 /// 참고: references/esbuild/internal/runtime/runtime.go:187
-pub const EXPORT_RUNTIME = "var __export = (target, all) => {\n\tfor (var name in all)\n\t\tObject.defineProperty(target, name, { get: all[name], enumerable: true, configurable: true });\n};\n";
-pub const EXPORT_RUNTIME_MIN = "var __export=(target,all)=>{for(var name in all)Object.defineProperty(target,name,{get:all[name],enumerable:true,configurable:true})};";
+pub const EXPORT_RUNTIME = "var __export = (target, all) => {\n\tfor (var name in all)\n\t\tObject.defineProperty(target, name, { get: all[name], enumerable: true });\n};\n";
+pub const EXPORT_RUNTIME_MIN = "var __export=(target,all)=>{for(var name in all)Object.defineProperty(target,name,{get:all[name],enumerable:true})};";
+
+/// __export configurable 버전: RN/Hermes 호환.
+pub const EXPORT_RUNTIME_CONFIGURABLE = "var __export = (target, all) => {\n\tfor (var name in all)\n\t\tObject.defineProperty(target, name, { get: all[name], enumerable: true, configurable: true });\n};\n";
+pub const EXPORT_RUNTIME_CONFIGURABLE_MIN = "var __export=(target,all)=>{for(var name in all)Object.defineProperty(target,name,{get:all[name],enumerable:true,configurable:true})};";
 
 /// __toCommonJS: ESM namespace → CJS 호환 객체 변환 (esbuild 호환).
 /// { __esModule: true } + 원본 프로퍼티 복사. CJS가 ESM을 require()할 때 사용.
 /// 참고: references/esbuild/internal/runtime/runtime.go:247
 /// __copyProps, __defProp은 __toESM 런타임에 이미 정의됨.
-pub const TOCOMMONJS_RUNTIME = "var __toCommonJS = mod => __copyProps(__defProp({}, '__esModule', { value: true, configurable: true }), mod);\n";
-pub const TOCOMMONJS_RUNTIME_MIN = "var __toCommonJS=mod=>__copyProps(__defProp({},\"__esModule\",{value:true,configurable:true}),mod);";
+pub const TOCOMMONJS_RUNTIME = "var __toCommonJS = mod => __copyProps(__defProp({}, '__esModule', { value: true }), mod);\n";
+pub const TOCOMMONJS_RUNTIME_MIN = "var __toCommonJS=mod=>__copyProps(__defProp({},\"__esModule\",{value:true}),mod);";
+
+/// __toCommonJS configurable 버전: RN/Hermes 호환.
+pub const TOCOMMONJS_RUNTIME_CONFIGURABLE = "var __toCommonJS = mod => __copyProps(__defProp({}, '__esModule', { value: true, configurable: true }), mod);\n";
+pub const TOCOMMONJS_RUNTIME_CONFIGURABLE_MIN = "var __toCommonJS=mod=>__copyProps(__defProp({},\"__esModule\",{value:true,configurable:true}),mod);";
 
 // ============================================================
 // Decorator
@@ -335,28 +355,28 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
 }
 
 /// CJS interop 런타임을 ���입한다 (__commonJS + __toESM).
-pub fn appendCjsRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool) !void {
+pub fn appendCjsRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
     if (minify) {
         try buf.appendSlice(allocator, CJS_RUNTIME_MIN);
-        try buf.appendSlice(allocator, TOESM_RUNTIME_MIN);
+        try buf.appendSlice(allocator, if (configurable) TOESM_RUNTIME_CONFIGURABLE_MIN else TOESM_RUNTIME_MIN);
     } else {
         try buf.appendSlice(allocator, CJS_RUNTIME);
-        try buf.appendSlice(allocator, TOESM_RUNTIME);
+        try buf.appendSlice(allocator, if (configurable) TOESM_RUNTIME_CONFIGURABLE else TOESM_RUNTIME);
     }
 }
 
 /// ESM wrap 런타임을 주입한다 (__esm + __export + __toCommonJS).
 /// WrapKind.esm 모듈이 하나라도 있을 때 호출.
 /// __toCommonJS는 __copyProps/__defProp에 의존하므로 __toESM 런타임 후에 주입해야 함.
-pub fn appendEsmWrapRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool) !void {
+pub fn appendEsmWrapRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
     if (minify) {
         try buf.appendSlice(allocator, ESM_RUNTIME_MIN);
-        try buf.appendSlice(allocator, EXPORT_RUNTIME_MIN);
-        try buf.appendSlice(allocator, TOCOMMONJS_RUNTIME_MIN);
+        try buf.appendSlice(allocator, if (configurable) EXPORT_RUNTIME_CONFIGURABLE_MIN else EXPORT_RUNTIME_MIN);
+        try buf.appendSlice(allocator, if (configurable) TOCOMMONJS_RUNTIME_CONFIGURABLE_MIN else TOCOMMONJS_RUNTIME_MIN);
     } else {
         try buf.appendSlice(allocator, ESM_RUNTIME);
-        try buf.appendSlice(allocator, EXPORT_RUNTIME);
-        try buf.appendSlice(allocator, TOCOMMONJS_RUNTIME);
+        try buf.appendSlice(allocator, if (configurable) EXPORT_RUNTIME_CONFIGURABLE else EXPORT_RUNTIME);
+        try buf.appendSlice(allocator, if (configurable) TOCOMMONJS_RUNTIME_CONFIGURABLE else TOCOMMONJS_RUNTIME);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -85,6 +85,9 @@ const CliOptions = struct {
     flow: bool = false,
     /// .js 파일에서도 JSX 파싱 활성화. --platform=react-native 프리셋에서 자동 설정.
     jsx_in_js: bool = false,
+    /// Object.defineProperty에 configurable: true 추가 (RN/Hermes 호환).
+    /// --platform=react-native에서 자동 활성화.
+    configurable_exports: bool = false,
     /// JSX 런타임 모드 (--jsx=classic|automatic|automatic-dev, --jsx-dev)
     /// null이면 사용자 미지정 — 플랫폼 프리셋 또는 tsconfig에서 결정.
     jsx_runtime: ?lib.codegen.codegen.JsxRuntime = null,
@@ -1068,6 +1071,7 @@ pub fn main() !void {
             }
             opts.flow = true;
             opts.jsx_in_js = true; // RN의 .js 파일은 Flow + JSX 혼용
+            opts.configurable_exports = true; // RN/Hermes: defineProperty에 configurable: true 필요
             // Metro는 automatic JSX transform 사용 — 사용자가 명시하지 않았으면 자동 설정
             if (opts.jsx_runtime == null) {
                 opts.jsx_runtime = .automatic;
@@ -1144,6 +1148,7 @@ pub fn main() !void {
             .plugins = plugin_list.items,
             .flow = opts.flow,
             .jsx_in_js = opts.jsx_in_js,
+            .configurable_exports = opts.configurable_exports,
             .jsx_runtime = opts.jsx_runtime.?,
             .jsx_factory = opts.jsx_factory,
             .jsx_fragment = opts.jsx_fragment,


### PR DESCRIPTION
## Summary
- `configurable_exports` 옵션 추가 (`BundleOptions`, `EmitOptions`, CLI)
- `false`(기본): esbuild 호환 동작 (configurable 미설정)
- `true`: Object.defineProperty에 `configurable: true` 추가 (RN/Hermes 호환)
- `--platform=react-native` 시 자동 `true`

## 변경 파일
- `runtime_helpers.zig` — 기본 버전 복원 + `_CONFIGURABLE` 별도 상수
- `bundler.zig` — `configurable_exports` 필드 + `makeEmitOptions` 전달
- `emitter.zig` — `configurable_exports` 필드 + 런타임 주입 분기
- `main.zig` — CLI opts + RN 프리셋 자동 설정 + bundle_opts 전달

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/bundle-smoke.test.ts` 99개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)