### PR TITLE
fix(transformer): spread in new expression 괄호 누락 수정 (#783)

### DIFF
--- a/src/transformer/es2015_spread.zig
+++ b/src/transformer/es2015_spread.zig
@@ -212,9 +212,16 @@ pub fn ES2015Spread(comptime Transformer: type) type {
             });
 
             // new (Foo.bind.apply(Foo, [null].concat(args)))()
+            // bind.apply() 호출을 괄호로 감싸야 new 연산자가 올바르게 적용됨.
+            // 괄호 없으면: new Foo.bind.apply(...)() → new (Foo.bind).apply(...)()
+            const paren_callee = try self.ast.addNode(.{
+                .tag = .parenthesized_expression,
+                .span = span,
+                .data = .{ .unary = .{ .operand = bind_apply_call, .flags = 0 } },
+            });
             const empty_new_args = try self.ast.addNodeList(&.{});
             const new_extra = try self.ast.addExtras(&.{
-                @intFromEnum(bind_apply_call), empty_new_args.start, empty_new_args.len, 0,
+                @intFromEnum(paren_callee), empty_new_args.start, empty_new_args.len, 0,
             });
             return self.ast.addNode(.{
                 .tag = .new_expression,

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1276,8 +1276,8 @@ describe("ES 다운레벨링 런타임 테스트", () => {
 
     // --- SWC 대비 추가 테스트: Spread ---
 
-    // TODO: spread in new에서 괄호 누락 — new Foo.bind.apply(...)() → new (Foo.bind.apply(...))()
-    test.todo("spread in new expression", async () => {
+    // #783: spread in new에서 bind.apply()를 괄호로 감싸기
+    test("spread in new expression (#783)", async () => {
       const result = await bundleAndRun(
         {
           "index.ts": `


### PR DESCRIPTION
## Summary
- `new Pair(...args)` → `new (Pair.bind.apply(Pair, [null].concat(args)))()`
- `bind.apply()` 호출을 `parenthesized_expression`으로 감싸서 new 연산자 우선순위 보존
- 기존 test.todo 1개 활성화

## Test plan
- [x] 유닛 테스트 전체 통과
- [x] 통합 테스트 153 pass / 0 fail

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)