### PR TITLE
feat: add --jobs=N option for thread pool size control

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -124,6 +124,8 @@ pub const BundleOptions = struct {
     keep_names: bool = false,
     /// 플러그인 배열 (resolveId, load, transform, renderChunk, generateBundle 훅)
     plugins: []const plugin_mod.Plugin = &.{},
+    /// 최대 워커 스레드 수. 0이면 기본값(CPU 코어 수). 1이면 단일 스레드.
+    max_threads: u32 = 0,
     /// Flow 모드 강제 활성화 (--flow). @flow pragma 없이도 .js/.jsx를 Flow로 파싱.
     flow: bool = false,
     /// .js 파일에서도 JSX 파싱 활성화 (--platform=react-native 프리셋).
@@ -413,6 +415,7 @@ pub const Bundler = struct {
         worker_graph.loader_overrides = self.options.loader_overrides;
         worker_graph.public_path = self.options.public_path;
         worker_graph.plugins = self.options.plugins;
+        worker_graph.max_threads = self.options.max_threads;
         worker_graph.flow = self.options.flow;
         worker_graph.jsx_in_js = self.options.jsx_in_js;
         worker_graph.jsx_runtime = self.options.jsx_runtime;
@@ -528,6 +531,7 @@ pub const Bundler = struct {
         defer if (combined_inject) |c| self.allocator.free(c);
         graph.inject_files = combined_inject orelse self.options.inject;
         graph.plugins = self.options.plugins;
+        graph.max_threads = self.options.max_threads;
         graph.flow = self.options.flow;
         graph.jsx_in_js = self.options.jsx_in_js;
         graph.jsx_runtime = self.options.jsx_runtime;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -76,6 +76,8 @@ pub const ModuleGraph = struct {
     inject_files: []const []const u8 = &.{},
     /// 플러그인 배열. bundler에서 전파.
     plugins: []const plugin_mod.Plugin = &.{},
+    /// 최대 워커 스레드 수. 0이면 기본값(CPU 코어 수). 1이면 단일 스레드 (플러그인 IPC 디버깅용).
+    max_threads: u32 = 0,
     /// Flow 모드 강제 활성화 (--flow). bundler에서 전파.
     flow: bool = false,
     /// .js 파일에서도 JSX 파싱 활성화 (--platform=react-native 프리셋).
@@ -168,7 +170,11 @@ pub const ModuleGraph = struct {
         }
 
         var pool: std.Thread.Pool = undefined;
-        const pool_ok = if (pool.init(.{ .allocator = self.allocator })) |_| true else |_| false;
+        const pool_opts: std.Thread.Pool.Options = if (self.max_threads > 0)
+            .{ .allocator = self.allocator, .n_jobs = self.max_threads }
+        else
+            .{ .allocator = self.allocator };
+        const pool_ok = if (pool.init(pool_opts)) |_| true else |_| false;
         defer if (pool_ok) pool.deinit();
 
         var scan_timer: ?std.time.Timer = if (self.timing) std.time.Timer.start() catch null else null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -136,6 +136,8 @@ const CliOptions = struct {
     watch_delay_ms: u32 = 100,
     /// --clean: 빌드 전 출력 디렉토리 정리
     clean: bool = false,
+    /// --jobs=N: 병렬 워커 스레드 수 (0=기본값/CPU코어수, 1=단일스레드)
+    max_threads: u32 = 0,
     /// --preserve-modules: 모듈 1개 = 출력 파일 1개 (라이브러리 빌드용)
     preserve_modules: bool = false,
     /// --preserve-modules-root=<dir>: 출력 디렉토리 구조의 기준 경로
@@ -550,6 +552,12 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             };
         } else if (std.mem.eql(u8, arg, "--clean")) {
             opts.clean = true;
+        } else if (std.mem.startsWith(u8, arg, "--jobs=")) {
+            const val = arg["--jobs=".len..];
+            opts.max_threads = std.fmt.parseInt(u32, val, 10) catch {
+                try stderr.print("zts: --jobs requires a number: {s}\n", .{val});
+                std.process.exit(1);
+            };
         } else if (std.mem.eql(u8, arg, "--plugin")) {
             if (i + 1 < args.len) {
                 i += 1;
@@ -1293,6 +1301,7 @@ pub fn main() !void {
             .keep_names = opts.keep_names,
             .shim_missing_exports = opts.shim_missing_exports,
             .plugins = plugin_list.items,
+            .max_threads = opts.max_threads,
             .flow = opts.flow,
             .jsx_in_js = opts.jsx_in_js,
             .configurable_exports = opts.configurable_exports or opts.dev, // HMR: export 재정의 필요


### PR DESCRIPTION
## Summary
- `--jobs=N` CLI option to control worker thread count
- `--jobs=0` (default): all CPU cores
- `--jobs=1`: single-threaded mode

## Motivation
Transform plugins (e.g., Babel for react-native-reanimated) use IPC to communicate with the ZTS process. When ZTS parses modules in parallel, multiple threads send transform IPC requests simultaneously, causing race conditions where plugin responses get lost or misrouted.

`--jobs=1` forces single-threaded execution, ensuring transform IPC requests and responses are serialized correctly.

## Changes
- `main.zig`: Add `--jobs=N` arg parsing + `max_threads` field
- `bundler.zig`: Propagate `max_threads` to `ModuleGraph` 
- `graph.zig`: Use `max_threads` in `Thread.Pool.init` via `n_jobs` option

## Test
```bash
zts --bundle index.js --jobs=1 \
  --plugin asset-plugin.ts \
  --plugin babel-plugin.ts
# worklet: 27 ✅ (vs 24 without --jobs=1)
```