### PR TITLE
fix(sourcemap): ESM 래핑 모듈의 column 0 매핑 추가 (RN DevTools 콘솔)

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -676,16 +676,40 @@ pub fn emitEsmWrappedModule(
     {
         const hm = hoist_mappings orelse &[_]SourceMap.Mapping{};
         const bm = if (body_cg.sm_builder) |*sm| sm.mappings.items else &[_]SourceMap.Mapping{};
+        const all_maps = [_][]const SourceMap.Mapping{ hm, bm };
+        const line_offsets = [_]u32{ hoist_preamble_lines, body_preamble_lines };
         const total = hm.len + bm.len;
         if (total > 0) {
-            const buf = try allocator.alloc(SourceMap.Mapping, total);
-            for (hm, 0..) |m, i| {
-                buf[i] = .{ .generated_line = m.generated_line + hoist_preamble_lines, .generated_column = m.generated_column, .source_index = m.source_index, .original_line = m.original_line, .original_column = m.original_column };
+            // 각 줄의 첫 매핑이 column 0이 아니면, column 0 매핑을 추가.
+            // DevTools가 col 0으로 소스맵을 역참조할 때 올바른 줄을 반환하도록.
+            var col0_count: usize = 0;
+            for (all_maps, line_offsets) |maps, offset| {
+                var prev_gl: u32 = std.math.maxInt(u32);
+                for (maps) |m| {
+                    const gl = m.generated_line + offset;
+                    if (gl != prev_gl) {
+                        if (m.generated_column > 0) col0_count += 1;
+                        prev_gl = gl;
+                    }
+                }
             }
-            for (bm, 0..) |m, i| {
-                buf[hm.len + i] = .{ .generated_line = m.generated_line + body_preamble_lines, .generated_column = m.generated_column, .source_index = m.source_index, .original_line = m.original_line, .original_column = m.original_column };
+
+            const buf = try allocator.alloc(SourceMap.Mapping, total + col0_count);
+            var wi: usize = 0;
+            for (all_maps, line_offsets) |maps, offset| {
+                var prev_gl: u32 = std.math.maxInt(u32);
+                for (maps) |m| {
+                    const gl = m.generated_line + offset;
+                    if (gl != prev_gl and m.generated_column > 0) {
+                        buf[wi] = .{ .generated_line = gl, .generated_column = 0, .source_index = m.source_index, .original_line = m.original_line, .original_column = m.original_column };
+                        wi += 1;
+                    }
+                    prev_gl = gl;
+                    buf[wi] = .{ .generated_line = gl, .generated_column = m.generated_column, .source_index = m.source_index, .original_line = m.original_line, .original_column = m.original_column };
+                    wi += 1;
+                }
             }
-            mappings = buf;
+            mappings = buf[0..wi];
         }
     }
 


### PR DESCRIPTION
## Summary
ESM 래핑 모듈(RN 플랫폼)에서 호이스팅/body 코드의 각 줄 첫 매핑이 column 0이 아닌 경우,
RN DevTools가 console.log의 소스 위치를 찾지 못해 잘못된 줄 번호가 표시되는 문제 수정.

## Root cause
ESM body 코드는 `appendIndented`로 `\t` 들여쓰기가 추가되고, 호이스팅 함수 내부는 codegen이 자체 indent를 생성. 둘 다 각 줄의 첫 매핑이 column > 0에서 시작.

DevTools가 console.log call site를 column 0으로 역참조하면, 해당 줄에 column 0 매핑이 없어 이전 줄의 마지막 매핑으로 fallback → 잘못된 소스 라인 표시.

## Fix
각 줄의 첫 매핑 앞에 `column 0 → 같은 소스 위치` 매핑을 자동 삽입.

Before: `seg[0] gen_col=2 → App.tsx:64:4`
After: `seg[0] gen_col=0 → App.tsx:64:4, seg[1] gen_col=2 → App.tsx:64:4`

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun test tests/sourcemap.test.ts` 12개 통과
- [x] RN ExampleApp console.log 매핑: column 0에서 정확한 소스 라인 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)