### PR TITLE
style: UMD/AMD simplify 수정

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -880,7 +880,7 @@ fn parseBuildOptions(
     const format_str = getObjectString(env, opts_obj, "format", native_alloc);
     if (format_str) |s| if (!trackStr(owned_strings, s)) return null;
     const format: EmitFormat = if (format_str) |s|
-        if (std.mem.eql(u8, s, "cjs")) .cjs else if (std.mem.eql(u8, s, "iife")) .iife else if (std.mem.eql(u8, s, "umd")) .umd else if (std.mem.eql(u8, s, "amd")) .amd else .esm
+        std.meta.stringToEnum(EmitFormat, s) orelse .esm
     else
         .esm;
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -961,7 +961,7 @@ pub fn emitModule(
 
     const final_exports = if (raw_final_exports) |fe| blk: {
         if (options.format.isWrappedFormat()) {
-            if (options.global_name != null or options.format == .umd or options.format == .amd) {
+            if (options.format != .iife or options.global_name != null) {
                 if (std.mem.startsWith(u8, fe, "export {")) {
                     wrapped_return_buf = try std.mem.concat(allocator, u8, &.{ "return {", fe["export {".len..] });
                     break :blk wrapped_return_buf.?;
@@ -1350,7 +1350,9 @@ fn emitFormatPrologue(
             }
         },
         .umd => {
-            // UMD: CommonJS + AMD + 글로벌 자동 감지
+            if (has_tla) {
+                try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
+            }
             try output.appendSlice(allocator, "(function(root, factory) {\n");
             try output.appendSlice(allocator, "  if (typeof define === \"function\" && define.amd) define([], factory);\n");
             try output.appendSlice(allocator, "  else if (typeof module === \"object\" && module.exports) module.exports = factory();\n");
@@ -1364,7 +1366,9 @@ fn emitFormatPrologue(
             try output.appendSlice(allocator, "})(typeof self !== \"undefined\" ? self : this, function() {\n");
         },
         .amd => {
-            // AMD: define() 래핑
+            if (has_tla) {
+                try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
+            }
             try output.appendSlice(allocator, "define([], function() {\n");
         },
         .cjs => try output.appendSlice(allocator, "\"use strict\";\n"),
@@ -1376,8 +1380,7 @@ fn emitFormatPrologue(
 fn emitFormatEpilogue(output: *std.ArrayList(u8), allocator: std.mem.Allocator, format: types.Format) !void {
     switch (format) {
         .iife => try output.appendSlice(allocator, "})();\n"),
-        .umd => try output.appendSlice(allocator, "});\n"),
-        .amd => try output.appendSlice(allocator, "});\n"),
+        .umd, .amd => try output.appendSlice(allocator, "});\n"),
         .cjs, .esm => {},
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1400,12 +1400,8 @@ pub fn main() !void {
             // format
             if (!opts.bundle_format_explicit) {
                 if (sp.config.format) |fmt| {
-                    if (std.mem.eql(u8, fmt, "esm")) {
-                        bundle_opts.format = .esm;
-                    } else if (std.mem.eql(u8, fmt, "cjs")) {
-                        bundle_opts.format = .cjs;
-                    } else if (std.mem.eql(u8, fmt, "iife")) {
-                        bundle_opts.format = .iife;
+                    if (std.meta.stringToEnum(emitter.EmitOptions.Format, fmt)) |f| {
+                        bundle_opts.format = f;
                     }
                 }
             }
@@ -2224,7 +2220,7 @@ fn printUsage(writer: anytype) !void {
         \\  -o, --out-file <path>            Output file path
         \\  --outdir <path>                  Output directory (for directory input)
         \\  --minify                         Minify output
-        \\  --format=esm|cjs|iife            Module format (default: esm)
+        \\  --format=esm|cjs|iife|umd|amd    Module format (default: esm)
         \\  --drop=console                   Remove console.* calls
         \\  --drop=debugger                  Remove debugger statements
         \\  --define:KEY=VALUE               Replace KEY with VALUE globally


### PR DESCRIPTION
## Summary
/simplify 리뷰 결과 수정:
- **버그**: tsconfig config format 파싱에 umd/amd 누락 → `std.meta.stringToEnum`으로 교체
- **버그**: UMD/AMD prologue에 TLA 경고 누락 → IIFE와 동일하게 추가
- NAPI format 파싱 → `std.meta.stringToEnum` (새 포맷 자동 대응)
- epilogue `.umd, .amd` 합치기, export 조건 명확화
- help 텍스트 업데이트

## Test plan
- [x] `bun test index.test.ts` — 182개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)