### PR TITLE
fix(parser): jsx_in_js가 .ts 파일의 제네릭을 JSX로 오파싱하는 버그

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -838,7 +838,9 @@ pub const ModuleGraph = struct {
             }
         }
         // .js 파일에서 JSX 파싱 활성화 (--platform=react-native 프리셋)
-        if (self.jsx_in_js) {
+        // .ts 파일은 이미 configureForBundler에서 JSX 설정됨 (.tsx만 true)
+        // .ts에 강제 jsx=true하면 <T> 제네릭이 JSX로 오파싱됨
+        if (self.jsx_in_js and !parser.is_ts) {
             parser.is_jsx = true;
         }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -185,7 +185,7 @@ pub fn transpileWithCallback(
             parser.configureFlowFromPath(file_path);
         }
     }
-    if (options.jsx_in_js) {
+    if (options.jsx_in_js and !parser.is_ts) {
         parser.is_jsx = true;
     }
     _ = parser.parse() catch return error.ParseError;


### PR DESCRIPTION
## Summary
- `jsx_in_js` 옵션이 `.ts` 파일에도 `is_jsx=true`를 설정하여 `<T>` 제네릭이 JSX 태그로 잘못 파싱됨
- `graph.zig`, `transpile.zig` 두 곳에 `!parser.is_ts` 조건 추가

## 원인
RN 프리셋에서 `jsx_in_js=true`는 `.js` 파일에서 JSX를 허용하기 위한 옵션인데,
확장자 체크 없이 모든 파일에 적용되어 `.ts` 파일의 angle bracket 제네릭 (`<AnimatedRef<TRef>>`)이 JSX로 오파싱됨.

## Test plan
- [x] `zig build test` 전체 통과
- [x] `--flow --jsx-in-js useAnimatedRef.ts` 단독 transpile 성공
- [x] `.js` 파일의 JSX는 여전히 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)