### PR TITLE
feat(napi): vitePlugin async 훅 지원

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1890,3 +1890,112 @@ describe("BuildOptions: 누락 옵션 노출 (#1005)", () => {
     rmSync(join(dir, "sm-out"), { recursive: true, force: true });
   });
 });
+
+// ─── vitePlugin async 훅 테스트 (#1007) ───
+
+describe("vitePlugin async 훅 지원", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-async-plugin-"));
+    writeFileSync(join(dir, "entry.ts"), 'import val from "./data.custom";\nconsole.log(val);');
+    writeFileSync(join(dir, "data.custom"), "CUSTOM_DATA");
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("async load 훅", async () => {
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        vitePlugin({
+          name: "async-loader",
+          async load(id) {
+            if (id.endsWith(".custom")) {
+              await new Promise((r) => setTimeout(r, 10));
+              return { code: 'export default "ASYNC_LOADED";' };
+            }
+          },
+        }),
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("ASYNC_LOADED");
+  });
+
+  test("async resolveId 훅", async () => {
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        vitePlugin({
+          name: "async-resolver",
+          async resolveId(source) {
+            if (source.endsWith(".custom")) {
+              await new Promise((r) => setTimeout(r, 10));
+              return join(dir, "data.custom");
+            }
+          },
+          load(id) {
+            if (id.endsWith(".custom")) {
+              return { code: 'export default "RESOLVED";' };
+            }
+          },
+        }),
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("RESOLVED");
+  });
+
+  test("async transform 훅", async () => {
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        vitePlugin({
+          name: "async-transformer",
+          async transform(code, id) {
+            if (id.endsWith(".ts")) {
+              await new Promise((r) => setTimeout(r, 10));
+              return code.replace("console.log", "console.info");
+            }
+          },
+        }),
+        vitePlugin({
+          name: "custom-loader",
+          load(id) {
+            if (id.endsWith(".custom")) return { code: 'export default "X";' };
+          },
+        }),
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("console.info");
+    expect(result.outputFiles[0].text).not.toContain("console.log");
+  });
+
+  test("동기 + 비동기 훅 혼합", async () => {
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        vitePlugin({
+          name: "sync-plugin",
+          load(id) {
+            if (id.endsWith(".custom")) return { code: 'export default "SYNC";' };
+          },
+        }),
+        vitePlugin({
+          name: "async-plugin",
+          async transform(code) {
+            await new Promise((r) => setTimeout(r, 5));
+            return code.replace("console.log", "console.warn");
+          },
+        }),
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("SYNC");
+    expect(result.outputFiles[0].text).toContain("console.warn");
+  });
+});

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -240,7 +240,7 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
     transform: (arg1, arg2) => [arg2 ?? "", { code: arg1, path: arg2 }],
   };
 
-  return function dispatcher(hookName: string, arg1: string, arg2: string | null) {
+  return async function dispatcher(hookName: string, arg1: string, arg2: string | null) {
     const hookList = hooks[hookName];
     if (!hookList) return null;
 
@@ -251,7 +251,7 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
       for (const h of hookList) {
         if (h.filter.test(arg2 ?? "")) {
           try {
-            const result = h.callback({ code: currentCode, path: arg2 });
+            const result = await h.callback({ code: currentCode, path: arg2 });
             if (result != null) {
               const newCode = typeof result === "string" ? result : result.code;
               if (newCode != null) {
@@ -274,7 +274,7 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
     for (const h of hookList) {
       if (h.filter.test(filterTarget)) {
         try {
-          const result = h.callback(cbArgs);
+          const result = await h.callback(cbArgs);
           if (result != null) return result;
         } catch {
           return null;
@@ -399,17 +399,19 @@ export function close(): void {
  * ```
  */
 
+type MaybePromise<T> = T | Promise<T>;
+
 export interface RollupPlugin {
   name: string;
   resolveId?(
     source: string,
     importer?: string | null,
-  ): string | null | undefined | void | { id: string; external?: boolean };
-  load?(id: string): string | null | undefined | void | { code: string; map?: unknown };
+  ): MaybePromise<string | null | undefined | void | { id: string; external?: boolean }>;
+  load?(id: string): MaybePromise<string | null | undefined | void | { code: string; map?: unknown }>;
   transform?(
     code: string,
     id: string,
-  ): string | null | undefined | void | { code: string; map?: unknown };
+  ): MaybePromise<string | null | undefined | void | { code: string; map?: unknown }>;
 }
 
 export function vitePlugin(rollupPlugin: RollupPlugin): ZtsPlugin {
@@ -418,8 +420,8 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZtsPlugin {
     setup(build) {
       if (rollupPlugin.resolveId) {
         const hook = rollupPlugin.resolveId;
-        build.onResolve({ filter: /.*/ }, (args) => {
-          const result = hook(args.path, args.importer);
+        build.onResolve({ filter: /.*/ }, async (args) => {
+          const result = await hook(args.path, args.importer);
           if (result == null) return null;
           if (typeof result === "string") return { path: result };
           if (typeof result === "object" && "id" in result) {
@@ -431,8 +433,8 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZtsPlugin {
 
       if (rollupPlugin.load) {
         const hook = rollupPlugin.load;
-        build.onLoad({ filter: /.*/ }, (args) => {
-          const result = hook(args.path);
+        build.onLoad({ filter: /.*/ }, async (args) => {
+          const result = await hook(args.path);
           if (result == null) return null;
           if (typeof result === "string") return { contents: result };
           if (typeof result === "object" && "code" in result) {
@@ -444,8 +446,8 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZtsPlugin {
 
       if (rollupPlugin.transform) {
         const hook = rollupPlugin.transform;
-        build.onTransform({ filter: /.*/ }, (args) => {
-          const result = hook(args.code, args.path);
+        build.onTransform({ filter: /.*/ }, async (args) => {
+          const result = await hook(args.code, args.path);
           if (result == null) return null;
           if (typeof result === "string") return { code: result };
           if (typeof result === "object" && "code" in result) {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -407,7 +407,9 @@ export interface RollupPlugin {
     source: string,
     importer?: string | null,
   ): MaybePromise<string | null | undefined | void | { id: string; external?: boolean }>;
-  load?(id: string): MaybePromise<string | null | undefined | void | { code: string; map?: unknown }>;
+  load?(
+    id: string,
+  ): MaybePromise<string | null | undefined | void | { code: string; map?: unknown }>;
   transform?(
     code: string,
     id: string,

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -415,16 +415,67 @@ const NapiPlugin = struct {
         cond: std.Thread.Condition = .{},
     };
 
+    /// JS 결과 객체에서 PluginResponse 필드를 추출한다.
+    fn parseJsResult(env: c.napi_env, js_result: c.napi_value) PluginResponse {
+        var result_type: c.napi_valuetype = undefined;
+        _ = c.napi_typeof(env, js_result, &result_type);
+        if (result_type == c.napi_null or result_type == c.napi_undefined) {
+            return .{};
+        }
+
+        var resp = PluginResponse{};
+        if (getObjectString(env, js_result, "path", native_alloc)) |path| {
+            resp.resolved_path = path;
+        }
+        resp.is_external = getObjectBool(env, js_result, "external", false);
+        if (getObjectString(env, js_result, "contents", native_alloc)) |contents| {
+            resp.code = contents;
+        }
+        if (resp.code == null) {
+            if (getObjectString(env, js_result, "code", native_alloc)) |code| {
+                resp.code = code;
+            }
+        }
+        return resp;
+    }
+
+    /// CallContext에 응답을 기록하고 워커 스레드에 시그널을 보낸다.
+    fn signalResponse(ctx: *CallContext, resp: PluginResponse) void {
+        ctx.mutex.lock();
+        ctx.response = resp;
+        ctx.response_ready = true;
+        ctx.mutex.unlock();
+        ctx.cond.signal();
+    }
+
+    /// Promise의 .then() 콜백 — resolve 시 결과를 파싱하여 워커 스레드에 전달
+    fn promiseThenCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var argc: usize = 1;
+        var argv: [1]c.napi_value = undefined;
+        var cb_data: ?*anyopaque = null;
+        _ = c.napi_get_cb_info(env, info, &argc, &argv, null, &cb_data);
+        const ctx: *CallContext = @ptrCast(@alignCast(cb_data.?));
+        signalResponse(ctx, if (argc > 0) parseJsResult(env, argv[0]) else .{});
+        var undef: c.napi_value = undefined;
+        _ = c.napi_get_undefined(env, &undef);
+        return undef;
+    }
+
+    /// Promise의 .catch() 콜백 — reject 시 빈 응답으로 워커 스레드에 전달
+    fn promiseCatchCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var cb_data: ?*anyopaque = null;
+        _ = c.napi_get_cb_info(env, info, null, null, null, &cb_data);
+        const ctx: *CallContext = @ptrCast(@alignCast(cb_data.?));
+        signalResponse(ctx, .{});
+        var undef: c.napi_value = undefined;
+        _ = c.napi_get_undefined(env, &undef);
+        return undef;
+    }
+
     /// threadsafe function의 call_js 콜백 (메인 스레드에서 실행)
-    /// data = CallContext 포인터 (per-call, 워커 스레드가 스택/힙에 소유)
+    /// data = CallContext 포인터 (per-call, 워커 스레드가 스택에 소유하며 condvar 대기 중)
     fn callJsCallback(env: c.napi_env, js_callback: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
         const ctx: *CallContext = @ptrCast(@alignCast(data.?));
-        ctx.mutex.lock();
-        defer {
-            ctx.response_ready = true;
-            ctx.mutex.unlock();
-            ctx.cond.signal();
-        }
 
         // JS dispatcher 호출: dispatcher(hookName, arg1, arg2)
         var hook_str: c.napi_value = undefined;
@@ -450,35 +501,39 @@ const NapiPlugin = struct {
         var js_undefined: c.napi_value = undefined;
         _ = c.napi_get_undefined(env, &js_undefined);
         if (c.napi_call_function(env, js_undefined, js_callback, 3, &args, &js_result) != c.napi_ok) {
-            ctx.response = .{};
+            signalResponse(ctx, .{});
             return;
         }
 
-        // 결과 파싱
-        var result_type: c.napi_valuetype = undefined;
-        _ = c.napi_typeof(env, js_result, &result_type);
-        if (result_type == c.napi_null or result_type == c.napi_undefined) {
-            ctx.response = .{};
-            return;
-        }
-
-        // 객체에서 필드 추출
-        var resp = PluginResponse{};
-
-        if (getObjectString(env, js_result, "path", native_alloc)) |path| {
-            resp.resolved_path = path;
-        }
-        resp.is_external = getObjectBool(env, js_result, "external", false);
-        if (getObjectString(env, js_result, "contents", native_alloc)) |contents| {
-            resp.code = contents;
-        }
-        if (resp.code == null) {
-            if (getObjectString(env, js_result, "code", native_alloc)) |code| {
-                resp.code = code;
+        // Promise 체크: 결과가 Promise이면 .then()/.catch()로 비동기 대기
+        var is_promise: bool = false;
+        _ = c.napi_is_promise(env, js_result, &is_promise);
+        if (is_promise) {
+            // .then(onFulfilled) 등록
+            var then_fn: c.napi_value = undefined;
+            if (getNamedProperty(env, js_result, "then")) |t| {
+                then_fn = t;
+            } else {
+                signalResponse(ctx, .{});
+                return;
             }
+
+            var on_fulfilled: c.napi_value = undefined;
+            _ = c.napi_create_function(env, "onFulfilled", "onFulfilled".len, promiseThenCallback, @ptrCast(ctx), &on_fulfilled);
+            var on_rejected: c.napi_value = undefined;
+            _ = c.napi_create_function(env, "onRejected", "onRejected".len, promiseCatchCallback, @ptrCast(ctx), &on_rejected);
+
+            var then_args = [_]c.napi_value{ on_fulfilled, on_rejected };
+            var then_result: c.napi_value = undefined;
+            if (c.napi_call_function(env, js_result, then_fn, 2, &then_args, &then_result) != c.napi_ok) {
+                signalResponse(ctx, .{});
+            }
+            // Promise 경우: 여기서 리턴. 워커 스레드는 then/catch 콜백이 signal할 때까지 대기.
+            return;
         }
 
-        ctx.response = resp;
+        // 동기 결과: 즉시 파싱하여 시그널
+        signalResponse(ctx, parseJsResult(env, js_result));
     }
 
     /// 워커 스레드에서 호출 — JS 콜백 실행 후 결과 대기.


### PR DESCRIPTION
## Summary
- NAPI `callJsCallback`에서 `napi_is_promise` 체크 → Promise면 `.then()/.catch()` 콜백으로 비동기 결과 대기
- `createPluginDispatcher` → async 변환하여 Promise 반환 훅 await 지원
- `vitePlugin` 래퍼 → async 변환하여 Vite/Rollup async 훅 투명하게 처리
- `RollupPlugin` 인터페이스에 `MaybePromise` 반환 타입 추가

## Test plan
- [x] `bun test index.test.ts` — 136개 전체 통과
- [x] async load 훅 테스트 (setTimeout 포함)
- [x] async resolveId 훅 테스트
- [x] async transform 훅 테스트
- [x] 동기 + 비동기 플러그인 혼합 테스트
- [x] 기존 동기 플러그인 테스트 호환성 유지

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)