### PR TITLE
fix(transformer): class accessor extra_data dangling pointer 크래시 수정 (#788)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1426,14 +1426,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
         /// static method → ClassName.method = function() {}
         fn buildPrototypeAssignment(self: *Transformer, info: MethodInfo, class_name_span: Span, span: Span) Transformer.Error!NodeIndex {
             const member = self.ast.getNode(info.member_idx);
-            const method_extras = self.ast.extra_data.items;
+            // 주의: extra_data.items를 캐시하면 안 됨.
+            // visitExtraList/visitNode가 extra_data에 append하면 ArrayList가 재할당되어
+            // 캐시된 슬라이스가 dangling pointer가 됨. 매번 직접 읽기.
             const me = member.data.extra;
 
-            const key_idx: NodeIndex = @enumFromInt(method_extras[me]);
-            const params_start = method_extras[me + 1];
-            const params_len = method_extras[me + 2];
-            const body_idx: NodeIndex = @enumFromInt(method_extras[me + 3]);
-            const flags = method_extras[me + 4];
+            const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
+            const params_start = self.ast.extra_data.items[me + 1];
+            const params_len = self.ast.extra_data.items[me + 2];
+            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 3]);
+            const flags = self.ast.extra_data.items[me + 4];
 
             // function expression 생성 — ES2015 params lowering은 Pass 2에서 일괄 처리
             const new_params = try self.visitExtraList(params_start, params_len);
@@ -1560,9 +1562,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 used[i] = true;
 
                 const member = self.ast.getNode(info.member_idx);
-                const method_extras = self.ast.extra_data.items;
+                // 주의: extra_data.items를 캐시하면 안 됨 (#788).
+                // buildAccessorFunc → visitNode가 extra_data에 append하면
+                // ArrayList가 재할당되어 캐시된 슬라이스가 dangling pointer가 됨.
                 const me = member.data.extra;
-                const key_idx: NodeIndex = @enumFromInt(method_extras[me]);
+                const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
 
                 const func_expr = try buildAccessorFunc(self, info.member_idx, span);
                 const accessor_key = try es_helpers.makeIdentifierRef(self, if (info.is_getter) "get" else "set");
@@ -1578,7 +1582,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     if (used[j]) continue;
                     const next_member = self.ast.getNode(next.member_idx);
                     const next_me = next_member.data.extra;
-                    const next_key: NodeIndex = @enumFromInt(method_extras[next_me]);
+                    const next_key: NodeIndex = @enumFromInt(self.ast.extra_data.items[next_me]);
                     if (info.is_static == next.is_static and info.is_getter != next.is_getter and
                         keysMatch(self, key_idx, next_key))
                     {


### PR DESCRIPTION
## Summary
- `emitAccessors`에서 `self.ast.extra_data.items`를 슬라이스로 캐시한 뒤 `buildAccessorFunc` → `visitNode`가 extra_data에 append → ArrayList 재할당 → 캐시된 슬라이스가 dangling pointer
- 이후 `method_extras[next_me]`로 접근 시 0xAAAAAAAA 같은 쓰레기 값 → index out of bounds 패닉
- `buildPrototypeAssignment`에서도 동일 패턴 방어적 수정

## Test plan
- [x] RN ExampleApp `--target=es5` 번들링 크래시 해소 확인 (exitCode 0)
- [x] `es5-rn.test.ts` 17 pass / 0 fail
- [x] `downlevel.test.ts` 150 pass / 0 fail
- [x] 유닛 테스트 전체 통과

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)