### PR TITLE
feat: hashbang 보존/제거 + 테스트 7개 + CI NAPI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,56 @@ jobs:
       - name: Check formatting
         run: zig fmt --check src/
 
+  napi:
+    name: NAPI Build & Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build NAPI module
+        run: zig build napi
+
+      - name: Build JS wrapper
+        run: cd packages/core && bun build index.ts --outdir dist --format esm --target node
+
+      - name: Copy .node to package
+        run: cp zig-out/lib/zts.node packages/core/zts.node 2>/dev/null || true
+
+      - name: Run NAPI tests (Bun)
+        run: cd packages/core && bun test index.test.ts
+
+      - name: Run NAPI tests (Node.js)
+        run: node --test packages/core/napi.test.mjs
+
+      - name: Run CLI tests (Bun)
+        run: cd packages/core && bun test bin/zts.test.ts
+
   wasm:
     name: WASM Build
     runs-on: ubuntu-latest

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1002,6 +1002,62 @@ describe("@zts/core build 옵션 조합", () => {
   });
 });
 
+// ─── ES2023 + hashbang ───
+
+describe("@zts/core ES2023/hashbang", () => {
+  test("target es5: hashbang이 제거됨", () => {
+    const result = transpile("#!/usr/bin/env node\nconsole.log('hello');", {
+      target: "es5",
+    });
+    expect(result.code).not.toContain("#!");
+    expect(result.code).toContain("hello");
+  });
+
+  test("target es2022: hashbang이 제거됨 (es2022 < es2023)", () => {
+    const result = transpile("#!/usr/bin/env node\nconst x = 1;", {
+      target: "es2022",
+    });
+    expect(result.code).not.toContain("#!");
+    expect(result.code).toContain("x = 1");
+  });
+
+  test("target es2023: hashbang이 유지됨", () => {
+    const result = transpile("#!/usr/bin/env node\nconst x = 1;", {
+      target: "es2023",
+    });
+    expect(result.code).toContain("#!/usr/bin/env node");
+    expect(result.code).toContain("x = 1");
+  });
+
+  test("target esnext: hashbang이 유지됨", () => {
+    const result = transpile("#!/usr/bin/env node\nconst x = 1;", {
+      target: "esnext",
+    });
+    expect(result.code).toContain("#!/usr/bin/env node");
+  });
+
+  test("hashbang 없는 파일에서 es2022 타겟 — 정상 동작", () => {
+    const result = transpile("const x: number = 1;", { target: "es2022" });
+    expect(result.code).toContain("const x = 1");
+  });
+
+  test("target 미지정: hashbang이 유지됨 (기본 esnext)", () => {
+    const result = transpile("#!/usr/bin/env node\nconst x = 1;");
+    expect(result.code).toContain("#!/usr/bin/env node");
+  });
+
+  test("es2023 타겟 번들링", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-es2023-build-"));
+    writeFileSync(join(dir, "index.ts"), "#!/usr/bin/env node\nconsole.log(1);");
+    // buildSync에 target 옵션이 없으므로 transpile로 테스트
+    const result = transpile(readFileSync(join(dir, "index.ts"), "utf8"), {
+      target: "es2023",
+    });
+    expect(result.code).toContain("#!/usr/bin/env node");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
 // ─── define/alias 옵션 ───
 
 describe("@zts/core define/alias", () => {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -212,6 +212,18 @@ pub const Codegen = struct {
     pub fn generate(self: *Codegen, root: NodeIndex) ![]const u8 {
         // 출력 크기는 보통 소스 크기와 비슷 → 사전 할당
         try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len);
+
+        // hashbang: 소스가 #!로 시작하면 strip_hashbang이 아닐 때 보존
+        if (!self.options.strip_hashbang and self.ast.source.len >= 2 and
+            self.ast.source[0] == '#' and self.ast.source[1] == '!')
+        {
+            // 첫 번째 줄 끝까지 출력
+            var end: usize = 0;
+            while (end < self.ast.source.len and self.ast.source[end] != '\n') : (end += 1) {}
+            try self.write(self.ast.source[0..end]);
+            try self.writeByte('\n');
+        }
+
         // namespace var 중복 제거: top-level 선언 이름 사전 수집
         self.collectTopLevelDeclNames(root);
         try self.emitNode(root);


### PR DESCRIPTION
## Summary
- codegen에서 hashbang (#!) 보존: 소스가 #!로 시작하면 strip_hashbang이 아닐 때 첫 줄 출력
- hashbang 테스트 7개 (es5/es2022 제거, es2023/esnext/미지정 유지 등)
- CI에 NAPI Build & Test job 추가 (ubuntu + macos, Bun + Node.js)

## Test plan
- [x] Zig 전체 테스트 통과
- [x] NAPI 107/107 통과 (1295 expect calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)