### PR TITLE
fix(transformer): __rest 제외 목록에서 string literal 키 누락 수정

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -1992,6 +1992,23 @@ test "ES2015: arrow destructuring with rename lowered" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__rest") != null);
 }
 
+test "ES2015: __rest includes string literal keys in exclude list" {
+    var r = try e2eTarget(std.testing.allocator, "var f=({'aria-busy':ariaBusy,style,...rest})=>rest;", .es5);
+    defer r.deinit();
+    // 'aria-busy'가 __rest 제외 목록에 포함되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"aria-busy\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"style\"") != null);
+}
+
+test "ES2015: __rest with multiple string literal keys" {
+    var r = try e2eTarget(std.testing.allocator, "var f=({ref:fwd,'aria-busy':ab,'aria-label':al,style,...rest})=>rest;", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"ref\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"aria-busy\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"aria-label\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"style\"") != null);
+}
+
 test "ES2015: arrow default param lowered" {
     var r = try e2eTarget(std.testing.allocator, "var f=(x=1)=>x;", .es5);
     defer r.deinit();

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -327,11 +327,20 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 const key_idx_inner = prop.data.binary.left;
                 if (!key_idx_inner.isNone()) {
                     const key_node_inner = self.old_ast.getNode(key_idx_inner);
-                    if ((key_node_inner.tag == .identifier_reference or key_node_inner.tag == .binding_identifier) and
-                        exclude_count < exclude_keys.len)
-                    {
-                        exclude_keys[exclude_count] = self.old_ast.source[key_node_inner.span.start..key_node_inner.span.end];
-                        exclude_count += 1;
+                    if (exclude_count < exclude_keys.len) {
+                        if (key_node_inner.tag == .identifier_reference or key_node_inner.tag == .binding_identifier) {
+                            exclude_keys[exclude_count] = self.old_ast.source[key_node_inner.span.start..key_node_inner.span.end];
+                            exclude_count += 1;
+                        } else if (key_node_inner.tag == .string_literal) {
+                            // 'aria-busy' 같은 string literal key — 따옴표를 제외한 내용
+                            const raw = self.old_ast.source[key_node_inner.span.start..key_node_inner.span.end];
+                            if (raw.len >= 2 and (raw[0] == '\'' or raw[0] == '"')) {
+                                exclude_keys[exclude_count] = raw[1 .. raw.len - 1];
+                            } else {
+                                exclude_keys[exclude_count] = raw;
+                            }
+                            exclude_count += 1;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- `{'aria-busy': ariaBusy, ...rest}` 패턴에서 `__rest` 제외 배열에 `"aria-busy"`가 빠져 restProps에 중복으로 남는 버그 수정
- RN Text 컴포넌트의 aria-* props가 NativeText에 불필요하게 전달되는 원인

## 원인
`emitObjectPatternDeclarators`에서 exclude 키 수집 시 `identifier_reference`와 `binding_identifier`만 체크하고, `string_literal` 키를 무시

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/es5-rn.test.ts` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)