### PR TITLE
fix(ast): export_default_declaration, jsx_fragment 레이아웃 오분류 수정

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -625,14 +625,14 @@ pub const Node = struct {
                 .import_declaration => .{ .kind = .extra, .child_offsets = &.{2} },
                 // export_named: extra = [decl(0), specs_start, specs_len, source(3)]
                 .export_named_declaration => .{ .kind = .extra, .child_offsets = &.{ 0, 3 } },
-                // export_default: extra = [decl(0), ...] — decl만 NodeIndex
-                .export_default_declaration => .{ .kind = .extra, .child_offsets = &.{0} },
+                // export_default: unary = { operand: decl, flags: 0 }
+                .export_default_declaration => .{ .kind = .unary },
                 // jsx_element: extra = [tag(0), attrs_start, attrs_len, children_start, children_len]
                 .jsx_element => .{ .kind = .extra, .child_offsets = &.{0} },
                 // jsx_opening_element: extra = [tag(0), attrs_start, attrs_len]
                 .jsx_opening_element => .{ .kind = .extra, .child_offsets = &.{0} },
-                // jsx_fragment: transformer에서 list로 처리하지만 extra로 분류
-                .jsx_fragment => .{ .kind = .extra, .child_offsets = &.{} },
+                // jsx_fragment: list = children (파서에서 .list로 저장)
+                .jsx_fragment => .{ .kind = .list },
                 // flow_component_wrapper: extra = [func_decl(0), const_decl(1)]
                 .flow_component_wrapper => .{ .kind = .extra, .child_offsets = &.{ 0, 1 } },
                 // TS declarations — 대부분 타입 전용이므로 런타임 워커에서 무시 가능

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -983,6 +983,42 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(code).toContain("var ");
     });
 
+    // AST layout 정합성: export_default_declaration (unary) + jsx_fragment (list)
+    test("export default + es5 target: layout mismatch 수정 확인", async () => {
+      const { dir, cleanup: cl } = await createFixture({
+        "index.ts": `
+          function greet() { return "hello"; }
+          export default greet;
+        `,
+      });
+      cleanup = cl;
+      const outFile = join(dir, "out.js");
+      const transpile = await runZts([join(dir, "index.ts"), "-o", outFile, "--target=es5"]);
+      expect(transpile.exitCode).toBe(0);
+      const code = readFileSync(outFile, "utf-8");
+      expect(code).toContain("export default greet");
+    });
+
+    test("jsx fragment in for-let: layout mismatch 수정 확인", async () => {
+      const { dir, cleanup: cl } = await createFixture({
+        "index.tsx": `
+          const items: any[] = [];
+          for (let i = 0; i < 3; i++) {
+            items.push(<><span>{i}</span></>);
+          }
+          console.log(items.length);
+        `,
+      });
+      cleanup = cl;
+      const outFile = join(dir, "out.js");
+      const transpile = await runZts([join(dir, "index.tsx"), "-o", outFile, "--target=es5"]);
+      expect(transpile.exitCode).toBe(0);
+      const code = readFileSync(outFile, "utf-8");
+      // let/const가 var로 변환되었는지 확인
+      expect(code).not.toContain("let ");
+      expect(code).toContain("var ");
+    });
+
     // TODO: block scoping은 let→var만 변환, 블록 스코프 격리 미구현 (Phase 4)
     test.todo("let shadow in nested block", async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
## Summary
- #790 수정 시 발견된 추가 AST 노드 레이아웃 불일치 2건 수정
- `export_default_declaration`: getLayout()이 `.extra`였지만 파서는 `.unary`로 저장 → `.unary`로 수정
- `jsx_fragment`: getLayout()이 `.extra`였지만 파서는 `.list`로 저장 → `.list`로 수정
- `object_property` (#790)과 동일한 종류의 버그 — `collectChildIndices`가 잘못된 data 경로를 타서 오동작 가능

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] 통합 테스트 (`downlevel.test.ts`) 150 pass / 0 fail
- [x] export default + es5 변환 테스트 추가
- [x] jsx fragment in for-let + es5 변환 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)