### PR TITLE
feat(bundler): allowOverwrite 입출력 동일 경로 체크

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -2599,4 +2599,25 @@ describe("옵션 조합 통합 테스트", () => {
     expect(hooks).toContain("generateBundle");
     expect(result.outputFiles[0].text).toContain("/* built */");
   });
+
+  test("allowOverwrite: false → 입력=출력 시 에러", () => {
+    expect(() =>
+      buildSync({
+        entryPoints: [join(dir, "lib.ts")],
+        outfile: join(dir, "lib.ts"),
+      }),
+    ).toThrow("overwrite");
+  });
+
+  test("allowOverwrite: true → 입력=출력 허용", () => {
+    const outfile = join(dir, "overwrite-test.ts");
+    writeFileSync(outfile, "export const z = 1;");
+    const result = buildSync({
+      entryPoints: [outfile],
+      outfile,
+      allowOverwrite: true,
+    });
+    expect(result.errors.length).toBe(0);
+    rmSync(outfile, { force: true });
+  });
 });

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -174,6 +174,8 @@ export interface BuildOptions {
   outfile?: string;
   /** 디스크 쓰기 여부 (기본: false, outdir/outfile 지정 시 자동 true) */
   write?: boolean;
+  /** 출력 파일이 입력 파일을 덮어쓰는 것을 허용 */
+  allowOverwrite?: boolean;
   /** 엔트리 포인트 공통 기준 경로 (출력 디렉토리 구조 결정) */
   outbase?: string;
   /** 모든 bare import를 external 처리 */
@@ -379,6 +381,7 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   delete napiOptions.write;
   delete napiOptions.outdir;
   delete napiOptions.plugins;
+  delete napiOptions.allowOverwrite;
   return napiOptions;
 }
 
@@ -388,6 +391,18 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
 function writeOutputFiles(result: BuildResult, options: BuildOptions): void {
   const shouldWrite = options.write ?? (options.outdir != null || options.outfile != null);
   if (!shouldWrite) return;
+
+  // allowOverwrite 체크: 입력 파일과 동일 경로에 출력 방지
+  if (!options.allowOverwrite && options.outfile) {
+    const outResolved = resolve(options.outfile);
+    for (const entry of options.entryPoints) {
+      if (resolve(entry) === outResolved) {
+        throw new Error(
+          `@zts/core: output file '${options.outfile}' would overwrite input file (set allowOverwrite: true to permit)`,
+        );
+      }
+    }
+  }
 
   const createdDirs = new Set<string>();
   const outfileResolved = options.outfile ? resolve(options.outfile) : null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -675,6 +675,8 @@ const TranspileOptions = struct {
     core: lib.transpile.TranspileOptions = .{},
     /// CLI 전용: 파이프라인 단계별 소요시간 출력 (--timing)
     timing: bool = false,
+    /// --allow-overwrite: 출력 파일이 입력 파일을 덮어쓰는 것을 허용
+    allow_overwrite: bool = false,
 };
 
 /// transpile.zig 에러 콜백: 파서/시맨틱 에러 발생 시 코드 프레임 출력
@@ -779,6 +781,18 @@ fn transpileFile(
     if (timer) |*t| {
         t_transpile = t.read();
         t.reset();
+    }
+
+    // --allow-overwrite 체크
+    if (!options.allow_overwrite) {
+        if (output_path) |out_path| {
+            const in_abs = std.fs.cwd().realpathAlloc(arena_alloc, file_path) catch file_path;
+            const out_abs = std.fs.cwd().realpathAlloc(arena_alloc, out_path) catch out_path;
+            if (std.mem.eql(u8, in_abs, out_abs)) {
+                try stderr.print("zts: output file '{s}' would overwrite input file (use --allow-overwrite to permit)\n", .{out_path});
+                return error.TranspileFailed;
+            }
+        }
     }
 
     // 출력
@@ -1503,6 +1517,18 @@ pub fn main() !void {
             }
         }
 
+        // --allow-overwrite 체크: 출력 파일이 입력 파일을 덮어쓰지 않도록
+        if (!opts.allow_overwrite) {
+            const entry_abs = abs_entry;
+            if (opts.output_file) |out_path| {
+                const out_abs = std.fs.cwd().realpathAlloc(allocator, out_path) catch out_path;
+                if (std.mem.eql(u8, entry_abs, out_abs)) {
+                    try stderr.print("zts: output file '{s}' would overwrite input file (use --allow-overwrite to permit)\n", .{out_path});
+                    return error.TranspileFailed;
+                }
+            }
+        }
+
         // 출력
         // --watch-json 모드에서는 stdout이 NDJSON 전용이므로
         // 상태 메시지와 raw 번들 출력은 억제
@@ -1924,6 +1950,7 @@ pub fn main() !void {
             .jsx_import_source = opts.jsx_import_source,
         },
         .timing = opts.timing,
+        .allow_overwrite = opts.allow_overwrite,
     };
 
     const is_stdin = std.mem.eql(u8, input_path_str, "-");


### PR DESCRIPTION
## Summary
- CLI: `--allow-overwrite` 플래그 구현 (트랜스파일 + 번들 모드)
- NAPI: `allowOverwrite` BuildOptions + `writeOutputFiles` 체크
- 테스트 2개 추가

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)