### PR TITLE
fix(napi): watch 초기 빌드 + rebuild 시 파일 쓰기 추가

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1163,12 +1163,37 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         }
     }
 
-    // 초기 빌드 바이트 수 계산
+    // 초기 빌드 결과를 파일에 쓰기 (onReady 전에 완료해야 서버가 읽을 수 있음)
     var initial_bytes: usize = 0;
     if (result.outputs) |outputs| {
         for (outputs) |o| initial_bytes += o.contents.len;
+        // code splitting: 각 output의 path로 직접 쓰기
+        for (outputs) |o| {
+            if (std.fs.path.dirname(o.path)) |dir| std.fs.cwd().makePath(dir) catch {};
+            const file = std.fs.cwd().createFile(o.path, .{}) catch continue;
+            defer file.close();
+            file.writeAll(o.contents) catch continue;
+        }
     } else {
         initial_bytes = result.output.len;
+        // 단일 파일: output_filename으로 쓰기
+        if (bundle_opts.output_filename.len > 0) {
+            if (std.fs.path.dirname(bundle_opts.output_filename)) |dir| std.fs.cwd().makePath(dir) catch {};
+            if (std.fs.cwd().createFile(bundle_opts.output_filename, .{})) |file| {
+                defer file.close();
+                file.writeAll(result.output) catch {};
+                if (result.sourcemap) |sm| {
+                    const map_path = std.fmt.allocPrint(allocator, "{s}.map", .{bundle_opts.output_filename}) catch null;
+                    if (map_path) |mp| {
+                        defer allocator.free(mp);
+                        if (std.fs.cwd().createFile(mp, .{})) |sm_file| {
+                            defer sm_file.close();
+                            sm_file.writeAll(sm) catch {};
+                        } else |_| {}
+                    }
+                }
+            } else |_| {}
+        }
     }
 
     // ready 이벤트 전송
@@ -1229,12 +1254,35 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         };
         defer rebuild_result.deinit(allocator);
 
-        // 출력 바이트 수 계산
+        // 출력 파일 쓰기 + 바이트 수 계산
         var output_bytes: usize = 0;
         if (rebuild_result.outputs) |outputs| {
             for (outputs) |o| output_bytes += o.contents.len;
+            for (outputs) |o| {
+                if (std.fs.path.dirname(o.path)) |dir| std.fs.cwd().makePath(dir) catch {};
+                const file = std.fs.cwd().createFile(o.path, .{}) catch continue;
+                defer file.close();
+                file.writeAll(o.contents) catch continue;
+            }
         } else {
             output_bytes = rebuild_result.output.len;
+            if (bundle_opts.output_filename.len > 0) {
+                if (std.fs.path.dirname(bundle_opts.output_filename)) |dir| std.fs.cwd().makePath(dir) catch {};
+                if (std.fs.cwd().createFile(bundle_opts.output_filename, .{})) |file| {
+                    defer file.close();
+                    file.writeAll(rebuild_result.output) catch {};
+                    if (rebuild_result.sourcemap) |sm| {
+                        const map_path = std.fmt.allocPrint(allocator, "{s}.map", .{bundle_opts.output_filename}) catch null;
+                        if (map_path) |mp| {
+                            defer allocator.free(mp);
+                            if (std.fs.cwd().createFile(mp, .{})) |sm_file| {
+                                defer sm_file.close();
+                                sm_file.writeAll(sm) catch {};
+                            } else |_| {}
+                        }
+                    }
+                } else |_| {}
+            }
         }
 
         // rebuild 이벤트 생성


### PR DESCRIPTION
## Summary
- watch worker thread에서 초기 빌드/rebuild 결과를 output_filename으로 파일에 쓰는 로직 추가
- 번개 dev 서버에서 `Build produced no output` 에러 수정

## Test plan
- [x] `zig build napi` 빌드 성공
- [x] 232개 NAPI 테스트 통과
- [ ] 번개 dev 서버에서 번들 파일 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)