### PR TITLE
fix(emitter): dev 모드 ESM import binding을 namespace 접근 패턴으로 변경

### DIFF
--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -1527,6 +1527,46 @@ test "Bundler: dev mode named imports from multiple modules are not mixed" {
     try std.testing.expect(std.mem.indexOf(u8, output, "console.log") != null);
 }
 
+test "Bundler: dev mode ESM→CJS named import uses namespace access pattern" {
+    // dev 모드에서 CJS 모듈의 named import → namespace 접근 패턴.
+    // 호이스팅된 함수에서 import binding을 안전하게 참조하기 위해
+    // 개별 구조분해 대신 __ns_N.prop 형태로 접근한다 (rolldown 방식).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "react.js", "module.exports = { useState: function(v) { return [v, function(){}]; }, useEffect: function(f) { f(); } };");
+    try writeFile(tmp.dir, "app.ts",
+        \\import { useState, useEffect } from './react';
+        \\export function App() {
+        \\  const [count, setCount] = useState(0);
+        \\  useEffect(() => { console.log(count); }, [count]);
+        \\  return count;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "app.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const output = result.output;
+
+    // namespace 변수가 호이스팅됨
+    try std.testing.expect(std.mem.indexOf(u8, output, "__ns_0") != null);
+    // namespace 접근 패턴: __ns_0.useState, __ns_0.useEffect
+    try std.testing.expect(std.mem.indexOf(u8, output, "__ns_0.useState") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "__ns_0.useEffect") != null);
+    // 구조분해 패턴 없음 (({useState:...} = ...) 형태가 아님)
+    try std.testing.expect(std.mem.indexOf(u8, output, "{useState") == null);
+}
+
 test "Profile: pipeline stage timing (dev only, not for CI)" {
     // 프로세스 시작 비용 없이 순수 파이프라인 단계별 시간 측정
     const alloc = std.testing.allocator;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1299,7 +1299,11 @@ pub fn collectImportBindingNames(
                 if (!local_idx.isNone()) {
                     const local_node = esm_ast.nodes.items[@intFromEnum(local_idx)];
                     const name = esm_ast.getText(local_node.data.string_ref);
-                    try out.append(allocator, resolveNodeName(md, @intFromEnum(local_idx), name));
+                    const resolved = resolveNodeName(md, @intFromEnum(local_idx), name);
+                    // namespace 접근 패턴 rename (__ns_N.prop)은 var 선언에 넣을 수 없음.
+                    // namespace 변수는 dev_ns_vars로 별도 호이스팅됨.
+                    if (std.mem.indexOfScalar(u8, resolved, '.') != null) continue;
+                    try out.append(allocator, resolved);
                 }
             },
             else => {},

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -190,6 +190,16 @@ pub fn emitEsmWrappedModule(
         }
     }
 
+    // dev 모드 namespace 변수 호이스팅: named import를 namespace 접근 패턴으로
+    // 전환할 때 __ns_N 변수를 __esm 바깥에 선언해야 호이스팅된 함수에서 접근 가능.
+    if (metadata) |md| {
+        if (md.dev_ns_vars) |ns_vars| {
+            for (ns_vars) |ns_var| {
+                try hoisted_var_names.append(allocator, ns_var);
+            }
+        }
+    }
+
     // codegen 공통 옵션
     const cg_linking = if (metadata) |m| @as(?*const LinkingMetadata, m) else null;
 

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -59,6 +59,10 @@ pub const LinkingMetadata = struct {
     const_values: std.AutoHashMapUnmanaged(u32, @import("../semantic/symbol.zig").ConstValue) = .{},
     /// nested mangling에서 소유권을 이전받은 문자열. deinit에서 해제.
     owned_rename_values: std.ArrayListUnmanaged([]const u8) = .empty,
+    /// dev 모드 namespace import 변수명. esm_wrap에서 __esm 바깥으로 호이스팅.
+    /// named import를 namespace 접근 패턴으로 전환할 때 사용.
+    /// e.g., ["__ns_0", "__ns_1"] → 호이스팅: var __ns_0, __ns_1;
+    dev_ns_vars: ?[]const []const u8 = null,
     allocator: std.mem.Allocator,
 
     pub const NsMemberRewrites = struct {
@@ -134,6 +138,11 @@ pub const LinkingMetadata = struct {
             self.allocator.free(self.ns_inline_objects.entries);
         }
         self.export_getter_overrides.deinit(self.allocator);
+        // dev_ns_vars 해제
+        if (self.dev_ns_vars) |vars| {
+            for (vars) |v| self.allocator.free(v);
+            self.allocator.free(vars);
+        }
     }
 };
 
@@ -1676,6 +1685,20 @@ pub const PreambleWriter = struct {
         try self.write(" } = __zts_require(\"");
         try self.write(path);
         try self.write("\");\n");
+    }
+
+    /// dev 모드 namespace 할당 (assign-only, var 없음).
+    /// __esm init 안에서: __ns_0 = __zts_require("path");
+    /// CJS 타겟이면: __ns_0 = __toESM(__zts_require("path"));
+    pub fn writeDevRequireNamespace(self: *PreambleWriter, ns_var: []const u8, path: []const u8, to_esm: bool) !void {
+        try self.write(ns_var);
+        try self.write(" = ");
+        if (to_esm) try self.write("__toESM(");
+        try self.write("__zts_require(\"");
+        try self.write(path);
+        try self.write("\")");
+        if (to_esm) try self.write(")");
+        try self.write(";\n");
     }
 
     pub fn writeNamespaceObject(self: *PreambleWriter, var_name: []const u8, object_literal: []const u8) !void {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -22,6 +22,10 @@ const Span = @import("../lexer/token.zig").Span;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Ast = @import("../parser/ast.zig").Ast;
 
+/// namespace 접근 패턴에서 생성되는 변수 prefix.
+/// metadata.zig, codegen.zig, emitter.zig에서 공유.
+pub const NS_VAR_PREFIX = "__ns_";
+
 /// 크로스 모듈 심볼 참조. 어떤 모듈의 어떤 export를 가리키는지.
 /// codegen에 전달하는 per-module 메타데이터.
 /// AST를 수정하지 않고 codegen이 출력 시 참조.
@@ -1647,12 +1651,13 @@ pub const PreambleWriter = struct {
     }
 
     pub fn writeDevRequire(self: *PreambleWriter, local_name: []const u8, path: []const u8, suffix: ?[]const u8) !void {
-        return self.writeDevRequireInterop(local_name, path, suffix, false);
+        return self.writeDevRequireInterop(local_name, path, suffix, false, false);
     }
 
-    /// CJS interop 포함: var x = __toESM(__zts_require("path")).default;
-    pub fn writeDevRequireInterop(self: *PreambleWriter, local_name: []const u8, path: []const u8, suffix: ?[]const u8, to_esm: bool) !void {
-        try self.write("var ");
+    /// CJS interop 포함: [var ]x = [__toESM(]__zts_require("path")[)][.default];
+    /// assign_only=true 일 때 var 키워드 생략 (namespace 패턴에서 호이스팅된 변수에 할당만).
+    pub fn writeDevRequireInterop(self: *PreambleWriter, local_name: []const u8, path: []const u8, suffix: ?[]const u8, to_esm: bool, assign_only: bool) !void {
+        if (!assign_only) try self.write("var ");
         try self.write(local_name);
         try self.write(" = ");
         if (to_esm) try self.write("__toESM(");
@@ -1685,20 +1690,6 @@ pub const PreambleWriter = struct {
         try self.write(" } = __zts_require(\"");
         try self.write(path);
         try self.write("\");\n");
-    }
-
-    /// dev 모드 namespace 할당 (assign-only, var 없음).
-    /// __esm init 안에서: __ns_0 = __zts_require("path");
-    /// CJS 타겟이면: __ns_0 = __toESM(__zts_require("path"));
-    pub fn writeDevRequireNamespace(self: *PreambleWriter, ns_var: []const u8, path: []const u8, to_esm: bool) !void {
-        try self.write(ns_var);
-        try self.write(" = ");
-        if (to_esm) try self.write("__toESM(");
-        try self.write("__zts_require(\"");
-        try self.write(path);
-        try self.write("\")");
-        if (to_esm) try self.write(")");
-        try self.write(";\n");
     }
 
     pub fn writeNamespaceObject(self: *PreambleWriter, var_name: []const u8, object_literal: []const u8) !void {

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -23,6 +23,7 @@ const getOrCreateRequireVar = linker_mod.getOrCreateRequireVar;
 const isNamespaceUsedAsValue = Linker.isNamespaceUsedAsValue;
 const isReservedName = Linker.isReservedName;
 const NamePair = PreambleWriter.NamePair;
+const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
 
 pub fn buildSkipNodes(allocator: std.mem.Allocator, ast: *const Ast, skip_imports: bool) !std.DynamicBitSet {
     const node_count = ast.nodes.items.len;
@@ -231,20 +232,13 @@ pub fn buildMetadataForAst(
 
                     // CJS 모듈별 namespace var 생성 (한 번만)
                     const ns_var = if (cjs_ns_cache.get(@intCast(canonical_mod))) |cached| cached else blk: {
-                        const ns_name = try std.fmt.allocPrint(self.allocator, "__ns_{d}", .{cjs_ns_cache.count()});
+                        const ns_name = try std.fmt.allocPrint(self.allocator, NS_VAR_PREFIX ++ "{d}", .{cjs_ns_cache.count()});
                         try cjs_ns_cache.put(@intCast(canonical_mod), ns_name);
                         try ns_var_list.append(self.allocator, ns_name);
-                        // preamble: ns_var = __toESM(require_xxx()) (assign-only)
-                        const toesm_suffix: []const u8 = if (interop_mode == .node) "(), 1)" else "())";
-                        try preamble.write(ns_name);
-                        try preamble.write(" = __toESM(");
-                        try preamble.write(req_var);
-                        try preamble.write(toesm_suffix);
-                        try preamble.write(";\n");
+                        try preamble.writeCjsImportInner(ns_name, "", req_var, true, interop_mode, true);
                         break :blk ns_name;
                     };
 
-                    // rename: symbol_id → "ns_var.imported_name"
                     if (module_scope.get(ib.local_name)) |sym_idx| {
                         const rename = try std.fmt.allocPrint(self.allocator, "{s}.{s}", .{ ns_var, ib.imported_name });
                         try owned_nested_renames.append(self.allocator, rename);
@@ -555,13 +549,11 @@ pub fn buildMetadataForAst(
     // 내부 require() 호출도 require_xxx()로 치환해야 함.
     const require_rewrites = try self.buildRequireRewrites(&m);
 
-    // ns_var_list → dev_ns_vars: 소유권 이전
+    // ns_var_list → dev_ns_vars: backing slice 소유권 이전 (복사 없음)
     const dev_ns_vars: ?[]const []const u8 = if (ns_var_list.items.len > 0)
-        try self.allocator.dupe([]const u8, ns_var_list.items)
+        try ns_var_list.toOwnedSlice(self.allocator)
     else
         null;
-    // dupe 후 list는 해제하되 개별 문자열은 유지 (dev_ns_vars가 소유)
-    ns_var_list.deinit(self.allocator);
 
     return .{
         .skip_nodes = skip_nodes,
@@ -885,7 +877,7 @@ pub fn buildDevMetadataForAst(
         var vi: u32 = 0;
         for (record_infos[0..m.import_records.len], 0..) |info_r, ri| {
             if (info_r.named_count > 0) {
-                vars[vi] = try std.fmt.allocPrint(self.allocator, "__ns_{d}", .{vi});
+                vars[vi] = try std.fmt.allocPrint(self.allocator, NS_VAR_PREFIX ++ "{d}", .{vi});
                 ns_var_for_record[ri] = vars[vi];
                 vi += 1;
             }
@@ -936,19 +928,15 @@ pub fn buildDevMetadataForAst(
         const is_cjs_target = resolved_mod < self.modules.len and self.modules[resolved_mod].wrap_kind == .cjs;
 
         if (info.namespace_local) |ns_local| {
-            // CJS: var ns = __toESM(__zts_require("path"));
-            // ESM: var ns = __zts_require("path");
-            try dev_preamble.writeDevRequireInterop(ns_local, resolved_path, null, is_cjs_target);
+            try dev_preamble.writeDevRequireInterop(ns_local, resolved_path, null, is_cjs_target, false);
         }
         if (info.default_local) |def_local| {
-            // CJS: var def = __toESM(__zts_require("path")).default;
-            // ESM: var def = __zts_require("path").default;
-            try dev_preamble.writeDevRequireInterop(def_local, resolved_path, ".default", is_cjs_target);
+            try dev_preamble.writeDevRequireInterop(def_local, resolved_path, ".default", is_cjs_target, false);
         }
         if (info.named_count > 0) {
-            // namespace 접근 패턴: __ns_N = [__toESM(]__zts_require("path")[)];
+            // namespace 접근 패턴: assign-only (var는 esm_wrap에서 호이스팅)
             if (ns_var_for_record[i]) |ns_var| {
-                try dev_preamble.writeDevRequireNamespace(ns_var, resolved_path, is_cjs_target);
+                try dev_preamble.writeDevRequireInterop(ns_var, resolved_path, null, is_cjs_target, true);
             }
         }
     }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -151,6 +151,17 @@ pub fn buildMetadataForAst(
         cjs_var_cache.deinit();
     }
 
+    // CJS 모듈별 namespace 변수명 캐시 (ESM-wrapped → CJS named import의 namespace 접근 패턴)
+    var cjs_ns_cache = std.AutoHashMap(u32, []const u8).init(self.allocator);
+    defer cjs_ns_cache.deinit(); // 값은 ns_var_list가 소유
+    var ns_var_list: std.ArrayListUnmanaged([]const u8) = .empty;
+    // ns_var_list 소유권은 metadata.dev_ns_vars로 이전됨 (정상 경로)
+    // 에러 시에만 여기서 해제
+    errdefer {
+        for (ns_var_list.items) |v| self.allocator.free(v);
+        ns_var_list.deinit(self.allocator);
+    }
+
     // namespace import export 수집 캐시: target_mod_idx → []NsExportPair
     // 같은 타겟을 여러 모듈이 namespace import할 때 collectExportsRecursive 반복 순회 방지.
     var ns_export_cache = std.AutoHashMap(u32, []NsExportPair).init(self.allocator);
@@ -205,10 +216,41 @@ pub fn buildMetadataForAst(
             // 할당문 + init 호출을 처리하므로 preamble 생성 skip.
             // __esm → __esm은 live binding (preamble init + canonical rename) 사용.
             // 단, synthetic binding(JSX runtime 등)은 AST body에 require()가 없으므로 skip하지 않음.
+            //
+            // named import from CJS in ESM-wrapped → namespace 접근 패턴:
+            // 호이스팅된 함수에서 import binding을 안전하게 참조하기 위해
+            // 개별 구조분해 대신 namespace 객체 프로퍼티 접근을 사용한다 (rolldown 방식).
+            // preamble에서 ns_var = __toESM(require_xxx()) 생성 + rename 등록.
             const is_synthetic = ib.local_span.start >= 0xFFFF_0000;
             if (!is_synthetic and m.wrap_kind == .esm and canonical_mod < self.modules.len and
                 (self.modules[canonical_mod].wrap_kind == .cjs or canonical_mod == module_index))
             {
+                if (ib.kind == .named and self.modules[canonical_mod].wrap_kind == .cjs) {
+                    const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
+                    const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
+
+                    // CJS 모듈별 namespace var 생성 (한 번만)
+                    const ns_var = if (cjs_ns_cache.get(@intCast(canonical_mod))) |cached| cached else blk: {
+                        const ns_name = try std.fmt.allocPrint(self.allocator, "__ns_{d}", .{cjs_ns_cache.count()});
+                        try cjs_ns_cache.put(@intCast(canonical_mod), ns_name);
+                        try ns_var_list.append(self.allocator, ns_name);
+                        // preamble: ns_var = __toESM(require_xxx()) (assign-only)
+                        const toesm_suffix: []const u8 = if (interop_mode == .node) "(), 1)" else "())";
+                        try preamble.write(ns_name);
+                        try preamble.write(" = __toESM(");
+                        try preamble.write(req_var);
+                        try preamble.write(toesm_suffix);
+                        try preamble.write(";\n");
+                        break :blk ns_name;
+                    };
+
+                    // rename: symbol_id → "ns_var.imported_name"
+                    if (module_scope.get(ib.local_name)) |sym_idx| {
+                        const rename = try std.fmt.allocPrint(self.allocator, "{s}.{s}", .{ ns_var, ib.imported_name });
+                        try owned_nested_renames.append(self.allocator, rename);
+                        try renames.put(@intCast(sym_idx), rename);
+                    }
+                }
                 continue;
             }
 
@@ -513,6 +555,14 @@ pub fn buildMetadataForAst(
     // 내부 require() 호출도 require_xxx()로 치환해야 함.
     const require_rewrites = try self.buildRequireRewrites(&m);
 
+    // ns_var_list → dev_ns_vars: 소유권 이전
+    const dev_ns_vars: ?[]const []const u8 = if (ns_var_list.items.len > 0)
+        try self.allocator.dupe([]const u8, ns_var_list.items)
+    else
+        null;
+    // dupe 후 list는 해제하되 개별 문자열은 유지 (dev_ns_vars가 소유)
+    ns_var_list.deinit(self.allocator);
+
     return .{
         .skip_nodes = skip_nodes,
         .renames = renames,
@@ -526,6 +576,7 @@ pub fn buildMetadataForAst(
         .const_values = const_values,
         .export_getter_overrides = export_getter_overrides,
         .owned_rename_values = owned_nested_renames,
+        .dev_ns_vars = dev_ns_vars,
         .allocator = self.allocator,
     };
 }
@@ -703,11 +754,30 @@ pub fn finalizeNamespaceData(
     };
 }
 
+/// import binding의 local_span으로 symbol_id를 탐색한다.
+/// 파서에서 import specifier의 로컬 이름은 identifier_reference 또는 binding_identifier로 생성되므로
+/// 두 태그 모두 매칭한다.
+fn findSymbolIdBySpan(symbol_ids: []const ?u32, ast: *const Ast, span: Span) ?u32 {
+    const node_count = ast.nodes.items.len;
+    for (symbol_ids, 0..) |maybe_sid, node_i| {
+        if (maybe_sid) |sid| {
+            if (node_i >= node_count) continue;
+            const node = ast.nodes.items[node_i];
+            if ((node.tag == .binding_identifier or node.tag == .identifier_reference) and
+                node.span.start == span.start and node.span.end == span.end)
+            {
+                return sid;
+            }
+        }
+    }
+    return null;
+}
+
 /// Dev mode용 LinkingMetadata를 생성한다.
 ///
 /// 프로덕션 buildMetadataForAst와의 차이:
-///   - renames 없음 (스코프 호이스팅 안 함, 각 모듈이 자체 스코프 유지)
-///   - cjs_import_preamble: `const { x } = __zts_require("./path")` 형태
+///   - renames: named import에 한해 namespace 접근 패턴 renames 생성
+///   - cjs_import_preamble: `__ns_N = __zts_require("./path")` 형태 (namespace 할당)
 ///   - final_exports: 모든 모듈에 `exports.x = x;` 형태 (entry만이 아닌 전체)
 pub fn buildDevMetadataForAst(
     self: *const Linker,
@@ -790,6 +860,67 @@ pub fn buildDevMetadataForAst(
         info.named_count += 1;
     }
 
+    // namespace 접근 패턴: named import → namespace 변수 프로퍼티 접근.
+    // 호이스팅된 함수에서 import binding을 안전하게 참조하기 위해
+    // 개별 구조분해 대신 namespace 객체를 사용한다 (rolldown 방식).
+    //
+    // Before: var { useState } = __zts_require("react");  (inside __esm, function-scoped)
+    // After:  __ns_0 = __zts_require("react");             (inside __esm, assign-only)
+    //         var __ns_0;                                   (hoisted outside __esm)
+    //         → codegen: useState → __ns_0.useState
+
+    // record별 namespace 변수명 생성
+    var ns_record_count: u32 = 0;
+    for (record_infos[0..m.import_records.len]) |info_r| {
+        if (info_r.named_count > 0) ns_record_count += 1;
+    }
+
+    var dev_ns_vars: ?[][]const u8 = null;
+    const ns_var_for_record = try self.allocator.alloc(?[]const u8, m.import_records.len);
+    defer self.allocator.free(ns_var_for_record);
+    @memset(ns_var_for_record, null);
+
+    if (ns_record_count > 0) {
+        const vars = try self.allocator.alloc([]const u8, ns_record_count);
+        var vi: u32 = 0;
+        for (record_infos[0..m.import_records.len], 0..) |info_r, ri| {
+            if (info_r.named_count > 0) {
+                vars[vi] = try std.fmt.allocPrint(self.allocator, "__ns_{d}", .{vi});
+                ns_var_for_record[ri] = vars[vi];
+                vi += 1;
+            }
+        }
+        dev_ns_vars = vars;
+    }
+    errdefer if (dev_ns_vars) |vars| {
+        for (vars) |v| self.allocator.free(v);
+        self.allocator.free(vars);
+    };
+
+    // named binding의 symbol_id → "ns_var.imported_name" renames 등록
+    var renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
+    errdefer renames.deinit();
+    var owned_rename_values: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer {
+        for (owned_rename_values.items) |v| self.allocator.free(v);
+        owned_rename_values.deinit(self.allocator);
+    }
+
+    if (ns_record_count > 0) {
+        if (m.semantic) |sem| {
+            for (m.import_bindings) |ib| {
+                if (ib.kind != .named) continue;
+                if (ib.import_record_index >= m.import_records.len) continue;
+                const ns_var = ns_var_for_record[ib.import_record_index] orelse continue;
+                // binding_identifier의 span으로 symbol_id 탐색
+                const sym_id = findSymbolIdBySpan(sem.symbol_ids, ast, ib.local_span) orelse continue;
+                const rename = try std.fmt.allocPrint(self.allocator, "{s}.{s}", .{ ns_var, ib.imported_name });
+                try owned_rename_values.append(self.allocator, rename);
+                try renames.put(sym_id, rename);
+            }
+        }
+    }
+
     for (m.import_records, 0..) |rec, i| {
         if (rec.resolved.isNone()) continue;
         if (rec.kind == .dynamic_import) continue;
@@ -815,8 +946,10 @@ pub fn buildDevMetadataForAst(
             try dev_preamble.writeDevRequireInterop(def_local, resolved_path, ".default", is_cjs_target);
         }
         if (info.named_count > 0) {
-            const start = info.named_start;
-            try dev_preamble.writeDevRequireNamed(named_bindings[start .. start + info.named_count], resolved_path);
+            // namespace 접근 패턴: __ns_N = [__toESM(]__zts_require("path")[)];
+            if (ns_var_for_record[i]) |ns_var| {
+                try dev_preamble.writeDevRequireNamespace(ns_var, resolved_path, is_cjs_target);
+            }
         }
     }
 
@@ -868,19 +1001,23 @@ pub fn buildDevMetadataForAst(
 
     const sem = m.semantic orelse return .{
         .skip_nodes = skip_nodes,
-        .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
+        .renames = renames,
         .final_exports = final_exports,
         .symbol_ids = &.{},
         .cjs_import_preamble = cjs_import_preamble,
+        .dev_ns_vars = dev_ns_vars,
+        .owned_rename_values = owned_rename_values,
         .allocator = self.allocator,
     };
 
     return .{
         .skip_nodes = skip_nodes,
-        .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
+        .renames = renames,
         .final_exports = final_exports,
         .symbol_ids = sem.symbol_ids,
         .cjs_import_preamble = cjs_import_preamble,
+        .dev_ns_vars = dev_ns_vars,
+        .owned_rename_values = owned_rename_values,
         .allocator = self.allocator,
     };
 }

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1181,8 +1181,10 @@ test "preamble: unresolved import generates require()" {
     try std.testing.expect(std.mem.indexOf(u8, preamble, ".readFile") != null);
 }
 
-test "preamble: dev mode — __zts_require named destructuring" {
-    // dev mode에서 named import는 var { a } = __zts_require("./path") 형태
+test "preamble: dev mode — named import uses namespace access pattern" {
+    // dev mode에서 named import는 namespace 접근 패턴: __ns_0 = __zts_require("./path")
+    // 호이스팅된 함수에서 import binding을 안전하게 참조하기 위해
+    // 구조분해 대신 namespace 객체 프로퍼티 접근을 사용한다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "import { add } from './math';\nconsole.log(add(1,2));");
@@ -1199,10 +1201,25 @@ test "preamble: dev mode — __zts_require named destructuring" {
 
     try std.testing.expect(md.cjs_import_preamble != null);
     const preamble = md.cjs_import_preamble.?;
-    // __zts_require 호출 포함
+    // namespace 할당: __ns_0 = __zts_require("./path")
+    try std.testing.expect(std.mem.indexOf(u8, preamble, "__ns_0") != null);
     try std.testing.expect(std.mem.indexOf(u8, preamble, "__zts_require(") != null);
-    // named destructuring: { add }
-    try std.testing.expect(std.mem.indexOf(u8, preamble, "add") != null);
+    // 구조분해 패턴 없음 (var { add } 형태가 아님)
+    try std.testing.expect(std.mem.indexOf(u8, preamble, "{ ") == null);
+    // dev_ns_vars가 호이스팅용으로 설정됨
+    try std.testing.expect(md.dev_ns_vars != null);
+    try std.testing.expectEqual(@as(usize, 1), md.dev_ns_vars.?.len);
+    try std.testing.expectEqualStrings("__ns_0", md.dev_ns_vars.?[0]);
+    // renames에 add → __ns_0.add 매핑 등록 확인
+    var rename_found = false;
+    var it = md.renames.iterator();
+    while (it.next()) |entry| {
+        if (std.mem.eql(u8, entry.value_ptr.*, "__ns_0.add")) {
+            rename_found = true;
+            break;
+        }
+    }
+    try std.testing.expect(rename_found);
 }
 
 test "preamble: dev mode — default import uses .default" {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2253,6 +2253,37 @@ pub const Codegen = struct {
             }
         }
 
+        // namespace 접근 패턴: named import만 있고, 모든 named binding이
+        // __ns_N.prop 형태의 rename을 가지면 이 import 선언을 skip한다.
+        // preamble에서 이미 ns_var = __toESM(require_xxx())가 생성되었으므로
+        // body의 destructuring assignment는 불필요.
+        if (named_count > 0 and !has_default and !has_namespace and self.options.linking_metadata != null) {
+            const meta = self.options.linking_metadata.?;
+            var all_ns_renamed = true;
+            for (spec_indices) |raw_idx| {
+                const spec = self.ast.getNode(@enumFromInt(raw_idx));
+                if (spec.tag != .import_specifier) continue;
+                const local_idx = spec.data.binary.right;
+                if (!local_idx.isNone()) {
+                    if (self.resolveSymbolId(local_idx, meta)) |sid| {
+                        if (meta.renames.get(sid)) |rename| {
+                            if (!std.mem.startsWith(u8, rename, "__ns_")) {
+                                all_ns_renamed = false;
+                                break;
+                            }
+                        } else {
+                            all_ns_renamed = false;
+                            break;
+                        }
+                    } else {
+                        all_ns_renamed = false;
+                        break;
+                    }
+                }
+            }
+            if (all_ns_renamed) return;
+        }
+
         // __esm 호이스팅: var 선언이 래퍼 밖에 있으므로 body에서는 할당만.
         // named import ({a, b})는 destructuring assignment — var 생략 시 ({a,b}=expr) 괄호 필요.
         const skip_keyword = self.options.esm_var_assign_only;

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -47,7 +47,8 @@ pub const IndentChar = enum {
 
 /// 번들러 linker가 생성하는 per-module 메타데이터.
 /// codegen이 import 스킵 + 식별자 리네임에 사용.
-pub const LinkingMetadata = @import("../bundler/linker.zig").LinkingMetadata;
+const linker_mod = @import("../bundler/linker.zig");
+pub const LinkingMetadata = linker_mod.LinkingMetadata;
 
 pub const QuoteStyle = enum {
     double, // " (기본, esbuild/oxc/SWC 호환)
@@ -2267,7 +2268,7 @@ pub const Codegen = struct {
                 if (!local_idx.isNone()) {
                     if (self.resolveSymbolId(local_idx, meta)) |sid| {
                         if (meta.renames.get(sid)) |rename| {
-                            if (!std.mem.startsWith(u8, rename, "__ns_")) {
+                            if (!std.mem.startsWith(u8, rename, linker_mod.NS_VAR_PREFIX)) {
                                 all_ns_renamed = false;
                                 break;
                             }


### PR DESCRIPTION
## Summary
- ESM-wrapped 모듈에서 CJS named import를 개별 구조분해 대신 namespace 객체 프로퍼티 접근으로 변환 (rolldown 방식)
- 호이스팅된 함수에서 import binding을 안전하게 참조하기 위해 `__ns_N` 변수를 `__esm` 바깥에 호이스팅
- codegen에서 identifier reference를 `__ns_N.imported_name` 패턴으로 변환

## Changes
| 파일 | 변경 |
|------|------|
| `linker.zig` | `LinkingMetadata.dev_ns_vars` 필드 + `PreambleWriter.writeDevRequireNamespace` |
| `metadata.zig` | `buildMetadataForAst` CJS named import namespace 처리 + `buildDevMetadataForAst` 동일 패턴 + `findSymbolIdBySpan` |
| `esm_wrap.zig` | `dev_ns_vars` 호이스팅 |
| `emitter.zig` | `collectImportBindingNames` namespace rename 필터링 |
| `codegen.zig` | `emitImportCJS` namespace rename 감지 시 skip |

## Before / After
```javascript
// Before (구조분해 → 호이스팅된 함수에서 undefined 가능)
var useState$16;
function useSharedValue(v) { useState$16(v); }
var init = __esm({ "mod.ts"() { ({useState:useState$16} = require_react()); } });

// After (namespace 접근 → 런타임에 프로퍼티 해석)
var __ns_0;
function useSharedValue(v) { __ns_0.useState(v); }
var init = __esm({ "mod.ts"() { __ns_0 = __toESM(require_react()); } });
```

## Test plan
- [x] 유닛 테스트 2420개 통과
- [x] NAPI 테스트 239개 통과
- [ ] RN fixture 재생성 후 Hermes 구문 검증

Closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)