### PR TITLE
fix(transformer): rest_element/yield/decorator JSX 분기 잘못 라우팅 수정

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -506,6 +506,7 @@ pub const Transformer = struct {
             .yield_expression,
             .rest_element,
             .decorator,
+            => self.visitUnaryNode(node),
             // JSX
             .jsx_spread_attribute,
             .jsx_expression_container,

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -173,8 +173,8 @@ pub fn transpileWithCallback(
         .use_define_for_class_fields = options.use_define_for_class_fields,
         .experimental_decorators = options.experimental_decorators,
         .unsupported = options.unsupported,
-        // JSX lowering: 트랜스파일 모드에서 항상 활성화
-        .jsx_transform = true,
+        // JSX lowering: JSX가 있는 모듈에서만 활성화
+        .jsx_transform = parser.ast.has_jsx,
         .jsx_runtime = options.jsx_runtime,
         .jsx_factory = options.jsx_factory,
         .jsx_fragment = options.jsx_fragment,


### PR DESCRIPTION
## Summary
JSX transform 리팩터링(PR #764)에서 `visitNode` switch의 `.rest_element`, `.yield_expression`, `.decorator`가 `.jsx_expression_container`와 같은 분기에 묶여, `jsx_transform=true`일 때 rest pattern(`...a`)이 드롭되는 버그.

## 수정
1. `.rest_element`, `.yield_expression`, `.decorator`를 JSX 분기에서 분리 → `visitUnaryNode` 분기로 이동
2. `transpile.zig`: `jsx_transform = true` → `jsx_transform = parser.ast.has_jsx` (JSX 없는 모듈은 기존 경로 유지)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun test tests/bundle-smoke.test.ts` 99개 통과
- [x] `bun test tests/tsc/` 2177개 통과 (0 fail)
- [x] `var p2 = ([...a]) => {}` 수동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)