### PR TITLE
feat: Node.js/Bun CLI (Rolldown 방식 전환)

### DIFF
--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,0 +1,2 @@
+packages/core/dist/
+packages/core/zts.node

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -1,0 +1,829 @@
+#!/usr/bin/env node
+
+/**
+ * ZTS CLI — Node.js/Bun 호환 CLI
+ *
+ * 내부적으로 @zts/core NAPI 바인딩을 사용하여 트랜스파일/번들링을 수행.
+ * Watch/Serve는 JS 레이어에서 구현.
+ */
+
+// Node.js: dist/index.js, Bun: index.ts 직접
+let coreModule;
+try {
+  coreModule = await import("../dist/index.js");
+} catch {
+  coreModule = await import("../index.ts");
+}
+const { init, transpile, build, buildSync } = coreModule;
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import { resolve, dirname, basename, extname, join } from "node:path";
+import { createServer } from "node:http";
+
+// ─── CLI 인자 파싱 ───
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = {
+    entryPoints: [],
+    outfile: null,
+    outdir: null,
+    bundle: false,
+    watch: false,
+    watchJson: false,
+    watchDelay: 100,
+    serve: false,
+    serveDir: ".",
+    port: 12300,
+    host: "localhost",
+    open: false,
+    proxy: {},
+    format: undefined,
+    platform: undefined,
+    minify: false,
+    minifyWhitespace: false,
+    minifyIdentifiers: false,
+    minifySyntax: false,
+    sourcemap: false,
+    sourcemapDebugIds: false,
+    sourcesContent: true,
+    splitting: false,
+    metafile: undefined,
+    analyze: false,
+    treeShaking: true,
+    external: [],
+    define: {},
+    alias: {},
+    banner: undefined,
+    footer: undefined,
+    globalName: undefined,
+    publicPath: undefined,
+    entryNames: undefined,
+    chunkNames: undefined,
+    assetNames: undefined,
+    jsx: undefined,
+    jsxDev: false,
+    jsxFactory: undefined,
+    jsxFragment: undefined,
+    jsxImportSource: undefined,
+    flow: false,
+    experimentalDecorators: false,
+    useDefineForClassFields: true,
+    keepNames: false,
+    shimMissingExports: false,
+    charsetUtf8: false,
+    asciiOnly: false,
+    quotes: undefined,
+    inject: [],
+    plugins: [],
+    pluginPaths: [],
+    stdin: false,
+    project: undefined,
+    logLevel: "info",
+    jobs: undefined,
+    clean: false,
+    preserveModules: false,
+    preserveModulesRoot: undefined,
+    loader: {},
+    legalComments: undefined,
+    resolveExtensions: [],
+    mainFields: [],
+    rnPlatform: undefined,
+    jsxInJs: false,
+    outExtensionJs: undefined,
+    sourceRoot: undefined,
+    drop: [],
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    // stdin
+    if (arg === "-") {
+      opts.stdin = true;
+      continue;
+    }
+
+    // positional (파일 경로)
+    if (!arg.startsWith("-")) {
+      opts.entryPoints.push(arg);
+      continue;
+    }
+
+    // flags
+    if (arg === "--bundle") {
+      opts.bundle = true;
+      continue;
+    }
+    if (arg === "-w" || arg === "--watch") {
+      opts.watch = true;
+      continue;
+    }
+    if (arg === "--watch-json") {
+      opts.watch = true;
+      opts.watchJson = true;
+      continue;
+    }
+    if (arg === "--serve") {
+      opts.serve = true;
+      continue;
+    }
+    if (arg === "--open") {
+      opts.open = true;
+      continue;
+    }
+    if (arg === "--minify") {
+      opts.minify = true;
+      continue;
+    }
+    if (arg === "--sourcemap") {
+      opts.sourcemap = true;
+      continue;
+    }
+    if (arg === "--sourcemap-debug-ids") {
+      opts.sourcemapDebugIds = true;
+      continue;
+    }
+    if (arg === "--splitting") {
+      opts.splitting = true;
+      continue;
+    }
+    if (arg === "--metafile") {
+      opts.metafile = "meta.json";
+      continue;
+    }
+    if (arg === "--analyze") {
+      opts.analyze = true;
+      opts.metafile = "meta.json";
+      continue;
+    }
+    if (arg === "--flow") {
+      opts.flow = true;
+      continue;
+    }
+    if (arg === "--experimental-decorators") {
+      opts.experimentalDecorators = true;
+      continue;
+    }
+    if (arg === "--keep-names") {
+      opts.keepNames = true;
+      continue;
+    }
+    if (arg === "--shim-missing-exports") {
+      opts.shimMissingExports = true;
+      continue;
+    }
+    if (arg === "--ascii-only") {
+      opts.asciiOnly = true;
+      continue;
+    }
+    if (arg === "--preserve-symlinks") {
+      continue;
+    } // TODO
+    if (arg === "--preserve-modules") {
+      opts.preserveModules = true;
+      continue;
+    }
+    if (arg === "--jsx-dev") {
+      opts.jsxDev = true;
+      continue;
+    }
+    if (arg === "--clean") {
+      opts.clean = true;
+      continue;
+    }
+    if (arg === "--minify-whitespace") {
+      opts.minifyWhitespace = true;
+      continue;
+    }
+    if (arg === "--minify-identifiers") {
+      opts.minifyIdentifiers = true;
+      continue;
+    }
+    if (arg === "--minify-syntax") {
+      opts.minifySyntax = true;
+      continue;
+    }
+
+    // --key=value
+    if (arg.startsWith("--format=")) {
+      opts.format = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--platform=")) {
+      opts.platform = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--jsx=")) {
+      opts.jsx = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--jsx-factory=")) {
+      opts.jsxFactory = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--jsx-fragment=")) {
+      opts.jsxFragment = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--jsx-import-source=")) {
+      opts.jsxImportSource = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--global-name=")) {
+      opts.globalName = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--public-path=")) {
+      opts.publicPath = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--banner:js=")) {
+      opts.banner = arg.split("=").slice(1).join("=");
+      continue;
+    }
+    if (arg.startsWith("--footer:js=")) {
+      opts.footer = arg.split("=").slice(1).join("=");
+      continue;
+    }
+    if (arg.startsWith("--entry-names=")) {
+      opts.entryNames = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--chunk-names=")) {
+      opts.chunkNames = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--asset-names=")) {
+      opts.assetNames = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--quotes=")) {
+      opts.quotes = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--log-level=")) {
+      opts.logLevel = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--charset=")) {
+      if (arg.split("=")[1] === "utf8") opts.charsetUtf8 = true;
+      continue;
+    }
+    if (arg.startsWith("--sources-content=")) {
+      opts.sourcesContent = arg.split("=")[1] !== "false";
+      continue;
+    }
+    if (arg.startsWith("--use-define-for-class-fields=")) {
+      opts.useDefineForClassFields = arg.split("=")[1] !== "false";
+      continue;
+    }
+    if (arg.startsWith("--legal-comments=")) {
+      opts.legalComments = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--preserve-modules-root=")) {
+      opts.preserveModulesRoot = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--out-extension:.js=")) {
+      opts.outExtensionJs = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--source-root=")) {
+      opts.sourceRoot = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--watch-delay=")) {
+      opts.watchDelay = parseInt(arg.split("=")[1]);
+      continue;
+    }
+    if (arg.startsWith("--rn-platform=")) {
+      opts.rnPlatform = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--port=")) {
+      opts.port = parseInt(arg.split("=")[1]);
+      continue;
+    }
+    if (arg.startsWith("--host=")) {
+      opts.host = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--metafile=")) {
+      opts.metafile = arg.split("=")[1];
+      continue;
+    }
+    if (arg.startsWith("--jobs=")) {
+      opts.jobs = parseInt(arg.split("=")[1]);
+      continue;
+    }
+
+    // --key value
+    if (arg === "-o" || arg === "--outfile") {
+      opts.outfile = args[++i];
+      continue;
+    }
+    if (arg === "--outdir") {
+      opts.outdir = args[++i];
+      continue;
+    }
+    if (arg === "--port") {
+      opts.port = parseInt(args[++i]);
+      continue;
+    }
+    if (arg === "--host") {
+      opts.host = args[++i] || "0.0.0.0";
+      continue;
+    }
+    if (arg === "-p" || arg === "--project") {
+      opts.project = args[++i];
+      continue;
+    }
+    if (arg === "--plugin") {
+      opts.pluginPaths.push(args[++i]);
+      continue;
+    }
+
+    // repeatable
+    if (arg === "--external") {
+      opts.external.push(args[++i]);
+      continue;
+    }
+    if (arg.startsWith("--external=")) {
+      opts.external.push(arg.split("=")[1]);
+      continue;
+    }
+    if (arg.startsWith("--inject:")) {
+      opts.inject.push(arg.split(":")[1]);
+      continue;
+    }
+    if (arg.startsWith("--define:")) {
+      const [k, ...v] = arg.slice("--define:".length).split("=");
+      opts.define[k] = v.join("=");
+      continue;
+    }
+    if (arg.startsWith("--alias:")) {
+      const [k, ...v] = arg.slice("--alias:".length).split("=");
+      opts.alias[k] = v.join("=");
+      continue;
+    }
+    if (arg.startsWith("--loader:")) {
+      const [ext, type] = arg.slice("--loader:".length).split("=");
+      opts.loader[ext] = type;
+      continue;
+    }
+    if (arg.startsWith("--drop=")) {
+      opts.drop.push(arg.split("=")[1]);
+      continue;
+    }
+    if (arg.startsWith("--proxy")) {
+      const [path, target] =
+        arg.split("=").length > 1
+          ? [arg.split(" ")[0].replace("--proxy", "").replace("=", ""), args[i].split("=")[1]]
+          : [args[++i]?.split("=")[0], args[i]?.split("=")[1]];
+      if (path && target) opts.proxy[path] = target;
+      continue;
+    }
+    if (arg.startsWith("--resolve-extensions=")) {
+      opts.resolveExtensions = arg.split("=")[1].split(",");
+      continue;
+    }
+    if (arg.startsWith("--main-fields=")) {
+      opts.mainFields = arg.split("=")[1].split(",");
+      continue;
+    }
+
+    // unknown
+    if (opts.logLevel !== "silent") {
+      console.error(`warning: unknown option '${arg}'`);
+    }
+  }
+
+  // jsx-dev 단축어
+  if (opts.jsxDev) opts.jsx = "automatic-dev";
+
+  // drop 처리
+  for (const d of opts.drop) {
+    if (d === "console") opts.define["console.log"] = "undefined";
+    if (d === "debugger") opts.define["debugger"] = "";
+  }
+
+  return opts;
+}
+
+// ─── 파일 출력 ───
+
+function writeOutputFiles(outputFiles, outfile, outdir) {
+  if (outfile) {
+    mkdirSync(dirname(resolve(outfile)), { recursive: true });
+    writeFileSync(resolve(outfile), outputFiles[0].text);
+    if (outputFiles.length > 1) {
+      // sourcemap
+      writeFileSync(resolve(outfile + ".map"), outputFiles[1].text);
+    }
+  } else if (outdir) {
+    mkdirSync(resolve(outdir), { recursive: true });
+    for (const file of outputFiles) {
+      const outPath = join(resolve(outdir), basename(file.path));
+      writeFileSync(outPath, file.text);
+    }
+  }
+}
+
+// ─── Transpile 모드 ───
+
+async function runTranspile(opts) {
+  let source;
+  if (opts.stdin) {
+    // stdin 읽기
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    source = Buffer.concat(chunks).toString();
+  } else {
+    source = readFileSync(resolve(opts.entryPoints[0]), "utf8");
+  }
+
+  const result = transpile(source, {
+    filename: opts.stdin ? "stdin.ts" : opts.entryPoints[0],
+    sourcemap: opts.sourcemap,
+    minify: opts.minify,
+    minifyWhitespace: opts.minifyWhitespace,
+    minifyIdentifiers: opts.minifyIdentifiers,
+    minifySyntax: opts.minifySyntax,
+    jsx: opts.jsx,
+    jsxFactory: opts.jsxFactory,
+    jsxFragment: opts.jsxFragment,
+    jsxImportSource: opts.jsxImportSource,
+    flow: opts.flow,
+    experimentalDecorators: opts.experimentalDecorators,
+    useDefineForClassFields: opts.useDefineForClassFields,
+    asciiOnly: opts.asciiOnly,
+    charsetUtf8: opts.charsetUtf8,
+    quotes: opts.quotes,
+    format: opts.format,
+    platform: opts.platform,
+    dropConsole: opts.drop.includes("console"),
+    dropDebugger: opts.drop.includes("debugger"),
+  });
+
+  if (opts.outfile) {
+    mkdirSync(dirname(resolve(opts.outfile)), { recursive: true });
+    writeFileSync(resolve(opts.outfile), result.code);
+    if (result.map) {
+      writeFileSync(resolve(opts.outfile + ".map"), result.map);
+    }
+  } else if (opts.outdir) {
+    mkdirSync(resolve(opts.outdir), { recursive: true });
+    const name = basename(opts.entryPoints[0]).replace(/\.[^.]+$/, ".js");
+    writeFileSync(join(resolve(opts.outdir), name), result.code);
+  } else {
+    process.stdout.write(result.code);
+  }
+}
+
+// ─── Bundle 모드 ───
+
+async function runBundle(opts) {
+  // 플러그인 로드
+  const plugins = [];
+  for (const pluginPath of opts.pluginPaths) {
+    const absPath = resolve(pluginPath);
+    const mod = await import(absPath);
+    const config = mod.default || mod;
+    if (config.plugins) {
+      plugins.push(...config.plugins);
+    } else if (typeof config.setup === "function") {
+      plugins.push(config);
+    }
+  }
+
+  const buildOpts = {
+    entryPoints: opts.entryPoints.map((e) => resolve(e)),
+    format: opts.format,
+    platform: opts.platform,
+    external: opts.external,
+    minify: opts.minify,
+    minifyWhitespace: opts.minifyWhitespace,
+    minifyIdentifiers: opts.minifyIdentifiers,
+    minifySyntax: opts.minifySyntax,
+    splitting: opts.splitting,
+    sourcemap: opts.sourcemap,
+    sourcemapDebugIds: opts.sourcemapDebugIds,
+    sourcesContent: opts.sourcesContent,
+    treeShaking: opts.treeShaking,
+    metafile: !!opts.metafile,
+    keepNames: opts.keepNames,
+    shimMissingExports: opts.shimMissingExports,
+    flow: opts.flow,
+    jsxInJs: opts.jsxInJs,
+    charsetUtf8: opts.charsetUtf8,
+    useDefineForClassFields: opts.useDefineForClassFields,
+    experimentalDecorators: opts.experimentalDecorators,
+    banner: opts.banner,
+    footer: opts.footer,
+    globalName: opts.globalName,
+    publicPath: opts.publicPath,
+    entryNames: opts.entryNames,
+    chunkNames: opts.chunkNames,
+    assetNames: opts.assetNames,
+    jsx: opts.jsx,
+    jsxFactory: opts.jsxFactory,
+    jsxFragment: opts.jsxFragment,
+    jsxImportSource: opts.jsxImportSource,
+    inject: opts.inject.map((p) => resolve(p)),
+    jobs: opts.jobs,
+    plugins: plugins.length > 0 ? plugins : undefined,
+  };
+
+  const result = plugins.length > 0 ? await build(buildOpts) : buildSync(buildOpts);
+
+  if (result.errors.length > 0 && opts.logLevel !== "silent") {
+    for (const err of result.errors) {
+      const loc = err.location ? `${err.location.file}: ` : "";
+      console.error(`error: ${loc}${err.text}`);
+    }
+  }
+  if (result.warnings.length > 0 && opts.logLevel !== "silent" && opts.logLevel !== "error") {
+    for (const warn of result.warnings) {
+      console.error(`warning: ${warn.text}`);
+    }
+  }
+
+  // 출력
+  if (opts.outfile || opts.outdir) {
+    if (opts.clean && opts.outdir) {
+      rmSync(resolve(opts.outdir), { recursive: true, force: true });
+    }
+    writeOutputFiles(result.outputFiles, opts.outfile, opts.outdir);
+  } else {
+    // stdout
+    if (result.outputFiles.length > 0) {
+      process.stdout.write(result.outputFiles[0].text);
+    }
+  }
+
+  // metafile
+  if (opts.metafile && result.metafile) {
+    if (opts.analyze) {
+      console.error(result.metafile);
+    } else {
+      writeFileSync(resolve(opts.metafile), result.metafile);
+    }
+  }
+
+  return result;
+}
+
+// ─── Watch 모드 ───
+
+async function runWatch(opts) {
+  const { watch } = await import("node:fs");
+
+  let building = false;
+  let pendingRebuild = false;
+  let debounceTimer = null;
+
+  async function rebuild() {
+    if (building) {
+      pendingRebuild = true;
+      return;
+    }
+    building = true;
+
+    try {
+      const start = performance.now();
+      const result = await runBundle(opts);
+      const elapsed = Math.round(performance.now() - start);
+      const files = result.outputFiles?.length ?? 0;
+
+      if (opts.watchJson) {
+        const event =
+          result.errors.length > 0
+            ? { type: "rebuild", success: false, error: result.errors[0]?.text }
+            : { type: "rebuild", success: true, files, ms: elapsed };
+        console.log(JSON.stringify(event));
+      } else if (opts.logLevel !== "silent") {
+        if (result.errors.length === 0) {
+          console.error(`[watch] rebuilt in ${elapsed}ms`);
+        }
+      }
+    } catch (err) {
+      if (opts.watchJson) {
+        console.log(JSON.stringify({ type: "rebuild", success: false, error: String(err) }));
+      } else if (opts.logLevel !== "silent") {
+        console.error(`[watch] error: ${err}`);
+      }
+    } finally {
+      building = false;
+      if (pendingRebuild) {
+        pendingRebuild = false;
+        rebuild();
+      }
+    }
+  }
+
+  // 초기 빌드
+  await rebuild();
+
+  if (opts.watchJson) {
+    console.log(JSON.stringify({ type: "ready" }));
+  } else if (opts.logLevel !== "silent") {
+    console.error("[watch] watching for changes...");
+  }
+
+  // 파일 감시
+  const watchDirs = new Set();
+  for (const entry of opts.entryPoints) {
+    watchDirs.add(dirname(resolve(entry)));
+  }
+
+  for (const dir of watchDirs) {
+    watch(dir, { recursive: true }, (_event, filename) => {
+      if (!filename) return;
+      // node_modules, .git, 출력 디렉토리 무시
+      if (filename.includes("node_modules") || filename.includes(".git")) return;
+      if (opts.outdir && filename.startsWith(basename(resolve(opts.outdir)))) return;
+
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(rebuild, opts.watchDelay);
+    });
+  }
+}
+
+// ─── Serve 모드 ───
+
+async function runServe(opts) {
+  const isBun = typeof globalThis.Bun !== "undefined";
+  const mimeTypes = {
+    ".html": "text/html",
+    ".js": "application/javascript",
+    ".mjs": "application/javascript",
+    ".css": "text/css",
+    ".json": "application/json",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".gif": "image/gif",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".map": "application/json",
+  };
+
+  // 번들 모드면 먼저 빌드
+  if (opts.bundle && opts.entryPoints.length > 0) {
+    opts.outdir = opts.outdir || join(opts.serveDir, ".zts-serve");
+    await runBundle(opts);
+
+    // watch도 같이
+    if (!opts.watch) {
+      opts.watch = true;
+    }
+  }
+
+  const serveDir = resolve(opts.outdir || opts.serveDir);
+
+  function handleRequest(reqUrl) {
+    let pathname = new URL(reqUrl, "http://localhost").pathname;
+    if (pathname === "/") pathname = "/index.html";
+
+    const filePath = join(serveDir, pathname);
+    if (!existsSync(filePath)) {
+      return { status: 404, body: "Not Found", type: "text/plain" };
+    }
+
+    const ext = extname(filePath);
+    const type = mimeTypes[ext] || "application/octet-stream";
+    const body = readFileSync(filePath);
+    return { status: 200, body, type };
+  }
+
+  if (isBun) {
+    // Bun.serve
+    globalThis.Bun.serve({
+      port: opts.port,
+      hostname: opts.host,
+      fetch(req) {
+        // 프록시 처리
+        const url = new URL(req.url);
+        for (const [prefix, target] of Object.entries(opts.proxy)) {
+          if (url.pathname.startsWith(prefix)) {
+            return fetch(target + url.pathname.slice(prefix.length) + url.search);
+          }
+        }
+
+        const { status, body, type } = handleRequest(req.url);
+        return new Response(body, {
+          status,
+          headers: {
+            "Content-Type": type,
+            "Access-Control-Allow-Origin": "*",
+          },
+        });
+      },
+    });
+  } else {
+    // Node.js http
+    const server = createServer(async (req, res) => {
+      // 프록시 처리
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      for (const [prefix, target] of Object.entries(opts.proxy)) {
+        if (url.pathname.startsWith(prefix)) {
+          try {
+            const proxyRes = await fetch(target + url.pathname.slice(prefix.length) + url.search, {
+              method: req.method,
+              headers: req.headers,
+            });
+            res.writeHead(proxyRes.status, Object.fromEntries(proxyRes.headers));
+            const body = await proxyRes.arrayBuffer();
+            res.end(Buffer.from(body));
+          } catch {
+            res.writeHead(502);
+            res.end("Bad Gateway");
+          }
+          return;
+        }
+      }
+
+      const { status, body, type } = handleRequest(req.url);
+      res.writeHead(status, {
+        "Content-Type": type,
+        "Access-Control-Allow-Origin": "*",
+      });
+      res.end(body);
+    });
+    server.listen(opts.port, opts.host);
+  }
+
+  if (opts.logLevel !== "silent") {
+    console.error(`[serve] http://${opts.host}:${opts.port}`);
+  }
+
+  // watch 시작 (번들 모드일 때)
+  if (opts.watch && opts.bundle) {
+    const { watch: fsWatch } = await import("node:fs");
+    let debounceTimer = null;
+
+    const watchDirs = new Set();
+    for (const entry of opts.entryPoints) {
+      watchDirs.add(dirname(resolve(entry)));
+    }
+
+    for (const dir of watchDirs) {
+      fsWatch(dir, { recursive: true }, (_event, filename) => {
+        if (!filename || filename.includes("node_modules") || filename.includes(".git")) return;
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(async () => {
+          try {
+            await runBundle(opts);
+            if (opts.logLevel !== "silent") console.error("[serve] rebuilt");
+          } catch (err) {
+            console.error("[serve] rebuild error:", err);
+          }
+        }, opts.watchDelay);
+      });
+    }
+  }
+
+  // open browser
+  if (opts.open) {
+    const url = `http://${opts.host === "0.0.0.0" ? "localhost" : opts.host}:${opts.port}`;
+    const { exec } = await import("node:child_process");
+    const cmd =
+      process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+    exec(`${cmd} ${url}`);
+  }
+}
+
+// ─── Main ───
+
+async function main() {
+  const opts = parseArgs(process.argv);
+
+  if (opts.entryPoints.length === 0 && !opts.stdin && !opts.serve) {
+    console.error("Usage: zts [options] <file.ts>");
+    console.error("       zts --bundle <entry.ts> -o out.js");
+    console.error("       zts --serve --bundle <entry.ts>");
+    process.exit(1);
+  }
+
+  init();
+
+  try {
+    if (opts.serve) {
+      await runServe(opts);
+    } else if (opts.watch) {
+      await runWatch(opts);
+    } else if (opts.bundle) {
+      const result = await runBundle(opts);
+      if (result.errors.length > 0) process.exit(1);
+    } else {
+      await runTranspile(opts);
+    }
+  } catch (err) {
+    console.error(`error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/core/dist/index.js
+++ b/packages/core/dist/index.js
@@ -1,0 +1,151 @@
+// index.ts
+import { createRequire } from "module";
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// ../shared/index.ts
+var ES_TARGET_BITS = {
+  es5: 2097151,
+  es2015: 2095104,
+  es2016: 2093056,
+  es2017: 2088960,
+  es2018: 2080768,
+  es2019: 2064384,
+  es2020: 1966080,
+  es2021: 1835008,
+  es2022: 1048576,
+  es2024: 1048576,
+  es2025: 0,
+  esnext: 0,
+};
+function encodeFlags(opts = {}) {
+  let flags = 0;
+  if (opts.sourcemap) flags |= 1 << 0;
+  if (opts.minifyWhitespace || opts.minify) flags |= 1 << 1;
+  if (opts.minifyIdentifiers || opts.minify) flags |= 1 << 2;
+  if (opts.minifySyntax || opts.minify) flags |= 1 << 3;
+  if (opts.jsx === "automatic") flags |= 1 << 4;
+  if (opts.jsx === "automatic-dev") flags |= 1 << 5;
+  if (opts.dropConsole) flags |= 1 << 6;
+  if (opts.dropDebugger) flags |= 1 << 7;
+  if (opts.asciiOnly) flags |= 1 << 8;
+  if (opts.flow) flags |= 1 << 9;
+  if (opts.experimentalDecorators) flags |= 1 << 10;
+  if (opts.emitDecoratorMetadata) flags |= 1 << 11;
+  if (opts.format === "cjs") flags |= 1 << 12;
+  if (opts.quotes === "single") flags |= 1 << 14;
+  if (opts.quotes === "preserve") flags |= 2 << 14;
+  if (opts.useDefineForClassFields !== false) flags |= 1 << 16;
+  if (opts.charsetUtf8) flags |= 1 << 17;
+  if (opts.platform === "node") flags |= 1 << 18;
+  if (opts.platform === "neutral") flags |= 2 << 18;
+  if (opts.platform === "react-native") flags |= 3 << 18;
+  if (opts.jsxInJs) flags |= 1 << 20;
+  if (opts.sourcemapDebugIds) flags |= 1 << 21;
+  if (opts.sourcesContent !== false) flags |= 1 << 22;
+  return flags;
+}
+
+// index.ts
+var native = null;
+function findAddon() {
+  const __dirname2 = dirname(fileURLToPath(import.meta.url));
+  const local = join(__dirname2, "zts.node");
+  if (existsSync(local)) return local;
+  const parent = join(__dirname2, "../zts.node");
+  if (existsSync(parent)) return parent;
+  const zigOut = join(__dirname2, "../../zig-out/lib/zts.node");
+  if (existsSync(zigOut)) return zigOut;
+  const zigOut2 = join(__dirname2, "../../../zig-out/lib/zts.node");
+  if (existsSync(zigOut2)) return zigOut2;
+  throw new Error("@zts/core: zts.node not found. Run `zig build napi` first.");
+}
+function init(addonPath) {
+  if (native) return;
+  const path = addonPath ?? findAddon();
+  const require2 = createRequire(import.meta.url);
+  native = require2(path);
+}
+function transpile(source, options = {}) {
+  if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
+  if (!source) throw new Error("@zts/core: empty source");
+  const flags = encodeFlags(options);
+  const unsupported = options.target ? (ES_TARGET_BITS[options.target] ?? 0) : 0;
+  return native.transpile(
+    source,
+    options.filename ?? "input.ts",
+    flags,
+    unsupported,
+    options.jsxFactory ?? "",
+    options.jsxFragment ?? "",
+    options.jsxImportSource ?? "",
+  );
+}
+function createPluginDispatcher(plugins) {
+  const hooks = {
+    resolveId: [],
+    load: [],
+    transform: [],
+  };
+  for (const plugin of plugins) {
+    const build = {
+      onResolve(opts, cb) {
+        hooks.resolveId.push({ filter: opts.filter, callback: cb });
+      },
+      onLoad(opts, cb) {
+        hooks.load.push({ filter: opts.filter, callback: cb });
+      },
+      onTransform(opts, cb) {
+        hooks.transform.push({ filter: opts.filter, callback: cb });
+      },
+    };
+    plugin.setup(build);
+  }
+  const argBuilders = {
+    resolveId: (arg1, arg2) => [arg1, { path: arg1, importer: arg2 }],
+    load: (arg1, _) => [arg1, { path: arg1 }],
+    transform: (arg1, arg2) => [arg2 ?? "", { code: arg1, path: arg2 }],
+  };
+  return function dispatcher(hookName, arg1, arg2) {
+    const hookList = hooks[hookName];
+    const buildArgs = argBuilders[hookName];
+    if (!hookList || !buildArgs) return null;
+    const [filterTarget, cbArgs] = buildArgs(arg1, arg2);
+    for (const h of hookList) {
+      if (h.filter.test(filterTarget)) {
+        try {
+          const result = h.callback(cbArgs);
+          if (result != null) return result;
+        } catch {
+          return null;
+        }
+      }
+    }
+    return null;
+  };
+}
+async function build(options) {
+  if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
+  if (!options.entryPoints?.length) throw new Error("@zts/core: entryPoints is required");
+  const napiOptions = { ...options };
+  if (options.plugins?.length) {
+    napiOptions._pluginDispatcher = createPluginDispatcher(options.plugins);
+    delete napiOptions.plugins;
+  }
+  return native.build(napiOptions);
+}
+function buildSync(options) {
+  if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
+  if (!options.entryPoints?.length) throw new Error("@zts/core: entryPoints is required");
+  if (options.plugins?.length) {
+    throw new Error(
+      "@zts/core: plugins are only supported with build() (async). Use build() instead of buildSync().",
+    );
+  }
+  return native.buildSync(options);
+}
+function close() {
+  native = null;
+}
+export { transpile, init, close, buildSync, build };

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -62,11 +62,21 @@ let native: NativeModule | null = null;
 function findAddon(): string {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
+  // 1. 같은 디렉토리 (소스에서 직접 사용)
   const local = join(__dirname, "zts.node");
   if (existsSync(local)) return local;
 
+  // 2. 한 단계 위 (dist/index.js에서 사용 시)
+  const parent = join(__dirname, "../zts.node");
+  if (existsSync(parent)) return parent;
+
+  // 3. zig-out (개발 시)
   const zigOut = join(__dirname, "../../zig-out/lib/zts.node");
   if (existsSync(zigOut)) return zigOut;
+
+  // 4. dist에서 3단계 위
+  const zigOut2 = join(__dirname, "../../../zig-out/lib/zts.node");
+  if (existsSync(zigOut2)) return zigOut2;
 
   throw new Error("@zts/core: zts.node not found. Run `zig build napi` first.");
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,8 +3,12 @@
   "version": "0.1.0",
   "description": "ZTS TypeScript transpiler — native binding",
   "license": "MIT",
+  "bin": {
+    "zts": "./bin/zts.mjs"
+  },
   "files": [
     "dist/",
+    "bin/",
     "zts.node"
   ],
   "type": "module",


### PR DESCRIPTION
## Summary
CLI를 Node.js 스크립트로 전환하여 플러그인 경로를 NAPI로 통일.
Watch/Serve는 JS 레이어, 코어 번들링은 NAPI.

### `packages/core/bin/zts.mjs`
- `#!/usr/bin/env node` — Node.js + Bun 호환
- **transpile**: stdin (`-`), 파일, stdout, `-o`, `--outdir`
- **bundle**: `buildSync`/`build` + 파일 출력 + `--plugin` NAPI 플러그인
- **watch**: `fs.watch` + 디바운스 리빌드 + `--watch-json` NDJSON
- **serve**: Node.js `http.createServer` / Bun `Bun.serve` 런타임 분기
- 프록시 (`--proxy`), `--open`, `--clean`, 전체 CLI 옵션 파싱

### 검증
```bash
# transpile
echo "const x: number = 1;" | node packages/core/bin/zts.mjs -
# → const x = 1;

# bundle
node packages/core/bin/zts.mjs --bundle entry.ts -o out.js

# Bun에서도 동작
bun packages/core/bin/zts.mjs --bundle entry.ts
```

## Test plan
- [x] Node.js stdin/파일/번들 동작 확인
- [x] Bun 번들 동작 확인
- [x] 기존 80개 NAPI 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)