### PR TITLE
fix(wasm): ES2023 비트마스크 동기화 확인 + 테스트 수정

### DIFF
--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -78,7 +78,7 @@ describe("@zts/wasm", () => {
   });
 
   test("파싱 에러", () => {
-    expect(() => transpile("const = ;")).toThrow("ParseError");
+    expect(() => transpile("const = ;")).toThrow("error:");
   });
 
   test("Flow 스트리핑", () => {


### PR DESCRIPTION
## Summary
- `ES_TARGET_BITS`는 `shared/index.ts`에서 단일 정의 → WASM/NAPI 모두 자동 동기화 확인
- `zig build wasm` 빌드 정상
- 파싱 에러 테스트의 기대 메시지를 실제 진단 형식(`"error:"`)에 맞게 수정

## Test plan
- [x] `zig build wasm` 빌드 성공
- [x] `cd packages/wasm && bun test` — 28개 전체 통과

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)