### PR TITLE
fix(cli): tsconfig URL 문자열 주석 제거 버그 수정

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -442,9 +442,11 @@ function loadTsConfig(opts) {
   if (!tsconfigPath || !existsSync(tsconfigPath)) return;
 
   try {
-    // JSON with comments를 간단히 파싱 (줄 주석, 블록 주석 제거)
+    // JSON with comments 파싱 — 문자열 리터럴 내의 // 를 보호
     const raw = readFileSync(resolve(tsconfigPath), "utf8");
-    const stripped = raw.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+    const stripped = raw.replace(/"(?:[^"\\]|\\.)*"|\/\/.*$|\/\*[\s\S]*?\*\//gm, (m) =>
+      m.startsWith('"') ? m : "",
+    );
     const config = JSON.parse(stripped);
     const co = config.compilerOptions;
     if (!co) return;
@@ -489,7 +491,7 @@ function loadTsConfig(opts) {
         es2020: "es2020",
         es2021: "es2021",
         es2022: "es2022",
-        es2023: "es2024",
+        es2023: "es2024", // ZTS에 es2023 타겟이 없으므로 es2024로 올림
         es2024: "es2024",
         esnext: "esnext",
       };

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -642,4 +642,27 @@ describe("CLI: tsconfig", () => {
     expect(stdout).toContain("this.x");
     rmSync(dir, { recursive: true, force: true });
   });
+
+  test("tsconfig에 URL이 포함된 문자열이 있어도 파싱 성공", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-tsconfig-url-"));
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      `{
+  // tsconfig with URL in value
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "baseUrl": "https://example.com/path"
+  }
+}`,
+    );
+    writeFileSync(
+      join(dir, "input.ts"),
+      "@sealed\nclass G { x: string; constructor(m: string) { this.x = m; } }",
+    );
+
+    const { stdout, exitCode } = runCli([join(dir, "input.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("__decorate");
+    rmSync(dir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary
tsconfig.json 파싱 시 \`"https://..."\` 같은 URL이 포함된 문자열이 주석으로 오인되어 삭제되는 버그 수정.

### 수정
\`/\/\/.*$/gm\` → 문자열 리터럴을 먼저 보호하는 정규식으로 교체

## Test plan
- [x] CLI 44/44 통과 (URL 포함 tsconfig 테스트 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)