### PR TITLE
docs: Stage 3 decorators 완료로 로드맵 업데이트

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,6 +47,7 @@
 | 34. 플러그인 훅 확장 | renderChunk/generateBundle NAPI 노출 + vitePlugin 매핑 | ✅ |
 | 35. async 플러그인 | 모든 훅 async/Promise 반환 지원 (MaybePromise) | ✅ |
 | 36. import.meta.glob | Vite 호환 `import.meta.glob()`, eager/import 옵션 | ✅ |
+| 37. Stage 3 decorators | TC39 Stage 3 데코레이터 (method/getter/setter/field/accessor/class, MobX 6 호환) | ✅ |
 
 ## 번들러 성능 현황 (2026-04-10 실측)
 
@@ -170,7 +171,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 - **mangleProps** — `XL` | 선행: 없음 | 배치: 단독
 - ~~**import.meta.glob**~~ — ✅ 완료. Vite 호환 `import.meta.glob()` (eager/import 옵션 지원)
 - ~~**Virtual modules**~~ — ✅ 완료. `\0` prefix 기반 virtual module 지원 (플러그인 resolveId/load)
-- **Stage 3 decorators** — `XL` | TC39 최신 데코레이터 다운레벨링 (현재 legacy만)
+- ~~**Stage 3 decorators**~~ — ✅ 완료. TC39 Stage 3 데코레이터 다운레벨링 (method/getter/setter/field/accessor/class, initializer 체이닝, MobX 6 호환)
 - **Module Concatenation 고도화** — `XL` | rspack/rolldown 수준 scope hoisting
 - **innerGraph** — `L` | 변수 할당 분석으로 더 정밀한 DCE
 - **lazyBarrel** — `L` | barrel 파일 re-export 컴파일 생략 (rolldown)
@@ -188,7 +189,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 | **Persistent caching** | XL | ❌ | ❌ | ✅ | ❌ | 디스크 캐시, 콜드 리빌드 250%↑ |
 | **Module Federation** | XL | ❌ | ❌ | ✅ | ❌ | 마이크로프론트엔드 코드/리소스 공유 |
 | **Lazy compilation** | XL | ❌ | ❌ | ✅ | ❌ | 온디맨드 모듈 컴파일 (dev 시작 가속) |
-| **Stage 3 decorators** | XL | ❌ | ✅ | ✅ | ❌ | TC39 최신 데코레이터 (현재 legacy만) |
+| ~~**Stage 3 decorators**~~ | ✅ | ❌ | ✅ | ✅ | ✅ | TC39 Stage 3 데코레이터 (legacy + Stage 3) |
 | **mangleProps** | XL | ✅ | ❌ | ❌ | ❌ | cross-module 프로퍼티 난독화 |
 | **lazyBarrel** | L | ❌ | ✅ | ❌ | ❌ | barrel re-export 컴파일 생략 |
 | ~~**import.meta.glob**~~ | ✅ | ❌ | ✅ | ❌ | ✅ | Vite 호환 glob import |
@@ -223,7 +224,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
   Web Worker ✅ 완료 — new Worker(new URL(...)) 자동 감지+IIFE 번들 (esbuild 미지원)
   import.meta.glob ✅ 완료 — Vite 호환 glob import (eager/import 옵션)
   mangleProps (1주+) — cross-module 프로퍼티 추적
-  Stage 3 decorators — TC39 최신 데코레이터 (현재 legacy만)
+  Stage 3 decorators ✅ 완료 — TC39 Stage 3 데코레이터 (legacy + Stage 3, MobX 6 호환)
   Module Concatenation 고도화 — rspack/rolldown 수준 scope hoisting
   manualChunks (3~5일) — 사용자 정의 청크 분할
   innerGraph (3~5일) — 변수 할당 추적 정밀 DCE


### PR DESCRIPTION
## Summary
- Stage 3 decorators 항목을 미완료 → 완료로 업데이트
- 번들러 비교표에서 ZTS Stage 3 decorators ❌ → ✅ 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)