### PR TITLE
fix(napi): OOM 안전성 + 엣지케이스 테스트 21개 추가

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -433,3 +433,188 @@ describe("@zts/core build + plugins", () => {
     ).toThrow("plugins are only supported with build()");
   });
 });
+
+// ─── 엣지케이스 테스트 ───
+
+describe("@zts/core edge cases", () => {
+  // transpile 엣지케이스
+  test("매우 긴 소스코드 트랜스파일", () => {
+    const lines = Array.from({ length: 10000 }, (_, i) => `export const v${i}: number = ${i};`);
+    const result = transpile(lines.join("\n"));
+    expect(result.code).toContain("v9999 = 9999");
+  });
+
+  test("유니코드 소스코드", () => {
+    const result = transpile('const 이름: string = "한글 테스트";');
+    expect(result.code).toContain("한글 테스트");
+  });
+
+  test("빈 인터페이스만 있는 파일", () => {
+    const result = transpile("interface Empty {}\n");
+    expect(result.code.trim()).toBe("");
+  });
+
+  test("타입만 있는 파일", () => {
+    const result = transpile("type Foo = string;\ntype Bar = number;\n");
+    expect(result.code.trim()).toBe("");
+  });
+
+  test("복잡한 제네릭 타입", () => {
+    const result = transpile(
+      "function identity<T extends Record<string, unknown>>(x: T): T { return x; }",
+    );
+    expect(result.code).toContain("function identity(x)");
+    expect(result.code).not.toContain("<T");
+  });
+
+  test("enum + namespace 병합", () => {
+    const result = transpile("enum Direction { Up, Down }\nconst d: Direction = Direction.Up;");
+    expect(result.code).toContain("Direction");
+  });
+
+  test("optional chaining + nullish coalescing", () => {
+    const result = transpile("const x = a?.b?.c ?? 'default';");
+    expect(result.code).toContain("??");
+  });
+
+  test("decorator (experimental)", () => {
+    const result = transpile(
+      "@sealed\nclass Greeter {\n  greeting: string;\n  constructor(message: string) { this.greeting = message; }\n}",
+      { experimentalDecorators: true },
+    );
+    expect(result.code).toContain("__decorate");
+  });
+
+  test("소스맵 + minify 동시 사용", () => {
+    const result = transpile(
+      "const longVariableName: number = 42;\nconsole.log(longVariableName);",
+      {
+        sourcemap: true,
+        minify: true,
+      },
+    );
+    expect(result.code.length).toBeLessThan(60);
+    expect(result.map).toBeDefined();
+    const map = JSON.parse(result.map!);
+    expect(map.version).toBe(3);
+  });
+
+  // init 엣지케이스
+  test("init 전에 transpile 호출 시 에러", () => {
+    // 이미 init됨, close 후 테스트
+    close();
+    expect(() => transpile("const x = 1;")).toThrow("not initialized");
+    init(); // 복원
+  });
+
+  test("init 전에 buildSync 호출 시 에러", () => {
+    close();
+    expect(() => buildSync({ entryPoints: ["/nonexistent"] })).toThrow("not initialized");
+    init(); // 복원
+  });
+
+  test("init 전에 build 호출 시 에러", async () => {
+    close();
+    await expect(build({ entryPoints: ["/nonexistent"] })).rejects.toThrow("not initialized");
+    init(); // 복원
+  });
+
+  // buildSync 엣지케이스
+  test("buildSync: 빈 entryPoints 에러", () => {
+    expect(() => buildSync({ entryPoints: [] })).toThrow("entryPoints is required");
+  });
+
+  test("buildSync: 존재하지 않는 파일", () => {
+    const result = buildSync({ entryPoints: ["/nonexistent/file.ts"] });
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test("buildSync: 모든 옵션 동시 사용", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-edge-all-opts-"));
+    writeFileSync(join(dir, "index.ts"), "export const x = 1;");
+    const result = buildSync({
+      entryPoints: [join(dir, "index.ts")],
+      format: "esm",
+      platform: "browser",
+      minify: true,
+      sourcemap: true,
+      metafile: true,
+      treeShaking: true,
+      keepNames: true,
+      charsetUtf8: true,
+      banner: "/* banner */",
+      footer: "/* footer */",
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("/* banner */");
+    expect(result.outputFiles[0].text).toContain("/* footer */");
+    expect(result.metafile).toBeDefined();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // build async 엣지케이스
+  test("build: 빈 entryPoints 에러", async () => {
+    await expect(build({ entryPoints: [] })).rejects.toThrow("entryPoints is required");
+  });
+
+  test("build: 존재하지 않는 파일", async () => {
+    const result = await build({ entryPoints: ["/nonexistent/file.ts"] });
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test("build: 병렬 호출", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-edge-parallel-"));
+    writeFileSync(join(dir, "a.ts"), "export const a = 1;");
+    writeFileSync(join(dir, "b.ts"), "export const b = 2;");
+
+    const [resultA, resultB] = await Promise.all([
+      build({ entryPoints: [join(dir, "a.ts")] }),
+      build({ entryPoints: [join(dir, "b.ts")] }),
+    ]);
+    expect(resultA.errors.length).toBe(0);
+    expect(resultB.errors.length).toBe(0);
+    expect(resultA.outputFiles[0].text).toContain("a = 1");
+    expect(resultB.outputFiles[0].text).toContain("b = 2");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // 플러그인 엣지케이스
+  test("plugin: null 반환 시 기본 동작", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-edge-plugin-null-"));
+    writeFileSync(join(dir, "index.ts"), "export const x = 1;");
+
+    const noopPlugin: ZtsPlugin = {
+      name: "noop",
+      setup(build) {
+        build.onLoad({ filter: /never-match/ }, () => null);
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      plugins: [noopPlugin],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("x = 1");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("plugin: setup에서 아무 훅도 등록하지 않음", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-edge-empty-plugin-"));
+    writeFileSync(join(dir, "index.ts"), "export const x = 1;");
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      plugins: [{ name: "empty", setup() {} }],
+    });
+    expect(result.errors.length).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("transpile: 반복 호출 1000회 메모리 안정성", () => {
+    for (let i = 0; i < 1000; i++) {
+      const result = transpile(`const x${i} = ${i};`);
+      expect(result.code).toContain(`x${i} = ${i}`);
+    }
+  });
+});

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -606,6 +606,13 @@ fn buildComplete(env: c.napi_env, _: c.napi_status, data: ?*anyopaque) callconv(
             _ = c.napi_create_error(env, null, js_err_str, &js_error);
             _ = c.napi_reject_deferred(env, async_data.deferred, js_error);
         }
+    } else {
+        // 방어 코드: result와 err_msg 모두 null인 경우 (이론상 불가능)
+        var js_err_str: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, "unknown build error", "unknown build error".len, &js_err_str);
+        var js_error: c.napi_value = undefined;
+        _ = c.napi_create_error(env, null, js_err_str, &js_error);
+        _ = c.napi_reject_deferred(env, async_data.deferred, js_error);
     }
 }
 
@@ -711,33 +718,35 @@ fn parseBuildOptions(
     owned_strings: *std.ArrayList([]const u8),
     owned_string_arrays: *std.ArrayList([]const []const u8),
 ) ?BundleOptions {
-    // 문자열 소유권 추적 헬퍼
+    // 문자열 소유권 추적 헬퍼 (OOM 시 false 반환)
     const trackStr = struct {
-        fn f(list: *std.ArrayList([]const u8), s: []const u8) void {
-            list.append(native_alloc, s) catch {};
+        fn f(list: *std.ArrayList([]const u8), s: []const u8) bool {
+            list.append(native_alloc, s) catch return false;
+            return true;
         }
     }.f;
     const trackArr = struct {
-        fn f(list: *std.ArrayList([]const []const u8), arr: []const []const u8) void {
-            list.append(native_alloc, arr) catch {};
+        fn f(list: *std.ArrayList([]const []const u8), arr: []const []const u8) bool {
+            list.append(native_alloc, arr) catch return false;
+            return true;
         }
     }.f;
 
     // entryPoints
     const raw_entries = getObjectStringArray(env, opts_obj, "entryPoints", native_alloc) orelse return null;
-    for (raw_entries) |e| trackStr(owned_strings, e);
-    trackArr(owned_string_arrays, raw_entries);
+    for (raw_entries) |e| if (!trackStr(owned_strings, e)) return null;
+    if (!trackArr(owned_string_arrays, raw_entries)) return null;
 
     const entries = native_alloc.alloc([]const u8, raw_entries.len) catch return null;
-    trackArr(owned_string_arrays, entries);
+    if (!trackArr(owned_string_arrays, entries)) return null;
     for (raw_entries, 0..) |e, i| {
         entries[i] = resolveEntryPoint(native_alloc, e) orelse return null;
-        trackStr(owned_strings, entries[i]);
+        if (!trackStr(owned_strings, entries[i])) return null;
     }
 
     // format
     const format_str = getObjectString(env, opts_obj, "format", native_alloc);
-    if (format_str) |s| trackStr(owned_strings, s);
+    if (format_str) |s| if (!trackStr(owned_strings, s)) return null;
     const format: EmitFormat = if (format_str) |s|
         if (std.mem.eql(u8, s, "cjs")) .cjs else if (std.mem.eql(u8, s, "iife")) .iife else .esm
     else
@@ -745,7 +754,7 @@ fn parseBuildOptions(
 
     // platform
     const platform_str = getObjectString(env, opts_obj, "platform", native_alloc);
-    if (platform_str) |s| trackStr(owned_strings, s);
+    if (platform_str) |s| if (!trackStr(owned_strings, s)) return null;
     const platform: Platform = if (platform_str) |s|
         if (std.mem.eql(u8, s, "node")) .node else if (std.mem.eql(u8, s, "neutral")) .neutral else if (std.mem.eql(u8, s, "react-native")) .react_native else .browser
     else
@@ -754,15 +763,18 @@ fn parseBuildOptions(
     // external
     const external = getObjectStringArray(env, opts_obj, "external", native_alloc);
     if (external) |exts| {
-        for (exts) |e| trackStr(owned_strings, e);
-        trackArr(owned_string_arrays, exts);
+        for (exts) |e| if (!trackStr(owned_strings, e)) return null;
+        if (!trackArr(owned_string_arrays, exts)) return null;
     }
 
     // 문자열 옵션 헬퍼
     const ownStr = struct {
         fn f(e: c.napi_env, obj: c.napi_value, key: [*:0]const u8, list: *std.ArrayList([]const u8)) ?[]const u8 {
             const s = getObjectString(e, obj, key, native_alloc) orelse return null;
-            list.append(native_alloc, s) catch {};
+            list.append(native_alloc, s) catch {
+                native_alloc.free(s);
+                return null;
+            };
             return s;
         }
     }.f;
@@ -788,8 +800,8 @@ fn parseBuildOptions(
     // inject
     const inject = getObjectStringArray(env, opts_obj, "inject", native_alloc);
     if (inject) |arr| {
-        for (arr) |s| trackStr(owned_strings, s);
-        trackArr(owned_string_arrays, arr);
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
     const minify = getObjectBool(env, opts_obj, "minify", false);


### PR DESCRIPTION
## Summary
/simplify 리뷰 반영 + 엣지케이스 테스트 대거 추가

### 버그 수정
- `parseBuildOptions`의 `trackStr/trackArr` OOM 시 null 반환 (기존: `catch {}` → 메모리 누수)
- `buildComplete`에서 result/err 둘 다 null인 경우 reject (기존: Promise 영원히 pending)
- `ownStr` OOM 시 할당된 문자열 즉시 해제

### 테스트 추가 (21개 → 총 64개)
**transpile 엣지케이스**: 10K줄 소스, 유니코드, 빈 인터페이스/타입, 제네릭, enum, decorator, 소스맵+minify 동시, optional chaining
**init 엣지케이스**: init 전 transpile/buildSync/build 호출 에러
**buildSync 엣지케이스**: 빈 entryPoints, 존재하지 않는 파일, 모든 옵션 동시 사용
**build async 엣지케이스**: 빈 entryPoints, 존재하지 않는 파일, 병렬 호출 2개
**플러그인 엣지케이스**: null 반환, 빈 setup, 1000회 반복 안정성

## Test plan
- [x] 64/64 통과 (1198 expect calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)