### PR TITLE
fix(plugin): transform 훅 응답에서 code 필드 인식

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -505,7 +505,7 @@ class PluginHost {
         const ctx = this.createContext(i);
         const result = await hookFn.call(ctx, currentCode, key);
         if (result == null) continue;
-        const code = typeof result === "string" ? result : result.contents;
+        const code = typeof result === "string" ? result : (result.contents ?? result.code);
         if (code != null) {
           currentCode = code;
           changed = true;

--- a/src/bundler/subprocess_plugin.zig
+++ b/src/bundler/subprocess_plugin.zig
@@ -419,8 +419,10 @@ pub const SubprocessPlugin = struct {
         }
 
         if (parsed.value.result) |result| {
-            if (result.contents) |contents| {
-                return allocator.dupe(u8, contents) catch return error.OutOfMemory;
+            // contents 우선, 없으면 code (Rolldown 호환)
+            const transformed = result.contents orelse result.code;
+            if (transformed) |t| {
+                return allocator.dupe(u8, t) catch return error.OutOfMemory;
             }
         }
         return null;
@@ -456,8 +458,9 @@ pub const SubprocessPlugin = struct {
         }
 
         if (parsed.value.result) |result| {
-            if (result.contents) |contents| {
-                return allocator.dupe(u8, contents) catch return error.OutOfMemory;
+            const transformed = result.contents orelse result.code;
+            if (transformed) |t| {
+                return allocator.dupe(u8, t) catch return error.OutOfMemory;
             }
         }
         return null;
@@ -630,6 +633,8 @@ const HookResponse = struct {
     const HookResult = struct {
         path: ?[]const u8 = null,
         contents: ?[]const u8 = null,
+        /// Rolldown 호환: transform 훅에서 `code` 필드도 `contents`와 동일하게 인식
+        code: ?[]const u8 = null,
         loader: ?[]const u8 = null,
     };
 };

--- a/tests/integration/tests/plugin.test.ts
+++ b/tests/integration/tests/plugin.test.ts
@@ -102,6 +102,37 @@ describe("Plugin: subprocess", () => {
     }
   });
 
+  test("transform hook accepts 'code' field in result (#966)", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `const x = 1;\nconsole.log(x);`,
+      "package.json": '{"type": "module"}',
+      "plugin.js": `
+        import { defineConfig } from '${CORE_PATH}';
+        defineConfig({ plugins: [{
+          name: 'code-field',
+          transform(code, id) {
+            if (!id.endsWith('.ts')) return null;
+            return { code: 'var __CODE_FIELD__ = true;\\n' + code };
+          }
+        }] });
+      `,
+    });
+
+    try {
+      const result = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "--plugin",
+        join(dir, "plugin.js"),
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("__CODE_FIELD__");
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("plugin error shows descriptive message", async () => {
     const { dir, cleanup } = await createFixture({
       "entry.ts": `import './broken.css';`,


### PR DESCRIPTION
## Summary
- `HookResult`에 `code` 필드 추가 → `contents`와 `code` 모두 지원 (Rolldown 호환)
- `contents` 우선, 없으면 `code` 사용 (transform + renderChunk)
- JS 런타임(`packages/core`)에서도 `result.code` fallback 추가

## Test plan
- [x] `zig build test` 전체 통과
- [x] 통합 테스트 `code` 필드 사용 테스트 추가 + 20/20 통과
- [x] pre-push hook 통과

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)