### PR TITLE
fix(plugin): LoadResult 타입에 code 필드 추가

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -107,7 +107,9 @@ export type Target =
 /** Result returned by a plugin's `load` or `transform` hook. */
 export interface LoadResult {
   /** The transformed source code. */
-  contents: string;
+  contents?: string;
+  /** Alias for `contents` (Rolldown compatibility). `contents` takes precedence if both are set. */
+  code?: string;
   /** Optional loader override for this file. */
   loader?: Loader;
 }


### PR DESCRIPTION
## Summary
- `LoadResult` 인터페이스에 `code` optional 필드 추가 (Rolldown 호환)
- 7bc8e7e에서 런타임 코드에 `result.code` fallback을 추가했지만 타입 정의 누락으로 TypeDoc 빌드 실패 수정

## Test plan
- [ ] CI docs job 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)