### PR TITLE
fix(transformer): constructor/async/generator ES5 params lowering 누락 일괄 수정

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -2030,6 +2030,30 @@ test "ES2015: class method default param lowered" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "void 0") != null);
 }
 
+test "ES2015: class constructor destructuring params lowered" {
+    var r = try e2eTarget(std.testing.allocator, "class Foo { constructor({x,...rest}:any) { console.log(rest); } }", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function Foo(_a)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__rest") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...rest") == null);
+}
+
+test "ES2015: async function destructuring params lowered" {
+    var r = try e2eTarget(std.testing.allocator, "async function f({a,...r}:any) { return r; }", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function f(_a)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__rest") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...r") == null);
+}
+
+test "ES2015: generator function destructuring params lowered" {
+    var r = try e2eTarget(std.testing.allocator, "function* g({x,...rest}:any) { yield rest; }", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function g(_a)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__rest") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "...rest") == null);
+}
+
 // --- ES2015: for-of ---
 
 test "ES2015: for-of with const" {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1070,7 +1070,18 @@ pub fn ES2015Class(comptime Transformer: type) type {
             self.super_call_this_alias = false;
             defer self.super_call_this_alias = saved_super_alias;
 
-            const new_params = try self.visitExtraList(params_start, params_len);
+            // ES2015 params lowering (constructor destructuring/rest/default)
+            var es2015_body_stmts: ?std.ArrayList(NodeIndex) = null;
+            defer if (es2015_body_stmts) |*s| s.deinit(self.allocator);
+
+            const new_params = if (self.options.unsupported.default_params and
+                es2015_params_mod.ES2015Params(Transformer).hasDefaultOrRest(self, params_start, params_len))
+            blk: {
+                const lr = try es2015_params_mod.ES2015Params(Transformer).lowerParams(self, params_start, params_len, span);
+                es2015_body_stmts = lr.body_stmts;
+                break :blk lr.new_params;
+            } else try self.visitExtraList(params_start, params_len);
+
             var new_body = try visitMethodBody(self, body_idx, span);
 
             // super() 호출이 있었으면 body 후처리:
@@ -1078,6 +1089,13 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // 2. body 끝에 return _this 추가
             if (self.super_call_this_alias) {
                 new_body = try postProcessSuperCallBody(self, new_body, instance_fields, span);
+            }
+
+            // ES2015 params body 문 삽입
+            if (es2015_body_stmts) |stmts| {
+                if (stmts.items.len > 0 and !new_body.isNone()) {
+                    new_body = try self.prependStatementsToBody(new_body, stmts.items);
+                }
             }
 
             const none = @intFromEnum(NodeIndex.none);

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -40,6 +40,7 @@ const Tag = Node.Tag;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
+const es2015_params_mod = @import("es2015_params.zig");
 
 /// 상태 머신의 개별 연산.
 const OpCode = enum {
@@ -83,7 +84,18 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const flags = extras[e + 4];
 
             const new_name = try self.visitNode(name_idx);
-            const new_params = try self.visitExtraList(params_start, params_len);
+
+            // ES2015 params lowering
+            var es2015_body_stmts: ?std.ArrayList(NodeIndex) = null;
+            defer if (es2015_body_stmts) |*s| s.deinit(self.allocator);
+
+            const new_params = if (self.options.unsupported.default_params and
+                es2015_params_mod.ES2015Params(Transformer).hasDefaultOrRest(self, params_start, params_len))
+            blk: {
+                const lr = try es2015_params_mod.ES2015Params(Transformer).lowerParams(self, params_start, params_len, span);
+                es2015_body_stmts = lr.body_stmts;
+                break :blk lr.new_params;
+            } else try self.visitExtraList(params_start, params_len);
 
             const sm_result = try buildStateMachine(self, body_idx, span);
             if (sm_result.body.isNone()) return .none;
@@ -97,11 +109,21 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 .data = .{ .unary = .{ .operand = gen_call, .flags = 0 } },
             });
 
-            // hoisted var 선언을 __generator 밖에 배치
-            const body_list = if (sm_result.var_decl.isNone())
-                try self.new_ast.addNodeList(&.{ret_stmt})
-            else
-                try self.new_ast.addNodeList(&.{ sm_result.var_decl, ret_stmt });
+            // hoisted var + ES2015 params body stmts + return __generator(...)
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+            if (!sm_result.var_decl.isNone()) {
+                try self.scratch.append(self.allocator, sm_result.var_decl);
+            }
+            if (es2015_body_stmts) |stmts| {
+                for (stmts.items) |stmt| {
+                    try self.scratch.append(self.allocator, stmt);
+                }
+            }
+            try self.scratch.append(self.allocator, ret_stmt);
+
+            const body_list = try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
             const new_body = try self.new_ast.addNode(.{
                 .tag = .block_statement,
                 .span = span,

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -15,6 +15,7 @@ const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const es_helpers = @import("es_helpers.zig");
 const es2015_generator = @import("es2015_generator.zig");
+const es2015_params_mod = @import("es2015_params.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const token_mod = @import("../lexer/token.zig");
@@ -46,7 +47,18 @@ pub fn ES2017(comptime Transformer: type) type {
 
             const new_name = try self.visitNode(name_idx);
             const new_body = try self.visitNode(body_idx);
-            const new_params = try self.visitExtraList(params_start, params_len);
+
+            // ES2015 params lowering
+            var es2015_body_stmts: ?std.ArrayList(NodeIndex) = null;
+            defer if (es2015_body_stmts) |*s| s.deinit(self.allocator);
+
+            const new_params = if (self.options.unsupported.default_params and
+                es2015_params_mod.ES2015Params(Transformer).hasDefaultOrRest(self, params_start, params_len))
+            blk: {
+                const lr = try es2015_params_mod.ES2015Params(Transformer).lowerParams(self, params_start, params_len, node.span);
+                es2015_body_stmts = lr.body_stmts;
+                break :blk lr.new_params;
+            } else try self.visitExtraList(params_start, params_len);
 
             const gen_func = try es_helpers.buildGeneratorWrapper(self, new_body, node.span);
             const async_call = try es_helpers.buildAsyncHelperCall(self, gen_func, node.span);
@@ -56,7 +68,16 @@ pub fn ES2017(comptime Transformer: type) type {
                 .span = node.span,
                 .data = .{ .unary = .{ .operand = async_call, .flags = 0 } },
             });
-            const body_list = try self.new_ast.addNodeList(&.{return_stmt});
+
+            // ES2015 params body stmts + return __async(...)
+            const body_list = if (es2015_body_stmts) |stmts| blk: {
+                const scratch_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                for (stmts.items) |stmt| try self.scratch.append(self.allocator, stmt);
+                try self.scratch.append(self.allocator, return_stmt);
+                break :blk try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+            } else try self.new_ast.addNodeList(&.{return_stmt});
+
             const wrapper_body = try self.new_ast.addNode(.{
                 .tag = .block_statement,
                 .span = node.span,
@@ -139,7 +160,18 @@ pub fn ES2017(comptime Transformer: type) type {
             const flags = extras[e + 4];
 
             const new_name = try self.visitNode(name_idx);
-            const new_params = try self.visitExtraList(params_start, params_len);
+
+            // ES2015 params lowering
+            var es2015_body_stmts2: ?std.ArrayList(NodeIndex) = null;
+            defer if (es2015_body_stmts2) |*s| s.deinit(self.allocator);
+
+            const new_params = if (self.options.unsupported.default_params and
+                es2015_params_mod.ES2015Params(Transformer).hasDefaultOrRest(self, params_start, params_len))
+            blk: {
+                const lr = try es2015_params_mod.ES2015Params(Transformer).lowerParams(self, params_start, params_len, span);
+                es2015_body_stmts2 = lr.body_stmts;
+                break :blk lr.new_params;
+            } else try self.visitExtraList(params_start, params_len);
 
             const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
             if (sm_result.body.isNone()) return .none;
@@ -156,11 +188,15 @@ pub fn ES2017(comptime Transformer: type) type {
                 .data = .{ .unary = .{ .operand = async_call, .flags = 0 } },
             });
 
-            // hoisted var 선언을 __generator 밖에 배치
-            const body_list = if (sm_result.var_decl.isNone())
-                try self.new_ast.addNodeList(&.{return_stmt})
-            else
-                try self.new_ast.addNodeList(&.{ sm_result.var_decl, return_stmt });
+            // hoisted var + ES2015 params stmts + return __async(...)
+            const body_list = blk: {
+                const scratch_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                if (!sm_result.var_decl.isNone()) try self.scratch.append(self.allocator, sm_result.var_decl);
+                if (es2015_body_stmts2) |stmts| for (stmts.items) |stmt| try self.scratch.append(self.allocator, stmt);
+                try self.scratch.append(self.allocator, return_stmt);
+                break :blk try self.new_ast.addNodeList(self.scratch.items[scratch_top..]);
+            };
             const wrapper_body = try self.new_ast.addNode(.{
                 .tag = .block_statement,
                 .span = span,


### PR DESCRIPTION
## Summary
- `new_ast`에 함수를 직접 생성하는 **모든** 남은 경로에서 ES2015 params lowering 적용
- constructor, async function, generator function의 destructuring/rest/default 파라미터가 ES5로 변환되지 않는 버그 수정
- 테스트 3개 추가

## 수정 대상
| 파일 | 함수 | 용도 |
|---|---|---|
| `es2015_class.zig` | `buildFunctionFromConstructor` | class constructor |
| `es2015_generator.zig` | `lowerGeneratorFunction` | generator function |
| `es2017.zig` | `lowerAsyncFunction` | async function |
| `es2017.zig` | `lowerAsyncToStateMachine` | async+generator |
| `transformer.zig` | `visitMethodDefinition` | method (class 미사용 시) |

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/es5-rn.test.ts` 통과
- [x] pre-push hook 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)