### PR TITLE
feat(napi): BundleOptions 전체 필드 노출

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -2313,3 +2313,109 @@ describe("배치 E: S급 BuildOptions", () => {
     expect(mapFile!.text).toContain("https://example.com/src");
   });
 });
+
+// ─── 나머지 BundleOptions 전체 노출 테스트 ───
+
+describe("BundleOptions: 전체 옵션 노출", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-all-opts-"));
+    writeFileSync(join(dir, "entry.ts"), "/** @license MIT */\nexport const x = 1;");
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("legalComments: none → 라이센스 주석 제거", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      legalComments: "none",
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).not.toContain("@license");
+  });
+
+  test("legalComments: eof → 파일 끝에 주석 이동", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      legalComments: "eof",
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("@license");
+  });
+
+  test("preserveModules: 모듈별 개별 파일 출력", async () => {
+    writeFileSync(join(dir, "mod-a.ts"), "export const a = 1;");
+    writeFileSync(join(dir, "mod-entry.ts"), 'import { a } from "./mod-a";\nexport const b = a + 1;');
+    const result = await build({
+      entryPoints: [join(dir, "mod-entry.ts")],
+      preserveModules: true,
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("preserveModulesRoot: 출력 경로 기준", async () => {
+    const result = await build({
+      entryPoints: [join(dir, "mod-entry.ts")],
+      preserveModules: true,
+      preserveModulesRoot: dir,
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("timing: 옵션 파싱 확인", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      timing: true,
+    });
+    expect(result.errors.length).toBe(0);
+  });
+
+  test("devMode: dev 모드 활성화", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      devMode: true,
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("__zts_modules");
+  });
+
+  test("reactRefresh: Fast Refresh 활성화", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      devMode: true,
+      reactRefresh: true,
+    });
+    expect(result.errors.length).toBe(0);
+  });
+
+  test("configurableExports: configurable:true 추가", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      configurableExports: true,
+    });
+    expect(result.errors.length).toBe(0);
+  });
+
+  test("globalIdentifiers: 예약 식별자", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      globalIdentifiers: ["__global", "self"],
+    });
+    expect(result.errors.length).toBe(0);
+  });
+
+  test("rootDir + collectModuleCodes: dev 모드 옵션 조합", () => {
+    const result = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      devMode: true,
+      rootDir: dir,
+      collectModuleCodes: true,
+    });
+    expect(result.errors.length).toBe(0);
+  });
+});

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -2348,7 +2348,10 @@ describe("BundleOptions: 전체 옵션 노출", () => {
 
   test("preserveModules: 모듈별 개별 파일 출력", async () => {
     writeFileSync(join(dir, "mod-a.ts"), "export const a = 1;");
-    writeFileSync(join(dir, "mod-entry.ts"), 'import { a } from "./mod-a";\nexport const b = a + 1;');
+    writeFileSync(
+      join(dir, "mod-entry.ts"),
+      'import { a } from "./mod-a";\nexport const b = a + 1;',
+    );
     const result = await build({
       entryPoints: [join(dir, "mod-entry.ts")],
       preserveModules: true,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -200,6 +200,30 @@ export interface BuildOptions {
   outExtension?: string;
   /** 소스맵 sourceRoot 필드 */
   sourceRoot?: string;
+  /** 라이센스 주석 처리 ("none" | "inline" | "eof" | "linked") */
+  legalComments?: "none" | "inline" | "eof" | "linked";
+  /** 모듈별 개별 파일 출력 (라이브러리 빌드) */
+  preserveModules?: boolean;
+  /** preserve-modules 출력 디렉토리 구조 기준 경로 */
+  preserveModulesRoot?: string;
+  /** 파이프라인 단계별 타이밍 출력 */
+  timing?: boolean;
+  /** dev mode: 모듈을 __zts_register() 팩토리로 래핑 + HMR 런타임 주입 */
+  devMode?: boolean;
+  /** dev mode 모듈 ID 기준 경로 */
+  rootDir?: string;
+  /** React Fast Refresh 활성화 */
+  reactRefresh?: boolean;
+  /** dev mode per-module codes 수집 (HMR rebuild용) */
+  collectModuleCodes?: boolean;
+  /** Object.defineProperty에 configurable: true 추가 (RN/Hermes 호환) */
+  configurableExports?: boolean;
+  /** scope hoisting 시 예약할 전역 식별자 */
+  globalIdentifiers?: string[];
+  /** 번들 시작 시 즉시 실행 폴리필 경로 */
+  polyfills?: string[];
+  /** 엔트리 모듈 직전에 실행할 모듈 경로 */
+  runBeforeMain?: string[];
 }
 
 export interface ZtsPlugin {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1013,6 +1013,40 @@ fn parseBuildOptions(
     const tsconfig_raw = ownStr(env, opts_obj, "tsconfigRaw", owned_strings);
     const out_extension_js = ownStr(env, opts_obj, "outExtension", owned_strings);
     const source_root = ownStr(env, opts_obj, "sourceRoot", owned_strings);
+    const root_dir = ownStr(env, opts_obj, "rootDir", owned_strings);
+    const preserve_modules_root = ownStr(env, opts_obj, "preserveModulesRoot", owned_strings);
+
+    // legalComments: "none" | "inline" | "eof" | "linked"
+    const legal_str = getObjectString(env, opts_obj, "legalComments", native_alloc);
+    if (legal_str) |s| if (!trackStr(owned_strings, s)) return null;
+    const legal_comments: bundler_mod.types.LegalComments = if (legal_str) |s|
+        if (std.mem.eql(u8, s, "none")) .none
+        else if (std.mem.eql(u8, s, "inline")) .@"inline"
+        else if (std.mem.eql(u8, s, "eof")) .eof
+        else if (std.mem.eql(u8, s, "linked")) .linked
+        else .default
+    else .default;
+
+    // globalIdentifiers: string[]
+    const global_identifiers = getObjectStringArray(env, opts_obj, "globalIdentifiers", native_alloc);
+    if (global_identifiers) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
+    // polyfills: string[]
+    const polyfills = getObjectStringArray(env, opts_obj, "polyfills", native_alloc);
+    if (polyfills) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
+    // runBeforeMain: string[]
+    const run_before_main = getObjectStringArray(env, opts_obj, "runBeforeMain", native_alloc);
+    if (run_before_main) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
 
     // dropLabels: string[]
     const drop_labels = getObjectStringArray(env, opts_obj, "dropLabels", native_alloc);
@@ -1093,6 +1127,18 @@ fn parseBuildOptions(
         .line_limit = getObjectUint32(env, opts_obj, "lineLimit", 0),
         .out_extension_js = out_extension_js,
         .source_root = source_root,
+        .legal_comments = legal_comments,
+        .preserve_modules = getObjectBool(env, opts_obj, "preserveModules", false),
+        .preserve_modules_root = preserve_modules_root,
+        .timing = getObjectBool(env, opts_obj, "timing", false),
+        .dev_mode = getObjectBool(env, opts_obj, "devMode", false),
+        .root_dir = root_dir,
+        .react_refresh = getObjectBool(env, opts_obj, "reactRefresh", false),
+        .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
+        .configurable_exports = getObjectBool(env, opts_obj, "configurableExports", false),
+        .global_identifiers = global_identifiers orelse &.{},
+        .polyfills = polyfills orelse &.{},
+        .run_before_main = run_before_main orelse &.{},
     };
 }
 


### PR DESCRIPTION
## Summary
module_store(내부 포인터)를 제외한 모든 BundleOptions 필드를 NAPI에 노출:
- legalComments, preserveModules, preserveModulesRoot
- timing, devMode, rootDir, reactRefresh, collectModuleCodes
- configurableExports, globalIdentifiers, polyfills, runBeforeMain
- 테스트 10개 추가

## Test plan
- [x] `bun test index.test.ts` — 167개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)