### PR TITLE
fix: CI 경로 수정 + decodeFlags/타입 중복 제거

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -34,8 +34,8 @@ export default defineConfig({
       plugins: [
         starlightLinksValidator({ exclude: ["/zts/playground/", "/zts/en/playground/"] }),
         starlightTypeDoc({
-          entryPoints: ["../packages/core/index.ts"],
-          tsconfig: "../packages/core/tsconfig.json",
+          entryPoints: ["../packages/plugin/index.ts"],
+          tsconfig: "../packages/plugin/tsconfig.json",
           output: "reference/api",
           sidebar: {
             label: "API Reference",

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -18,83 +18,9 @@ import { existsSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
-// ─── Types (packages/wasm과 동일) ───
-
-export type Target =
-  | "es5"
-  | "es2015"
-  | "es2016"
-  | "es2017"
-  | "es2018"
-  | "es2019"
-  | "es2020"
-  | "es2021"
-  | "es2022"
-  | "es2024"
-  | "es2025"
-  | "esnext";
-
-export type Platform = "browser" | "node" | "neutral" | "react-native";
-
-export interface TranspileOptions {
-  /** 파일 경로 (확장자 감지용, 기본: "input.ts") */
-  filename?: string;
-  /** 소스맵 생성 */
-  sourcemap?: boolean;
-  /** 소스맵 Debug ID (Sentry 호환) */
-  sourcemapDebugIds?: boolean;
-  /** 소스맵에 원본 소스 포함 (기본: true) */
-  sourcesContent?: boolean;
-  /** 공백 축소 */
-  minifyWhitespace?: boolean;
-  /** 식별자 축소 */
-  minifyIdentifiers?: boolean;
-  /** 구문 축소 */
-  minifySyntax?: boolean;
-  /** 전체 축소 (whitespace + identifiers + syntax) */
-  minify?: boolean;
-  /** JSX 런타임 */
-  jsx?: "classic" | "automatic" | "automatic-dev";
-  /** classic 모드 JSX factory (기본: "React.createElement") */
-  jsxFactory?: string;
-  /** classic 모드 Fragment factory (기본: "React.Fragment") */
-  jsxFragment?: string;
-  /** automatic 모드 import source (기본: "react") */
-  jsxImportSource?: string;
-  /** JS 파일에서도 JSX 허용 */
-  jsxInJs?: boolean;
-  /** console.* 호출 제거 */
-  dropConsole?: boolean;
-  /** debugger 문 제거 */
-  dropDebugger?: boolean;
-  /** non-ASCII를 \uXXXX로 이스케이프 */
-  asciiOnly?: boolean;
-  /** non-ASCII를 이스케이프하지 않음 */
-  charsetUtf8?: boolean;
-  /** Flow 타입 스트리핑 */
-  flow?: boolean;
-  /** legacy decorator 변환 */
-  experimentalDecorators?: boolean;
-  /** decorator metadata emit */
-  emitDecoratorMetadata?: boolean;
-  /** class field → constructor this.x = v 변환 (기본: true) */
-  useDefineForClassFields?: boolean;
-  /** 모듈 포맷 */
-  format?: "esm" | "cjs";
-  /** 문자열 따옴표 스타일 */
-  quotes?: "double" | "single" | "preserve";
-  /** 타겟 플랫폼 */
-  platform?: Platform;
-  /** ES 다운레벨 타겟 */
-  target?: Target;
-}
-
-export interface TranspileResult {
-  /** 변환된 JavaScript 코드 */
-  code: string;
-  /** 소스맵 JSON (sourcemap: true 시) */
-  map?: string;
-}
+export type { Target, Platform, TranspileOptions, TranspileResult } from "../shared/index";
+import type { TranspileOptions } from "../shared/index";
+import { encodeFlags, ES_TARGET_BITS } from "../shared/index";
 
 // ─── FFI Instance ───
 
@@ -123,53 +49,6 @@ interface ZtsLib {
 }
 
 let lib: ZtsLib | null = null;
-
-// ─── ES Target → UnsupportedFeatures bitmask ───
-
-const ES_TARGET_BITS: Record<string, number> = {
-  es5: 0x1fffff,
-  es2015: 0x1ff800,
-  es2016: 0x1ff000,
-  es2017: 0x1fe000,
-  es2018: 0x1fc000,
-  es2019: 0x1f8000,
-  es2020: 0x1e0000,
-  es2021: 0x1c0000,
-  es2022: 0x100000,
-  es2024: 0x100000,
-  es2025: 0x0,
-  esnext: 0x0,
-};
-
-// ─── 옵션 인코딩 (wasm/index.ts와 동일한 비트 레이아웃) ───
-
-function encodeFlags(opts: TranspileOptions = {}): number {
-  let flags = 0;
-  if (opts.sourcemap) flags |= 1 << 0;
-  if (opts.minifyWhitespace || opts.minify) flags |= 1 << 1;
-  if (opts.minifyIdentifiers || opts.minify) flags |= 1 << 2;
-  if (opts.minifySyntax || opts.minify) flags |= 1 << 3;
-  if (opts.jsx === "automatic") flags |= 1 << 4;
-  if (opts.jsx === "automatic-dev") flags |= 1 << 5;
-  if (opts.dropConsole) flags |= 1 << 6;
-  if (opts.dropDebugger) flags |= 1 << 7;
-  if (opts.asciiOnly) flags |= 1 << 8;
-  if (opts.flow) flags |= 1 << 9;
-  if (opts.experimentalDecorators) flags |= 1 << 10;
-  if (opts.emitDecoratorMetadata) flags |= 1 << 11;
-  if (opts.format === "cjs") flags |= 1 << 12;
-  if (opts.quotes === "single") flags |= 1 << 14;
-  if (opts.quotes === "preserve") flags |= 2 << 14;
-  if (opts.useDefineForClassFields !== false) flags |= 1 << 16;
-  if (opts.charsetUtf8) flags |= 1 << 17;
-  if (opts.platform === "node") flags |= 1 << 18;
-  if (opts.platform === "neutral") flags |= 2 << 18;
-  if (opts.platform === "react-native") flags |= 3 << 18;
-  if (opts.jsxInJs) flags |= 1 << 20;
-  if (opts.sourcemapDebugIds) flags |= 1 << 21;
-  if (opts.sourcesContent !== false) flags |= 1 << 22;
-  return flags;
-}
 
 // ─── dylib 경로 탐색 ───
 

--- a/packages/core/src/ffi_entry.zig
+++ b/packages/core/src/ffi_entry.zig
@@ -29,50 +29,7 @@ fn freeError() void {
     last_error = null;
 }
 
-/// 옵션 플래그 디코딩 (wasm_entry.zig와 동일한 비트 레이아웃)
-fn decodeFlags(flags: u32) TranspileOptions {
-    return .{
-        .sourcemap = flags & (1 << 0) != 0,
-        .minify_whitespace = flags & (1 << 1) != 0,
-        .minify_identifiers = flags & (1 << 2) != 0,
-        .minify_syntax = flags & (1 << 3) != 0,
-        .jsx_runtime = if (flags & (1 << 5) != 0)
-            .automatic_dev
-        else if (flags & (1 << 4) != 0)
-            .automatic
-        else
-            .classic,
-        .drop_console = flags & (1 << 6) != 0,
-        .drop_debugger = flags & (1 << 7) != 0,
-        .ascii_only = flags & (1 << 8) != 0,
-        .flow = flags & (1 << 9) != 0,
-        .experimental_decorators = flags & (1 << 10) != 0,
-        .emit_decorator_metadata = flags & (1 << 11) != 0,
-        .module_format = switch ((flags >> 12) & 0x3) {
-            0 => .esm,
-            1 => .cjs,
-            else => .esm,
-        },
-        .quote_style = switch ((flags >> 14) & 0x3) {
-            0 => .double,
-            1 => .single,
-            2 => .preserve,
-            else => .double,
-        },
-        .use_define_for_class_fields = flags & (1 << 16) != 0,
-        .charset_utf8 = flags & (1 << 17) != 0,
-        .platform = switch ((flags >> 18) & 0x3) {
-            0 => .browser,
-            1 => .node,
-            2 => .neutral,
-            3 => .react_native,
-            else => .browser,
-        },
-        .jsx_in_js = flags & (1 << 20) != 0,
-        .sourcemap_debug_ids = flags & (1 << 21) != 0,
-        .sources_content = flags & (1 << 22) != 0,
-    };
-}
+const decodeFlags = transpile_mod.decodeFlags;
 
 /// 소스 코드를 트랜스파일한다.
 ///

--- a/packages/plugin/index.test.ts
+++ b/packages/plugin/index.test.ts
@@ -1,6 +1,6 @@
 /**
  * @zts/plugin 단위 테스트
- * bun test packages/core/index.test.ts
+ * bun test packages/plugin/index.test.ts
  */
 import { describe, test, expect } from "bun:test";
 

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,0 +1,133 @@
+/**
+ * @zts/shared — @zts/core와 @zts/wasm에서 공유하는 타입 및 유틸리티
+ */
+
+// ─── Types ───
+
+export type Target =
+  | "es5"
+  | "es2015"
+  | "es2016"
+  | "es2017"
+  | "es2018"
+  | "es2019"
+  | "es2020"
+  | "es2021"
+  | "es2022"
+  | "es2024"
+  | "es2025"
+  | "esnext";
+
+export type Platform = "browser" | "node" | "neutral" | "react-native";
+
+export interface TranspileOptions {
+  /** 파일 경로 (확장자 감지용, 기본: "input.ts") */
+  filename?: string;
+  /** 소스맵 생성 */
+  sourcemap?: boolean;
+  /** 소스맵 Debug ID (Sentry 호환) */
+  sourcemapDebugIds?: boolean;
+  /** 소스맵에 원본 소스 포함 (기본: true) */
+  sourcesContent?: boolean;
+  /** 공백 축소 */
+  minifyWhitespace?: boolean;
+  /** 식별자 축소 */
+  minifyIdentifiers?: boolean;
+  /** 구문 축소 */
+  minifySyntax?: boolean;
+  /** 전체 축소 (whitespace + identifiers + syntax) */
+  minify?: boolean;
+  /** JSX 런타임 */
+  jsx?: "classic" | "automatic" | "automatic-dev";
+  /** classic 모드 JSX factory (기본: "React.createElement") */
+  jsxFactory?: string;
+  /** classic 모드 Fragment factory (기본: "React.Fragment") */
+  jsxFragment?: string;
+  /** automatic 모드 import source (기본: "react") */
+  jsxImportSource?: string;
+  /** JS 파일에서도 JSX 허용 */
+  jsxInJs?: boolean;
+  /** console.* 호출 제거 */
+  dropConsole?: boolean;
+  /** debugger 문 제거 */
+  dropDebugger?: boolean;
+  /** non-ASCII를 \uXXXX로 이스케이프 */
+  asciiOnly?: boolean;
+  /** non-ASCII를 이스케이프하지 않음 */
+  charsetUtf8?: boolean;
+  /** Flow 타입 스트리핑 */
+  flow?: boolean;
+  /** legacy decorator 변환 */
+  experimentalDecorators?: boolean;
+  /** decorator metadata emit */
+  emitDecoratorMetadata?: boolean;
+  /** class field → constructor this.x = v 변환 (기본: true) */
+  useDefineForClassFields?: boolean;
+  /** 모듈 포맷 */
+  format?: "esm" | "cjs";
+  /** 문자열 따옴표 스타일 */
+  quotes?: "double" | "single" | "preserve";
+  /** 타겟 플랫폼 */
+  platform?: Platform;
+  /** ES 다운레벨 타겟 */
+  target?: Target;
+}
+
+export interface TranspileResult {
+  /** 변환된 JavaScript 코드 */
+  code: string;
+  /** 소스맵 JSON (sourcemap: true 시) */
+  map?: string;
+}
+
+// ─── ES Target → UnsupportedFeatures bitmask ───
+
+export const ES_TARGET_BITS: Record<string, number> = {
+  es5: 0x1fffff,
+  es2015: 0x1ff800,
+  es2016: 0x1ff000,
+  es2017: 0x1fe000,
+  es2018: 0x1fc000,
+  es2019: 0x1f8000,
+  es2020: 0x1e0000,
+  es2021: 0x1c0000,
+  es2022: 0x100000,
+  es2024: 0x100000,
+  es2025: 0x0,
+  esnext: 0x0,
+};
+
+// ─── 옵션 인코딩 (Zig decodeFlags와 동일한 비트 레이아웃) ───
+
+export function encodeFlags(opts: TranspileOptions = {}): number {
+  let flags = 0;
+  if (opts.sourcemap) flags |= 1 << 0;
+  if (opts.minifyWhitespace || opts.minify) flags |= 1 << 1;
+  if (opts.minifyIdentifiers || opts.minify) flags |= 1 << 2;
+  if (opts.minifySyntax || opts.minify) flags |= 1 << 3;
+  if (opts.jsx === "automatic") flags |= 1 << 4;
+  if (opts.jsx === "automatic-dev") flags |= 1 << 5;
+  if (opts.dropConsole) flags |= 1 << 6;
+  if (opts.dropDebugger) flags |= 1 << 7;
+  if (opts.asciiOnly) flags |= 1 << 8;
+  if (opts.flow) flags |= 1 << 9;
+  if (opts.experimentalDecorators) flags |= 1 << 10;
+  if (opts.emitDecoratorMetadata) flags |= 1 << 11;
+  if (opts.format === "cjs") flags |= 1 << 12;
+  if (opts.quotes === "single") flags |= 1 << 14;
+  if (opts.quotes === "preserve") flags |= 2 << 14;
+  if (opts.useDefineForClassFields !== false) flags |= 1 << 16;
+  if (opts.charsetUtf8) flags |= 1 << 17;
+  if (opts.platform === "node") flags |= 1 << 18;
+  if (opts.platform === "neutral") flags |= 2 << 18;
+  if (opts.platform === "react-native") flags |= 3 << 18;
+  if (opts.jsxInJs) flags |= 1 << 20;
+  if (opts.sourcemapDebugIds) flags |= 1 << 21;
+  if (opts.sourcesContent !== false) flags |= 1 << 22;
+  return flags;
+}
+
+export function targetToUnsupported(target?: Target): number {
+  if (!target) return 0;
+  return ES_TARGET_BITS[target] ?? 0;
+}

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -10,83 +10,9 @@
  * ```
  */
 
-// ─── Types ───
-
-export type Target =
-  | "es5"
-  | "es2015"
-  | "es2016"
-  | "es2017"
-  | "es2018"
-  | "es2019"
-  | "es2020"
-  | "es2021"
-  | "es2022"
-  | "es2024"
-  | "es2025"
-  | "esnext";
-
-export type Platform = "browser" | "node" | "neutral" | "react-native";
-
-export interface TranspileOptions {
-  /** 파일 경로 (확장자 감지용, 기본: "input.ts") */
-  filename?: string;
-  /** 소스맵 생성 */
-  sourcemap?: boolean;
-  /** 소스맵 Debug ID (Sentry 호환) */
-  sourcemapDebugIds?: boolean;
-  /** 소스맵에 원본 소스 포함 (기본: true) */
-  sourcesContent?: boolean;
-  /** 공백 축소 */
-  minifyWhitespace?: boolean;
-  /** 식별자 축소 */
-  minifyIdentifiers?: boolean;
-  /** 구문 축소 */
-  minifySyntax?: boolean;
-  /** 전체 축소 (whitespace + identifiers + syntax) */
-  minify?: boolean;
-  /** JSX 런타임 */
-  jsx?: "classic" | "automatic" | "automatic-dev";
-  /** classic 모드 JSX factory (기본: "React.createElement") */
-  jsxFactory?: string;
-  /** classic 모드 Fragment factory (기본: "React.Fragment") */
-  jsxFragment?: string;
-  /** automatic 모드 import source (기본: "react") */
-  jsxImportSource?: string;
-  /** JS 파일에서도 JSX 허용 */
-  jsxInJs?: boolean;
-  /** console.* 호출 제거 */
-  dropConsole?: boolean;
-  /** debugger 문 제거 */
-  dropDebugger?: boolean;
-  /** non-ASCII를 \uXXXX로 이스케이프 */
-  asciiOnly?: boolean;
-  /** non-ASCII를 이스케이프하지 않음 */
-  charsetUtf8?: boolean;
-  /** Flow 타입 스트리핑 */
-  flow?: boolean;
-  /** legacy decorator 변환 */
-  experimentalDecorators?: boolean;
-  /** decorator metadata emit */
-  emitDecoratorMetadata?: boolean;
-  /** class field → constructor this.x = v 변환 (기본: true) */
-  useDefineForClassFields?: boolean;
-  /** 모듈 포맷 */
-  format?: "esm" | "cjs";
-  /** 문자열 따옴표 스타일 */
-  quotes?: "double" | "single" | "preserve";
-  /** 타겟 플랫폼 */
-  platform?: Platform;
-  /** ES 다운레벨 타겟 */
-  target?: Target;
-}
-
-export interface TranspileResult {
-  /** 변환된 JavaScript 코드 */
-  code: string;
-  /** 소스맵 JSON (sourcemap: true 시) */
-  map?: string;
-}
+export type { Target, Platform, TranspileOptions, TranspileResult } from "../shared/index";
+import type { TranspileOptions } from "../shared/index";
+import { encodeFlags, targetToUnsupported } from "../shared/index";
 
 // ─── WASM Instance ───
 
@@ -158,62 +84,6 @@ function createWasiImports(memory: () => WebAssembly.Memory) {
       },
     },
   };
-}
-
-// ─── ES Target → UnsupportedFeatures bitmask ───
-// compat.zig의 Feature enum/ESTarget과 동일한 비트 레이아웃
-
-const ES_TARGET_BITS: Record<string, number> = {
-  es5: 0x1fffff, // bit 0-20: 모든 feature unsupported
-  es2015: 0x1ff800, // bit 11-20
-  es2016: 0x1ff000, // bit 12-20
-  es2017: 0x1fe000, // bit 13-20
-  es2018: 0x1fc000, // bit 14-20
-  es2019: 0x1f8000, // bit 15-20
-  es2020: 0x1e0000, // bit 17-20
-  es2021: 0x1c0000, // bit 18-20
-  es2022: 0x100000, // bit 20 (using)
-  es2024: 0x100000, // bit 20 (using) — es2022와 동일
-  es2025: 0x0,
-  esnext: 0x0,
-};
-
-function targetToUnsupported(target?: Target): number {
-  if (!target) return 0;
-  return ES_TARGET_BITS[target] ?? 0;
-}
-
-// ─── 옵션 인코딩 ───
-
-function encodeFlags(opts: TranspileOptions = {}): number {
-  let flags = 0;
-  if (opts.sourcemap) flags |= 1 << 0;
-  if (opts.minifyWhitespace || opts.minify) flags |= 1 << 1;
-  if (opts.minifyIdentifiers || opts.minify) flags |= 1 << 2;
-  if (opts.minifySyntax || opts.minify) flags |= 1 << 3;
-  if (opts.jsx === "automatic") flags |= 1 << 4;
-  if (opts.jsx === "automatic-dev") flags |= 1 << 5;
-  if (opts.dropConsole) flags |= 1 << 6;
-  if (opts.dropDebugger) flags |= 1 << 7;
-  if (opts.asciiOnly) flags |= 1 << 8;
-  if (opts.flow) flags |= 1 << 9;
-  if (opts.experimentalDecorators) flags |= 1 << 10;
-  if (opts.emitDecoratorMetadata) flags |= 1 << 11;
-  if (opts.format === "cjs") flags |= 1 << 12;
-  if (opts.quotes === "single") flags |= 1 << 14;
-  if (opts.quotes === "preserve") flags |= 2 << 14;
-  // useDefineForClassFields: 기본값 true, false일 때만 비트 0
-  if (opts.useDefineForClassFields !== false) flags |= 1 << 16;
-  if (opts.charsetUtf8) flags |= 1 << 17;
-  // platform
-  if (opts.platform === "node") flags |= 1 << 18;
-  if (opts.platform === "neutral") flags |= 2 << 18;
-  if (opts.platform === "react-native") flags |= 3 << 18;
-  if (opts.jsxInJs) flags |= 1 << 20;
-  if (opts.sourcemapDebugIds) flags |= 1 << 21;
-  // sourcesContent: 기본값 true
-  if (opts.sourcesContent !== false) flags |= 1 << 22;
-  return flags;
 }
 
 // ─── 문자열 헬퍼 ───

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -118,71 +118,7 @@ export fn dealloc(ptr: u32, len: u32) void {
     wasm_alloc.free(slice[0..len]);
 }
 
-/// 트랜스파일 옵션 플래그 (비트마스크)
-///
-///   bit 0:  sourcemap
-///   bit 1:  minify_whitespace
-///   bit 2:  minify_identifiers
-///   bit 3:  minify_syntax
-///   bit 4:  jsx_runtime (automatic)
-///   bit 5:  jsx_dev (automatic-dev)
-///   bit 6:  drop_console
-///   bit 7:  drop_debugger
-///   bit 8:  ascii_only
-///   bit 9:  flow
-///   bit 10: experimental_decorators
-///   bit 11: emit_decorator_metadata
-///   bit 12-13: module_format (00=esm, 01=cjs)
-///   bit 14-15: quote_style (00=double, 01=single, 10=preserve)
-///   bit 16: use_define_for_class_fields (1=true, 기본값 true)
-///   bit 17: charset_utf8
-///   bit 18-19: platform (00=browser, 01=node, 10=neutral, 11=react-native)
-///   bit 20: jsx_in_js
-///   bit 21: sourcemap_debug_ids
-///   bit 22: sources_content (1=true, 기본값 true)
-fn decodeFlags(flags: u32) TranspileOptions {
-    return .{
-        .sourcemap = flags & (1 << 0) != 0,
-        .minify_whitespace = flags & (1 << 1) != 0,
-        .minify_identifiers = flags & (1 << 2) != 0,
-        .minify_syntax = flags & (1 << 3) != 0,
-        .jsx_runtime = if (flags & (1 << 5) != 0)
-            .automatic_dev
-        else if (flags & (1 << 4) != 0)
-            .automatic
-        else
-            .classic,
-        .drop_console = flags & (1 << 6) != 0,
-        .drop_debugger = flags & (1 << 7) != 0,
-        .ascii_only = flags & (1 << 8) != 0,
-        .flow = flags & (1 << 9) != 0,
-        .experimental_decorators = flags & (1 << 10) != 0,
-        .emit_decorator_metadata = flags & (1 << 11) != 0,
-        .module_format = switch ((flags >> 12) & 0x3) {
-            0 => .esm,
-            1 => .cjs,
-            else => .esm,
-        },
-        .quote_style = switch ((flags >> 14) & 0x3) {
-            0 => .double,
-            1 => .single,
-            2 => .preserve,
-            else => .double,
-        },
-        .use_define_for_class_fields = flags & (1 << 16) != 0,
-        .charset_utf8 = flags & (1 << 17) != 0,
-        .platform = switch ((flags >> 18) & 0x3) {
-            0 => .browser,
-            1 => .node,
-            2 => .neutral,
-            3 => .react_native,
-            else => .browser,
-        },
-        .jsx_in_js = flags & (1 << 20) != 0,
-        .sourcemap_debug_ids = flags & (1 << 21) != 0,
-        .sources_content = flags & (1 << 22) != 0,
-    };
-}
+const decodeFlags = transpile_mod.decodeFlags;
 
 /// 소스 코드를 트랜스파일한다.
 ///

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -63,6 +63,52 @@ pub const TranspileOptions = struct {
     es_target: ?@import("transformer/compat.zig").ESTarget = null,
 };
 
+/// WASM/FFI 진입점 공용 플래그 디코더.
+/// 비트마스크 → TranspileOptions 변환 (비트 레이아웃은 packages/wasm, packages/core 참조).
+pub fn decodeFlags(flags: u32) TranspileOptions {
+    return .{
+        .sourcemap = flags & (1 << 0) != 0,
+        .minify_whitespace = flags & (1 << 1) != 0,
+        .minify_identifiers = flags & (1 << 2) != 0,
+        .minify_syntax = flags & (1 << 3) != 0,
+        .jsx_runtime = if (flags & (1 << 5) != 0)
+            .automatic_dev
+        else if (flags & (1 << 4) != 0)
+            .automatic
+        else
+            .classic,
+        .drop_console = flags & (1 << 6) != 0,
+        .drop_debugger = flags & (1 << 7) != 0,
+        .ascii_only = flags & (1 << 8) != 0,
+        .flow = flags & (1 << 9) != 0,
+        .experimental_decorators = flags & (1 << 10) != 0,
+        .emit_decorator_metadata = flags & (1 << 11) != 0,
+        .module_format = switch ((flags >> 12) & 0x3) {
+            0 => .esm,
+            1 => .cjs,
+            else => .esm,
+        },
+        .quote_style = switch ((flags >> 14) & 0x3) {
+            0 => .double,
+            1 => .single,
+            2 => .preserve,
+            else => .double,
+        },
+        .use_define_for_class_fields = flags & (1 << 16) != 0,
+        .charset_utf8 = flags & (1 << 17) != 0,
+        .platform = switch ((flags >> 18) & 0x3) {
+            0 => .browser,
+            1 => .node,
+            2 => .neutral,
+            3 => .react_native,
+            else => .browser,
+        },
+        .jsx_in_js = flags & (1 << 20) != 0,
+        .sourcemap_debug_ids = flags & (1 << 21) != 0,
+        .sources_content = flags & (1 << 22) != 0,
+    };
+}
+
 pub const TranspileError = error{
     ParseError,
     SemanticError,

--- a/tests/integration/tests/config-options.test.ts
+++ b/tests/integration/tests/config-options.test.ts
@@ -3,7 +3,7 @@ import { join, resolve } from "node:path";
 import { createFixture, runZtsInDir } from "./helpers";
 import { spawn } from "bun";
 
-const CORE_PATH = resolve(import.meta.dir, "../../../packages/core/index.ts");
+const CORE_PATH = resolve(import.meta.dir, "../../../packages/plugin/index.ts");
 
 describe("config 옵션 확장", () => {
   let cleanup: (() => Promise<void>) | undefined;

--- a/tests/integration/tests/devserver.test.ts
+++ b/tests/integration/tests/devserver.test.ts
@@ -203,7 +203,7 @@ describe("Dev Server", () => {
   test.skipIf(!!process.env.CI && process.platform === "linux")(
     "--serve with --plugin loads CSS via plugin",
     async () => {
-      const CORE_PATH = join(import.meta.dir, "../../../packages/core/index.ts");
+      const CORE_PATH = join(import.meta.dir, "../../../packages/plugin/index.ts");
 
       const fixture = await createFixture({
         "index.ts": `import css from './style.css';\nconsole.log(css);`,

--- a/tests/integration/tests/plugin.test.ts
+++ b/tests/integration/tests/plugin.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "bun:test";
 import { createFixture, runZts, runZtsInDir, ZTS_BIN } from "./helpers";
 import { join, resolve } from "node:path";
 
-const CORE_PATH = resolve(import.meta.dir, "../../../packages/core/index.ts");
+const CORE_PATH = resolve(import.meta.dir, "../../../packages/plugin/index.ts");
 
 describe("Plugin: subprocess", () => {
   test("load hook transforms .css to JS export", async () => {


### PR DESCRIPTION
## Summary
- 통합 테스트: `packages/core` → `packages/plugin` 경로 참조 수정 (26개 테스트 실패 해결)
- TypeDoc: entryPoints를 `packages/plugin`으로 변경 (docs 빌드 실패 해결)
- Zig `decodeFlags()`를 `src/transpile.zig`로 추출 → wasm/ffi 진입점에서 공유
- TypeScript 타입/유틸을 `packages/shared/`로 추출 → core/wasm에서 import

## Test plan
- [x] `packages/core/` 28개 통과
- [x] `packages/wasm/` 27개 통과 (1개 기존 실패)
- [x] Zig 유닛 테스트 통과
- [x] pre-push hook 통과
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)