### PR TITLE
fix(codegen): restore indent_level guard for esm_var_assign_only

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2086,11 +2086,11 @@ pub const Codegen = struct {
         const list_start = extras[1];
         const list_len = extras[2];
 
-        // __esm 호이스팅: 변수 선언에서 키워드 제거 (할당문으로 변환).
-        // indent_level 무관: __esm factory 안에서도 var → assignment 변환 필요.
-        // (var 선언은 이미 __esm 밖 top-level에 hoisted_var_names로 선언됨)
+        // __esm 호이스팅: top-level 단순 변수 선언만 키워드 제거 (할당문으로 변환).
+        // indent_level == 0: factory body의 top-level에서만 적용.
+        // 함수 안의 const/let/var는 그대로 유지해야 함.
         // destructuring 패턴이 있으면 normal 경로 (키워드 필요).
-        if (self.options.esm_var_assign_only and !self.in_for_init) {
+        if (self.options.esm_var_assign_only and self.indent_level == 0 and !self.in_for_init) {
             const declarators = self.ast.extra_data.items[list_start .. list_start + list_len];
             // destructuring 여부 확인: 하나라도 binding_identifier가 아니면 normal 경로
             var has_destructuring = false;


### PR DESCRIPTION
## Summary

이전 PR(#1073)에서 `indent_level == 0` 체크를 제거한 것이 함수 내부의 `const`/`let`/`var` 선언 키워드까지 제거하는 부작용 발생.

### 증상

- `EventTarget.addEventListener` 내부의 `const processedType`, `let capture` 등이 bare assignment로 변환
- `ws.addEventListener is not a function` 에러 (WebSocket이 EventTarget을 제대로 상속하지 못함)

### 수정

`indent_level == 0` 가드를 복원하여 factory body의 top-level 변수 선언에만 `var` 키워드 제거 적용. enum IIFE는 `emitEnumIIFE()`에서 별도로 처리하므로 영향 없음.

## Test plan

- [x] bundle-smoke 120개, esm-enum-hoisting 5개, ns-var-collision 2개 모두 통과
- [x] EventTarget.addEventListener 내부 변수 선언(`var processedType`, `var capture`) 유지 확인
- [x] RuntimeKind enum top-level 호이스팅 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)