### PR TITLE
docs: 문서 전면 업데이트 + transform 체이닝 수정 + Vite 테스트 5개

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # ZTS - Zig TypeScript Transpiler
 
 ## Project Overview
-Zig로 작성하는 JavaScript/TypeScript/Flow 트랜스파일러. SWC/oxc 수준의 프로덕션 레벨 품질을 목표로 하는 학습 + 실용 프로젝트. 추후 번들러까지 확장 예정.
+Zig로 작성하는 JavaScript/TypeScript/Flow 트랜스파일러 + 번들러. SWC/oxc 수준의 프로덕션 레벨 품질을 목표.
+C NAPI 바인딩으로 Node.js/Bun에서 in-process 사용 가능. Vite/Rollup 플러그인 어댑터 지원.
 
 ## Tech Stack
 - **Language**: Zig 0.15.2
@@ -89,6 +90,36 @@ const result = await build({
   }],
 });
 ```
+
+### Vite/Rollup 플러그인 어댑터
+```typescript
+import { vitePlugin } from "@zts/core";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  plugins: [
+    vitePlugin({
+      name: "json-loader",
+      resolveId(source) { if (source.endsWith(".json")) return resolve(source); },
+      load(id) { if (id.endsWith(".json")) return `export default ${readFileSync(id)}`; },
+      transform(code, id) { return code.replace("import.meta.env.MODE", '"production"'); },
+    }),
+  ],
+});
+```
+
+### define/alias
+```typescript
+buildSync({
+  entryPoints: ["index.ts"],
+  define: { "process.env.NODE_ENV": '"production"', __DEV__: "false" },
+  alias: { "@alias/mod": "./real.ts" },
+});
+```
+
+### ES 다운레벨 타겟
+`es5` ~ `es2025`, `esnext` 지원. tsconfig `target`과 연동.
+ES2023: hashbang (#!) 다운레벨 (strip). ES2025: `using` 선언 다운레벨.
 
 ### Node.js CLI (`packages/core/bin/zts.mjs`)
 Zig 독립 바이너리(`zig-out/bin/zts`)를 대체하는 Node.js/Bun 호환 CLI.

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -126,11 +126,12 @@ const result = await build({
 
 **제한사항**: `buildSync()`에서는 JS 플러그인 미지원 (메인 스레드 데드락). `build()` (async)에서만 사용 가능.
 
-### 4단계: Vite/Rollup 호환 어댑터 (예정)
-- Vite/Rollup 플러그인(`resolveId`, `load`, `transform`, `renderChunk`, `generateBundle`)을
-  3단계의 esbuild 스타일 API로 변환하는 JS 어댑터
-- Zig 코어 수정 없이 JS 레이어에서 처리
-- `this.resolve()`, `this.emitFile()` 등 Rollup 컨텍스트 메서드 구현
+### 4단계: Vite/Rollup 호환 어댑터 ✅ 완료 (#992)
+- `vitePlugin()` 함수로 Rollup 스타일 플러그인을 ZTS 플러그인으로 변환
+- `resolveId`, `load`, `transform` 훅 지원 (문자열/객체/null 반환)
+- ZTS 네이티브 플러그인과 혼합 사용 가능
+- 13개 테스트 (JSON 플러그인, 환경 변수 치환 등 실전 패턴 포함)
+- **미지원**: `renderChunk`, `generateBundle`, `this.resolve()`, `this.emitFile()` (후순위)
 
 ### 5단계: Tapable 하이브리드 — webpack/Rspack 호환 (예정)
 > 방식 C: Zig에 Tapable 스타일 훅을 네이티브로 구현하고 NAPI로 노출.
@@ -233,7 +234,7 @@ pub const Plugin = struct {
 4. ✅ subprocess JSON 프로토콜 (JS 플러그인 호스트) — 2단계
 5. ✅ @zts/plugin npm 패키지 (JS API 래퍼) — 2단계
 6. ✅ C NAPI .node addon + esbuild 스타일 JS 플러그인 — 3단계
-7. Vite/Rollup 플러그인 어댑터 (JS 레이어) — 4단계
+7. ✅ Vite/Rollup 플러그인 어댑터 (`vitePlugin()`) — 4단계
 8. Tapable 하이브리드: Zig 훅 포인트 + NAPI 노출 — 5단계
 9. webpack Compiler/Compilation 호환 — 5단계
 10. Loader 시스템 (module.rules) — 5단계

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,6 +37,12 @@
 | 24. RN 호환 | self-require 방지, shimMissingExports, __rest Symbol, class field _this 캡처 | ✅ |
 | 25. ES5 다운레벨 | let→var void 0 초기화, spread string, for-in destructuring, computed destr, super computed | ✅ |
 | 26. compat-table | kangax ES5~ES2022 100% + SWC 비교 29 cases × 9 targets CI | ✅ |
+| 27. ES2023 | `--target=es2023`, hashbang (#!) 다운레벨, compat_table 엔진 버전 | ✅ |
+| 28. NAPI | C NAPI 바인딩: transpile, buildSync, build (async + plugins) | ✅ |
+| 29. Node.js CLI | Zig CLI → Node.js/Bun CLI 전환 (Rolldown 방식), watch/serve JS 구현 | ✅ |
+| 30. Vite 어댑터 | `vitePlugin()` Rollup→ZTS 플러그인 변환, resolveId/load/transform | ✅ |
+| 31. define/alias | NAPI BuildOptions에 `define`/`alias` 옵션 노출 | ✅ |
+| 32. tsconfig | CLI에서 tsconfig.json 자동 탐색+로드 (experimentalDecorators, jsx 등) | ✅ |
 
 ## 번들러 성능 현황 (2026-04-10 실측)
 

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1409,4 +1409,159 @@ describe("vitePlugin 어댑터", () => {
     expect(result.outputFiles[0].text).toContain("production");
     rmSync(envDir, { recursive: true, force: true });
   });
+
+  test("실전 패턴: YAML 로더 플러그인", async () => {
+    const yamlDir = mkdtempSync(join(tmpdir(), "zts-vite-yaml-"));
+    writeFileSync(join(yamlDir, "config.yaml"), "name: test\nversion: 2.0");
+    writeFileSync(
+      join(yamlDir, "index.ts"),
+      'import config from "./config.yaml";\nconsole.log(config);',
+    );
+
+    const yamlPlugin: RollupPlugin = {
+      name: "rollup-yaml",
+      resolveId(source, importer) {
+        if (source.endsWith(".yaml") && importer) return resolve(yamlDir, source);
+        return null;
+      },
+      load(id) {
+        if (id.endsWith(".yaml")) {
+          const content = readFileSync(id, "utf8");
+          const obj: Record<string, string> = {};
+          for (const line of content.split("\n")) {
+            const [k, v] = line.split(": ");
+            if (k && v) obj[k.trim()] = v.trim();
+          }
+          return `export default ${JSON.stringify(obj)};`;
+        }
+        return null;
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(yamlDir, "index.ts")],
+      plugins: [vitePlugin(yamlPlugin)],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("test");
+    expect(result.outputFiles[0].text).toContain("2.0");
+    rmSync(yamlDir, { recursive: true, force: true });
+  });
+
+  test("실전 패턴: SVG → React 컴포넌트 플러그인", async () => {
+    const svgDir = mkdtempSync(join(tmpdir(), "zts-vite-svg-"));
+    writeFileSync(join(svgDir, "icon.svg"), '<svg><circle r="10"/></svg>');
+    writeFileSync(join(svgDir, "index.tsx"), 'import Icon from "./icon.svg";\nconsole.log(Icon);');
+
+    const svgPlugin: RollupPlugin = {
+      name: "rollup-svg-react",
+      resolveId(source, importer) {
+        if (source.endsWith(".svg") && importer) return resolve(svgDir, source);
+        return null;
+      },
+      load(id) {
+        if (id.endsWith(".svg")) {
+          const svg = readFileSync(id, "utf8");
+          return `export default function SvgIcon() { return "${svg.replace(/"/g, '\\"')}"; }`;
+        }
+        return null;
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(svgDir, "index.tsx")],
+      plugins: [vitePlugin(svgPlugin)],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("SvgIcon");
+    expect(result.outputFiles[0].text).toContain("circle");
+    rmSync(svgDir, { recursive: true, force: true });
+  });
+
+  test("실전 패턴: GraphQL 쿼리 로더", async () => {
+    const gqlDir = mkdtempSync(join(tmpdir(), "zts-vite-gql-"));
+    writeFileSync(join(gqlDir, "query.graphql"), "query GetUser { user { name } }");
+    writeFileSync(
+      join(gqlDir, "index.ts"),
+      'import query from "./query.graphql";\nconsole.log(query);',
+    );
+
+    const gqlPlugin: RollupPlugin = {
+      name: "rollup-graphql",
+      resolveId(source, importer) {
+        if (source.endsWith(".graphql") && importer) return resolve(gqlDir, source);
+        return null;
+      },
+      load(id) {
+        if (id.endsWith(".graphql")) {
+          const content = readFileSync(id, "utf8");
+          return `export default ${JSON.stringify(content)};`;
+        }
+        return null;
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(gqlDir, "index.ts")],
+      plugins: [vitePlugin(gqlPlugin)],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("GetUser");
+    rmSync(gqlDir, { recursive: true, force: true });
+  });
+
+  test("실전 패턴: 코드 내 console.log 자동 제거 transform", async () => {
+    const stripDir = mkdtempSync(join(tmpdir(), "zts-vite-strip-"));
+    writeFileSync(
+      join(stripDir, "index.ts"),
+      'console.log("debug");\nconst x = 1;\nconsole.log("also debug");\nconsole.warn("keep");',
+    );
+
+    const stripPlugin: RollupPlugin = {
+      name: "rollup-strip-console-log",
+      transform(code, _id) {
+        return code.replace(/console\.log\([^)]*\);?\n?/g, "");
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(stripDir, "index.ts")],
+      plugins: [vitePlugin(stripPlugin)],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).not.toContain("console.log");
+    expect(result.outputFiles[0].text).toContain("console.warn");
+    expect(result.outputFiles[0].text).toContain("x = 1");
+    rmSync(stripDir, { recursive: true, force: true });
+  });
+
+  test("실전 패턴: 다중 vitePlugin transform 체이닝", async () => {
+    const chainDir = mkdtempSync(join(tmpdir(), "zts-vite-chain-"));
+    writeFileSync(join(chainDir, "index.ts"), 'const msg = "HELLO_WORLD";');
+
+    // 첫 번째 플러그인: HELLO → Hello
+    const lowercasePlugin: RollupPlugin = {
+      name: "lowercase-first",
+      transform(code) {
+        return code.replace("HELLO", "Hello");
+      },
+    };
+
+    // 두 번째 플러그인: _WORLD → _World (첫 번째 결과를 입력으로 받음)
+    const capitalizePlugin: RollupPlugin = {
+      name: "capitalize-second",
+      transform(code) {
+        return code.replace("_WORLD", "_World");
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(chainDir, "index.ts")],
+      plugins: [vitePlugin(lowercasePlugin), vitePlugin(capitalizePlugin)],
+    });
+    expect(result.errors.length).toBe(0);
+    // 두 플러그인의 transform이 순차 체이닝되어야 함
+    expect(result.outputFiles[0].text).toContain("Hello_World");
+    rmSync(chainDir, { recursive: true, force: true });
+  });
 });

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -226,9 +226,34 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
 
   return function dispatcher(hookName: string, arg1: string, arg2: string | null) {
     const hookList = hooks[hookName];
-    const buildArgs = argBuilders[hookName];
-    if (!hookList || !buildArgs) return null;
+    if (!hookList) return null;
 
+    // transform은 체이닝: 이전 결과의 code가 다음 입력이 됨
+    if (hookName === "transform") {
+      let currentCode = arg1;
+      let changed = false;
+      for (const h of hookList) {
+        if (h.filter.test(arg2 ?? "")) {
+          try {
+            const result = h.callback({ code: currentCode, path: arg2 });
+            if (result != null) {
+              const newCode = typeof result === "string" ? result : result.code;
+              if (newCode != null) {
+                currentCode = newCode;
+                changed = true;
+              }
+            }
+          } catch {
+            // 에러 시 해당 플러그인 건너뛰고 다음으로
+          }
+        }
+      }
+      return changed ? { code: currentCode } : null;
+    }
+
+    // resolveId/load: 첫 번째 매칭 반환 (first 모드)
+    const buildArgs = argBuilders[hookName];
+    if (!buildArgs) return null;
     const [filterTarget, cbArgs] = buildArgs(arg1, arg2);
     for (const h of hookList) {
       if (h.filter.test(filterTarget)) {


### PR DESCRIPTION
## Summary
### 버그 수정
- `createPluginDispatcher`: transform 훅을 체이닝으로 변경 (기존: first 모드로 첫 결과만 반환)
  - 다중 vitePlugin 간 transform이 이제 순차 체이닝됨

### 문서 업데이트
- CLAUDE.md: Vite 어댑터, define/alias, ES2023 다운레벨 추가
- PLUGINS.md: 4단계 완료 표시
- docs/ROADMAP.md: Phase 27~32 추가

### Vite 실전 테스트 5개
- YAML 로더, SVG→React, GraphQL 쿼리, console.log 제거, 다중 vitePlugin 체이닝

## Test plan
- [x] 112/112 통과 (1309 expect calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)