### PR TITLE
feat(napi): buildSync() 번들링 NAPI 추가

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { init, transpile, close } from "./index";
+import { init, transpile, buildSync, close } from "./index";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 beforeAll(() => {
   init();
@@ -191,5 +194,93 @@ describe("@zts/core", () => {
       const result = transpile(`const x${i}: number = ${i};`);
       expect(result.code).toContain(`const x${i} = ${i};`);
     }
+  });
+});
+
+describe("@zts/core buildSync", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-napi-build-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      'import { hello } from "./util";\nconsole.log(hello("world"));',
+    );
+    writeFileSync(
+      join(dir, "util.ts"),
+      "export function hello(name: string): string { return `Hello, ${name}!`; }",
+    );
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("기본 번들링", () => {
+    const result = buildSync({ entryPoints: [join(dir, "entry.ts")] });
+    expect(result.outputFiles.length).toBeGreaterThan(0);
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("hello");
+    expect(result.outputFiles[0].text).toContain("Hello");
+  });
+
+  test("CJS 포맷", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      format: "cjs",
+    });
+    expect(result.outputFiles[0].text).toContain("use strict");
+  });
+
+  test("minify", () => {
+    const normal = buildSync({ entryPoints: [join(dir, "entry.ts")] });
+    const minified = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      minify: true,
+    });
+    expect(minified.outputFiles[0].text.length).toBeLessThan(normal.outputFiles[0].text.length);
+  });
+
+  test("소스맵 생성", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      sourcemap: true,
+    });
+    // 소스맵이 별도 outputFile로 포함
+    expect(result.outputFiles.length).toBe(2);
+    const smFile = result.outputFiles.find((f) => f.path.endsWith(".map"));
+    expect(smFile).toBeDefined();
+    const map = JSON.parse(smFile!.text);
+    expect(map.version).toBe(3);
+  });
+
+  test("metafile 생성", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      metafile: true,
+    });
+    expect(result.metafile).toBeDefined();
+    const meta = JSON.parse(result.metafile!);
+    expect(meta.outputs).toBeDefined();
+  });
+
+  test("에러 반환", () => {
+    const badDir = mkdtempSync(join(tmpdir(), "zts-napi-err-"));
+    writeFileSync(join(badDir, "bad.ts"), 'import { x } from "./nonexistent";');
+    const result = buildSync({ entryPoints: [join(badDir, "bad.ts")] });
+    expect(result.errors.length).toBeGreaterThan(0);
+    rmSync(badDir, { recursive: true, force: true });
+  });
+
+  test("external", () => {
+    const extDir = mkdtempSync(join(tmpdir(), "zts-napi-ext-"));
+    writeFileSync(join(extDir, "app.ts"), 'import React from "react";\nconsole.log(React);');
+    const result = buildSync({
+      entryPoints: [join(extDir, "app.ts")],
+      external: ["react"],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("react");
+    rmSync(extDir, { recursive: true, force: true });
   });
 });

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -24,6 +24,23 @@ import { encodeFlags, ES_TARGET_BITS } from "../shared/index";
 
 // ─── NAPI Module ───
 
+interface OutputFile {
+  path: string;
+  text: string;
+}
+
+interface Diagnostic {
+  text: string;
+  location?: { file: string };
+}
+
+interface NativeBuildResult {
+  outputFiles: OutputFile[];
+  errors: Diagnostic[];
+  warnings: Diagnostic[];
+  metafile?: string;
+}
+
 interface NativeModule {
   transpile(
     source: string,
@@ -34,6 +51,7 @@ interface NativeModule {
     jsxFragment: string,
     jsxImportSource: string,
   ): { code: string; map?: string };
+  buildSync(options: Record<string, unknown>): NativeBuildResult;
 }
 
 let native: NativeModule | null = null;
@@ -84,6 +102,65 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
     options.jsxFragment ?? "",
     options.jsxImportSource ?? "",
   );
+}
+
+// ─── Build API ───
+
+export type { OutputFile, Diagnostic };
+
+export interface BuildOptions {
+  entryPoints: string[];
+  format?: "esm" | "cjs" | "iife";
+  platform?: "browser" | "node" | "neutral" | "react-native";
+  external?: string[];
+  minify?: boolean;
+  minifyWhitespace?: boolean;
+  minifyIdentifiers?: boolean;
+  minifySyntax?: boolean;
+  splitting?: boolean;
+  sourcemap?: boolean;
+  sourcemapDebugIds?: boolean;
+  sourcesContent?: boolean;
+  treeShaking?: boolean;
+  metafile?: boolean;
+  keepNames?: boolean;
+  shimMissingExports?: boolean;
+  flow?: boolean;
+  jsxInJs?: boolean;
+  charsetUtf8?: boolean;
+  useDefineForClassFields?: boolean;
+  experimentalDecorators?: boolean;
+  emitDecoratorMetadata?: boolean;
+  banner?: string;
+  footer?: string;
+  globalName?: string;
+  publicPath?: string;
+  entryNames?: string;
+  chunkNames?: string;
+  assetNames?: string;
+  jsx?: "classic" | "automatic" | "automatic-dev";
+  jsxFactory?: string;
+  jsxFragment?: string;
+  jsxImportSource?: string;
+  inject?: string[];
+  jobs?: number;
+}
+
+export interface BuildResult {
+  outputFiles: OutputFile[];
+  errors: Diagnostic[];
+  warnings: Diagnostic[];
+  metafile?: string;
+}
+
+/**
+ * 번들링을 동기적으로 실행한다.
+ */
+export function buildSync(options: BuildOptions): BuildResult {
+  if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
+  if (!options.entryPoints?.length) throw new Error("@zts/core: entryPoints is required");
+
+  return native.buildSync(options as unknown as Record<string, unknown>);
 }
 
 /**

--- a/packages/core/napi.test.mjs
+++ b/packages/core/napi.test.mjs
@@ -5,7 +5,7 @@
  * 실행: node --test packages/core/napi.test.mjs
  */
 
-import { describe, it } from "node:test";
+import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { join, dirname } from "node:path";
@@ -188,5 +188,64 @@ describe("@zts/core NAPI (Node.js)", () => {
       );
       assert.ok(result.code.includes(`const x${i} = ${i};`));
     }
+  });
+});
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+describe("@zts/core buildSync NAPI (Node.js)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "zts-napi-build-"));
+  writeFileSync(
+    join(dir, "entry.ts"),
+    'import { hello } from "./util";\nconsole.log(hello("world"));',
+  );
+  writeFileSync(
+    join(dir, "util.ts"),
+    "export function hello(name: string): string { return `Hello, ${name}!`; }",
+  );
+
+  after(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("기본 번들링", () => {
+    const result = native.buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+    });
+    assert.ok(result.outputFiles.length > 0);
+    assert.equal(result.errors.length, 0);
+    assert.ok(result.outputFiles[0].text.includes("hello"));
+  });
+
+  it("소스맵 생성", () => {
+    const result = native.buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      sourcemap: true,
+    });
+    assert.equal(result.outputFiles.length, 2);
+    const smFile = result.outputFiles.find((f) => f.path.endsWith(".map"));
+    assert.ok(smFile);
+    const map = JSON.parse(smFile.text);
+    assert.equal(map.version, 3);
+  });
+
+  it("minify", () => {
+    const normal = native.buildSync({ entryPoints: [join(dir, "entry.ts")] });
+    const minified = native.buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      minify: true,
+    });
+    assert.ok(minified.outputFiles[0].text.length < normal.outputFiles[0].text.length);
+  });
+
+  it("metafile", () => {
+    const result = native.buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      metafile: true,
+    });
+    assert.ok(result.metafile);
+    const meta = JSON.parse(result.metafile);
+    assert.ok(meta.outputs);
   });
 });

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -9,7 +9,14 @@
 //!   // result = { code: string, map?: string }
 
 const std = @import("std");
-const transpile_mod = @import("zts_lib").transpile;
+const zts_lib = @import("zts_lib");
+const transpile_mod = zts_lib.transpile;
+const bundler_mod = zts_lib.bundler;
+const Bundler = bundler_mod.Bundler;
+const BundleOptions = bundler_mod.BundleOptions;
+const Platform = zts_lib.codegen.codegen.Platform;
+const JsxRuntime = zts_lib.codegen.codegen.JsxRuntime;
+const EmitFormat = bundler_mod.emitter.EmitOptions.Format;
 const c = @cImport({
     @cDefine("NAPI_VERSION", "8");
     @cInclude("node_api.h");
@@ -134,11 +141,322 @@ fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     return js_result;
 }
 
+// ─── 객체 프로퍼티 헬퍼 ───
+
+fn getNamedProperty(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8) ?c.napi_value {
+    var val: c.napi_value = undefined;
+    if (c.napi_get_named_property(env, obj, key, &val) != c.napi_ok) return null;
+    // undefined/null 체크
+    var val_type: c.napi_valuetype = undefined;
+    _ = c.napi_typeof(env, val, &val_type);
+    if (val_type == c.napi_undefined or val_type == c.napi_null) return null;
+    return val;
+}
+
+fn getObjectBool(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, default_val: bool) bool {
+    const val = getNamedProperty(env, obj, key) orelse return default_val;
+    var result: bool = default_val;
+    _ = c.napi_get_value_bool(env, val, &result);
+    return result;
+}
+
+fn getObjectUint32(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, default_val: u32) u32 {
+    const val = getNamedProperty(env, obj, key) orelse return default_val;
+    var result: u32 = default_val;
+    _ = c.napi_get_value_uint32(env, val, &result);
+    return result;
+}
+
+fn getObjectString(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const u8 {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+    return getStringArg(env, val, alloc);
+}
+
+fn getObjectStringArray(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const []const u8 {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+    var is_array: bool = false;
+    _ = c.napi_is_array(env, val, &is_array);
+    if (!is_array) return null;
+    var len: u32 = 0;
+    _ = c.napi_get_array_length(env, val, &len);
+    if (len == 0) return null;
+    const result = alloc.alloc([]const u8, len) catch return null;
+    var count: u32 = 0;
+    for (0..len) |i| {
+        var elem: c.napi_value = undefined;
+        if (c.napi_get_element(env, val, @intCast(i), &elem) != c.napi_ok) continue;
+        if (getStringArg(env, elem, alloc)) |s| {
+            result[count] = s;
+            count += 1;
+        }
+    }
+    if (count == 0) {
+        alloc.free(result);
+        return null;
+    }
+    return result[0..count];
+}
+
+fn resolveEntryPoint(alloc: std.mem.Allocator, path: []const u8) ?[]const u8 {
+    const resolved = std.fs.cwd().realpathAlloc(alloc, path) catch return alloc.dupe(u8, path) catch null;
+    return resolved;
+}
+
+// ─── buildSync 함수 ───
+
+fn napiBuildSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "failed to get arguments");
+    }
+    if (argc < 1) return throwError(env, "buildSync requires an options object");
+
+    const opts_obj = argv[0];
+
+    // entryPoints (필수)
+    const raw_entries = getObjectStringArray(env, opts_obj, "entryPoints", native_alloc) orelse {
+        return throwError(env, "entryPoints is required");
+    };
+    defer {
+        for (raw_entries) |e| native_alloc.free(e);
+        native_alloc.free(raw_entries);
+    }
+
+    // 절대 경로로 해석
+    const entries = native_alloc.alloc([]const u8, raw_entries.len) catch return throwError(env, "OutOfMemory");
+    defer {
+        for (entries) |e| native_alloc.free(e);
+        native_alloc.free(entries);
+    }
+    for (raw_entries, 0..) |e, i| {
+        entries[i] = resolveEntryPoint(native_alloc, e) orelse return throwError(env, "failed to resolve entry point");
+    }
+
+    // format
+    const format_str = getObjectString(env, opts_obj, "format", native_alloc);
+    defer if (format_str) |s| native_alloc.free(s);
+    const format: EmitFormat = if (format_str) |s|
+        if (std.mem.eql(u8, s, "cjs")) .cjs else if (std.mem.eql(u8, s, "iife")) .iife else .esm
+    else
+        .esm;
+
+    // platform
+    const platform_str = getObjectString(env, opts_obj, "platform", native_alloc);
+    defer if (platform_str) |s| native_alloc.free(s);
+    const platform: Platform = if (platform_str) |s|
+        if (std.mem.eql(u8, s, "node")) .node else if (std.mem.eql(u8, s, "neutral")) .neutral else if (std.mem.eql(u8, s, "react-native")) .react_native else .browser
+    else
+        .browser;
+
+    // external
+    const external = getObjectStringArray(env, opts_obj, "external", native_alloc);
+    defer if (external) |exts| {
+        for (exts) |e| native_alloc.free(e);
+        native_alloc.free(exts);
+    };
+
+    // 문자열 옵션
+    const banner_js = getObjectString(env, opts_obj, "banner", native_alloc);
+    defer if (banner_js) |s| native_alloc.free(s);
+    const footer_js = getObjectString(env, opts_obj, "footer", native_alloc);
+    defer if (footer_js) |s| native_alloc.free(s);
+    const global_name = getObjectString(env, opts_obj, "globalName", native_alloc);
+    defer if (global_name) |s| native_alloc.free(s);
+    const public_path = getObjectString(env, opts_obj, "publicPath", native_alloc);
+    defer if (public_path) |s| native_alloc.free(s);
+    const entry_names = getObjectString(env, opts_obj, "entryNames", native_alloc);
+    defer if (entry_names) |s| native_alloc.free(s);
+    const chunk_names = getObjectString(env, opts_obj, "chunkNames", native_alloc);
+    defer if (chunk_names) |s| native_alloc.free(s);
+    const asset_names = getObjectString(env, opts_obj, "assetNames", native_alloc);
+    defer if (asset_names) |s| native_alloc.free(s);
+
+    // JSX 옵션
+    const jsx_str = getObjectString(env, opts_obj, "jsx", native_alloc);
+    defer if (jsx_str) |s| native_alloc.free(s);
+    const jsx_runtime: JsxRuntime = if (jsx_str) |s|
+        if (std.mem.eql(u8, s, "automatic")) .automatic else if (std.mem.eql(u8, s, "automatic-dev")) .automatic_dev else .classic
+    else
+        .classic;
+    const jsx_factory = getObjectString(env, opts_obj, "jsxFactory", native_alloc);
+    defer if (jsx_factory) |s| native_alloc.free(s);
+    const jsx_fragment = getObjectString(env, opts_obj, "jsxFragment", native_alloc);
+    defer if (jsx_fragment) |s| native_alloc.free(s);
+    const jsx_import_source = getObjectString(env, opts_obj, "jsxImportSource", native_alloc);
+    defer if (jsx_import_source) |s| native_alloc.free(s);
+
+    // inject
+    const inject = getObjectStringArray(env, opts_obj, "inject", native_alloc);
+    defer if (inject) |arr| {
+        for (arr) |s| native_alloc.free(s);
+        native_alloc.free(arr);
+    };
+
+    // BundleOptions 구성
+    const minify = getObjectBool(env, opts_obj, "minify", false);
+    const bundle_opts = BundleOptions{
+        .entry_points = entries,
+        .format = format,
+        .platform = platform,
+        .external = external orelse &.{},
+        .minify_whitespace = if (minify) true else getObjectBool(env, opts_obj, "minifyWhitespace", false),
+        .minify_identifiers = if (minify) true else getObjectBool(env, opts_obj, "minifyIdentifiers", false),
+        .minify_syntax = if (minify) true else getObjectBool(env, opts_obj, "minifySyntax", false),
+        .code_splitting = getObjectBool(env, opts_obj, "splitting", false),
+        .sourcemap = getObjectBool(env, opts_obj, "sourcemap", false),
+        .sourcemap_debug_ids = getObjectBool(env, opts_obj, "sourcemapDebugIds", false),
+        .sources_content = getObjectBool(env, opts_obj, "sourcesContent", true),
+        .tree_shaking = getObjectBool(env, opts_obj, "treeShaking", true),
+        .scope_hoist = getObjectBool(env, opts_obj, "scopeHoist", true),
+        .metafile = getObjectBool(env, opts_obj, "metafile", false),
+        .keep_names = getObjectBool(env, opts_obj, "keepNames", false),
+        .shim_missing_exports = getObjectBool(env, opts_obj, "shimMissingExports", false),
+        .flow = getObjectBool(env, opts_obj, "flow", false),
+        .jsx_in_js = getObjectBool(env, opts_obj, "jsxInJs", false),
+        .charset_utf8 = getObjectBool(env, opts_obj, "charsetUtf8", false),
+        .use_define_for_class_fields = getObjectBool(env, opts_obj, "useDefineForClassFields", true),
+        .experimental_decorators = getObjectBool(env, opts_obj, "experimentalDecorators", false),
+        .emit_decorator_metadata = getObjectBool(env, opts_obj, "emitDecoratorMetadata", false),
+        .banner_js = banner_js,
+        .footer_js = footer_js,
+        .global_name = global_name,
+        .public_path = public_path orelse "",
+        .entry_names = entry_names orelse "[name]",
+        .chunk_names = chunk_names orelse "[name]-[hash]",
+        .asset_names = asset_names orelse "[name]-[hash]",
+        .jsx_runtime = jsx_runtime,
+        .jsx_factory = jsx_factory orelse "React.createElement",
+        .jsx_fragment = jsx_fragment orelse "React.Fragment",
+        .jsx_import_source = jsx_import_source orelse "react",
+        .inject = inject orelse &.{},
+        .max_threads = getObjectUint32(env, opts_obj, "jobs", 0),
+    };
+
+    // 번들 실행
+    var bundler = Bundler.init(native_alloc, bundle_opts);
+    var result = bundler.bundle() catch |err| {
+        return throwError(env, @errorName(err));
+    };
+    defer result.deinit(native_alloc);
+
+    // JS 결과 객체 생성: { outputFiles: [...], errors: [...], warnings: [...], metafile?: string }
+    return buildResultToJS(env, &result);
+}
+
+fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult) c.napi_value {
+    var js_result: c.napi_value = undefined;
+    if (c.napi_create_object(env, &js_result) != c.napi_ok) return null;
+
+    // outputFiles 배열
+    var js_outputs: c.napi_value = undefined;
+    _ = c.napi_create_array(env, &js_outputs);
+
+    if (result.outputs) |outputs| {
+        // code splitting: 다중 파일
+        for (outputs, 0..) |out, i| {
+            var js_file: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_file);
+
+            var js_path: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, out.path.ptr, out.path.len, &js_path);
+            _ = c.napi_set_named_property(env, js_file, "path", js_path);
+
+            var js_text: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, out.contents.ptr, out.contents.len, &js_text);
+            _ = c.napi_set_named_property(env, js_file, "text", js_text);
+
+            _ = c.napi_set_element(env, js_outputs, @intCast(i), js_file);
+        }
+    } else {
+        // 단일 파일
+        var js_file: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_file);
+
+        var js_path: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, "bundle.js", "bundle.js".len, &js_path);
+        _ = c.napi_set_named_property(env, js_file, "path", js_path);
+
+        var js_text: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, result.output.ptr, result.output.len, &js_text);
+        _ = c.napi_set_named_property(env, js_file, "text", js_text);
+
+        _ = c.napi_set_element(env, js_outputs, 0, js_file);
+
+        // 소스맵이 있으면 별도 파일로 추가
+        if (result.sourcemap) |sm| {
+            var js_sm_file: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_sm_file);
+
+            var js_sm_path: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, "bundle.js.map", "bundle.js.map".len, &js_sm_path);
+            _ = c.napi_set_named_property(env, js_sm_file, "path", js_sm_path);
+
+            var js_sm_text: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, sm.ptr, sm.len, &js_sm_text);
+            _ = c.napi_set_named_property(env, js_sm_file, "text", js_sm_text);
+
+            _ = c.napi_set_element(env, js_outputs, 1, js_sm_file);
+        }
+    }
+    _ = c.napi_set_named_property(env, js_result, "outputFiles", js_outputs);
+
+    // errors/warnings 배열
+    var js_errors: c.napi_value = undefined;
+    _ = c.napi_create_array(env, &js_errors);
+    var js_warnings: c.napi_value = undefined;
+    _ = c.napi_create_array(env, &js_warnings);
+
+    var err_idx: u32 = 0;
+    var warn_idx: u32 = 0;
+    for (result.getDiagnostics()) |d| {
+        var js_diag: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_diag);
+
+        var js_msg: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, d.message.ptr, d.message.len, &js_msg);
+        _ = c.napi_set_named_property(env, js_diag, "text", js_msg);
+
+        if (d.file_path.len > 0) {
+            var js_loc: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_loc);
+            var js_file_path: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, d.file_path.ptr, d.file_path.len, &js_file_path);
+            _ = c.napi_set_named_property(env, js_loc, "file", js_file_path);
+            _ = c.napi_set_named_property(env, js_diag, "location", js_loc);
+        }
+
+        if (d.severity == .@"error") {
+            _ = c.napi_set_element(env, js_errors, err_idx, js_diag);
+            err_idx += 1;
+        } else {
+            _ = c.napi_set_element(env, js_warnings, warn_idx, js_diag);
+            warn_idx += 1;
+        }
+    }
+    _ = c.napi_set_named_property(env, js_result, "errors", js_errors);
+    _ = c.napi_set_named_property(env, js_result, "warnings", js_warnings);
+
+    // metafile
+    if (result.metafile_json) |mf| {
+        var js_mf: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, mf.ptr, mf.len, &js_mf);
+        _ = c.napi_set_named_property(env, js_result, "metafile", js_mf);
+    }
+
+    return js_result;
+}
+
 // ─── 모듈 등록 ───
 
 export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi_value {
     var fn_value: c.napi_value = undefined;
     _ = c.napi_create_function(env, "transpile", "transpile".len, napiTranspile, null, &fn_value);
     _ = c.napi_set_named_property(env, exports, "transpile", fn_value);
+
+    var build_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "buildSync", "buildSync".len, napiBuildSync, null, &build_fn);
+    _ = c.napi_set_named_property(env, exports, "buildSync", build_fn);
+
     return exports;
 }


### PR DESCRIPTION
## Summary
- `buildSync()` NAPI 함수 추가 — JS에서 in-process 번들링 가능
- esbuild의 `buildSync()`와 유사한 API

### 사용법
```typescript
import { init, buildSync } from "@zts/core";
init();
const result = buildSync({
  entryPoints: ["src/index.ts"],
  format: "esm",
  minify: true,
  sourcemap: true,
});
console.log(result.outputFiles[0].text);
```

### 지원 옵션
entryPoints, format, platform, external, minify, splitting, sourcemap, metafile, treeShaking, scopeHoist, jsx (classic/automatic/automatic-dev), jsxFactory, jsxFragment, jsxImportSource, banner, footer, globalName, publicPath, entryNames, chunkNames, assetNames, inject, keepNames, flow, charsetUtf8, experimentalDecorators, emitDecoratorMetadata, useDefineForClassFields, jobs

### 결과 구조
```typescript
interface BuildResult {
  outputFiles: Array<{ path: string; text: string }>;
  errors: Array<{ text: string; location?: { file: string } }>;
  warnings: Array<{ text: string; location?: { file: string } }>;
  metafile?: string;
}
```

## Test plan
- [x] Bun: 35/35 통과 (transpile 28 + buildSync 7)
- [x] Node.js: 18/18 통과 (transpile 14 + buildSync 4)
- [x] Zig 유닛 테스트 통과
- [x] pre-push hook 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)