### PR TITLE
refactor(plugin): parseModule 내 PluginRunner 초기화 통합

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -666,10 +666,15 @@ pub const ModuleGraph = struct {
         var module = &self.modules.items[mod_idx];
         module.state = .parsing;
 
+        // Plugin runner: parseModule 내에서 load + transform 훅에 공용
+        const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
+            plugin_mod.PluginRunner.init(self.plugins)
+        else
+            null;
+
         // Plugin: load 훅 — 모든 module_type 분기 전에 플러그인에게 기회를 줌.
         // 플러그인이 내용을 반환하면 JS 모듈로 전환 (예: .css → JS export).
-        if (self.plugins.len > 0) {
-            const runner = plugin_mod.PluginRunner.init(self.plugins);
+        if (plugin_runner) |runner| {
             // 임시 allocator로 load 결과만 확인 (성공 시 arena를 생성)
             var tmp_arena = std.heap.ArenaAllocator.init(self.allocator);
             const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
@@ -787,8 +792,7 @@ pub const ModuleGraph = struct {
         // Plugin: transform 훅 — 소스 읽기 후, 파싱 전에 호출 (Rolldown 호환).
         // 플러그인이 코드를 변환하면 변환된 소스로 파싱한다.
         // Babel 플러그인(예: react-native-reanimated/plugin)이 유저 코드를 변환할 수 있다.
-        if (self.plugins.len > 0) {
-            const runner = plugin_mod.PluginRunner.init(self.plugins);
+        if (plugin_runner) |runner| {
             const transform_result = runner.runTransform(module.source, module.path, arena_alloc) catch |err| switch (err) {
                 error.PluginFailed => null,
                 error.OutOfMemory => {

--- a/tests/integration/tests/plugin.test.ts
+++ b/tests/integration/tests/plugin.test.ts
@@ -81,7 +81,7 @@ describe("Plugin: subprocess", () => {
           name: 'banner',
           transform(code, id) {
             if (!id.endsWith('.ts')) return null;
-            return '/* BANNER */\\n' + code;
+            return 'var __BANNER__ = true;\\n' + code;
           }
         }] });
       `,
@@ -96,7 +96,7 @@ describe("Plugin: subprocess", () => {
       ]);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("/* BANNER */");
+      expect(result.stdout).toContain("__BANNER__");
     } finally {
       await cleanup();
     }
@@ -157,7 +157,7 @@ describe("Plugin: subprocess", () => {
           name: 'banner',
           transform(code, id) {
             if (!id.endsWith('.ts')) return null;
-            return '/* MULTI-PLUGIN */\\n' + code;
+            return 'var __MULTI_PLUGIN__ = true;\\n' + code;
           }
         }] });
       `,
@@ -175,7 +175,7 @@ describe("Plugin: subprocess", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("h1 { font-size: 24px; }");
-      expect(result.stdout).toContain("/* MULTI-PLUGIN */");
+      expect(result.stdout).toContain("__MULTI_PLUGIN__");
     } finally {
       await cleanup();
     }
@@ -278,7 +278,7 @@ describe("Plugin: subprocess", () => {
           name: 'plugin-a',
           transform(code, id) {
             if (!id.endsWith('.ts')) return null;
-            return '/* FROM_A */\\n' + code;
+            return 'var __FROM_A__ = true;\\n' + code;
           }
         }] });
       `,
@@ -288,7 +288,7 @@ describe("Plugin: subprocess", () => {
           name: 'plugin-b',
           transform(code, id) {
             if (!id.endsWith('.ts')) return null;
-            return '/* FROM_B */\\n' + code;
+            return 'var __FROM_B__ = true;\\n' + code;
           }
         }] });
       `,
@@ -305,8 +305,8 @@ describe("Plugin: subprocess", () => {
       ]);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("FROM_A");
-      expect(result.stdout).toContain("FROM_B");
+      expect(result.stdout).toContain("__FROM_A__");
+      expect(result.stdout).toContain("__FROM_B__");
     } finally {
       await cleanup();
     }
@@ -456,7 +456,7 @@ describe("Plugin: auto config detection", () => {
           name: 'ts-banner',
           transform(code: string, id: string) {
             if (!id.endsWith('.ts') || id.includes('zts.config')) return null;
-            return '/* TS-CONFIG */\\n' + code;
+            return 'var __TS_CONFIG__ = true;\\n' + code;
           }
         }] });
       `,
@@ -467,7 +467,7 @@ describe("Plugin: auto config detection", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stderr).toContain("Using config: zts.config.ts");
-      expect(result.stdout).toContain("/* TS-CONFIG */");
+      expect(result.stdout).toContain("__TS_CONFIG__");
     } finally {
       await cleanup();
     }
@@ -481,14 +481,14 @@ describe("Plugin: auto config detection", () => {
         import { defineConfig } from '${CORE_PATH}';
         defineConfig({ plugins: [{
           name: 'should-not-load',
-          transform(code) { return '/* AUTO */\\n' + code; }
+          transform(code) { return 'var __AUTO__ = true;\\n' + code; }
         }] });
       `,
       "custom.js": `
         import { defineConfig } from '${CORE_PATH}';
         defineConfig({ plugins: [{
           name: 'custom',
-          transform(code) { return '/* CUSTOM */\\n' + code; }
+          transform(code) { return 'var __CUSTOM__ = true;\\n' + code; }
         }] });
       `,
     });
@@ -498,8 +498,8 @@ describe("Plugin: auto config detection", () => {
       const result = await runZtsInDir(dir, ["--bundle", "entry.ts", "--plugin", "custom.js"]);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("/* CUSTOM */");
-      expect(result.stdout).not.toContain("/* AUTO */");
+      expect(result.stdout).toContain("__CUSTOM__");
+      expect(result.stdout).not.toContain("__AUTO__");
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## Summary
- `parseModule`에서 load/transform 훅마다 별도 생성하던 `PluginRunner`를 함수 상단에서 한 번만 생성하여 재사용
- 이전 PR(#965)에서 누락된 통합 테스트 수정: transform 훅이 주석 대신 변수 선언을 삽입하도록 변경 (파싱 전 transform 이동으로 주석이 파서에 의해 제거)

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun test` 통합 테스트 2642 pass / 0 fail
- [x] pre-push hook 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)