### PR TITLE
fix(emitter): UMD/AMD 포맷 external 의존성 올바르게 처리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ zts --bundle <entry.ts> --plugin zts.config.js     # JS 플러그인
 
 ### 공통 옵션
 ```
---format=esm|cjs|iife            모듈 포맷 (기본: esm, --platform=browser 시 iife)
+--format=esm|cjs|iife|umd|amd    모듈 포맷 (기본: esm, --platform=browser 시 iife)
 --platform=browser|node|neutral|react-native  타겟 플랫폼 (기본: browser)
 --minify                         출력 압축
 --sourcemap                      소스맵 생성 (.js.map)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -155,7 +155,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
   ES 버전 타겟(`--target=es2015~esnext`)도 동일한 UnsupportedFeatures bitmask로 통합.
 
 - ~~**jsx-dev**~~ — ✅ 완료. `--jsx=automatic-dev` / `--jsx-dev` React 개발 모드 `jsxDEV` + `__source`/`__self`
-- **UMD/AMD 포맷** — `M` | `--format=umd` / `--format=amd` 출력 (라이브러리 빌드)
+- ~~**UMD/AMD 포맷**~~ — ✅ 완료. `--format=umd` / `--format=amd` + external dependency array + factory params
 - **manualChunks** — `L` | 사용자 정의 청크 분할 규칙 (rolldown advancedChunks)
 - ~~**preserveModules**~~ — ✅ 완료. `--preserve-modules` + `--preserve-modules-root` (Rollup/Rolldown 호환)
 - ~~**using 다운레벨링**~~ — ✅ 완료. `using`/`await using` → try-finally + `__using`/`__callDispose` (esbuild 호환)

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -488,6 +488,81 @@ describe("CLI: UMD/AMD format", () => {
 
     rmSync(mockDir, { recursive: true, force: true });
   });
+
+  test("UMD: 실제 React로 CJS 실행 E2E", () => {
+    const umdDir = mkdtempSync(join(tmpdir(), "zts-umd-react-"));
+    writeFileSync(
+      join(umdDir, "pure.tsx"),
+      [
+        'import React, { createElement } from "react";',
+        "export function Greeting(props: { name: string }) {",
+        '  return createElement("h1", null, "Hello " + props.name);',
+        "}",
+        "export const version = React.version;",
+      ].join("\n"),
+    );
+
+    const outFile = join(umdDir, "bundle.js");
+    const { exitCode } = runCli([
+      "--bundle",
+      join(umdDir, "pure.tsx"),
+      "--format=umd",
+      "--external",
+      "react",
+      "--global-name=MyLib",
+      "-o",
+      outFile,
+    ]);
+    expect(exitCode).toBe(0);
+
+    // Node.js에서 UMD 번들을 require → 실제 React 모듈이 factory로 주입됨
+    const projectRoot = resolve(import.meta.dir, "../../..");
+    const run = spawnSync(
+      "node",
+      [
+        "-e",
+        `const m = require("${outFile}"); console.log(m.version); const el = m.Greeting({ name: "ZTS" }); console.log(el.type + ":" + el.props.children);`,
+      ],
+      {
+        cwd: projectRoot,
+        env: { ...process.env, NODE_PATH: join(projectRoot, "node_modules") },
+      },
+    );
+    const lines = (run.stdout?.toString().trim() ?? "").split("\n");
+    // React.version이 존재 (실제 react 패키지에서 읽힌 값)
+    expect(lines[0]).toMatch(/^\d+\.\d+\.\d+$/);
+    // createElement 결과: h1:Hello ZTS
+    expect(lines[1]).toBe("h1:Hello ZTS");
+
+    rmSync(umdDir, { recursive: true, force: true });
+  });
+
+  test("AMD: 실제 React로 출력 구조 검증", () => {
+    const amdDir = mkdtempSync(join(tmpdir(), "zts-amd-react-"));
+    writeFileSync(
+      join(amdDir, "lib.tsx"),
+      'import React from "react";\nexport const ver = React.version;\nexport const el = React.createElement("span", null, "hi");',
+    );
+
+    const { stdout, exitCode } = runCli([
+      "--bundle",
+      join(amdDir, "lib.tsx"),
+      "--format=amd",
+      "--external",
+      "react",
+    ]);
+    expect(exitCode).toBe(0);
+    // AMD wrapper 구조
+    expect(stdout).toContain('define(["react"]');
+    expect(stdout).toContain("function(React)");
+    // body에서 React 직접 참조 (require 아님)
+    expect(stdout).toContain("React.version");
+    expect(stdout).toContain("React.createElement");
+    // bare require("react") 없음
+    expect(stdout).not.toContain('require("react")');
+
+    rmSync(amdDir, { recursive: true, force: true });
+  });
 });
 
 // ─── Bundle + Plugin ───

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -402,6 +402,94 @@ describe("CLI: import.meta.glob", () => {
   });
 });
 
+// ─── UMD/AMD 포맷 ───
+
+describe("CLI: UMD/AMD format", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-cli-umd-"));
+    writeFileSync(
+      join(dir, "app.ts"),
+      'import { useState } from "react";\nexport function App() { return useState(0); }',
+    );
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("UMD: external dependency array + factory params", () => {
+    const { stdout, exitCode } = runCli([
+      "--bundle",
+      join(dir, "app.ts"),
+      "--format=umd",
+      "--external",
+      "react",
+      "--global-name=MyApp",
+    ]);
+    expect(exitCode).toBe(0);
+    // dependency array에 "react" 포함
+    expect(stdout).toContain('define(["react"]');
+    // factory 매개변수
+    expect(stdout).toContain("function(React)");
+    // CJS require 경로
+    expect(stdout).toContain('require("react")');
+    // IIFE 글로벌
+    expect(stdout).toContain("root.React");
+    // body에 named import → factory param 프로퍼티 접근
+    expect(stdout).toContain("React.useState");
+    // body에 bare require("react") 없음
+    expect(stdout).not.toContain('var React = require("react")');
+  });
+
+  test("AMD: external dependency array + factory params", () => {
+    const { stdout, exitCode } = runCli([
+      "--bundle",
+      join(dir, "app.ts"),
+      "--format=amd",
+      "--external",
+      "react",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('define(["react"]');
+    expect(stdout).toContain("function(React)");
+    expect(stdout).toContain("React.useState");
+  });
+
+  test("UMD: Node.js에서 실행 가능", () => {
+    // react mock + UMD 번들을 Node.js에서 실행
+    const mockDir = mkdtempSync(join(tmpdir(), "zts-umd-e2e-"));
+    writeFileSync(
+      join(mockDir, "app.ts"),
+      'import { greet } from "mylib";\nexport const msg = greet("world");',
+    );
+    mkdirSync(join(mockDir, "node_modules", "mylib"), { recursive: true });
+    writeFileSync(
+      join(mockDir, "node_modules", "mylib", "index.js"),
+      'exports.greet = function(n) { return "Hello " + n; };',
+    );
+
+    const outFile = join(mockDir, "bundle.js");
+    const { exitCode } = runCli([
+      "--bundle",
+      join(mockDir, "app.ts"),
+      "--format=umd",
+      "--external",
+      "mylib",
+      "-o",
+      outFile,
+    ]);
+    expect(exitCode).toBe(0);
+
+    // Node.js에서 UMD 번들 require → CJS 경로로 실행
+    const run = spawnSync("node", ["-e", `const m = require("${outFile}"); console.log(m.msg);`], {
+      cwd: mockDir,
+    });
+    expect(run.stdout?.toString().trim()).toBe("Hello world");
+
+    rmSync(mockDir, { recursive: true, force: true });
+  });
+});
+
 // ─── Bundle + Plugin ───
 
 describe("CLI: bundle + plugin", () => {

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -3214,8 +3214,8 @@ describe("엣지 케이스 + 조합 보강", () => {
       nodePaths: [projectNodeModules],
     });
     expect(result.errors.length).toBe(0);
-    expect(result.outputFiles[0].text).toContain("define([]");
-    expect(result.outputFiles[0].text).toContain("require");
+    expect(result.outputFiles[0].text).toContain('define(["react"]');
+    expect(result.outputFiles[0].text).toContain("function(React)");
   });
 
   // --- minifyIdentifiers + for-in (NAPI 레벨 검증) ---

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -705,3 +705,64 @@ test "Bundler: import.meta.glob import option" {
 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "m.setup") != null);
 }
+
+test "Bundler: UMD external dependencies in wrapper" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.ts", "import { useState } from 'react';\nconsole.log(useState);");
+
+    const entry = try absPath(&tmp, "app.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .umd,
+        .external = &.{"react"},
+        .global_name = "MyApp",
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const output = result.output;
+
+    // UMD wrapper에 dependency array 포함
+    try std.testing.expect(std.mem.indexOf(u8, output, "define([\"react\"]") != null);
+    // factory 매개변수 포함
+    try std.testing.expect(std.mem.indexOf(u8, output, "function(React)") != null);
+    // CJS 경로에 require("react") 포함
+    try std.testing.expect(std.mem.indexOf(u8, output, "require(\"react\")") != null);
+    // IIFE 글로벌 경로
+    try std.testing.expect(std.mem.indexOf(u8, output, "root.React") != null);
+    // body에 bare require("react") 없음 (factory param으로 대체됨)
+    try std.testing.expect(std.mem.indexOf(u8, output, "var React = require(\"react\")") == null);
+    // named import → factory param 프로퍼티 접근
+    try std.testing.expect(std.mem.indexOf(u8, output, "React.useState") != null);
+}
+
+test "Bundler: AMD external dependencies in wrapper" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.ts", "import lodash from 'lodash';\nexport const x = lodash.get;");
+
+    const entry = try absPath(&tmp, "lib.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .amd,
+        .external = &.{"lodash"},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const output = result.output;
+
+    // AMD wrapper에 dependency array 포함
+    try std.testing.expect(std.mem.indexOf(u8, output, "define([\"lodash\"]") != null);
+    // factory 매개변수 포함
+    try std.testing.expect(std.mem.indexOf(u8, output, "function(Lodash)") != null);
+}

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -213,8 +213,34 @@ pub fn emitWithTreeShaking(
     };
     const factory_fn = if (has_tla) "(async function() {\n" else "(function() {\n";
 
+    // UMD/AMD: external specifier 수집 (dependency array + factory params 생성용)
+    var ext_specifiers: std.ArrayList([]const u8) = .empty;
+    defer ext_specifiers.deinit(allocator);
+    if (options.format == .umd or options.format == .amd) {
+        var seen = std.StringHashMap(void).init(allocator);
+        defer seen.deinit();
+        for (sorted.items) |m| {
+            for (m.import_records) |rec| {
+                if (rec.is_external and !seen.contains(rec.specifier)) {
+                    try seen.put(rec.specifier, {});
+                    try ext_specifiers.append(allocator, rec.specifier);
+                }
+            }
+        }
+    }
+
+    // UMD/AMD: specifier → factory 매개변수명 precompute
+    var ext_param_names: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (ext_param_names.items) |n| allocator.free(n);
+        ext_param_names.deinit(allocator);
+    }
+    for (ext_specifiers.items) |spec| {
+        try ext_param_names.append(allocator, try types.specifierToParamName(allocator, spec));
+    }
+
     // 포맷별 prologue
-    try emitFormatPrologue(&output, allocator, options.format, options.global_name, factory_fn, has_tla);
+    try emitFormatPrologue(&output, allocator, options.format, options.global_name, factory_fn, has_tla, ext_specifiers.items, ext_param_names.items);
 
     // 폴리필 주입 (--polyfill): IIFE로 감싸서 즉시 실행.
     // Metro/롤다운과 동일하게 모듈 그래프 밖에서 런타임 헬퍼보다 먼저 실행.
@@ -1332,6 +1358,8 @@ fn emitFormatPrologue(
     global_name: ?[]const u8,
     factory_fn: []const u8,
     has_tla: bool,
+    external_specifiers: []const []const u8,
+    ext_param_names: []const []const u8,
 ) !void {
     switch (format) {
         .iife => {
@@ -1359,22 +1387,64 @@ fn emitFormatPrologue(
                 try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
             }
             try output.appendSlice(allocator, "(function(root, factory) {\n");
-            try output.appendSlice(allocator, "  if (typeof define === \"function\" && define.amd) define([], factory);\n");
-            try output.appendSlice(allocator, "  else if (typeof module === \"object\" && module.exports) module.exports = factory();\n");
+            // AMD 경로: define(["react", "react-dom"], factory)
+            try output.appendSlice(allocator, "  if (typeof define === \"function\" && define.amd) define([");
+            for (external_specifiers, 0..) |spec, i| {
+                if (i > 0) try output.appendSlice(allocator, ", ");
+                try output.append(allocator, '"');
+                try output.appendSlice(allocator, spec);
+                try output.append(allocator, '"');
+            }
+            try output.appendSlice(allocator, "], factory);\n");
+            // CJS 경로: factory(require("react"), require("react-dom"))
+            try output.appendSlice(allocator, "  else if (typeof module === \"object\" && module.exports) module.exports = factory(");
+            for (external_specifiers, 0..) |spec, i| {
+                if (i > 0) try output.appendSlice(allocator, ", ");
+                try output.appendSlice(allocator, "require(\"");
+                try output.appendSlice(allocator, spec);
+                try output.appendSlice(allocator, "\")");
+            }
+            try output.appendSlice(allocator, ");\n");
+            // IIFE 경로: root.globalName = factory(root.React, root.ReactDOM)
             if (global_name) |gn| {
                 try output.appendSlice(allocator, "  else root.");
                 try output.appendSlice(allocator, gn);
-                try output.appendSlice(allocator, " = factory();\n");
+                try output.appendSlice(allocator, " = factory(");
             } else {
-                try output.appendSlice(allocator, "  else factory();\n");
+                try output.appendSlice(allocator, "  else factory(");
             }
-            try output.appendSlice(allocator, "})(typeof self !== \"undefined\" ? self : this, function() {\n");
+            for (ext_param_names, 0..) |name, i| {
+                if (i > 0) try output.appendSlice(allocator, ", ");
+                try output.appendSlice(allocator, "root.");
+                try output.appendSlice(allocator, name);
+            }
+            try output.appendSlice(allocator, ");\n");
+            // factory 함수 시작: function(React, ReactDOM) {
+            try output.appendSlice(allocator, "})(typeof self !== \"undefined\" ? self : this, function(");
+            for (ext_param_names, 0..) |name, i| {
+                if (i > 0) try output.appendSlice(allocator, ", ");
+                try output.appendSlice(allocator, name);
+            }
+            try output.appendSlice(allocator, ") {\n");
         },
         .amd => {
             if (has_tla) {
                 try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
             }
-            try output.appendSlice(allocator, "define([], function() {\n");
+            // define(["react", "react-dom"], function(React, ReactDOM) {
+            try output.appendSlice(allocator, "define([");
+            for (external_specifiers, 0..) |spec, i| {
+                if (i > 0) try output.appendSlice(allocator, ", ");
+                try output.append(allocator, '"');
+                try output.appendSlice(allocator, spec);
+                try output.append(allocator, '"');
+            }
+            try output.appendSlice(allocator, "], function(");
+            for (ext_param_names, 0..) |name, i| {
+                if (i > 0) try output.appendSlice(allocator, ", ");
+                try output.appendSlice(allocator, name);
+            }
+            try output.appendSlice(allocator, ") {\n");
         },
         .cjs => try output.appendSlice(allocator, "\"use strict\";\n"),
         .esm => {},

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1387,25 +1387,12 @@ fn emitFormatPrologue(
                 try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
             }
             try output.appendSlice(allocator, "(function(root, factory) {\n");
-            // AMD 경로: define(["react", "react-dom"], factory)
             try output.appendSlice(allocator, "  if (typeof define === \"function\" && define.amd) define([");
-            for (external_specifiers, 0..) |spec, i| {
-                if (i > 0) try output.appendSlice(allocator, ", ");
-                try output.append(allocator, '"');
-                try output.appendSlice(allocator, spec);
-                try output.append(allocator, '"');
-            }
+            try writeDepArray(output, allocator, external_specifiers);
             try output.appendSlice(allocator, "], factory);\n");
-            // CJS 경로: factory(require("react"), require("react-dom"))
             try output.appendSlice(allocator, "  else if (typeof module === \"object\" && module.exports) module.exports = factory(");
-            for (external_specifiers, 0..) |spec, i| {
-                if (i > 0) try output.appendSlice(allocator, ", ");
-                try output.appendSlice(allocator, "require(\"");
-                try output.appendSlice(allocator, spec);
-                try output.appendSlice(allocator, "\")");
-            }
+            try writeCjsRequireList(output, allocator, external_specifiers);
             try output.appendSlice(allocator, ");\n");
-            // IIFE 경로: root.globalName = factory(root.React, root.ReactDOM)
             if (global_name) |gn| {
                 try output.appendSlice(allocator, "  else root.");
                 try output.appendSlice(allocator, gn);
@@ -1413,41 +1400,59 @@ fn emitFormatPrologue(
             } else {
                 try output.appendSlice(allocator, "  else factory(");
             }
-            for (ext_param_names, 0..) |name, i| {
-                if (i > 0) try output.appendSlice(allocator, ", ");
-                try output.appendSlice(allocator, "root.");
-                try output.appendSlice(allocator, name);
-            }
+            try writeGlobalsList(output, allocator, ext_param_names);
             try output.appendSlice(allocator, ");\n");
-            // factory 함수 시작: function(React, ReactDOM) {
             try output.appendSlice(allocator, "})(typeof self !== \"undefined\" ? self : this, function(");
-            for (ext_param_names, 0..) |name, i| {
-                if (i > 0) try output.appendSlice(allocator, ", ");
-                try output.appendSlice(allocator, name);
-            }
+            try writeParamList(output, allocator, ext_param_names);
             try output.appendSlice(allocator, ") {\n");
         },
         .amd => {
             if (has_tla) {
                 try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
             }
-            // define(["react", "react-dom"], function(React, ReactDOM) {
             try output.appendSlice(allocator, "define([");
-            for (external_specifiers, 0..) |spec, i| {
-                if (i > 0) try output.appendSlice(allocator, ", ");
-                try output.append(allocator, '"');
-                try output.appendSlice(allocator, spec);
-                try output.append(allocator, '"');
-            }
+            try writeDepArray(output, allocator, external_specifiers);
             try output.appendSlice(allocator, "], function(");
-            for (ext_param_names, 0..) |name, i| {
-                if (i > 0) try output.appendSlice(allocator, ", ");
-                try output.appendSlice(allocator, name);
-            }
+            try writeParamList(output, allocator, ext_param_names);
             try output.appendSlice(allocator, ") {\n");
         },
         .cjs => try output.appendSlice(allocator, "\"use strict\";\n"),
         .esm => {},
+    }
+}
+
+// UMD/AMD prologue 헬퍼: 반복되는 리스트 출력을 공유.
+
+fn writeDepArray(output: *std.ArrayList(u8), allocator: std.mem.Allocator, specifiers: []const []const u8) !void {
+    for (specifiers, 0..) |spec, i| {
+        if (i > 0) try output.appendSlice(allocator, ", ");
+        try output.append(allocator, '"');
+        try output.appendSlice(allocator, spec);
+        try output.append(allocator, '"');
+    }
+}
+
+fn writeCjsRequireList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, specifiers: []const []const u8) !void {
+    for (specifiers, 0..) |spec, i| {
+        if (i > 0) try output.appendSlice(allocator, ", ");
+        try output.appendSlice(allocator, "require(\"");
+        try output.appendSlice(allocator, spec);
+        try output.appendSlice(allocator, "\")");
+    }
+}
+
+fn writeGlobalsList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, names: []const []const u8) !void {
+    for (names, 0..) |name, i| {
+        if (i > 0) try output.appendSlice(allocator, ", ");
+        try output.appendSlice(allocator, "root.");
+        try output.appendSlice(allocator, name);
+    }
+}
+
+fn writeParamList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, names: []const []const u8) !void {
+    for (names, 0..) |name, i| {
+        if (i > 0) try output.appendSlice(allocator, ", ");
+        try output.appendSlice(allocator, name);
     }
 }
 

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -201,12 +201,36 @@ pub fn buildMetadataForAst(
             const rec = m.import_records[ib.import_record_index];
 
             // resolve 미완료: external 또는 resolve 실패.
-            // 모든 포맷에서 require() preamble 생성.
-            // ESM 번들도 import 구문 없이 출력되므로 Node가 CJS로 파싱 (esbuild 동일).
             if (rec.resolved.isNone()) {
                 if (rec.kind == .static_import or rec.kind == .side_effect or rec.kind == .re_export) {
                     const preamble_name = self.getCanonicalName(module_index, ib.local_name) orelse ib.local_name;
-                    try preamble.writeUnresolvedRequire(preamble_name, rec.specifier, ib.imported_name, ib.kind == .namespace);
+                    if (rec.is_external and (self.format == .umd or self.format == .amd)) {
+                        // UMD/AMD: factory 매개변수에서 직접 참조
+                        const param_name = try types.specifierToParamName(self.allocator, rec.specifier);
+                        defer self.allocator.free(param_name);
+                        if (ib.kind == .namespace or std.mem.eql(u8, ib.imported_name, "default")) {
+                            // import * as React / import React → factory param 직접 사용
+                            if (!std.mem.eql(u8, preamble_name, param_name)) {
+                                try preamble.write("var ");
+                                try preamble.write(preamble_name);
+                                try preamble.write(" = ");
+                                try preamble.write(param_name);
+                                try preamble.write(";\n");
+                            }
+                        } else {
+                            // import { useState } → var useState = React.useState
+                            try preamble.write("var ");
+                            try preamble.write(preamble_name);
+                            try preamble.write(" = ");
+                            try preamble.write(param_name);
+                            try preamble.write(".");
+                            try preamble.write(ib.imported_name);
+                            try preamble.write(";\n");
+                        }
+                    } else {
+                        // ESM/CJS/IIFE: require() preamble 생성
+                        try preamble.writeUnresolvedRequire(preamble_name, rec.specifier, ib.imported_name, ib.kind == .namespace);
+                    }
                 }
                 continue;
             }
@@ -579,7 +603,20 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
     var require_rewrites: std.StringHashMapUnmanaged([]const u8) = .{};
     const self_idx = @intFromEnum(m.index);
     for (m.import_records) |rec| {
-        if (rec.resolved.isNone()) continue;
+        if (rec.resolved.isNone()) {
+            // UMD/AMD: external require → factory 매개변수 참조.
+            // require("react") → React (factory params에서 주입)
+            if (rec.is_external and (self.format == .umd or self.format == .amd)) {
+                if (!require_rewrites.contains(rec.specifier)) {
+                    const param = try types.specifierToParamName(self.allocator, rec.specifier);
+                    defer self.allocator.free(param);
+                    // "(React)" 형태로 저장 — emitRewriteValue가 '('로 시작하면 ()를 붙이지 않음
+                    const owned = try std.fmt.allocPrint(self.allocator, "({s})", .{param});
+                    try require_rewrites.put(self.allocator, rec.specifier, owned);
+                }
+            }
+            continue;
+        }
         const target = @intFromEnum(rec.resolved);
         if (target >= self.modules.len) continue;
         const target_mod = &self.modules[target];

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -469,6 +469,37 @@ pub fn fmtDevRequireExpr(allocator: std.mem.Allocator, dev_id: []const u8) ![]co
     return std.fmt.allocPrint(allocator, "(__zts_modules[\"{s}\"].fn(), __toCommonJS(__zts_modules[\"{s}\"].exports))", .{ dev_id, dev_id });
 }
 
+/// npm 패키지 specifier를 UMD/AMD factory 매개변수명으로 변환.
+/// "react" → "React", "react-dom" → "ReactDOM", "lodash/fp" → "LodashFp"
+/// PascalCase 변환 + 특수문자 제거. 호출자가 반환값을 소유.
+pub fn specifierToParamName(allocator: std.mem.Allocator, specifier: []const u8) ![]const u8 {
+    // 스코프 패키지: @scope/name → name 부분만 사용
+    const base = if (std.mem.indexOfScalar(u8, specifier, '/')) |slash| blk: {
+        if (specifier.len > 0 and specifier[0] == '@') {
+            break :blk specifier[slash + 1 ..];
+        }
+        break :blk specifier;
+    } else specifier;
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    var capitalize_next = true; // PascalCase: 첫 글자 대문자
+    for (base) |c| {
+        if (c == '-' or c == '/' or c == '.' or c == '@') {
+            capitalize_next = true;
+            continue;
+        }
+        if (capitalize_next) {
+            try buf.append(allocator, std.ascii.toUpper(c));
+            capitalize_next = false;
+        } else {
+            try buf.append(allocator, c);
+        }
+    }
+    if (buf.items.len == 0) return try allocator.dupe(u8, specifier);
+    return try allocator.dupe(u8, buf.items);
+}
+
 /// Span을 u64 키로 변환. 번들러 전역에서 식별자/노드를 고유 식별하는 데 사용.
 /// binding_scanner, linker 등에서 동일 함수를 공유하여 키 불일치 방지.
 pub fn spanKey(span: Span) u64 {

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -497,7 +497,7 @@ pub fn specifierToParamName(allocator: std.mem.Allocator, specifier: []const u8)
         }
     }
     if (buf.items.len == 0) return try allocator.dupe(u8, specifier);
-    return try allocator.dupe(u8, buf.items);
+    return try buf.toOwnedSlice(allocator);
 }
 
 /// Span을 u64 키로 변환. 번들러 전역에서 식별자/노드를 고유 식별하는 데 사용.


### PR DESCRIPTION
## Summary
- UMD/AMD wrapper에서 external 의존성을 dependency array + factory 매개변수로 전달
- body 내부의 `require()` 호출을 factory param 참조로 대체
- specifier → PascalCase 매개변수명 변환 (`react` → `React`, `react-dom` → `ReactDom`)

## Before / After
```javascript
// Before (broken)
define([], function() {
  var React = require("react");  // 브라우저에서 실행 불가
});

// After (fixed)
define(["react"], function(React) {
  var useState = React.useState;  // factory param에서 접근
});
```

## Test plan
- [x] 유닛 테스트 통과 (UMD/AMD external 테스트 2개 추가)
- [x] UMD 출력: dependency array + CJS require + IIFE globals + factory params 검증
- [x] AMD 출력: dependency array + factory params 검증
- [x] IIFE 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)