### PR TITLE
fix(semantic): assignment_target_identifier symbol_id 누락 수정

### DIFF
--- a/src/bundler/bundler_test/patterns.zig
+++ b/src/bundler/bundler_test/patterns.zig
@@ -388,6 +388,35 @@ test "Format: minify removes module boundary comments" {
     try std.testing.expect(std.mem.indexOf(u8, r2.output, "// ---") == null);
 }
 
+test "minifyIdentifiers: for-in LHS identifier should be renamed" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\var myObj = { a: 1, b: 2 };
+        \\var myKey;
+        \\for (myKey in myObj) {
+        \\  console.log(myKey);
+        \\}
+        \\export var result = myKey;
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const r = try b.bundle();
+    defer r.deinit(std.testing.allocator);
+
+    // "myKey" should NOT appear in the output (it should be renamed)
+    // The for-in LHS must use the same renamed identifier as the var declaration
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "myKey") == null);
+    // "myObj" should also be renamed
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "myObj") == null);
+}
+
 test "Format: scope_hoist false with all three formats" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1134,7 +1134,7 @@ pub const SemanticAnalyzer = struct {
             },
 
             // ---- 식별자 참조 추적 ----
-            .identifier_reference => {
+            .identifier_reference, .assignment_target_identifier => {
                 const name = self.ast.getSourceText(node.span);
                 self.resolveIdentifier(name, @intFromEnum(idx));
             },


### PR DESCRIPTION
## Summary
semantic analyzer의 `visitNode`에서 `assignment_target_identifier`가 `else => {}`로 빠져 `resolveIdentifier()`가 호출되지 않는 버그 수정.

**근본 원인**: `for (key in obj)` 등의 for-in LHS가 `assignment_target_identifier` 태그인데, `identifier_reference`만 심볼 등록 경로에 있었음.

**결과**: `minifyIdentifiers` 시 for-in LHS가 리네이밍되지 않아 변수명 불일치 → 런타임 에러.

**수정**: `.assignment_target_identifier`를 `.identifier_reference`와 같은 `resolveIdentifier` 경로에 추가.

> CJS 래핑 모듈(React 등)에서의 symbol_ids 불일치는 별도 구조 수정 필요 (#1041 참조)

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `bun test index.test.ts` — 198개 전체 통과
- [x] Zig 유닛 테스트 추가: for-in LHS minify 검증

Partially fixes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)