### PR TITLE
fix(emitter): dev 모드 __esm에서 function 호이스팅 비활성화

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -104,9 +104,15 @@ pub fn emitEsmWrappedModule(
 
         switch (effective_tag) {
             .function_declaration => {
-                // rolldown 방식: function은 __esm 밖으로 호이스팅.
-                // live binding으로 canonical 변수를 직접 참조하므로 TDZ 없음.
-                try hoisted_stmts.append(allocator, raw_idx);
+                // dev 모드: function을 init 안에 유지. import binding이 rename된 경우
+                // var로 호이스팅되지만 할당은 init 안에서 발생하므로,
+                // 호이스팅된 function이 init 전에 참조하면 undefined.
+                // prod: rolldown 방식 — function은 __esm 밖으로 호이스팅.
+                if (options.dev_mode) {
+                    try body_stmts.append(allocator, raw_idx);
+                } else {
+                    try hoisted_stmts.append(allocator, raw_idx);
+                }
             },
             .class_declaration => {
                 // class는 block-scoped → var 호이스팅 + init 안에서 할당문으로 변환.


### PR DESCRIPTION
## Summary
dev 모드에서 import binding이 rename되면 `var useState$16;`로 호이스팅되지만
할당은 `__esm` init 안에서 발생. function 선언이 init 밖으로 호이스팅되면
참조하는 import binding이 아직 undefined인 상태에서 실행됨.

reanimated `useSharedValue` → `useState$16 is not a function` 에러.

## Fix
dev 모드에서만 function을 init 안에 유지, prod는 기존 rolldown 방식 호이스팅 유지.

## Test plan
- [x] `zig build test` 전체 통과
- [x] dev 번들에서 `function useSharedValue()`가 `__esm` init 안에 위치 확인
- [x] `useState$16` 할당 이후에 함수 정의 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)