### PR TITLE
feat(decorator): TC39 Stage 3 decorator 변환 구현

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,6 +46,7 @@
 | 33. BuildOptions 확장 | loader, conditions, resolveExtensions, mainFields, target, outdir, outfile, write | ✅ |
 | 34. 플러그인 훅 확장 | renderChunk/generateBundle NAPI 노출 + vitePlugin 매핑 | ✅ |
 | 35. async 플러그인 | 모든 훅 async/Promise 반환 지원 (MaybePromise) | ✅ |
+| 36. import.meta.glob | Vite 호환 `import.meta.glob()`, eager/import 옵션 | ✅ |
 
 ## 번들러 성능 현황 (2026-04-10 실측)
 
@@ -91,8 +92,8 @@
 - `packages/core`에서 `defineConfig()` + `build()` 내보냄
 - CLI `--plugin <path>`로 JS 설정 파일 로드
 
-**import.meta.glob** — M (1~2일)
-- Vite 호환 기능, DX 개선
+~~**import.meta.glob**~~ — ✅ 완료
+- Vite 호환 `import.meta.glob()`, eager/import 옵션 지원
 
 ## ⏳ 미완료
 - **.d.ts 생성** (isolatedDeclarations) — 후순위, 당분간 tsc에 위임
@@ -156,7 +157,8 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 
 - ~~**jsx-dev**~~ — ✅ 완료. `--jsx=automatic-dev` / `--jsx-dev` React 개발 모드 `jsxDEV` + `__source`/`__self`
 - ~~**UMD/AMD 포맷**~~ — ✅ 완료. `--format=umd` / `--format=amd` + external dependency array + factory params
-- **manualChunks** — `L` | 사용자 정의 청크 분할 규칙 (rolldown advancedChunks)
+- **manualChunks** — `L` | 사용자 정의 청크 분할 규칙 (rolldown advancedChunks, rspack splitChunks)
+  프로덕션 청크 최적화 시 벤더/공통 코드 분리 필수. rolldown은 `advancedChunks`, rspack은 webpack의 `splitChunks` 호환.
 - ~~**preserveModules**~~ — ✅ 완료. `--preserve-modules` + `--preserve-modules-root` (Rollup/Rolldown 호환)
 - ~~**using 다운레벨링**~~ — ✅ 완료. `using`/`await using` → try-finally + `__using`/`__callDispose` (esbuild 호환)
 - ~~**설정 파일 (zts.config.js)**~~ — ✅ 완료. `packages/core`에서 `defineConfig()` 내보냄.
@@ -166,7 +168,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 ### Nice to Have
 
 - **mangleProps** — `XL` | 선행: 없음 | 배치: 단독
-- **import.meta.glob** — `M` | 선행: 없음 | 배치: 단독
+- ~~**import.meta.glob**~~ — ✅ 완료. Vite 호환 `import.meta.glob()` (eager/import 옵션 지원)
 - ~~**Virtual modules**~~ — ✅ 완료. `\0` prefix 기반 virtual module 지원 (플러그인 resolveId/load)
 - **Stage 3 decorators** — `XL` | TC39 최신 데코레이터 다운레벨링 (현재 legacy만)
 - **Module Concatenation 고도화** — `XL` | rspack/rolldown 수준 scope hoisting
@@ -176,16 +178,25 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 - ~~**sourcemapDebugIds**~~ — ✅ 완료. `--sourcemap-debug-ids` UUID v4, 번들+소스맵 매칭
 - ~~**shimMissingExports**~~ — ✅ 완료. `--shim-missing-exports` 롤다운 호환
 
-### 번들러 인프라 (미구현)
+### 번들러 인프라 — rolldown/rspack 비교
 
-| 항목 | 난이도 | esbuild | rolldown | rspack | 설명 |
-|------|--------|---------|----------|--------|------|
-| **CSS 번들링** | XL | ✅ | ✅ | ✅ | 자체 CSS 파서, @import, CSS Modules |
-| ~~**플러그인 N-API**~~ | ✅ | ✅ (Go) | ✅ (Rust) | ✅ | in-process NAPI 플러그인 + async 훅 + Vite 어댑터 |
-| ~~**HMR module-level**~~ | ✅ | ❌ | ✅ | ✅ | `import.meta.hot.accept()` 구현 완료 |
-| ~~**설정 파일**~~ | ✅ | ❌ | ✅ | ✅ | `defineConfig()` in @zts/plugin |
-| ~~**JS Build API**~~ | ✅ | ✅ | ✅ | ✅ | `build()` in @zts/plugin |
-| ~~**HTTPS dev server**~~ | ✅ | ❌ | ✅ | ✅ | `--certfile`/`--keyfile` |
+| 항목 | 난이도 | esbuild | rolldown | rspack | ZTS | 설명 |
+|------|--------|---------|----------|--------|-----|------|
+| **CSS 번들링** | XL | ✅ | ✅ | ✅ | ❌ | 자체 CSS 파서, @import, CSS Modules |
+| **manualChunks** | L | ❌ | ✅ advancedChunks | ✅ splitChunks | ❌ | 사용자 정의 청크 분할 규칙 |
+| **innerGraph** | L | ❌ | ✅ | ✅ | ❌ | 변수 할당 추적으로 정밀 DCE |
+| **Persistent caching** | XL | ❌ | ❌ | ✅ | ❌ | 디스크 캐시, 콜드 리빌드 250%↑ |
+| **Module Federation** | XL | ❌ | ❌ | ✅ | ❌ | 마이크로프론트엔드 코드/리소스 공유 |
+| **Lazy compilation** | XL | ❌ | ❌ | ✅ | ❌ | 온디맨드 모듈 컴파일 (dev 시작 가속) |
+| **Stage 3 decorators** | XL | ❌ | ✅ | ✅ | ❌ | TC39 최신 데코레이터 (현재 legacy만) |
+| **mangleProps** | XL | ✅ | ❌ | ❌ | ❌ | cross-module 프로퍼티 난독화 |
+| **lazyBarrel** | L | ❌ | ✅ | ❌ | ❌ | barrel re-export 컴파일 생략 |
+| ~~**import.meta.glob**~~ | ✅ | ❌ | ✅ | ❌ | ✅ | Vite 호환 glob import |
+| ~~**플러그인 N-API**~~ | ✅ | ✅ (Go) | ✅ (Rust) | ✅ | ✅ | in-process NAPI + async 훅 + Vite 어댑터 |
+| ~~**HMR module-level**~~ | ✅ | ❌ | ✅ | ✅ | ✅ | `import.meta.hot.accept()` |
+| ~~**설정 파일**~~ | ✅ | ❌ | ✅ | ✅ | ✅ | `defineConfig()` |
+| ~~**JS Build API**~~ | ✅ | ✅ | ✅ | ✅ | ✅ | `build()` |
+| ~~**HTTPS dev server**~~ | ✅ | ❌ | ✅ | ✅ | ✅ | `--certfile`/`--keyfile` |
 
 ### 배치 그룹 & 구현 순서
 
@@ -210,9 +221,12 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
   플러그인 API ✅ 1-4단계 완료 — NAPI + Vite 어댑터 + async 훅
   엔진 타겟 ✅ 완료 — esbuild compat-table 기반 (8엔진 × 18 feature)
   Web Worker ✅ 완료 — new Worker(new URL(...)) 자동 감지+IIFE 번들 (esbuild 미지원)
+  import.meta.glob ✅ 완료 — Vite 호환 glob import (eager/import 옵션)
   mangleProps (1주+) — cross-module 프로퍼티 추적
   Stage 3 decorators — TC39 최신 데코레이터 (현재 legacy만)
   Module Concatenation 고도화 — rspack/rolldown 수준 scope hoisting
+  manualChunks (3~5일) — 사용자 정의 청크 분할
+  innerGraph (3~5일) — 변수 할당 추적 정밀 DCE
 ```
 
 ### 기술부채 & 구조적 제약
@@ -311,7 +325,7 @@ SWC 비교 테스트: 29 cases × 9 targets 전부 통과.
 | 항목 | 난이도 | 현재 상태 | 설명 |
 |------|--------|----------|------|
 | **플러그인 예제** | S~M | 없음 | PostCSS, Tailwind, SVG, YAML 등 커뮤니티 플러그인 레퍼런스 |
-| **import.meta.glob** | M | 미구현 | Vite 사용자 마이그레이션 핵심 기능 |
+| ~~**import.meta.glob**~~ | ✅ | 완료 | Vite 호환 glob import (eager/import 옵션) |
 | **마이그레이션 가이드** | S | 없음 | esbuild → ZTS, Vite → ZTS 설정 대응표 |
 | **프레임워크 통합** | XL | 없음 | Next.js/Remix/SvelteKit 플러그인 또는 어댑터 |
 | **Vite 호환 모드** | XL | 없음 | `vite.config.js` 읽어서 마이그레이션 비용 제로 (장기 목표) |

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -366,7 +366,7 @@ pub fn emitWithTreeShaking(
 
     for (sorted.items, 0..) |m, i| {
         // helpers 합산 (bitwise OR)
-        collected_helpers = @bitCast(@as(u16, @bitCast(collected_helpers)) | @as(u16, @bitCast(results[i].helpers)));
+        collected_helpers = @bitCast(@as(u32, @bitCast(collected_helpers)) | @as(u32, @bitCast(results[i].helpers)));
 
         const code = results[i].code orelse continue;
 
@@ -719,9 +719,9 @@ pub fn emitModule(
     }
 
     // 런타임 헬퍼 사용 추적: transformer가 설정한 플래그를 out parameter로 전달
-    // packed struct(u16)이므로 bitwise OR로 한번에 합친다
+    // packed struct(u32)이므로 bitwise OR로 한번에 합친다
     if (helpers_out) |h| {
-        h.* = @bitCast(@as(u16, @bitCast(h.*)) | @as(u16, @bitCast(transformer.runtime_helpers)));
+        h.* = @bitCast(@as(u32, @bitCast(h.*)) | @as(u32, @bitCast(transformer.runtime_helpers)));
     }
 
     // Linker 메타데이터 생성 (있으면) — ast 기준으로 구축
@@ -1220,6 +1220,7 @@ pub fn emitChunkRuntimeHelpers(
     chunk: *const Chunk,
     modules: []const Module,
     options: EmitOptions,
+    collected_helpers: ?RuntimeHelpers,
 ) !void {
     var needs_cjs_runtime = false;
     var needs_esm_wrap_runtime = false;
@@ -1240,6 +1241,11 @@ pub fn emitChunkRuntimeHelpers(
     }
     if (options.experimental_decorators) {
         try rt.appendDecoratorRuntime(output, allocator, options.minify_whitespace);
+    }
+    if (collected_helpers) |h| {
+        if (h.es_decorator) {
+            try output.appendSlice(allocator, if (options.minify_whitespace) rt.ES_DECORATOR_RUNTIME_MIN else rt.ES_DECORATOR_RUNTIME);
+        }
     }
     if (options.unsupported.async_await) {
         try rt.appendAsyncRuntime(output, allocator, options.minify_whitespace, options.unsupported.arrow);

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -88,7 +88,7 @@ pub fn emitChunks(
         }
 
         // 청크별 런타임 헬퍼 주입
-        try emitChunkRuntimeHelpers(&chunk_output, allocator, chunk, modules, options);
+        try emitChunkRuntimeHelpers(&chunk_output, allocator, chunk, modules, options, null);
 
         // 크로스 청크 import deconfliction:
         // 여러 청크에서 같은 이름의 심볼을 import할 때 충돌 방지.

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -141,6 +141,77 @@ pub const METADATA_RUNTIME =
 pub const METADATA_RUNTIME_MIN = "var __metadata=(key,value)=>{if(typeof Reflect!==\"undefined\"&&typeof Reflect.metadata===\"function\")return Reflect.metadata(key,value)};";
 
 // ============================================================
+// TC39 Stage 3 Decorators (TypeScript 5.0+ / tslib 호환)
+// ============================================================
+
+/// __esDecorate: Stage 3 decorator를 class/member에 적용 (tslib 호환).
+/// ctor=null이면 field/class, descriptorIn=null이면 prototype/constructor에서 descriptor 조회.
+/// contextIn.kind에 따라 "class", "method", "getter", "setter", "field", "accessor" 분기.
+pub const ES_DECORATOR_RUNTIME =
+    \\var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+    \\  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+    \\  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+    \\  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+    \\  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+    \\  var _, done = false;
+    \\  for (var i = decorators.length - 1; i >= 0; i--) {
+    \\    var context = {};
+    \\    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    \\    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    \\    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    \\    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    \\    if (kind === "accessor") {
+    \\      if (result === void 0) continue;
+    \\      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+    \\      if (_ = accept(result.get)) descriptor.get = _;
+    \\      if (_ = accept(result.set)) descriptor.set = _;
+    \\      if (_ = accept(result.init)) initializers.unshift(_);
+    \\    } else if (_ = accept(result)) {
+    \\      if (kind === "field") initializers.unshift(_);
+    \\      else descriptor[key] = _;
+    \\    }
+    \\  }
+    \\  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+    \\  done = true;
+    \\};
+    \\var __runInitializers = function(thisArg, initializers, value) {
+    \\  var useValue = arguments.length > 2;
+    \\  for (var i = 0; i < initializers.length; i++) {
+    \\    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+    \\  }
+    \\  return useValue ? value : void 0;
+    \\};
+    \\var __setFunctionName = function(f, name, prefix) {
+    \\  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+    \\  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+    \\};
+    \\var __propKey = function(x) {
+    \\  return typeof x === "symbol" ? x : "".concat(x);
+    \\};
+    \\
+;
+
+pub const ES_DECORATOR_RUNTIME_MIN =
+    "var __esDecorate=function(ctor,descriptorIn,decorators,contextIn,initializers,extraInitializers){" ++
+    "function accept(f){if(f!==void 0&&typeof f!==\"function\")throw new TypeError(\"Function expected\");return f}" ++
+    "var kind=contextIn.kind,key=kind===\"getter\"?\"get\":kind===\"setter\"?\"set\":\"value\";" ++
+    "var target=!descriptorIn&&ctor?contextIn[\"static\"]?ctor:ctor.prototype:null;" ++
+    "var descriptor=descriptorIn||(target?Object.getOwnPropertyDescriptor(target,contextIn.name):{});" ++
+    "var _,done=false;" ++
+    "for(var i=decorators.length-1;i>=0;i--){" ++
+    "var context={};for(var p in contextIn)context[p]=p===\"access\"?{}:contextIn[p];" ++
+    "for(var p in contextIn.access)context.access[p]=contextIn.access[p];" ++
+    "context.addInitializer=function(f){if(done)throw new TypeError(\"Cannot add initializers after decoration has completed\");extraInitializers.push(accept(f||null))};" ++
+    "var result=(0,decorators[i])(kind===\"accessor\"?{get:descriptor.get,set:descriptor.set}:descriptor[key],context);" ++
+    "if(kind===\"accessor\"){if(result===void 0)continue;if(result===null||typeof result!==\"object\")throw new TypeError(\"Object expected\");" ++
+    "if(_=accept(result.get))descriptor.get=_;if(_=accept(result.set))descriptor.set=_;if(_=accept(result.init))initializers.unshift(_)}" ++
+    "else if(_=accept(result)){if(kind===\"field\")initializers.unshift(_);else descriptor[key]=_}}" ++
+    "if(target)Object.defineProperty(target,contextIn.name,descriptor);done=true};" ++
+    "var __runInitializers=function(thisArg,initializers,value){var useValue=arguments.length>2;for(var i=0;i<initializers.length;i++){value=useValue?initializers[i].call(thisArg,value):initializers[i].call(thisArg)}return useValue?value:void 0};" ++
+    "var __setFunctionName=function(f,name,prefix){if(typeof name===\"symbol\")name=name.description?\"[\".concat(name.description,\"]\"):\"\";return Object.defineProperty(f,\"name\",{configurable:true,value:prefix?\"\".concat(prefix,\" \",name):name})};" ++
+    "var __propKey=function(x){return typeof x===\"symbol\"?x:\"\".concat(x)};";
+
+// ============================================================
 // ES2015+ Downlevel
 // ============================================================
 
@@ -687,6 +758,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
         } else {
             try buf.appendSlice(allocator, if (minify) USING_RUNTIME_MIN else USING_RUNTIME);
         }
+    }
+    if (helpers.es_decorator) {
+        try buf.appendSlice(allocator, if (minify) ES_DECORATOR_RUNTIME_MIN else ES_DECORATOR_RUNTIME);
     }
 }
 

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -725,7 +725,7 @@ pub const Codegen = struct {
             .class_body => try self.emitClassBody(node),
             .method_definition => try self.emitMethodDef(node),
             .property_definition => try self.emitPropertyDef(node),
-            .static_block => try self.writeNodeSpan(node),
+            .static_block => try self.emitStaticBlock(node),
             .decorator => try self.emitDecorator(node),
             .accessor_property => try self.emitAccessorProp(node),
 
@@ -1934,6 +1934,21 @@ pub const Codegen = struct {
 
     fn emitClassBody(self: *Codegen, node: Node) !void {
         try self.emitBracedList(node);
+    }
+
+    // static_block: unary = { operand = body(block_statement) }
+    // 파서 노드는 writeNodeSpan으로 처리하지만,
+    // transformer가 생성한 합성 노드(span={0,0})는 AST 기반으로 출력한다.
+    fn emitStaticBlock(self: *Codegen, node: Node) !void {
+        if (node.span.start != 0 or node.span.end != 0) {
+            // 파서 원본 노드 → 소스 텍스트 그대로 출력
+            try self.writeNodeSpan(node);
+            return;
+        }
+        // 합성 노드 → AST 기반 출력
+        try self.write("static");
+        try self.writeSpace();
+        try self.emitNode(node.data.unary.operand);
     }
 
     // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -740,3 +740,48 @@ test "stage3: class expression with method decorator" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
 }
+
+// --- Private member decorator ---
+
+test "stage3: private method decorator → private: true" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  #secret() { return 42; }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"#secret\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "private: true") != null);
+}
+
+test "stage3: private field decorator → private: true + initializers" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  #value = 99;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"#value\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "private: true") != null);
+    // private field의 변수명에서 # 제거: _value_initializers
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_value_initializers") != null);
+}
+
+test "stage3: private getter decorator → private: true" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  get #x() { return 1; }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"getter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "private: true") != null);
+}

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -517,6 +517,8 @@ test "stage3: field decorator → kind field + initializers" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"x\"") != null);
     // field은 per-field initializers를 사용
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x_initializers") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x_extraInitializers") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__runInitializers") != null);
 }
 

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -785,3 +785,173 @@ test "stage3: private getter decorator → private: true" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"getter\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "private: true") != null);
 }
+
+// --- Private setter ---
+
+test "stage3: private setter decorator → private: true + set access" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  set #x(v: number) {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"setter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "private: true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"#x\"") != null);
+}
+
+// --- Static getter/setter ---
+
+test "stage3: static getter decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  static get count() { return 0; }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"getter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static: true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"count\"") != null);
+}
+
+test "stage3: static setter decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  static set count(v: number) {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"setter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static: true") != null);
+}
+
+// --- Private static ---
+
+test "stage3: private static method decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  static #internal() {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static: true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "private: true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"#internal\"") != null);
+    // private method → descriptor 래핑
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_private_internal_descriptor") != null);
+}
+
+test "stage3: private static field decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  static #count = 0;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static: true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "private: true") != null);
+}
+
+// --- Private method descriptor 래핑 검증 ---
+
+test "stage3: private method → getter + descriptor" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  #compute() { return 42; }
+        \\}
+    );
+    defer r.deinit();
+    // descriptor 변수 선언
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_private_compute_descriptor") != null);
+    // __setFunctionName 호출
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__setFunctionName") != null);
+    // getter로 변환: get #compute()
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "get #compute()") != null);
+    // getter body: return _private_compute_descriptor.value
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_private_compute_descriptor.value") != null);
+}
+
+// --- Decorator with complex arguments ---
+
+test "stage3: decorator with object argument" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\@Reflect.metadata("key", "value")
+        \\class Foo {}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
+}
+
+// --- Multiple members of different kinds ---
+
+test "stage3: getter + setter same name different decorators" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @getDec
+        \\  get x() { return 1; }
+        \\  @setDec
+        \\  set x(v: number) {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"getter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"setter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "getDec") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "setDec") != null);
+}
+
+// --- Class with extends + class decorator + member decorator ---
+
+test "stage3: extends + class + method decorators combined" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Base {}
+        \\@classDec
+        \\class Child extends Base {
+        \\  @methodDec method() {}
+        \\  @fieldDec x = 1;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "extends") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "classDec") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "methodDec") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "fieldDec") != null);
+}
+
+// --- Accessor + field mixed ---
+
+test "stage3: accessor + field mixed" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec accessor x = 1;
+        \\  @dec y = 2;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"accessor\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x_initializers") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_y_initializers") != null);
+}
+
+// --- Empty class body with class decorator ---
+
+test "stage3: class decorator on empty class" {
+    var r = try e2eStage3Decorator(std.testing.allocator, "@dec class Empty {}");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let Empty") != null);
+}

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -3,6 +3,7 @@ const helpers = @import("helpers.zig");
 const e2eDecorator = helpers.e2eDecorator;
 const e2eDecoratorES5 = helpers.e2eDecoratorES5;
 const e2eDecoratorMetadata = helpers.e2eDecoratorMetadata;
+const e2eStage3Decorator = helpers.e2eStage3Decorator;
 const e2eFull = helpers.e2eFull;
 const TransformOptions = helpers.TransformOptions;
 const TestResult = helpers.TestResult;
@@ -394,4 +395,182 @@ test "metadata: mixed primitive + class params" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Number") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "String") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "MyService") != null);
+}
+
+// ============================================================
+// Stage 3 (TC39) Decorator — TypeScript 5.0+ 출력 검증
+// ============================================================
+//
+// experimental_decorators=false(기본값)일 때 Stage 3 변환이 동작해야 한다.
+// TypeScript/Babel/SWC와 동일한 __esDecorate + __runInitializers 패턴.
+
+// --- Class decorator ---
+
+test "stage3: class decorator → __esDecorate + IIFE" {
+    // @dec class Foo {}
+    // → let Foo = (() => { ... __esDecorate(null, _classDescriptor = { value: _classThis }, ...) ... })();
+    var r = try e2eStage3Decorator(std.testing.allocator, "@dec class Foo {}");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__runInitializers") != null);
+    // IIFE 래핑: (() => { ... })() 또는 (function() { ... })()
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let Foo") != null);
+    // class 키워드가 여전히 존재 (내부 var Foo = class { ... })
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "class") != null);
+    // kind: "class" context
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
+}
+
+test "stage3: class decorator with extends" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Base {}
+        \\@dec class Child extends Base {}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "extends") != null);
+}
+
+test "stage3: multiple class decorators" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\@dec1
+        \\@dec2
+        \\class Foo {}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "dec1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "dec2") != null);
+}
+
+// --- Method decorator ---
+
+test "stage3: method decorator → __esDecorate with kind method" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  greet() { return "hi"; }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"greet\"") != null);
+    // instance method → __runInitializers in constructor
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__runInitializers") != null);
+}
+
+test "stage3: static method decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  static create() {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static: true") != null);
+}
+
+// --- Getter/Setter decorator ---
+
+test "stage3: getter decorator → kind getter" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  get x() { return 1; }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"getter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"x\"") != null);
+}
+
+test "stage3: setter decorator → kind setter" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  set x(v: number) {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"setter\"") != null);
+}
+
+// --- Field decorator ---
+
+test "stage3: field decorator → kind field + initializers" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  x = 1;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"x\"") != null);
+    // field은 per-field initializers를 사용
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__runInitializers") != null);
+}
+
+test "stage3: static field decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  static x = 42;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static: true") != null);
+}
+
+// --- Auto-accessor decorator ---
+
+test "stage3: accessor decorator → kind accessor + backing field" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  accessor x = 1;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"accessor\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"x\"") != null);
+    // accessor는 getter/setter pair를 생성
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "get") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "set") != null);
+}
+
+// --- No decorator → passthrough ---
+
+test "stage3: no decorator → class preserved as-is" {
+    var r = try e2eStage3Decorator(std.testing.allocator, "class Foo { greet() {} }");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "class Foo") != null);
+}
+
+// --- Mixed decorators ---
+
+test "stage3: class + method mixed" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\@classDec
+        \\class Foo {
+        \\  @methodDec
+        \\  greet() {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "classDec") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "methodDec") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
 }

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -543,9 +543,9 @@ test "stage3: accessor decorator → kind accessor + backing field" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"accessor\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"x\"") != null);
-    // accessor는 getter/setter pair를 생성
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "get") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "set") != null);
+    // TODO Phase 4: accessor는 getter/setter pair를 생성 (backing field + __privateAdd)
+    // try std.testing.expect(std.mem.indexOf(u8, r.output, "get") != null);
+    // try std.testing.expect(std.mem.indexOf(u8, r.output, "set") != null);
 }
 
 // --- No decorator → passthrough ---

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -582,3 +582,131 @@ test "stage3: class + method mixed" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
 }
+
+// --- Decorator factory @dec(arg) ---
+
+test "stage3: decorator factory call expression" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\@Component({ selector: "app" })
+        \\class AppComponent {}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Component") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "selector") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
+}
+
+// --- Multiple decorators on same member ---
+
+test "stage3: multiple decorators on method" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Ctrl {
+        \\  @Get("/")
+        \\  @Auth("admin")
+        \\  index() {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+    // 두 decorator 모두 출력에 포함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Get") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Auth") != null);
+}
+
+// --- extends + member decorator ---
+
+test "stage3: derived class with member decorators" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Base {}
+        \\class Child extends Base {
+        \\  @log
+        \\  method() {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "extends") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+}
+
+// --- Field without initializer ---
+
+test "stage3: field decorator without initializer" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  x;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x_initializers") != null);
+}
+
+// --- Multiple fields with decorators ---
+
+test "stage3: multiple decorated fields" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec x = 1;
+        \\  @dec y = 2;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x_initializers") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_y_initializers") != null);
+}
+
+// --- All member kinds mixed ---
+
+test "stage3: method + getter + setter + field mixed" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec method() {}
+        \\  @dec get prop() { return 1; }
+        \\  @dec set prop(v: number) {}
+        \\  @dec field = 42;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"getter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"setter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"field\"") != null);
+}
+
+// --- Static accessor ---
+
+test "stage3: static accessor decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  static accessor count = 0;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"accessor\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static: true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#_count_accessor_storage") != null);
+}
+
+// --- Class decorator only, no member decorators → IIFE but no _instanceExtraInitializers ---
+
+test "stage3: class-only decorator has no instance extra initializers" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\@sealed
+        \\class Foo {
+        \\  method() {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
+    // class-only → _instanceExtraInitializers 불필요
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_instanceExtraInitializers") == null);
+}

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -456,6 +456,9 @@ test "stage3: method decorator → __esDecorate with kind method" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"greet\"") != null);
+    // access: { has: obj => "greet" in obj, get: obj => obj.greet }
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "access") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "has") != null);
     // instance method → __runInitializers in constructor
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__runInitializers") != null);
 }

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -710,3 +710,33 @@ test "stage3: class-only decorator has no instance extra initializers" {
     // class-only → _instanceExtraInitializers 불필요
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_instanceExtraInitializers") == null);
 }
+
+// --- Class expression ---
+
+test "stage3: class expression decorator → IIFE as expression" {
+    var r = try e2eStage3Decorator(std.testing.allocator, "const Foo = @dec class {};");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    // class expression → IIFE가 대입의 우변으로 사용됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Foo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"class\"") != null);
+}
+
+test "stage3: named class expression decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator, "const x = @dec class Foo {};");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Foo") != null);
+}
+
+test "stage3: class expression with method decorator" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\const Foo = class {
+        \\  @dec
+        \\  greet() {}
+        \\};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"method\"") != null);
+}

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -548,9 +548,12 @@ test "stage3: accessor decorator → kind accessor + backing field" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__esDecorate") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"accessor\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"x\"") != null);
-    // TODO Phase 4: accessor는 getter/setter pair를 생성 (backing field + __privateAdd)
-    // try std.testing.expect(std.mem.indexOf(u8, r.output, "get") != null);
-    // try std.testing.expect(std.mem.indexOf(u8, r.output, "set") != null);
+    // accessor → private backing field + getter/setter pair
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#_x_accessor_storage") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "get x()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "set x(") != null);
+    // per-field initializers
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x_initializers") != null);
 }
 
 // --- No decorator → passthrough ---

--- a/src/codegen/codegen_test/helpers.zig
+++ b/src/codegen/codegen_test/helpers.zig
@@ -247,6 +247,14 @@ pub fn e2eDecoratorMetadata(allocator: std.mem.Allocator, source: []const u8) !T
     }, .{ .minify_whitespace = true }, ".ts");
 }
 
+/// Stage 3 (TC39) decorator e2e: experimental_decorators=false (기본값).
+/// TypeScript 5.0+ 형식의 __esDecorate/__runInitializers 출력을 검증.
+pub fn e2eStage3Decorator(allocator: std.mem.Allocator, source: []const u8) !TestResult {
+    return e2eFull(allocator, source, .{
+        // experimental_decorators 기본값 = false → Stage 3 경로
+    }, .{}, ".ts");
+}
+
 pub fn e2eDecoratorES5(allocator: std.mem.Allocator, source: []const u8) !TestResult {
     return e2eFull(allocator, source, .{
         .experimental_decorators = true,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2660,6 +2660,21 @@ pub const Transformer = struct {
     pub const buildParamTypesArray = class_deco.buildParamTypesArray;
     pub const appendMemberMetadata = class_deco.appendMemberMetadata;
     pub const appendClassMetadata = class_deco.appendClassMetadata;
+    // Stage 3 (TC39) decorator
+    pub const hasAnyMemberDecorators = class_deco.hasAnyMemberDecorators;
+    pub const transformStage3Decorators = class_deco.transformStage3Decorators;
+    pub const memberKeyToStringLiteral = class_deco.memberKeyToStringLiteral;
+    pub const collectStage3Decorators = class_deco.collectStage3Decorators;
+    pub const buildEsDecorateCall = class_deco.buildEsDecorateCall;
+    pub const buildClassEsDecorateCall = class_deco.buildClassEsDecorateCall;
+    pub const buildContextObject = class_deco.buildContextObject;
+    pub const buildMetadataDecl = class_deco.buildMetadataDecl;
+    pub const buildClassReassign = class_deco.buildClassReassign;
+    pub const buildRunInitializersCall = class_deco.buildRunInitializersCall;
+    pub const buildRunInitializersCall2 = class_deco.buildRunInitializersCall2;
+    pub const buildStage3LetDeclarations = class_deco.buildStage3LetDeclarations;
+    pub const makeLet = class_deco.makeLet;
+    pub const makeObjProp = class_deco.makeObjProp;
     pub const extractTypeFromSource = class_deco.extractTypeFromSource;
 
     fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2675,6 +2675,7 @@ pub const Transformer = struct {
     pub const buildStage3LetDeclarations = class_deco.buildStage3LetDeclarations;
     pub const makeLet = class_deco.makeLet;
     pub const makeObjProp = class_deco.makeObjProp;
+    pub const buildAccessObject = class_deco.buildAccessObject;
     pub const extractTypeFromSource = class_deco.extractTypeFromSource;
 
     fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2677,6 +2677,7 @@ pub const Transformer = struct {
     pub const makeObjProp = class_deco.makeObjProp;
     pub const buildAccessObject = class_deco.buildAccessObject;
     pub const buildFieldInitNames = class_deco.buildFieldInitNames;
+    pub const buildMetadataDefineProperty = class_deco.buildMetadataDefineProperty;
     pub const extractTypeFromSource = class_deco.extractTypeFromSource;
 
     fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2680,6 +2680,7 @@ pub const Transformer = struct {
     pub const buildMetadataDefineProperty = class_deco.buildMetadataDefineProperty;
     pub const buildGetterMethod = class_deco.buildGetterMethod;
     pub const extractCleanVarName = class_deco.extractCleanVarName;
+    pub const wrapInStringLiteral = class_deco.wrapInStringLiteral;
     pub const extractTypeFromSource = class_deco.extractTypeFromSource;
 
     fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2678,6 +2678,8 @@ pub const Transformer = struct {
     pub const buildAccessObject = class_deco.buildAccessObject;
     pub const buildFieldInitNames = class_deco.buildFieldInitNames;
     pub const buildMetadataDefineProperty = class_deco.buildMetadataDefineProperty;
+    pub const buildGetterMethod = class_deco.buildGetterMethod;
+    pub const extractCleanVarName = class_deco.extractCleanVarName;
     pub const extractTypeFromSource = class_deco.extractTypeFromSource;
 
     fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -101,7 +101,7 @@ pub const TransformOptions = struct {
 /// 런타임 헬퍼 사용 추적 비트맵.
 /// transformer가 각 변환 시 해당 비트를 설정하고,
 /// 번들러 emitter가 필요한 헬퍼만 출력에 주입한다.
-pub const RuntimeHelpers = packed struct(u16) {
+pub const RuntimeHelpers = packed struct(u32) {
     /// __async: async/await → generator wrapper (ES2017)
     async_helper: bool = false,
     /// __extends: class 상속 prototype chain (ES2015)
@@ -132,7 +132,9 @@ pub const RuntimeHelpers = packed struct(u16) {
     using_ctx: bool = false,
     /// __classStaticPrivateFieldSpecGet/Set: static private field accessor
     class_static_private_field: bool = false,
-    _padding: u1 = 0,
+    /// __esDecorate/__runInitializers: TC39 Stage 3 decorator 변환 (TypeScript 5.0+)
+    es_decorator: bool = false,
+    _padding: u16 = 0,
 };
 
 /// 단일 AST append-only 변환기.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2680,6 +2680,7 @@ pub const Transformer = struct {
     pub const buildMetadataDefineProperty = class_deco.buildMetadataDefineProperty;
     pub const buildGetterMethod = class_deco.buildGetterMethod;
     pub const extractCleanVarName = class_deco.extractCleanVarName;
+    pub const appendEsDecorateStmt = class_deco.appendEsDecorateStmt;
     pub const wrapInStringLiteral = class_deco.wrapInStringLiteral;
     pub const extractTypeFromSource = class_deco.extractTypeFromSource;
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2676,6 +2676,7 @@ pub const Transformer = struct {
     pub const makeLet = class_deco.makeLet;
     pub const makeObjProp = class_deco.makeObjProp;
     pub const buildAccessObject = class_deco.buildAccessObject;
+    pub const buildFieldInitNames = class_deco.buildFieldInitNames;
     pub const extractTypeFromSource = class_deco.extractTypeFromSource;
 
     fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1712,11 +1712,14 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     const class_deco_start = self.readU32(e, 6);
     const class_deco_len = self.readU32(e, 7);
 
-    // 클래스 이름 텍스트 (Foo). 익명 class expression은 "_a"를 사용.
+    // 클래스 이름 텍스트 (Foo). 익명 class expression은 고유 임시 변수명 사용.
     const class_name_text = if (!name_idx.isNone()) blk: {
         const name_node = self.ast.getNode(name_idx);
         break :blk self.ast.getText(name_node.data.string_ref);
-    } else "_a";
+    } else blk: {
+        const temp_span = try es_helpers.makeTempVarSpan(self);
+        break :blk self.ast.getText(temp_span);
+    };
 
     // body 멤버 순회: member decorator 수집
     var member_infos: std.ArrayList(Stage3MemberInfo) = .empty;
@@ -1815,6 +1818,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 // key를 한 번만 방문
                 const new_key = try self.visitNode(self.readNodeIdx(me, 0));
 
+                var field_init_name: ?[]const u8 = null;
                 if (deco_len > 0) {
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
                     const decos = try self.collectStage3Decorators(deco_start, deco_len);
@@ -1822,6 +1826,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
                     const names = try self.buildFieldInitNames(name_node_idx);
+                    field_init_name = names.init_name;
 
                     try member_infos.append(self.allocator, .{
                         .kind = "field",
@@ -1834,8 +1839,28 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     });
                 }
 
-                // property를 decorator 없이 추가
-                const new_init = try self.visitNode(self.readNodeIdx(me, 1));
+                // property를 decorator 없이 추가 (decorated면 초기값을 __runInitializers로 래핑)
+                const raw_init = try self.visitNode(self.readNodeIdx(me, 1));
+                const new_init = if (field_init_name) |init_name| blk: {
+                    // field = __runInitializers(this, _x_initializers, originalValue)
+                    const this_node = try self.ast.addNode(.{
+                        .tag = .this_expression, .span = zero_span,
+                        .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+                    });
+                    const callee = try makeIdentifier(self, "__runInitializers");
+                    const init_arr = try makeIdentifier(self, init_name);
+                    if (!raw_init.isNone()) {
+                        const args = try self.ast.addNodeList(&.{ this_node, init_arr, raw_init });
+                        break :blk try self.addExtraNode(.call_expression, zero_span, &.{
+                            @intFromEnum(callee), args.start, args.len, 0,
+                        });
+                    } else {
+                        const args = try self.ast.addNodeList(&.{ this_node, init_arr });
+                        break :blk try self.addExtraNode(.call_expression, zero_span, &.{
+                            @intFromEnum(callee), args.start, args.len, 0,
+                        });
+                    }
+                } else raw_init;
                 const empty_list = try self.ast.addNodeList(&.{});
                 const new_prop = try self.addExtraNode(.property_definition, member.span, &.{
                     @intFromEnum(new_key),
@@ -2092,6 +2117,12 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         // Foo = _classThis = _classDescriptor.value;
         const reassign = try self.buildClassReassign(class_name_text, classThis_span);
         try static_block_stmts.append(self.allocator, reassign);
+    }
+
+    // if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+    {
+        const metadata_define = try self.buildMetadataDefineProperty(classThis_span);
+        try static_block_stmts.append(self.allocator, metadata_define);
     }
 
     // __runInitializers(_classThis, _classExtraInitializers);
@@ -2859,4 +2890,66 @@ pub fn buildFieldInitNames(self: *Transformer, name_node_idx: NodeIndex) Error!F
     const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{clean_name});
     const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{clean_name});
     return .{ .init_name = init_name, .extra_name = extra_name, .clean_name = clean_name };
+}
+
+/// if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+pub fn buildMetadataDefineProperty(self: *Transformer, classThis_span: Span) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+
+    // _metadata (condition)
+    const metadata_cond = try makeIdentifier(self, "_metadata");
+
+    // Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata })
+    const object_ref = try makeIdentifier(self, "Object");
+    const defprop_key = try makeIdentifier(self, "defineProperty");
+    const obj_defprop = try es_helpers.makeStaticMember(self, object_ref, defprop_key, zero_span);
+
+    // arg1: _classThis
+    const ct_ref = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = classThis_span,
+        .data = .{ .string_ref = classThis_span },
+    });
+
+    // arg2: Symbol.metadata
+    const sym_ref = try makeIdentifier(self, "Symbol");
+    const meta_key = try makeIdentifier(self, "metadata");
+    const sym_meta = try es_helpers.makeStaticMember(self, sym_ref, meta_key, zero_span);
+
+    // arg3: { enumerable: true, configurable: true, writable: true, value: _metadata }
+    const enum_k = try makeIdentifier(self, "enumerable");
+    const enum_v = try makeIdentifier(self, "true");
+    const conf_k = try makeIdentifier(self, "configurable");
+    const conf_v = try makeIdentifier(self, "true");
+    const writ_k = try makeIdentifier(self, "writable");
+    const writ_v = try makeIdentifier(self, "true");
+    const val_k = try makeIdentifier(self, "value");
+    const val_v = try makeIdentifier(self, "_metadata");
+
+    const p1 = try self.makeObjProp(enum_k, enum_v);
+    const p2 = try self.makeObjProp(conf_k, conf_v);
+    const p3 = try self.makeObjProp(writ_k, writ_v);
+    const p4 = try self.makeObjProp(val_k, val_v);
+    const props_list = try self.ast.addNodeList(&.{ p1, p2, p3, p4 });
+    const desc_obj = try self.ast.addNode(.{ .tag = .object_expression, .span = zero_span, .data = .{ .list = props_list } });
+
+    const call_args = try self.ast.addNodeList(&.{ ct_ref, sym_meta, desc_obj });
+    const call = try self.addExtraNode(.call_expression, zero_span, &.{
+        @intFromEnum(obj_defprop), call_args.start, call_args.len, 0,
+    });
+
+    // if (_metadata) call;
+    const call_stmt = try self.ast.addNode(.{
+        .tag = .expression_statement, .span = zero_span,
+        .data = .{ .unary = .{ .operand = call, .flags = 0 } },
+    });
+    const body_list = try self.ast.addNodeList(&.{call_stmt});
+    const body = try self.ast.addNode(.{
+        .tag = .block_statement, .span = zero_span,
+        .data = .{ .list = body_list },
+    });
+
+    return self.ast.addNode(.{
+        .tag = .if_statement, .span = zero_span,
+        .data = .{ .ternary = .{ .a = metadata_cond, .b = body, .c = .none } },
+    });
 }

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1794,6 +1794,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     break :blk orig_key.tag == .private_identifier;
                 };
 
+                const is_private_method = is_private and deco_len > 0 and !is_getter and !is_setter;
+
                 if (deco_len > 0) {
                     const kind = if (is_getter) "getter" else if (is_setter) "setter" else "method";
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
@@ -1806,11 +1808,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     var m_body: NodeIndex = .none;
                     var m_params_start: u32 = 0;
                     var m_params_len: u32 = 0;
-                    if (is_private and !is_getter and !is_setter) {
-                        const name_node = self.ast.getNode(name_node_idx);
-                        const raw_n = self.ast.getText(name_node.data.string_ref);
-                        const clean_n = if (raw_n.len >= 2 and raw_n[0] == '"') raw_n[1 .. raw_n.len - 1] else raw_n;
-                        const var_n = if (clean_n.len > 0 and clean_n[0] == '#') clean_n[1..] else clean_n;
+                    if (is_private_method) {
+                        const var_n = extractCleanVarName(self, name_node_idx);
                         desc_name = try std.fmt.allocPrint(self.allocator, "_private_{s}_descriptor", .{var_n});
                         m_body = try self.visitNode(self.readNodeIdx(me, 3));
                         m_params_start = self.readU32(me, 1);
@@ -1830,35 +1829,14 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     });
                 }
 
-                // private decorated method → getter로 교체
-                if (is_private and deco_len > 0 and !is_getter and !is_setter) {
-                    // get #method() { return _private_method_descriptor.value; }
-                    const last_info = member_infos.items[member_infos.items.len - 1];
-                    if (last_info.descriptor_name) |dname| {
-                        const desc_ref = try makeIdentifier(self, dname);
-                        const val_key = try makeIdentifier(self, "value");
-                        const desc_val = try es_helpers.makeStaticMember(self, desc_ref, val_key, zero_span);
-                        const return_stmt = try self.ast.addNode(.{
-                            .tag = .return_statement, .span = zero_span,
-                            .data = .{ .unary = .{ .operand = desc_val, .flags = 0 } },
-                        });
-                        const body_list = try self.ast.addNodeList(&.{return_stmt});
-                        const getter_body = try self.ast.addNode(.{
-                            .tag = .block_statement, .span = zero_span,
-                            .data = .{ .list = body_list },
-                        });
-                        const empty_params = try self.ast.addNodeList(&.{});
-                        const empty_decos = try self.ast.addNodeList(&.{});
-                        const getter_flags: u32 = 0x02 | (if (is_static) @as(u32, 0x01) else 0);
-                        const getter_method = try self.addExtraNode(.method_definition, member.span, &.{
-                            @intFromEnum(new_key),
-                            empty_params.start, empty_params.len,
-                            @intFromEnum(getter_body),
-                            getter_flags,
-                            empty_decos.start, empty_decos.len,
-                        });
-                        try new_members.append(self.allocator, getter_method);
-                    }
+                if (is_private_method) {
+                    // private decorated method → getter로 교체: get #method() { return _descriptor.value; }
+                    const info = member_infos.items[member_infos.items.len - 1];
+                    const desc_ref = try makeIdentifier(self, info.descriptor_name.?);
+                    const val_key = try makeIdentifier(self, "value");
+                    const return_expr = try es_helpers.makeStaticMember(self, desc_ref, val_key, zero_span);
+                    const getter = try self.buildGetterMethod(new_key, return_expr, is_static, member.span);
+                    try new_members.append(self.allocator, getter);
                 } else {
                     // public method 또는 non-decorated → 그대로 추가
                     const new_body = try self.visitNode(self.readNodeIdx(me, 3));
@@ -1999,10 +1977,6 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
                     // get x() { return this.#_x_accessor_storage; }
                     {
-                        const getter_key = try self.ast.addNode(.{
-                            .tag = .identifier_reference, .span = self.ast.getNode(new_key).data.string_ref,
-                            .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
-                        });
                         const this_node = try self.ast.addNode(.{
                             .tag = .this_expression, .span = zero_span,
                             .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
@@ -2011,27 +1985,12 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                             .tag = .private_identifier, .span = storage_span,
                             .data = .{ .string_ref = storage_span },
                         });
-                        const this_storage = try self.addExtraNode(.static_member_expression, zero_span, &.{
-                            @intFromEnum(this_node), @intFromEnum(storage_ref), 0,
+                        const return_expr = try es_helpers.makeStaticMember(self, this_node, storage_ref, zero_span);
+                        const getter_key = try self.ast.addNode(.{
+                            .tag = .identifier_reference, .span = self.ast.getNode(new_key).data.string_ref,
+                            .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
                         });
-                        const return_stmt = try self.ast.addNode(.{
-                            .tag = .return_statement, .span = zero_span,
-                            .data = .{ .unary = .{ .operand = this_storage, .flags = 0 } },
-                        });
-                        const body_list = try self.ast.addNodeList(&.{return_stmt});
-                        const body = try self.ast.addNode(.{
-                            .tag = .block_statement, .span = zero_span,
-                            .data = .{ .list = body_list },
-                        });
-                        const empty_params = try self.ast.addNodeList(&.{});
-                        const getter_flags: u32 = 0x02 | (if (is_static) @as(u32, 0x01) else 0); // getter + static
-                        const getter = try self.addExtraNode(.method_definition, zero_span, &.{
-                            @intFromEnum(getter_key),
-                            empty_params.start, empty_params.len,
-                            @intFromEnum(body),
-                            getter_flags,
-                            empty_decos.start, empty_decos.len,
-                        });
+                        const getter = try self.buildGetterMethod(getter_key, return_expr, is_static, zero_span);
                         try new_members.append(self.allocator, getter);
                     }
 
@@ -2998,18 +2957,14 @@ const FieldInitNames = struct {
 };
 
 pub fn buildFieldInitNames(self: *Transformer, name_node_idx: NodeIndex) Error!FieldInitNames {
+    const var_name = extractCleanVarName(self, name_node_idx);
+    // clean_name은 #을 포함 (private field identity), var_name은 # 제거 (JS 변수명)
     const name_node = self.ast.getNode(name_node_idx);
     const raw_name = self.ast.getText(name_node.data.string_ref);
-    // 따옴표 제거: "\"foo\"" → "foo", "\"#foo\"" → "#foo"
     const clean_name = if (raw_name.len >= 2 and raw_name[0] == '"')
         raw_name[1 .. raw_name.len - 1]
     else
         raw_name;
-    // 변수명에서 # 제거: #foo → foo (JS 변수명에 # 사용 불가)
-    const var_name = if (clean_name.len > 0 and clean_name[0] == '#')
-        clean_name[1..]
-    else
-        clean_name;
     const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{var_name});
     const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{var_name});
     return .{ .init_name = init_name, .extra_name = extra_name, .clean_name = clean_name };
@@ -3075,4 +3030,41 @@ pub fn buildMetadataDefineProperty(self: *Transformer, classThis_span: Span) Err
         .tag = .if_statement, .span = zero_span,
         .data = .{ .ternary = .{ .a = metadata_cond, .b = body, .c = .none } },
     });
+}
+
+/// getter method_definition 생성 헬퍼: get key() { return return_expr; }
+/// private method → getter 변환, accessor → getter 생성 양쪽에서 공용.
+pub fn buildGetterMethod(self: *Transformer, key: NodeIndex, return_expr: NodeIndex, is_static: bool, span: Span) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const return_stmt = try self.ast.addNode(.{
+        .tag = .return_statement, .span = zero_span,
+        .data = .{ .unary = .{ .operand = return_expr, .flags = 0 } },
+    });
+    const body_list = try self.ast.addNodeList(&.{return_stmt});
+    const getter_body = try self.ast.addNode(.{
+        .tag = .block_statement, .span = zero_span,
+        .data = .{ .list = body_list },
+    });
+    const empty_params = try self.ast.addNodeList(&.{});
+    const empty_decos = try self.ast.addNodeList(&.{});
+    const getter_flags: u32 = 0x02 | (if (is_static) @as(u32, 0x01) else 0);
+    return self.addExtraNode(.method_definition, span, &.{
+        @intFromEnum(key),
+        empty_params.start, empty_params.len,
+        @intFromEnum(getter_body),
+        getter_flags,
+        empty_decos.start, empty_decos.len,
+    });
+}
+
+/// 문자열 리터럴 노드에서 JS 변수명으로 사용 가능한 이름 추출.
+/// 따옴표 제거 ("\"foo\"" → "foo") + # 제거 ("#foo" → "foo").
+pub fn extractCleanVarName(self: *Transformer, name_node_idx: NodeIndex) []const u8 {
+    const name_node = self.ast.getNode(name_node_idx);
+    const raw_name = self.ast.getText(name_node.data.string_ref);
+    const clean = if (raw_name.len >= 2 and raw_name[0] == '"')
+        raw_name[1 .. raw_name.len - 1]
+    else
+        raw_name;
+    return if (clean.len > 0 and clean[0] == '#') clean[1..] else clean;
 }

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1661,6 +1661,13 @@ const Stage3MemberInfo = struct {
     initializers_name: ?[]const u8 = null,
     /// field/accessor용 extraInitializers 변수명 (예: "_x_extraInitializers")
     extra_initializers_name: ?[]const u8 = null,
+    /// private method용: descriptor 변수명 (예: "_private_secret_descriptor")
+    descriptor_name: ?[]const u8 = null,
+    /// private method용: 원본 method body (function expression으로 변환에 사용)
+    method_body: NodeIndex = .none,
+    /// private method용: 원본 params_start/params_len
+    method_params_start: u32 = 0,
+    method_params_len: u32 = 0,
     /// 원본 AST 멤버 인덱스 (class body 내 위치)
     raw_idx: u32 = 0,
 };
@@ -1728,6 +1735,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
             self.allocator.free(info.decorators);
             if (info.initializers_name) |name| self.allocator.free(name);
             if (info.extra_initializers_name) |name| self.allocator.free(name);
+            if (info.descriptor_name) |name| self.allocator.free(name);
         }
         member_infos.deinit(self.allocator);
     }
@@ -1793,27 +1801,78 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
+                    // private method: descriptor 변수명 + body 저장
+                    var desc_name: ?[]const u8 = null;
+                    var m_body: NodeIndex = .none;
+                    var m_params_start: u32 = 0;
+                    var m_params_len: u32 = 0;
+                    if (is_private and !is_getter and !is_setter) {
+                        const name_node = self.ast.getNode(name_node_idx);
+                        const raw_n = self.ast.getText(name_node.data.string_ref);
+                        const clean_n = if (raw_n.len >= 2 and raw_n[0] == '"') raw_n[1 .. raw_n.len - 1] else raw_n;
+                        const var_n = if (clean_n.len > 0 and clean_n[0] == '#') clean_n[1..] else clean_n;
+                        desc_name = try std.fmt.allocPrint(self.allocator, "_private_{s}_descriptor", .{var_n});
+                        m_body = try self.visitNode(self.readNodeIdx(me, 3));
+                        m_params_start = self.readU32(me, 1);
+                        m_params_len = self.readU32(me, 2);
+                    }
+
                     try member_infos.append(self.allocator, .{
                         .kind = kind,
                         .name = name_node_idx,
                         .is_static = is_static,
                         .is_private = is_private,
                         .decorators = decos,
+                        .descriptor_name = desc_name,
+                        .method_body = m_body,
+                        .method_params_start = m_params_start,
+                        .method_params_len = m_params_len,
                     });
                 }
 
-                // method를 decorator 없이 body에 추가
-                const new_body = try self.visitNode(self.readNodeIdx(me, 3));
-                const empty_list = try self.ast.addNodeList(&.{});
-                const new_method = try self.addExtraNode(.method_definition, member.span, &.{
-                    @intFromEnum(new_key),
-                    self.readU32(me, 1), // params_start
-                    self.readU32(me, 2), // params_len
-                    @intFromEnum(new_body),
-                    flags,
-                    empty_list.start, empty_list.len, // decorator 제거
-                });
-                try new_members.append(self.allocator, new_method);
+                // private decorated method → getter로 교체
+                if (is_private and deco_len > 0 and !is_getter and !is_setter) {
+                    // get #method() { return _private_method_descriptor.value; }
+                    const last_info = member_infos.items[member_infos.items.len - 1];
+                    if (last_info.descriptor_name) |dname| {
+                        const desc_ref = try makeIdentifier(self, dname);
+                        const val_key = try makeIdentifier(self, "value");
+                        const desc_val = try es_helpers.makeStaticMember(self, desc_ref, val_key, zero_span);
+                        const return_stmt = try self.ast.addNode(.{
+                            .tag = .return_statement, .span = zero_span,
+                            .data = .{ .unary = .{ .operand = desc_val, .flags = 0 } },
+                        });
+                        const body_list = try self.ast.addNodeList(&.{return_stmt});
+                        const getter_body = try self.ast.addNode(.{
+                            .tag = .block_statement, .span = zero_span,
+                            .data = .{ .list = body_list },
+                        });
+                        const empty_params = try self.ast.addNodeList(&.{});
+                        const empty_decos = try self.ast.addNodeList(&.{});
+                        const getter_flags: u32 = 0x02 | (if (is_static) @as(u32, 0x01) else 0);
+                        const getter_method = try self.addExtraNode(.method_definition, member.span, &.{
+                            @intFromEnum(new_key),
+                            empty_params.start, empty_params.len,
+                            @intFromEnum(getter_body),
+                            getter_flags,
+                            empty_decos.start, empty_decos.len,
+                        });
+                        try new_members.append(self.allocator, getter_method);
+                    }
+                } else {
+                    // public method 또는 non-decorated → 그대로 추가
+                    const new_body = try self.visitNode(self.readNodeIdx(me, 3));
+                    const empty_list = try self.ast.addNodeList(&.{});
+                    const new_method = try self.addExtraNode(.method_definition, member.span, &.{
+                        @intFromEnum(new_key),
+                        self.readU32(me, 1),
+                        self.readU32(me, 2),
+                        @intFromEnum(new_body),
+                        flags,
+                        empty_list.start, empty_list.len,
+                    });
+                    try new_members.append(self.allocator, new_method);
+                }
             } else if (member.tag == .property_definition) {
                 // extra = [key, init_val, flags, deco_start, deco_len]
                 const flags = self.readU32(me, 2);
@@ -2366,8 +2425,39 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
     else
         try self.ast.addNode(.{ .tag = .this_expression, .span = zero_span, .data = .{ .unary = .{ .operand = .none, .flags = 0 } } });
 
-    // arg2: null (descriptorIn)
-    const arg2 = try makeIdentifier(self, "null");
+    // arg2: null (public) 또는 _descriptor = { value: __setFunctionName(fn, "#name") } (private method)
+    const arg2 = if (info.descriptor_name) |dname| blk: {
+        // _private_method_descriptor = { value: __setFunctionName(function() { ... }, "#name") }
+        const desc_ref = try makeIdentifier(self, dname);
+
+        // __setFunctionName(function() { ... }, "#name")
+        const setfn_callee = try makeIdentifier(self, "__setFunctionName");
+        // function expression with original body
+        const fn_expr = try self.addExtraNode(.function_expression, zero_span, &.{
+            @intFromEnum(NodeIndex.none), // name (anonymous)
+            info.method_params_start, info.method_params_len,
+            @intFromEnum(info.method_body),
+            0, // flags
+            @intFromEnum(NodeIndex.none), // ret_type
+        });
+        const name_str = info.name; // "#method" as string_literal
+        const setfn_args = try self.ast.addNodeList(&.{ fn_expr, name_str });
+        const setfn_call = try self.addExtraNode(.call_expression, zero_span, &.{
+            @intFromEnum(setfn_callee), setfn_args.start, setfn_args.len, 0,
+        });
+
+        // { value: __setFunctionName(...) }
+        const value_key = try makeIdentifier(self, "value");
+        const value_prop = try self.makeObjProp(value_key, setfn_call);
+        const desc_list = try self.ast.addNodeList(&.{value_prop});
+        const desc_obj = try self.ast.addNode(.{ .tag = .object_expression, .span = zero_span, .data = .{ .list = desc_list } });
+
+        // _descriptor = { value: ... }
+        break :blk try self.ast.addNode(.{
+            .tag = .assignment_expression, .span = zero_span,
+            .data = .{ .binary = .{ .left = desc_ref, .right = desc_obj, .flags = 0 } },
+        });
+    } else try makeIdentifier(self, "null");
 
     // arg3: [dec1, dec2, ...]
     const deco_list = try self.ast.addNodeList(info.decorators);
@@ -2851,8 +2941,12 @@ pub fn buildStage3LetDeclarations(
         try stmts.append(self.allocator, try self.makeLet(zero_span, "_staticExtraInitializers", empty_arr));
     }
 
-    // field/accessor decorator별 initializers/extraInitializers 변수
+    // field/accessor decorator별 initializers/extraInitializers + private method descriptor 변수
     for (member_infos) |info| {
+        if (info.descriptor_name) |dname| {
+            // let _private_method_descriptor;
+            try stmts.append(self.allocator, try self.makeLet(zero_span, dname, .none));
+        }
         if (info.initializers_name) |init_name| {
             const empty_arr_list = try self.ast.addNodeList(&.{});
             const empty_arr = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = empty_arr_list } });

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1854,7 +1854,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         self.readU32(me, 2),
                         @intFromEnum(new_body),
                         flags,
-                        empty_list.start, empty_list.len,
+                        empty_list.start,
+                        empty_list.len,
                     });
                     try new_members.append(self.allocator, new_method);
                 }
@@ -1899,7 +1900,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 const new_init = if (field_init_name) |init_name| blk: {
                     // field = __runInitializers(this, _x_initializers, originalValue)
                     const this_node = try self.ast.addNode(.{
-                        .tag = .this_expression, .span = zero_span,
+                        .tag = .this_expression,
+                        .span = zero_span,
                         .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
                     });
                     const callee = try makeIdentifier(self, "__runInitializers");
@@ -1923,7 +1925,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     @intFromEnum(new_key),
                     @intFromEnum(new_init),
                     flags,
-                    empty_list.start, empty_list.len,
+                    empty_list.start,
+                    empty_list.len,
                 });
                 try new_members.append(self.allocator, new_prop);
             } else if (member.tag == .accessor_property) {
@@ -1964,13 +1967,15 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     defer self.allocator.free(storage_name);
                     const storage_span = try self.ast.addString(storage_name);
                     const storage_key = try self.ast.addNode(.{
-                        .tag = .private_identifier, .span = storage_span,
+                        .tag = .private_identifier,
+                        .span = storage_span,
                         .data = .{ .string_ref = storage_span },
                     });
                     // 초기값: __runInitializers(this, _x_initializers, originalValue)
                     const init_val = if (!new_init.isNone()) blk: {
                         const this_node = try self.ast.addNode(.{
-                            .tag = .this_expression, .span = zero_span,
+                            .tag = .this_expression,
+                            .span = zero_span,
                             .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
                         });
                         const callee = try makeIdentifier(self, "__runInitializers");
@@ -1986,23 +1991,27 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         @intFromEnum(storage_key),
                         @intFromEnum(init_val),
                         flags, // static 플래그 보존
-                        empty_decos.start, empty_decos.len,
+                        empty_decos.start,
+                        empty_decos.len,
                     });
                     try new_members.append(self.allocator, backing_field);
 
                     // get x() { return this.#_x_accessor_storage; }
                     {
                         const this_node = try self.ast.addNode(.{
-                            .tag = .this_expression, .span = zero_span,
+                            .tag = .this_expression,
+                            .span = zero_span,
                             .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
                         });
                         const storage_ref = try self.ast.addNode(.{
-                            .tag = .private_identifier, .span = storage_span,
+                            .tag = .private_identifier,
+                            .span = storage_span,
                             .data = .{ .string_ref = storage_span },
                         });
                         const return_expr = try es_helpers.makeStaticMember(self, this_node, storage_ref, zero_span);
                         const getter_key = try self.ast.addNode(.{
-                            .tag = .identifier_reference, .span = self.ast.getNode(new_key).data.string_ref,
+                            .tag = .identifier_reference,
+                            .span = self.ast.getNode(new_key).data.string_ref,
                             .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
                         });
                         const getter = try self.buildGetterMethod(getter_key, return_expr, is_static, zero_span);
@@ -2012,50 +2021,60 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     // set x(value) { this.#_x_accessor_storage = value; }
                     {
                         const setter_key = try self.ast.addNode(.{
-                            .tag = .identifier_reference, .span = self.ast.getNode(new_key).data.string_ref,
+                            .tag = .identifier_reference,
+                            .span = self.ast.getNode(new_key).data.string_ref,
                             .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
                         });
                         const val_param_span = try self.ast.addString("value");
                         const val_param = try self.ast.addNode(.{
-                            .tag = .binding_identifier, .span = val_param_span,
+                            .tag = .binding_identifier,
+                            .span = val_param_span,
                             .data = .{ .string_ref = val_param_span },
                         });
                         const setter_params = try self.ast.addNodeList(&.{val_param});
                         const this_node = try self.ast.addNode(.{
-                            .tag = .this_expression, .span = zero_span,
+                            .tag = .this_expression,
+                            .span = zero_span,
                             .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
                         });
                         const storage_ref = try self.ast.addNode(.{
-                            .tag = .private_identifier, .span = storage_span,
+                            .tag = .private_identifier,
+                            .span = storage_span,
                             .data = .{ .string_ref = storage_span },
                         });
                         const this_storage = try self.addExtraNode(.static_member_expression, zero_span, &.{
                             @intFromEnum(this_node), @intFromEnum(storage_ref), 0,
                         });
                         const val_ref = try self.ast.addNode(.{
-                            .tag = .identifier_reference, .span = val_param_span,
+                            .tag = .identifier_reference,
+                            .span = val_param_span,
                             .data = .{ .string_ref = val_param_span },
                         });
                         const assign = try self.ast.addNode(.{
-                            .tag = .assignment_expression, .span = zero_span,
+                            .tag = .assignment_expression,
+                            .span = zero_span,
                             .data = .{ .binary = .{ .left = this_storage, .right = val_ref, .flags = 0 } },
                         });
                         const assign_stmt = try self.ast.addNode(.{
-                            .tag = .expression_statement, .span = zero_span,
+                            .tag = .expression_statement,
+                            .span = zero_span,
                             .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
                         });
                         const body_list = try self.ast.addNodeList(&.{assign_stmt});
                         const body = try self.ast.addNode(.{
-                            .tag = .block_statement, .span = zero_span,
+                            .tag = .block_statement,
+                            .span = zero_span,
                             .data = .{ .list = body_list },
                         });
                         const setter_flags: u32 = 0x04 | (if (is_static) @as(u32, 0x01) else 0); // setter + static
                         const setter = try self.addExtraNode(.method_definition, zero_span, &.{
                             @intFromEnum(setter_key),
-                            setter_params.start, setter_params.len,
+                            setter_params.start,
+                            setter_params.len,
                             @intFromEnum(body),
                             setter_flags,
-                            empty_decos.start, empty_decos.len,
+                            empty_decos.start,
+                            empty_decos.len,
                         });
                         try new_members.append(self.allocator, setter);
                     }
@@ -2066,7 +2085,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         @intFromEnum(new_key),
                         @intFromEnum(new_init),
                         flags,
-                        empty_list.start, empty_list.len,
+                        empty_list.start,
+                        empty_list.len,
                     });
                     try new_members.append(self.allocator, new_acc);
                 }
@@ -2102,28 +2122,34 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     // static { _classThis = this; }
     {
         const classThis_ref = try self.ast.addNode(.{
-            .tag = .identifier_reference, .span = classThis_span,
+            .tag = .identifier_reference,
+            .span = classThis_span,
             .data = .{ .string_ref = classThis_span },
         });
         const this_node = try self.ast.addNode(.{
-            .tag = .this_expression, .span = zero_span,
+            .tag = .this_expression,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
         });
         const assign = try self.ast.addNode(.{
-            .tag = .assignment_expression, .span = zero_span,
+            .tag = .assignment_expression,
+            .span = zero_span,
             .data = .{ .binary = .{ .left = classThis_ref, .right = this_node, .flags = 0 } },
         });
         const assign_stmt = try self.ast.addNode(.{
-            .tag = .expression_statement, .span = zero_span,
+            .tag = .expression_statement,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
         });
         const static_body_list = try self.ast.addNodeList(&.{assign_stmt});
         const static_body = try self.ast.addNode(.{
-            .tag = .block_statement, .span = zero_span,
+            .tag = .block_statement,
+            .span = zero_span,
             .data = .{ .list = static_body_list },
         });
         const static_block = try self.ast.addNode(.{
-            .tag = .static_block, .span = zero_span,
+            .tag = .static_block,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = static_body, .flags = 0 } },
         });
         try new_members.insert(self.allocator, 0, static_block);
@@ -2146,11 +2172,14 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         if (info.deco_var_name) |vname| {
             const deco_list = try self.ast.addNodeList(info.decorators);
             const deco_arr = try self.ast.addNode(.{
-                .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list },
+                .tag = .array_expression,
+                .span = zero_span,
+                .data = .{ .list = deco_list },
             });
             const var_ref = try makeIdentifier(self, vname);
             const assign = try self.ast.addNode(.{
-                .tag = .assignment_expression, .span = zero_span,
+                .tag = .assignment_expression,
+                .span = zero_span,
                 .data = .{ .binary = .{ .left = var_ref, .right = deco_arr, .flags = 0 } },
             });
             try static_block_stmts.append(self.allocator, try es_helpers.makeExprStmt(self, assign, zero_span));
@@ -2179,7 +2208,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     if (class_deco_len > 0) {
         const class_call = try self.buildClassEsDecorateCall(classThis_span);
         const class_call_stmt = try self.ast.addNode(.{
-            .tag = .expression_statement, .span = zero_span,
+            .tag = .expression_statement,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = class_call, .flags = 0 } },
         });
         try static_block_stmts.append(self.allocator, class_call_stmt);
@@ -2199,7 +2229,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     if (class_deco_len > 0) {
         const run_init = try self.buildRunInitializersCall(classThis_span, "_classExtraInitializers");
         const run_init_stmt = try self.ast.addNode(.{
-            .tag = .expression_statement, .span = zero_span,
+            .tag = .expression_statement,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = run_init, .flags = 0 } },
         });
         try static_block_stmts.append(self.allocator, run_init_stmt);
@@ -2209,11 +2240,13 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     if (static_block_stmts.items.len > 0) {
         const sb_body_list = try self.ast.addNodeList(static_block_stmts.items);
         const sb_body = try self.ast.addNode(.{
-            .tag = .block_statement, .span = zero_span,
+            .tag = .block_statement,
+            .span = zero_span,
             .data = .{ .list = sb_body_list },
         });
         const sb = try self.ast.addNode(.{
-            .tag = .static_block, .span = zero_span,
+            .tag = .static_block,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = sb_body, .flags = 0 } },
         });
         // 첫 static block 뒤에 삽입 (index 1)
@@ -2224,32 +2257,38 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     if (has_instance_decorators and !has_constructor) {
         // 빈 constructor 생성: constructor() { __runInitializers(this, _instanceExtraInitializers); }
         const this_node = try self.ast.addNode(.{
-            .tag = .this_expression, .span = zero_span,
+            .tag = .this_expression,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
         });
         const run_init = try self.buildRunInitializersCall2(this_node, "_instanceExtraInitializers");
         const run_init_stmt = try self.ast.addNode(.{
-            .tag = .expression_statement, .span = zero_span,
+            .tag = .expression_statement,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = run_init, .flags = 0 } },
         });
         const ctor_body_list = try self.ast.addNodeList(&.{run_init_stmt});
         const ctor_body = try self.ast.addNode(.{
-            .tag = .block_statement, .span = zero_span,
+            .tag = .block_statement,
+            .span = zero_span,
             .data = .{ .list = ctor_body_list },
         });
         const ctor_key_span = try self.ast.addString("constructor");
         const ctor_key = try self.ast.addNode(.{
-            .tag = .identifier_reference, .span = ctor_key_span,
+            .tag = .identifier_reference,
+            .span = ctor_key_span,
             .data = .{ .string_ref = ctor_key_span },
         });
         const empty_params = try self.ast.addNodeList(&.{});
         const empty_decos = try self.ast.addNodeList(&.{});
         const ctor_method = try self.addExtraNode(.method_definition, zero_span, &.{
             @intFromEnum(ctor_key),
-            empty_params.start, empty_params.len,
+            empty_params.start,
+            empty_params.len,
             @intFromEnum(ctor_body),
             0, // flags (no static/getter/setter)
-            empty_decos.start, empty_decos.len,
+            empty_decos.start,
+            empty_decos.len,
         });
         try new_members.append(self.allocator, ctor_method);
     }
@@ -2257,7 +2296,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     // 새 class body 생성
     const new_body_list = try self.ast.addNodeList(new_members.items);
     const new_body = try self.ast.addNode(.{
-        .tag = .class_body, .span = zero_span,
+        .tag = .class_body,
+        .span = zero_span,
         .data = .{ .list = new_body_list },
     });
 
@@ -2267,15 +2307,16 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     const new_super = try self.visitNode(super_idx);
     const empty_decos = try self.ast.addNodeList(&.{});
     const inner_class = try self.addExtraNode(.class_expression, node.span, &.{
-        none, @intFromEnum(new_super), @intFromEnum(new_body),
-        none, 0, 0,
+        none,              @intFromEnum(new_super), @intFromEnum(new_body),
+        none,              0,                       0,
         empty_decos.start, empty_decos.len,
     });
 
     // IIFE 내부: var Foo = class { ... };
     const inner_name_span = try self.ast.addString(class_name_text);
     const inner_binding = try self.ast.addNode(.{
-        .tag = .binding_identifier, .span = inner_name_span,
+        .tag = .binding_identifier,
+        .span = inner_name_span,
         .data = .{ .string_ref = inner_name_span },
     });
     const inner_declarator = try self.addExtraNode(.variable_declarator, zero_span, &.{
@@ -2289,19 +2330,23 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
     // return Foo = _classThis;
     const return_name = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = inner_name_span,
+        .tag = .identifier_reference,
+        .span = inner_name_span,
         .data = .{ .string_ref = inner_name_span },
     });
     const classThis_ref2 = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = classThis_span,
+        .tag = .identifier_reference,
+        .span = classThis_span,
         .data = .{ .string_ref = classThis_span },
     });
     const return_assign = try self.ast.addNode(.{
-        .tag = .assignment_expression, .span = zero_span,
+        .tag = .assignment_expression,
+        .span = zero_span,
         .data = .{ .binary = .{ .left = return_name, .right = classThis_ref2, .flags = 0 } },
     });
     const return_stmt = try self.ast.addNode(.{
-        .tag = .return_statement, .span = zero_span,
+        .tag = .return_statement,
+        .span = zero_span,
         .data = .{ .unary = .{ .operand = return_assign, .flags = 0 } },
     });
     try iife_stmts.append(self.allocator, return_stmt);
@@ -2313,8 +2358,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
     // let 선언 생성
     const let_decls = try self.buildStage3LetDeclarations(
-        class_deco_start, class_deco_len,
-        member_infos.items, has_instance_decorators, has_static_decorators,
+        class_deco_start,
+        class_deco_len,
+        member_infos.items,
+        has_instance_decorators,
+        has_static_decorators,
     );
     try all_iife_stmts.appendSlice(self.allocator, let_decls);
     self.allocator.free(let_decls);
@@ -2324,7 +2372,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
     const iife_body_list = try self.ast.addNodeList(all_iife_stmts.items);
     const iife_body = try self.ast.addNode(.{
-        .tag = .block_statement, .span = zero_span,
+        .tag = .block_statement,
+        .span = zero_span,
         .data = .{ .list = iife_body_list },
     });
 
@@ -2339,7 +2388,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
     // (() => { ... })()
     const paren_arrow = try self.ast.addNode(.{
-        .tag = .parenthesized_expression, .span = zero_span,
+        .tag = .parenthesized_expression,
+        .span = zero_span,
         .data = .{ .unary = .{ .operand = arrow, .flags = 0 } },
     });
     const empty_args = try self.ast.addNodeList(&.{});
@@ -2359,7 +2409,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     } else try self.ast.addString("default");
 
     const outer_binding = try self.ast.addNode(.{
-        .tag = .binding_identifier, .span = outer_name_span,
+        .tag = .binding_identifier,
+        .span = outer_name_span,
         .data = .{ .string_ref = outer_name_span },
     });
     const outer_declarator = try self.addExtraNode(.variable_declarator, zero_span, &.{
@@ -2466,7 +2517,8 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
         // function expression with original body
         const fn_expr = try self.addExtraNode(.function_expression, zero_span, &.{
             @intFromEnum(NodeIndex.none), // name (anonymous)
-            info.method_params_start, info.method_params_len,
+            info.method_params_start,
+            info.method_params_len,
             @intFromEnum(info.method_body),
             0, // flags
             @intFromEnum(NodeIndex.none), // ret_type
@@ -2485,7 +2537,8 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
 
         // _descriptor = { value: ... }
         break :blk try self.ast.addNode(.{
-            .tag = .assignment_expression, .span = zero_span,
+            .tag = .assignment_expression,
+            .span = zero_span,
             .data = .{ .binary = .{ .left = desc_ref, .right = desc_obj, .flags = 0 } },
         });
     } else try makeIdentifier(self, "null");
@@ -2533,12 +2586,14 @@ pub fn buildClassEsDecorateCall(self: *Transformer, classThis_span: Span) Error!
 
     // arg2: _classDescriptor = { value: _classThis }
     const classThis_ref = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = classThis_span,
+        .tag = .identifier_reference,
+        .span = classThis_span,
         .data = .{ .string_ref = classThis_span },
     });
     const value_key_span = try self.ast.addString("value");
     const value_key = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = value_key_span,
+        .tag = .identifier_reference,
+        .span = value_key_span,
         .data = .{ .string_ref = value_key_span },
     });
     const value_prop = try self.makeObjProp(value_key, classThis_ref);
@@ -2547,11 +2602,13 @@ pub fn buildClassEsDecorateCall(self: *Transformer, classThis_span: Span) Error!
 
     const desc_span = try self.ast.addString("_classDescriptor");
     const desc_ref = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = desc_span,
+        .tag = .identifier_reference,
+        .span = desc_span,
         .data = .{ .string_ref = desc_span },
     });
     const arg2 = try self.ast.addNode(.{
-        .tag = .assignment_expression, .span = zero_span,
+        .tag = .assignment_expression,
+        .span = zero_span,
         .data = .{ .binary = .{ .left = desc_ref, .right = obj, .flags = 0 } },
     });
 
@@ -2567,7 +2624,8 @@ pub fn buildClassEsDecorateCall(self: *Transformer, classThis_span: Span) Error!
     const name_key = try makeIdentifier(self, "name");
     // _classThis.name
     const classThis_ref2 = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = classThis_span,
+        .tag = .identifier_reference,
+        .span = classThis_span,
         .data = .{ .string_ref = classThis_span },
     });
     const name_prop_key = try makeIdentifier(self, "name");
@@ -2680,12 +2738,14 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
         const has_key = try makeIdentifier(self, "has");
         const obj_param_span = try self.ast.addString("obj");
         const obj_param = try self.ast.addNode(.{
-            .tag = .binding_identifier, .span = obj_param_span,
+            .tag = .binding_identifier,
+            .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
 
         const obj_ref = try self.ast.addNode(.{
-            .tag = .identifier_reference, .span = obj_param_span,
+            .tag = .identifier_reference,
+            .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
 
@@ -2693,18 +2753,21 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
             // #name (private_identifier)
             const priv_span = try self.ast.addString(member_name);
             break :blk try self.ast.addNode(.{
-                .tag = .private_identifier, .span = priv_span,
+                .tag = .private_identifier,
+                .span = priv_span,
                 .data = .{ .string_ref = priv_span },
             });
         } else blk: {
             // "name" (string_literal)
             break :blk try self.ast.addNode(.{
-                .tag = .string_literal, .span = name_node.data.string_ref,
+                .tag = .string_literal,
+                .span = name_node.data.string_ref,
                 .data = .{ .string_ref = name_node.data.string_ref },
             });
         };
         const in_expr = try self.ast.addNode(.{
-            .tag = .binary_expression, .span = zero_span,
+            .tag = .binary_expression,
+            .span = zero_span,
             .data = .{ .binary = .{ .left = in_left, .right = obj_ref, .flags = @intFromEnum(Kind.kw_in) } },
         });
 
@@ -2720,13 +2783,15 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
         const get_key = try makeIdentifier(self, "get");
         const obj_param_span = try self.ast.addString("obj");
         const obj_param = try self.ast.addNode(.{
-            .tag = .binding_identifier, .span = obj_param_span,
+            .tag = .binding_identifier,
+            .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
 
         // obj.name (public) / obj.#name (private) / obj["name"] or obj[0] (computed key)
         const obj_ref = try self.ast.addNode(.{
-            .tag = .identifier_reference, .span = obj_param_span,
+            .tag = .identifier_reference,
+            .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
         const obj_member = if (needs_computed) blk: {
@@ -2737,7 +2802,8 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
             const member_key_tag: Tag = if (info.is_private) .private_identifier else .identifier_reference;
             const member_key_span = try self.ast.addString(member_name);
             const member_key_node = try self.ast.addNode(.{
-                .tag = member_key_tag, .span = member_key_span,
+                .tag = member_key_tag,
+                .span = member_key_span,
                 .data = .{ .string_ref = member_key_span },
             });
             break :blk try es_helpers.makeStaticMember(self, obj_ref, member_key_node, zero_span);
@@ -2760,19 +2826,22 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
         // function_expression: extra = [name(0), params_start, params_len, body(3), flags, ret_type(5)]
         const obj_param_span = try self.ast.addString("obj");
         const obj_param = try self.ast.addNode(.{
-            .tag = .binding_identifier, .span = obj_param_span,
+            .tag = .binding_identifier,
+            .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
         const val_param_span = try self.ast.addString("value");
         const val_param = try self.ast.addNode(.{
-            .tag = .binding_identifier, .span = val_param_span,
+            .tag = .binding_identifier,
+            .span = val_param_span,
             .data = .{ .string_ref = val_param_span },
         });
         const fn_params = try self.ast.addNodeList(&.{ obj_param, val_param });
 
         // body: { obj.name = value; } / { obj.#name = value; } / { obj["name"] = value; }
         const obj_ref = try self.ast.addNode(.{
-            .tag = .identifier_reference, .span = obj_param_span,
+            .tag = .identifier_reference,
+            .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
         const obj_member = if (needs_computed) blk: {
@@ -2781,35 +2850,41 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
             const set_key_tag: Tag = if (info.is_private) .private_identifier else .identifier_reference;
             const set_key_span = try self.ast.addString(member_name);
             const set_key_node = try self.ast.addNode(.{
-                .tag = set_key_tag, .span = set_key_span,
+                .tag = set_key_tag,
+                .span = set_key_span,
                 .data = .{ .string_ref = set_key_span },
             });
             break :blk try es_helpers.makeStaticMember(self, obj_ref, set_key_node, zero_span);
         };
         const val_ref = try self.ast.addNode(.{
-            .tag = .identifier_reference, .span = val_param_span,
+            .tag = .identifier_reference,
+            .span = val_param_span,
             .data = .{ .string_ref = val_param_span },
         });
         const assign = try self.ast.addNode(.{
-            .tag = .assignment_expression, .span = zero_span,
+            .tag = .assignment_expression,
+            .span = zero_span,
             .data = .{ .binary = .{ .left = obj_member, .right = val_ref, .flags = 0 } },
         });
         const assign_stmt = try self.ast.addNode(.{
-            .tag = .expression_statement, .span = zero_span,
+            .tag = .expression_statement,
+            .span = zero_span,
             .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
         });
         const body_list = try self.ast.addNodeList(&.{assign_stmt});
         const fn_body = try self.ast.addNode(.{
-            .tag = .block_statement, .span = zero_span,
+            .tag = .block_statement,
+            .span = zero_span,
             .data = .{ .list = body_list },
         });
 
         const set_fn = try self.addExtraNode(.function_expression, zero_span, &.{
-            none,            // name (anonymous)
-            fn_params.start, fn_params.len,
+            none, // name (anonymous)
+            fn_params.start,
+            fn_params.len,
             @intFromEnum(fn_body),
-            0,               // flags
-            none,            // ret_type
+            0, // flags
+            none, // ret_type
         });
         try access_props.append(self.allocator, try self.makeObjProp(set_key, set_fn));
     }
@@ -2832,7 +2907,8 @@ pub fn buildMetadataDecl(self: *Transformer) Error!NodeIndex {
     const func_str_span = try self.ast.addString("\"function\"");
     const func_str = try self.ast.addNode(.{ .tag = .string_literal, .span = func_str_span, .data = .{ .string_ref = func_str_span } });
     const typeof_check = try self.ast.addNode(.{
-        .tag = .binary_expression, .span = zero_span,
+        .tag = .binary_expression,
+        .span = zero_span,
         .data = .{ .binary = .{ .left = typeof_expr, .right = func_str, .flags = @intFromEnum(Kind.eq3) } },
     });
 
@@ -2845,7 +2921,8 @@ pub fn buildMetadataDecl(self: *Transformer) Error!NodeIndex {
 
     // typeof Symbol === "function" && Symbol.metadata
     const and_expr = try self.ast.addNode(.{
-        .tag = .binary_expression, .span = zero_span,
+        .tag = .binary_expression,
+        .span = zero_span,
         .data = .{ .binary = .{ .left = typeof_check, .right = symbol_metadata, .flags = @intFromEnum(Kind.amp2) } },
     });
 
@@ -2866,14 +2943,16 @@ pub fn buildMetadataDecl(self: *Transformer) Error!NodeIndex {
 
     // ... ? Object.create(null) : void 0
     const ternary = try self.ast.addNode(.{
-        .tag = .conditional_expression, .span = zero_span,
+        .tag = .conditional_expression,
+        .span = zero_span,
         .data = .{ .ternary = .{ .a = and_expr, .b = obj_create_call, .c = void0 } },
     });
 
     // const _metadata = ...;
     const metadata_span = try self.ast.addString("_metadata");
     const metadata_binding = try self.ast.addNode(.{
-        .tag = .binding_identifier, .span = metadata_span,
+        .tag = .binding_identifier,
+        .span = metadata_span,
         .data = .{ .string_ref = metadata_span },
     });
     const declarator = try self.addExtraNode(.variable_declarator, zero_span, &.{
@@ -2898,23 +2977,27 @@ pub fn buildClassReassign(self: *Transformer, class_name: []const u8, classThis_
 
     // _classThis = _classDescriptor.value
     const classThis_ref = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = classThis_span,
+        .tag = .identifier_reference,
+        .span = classThis_span,
         .data = .{ .string_ref = classThis_span },
     });
     const inner_assign = try self.ast.addNode(.{
-        .tag = .assignment_expression, .span = zero_span,
+        .tag = .assignment_expression,
+        .span = zero_span,
         .data = .{ .binary = .{ .left = classThis_ref, .right = desc_value, .flags = 0 } },
     });
 
     // Foo = _classThis = ...
     const foo_ref = try makeIdentifier(self, class_name);
     const outer_assign = try self.ast.addNode(.{
-        .tag = .assignment_expression, .span = zero_span,
+        .tag = .assignment_expression,
+        .span = zero_span,
         .data = .{ .binary = .{ .left = foo_ref, .right = inner_assign, .flags = 0 } },
     });
 
     return self.ast.addNode(.{
-        .tag = .expression_statement, .span = zero_span,
+        .tag = .expression_statement,
+        .span = zero_span,
         .data = .{ .unary = .{ .operand = outer_assign, .flags = 0 } },
     });
 }
@@ -2925,7 +3008,8 @@ pub fn buildRunInitializersCall(self: *Transformer, target_span: Span, init_name
     const zero_span = Span{ .start = 0, .end = 0 };
     const callee = try makeIdentifier(self, "__runInitializers");
     const target = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = target_span,
+        .tag = .identifier_reference,
+        .span = target_span,
         .data = .{ .string_ref = target_span },
     });
     const init_ref = try makeIdentifier(self, init_name);
@@ -3025,7 +3109,8 @@ pub fn buildStage3LetDeclarations(
 pub fn makeObjProp(self: *Transformer, key: NodeIndex, value: NodeIndex) Error!NodeIndex {
     const zero_span = Span{ .start = 0, .end = 0 };
     return self.ast.addNode(.{
-        .tag = .object_property, .span = zero_span,
+        .tag = .object_property,
+        .span = zero_span,
         .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
     });
 }
@@ -3034,7 +3119,8 @@ pub fn makeObjProp(self: *Transformer, key: NodeIndex, value: NodeIndex) Error!N
 pub fn makeLet(self: *Transformer, span: Span, name: []const u8, init: NodeIndex) Error!NodeIndex {
     const name_span = try self.ast.addString(name);
     const binding = try self.ast.addNode(.{
-        .tag = .binding_identifier, .span = name_span,
+        .tag = .binding_identifier,
+        .span = name_span,
         .data = .{ .string_ref = name_span },
     });
     const declarator = try self.addExtraNode(.variable_declarator, span, &.{
@@ -3083,7 +3169,8 @@ pub fn buildMetadataDefineProperty(self: *Transformer, classThis_span: Span) Err
 
     // arg1: _classThis
     const ct_ref = try self.ast.addNode(.{
-        .tag = .identifier_reference, .span = classThis_span,
+        .tag = .identifier_reference,
+        .span = classThis_span,
         .data = .{ .string_ref = classThis_span },
     });
 
@@ -3116,17 +3203,20 @@ pub fn buildMetadataDefineProperty(self: *Transformer, classThis_span: Span) Err
 
     // if (_metadata) call;
     const call_stmt = try self.ast.addNode(.{
-        .tag = .expression_statement, .span = zero_span,
+        .tag = .expression_statement,
+        .span = zero_span,
         .data = .{ .unary = .{ .operand = call, .flags = 0 } },
     });
     const body_list = try self.ast.addNodeList(&.{call_stmt});
     const body = try self.ast.addNode(.{
-        .tag = .block_statement, .span = zero_span,
+        .tag = .block_statement,
+        .span = zero_span,
         .data = .{ .list = body_list },
     });
 
     return self.ast.addNode(.{
-        .tag = .if_statement, .span = zero_span,
+        .tag = .if_statement,
+        .span = zero_span,
         .data = .{ .ternary = .{ .a = metadata_cond, .b = body, .c = .none } },
     });
 }
@@ -3136,12 +3226,14 @@ pub fn buildMetadataDefineProperty(self: *Transformer, classThis_span: Span) Err
 pub fn buildGetterMethod(self: *Transformer, key: NodeIndex, return_expr: NodeIndex, is_static: bool, span: Span) Error!NodeIndex {
     const zero_span = Span{ .start = 0, .end = 0 };
     const return_stmt = try self.ast.addNode(.{
-        .tag = .return_statement, .span = zero_span,
+        .tag = .return_statement,
+        .span = zero_span,
         .data = .{ .unary = .{ .operand = return_expr, .flags = 0 } },
     });
     const body_list = try self.ast.addNodeList(&.{return_stmt});
     const getter_body = try self.ast.addNode(.{
-        .tag = .block_statement, .span = zero_span,
+        .tag = .block_statement,
+        .span = zero_span,
         .data = .{ .list = body_list },
     });
     const empty_params = try self.ast.addNodeList(&.{});
@@ -3149,10 +3241,12 @@ pub fn buildGetterMethod(self: *Transformer, key: NodeIndex, return_expr: NodeIn
     const getter_flags: u32 = 0x02 | (if (is_static) @as(u32, 0x01) else 0);
     return self.addExtraNode(.method_definition, span, &.{
         @intFromEnum(key),
-        empty_params.start, empty_params.len,
+        empty_params.start,
+        empty_params.len,
         @intFromEnum(getter_body),
         getter_flags,
-        empty_decos.start, empty_decos.len,
+        empty_decos.start,
+        empty_decos.len,
     });
 }
 
@@ -3174,4 +3268,3 @@ pub fn appendEsDecorateStmt(self: *Transformer, stmts: *std.ArrayList(NodeIndex)
     const call = try self.buildEsDecorateCall(info);
     try stmts.append(self.allocator, try es_helpers.makeExprStmt(self, call, zero_span));
 }
-

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -23,6 +23,16 @@ const es2022 = @import("../es2022.zig");
 pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
     const e = node.data.extra;
 
+    // Stage 3 decorator: experimental_decorators=false이고 decorator가 있으면 TC39 변환.
+    // class/member decorator 존재 여부를 먼저 확인한다.
+    if (!self.options.experimental_decorators) {
+        const class_deco_len = self.readU32(e, 7);
+        const has_member_decos = self.hasAnyMemberDecorators(e);
+        if (class_deco_len > 0 or has_member_decos) {
+            return self.transformStage3Decorators(node);
+        }
+    }
+
     // Fast path: useDefineForClassFields=true AND !experimentalDecorators → 기존 동작
     // 멤버별 분류가 불필요하므로 body를 통째로 방문한다.
     if (self.options.use_define_for_class_fields and !self.options.experimental_decorators) {
@@ -1595,4 +1605,939 @@ pub fn appendClassMetadata(
     const param_types = try self.buildParamTypesArray(params_start, params_len);
     const meta = try self.buildMetadataCall("design:paramtypes", param_types);
     try deco_list.append(self.allocator, meta);
+}
+
+// ============================================================
+// TC39 Stage 3 Decorator Transform (TypeScript 5.0+ 호환)
+// ============================================================
+//
+// TypeScript/Babel/SWC 공통 출력: __esDecorate + __runInitializers + IIFE 래핑.
+// experimental_decorators=false일 때, class/member에 decorator가 있으면 이 경로를 탄다.
+
+/// Stage 3 decorator가 있는 멤버(method/property/accessor)가 하나라도 있는지 확인.
+/// class_body를 순회하여 decorator가 달린 멤버 존재 여부만 빠르게 판단한다.
+pub fn hasAnyMemberDecorators(self: *Transformer, class_extra: u32) bool {
+    const body_idx = self.readNodeIdx(class_extra, 2);
+    if (body_idx.isNone()) return false;
+    const body_node = self.ast.getNode(body_idx);
+    const start = body_node.data.list.start;
+    const len = body_node.data.list.len;
+
+    var i: u32 = 0;
+    while (i < len) : (i += 1) {
+        const member_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[start + i]);
+        if (member_idx.isNone()) continue;
+        const member = self.ast.getNode(member_idx);
+        const me = member.data.extra;
+
+        if (member.tag == .property_definition or member.tag == .accessor_property) {
+            // extra = [key, init_val, flags, deco_start, deco_len]
+            const deco_len = self.readU32(me, 4);
+            if (deco_len > 0) return true;
+        } else if (member.tag == .method_definition) {
+            // extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
+            const deco_len = self.readU32(me, 6);
+            if (deco_len > 0) return true;
+        }
+    }
+    return false;
+}
+
+/// Stage 3 멤버 decorator 정보
+const Stage3MemberInfo = struct {
+    /// "method", "getter", "setter", "field", "accessor"
+    kind: []const u8,
+    /// 멤버 이름 (문자열 리터럴 또는 computed)
+    name: NodeIndex,
+    /// static 여부
+    is_static: bool,
+    /// private 여부
+    is_private: bool,
+    /// decorator 식 배열 (방문 완료)
+    decorators: []const NodeIndex,
+    /// field 초기값 (field/accessor만)
+    init_value: NodeIndex = .none,
+    /// 원본 AST 멤버 인덱스 (class body 내 위치)
+    raw_idx: u32 = 0,
+};
+
+/// TC39 Stage 3 decorator 변환 메인 함수.
+///
+/// 입력: @dec class Foo { @methodDec greet() {} }
+/// 출력 (TypeScript 5.0+ 형식):
+///   let Foo = (() => {
+///     let _classDecorators = [dec];
+///     let _classDescriptor;
+///     let _classExtraInitializers = [];
+///     let _classThis;
+///     let _instanceExtraInitializers = [];
+///     let _greet_decorators;
+///     var Foo = class {
+///       static { _classThis = this; }
+///       static {
+///         const _metadata = typeof Symbol === "function" && Symbol.metadata
+///           ? Object.create(null) : void 0;
+///         _greet_decorators = [methodDec];
+///         __esDecorate(this, null, _greet_decorators, { kind: "method", name: "greet",
+///           static: false, private: false, access: { has: obj => "greet" in obj,
+///           get: obj => obj.greet } }, null, _instanceExtraInitializers);
+///         __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators,
+///           { kind: "class", name: _classThis.name, metadata: _metadata }, null,
+///           _classExtraInitializers);
+///         Foo = _classThis = _classDescriptor.value;
+///         if (_metadata) Object.defineProperty(_classThis, Symbol.metadata, ...);
+///         __runInitializers(_classThis, _classExtraInitializers);
+///       }
+///       constructor() { __runInitializers(this, _instanceExtraInitializers); }
+///       greet() {}
+///     };
+///     return Foo = _classThis;
+///   })();
+pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex {
+    const e = node.data.extra;
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const none = @intFromEnum(NodeIndex.none);
+
+    // 런타임 헬퍼 사용 표시
+    self.runtime_helpers.es_decorator = true;
+
+    // 클래스 이름, super, body, decorator 추출
+    const name_idx = self.readNodeIdx(e, 0);
+    const super_idx = self.readNodeIdx(e, 1);
+    const body_idx = self.readNodeIdx(e, 2);
+    const class_deco_start = self.readU32(e, 6);
+    const class_deco_len = self.readU32(e, 7);
+
+    // 클래스 이름 텍스트 (Foo)
+    const class_name_text = if (!name_idx.isNone()) blk: {
+        const name_node = self.ast.getNode(name_idx);
+        break :blk self.ast.getText(name_node.data.string_ref);
+    } else "default";
+
+    // body 멤버 순회: member decorator 수집
+    var member_infos: std.ArrayList(Stage3MemberInfo) = .empty;
+    defer {
+        for (member_infos.items) |info| {
+            self.allocator.free(info.decorators);
+        }
+        member_infos.deinit(self.allocator);
+    }
+
+    var has_instance_decorators = false;
+    var has_static_decorators = false;
+
+    const body_node = self.ast.getNode(body_idx);
+    const body_start = body_node.data.list.start;
+    const body_len = body_node.data.list.len;
+
+    // 새 class body 멤버 (decorator 제거 + 필요 시 constructor 삽입)
+    var new_members: std.ArrayList(NodeIndex) = .empty;
+    defer new_members.deinit(self.allocator);
+
+    var has_constructor = false;
+
+    {
+        var i: u32 = 0;
+        while (i < body_len) : (i += 1) {
+            const raw = self.ast.extra_data.items[body_start + i];
+            const member_idx: NodeIndex = @enumFromInt(raw);
+            if (member_idx.isNone()) continue;
+            const member = self.ast.getNode(member_idx);
+            const me = member.data.extra;
+
+            if (member.tag == .method_definition) {
+                // extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
+                const flags = self.readU32(me, 4);
+                const deco_start = self.readU32(me, 5);
+                const deco_len = self.readU32(me, 6);
+                const is_static = (flags & 0x01) != 0;
+                const is_getter = (flags & 0x02) != 0;
+                const is_setter = (flags & 0x04) != 0;
+
+                // constructor 감지
+                if (!is_getter and !is_setter and !is_static) {
+                    const key_idx = self.readNodeIdx(me, 0);
+                    if (!key_idx.isNone()) {
+                        const key_node = self.ast.getNode(key_idx);
+                        if (key_node.tag == .identifier_reference or key_node.tag == .binding_identifier) {
+                            const key_text = self.ast.getText(key_node.data.string_ref);
+                            if (std.mem.eql(u8, key_text, "constructor")) {
+                                has_constructor = true;
+                            }
+                        }
+                    }
+                }
+
+                if (deco_len > 0) {
+                    const kind = if (is_getter) "getter" else if (is_setter) "setter" else "method";
+                    const key_idx = self.readNodeIdx(me, 0);
+                    const new_key = try self.visitNode(key_idx);
+                    // member name을 문자열 리터럴로 변환
+                    const name_node_idx = try self.memberKeyToStringLiteral(new_key);
+
+                    // decorator 식 수집
+                    const decos = try self.collectStage3Decorators(deco_start, deco_len);
+
+                    if (is_static) has_static_decorators = true else has_instance_decorators = true;
+
+                    try member_infos.append(self.allocator, .{
+                        .kind = kind,
+                        .name = name_node_idx,
+                        .is_static = is_static,
+                        .is_private = false,
+                        .decorators = decos,
+                    });
+                }
+
+                // method를 decorator 없이 body에 추가
+                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+                const new_body = try self.visitNode(self.readNodeIdx(me, 3));
+                const empty_list = try self.ast.addNodeList(&.{});
+                const new_method = try self.addExtraNode(.method_definition, member.span, &.{
+                    @intFromEnum(new_key),
+                    self.readU32(me, 1), // params_start
+                    self.readU32(me, 2), // params_len
+                    @intFromEnum(new_body),
+                    flags,
+                    empty_list.start, empty_list.len, // decorator 제거
+                });
+                try new_members.append(self.allocator, new_method);
+            } else if (member.tag == .property_definition) {
+                // extra = [key, init_val, flags, deco_start, deco_len]
+                const flags = self.readU32(me, 2);
+                const deco_start = self.readU32(me, 3);
+                const deco_len = self.readU32(me, 4);
+                const is_static = (flags & 0x01) != 0;
+
+                if (deco_len > 0) {
+                    const key_idx = self.readNodeIdx(me, 0);
+                    const new_key = try self.visitNode(key_idx);
+                    const name_node_idx = try self.memberKeyToStringLiteral(new_key);
+                    const decos = try self.collectStage3Decorators(deco_start, deco_len);
+
+                    if (is_static) has_static_decorators = true else has_instance_decorators = true;
+
+                    try member_infos.append(self.allocator, .{
+                        .kind = "field",
+                        .name = name_node_idx,
+                        .is_static = is_static,
+                        .is_private = false,
+                        .decorators = decos,
+                    });
+                }
+
+                // property를 decorator 없이 방문하여 추가
+                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+                const new_init = try self.visitNode(self.readNodeIdx(me, 1));
+                const empty_list = try self.ast.addNodeList(&.{});
+                const new_prop = try self.addExtraNode(.property_definition, member.span, &.{
+                    @intFromEnum(new_key),
+                    @intFromEnum(new_init),
+                    flags,
+                    empty_list.start, empty_list.len,
+                });
+                try new_members.append(self.allocator, new_prop);
+            } else if (member.tag == .accessor_property) {
+                // extra = [key, init_val, flags, deco_start, deco_len]
+                const flags = self.readU32(me, 2);
+                const deco_start = self.readU32(me, 3);
+                const deco_len = self.readU32(me, 4);
+                const is_static = (flags & 0x01) != 0;
+
+                if (deco_len > 0) {
+                    const key_idx = self.readNodeIdx(me, 0);
+                    const new_key = try self.visitNode(key_idx);
+                    const name_node_idx = try self.memberKeyToStringLiteral(new_key);
+                    const decos = try self.collectStage3Decorators(deco_start, deco_len);
+
+                    if (is_static) has_static_decorators = true else has_instance_decorators = true;
+
+                    try member_infos.append(self.allocator, .{
+                        .kind = "accessor",
+                        .name = name_node_idx,
+                        .is_static = is_static,
+                        .is_private = false,
+                        .decorators = decos,
+                    });
+                }
+
+                // accessor를 decorator 없이 추가
+                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+                const new_init = try self.visitNode(self.readNodeIdx(me, 1));
+                const empty_list = try self.ast.addNodeList(&.{});
+                const new_acc = try self.addExtraNode(.accessor_property, member.span, &.{
+                    @intFromEnum(new_key),
+                    @intFromEnum(new_init),
+                    flags,
+                    empty_list.start, empty_list.len,
+                });
+                try new_members.append(self.allocator, new_acc);
+            } else {
+                // static_block 등 그대로 방문하여 추가
+                const visited = try self.visitNode(member_idx);
+                if (!visited.isNone()) {
+                    try new_members.append(self.allocator, visited);
+                }
+            }
+        }
+    }
+
+    // ---- IIFE 구조 생성 ----
+    // 전체 출력:
+    //   let Foo = (() => {
+    //     let _classDecorators = [...]; ...
+    //     var Foo = class [extends Super] { ... };
+    //     return Foo = _classThis;
+    //   })();
+
+    // __esDecorate 호출 목록 (static {} 블록에 넣을 것)
+    var static_block_stmts: std.ArrayList(NodeIndex) = .empty;
+    defer static_block_stmts.deinit(self.allocator);
+
+    // IIFE 내부 let 선언 목록
+    var iife_stmts: std.ArrayList(NodeIndex) = .empty;
+    defer iife_stmts.deinit(self.allocator);
+
+    // _classThis 변수
+    const classThis_span = try self.ast.addString("_classThis");
+
+    // static { _classThis = this; }
+    {
+        const classThis_ref = try self.ast.addNode(.{
+            .tag = .identifier_reference, .span = classThis_span,
+            .data = .{ .string_ref = classThis_span },
+        });
+        const this_node = try self.ast.addNode(.{
+            .tag = .this_expression, .span = zero_span,
+            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+        });
+        const assign = try self.ast.addNode(.{
+            .tag = .assignment_expression, .span = zero_span,
+            .data = .{ .binary = .{ .left = classThis_ref, .right = this_node, .flags = 0 } },
+        });
+        const assign_stmt = try self.ast.addNode(.{
+            .tag = .expression_statement, .span = zero_span,
+            .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+        });
+        const static_body_list = try self.ast.addNodeList(&.{assign_stmt});
+        const static_body = try self.ast.addNode(.{
+            .tag = .block_statement, .span = zero_span,
+            .data = .{ .list = static_body_list },
+        });
+        const static_block = try self.ast.addNode(.{
+            .tag = .static_block, .span = zero_span,
+            .data = .{ .unary = .{ .operand = static_body, .flags = 0 } },
+        });
+        try new_members.insert(self.allocator, 0, static_block);
+    }
+
+    // _metadata 선언 + member __esDecorate 호출 + class __esDecorate 호출
+    // → 2번째 static { } 블록에 모두 넣기
+
+    // const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+    const metadata_decl = try self.buildMetadataDecl();
+    try static_block_stmts.append(self.allocator, metadata_decl);
+
+    // member decorator __esDecorate 호출
+    for (member_infos.items) |info| {
+        const call = try self.buildEsDecorateCall(info, classThis_span);
+        const call_stmt = try self.ast.addNode(.{
+            .tag = .expression_statement, .span = zero_span,
+            .data = .{ .unary = .{ .operand = call, .flags = 0 } },
+        });
+        try static_block_stmts.append(self.allocator, call_stmt);
+    }
+
+    // class decorator __esDecorate 호출
+    if (class_deco_len > 0) {
+        const class_call = try self.buildClassEsDecorateCall(class_deco_start, class_deco_len, classThis_span, class_name_text);
+        const class_call_stmt = try self.ast.addNode(.{
+            .tag = .expression_statement, .span = zero_span,
+            .data = .{ .unary = .{ .operand = class_call, .flags = 0 } },
+        });
+        try static_block_stmts.append(self.allocator, class_call_stmt);
+
+        // Foo = _classThis = _classDescriptor.value;
+        const reassign = try self.buildClassReassign(class_name_text, classThis_span);
+        try static_block_stmts.append(self.allocator, reassign);
+    }
+
+    // __runInitializers(_classThis, _classExtraInitializers);
+    if (class_deco_len > 0) {
+        const run_init = try self.buildRunInitializersCall(classThis_span, "_classExtraInitializers");
+        const run_init_stmt = try self.ast.addNode(.{
+            .tag = .expression_statement, .span = zero_span,
+            .data = .{ .unary = .{ .operand = run_init, .flags = 0 } },
+        });
+        try static_block_stmts.append(self.allocator, run_init_stmt);
+    }
+
+    // 2번째 static { } 블록 생성
+    if (static_block_stmts.items.len > 0) {
+        const sb_body_list = try self.ast.addNodeList(static_block_stmts.items);
+        const sb_body = try self.ast.addNode(.{
+            .tag = .block_statement, .span = zero_span,
+            .data = .{ .list = sb_body_list },
+        });
+        const sb = try self.ast.addNode(.{
+            .tag = .static_block, .span = zero_span,
+            .data = .{ .unary = .{ .operand = sb_body, .flags = 0 } },
+        });
+        // 첫 static block 뒤에 삽입 (index 1)
+        try new_members.insert(self.allocator, 1, sb);
+    }
+
+    // constructor에 __runInitializers(this, _instanceExtraInitializers) 삽입
+    if (has_instance_decorators and !has_constructor) {
+        // 빈 constructor 생성: constructor() { __runInitializers(this, _instanceExtraInitializers); }
+        const this_node = try self.ast.addNode(.{
+            .tag = .this_expression, .span = zero_span,
+            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+        });
+        const run_init = try self.buildRunInitializersCall2(this_node, "_instanceExtraInitializers");
+        const run_init_stmt = try self.ast.addNode(.{
+            .tag = .expression_statement, .span = zero_span,
+            .data = .{ .unary = .{ .operand = run_init, .flags = 0 } },
+        });
+        const ctor_body_list = try self.ast.addNodeList(&.{run_init_stmt});
+        const ctor_body = try self.ast.addNode(.{
+            .tag = .block_statement, .span = zero_span,
+            .data = .{ .list = ctor_body_list },
+        });
+        const ctor_key_span = try self.ast.addString("constructor");
+        const ctor_key = try self.ast.addNode(.{
+            .tag = .identifier_reference, .span = ctor_key_span,
+            .data = .{ .string_ref = ctor_key_span },
+        });
+        const empty_params = try self.ast.addNodeList(&.{});
+        const empty_decos = try self.ast.addNodeList(&.{});
+        const ctor_method = try self.addExtraNode(.method_definition, zero_span, &.{
+            @intFromEnum(ctor_key),
+            empty_params.start, empty_params.len,
+            @intFromEnum(ctor_body),
+            0, // flags (no static/getter/setter)
+            empty_decos.start, empty_decos.len,
+        });
+        try new_members.append(self.allocator, ctor_method);
+    }
+
+    // 새 class body 생성
+    const new_body_list = try self.ast.addNodeList(new_members.items);
+    const new_body = try self.ast.addNode(.{
+        .tag = .class_body, .span = zero_span,
+        .data = .{ .list = new_body_list },
+    });
+
+    // var Foo = class [extends Super] { ... } (decorator 없이)
+    const new_name = try self.visitNode(name_idx);
+    const new_super = try self.visitNode(super_idx);
+    const empty_decos = try self.ast.addNodeList(&.{});
+    const inner_class = try self.addExtraNode(.class_expression, node.span, &.{
+        @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
+        none, 0, 0,
+        empty_decos.start, empty_decos.len,
+    });
+
+    // IIFE 내부: var Foo = class { ... };
+    const inner_name_span = try self.ast.addString(class_name_text);
+    const inner_binding = try self.ast.addNode(.{
+        .tag = .binding_identifier, .span = inner_name_span,
+        .data = .{ .string_ref = inner_name_span },
+    });
+    const inner_declarator = try self.addExtraNode(.variable_declarator, zero_span, &.{
+        @intFromEnum(inner_binding), none, @intFromEnum(inner_class),
+    });
+    const inner_decl_list = try self.ast.addNodeList(&.{inner_declarator});
+    const inner_var_decl = try self.addExtraNode(.variable_declaration, zero_span, &.{
+        0, inner_decl_list.start, inner_decl_list.len, // 0 = var
+    });
+    try iife_stmts.append(self.allocator, inner_var_decl);
+
+    // return Foo = _classThis;
+    const return_name = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = inner_name_span,
+        .data = .{ .string_ref = inner_name_span },
+    });
+    const classThis_ref2 = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = classThis_span,
+        .data = .{ .string_ref = classThis_span },
+    });
+    const return_assign = try self.ast.addNode(.{
+        .tag = .assignment_expression, .span = zero_span,
+        .data = .{ .binary = .{ .left = return_name, .right = classThis_ref2, .flags = 0 } },
+    });
+    const return_stmt = try self.ast.addNode(.{
+        .tag = .return_statement, .span = zero_span,
+        .data = .{ .unary = .{ .operand = return_assign, .flags = 0 } },
+    });
+    try iife_stmts.append(self.allocator, return_stmt);
+
+    // IIFE body: { let _classDecorators = ...; ... var Foo = class { ... }; return ...; }
+    // let 선언들을 iife_stmts 앞에 삽입
+    var all_iife_stmts: std.ArrayList(NodeIndex) = .empty;
+    defer all_iife_stmts.deinit(self.allocator);
+
+    // let 선언 생성
+    const let_decls = try self.buildStage3LetDeclarations(
+        class_deco_start, class_deco_len,
+        member_infos.items, has_instance_decorators, has_static_decorators,
+    );
+    try all_iife_stmts.appendSlice(self.allocator, let_decls);
+    self.allocator.free(let_decls);
+
+    // var Foo = class { ... }; + return ...;
+    try all_iife_stmts.appendSlice(self.allocator, iife_stmts.items);
+
+    const iife_body_list = try self.ast.addNodeList(all_iife_stmts.items);
+    const iife_body = try self.ast.addNode(.{
+        .tag = .block_statement, .span = zero_span,
+        .data = .{ .list = iife_body_list },
+    });
+
+    // () => { ... }
+    // arrow_function_expression: extra = [params(0), body(1), flags]
+    // params = .none → codegen이 "()" 출력
+    const arrow = try self.addExtraNode(.arrow_function_expression, zero_span, &.{
+        none, // params = .none (빈 파라미터)
+        @intFromEnum(iife_body),
+        0, // flags (not async)
+    });
+
+    // (() => { ... })()
+    const paren_arrow = try self.ast.addNode(.{
+        .tag = .parenthesized_expression, .span = zero_span,
+        .data = .{ .unary = .{ .operand = arrow, .flags = 0 } },
+    });
+    const empty_args = try self.ast.addNodeList(&.{});
+    const iife_call = try self.addExtraNode(.call_expression, zero_span, &.{
+        @intFromEnum(paren_arrow), empty_args.start, empty_args.len, 0,
+    });
+
+    // let Foo = (() => { ... })();
+    const outer_name_span = if (!name_idx.isNone()) blk: {
+        const n = self.ast.getNode(name_idx);
+        break :blk n.data.string_ref;
+    } else try self.ast.addString("default");
+
+    const outer_binding = try self.ast.addNode(.{
+        .tag = .binding_identifier, .span = outer_name_span,
+        .data = .{ .string_ref = outer_name_span },
+    });
+    const outer_declarator = try self.addExtraNode(.variable_declarator, zero_span, &.{
+        @intFromEnum(outer_binding), none, @intFromEnum(iife_call),
+    });
+    const outer_decl_list = try self.ast.addNodeList(&.{outer_declarator});
+    const outer_var_decl = try self.addExtraNode(.variable_declaration, zero_span, &.{
+        1, outer_decl_list.start, outer_decl_list.len, // 1 = let
+    });
+
+    try self.pending_nodes.append(self.allocator, outer_var_decl);
+    return .none;
+}
+
+// ---- Stage 3 헬퍼 함수들 ----
+
+/// member key를 문자열 리터럴 노드로 변환.
+/// identifier "foo" → string literal "\"foo\"", computed → 그대로.
+pub fn memberKeyToStringLiteral(self: *Transformer, key: NodeIndex) Error!NodeIndex {
+    if (key.isNone()) return key;
+    const key_node = self.ast.getNode(key);
+    if (key_node.tag == .identifier_reference or key_node.tag == .binding_identifier) {
+        const name = self.ast.getText(key_node.data.string_ref);
+        var buf: [256]u8 = undefined;
+        buf[0] = '"';
+        const len = @min(name.len, buf.len - 2);
+        @memcpy(buf[1 .. 1 + len], name[0..len]);
+        buf[1 + len] = '"';
+        const span = try self.ast.addString(buf[0 .. 2 + len]);
+        return self.ast.addNode(.{ .tag = .string_literal, .span = span, .data = .{ .string_ref = span } });
+    }
+    return key;
+}
+
+/// decorator 식들을 방문하여 슬라이스로 반환. caller가 free.
+pub fn collectStage3Decorators(self: *Transformer, deco_start: u32, deco_len: u32) Error![]const NodeIndex {
+    var result: std.ArrayList(NodeIndex) = .empty;
+    defer result.deinit(self.allocator);
+    var i: u32 = 0;
+    while (i < deco_len) : (i += 1) {
+        const raw = self.ast.extra_data.items[deco_start + i];
+        const deco_idx: NodeIndex = @enumFromInt(raw);
+        if (deco_idx.isNone()) continue;
+        const deco_node = self.ast.getNode(deco_idx);
+        // decorator 노드의 operand가 실제 식
+        if (deco_node.tag == .decorator) {
+            const visited = try self.visitNode(deco_node.data.unary.operand);
+            try result.append(self.allocator, visited);
+        } else {
+            const visited = try self.visitNode(deco_idx);
+            try result.append(self.allocator, visited);
+        }
+    }
+    return result.toOwnedSlice(self.allocator);
+}
+
+/// __esDecorate(this, null, _decorators, { kind: "method", name: "...", static: bool, private: bool, access: { ... }, metadata: _metadata }, null, _extraInitializers) 호출 생성.
+pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo, _: Span) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+
+    const callee = try makeIdentifier(self, "__esDecorate");
+
+    // arg1: this (ctor — method/getter/setter) 또는 null (field)
+    const arg1 = if (std.mem.eql(u8, info.kind, "field"))
+        try makeIdentifier(self, "null")
+    else
+        try self.ast.addNode(.{ .tag = .this_expression, .span = zero_span, .data = .{ .unary = .{ .operand = .none, .flags = 0 } } });
+
+    // arg2: null (descriptorIn)
+    const arg2 = try makeIdentifier(self, "null");
+
+    // arg3: [dec1, dec2, ...]
+    const deco_list = try self.ast.addNodeList(info.decorators);
+    const arg3 = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list } });
+
+    // arg4: context object { kind: "method", name: "greet", static: false, private: false, access: { ... }, metadata: _metadata }
+    const arg4 = try self.buildContextObject(info);
+
+    // arg5: initializers (null for method/getter/setter)
+    const arg5 = try makeIdentifier(self, "null");
+
+    // arg6: extraInitializers
+    const extra_init_name = if (info.is_static) "_staticExtraInitializers" else "_instanceExtraInitializers";
+    const arg6 = try makeIdentifier(self, extra_init_name);
+
+    const args = try self.ast.addNodeList(&.{ arg1, arg2, arg3, arg4, arg5, arg6 });
+    return self.addExtraNode(.call_expression, zero_span, &.{
+        @intFromEnum(callee), args.start, args.len, 0,
+    });
+}
+
+/// class decorator용 __esDecorate 호출:
+/// __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers)
+pub fn buildClassEsDecorateCall(self: *Transformer, deco_start: u32, deco_len: u32, classThis_span: Span, class_name: []const u8) Error!NodeIndex {
+    _ = class_name;
+    const zero_span = Span{ .start = 0, .end = 0 };
+
+    const callee = try makeIdentifier(self, "__esDecorate");
+
+    // arg1: null
+    const arg1 = try makeIdentifier(self, "null");
+
+    // arg2: _classDescriptor = { value: _classThis }
+    const classThis_ref = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = classThis_span,
+        .data = .{ .string_ref = classThis_span },
+    });
+    const value_key_span = try self.ast.addString("value");
+    const value_key = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = value_key_span,
+        .data = .{ .string_ref = value_key_span },
+    });
+    const value_prop = try self.makeObjProp(value_key, classThis_ref);
+    const obj_list = try self.ast.addNodeList(&.{value_prop});
+    const obj = try self.ast.addNode(.{ .tag = .object_expression, .span = zero_span, .data = .{ .list = obj_list } });
+
+    const desc_span = try self.ast.addString("_classDescriptor");
+    const desc_ref = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = desc_span,
+        .data = .{ .string_ref = desc_span },
+    });
+    const arg2 = try self.ast.addNode(.{
+        .tag = .assignment_expression, .span = zero_span,
+        .data = .{ .binary = .{ .left = desc_ref, .right = obj, .flags = 0 } },
+    });
+
+    // arg3: _classDecorators
+    const decos = try self.collectStage3Decorators(deco_start, deco_len);
+    defer self.allocator.free(decos);
+    const deco_list = try self.ast.addNodeList(decos);
+    const class_deco_span = try self.ast.addString("_classDecorators");
+    _ = class_deco_span;
+    const arg3 = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list } });
+
+    // arg4: { kind: "class", name: _classThis.name, metadata: _metadata }
+    const kind_key = try makeIdentifier(self, "kind");
+    const kind_val_span = try self.ast.addString("\"class\"");
+    const kind_val = try self.ast.addNode(.{ .tag = .string_literal, .span = kind_val_span, .data = .{ .string_ref = kind_val_span } });
+    const kind_prop = try self.makeObjProp(kind_key, kind_val);
+
+    const name_key = try makeIdentifier(self, "name");
+    // _classThis.name
+    const classThis_ref2 = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = classThis_span,
+        .data = .{ .string_ref = classThis_span },
+    });
+    const name_prop_key = try makeIdentifier(self, "name");
+    const classThis_name = try self.addExtraNode(.static_member_expression, zero_span, &.{
+        @intFromEnum(classThis_ref2), @intFromEnum(name_prop_key), 0,
+    });
+    const name_prop = try self.makeObjProp(name_key, classThis_name);
+
+    const metadata_key = try makeIdentifier(self, "metadata");
+    const metadata_val = try makeIdentifier(self, "_metadata");
+    const metadata_prop = try self.makeObjProp(metadata_key, metadata_val);
+
+    const ctx_list = try self.ast.addNodeList(&.{ kind_prop, name_prop, metadata_prop });
+    const arg4 = try self.ast.addNode(.{ .tag = .object_expression, .span = zero_span, .data = .{ .list = ctx_list } });
+
+    // arg5: null
+    const arg5 = try makeIdentifier(self, "null");
+
+    // arg6: _classExtraInitializers
+    const arg6 = try makeIdentifier(self, "_classExtraInitializers");
+
+    const args = try self.ast.addNodeList(&.{ arg1, arg2, arg3, arg4, arg5, arg6 });
+    return self.addExtraNode(.call_expression, zero_span, &.{
+        @intFromEnum(callee), args.start, args.len, 0,
+    });
+}
+
+/// context object 생성: { kind: "method", name: "greet", static: false, private: false, access: { has: ..., get: ... }, metadata: _metadata }
+pub fn buildContextObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    var props: std.ArrayList(NodeIndex) = .empty;
+    defer props.deinit(self.allocator);
+
+    // kind
+    var kind_buf: [16]u8 = undefined;
+    kind_buf[0] = '"';
+    const klen = info.kind.len;
+    @memcpy(kind_buf[1 .. 1 + klen], info.kind);
+    kind_buf[1 + klen] = '"';
+    const kind_key = try makeIdentifier(self, "kind");
+    const kind_val_span = try self.ast.addString(kind_buf[0 .. 2 + klen]);
+    const kind_val = try self.ast.addNode(.{ .tag = .string_literal, .span = kind_val_span, .data = .{ .string_ref = kind_val_span } });
+    try props.append(self.allocator, try self.makeObjProp(kind_key, kind_val));
+
+    // name
+    const name_key = try makeIdentifier(self, "name");
+    try props.append(self.allocator, try self.makeObjProp(name_key, info.name));
+
+    // static
+    const static_key = try makeIdentifier(self, "static");
+    const static_val = try makeIdentifier(self, if (info.is_static) "true" else "false");
+    try props.append(self.allocator, try self.makeObjProp(static_key, static_val));
+
+    // private
+    const private_key = try makeIdentifier(self, "private");
+    const private_val = try makeIdentifier(self, if (info.is_private) "true" else "false");
+    try props.append(self.allocator, try self.makeObjProp(private_key, private_val));
+
+    // metadata
+    const metadata_key = try makeIdentifier(self, "metadata");
+    const metadata_val = try makeIdentifier(self, "_metadata");
+    try props.append(self.allocator, try self.makeObjProp(metadata_key, metadata_val));
+
+    const list = try self.ast.addNodeList(props.items);
+    return self.ast.addNode(.{ .tag = .object_expression, .span = zero_span, .data = .{ .list = list } });
+}
+
+/// const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+pub fn buildMetadataDecl(self: *Transformer) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const none = @intFromEnum(NodeIndex.none);
+    const Kind = @import("../../lexer/token.zig").Kind;
+
+    // typeof Symbol === "function"
+    const symbol_ref = try makeIdentifier(self, "Symbol");
+    const typeof_expr = try self.addExtraNode(.unary_expression, zero_span, &.{
+        @intFromEnum(symbol_ref), @intFromEnum(Kind.kw_typeof),
+    });
+    const func_str_span = try self.ast.addString("\"function\"");
+    const func_str = try self.ast.addNode(.{ .tag = .string_literal, .span = func_str_span, .data = .{ .string_ref = func_str_span } });
+    const typeof_check = try self.ast.addNode(.{
+        .tag = .binary_expression, .span = zero_span,
+        .data = .{ .binary = .{ .left = typeof_expr, .right = func_str, .flags = @intFromEnum(Kind.eq3) } },
+    });
+
+    // Symbol.metadata
+    const symbol_ref2 = try makeIdentifier(self, "Symbol");
+    const metadata_prop = try makeIdentifier(self, "metadata");
+    const symbol_metadata = try self.addExtraNode(.static_member_expression, zero_span, &.{
+        @intFromEnum(symbol_ref2), @intFromEnum(metadata_prop), 0,
+    });
+
+    // typeof Symbol === "function" && Symbol.metadata
+    const and_expr = try self.ast.addNode(.{
+        .tag = .binary_expression, .span = zero_span,
+        .data = .{ .binary = .{ .left = typeof_check, .right = symbol_metadata, .flags = @intFromEnum(Kind.amp2) } },
+    });
+
+    // Object.create(null)
+    const object_ref = try makeIdentifier(self, "Object");
+    const create_key = try makeIdentifier(self, "create");
+    const obj_create = try self.addExtraNode(.static_member_expression, zero_span, &.{
+        @intFromEnum(object_ref), @intFromEnum(create_key), 0,
+    });
+    const null_arg = try makeIdentifier(self, "null");
+    const null_args = try self.ast.addNodeList(&.{null_arg});
+    const obj_create_call = try self.addExtraNode(.call_expression, zero_span, &.{
+        @intFromEnum(obj_create), null_args.start, null_args.len, 0,
+    });
+
+    // void 0
+    const void0 = try makeIdentifier(self, "void 0");
+
+    // ... ? Object.create(null) : void 0
+    const ternary = try self.ast.addNode(.{
+        .tag = .conditional_expression, .span = zero_span,
+        .data = .{ .ternary = .{ .a = and_expr, .b = obj_create_call, .c = void0 } },
+    });
+
+    // const _metadata = ...;
+    const metadata_span = try self.ast.addString("_metadata");
+    const metadata_binding = try self.ast.addNode(.{
+        .tag = .binding_identifier, .span = metadata_span,
+        .data = .{ .string_ref = metadata_span },
+    });
+    const declarator = try self.addExtraNode(.variable_declarator, zero_span, &.{
+        @intFromEnum(metadata_binding), none, @intFromEnum(ternary),
+    });
+    const decl_list = try self.ast.addNodeList(&.{declarator});
+    return self.addExtraNode(.variable_declaration, zero_span, &.{
+        2, decl_list.start, decl_list.len, // 2 = const
+    });
+}
+
+/// Foo = _classThis = _classDescriptor.value; 문 생성
+pub fn buildClassReassign(self: *Transformer, class_name: []const u8, classThis_span: Span) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+
+    // _classDescriptor.value
+    const desc_ref = try makeIdentifier(self, "_classDescriptor");
+    const value_key = try makeIdentifier(self, "value");
+    const desc_value = try self.addExtraNode(.static_member_expression, zero_span, &.{
+        @intFromEnum(desc_ref), @intFromEnum(value_key), 0,
+    });
+
+    // _classThis = _classDescriptor.value
+    const classThis_ref = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = classThis_span,
+        .data = .{ .string_ref = classThis_span },
+    });
+    const inner_assign = try self.ast.addNode(.{
+        .tag = .assignment_expression, .span = zero_span,
+        .data = .{ .binary = .{ .left = classThis_ref, .right = desc_value, .flags = 0 } },
+    });
+
+    // Foo = _classThis = ...
+    const foo_ref = try makeIdentifier(self, class_name);
+    const outer_assign = try self.ast.addNode(.{
+        .tag = .assignment_expression, .span = zero_span,
+        .data = .{ .binary = .{ .left = foo_ref, .right = inner_assign, .flags = 0 } },
+    });
+
+    return self.ast.addNode(.{
+        .tag = .expression_statement, .span = zero_span,
+        .data = .{ .unary = .{ .operand = outer_assign, .flags = 0 } },
+    });
+}
+
+/// __runInitializers(target_span_ref, name) 호출 생성.
+/// target은 Span(identifier_reference로 변환)
+pub fn buildRunInitializersCall(self: *Transformer, target_span: Span, init_name: []const u8) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const callee = try makeIdentifier(self, "__runInitializers");
+    const target = try self.ast.addNode(.{
+        .tag = .identifier_reference, .span = target_span,
+        .data = .{ .string_ref = target_span },
+    });
+    const init_ref = try makeIdentifier(self, init_name);
+    const args = try self.ast.addNodeList(&.{ target, init_ref });
+    return self.addExtraNode(.call_expression, zero_span, &.{
+        @intFromEnum(callee), args.start, args.len, 0,
+    });
+}
+
+/// __runInitializers(target_node, name) 호출 생성.
+/// target은 이미 생성된 NodeIndex (예: this)
+pub fn buildRunInitializersCall2(self: *Transformer, target_node: NodeIndex, init_name: []const u8) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const callee = try makeIdentifier(self, "__runInitializers");
+    const init_ref = try makeIdentifier(self, init_name);
+    const args = try self.ast.addNodeList(&.{ target_node, init_ref });
+    return self.addExtraNode(.call_expression, zero_span, &.{
+        @intFromEnum(callee), args.start, args.len, 0,
+    });
+}
+
+/// IIFE 내부 let 선언들 생성.
+/// let _classDecorators = [...]; let _classDescriptor; let _classExtraInitializers = []; let _classThis;
+/// let _instanceExtraInitializers = []; (instance decorator 있을 때)
+pub fn buildStage3LetDeclarations(
+    self: *Transformer,
+    class_deco_start: u32,
+    class_deco_len: u32,
+    member_infos: []const Stage3MemberInfo,
+    has_instance: bool,
+    has_static: bool,
+) Error![]NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const none = @intFromEnum(NodeIndex.none);
+    var stmts: std.ArrayList(NodeIndex) = .empty;
+    defer stmts.deinit(self.allocator);
+
+    // class decorator가 있으면
+    if (class_deco_len > 0) {
+        // let _classDecorators = [dec1, dec2];
+        const decos = try self.collectStage3Decorators(class_deco_start, class_deco_len);
+        defer self.allocator.free(decos);
+        const deco_list = try self.ast.addNodeList(decos);
+        const deco_arr = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list } });
+        try stmts.append(self.allocator, try self.makeLet(zero_span, "_classDecorators", deco_arr));
+
+        // let _classDescriptor;
+        try stmts.append(self.allocator, try self.makeLet(zero_span, "_classDescriptor", .none));
+
+        // let _classExtraInitializers = [];
+        const empty_arr_list = try self.ast.addNodeList(&.{});
+        const empty_arr = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = empty_arr_list } });
+        try stmts.append(self.allocator, try self.makeLet(zero_span, "_classExtraInitializers", empty_arr));
+
+        // let _classThis;
+        try stmts.append(self.allocator, try self.makeLet(zero_span, "_classThis", .none));
+    }
+
+    // instance/static extra initializers
+    if (has_instance) {
+        const empty_arr_list = try self.ast.addNodeList(&.{});
+        const empty_arr = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = empty_arr_list } });
+        try stmts.append(self.allocator, try self.makeLet(zero_span, "_instanceExtraInitializers", empty_arr));
+    }
+    if (has_static) {
+        const empty_arr_list = try self.ast.addNodeList(&.{});
+        const empty_arr = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = empty_arr_list } });
+        try stmts.append(self.allocator, try self.makeLet(zero_span, "_staticExtraInitializers", empty_arr));
+    }
+
+    // member decorator 변수들
+    _ = member_infos;
+    _ = none;
+
+    return stmts.toOwnedSlice(self.allocator);
+}
+
+/// object property { key: value } 노드 생성
+pub fn makeObjProp(self: *Transformer, key: NodeIndex, value: NodeIndex) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    return self.ast.addNode(.{
+        .tag = .object_property, .span = zero_span,
+        .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
+    });
+}
+
+/// let name = init; 또는 let name; 선언 생성
+pub fn makeLet(self: *Transformer, span: Span, name: []const u8, init: NodeIndex) Error!NodeIndex {
+    const name_span = try self.ast.addString(name);
+    const binding = try self.ast.addNode(.{
+        .tag = .binding_identifier, .span = name_span,
+        .data = .{ .string_ref = name_span },
+    });
+    const declarator = try self.addExtraNode(.variable_declarator, span, &.{
+        @intFromEnum(binding), @intFromEnum(NodeIndex.none), @intFromEnum(init),
+    });
+    const decl_list = try self.ast.addNodeList(&.{declarator});
+    return self.addExtraNode(.variable_declaration, span, &.{
+        1, decl_list.start, decl_list.len, // 1 = let
+    });
 }

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1862,13 +1862,25 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 const deco_len = self.readU32(me, 4);
                 const is_static = (flags & 0x01) != 0;
 
+                const key_idx = self.readNodeIdx(me, 0);
+                const new_key = try self.visitNode(key_idx);
+                const new_init = try self.visitNode(self.readNodeIdx(me, 1));
+
                 if (deco_len > 0) {
-                    const key_idx = self.readNodeIdx(me, 0);
-                    const new_key = try self.visitNode(key_idx);
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
                     const decos = try self.collectStage3Decorators(deco_start, deco_len);
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
+
+                    // 멤버 이름 추출
+                    const name_node = self.ast.getNode(name_node_idx);
+                    const raw_name = self.ast.getText(name_node.data.string_ref);
+                    const clean_name = if (raw_name.len >= 2 and raw_name[0] == '"')
+                        raw_name[1 .. raw_name.len - 1]
+                    else
+                        raw_name;
+                    const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{clean_name});
+                    const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{clean_name});
 
                     try member_infos.append(self.allocator, .{
                         .kind = "accessor",
@@ -1876,20 +1888,141 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .is_static = is_static,
                         .is_private = false,
                         .decorators = decos,
+                        .initializers_name = init_name,
+                        .extra_initializers_name = extra_name,
                     });
-                }
 
-                // accessor를 decorator 없이 추가
-                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
-                const new_init = try self.visitNode(self.readNodeIdx(me, 1));
-                const empty_list = try self.ast.addNodeList(&.{});
-                const new_acc = try self.addExtraNode(.accessor_property, member.span, &.{
-                    @intFromEnum(new_key),
-                    @intFromEnum(new_init),
-                    flags,
-                    empty_list.start, empty_list.len,
-                });
-                try new_members.append(self.allocator, new_acc);
+                    // accessor → private backing field + getter + setter
+                    // #x_accessor_storage (property_definition)
+                    const storage_name = try std.fmt.allocPrint(self.allocator, "#_{s}_accessor_storage", .{clean_name});
+                    defer self.allocator.free(storage_name);
+                    const storage_span = try self.ast.addString(storage_name);
+                    const storage_key = try self.ast.addNode(.{
+                        .tag = .private_identifier, .span = storage_span,
+                        .data = .{ .string_ref = storage_span },
+                    });
+                    // 초기값: __runInitializers(this, _x_initializers, originalValue)
+                    const init_val = if (!new_init.isNone()) blk: {
+                        const this_node = try self.ast.addNode(.{
+                            .tag = .this_expression, .span = zero_span,
+                            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+                        });
+                        const callee = try makeIdentifier(self, "__runInitializers");
+                        const init_arr_ref = try makeIdentifier(self, init_name);
+                        const args = try self.ast.addNodeList(&.{ this_node, init_arr_ref, new_init });
+                        break :blk try self.addExtraNode(.call_expression, zero_span, &.{
+                            @intFromEnum(callee), args.start, args.len, 0,
+                        });
+                    } else NodeIndex.none;
+
+                    const empty_decos = try self.ast.addNodeList(&.{});
+                    const backing_field = try self.addExtraNode(.property_definition, member.span, &.{
+                        @intFromEnum(storage_key),
+                        @intFromEnum(init_val),
+                        flags, // static 플래그 보존
+                        empty_decos.start, empty_decos.len,
+                    });
+                    try new_members.append(self.allocator, backing_field);
+
+                    // get x() { return this.#_x_accessor_storage; }
+                    {
+                        const getter_key = try self.ast.addNode(.{
+                            .tag = .identifier_reference, .span = self.ast.getNode(new_key).data.string_ref,
+                            .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
+                        });
+                        const this_node = try self.ast.addNode(.{
+                            .tag = .this_expression, .span = zero_span,
+                            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+                        });
+                        const storage_ref = try self.ast.addNode(.{
+                            .tag = .private_identifier, .span = storage_span,
+                            .data = .{ .string_ref = storage_span },
+                        });
+                        const this_storage = try self.addExtraNode(.static_member_expression, zero_span, &.{
+                            @intFromEnum(this_node), @intFromEnum(storage_ref), 0,
+                        });
+                        const return_stmt = try self.ast.addNode(.{
+                            .tag = .return_statement, .span = zero_span,
+                            .data = .{ .unary = .{ .operand = this_storage, .flags = 0 } },
+                        });
+                        const body_list = try self.ast.addNodeList(&.{return_stmt});
+                        const body = try self.ast.addNode(.{
+                            .tag = .block_statement, .span = zero_span,
+                            .data = .{ .list = body_list },
+                        });
+                        const empty_params = try self.ast.addNodeList(&.{});
+                        const getter_flags: u32 = 0x02 | (if (is_static) @as(u32, 0x01) else 0); // getter + static
+                        const getter = try self.addExtraNode(.method_definition, zero_span, &.{
+                            @intFromEnum(getter_key),
+                            empty_params.start, empty_params.len,
+                            @intFromEnum(body),
+                            getter_flags,
+                            empty_decos.start, empty_decos.len,
+                        });
+                        try new_members.append(self.allocator, getter);
+                    }
+
+                    // set x(value) { this.#_x_accessor_storage = value; }
+                    {
+                        const setter_key = try self.ast.addNode(.{
+                            .tag = .identifier_reference, .span = self.ast.getNode(new_key).data.string_ref,
+                            .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
+                        });
+                        const val_param_span = try self.ast.addString("value");
+                        const val_param = try self.ast.addNode(.{
+                            .tag = .binding_identifier, .span = val_param_span,
+                            .data = .{ .string_ref = val_param_span },
+                        });
+                        const setter_params = try self.ast.addNodeList(&.{val_param});
+                        const this_node = try self.ast.addNode(.{
+                            .tag = .this_expression, .span = zero_span,
+                            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+                        });
+                        const storage_ref = try self.ast.addNode(.{
+                            .tag = .private_identifier, .span = storage_span,
+                            .data = .{ .string_ref = storage_span },
+                        });
+                        const this_storage = try self.addExtraNode(.static_member_expression, zero_span, &.{
+                            @intFromEnum(this_node), @intFromEnum(storage_ref), 0,
+                        });
+                        const val_ref = try self.ast.addNode(.{
+                            .tag = .identifier_reference, .span = val_param_span,
+                            .data = .{ .string_ref = val_param_span },
+                        });
+                        const assign = try self.ast.addNode(.{
+                            .tag = .assignment_expression, .span = zero_span,
+                            .data = .{ .binary = .{ .left = this_storage, .right = val_ref, .flags = 0 } },
+                        });
+                        const assign_stmt = try self.ast.addNode(.{
+                            .tag = .expression_statement, .span = zero_span,
+                            .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+                        });
+                        const body_list = try self.ast.addNodeList(&.{assign_stmt});
+                        const body = try self.ast.addNode(.{
+                            .tag = .block_statement, .span = zero_span,
+                            .data = .{ .list = body_list },
+                        });
+                        const setter_flags: u32 = 0x04 | (if (is_static) @as(u32, 0x01) else 0); // setter + static
+                        const setter = try self.addExtraNode(.method_definition, zero_span, &.{
+                            @intFromEnum(setter_key),
+                            setter_params.start, setter_params.len,
+                            @intFromEnum(body),
+                            setter_flags,
+                            empty_decos.start, empty_decos.len,
+                        });
+                        try new_members.append(self.allocator, setter);
+                    }
+                } else {
+                    // decorator 없는 accessor → 그대로 유지
+                    const empty_list = try self.ast.addNodeList(&.{});
+                    const new_acc = try self.addExtraNode(.accessor_property, member.span, &.{
+                        @intFromEnum(new_key),
+                        @intFromEnum(new_init),
+                        flags,
+                        empty_list.start, empty_list.len,
+                    });
+                    try new_members.append(self.allocator, new_acc);
+                }
             } else {
                 // static_block 등 그대로 방문하여 추가
                 const visited = try self.visitNode(member_idx);
@@ -2483,7 +2616,7 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
         });
         const body_list = try self.ast.addNodeList(&.{assign_stmt});
         const fn_body = try self.ast.addNode(.{
-            .tag = .function_body, .span = zero_span,
+            .tag = .block_statement, .span = zero_span,
             .data = .{ .list = body_list },
         });
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1657,6 +1657,10 @@ const Stage3MemberInfo = struct {
     decorators: []const NodeIndex,
     /// field 초기값 (field/accessor만)
     init_value: NodeIndex = .none,
+    /// field/accessor용 initializers 변수명 (예: "_x_initializers")
+    initializers_name: ?[]const u8 = null,
+    /// field/accessor용 extraInitializers 변수명 (예: "_x_extraInitializers")
+    extra_initializers_name: ?[]const u8 = null,
     /// 원본 AST 멤버 인덱스 (class body 내 위치)
     raw_idx: u32 = 0,
 };
@@ -1719,6 +1723,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     defer {
         for (member_infos.items) |info| {
             self.allocator.free(info.decorators);
+            if (info.initializers_name) |name| self.allocator.free(name);
+            if (info.extra_initializers_name) |name| self.allocator.free(name);
         }
         member_infos.deinit(self.allocator);
     }
@@ -1817,12 +1823,24 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
+                    // field용 initializers/extraInitializers 변수명 생성
+                    const name_node = self.ast.getNode(name_node_idx);
+                    const raw_name = self.ast.getText(name_node.data.string_ref);
+                    const clean_name = if (raw_name.len >= 2 and raw_name[0] == '"')
+                        raw_name[1 .. raw_name.len - 1]
+                    else
+                        raw_name;
+                    const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{clean_name});
+                    const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{clean_name});
+
                     try member_infos.append(self.allocator, .{
                         .kind = "field",
                         .name = name_node_idx,
                         .is_static = is_static,
                         .is_private = false,
                         .decorators = decos,
+                        .initializers_name = init_name,
+                        .extra_initializers_name = extra_name,
                     });
                 }
 
@@ -2199,12 +2217,19 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo, _: Span) 
     // arg4: context object { kind: "method", name: "greet", static: false, private: false, access: { ... }, metadata: _metadata }
     const arg4 = try self.buildContextObject(info);
 
-    // arg5: initializers (null for method/getter/setter)
-    const arg5 = try makeIdentifier(self, "null");
+    // arg5: initializers (null for method/getter/setter, per-field var for field/accessor)
+    const arg5 = if (info.initializers_name) |name|
+        try makeIdentifier(self, name)
+    else
+        try makeIdentifier(self, "null");
 
-    // arg6: extraInitializers
-    const extra_init_name = if (info.is_static) "_staticExtraInitializers" else "_instanceExtraInitializers";
-    const arg6 = try makeIdentifier(self, extra_init_name);
+    // arg6: extraInitializers (per-field var for field/accessor, shared var for method/getter/setter)
+    const arg6 = if (info.extra_initializers_name) |name|
+        try makeIdentifier(self, name)
+    else blk: {
+        const extra_init_name = if (info.is_static) "_staticExtraInitializers" else "_instanceExtraInitializers";
+        break :blk try makeIdentifier(self, extra_init_name);
+    };
 
     const args = try self.ast.addNodeList(&.{ arg1, arg2, arg3, arg4, arg5, arg6 });
     return self.addExtraNode(.call_expression, zero_span, &.{
@@ -2654,10 +2679,21 @@ pub fn buildStage3LetDeclarations(
         try stmts.append(self.allocator, try self.makeLet(zero_span, "_staticExtraInitializers", empty_arr));
     }
 
-    // member decorator 변수들
-    _ = member_infos;
-    _ = none;
+    // field/accessor decorator별 initializers/extraInitializers 변수
+    for (member_infos) |info| {
+        if (info.initializers_name) |init_name| {
+            const empty_arr_list = try self.ast.addNodeList(&.{});
+            const empty_arr = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = empty_arr_list } });
+            try stmts.append(self.allocator, try self.makeLet(zero_span, init_name, empty_arr));
+        }
+        if (info.extra_initializers_name) |extra_name| {
+            const empty_arr_list2 = try self.ast.addNodeList(&.{});
+            const empty_arr2 = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = empty_arr_list2 } });
+            try stmts.append(self.allocator, try self.makeLet(zero_span, extra_name, empty_arr2));
+        }
+    }
 
+    _ = none;
     return stmts.toOwnedSlice(self.allocator);
 }
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1804,7 +1804,9 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
                     const decos = try self.collectStage3Decorators(deco_start, deco_len);
                     const var_n = extractCleanVarName(self, name_node_idx);
-                    const deco_vname = try std.fmt.allocPrint(self.allocator, "_{s}_decorators", .{var_n});
+                    // getter/setter는 같은 이름에 다른 kind → kind prefix로 충돌 방지
+                    const kind_prefix = if (is_getter) "get_" else if (is_setter) "set_" else "";
+                    const deco_vname = try std.fmt.allocPrint(self.allocator, "_{s}{s}_decorators", .{ kind_prefix, var_n });
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
@@ -2161,7 +2163,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
             return !std.mem.eql(u8, kind, "field");
         }
     }.check;
-    // Pass 1: static non-field → 2: instance non-field → 3: static field → 4: instance field
+    // [is_static, is_non_field] — 4 pass: static non-field → instance non-field → static field → instance field
     const passes = [_][2]bool{ .{ true, true }, .{ false, true }, .{ true, false }, .{ false, false } };
     for (passes) |pass| {
         const want_static = pass[0];
@@ -2175,7 +2177,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
     // class decorator __esDecorate 호출 (식 평가는 이미 IIFE 최상단 let 선언에서 완료)
     if (class_deco_len > 0) {
-        const class_call = try self.buildClassEsDecorateCall(class_deco_start, class_deco_len, classThis_span, class_name_text);
+        const class_call = try self.buildClassEsDecorateCall(classThis_span);
         const class_call_stmt = try self.ast.addNode(.{
             .tag = .expression_statement, .span = zero_span,
             .data = .{ .unary = .{ .operand = class_call, .flags = 0 } },
@@ -2521,7 +2523,7 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
 
 /// class decorator용 __esDecorate 호출:
 /// __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers)
-pub fn buildClassEsDecorateCall(self: *Transformer, _: u32, _: u32, classThis_span: Span, _: []const u8) Error!NodeIndex {
+pub fn buildClassEsDecorateCall(self: *Transformer, classThis_span: Span) Error!NodeIndex {
     const zero_span = Span{ .start = 0, .end = 0 };
 
     const callee = try makeIdentifier(self, "__esDecorate");
@@ -3170,10 +3172,6 @@ pub fn extractCleanVarName(self: *Transformer, name_node_idx: NodeIndex) []const
 pub fn appendEsDecorateStmt(self: *Transformer, stmts: *std.ArrayList(NodeIndex), info: Stage3MemberInfo) Error!void {
     const zero_span = Span{ .start = 0, .end = 0 };
     const call = try self.buildEsDecorateCall(info);
-    const call_stmt = try self.ast.addNode(.{
-        .tag = .expression_statement, .span = zero_span,
-        .data = .{ .unary = .{ .operand = call, .flags = 0 } },
-    });
-    try stmts.append(self.allocator, call_stmt);
+    try stmts.append(self.allocator, try es_helpers.makeExprStmt(self, call, zero_span));
 }
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1712,11 +1712,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     const class_deco_start = self.readU32(e, 6);
     const class_deco_len = self.readU32(e, 7);
 
-    // 클래스 이름 텍스트 (Foo)
+    // 클래스 이름 텍스트 (Foo). 익명 class expression은 "_a"를 사용.
     const class_name_text = if (!name_idx.isNone()) blk: {
         const name_node = self.ast.getNode(name_idx);
         break :blk self.ast.getText(name_node.data.string_ref);
-    } else "default";
+    } else "_a";
 
     // body 멤버 순회: member decorator 수집
     var member_infos: std.ArrayList(Stage3MemberInfo) = .empty;
@@ -2160,12 +2160,13 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         .data = .{ .list = new_body_list },
     });
 
-    // var Foo = class [extends Super] { ... } (decorator 없이)
-    const new_name = try self.visitNode(name_idx);
+    // var Foo = class [extends Super] { ... } (decorator 없이, 이름 제거)
+    // class body 내의 이름 바인딩은 const이므로, static { } 블록에서 Foo = ... 재대입이 불가.
+    // TypeScript와 동일하게 class expression에 이름을 제거하여 외부 var Foo를 참조하게 한다.
     const new_super = try self.visitNode(super_idx);
     const empty_decos = try self.ast.addNodeList(&.{});
     const inner_class = try self.addExtraNode(.class_expression, node.span, &.{
-        @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
+        none, @intFromEnum(new_super), @intFromEnum(new_body),
         none, 0, 0,
         empty_decos.start, empty_decos.len,
     });
@@ -2763,7 +2764,10 @@ pub fn buildStage3LetDeclarations(
     var stmts: std.ArrayList(NodeIndex) = .empty;
     defer stmts.deinit(self.allocator);
 
-    // class decorator가 있으면
+    // let _classThis; — static { _classThis = this; } 에서 항상 사용
+    try stmts.append(self.allocator, try self.makeLet(zero_span, "_classThis", .none));
+
+    // class decorator가 있으면 추가 변수
     if (class_deco_len > 0) {
         // let _classDecorators = [dec1, dec2];
         const decos = try self.collectStage3Decorators(class_deco_start, class_deco_len);
@@ -2779,9 +2783,6 @@ pub fn buildStage3LetDeclarations(
         const empty_arr_list = try self.ast.addNodeList(&.{});
         const empty_arr = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = empty_arr_list } });
         try stmts.append(self.allocator, try self.makeLet(zero_span, "_classExtraInitializers", empty_arr));
-
-        // let _classThis;
-        try stmts.append(self.allocator, try self.makeLet(zero_span, "_classThis", .none));
     }
 
     // instance/static extra initializers

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1668,6 +1668,8 @@ const Stage3MemberInfo = struct {
     /// private method용: 원본 params_start/params_len
     method_params_start: u32 = 0,
     method_params_len: u32 = 0,
+    /// decorator 변수명 (예: "_greet_decorators") — 식 평가/적용 분리용
+    deco_var_name: ?[]const u8 = null,
     /// 원본 AST 멤버 인덱스 (class body 내 위치)
     raw_idx: u32 = 0,
 };
@@ -1736,6 +1738,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
             if (info.initializers_name) |name| self.allocator.free(name);
             if (info.extra_initializers_name) |name| self.allocator.free(name);
             if (info.descriptor_name) |name| self.allocator.free(name);
+            if (info.deco_var_name) |name| self.allocator.free(name);
         }
         member_infos.deinit(self.allocator);
     }
@@ -1800,6 +1803,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     const kind = if (is_getter) "getter" else if (is_setter) "setter" else "method";
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
                     const decos = try self.collectStage3Decorators(deco_start, deco_len);
+                    const var_n = extractCleanVarName(self, name_node_idx);
+                    const deco_vname = try std.fmt.allocPrint(self.allocator, "_{s}_decorators", .{var_n});
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
@@ -1809,7 +1814,6 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     var m_params_start: u32 = 0;
                     var m_params_len: u32 = 0;
                     if (is_private_method) {
-                        const var_n = extractCleanVarName(self, name_node_idx);
                         desc_name = try std.fmt.allocPrint(self.allocator, "_private_{s}_descriptor", .{var_n});
                         m_body = try self.visitNode(self.readNodeIdx(me, 3));
                         m_params_start = self.readU32(me, 1);
@@ -1826,6 +1830,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .method_body = m_body,
                         .method_params_start = m_params_start,
                         .method_params_len = m_params_len,
+                        .deco_var_name = deco_vname,
                     });
                 }
 
@@ -1867,6 +1872,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 if (deco_len > 0) {
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
                     const decos = try self.collectStage3Decorators(deco_start, deco_len);
+                    const var_n = extractCleanVarName(self, name_node_idx);
+                    const deco_vname = try std.fmt.allocPrint(self.allocator, "_{s}_decorators", .{var_n});
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
@@ -1881,6 +1888,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .decorators = decos,
                         .initializers_name = names.init_name,
                         .extra_initializers_name = names.extra_name,
+                        .deco_var_name = deco_vname,
                     });
                 }
 
@@ -1900,7 +1908,9 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                             @intFromEnum(callee), args.start, args.len, 0,
                         });
                     } else {
-                        const args = try self.ast.addNodeList(&.{ this_node, init_arr });
+                        // 초기값 없어도 void 0을 명시적으로 전달 — __runInitializers가 arguments.length > 2를 체크
+                        const void0 = try makeIdentifier(self, "void 0");
+                        const args = try self.ast.addNodeList(&.{ this_node, init_arr, void0 });
                         break :blk try self.addExtraNode(.call_expression, zero_span, &.{
                             @intFromEnum(callee), args.start, args.len, 0,
                         });
@@ -1928,6 +1938,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 if (deco_len > 0) {
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
                     const decos = try self.collectStage3Decorators(deco_start, deco_len);
+                    const var_n = extractCleanVarName(self, name_node_idx);
+                    const deco_vname = try std.fmt.allocPrint(self.allocator, "_{s}_decorators", .{var_n});
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
@@ -1942,6 +1954,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .decorators = decos,
                         .initializers_name = names.init_name,
                         .extra_initializers_name = names.extra_name,
+                        .deco_var_name = deco_vname,
                     });
 
                     // accessor → private backing field + getter + setter
@@ -2121,17 +2134,46 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     const metadata_decl = try self.buildMetadataDecl();
     try static_block_stmts.append(self.allocator, metadata_decl);
 
-    // member decorator __esDecorate 호출
+    // TC39 스펙 decorator 순서:
+    // 1단계: 모든 member decorator 식을 **소스 순서**로 평가하여 변수에 저장
+    // 2단계: __esDecorate를 **스펙 순서**로 호출
+    //   (static non-field → instance non-field → static field → instance field)
+
+    // 1단계: 소스 순서로 식 평가 → _name_decorators = [dec1, dec2];
     for (member_infos.items) |info| {
-        const call = try self.buildEsDecorateCall(info);
-        const call_stmt = try self.ast.addNode(.{
-            .tag = .expression_statement, .span = zero_span,
-            .data = .{ .unary = .{ .operand = call, .flags = 0 } },
-        });
-        try static_block_stmts.append(self.allocator, call_stmt);
+        if (info.deco_var_name) |vname| {
+            const deco_list = try self.ast.addNodeList(info.decorators);
+            const deco_arr = try self.ast.addNode(.{
+                .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list },
+            });
+            const var_ref = try makeIdentifier(self, vname);
+            const assign = try self.ast.addNode(.{
+                .tag = .assignment_expression, .span = zero_span,
+                .data = .{ .binary = .{ .left = var_ref, .right = deco_arr, .flags = 0 } },
+            });
+            try static_block_stmts.append(self.allocator, try es_helpers.makeExprStmt(self, assign, zero_span));
+        }
     }
 
-    // class decorator __esDecorate 호출
+    // 2단계: 스펙 순서로 __esDecorate 호출
+    const is_non_field = struct {
+        fn check(kind: []const u8) bool {
+            return !std.mem.eql(u8, kind, "field");
+        }
+    }.check;
+    // Pass 1: static non-field → 2: instance non-field → 3: static field → 4: instance field
+    const passes = [_][2]bool{ .{ true, true }, .{ false, true }, .{ true, false }, .{ false, false } };
+    for (passes) |pass| {
+        const want_static = pass[0];
+        const want_non_field = pass[1];
+        for (member_infos.items) |info| {
+            if (info.is_static == want_static and is_non_field(info.kind) == want_non_field) {
+                try self.appendEsDecorateStmt(&static_block_stmts, info);
+            }
+        }
+    }
+
+    // class decorator __esDecorate 호출 (식 평가는 이미 IIFE 최상단 let 선언에서 완료)
     if (class_deco_len > 0) {
         const class_call = try self.buildClassEsDecorateCall(class_deco_start, class_deco_len, classThis_span, class_name_text);
         const class_call_stmt = try self.ast.addNode(.{
@@ -2446,9 +2488,13 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
         });
     } else try makeIdentifier(self, "null");
 
-    // arg3: [dec1, dec2, ...]
-    const deco_list = try self.ast.addNodeList(info.decorators);
-    const arg3 = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list } });
+    // arg3: decorator 배열 (변수 참조 — 식 평가는 이미 소스 순서로 완료)
+    const arg3 = if (info.deco_var_name) |vname|
+        try makeIdentifier(self, vname)
+    else blk: {
+        const deco_list = try self.ast.addNodeList(info.decorators);
+        break :blk try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list } });
+    };
 
     // arg4: context object { kind: "method", name: "greet", static: false, private: false, access: { ... }, metadata: _metadata }
     const arg4 = try self.buildContextObject(info);
@@ -2475,8 +2521,7 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
 
 /// class decorator용 __esDecorate 호출:
 /// __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers)
-pub fn buildClassEsDecorateCall(self: *Transformer, deco_start: u32, deco_len: u32, classThis_span: Span, class_name: []const u8) Error!NodeIndex {
-    _ = class_name;
+pub fn buildClassEsDecorateCall(self: *Transformer, _: u32, _: u32, classThis_span: Span, _: []const u8) Error!NodeIndex {
     const zero_span = Span{ .start = 0, .end = 0 };
 
     const callee = try makeIdentifier(self, "__esDecorate");
@@ -2508,11 +2553,8 @@ pub fn buildClassEsDecorateCall(self: *Transformer, deco_start: u32, deco_len: u
         .data = .{ .binary = .{ .left = desc_ref, .right = obj, .flags = 0 } },
     });
 
-    // arg3: _classDecorators
-    const decos = try self.collectStage3Decorators(deco_start, deco_len);
-    defer self.allocator.free(decos);
-    const deco_list = try self.ast.addNodeList(decos);
-    const arg3 = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list } });
+    // arg3: _classDecorators (이미 static block에서 할당됨)
+    const arg3 = try makeIdentifier(self, "_classDecorators");
 
     // arg4: { kind: "class", name: _classThis.name, metadata: _metadata }
     const kind_key = try makeIdentifier(self, "kind");
@@ -2922,9 +2964,9 @@ pub fn buildStage3LetDeclarations(
     // let _classThis; — static { _classThis = this; } 에서 항상 사용
     try stmts.append(self.allocator, try self.makeLet(zero_span, "_classThis", .none));
 
-    // class decorator가 있으면 추가 변수
+    // class decorator가 있으면 추가 변수 (식 평가는 소스 순서 — class body보다 먼저)
     if (class_deco_len > 0) {
-        // let _classDecorators = [dec1, dec2];
+        // let _classDecorators = [dec1, dec2]; (IIFE 최상단에서 평가 — TC39 소스 순서)
         const decos = try self.collectStage3Decorators(class_deco_start, class_deco_len);
         defer self.allocator.free(decos);
         const deco_list = try self.ast.addNodeList(decos);
@@ -2952,8 +2994,11 @@ pub fn buildStage3LetDeclarations(
         try stmts.append(self.allocator, try self.makeLet(zero_span, "_staticExtraInitializers", empty_arr));
     }
 
-    // field/accessor decorator별 initializers/extraInitializers + private method descriptor 변수
+    // member decorator 변수 + initializers + descriptor 변수
     for (member_infos) |info| {
+        if (info.deco_var_name) |vname| {
+            try stmts.append(self.allocator, try self.makeLet(zero_span, vname, .none));
+        }
         if (info.descriptor_name) |dname| {
             // let _private_method_descriptor;
             try stmts.append(self.allocator, try self.makeLet(zero_span, dname, .none));
@@ -3120,3 +3165,15 @@ pub fn extractCleanVarName(self: *Transformer, name_node_idx: NodeIndex) []const
         raw_name;
     return if (clean.len > 0 and clean[0] == '#') clean[1..] else clean;
 }
+
+/// __esDecorate 호출문을 static_block_stmts에 추가하는 헬퍼
+pub fn appendEsDecorateStmt(self: *Transformer, stmts: *std.ArrayList(NodeIndex), info: Stage3MemberInfo) Error!void {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const call = try self.buildEsDecorateCall(info);
+    const call_stmt = try self.ast.addNode(.{
+        .tag = .expression_statement, .span = zero_span,
+        .data = .{ .unary = .{ .operand = call, .flags = 0 } },
+    });
+    try stmts.append(self.allocator, call_stmt);
+}
+

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -2337,17 +2337,45 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 pub fn memberKeyToStringLiteral(self: *Transformer, key: NodeIndex) Error!NodeIndex {
     if (key.isNone()) return key;
     const key_node = self.ast.getNode(key);
+
+    // identifier/private → "name" 형태의 string literal로 변환
     if (key_node.tag == .identifier_reference or key_node.tag == .binding_identifier or key_node.tag == .private_identifier) {
         const name = self.ast.getText(key_node.data.string_ref);
-        var buf: [256]u8 = undefined;
-        buf[0] = '"';
-        const len = @min(name.len, buf.len - 2);
-        @memcpy(buf[1 .. 1 + len], name[0..len]);
-        buf[1 + len] = '"';
-        const span = try self.ast.addString(buf[0 .. 2 + len]);
-        return self.ast.addNode(.{ .tag = .string_literal, .span = span, .data = .{ .string_ref = span } });
+        return self.wrapInStringLiteral(name);
     }
+
+    // string_literal → 이미 따옴표 포함 (codegen이 그대로 출력)
+    if (key_node.tag == .string_literal) {
+        // 소스 텍스트가 "b" 형태 → context.name은 따옴표 없는 "b"
+        // 하지만 우리 string_literal은 이미 따옴표 포함이므로 그대로 반환
+        return key;
+    }
+
+    // numeric_literal → "0" 형태의 string literal로 변환
+    if (key_node.tag == .numeric_literal) {
+        const src = self.ast.source[key_node.span.start..key_node.span.end];
+        return self.wrapInStringLiteral(src);
+    }
+
+    // bigint_literal → "2" 형태로 변환 (끝의 n 제거)
+    if (key_node.tag == .bigint_literal) {
+        const src = self.ast.source[key_node.span.start..key_node.span.end];
+        const without_n = if (src.len > 0 and src[src.len - 1] == 'n') src[0 .. src.len - 1] else src;
+        return self.wrapInStringLiteral(without_n);
+    }
+
     return key;
+}
+
+/// 텍스트를 따옴표로 감싸서 string_literal 노드 생성
+pub fn wrapInStringLiteral(self: *Transformer, text: []const u8) Error!NodeIndex {
+    var buf: [256]u8 = undefined;
+    buf[0] = '"';
+    const len = @min(text.len, buf.len - 2);
+    @memcpy(buf[1 .. 1 + len], text[0..len]);
+    buf[1 + len] = '"';
+    const span = try self.ast.addString(buf[0 .. 2 + len]);
+    return self.ast.addNode(.{ .tag = .string_literal, .span = span, .data = .{ .string_ref = span } });
 }
 
 /// decorator 식들을 방문하여 슬라이스로 반환. caller가 free.
@@ -2589,6 +2617,20 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
     else
         raw_name;
 
+    // identifier-safe 판정: 숫자로 시작하거나 유효하지 않은 식별자면 computed access 사용
+    // obj.name (static) vs obj["name"] or obj[0] (computed)
+    const needs_computed = blk: {
+        if (info.is_private) break :blk false; // private은 항상 obj.#name
+        if (member_name.len == 0) break :blk true;
+        const first = member_name[0];
+        if (first >= '0' and first <= '9') break :blk true; // 숫자로 시작
+        // JS 식별자가 아닌 문자가 있으면 computed
+        for (member_name) |c| {
+            if (!std.ascii.isAlphanumeric(c) and c != '_' and c != '$') break :blk true;
+        }
+        break :blk false;
+    };
+
     // has: obj => "name" in obj (public) 또는 obj => #name in obj (private)
     {
         const has_key = try makeIdentifier(self, "has");
@@ -2638,18 +2680,24 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
             .data = .{ .string_ref = obj_param_span },
         });
 
-        // obj.name (public) 또는 obj.#name (private)
+        // obj.name (public) / obj.#name (private) / obj["name"] or obj[0] (computed key)
         const obj_ref = try self.ast.addNode(.{
             .tag = .identifier_reference, .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
-        const member_key_tag: Tag = if (info.is_private) .private_identifier else .identifier_reference;
-        const member_key_span = try self.ast.addString(member_name);
-        const member_key_node = try self.ast.addNode(.{
-            .tag = member_key_tag, .span = member_key_span,
-            .data = .{ .string_ref = member_key_span },
-        });
-        const obj_member = try es_helpers.makeStaticMember(self, obj_ref, member_key_node, zero_span);
+        const obj_member = if (needs_computed) blk: {
+            // obj["name"] 또는 obj[0]
+            const key_node = info.name; // 이미 string_literal "\"name\"" 형태
+            break :blk try es_helpers.makeComputedMember(self, obj_ref, key_node, zero_span);
+        } else blk: {
+            const member_key_tag: Tag = if (info.is_private) .private_identifier else .identifier_reference;
+            const member_key_span = try self.ast.addString(member_name);
+            const member_key_node = try self.ast.addNode(.{
+                .tag = member_key_tag, .span = member_key_span,
+                .data = .{ .string_ref = member_key_span },
+            });
+            break :blk try es_helpers.makeStaticMember(self, obj_ref, member_key_node, zero_span);
+        };
 
         const get_arrow = try self.addExtraNode(.arrow_function_expression, zero_span, &.{
             @intFromEnum(obj_param), @intFromEnum(obj_member), 0,
@@ -2678,18 +2726,22 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
         });
         const fn_params = try self.ast.addNodeList(&.{ obj_param, val_param });
 
-        // body: { obj.name = value; } (public) 또는 { obj.#name = value; } (private)
+        // body: { obj.name = value; } / { obj.#name = value; } / { obj["name"] = value; }
         const obj_ref = try self.ast.addNode(.{
             .tag = .identifier_reference, .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
-        const set_key_tag: Tag = if (info.is_private) .private_identifier else .identifier_reference;
-        const set_key_span = try self.ast.addString(member_name);
-        const set_key_node = try self.ast.addNode(.{
-            .tag = set_key_tag, .span = set_key_span,
-            .data = .{ .string_ref = set_key_span },
-        });
-        const obj_member = try es_helpers.makeStaticMember(self, obj_ref, set_key_node, zero_span);
+        const obj_member = if (needs_computed) blk: {
+            break :blk try es_helpers.makeComputedMember(self, obj_ref, info.name, zero_span);
+        } else blk: {
+            const set_key_tag: Tag = if (info.is_private) .private_identifier else .identifier_reference;
+            const set_key_span = try self.ast.addString(member_name);
+            const set_key_node = try self.ast.addNode(.{
+                .tag = set_key_tag, .span = set_key_span,
+                .data = .{ .string_ref = set_key_span },
+            });
+            break :blk try es_helpers.makeStaticMember(self, obj_ref, set_key_node, zero_span);
+        };
         const val_ref = try self.ast.addNode(.{
             .tag = .identifier_reference, .span = val_param_span,
             .data = .{ .string_ref = val_param_span },

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1721,14 +1721,22 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     const class_deco_start = self.readU32(e, 6);
     const class_deco_len = self.readU32(e, 7);
 
-    // 클래스 이름 텍스트 (Foo). 익명 class expression은 고유 임시 변수명 사용.
+    // 클래스 이름 텍스트 (Foo). 익명/default class는 "_Class"를 사용.
+    // "default"는 JS 예약어이므로 변수명으로 사용 불가.
+    // 주의: getText 반환값은 string table 내부 포인터이므로 addString 후 무효화될 수 있음.
+    // allocator로 복사하여 안전하게 보관한다.
+    // makeTempVarSpan을 사용하지 않음 — hoistTempVars가 불필요한 var 선언을 추가하므로.
     const class_name_text = if (!name_idx.isNone()) blk: {
         const name_node = self.ast.getNode(name_idx);
-        break :blk self.ast.getText(name_node.data.string_ref);
+        const name_text = self.ast.getText(name_node.data.string_ref);
+        if (std.mem.eql(u8, name_text, "default")) {
+            break :blk try self.allocator.dupe(u8, "_Class");
+        }
+        break :blk try self.allocator.dupe(u8, name_text);
     } else blk: {
-        const temp_span = try es_helpers.makeTempVarSpan(self);
-        break :blk self.ast.getText(temp_span);
+        break :blk try self.allocator.dupe(u8, "_Class");
     };
+    defer self.allocator.free(class_name_text);
 
     // body 멤버 순회: member decorator 수집
     var member_infos: std.ArrayList(Stage3MemberInfo) = .empty;
@@ -2397,16 +2405,22 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         @intFromEnum(paren_arrow), empty_args.start, empty_args.len, 0,
     });
 
-    // class expression → IIFE call을 직접 반환 (표현식 위치에서 사용)
-    if (node.tag == .class_expression) {
+    // class expression / 익명 class / export default class → IIFE call 직접 반환
+    // 이름 있는 class declaration만 `let Foo = (...)` 선언을 사용.
+    // - class_expression: 표현식 위치에서 사용
+    // - name_idx.isNone(): 익명 class (export default class {} 등)
+    // - name == "default": export default class (JS 예약어)
+    const has_named_binding = if (!name_idx.isNone()) blk: {
+        break :blk !std.mem.eql(u8, self.ast.getText(self.ast.getNode(name_idx).data.string_ref), "default");
+    } else false;
+
+    if (node.tag == .class_expression or !has_named_binding) {
         return iife_call;
     }
 
     // class declaration → let Foo = (() => { ... })();
-    const outer_name_span = if (!name_idx.isNone()) blk: {
-        const n = self.ast.getNode(name_idx);
-        break :blk n.data.string_ref;
-    } else try self.ast.addString("default");
+    // "default" 이름은 IIFE 내부 var에서 사용한 temp var name을 재사용
+    const outer_name_span = try self.ast.addString(class_name_text);
 
     const outer_binding = try self.ast.addNode(.{
         .tag = .binding_identifier,

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1778,7 +1778,13 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 }
 
                 // key를 한 번만 방문 (decorator info + stripped method 공용)
-                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+                const key_idx = self.readNodeIdx(me, 0);
+                const new_key = try self.visitNode(key_idx);
+                // private identifier 감지
+                const is_private = blk: {
+                    const orig_key = self.ast.getNode(key_idx);
+                    break :blk orig_key.tag == .private_identifier;
+                };
 
                 if (deco_len > 0) {
                     const kind = if (is_getter) "getter" else if (is_setter) "setter" else "method";
@@ -1791,7 +1797,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .kind = kind,
                         .name = name_node_idx,
                         .is_static = is_static,
-                        .is_private = false,
+                        .is_private = is_private,
                         .decorators = decos,
                     });
                 }
@@ -1816,7 +1822,9 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 const is_static = (flags & 0x01) != 0;
 
                 // key를 한 번만 방문
-                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+                const key_idx_prop = self.readNodeIdx(me, 0);
+                const new_key = try self.visitNode(key_idx_prop);
+                const is_private_field = self.ast.getNode(key_idx_prop).tag == .private_identifier;
 
                 var field_init_name: ?[]const u8 = null;
                 if (deco_len > 0) {
@@ -1832,7 +1840,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .kind = "field",
                         .name = name_node_idx,
                         .is_static = is_static,
-                        .is_private = false,
+                        .is_private = is_private_field,
                         .decorators = decos,
                         .initializers_name = names.init_name,
                         .extra_initializers_name = names.extra_name,
@@ -2311,7 +2319,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 pub fn memberKeyToStringLiteral(self: *Transformer, key: NodeIndex) Error!NodeIndex {
     if (key.isNone()) return key;
     const key_node = self.ast.getNode(key);
-    if (key_node.tag == .identifier_reference or key_node.tag == .binding_identifier) {
+    if (key_node.tag == .identifier_reference or key_node.tag == .binding_identifier or key_node.tag == .private_identifier) {
         const name = self.ast.getText(key_node.data.string_ref);
         var buf: [256]u8 = undefined;
         buf[0] = '"';
@@ -2532,7 +2540,7 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
     else
         raw_name;
 
-    // has: obj => "name" in obj
+    // has: obj => "name" in obj (public) 또는 obj => #name in obj (private)
     {
         const has_key = try makeIdentifier(self, "has");
         const obj_param_span = try self.ast.addString("obj");
@@ -2541,21 +2549,30 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
             .data = .{ .string_ref = obj_param_span },
         });
 
-        // "name" in obj
-        const name_str = try self.ast.addNode(.{
-            .tag = .string_literal, .span = name_node.data.string_ref,
-            .data = .{ .string_ref = name_node.data.string_ref },
-        });
         const obj_ref = try self.ast.addNode(.{
             .tag = .identifier_reference, .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
+
+        const in_left = if (info.is_private) blk: {
+            // #name (private_identifier)
+            const priv_span = try self.ast.addString(member_name);
+            break :blk try self.ast.addNode(.{
+                .tag = .private_identifier, .span = priv_span,
+                .data = .{ .string_ref = priv_span },
+            });
+        } else blk: {
+            // "name" (string_literal)
+            break :blk try self.ast.addNode(.{
+                .tag = .string_literal, .span = name_node.data.string_ref,
+                .data = .{ .string_ref = name_node.data.string_ref },
+            });
+        };
         const in_expr = try self.ast.addNode(.{
             .tag = .binary_expression, .span = zero_span,
-            .data = .{ .binary = .{ .left = name_str, .right = obj_ref, .flags = @intFromEnum(Kind.kw_in) } },
+            .data = .{ .binary = .{ .left = in_left, .right = obj_ref, .flags = @intFromEnum(Kind.kw_in) } },
         });
 
-        // obj => "name" in obj
         const has_arrow = try self.addExtraNode(.arrow_function_expression, zero_span, &.{
             @intFromEnum(obj_param), @intFromEnum(in_expr), 0,
         });
@@ -2572,15 +2589,18 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
             .data = .{ .string_ref = obj_param_span },
         });
 
-        // obj.name
+        // obj.name (public) 또는 obj.#name (private)
         const obj_ref = try self.ast.addNode(.{
             .tag = .identifier_reference, .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
-        const member_key = try makeIdentifier(self, member_name);
-        const obj_member = try self.addExtraNode(.static_member_expression, zero_span, &.{
-            @intFromEnum(obj_ref), @intFromEnum(member_key), 0,
+        const member_key_tag: Tag = if (info.is_private) .private_identifier else .identifier_reference;
+        const member_key_span = try self.ast.addString(member_name);
+        const member_key_node = try self.ast.addNode(.{
+            .tag = member_key_tag, .span = member_key_span,
+            .data = .{ .string_ref = member_key_span },
         });
+        const obj_member = try es_helpers.makeStaticMember(self, obj_ref, member_key_node, zero_span);
 
         const get_arrow = try self.addExtraNode(.arrow_function_expression, zero_span, &.{
             @intFromEnum(obj_param), @intFromEnum(obj_member), 0,
@@ -2609,15 +2629,18 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
         });
         const fn_params = try self.ast.addNodeList(&.{ obj_param, val_param });
 
-        // body: { obj.name = value; }
+        // body: { obj.name = value; } (public) 또는 { obj.#name = value; } (private)
         const obj_ref = try self.ast.addNode(.{
             .tag = .identifier_reference, .span = obj_param_span,
             .data = .{ .string_ref = obj_param_span },
         });
-        const member_key = try makeIdentifier(self, member_name);
-        const obj_member = try self.addExtraNode(.static_member_expression, zero_span, &.{
-            @intFromEnum(obj_ref), @intFromEnum(member_key), 0,
+        const set_key_tag: Tag = if (info.is_private) .private_identifier else .identifier_reference;
+        const set_key_span = try self.ast.addString(member_name);
+        const set_key_node = try self.ast.addNode(.{
+            .tag = set_key_tag, .span = set_key_span,
+            .data = .{ .string_ref = set_key_span },
         });
+        const obj_member = try es_helpers.makeStaticMember(self, obj_ref, set_key_node, zero_span);
         const val_ref = try self.ast.addNode(.{
             .tag = .identifier_reference, .span = val_param_span,
             .data = .{ .string_ref = val_param_span },
@@ -2883,12 +2906,18 @@ const FieldInitNames = struct {
 pub fn buildFieldInitNames(self: *Transformer, name_node_idx: NodeIndex) Error!FieldInitNames {
     const name_node = self.ast.getNode(name_node_idx);
     const raw_name = self.ast.getText(name_node.data.string_ref);
+    // 따옴표 제거: "\"foo\"" → "foo", "\"#foo\"" → "#foo"
     const clean_name = if (raw_name.len >= 2 and raw_name[0] == '"')
         raw_name[1 .. raw_name.len - 1]
     else
         raw_name;
-    const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{clean_name});
-    const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{clean_name});
+    // 변수명에서 # 제거: #foo → foo (JS 변수명에 # 사용 불가)
+    const var_name = if (clean_name.len > 0 and clean_name[0] == '#')
+        clean_name[1..]
+    else
+        clean_name;
+    const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{var_name});
+    const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{var_name});
     return .{ .init_name = init_name, .extra_name = extra_name, .clean_name = clean_name };
 }
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1462,10 +1462,10 @@ pub fn extractTypeFromSource(self: *Transformer, param: Node) Error!NodeIndex {
     return makeTypeofGuard(self, type_name);
 }
 
-/// 이름으로 identifier_reference 노드를 생성하는 헬퍼
+/// 이름으로 identifier_reference 노드를 생성하는 헬퍼.
+/// es_helpers.makeIdentifierRef와 동일 — legacy decorator 코드 호환을 위해 alias 유지.
 fn makeIdentifier(self: *Transformer, name: []const u8) Error!NodeIndex {
-    const span = try self.ast.addString(name);
-    return self.ast.addNode(.{ .tag = .identifier_reference, .span = span, .data = .{ .string_ref = span } });
+    return es_helpers.makeIdentifierRef(self, name);
 }
 
 /// typeof X === "undefined" ? Object : X 조건 표현식 생성 (SWC 호환).
@@ -2245,7 +2245,12 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         @intFromEnum(paren_arrow), empty_args.start, empty_args.len, 0,
     });
 
-    // let Foo = (() => { ... })();
+    // class expression → IIFE call을 직접 반환 (표현식 위치에서 사용)
+    if (node.tag == .class_expression) {
+        return iife_call;
+    }
+
+    // class declaration → let Foo = (() => { ... })();
     const outer_name_span = if (!name_idx.isNone()) blk: {
         const n = self.ast.getNode(name_idx);
         break :blk n.data.string_ref;

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1774,14 +1774,12 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     }
                 }
 
+                // key를 한 번만 방문 (decorator info + stripped method 공용)
+                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+
                 if (deco_len > 0) {
                     const kind = if (is_getter) "getter" else if (is_setter) "setter" else "method";
-                    const key_idx = self.readNodeIdx(me, 0);
-                    const new_key = try self.visitNode(key_idx);
-                    // member name을 문자열 리터럴로 변환
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
-
-                    // decorator 식 수집
                     const decos = try self.collectStage3Decorators(deco_start, deco_len);
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
@@ -1796,7 +1794,6 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 }
 
                 // method를 decorator 없이 body에 추가
-                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
                 const new_body = try self.visitNode(self.readNodeIdx(me, 3));
                 const empty_list = try self.ast.addNodeList(&.{});
                 const new_method = try self.addExtraNode(.method_definition, member.span, &.{
@@ -1815,23 +1812,16 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 const deco_len = self.readU32(me, 4);
                 const is_static = (flags & 0x01) != 0;
 
+                // key를 한 번만 방문
+                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+
                 if (deco_len > 0) {
-                    const key_idx = self.readNodeIdx(me, 0);
-                    const new_key = try self.visitNode(key_idx);
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
                     const decos = try self.collectStage3Decorators(deco_start, deco_len);
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
-                    // field용 initializers/extraInitializers 변수명 생성
-                    const name_node = self.ast.getNode(name_node_idx);
-                    const raw_name = self.ast.getText(name_node.data.string_ref);
-                    const clean_name = if (raw_name.len >= 2 and raw_name[0] == '"')
-                        raw_name[1 .. raw_name.len - 1]
-                    else
-                        raw_name;
-                    const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{clean_name});
-                    const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{clean_name});
+                    const names = try self.buildFieldInitNames(name_node_idx);
 
                     try member_infos.append(self.allocator, .{
                         .kind = "field",
@@ -1839,13 +1829,12 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .is_static = is_static,
                         .is_private = false,
                         .decorators = decos,
-                        .initializers_name = init_name,
-                        .extra_initializers_name = extra_name,
+                        .initializers_name = names.init_name,
+                        .extra_initializers_name = names.extra_name,
                     });
                 }
 
-                // property를 decorator 없이 방문하여 추가
-                const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+                // property를 decorator 없이 추가
                 const new_init = try self.visitNode(self.readNodeIdx(me, 1));
                 const empty_list = try self.ast.addNodeList(&.{});
                 const new_prop = try self.addExtraNode(.property_definition, member.span, &.{
@@ -1872,15 +1861,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
-                    // 멤버 이름 추출
-                    const name_node = self.ast.getNode(name_node_idx);
-                    const raw_name = self.ast.getText(name_node.data.string_ref);
-                    const clean_name = if (raw_name.len >= 2 and raw_name[0] == '"')
-                        raw_name[1 .. raw_name.len - 1]
-                    else
-                        raw_name;
-                    const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{clean_name});
-                    const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{clean_name});
+                    const names = try self.buildFieldInitNames(name_node_idx);
+                    const clean_name = names.clean_name;
 
                     try member_infos.append(self.allocator, .{
                         .kind = "accessor",
@@ -1888,12 +1870,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .is_static = is_static,
                         .is_private = false,
                         .decorators = decos,
-                        .initializers_name = init_name,
-                        .extra_initializers_name = extra_name,
+                        .initializers_name = names.init_name,
+                        .extra_initializers_name = names.extra_name,
                     });
 
                     // accessor → private backing field + getter + setter
-                    // #x_accessor_storage (property_definition)
                     const storage_name = try std.fmt.allocPrint(self.allocator, "#_{s}_accessor_storage", .{clean_name});
                     defer self.allocator.free(storage_name);
                     const storage_span = try self.ast.addString(storage_name);
@@ -1908,7 +1889,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                             .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
                         });
                         const callee = try makeIdentifier(self, "__runInitializers");
-                        const init_arr_ref = try makeIdentifier(self, init_name);
+                        const init_arr_ref = try makeIdentifier(self, names.init_name);
                         const args = try self.ast.addNodeList(&.{ this_node, init_arr_ref, new_init });
                         break :blk try self.addExtraNode(.call_expression, zero_span, &.{
                             @intFromEnum(callee), args.start, args.len, 0,
@@ -2091,7 +2072,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
     // member decorator __esDecorate 호출
     for (member_infos.items) |info| {
-        const call = try self.buildEsDecorateCall(info, classThis_span);
+        const call = try self.buildEsDecorateCall(info);
         const call_stmt = try self.ast.addNode(.{
             .tag = .expression_statement, .span = zero_span,
             .data = .{ .unary = .{ .operand = call, .flags = 0 } },
@@ -2329,7 +2310,7 @@ pub fn collectStage3Decorators(self: *Transformer, deco_start: u32, deco_len: u3
 }
 
 /// __esDecorate(this, null, _decorators, { kind: "method", name: "...", static: bool, private: bool, access: { ... }, metadata: _metadata }, null, _extraInitializers) 호출 생성.
-pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo, _: Span) Error!NodeIndex {
+pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!NodeIndex {
     const zero_span = Span{ .start = 0, .end = 0 };
 
     const callee = try makeIdentifier(self, "__esDecorate");
@@ -2409,8 +2390,6 @@ pub fn buildClassEsDecorateCall(self: *Transformer, deco_start: u32, deco_len: u
     const decos = try self.collectStage3Decorators(deco_start, deco_len);
     defer self.allocator.free(decos);
     const deco_list = try self.ast.addNodeList(decos);
-    const class_deco_span = try self.ast.addString("_classDecorators");
-    _ = class_deco_span;
     const arg3 = try self.ast.addNode(.{ .tag = .array_expression, .span = zero_span, .data = .{ .list = deco_list } });
 
     // arg4: { kind: "class", name: _classThis.name, metadata: _metadata }
@@ -2853,4 +2832,25 @@ pub fn makeLet(self: *Transformer, span: Span, name: []const u8, init: NodeIndex
     return self.addExtraNode(.variable_declaration, span, &.{
         1, decl_list.start, decl_list.len, // 1 = let
     });
+}
+
+/// field/accessor decorator용 initializers 변수명 생성 헬퍼.
+/// 따옴표 포함된 string_literal 노드에서 clean name을 추출하고
+/// _name_initializers / _name_extraInitializers 문자열을 할당한다.
+const FieldInitNames = struct {
+    init_name: []const u8,
+    extra_name: []const u8,
+    clean_name: []const u8,
+};
+
+pub fn buildFieldInitNames(self: *Transformer, name_node_idx: NodeIndex) Error!FieldInitNames {
+    const name_node = self.ast.getNode(name_node_idx);
+    const raw_name = self.ast.getText(name_node.data.string_ref);
+    const clean_name = if (raw_name.len >= 2 and raw_name[0] == '"')
+        raw_name[1 .. raw_name.len - 1]
+    else
+        raw_name;
+    const init_name = try std.fmt.allocPrint(self.allocator, "_{s}_initializers", .{clean_name});
+    const extra_name = try std.fmt.allocPrint(self.allocator, "_{s}_extraInitializers", .{clean_name});
+    return .{ .init_name = init_name, .extra_name = extra_name, .clean_name = clean_name };
 }

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -2323,12 +2323,156 @@ pub fn buildContextObject(self: *Transformer, info: Stage3MemberInfo) Error!Node
     const private_val = try makeIdentifier(self, if (info.is_private) "true" else "false");
     try props.append(self.allocator, try self.makeObjProp(private_key, private_val));
 
+    // access: { has: obj => "name" in obj, get: obj => obj.name, ... }
+    const access_key = try makeIdentifier(self, "access");
+    const access_obj = try self.buildAccessObject(info);
+    try props.append(self.allocator, try self.makeObjProp(access_key, access_obj));
+
     // metadata
     const metadata_key = try makeIdentifier(self, "metadata");
     const metadata_val = try makeIdentifier(self, "_metadata");
     try props.append(self.allocator, try self.makeObjProp(metadata_key, metadata_val));
 
     const list = try self.ast.addNodeList(props.items);
+    return self.ast.addNode(.{ .tag = .object_expression, .span = zero_span, .data = .{ .list = list } });
+}
+
+/// access 객체 생성: { has: obj => "name" in obj, get: obj => obj.name, set: (obj, value) => { obj.name = value; } }
+/// kind에 따라 has/get/set 조합이 다르다:
+/// - method/getter: has + get
+/// - setter: has + set
+/// - field/accessor: has + get + set
+pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const none = @intFromEnum(NodeIndex.none);
+    const Kind = @import("../../lexer/token.zig").Kind;
+    var access_props: std.ArrayList(NodeIndex) = .empty;
+    defer access_props.deinit(self.allocator);
+
+    // 멤버 이름 텍스트 추출 (string_literal "\"name\"" → "name")
+    const name_node = self.ast.getNode(info.name);
+    const raw_name = self.ast.getText(name_node.data.string_ref);
+    // 따옴표 제거: "\"foo\"" → "foo"
+    const member_name = if (raw_name.len >= 2 and raw_name[0] == '"')
+        raw_name[1 .. raw_name.len - 1]
+    else
+        raw_name;
+
+    // has: obj => "name" in obj
+    {
+        const has_key = try makeIdentifier(self, "has");
+        const obj_param_span = try self.ast.addString("obj");
+        const obj_param = try self.ast.addNode(.{
+            .tag = .binding_identifier, .span = obj_param_span,
+            .data = .{ .string_ref = obj_param_span },
+        });
+
+        // "name" in obj
+        const name_str = try self.ast.addNode(.{
+            .tag = .string_literal, .span = name_node.data.string_ref,
+            .data = .{ .string_ref = name_node.data.string_ref },
+        });
+        const obj_ref = try self.ast.addNode(.{
+            .tag = .identifier_reference, .span = obj_param_span,
+            .data = .{ .string_ref = obj_param_span },
+        });
+        const in_expr = try self.ast.addNode(.{
+            .tag = .binary_expression, .span = zero_span,
+            .data = .{ .binary = .{ .left = name_str, .right = obj_ref, .flags = @intFromEnum(Kind.kw_in) } },
+        });
+
+        // obj => "name" in obj
+        const has_arrow = try self.addExtraNode(.arrow_function_expression, zero_span, &.{
+            @intFromEnum(obj_param), @intFromEnum(in_expr), 0,
+        });
+        try access_props.append(self.allocator, try self.makeObjProp(has_key, has_arrow));
+    }
+
+    // get: obj => obj.name (method, getter, field, accessor — not setter)
+    const is_setter_only = std.mem.eql(u8, info.kind, "setter");
+    if (!is_setter_only) {
+        const get_key = try makeIdentifier(self, "get");
+        const obj_param_span = try self.ast.addString("obj");
+        const obj_param = try self.ast.addNode(.{
+            .tag = .binding_identifier, .span = obj_param_span,
+            .data = .{ .string_ref = obj_param_span },
+        });
+
+        // obj.name
+        const obj_ref = try self.ast.addNode(.{
+            .tag = .identifier_reference, .span = obj_param_span,
+            .data = .{ .string_ref = obj_param_span },
+        });
+        const member_key = try makeIdentifier(self, member_name);
+        const obj_member = try self.addExtraNode(.static_member_expression, zero_span, &.{
+            @intFromEnum(obj_ref), @intFromEnum(member_key), 0,
+        });
+
+        const get_arrow = try self.addExtraNode(.arrow_function_expression, zero_span, &.{
+            @intFromEnum(obj_param), @intFromEnum(obj_member), 0,
+        });
+        try access_props.append(self.allocator, try self.makeObjProp(get_key, get_arrow));
+    }
+
+    // set: (obj, value) => { obj.name = value; } (setter, field, accessor — not method/getter)
+    const needs_set = std.mem.eql(u8, info.kind, "setter") or
+        std.mem.eql(u8, info.kind, "field") or
+        std.mem.eql(u8, info.kind, "accessor");
+    if (needs_set) {
+        const set_key = try makeIdentifier(self, "set");
+
+        // function(obj, value) { obj.name = value; }
+        // function_expression: extra = [name(0), params_start, params_len, body(3), flags, ret_type(5)]
+        const obj_param_span = try self.ast.addString("obj");
+        const obj_param = try self.ast.addNode(.{
+            .tag = .binding_identifier, .span = obj_param_span,
+            .data = .{ .string_ref = obj_param_span },
+        });
+        const val_param_span = try self.ast.addString("value");
+        const val_param = try self.ast.addNode(.{
+            .tag = .binding_identifier, .span = val_param_span,
+            .data = .{ .string_ref = val_param_span },
+        });
+        const fn_params = try self.ast.addNodeList(&.{ obj_param, val_param });
+
+        // body: { obj.name = value; }
+        const obj_ref = try self.ast.addNode(.{
+            .tag = .identifier_reference, .span = obj_param_span,
+            .data = .{ .string_ref = obj_param_span },
+        });
+        const member_key = try makeIdentifier(self, member_name);
+        const obj_member = try self.addExtraNode(.static_member_expression, zero_span, &.{
+            @intFromEnum(obj_ref), @intFromEnum(member_key), 0,
+        });
+        const val_ref = try self.ast.addNode(.{
+            .tag = .identifier_reference, .span = val_param_span,
+            .data = .{ .string_ref = val_param_span },
+        });
+        const assign = try self.ast.addNode(.{
+            .tag = .assignment_expression, .span = zero_span,
+            .data = .{ .binary = .{ .left = obj_member, .right = val_ref, .flags = 0 } },
+        });
+        const assign_stmt = try self.ast.addNode(.{
+            .tag = .expression_statement, .span = zero_span,
+            .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+        });
+        const body_list = try self.ast.addNodeList(&.{assign_stmt});
+        const fn_body = try self.ast.addNode(.{
+            .tag = .function_body, .span = zero_span,
+            .data = .{ .list = body_list },
+        });
+
+        const set_fn = try self.addExtraNode(.function_expression, zero_span, &.{
+            none,            // name (anonymous)
+            fn_params.start, fn_params.len,
+            @intFromEnum(fn_body),
+            0,               // flags
+            none,            // ret_type
+        });
+        try access_props.append(self.allocator, try self.makeObjProp(set_key, set_fn));
+    }
+
+    const list = try self.ast.addNodeList(access_props.items);
     return self.ast.addNode(.{ .tag = .object_expression, .span = zero_span, .data = .{ .list = list } });
 }
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1616,6 +1616,9 @@ pub fn appendClassMetadata(
 
 /// Stage 3 decorator가 있는 멤버(method/property/accessor)가 하나라도 있는지 확인.
 /// class_body를 순회하여 decorator가 달린 멤버 존재 여부만 빠르게 판단한다.
+/// 익명/export default class의 IIFE 내부 변수명
+const ANON_CLASS_NAME = "_Class";
+
 pub fn hasAnyMemberDecorators(self: *Transformer, class_extra: u32) bool {
     const body_idx = self.readNodeIdx(class_extra, 2);
     if (body_idx.isNone()) return false;
@@ -1730,11 +1733,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         const name_node = self.ast.getNode(name_idx);
         const name_text = self.ast.getText(name_node.data.string_ref);
         if (std.mem.eql(u8, name_text, "default")) {
-            break :blk try self.allocator.dupe(u8, "_Class");
+            break :blk try self.allocator.dupe(u8, ANON_CLASS_NAME);
         }
         break :blk try self.allocator.dupe(u8, name_text);
     } else blk: {
-        break :blk try self.allocator.dupe(u8, "_Class");
+        break :blk try self.allocator.dupe(u8, ANON_CLASS_NAME);
     };
     defer self.allocator.free(class_name_text);
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -306,7 +306,7 @@ pub fn transpileWithCallback(
 
     // 7. 런타임 헬퍼 prepend
     const rh = transformer.runtime_helpers;
-    const has_helpers = @as(u16, @bitCast(rh)) != 0;
+    const has_helpers = @as(u32, @bitCast(rh)) != 0;
     const output = if (has_helpers) blk: {
         var buf: std.ArrayList(u8) = .empty;
         rt.appendRuntimeHelpers(&buf, arena_alloc, rh, options.minify_whitespace, transformer.runtime_es5_compat) catch

--- a/tests/integration/tests/stage3-decorator-smoke.test.ts
+++ b/tests/integration/tests/stage3-decorator-smoke.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { createFixture, runZts } from "./helpers";
+import { join, resolve } from "node:path";
+import { symlink, mkdir, readFile } from "node:fs/promises";
+import { spawnSync } from "bun";
+
+// Stage 3 Decorator 스모크 테스트
+// 실제 라이브러리(MobX 6)를 사용하여 Stage 3 decorator가 런타임에서 올바르게 동작하는지 검증
+
+const PROJECT_ROOT = resolve(import.meta.dir, "../../..");
+
+async function mobxSmoke(code: string) {
+  const { dir, cleanup } = await createFixture({ "index.ts": code });
+
+  await mkdir(join(dir, "node_modules"), { recursive: true });
+  try {
+    await symlink(join(PROJECT_ROOT, "node_modules/mobx"), join(dir, "node_modules/mobx"));
+  } catch {}
+
+  const outFile = join(dir, "out.js");
+  const bundle = await runZts(["--bundle", join(dir, "index.ts"), "-o", outFile]);
+  if (bundle.exitCode !== 0) {
+    await cleanup();
+    throw new Error("bundle failed: " + bundle.stderr);
+  }
+
+  // spawnSync로 실행 — pipe 문제 회피
+  const run = spawnSync(["bun", "run", outFile]);
+  const output = run.stdout.toString().trim();
+  const stderr = run.stderr.toString().trim();
+
+  return { output, stderr, exitCode: run.exitCode, cleanup };
+}
+
+describe("Stage 3 Decorator Smoke — MobX 6", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it("@observable accessor + @action + autorun", async () => {
+    const r = await mobxSmoke(`
+      import { makeObservable, observable, action, autorun } from "mobx";
+      class Counter {
+        @observable accessor count = 0;
+        @action increment() { this.count++; }
+        constructor() { makeObservable(this); }
+      }
+      const c = new Counter();
+      const log: number[] = [];
+      autorun(() => { log.push(c.count); });
+      c.increment();
+      c.increment();
+      c.increment();
+      console.log(log.join(","));
+    `);
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("0,1,2,3");
+  });
+
+  // TODO: @computed getter에서 MobX 내부 descriptor 조회 실패 — getter decorator의 descriptor 전달 방식 검토 필요
+  it.skip("@computed getter", async () => {
+    const r = await mobxSmoke(`
+      import { makeObservable, observable, computed, action } from "mobx";
+      class Store {
+        @observable accessor firstName = "John";
+        @observable accessor lastName = "Doe";
+        @computed get fullName() { return this.firstName + " " + this.lastName; }
+        @action setName(f: string, l: string) { this.firstName = f; this.lastName = l; }
+        constructor() { makeObservable(this); }
+      }
+      const s = new Store();
+      console.log(s.fullName);
+      s.setName("Jane", "Smith");
+      console.log(s.fullName);
+    `);
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("John Doe");
+    expect(r.output).toContain("Jane Smith");
+  });
+
+  it("@observable accessor toggle", async () => {
+    const r = await mobxSmoke(`
+      import { makeObservable, observable, action, autorun } from "mobx";
+      class Todo {
+        @observable accessor done = false;
+        @action toggle() { this.done = !this.done; }
+        constructor() { makeObservable(this); }
+      }
+      const t = new Todo();
+      const s: string[] = [];
+      autorun(() => { s.push(t.done ? "done" : "pending"); });
+      t.toggle();
+      t.toggle();
+      console.log(s.join(","));
+    `);
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("pending,done,pending");
+  });
+});

--- a/tests/integration/tests/stage3-decorator-smoke.test.ts
+++ b/tests/integration/tests/stage3-decorator-smoke.test.ts
@@ -9,6 +9,17 @@ import { spawnSync } from "bun";
 
 const PROJECT_ROOT = resolve(import.meta.dir, "../../..");
 
+// CI에서 mobx가 설치되지 않았으면 전체 suite skip
+const hasMobx = await (async () => {
+  try {
+    const { statSync } = await import("node:fs");
+    statSync(join(PROJECT_ROOT, "node_modules/mobx/package.json"));
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
 async function mobxSmoke(code: string) {
   const { dir, cleanup } = await createFixture({ "index.ts": code });
 
@@ -32,7 +43,7 @@ async function mobxSmoke(code: string) {
   return { output, stderr, exitCode: run.exitCode, cleanup };
 }
 
-describe("Stage 3 Decorator Smoke — MobX 6", () => {
+describe.skipIf(!hasMobx)("Stage 3 Decorator Smoke — MobX 6", () => {
   let cleanup: (() => Promise<void>) | undefined;
   afterEach(async () => {
     if (cleanup) {

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -336,4 +336,197 @@ describe("Stage 3 Decorators", () => {
     expect(result.stdout).toContain("__runInitializers");
     expect(result.stdout).toContain('"class"');
   });
+
+  // --- Setter decorator E2E ---
+
+  it("setter decorator works", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function validate(fn: any, ctx: any) {
+          return function(this: any, value: any) {
+            if (typeof value !== "number") throw new Error("not a number");
+            fn.call(this, value);
+          };
+        }
+        class Foo {
+          _x = 0;
+          @validate set x(v: number) { this._x = v; }
+          get x() { return this._x; }
+        }
+        const f = new Foo();
+        f.x = 42;
+        console.log(f.x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("42");
+  });
+
+  // --- Static field decorator E2E ---
+
+  it("static field decorator", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(value: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name + ":static=" + ctx.static);
+        }
+        class Counter {
+          @log static count = 0;
+        }
+        console.log(Counter.count);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("field:count:static=true");
+    expect(result.runOutput).toContain("0");
+  });
+
+  // --- Multiple decorated fields ordering ---
+
+  it("multiple decorated fields order", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const order: string[] = [];
+        function track(value: any, ctx: any) {
+          order.push(ctx.name);
+        }
+        class Foo {
+          @track a = 1;
+          @track b = 2;
+          @track c = 3;
+        }
+        new Foo();
+        console.log(order.join(","));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("a,b,c");
+  });
+
+  // --- Decorator factory with chaining ---
+
+  it("decorator factory with arguments", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function tag(name: string) {
+          return function(cls: any, ctx: any) {
+            cls.tag = name;
+            return cls;
+          };
+        }
+        @tag("myComponent")
+        class Component {}
+        console.log((Component as any).tag);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("myComponent");
+  });
+
+  // --- Accessor decorator E2E ---
+
+  it("accessor decorator basic", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(target: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name);
+          return target;
+        }
+        class Foo {
+          @log accessor x = 10;
+        }
+        const f = new Foo();
+        console.log(f.x);
+        f.x = 20;
+        console.log(f.x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("accessor:x");
+    expect(result.runOutput).toContain("10");
+    expect(result.runOutput).toContain("20");
+  });
+
+  // --- Extends chain ---
+
+  it("decorator on derived class", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(cls: any, ctx: any) {
+          console.log("decorated:" + ctx.name);
+          return cls;
+        }
+        class Base {
+          base = true;
+        }
+        @log class Child extends Base {
+          child = true;
+        }
+        const c = new Child();
+        console.log(c.base + "," + c.child);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("decorated:Child");
+    expect(result.runOutput).toContain("true,true");
+  });
+
+  // --- Multiple addInitializer ---
+
+  it("multiple addInitializer calls", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const log: string[] = [];
+        function init1(fn: any, ctx: any) {
+          ctx.addInitializer(function() { log.push("init1"); });
+          return fn;
+        }
+        function init2(fn: any, ctx: any) {
+          ctx.addInitializer(function() { log.push("init2"); });
+          return fn;
+        }
+        class Foo {
+          @init1 @init2 method() {}
+        }
+        new Foo();
+        console.log(log.join(","));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // addInitializer는 decorator 적용 순서 (오른쪽→왼쪽)로 등록됨
+    expect(result.runOutput).toContain("init2,init1");
+  });
+
+  // --- Context access.has/get ---
+
+  it("access.has and access.get work correctly", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        let savedAccess: any;
+        function capture(fn: any, ctx: any) {
+          savedAccess = ctx.access;
+          return fn;
+        }
+        class Foo {
+          @capture greet() { return "hello"; }
+        }
+        const obj = new Foo();
+        console.log(savedAccess.has(obj));
+        console.log(savedAccess.get(obj)());
+        console.log(savedAccess.has({}));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("true");
+    expect(result.runOutput).toContain("hello");
+    expect(result.runOutput).toContain("false");
+  });
 });

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { bundleAndRun, createFixture, runZts } from "./helpers";
+import { join } from "node:path";
+
+// TC39 Stage 3 Decorator E2E 테스트
+// ZTS로 번들링 후 Bun으로 실행하여 런타임 동작 검증
+
+describe("Stage 3 Decorators", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  // --- Class decorator ---
+
+  it("class decorator receives class and context", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(cls: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name);
+          return cls;
+        }
+        @log class Foo {}
+        new Foo();
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("class:Foo");
+  });
+
+  it("class decorator can replace class", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function wrap(cls: any, ctx: any) {
+          return class extends cls {
+            extra = true;
+          };
+        }
+        @wrap class Foo {
+          value = 42;
+        }
+        const f = new Foo() as any;
+        console.log(f.value + "," + f.extra);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("42,true");
+  });
+
+  it("multiple class decorators apply right to left", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const order: string[] = [];
+        function d1(cls: any, ctx: any) { order.push("d1"); return cls; }
+        function d2(cls: any, ctx: any) { order.push("d2"); return cls; }
+        @d1 @d2 class Foo {}
+        console.log(order.join(","));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // decorator는 아래부터 위로 (오른쪽부터 왼쪽으로) 적용
+    expect(result.runOutput).toContain("d2,d1");
+  });
+
+  // --- Method decorator ---
+
+  it("method decorator receives function and context", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(fn: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name);
+          return fn;
+        }
+        class Foo {
+          @log greet() { return "hello"; }
+        }
+        console.log(new Foo().greet());
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("method:greet");
+    expect(result.runOutput).toContain("hello");
+  });
+
+  it("method decorator can wrap function", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function double(fn: any, ctx: any) {
+          return function(this: any, ...args: any[]) {
+            return fn.call(this, ...args) * 2;
+          };
+        }
+        class Calc {
+          @double compute() { return 21; }
+        }
+        console.log(new Calc().compute());
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("42");
+  });
+
+  // --- Getter/Setter decorator ---
+
+  it("getter decorator works", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(fn: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name);
+          return fn;
+        }
+        class Foo {
+          @log get x() { return 42; }
+        }
+        console.log(new Foo().x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("getter:x");
+    expect(result.runOutput).toContain("42");
+  });
+
+  // --- Field decorator ---
+
+  it("field decorator receives undefined and context", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(value: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name + ":" + (value === undefined));
+        }
+        class Foo {
+          @log x = 123;
+        }
+        new Foo();
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("field:x:true");
+  });
+
+  // TODO: field 초기값을 __runInitializers로 래핑하는 변환 구현 후 활성화
+  it.skip("field decorator can transform initial value", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function multiply(factor: number) {
+          return function(value: any, ctx: any) {
+            return function(initialValue: number) {
+              return initialValue * factor;
+            };
+          };
+        }
+        class Foo {
+          @multiply(10) x = 5;
+        }
+        console.log(new Foo().x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("50");
+  });
+
+  // --- addInitializer ---
+
+  it("addInitializer runs during construction", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function track(fn: any, ctx: any) {
+          ctx.addInitializer(function(this: any) {
+            console.log("init:" + this.constructor.name);
+          });
+          return fn;
+        }
+        class Foo {
+          @track greet() { return "hi"; }
+        }
+        new Foo();
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("init:Foo");
+  });
+
+  // --- Class expression ---
+
+  it("class expression with decorator", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(cls: any, ctx: any) {
+          console.log(ctx.kind);
+          return cls;
+        }
+        const Foo = @log class {};
+        console.log(typeof Foo);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("class");
+    expect(result.runOutput).toContain("function");
+  });
+
+  // --- Static member decorator ---
+
+  it("static method decorator", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(fn: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name + ":static=" + ctx.static);
+          return fn;
+        }
+        class Foo {
+          @log static create() { return new Foo(); }
+        }
+        Foo.create();
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("method:create:static=true");
+  });
+
+  // --- Mixed decorators ---
+
+  it("class + method + field mixed", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const kinds: string[] = [];
+        function track(target: any, ctx: any) {
+          kinds.push(ctx.kind + ":" + ctx.name);
+          return target;
+        }
+        @track class Foo {
+          @track greet() {}
+          @track x = 1;
+        }
+        new Foo();
+        console.log(kinds.sort().join("|"));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // 3개 decorator 모두 실행
+    expect(result.runOutput).toContain("class:Foo");
+    expect(result.runOutput).toContain("field:x");
+    expect(result.runOutput).toContain("method:greet");
+  });
+
+  // --- Decorator metadata (Symbol.metadata) ---
+  // TODO: Object.defineProperty(_classThis, Symbol.metadata, ...) 호출 생성 후 활성화
+  // it("metadata is set on class", async () => { ... });
+
+  // --- Transpile (non-bundle) mode ---
+
+  it("transpile mode outputs __esDecorate", async () => {
+    const { dir, cleanup: c } = await createFixture({
+      "input.ts": `
+        function dec(cls: any, ctx: any) { return cls; }
+        @dec class Foo {}
+      `,
+    });
+    cleanup = c;
+
+    const result = await runZts([join(dir, "input.ts")]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("__esDecorate");
+    expect(result.stdout).toContain("__runInitializers");
+    expect(result.stdout).toContain('"class"');
+  });
+});

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -282,6 +282,44 @@ describe("Stage 3 Decorators", () => {
     expect(result.runOutput).toContain("true");
   });
 
+  // --- Private member decorator ---
+
+  // TODO: private method는 descriptor 래핑 + getter 변환이 필요 (TypeScript: __setFunctionName + get #method())
+  it.skip("private method decorator context", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(fn: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name + ":private=" + ctx.private);
+          return fn;
+        }
+        class Foo {
+          @log #secret() { return 42; }
+        }
+        new Foo();
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("method:#secret:private=true");
+  });
+
+  it("private field decorator context", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function log(value: any, ctx: any) {
+          console.log(ctx.kind + ":" + ctx.name + ":private=" + ctx.private);
+        }
+        class Foo {
+          @log #value = 42;
+        }
+        new Foo();
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("field:#value:private=true");
+  });
+
   // --- Transpile (non-bundle) mode ---
 
   it("transpile mode outputs __esDecorate", async () => {

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -284,8 +284,7 @@ describe("Stage 3 Decorators", () => {
 
   // --- Private member decorator ---
 
-  // TODO: private method는 descriptor 래핑 + getter 변환이 필요 (TypeScript: __setFunctionName + get #method())
-  it.skip("private method decorator context", async () => {
+  it("private method decorator context", async () => {
     const result = await bundleAndRun({
       "index.ts": `
         function log(fn: any, ctx: any) {

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -149,8 +149,7 @@ describe("Stage 3 Decorators", () => {
     expect(result.runOutput).toContain("field:x:true");
   });
 
-  // TODO: field 초기값을 __runInitializers로 래핑하는 변환 구현 후 활성화
-  it.skip("field decorator can transform initial value", async () => {
+  it("field decorator can transform initial value", async () => {
     const result = await bundleAndRun({
       "index.ts": `
         function multiply(factor: number) {
@@ -259,8 +258,29 @@ describe("Stage 3 Decorators", () => {
   });
 
   // --- Decorator metadata (Symbol.metadata) ---
-  // TODO: Object.defineProperty(_classThis, Symbol.metadata, ...) 호출 생성 후 활성화
-  // it("metadata is set on class", async () => { ... });
+
+  it("metadata is set on class", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        // Symbol.metadata polyfill (Bun 1.x에서 아직 미지원)
+        if (!("metadata" in Symbol)) {
+          (Symbol as any).metadata = Symbol("Symbol.metadata");
+        }
+        function meta(value: any, ctx: any) {
+          if (ctx.metadata) {
+            ctx.metadata.decorated = true;
+          }
+          return value;
+        }
+        @meta class Foo {}
+        const m = (Foo as any)[Symbol.metadata];
+        console.log(m ? m.decorated : "no-metadata");
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("true");
+  });
 
   // --- Transpile (non-bundle) mode ---
 

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -529,4 +529,307 @@ describe("Stage 3 Decorators", () => {
     expect(result.runOutput).toContain("hello");
     expect(result.runOutput).toContain("false");
   });
+
+  // ============================================================
+  // Babel 2023-11 conformance tests 포팅
+  // (babel/babel packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-*)
+  // ============================================================
+
+  // --- 2023-11-classes/ctx ---
+
+  it("babel: class decorator context kind and name", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const logs: string[] = [];
+        function dec(value: any, ctx: any) {
+          logs.push(ctx.kind, ctx.name);
+        }
+        @dec class A {}
+        console.log(JSON.stringify(logs));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain('["class","A"]');
+  });
+
+  // --- 2023-11-methods/context-name (간소화) ---
+
+  // TODO: string literal ("b") 및 numeric literal (0) 키에 대한 context.name 지원
+  it.skip("babel: method decorator context.name for various key types", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const logs: string[] = [];
+        const dec = (value: any, context: any) => { logs.push(context.name); };
+        class Foo {
+          @dec a() {}
+          @dec "b"() {}
+          @dec 0() {}
+        }
+        console.log(JSON.stringify(logs));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain('["a","b","0"]');
+  });
+
+  // --- 2023-11-fields/context-name (간소화) ---
+
+  // TODO: string literal ("b") 및 numeric literal (0) 키에 대한 context.name 지원
+  it.skip("babel: field decorator context.name for various key types", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const logs: string[] = [];
+        const dec = (value: any, context: any) => { logs.push(context.name); };
+        class Foo {
+          @dec a: any;
+          @dec "b": any;
+          @dec 0: any;
+        }
+        new Foo();
+        console.log(JSON.stringify(logs));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain('["a","b","0"]');
+  });
+
+  // --- 2023-11-misc/initializer-property-ignored ---
+
+  it("babel: accessor decorator uses init, not initializer property", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        let initCalled = false;
+        let initializerCalled = false;
+        function decorator() {
+          return {
+            get init() { initCalled = true; return () => {}; },
+            get initializer() { initializerCalled = true; return () => {}; },
+          };
+        }
+        class A {
+          @decorator accessor x: any;
+        }
+        new A();
+        console.log("init:" + initCalled + ",initializer:" + initializerCalled);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("init:true,initializer:false");
+  });
+
+  // --- 2023-11-ordering: decorator 적용 순서 (간소화) ---
+
+  it("babel: decorator evaluation order — method before class", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const log: string[] = [];
+        const classDec = (cls: any, ctx: any) => { log.push("class"); return cls; };
+        const methodDec = (fn: any, ctx: any) => { log.push("method"); return fn; };
+        const fieldDec = (value: any, ctx: any) => { log.push("field"); };
+        @classDec
+        class Foo {
+          @methodDec method() {}
+          @fieldDec x = 1;
+        }
+        new Foo();
+        console.log(log.join(","));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // 스펙 순서: method → field → class
+    expect(result.runOutput).toContain("method,field,class");
+  });
+
+  // --- 2023-11-ordering: addInitializer 순서 ---
+
+  it("babel: addInitializer order — right-to-left registration, left-to-right execution", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const log: string[] = [];
+        const dec1 = (fn: any, ctx: any) => {
+          log.push("d1");
+          ctx.addInitializer(() => log.push("i1"));
+          return fn;
+        };
+        const dec2 = (fn: any, ctx: any) => {
+          log.push("d2");
+          ctx.addInitializer(() => log.push("i2"));
+          return fn;
+        };
+        class Foo {
+          @dec1 @dec2 method() {}
+        }
+        new Foo();
+        console.log(log.join(","));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // decorators: 오른쪽→왼쪽 (d2,d1), initializers: 등록 순 (i2,i1)
+    expect(result.runOutput).toContain("d2,d1,i2,i1");
+  });
+
+  // --- 2023-11-misc: decorator return value for method ---
+
+  it("babel: method decorator return value replaces method", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function replace(original: any, ctx: any) {
+          return function(this: any) { return original.call(this) * 3; };
+        }
+        class Foo {
+          @replace getValue() { return 7; }
+        }
+        console.log(new Foo().getValue());
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("21");
+  });
+
+  // --- 2023-11: getter decorator return value replaces getter ---
+
+  it("babel: getter decorator return value replaces getter", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function multiply(original: any, ctx: any) {
+          return function(this: any) { return original.call(this) * 2; };
+        }
+        class Foo {
+          _val = 5;
+          @multiply get value() { return this._val; }
+        }
+        console.log(new Foo().value);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("10");
+  });
+
+  // --- 2023-11: field decorator return initializer ---
+
+  it("babel: field decorator returns initializer function", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function double(value: any, ctx: any) {
+          return (initialValue: number) => initialValue * 2;
+        }
+        class Foo {
+          @double x = 10;
+        }
+        console.log(new Foo().x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("20");
+  });
+
+  // --- 2023-11: class decorator addInitializer ---
+
+  it("babel: class decorator addInitializer runs after class definition", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const log: string[] = [];
+        function dec(cls: any, ctx: any) {
+          ctx.addInitializer(() => {
+            log.push("classInit:" + cls.name);
+          });
+          return cls;
+        }
+        @dec class Foo {}
+        log.push("afterClass");
+        console.log(log.join(","));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // class addInitializer는 class 정의 완료 후, 외부 코드 실행 전
+    expect(result.runOutput).toContain("classInit:");
+  });
+
+  // --- 2023-11: static method decorator ---
+
+  it("babel: static method decorator context", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const logs: any[] = [];
+        function dec(fn: any, ctx: any) {
+          logs.push({ kind: ctx.kind, name: ctx.name, static: ctx.static, private: ctx.private });
+        }
+        class Foo {
+          @dec static hello() {}
+          @dec world() {}
+        }
+        console.log(JSON.stringify(logs));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    const output = result.runOutput;
+    expect(output).toContain('"kind":"method"');
+    expect(output).toContain('"name":"hello"');
+    expect(output).toContain('"static":true');
+    expect(output).toContain('"name":"world"');
+    expect(output).toContain('"static":false');
+  });
+
+  // --- 2023-11: accessor decorator return { get, set, init } ---
+
+  it("babel: accessor decorator can override get/set/init", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function logged(target: any, ctx: any) {
+          return {
+            get() { return target.get.call(this) + 100; },
+            set(val: number) { target.set.call(this, val * 2); },
+            init(val: number) { return val + 1; },
+          };
+        }
+        class Foo {
+          @logged accessor x = 10;
+        }
+        const f = new Foo();
+        console.log("get:" + f.x);
+        f.x = 5;
+        console.log("afterSet:" + f.x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // init: 10+1=11, get: 11+100=111
+    expect(result.runOutput).toContain("get:111");
+    // set: 5*2=10, get: 10+100=110
+    expect(result.runOutput).toContain("afterSet:110");
+  });
+
+  // --- 2023-11-misc: access.set for field ---
+
+  it("babel: field decorator access.set works", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        let savedAccess: any;
+        function capture(value: any, ctx: any) {
+          savedAccess = ctx.access;
+        }
+        class Foo {
+          @capture x = 0;
+        }
+        const f = new Foo();
+        savedAccess.set(f, 42);
+        console.log(f.x);
+        console.log(savedAccess.get(f));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("42");
+  });
 });

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -555,8 +555,7 @@ describe("Stage 3 Decorators", () => {
 
   // --- 2023-11-methods/context-name (간소화) ---
 
-  // TODO: string literal ("b") 및 numeric literal (0) 키에 대한 context.name 지원
-  it.skip("babel: method decorator context.name for various key types", async () => {
+  it("babel: method decorator context.name for various key types", async () => {
     const result = await bundleAndRun({
       "index.ts": `
         const logs: string[] = [];
@@ -576,8 +575,7 @@ describe("Stage 3 Decorators", () => {
 
   // --- 2023-11-fields/context-name (간소화) ---
 
-  // TODO: string literal ("b") 및 numeric literal (0) 키에 대한 context.name 지원
-  it.skip("babel: field decorator context.name for various key types", async () => {
+  it("babel: field decorator context.name for various key types", async () => {
     const result = await bundleAndRun({
       "index.ts": `
         const logs: string[] = [];

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -833,9 +833,7 @@ describe("Stage 3 Decorators", () => {
 
   // --- Babel 2023-11-classes/decorator-access-modified-fields ---
 
-  // TODO: class decorator가 member-decorated field의 변환된 초기값을 보려면
-  // __esDecorate 호출 순서가 member → class 순이어야 함 (현재 동일 static block에서 순차 호출)
-  it.skip("babel: class decorator sees member-decorated field value", async () => {
+  it("babel: class decorator sees member-decorated field value", async () => {
     const result = await bundleAndRun({
       "index.ts": `
         var value: any;
@@ -857,9 +855,7 @@ describe("Stage 3 Decorators", () => {
 
   // --- Babel 2023-11-ordering: decorator evaluation order (간소화) ---
 
-  // TODO: decorator 평가 순서가 스펙과 정확히 일치해야 함
-  // (method → field → class, 각각 inner→outer 순)
-  it.skip("babel: decorator evaluation order across element kinds", async () => {
+  it("babel: decorator evaluation order across element kinds", async () => {
     const result = await bundleAndRun({
       "index.ts": `
         const log: number[] = [];
@@ -879,10 +875,11 @@ describe("Stage 3 Decorators", () => {
     });
     cleanup = result.cleanup;
     expect(result.exitCode).toBe(0);
-    // 스펙 순서: method decs(3,2) → field decs(4) → class decs(1,0) → method results(6,7) → field result(5) → class results(8,9)
     const output = result.runOutput;
-    // decorator 평가: method → field → class 순
-    expect(output).toContain("3,2,4");
+    // TC39 스펙 순서:
+    // 식 평가 (소스 순서): class(0,1) → method(2,3) → field(4)
+    // 적용 (스펙 순서): method(6,7) → field(5) → class(8,9)
+    expect(output).toContain("0,1,2,3,4,6,7,5,8,9");
   });
 
   // --- Babel 2023-11-getters/context-name (간소화) ---

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -830,4 +830,210 @@ describe("Stage 3 Decorators", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toContain("42");
   });
+
+  // --- Babel 2023-11-classes/decorator-access-modified-fields ---
+
+  // TODO: class decorator가 member-decorated field의 변환된 초기값을 보려면
+  // __esDecorate 호출 순서가 member → class 순이어야 함 (현재 동일 static block에서 순차 호출)
+  it.skip("babel: class decorator sees member-decorated field value", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        var value: any;
+        const classDec = (Class: any) => {
+          value = (new Class).m;
+          return Class;
+        };
+        const memberDec = () => () => 42;
+        @classDec class C {
+          @memberDec m: any;
+        }
+        console.log(value);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("42");
+  });
+
+  // --- Babel 2023-11-ordering: decorator evaluation order (간소화) ---
+
+  // TODO: decorator 평가 순서가 스펙과 정확히 일치해야 함
+  // (method → field → class, 각각 inner→outer 순)
+  it.skip("babel: decorator evaluation order across element kinds", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const log: number[] = [];
+        function push(x: number) { log.push(x); return x; }
+        function logDec(a: number, b: number) {
+          push(a);
+          return function(el: any) { push(b); return el; };
+        }
+        @logDec(0, 9) @logDec(1, 8)
+        class A {
+          @logDec(2, 7) @logDec(3, 6) method() {}
+          @logDec(4, 5) x: any;
+        }
+        new A();
+        console.log(log.join(","));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // 스펙 순서: method decs(3,2) → field decs(4) → class decs(1,0) → method results(6,7) → field result(5) → class results(8,9)
+    const output = result.runOutput;
+    // decorator 평가: method → field → class 순
+    expect(output).toContain("3,2,4");
+  });
+
+  // --- Babel 2023-11-getters/context-name (간소화) ---
+
+  it("babel: getter decorator context.name for various key types", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const logs: string[] = [];
+        const dec = (value: any, context: any) => { logs.push(context.name); };
+        class Foo {
+          @dec static get a() { return 0; }
+          @dec static get "b"() { return 0; }
+          @dec static get 0() { return 0; }
+        }
+        console.log(JSON.stringify(logs));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain('["a","b","0"]');
+  });
+
+  // --- Babel 2023-11-setters/context-name (간소화) ---
+
+  it("babel: setter decorator context.name for various key types", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const logs: string[] = [];
+        const dec = (value: any, context: any) => { logs.push(context.name); };
+        class Foo {
+          @dec static set a(v: any) {}
+          @dec static set "b"(v: any) {}
+          @dec static set 0(v: any) {}
+        }
+        console.log(JSON.stringify(logs));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain('["a","b","0"]');
+  });
+
+  // --- Babel 2023-11-misc: context.access on other objects ---
+
+  it("babel: context.access.set works on arbitrary objects", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        let access: any;
+        function dec(value: any, ctx: any) { access = ctx.access; }
+        class C {
+          @dec x = 1;
+        }
+        const other = { x: 0 };
+        access.set(other, 99);
+        console.log(other.x);
+        console.log(access.get(other));
+        console.log(access.has(other));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("99");
+    expect(result.runOutput).toContain("true");
+  });
+
+  // --- Babel 2023-11: accessor context ---
+
+  it("babel: accessor decorator context has correct kind and static", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        const logs: any[] = [];
+        function dec(target: any, ctx: any) {
+          logs.push({ kind: ctx.kind, name: ctx.name, static: ctx.static });
+          return target;
+        }
+        class Foo {
+          @dec accessor x = 1;
+          @dec static accessor y = 2;
+        }
+        new Foo();
+        console.log(JSON.stringify(logs));
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    const output = result.runOutput;
+    expect(output).toContain('"kind":"accessor"');
+    expect(output).toContain('"name":"x"');
+    expect(output).toContain('"name":"y"');
+  });
+
+  // --- Babel: method available during field initialization ---
+
+  it("babel: method available before field initializer runs", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        let methodAvailable = false;
+        @((x: any) => x)
+        class A {
+          foo = (() => {
+            methodAvailable = typeof this.method === "function";
+            return "foo";
+          })();
+          method() {}
+        }
+        new A();
+        console.log("methodAvailable:" + methodAvailable);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("methodAvailable:true");
+  });
+
+  // --- Babel: multiple field decorators with init transform ---
+
+  it("babel: multiple field decorators chain initializers", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function add(n: number) {
+          return (value: any, ctx: any) => {
+            return (v: number) => v + n;
+          };
+        }
+        class Foo {
+          @add(1) @add(2) x = 10;
+        }
+        console.log(new Foo().x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    // 스펙: 오른쪽→왼쪽 적용, init 체이닝: (10 + 2) + 1 = 13
+    expect(result.runOutput).toContain("13");
+  });
+
+  // --- Babel: static field initializer with class reference ---
+
+  it("babel: static field initializer runs after class is defined", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function dec(value: any, ctx: any) { return value; }
+        @dec class Foo {
+          static instance = new Foo();
+          value = 42;
+        }
+        console.log(Foo.instance.value);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("42");
+  });
 });

--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -2615,7 +2615,47 @@ class Derived4 extends Base {
 `;
 
 exports[`TSC: classes derivedClassSuperProperties 1`] = `
-"class Base {
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+class Base {
 	constructor(a) {
 	}
 	receivesAnything(param) {
@@ -2695,29 +2735,90 @@ class DerivedWithArrowFunctionParameter extends Base {
 class DerivedWithDecoratorOnClass extends Base {
 	prop = true;
 	constructor() {
-		@decorate(this) class InnerClass {
-		}
+		let InnerClass = (() => {
+			let _classThis;
+			let _classDecorators = [decorate(this)];
+			let _classDescriptor;
+			let _classExtraInitializers = [];
+			var InnerClass = class {
+				static {
+					_classThis = this;
+				}
+				static {
+					const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+					__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+					InnerClass = _classThis = _classDescriptor.value;
+					if (_metadata) {
+						Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+					}
+					__runInitializers(_classThis, _classExtraInitializers);
+				}
+			};
+			return InnerClass = _classThis;
+		})();
 		super();
 	}
 }
 class DerivedWithDecoratorOnClassMethod extends Base {
 	prop = true;
 	constructor() {
-		class InnerClass {
-			@decorate(this)
-			innerMethod() {
-			}
-		}
+		let InnerClass = (() => {
+			let _classThis;
+			let _instanceExtraInitializers = [];
+			let _innerMethod_decorators;
+			var InnerClass = class {
+				static {
+					_classThis = this;
+				}
+				static {
+					const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+					_innerMethod_decorators = [decorate(this)];
+					__esDecorate(this, null, _innerMethod_decorators, { kind: "method", name: "innerMethod", static: false, private: false, access: { has: (obj) => "innerMethod" in obj, get: (obj) => obj.innerMethod }, metadata: _metadata }, null, _instanceExtraInitializers);
+					if (_metadata) {
+						Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+					}
+				}
+				innerMethod() {
+				}
+				constructor() {
+					__runInitializers(this, _instanceExtraInitializers);
+				}
+			};
+			return InnerClass = _classThis;
+		})();
 		super();
 	}
 }
 class DerivedWithDecoratorOnClassProperty extends Base {
 	prop = true;
 	constructor() {
-		class InnerClass {
-			@decorate(this)
-			innerProp = true;
-		}
+		let InnerClass = (() => {
+			let _classThis;
+			let _instanceExtraInitializers = [];
+			let _innerProp_decorators;
+			let _innerProp_initializers = [];
+			let _innerProp_extraInitializers = [];
+			var InnerClass = class {
+				static {
+					_classThis = this;
+				}
+				static {
+					const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+					_innerProp_decorators = [decorate(this)];
+					__esDecorate(null, null, _innerProp_decorators, { kind: "field", name: "innerProp", static: false, private: false, access: { has: (obj) => "innerProp" in obj, get: (obj) => obj.innerProp, set: function(obj,value) {
+						obj.innerProp = value;
+					} }, metadata: _metadata }, _innerProp_initializers, _innerProp_extraInitializers);
+					if (_metadata) {
+						Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+					}
+				}
+				innerProp = __runInitializers(this, _innerProp_initializers, true);
+				constructor() {
+					__runInitializers(this, _instanceExtraInitializers);
+				}
+			};
+			return InnerClass = _classThis;
+		})();
 		super();
 	}
 }
@@ -5376,28 +5477,106 @@ var r7 = new t2("");
 `;
 
 exports[`TSC: classes typeOfThisInStaticMembers10 1`] = `
-"@foo class C {
-	static a = 1;
-	static b = this.a + 1;
-}
-@foo class D extends C {
-	static c = 2;
-	static d = this.c + 1;
-	static e = super.a + this.c + 1;
-	static f = () => this.c + 1;
-	static ff = function() {
-		this.c + 1;
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C = (() => {
+	let _classThis;
+	let _classDecorators = [foo];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var C = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			C = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+		static a = 1;
+		static b = this.a + 1;
 	};
-	static foo() {
-		return this.c + 1;
-	}
-	static get fa() {
-		return this.c + 1;
-	}
-	static set fa(v) {
-		this.c = v + 1;
-	}
-}
+	return C = _classThis;
+})();
+let D = (() => {
+	let _classThis;
+	let _classDecorators = [foo];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var D = class extends C {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			D = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+		static c = 2;
+		static d = this.c + 1;
+		static e = super.a + this.c + 1;
+		static f = () => this.c + 1;
+		static ff = function() {
+			this.c + 1;
+		};
+		static foo() {
+			return this.c + 1;
+		}
+		static get fa() {
+			return this.c + 1;
+		}
+		static set fa(v) {
+			this.c = v + 1;
+		}
+	};
+	return D = _classThis;
+})();
 class CC {
 	static a = 1;
 	static b = this.a + 1;
@@ -5424,28 +5603,106 @@ class DD extends CC {
 `;
 
 exports[`TSC: classes typeOfThisInStaticMembers11 1`] = `
-"@foo class C {
-	static a = 1;
-	static b = this.a + 1;
-}
-@foo class D extends C {
-	static c = 2;
-	static d = this.c + 1;
-	static e = super.a + this.c + 1;
-	static f = () => this.c + 1;
-	static ff = function() {
-		this.c + 1;
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C = (() => {
+	let _classThis;
+	let _classDecorators = [foo];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var C = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			C = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+		static a = 1;
+		static b = this.a + 1;
 	};
-	static foo() {
-		return this.c + 1;
-	}
-	static get fa() {
-		return this.c + 1;
-	}
-	static set fa(v) {
-		this.c = v + 1;
-	}
-}
+	return C = _classThis;
+})();
+let D = (() => {
+	let _classThis;
+	let _classDecorators = [foo];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var D = class extends C {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			D = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+		static c = 2;
+		static d = this.c + 1;
+		static e = super.a + this.c + 1;
+		static f = () => this.c + 1;
+		static ff = function() {
+			this.c + 1;
+		};
+		static foo() {
+			return this.c + 1;
+		}
+		static get fa() {
+			return this.c + 1;
+		}
+		static set fa(v) {
+			this.c = v + 1;
+		}
+	};
+	return D = _classThis;
+})();
 class CC {
 	static a = 1;
 	static b = this.a + 1;
@@ -7120,15 +7377,83 @@ console.log(new C().foo());
 `;
 
 exports[`TSC: classes privateNamesAndDecorators 1`] = `
-"class A {
-	@dec
-	// Error
-#foo = 1;
-	@dec
-	// Error
-#bar() {
-	}
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let A = (() => {
+	let _classThis;
+	let _instanceExtraInitializers = [];
+	let _foo_decorators;
+	let _foo_initializers = [];
+	let _foo_extraInitializers = [];
+	let _bar_decorators;
+	let _private_bar_descriptor;
+	var A = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			_foo_decorators = [dec];
+			_bar_decorators = [// Error
+dec];
+			__esDecorate(this, _private_bar_descriptor = { value: __setFunctionName(function()// Error
+{
+			}, "#bar") }, _bar_decorators, { kind: "method", name: "#bar", static: false, private: true, access: { has: (obj) => #bar in obj, get: (obj) => obj.#bar }, metadata: _metadata }, null, _instanceExtraInitializers);
+			__esDecorate(null, null, _foo_decorators, { kind: "field", name: "#foo", static: false, private: true, access: { has: (obj) => #foo in obj, get: (obj) => obj.#foo, set: function(obj,value) {
+				obj.#foo = value;
+			} }, metadata: _metadata }, _foo_initializers, _foo_extraInitializers);
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+		}
+		#foo = __runInitializers(this, _foo_initializers, 1);
+		get #bar() {
+			return _private_bar_descriptor.value;
+		}
+		constructor() {
+			__runInitializers(this, _instanceExtraInitializers);
+		}
+	};
+	return A = _classThis;
+})();
 "
 `;
 
@@ -10392,17 +10717,99 @@ accessor y = 2;
 `;
 
 exports[`TSC: classes staticAutoAccessorsWithDecorators 1`] = `
-"// https://github.com/microsoft/TypeScript/issues/53752
-class A {
-	// uses class reference
-@((t,c) => {
-	})
-	static accessor x = 1;
-	// uses 'this'
-@((t,c) => {
-	})
-	accessor y = 2;
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+// https://github.com/microsoft/TypeScript/issues/53752
+let A = (() => {
+	let _classThis;
+	let _instanceExtraInitializers = [];
+	let _staticExtraInitializers = [];
+	let _x_decorators;
+	let _x_initializers = [];
+	let _x_extraInitializers = [];
+	let _y_decorators;
+	let _y_initializers = [];
+	let _y_extraInitializers = [];
+	var A = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			_x_decorators = [// uses class reference
+((t,c) => {
+			})];
+			_y_decorators = [// uses 'this'
+((t,c) => {
+			})];
+			__esDecorate(this, null, _x_decorators, { kind: "accessor", name: "x", static: true, private: false, access: { has: (obj) => "x" in obj, get: (obj) => obj.x, set: function(obj,value) {
+				obj.x = value;
+			} }, metadata: _metadata }, _x_initializers, _x_extraInitializers);
+			__esDecorate(this, null, _y_decorators, { kind: "accessor", name: "y", static: false, private: false, access: { has: (obj) => "y" in obj, get: (obj) => obj.y, set: function(obj,value) {
+				obj.y = value;
+			} }, metadata: _metadata }, _y_initializers, _y_extraInitializers);
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+		}
+		static #_x_accessor_storage = __runInitializers(this, _x_initializers, 1);
+		static get x() {
+			return this.#_x_accessor_storage;
+		}
+		static set x(value) {
+			this.#_x_accessor_storage = value;
+		}
+		#_y_accessor_storage = __runInitializers(this, _y_initializers, 2);
+		get y() {
+			return this.#_y_accessor_storage;
+		}
+		set y(value) {
+			this.#_y_accessor_storage = value;
+		}
+		constructor() {
+			__runInitializers(this, _instanceExtraInitializers);
+		}
+	};
+	return A = _classThis;
+})();
 "
 `;
 

--- a/tests/integration/tests/tsc/__snapshots__/es6-decorators.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-decorators.test.ts.snap
@@ -1,18 +1,138 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`TSC: es6/decorators decoratorOnClassAccessor1.es6 1`] = `
-"export default class {
-	@dec
-	get accessor() {
-		return 1;
-	}
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+var _a;
+let default = (() => {
+	let _classThis;
+	let _instanceExtraInitializers = [];
+	let _get_accessor_decorators;
+	var �� = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			_get_accessor_decorators = [dec];
+			__esDecorate(this, null, _get_accessor_decorators, { kind: "getter", name: "accessor", static: false, private: false, access: { has: (obj) => "accessor" in obj, get: (obj) => obj.accessor }, metadata: _metadata }, null, _instanceExtraInitializers);
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+		}
+		get accessor() {
+			return 1;
+		}
+		constructor() {
+			__runInitializers(this, _instanceExtraInitializers);
+		}
+	};
+	return �� = _classThis;
+})();
+export default _Class;
 "
 `;
 
 exports[`TSC: es6/decorators decoratorOnClass1.es6 1`] = `
-"@dec class C {
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C = (() => {
+	let _classThis;
+	let _classDecorators = [dec];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var C = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			C = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+	};
+	return C = _classThis;
+})();
 let c = new C();
 "
 `;
@@ -38,12 +158,71 @@ exports[`TSC: es6/decorators decoratorOnClass4.es6 1`] = `
 `;
 
 exports[`TSC: es6/decorators decoratorOnClass5.es6 1`] = `
-"@dec class C {
-	static x() {
-		return C.y;
-	}
-	static y = 1;
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C = (() => {
+	let _classThis;
+	let _classDecorators = [dec];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var C = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			C = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+		static x() {
+			return C.y;
+		}
+		static y = 1;
+	};
+	return C = _classThis;
+})();
 let c = new C();
 "
 `;
@@ -78,11 +257,72 @@ exports[`TSC: es6/decorators decoratorOnClass8.es6 1`] = `
 `;
 
 exports[`TSC: es6/decorators decoratorOnClassMethod1.es6 1`] = `
-"export default class {
-	@dec
-	method() {
-	}
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+var _a;
+let default = (() => {
+	let _classThis;
+	let _instanceExtraInitializers = [];
+	let _method_decorators;
+	var �� = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			_method_decorators = [dec];
+			__esDecorate(this, null, _method_decorators, { kind: "method", name: "method", static: false, private: false, access: { has: (obj) => "method" in obj, get: (obj) => obj.method }, metadata: _metadata }, null, _instanceExtraInitializers);
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+		}
+		method() {
+		}
+		constructor() {
+			__runInitializers(this, _instanceExtraInitializers);
+		}
+	};
+	return �� = _classThis;
+})();
+export default _Class;
 "
 `;
 
@@ -95,9 +335,74 @@ exports[`TSC: es6/decorators decoratorOnClassMethodParameter1.es6 1`] = `
 `;
 
 exports[`TSC: es6/decorators decoratorOnClassProperty1.es6 1`] = `
-"export default class {
-	@dec
-	prop;
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+var _a;
+let default = (() => {
+	let _classThis;
+	let _instanceExtraInitializers = [];
+	let _prop_decorators;
+	let _prop_initializers = [];
+	let _prop_extraInitializers = [];
+	var �� = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			_prop_decorators = [dec];
+			__esDecorate(null, null, _prop_decorators, { kind: "field", name: "prop", static: false, private: false, access: { has: (obj) => "prop" in obj, get: (obj) => obj.prop, set: function(obj,value) {
+				obj.prop = value;
+			} }, metadata: _metadata }, _prop_initializers, _prop_extraInitializers);
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+		}
+		prop = __runInitializers(this, _prop_initializers, void 0);
+		constructor() {
+			__runInitializers(this, _instanceExtraInitializers);
+		}
+	};
+	return �� = _classThis;
+})();
+export default _Class;
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/es6-decorators.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-decorators.test.ts.snap
@@ -41,12 +41,11 @@ var __setFunctionName = function(f, name, prefix) {
 var __propKey = function(x) {
   return typeof x === "symbol" ? x : "".concat(x);
 };
-var _a;
-let default = (() => {
+export default (() => {
 	let _classThis;
 	let _instanceExtraInitializers = [];
 	let _get_accessor_decorators;
-	var �� = class {
+	var _Class = class {
 		static {
 			_classThis = this;
 		}
@@ -65,9 +64,8 @@ let default = (() => {
 			__runInitializers(this, _instanceExtraInitializers);
 		}
 	};
-	return �� = _classThis;
+	return _Class = _classThis;
 })();
-export default _Class;
 "
 `;
 
@@ -297,12 +295,11 @@ var __setFunctionName = function(f, name, prefix) {
 var __propKey = function(x) {
   return typeof x === "symbol" ? x : "".concat(x);
 };
-var _a;
-let default = (() => {
+export default (() => {
 	let _classThis;
 	let _instanceExtraInitializers = [];
 	let _method_decorators;
-	var �� = class {
+	var _Class = class {
 		static {
 			_classThis = this;
 		}
@@ -320,9 +317,8 @@ let default = (() => {
 			__runInitializers(this, _instanceExtraInitializers);
 		}
 	};
-	return �� = _classThis;
+	return _Class = _classThis;
 })();
-export default _Class;
 "
 `;
 
@@ -375,14 +371,13 @@ var __setFunctionName = function(f, name, prefix) {
 var __propKey = function(x) {
   return typeof x === "symbol" ? x : "".concat(x);
 };
-var _a;
-let default = (() => {
+export default (() => {
 	let _classThis;
 	let _instanceExtraInitializers = [];
 	let _prop_decorators;
 	let _prop_initializers = [];
 	let _prop_extraInitializers = [];
-	var �� = class {
+	var _Class = class {
 		static {
 			_classThis = this;
 		}
@@ -401,8 +396,7 @@ let default = (() => {
 			__runInitializers(this, _instanceExtraInitializers);
 		}
 	};
-	return �� = _classThis;
+	return _Class = _classThis;
 })();
-export default _Class;
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/es6-yieldExpressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-yieldExpressions.test.ts.snap
@@ -561,12 +561,71 @@ exports[`TSC: es6/yieldExpressions generatorTypeCheck56 1`] = `
 `;
 
 exports[`TSC: es6/yieldExpressions generatorTypeCheck59 1`] = `
-"function* g() {
-	class C {
-		@(yield "")
-		m() {
-		}
-	}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+function* g() {
+	let C = (() => {
+		let _classThis;
+		let _instanceExtraInitializers = [];
+		let _m_decorators;
+		var C = class {
+			static {
+				_classThis = this;
+			}
+			static {
+				const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+				_m_decorators = [(yield "")];
+				__esDecorate(this, null, _m_decorators, { kind: "method", name: "m", static: false, private: false, access: { has: (obj) => "m" in obj, get: (obj) => obj.m }, metadata: _metadata }, null, _instanceExtraInitializers);
+				if (_metadata) {
+					Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+				}
+			}
+			m() {
+			}
+			constructor() {
+				__runInitializers(this, _instanceExtraInitializers);
+			}
+		};
+		return C = _classThis;
+	})();
 	;
 }
 "
@@ -588,9 +647,68 @@ exports[`TSC: es6/yieldExpressions generatorTypeCheck60 1`] = `
 `;
 
 exports[`TSC: es6/yieldExpressions generatorTypeCheck61 1`] = `
-"function* g() {
-	@(yield 0) class C {
-	}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+function* g() {
+	let C = (() => {
+		let _classThis;
+		let _classDecorators = [(yield 0)];
+		let _classDescriptor;
+		let _classExtraInitializers = [];
+		var C = class {
+			static {
+				_classThis = this;
+			}
+			static {
+				const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+				__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+				C = _classThis = _classDescriptor.value;
+				if (_metadata) {
+					Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+				}
+				__runInitializers(_classThis, _classExtraInitializers);
+			}
+		};
+		return C = _classThis;
+	})();
 	;
 }
 "


### PR DESCRIPTION
## Summary

TypeScript 5.0+/Babel/SWC 호환 TC39 Stage 3 decorator 변환 구현.
`experimental_decorators=false`(기본값)일 때 decorator가 있으면 `__esDecorate` + `__runInitializers` 패턴으로 변환.

### 구현된 decorator kind
- **Class**: IIFE 래핑 + static block + `__esDecorate` + `__runInitializers`
- **Method**: `{ kind: "method", access: { has, get } }`
- **Getter/Setter**: `{ kind: "getter"/"setter", access: { has, get/set } }`
- **Field**: per-field `_initializers` / `_extraInitializers` + `__runInitializers` 래핑
- **Auto-accessor**: private backing field + getter/setter 변환
- **Private member**: `private: true`, `#name in obj`, descriptor 래핑
- **Class expression**: IIFE call을 expression으로 반환
- **Symbol.metadata**: `Object.defineProperty(_classThis, Symbol.metadata, ...)`

### TC39 스펙 준수
- Decorator 식 평가: **소스 순서** (class → method → field)
- Decorator 적용: **스펙 순서** (static non-field → instance non-field → static field → instance field → class)
- `context.name`: identifier, string literal, numeric literal, bigint, private identifier 지원
- `context.access`: public `obj.name` / private `obj.#name` / computed `obj["name"]`

### 테스트
- **유닛 테스트 40개**: 출력 형식 검증 (Zig)
- **E2E 통합 테스트 46개**: 번들 + 실행 검증 (Bun)
  - Babel 2023-11 conformance 포팅 포함 (ordering, field init, metadata, access API 등)
- **0 skip, 0 fail**

## Test plan

- [x] `zig build test` — 유닛 테스트 전체 통과
- [x] `cd tests/integration && bun test tests/stage3-decorator.test.ts` — E2E 46개 통과
- [x] 기존 테스트 전체 통과 (regression 없음)
- [x] 성능 영향 없음 (벤치마크 변화 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)