### PR TITLE
fix(emitter): ESM-wrapped 모듈 JSX binding 스코프 + hoisted function JSX 옵션 누락 수정

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -2446,6 +2446,16 @@ fn emitEsmWrappedModule(
         }
     }
 
+    // synthetic JSX import binding: top-level에 var 선언이 필요.
+    // preamble은 __esm init 블록 안에 삽입되므로, var _jsxDEV = ... 형태면
+    // 호이스팅된 함수에서 접근 불가. var _jsxDEV;를 top-level에 선언하고
+    // init 안에서 _jsxDEV = ... (할당만)으로 처리해야 함.
+    for (module.import_bindings) |ib| {
+        if (ib.local_span.start >= 0xFFFF_0000) {
+            try hoisted_var_names.append(allocator, ib.local_name);
+        }
+    }
+
     // codegen 공통 옵션
     const cg_linking = if (metadata) |m| @as(?*const LinkingMetadata, m) else null;
 
@@ -2488,6 +2498,11 @@ fn emitEsmWrappedModule(
             .linking_metadata = cg_linking,
             .replace_import_meta = options.format != .esm,
             .platform = options.platform,
+            .jsx_runtime = options.jsx_runtime,
+            .jsx_factory = options.jsx_factory,
+            .jsx_fragment = options.jsx_fragment,
+            .jsx_import_source = options.jsx_import_source,
+            .jsx_filename = module.path,
         });
         const hoisted_code = try hoist_cg.generateStatements(root, hoisted_stmts.items);
         try wrapped.appendSlice(allocator, hoisted_code);

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -972,7 +972,12 @@ pub const Linker = struct {
                     const preamble_name = self.getCanonicalName(module_index, ib.local_name) orelse ib.local_name;
                     const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
                     const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
-                    try preamble.writeCjsImport(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                    // ESM-wrapped + synthetic binding: top-level에 이미 var 선언됨 → 할당만
+                    if (is_synthetic and m.wrap_kind == .esm) {
+                        try preamble.writeCjsImportAssignOnly(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                    } else {
+                        try preamble.writeCjsImport(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                    }
                     continue;
                 }
 
@@ -2416,7 +2421,30 @@ const PreambleWriter = struct {
         is_namespace: bool,
         interop: types.Interop,
     ) !void {
-        try self.write("var ");
+        try self.writeCjsImportInner(local_name, imported_name, req_var, is_namespace, interop, false);
+    }
+
+    fn writeCjsImportAssignOnly(
+        self: *PreambleWriter,
+        local_name: []const u8,
+        imported_name: []const u8,
+        req_var: []const u8,
+        is_namespace: bool,
+        interop: types.Interop,
+    ) !void {
+        try self.writeCjsImportInner(local_name, imported_name, req_var, is_namespace, interop, true);
+    }
+
+    fn writeCjsImportInner(
+        self: *PreambleWriter,
+        local_name: []const u8,
+        imported_name: []const u8,
+        req_var: []const u8,
+        is_namespace: bool,
+        interop: types.Interop,
+        assign_only: bool,
+    ) !void {
+        if (!assign_only) try self.write("var ");
         try self.write(local_name);
         // Rolldown Interop: node → __toESM(req(), 1), babel → __toESM(req())
         const toesm_suffix: []const u8 = if (interop == .node) "(), 1)" else "())";


### PR DESCRIPTION
## Summary
3가지 버그 수정:
1. **스코프 문제**: synthetic JSX binding이 `__esm` init 블록 안에 `var`로 선언되어 호이스팅된 함수에서 접근 불가 → top-level `var _jsxDEV;` 선언 + init 안에서 할당만
2. **assign-only**: `writeCjsImportAssignOnly()` 추가하여 ESM-wrapped + synthetic일 때 `var` 생략
3. **JSX 옵션 누락**: 호이스팅된 function codegen에 JSX 옵션 미전달 → `React.createElement` 대신 `_jsxDEV` 사용

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/bundle-smoke.test.ts` 99개 통과
- [x] ESM-wrapped + CJS jsx-runtime 번들 출력에서 top-level var + init 할당 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)