### PR TITLE
fix(napi): 플러그인 condvar signal 순서 + 타임아웃

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -444,8 +444,8 @@ const NapiPlugin = struct {
         ctx.mutex.lock();
         ctx.response = resp;
         ctx.response_ready = true;
-        ctx.mutex.unlock();
         ctx.cond.signal();
+        ctx.mutex.unlock();
     }
 
     /// Promise의 .then() 콜백 — resolve 시 결과를 파싱하여 워커 스레드에 전달
@@ -551,10 +551,15 @@ const NapiPlugin = struct {
         }
 
         // 결과 대기 (메인 스레드에서 callJsCallback이 ctx에 결과를 씀)
+        // 30초 타임아웃: Promise가 resolve/reject되지 않는 경우 hang 방지
         ctx.mutex.lock();
         defer ctx.mutex.unlock();
+        const timeout_ns: u64 = 30 * std.time.ns_per_s;
         while (!ctx.response_ready) {
-            ctx.cond.wait(&ctx.mutex);
+            ctx.cond.timedWait(&ctx.mutex, timeout_ns) catch {
+                // 타임아웃: 플러그인 응답 없음으로 처리
+                return null;
+            };
         }
 
         return ctx.response;


### PR DESCRIPTION
## Summary
- `signalResponse`에서 `cond.signal()`을 mutex lock 안에서 호출하도록 순서 변경 (이론적 race 방지)
- `callHook`에 30초 `timedWait` 추가 — Promise가 resolve/reject되지 않을 때 영구 hang 방지

## Test plan
- [x] `bun test index.test.ts` — 136개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)