### PR TITLE
feat(server): HTTPS dev server 지원 (--certfile / --keyfile)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,8 @@ zts --bundle <entry.ts> --plugin zts.config.js     # JS 플러그인
 --host [addr]                    바인딩 주소 (기본: localhost, 생략 시 0.0.0.0)
 --open                           브라우저 자동 열기
 --proxy /api=http://host:port    API 프록시 (반복 가능)
+--certfile <path>                TLS 인증서 파일 (HTTPS dev server)
+--keyfile <path>                 TLS 개인키 파일 (HTTPS dev server)
 ```
 
 ### 자동 동작 (esbuild 호환)

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -18,6 +18,7 @@ const { init, transpile, build, buildSync } = coreModule;
 import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { resolve, dirname, basename, extname, join } from "node:path";
 import { createServer } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
 
 // ─── CLI 인자 파싱 ───
 
@@ -94,6 +95,8 @@ function parseArgs(argv) {
     target: undefined,
     emitDecoratorMetadata: false,
     drop: [],
+    certfile: undefined,
+    keyfile: undefined,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -339,6 +342,14 @@ function parseArgs(argv) {
     }
     if (arg === "--host") {
       opts.host = args[++i] || "0.0.0.0";
+      continue;
+    }
+    if (arg === "--certfile") {
+      opts.certfile = args[++i];
+      continue;
+    }
+    if (arg === "--keyfile") {
+      opts.keyfile = args[++i];
       continue;
     }
     if (arg === "-p" || arg === "--project") {
@@ -793,9 +804,11 @@ async function runServe(opts) {
     return { status: 200, body, type };
   }
 
+  const useTls = opts.certfile && opts.keyfile;
+
   if (isBun) {
     // Bun.serve
-    globalThis.Bun.serve({
+    const serveOpts = {
       port: opts.port,
       hostname: opts.host,
       fetch(req) {
@@ -816,12 +829,19 @@ async function runServe(opts) {
           },
         });
       },
-    });
+    };
+    if (useTls) {
+      serveOpts.tls = {
+        cert: globalThis.Bun.file(opts.certfile),
+        key: globalThis.Bun.file(opts.keyfile),
+      };
+    }
+    globalThis.Bun.serve(serveOpts);
   } else {
-    // Node.js http
-    const server = createServer(async (req, res) => {
+    // Node.js http/https
+    const handler = async (req, res) => {
       // 프록시 처리
-      const url = new URL(req.url, `http://${req.headers.host}`);
+      const url = new URL(req.url, `${useTls ? "https" : "http"}://${req.headers.host}`);
       for (const [prefix, target] of Object.entries(opts.proxy)) {
         if (url.pathname.startsWith(prefix)) {
           try {
@@ -846,12 +866,16 @@ async function runServe(opts) {
         "Access-Control-Allow-Origin": "*",
       });
       res.end(body);
-    });
+    };
+    const server = useTls
+      ? createHttpsServer({ cert: readFileSync(opts.certfile), key: readFileSync(opts.keyfile) }, handler)
+      : createServer(handler);
     server.listen(opts.port, opts.host);
   }
 
+  const protocol = useTls ? "https" : "http";
   if (opts.logLevel !== "silent") {
-    console.error(`[serve] http://${opts.host}:${opts.port}`);
+    console.error(`[serve] ${protocol}://${opts.host}:${opts.port}`);
   }
 
   // watch 시작 (번들 모드일 때)
@@ -882,7 +906,7 @@ async function runServe(opts) {
 
   // open browser
   if (opts.open) {
-    const url = `http://${opts.host === "0.0.0.0" ? "localhost" : opts.host}:${opts.port}`;
+    const url = `${protocol}://${opts.host === "0.0.0.0" ? "localhost" : opts.host}:${opts.port}`;
     const { exec } = await import("node:child_process");
     const cmd =
       process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -868,7 +868,10 @@ async function runServe(opts) {
       res.end(body);
     };
     const server = useTls
-      ? createHttpsServer({ cert: readFileSync(opts.certfile), key: readFileSync(opts.keyfile) }, handler)
+      ? createHttpsServer(
+          { cert: readFileSync(opts.certfile), key: readFileSync(opts.keyfile) },
+          handler,
+        )
       : createServer(handler);
     server.listen(opts.port, opts.host);
   }

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -6,9 +6,8 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, execSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, mkdirSync } from "node:fs";
-import { execSync } from "node:child_process";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -8,16 +8,19 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, mkdirSync } from "node:fs";
+import { execSync } from "node:child_process";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
 const CLI = resolve(import.meta.dir, "zts.mjs");
 const RUNTIME = "bun";
 
-async function waitForServer(port: number, maxRetries = 20, interval = 100) {
+async function waitForServer(port: number, maxRetries = 20, interval = 100, protocol = "http") {
   for (let i = 0; i < maxRetries; i++) {
     try {
-      await fetch(`http://localhost:${port}/`);
+      await fetch(`${protocol}://localhost:${port}/`, {
+        tls: { rejectUnauthorized: false },
+      } as any);
       return;
     } catch {
       await new Promise((r) => setTimeout(r, interval));
@@ -419,6 +422,117 @@ describe("CLI: serve", () => {
 
     try {
       const res = await fetch(`http://localhost:${port}/`);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    } finally {
+      proc.kill();
+    }
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("HTTPS 서빙 (--certfile / --keyfile)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-https-"));
+    writeFileSync(join(dir, "index.html"), "<h1>Secure</h1>");
+
+    // 자체 서명 인증서 생성
+    const certFile = join(dir, "cert.pem");
+    const keyFile = join(dir, "key.pem");
+    execSync(
+      `openssl req -x509 -newkey rsa:2048 -keyout ${keyFile} -out ${certFile} -days 1 -nodes -subj "/CN=localhost" 2>/dev/null`,
+    );
+
+    const port = 12600 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [
+      CLI,
+      "--serve",
+      dir,
+      `--port=${port}`,
+      "--certfile",
+      certFile,
+      "--keyfile",
+      keyFile,
+    ]);
+
+    await waitForServer(port, 20, 100, "https");
+
+    try {
+      const res = await fetch(`https://localhost:${port}/`, {
+        tls: { rejectUnauthorized: false },
+      } as any);
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain("<h1>Secure</h1>");
+    } finally {
+      proc.kill();
+    }
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("HTTPS 없는 파일 → 404", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-https-404-"));
+    writeFileSync(join(dir, "index.html"), "<h1>OK</h1>");
+
+    const certFile = join(dir, "cert.pem");
+    const keyFile = join(dir, "key.pem");
+    execSync(
+      `openssl req -x509 -newkey rsa:2048 -keyout ${keyFile} -out ${certFile} -days 1 -nodes -subj "/CN=localhost" 2>/dev/null`,
+    );
+
+    const port = 12700 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [
+      CLI,
+      "--serve",
+      dir,
+      `--port=${port}`,
+      "--certfile",
+      certFile,
+      "--keyfile",
+      keyFile,
+    ]);
+
+    await waitForServer(port, 20, 100, "https");
+
+    try {
+      const res = await fetch(`https://localhost:${port}/nonexistent`, {
+        tls: { rejectUnauthorized: false },
+      } as any);
+      expect(res.status).toBe(404);
+    } finally {
+      proc.kill();
+    }
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("HTTPS CORS 헤더 포함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-https-cors-"));
+    writeFileSync(join(dir, "index.html"), "<h1>CORS</h1>");
+
+    const certFile = join(dir, "cert.pem");
+    const keyFile = join(dir, "key.pem");
+    execSync(
+      `openssl req -x509 -newkey rsa:2048 -keyout ${keyFile} -out ${certFile} -days 1 -nodes -subj "/CN=localhost" 2>/dev/null`,
+    );
+
+    const port = 12800 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [
+      CLI,
+      "--serve",
+      dir,
+      `--port=${port}`,
+      "--certfile",
+      certFile,
+      "--keyfile",
+      keyFile,
+    ]);
+
+    await waitForServer(port, 20, 100, "https");
+
+    try {
+      const res = await fetch(`https://localhost:${port}/`, {
+        tls: { rejectUnauthorized: false },
+      } as any);
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
     } finally {
       proc.kill();


### PR DESCRIPTION
## Summary
- Node.js/Bun CLI에서 `--certfile`과 `--keyfile` 옵션으로 HTTPS dev server 지원
- Zig 바이너리 크기 영향 없음 — JS 런타임의 TLS 지원 활용

## 사용법
```bash
zts --serve --bundle entry.ts --certfile cert.pem --keyfile key.pem
```

## Test plan
- [x] Node.js HTTPS 서버 동작 확인 (curl -sk https://localhost)
- [x] Bun HTTPS 서버 동작 확인
- [x] HTTP 기존 동작 유지 확인
- [x] CLI 테스트 44개 통과

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)