### PR TITLE
refactor(codegen): import.meta.glob AST 수준 교체

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -866,6 +866,7 @@ pub fn emitModule(
         // codegen은 jsx_element/jsx_fragment를 만나지 않으므로 JSX 옵션 불필요.
         // dev mode: import.meta.hot → __zts_make_hot("dev_id")
         .dev_module_id = if (options.dev_mode and module.dev_id.len > 0) module.dev_id else null,
+        .import_records = module.import_records,
     });
     // 소스맵용: line_offsets와 소스 파일 등록
     if (options.sourcemap) {
@@ -873,9 +874,6 @@ pub fn emitModule(
         try cg.addSourceFile(sourcemapSourcePath(module.path, options));
     }
     var code = try cg.generate(root);
-
-    // import.meta.glob: 코드에서 glob 호출을 매칭 파일 객체로 교체
-    code = try replaceImportMetaGlob(arena_alloc, code, module.import_records);
 
     // React Fast Refresh: 컴포넌트가 있는 모듈에 hot.accept() 자동 삽입.
     // accept() 없으면 __zts_apply_update가 full reload로 fallback.
@@ -1386,92 +1384,4 @@ fn emitFormatEpilogue(output: *std.ArrayList(u8), allocator: std.mem.Allocator, 
         .umd, .amd => try output.appendSlice(allocator, "});\n"),
         .cjs, .esm => {},
     }
-}
-
-// --- import.meta.glob 코드 교체 ---
-
-/// 코드에서 `import.meta.glob("pattern")` 호출을 매칭 파일 객체 리터럴로 교체한다.
-/// Vite 호환: lazy → `{ "./a.ts": () => import("./a.ts"), ... }`
-fn replaceImportMetaGlob(
-    allocator: std.mem.Allocator,
-    code: []const u8,
-    import_records: []const types.ImportRecord,
-) ![]const u8 {
-    // glob 레코드가 있는지 확인
-    var has_glob = false;
-    for (import_records) |rec| {
-        if (rec.kind == .glob) {
-            has_glob = true;
-            break;
-        }
-    }
-    if (!has_glob) return code;
-
-    // 코드에서 import.meta.glob( 패턴을 찾아 교체
-    var result: std.ArrayList(u8) = .empty;
-    var pos: usize = 0;
-
-    while (std.mem.indexOf(u8, code[pos..], "import.meta.glob(")) |rel_idx| {
-        const start = pos + rel_idx;
-        // 닫는 괄호 찾기 (중첩 괄호 고려)
-        var paren_depth: u32 = 0;
-        var end = start + "import.meta.glob(".len;
-        while (end < code.len) : (end += 1) {
-            if (code[end] == '(') {
-                paren_depth += 1;
-            } else if (code[end] == ')') {
-                if (paren_depth == 0) {
-                    end += 1; // ')' 포함
-                    break;
-                }
-                paren_depth -= 1;
-            }
-        }
-
-        // 이 glob 호출에 대응하는 import_record 찾기
-        var matching_record: ?*const types.ImportRecord = null;
-        for (import_records) |*rec| {
-            if (rec.kind == .glob) {
-                // 패턴 문자열이 이 위치의 코드에 포함되어 있는지 확인
-                const glob_code = code[start..end];
-                if (std.mem.indexOf(u8, glob_code, rec.specifier) != null) {
-                    matching_record = rec;
-                    break;
-                }
-            }
-        }
-
-        // 교체 전 코드 복사
-        try result.appendSlice(allocator, code[pos..start]);
-
-        if (matching_record) |rec| {
-            if (rec.glob_matches) |matches| {
-                // 객체 리터럴 생성: { "./a.ts": () => import("./a.ts"), ... }
-                try result.appendSlice(allocator, "{\n");
-                for (matches, 0..) |match_path, i| {
-                    if (i > 0) try result.appendSlice(allocator, ",\n");
-                    try result.appendSlice(allocator, "  \"");
-                    try result.appendSlice(allocator, match_path);
-                    // TODO: eager 모드 구현 시 정적 import로 변경
-                    try result.appendSlice(allocator, "\": () => import(\"");
-                    try result.appendSlice(allocator, match_path);
-                    try result.appendSlice(allocator, "\")");
-                }
-                try result.appendSlice(allocator, "\n}");
-            } else {
-                // 매칭 파일 없음 → 빈 객체
-                try result.appendSlice(allocator, "{}");
-            }
-        } else {
-            // 매칭 레코드 없음 → 원본 유지
-            try result.appendSlice(allocator, code[start..end]);
-        }
-
-        pos = end;
-    }
-
-    // 남은 코드 복사
-    try result.appendSlice(allocator, code[pos..]);
-
-    return try result.toOwnedSlice(allocator);
 }

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -112,6 +112,8 @@ pub const CodegenOptions = struct {
     esm_var_assign_only: bool = false,
     /// dev mode 모듈 ID. 설정 시 import.meta.hot → __zts_make_hot("id") 변환.
     dev_module_id: ?[]const u8 = null,
+    /// import.meta.glob 레코드. codegen이 glob 호출을 객체 리터럴로 직접 출력.
+    import_records: []const @import("../bundler/types.zig").ImportRecord = &.{},
 };
 
 /// keepNames 엔트리. codegen이 수집하고 emitter가 __name() 호출로 변환.
@@ -1571,12 +1573,78 @@ pub const Codegen = struct {
         // CJS require() 치환: require('specifier') → require_xxx()
         if (try self.tryRewriteRequire(callee, args_start, args_len)) return;
 
+        // import.meta.glob() → 객체 리터럴 직접 출력
+        if (try self.tryEmitGlobObject(callee, args_start, args_len)) return;
+
         if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
         try self.emitNode(callee);
         if (is_optional) try self.write("?.");
         try self.writeByte('(');
         try self.emitNodeList(args_start, args_len, if (self.options.minify_whitespace) "," else ", ");
         try self.writeByte(')');
+    }
+
+    /// import.meta.glob("pattern") 호출을 감지하고 매칭 파일 객체 리터럴을 직접 출력한다.
+    /// AST 수준 교체: 문자열 후처리보다 안전 (minify, 문자열 리터럴 내 패턴에 영향 안 받음).
+    fn tryEmitGlobObject(self: *Codegen, callee: ast_mod.NodeIndex, args_start: u32, args_len: u32) !bool {
+        if (self.options.import_records.len == 0) return false;
+        if (callee.isNone() or @intFromEnum(callee) >= self.ast.nodes.items.len) return false;
+
+        // callee: static_member_expression(import.meta.glob)
+        const callee_node = self.ast.getNode(callee);
+        if (callee_node.tag != .static_member_expression) return false;
+
+        const extras = self.ast.extra_data.items;
+        if (callee_node.data.extra + 2 >= extras.len) return false;
+
+        const obj_idx = @as(ast_mod.NodeIndex, @enumFromInt(extras[callee_node.data.extra]));
+        const prop_idx = @as(ast_mod.NodeIndex, @enumFromInt(extras[callee_node.data.extra + 1]));
+        if (obj_idx.isNone() or prop_idx.isNone()) return false;
+        if (@intFromEnum(obj_idx) >= self.ast.nodes.items.len or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) return false;
+
+        const obj_node = self.ast.getNode(obj_idx);
+        if (obj_node.tag != .meta_property or obj_node.data.none != 0) return false;
+
+        const prop_node = self.ast.getNode(prop_idx);
+        const prop_name = self.ast.source[prop_node.span.start..prop_node.span.end];
+        if (!std.mem.eql(u8, prop_name, "glob")) return false;
+
+        // 첫 번째 인수에서 패턴 추출
+        if (args_len == 0 or args_start >= extras.len) return false;
+        const arg0_idx = @as(ast_mod.NodeIndex, @enumFromInt(extras[args_start]));
+        if (arg0_idx.isNone() or @intFromEnum(arg0_idx) >= self.ast.nodes.items.len) return false;
+        const arg0_node = self.ast.getNode(arg0_idx);
+        if (arg0_node.tag != .string_literal) return false;
+        const raw = self.ast.source[arg0_node.span.start..arg0_node.span.end];
+        const pattern = Ast.stripStringQuotes(raw);
+
+        // import_records에서 매칭되는 glob 레코드 찾기
+        const ImportRecord = @import("../bundler/types.zig").ImportRecord;
+        for (self.options.import_records) |rec| {
+            if (rec.kind != .glob) continue;
+            if (!std.mem.eql(u8, rec.specifier, pattern)) continue;
+
+            // 매칭 → 객체 리터럴 출력
+            if (rec.glob_matches) |matches| {
+                try self.write("{\n");
+                for (matches, 0..) |match_path, i| {
+                    if (i > 0) try self.write(",\n");
+                    try self.write("  \"");
+                    try self.write(match_path);
+                    // TODO: eager 모드 구현 시 정적 import로 변경
+                    try self.write("\": () => import(\"");
+                    try self.write(match_path);
+                    try self.write("\")");
+                }
+                try self.write("\n}");
+            } else {
+                try self.write("{}");
+            }
+            return true;
+        }
+        _ = ImportRecord;
+
+        return false;
     }
 
     /// string_literal 노드에서 specifier를 추출하고 require_rewrites 맵에서 조회.


### PR DESCRIPTION
## Summary
문자열 후처리(`replaceImportMetaGlob`)를 제거하고 **codegen에서 AST 수준으로 직접 교체**.

**이전 방식** (취약):
```
codegen → 코드 문자열 → "import.meta.glob(" 문자열 검색 → 교체
```
- 문자열 리터럴 내 false match 가능
- minify/포맷 변경에 영향

**현재 방식** (안전):
```
codegen → emitCall → AST 노드 타입 확인 → 객체 리터럴 직접 출력
```
- AST 태그 기반 감지: `call_expression → static_member_expression → meta_property`
- 문자열 내용과 무관하게 정확한 감지

## Test plan
- [x] `zig build test` — 전체 통과
- [x] `bun test index.test.ts` — 201개 전체 통과
- [x] glob 테스트 3개 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)