### PR TITLE
fix(resolver): nodePaths bare specifier resolve 버그 수정

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -2783,15 +2783,10 @@ describe("옵션 조합 통합 테스트", () => {
 
 describe("실제 라이브러리 번들링", () => {
   let dir: string;
-  const projectRoot = resolve(__dirname, "../..");
+  const projectNodeModules = resolve(__dirname, "../../node_modules");
 
   beforeAll(() => {
     dir = mkdtempSync(join(tmpdir(), "zts-real-lib-"));
-    // tmp 디렉토리에서 node_modules를 resolve할 수 있도록 symlink 생성
-    const { symlinkSync } = require("fs");
-    try {
-      symlinkSync(join(projectRoot, "node_modules"), join(dir, "node_modules"), "junction");
-    } catch {}
   });
 
   afterAll(() => {
@@ -2807,6 +2802,7 @@ describe("실제 라이브러리 번들링", () => {
       entryPoints: [join(dir, "react-app.tsx")],
       format: "esm",
       jsx: "classic",
+      nodePaths: [projectNodeModules],
     });
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles[0].text).toContain("createElement");
@@ -2823,6 +2819,7 @@ describe("실제 라이브러리 번들링", () => {
       globalName: "ReactApp",
       external: ["react"],
       jsx: "classic",
+      nodePaths: [projectNodeModules],
     });
     expect(result.errors.length).toBe(0);
     const text = result.outputFiles[0].text;
@@ -2839,6 +2836,7 @@ describe("실제 라이브러리 번들링", () => {
       entryPoints: [join(dir, "react-iife.tsx")],
       format: "iife",
       globalName: "ReactBundle",
+      nodePaths: [projectNodeModules],
     });
     expect(result.errors.length).toBe(0);
     const fn = new Function(result.outputFiles[0].text + "\nreturn ReactBundle;");
@@ -2855,12 +2853,14 @@ describe("실제 라이브러리 번들링", () => {
       entryPoints: [join(dir, "react-min.tsx")],
       format: "iife",
       globalName: "R",
+      nodePaths: [projectNodeModules],
     });
     const minified = await build({
       entryPoints: [join(dir, "react-min.tsx")],
       format: "iife",
       globalName: "R",
       minify: true,
+      nodePaths: [projectNodeModules],
     });
     expect(minified.errors.length).toBe(0);
     expect(minified.outputFiles[0].text.length).toBeLessThan(normal.outputFiles[0].text.length);
@@ -2875,6 +2875,7 @@ describe("실제 라이브러리 번들링", () => {
       entryPoints: [join(dir, "lodash-app.ts")],
       format: "esm",
       minify: true,
+      nodePaths: [projectNodeModules],
     });
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles[0].text.length).toBeLessThan(50000);
@@ -2894,6 +2895,7 @@ describe("실제 라이브러리 번들링", () => {
       splitting: true,
       format: "esm",
       jsx: "classic",
+      nodePaths: [projectNodeModules],
     });
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles.length).toBeGreaterThanOrEqual(3);
@@ -2905,6 +2907,7 @@ describe("실제 라이브러리 번들링", () => {
       entryPoints: [join(dir, "jsx-auto.tsx")],
       jsx: "automatic",
       format: "esm",
+      nodePaths: [projectNodeModules],
     });
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles[0].text).toContain("jsx");
@@ -2922,6 +2925,7 @@ describe("실제 라이브러리 번들링", () => {
       platform: "browser",
       define: { "process.env.NODE_ENV": '"production"' },
       minify: true,
+      nodePaths: [projectNodeModules],
     });
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles[0].text).not.toContain('"dev"');

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -139,6 +139,7 @@ pub const ResolveCache = struct {
         r.alias = alias;
         r.custom_extensions = options.resolve_extensions;
         r.main_fields = options.main_fields;
+        r.node_paths = options.node_paths;
         const has_custom = custom_conditions.len > 0;
         const cond_import = if (has_custom)
             buildConditions(allocator, baseConditionsFor(platform, .static_import), custom_conditions) catch baseConditionsFor(platform, .static_import)

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -202,6 +202,8 @@ pub const Resolver = struct {
     main_fields: []const []const u8 = &.{},
     /// 디렉토리 엔트리 캐시. null이면 캐시 없이 매번 stat() 호출 (테스트용).
     dir_cache: ?*DirEntryCache = null,
+    /// NODE_PATH 추가 탐색 경로 (--node-paths). 상위 디렉토리 탐색 실패 시 폴백.
+    node_paths: []const []const u8 = &.{},
 
     pub fn init(allocator: std.mem.Allocator) Resolver {
         return .{ .allocator = allocator };
@@ -420,6 +422,19 @@ pub const Resolver = struct {
             const parent = std.fs.path.dirname(current_dir) orelse break;
             if (std.mem.eql(u8, parent, current_dir)) break; // 루트 도달
             current_dir = parent;
+        }
+
+        // NODE_PATH 폴백: --node-paths로 지정된 추가 경로에서 탐색
+        for (self.node_paths) |np| {
+            const pkg_dir_path = std.fs.path.resolve(self.allocator, &.{ np, pkg_name }) catch
+                return error.OutOfMemory;
+            defer self.allocator.free(pkg_dir_path);
+
+            if (self.dirExists(pkg_dir_path)) {
+                if (try self.resolvePackage(pkg_dir_path, subpath)) |result| {
+                    return result;
+                }
+            }
         }
 
         return error.ModuleNotFound;


### PR DESCRIPTION
## Summary
- `Resolver.node_paths` 필드 추가
- `resolveNodeModules`에서 상위 디렉토리 탐색 실패 후 `node_paths`를 폴백으로 탐색
- `resolve_cache.zig`에서 `node_paths`를 resolver에 전달
- 테스트: symlink 우회 → `nodePaths` 옵션으로 교체

## Test plan
- [x] `bun test index.test.ts` — 198개 전체 통과
- [x] `/tmp`에서 `nodePaths`로 프로젝트 `node_modules`를 지정하여 React resolve 확인

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)