### PR TITLE
feat(ffi): 네이티브 FFI 바인딩 패키지 (@zts/ffi)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -167,6 +167,35 @@ pub fn build(b: *std.Build) void {
         wasm_step.dependOn(&wasm_install.step);
     }
 
+    // ─── FFI 동적 라이브러리 빌드 ───
+    // `zig build ffi` — 네이티브 공유 라이브러리(.dylib/.so)를 빌드한다.
+    // bun:ffi 등에서 로드하여 in-process 트랜스파일을 수행할 수 있다.
+    {
+        const ffi_lib_mod = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+        });
+
+        const ffi_mod = b.createModule(.{
+            .root_source_file = b.path("packages/ffi/src/ffi_entry.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+        });
+        ffi_mod.addImport("zts_lib", ffi_lib_mod);
+
+        const ffi_lib = b.addLibrary(.{
+            .linkage = .dynamic,
+            .name = "zts",
+            .root_module = ffi_mod,
+        });
+        ffi_lib.linkLibC();
+
+        const ffi_install = b.addInstallArtifact(ffi_lib, .{});
+        const ffi_step = b.step("ffi", "Build native shared library (.dylib/.so) for FFI");
+        ffi_step.dependOn(&ffi_install.step);
+    }
+
     // Test262 러너 테스트 (유닛 테스트)
     // lib_mod에 이미 test262가 포함되어 있으므로 같은 모듈로 테스트.
     const test262_step = b.step("test262", "Run Test262 runner unit tests");

--- a/packages/ffi/index.test.ts
+++ b/packages/ffi/index.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { init, transpile, close } from "./index";
+
+beforeAll(() => {
+  init();
+});
+
+afterAll(() => {
+  close();
+});
+
+describe("@zts/ffi", () => {
+  test("기본 TypeScript 트랜스파일", () => {
+    const result = transpile("const x: number = 1;");
+    expect(result.code).toContain("const x = 1;");
+    expect(result.map).toBeUndefined();
+  });
+
+  test("인터페이스 스트리핑", () => {
+    const result = transpile("interface Foo { bar: string; }\nconst x = 1;");
+    expect(result.code).not.toContain("interface");
+    expect(result.code).toContain("const x = 1;");
+  });
+
+  test("타입 어노테이션 제거", () => {
+    const result = transpile("function add(a: number, b: number): number { return a + b; }");
+    expect(result.code).toContain("function add(a,b)");
+    expect(result.code).not.toContain(": number");
+  });
+
+  test("enum 변환", () => {
+    const result = transpile("enum Color { Red, Green, Blue }");
+    expect(result.code).toContain("Color");
+  });
+
+  test("JSX 트랜스파일 (classic)", () => {
+    const result = transpile('<div className="app">hello</div>', {
+      filename: "app.tsx",
+      jsx: "classic",
+    });
+    expect(result.code).toContain("React.createElement");
+  });
+
+  test("JSX 트랜스파일 (automatic)", () => {
+    const result = transpile('<div className="app">hello</div>', {
+      filename: "app.tsx",
+      jsx: "automatic",
+    });
+    expect(result.code).toContain("jsx");
+  });
+
+  test("소스맵 생성", () => {
+    const result = transpile("const x: number = 1;", { sourcemap: true });
+    expect(result.code).toContain("const x = 1;");
+    expect(result.map).toBeDefined();
+    const map = JSON.parse(result.map!);
+    expect(map.version).toBe(3);
+    expect(map.mappings).toBeDefined();
+  });
+
+  test("minify", () => {
+    const result = transpile("const   x: number   =   1;", {
+      minifyWhitespace: true,
+    });
+    expect(result.code.length).toBeLessThan("const   x   =   1;".length);
+  });
+
+  test("CJS 포맷", () => {
+    const result = transpile('export const x = 1; export default "hello";', {
+      format: "cjs",
+    });
+    expect(result.code).toContain("exports");
+  });
+
+  test("빈 소스 에러", () => {
+    expect(() => transpile("")).toThrow();
+  });
+
+  test("파싱 에러", () => {
+    expect(() => transpile("const = ;")).toThrow();
+  });
+
+  test("Flow 스트리핑", () => {
+    const result = transpile("// @flow\nfunction foo(x: string): number { return 1; }", {
+      flow: true,
+      filename: "test.js",
+    });
+    expect(result.code).not.toContain(": string");
+    expect(result.code).not.toContain(": number");
+  });
+
+  test("drop console", () => {
+    const result = transpile('console.log("hello"); const x = 1;', {
+      dropConsole: true,
+    });
+    expect(result.code).not.toContain("console.log");
+    expect(result.code).toContain("const x = 1;");
+  });
+
+  test("filename으로 확장자 감지 (.tsx)", () => {
+    const result = transpile("const el = <div />;", { filename: "comp.tsx" });
+    expect(result.code).not.toContain("<div");
+  });
+
+  test("JSX 트랜스파일 (automatic-dev)", () => {
+    const result = transpile('<div className="app">hello</div>', {
+      filename: "app.tsx",
+      jsx: "automatic-dev",
+    });
+    expect(result.code).toContain("jsxDEV");
+  });
+
+  test("minify 단축 옵션 (whitespace + identifiers + syntax)", () => {
+    const result = transpile("const   longVariableName: number   =   1;", {
+      minify: true,
+    });
+    expect(result.code.length).toBeLessThan("const longVariableName = 1;".length);
+  });
+
+  test("drop debugger", () => {
+    const result = transpile("debugger; const x = 1;", {
+      dropDebugger: true,
+    });
+    expect(result.code).not.toContain("debugger");
+    expect(result.code).toContain("const x = 1;");
+  });
+
+  test("quotes: single", () => {
+    const result = transpile('const x = "hello";', { quotes: "single" });
+    expect(result.code).toContain("'hello'");
+  });
+
+  test("ascii only", () => {
+    const result = transpile('const x = "한글";');
+    const asciiResult = transpile('const x = "한글";', { asciiOnly: true });
+    expect(asciiResult.code).toContain("\\u");
+    expect(result.code).toContain("한글");
+  });
+
+  test("ES5 다운레벨링", () => {
+    const result = transpile("const x = () => 1;", { target: "es5" });
+    expect(result.code).not.toContain("=>");
+    expect(result.code).toContain("function");
+  });
+
+  test("ES2015 다운레벨링 (template literal)", () => {
+    const result = transpile("const s = `hello ${name}`;", { target: "es5" });
+    expect(result.code).not.toContain("`");
+  });
+
+  test("target esnext (변환 없음)", () => {
+    const result = transpile("const x = () => 1;", { target: "esnext" });
+    expect(result.code).toContain("=>");
+  });
+
+  test("platform node", () => {
+    const result = transpile("const x: number = 1;", { platform: "node" });
+    expect(result.code).toContain("const x = 1;");
+  });
+
+  test("jsxFactory 커스텀", () => {
+    const result = transpile("<div />", {
+      filename: "app.tsx",
+      jsx: "classic",
+      jsxFactory: "h",
+    });
+    expect(result.code).toContain("h(");
+    expect(result.code).not.toContain("React.createElement");
+  });
+
+  test("jsxImportSource 커스텀", () => {
+    const result = transpile("<div />", {
+      filename: "app.tsx",
+      jsx: "automatic",
+      jsxImportSource: "preact",
+    });
+    expect(result.code).toContain("preact");
+  });
+
+  test("useDefineForClassFields false", () => {
+    const result = transpile("class A { x = 1; }", { useDefineForClassFields: false });
+    expect(result.code).toContain("this.x");
+  });
+
+  test("init 중복 호출은 무시", () => {
+    expect(() => init()).not.toThrow();
+  });
+
+  test("여러 번 호출해도 메모리 누수 없이 동작", () => {
+    for (let i = 0; i < 100; i++) {
+      const result = transpile(`const x${i}: number = ${i};`);
+      expect(result.code).toContain(`const x${i} = ${i};`);
+    }
+  });
+});

--- a/packages/ffi/index.ts
+++ b/packages/ffi/index.ts
@@ -101,12 +101,18 @@ export interface TranspileResult {
 interface ZtsLib {
   symbols: {
     zts_transpile(
-      srcPtr: number, srcLen: number,
-      filePtr: number, fileLen: number,
-      flags: number, unsupported: number,
-      jsxFactoryPtr: number, jsxFactoryLen: number,
-      jsxFragmentPtr: number, jsxFragmentLen: number,
-      jsxImportSourcePtr: number, jsxImportSourceLen: number,
+      srcPtr: number,
+      srcLen: number,
+      filePtr: number,
+      fileLen: number,
+      flags: number,
+      unsupported: number,
+      jsxFactoryPtr: number,
+      jsxFactoryLen: number,
+      jsxFragmentPtr: number,
+      jsxFragmentLen: number,
+      jsxImportSourcePtr: number,
+      jsxImportSourceLen: number,
     ): number | null;
     zts_result_len(): number;
     zts_error_ptr(): number | null;
@@ -178,9 +184,7 @@ function findDylib(): string {
   const zigOut = join(__dirname, "../../zig-out/lib/libzts.dylib");
   if (existsSync(zigOut)) return zigOut;
 
-  throw new Error(
-    "zts-ffi: libzts.dylib not found. Run `zig build ffi` first.",
-  );
+  throw new Error("zts-ffi: libzts.dylib not found. Run `zig build ffi` first.");
 }
 
 // ─── Public API ───
@@ -198,13 +202,18 @@ export function init(dylibPath?: string): void {
   lib = dlopen(path, {
     zts_transpile: {
       args: [
-        FFIType.ptr, FFIType.u32, // src
-        FFIType.ptr, FFIType.u32, // file
-        FFIType.u32,              // flags
-        FFIType.u32,              // unsupported
-        FFIType.ptr, FFIType.u32, // jsx_factory
-        FFIType.ptr, FFIType.u32, // jsx_fragment
-        FFIType.ptr, FFIType.u32, // jsx_import_source
+        FFIType.ptr,
+        FFIType.u32, // src
+        FFIType.ptr,
+        FFIType.u32, // file
+        FFIType.u32, // flags
+        FFIType.u32, // unsupported
+        FFIType.ptr,
+        FFIType.u32, // jsx_factory
+        FFIType.ptr,
+        FFIType.u32, // jsx_fragment
+        FFIType.ptr,
+        FFIType.u32, // jsx_import_source
       ],
       returns: FFIType.ptr,
     },
@@ -242,12 +251,18 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
   const importSourceBuf = options.jsxImportSource ? Buffer.from(options.jsxImportSource) : null;
 
   const resultPtr = lib.symbols.zts_transpile(
-    ptr(srcBuf), srcBuf.length,
-    ptr(fileBuf), fileBuf.length,
-    flags, unsupported,
-    factoryBuf ? ptr(factoryBuf) : 0, factoryBuf?.length ?? 0,
-    fragmentBuf ? ptr(fragmentBuf) : 0, fragmentBuf?.length ?? 0,
-    importSourceBuf ? ptr(importSourceBuf) : 0, importSourceBuf?.length ?? 0,
+    ptr(srcBuf),
+    srcBuf.length,
+    ptr(fileBuf),
+    fileBuf.length,
+    flags,
+    unsupported,
+    factoryBuf ? ptr(factoryBuf) : 0,
+    factoryBuf?.length ?? 0,
+    fragmentBuf ? ptr(fragmentBuf) : 0,
+    fragmentBuf?.length ?? 0,
+    importSourceBuf ? ptr(importSourceBuf) : 0,
+    importSourceBuf?.length ?? 0,
   );
 
   if (resultPtr === null || resultPtr === 0) {

--- a/packages/ffi/index.ts
+++ b/packages/ffi/index.ts
@@ -1,0 +1,286 @@
+/**
+ * @zts/ffi — ZTS TypeScript 트랜스파일러 네이티브 FFI 바인딩
+ *
+ * bun:ffi를 사용하여 네이티브 dylib을 in-process로 로드.
+ * NAPI와 동일한 성능 특성 (프로세스 spawn 없음, 직렬화 없음).
+ *
+ * @example
+ * ```ts
+ * import { init, transpile } from "@zts/ffi";
+ * init(); // 또는 init("/path/to/libzts.dylib")
+ * const result = transpile("const x: number = 1;");
+ * console.log(result.code);
+ * ```
+ */
+
+import { dlopen, FFIType, ptr, toBuffer } from "bun:ffi";
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// ─── Types (packages/wasm과 동일) ───
+
+export type Target =
+  | "es5"
+  | "es2015"
+  | "es2016"
+  | "es2017"
+  | "es2018"
+  | "es2019"
+  | "es2020"
+  | "es2021"
+  | "es2022"
+  | "es2024"
+  | "es2025"
+  | "esnext";
+
+export type Platform = "browser" | "node" | "neutral" | "react-native";
+
+export interface TranspileOptions {
+  /** 파일 경로 (확장자 감지용, 기본: "input.ts") */
+  filename?: string;
+  /** 소스맵 생성 */
+  sourcemap?: boolean;
+  /** 소스맵 Debug ID (Sentry 호환) */
+  sourcemapDebugIds?: boolean;
+  /** 소스맵에 원본 소스 포함 (기본: true) */
+  sourcesContent?: boolean;
+  /** 공백 축소 */
+  minifyWhitespace?: boolean;
+  /** 식별자 축소 */
+  minifyIdentifiers?: boolean;
+  /** 구문 축소 */
+  minifySyntax?: boolean;
+  /** 전체 축소 (whitespace + identifiers + syntax) */
+  minify?: boolean;
+  /** JSX 런타임 */
+  jsx?: "classic" | "automatic" | "automatic-dev";
+  /** classic 모드 JSX factory (기본: "React.createElement") */
+  jsxFactory?: string;
+  /** classic 모드 Fragment factory (기본: "React.Fragment") */
+  jsxFragment?: string;
+  /** automatic 모드 import source (기본: "react") */
+  jsxImportSource?: string;
+  /** JS 파일에서도 JSX 허용 */
+  jsxInJs?: boolean;
+  /** console.* 호출 제거 */
+  dropConsole?: boolean;
+  /** debugger 문 제거 */
+  dropDebugger?: boolean;
+  /** non-ASCII를 \uXXXX로 이스케이프 */
+  asciiOnly?: boolean;
+  /** non-ASCII를 이스케이프하지 않음 */
+  charsetUtf8?: boolean;
+  /** Flow 타입 스트리핑 */
+  flow?: boolean;
+  /** legacy decorator 변환 */
+  experimentalDecorators?: boolean;
+  /** decorator metadata emit */
+  emitDecoratorMetadata?: boolean;
+  /** class field → constructor this.x = v 변환 (기본: true) */
+  useDefineForClassFields?: boolean;
+  /** 모듈 포맷 */
+  format?: "esm" | "cjs";
+  /** 문자열 따옴표 스타일 */
+  quotes?: "double" | "single" | "preserve";
+  /** 타겟 플랫폼 */
+  platform?: Platform;
+  /** ES 다운레벨 타겟 */
+  target?: Target;
+}
+
+export interface TranspileResult {
+  /** 변환된 JavaScript 코드 */
+  code: string;
+  /** 소스맵 JSON (sourcemap: true 시) */
+  map?: string;
+}
+
+// ─── FFI Instance ───
+
+interface ZtsLib {
+  symbols: {
+    zts_transpile(
+      srcPtr: number, srcLen: number,
+      filePtr: number, fileLen: number,
+      flags: number, unsupported: number,
+      jsxFactoryPtr: number, jsxFactoryLen: number,
+      jsxFragmentPtr: number, jsxFragmentLen: number,
+      jsxImportSourcePtr: number, jsxImportSourceLen: number,
+    ): number | null;
+    zts_result_len(): number;
+    zts_error_ptr(): number | null;
+    zts_error_len(): number;
+    zts_free_result(): void;
+  };
+  close(): void;
+}
+
+let lib: ZtsLib | null = null;
+
+// ─── ES Target → UnsupportedFeatures bitmask ───
+
+const ES_TARGET_BITS: Record<string, number> = {
+  es5: 0x1fffff,
+  es2015: 0x1ff800,
+  es2016: 0x1ff000,
+  es2017: 0x1fe000,
+  es2018: 0x1fc000,
+  es2019: 0x1f8000,
+  es2020: 0x1e0000,
+  es2021: 0x1c0000,
+  es2022: 0x100000,
+  es2024: 0x100000,
+  es2025: 0x0,
+  esnext: 0x0,
+};
+
+// ─── 옵션 인코딩 (wasm/index.ts와 동일한 비트 레이아웃) ───
+
+function encodeFlags(opts: TranspileOptions = {}): number {
+  let flags = 0;
+  if (opts.sourcemap) flags |= 1 << 0;
+  if (opts.minifyWhitespace || opts.minify) flags |= 1 << 1;
+  if (opts.minifyIdentifiers || opts.minify) flags |= 1 << 2;
+  if (opts.minifySyntax || opts.minify) flags |= 1 << 3;
+  if (opts.jsx === "automatic") flags |= 1 << 4;
+  if (opts.jsx === "automatic-dev") flags |= 1 << 5;
+  if (opts.dropConsole) flags |= 1 << 6;
+  if (opts.dropDebugger) flags |= 1 << 7;
+  if (opts.asciiOnly) flags |= 1 << 8;
+  if (opts.flow) flags |= 1 << 9;
+  if (opts.experimentalDecorators) flags |= 1 << 10;
+  if (opts.emitDecoratorMetadata) flags |= 1 << 11;
+  if (opts.format === "cjs") flags |= 1 << 12;
+  if (opts.quotes === "single") flags |= 1 << 14;
+  if (opts.quotes === "preserve") flags |= 2 << 14;
+  if (opts.useDefineForClassFields !== false) flags |= 1 << 16;
+  if (opts.charsetUtf8) flags |= 1 << 17;
+  if (opts.platform === "node") flags |= 1 << 18;
+  if (opts.platform === "neutral") flags |= 2 << 18;
+  if (opts.platform === "react-native") flags |= 3 << 18;
+  if (opts.jsxInJs) flags |= 1 << 20;
+  if (opts.sourcemapDebugIds) flags |= 1 << 21;
+  if (opts.sourcesContent !== false) flags |= 1 << 22;
+  return flags;
+}
+
+// ─── dylib 경로 탐색 ───
+
+function findDylib(): string {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+
+  // 1. 패키지 루트 (배포 시)
+  const local = join(__dirname, "libzts.dylib");
+  if (existsSync(local)) return local;
+
+  // 2. zig-out (개발 시)
+  const zigOut = join(__dirname, "../../zig-out/lib/libzts.dylib");
+  if (existsSync(zigOut)) return zigOut;
+
+  throw new Error(
+    "zts-ffi: libzts.dylib not found. Run `zig build ffi` first.",
+  );
+}
+
+// ─── Public API ───
+
+/**
+ * 네이티브 FFI 라이브러리를 로드한다.
+ * 이미 로드된 경우 무시한다.
+ *
+ * @param dylibPath - dylib 경로 (생략 시 자동 탐색)
+ */
+export function init(dylibPath?: string): void {
+  if (lib) return;
+
+  const path = dylibPath ?? findDylib();
+  lib = dlopen(path, {
+    zts_transpile: {
+      args: [
+        FFIType.ptr, FFIType.u32, // src
+        FFIType.ptr, FFIType.u32, // file
+        FFIType.u32,              // flags
+        FFIType.u32,              // unsupported
+        FFIType.ptr, FFIType.u32, // jsx_factory
+        FFIType.ptr, FFIType.u32, // jsx_fragment
+        FFIType.ptr, FFIType.u32, // jsx_import_source
+      ],
+      returns: FFIType.ptr,
+    },
+    zts_result_len: { args: [], returns: FFIType.u32 },
+    zts_error_ptr: { args: [], returns: FFIType.ptr },
+    zts_error_len: { args: [], returns: FFIType.u32 },
+    zts_free_result: { args: [], returns: FFIType.void },
+  }) as unknown as ZtsLib;
+}
+
+/**
+ * TypeScript/JSX 소스 코드를 트랜스파일한다.
+ *
+ * @param source - 소스 코드 문자열
+ * @param options - 트랜스파일 옵션
+ * @returns 변환된 코드와 선택적 소스맵
+ */
+export function transpile(source: string, options: TranspileOptions = {}): TranspileResult {
+  if (!lib) {
+    throw new Error("zts-ffi: not initialized. Call init() first.");
+  }
+
+  if (!source) {
+    throw new Error("zts-ffi: empty source");
+  }
+
+  const srcBuf = Buffer.from(source);
+  const fileBuf = Buffer.from(options.filename ?? "input.ts");
+  const flags = encodeFlags(options);
+  const unsupported = options.target ? (ES_TARGET_BITS[options.target] ?? 0) : 0;
+
+  // 문자열 옵션 (없으면 빈 Buffer → ptr=0, len=0)
+  const factoryBuf = options.jsxFactory ? Buffer.from(options.jsxFactory) : null;
+  const fragmentBuf = options.jsxFragment ? Buffer.from(options.jsxFragment) : null;
+  const importSourceBuf = options.jsxImportSource ? Buffer.from(options.jsxImportSource) : null;
+
+  const resultPtr = lib.symbols.zts_transpile(
+    ptr(srcBuf), srcBuf.length,
+    ptr(fileBuf), fileBuf.length,
+    flags, unsupported,
+    factoryBuf ? ptr(factoryBuf) : 0, factoryBuf?.length ?? 0,
+    fragmentBuf ? ptr(fragmentBuf) : 0, fragmentBuf?.length ?? 0,
+    importSourceBuf ? ptr(importSourceBuf) : 0, importSourceBuf?.length ?? 0,
+  );
+
+  if (resultPtr === null || resultPtr === 0) {
+    const errLen = lib.symbols.zts_error_len();
+    const errPtr = lib.symbols.zts_error_ptr();
+    if (errPtr && errLen > 0) {
+      const errMsg = Buffer.from(toBuffer(errPtr, 0, errLen)).toString();
+      lib.symbols.zts_free_result();
+      throw new Error(`zts-ffi: ${errMsg}`);
+    }
+    lib.symbols.zts_free_result();
+    throw new Error("zts-ffi: transpile failed");
+  }
+
+  const len = lib.symbols.zts_result_len();
+  const raw = Buffer.from(toBuffer(resultPtr, 0, len)).toString();
+  lib.symbols.zts_free_result();
+
+  // 소스맵이 있으면 \0 구분자로 분리
+  const nullIdx = options.sourcemap ? raw.indexOf("\0") : -1;
+  if (nullIdx !== -1) {
+    return { code: raw.slice(0, nullIdx), map: raw.slice(nullIdx + 1) };
+  }
+
+  return { code: raw };
+}
+
+/**
+ * FFI 라이브러리를 언로드한다.
+ */
+export function close(): void {
+  if (lib) {
+    lib.close();
+    lib = null;
+  }
+}

--- a/packages/ffi/package.json
+++ b/packages/ffi/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "description": "ZTS TypeScript transpiler — native FFI binding (NAPI-like performance)",
   "license": "MIT",
-  "files": ["dist/", "libzts.dylib"],
+  "files": [
+    "dist/",
+    "libzts.dylib"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ffi/package.json
+++ b/packages/ffi/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zts/ffi",
+  "version": "0.1.0",
+  "description": "ZTS TypeScript transpiler — native FFI binding (NAPI-like performance)",
+  "license": "MIT",
+  "files": ["dist/", "libzts.dylib"],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build:ffi": "cd ../.. && zig build ffi",
+    "build:js": "bun build index.ts --outdir dist --format esm --target bun",
+    "build": "bun run build:ffi && cp ../../zig-out/lib/libzts.dylib . && bun run build:js",
+    "test": "bun test"
+  }
+}

--- a/packages/ffi/src/ffi_entry.zig
+++ b/packages/ffi/src/ffi_entry.zig
@@ -1,0 +1,192 @@
+//! ZTS FFI 진입점
+//!
+//! 네이티브 공유 라이브러리(.dylib/.so) 타겟용 진입점.
+//! bun:ffi 등에서 직접 로드하여 in-process로 트랜스파일을 수행한다.
+//!
+//! 호출 순서:
+//!   1. zts_transpile(src_ptr, src_len, file_ptr, file_len, flags) → result_ptr (null이면 에러)
+//!   2. zts_result_len() → 결과 길이
+//!   3. 결과 읽기 후 zts_free_result()로 해제
+
+const std = @import("std");
+const transpile_mod = @import("zts_lib").transpile;
+const TranspileOptions = transpile_mod.TranspileOptions;
+
+/// 네이티브 dylib에서는 c_allocator 사용 (page_allocator는 dylib에서 불안정)
+const native_alloc = std.heap.c_allocator;
+
+/// 마지막 결과/에러를 저장하는 전역 상태
+var last_result: ?[]const u8 = null;
+var last_error: ?[]const u8 = null;
+
+fn freeResult() void {
+    if (last_result) |old| native_alloc.free(old);
+    last_result = null;
+}
+
+fn freeError() void {
+    if (last_error) |old| native_alloc.free(old);
+    last_error = null;
+}
+
+/// 옵션 플래그 디코딩 (wasm_entry.zig와 동일한 비트 레이아웃)
+fn decodeFlags(flags: u32) TranspileOptions {
+    return .{
+        .sourcemap = flags & (1 << 0) != 0,
+        .minify_whitespace = flags & (1 << 1) != 0,
+        .minify_identifiers = flags & (1 << 2) != 0,
+        .minify_syntax = flags & (1 << 3) != 0,
+        .jsx_runtime = if (flags & (1 << 5) != 0)
+            .automatic_dev
+        else if (flags & (1 << 4) != 0)
+            .automatic
+        else
+            .classic,
+        .drop_console = flags & (1 << 6) != 0,
+        .drop_debugger = flags & (1 << 7) != 0,
+        .ascii_only = flags & (1 << 8) != 0,
+        .flow = flags & (1 << 9) != 0,
+        .experimental_decorators = flags & (1 << 10) != 0,
+        .emit_decorator_metadata = flags & (1 << 11) != 0,
+        .module_format = switch ((flags >> 12) & 0x3) {
+            0 => .esm,
+            1 => .cjs,
+            else => .esm,
+        },
+        .quote_style = switch ((flags >> 14) & 0x3) {
+            0 => .double,
+            1 => .single,
+            2 => .preserve,
+            else => .double,
+        },
+        .use_define_for_class_fields = flags & (1 << 16) != 0,
+        .charset_utf8 = flags & (1 << 17) != 0,
+        .platform = switch ((flags >> 18) & 0x3) {
+            0 => .browser,
+            1 => .node,
+            2 => .neutral,
+            3 => .react_native,
+            else => .browser,
+        },
+        .jsx_in_js = flags & (1 << 20) != 0,
+        .sourcemap_debug_ids = flags & (1 << 21) != 0,
+        .sources_content = flags & (1 << 22) != 0,
+    };
+}
+
+/// 소스 코드를 트랜스파일한다.
+///
+/// 성공 시 결과 포인터 반환, 실패 시 null 반환.
+/// 결과 길이는 zts_result_len()으로 조회.
+/// 에러 메시지는 zts_error_ptr() + zts_error_len()으로 조회.
+fn readStr(p: ?[*]const u8, len: u32) []const u8 {
+    if (p) |valid| {
+        if (len > 0) return valid[0..len];
+    }
+    return "";
+}
+
+export fn zts_transpile(
+    src_ptr: ?[*]const u8,
+    src_len: u32,
+    file_ptr: ?[*]const u8,
+    file_len: u32,
+    flags: u32,
+    unsupported: u32,
+    jsx_factory_ptr: ?[*]const u8,
+    jsx_factory_len: u32,
+    jsx_fragment_ptr: ?[*]const u8,
+    jsx_fragment_len: u32,
+    jsx_import_source_ptr: ?[*]const u8,
+    jsx_import_source_len: u32,
+) ?[*]const u8 {
+    freeResult();
+    freeError();
+
+    const source = if (src_ptr) |p| p[0..src_len] else {
+        last_error = native_alloc.dupe(u8, "empty source") catch null;
+        return null;
+    };
+    if (src_len == 0) {
+        last_error = native_alloc.dupe(u8, "empty source") catch null;
+        return null;
+    }
+
+    const file_path = if (file_ptr) |p|
+        if (file_len > 0) p[0..file_len] else "input.ts"
+    else
+        "input.ts";
+
+    var options = decodeFlags(flags);
+
+    // UnsupportedFeatures (ES 다운레벨링 타겟)
+    options.unsupported = @bitCast(unsupported);
+
+    // 문자열 옵션
+    const factory = readStr(jsx_factory_ptr, jsx_factory_len);
+    if (factory.len > 0) options.jsx_factory = factory;
+    const fragment = readStr(jsx_fragment_ptr, jsx_fragment_len);
+    if (fragment.len > 0) options.jsx_fragment = fragment;
+    const import_source = readStr(jsx_import_source_ptr, jsx_import_source_len);
+    if (import_source.len > 0) options.jsx_import_source = import_source;
+
+    var result = transpile_mod.transpile(native_alloc, source, file_path, options) catch |err| {
+        const msg: []const u8 = switch (err) {
+            error.ParseError => "ParseError",
+            error.SemanticError => "SemanticError",
+            error.TransformError => "TransformError",
+            error.CodegenError => "CodegenError",
+            error.OutOfMemory => "OutOfMemory",
+        };
+        last_error = native_alloc.dupe(u8, msg) catch null;
+        return null;
+    };
+
+    // 결과를 native_alloc 소유의 메모리로 복사 (transpile 내부는 arena 사용)
+    const output = if (result.sourcemap) |sm| blk: {
+        const total = result.code.len + 1 + sm.len;
+        const combined = native_alloc.alloc(u8, total) catch {
+            last_error = native_alloc.dupe(u8, "OutOfMemory") catch null;
+            result.deinit(native_alloc);
+            return null;
+        };
+        @memcpy(combined[0..result.code.len], result.code);
+        combined[result.code.len] = 0;
+        @memcpy(combined[result.code.len + 1 ..], sm);
+        result.deinit(native_alloc);
+        break :blk combined;
+    } else blk: {
+        // code를 native_alloc으로 복사 후 원본 해제
+        const copy = native_alloc.dupe(u8, result.code) catch {
+            last_error = native_alloc.dupe(u8, "OutOfMemory") catch null;
+            result.deinit(native_alloc);
+            return null;
+        };
+        result.deinit(native_alloc);
+        break :blk copy;
+    };
+
+    last_result = output;
+    return output.ptr;
+}
+
+/// 마지막 트랜스파일 결과의 길이를 반환한다.
+export fn zts_result_len() u32 {
+    return if (last_result) |r| @intCast(r.len) else 0;
+}
+
+/// 마지막 에러 메시지의 포인터를 반환한다.
+export fn zts_error_ptr() ?[*]const u8 {
+    return if (last_error) |e| e.ptr else null;
+}
+
+/// 마지막 에러 메시지의 길이를 반환한다.
+export fn zts_error_len() u32 {
+    return if (last_error) |e| @intCast(e.len) else 0;
+}
+
+/// 마지막 결과 메모리를 해제한다.
+export fn zts_free_result() void {
+    freeResult();
+    freeError();
+}

--- a/packages/ffi/tsconfig.json
+++ b/packages/ffi/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}

--- a/tests/benchmark/ffi-bench.ts
+++ b/tests/benchmark/ffi-bench.ts
@@ -196,7 +196,8 @@ interface BenchResult {
 }
 
 function runWorker(method: "ffi" | "wasm" | "cli", scale: string, sourceFile: string): BenchResult {
-  const label = method === "ffi" ? "FFI (NAPI-like)" : method === "wasm" ? "WASM" : "CLI (subprocess)";
+  const label =
+    method === "ffi" ? "FFI (NAPI-like)" : method === "wasm" ? "WASM" : "CLI (subprocess)";
   const workerPath = createWorkerScript(method, sourceFile);
 
   const result = spawnSync("bun", ["run", workerPath], {
@@ -209,7 +210,8 @@ function runWorker(method: "ffi" | "wasm" | "cli", scale: string, sourceFile: st
 
   if (result.status !== 0) {
     console.error(`  ${label}: FAILED`);
-    if (result.stderr.length > 0) console.error(`  stderr: ${result.stderr.toString().slice(0, 200)}`);
+    if (result.stderr.length > 0)
+      console.error(`  stderr: ${result.stderr.toString().slice(0, 200)}`);
     return { method: label, scale, medianUs: -1, minUs: -1, maxUs: -1 };
   }
 
@@ -286,7 +288,9 @@ for (const scale of scales) {
     const min = r.minUs === -1 ? "-" : String(r.minUs);
     const max = r.maxUs === -1 ? "-" : String(r.maxUs);
     const ratio = r.medianUs > 0 ? `${(r.medianUs / fastest).toFixed(1)}x` : "-";
-    console.log(`| ${r.method.padEnd(15)} | ${median.padStart(11)} | ${min.padStart(8)} | ${max.padStart(8)} | ${ratio.padStart(10)} |`);
+    console.log(
+      `| ${r.method.padEnd(15)} | ${median.padStart(11)} | ${min.padStart(8)} | ${max.padStart(8)} | ${ratio.padStart(10)} |`,
+    );
   }
   console.log();
 }

--- a/tests/benchmark/ffi-bench.ts
+++ b/tests/benchmark/ffi-bench.ts
@@ -1,0 +1,292 @@
+#!/usr/bin/env bun
+/**
+ * ZTS FFI vs WASM vs CLI 벤치마크
+ *
+ * 세 가지 호출 방식의 트랜스파일 성능을 비교한다:
+ *   - CLI: subprocess spawn (현재 방식)
+ *   - WASM: WebAssembly in-process (별도 프로세스에서 실행)
+ *   - FFI: 네이티브 dylib in-process (NAPI와 동일한 성능 특성)
+ *
+ * WASM과 FFI를 같은 프로세스에서 로드하면 심볼 충돌로 크래시하므로
+ * 각 방식을 별도 프로세스로 실행한 뒤 결과를 취합한다.
+ */
+
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+const ROOT = resolve(import.meta.dir, "../..");
+const WARMUP = 3;
+const ITERATIONS = 10;
+
+// ─── Fixture 생성 ───
+
+function generateTS(lines: number): string {
+  const parts: string[] = [];
+  for (let i = 0; i < lines; i++) {
+    parts.push(`export const value${i}: number = ${i} * 2;`);
+    if (i % 50 === 0) {
+      parts.push(`export function compute${i}(x: number): number { return x * ${i}; }`);
+    }
+  }
+  parts.push(`export default function main() { return value0; }`);
+  return parts.join("\n");
+}
+
+// ─── 워커 스크립트 생성 ───
+
+function createWorkerScript(method: "ffi" | "wasm" | "cli", sourceFile: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "zts-bench-worker-"));
+
+  if (method === "ffi") {
+    const script = `
+import { dlopen, FFIType, ptr, toBuffer } from "bun:ffi";
+import { readFileSync } from "node:fs";
+
+const DYLIB = "${resolve(ROOT, "zig-out/lib/libzts.dylib")}";
+const lib = dlopen(DYLIB, {
+  zts_transpile: { args: [FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.u32, FFIType.u32, FFIType.u32, FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.u32], returns: FFIType.ptr },
+  zts_result_len: { args: [], returns: FFIType.u32 },
+  zts_free_result: { args: [], returns: FFIType.void },
+});
+
+const source = readFileSync("${sourceFile}", "utf8");
+const flags = (1 << 16) | (1 << 22);
+const WARMUP = ${WARMUP};
+const ITERATIONS = ${ITERATIONS};
+
+function run() {
+  const srcBuf = Buffer.from(source);
+  const fileBuf = Buffer.from("input.ts");
+  const rp = lib.symbols.zts_transpile(ptr(srcBuf), srcBuf.length, ptr(fileBuf), fileBuf.length, flags, 0, 0, 0, 0, 0, 0, 0);
+  if (rp === null || rp === 0) throw new Error("FFI failed");
+  lib.symbols.zts_free_result();
+}
+
+for (let i = 0; i < WARMUP; i++) run();
+const times = [];
+for (let i = 0; i < ITERATIONS; i++) {
+  const start = Bun.nanoseconds();
+  run();
+  times.push((Bun.nanoseconds() - start) / 1000);
+}
+times.sort((a, b) => a - b);
+console.log(JSON.stringify({
+  medianUs: Math.round(times[Math.floor(times.length / 2)]),
+  minUs: Math.round(times[0]),
+  maxUs: Math.round(times[times.length - 1]),
+}));
+lib.close();
+`;
+    const path = resolve(dir, "worker.ts");
+    writeFileSync(path, script);
+    return path;
+  }
+
+  if (method === "wasm") {
+    const script = `
+import { readFileSync } from "node:fs";
+
+const WASM_PATH = "${resolve(ROOT, "zig-out/bin/zts.wasm")}";
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const wasmBytes = readFileSync(WASM_PATH);
+let memory;
+const imports = {
+  wasi_snapshot_preview1: {
+    fd_write(fd, iovs_ptr, iovs_len, nwritten_ptr) {
+      new DataView(memory.buffer).setUint32(nwritten_ptr, 0, true);
+      return 0;
+    },
+    fd_read: () => 8, fd_seek: () => 8, fd_pwrite: () => 8, fd_filestat_get: () => 8,
+    random_get(buf_ptr, buf_len) {
+      crypto.getRandomValues(new Uint8Array(memory.buffer, buf_ptr, buf_len));
+      return 0;
+    },
+  },
+};
+const mod = new WebAssembly.Module(wasmBytes);
+const instance = new WebAssembly.Instance(mod, imports);
+memory = instance.exports.memory;
+const w = instance.exports;
+
+const source = readFileSync("${sourceFile}", "utf8");
+const flags = (1 << 16) | (1 << 22);
+const WARMUP = ${WARMUP};
+const ITERATIONS = ${ITERATIONS};
+
+function run() {
+  const bytes = encoder.encode(source);
+  const srcPtr = w.alloc(bytes.length);
+  new Uint8Array(w.memory.buffer, srcPtr, bytes.length).set(bytes);
+  const fileBytes = encoder.encode("input.ts");
+  const filePtr = w.alloc(fileBytes.length);
+  new Uint8Array(w.memory.buffer, filePtr, fileBytes.length).set(fileBytes);
+  const packed = w.transpile(srcPtr, bytes.length, filePtr, fileBytes.length, flags, 0, 0, 0, 0, 0, 0, 0);
+  w.dealloc(srcPtr, bytes.length);
+  w.dealloc(filePtr, fileBytes.length);
+  const outPtr = Number(packed >> 32n);
+  const outLen = Number(packed & 0xffffffffn);
+  if (outPtr === 0) throw new Error("WASM failed");
+  w.dealloc(outPtr, outLen);
+}
+
+for (let i = 0; i < WARMUP; i++) run();
+const times = [];
+for (let i = 0; i < ITERATIONS; i++) {
+  const start = Bun.nanoseconds();
+  run();
+  times.push((Bun.nanoseconds() - start) / 1000);
+}
+times.sort((a, b) => a - b);
+console.log(JSON.stringify({
+  medianUs: Math.round(times[Math.floor(times.length / 2)]),
+  minUs: Math.round(times[0]),
+  maxUs: Math.round(times[times.length - 1]),
+}));
+`;
+    const path = resolve(dir, "worker.ts");
+    writeFileSync(path, script);
+    return path;
+  }
+
+  // CLI
+  const script = `
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const ZTS_BIN = "${resolve(ROOT, "zig-out/bin/zts")}";
+const source = readFileSync("${sourceFile}", "utf8");
+const WARMUP = ${WARMUP};
+const ITERATIONS = ${ITERATIONS};
+
+function run() {
+  spawnSync(ZTS_BIN, ["-"], { input: source, stdio: ["pipe", "pipe", "pipe"] });
+}
+
+for (let i = 0; i < WARMUP; i++) run();
+const times = [];
+for (let i = 0; i < ITERATIONS; i++) {
+  const start = Bun.nanoseconds();
+  run();
+  times.push((Bun.nanoseconds() - start) / 1000);
+}
+times.sort((a, b) => a - b);
+console.log(JSON.stringify({
+  medianUs: Math.round(times[Math.floor(times.length / 2)]),
+  minUs: Math.round(times[0]),
+  maxUs: Math.round(times[times.length - 1]),
+}));
+`;
+  const path = resolve(dir, "worker.ts");
+  writeFileSync(path, script);
+  return path;
+}
+
+// ─── 워커 실행 ───
+
+interface BenchResult {
+  method: string;
+  scale: string;
+  medianUs: number;
+  minUs: number;
+  maxUs: number;
+}
+
+function runWorker(method: "ffi" | "wasm" | "cli", scale: string, sourceFile: string): BenchResult {
+  const label = method === "ffi" ? "FFI (NAPI-like)" : method === "wasm" ? "WASM" : "CLI (subprocess)";
+  const workerPath = createWorkerScript(method, sourceFile);
+
+  const result = spawnSync("bun", ["run", workerPath], {
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 120000,
+  });
+
+  // 임시 파일 정리
+  rmSync(resolve(workerPath, ".."), { recursive: true, force: true });
+
+  if (result.status !== 0) {
+    console.error(`  ${label}: FAILED`);
+    if (result.stderr.length > 0) console.error(`  stderr: ${result.stderr.toString().slice(0, 200)}`);
+    return { method: label, scale, medianUs: -1, minUs: -1, maxUs: -1 };
+  }
+
+  const stdout = result.stdout.toString().trim();
+  try {
+    const data = JSON.parse(stdout);
+    return { method: label, scale, ...data };
+  } catch {
+    console.error(`  ${label}: parse error: ${stdout.slice(0, 200)}`);
+    return { method: label, scale, medianUs: -1, minUs: -1, maxUs: -1 };
+  }
+}
+
+// ─── Main ───
+
+console.log("ZTS FFI vs WASM vs CLI Benchmark");
+console.log(`  Warmup: ${WARMUP}, Iterations: ${ITERATIONS} (median)`);
+console.log(`  Platform: ${process.platform} ${process.arch}`);
+console.log(`  각 방식은 별도 프로세스에서 실행 (심볼 충돌 방지)\n`);
+
+const scales = [
+  { name: "small (100 lines)", lines: 100 },
+  { name: "medium (1K lines)", lines: 1000 },
+  { name: "large (5K lines)", lines: 5000 },
+  { name: "xlarge (10K lines)", lines: 10000 },
+];
+
+const results: BenchResult[] = [];
+
+for (const scale of scales) {
+  const source = generateTS(scale.lines);
+  const sizeKB = (Buffer.byteLength(source) / 1024).toFixed(0);
+
+  // 소스 파일을 임시 파일에 저장
+  const tmpDir = mkdtempSync(resolve(tmpdir(), "zts-bench-src-"));
+  const sourceFile = resolve(tmpDir, "input.ts");
+  writeFileSync(sourceFile, source);
+
+  console.log(`--- ${scale.name} (${sizeKB} KB) ---`);
+
+  for (const method of ["ffi", "wasm", "cli"] as const) {
+    const label = method === "ffi" ? "FFI" : method === "wasm" ? "WASM" : "CLI";
+    process.stdout.write(`  ${label}... `);
+    const r = runWorker(method, scale.name, sourceFile);
+    if (r.medianUs > 0) {
+      console.log(`${r.medianUs} us (min: ${r.minUs}, max: ${r.maxUs})`);
+    }
+    results.push(r);
+  }
+
+  rmSync(tmpDir, { recursive: true, force: true });
+}
+
+// ─── 결과 출력 ───
+
+console.log("\n===== Results =====\n");
+
+for (const scale of scales) {
+  const group = results
+    .filter((r) => r.scale === scale.name)
+    .sort((a, b) => {
+      if (a.medianUs === -1) return 1;
+      if (b.medianUs === -1) return -1;
+      return a.medianUs - b.medianUs;
+    });
+
+  const fastest = group.find((r) => r.medianUs > 0)?.medianUs ?? 1;
+
+  console.log(`### ${scale.name}`);
+  console.log("| Method          | Median (us) | Min (us) | Max (us) | vs fastest |");
+  console.log("|-----------------|-------------|----------|----------|------------|");
+  for (const r of group) {
+    const median = r.medianUs === -1 ? "FAIL" : String(r.medianUs);
+    const min = r.minUs === -1 ? "-" : String(r.minUs);
+    const max = r.maxUs === -1 ? "-" : String(r.maxUs);
+    const ratio = r.medianUs > 0 ? `${(r.medianUs / fastest).toFixed(1)}x` : "-";
+    console.log(`| ${r.method.padEnd(15)} | ${median.padStart(11)} | ${min.padStart(8)} | ${max.padStart(8)} | ${ratio.padStart(10)} |`);
+  }
+  console.log();
+}


### PR DESCRIPTION
## Summary
- `packages/ffi/`: bun:ffi 기반 네이티브 dylib 트랜스파일 바인딩 (@zts/wasm과 동일 API)
- `build.zig`: `zig build ffi` 동적 라이브러리(.dylib/.so) 빌드 스텝 추가
- `tests/benchmark/ffi-bench.ts`: FFI vs WASM vs CLI 성능 비교 벤치마크

### 벤치마크 결과 (darwin arm64)
| 규모 | FFI (us) | WASM (us) | CLI (us) | FFI vs WASM | FFI vs CLI |
|------|----------|-----------|----------|-------------|------------|
| 100줄 | **58** | 673 | 6,273 | 11.6x | 108x |
| 1K줄 | **548** | 3,781 | 50,447 | 6.9x | 92x |
| 5K줄 | **2,731** | 6,003 | 199,795 | 2.2x | 73x |
| 10K줄 | **5,487** | 12,019 | 144,665 | 2.2x | 26x |

## Test plan
- [x] `packages/ffi/` 유닛 테스트 28개 전체 통과
- [x] pre-push hook (zig test + oxlint + oxfmt) 통과
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)