### PR TITLE
feat(napi): renderChunk/generateBundle 훅 노출

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1999,3 +1999,108 @@ describe("vitePlugin async 훅 지원", () => {
     expect(result.outputFiles[0].text).toContain("console.warn");
   });
 });
+
+// ─── renderChunk/generateBundle 훅 테스트 (#1004) ───
+
+describe("renderChunk/generateBundle 훅", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-chunk-hooks-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("renderChunk: 청크 코드 후처리", async () => {
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        {
+          name: "chunk-banner",
+          setup(build) {
+            build.onRenderChunk({ filter: /.*/ }, (args) => {
+              return { code: `/* CHUNK: ${args.chunk} */\n${args.code}` };
+            });
+          },
+        },
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("/* CHUNK:");
+    expect(result.outputFiles[0].text).toContain("x = 1");
+  });
+
+  test("renderChunk via vitePlugin", async () => {
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        vitePlugin({
+          name: "vite-chunk",
+          renderChunk(code) {
+            return code.replace("x = 1", "x = 42");
+          },
+        }),
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("x = 42");
+  });
+
+  test("async renderChunk", async () => {
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        vitePlugin({
+          name: "async-chunk",
+          async renderChunk(code) {
+            await new Promise((r) => setTimeout(r, 5));
+            return `/* ASYNC */\n${code}`;
+          },
+        }),
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("/* ASYNC */");
+  });
+
+  test("generateBundle: 번들 완료 콜백", async () => {
+    const collected: string[] = [];
+    const result = await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        {
+          name: "bundle-inspector",
+          setup(build) {
+            build.onGenerateBundle((outputs) => {
+              for (const f of outputs) {
+                collected.push(f.path);
+              }
+            });
+          },
+        },
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(collected.length).toBeGreaterThan(0);
+  });
+
+  test("generateBundle via vitePlugin", async () => {
+    let called = false;
+    await build({
+      entryPoints: [join(dir, "entry.ts")],
+      plugins: [
+        vitePlugin({
+          name: "vite-generate",
+          generateBundle(outputs) {
+            called = true;
+            expect(outputs.length).toBeGreaterThan(0);
+          },
+        }),
+      ],
+    });
+    expect(called).toBe(true);
+  });
+});

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -197,6 +197,11 @@ export interface PluginBuild {
     options: { filter: RegExp },
     callback: (args: { code: string; path: string }) => { code: string } | null | undefined,
   ): void;
+  onRenderChunk(
+    options: { filter: RegExp },
+    callback: (args: { code: string; chunk: string }) => { code: string } | null | undefined,
+  ): void;
+  onGenerateBundle(callback: (outputs: OutputFile[]) => void): void;
 }
 
 export interface BuildResult {
@@ -216,7 +221,9 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
     resolveId: [],
     load: [],
     transform: [],
+    renderChunk: [],
   };
+  const generateBundleCallbacks: Array<(outputs: OutputFile[]) => void> = [];
 
   for (const plugin of plugins) {
     const build: PluginBuild = {
@@ -229,6 +236,12 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
       onTransform(opts, cb) {
         hooks.transform.push({ filter: opts.filter, callback: cb });
       },
+      onRenderChunk(opts, cb) {
+        hooks.renderChunk.push({ filter: opts.filter, callback: cb });
+      },
+      onGenerateBundle(cb) {
+        generateBundleCallbacks.push(cb);
+      },
     };
     plugin.setup(build);
   }
@@ -237,21 +250,42 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
   const argBuilders: Record<string, (arg1: string, arg2: string | null) => [string, unknown]> = {
     resolveId: (arg1, arg2) => [arg1, { path: arg1, importer: arg2 }],
     load: (arg1, _) => [arg1, { path: arg1 }],
-    transform: (arg1, arg2) => [arg2 ?? "", { code: arg1, path: arg2 }],
+    renderChunk: (arg1, arg2) => [arg2 ?? "", { code: arg1, chunk: arg2 }],
   };
 
-  return async function dispatcher(hookName: string, arg1: string, arg2: string | null) {
+  return async function dispatcher(
+    hookName: string,
+    arg1: string | OutputFile[],
+    arg2: string | null,
+  ) {
+    // generateBundle: arg1이 OutputFile[] 배열
+    if (hookName === "generateBundle") {
+      const outputs = arg1 as OutputFile[];
+      for (const cb of generateBundleCallbacks) {
+        try {
+          await cb(outputs);
+        } catch {
+          // 에러 시 건너뛰기
+        }
+      }
+      return null;
+    }
+
     const hookList = hooks[hookName];
     if (!hookList) return null;
 
-    // transform은 체이닝: 이전 결과의 code가 다음 입력이 됨
-    if (hookName === "transform") {
-      let currentCode = arg1;
+    // transform/renderChunk: 체이닝 (이전 결과의 code가 다음 입력)
+    if (hookName === "transform" || hookName === "renderChunk") {
+      let currentCode = arg1 as string;
       let changed = false;
       for (const h of hookList) {
         if (h.filter.test(arg2 ?? "")) {
           try {
-            const result = await h.callback({ code: currentCode, path: arg2 });
+            const cbArgs =
+              hookName === "transform"
+                ? { code: currentCode, path: arg2 }
+                : { code: currentCode, chunk: arg2 };
+            const result = await h.callback(cbArgs);
             if (result != null) {
               const newCode = typeof result === "string" ? result : result.code;
               if (newCode != null) {
@@ -270,7 +304,7 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
     // resolveId/load: 첫 번째 매칭 반환 (first 모드)
     const buildArgs = argBuilders[hookName];
     if (!buildArgs) return null;
-    const [filterTarget, cbArgs] = buildArgs(arg1, arg2);
+    const [filterTarget, cbArgs] = buildArgs(arg1 as string, arg2);
     for (const h of hookList) {
       if (h.filter.test(filterTarget)) {
         try {
@@ -414,6 +448,11 @@ export interface RollupPlugin {
     code: string,
     id: string,
   ): MaybePromise<string | null | undefined | void | { code: string; map?: unknown }>;
+  renderChunk?(
+    code: string,
+    chunk: string,
+  ): MaybePromise<string | null | undefined | void | { code: string }>;
+  generateBundle?(outputs: OutputFile[]): MaybePromise<void>;
 }
 
 export function vitePlugin(rollupPlugin: RollupPlugin): ZtsPlugin {
@@ -456,6 +495,26 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZtsPlugin {
             return { code: result.code };
           }
           return null;
+        });
+      }
+
+      if (rollupPlugin.renderChunk) {
+        const hook = rollupPlugin.renderChunk;
+        build.onRenderChunk({ filter: /.*/ }, async (args) => {
+          const result = await hook(args.code, args.chunk);
+          if (result == null) return null;
+          if (typeof result === "string") return { code: result };
+          if (typeof result === "object" && "code" in result) {
+            return { code: result.code };
+          }
+          return null;
+        });
+      }
+
+      if (rollupPlugin.generateBundle) {
+        const hook = rollupPlugin.generateBundle;
+        build.onGenerateBundle(async (outputs) => {
+          await hook(outputs);
         });
       }
     },

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -396,7 +396,7 @@ const NapiPlugin = struct {
     name: []const u8,
     tsfn: c.napi_threadsafe_function,
 
-    const HookType = enum { resolveId, load, transform };
+    const HookType = enum { resolveId, load, transform, renderChunk, generateBundle };
 
     const PluginResponse = struct {
         resolved_path: ?[]const u8 = null,
@@ -409,6 +409,8 @@ const NapiPlugin = struct {
         hook: HookType,
         arg1: []const u8,
         arg2: ?[]const u8,
+        /// generateBundle 전용: OutputFile 배열 (callJsCallback에서 JS 배열로 변환)
+        output_files: ?[]const bundler_mod.emitter.OutputFile = null,
         response: ?PluginResponse = null,
         response_ready: bool = false,
         mutex: std.Thread.Mutex = .{},
@@ -483,11 +485,29 @@ const NapiPlugin = struct {
             .resolveId => "resolveId",
             .load => "load",
             .transform => "transform",
+            .renderChunk => "renderChunk",
+            .generateBundle => "generateBundle",
         };
         _ = c.napi_create_string_utf8(env, hook_name.ptr, hook_name.len, &hook_str);
 
         var js_arg1: c.napi_value = undefined;
-        _ = c.napi_create_string_utf8(env, ctx.arg1.ptr, ctx.arg1.len, &js_arg1);
+        // generateBundle: arg1 대신 output_files JS 배열을 생성
+        if (ctx.output_files) |files| {
+            _ = c.napi_create_array_with_length(env, files.len, &js_arg1);
+            for (files, 0..) |file, i| {
+                var js_file: c.napi_value = undefined;
+                _ = c.napi_create_object(env, &js_file);
+                var js_path: c.napi_value = undefined;
+                _ = c.napi_create_string_utf8(env, file.path.ptr, file.path.len, &js_path);
+                _ = c.napi_set_named_property(env, js_file, "path", js_path);
+                var js_text: c.napi_value = undefined;
+                _ = c.napi_create_string_utf8(env, file.contents.ptr, file.contents.len, &js_text);
+                _ = c.napi_set_named_property(env, js_file, "text", js_text);
+                _ = c.napi_set_element(env, js_arg1, @intCast(i), js_file);
+            }
+        } else {
+            _ = c.napi_create_string_utf8(env, ctx.arg1.ptr, ctx.arg1.len, &js_arg1);
+        }
 
         var js_arg2: c.napi_value = undefined;
         if (ctx.arg2) |a2| {
@@ -614,6 +634,43 @@ const NapiPlugin = struct {
         return null;
     }
 
+    fn pluginRenderChunk(ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+        const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
+        const resp = self.callHook(.renderChunk, code, chunk_name) orelse return null;
+        defer {
+            if (resp.resolved_path) |p| native_alloc.free(p);
+        }
+
+        if (resp.code) |result_code| {
+            const result = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
+            native_alloc.free(result_code);
+            return result;
+        }
+        return null;
+    }
+
+    fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
+        const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
+        // output_files를 CallContext에 직접 전달 → callJsCallback에서 JS 배열로 변환
+        var call_ctx = CallContext{
+            .hook = .generateBundle,
+            .arg1 = "",
+            .arg2 = null,
+            .output_files = output_files,
+        };
+
+        if (c.napi_call_threadsafe_function(self.tsfn, @ptrCast(&call_ctx), c.napi_tsfn_blocking) != c.napi_ok) {
+            return;
+        }
+
+        call_ctx.mutex.lock();
+        defer call_ctx.mutex.unlock();
+        const timeout_ns: u64 = 30 * std.time.ns_per_s;
+        while (!call_ctx.response_ready) {
+            call_ctx.cond.timedWait(&call_ctx.mutex, timeout_ns) catch return;
+        }
+    }
+
     fn toPlugin(self: *NapiPlugin) Plugin {
         return .{
             .name = self.name,
@@ -621,6 +678,8 @@ const NapiPlugin = struct {
             .resolveId = pluginResolveId,
             .load = pluginLoad,
             .transform = pluginTransform,
+            .renderChunk = pluginRenderChunk,
+            .generateBundle = pluginGenerateBundle,
         };
     }
 


### PR DESCRIPTION
## Summary
- NAPI 플러그인에 `renderChunk`/`generateBundle` 훅 추가
- `renderChunk(code, chunkName)`: 청크 코드 후처리 (transform과 동일한 체이닝)
- `generateBundle(outputFiles)`: 번들 완료 콜백 (OutputFile[] JS 배열 직접 전달, JSON 직렬화 없음)
- `PluginBuild`에 `onRenderChunk`/`onGenerateBundle` 추가
- `RollupPlugin`/`vitePlugin` 어댑터에 매핑 추가
- 테스트 5개 추가

## Test plan
- [x] `bun test index.test.ts` — 141개 전체 통과
- [x] renderChunk 동기/비동기/vitePlugin 테스트
- [x] generateBundle 콜백/vitePlugin 테스트
- [x] 기존 플러그인 테스트 호환성 유지

Closes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)