### PR TITLE
feat(napi): define/alias 옵션 NAPI 노출

### DIFF
--- a/packages/core/dist/index.js
+++ b/packages/core/dist/index.js
@@ -148,4 +148,47 @@ function buildSync(options) {
 function close() {
   native = null;
 }
-export { transpile, init, close, buildSync, build };
+function vitePlugin(rollupPlugin) {
+  return {
+    name: rollupPlugin.name,
+    setup(build2) {
+      if (rollupPlugin.resolveId) {
+        const hook = rollupPlugin.resolveId;
+        build2.onResolve({ filter: /.*/ }, (args) => {
+          const result = hook(args.path, args.importer);
+          if (result == null) return null;
+          if (typeof result === "string") return { path: result };
+          if (typeof result === "object" && "id" in result) {
+            return { path: result.id, external: result.external };
+          }
+          return null;
+        });
+      }
+      if (rollupPlugin.load) {
+        const hook = rollupPlugin.load;
+        build2.onLoad({ filter: /.*/ }, (args) => {
+          const result = hook(args.path);
+          if (result == null) return null;
+          if (typeof result === "string") return { contents: result };
+          if (typeof result === "object" && "code" in result) {
+            return { contents: result.code };
+          }
+          return null;
+        });
+      }
+      if (rollupPlugin.transform) {
+        const hook = rollupPlugin.transform;
+        build2.onTransform({ filter: /.*/ }, (args) => {
+          const result = hook(args.code, args.path);
+          if (result == null) return null;
+          if (typeof result === "string") return { code: result };
+          if (typeof result === "object" && "code" in result) {
+            return { code: result.code };
+          }
+          return null;
+        });
+      }
+    },
+  };
+}
+export { vitePlugin, transpile, init, close, buildSync, build };

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1002,6 +1002,71 @@ describe("@zts/core build 옵션 조합", () => {
   });
 });
 
+// ─── define/alias 옵션 ───
+
+describe("@zts/core define/alias", () => {
+  test("define: 글로벌 상수 치환", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-define-"));
+    writeFileSync(
+      join(dir, "index.ts"),
+      "console.log(process.env.NODE_ENV);\nconsole.log(__DEV__);",
+    );
+
+    const result = buildSync({
+      entryPoints: [join(dir, "index.ts")],
+      define: {
+        "process.env.NODE_ENV": '"production"',
+        __DEV__: "false",
+      },
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("production");
+    expect(result.outputFiles[0].text).toContain("false");
+    expect(result.outputFiles[0].text).not.toContain("process.env.NODE_ENV");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("alias: import 경로 치환", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-alias-"));
+    writeFileSync(join(dir, "real.ts"), "export const x = 42;");
+    writeFileSync(join(dir, "index.ts"), 'import { x } from "@alias/mod";\nconsole.log(x);');
+
+    const result = buildSync({
+      entryPoints: [join(dir, "index.ts")],
+      alias: { "@alias/mod": join(dir, "real.ts") },
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("42");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("define: async build에서도 동작", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-define-async-"));
+    writeFileSync(join(dir, "index.ts"), "console.log(VERSION);");
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      define: { VERSION: '"1.0.0"' },
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("1.0.0");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("빈 define/alias 객체 → 무시", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-empty-define-"));
+    writeFileSync(join(dir, "index.ts"), "export const x = 1;");
+
+    const result = buildSync({
+      entryPoints: [join(dir, "index.ts")],
+      define: {},
+      alias: {},
+    });
+    expect(result.errors.length).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
 // ─── Vite/Rollup 플러그인 어댑터 ───
 
 describe("vitePlugin 어댑터", () => {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -153,6 +153,8 @@ export interface BuildOptions {
   jsxFactory?: string;
   jsxFragment?: string;
   jsxImportSource?: string;
+  define?: Record<string, string>;
+  alias?: Record<string, string>;
   inject?: string[];
   jobs?: number;
   plugins?: ZtsPlugin[];

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -197,6 +197,46 @@ fn getObjectStringArray(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, 
     return result[0..count];
 }
 
+/// JS 객체의 키-값 쌍을 [2][]const u8 배열로 추출. { "key": "value", ... }
+fn getObjectKeyValuePairs(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[][2][]const u8 {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+
+    // 프로퍼티 이름 목록 가져오기
+    var prop_names: c.napi_value = undefined;
+    if (c.napi_get_property_names(env, val, &prop_names) != c.napi_ok) return null;
+    var len: u32 = 0;
+    _ = c.napi_get_array_length(env, prop_names, &len);
+    if (len == 0) return null;
+
+    const result = alloc.alloc([2][]const u8, len) catch return null;
+    var count: u32 = 0;
+    for (0..len) |i| {
+        var prop_key: c.napi_value = undefined;
+        if (c.napi_get_element(env, prop_names, @intCast(i), &prop_key) != c.napi_ok) continue;
+        const k = getStringArg(env, prop_key, alloc) orelse continue;
+
+        // napi_get_property로 키에 대한 값 가져오기 (null-terminated 불필요)
+        var prop_val: c.napi_value = undefined;
+        if (c.napi_get_property(env, val, prop_key, &prop_val) != c.napi_ok) {
+            alloc.free(k);
+            continue;
+        }
+
+        const v = getStringArg(env, prop_val, alloc) orelse {
+            alloc.free(k);
+            continue;
+        };
+
+        result[count] = .{ k, v };
+        count += 1;
+    }
+    if (count == 0) {
+        alloc.free(result);
+        return null;
+    }
+    return result[0..count];
+}
+
 fn resolveEntryPoint(alloc: std.mem.Allocator, path: []const u8) ?[]const u8 {
     const resolved = std.fs.cwd().realpathAlloc(alloc, path) catch return alloc.dupe(u8, path) catch null;
     return resolved;
@@ -812,12 +852,43 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
+    // define: { "key": "value" } → []DefineEntry
+    const define_pairs = getObjectKeyValuePairs(env, opts_obj, "define", native_alloc);
+    var define_entries: []const @import("zts_lib").transformer.transformer.DefineEntry = &.{};
+    if (define_pairs) |pairs| {
+        const defs = native_alloc.alloc(@import("zts_lib").transformer.transformer.DefineEntry, pairs.len) catch return null;
+        for (pairs, 0..) |pair, idx| {
+            if (!trackStr(owned_strings, pair[0])) return null;
+            if (!trackStr(owned_strings, pair[1])) return null;
+            defs[idx] = .{ .key = pair[0], .value = pair[1] };
+        }
+        // pairs 배열 자체는 해제 (키/값은 owned_strings가 소유)
+        native_alloc.free(pairs);
+        define_entries = defs;
+    }
+
+    // alias: { "from": "to" } → []AliasEntry
+    const alias_pairs = getObjectKeyValuePairs(env, opts_obj, "alias", native_alloc);
+    var alias_entries: []const bundler_mod.types.AliasEntry = &.{};
+    if (alias_pairs) |pairs| {
+        const als = native_alloc.alloc(bundler_mod.types.AliasEntry, pairs.len) catch return null;
+        for (pairs, 0..) |pair, idx| {
+            if (!trackStr(owned_strings, pair[0])) return null;
+            if (!trackStr(owned_strings, pair[1])) return null;
+            als[idx] = .{ .from = pair[0], .to = pair[1] };
+        }
+        native_alloc.free(pairs);
+        alias_entries = als;
+    }
+
     const minify = getObjectBool(env, opts_obj, "minify", false);
     return .{
         .entry_points = entries,
         .format = format,
         .platform = platform,
         .external = external orelse &.{},
+        .define = define_entries,
+        .alias = alias_entries,
         .minify_whitespace = if (minify) true else getObjectBool(env, opts_obj, "minifyWhitespace", false),
         .minify_identifiers = if (minify) true else getObjectBool(env, opts_obj, "minifyIdentifiers", false),
         .minify_syntax = if (minify) true else getObjectBool(env, opts_obj, "minifySyntax", false),


### PR DESCRIPTION
## Summary
JS 객체 \`{ key: value }\`를 Zig \`DefineEntry\`/\`AliasEntry\`로 변환하여 NAPI에 노출.

### 사용법
\`\`\`typescript
buildSync({
  entryPoints: ["index.ts"],
  define: { "process.env.NODE_ENV": '"production"', __DEV__: "false" },
  alias: { "@alias/mod": "./real.ts" },
});
\`\`\`

## Test plan
- [x] 100/100 통과 (1285 expect calls)
- [x] define 치환, alias 경로 치환, async, 빈 객체

🤖 Generated with [Claude Code](https://claude.com/claude-code)