### PR TITLE
test: 추가 커버리지 테스트 9개

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1564,4 +1564,187 @@ describe("vitePlugin 어댑터", () => {
     expect(result.outputFiles[0].text).toContain("Hello_World");
     rmSync(chainDir, { recursive: true, force: true });
   });
+
+  test("실전 패턴: 3개 플러그인 transform 체이닝", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-vite-chain3-"));
+    writeFileSync(join(dir, "index.ts"), 'const x = "AAA_BBB_CCC";');
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      plugins: [
+        vitePlugin({ name: "p1", transform: (code) => code.replace("AAA", "aaa") }),
+        vitePlugin({ name: "p2", transform: (code) => code.replace("BBB", "bbb") }),
+        vitePlugin({ name: "p3", transform: (code) => code.replace("CCC", "ccc") }),
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("aaa_bbb_ccc");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("vitePlugin: resolveId에 importer가 올바르게 전달됨", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-vite-importer-"));
+    writeFileSync(join(dir, "entry.ts"), 'import x from "./data.custom";\nconsole.log(x);');
+
+    let receivedImporter: string | null | undefined = undefined;
+    const plugin: RollupPlugin = {
+      name: "check-importer",
+      resolveId(source, importer) {
+        if (source.endsWith(".custom")) {
+          receivedImporter = importer ?? null;
+          return resolve(dir, source);
+        }
+        return null;
+      },
+      load(id) {
+        if (id.endsWith(".custom")) return 'export default "custom-data";';
+        return null;
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [vitePlugin(plugin)],
+    });
+    expect(result.errors.length).toBe(0);
+    // importer는 entry.ts의 절대 경로여야 함
+    expect(receivedImporter).toContain("entry.ts");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("vitePlugin: transform이 { code, map } 반환 시 map 무시", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-vite-map-"));
+    writeFileSync(join(dir, "index.ts"), "const x = 1;");
+
+    const plugin: RollupPlugin = {
+      name: "with-map",
+      transform(code) {
+        return { code: code.replace("1", "42"), map: { version: 3, mappings: "" } };
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      plugins: [vitePlugin(plugin)],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("42");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ─── 옵션 조합 심화 테스트 ───
+
+describe("@zts/core 옵션 조합 심화", () => {
+  test("hashbang + minify", () => {
+    const result = transpile(
+      "#!/usr/bin/env node\nconst longVariableName = 42;\nconsole.log(longVariableName);",
+      {
+        minify: true,
+        target: "es2023",
+      },
+    );
+    expect(result.code).toContain("#!/usr/bin/env node");
+    expect(result.code.length).toBeLessThan(80);
+  });
+
+  test("hashbang + sourcemap + es2022 (hashbang 제거됨)", () => {
+    const result = transpile("#!/usr/bin/env node\nconst x = 1;", {
+      sourcemap: true,
+      target: "es2022",
+    });
+    expect(result.code).not.toContain("#!");
+    expect(result.map).toBeDefined();
+  });
+
+  test("buildSync + define + alias + sourcemap 동시", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-combo-all-"));
+    writeFileSync(join(dir, "real.ts"), "export const val = 42;");
+    writeFileSync(
+      join(dir, "index.ts"),
+      'import { val } from "@mod";\nconsole.log(val, __VERSION__);',
+    );
+
+    const result = buildSync({
+      entryPoints: [join(dir, "index.ts")],
+      define: { __VERSION__: '"1.0"' },
+      alias: { "@mod": join(dir, "real.ts") },
+      sourcemap: true,
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("42");
+    expect(result.outputFiles[0].text).toContain("1.0");
+    expect(result.outputFiles.length).toBe(2); // js + map
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("transpile: 모든 ES 타겟 순회 (es5~esnext)", () => {
+    const targets = [
+      "es5",
+      "es2015",
+      "es2016",
+      "es2017",
+      "es2018",
+      "es2019",
+      "es2020",
+      "es2021",
+      "es2022",
+      "es2023",
+      "es2024",
+      "es2025",
+      "esnext",
+    ] as const;
+    for (const target of targets) {
+      const result = transpile("const x = () => 1;", { target });
+      expect(result.code.length).toBeGreaterThan(0);
+      if (target === "es5") {
+        // es5에서만 arrow function 다운레벨
+        expect(result.code).not.toContain("=>");
+      } else {
+        // es2015+에서는 arrow function 유지
+        expect(result.code).toContain("=>");
+      }
+    }
+  });
+
+  test("build + platform=node + jsx=automatic + external", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-combo-node-jsx-"));
+    writeFileSync(join(dir, "app.tsx"), "export default () => <div>hello</div>;");
+
+    const result = await build({
+      entryPoints: [join(dir, "app.tsx")],
+      platform: "node",
+      jsx: "automatic",
+      external: ["react/jsx-runtime"],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("jsx-runtime");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("build + define + plugins (define은 NAPI, plugin은 JS)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-define-plugin-"));
+    writeFileSync(
+      join(dir, "index.ts"),
+      'import css from "./style.css";\nconsole.log(__MODE__, css);',
+    );
+
+    const cssPlugin: ZtsPlugin = {
+      name: "css",
+      setup(build) {
+        build.onResolve({ filter: /\.css$/ }, (args) => ({ path: resolve(dir, args.path) }));
+        build.onLoad({ filter: /\.css$/ }, () => ({ contents: 'export default "red";' }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      define: { __MODE__: '"production"' },
+      plugins: [cssPlugin],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("production");
+    expect(result.outputFiles[0].text).toContain("red");
+    rmSync(dir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary
미커버 영역 테스트 9개 추가:
- transform 체이닝 (3개 플러그인)
- vitePlugin importer 검증, map 무시
- hashbang + minify/sourcemap 조합
- 전체 ES 타겟 순회 (es5~esnext)
- platform/jsx/define/plugins 동시 조합

## Test plan
- [x] 121/121 통과 (1354 expect calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)