### PR TITLE
fix(es5): abstract/declare 메서드가 빈 function()으로 emit되는 버그

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1086,7 +1086,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const key: NodeIndex = self.readNodeIdx(me, 0);
                     const flags = self.readU32(me, 4);
                     const is_static = (flags & 0x01) != 0;
+                    const is_abstract = (flags & 0x20) != 0;
+                    const is_declare = (flags & 0x40) != 0;
                     const kind = (flags >> 1) & 0x03; // 0=method, 1=get, 2=set
+
+                    // abstract/declare 메서드는 타입 전용 → 스트리핑 (본문 없음)
+                    if (is_abstract or is_declare) continue;
 
                     if (!is_static and isConstructorKey(self, key)) {
                         cm.constructor_idx = @enumFromInt(raw_idx);


### PR DESCRIPTION
## Summary
ES5 class 다운레벨링에서 abstract/declare 메서드의 `is_abstract`/`is_declare` 플래그를 체크하지 않아 본문 없는 `Foo.prototype.method = function();`이 생성됨.

Hermes에서 `'{' expected in function expression` 런타임 에러 발생.

## Fix
`classifyMembers()`에서 `abstract(0x20)`/`declare(0x40)` 플래그 체크 추가하여 스킵.

## Test plan
- [x] `zig build test` 전체 통과
- [x] react-native-gesture-handler `Gesture` abstract class가 정상 ES5 변환 확인
- [x] ExampleApp dev 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)