### PR TITLE
fix(transformer): JSX spread props ES5 lowering + es_helpers 공유 헬퍼

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -4313,3 +4313,96 @@ test "JSX refactor guard: boolean and null props" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_jsx(\"input\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "disabled: true") != null);
 }
+
+// ============================================================
+// JSX + ES target: spread attribute lowering (Object.assign)
+// ============================================================
+
+fn e2eJSXAutomaticTarget(allocator: std.mem.Allocator, source: []const u8, target: TransformOptions.compat.ESTarget) !TestResult {
+    return e2eFull(allocator, source, .{
+        .jsx_transform = true,
+        .jsx_runtime = .automatic,
+        .jsx_import_source = "react",
+        .unsupported = TransformOptions.compat.fromESTarget(target),
+    }, .{ .minify_whitespace = true }, ".tsx");
+}
+
+fn e2eJSXClassicTarget(allocator: std.mem.Allocator, source: []const u8, target: TransformOptions.compat.ESTarget) !TestResult {
+    return e2eFull(allocator, source, .{
+        .jsx_transform = true,
+        .jsx_runtime = .classic,
+        .unsupported = TransformOptions.compat.fromESTarget(target),
+    }, .{ .minify_whitespace = true }, ".tsx");
+}
+
+test "JSX automatic + ES5: spread props → Object.assign" {
+    var r = try e2eJSXAutomaticTarget(std.testing.allocator,
+        \\const x = <div {...props} id="a" />;
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...props") == null);
+}
+
+test "JSX automatic + ES5: spread with children → Object.assign" {
+    var r = try e2eJSXAutomaticTarget(std.testing.allocator,
+        \\const x = <span style={s} {...rest}>hello</span>;
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...rest") == null);
+}
+
+test "JSX automatic + ES5: multiple spreads → Object.assign" {
+    var r = try e2eJSXAutomaticTarget(std.testing.allocator,
+        \\const x = <div {...a} {...b} id="c" />;
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...") == null);
+}
+
+test "JSX automatic + ES5: no spread → no Object.assign" {
+    var r = try e2eJSXAutomaticTarget(std.testing.allocator,
+        \\const x = <div id="a" className="b" />;
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_jsx(\"div\"") != null);
+}
+
+test "JSX automatic + esnext: spread preserved (no lowering)" {
+    var r = try e2eJSXAutomaticTarget(std.testing.allocator,
+        \\const x = <div {...props} id="a" />;
+    , .esnext);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...props") != null);
+}
+
+test "JSX classic + ES5: spread props → Object.assign" {
+    var r = try e2eJSXClassicTarget(std.testing.allocator,
+        \\const x = <div {...props} id="a" />;
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...props") == null);
+}
+
+test "JSX automatic + ES5: spread only → Object.assign with empty target" {
+    var r = try e2eJSXAutomaticTarget(std.testing.allocator,
+        \\const x = <div {...props} />;
+    , .es5);
+    defer r.deinit();
+    // spread만 있으면 Object.assign({}, props) 형태
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign({}") != null);
+}
+
+test "JSX automatic + ES5: props before spread → Object.assign({id:\"a\"}, props)" {
+    var r = try e2eJSXAutomaticTarget(std.testing.allocator,
+        \\const x = <div id="a" {...props} />;
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...") == null);
+}

--- a/src/transformer/es2018.zig
+++ b/src/transformer/es2018.zig
@@ -23,6 +23,7 @@ const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const helpers = @import("es_helpers.zig");
 
 /// Transformer 타입 (순환 import 방지를 위해 generic)
 pub fn ES2018(comptime Transformer: type) type {
@@ -40,40 +41,28 @@ pub fn ES2018(comptime Transformer: type) type {
 
         /// `{ a: 1, ...obj, b: 2 }` → `Object.assign({ a: 1 }, obj, { b: 2 })`
         ///
-        /// 알고리즘:
-        /// 1. 프로퍼티를 순회하면서 spread/non-spread 그룹으로 분할
-        /// 2. 연속된 non-spread 프로퍼티는 하나의 object literal로 묶음
-        /// 3. spread 프로퍼티는 피연산자만 추출 (spread를 벗김)
-        /// 4. 모든 그룹을 Object.assign(target, ...groups) 인자로 전달
-        /// 5. 첫 번째 인자가 이미 object literal이면 그것이 target, 아니면 {}를 삽입
+        /// old_ast의 object_expression을 방문하면서 각 프로퍼티를 visitNode로 변환하고,
+        /// 결과를 es_helpers.lowerObjectSpreadProps에 넘겨 Object.assign 호출을 생성한다.
         pub fn lowerObjectSpread(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const old_indices = self.old_ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
 
-            // scratch 버퍼를 사용해 Object.assign 인자 수집
+            // old_ast 프로퍼티를 방문하여 new_ast 노드로 변환
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
-
-            // 상태: 현재 non-spread 그룹을 쌓고 있는지
-            var group_start: usize = scratch_top;
 
             for (old_indices) |raw_idx| {
                 const child = self.old_ast.getNode(@enumFromInt(raw_idx));
                 if (child.tag == .spread_element) {
-                    // 1) 쌓아둔 non-spread 그룹을 object literal로 플러시
-                    if (self.scratch.items.len > group_start) {
-                        const obj = try buildObjectLiteral(self, node.span, self.scratch.items[group_start..]);
-                        // group 영역을 줄이고, 결과 노드를 인자로 추가
-                        self.scratch.shrinkRetainingCapacity(group_start);
-                        try self.scratch.append(self.allocator, obj);
-                        group_start = self.scratch.items.len;
-                    }
-
-                    // 2) spread의 피연산자를 방문하여 인자로 추가
+                    // spread: 피연산자를 방문하고 new_ast에 spread_element로 다시 감싸기
                     const operand = try self.visitNode(child.data.unary.operand);
-                    try self.scratch.append(self.allocator, operand);
-                    group_start = self.scratch.items.len;
+                    const new_spread = try self.new_ast.addNode(.{
+                        .tag = .spread_element,
+                        .span = child.span,
+                        .data = .{ .unary = .{ .operand = operand, .flags = 0 } },
+                    });
+                    try self.scratch.append(self.allocator, new_spread);
                 } else {
-                    // non-spread: 자식을 방문하고 그룹에 추가
+                    // non-spread: 자식을 방문하고 추가
                     const new_child = try self.visitNode(@enumFromInt(raw_idx));
                     if (!new_child.isNone()) {
                         try self.scratch.append(self.allocator, new_child);
@@ -81,102 +70,8 @@ pub fn ES2018(comptime Transformer: type) type {
                 }
             }
 
-            // 마지막 남은 non-spread 그룹 플러시
-            if (self.scratch.items.len > group_start) {
-                const obj = try buildObjectLiteral(self, node.span, self.scratch.items[group_start..]);
-                self.scratch.shrinkRetainingCapacity(group_start);
-                try self.scratch.append(self.allocator, obj);
-            }
-
-            // 인자 목록: scratch_top..현재
-            const args_slice = self.scratch.items[scratch_top..];
-
-            // 첫 인자가 object literal이 아니면 빈 {} 를 앞에 삽입
-            // (esbuild 동작: spread만 있거나, 첫 요소가 spread면 {}를 target으로 사용)
-            const need_empty_target = args_slice.len == 0 or blk: {
-                const first_node = self.new_ast.getNode(args_slice[0]);
-                break :blk first_node.tag != .object_expression;
-            };
-
-            if (need_empty_target) {
-                // 빈 object literal {} 생성
-                const empty_obj = try buildObjectLiteral(self, node.span, &.{});
-                // args_slice 앞에 삽입: scratch에 빈 obj를 끼워넣기
-                // 간단한 방법: 새 scratch 영역에 [empty_obj] + args_slice 복사
-                const old_args_len = args_slice.len;
-                // 공간 확보
-                try self.scratch.ensureUnusedCapacity(self.allocator, 1);
-                // 기존 인자를 한 칸 뒤로 밀기
-                if (old_args_len > 0) {
-                    // ensureUnusedCapacity 후 appendAssumeCapacity로 더미 추가
-                    self.scratch.appendAssumeCapacity(.none);
-                    const items = self.scratch.items;
-                    // scratch_top..(scratch_top + old_args_len) → scratch_top+1..(scratch_top + old_args_len + 1)
-                    std.mem.copyBackwards(NodeIndex, items[scratch_top + 1 .. scratch_top + 1 + old_args_len], items[scratch_top .. scratch_top + old_args_len]);
-                }
-                self.scratch.items[scratch_top] = empty_obj;
-            }
-
-            const final_args = self.scratch.items[scratch_top..];
-
-            return buildObjectAssignCall(self, node.span, final_args);
-        }
-
-        /// non-spread 프로퍼티 노드 인덱스 배열로 object_expression을 생성.
-        fn buildObjectLiteral(self: *Transformer, span: Span, props: []const NodeIndex) Transformer.Error!NodeIndex {
-            const list = try self.new_ast.addNodeList(props);
-            return self.new_ast.addNode(.{
-                .tag = .object_expression,
-                .span = span,
-                .data = .{ .list = list },
-            });
-        }
-
-        /// Object.assign(arg0, arg1, ...) 호출 노드를 생성.
-        fn buildObjectAssignCall(self: *Transformer, span: Span, args: []const NodeIndex) Transformer.Error!NodeIndex {
-            // "Object" 식별자
-            const object_span = try self.new_ast.addString("Object");
-            const object_node = try self.new_ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = object_span,
-                .data = .{ .string_ref = object_span },
-            });
-
-            // "assign" 식별자
-            const assign_span = try self.new_ast.addString("assign");
-            const assign_node = try self.new_ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = assign_span,
-                .data = .{ .string_ref = assign_span },
-            });
-
-            // Object.assign (static member expression) — extra = [object, property, flags]
-            const member_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(object_node),
-                @intFromEnum(assign_node),
-                0,
-            });
-            const callee = try self.new_ast.addNode(.{
-                .tag = .static_member_expression,
-                .span = span,
-                .data = .{ .extra = member_extra },
-            });
-
-            // 인자 리스트
-            const args_list = try self.new_ast.addNodeList(args);
-
-            // call_expression: extra = [callee, args_start, args_len, flags]
-            const call_extra = try self.new_ast.addExtras(&.{
-                @intFromEnum(callee),
-                args_list.start,
-                args_list.len,
-                0,
-            });
-            return self.new_ast.addNode(.{
-                .tag = .call_expression,
-                .span = span,
-                .data = .{ .extra = call_extra },
-            });
+            const new_props = self.scratch.items[scratch_top..];
+            return helpers.lowerObjectSpreadProps(self, new_props, node.span);
         }
     };
 }

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -238,6 +238,96 @@ pub fn makeExprStmt(self: anytype, expr: NodeIndex, span: Span) !NodeIndex {
 }
 
 // ============================================================
+// Object spread lowering 공용 헬퍼
+// ============================================================
+
+/// Object.assign(arg0, arg1, ...) 호출 노드를 생성.
+/// es2018, jsx_lowering 등에서 공용.
+pub fn makeObjectAssignCall(self: anytype, args: []const NodeIndex, span: Span) !NodeIndex {
+    const obj_ref = try makeIdentifierRef(self, "Object");
+    const assign_ref = try makeIdentifierRef(self, "assign");
+    const callee = try makeStaticMember(self, obj_ref, assign_ref, span);
+    return makeCallExpr(self, callee, args, span);
+}
+
+/// 이미 변환된 프로퍼티 목록(new_ast 노드, spread 포함)을 Object.assign()으로 변환.
+///
+/// { a: 1, ...obj, b: 2 } → Object.assign({ a: 1 }, obj, { b: 2 })
+///
+/// 알고리즘:
+/// 1. 프로퍼티를 순회하면서 spread/non-spread 그룹으로 분할
+/// 2. 연속된 non-spread 프로퍼티는 하나의 object literal로 묶음
+/// 3. spread 프로퍼티는 피연산자만 추출 (spread를 벗김)
+/// 4. 첫 번째 인자가 이미 object literal이면 그것이 target, 아니면 {}를 삽입
+/// 5. Object.assign(target, ...groups) 호출로 변환
+pub fn lowerObjectSpreadProps(self: anytype, properties: []const NodeIndex, span: Span) !NodeIndex {
+    const scratch_top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    var group_start: usize = scratch_top;
+
+    for (properties) |prop_idx| {
+        const prop = self.new_ast.getNode(prop_idx);
+        if (prop.tag == .spread_element) {
+            // 쌓아둔 non-spread 그룹을 object literal로 플러시
+            if (self.scratch.items.len > group_start) {
+                const obj = try makeObjectLiteral(self, self.scratch.items[group_start..], span);
+                self.scratch.shrinkRetainingCapacity(group_start);
+                try self.scratch.append(self.allocator, obj);
+                group_start = self.scratch.items.len;
+            }
+
+            // spread의 피연산자를 인자로 추가
+            try self.scratch.append(self.allocator, prop.data.unary.operand);
+            group_start = self.scratch.items.len;
+        } else {
+            // non-spread: 그룹에 추가
+            try self.scratch.append(self.allocator, prop_idx);
+        }
+    }
+
+    // 마지막 남은 non-spread 그룹 플러시
+    if (self.scratch.items.len > group_start) {
+        const obj = try makeObjectLiteral(self, self.scratch.items[group_start..], span);
+        self.scratch.shrinkRetainingCapacity(group_start);
+        try self.scratch.append(self.allocator, obj);
+    }
+
+    const args_slice = self.scratch.items[scratch_top..];
+
+    // 첫 인자가 object literal이 아니면 빈 {}를 target으로 삽입
+    const need_empty_target = args_slice.len == 0 or blk: {
+        const first_node = self.new_ast.getNode(args_slice[0]);
+        break :blk first_node.tag != .object_expression;
+    };
+
+    if (need_empty_target) {
+        const empty_obj = try makeObjectLiteral(self, &.{}, span);
+        try self.scratch.ensureUnusedCapacity(self.allocator, 1);
+        const old_args_len = args_slice.len;
+        if (old_args_len > 0) {
+            self.scratch.appendAssumeCapacity(.none);
+            const items = self.scratch.items;
+            std.mem.copyBackwards(NodeIndex, items[scratch_top + 1 .. scratch_top + 1 + old_args_len], items[scratch_top .. scratch_top + old_args_len]);
+        }
+        self.scratch.items[scratch_top] = empty_obj;
+    }
+
+    const final_args = self.scratch.items[scratch_top..];
+    return makeObjectAssignCall(self, final_args, span);
+}
+
+/// 프로퍼티 배열로 object_expression 생성 (spread 없는 단순 객체).
+fn makeObjectLiteral(self: anytype, props: []const NodeIndex, span: Span) !NodeIndex {
+    const list = try self.new_ast.addNodeList(props);
+    return self.new_ast.addNode(.{
+        .tag = .object_expression,
+        .span = span,
+        .data = .{ .list = list },
+    });
+}
+
+// ============================================================
 // Private Method 공용 헬퍼
 // ============================================================
 

--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -1134,7 +1134,21 @@ pub fn JsxLowering(comptime Transformer: type) type {
         }
 
         /// object_expression 노드 생성 (properties 리스트로)
+        /// --target < es2018 이면 spread가 포함된 경우 Object.assign()으로 변환
         fn makeObjectExpr(self: *Transformer, properties: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            // ES2018 object spread 다운레벨링: JSX lowering이 만든 object에 spread가 있으면
+            // Object.assign({a: 1}, obj, {b: 2}) 형태로 변환해야 한다.
+            // (JSX lowering이 new_ast에 직접 노드를 생성하므로, transformer의 visitNode를
+            //  다시 거치지 않아 es2018.lowerObjectSpread가 적용되지 않기 때문)
+            if (self.options.unsupported.object_spread) {
+                for (properties) |prop_idx| {
+                    const prop = self.new_ast.getNode(prop_idx);
+                    if (prop.tag == .spread_element) {
+                        return helpers.lowerObjectSpreadProps(self, properties, span);
+                    }
+                }
+            }
+
             const list = try self.new_ast.addNodeList(properties);
             return self.new_ast.addNode(.{
                 .tag = .object_expression,


### PR DESCRIPTION
## Summary
- JSX lowering이 생성한 `object_expression`의 spread가 `--target=es5`에서 `Object.assign`으로 변환되지 않는 버그 수정
- `es_helpers.zig`에 `lowerObjectSpreadProps` / `makeObjectAssignCall` 공유 헬퍼 추가, es2018과 jsx_lowering 모두 동일 헬퍼 사용
- JSX + ES5 target 테스트 8개 추가 (automatic/classic, spread 조합)

## 원인
JSX lowering이 `new_ast`에 직접 `object_expression`(spread 포함)을 생성하는데, transformer의 `visitNode`는 `old_ast` 노드만 순회하므로 ES2018 `lowerObjectSpread`가 적용되지 않았음

## 변경
- `es_helpers.zig`: `lowerObjectSpreadProps` (그룹핑 + Object.assign 생성), `makeObjectAssignCall` 추가
- `es2018.zig`: 기존 그룹핑/Object.assign 생성 코드 제거, `helpers.lowerObjectSpreadProps` 호출로 교체
- `jsx_lowering.zig`: `makeObjectExpr`에서 spread 감지 시 `helpers.lowerObjectSpreadProps` 호출
- `codegen_test.zig`: JSX + ES5 spread lowering 테스트 8개

## Test plan
- [x] `zig build test` — 유닛 테스트 전체 통과
- [x] `bun test tests/es5-rn.test.ts` — RN ES5 통합 테스트 통과
- [x] pre-push hook (zig fmt, oxlint, oxfmt) 통과

��� Generated with [Claude Code](https://claude.com/claude-code)