### PR TITLE
fix(bundler): TLA async 누락 수정 + 문서 현행화

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,12 +67,12 @@ Per-File Arena (단일 할당자, 파일 처리 후 한 번에 해제)
 ### TypeScript/Flow Handling (D002, D005, D024)
 - 타입 체크 안 함 (스트리핑만)
 - TS 5.8까지 전체 지원
-- Flow: 미지원 (현재 우선순위 낮음, RN 지원 시 결정. 상세: [FLOW.md](../FLOW.md))
+- ✅ Flow: TIER 1+2+3 타입 스트리핑 완료 (flow.zig 독립 구현, Metro 410/410 통과. 상세: [FLOW.md](../FLOW.md))
 - ✅ Legacy decorator 구현 완료 (experimentalDecorators)
 - Stage 3 decorator: 후순위 (스펙 안정화 후)
 
 ### Output (D006, D008, D009, D012)
-- ESM + CJS (UMD는 번들러 Phase)
+- ESM + CJS + IIFE (UMD/AMD는 후순위)
 - JSX Classic + Automatic 둘 다
 - 소스맵 inline + external + hidden 전부
 - 에러 출력: 코드 프레임 + JSON

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@
 | 6a-ex | exports 조건 해석 Node.js 스펙 준수 (tslib CJS→ESM 해결) | ✅ |
 | 6b. Dev server | HTTP+WS, Live Reload, HMR, React Fast Refresh, CSS 핫 리로드 | ✅ |
 | Test262 | 50,504건 100% 통과 | ✅ |
-| Smoke | 131개 패키지 (mitt, zustand, 엔진 타겟 4개 추가), avg 0.94x, ❌ 0개 | ✅ |
+| Smoke | 143개 패키지 (mitt, zustand, 엔진 타겟 4개 추가), avg 0.94x, ❌ 0개 | ✅ |
 | 7-2. emit 병렬화 | 모듈별 transform+codegen 스레드 풀 실행 | ✅ |
 | 7-3. resolve 병렬화 | 배치 내 resolve 스레드 풀 + ResolveCache Mutex | ✅ |
 | 7-fix. fixpoint oscillation | 미사용 모듈 제거를 fixpoint 후로 이동 (100회→2회) | ✅ |
@@ -33,6 +33,7 @@
 | 20. RN 플랫폼 | `--platform=react-native` 프리셋 (resolve-extensions, main-fields, Flow, exports 조건) | ✅ |
 | 21. watch-json | `--watch-json` NDJSON 이벤트 출력 (외부 번들러 연동용) | ✅ |
 | 22. 증분 빌드 | PersistentModuleStore 파싱 캐시 + ResolveCache 보존 (watch/serve 리빌드 최적화) | ✅ |
+| 23. jsx-dev | React 개발 모드 `jsxDEV` + `__source`/`__self`, `--jsx=automatic-dev` / `--jsx-dev` | ✅ |
 
 ## 번들러 성능 현황 (2592모듈, 2026-03-31 실측)
 ZTS 136ms vs esbuild 110ms (**1.24배**).
@@ -51,10 +52,6 @@ ZTS 136ms vs esbuild 110ms (**1.24배**).
 - esbuild/rolldown 호환 CLI 옵션 ~20개 일괄 추가
 - `--outbase`, `--packages=external`, `--drop-labels`, `--pure:fn`, `--line-limit` 등
 - 개별 난이도 S, 한 PR로 묶어서 처리
-
-**jsx-dev** — M (1~2일)
-- React 개발 모드 `jsxDEV` + `__source`/`__self` 정보 삽입
-- dev server HMR에서 에러 위치 표시에 필수
 
 **CSS 번들링** — XL (1주+)
 - 현재 플러그인 위임 (`--loader:.css=text` 또는 PostCSS/Lightning CSS 플러그인)
@@ -88,7 +85,7 @@ AST 안정화 ──────────────┬──→ WASM 공개
                          ├──→ 배치 E (S급 CLI 옵션 일괄)
                          └──→ ✅ 플러그인 API (1-2단계 완료, N-API 선택적)
 
-독립 (아무 때나): ✅ Flow (완료), SIMD, jsx-dev, using 다운레벨링
+독립 (아무 때나): ✅ Flow (완료), ✅ jsx-dev (완료), SIMD, using 다운레벨링
 ```
 
 ## 미지원 기능 (상용 번들러 대비)
@@ -129,7 +126,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
   esbuild compat-table 기반, 8개 엔진(chrome/firefox/safari/edge/node/deno/ios/hermes) × 18개 feature.
   ES 버전 타겟(`--target=es2015~esnext`)도 동일한 UnsupportedFeatures bitmask로 통합.
 
-- **jsx-dev** — `M` | React 개발 모드 `jsxDEV` + `__source`/`__self` 정보 삽입
+- ~~**jsx-dev**~~ — ✅ 완료. `--jsx=automatic-dev` / `--jsx-dev` React 개발 모드 `jsxDEV` + `__source`/`__self`
 - **UMD/AMD 포맷** — `M` | `--format=umd` / `--format=amd` 출력 (라이브러리 빌드)
 - **manualChunks** — `L` | 사용자 정의 청크 분할 규칙 (rolldown advancedChunks)
 - **preserveModules** — `L` | 모듈 구조 유지 출력 (라이브러리 빌드용)
@@ -193,10 +190,14 @@ CSS 번들링/플러그인 API는 JS 전용 경계를 넘어야 함.
 | Chunk | chunk.zig | CSS 별도 청크 타입 추가 |
 
 ### 최근 버그 수정
-- ✅ JSX 파서: closing tag 뒤 텍스트 파싱 실패 (advanceAfterJSXClose — Vite 템플릿 번들링 가능)
-- ✅ enum re-export: `enum Foo {} export { Foo }` semantic 에러 (predeclareEnumDecl 추가)
+- ✅ TLA(Top-Level Await): `__esm` 래핑 시 `async` 키워드 누락 + preamble `await` 누락 (#779)
+- ✅ _default 합성 변수 충돌: 여러 ESM 모듈의 export default가 같은 변수 공유 (#704)
+- ✅ re-export default 할당 누락: `export { default } from` 패턴에서 __esm body 비어있음 (#705)
+- ✅ var _default 중복 선언: import + export default 패턴에서 호이스팅 충돌 (#706)
+- ✅ CJS 엔트리 자동 호출 누락: IIFE 번들에서 `require_index()` 미삽입 (#707)
+- ✅ JSX 파서: closing tag 뒤 텍스트 파싱 실패 (advanceAfterJSXClose)
+- ✅ enum re-export: `enum Foo {} export { Foo }` semantic 에러
 - ✅ CLI memory leak: `--plugin`, `--proxy` 옵션의 ArrayList 미해제
-- ✅ `--external=pkg` 형태 미지원 (기존 `--external pkg`만 가능)
 
 ### 알려진 제한 (Known Limitations)
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -4,8 +4,10 @@
 src/
   main.zig                  # CLI 엔트리포인트 (zts 커맨드)
   root.zig                  # 라이브러리 엔트리포인트 (모든 모듈 re-export)
+  transpile.zig             # 트랜스파일 파이프라인 통합 (파일/stdin → JS 출력)
   diagnostic.zig            # 진단 시스템 (ParseError, SemanticError 통합)
   config.zig                # 설정 구조 (CompilerOptions, ResolverOptions, BundlerOptions)
+  mimalloc.zig              # mimalloc 바인딩 (릴리즈 빌드 backing allocator)
   lexer/                    # Phase 1: 렉서 ✅
     mod.zig                 #   렉서 엔트리 + re-export
     token.zig               #   토큰 종류(Kind ~208개), Span, Token, 키워드 맵
@@ -23,6 +25,7 @@ src/
     jsx.zig                 #   JSX 파싱 (element, fragment, attributes)
     module.zig              #   import/export 파싱
     ts.zig                  #   TypeScript 타입 어노테이션 파싱
+    flow.zig                #   Flow 타입 어노테이션 파싱 (TIER 1+2+3, Metro 검증)
   semantic/                 # 의미 분석 ✅
     mod.zig                 #   의미 분석 엔트리 + re-export
     analyzer.zig            #   의미 분석기 (~3000줄, 스코프/심볼 추적)
@@ -32,6 +35,9 @@ src/
   transformer/              # Phase 3: 트랜스포머 ✅ + ES 다운레벨링 ✅
     mod.zig                 #   트랜스포머 엔트리 + re-export
     transformer.zig         #   Visitor 기반 순회 + AST 변환
+    compat.zig              #   엔진 타겟 호환성 매핑 (chrome/safari/node 등 feature-level)
+    jsx_lowering.zig        #   JSX lowering (classic/automatic/automatic-dev)
+    es2024.zig              #   ES2024 다운레벨링 (using/await using)
     es2022.zig              #   ES2022 다운레벨링 (class static block, this 치환)
     es2021.zig              #   ES2021 다운레벨링 (??=, ||=, &&=)
     es2020.zig              #   ES2020 다운레벨링 (??, ?.)
@@ -76,9 +82,17 @@ src/
     resolve_cache.zig       #   해석 결과 캐싱 (import kind별)
     import_scanner.zig      #   import/export 문 추출
     binding_scanner.zig     #   심볼 바인딩 추적
+    plugin.zig              #   Zig builtin 플러그인 (함수 포인터 기반)
+    subprocess_plugin.zig   #   JS subprocess 플러그인 (stdin/stdout JSON IPC)
+    json_to_esm.zig         #   JSON → ESM AST 변환 (export default <value>)
+    mpsc_channel.zig        #   MPSC 채널 (Producer-Consumer 파이프라인)
+    module_store.zig        #   PersistentModuleStore (증분 빌드 파싱 캐시)
+    incremental.zig         #   증분 빌드 로직 (watch/serve 리빌드)
+    runtime_helpers.zig     #   런타임 헬퍼 (__esm, __commonJS, __export 등)
   server/                   # Phase 6b: 개발 서버 + HMR ✅
     mod.zig                 #   서버 엔트리 + re-export
     dev_server.zig          #   HTTP + WebSocket 서버 (HMR, Fast Refresh)
+    file_watcher.zig        #   파일 변경 감지 (watch/serve)
     mime.zig                #   MIME 타입 매핑
   regexp/                   # RegExp 검증 ✅
     mod.zig                 #   RegExp 엔트리 + re-export

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -24,8 +24,20 @@ zig build test                          # 모든 모듈 테스트
 cd tests/integration && bun test     # CLI 통합 테스트
 cd tests/e2e && bun test             # Playwright E2E (dev server)
 ```
+테스트 파일:
+- `tests/integration/tests/bundle-smoke.test.ts` — 번들 스모크 (99개 케이스)
+- `tests/integration/tests/devserver.test.ts` — 개발 서버
+- `tests/integration/tests/downlevel.test.ts` — ES 다운레벨링
+- `tests/integration/tests/es5-rn.test.ts` — RN ES5 + Hermes
+- `tests/integration/tests/flow-rn.test.ts` — Flow + React Native
+- `tests/integration/tests/hermes-runtime.test.ts` — Hermes 런타임
+- `tests/integration/tests/plugin.test.ts` — JS 플러그인
+- `tests/integration/tests/polyfill-rbm.test.ts` — 폴리필 + run-before-main
+- `tests/integration/tests/watch-json.test.ts` — watch-json NDJSON 이벤트
+- `tests/e2e/tests/smoke.test.ts` — E2E 스모크 (브라우저 실행)
+- `tests/e2e/tests/browser-smoke.test.ts` — 브라우저 번들 E2E
 
 ## 스모크 테스트 (실제 패키지 빌드)
 ```bash
-cd tests/benchmark && bun run smoke.ts  # 125개 패키지 빌드+실행 검증 (avg 0.74x)
+cd tests/benchmark && bun run smoke.ts  # 143개 패키지 빌드+실행 검증
 ```

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -335,6 +335,9 @@ pub fn emitWithTreeShaking(
                             types.makeInitVarName(allocator, rbm.path) catch null;
                         if (call_name) |name| {
                             defer allocator.free(name);
+                            if (rbm.wrap_kind != .cjs and rbm.uses_top_level_await) {
+                                try module_output.appendSlice(allocator, "await ");
+                            }
                             try module_output.appendSlice(allocator, name);
                             try module_output.appendSlice(allocator, "();\n");
                             module_line += 1;
@@ -2716,7 +2719,11 @@ fn emitEsmWrappedModule(
                         defer allocator.free(iv);
                         const ev = try types.makeExportsVarName(allocator, source_mod.path);
                         defer allocator.free(ev);
-                        try reexport_buf.appendSlice(allocator, "(");
+                        if (source_mod.uses_top_level_await) {
+                            try reexport_buf.appendSlice(allocator, "(await ");
+                        } else {
+                            try reexport_buf.appendSlice(allocator, "(");
+                        }
                         try reexport_buf.appendSlice(allocator, iv);
                         try reexport_buf.appendSlice(allocator, "(), __toCommonJS(");
                         try reexport_buf.appendSlice(allocator, ev);
@@ -2753,6 +2760,7 @@ fn emitEsmWrappedModule(
             const src_mod = &l.modules[src_i];
             switch (src_mod.wrap_kind) {
                 .esm => {
+                    if (src_mod.uses_top_level_await) try star_init_buf.appendSlice(allocator, "await ");
                     const iv = try types.makeInitVarName(allocator, src_mod.path);
                     defer allocator.free(iv);
                     try star_init_buf.appendSlice(allocator, iv);
@@ -2773,10 +2781,14 @@ fn emitEsmWrappedModule(
     //    호이스팅된 함수가 호출되기 전에 의존 모듈이 초기화되도록 보장한다.
     const preamble_code = if (metadata) |md| md.cjs_import_preamble else null;
 
+    const is_async = module.uses_top_level_await;
+
     if (options.minify_whitespace) {
         try wrapped.appendSlice(allocator, "var ");
         try wrapped.appendSlice(allocator, init_name);
-        try wrapped.appendSlice(allocator, "=__esm({\"");
+        try wrapped.appendSlice(allocator, "=__esm({");
+        if (is_async) try wrapped.appendSlice(allocator, "async ");
+        try wrapped.appendSlice(allocator, "\"");
         try wrapped.appendSlice(allocator, basename);
         try wrapped.appendSlice(allocator, "\"(){");
         if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
@@ -2787,7 +2799,9 @@ fn emitEsmWrappedModule(
     } else {
         try wrapped.appendSlice(allocator, "var ");
         try wrapped.appendSlice(allocator, init_name);
-        try wrapped.appendSlice(allocator, " = __esm({\n\t\"");
+        try wrapped.appendSlice(allocator, " = __esm({\n\t");
+        if (is_async) try wrapped.appendSlice(allocator, "async ");
+        try wrapped.appendSlice(allocator, "\"");
         try wrapped.appendSlice(allocator, basename);
         try wrapped.appendSlice(allocator, "\"() {\n");
         if (preamble_code) |p| {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -987,7 +987,9 @@ pub const Linker = struct {
                 if (canonical_mod < self.modules.len and self.modules[canonical_mod].wrap_kind == .esm) {
                     if (!esm_init_set.contains(@intCast(canonical_mod))) {
                         try esm_init_set.put(@intCast(canonical_mod), {});
-                        const init_name = try types.makeInitVarName(self.allocator, self.modules[canonical_mod].path);
+                        const target_mod = &self.modules[canonical_mod];
+                        if (target_mod.uses_top_level_await) try preamble.write("await ");
+                        const init_name = try types.makeInitVarName(self.allocator, target_mod.path);
                         defer self.allocator.free(init_name);
                         try preamble.write(init_name);
                         try preamble.write("();\n");


### PR DESCRIPTION
## Summary
- __esm 래핑 시 top-level await 모듈에 `async` 키워드 누락 수정 (#779)
  - emitter: `__esm({ async "file.js"() { await ... } })` 형태로 출력
  - linker preamble: `await init_xxx();` 호출
  - star init / re-export default / run-before-main 경로 모두 수정
- 문서 현행화: STRUCTURE.md, ARCHITECTURE.md, ROADMAP.md, TESTING.md

## 문서 변경 내역
- **STRUCTURE.md**: 누락 파일 14개 추가 (flow.zig, compat.zig, jsx_lowering.zig, es2024.zig, plugin.zig, subprocess_plugin.zig, json_to_esm.zig, mpsc_channel.zig, module_store.zig, incremental.zig, runtime_helpers.zig, file_watcher.zig, transpile.zig, mimalloc.zig)
- **ARCHITECTURE.md**: Flow "미지원" → "완료", 출력 포맷 ESM+CJS+IIFE 반영
- **ROADMAP.md**: jsx-dev 완료 추가, 스모크 131→143개, 최근 버그 수정 5건 추가 (#704~#707, #779)
- **TESTING.md**: 스모크 125→143개, 통합 테스트 11개 파일 목록 추가

## Test plan
- [x] `zig build test` 통과
- [x] `bun test tests/bundle-smoke.test.ts` 99개 통과
- [x] TLA 번들 출력 확인: `async "file.js"()` 키워드 정상 출력

🤖 Generated with [Claude Code](https://claude.com/claude-code)