### PR TITLE
fix(flow): component ref → React.forwardRef 래핑

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -3919,19 +3919,45 @@ test "Flow: class with typed methods does not crash transformer" {
 // Flow: component declaration → props destructuring
 // ============================================================
 
-test "Flow: component params → object destructuring" {
+test "Flow: component with ref → React.forwardRef" {
     var r = try e2eFlow(std.testing.allocator,
         \\component View(ref, ...props: any) {
         \\  return null;
         \\}
     );
     defer r.deinit();
-    // component View(ref, ...props) → function View({ ref:ref, ...props })
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "function View(") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "ref:ref") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "...props") != null);
-    // 별도 함수 파라미터가 아닌 단일 destructuring 파라미터여야 함
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "function View(ref,") == null);
+    // component View(ref, ...props) →
+    //   function View_withRef({...props}, ref) { ... }
+    //   const View = React.forwardRef(View_withRef);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function View_withRef(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "React.forwardRef(View_withRef)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const View") != null);
+    // ref는 두 번째 파라미터
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "},ref)") != null or
+        std.mem.indexOf(u8, r.output, "}, ref)") != null or
+        std.mem.indexOf(u8, r.output, " },ref)") != null);
+}
+
+test "Flow: component without ref → plain function" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\component Bar(name: string, age: number) {
+        \\  return null;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function Bar(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "forwardRef") == null);
+}
+
+test "Flow: component rest only → single param" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\component Baz(...props: any) {
+        \\  return null;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function Baz(props)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "forwardRef") == null);
 }
 
 test "Flow: component param with type annotation stripped" {

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -360,6 +360,9 @@ pub const Node = struct {
         flow_exact_object_type,
         /// match (expr) { ... } — Flow match expression
         flow_match_expression,
+        /// Flow component with ref → React.forwardRef wrapper
+        /// extra = [name, params_start, params_len, body]
+        flow_component_wrapper,
 
         // ==============================================================
         // TypeScript Expressions

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -971,10 +971,21 @@ fn parseFlowComponentOrHookType(self: *Parser) ParseError2!NodeIndex {
 
 /// Flow Component Syntax: `component View(ref?, ...props: Props) { ... }`
 /// Hook Syntax: `hook useFoo(x: number) { ... }`
-/// 타입 스트리핑 시 함수 선언으로 변환한다.
-/// 파라미터의 타입 어노테이션, renders 절, 제네릭은 모두 제거된다.
+///
+/// 변환 규칙 (hermes-parser 호환):
+/// - ref 파라미터가 있으면:
+///   `const View = React.forwardRef(View_withRef);`
+///   `function View_withRef({...props}, ref) { ... }`
+///   → ref는 두 번째 인자, 나머지는 props object destructuring
+/// - ref 없으면:
+///   `function View({name, ...props}) { ... }`
+/// - rest만 있으면 (...props):
+///   `function View(props) { ... }` (destructuring 아닌 단일 param)
+/// - hook은 ref 처리 없이 일반 함수 (component와 동일한 파라미터 파싱)
 pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
+    const keyword_text = self.ast.source[self.currentSpan().start..self.currentSpan().end];
+    const is_hook = std.mem.eql(u8, keyword_text, "hook");
     try self.advance(); // skip 'component' / 'hook'
 
     // 함수 이름
@@ -985,14 +996,18 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
         _ = try parseTypeParameterDeclaration(self);
     }
 
-    // component 파라미터를 단일 객체 destructuring 파라미터로 변환.
-    // component View(ref?, ...props: ViewProps) { ... }
-    // → function View({ ref, ...props }) { ... }
-    // React가 component를 View(props) 하나의 인자로 호출하므로,
-    // component 파라미터는 props 객체의 프로퍼티를 나타낸다.
+    // component 파라미터를 파싱.
+    // ref 파라미터가 있으면 분리하고, 나머지는 props object destructuring으로 변환.
     try self.expect(.l_paren);
     const scratch_top = self.saveScratch();
     const param_start_span = self.currentSpan();
+
+    var has_ref = false;
+    var ref_node: NodeIndex = .none;
+    var has_rest = false;
+    var rest_node: NodeIndex = .none;
+    var prop_count: u32 = 0;
+
     while (self.current() != .r_paren and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
 
@@ -1004,14 +1019,16 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
                 try self.advance();
                 _ = try parseType(self);
             }
-            try self.scratch.append(self.allocator, try self.ast.addNode(.{
+            has_rest = true;
+            rest_node = try self.ast.addNode(.{
                 .tag = .binding_rest_element,
                 .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
                 .data = .{ .unary = .{ .operand = rest_name, .flags = 0 } },
-            }));
+            });
         } else {
             // propName: Type = default → binding_property
             const prop_name = try self.parseSimpleIdentifier();
+            const prop_text = self.ast.source[self.ast.getNode(prop_name).span.start..self.ast.getNode(prop_name).span.end];
             _ = try self.eat(.question);
             if (self.current() == .colon) {
                 try self.advance();
@@ -1027,29 +1044,60 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
                 });
             } else prop_name;
 
-            try self.scratch.append(self.allocator, try self.ast.addNode(.{
-                .tag = .binding_property,
-                .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
-                .data = .{ .binary = .{ .left = prop_name, .right = right_node, .flags = 0 } },
-            }));
+            // ref 파라미터는 분리 (hook에서는 ref도 일반 prop으로 취급)
+            if (!is_hook and std.mem.eql(u8, prop_text, "ref")) {
+                has_ref = true;
+                ref_node = right_node; // ref 또는 assignment_pattern(ref = default)
+            } else {
+                try self.scratch.append(self.allocator, try self.ast.addNode(.{
+                    .tag = .binding_property,
+                    .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
+                    .data = .{ .binary = .{ .left = prop_name, .right = right_node, .flags = 0 } },
+                }));
+                prop_count += 1;
+            }
         }
 
         if (!try self.eat(.comma)) break;
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
-    const prop_items = self.scratch.items[scratch_top..];
-    const prop_list = try self.ast.addNodeList(prop_items);
+    // 파라미터 구성:
+    // - rest만 있고 다른 prop 없으면 → 단일 파라미터 (function Name(props))
+    // - prop이 있으면 → object_pattern ({ name, ...rest })
+    // - ref가 있으면 → 두 번째 파라미터로 추가
+    var params: ast_mod.NodeList = undefined;
+
+    if (prop_count == 0 and has_rest and !has_ref) {
+        // rest만 있으면 destructuring 없이 단일 param: function Baz(props)
+        const rest_inner = self.ast.getNode(rest_node).data.unary.operand;
+        params = try self.ast.addNodeList(&.{rest_inner});
+    } else if (prop_count == 0 and !has_rest and !has_ref) {
+        // 파라미터 없음
+        params = try self.ast.addNodeList(&.{});
+    } else {
+        // object_pattern 생성 (ref 제외한 props)
+        if (has_rest) {
+            try self.scratch.append(self.allocator, rest_node);
+        }
+        const all_prop_items = self.scratch.items[scratch_top..];
+        const prop_list = try self.ast.addNodeList(all_prop_items);
+
+        const obj_pattern = try self.ast.addNode(.{
+            .tag = .object_pattern,
+            .span = .{ .start = param_start_span.start, .end = self.currentSpan().start },
+            .data = .{ .list = prop_list },
+        });
+
+        if (has_ref) {
+            // 두 번째 파라미터로 ref 추가: function Name_withRef({...props}, ref)
+            params = try self.ast.addNodeList(&.{ obj_pattern, ref_node });
+        } else {
+            params = try self.ast.addNodeList(&.{obj_pattern});
+        }
+    }
+
     self.restoreScratch(scratch_top);
     try self.expect(.r_paren);
-
-    // object_pattern 노드 생성: { ref, ...props }
-    const obj_pattern = try self.ast.addNode(.{
-        .tag = .object_pattern,
-        .span = .{ .start = param_start_span.start, .end = self.currentSpan().start },
-        .data = .{ .list = prop_list },
-    });
-    // 단일 파라미터로 래핑
-    const params = try self.ast.addNodeList(&.{obj_pattern});
 
     try trySkipRendersClause(self);
 
@@ -1061,13 +1109,32 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
     const body = try self.parseBlockStatement();
     self.restoreFunctionContext(saved_ctx);
 
-    // 함수 선언 노드로 생성 (extra: [name, params_start, params_len, body, flags, return_type])
+    if (has_ref) {
+        // ref가 있으면 React.forwardRef로 래핑.
+        // 파서에서는 inner function (이름 없이)을 생성하고,
+        // transformer가 _withRef suffix 이름 생성 + forwardRef 래핑을 처리한다.
+        //
+        // flow_component_wrapper: extra = [name, params_start, params_len, body]
+        const wrapper_extra = try self.ast.addExtra(@intFromEnum(name));
+        _ = try self.ast.addExtra(params.start);
+        _ = try self.ast.addExtra(params.len);
+        _ = try self.ast.addExtra(@intFromEnum(body));
+
+        return try self.ast.addNode(.{
+            .tag = .flow_component_wrapper,
+            .span = .{ .start = start, .end = self.currentSpan().start },
+            .data = .{ .extra = wrapper_extra },
+        });
+    }
+
+    // ref가 없으면 일반 함수 선언
+    const none = @intFromEnum(NodeIndex.none);
     const extra_start = try self.ast.addExtra(@intFromEnum(name));
     _ = try self.ast.addExtra(params.start);
     _ = try self.ast.addExtra(params.len);
     _ = try self.ast.addExtra(@intFromEnum(body));
-    _ = try self.ast.addExtra(0); // flags: 0 (not async, not generator)
-    _ = try self.ast.addExtra(@intFromEnum(NodeIndex.none)); // return_type: stripped
+    _ = try self.ast.addExtra(0);
+    _ = try self.ast.addExtra(none);
 
     return try self.ast.addNode(.{
         .tag = .function_declaration,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -413,6 +413,9 @@ pub const Transformer = struct {
 
             .flow_match_expression => self.visitFlowMatch(node),
 
+            // Flow component with ref → function Name_withRef + const Name = React.forwardRef(...)
+            .flow_component_wrapper => self.visitFlowComponentWrapper(node),
+
             // === 리스트 노드: 자식을 하나씩 방문하며 복사 ===
             .program,
             .block_statement,
@@ -1274,6 +1277,86 @@ pub const Transformer = struct {
             .span = span,
             .data = .{ .extra = call_extra },
         });
+    }
+
+    /// Flow component with ref → 2개 statement로 변환:
+    ///   function Name_withRef({...props}, ref) { ... }    ← pending_nodes
+    ///   const Name = React.forwardRef(Name_withRef);       ← 반환값
+    ///
+    /// extra = [name, params_start, params_len, body]
+    fn visitFlowComponentWrapper(self: *Transformer, node: Node) Error!NodeIndex {
+        const extras = self.old_ast.extra_data.items;
+        const e = node.data.extra;
+        const name_idx: NodeIndex = @enumFromInt(extras[e]);
+        const params_start = extras[e + 1];
+        const params_len = extras[e + 2];
+        const body_idx: NodeIndex = @enumFromInt(extras[e + 3]);
+        const span = node.span;
+
+        // 원본 이름에서 _withRef suffix 생성
+        const name_node = self.old_ast.getNode(name_idx);
+        const name_text = self.old_ast.source[name_node.span.start..name_node.span.end];
+
+        const suffix = "_withRef";
+        const with_ref_buf = try self.allocator.alloc(u8, name_text.len + suffix.len);
+        @memcpy(with_ref_buf[0..name_text.len], name_text);
+        @memcpy(with_ref_buf[name_text.len..], suffix);
+
+        // 1) function Name_withRef({...props}, ref) { ... } 생성
+        const with_ref_span = try self.new_ast.addString(with_ref_buf);
+        const with_ref_name = try es_helpers.makeBindingIdentifier(self, with_ref_span);
+
+        // ES2015 params lowering
+        var es2015_body_stmts: ?std.ArrayList(NodeIndex) = null;
+        defer if (es2015_body_stmts) |*s| s.deinit(self.allocator);
+
+        const new_params = if (self.options.unsupported.default_params and
+            es2015_params.ES2015Params(Transformer).hasDefaultOrRest(self, params_start, params_len))
+        blk: {
+            const lr = try es2015_params.ES2015Params(Transformer).lowerParams(self, params_start, params_len, span);
+            es2015_body_stmts = lr.body_stmts;
+            break :blk lr.new_params;
+        } else try self.visitExtraList(params_start, params_len);
+
+        var new_body = try self.visitNode(body_idx);
+
+        if (es2015_body_stmts) |stmts| {
+            if (stmts.items.len > 0 and !new_body.isNone()) {
+                new_body = try self.prependStatementsToBody(new_body, stmts.items);
+            }
+        }
+
+        const none = @intFromEnum(NodeIndex.none);
+        const func_extra = try self.new_ast.addExtras(&.{
+            @intFromEnum(with_ref_name),
+            new_params.start,
+            new_params.len,
+            @intFromEnum(new_body),
+            0, // flags
+            none, // return_type
+        });
+        const inner_func = try self.new_ast.addNode(.{
+            .tag = .function_declaration,
+            .span = span,
+            .data = .{ .extra = func_extra },
+        });
+
+        // pending_nodes에 삽입 → visitExtraList가 이 문 다음에 const 선언을 배치
+        try self.pending_nodes.append(self.allocator, inner_func);
+
+        // 2) const Name = React.forwardRef(Name_withRef) 생성
+        const react_ref = try es_helpers.makeIdentifierRef(self, "React");
+        const forward_ref = try es_helpers.makeIdentifierRef(self, "forwardRef");
+        const callee = try es_helpers.makeStaticMember(self, react_ref, forward_ref, span);
+
+        const arg = try es_helpers.makeIdentifierRef(self, with_ref_buf);
+        const call = try es_helpers.makeCallExpr(self, callee, &.{arg}, span);
+
+        const binding_span = try self.new_ast.addString(name_text);
+        const binding = try es_helpers.makeBindingIdentifier(self, binding_span);
+        const declarator = try es_helpers.makeDeclarator(self, binding, call, span);
+
+        return es_helpers.makeVarDeclaration(self, &.{declarator}, 2, span); // 2 = const
     }
 
     fn visitTsExpression(self: *Transformer, node: Node) Error!NodeIndex {


### PR DESCRIPTION
## Summary
- Flow `component View(ref?, ...props)` 문법에서 ref를 props 안에 넣어서 React가 ref를 받지 못하는 버그 수정
- hermes-parser와 동일하게 `React.forwardRef` + 2번째 인자로 ref 분리
- RN View/Text 등 모든 component with ref 컴포넌트에 영향

## 변환 결과
```js
// Before (잘못됨)
function View({ref, ...props}) { ... }  // ref가 props 안에 → React가 ref 전달 불가

// After (hermes-parser 호환)
function View_withRef({...props}, ref) { ... }  // ref가 2번째 인자
const View = React.forwardRef(View_withRef);
```

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/es5-rn.test.ts` 통과
- [x] 테스트 3개 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)