### PR TITLE
fix(sourcemap): polyfill identity mapping + x_google_ignoreList

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -239,7 +239,13 @@ pub fn emitWithTreeShaking(
 
     // 폴리필 주입 (--polyfill): IIFE로 감싸서 즉시 실행.
     // Metro/롤다운과 동일하게 모듈 그래프 밖에서 런타임 헬퍼보다 먼저 실행.
+    // 소스맵: 각 폴리필의 라인 범위를 기록하여 identity mapping + x_google_ignoreList 생성.
+    const PolyfillRange = struct { start_line: u32, line_count: u32, name: []const u8, content: []const u8 };
+    var polyfill_ranges: [32]PolyfillRange = undefined;
+    var polyfill_count: usize = 0;
+
     for (options.polyfills) |poly| {
+        const start_line: u32 = @intCast(std.mem.count(u8, output.items, "\n"));
         if (!options.minify_whitespace) {
             try output.appendSlice(allocator, "// --- polyfill: ");
             try output.appendSlice(allocator, poly.name);
@@ -250,6 +256,17 @@ pub fn emitWithTreeShaking(
         try output.appendSlice(allocator, poly.content);
         if (!options.minify_whitespace) try output.append(allocator, '\n');
         try output.appendSlice(allocator, "})();\n");
+
+        if (options.sourcemap and polyfill_count < polyfill_ranges.len) {
+            const end_line: u32 = @intCast(std.mem.count(u8, output.items, "\n"));
+            polyfill_ranges[polyfill_count] = .{
+                .start_line = start_line,
+                .line_count = end_line - start_line,
+                .name = poly.name,
+                .content = poly.content,
+            };
+            polyfill_count += 1;
+        }
     }
 
     // 런타임 헬퍼 주입
@@ -496,6 +513,28 @@ pub fn emitWithTreeShaking(
                 mapping.generated_line += prologue_lines;
             }
         }
+
+        // 폴리필 identity mapping + x_google_ignoreList 추가.
+        // 각 폴리필 파일을 sources에 등록하고, 모든 줄에 identity mapping 생성.
+        // DevTools가 폴리필 프레임을 자동으로 무시하고 유저 코드 프레임을 표시.
+        for (polyfill_ranges[0..polyfill_count]) |pr| {
+            const src_idx = try sm.addSource(pr.name);
+            if (options.sources_content) {
+                try sm.addSourceContent(pr.content);
+            }
+            try sm.addIgnoredSource(src_idx);
+            // identity mapping: 각 줄을 원본의 같은 줄에 매핑
+            for (0..pr.line_count) |line| {
+                try sm.addMapping(.{
+                    .generated_line = pr.start_line + @as(u32, @intCast(line)),
+                    .generated_column = 0,
+                    .source_index = src_idx,
+                    .original_line = @intCast(line),
+                    .original_column = 0,
+                });
+            }
+        }
+
         // debugId 설정
         sm.debug_id = debug_id;
         const json = try sm.generateJSON(options.output_filename);

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -94,6 +94,9 @@ pub const SourceMapBuilder = struct {
     /// Sentry Debug ID. non-null이면 JSON에 "debugId" 필드를 추가한다.
     /// UUID v4 문자열 (예: "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx").
     debug_id: ?[]const u8 = null,
+    /// x_google_ignoreList: DevTools에서 무시할 소스 인덱스 목록.
+    /// 폴리필, node_modules 등 프레임워크 코드를 자동으로 스킵하도록 한다.
+    ignored_sources: std.ArrayList(u32) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) SourceMapBuilder {
         return .{
@@ -109,7 +112,13 @@ pub const SourceMapBuilder = struct {
         self.mappings.deinit(self.allocator);
         self.sources.deinit(self.allocator);
         self.source_contents.deinit(self.allocator);
+        self.ignored_sources.deinit(self.allocator);
         self.buf.deinit(self.allocator);
+    }
+
+    /// 소스를 x_google_ignoreList에 추가. DevTools가 해당 소스의 프레임을 스킵한다.
+    pub fn addIgnoredSource(self: *SourceMapBuilder, source_index: u32) !void {
+        try self.ignored_sources.append(self.allocator, source_index);
     }
 
     /// 소스 파일 추가. 인덱스를 반환.
@@ -169,6 +178,19 @@ pub const SourceMapBuilder = struct {
                 if (i > 0) try self.buf.append(self.allocator, ',');
                 // JSON 문자열로 이스케이프
                 try self.appendJsonString(content);
+            }
+            try self.buf.append(self.allocator, ']');
+        }
+
+        // x_google_ignoreList (DevTools 프레임 스킵용)
+        if (self.ignored_sources.items.len > 0) {
+            try self.buf.appendSlice(self.allocator, ",\"x_google_ignoreList\":[");
+            for (self.ignored_sources.items, 0..) |idx, i| {
+                if (i > 0) try self.buf.append(self.allocator, ',');
+                // u32를 10진수 문자열로 변환
+                var num_buf: [10]u8 = undefined;
+                const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{idx}) catch "0";
+                try self.buf.appendSlice(self.allocator, num_str);
             }
             try self.buf.append(self.allocator, ']');
         }

--- a/tests/integration/tests/sourcemap.test.ts
+++ b/tests/integration/tests/sourcemap.test.ts
@@ -420,4 +420,90 @@ describe("소스맵", () => {
     const bundleLine4 = bundleLines[line4Maps[0].genLine - 1] || "";
     expect(bundleLine4).toContain("from lib line 4");
   });
+
+  test("--polyfill 소스가 소스맵 sources에 포함되고 x_google_ignoreList에 등록된다", async () => {
+    const { mkdtempSync, writeFileSync: wfs, rmSync } = await import("node:fs");
+    const tmpDir = mkdtempSync(join(process.cwd(), ".tmp-sm-poly-"));
+    cleanup = async () => rmSync(tmpDir, { recursive: true, force: true });
+
+    wfs(join(tmpDir, "index.ts"), `console.log("hello");`);
+    wfs(join(tmpDir, "poly.js"), `console.log("polyfill loaded");`);
+
+    const outFile = join(tmpDir, "out.js");
+    const result = await runZts([
+      "--bundle",
+      join(tmpDir, "index.ts"),
+      "-o",
+      outFile,
+      "--sourcemap",
+      `--polyfill=${join(tmpDir, "poly.js")}`,
+    ]);
+    expect(result.exitCode).toBe(0);
+
+    const map = JSON.parse(readFileSync(outFile + ".map", "utf-8"));
+
+    // 폴리필이 sources에 포함
+    const polyIdx = map.sources.findIndex((s: string) => s.includes("poly.js"));
+    expect(polyIdx).toBeGreaterThanOrEqual(0);
+
+    // x_google_ignoreList에 폴리필 인덱스가 등록
+    expect(map.x_google_ignoreList).toBeArray();
+    expect(map.x_google_ignoreList).toContain(polyIdx);
+
+    // 폴리필 sourcesContent 포함
+    expect(map.sourcesContent[polyIdx]).toContain("polyfill loaded");
+  });
+
+  test("--polyfill 소스맵에 폴리필 줄의 identity mapping이 존재한다", async () => {
+    const { mkdtempSync, writeFileSync: wfs, rmSync } = await import("node:fs");
+    const tmpDir = mkdtempSync(join(process.cwd(), ".tmp-sm-polymap-"));
+    cleanup = async () => rmSync(tmpDir, { recursive: true, force: true });
+
+    wfs(join(tmpDir, "index.ts"), `console.log("hello");`);
+    wfs(join(tmpDir, "poly.js"), [`var x = 1;`, `var y = 2;`, `console.log(x + y);`].join("\n"));
+
+    const outFile = join(tmpDir, "out.js");
+    await runZts([
+      "--bundle",
+      join(tmpDir, "index.ts"),
+      "-o",
+      outFile,
+      "--sourcemap",
+      `--polyfill=${join(tmpDir, "poly.js")}`,
+    ]);
+
+    const map = JSON.parse(readFileSync(outFile + ".map", "utf-8"));
+    const bundleCode = readFileSync(outFile, "utf-8");
+    const bundleLines = bundleCode.split("\n");
+
+    // 폴리필 소스 인덱스 찾기
+    const polyIdx = map.sources.findIndex((s: string) => s.includes("poly.js"));
+    expect(polyIdx).toBeGreaterThanOrEqual(0);
+
+    // 폴리필에 대한 매핑 추출
+    const polyMappings = getMappedSourceLines(map.mappings, polyIdx);
+    expect(polyMappings.length).toBeGreaterThan(0);
+
+    // 매핑된 번들 줄에 폴리필 코드가 있어야 함
+    const polyGenLines = polyMappings.map((m) => bundleLines[m.genLine - 1] || "");
+    const hasPolyContent = polyGenLines.some(
+      (line) => line.includes("var x") || line.includes("var y") || line.includes("console.log"),
+    );
+    expect(hasPolyContent).toBe(true);
+  });
+
+  test("폴리필 없을 때 x_google_ignoreList가 없다", async () => {
+    const fixture = await createFixture({
+      "index.ts": `console.log("hello");`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outFile = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, "--sourcemap"]);
+
+    const map = JSON.parse(readFileSync(outFile + ".map", "utf-8"));
+
+    // 폴리필 없으면 x_google_ignoreList도 없어야 함
+    expect(map.x_google_ignoreList).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- SourceMapBuilder에 `x_google_ignoreList` 지원 추가 (ignored_sources 필드 + JSON 출력)
- `--polyfill`로 주입된 코드의 라인 범위를 기록하고, identity mapping을 소스맵에 추가
- 각 폴리필 소스를 `x_google_ignoreList`에 등록하여 DevTools가 자동으로 프레임 스킵

## 배경
RN DevTools 콘솔에서 모든 console.log가 폴리필 래퍼 라인(`:493`)을 표시하는 문제.
원인: prologue 영역(banner/polyfill/runtime)에 소스맵 매핑이 없어서 DevTools가 원본 소스로 역매핑 불가.
그래프 번들러(Metro)는 폴리필도 모듈로 취급하여 identity mapping + `x_google_ignoreList` 생성.

## Test plan
- [x] `zig build test` 통과
- [x] 소스맵 통합 테스트 15개 전부 통과
- [x] 새 테스트 3개 추가:
  - `--polyfill` 소스가 sources에 포함되고 `x_google_ignoreList`에 등록
  - 폴리필 줄의 identity mapping 존재 검증
  - 폴리필 없을 때 `x_google_ignoreList` 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)