### PR TITLE
fix(transformer): template literal 보간 표현식 괄호 추가 (#782)

### DIFF
--- a/src/transformer/es2015_template.zig
+++ b/src/transformer/es2015_template.zig
@@ -93,8 +93,14 @@ pub fn ES2015Template(comptime Transformer: type) type {
                         result = try buildBinaryPlus(self, result, str_node, span);
                     }
                 } else {
-                    const visited = try self.visitNode(@enumFromInt(raw_idx));
+                    var visited = try self.visitNode(@enumFromInt(raw_idx));
                     if (!visited.isNone()) {
+                        // 보간 표현식이 + 연산자 right에 올 때 우선순위 문제 방지.
+                        // 예: `${1+2}` → "" + (1 + 2), `${x ? "a" : "b"}` → "" + (x ? "a" : "b")
+                        if (needsParenForConcat(self, visited)) {
+                            const es_helpers = @import("es_helpers.zig");
+                            visited = try es_helpers.makeParenExpr(self, visited, span);
+                        }
                         result = try buildBinaryPlus(self, result, visited, span);
                     }
                 }
@@ -214,6 +220,42 @@ pub fn buildStringLiteral(self: anytype, text: []const u8) !NodeIndex {
 }
 
 /// a + b binary expression을 만든다.
+/// 보간 표현식이 string concat (+) right operand에 올 때 괄호가 필요한지 판별.
+/// +보다 낮은 우선순위(conditional, assignment, comma 등)나
+/// 같은 우선순위(+, -)는 left-to-right 결합으로 의미가 달라지므로 괄호 필요.
+/// 리터럴, identifier, call, member 등 원자적 표현식은 괄호 불필요.
+fn needsParenForConcat(self: anytype, idx: NodeIndex) bool {
+    if (idx.isNone()) return false;
+    const node = self.ast.getNode(idx);
+    return switch (node.tag) {
+        // 괄호 불필요: 원자적 표현식
+        .identifier_reference,
+        .this_expression,
+        .numeric_literal,
+        .string_literal,
+        .boolean_literal,
+        .null_literal,
+        .bigint_literal,
+        .regexp_literal,
+        .template_literal,
+        .array_expression,
+        .object_expression,
+        .call_expression,
+        .new_expression,
+        .static_member_expression,
+        .computed_member_expression,
+        .parenthesized_expression,
+        .tagged_template_expression,
+        .unary_expression,
+        .update_expression,
+        .await_expression,
+        .private_field_expression,
+        => false,
+        // 그 외(binary, conditional, assignment, sequence, yield 등)는 괄호 필요
+        else => true,
+    };
+}
+
 fn buildBinaryPlus(self: anytype, left: NodeIndex, right: NodeIndex, span: Span) !NodeIndex {
     return self.ast.addNode(.{
         .tag = .binary_expression,

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1481,8 +1481,8 @@ describe("ES 다운레벨링 런타임 테스트", () => {
 
     // --- SWC 대비 추가 테스트: Template Literals ---
 
-    // TODO: template literal 변환에서 연산자 우선순위 누락 — "" + 1 + 2 → "12" (기대: "3")
-    test.todo("template literal with expression", async () => {
+    // #782: template literal 변환에서 보간 표현식에 괄호 추가
+    test("template literal with expression (#782)", async () => {
       const result = await bundleAndRun(
         { "index.ts": "console.log(`${1 + 2} is three`);" },
         "index.ts",
@@ -1504,8 +1504,8 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("ab1cd");
     });
 
-    // TODO: template literal 변환에서 ternary 연산자 우선순위 누락
-    test.todo("template literal with ternary expression", async () => {
+    // #782: template literal 변환에서 ternary 표현식에 괄호 추가
+    test("template literal with ternary expression (#782)", async () => {
       const result = await bundleAndRun(
         { "index.ts": "const x = true; console.log(`val=${x ? 'yes' : 'no'}`);" },
         "index.ts",


### PR DESCRIPTION
## Summary
- template literal → string concat 변환에서 보간 표현식에 괄호 누락 수정
- `\${1 + 2}` → `"" + (1 + 2)` (기존: `"" + 1 + 2` → "12")
- `\${x ? "a" : "b"}` → `"" + (x ? "a" : "b")` (기존: `"val=" + x ? "a" : "b"` → "a")
- 리터럴/identifier/call 등 원자적 표현식은 괄호 생략

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] 통합 테스트 152 pass / 0 fail (기존 test.todo 2개 활성화)

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)