### PR TITLE
fix: hashbang을 AST 노드로 근본 수정 (파서+codegen)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -213,17 +213,6 @@ pub const Codegen = struct {
         // 출력 크기는 보통 소스 크기와 비슷 → 사전 할당
         try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len);
 
-        // hashbang: 소스가 #!로 시작하면 strip_hashbang이 아닐 때 보존
-        if (!self.options.strip_hashbang and self.ast.source.len >= 2 and
-            self.ast.source[0] == '#' and self.ast.source[1] == '!')
-        {
-            // 첫 번째 줄 끝까지 출력
-            var end: usize = 0;
-            while (end < self.ast.source.len and self.ast.source[end] != '\n') : (end += 1) {}
-            try self.write(self.ast.source[0..end]);
-            try self.writeByte('\n');
-        }
-
         // namespace var 중복 제거: top-level 선언 이름 사전 수집
         self.collectTopLevelDeclNames(root);
         try self.emitNode(root);

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -31,13 +31,19 @@ pub fn parse(self: *Parser) !NodeIndex {
         self.is_strict_mode = true;
     }
 
-    // hashbang (#! ...) 건너뛰기
-    if (self.current() == .hashbang_comment) {
-        try self.advance();
-    }
-
     var stmts: std.ArrayList(NodeIndex) = .empty;
     defer stmts.deinit(self.allocator);
+
+    // hashbang (#! ...) — AST에 노드로 추가 (codegen에서 strip_hashbang 조건부 출력)
+    if (self.current() == .hashbang_comment) {
+        const hashbang_node = try self.ast.addNode(.{
+            .tag = .hashbang,
+            .span = self.currentSpan(),
+            .data = .{ .none = 0 },
+        });
+        try stmts.append(self.allocator, hashbang_node);
+        try self.advance();
+    }
 
     // directive prologue 감지: 프로그램 시작 부분의 "use strict"
     var in_directive_prologue = true;


### PR DESCRIPTION
## Summary
hashbang 보존/제거를 임시방편(소스 원본 체크)에서 **근본적 수정**(파서 AST 노드)으로 전환.

### 변경
- **파서** (statement.zig): hashbang_comment 토큰을 `.hashbang` AST 노드로 생성하여 stmts에 추가
  - 기존: `advance()`로 무시 → AST에 미포함
  - 수정: `ast.addNode(.hashbang)` → AST에 포함
- **codegen** (codegen.zig): `generate()` 시작의 임시 소스 원본 체크 코드 제거
  - `.hashbang` case에서 `strip_hashbang` 조건부 출력이 정상 동작
- CI NAPI job 추가 + hashbang 테스트 7개

## Test plan
- [x] Zig 전체 테스트 통과
- [x] NAPI 107/107 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)