### PR TITLE
docs: PLUGINS.md + ROADMAP.md 업데이트

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -126,12 +126,13 @@ const result = await build({
 
 **제한사항**: `buildSync()`에서는 JS 플러그인 미지원 (메인 스레드 데드락). `build()` (async)에서만 사용 가능.
 
-### 4단계: Vite/Rollup 호환 어댑터 ✅ 완료 (#992)
+### 4단계: Vite/Rollup 호환 어댑터 ✅ 완료 (#992, #1004, #1007)
 - `vitePlugin()` 함수로 Rollup 스타일 플러그인을 ZTS 플러그인으로 변환
-- `resolveId`, `load`, `transform` 훅 지원 (문자열/객체/null 반환)
+- `resolveId`, `load`, `transform`, `renderChunk`, `generateBundle` 훅 지원
+- 모든 훅 async/Promise 반환 지원 (`MaybePromise<T>`)
 - ZTS 네이티브 플러그인과 혼합 사용 가능
-- 13개 테스트 (JSON 플러그인, 환경 변수 치환 등 실전 패턴 포함)
-- **미지원**: `renderChunk`, `generateBundle`, `this.resolve()`, `this.emitFile()` (후순위)
+- `onRenderChunk`: 청크 코드 후처리 (체이닝), `onGenerateBundle`: 번들 완료 콜백
+- **미지원**: `this.resolve()`, `this.emitFile()` (후순위)
 
 ### 5단계: Tapable 하이브리드 — webpack/Rspack 호환 (예정)
 > 방식 C: Zig에 Tapable 스타일 훅을 네이티브로 구현하고 NAPI로 노출.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,9 @@
 | 30. Vite 어댑터 | `vitePlugin()` Rollup→ZTS 플러그인 변환, resolveId/load/transform | ✅ |
 | 31. define/alias | NAPI BuildOptions에 `define`/`alias` 옵션 노출 | ✅ |
 | 32. tsconfig | CLI에서 tsconfig.json 자동 탐색+로드 (experimentalDecorators, jsx 등) | ✅ |
+| 33. BuildOptions 확장 | loader, conditions, resolveExtensions, mainFields, target, outdir, outfile, write | ✅ |
+| 34. 플러그인 훅 확장 | renderChunk/generateBundle NAPI 노출 + vitePlugin 매핑 | ✅ |
+| 35. async 플러그인 | 모든 훅 async/Promise 반환 지원 (MaybePromise) | ✅ |
 
 ## 번들러 성능 현황 (2026-04-10 실측)
 


### PR DESCRIPTION
## Summary
- **PLUGINS.md**: 4단계 Vite 어댑터에 renderChunk/generateBundle 완료 반영, async 훅 지원 문서화
- **ROADMAP.md**: Phase 33-35 추가 (BuildOptions 확장, 플러그인 훅 확장, async 플러그인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)