### PR TITLE
fix(ast): object_property 노드 레이아웃 오분류 수정 (#790)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -619,8 +619,8 @@ pub const Node = struct {
                 .formal_parameter => .{ .kind = .extra, .child_offsets = &.{ 0, 2 } },
                 // unary/update_expression: 파서에서 data.extra로 생성 — extra = [operand(0), flags]
                 .unary_expression, .update_expression => .{ .kind = .extra, .child_offsets = &.{0} },
-                // object_property: extra = [key(0), value(1), flags]
-                .object_property => .{ .kind = .extra, .child_offsets = &.{ 0, 1 } },
+                // object_property: binary = { left: key, right: value, flags: prop_flags }
+                .object_property => .{ .kind = .binary },
                 // import_declaration: extra = [specs_start, specs_len, source(2)]
                 .import_declaration => .{ .kind = .extra, .child_offsets = &.{2} },
                 // export_named: extra = [decl(0), specs_start, specs_len, source(3)]

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -949,6 +949,40 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("20");
     });
 
+    // #790: for-loop �� object_property가 block scoping 스캔에서 ��한 루프를 유발하던 버그 수정
+    test("block scoping: for-let with nested if + object property (#790)", async () => {
+      const { dir, cleanup: cl } = await createFixture({
+        "index.ts": `
+          function test(arr: {a: any, b: number}[]) {
+            const result: any[] = [];
+            for (let i = 0; i < arr.length; i++) {
+              if (arr[i].a == null) {
+                const y = arr[i].b;
+                if (typeof y === 'number') {
+                  result.push({ b: y });
+                } else {
+                  return null;
+                }
+              }
+            }
+            return result;
+          }
+          const out = test([{a: null, b: 42}, {a: null, b: 7}]);
+          console.log(JSON.stringify(out));
+        `,
+      });
+      cleanup = cl;
+      const outFile = join(dir, "out.js");
+      const transpile = await runZts([join(dir, "index.ts"), "-o", outFile, "--target=es5"]);
+      expect(transpile.exitCode).toBe(0);
+
+      const code = readFileSync(outFile, "utf-8");
+      // let/const�� var로 변환되었는지 확인
+      expect(code).not.toContain("let ");
+      expect(code).not.toContain("const ");
+      expect(code).toContain("var ");
+    });
+
     // TODO: block scoping은 let→var만 변환, 블록 스코프 격리 미구현 (Phase 4)
     test.todo("let shadow in nested block", async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
## Summary
- `object_property`의 `getLayout()`이 `.extra`로 정의되어 있었지만 파서는 `.binary`로 저장
- block scoping의 `collectChildIndices`가 `.extra` 경로를 타면서 `node.data.extra`를 extra_data 인덱스로 잘못 해석 → 자기 자신을 자식으로 추가 → 무한 루프
- `--target=es5`에서 `for (let ...)` 내부에 `object_property`가 있을 때 hang 발생

## Test plan
- [x] 최소 재현 케이스로 hang 해소 확인
- [x] 원본 파일(`processBackgroundImage.js`) 변환 정상 확인
- [x] 유닛 테스트 전체 통과
- [x] 통합 테스트 (`downlevel.test.ts`) 148 pass / 0 fail
- [x] 회귀 테스트 추가: `block scoping: for-let with nested if + object property (#790)`

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)