### PR TITLE
fix(linker): ESM-wrapped 모듈에서 synthetic JSX binding skip 버그 수정

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -959,7 +959,9 @@ pub const Linker = struct {
                 // __esm 모듈에서 CJS 타겟 또는 self-import: body의 require_rewrites가
                 // 할당문 + init 호출을 처리하므로 preamble 생성 skip.
                 // __esm → __esm은 live binding (preamble init + canonical rename) 사용.
-                if (m.wrap_kind == .esm and canonical_mod < self.modules.len and
+                // 단, synthetic binding(JSX runtime 등)은 AST body에 require()가 없으므로 skip하지 않음.
+                const is_synthetic = ib.local_span.start >= 0xFFFF_0000;
+                if (!is_synthetic and m.wrap_kind == .esm and canonical_mod < self.modules.len and
                     (self.modules[canonical_mod].wrap_kind == .cjs or canonical_mod == module_index))
                 {
                     continue;


### PR DESCRIPTION
## Summary
ESM-wrapped 모듈이 CJS 타겟(react/jsx-dev-runtime)을 import할 때,
linker가 preamble 생성을 skip하여 `var _jsxDEV = require_xxx().jsxDEV` 바인딩이 누락되는 버그 수정.

## 원인
linker.zig:962-966에서 `m.wrap_kind == .esm && target.wrap_kind == .cjs`이면
"body의 require_rewrites가 처리한다"는 전제로 `continue`. 그러나 synthetic JSX binding은
AST body에 `require()` 호출이 없어서 require_rewrites가 동작하지 않음.

## 수정
sentinel span(`>=0xFFFF_0000`)으로 synthetic binding을 식별하여 ESM-wrap skip을 건너뜀.

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/bundle-smoke.test.ts` 99개 통과
- [x] ESM-wrapped 모듈 + CJS jsx-dev-runtime 번들 출력에서 `_jsxDEV` 바인딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)