### PR TITLE
test: template literal 스냅샷 업데이트

### DIFF
--- a/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
@@ -1029,13 +1029,13 @@ exports[`TSC: es6/templates templateStringInCallExpressionES6 1`] = `
 
 exports[`TSC: es6/templates templateStringInConditional 1`] = `
 "// @target: es2015
-var x = \`abc\${ " " }def\`  ? \`abc\${ " " }def\`  : \`abc\${" "}def\`;
+var x = \`abc\${ " " }def\`  ? \`abc\${" "}def\` : \`abc\${" "}def\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringInConditionalES6 1`] = `
 "// @target: ES6
-var x = \`abc\${ " " }def\`  ? \`abc\${ " " }def\`  : \`abc\${" "}def\`;
+var x = \`abc\${ " " }def\`  ? \`abc\${" "}def\` : \`abc\${" "}def\`;
 "
 `;
 
@@ -1059,13 +1059,13 @@ var x = \`abc\${ 1 }def\`  / 1;
 
 exports[`TSC: es6/templates templateStringInEqualityChecks 1`] = `
 "// @target: es2015
-var x = \`abc\${0}abc\`  === \`abc\` || \`abc\` !== \`abc\${0}abc\`  && \`abc\${0}abc\` == "abc0abc" && "abc0abc" !== \`abc\${0}abc\`;
+var x = \`abc\${0}abc\`  === \`abc\` || \`abc\` !== \`abc\${0}abc\` && \`abc\${0}abc\` == "abc0abc" && "abc0abc" !== \`abc\${0}abc\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringInEqualityChecksES6 1`] = `
 "// @target: ES6
-var x = \`abc\${0}abc\`  === \`abc\` || \`abc\` !== \`abc\${0}abc\`  && \`abc\${0}abc\` == "abc0abc" && "abc0abc" !== \`abc\${0}abc\`;
+var x = \`abc\${0}abc\`  === \`abc\` || \`abc\` !== \`abc\${0}abc\` && \`abc\${0}abc\` == "abc0abc" && "abc0abc" !== \`abc\${0}abc\`;
 "
 `;
 
@@ -1073,7 +1073,7 @@ exports[`TSC: es6/templates templateStringInFunctionExpression 1`] = `
 "var x = function y() {
 	\`abc\${ 0 }def\`
     ;
-	return \`abc\${ 0 }def\`;
+	return \`abc\${0}def\`;
 };
 "
 `;
@@ -1082,7 +1082,7 @@ exports[`TSC: es6/templates templateStringInFunctionExpressionES6 1`] = `
 "var x = function y() {
 	\`abc\${ 0 }def\`
     ;
-	return \`abc\${ 0 }def\`;
+	return \`abc\${0}def\`;
 };
 "
 `;
@@ -1221,13 +1221,13 @@ switch (\`abc\${0}abc\`) {
 
 exports[`TSC: es6/templates templateStringInTaggedTemplate 1`] = `
 "// @target: es2015
-\`I AM THE \${ \`\${ \`TAG\` } \` } PORTION\`    \`I \${"AM"} THE TEMPLATE PORTION\`;
+\`I AM THE \${\`\${ \`TAG\` } \` } PORTION\`\`I \${"AM"} THE TEMPLATE PORTION\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringInTaggedTemplateES6 1`] = `
 "// @target: ES6
-\`I AM THE \${ \`\${ \`TAG\` } \` } PORTION\`    \`I \${"AM"} THE TEMPLATE PORTION\`;
+\`I AM THE \${\`\${ \`TAG\` } \` } PORTION\`\`I \${"AM"} THE TEMPLATE PORTION\`;
 "
 `;
 
@@ -1694,25 +1694,25 @@ var x = \`abc\${{ x: 10, y: 20 }}def\`;
 
 exports[`TSC: es6/templates templateStringWithEmbeddedTemplateString 1`] = `
 "// @target: es2015
-var x = \`123\${\`456 \${ " | " } 654\` }321 123\${\`456 \${ " | " } 654\` }321\`;
+var x = \`123\${\`456 \${ " | " } 654\` }321 123\${\`456 \${" | "} 654\`}321\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringWithEmbeddedTemplateStringES6 1`] = `
 "// @target: ES6
-var x = \`123\${\`456 \${ " | " } 654\` }321 123\${\`456 \${ " | " } 654\` }321\`;
+var x = \`123\${\`456 \${ " | " } 654\` }321 123\${\`456 \${" | "} 654\`}321\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringWithEmbeddedTypeAssertionOnAddition 1`] = `
 "// @target: es2015
-var x = \`abc\${ <any>(10 + 10) }def\`;
+var x = \`abc\${10 + 10}def\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringWithEmbeddedTypeAssertionOnAdditionES6 1`] = `
 "// @target: ES6
-var x = \`abc\${ <any>(10 + 10) }def\`;
+var x = \`abc\${10 + 10}def\`;
 "
 `;
 

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -213,7 +213,7 @@ exports[`TSC: expressions asOperator2 1`] = `
 `;
 
 exports[`TSC: expressions asOperator3 1`] = `
-"var a = \`\${123 + 456 as number}\`;
+"var a = \`\${123 + 456}\`;
 var b = \`leading \${123 + 456}\`;
 var c = \`\${123 + 456} trailing\`;
 var d = \`Hello \${123} World\`;


### PR DESCRIPTION
## Summary

단일 AST 통합 후 TS type assertion 스트리핑 시 template expression의 공백 출력이 변경됨.

- `abc${ <any>(10 + 10) }def` → `abc${10 + 10}def`
- 타입 제거 시 expression span이 inner span으로 축소되어 공백이 사라짐
- 의미적으로 동일한 코드, 스냅샷만 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)