### PR TITLE
revert: RN 소스맵 절대 경로 출력 되돌리기 (#958)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -386,7 +386,7 @@ pub fn emitWithTreeShaking(
             if (results[i].mappings) |maps| {
                 try addModuleMappings(
                     sm,
-                    sourcemapSourcePath(m.path, options),
+                    makeModuleId(m.path, options.root_dir),
                     m.source,
                     maps,
                     module_line,
@@ -529,13 +529,6 @@ const dev = @import("emitter/dev.zig");
 pub const DevBundleResult = dev.DevBundleResult;
 pub const addModuleMappings = dev.addModuleMappings;
 pub const makeModuleId = dev.makeModuleId;
-
-/// 소스맵 sources 배열에 사용할 경로를 반환.
-/// RN 플랫폼은 Metro 호환 절대 경로, 다른 플랫폼은 root_dir 기준 상대 경로.
-pub fn sourcemapSourcePath(path: []const u8, options: EmitOptions) []const u8 {
-    if (options.platform == .react_native) return path;
-    return makeModuleId(path, options.root_dir);
-}
 
 // --- Chunks functions (emitter/chunks.zig) ---
 const chunks = @import("emitter/chunks.zig");
@@ -872,7 +865,7 @@ pub fn emitModule(
     // 소스맵용: line_offsets와 소스 파일 등록
     if (options.sourcemap) {
         cg.line_offsets = module.line_offsets;
-        try cg.addSourceFile(sourcemapSourcePath(module.path, options));
+        try cg.addSourceFile(makeModuleId(module.path, options.root_dir));
     }
     var code = try cg.generate(root);
 

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -238,7 +238,7 @@ pub fn emitEsmWrappedModule(
         });
         if (options.sourcemap) {
             hoist_cg.line_offsets = module.line_offsets;
-            try hoist_cg.addSourceFile(parent.sourcemapSourcePath(module.path, options));
+            try hoist_cg.addSourceFile(parent.makeModuleId(module.path, options.root_dir));
         }
         hoist_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
         const hoisted_code = try hoist_cg.generateStatements(root, hoisted_stmts.items);
@@ -392,7 +392,7 @@ pub fn emitEsmWrappedModule(
     // 소스맵: 소스 파일 등록 + line_offsets 설정
     if (options.sourcemap) {
         body_cg.line_offsets = module.line_offsets;
-        try body_cg.addSourceFile(parent.sourcemapSourcePath(module.path, options));
+        try body_cg.addSourceFile(parent.makeModuleId(module.path, options.root_dir));
     }
     var body_code = try body_cg.generateStatements(root, body_stmts.items);
 


### PR DESCRIPTION
## Summary
PR #958 되돌리기. dev server 환경에서 소스맵 sources의 절대/상대 경로는 무의미.

롤리팝(Rolldown 기반 RN 번들러)도 상대 경로를 사용하며, 소스맵 해석은
서버 측 symbolicate 또는 DevTools의 `sourceMapConsumer.originalPositionFor(line, col)`로
처리되어 경로와 무관하게 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)