### PR TITLE
feat(bundler): CSS 번들링 Phase 1 — @import 인라이닝 + Lightning CSS minify

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,6 +48,7 @@
 | 35. async 플러그인 | 모든 훅 async/Promise 반환 지원 (MaybePromise) | ✅ |
 | 36. import.meta.glob | Vite 호환 `import.meta.glob()`, eager/import 옵션 | ✅ |
 | 37. Stage 3 decorators | TC39 Stage 3 데코레이터 (method/getter/setter/field/accessor/class, MobX 6 호환) | ✅ |
+| 38. CSS 번들링 | @import 인라이닝, 별도 .css 파일 emit, Lightning CSS minify 연동 | ✅ |
 
 ## 번들러 성능 현황 (2026-04-10 실측)
 
@@ -75,11 +76,11 @@
 
 ~~**배치 E (S급 일괄)**~~ — ✅ 완료 (CLI 옵션 13개: outbase, packages=external, drop-labels, pure, line-limit 등)
 
-**CSS 번들링** — 플러그인으로 사용 가능, 자체 파서는 후순위
-- ✅ 현재 가능: Lightning CSS / PostCSS를 JS 플러그인(`--plugin`)으로 연결하여 CSS 처리
-- 후순위: 자체 CSS 파서 (Zig 네이티브 `@import` 그래프 통합, CSS tree-shaking, CSS Modules)
-- 자체 파서가 필요한 이유: subprocess IPC 왕복 비용 제거 + `@import` 체인을 모듈 그래프에 통합
-- 대부분의 프로젝트는 Lightning CSS 플러그인으로 충분
+~~**CSS 번들링**~~ — ✅ Phase 1 완료 (자체 @import 스캐너 + Lightning CSS minify 연동)
+- ✅ `import './style.css'` → 별도 `.css` 파일 자동 생성
+- ✅ CSS `@import` 체이닝 → Zig 네이티브 스캐너로 모듈 그래프에 통합 + 인라이닝
+- ✅ `--minify` 시 Lightning CSS로 CSS minify (optionalDependency)
+- 후순위: CSS Modules (`.module.css`), 코드 스플리팅 시 청크별 CSS 분리
 
 **플러그인 3단계 (N-API)** — XL (2~3주)
 - 현재 subprocess IPC만 (매 모듈마다 JSON 왕복 — 느림)
@@ -138,11 +139,10 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
   - 4단계: ✅ Vite/Rollup 어댑터 — vitePlugin() + async 훅 + renderChunk/generateBundle
   플러그인 API로 CSS는 사용자가 PostCSS/Lightning CSS 플러그인으로 해결 가능.
 
-- **CSS 번들링** — 현재 플러그인 위임, 자체 구현은 후순위
-  현재: `--loader:.css=text`로 문자열 export 또는 플러그인으로 PostCSS/Lightning CSS 위임.
-  `--loader:.css=empty`로 CSS import 무시 후 별도 빌드 도구 사용도 가능.
-  자체 CSS 파서(Zig 네이티브 `@import` 해석, CSS tree-shaking, CSS Modules)는
-  플러그인만으로 부족할 때 검토. Bun도 자체 CSS 번들링 미지원.
+- ~~**CSS 번들링**~~ — ✅ Phase 1 완료
+  `import './style.css'` → 별도 `.css` 파일 자동 생성. Zig 네이티브 `@import` 스캐너로
+  모듈 그래프에 통합 + 인라이닝. `--minify` 시 Lightning CSS로 CSS minify (optional).
+  후순위: CSS Modules (`.module.css`), 코드 스플리팅 시 청크별 CSS 분리.
 
 - ~~**metafile**~~ — ✅ 완료. `--metafile=meta.json` esbuild 호환 JSON.
 - ~~**analyze**~~ — ✅ 완료. `--analyze` metafile JSON stderr 출력 (향후 트리 포맷 개선 예정).
@@ -183,7 +183,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 
 | 항목 | 난이도 | esbuild | rolldown | rspack | ZTS | 설명 |
 |------|--------|---------|----------|--------|-----|------|
-| **CSS 번들링** | XL | ✅ | ✅ | ✅ | ❌ | 자체 CSS 파서, @import, CSS Modules |
+| ~~**CSS 번들링**~~ | ✅ | ✅ | ✅ | ✅ | ✅ | @import 인라이닝 + Lightning CSS minify (CSS Modules 후순위) |
 | **manualChunks** | L | ❌ | ✅ advancedChunks | ✅ splitChunks | ❌ | 사용자 정의 청크 분할 규칙 |
 | **innerGraph** | L | ❌ | ✅ | ✅ | ❌ | 변수 할당 추적으로 정밀 DCE |
 | **Persistent caching** | XL | ❌ | ❌ | ✅ | ❌ | 디스크 캐시, 콜드 리빌드 250%↑ |
@@ -218,7 +218,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
   shimMissingExports, extensionAlias, sanitizeFileName
 
 단독 XL ────────────────────────────────────────────────────────
-  CSS 번들링 — 현재 플러그인 위임 (자체 CSS 파서는 후순위)
+  CSS 번들링 ✅ Phase 1 완료 — @import 인라이닝 + Lightning CSS minify (CSS Modules 후순위)
   플러그인 API ✅ 1-4단계 완료 — NAPI + Vite 어댑터 + async 훅
   엔진 타겟 ✅ 완료 — esbuild compat-table 기반 (8엔진 × 18 feature)
   Web Worker ✅ 완료 — new Worker(new URL(...)) 자동 감지+IIFE 번들 (esbuild 미지원)
@@ -316,7 +316,7 @@ SWC 비교 테스트: 29 cases × 9 targets 전부 통과.
 
 | 항목 | 난이도 | 현재 상태 | 설명 |
 |------|--------|----------|------|
-| **CSS 번들링 (자체 파서)** | XL (1주+) | Lightning CSS 플러그인으로 사용 가능 | 자체 Zig 파서는 성능 최적화 목적. 대부분 플러그인으로 충분 |
+| ~~**CSS 번들링**~~ | ✅ | Phase 1 완료 (@import 인라이닝 + Lightning CSS minify) | CSS Modules, 청크별 CSS는 후순위 |
 | **npm 배포** | L | 로컬 빌드만 | `npm install zts`로 설치. cross-platform prebuilt binary (macOS/Linux/Windows arm64/x64) |
 | **CI 크로스 플랫폼** | M | 없음 | GitHub Actions: Linux/macOS/Windows × arm64/x64 빌드+테스트 |
 | **릴리즈 자동화** | M | 없음 | 태그 push → 바이너리 빌드 → npm publish → GitHub Release |

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -415,6 +415,35 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
 }
 
 /**
+ * CSS 출력 파일을 Lightning CSS로 후처리한다 (minify, 프리픽스 등).
+ * lightningcss가 설치되어 있지 않으면 원본 그대로 반환.
+ */
+function postProcessCssOutputs(result: BuildResult, options: BuildOptions): void {
+  if (!options.minify) return;
+
+  let lcss: typeof import("lightningcss") | null = null;
+  try {
+    lcss = require("lightningcss");
+  } catch {
+    return; // lightningcss 미설치 — raw CSS 그대로 반환
+  }
+
+  for (const file of result.outputFiles) {
+    if (!file.path.endsWith(".css")) continue;
+    try {
+      const transformed = lcss.transform({
+        code: Buffer.from(file.text),
+        minify: true,
+        filename: file.path,
+      });
+      file.text = transformed.code.toString();
+    } catch {
+      // CSS 변환 실패 시 원본 유지
+    }
+  }
+}
+
+/**
  * write/outdir/outfile 옵션에 따라 빌드 결과를 디스크에 기록한다.
  */
 function writeOutputFiles(result: BuildResult, options: BuildOptions): void {
@@ -473,6 +502,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
   }
 
   const result: BuildResult = await native.build(napiOptions);
+  postProcessCssOutputs(result, options);
   writeOutputFiles(result, options);
   return result;
 }
@@ -492,6 +522,7 @@ export function buildSync(options: BuildOptions): BuildResult {
 
   const napiOptions = prepareNapiOptions(options);
   const result: BuildResult = native.buildSync(napiOptions);
+  postProcessCssOutputs(result, options);
   writeOutputFiles(result, options);
   return result;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,9 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "optionalDependencies": {
+    "lightningcss": "^1.28.0"
+  },
   "scripts": {
     "build:napi": "cd ../.. && zig build napi",
     "build:js": "bun build index.ts --outdir dist --format esm --target node",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,13 +20,13 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "optionalDependencies": {
-    "lightningcss": "^1.28.0"
-  },
   "scripts": {
     "build:napi": "cd ../.. && zig build napi",
     "build:js": "bun build index.ts --outdir dist --format esm --target node",
     "build": "bun run build:napi && cp ../../zig-out/lib/zts.node . && bun run build:js",
     "test": "bun test"
+  },
+  "optionalDependencies": {
+    "lightningcss": "^1.28.0"
   }
 }

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -97,6 +97,8 @@ pub const BundleOptions = struct {
     chunk_names: []const u8 = "[name]-[hash]",
     /// 에셋 파일명 패턴 (--asset-names, 기본: "[name]-[hash]")
     asset_names: []const u8 = "[name]-[hash]",
+    /// CSS 출력 파일명 패턴 (--css-names, 기본: "[name]")
+    css_names: []const u8 = "[name]",
     /// 확장자별 로더 오버라이드 (--loader:.png=file)
     loader_overrides: []const types.LoaderOverride = &.{},
     /// legal comments 처리 모드 (--legal-comments)
@@ -891,10 +893,24 @@ pub const Bundler = struct {
             runner.runGenerateBundle(gen_outputs);
         }
 
-        // Worker 출력 파일을 asset_outputs에 합침
-        const final_asset_outputs: ?[]OutputFile = if (worker_output_files.items.len > 0 or asset_outputs != null) blk: {
+        // 5.6. CSS 번들 수집 (엔트리별 CSS 모듈 연결)
+        var css_output_files: std.ArrayList(OutputFile) = .empty;
+        defer css_output_files.deinit(self.allocator);
+        {
+            const css_emit = @import("css_emitter.zig");
+            for (self.options.entry_points) |ep| {
+                // 엔트리 경로 → 모듈 인덱스 찾기
+                const resolved = graph.path_to_module.get(ep) orelse continue;
+                if (css_emit.emitCssBundle(self.allocator, graph.modules.items, resolved, self.options.css_names)) |css_out| {
+                    css_output_files.append(self.allocator, css_out) catch {};
+                }
+            }
+        }
+
+        // Worker + CSS 출력 파일을 asset_outputs에 합침
+        const final_asset_outputs: ?[]OutputFile = if (worker_output_files.items.len > 0 or asset_outputs != null or css_output_files.items.len > 0) blk: {
             const existing = if (asset_outputs) |a| a.len else 0;
-            const total = existing + worker_output_files.items.len;
+            const total = existing + worker_output_files.items.len + css_output_files.items.len;
             const merged = try self.allocator.alloc(OutputFile, total);
             if (asset_outputs) |a| {
                 @memcpy(merged[0..a.len], a);
@@ -902,6 +918,10 @@ pub const Bundler = struct {
             }
             for (worker_output_files.items, 0..) |wf, i| {
                 merged[existing + i] = wf;
+            }
+            const css_start = existing + worker_output_files.items.len;
+            for (css_output_files.items, 0..) |cf, i| {
+                merged[css_start + i] = cf;
             }
             break :blk merged;
         } else asset_outputs;

--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -1,0 +1,162 @@
+//! CSS 번들 Emitter
+//!
+//! 엔트리 JS 모듈에서 도달 가능한 CSS 모듈을 수집하고,
+//! @import 규칙을 strip한 뒤 exec_index 순으로 연결하여
+//! 단일 CSS 파일을 생성한다.
+
+const std = @import("std");
+const Module = @import("module.zig").Module;
+const ModuleIndex = @import("types.zig").ModuleIndex;
+const emitter = @import("emitter.zig");
+const OutputFile = emitter.OutputFile;
+const css_scanner = @import("css_scanner.zig");
+
+/// 엔트리 모듈에서 도달 가능한 CSS 모듈을 수집하여 연결된 CSS 번들을 생성한다.
+/// CSS 모듈이 없으면 null을 반환한다.
+pub fn emitCssBundle(
+    allocator: std.mem.Allocator,
+    modules: []const Module,
+    entry_idx: ModuleIndex,
+    css_names: []const u8,
+) ?OutputFile {
+    // DFS로 엔트리에서 도달 가능한 CSS 모듈 수집
+    var css_modules: std.ArrayListUnmanaged(*const Module) = .empty;
+    defer css_modules.deinit(allocator);
+
+    var visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
+    defer visited.deinit();
+
+    collectCssModules(allocator, modules, entry_idx, &css_modules, &visited);
+
+    if (css_modules.items.len == 0) return null;
+
+    // exec_index 순으로 정렬 (CSS 출력 순서 = JS 실행 순서)
+    std.mem.sort(*const Module, css_modules.items, {}, struct {
+        fn lessThan(_: void, a: *const Module, b: *const Module) bool {
+            return a.exec_index < b.exec_index;
+        }
+    }.lessThan);
+
+    // CSS 소스 연결 (@import strip)
+    var output: std.ArrayListUnmanaged(u8) = .empty;
+    defer output.deinit(allocator);
+
+    for (css_modules.items) |mod| {
+        const stripped = stripCssImports(allocator, mod.source, if (mod.css_data) |cd| cd.import_count else 0);
+        // 공백만 있는 경우 건너뜀
+        const trimmed = std.mem.trim(u8, stripped, " \t\n\r");
+        if (trimmed.len == 0) continue;
+
+        output.appendSlice(allocator, stripped) catch continue;
+        // 모듈 간 줄바꿈 구분
+        if (stripped.len > 0 and stripped[stripped.len - 1] != '\n') {
+            output.append(allocator, '\n') catch {};
+        }
+    }
+
+    if (output.items.len == 0) return null;
+
+    // 출력 파일명 결정
+    const entry_mod = &modules[@intFromEnum(entry_idx)];
+    const entry_path = entry_mod.path;
+    const css_path = applyCssNamingPattern(allocator, css_names, entry_path) catch return null;
+
+    return .{
+        .path = css_path,
+        .contents = output.toOwnedSlice(allocator) catch return null,
+    };
+}
+
+/// DFS로 모듈 그래프를 탐색하여 CSS 모듈을 수집한다.
+fn collectCssModules(
+    allocator: std.mem.Allocator,
+    modules: []const Module,
+    idx: ModuleIndex,
+    result: *std.ArrayListUnmanaged(*const Module),
+    visited: *std.AutoHashMap(ModuleIndex, void),
+) void {
+    if (idx == .none) return;
+    const i = @intFromEnum(idx);
+    if (i >= modules.len) return;
+    if (visited.contains(idx)) return;
+    visited.put(idx, {}) catch return;
+
+    const mod = &modules[i];
+
+    // 의존성 먼저 방문 (DFS)
+    for (mod.dependencies.items) |dep_idx| {
+        collectCssModules(allocator, modules, dep_idx, result, visited);
+    }
+
+    // CSS 모듈이면 결과에 추가
+    if (mod.module_type == .css and mod.css_data != null) {
+        result.append(allocator, mod) catch {};
+    }
+}
+
+/// CSS 소스에서 상단 @import 규칙을 strip한다.
+/// import_count개의 @import 규칙을 제거하고 나머지를 반환한다.
+fn stripCssImports(allocator: std.mem.Allocator, source: []const u8, import_count: u32) []const u8 {
+    if (import_count == 0) return source;
+
+    // css_scanner와 동일한 로직으로 @import 규칙 위치 찾기
+    const imports = css_scanner.extractCssImports(allocator, source);
+    defer allocator.free(imports);
+    if (imports.len == 0) return source;
+
+    // 마지막 @import의 끝 위치 이후부터 반환
+    const last_idx = @min(import_count, @as(u32, @intCast(imports.len)));
+    const strip_end = imports[last_idx - 1].span.end;
+    if (strip_end >= source.len) return "";
+    return source[strip_end..];
+}
+
+/// CSS 출력 파일명 패턴 적용.
+/// [name] → 엔트리 파일의 basename (확장자 제거) + .css
+fn applyCssNamingPattern(allocator: std.mem.Allocator, pattern: []const u8, entry_path: []const u8) ![]const u8 {
+    // 엔트리 파일의 basename 추출 (확장자 제거)
+    const basename = std.fs.path.basename(entry_path);
+    const name = if (std.mem.lastIndexOf(u8, basename, ".")) |dot|
+        basename[0..dot]
+    else
+        basename;
+
+    // [name] 패턴 치환
+    if (std.mem.indexOf(u8, pattern, "[name]")) |idx| {
+        const before = pattern[0..idx];
+        const after = pattern[idx + 6 ..]; // "[name]".len = 6
+        return std.fmt.allocPrint(allocator, "{s}{s}{s}.css", .{ before, name, after });
+    }
+
+    // 패턴에 [name] 없으면 그대로 + .css
+    return std.fmt.allocPrint(allocator, "{s}.css", .{pattern});
+}
+
+// ============================================================
+// 테스트
+// ============================================================
+
+test "stripCssImports: strips first import" {
+    const source = "@import \"./a.css\";\nbody { color: red; }";
+    const result = stripCssImports(std.testing.allocator, source, 1);
+    try std.testing.expect(std.mem.indexOf(u8, result, "body") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result, "@import") == null);
+}
+
+test "stripCssImports: no imports" {
+    const source = "body { color: red; }";
+    const result = stripCssImports(std.testing.allocator, source, 0);
+    try std.testing.expectEqualStrings(source, result);
+}
+
+test "applyCssNamingPattern: default pattern" {
+    const result = try applyCssNamingPattern(std.testing.allocator, "[name]", "/app/src/index.ts");
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("index.css", result);
+}
+
+test "applyCssNamingPattern: custom pattern" {
+    const result = try applyCssNamingPattern(std.testing.allocator, "styles/[name]", "/app/src/main.tsx");
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("styles/main.css", result);
+}

--- a/src/bundler/css_scanner.zig
+++ b/src/bundler/css_scanner.zig
@@ -234,7 +234,7 @@ test "extractCssImports: no imports" {
 }
 
 test "extractCssImports: empty source" {
-    const imports = extractCssImports(std.testing.allocator,"");
+    const imports = extractCssImports(std.testing.allocator, "");
     try std.testing.expectEqual(@as(usize, 0), imports.len);
 }
 

--- a/src/bundler/css_scanner.zig
+++ b/src/bundler/css_scanner.zig
@@ -1,0 +1,255 @@
+//! CSS @import 추출기
+//!
+//! CSS 파일 상단의 @import 규칙을 추출하는 경량 스캐너.
+//! @charset, 공백, 주석은 건너뛰고, 첫 번째 non-import 규칙에서 중단한다.
+//! 전체 CSS 파서 없이 @import 경로만 추출하여 모듈 그래프에 등록하는 용도.
+
+const std = @import("std");
+const Span = @import("../lexer/token.zig").Span;
+
+pub const CssImportRecord = struct {
+    /// import 경로 (따옴표/url() 제거된 순수 경로)
+    specifier: []const u8,
+    /// 소스 코드에서의 위치 (@import 시작 ~ 세미콜론)
+    span: Span,
+};
+
+/// CSS 소스에서 @import 규칙을 추출한다.
+/// @charset, 공백, 주석은 건너뛰고, 첫 번째 non-import 규칙에서 중단.
+/// 반환된 specifier는 source의 슬라이스. 결과 배열은 allocator로 할당.
+pub fn extractCssImports(allocator: std.mem.Allocator, source: []const u8) []const CssImportRecord {
+    const MAX_IMPORTS = 64;
+    var results: [MAX_IMPORTS]CssImportRecord = undefined;
+    var count: usize = 0;
+
+    var pos: u32 = 0;
+    const len: u32 = @intCast(source.len);
+
+    while (pos < len) {
+        // 공백 스킵
+        pos = skipWhitespace(source, pos, len);
+        if (pos >= len) break;
+
+        // 주석 스킵
+        if (pos + 1 < len and source[pos] == '/' and source[pos + 1] == '*') {
+            pos = skipBlockComment(source, pos, len);
+            continue;
+        }
+
+        // @charset 스킵
+        if (startsWithAt(source, pos, len, "charset")) {
+            pos = skipToSemicolon(source, pos, len);
+            continue;
+        }
+
+        // @layer (bare, 세미콜론으로 끝나는 형태만) 스킵
+        if (startsWithAt(source, pos, len, "layer")) {
+            // @layer가 블록 { 을 포함하면 non-import 규칙이므로 중단
+            const after = pos + 6; // "@layer" 길이
+            if (after < len and source[after] != ' ' and source[after] != '\t' and source[after] != ';') {
+                break; // @layer가 아닌 다른 at-rule
+            }
+            // 세미콜론까지만 스킵 (block @layer는 중단)
+            const semi_pos = skipToSemicolonOrBrace(source, pos, len);
+            if (semi_pos < len and source[semi_pos] == '{') break;
+            pos = semi_pos;
+            continue;
+        }
+
+        // @import 추출
+        if (startsWithAt(source, pos, len, "import")) {
+            const start = pos;
+            pos += 7; // "@import" 길이
+            pos = skipWhitespace(source, pos, len);
+            if (pos >= len) break;
+
+            // url("...") 또는 "..." 또는 '...' 파싱
+            const spec = extractSpecifier(source, pos, len) orelse break;
+            pos = skipToSemicolon(source, spec.end_pos, len);
+
+            if (count < MAX_IMPORTS) {
+                results[count] = .{
+                    .specifier = source[spec.start..spec.end],
+                    .span = .{ .start = start, .end = pos },
+                };
+                count += 1;
+            }
+            continue;
+        }
+
+        // 다른 규칙 → @import 영역 종료
+        break;
+    }
+
+    // allocator로 복사하여 lifetime 안전한 슬라이스 반환
+    const owned = allocator.alloc(CssImportRecord, count) catch return &.{};
+    @memcpy(owned, results[0..count]);
+    return owned;
+}
+
+const SpecifierResult = struct {
+    start: u32,
+    end: u32,
+    end_pos: u32,
+};
+
+fn extractSpecifier(source: []const u8, pos: u32, len: u32) ?SpecifierResult {
+    var p = pos;
+    if (p >= len) return null;
+
+    // url("...") 또는 url('...') 또는 url(...)
+    if (p + 3 < len and source[p] == 'u' and source[p + 1] == 'r' and source[p + 2] == 'l' and source[p + 3] == '(') {
+        p += 4;
+        p = skipWhitespace(source, p, len);
+        if (p >= len) return null;
+
+        if (source[p] == '"' or source[p] == '\'') {
+            const quote = source[p];
+            p += 1;
+            const start = p;
+            while (p < len and source[p] != quote) : (p += 1) {}
+            const end = p;
+            if (p < len) p += 1; // 닫는 따옴표
+            p = skipWhitespace(source, p, len);
+            if (p < len and source[p] == ')') p += 1;
+            return .{ .start = start, .end = end, .end_pos = p };
+        } else {
+            // url(path) — 따옴표 없는 형태
+            const start = p;
+            while (p < len and source[p] != ')' and source[p] != ' ' and source[p] != '\t') : (p += 1) {}
+            const end = p;
+            if (p < len and source[p] == ')') p += 1;
+            return .{ .start = start, .end = end, .end_pos = p };
+        }
+    }
+
+    // "..." 또는 '...'
+    if (source[p] == '"' or source[p] == '\'') {
+        const quote = source[p];
+        p += 1;
+        const start = p;
+        while (p < len and source[p] != quote) : (p += 1) {}
+        const end = p;
+        if (p < len) p += 1; // 닫는 따옴표
+        return .{ .start = start, .end = end, .end_pos = p };
+    }
+
+    return null;
+}
+
+fn skipWhitespace(source: []const u8, start: u32, len: u32) u32 {
+    var p = start;
+    while (p < len and (source[p] == ' ' or source[p] == '\t' or source[p] == '\n' or source[p] == '\r')) : (p += 1) {}
+    return p;
+}
+
+fn skipBlockComment(source: []const u8, start: u32, len: u32) u32 {
+    var p = start + 2; // "/*" 이후
+    while (p + 1 < len) : (p += 1) {
+        if (source[p] == '*' and source[p + 1] == '/') return p + 2;
+    }
+    return len;
+}
+
+fn skipToSemicolon(source: []const u8, start: u32, len: u32) u32 {
+    var p = start;
+    while (p < len and source[p] != ';') : (p += 1) {}
+    if (p < len) p += 1; // 세미콜론 포함
+    return p;
+}
+
+fn skipToSemicolonOrBrace(source: []const u8, start: u32, len: u32) u32 {
+    var p = start;
+    while (p < len and source[p] != ';' and source[p] != '{') : (p += 1) {}
+    if (p < len and source[p] == ';') p += 1;
+    return p;
+}
+
+fn startsWithAt(source: []const u8, pos: u32, len: u32, keyword: []const u8) bool {
+    if (pos >= len or source[pos] != '@') return false;
+    const after = pos + 1;
+    if (after + keyword.len > len) return false;
+    return std.mem.eql(u8, source[after .. after + keyword.len], keyword);
+}
+
+// ============================================================
+// 테스트
+// ============================================================
+
+test "extractCssImports: basic string import" {
+    const source = "@import \"./reset.css\";\nbody { color: red; }";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    try std.testing.expectEqual(@as(usize, 1), imports.len);
+    try std.testing.expectEqualStrings("./reset.css", imports[0].specifier);
+}
+
+test "extractCssImports: url() import" {
+    const source = "@import url(\"./base.css\");\n.foo {}";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    try std.testing.expectEqual(@as(usize, 1), imports.len);
+    try std.testing.expectEqualStrings("./base.css", imports[0].specifier);
+}
+
+test "extractCssImports: single-quoted" {
+    const source = "@import './theme.css';\n";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    try std.testing.expectEqual(@as(usize, 1), imports.len);
+    try std.testing.expectEqualStrings("./theme.css", imports[0].specifier);
+}
+
+test "extractCssImports: multiple imports" {
+    const source = "@import \"./a.css\";\n@import \"./b.css\";\n@import \"./c.css\";\nbody {}";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    try std.testing.expectEqual(@as(usize, 3), imports.len);
+    try std.testing.expectEqualStrings("./a.css", imports[0].specifier);
+    try std.testing.expectEqualStrings("./b.css", imports[1].specifier);
+    try std.testing.expectEqualStrings("./c.css", imports[2].specifier);
+}
+
+test "extractCssImports: @charset before import" {
+    const source = "@charset \"UTF-8\";\n@import \"./base.css\";\nbody {}";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    try std.testing.expectEqual(@as(usize, 1), imports.len);
+    try std.testing.expectEqualStrings("./base.css", imports[0].specifier);
+}
+
+test "extractCssImports: comment before import" {
+    const source = "/* reset */\n@import \"./reset.css\";\nbody {}";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    try std.testing.expectEqual(@as(usize, 1), imports.len);
+    try std.testing.expectEqualStrings("./reset.css", imports[0].specifier);
+}
+
+test "extractCssImports: no imports" {
+    const source = "body { color: red; }";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    try std.testing.expectEqual(@as(usize, 0), imports.len);
+}
+
+test "extractCssImports: empty source" {
+    const imports = extractCssImports(std.testing.allocator,"");
+    try std.testing.expectEqual(@as(usize, 0), imports.len);
+}
+
+test "extractCssImports: url without quotes" {
+    const source = "@import url(./bare.css);\n";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    try std.testing.expectEqual(@as(usize, 1), imports.len);
+    try std.testing.expectEqualStrings("./bare.css", imports[0].specifier);
+}
+
+test "extractCssImports: stops at non-import rule" {
+    const source = "@import \"./a.css\";\n.class { color: red; }\n@import \"./b.css\";\n";
+    const imports = extractCssImports(std.testing.allocator, source);
+    defer std.testing.allocator.free(imports);
+    // 두 번째 @import는 non-import 규칙(.class) 이후이므로 무시
+    try std.testing.expectEqual(@as(usize, 1), imports.len);
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -774,6 +774,12 @@ pub const ModuleGraph = struct {
             return;
         }
 
+        // CSS 모듈: @import 추출 → 모듈 그래프에 등록
+        if (module.module_type == .css and module.loader == .css) {
+            self.parseCssModule(module);
+            return;
+        }
+
         if (module.module_type != .javascript) {
             // loader=.none + 알 수 없는 확장자: 빌드 에러 (esbuild 호환)
             if (module.loader == .none and module.module_type != .css) {
@@ -1435,6 +1441,50 @@ pub const ModuleGraph = struct {
                 queue.append(self.allocator, importer_idx) catch return;
             }
         }
+    }
+
+    /// CSS 모듈을 파싱한다.
+    /// 파일을 읽어서 @import 규칙을 추출하고, import_records에 등록한다.
+    /// CSS 소스는 module.source에 보존하여 css_emitter에서 사용한다.
+    fn parseCssModule(self: *ModuleGraph, module: *Module) void {
+        const css_scanner_mod = @import("css_scanner.zig");
+
+        module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+        const arena_alloc = module.parse_arena.?.allocator();
+
+        // 파일 읽기
+        if (module.source.len == 0) {
+            module.source = std.fs.cwd().readFileAlloc(arena_alloc, module.path, 100 * 1024 * 1024) catch {
+                self.addDiag(.read_error, .@"error", module.path, Span.EMPTY, .parse, "Cannot read file", null);
+                module.state = .ready;
+                return;
+            };
+        }
+
+        // @import 규칙 추출 (arena에 할당)
+        const raw_imports = css_scanner_mod.extractCssImports(arena_alloc, module.source);
+        const import_count: u32 = @intCast(raw_imports.len);
+
+        if (import_count > 0) {
+            // import_records 생성
+            const records = arena_alloc.alloc(types.ImportRecord, import_count) catch {
+                module.state = .ready;
+                return;
+            };
+            for (raw_imports, 0..) |imp, i| {
+                records[i] = .{
+                    .specifier = imp.specifier,
+                    .kind = .side_effect,
+                    .span = imp.span,
+                };
+            }
+            module.import_records = records;
+        }
+
+        module.css_data = .{ .import_count = import_count };
+        module.exports_kind = .esm; // CSS는 ESM side-effect import로 처리
+        module.side_effects = true; // CSS는 항상 side-effect
+        module.state = .parsed;
     }
 
     /// Asset 로더 모듈을 파싱한다.

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -36,6 +36,8 @@ pub const json_to_esm = @import("json_to_esm.zig");
 pub const plugin = @import("plugin.zig");
 pub const subprocess_plugin = @import("subprocess_plugin.zig");
 pub const module_store = @import("module_store.zig");
+pub const css_scanner = @import("css_scanner.zig");
+pub const css_emitter = @import("css_emitter.zig");
 
 // 공개 타입 re-export
 pub const ModuleIndex = types.ModuleIndex;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -108,6 +108,8 @@ pub const Module = struct {
     state: State,
     /// file/copy 로더의 asset 출력 정보. null이면 asset이 아님.
     asset_data: ?AssetData = null,
+    /// CSS 번들링 메타데이터. null이면 CSS 모듈이 아님.
+    css_data: ?CssData = null,
 
     /// file/copy 로더용 asset 메타데이터. parse_arena 소유.
     /// emitter가 asset 파일을 출력 디렉토리에 복사할 때 사용.
@@ -120,6 +122,12 @@ pub const Module = struct {
         output_name: []const u8,
         /// 원본 확장자 (dot 포함, 예: ".png")
         ext: []const u8,
+    };
+
+    /// CSS 번들링 메타데이터. parseCssModule에서 설정.
+    pub const CssData = struct {
+        /// @import 규칙 개수. emit 시 소스 상단에서 이 수만큼 @import를 strip한다.
+        import_count: u32,
     };
 
     pub const State = enum {

--- a/tests/integration/tests/css-bundle.test.ts
+++ b/tests/integration/tests/css-bundle.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { createFixture, runZts } from "./helpers";
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+
+describe("CSS Bundling", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it("single CSS import → separate .css file", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './style.css';\nconsole.log("hello");`,
+      "style.css": `body { color: red; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    const result = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+    expect(result.exitCode).toBe(0);
+
+    // JS 출력에 CSS import가 없어야 함
+    const js = await readFile(outJs, "utf-8");
+    expect(js).toContain("console.log");
+    expect(js).not.toContain("color: red");
+
+    // CSS 파일이 생성되어야 함
+    const cssPath = join(fixture.dir, "index.css");
+    const css = await readFile(cssPath, "utf-8");
+    expect(css).toContain("body { color: red; }");
+  });
+
+  it("@import chaining → inlined in correct order", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './a.css';\nconsole.log("hello");`,
+      "a.css": `@import "./b.css";\nbody { color: red; }`,
+      "b.css": `* { margin: 0; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    // b.css가 a.css보다 먼저 나와야 함 (DFS 순서)
+    const marginIdx = css.indexOf("margin: 0");
+    const colorIdx = css.indexOf("color: red");
+    expect(marginIdx).toBeGreaterThanOrEqual(0);
+    expect(colorIdx).toBeGreaterThanOrEqual(0);
+    expect(marginIdx).toBeLessThan(colorIdx);
+    // @import 규칙은 제거되어야 함
+    expect(css).not.toContain("@import");
+  });
+
+  it("deep @import chain (3 levels)", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './a.css';`,
+      "a.css": `@import "./b.css";\n.a { color: red; }`,
+      "b.css": `@import "./c.css";\n.b { color: blue; }`,
+      "c.css": `.c { color: green; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    const cIdx = css.indexOf(".c");
+    const bIdx = css.indexOf(".b");
+    const aIdx = css.indexOf(".a");
+    expect(cIdx).toBeLessThan(bIdx);
+    expect(bIdx).toBeLessThan(aIdx);
+  });
+
+  it("no CSS imports → no .css file generated", async () => {
+    const fixture = await createFixture({
+      "index.ts": `console.log("no css");`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    let hasCss = true;
+    try {
+      await readFile(join(fixture.dir, "index.css"), "utf-8");
+    } catch {
+      hasCss = false;
+    }
+    expect(hasCss).toBe(false);
+  });
+
+  it("--loader:.css=empty → CSS ignored (existing behavior)", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './style.css';\nconsole.log("hello");`,
+      "style.css": `body { color: red; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outJs,
+      "--loader:.css=empty",
+    ]);
+
+    // empty 로더 → CSS 파일 미생성
+    let hasCss = true;
+    try {
+      await readFile(join(fixture.dir, "index.css"), "utf-8");
+    } catch {
+      hasCss = false;
+    }
+    expect(hasCss).toBe(false);
+  });
+
+  it("multiple CSS imports from same JS", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './a.css';\nimport './b.css';\nconsole.log("hello");`,
+      "a.css": `.a { color: red; }`,
+      "b.css": `.b { color: blue; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    expect(css).toContain(".a { color: red; }");
+    expect(css).toContain(".b { color: blue; }");
+    // a.css가 b.css보다 먼저 (import 순서)
+    expect(css.indexOf(".a")).toBeLessThan(css.indexOf(".b"));
+  });
+
+  it("CSS imported from nested JS module", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './components/button';\nconsole.log("app");`,
+      "components/button.ts": `import './button.css';\nexport const Button = "btn";`,
+      "components/button.css": `.button { padding: 8px; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    expect(css).toContain(".button { padding: 8px; }");
+  });
+
+  it("CSS with @charset and comments before @import", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './style.css';`,
+      "style.css": `@charset "UTF-8";\n/* header styles */\n@import "./header.css";\nbody { margin: 0; }`,
+      "header.css": `header { display: flex; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    expect(css).toContain("header { display: flex; }");
+    expect(css).toContain("body { margin: 0; }");
+    expect(css).not.toContain("@import");
+  });
+
+  it("duplicate CSS import is not duplicated in output", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './a.ts';\nimport './b.ts';`,
+      "a.ts": `import './shared.css';\nexport const a = 1;`,
+      "b.ts": `import './shared.css';\nexport const b = 2;`,
+      "shared.css": `.shared { color: green; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    // shared.css는 한 번만 나와야 함
+    const firstIdx = css.indexOf(".shared");
+    const secondIdx = css.indexOf(".shared", firstIdx + 1);
+    expect(firstIdx).toBeGreaterThanOrEqual(0);
+    expect(secondIdx).toBe(-1);
+  });
+
+  it("CSS-only entry (no JS logic) → still generates .css", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './global.css';`,
+      "global.css": `html { font-size: 16px; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    expect(css).toContain("html { font-size: 16px; }");
+
+    // JS는 빈 IIFE (또는 최소 출력)
+    const js = await readFile(outJs, "utf-8");
+    expect(js).not.toContain("font-size");
+  });
+
+  it("@import url() with single quotes", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './style.css';`,
+      "style.css": `@import url('./reset.css');\n.main { display: flex; }`,
+      "reset.css": `* { box-sizing: border-box; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, "out.js");
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs]);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    expect(css).toContain("box-sizing: border-box");
+    expect(css).toContain(".main { display: flex; }");
+    expect(css).not.toContain("@import");
+  });
+
+  it("--outdir with CSS", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './style.css';\nconsole.log("outdir test");`,
+      "style.css": `.test { color: blue; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "--splitting",
+      "--format=esm",
+      "--outdir",
+      outDir,
+    ]);
+
+    const css = await readFile(join(outDir, "index.css"), "utf-8");
+    expect(css).toContain(".test { color: blue; }");
+
+    const js = await readFile(join(outDir, "index.js"), "utf-8");
+    expect(js).toContain("console.log");
+  });
+});

--- a/tests/integration/tests/css-bundle.test.ts
+++ b/tests/integration/tests/css-bundle.test.ts
@@ -102,13 +102,7 @@ describe("CSS Bundling", () => {
     cleanup = fixture.cleanup;
 
     const outJs = join(fixture.dir, "out.js");
-    await runZts([
-      "--bundle",
-      join(fixture.dir, "index.ts"),
-      "-o",
-      outJs,
-      "--loader:.css=empty",
-    ]);
+    await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outJs, "--loader:.css=empty"]);
 
     // empty 로더 → CSS 파일 미생성
     let hasCss = true;


### PR DESCRIPTION
## Summary
- `import './style.css'` → 별도 `.css` 파일 자동 생성
- CSS `@import` 체이닝 → Zig 네이티브 스캐너로 모듈 그래프에 통합 + 인라이닝
- `--minify` 시 Lightning CSS로 CSS minify (`optionalDependencies`)
- 신규 파일: `css_scanner.zig` (경량 @import 추출기), `css_emitter.zig` (CSS 번들 생성)

## Test plan
- [x] css_scanner 유닛 테스트 10개 (@import 추출 정확성)
- [x] css_emitter 유닛 테스트 4개 (strip, naming pattern)
- [x] 통합 테스트 12개 (단일/체인/3레벨/중복/중첩JS/charset/url()/outdir 등)
- [x] `zig build test` 전체 통과
- [x] 기존 통합 테스트 회귀 없음 (2730 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)