### PR TITLE
feat(bundler): import.meta.glob 지원 (Vite 호환)

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -10,7 +10,7 @@ import {
   type RollupPlugin,
 } from "./index";
 import { resolve } from "node:path";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -2933,5 +2933,59 @@ describe("실제 라이브러리 번들링", () => {
     });
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles[0].text).not.toContain('"dev"');
+  });
+});
+
+// ─── import.meta.glob 테스트 (#1026) ───
+
+describe("import.meta.glob", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-glob-"));
+    mkdirSync(join(dir, "pages"), { recursive: true });
+    writeFileSync(join(dir, "pages", "Home.tsx"), 'export default "Home";');
+    writeFileSync(join(dir, "pages", "About.tsx"), 'export default "About";');
+    writeFileSync(join(dir, "pages", "Contact.tsx"), 'export default "Contact";');
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("기본 glob: lazy import 객체 생성", () => {
+    writeFileSync(
+      join(dir, "entry.ts"),
+      'const m = import.meta.glob("./pages/*.tsx");\nexport { m };',
+    );
+    const result = buildSync({ entryPoints: [join(dir, "entry.ts")], format: "esm" });
+    expect(result.errors.length).toBe(0);
+    const text = result.outputFiles[0].text;
+    expect(text).toContain("./pages/Home.tsx");
+    expect(text).toContain("./pages/About.tsx");
+    expect(text).toContain("./pages/Contact.tsx");
+    expect(text).toContain("() => import(");
+    expect(text).not.toContain("import.meta.glob");
+  });
+
+  test("매칭 파일 없는 패턴 → 빈 객체", () => {
+    writeFileSync(
+      join(dir, "empty.ts"),
+      'const m = import.meta.glob("./nonexistent/*.ts");\nexport { m };',
+    );
+    const result = buildSync({ entryPoints: [join(dir, "empty.ts")], format: "esm" });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).not.toContain("import(");
+  });
+
+  test("다른 확장자 패턴", () => {
+    writeFileSync(join(dir, "pages", "data.json"), '{"key":"value"}');
+    writeFileSync(
+      join(dir, "json-glob.ts"),
+      'const m = import.meta.glob("./pages/*.json");\nexport { m };',
+    );
+    const result = buildSync({ entryPoints: [join(dir, "json-glob.ts")], format: "esm" });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("./pages/data.json");
   });
 });

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -874,6 +874,9 @@ pub fn emitModule(
     }
     var code = try cg.generate(root);
 
+    // import.meta.glob: 코드에서 glob 호출을 매칭 파일 객체로 교체
+    code = try replaceImportMetaGlob(arena_alloc, code, module.import_records);
+
     // React Fast Refresh: 컴포넌트가 있는 모듈에 hot.accept() 자동 삽입.
     // accept() 없으면 __zts_apply_update가 full reload로 fallback.
     if (options.dev_mode and options.react_refresh and module.dev_id.len > 0) {
@@ -1383,4 +1386,96 @@ fn emitFormatEpilogue(output: *std.ArrayList(u8), allocator: std.mem.Allocator, 
         .umd, .amd => try output.appendSlice(allocator, "});\n"),
         .cjs, .esm => {},
     }
+}
+
+// --- import.meta.glob 코드 교체 ---
+
+/// 코드에서 `import.meta.glob("pattern")` 호출을 매칭 파일 객체 리터럴로 교체한다.
+/// Vite 호환: lazy → `{ "./a.ts": () => import("./a.ts"), ... }`
+fn replaceImportMetaGlob(
+    allocator: std.mem.Allocator,
+    code: []const u8,
+    import_records: []const types.ImportRecord,
+) ![]const u8 {
+    // glob 레코드가 있는지 확인
+    var has_glob = false;
+    for (import_records) |rec| {
+        if (rec.kind == .glob) {
+            has_glob = true;
+            break;
+        }
+    }
+    if (!has_glob) return code;
+
+    // 코드에서 import.meta.glob( 패턴을 찾아 교체
+    var result: std.ArrayList(u8) = .empty;
+    var pos: usize = 0;
+
+    while (std.mem.indexOf(u8, code[pos..], "import.meta.glob(")) |rel_idx| {
+        const start = pos + rel_idx;
+        // 닫는 괄호 찾기 (중첩 괄호 고려)
+        var paren_depth: u32 = 0;
+        var end = start + "import.meta.glob(".len;
+        while (end < code.len) : (end += 1) {
+            if (code[end] == '(') {
+                paren_depth += 1;
+            } else if (code[end] == ')') {
+                if (paren_depth == 0) {
+                    end += 1; // ')' 포함
+                    break;
+                }
+                paren_depth -= 1;
+            }
+        }
+
+        // 이 glob 호출에 대응하는 import_record 찾기
+        var matching_record: ?*const types.ImportRecord = null;
+        for (import_records) |*rec| {
+            if (rec.kind == .glob) {
+                // 패턴 문자열이 이 위치의 코드에 포함되어 있는지 확인
+                const glob_code = code[start..end];
+                if (std.mem.indexOf(u8, glob_code, rec.specifier) != null) {
+                    matching_record = rec;
+                    break;
+                }
+            }
+        }
+
+        // 교체 전 코드 복사
+        try result.appendSlice(allocator, code[pos..start]);
+
+        if (matching_record) |rec| {
+            if (rec.glob_matches) |matches| {
+                // 객체 리터럴 생성: { "./a.ts": () => import("./a.ts"), ... }
+                try result.appendSlice(allocator, "{\n");
+                for (matches, 0..) |match_path, i| {
+                    if (i > 0) try result.appendSlice(allocator, ",\n");
+                    try result.appendSlice(allocator, "  \"");
+                    try result.appendSlice(allocator, match_path);
+                    if (rec.glob_eager) {
+                        // eager: 정적 import (별도 처리 필요, 현재 미구현)
+                        try result.appendSlice(allocator, "\": () => import(\"");
+                    } else {
+                        try result.appendSlice(allocator, "\": () => import(\"");
+                    }
+                    try result.appendSlice(allocator, match_path);
+                    try result.appendSlice(allocator, "\")");
+                }
+                try result.appendSlice(allocator, "\n}");
+            } else {
+                // 매칭 파일 없음 → 빈 객체
+                try result.appendSlice(allocator, "{}");
+            }
+        } else {
+            // 매칭 레코드 없음 → 원본 유지
+            try result.appendSlice(allocator, code[start..end]);
+        }
+
+        pos = end;
+    }
+
+    // 남은 코드 복사
+    try result.appendSlice(allocator, code[pos..]);
+
+    return try result.toOwnedSlice(allocator);
 }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -627,7 +627,17 @@ pub const ModuleGraph = struct {
         else
             null;
 
+        // import.meta.glob: 워커에서 glob 확장 수행
+        for (self.modules.items[mod_idx].import_records) |*record| {
+            if (record.kind == .glob) {
+                const matches = expandGlob(self.allocator, source_dir, record.specifier) catch &.{};
+                record.glob_matches = matches;
+            }
+        }
+
         for (records, 0..) |record, rec_i| {
+            if (record.kind == .glob) continue;
+
             if (plugin_runner) |runner| {
                 const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
                     error.PluginFailed => null,
@@ -1218,7 +1228,22 @@ pub const ModuleGraph = struct {
         else
             null;
 
+        // import.meta.glob: glob 레코드를 파일 시스템에서 확장
+        for (self.modules.items[mod_idx].import_records) |*record| {
+            if (record.kind == .glob) {
+                const matches = try expandGlob(self.allocator, source_dir, record.specifier);
+                record.glob_matches = matches;
+                for (matches) |match_path| {
+                    const abs = std.fs.path.resolve(self.allocator, &.{ source_dir, match_path }) catch continue;
+                    defer self.allocator.free(abs);
+                    _ = self.addModule(abs) catch continue;
+                }
+            }
+        }
+
         for (records, 0..) |record, rec_i| {
+            if (record.kind == .glob) continue;
+
             // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
             if (plugin_runner) |runner| {
                 const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
@@ -1838,4 +1863,63 @@ pub fn determineExportsKind(
     if (std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".mts")) return .esm;
 
     return .none;
+}
+
+/// import.meta.glob 패턴을 파일 시스템에서 확장한다.
+/// 패턴: "./dir/*.ext" — prefix(./dir/) + *와 suffix(.ext)로 분리하여 디렉토리 탐색.
+/// 상대 경로 배열을 반환한다 (예: ["./pages/Home.tsx", "./pages/About.tsx"]).
+fn expandGlob(allocator: std.mem.Allocator, source_dir: []const u8, pattern: []const u8) ![]const []const u8 {
+    // 패턴에서 * 위치 찾기
+    const star_pos = std.mem.indexOf(u8, pattern, "*") orelse return &.{};
+    const prefix = pattern[0..star_pos]; // "./pages/"
+    const suffix = pattern[star_pos + 1 ..]; // ".tsx"
+
+    // prefix에서 디렉토리 경로 추출
+    const glob_dir_rel = if (prefix.len > 0 and prefix[prefix.len - 1] == '/')
+        prefix[0 .. prefix.len - 1]
+    else if (std.fs.path.dirname(prefix)) |d| d else ".";
+
+    // 절대 경로로 변환
+    const glob_dir_abs = try std.fs.path.resolve(allocator, &.{ source_dir, glob_dir_rel });
+    defer allocator.free(glob_dir_abs);
+
+    // 디렉토리 열기
+    var dir = std.fs.cwd().openDir(glob_dir_abs, .{ .iterate = true }) catch return &.{};
+    defer dir.close();
+
+    var results: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (results.items) |r| allocator.free(r);
+        results.deinit(allocator);
+    }
+
+    // prefix에서 디렉토리 이후 부분 (파일명 prefix)
+    const file_prefix = if (prefix.len > 0 and prefix[prefix.len - 1] == '/')
+        ""
+    else
+        std.fs.path.basename(prefix);
+
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .file and entry.kind != .sym_link) continue;
+        const name = entry.name;
+
+        // prefix 매칭
+        if (file_prefix.len > 0 and !std.mem.startsWith(u8, name, file_prefix)) continue;
+        // suffix 매칭 (확장자)
+        if (suffix.len > 0 and !std.mem.endsWith(u8, name, suffix)) continue;
+
+        // 상대 경로 생성: "./dir/filename.ext"
+        const rel_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ glob_dir_rel, name });
+        try results.append(allocator, rel_path);
+    }
+
+    // 결정적 순서를 위해 정렬
+    std.mem.sortUnstable([]const u8, results.items, {}, struct {
+        fn cmp(_: void, a: []const u8, b: []const u8) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.cmp);
+
+    return try results.toOwnedSlice(allocator);
 }

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -88,6 +88,8 @@ pub fn extractImportsWithCjsDetection(allocator: std.mem.Allocator, ast: *const 
                 if (tryExtractRequire(ast, node)) |record| {
                     has_cjs_require = true;
                     try records.append(allocator, record);
+                } else if (tryExtractGlob(ast, node)) |record| {
+                    try records.append(allocator, record);
                 }
             },
             .new_expression => {
@@ -409,4 +411,60 @@ pub fn stripQuotes(text: []const u8) ?[]const u8 {
         return text[1 .. text.len - 1];
     }
     return null;
+}
+
+/// import.meta.glob("pattern") 호출을 감지하여 glob ImportRecord를 생성한다.
+/// call_expression: extra [callee, args_start, args_len, flags]
+///   callee: static_member_expression (import.meta.glob)
+///     object: meta_property (import.meta, data.none == 0)
+///     property: "glob"
+///   args[0]: string_literal (패턴)
+///   args[1]: object_expression (옵션, optional)
+fn tryExtractGlob(ast: *const Ast, node: Node) ?ImportRecord {
+    if (node.tag != .call_expression) return null;
+    const extras = ast.extra_data.items;
+    const e = node.data.extra;
+    if (e + 2 >= extras.len) return null;
+
+    const callee_idx: NodeIndex = @enumFromInt(extras[e]);
+    const args_start = extras[e + 1];
+    const args_len = extras[e + 2];
+    if (args_len == 0) return null;
+    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return null;
+
+    // callee가 static_member_expression(import.meta.glob)인지 확인
+    const callee = ast.getNode(callee_idx);
+    if (callee.tag != .static_member_expression) return null;
+    if (callee.data.extra + 2 >= extras.len) return null;
+
+    const obj_idx: NodeIndex = @enumFromInt(extras[callee.data.extra]);
+    const prop_idx: NodeIndex = @enumFromInt(extras[callee.data.extra + 1]);
+    if (obj_idx.isNone() or prop_idx.isNone()) return null;
+    if (@intFromEnum(obj_idx) >= ast.nodes.items.len or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
+
+    // object: meta_property (import.meta)
+    const obj = ast.getNode(obj_idx);
+    if (obj.tag != .meta_property) return null;
+    if (obj.data.none != 0) return null; // 0 = import.meta, 1 = new.target
+
+    // property: "glob"
+    const prop = ast.getNode(prop_idx);
+    const prop_name = ast.source[prop.span.start..prop.span.end];
+    if (!std.mem.eql(u8, prop_name, "glob")) return null;
+
+    // args[0]: string_literal (패턴)
+    if (args_start >= extras.len) return null;
+    const arg0_idx: NodeIndex = @enumFromInt(extras[args_start]);
+    if (arg0_idx.isNone() or @intFromEnum(arg0_idx) >= ast.nodes.items.len) return null;
+    const arg0 = ast.getNode(arg0_idx);
+    if (arg0.tag != .string_literal) return null;
+
+    const pattern = stripQuotes(ast.source[arg0.span.start..arg0.span.end]) orelse return null;
+
+    return ImportRecord{
+        .specifier = pattern,
+        .kind = .glob,
+        .span = node.span,
+        .glob_eager = false,
+    };
 }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -66,6 +66,8 @@ pub const ImportKind = enum {
     require,
     /// new Worker(new URL('./worker.ts', import.meta.url))
     worker,
+    /// import.meta.glob("./pages/*.tsx") — Vite 호환
+    glob,
 };
 
 // ============================================================
@@ -345,6 +347,12 @@ pub const ImportRecord = struct {
     resolved: ModuleIndex = .none,
     /// --external로 명시적으로 제외된 모듈 (resolve 실패와 구분)
     is_external: bool = false,
+    /// glob: eager import 여부 (import.meta.glob의 { eager: true } 옵션)
+    glob_eager: bool = false,
+    /// glob: import할 export 이름 (import.meta.glob의 { import: "default" } 옵션)
+    glob_import_name: ?[]const u8 = null,
+    /// glob: 확장된 매칭 파일 목록 (resolve 후 graph가 설정)
+    glob_matches: ?[]const []const u8 = null,
 };
 
 // ============================================================

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -871,6 +871,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                 // Inline scan: require("specifier") → CJS import record
                 if (self.enable_scan) {
                     scanRequireCall(self, expr, arg_list);
+                    scanGlobCall(self, expr, arg_list);
                 }
 
                 expr = try self.ast.addNode(.{
@@ -2173,6 +2174,47 @@ fn scanRequireCall(self: *Parser, callee: NodeIndex, arg_list: NodeList) void {
         .span = arg_node.span,
     }) catch {};
     self.scan_result.has_cjs_require = true;
+}
+
+/// import.meta.glob("pattern") 호출을 감지하여 glob import 레코드를 생성한다.
+fn scanGlobCall(self: *Parser, callee: NodeIndex, arg_list: NodeList) void {
+    if (callee.isNone() or @intFromEnum(callee) >= self.ast.nodes.items.len) return;
+    const callee_node = self.ast.nodes.items[@intFromEnum(callee)];
+    if (callee_node.tag != .static_member_expression) return;
+
+    const extras = self.ast.extra_data.items;
+    if (callee_node.data.extra + 2 >= extras.len) return;
+
+    // object: meta_property (import.meta)
+    const obj_idx: NodeIndex = @enumFromInt(extras[callee_node.data.extra]);
+    if (obj_idx.isNone() or @intFromEnum(obj_idx) >= self.ast.nodes.items.len) return;
+    const obj_node = self.ast.nodes.items[@intFromEnum(obj_idx)];
+    if (obj_node.tag != .meta_property) return;
+    if (obj_node.data.none != 0) return;
+
+    // property: "glob"
+    const prop_idx: NodeIndex = @enumFromInt(extras[callee_node.data.extra + 1]);
+    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) return;
+    const prop_node = self.ast.nodes.items[@intFromEnum(prop_idx)];
+    const prop_name = self.ast.source[prop_node.span.start..prop_node.span.end];
+    if (!std.mem.eql(u8, prop_name, "glob")) return;
+
+    // 첫 번째 인수가 string_literal인지
+    if (arg_list.len == 0) return;
+    if (arg_list.start >= extras.len) return;
+    const arg_idx: NodeIndex = @enumFromInt(extras[arg_list.start]);
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= self.ast.nodes.items.len) return;
+    const arg_node = self.ast.nodes.items[@intFromEnum(arg_idx)];
+    if (arg_node.tag != .string_literal) return;
+
+    const raw = self.ast.source[arg_node.span.start..arg_node.span.end];
+    const specifier = import_scanner.stripQuotes(raw) orelse raw;
+
+    self.scan_import_records.append(self.allocator, .{
+        .specifier = specifier,
+        .kind = .glob,
+        .span = callee_node.span, // import.meta.glob 전체 span
+    }) catch {};
 }
 
 /// assignment_expression의 left에서 module.exports = ... / exports.x = ... 패턴을 감지한다.

--- a/src/parser/scan_results.zig
+++ b/src/parser/scan_results.zig
@@ -17,6 +17,7 @@ pub const ImportKind = enum {
     side_effect,
     require,
     worker,
+    glob,
 };
 
 /// 파서가 수집하는 import 레코드. bundler ImportRecord의 경량 버전.


### PR DESCRIPTION
## Summary
Vite 호환 `import.meta.glob` 구현.

```typescript
const modules = import.meta.glob("./pages/*.tsx");
// → { "./pages/About.tsx": () => import("./pages/About.tsx"), ... }
```

### 구현
- **파서**: `scanGlobCall()` — `import.meta.glob()` 호출을 inline scan으로 감지
- **graph**: `scanWorker` + `resolveModuleImports`에서 glob 레코드 → `expandGlob()` 파일 매칭
- **emitter**: `replaceImportMetaGlob()` 코드 후처리로 lazy import 객체 교체

### 지원 기능
- `*` 단일 레벨 glob 패턴
- 알파벳순 결과 정렬
- 매칭 없으면 빈 객체

### 미지원 (후속)
- `{ eager: true }` 옵션 (정적 import)
- `{ import: "default" }` 옵션
- `**` 재귀 글로빙
- 배열 패턴 + 제외 패턴

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `bun test index.test.ts` — 201개 전체 통과
- [x] 기본 glob: 3개 파일 매칭 + lazy import 생성
- [x] 빈 매칭: import() 없는 빈 객체
- [x] 다른 확장자: .json 파일 매칭

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)