### PR TITLE
fix(sourcemap): RN 번들 소스맵 경로 + 매핑 수정

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -386,7 +386,7 @@ pub fn emitWithTreeShaking(
             if (results[i].mappings) |maps| {
                 try addModuleMappings(
                     sm,
-                    makeModuleId(m.path, options.root_dir),
+                    sourcemapSourcePath(m.path, options),
                     m.source,
                     maps,
                     module_line,
@@ -529,6 +529,13 @@ const dev = @import("emitter/dev.zig");
 pub const DevBundleResult = dev.DevBundleResult;
 pub const addModuleMappings = dev.addModuleMappings;
 pub const makeModuleId = dev.makeModuleId;
+
+/// 소스맵 sources 배열에 사용할 경로를 반환.
+/// RN 플랫폼은 Metro 호환 절대 경로, 다른 플랫폼은 root_dir 기준 상대 경로.
+pub fn sourcemapSourcePath(path: []const u8, options: EmitOptions) []const u8 {
+    if (options.platform == .react_native) return path;
+    return makeModuleId(path, options.root_dir);
+}
 
 // --- Chunks functions (emitter/chunks.zig) ---
 const chunks = @import("emitter/chunks.zig");
@@ -865,7 +872,7 @@ pub fn emitModule(
     // 소스맵용: line_offsets와 소스 파일 등록
     if (options.sourcemap) {
         cg.line_offsets = module.line_offsets;
-        try cg.addSourceFile(makeModuleId(module.path, options.root_dir));
+        try cg.addSourceFile(sourcemapSourcePath(module.path, options));
     }
     var code = try cg.generate(root);
 

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -238,7 +238,7 @@ pub fn emitEsmWrappedModule(
         });
         if (options.sourcemap) {
             hoist_cg.line_offsets = module.line_offsets;
-            try hoist_cg.addSourceFile(parent.makeModuleId(module.path, options.root_dir));
+            try hoist_cg.addSourceFile(parent.sourcemapSourcePath(module.path, options));
         }
         hoist_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
         const hoisted_code = try hoist_cg.generateStatements(root, hoisted_stmts.items);
@@ -392,7 +392,7 @@ pub fn emitEsmWrappedModule(
     // 소스맵: 소스 파일 등록 + line_offsets 설정
     if (options.sourcemap) {
         body_cg.line_offsets = module.line_offsets;
-        try body_cg.addSourceFile(parent.makeModuleId(module.path, options.root_dir));
+        try body_cg.addSourceFile(parent.sourcemapSourcePath(module.path, options));
     }
     var body_code = try body_cg.generateStatements(root, body_stmts.items);
 


### PR DESCRIPTION
## Summary
Revert of revert — RN 플랫폼 소스맵 절대 경로 다시 적용.

Chrome DevTools Sources 탭은 소스맵의 `sources` 배열 경로를 직접 사용하여 폴더 구조를 구성하고,
콘솔 라인 매핑도 이 경로로 소스 파일을 찾음. 상대 경로로는 DevTools가 소스 파일을 찾지 못함.

rolliop이 상대 경로로 되는 이유는 symbolicate 서버 측 해석 때문이지만,
DevTools Sources 탭 + 콘솔 우측 라인 표시는 symbolicate가 아닌 소스맵 직접 참조.

Metro와 동일하게 절대 경로 필요.

## Test plan
- [x] `zig build test` 전체 통과
- [x] RN 번들 sources: 540개 모두 절대 경로

🤖 Generated with [Claude Code](https://claude.com/claude-code)