### PR TITLE
docs: CSS 번들링 관련 문서 5개 업데이트

### DIFF
--- a/BUNDLER.md
+++ b/BUNDLER.md
@@ -52,9 +52,11 @@ Phase B1: 기반 (✅ 완료)          Phase B2: 핵심 (✅ 대부분 완료) P
                                                                  ├ 플랫폼 확장자 (.ios/.android)
                                                                  ├ polyfill 주입
                                                                  └ Hermes 타겟 최적화
-                                                                CSS 번들링
-                                                                 ├ 별도 파서
-                                                                 └ CSS modules
+                                                                CSS 번들링 ✅
+                                                                 ├ @import 인라이닝 (css_scanner.zig)
+                                                                 ├ 별도 .css 파일 emit (css_emitter.zig)
+                                                                 ├ Lightning CSS minify (optional)
+                                                                 └ CSS modules (후순위)
 ```
 
 ## 모듈 설계 (책임 분리)
@@ -99,11 +101,21 @@ src/bundler/
   │   책임: 동적 import 분할, 공통 청크 추출
   │   의존: tree_shaker
   │
-  └─ emitter.zig          # 출력 생성
-      입력: 청크 목록 + 링킹 정보
-      출력: JS 파일 + 소스맵
-      책임: exec_index 순서로 코드 배치, 런타임 로더 생성
-      의존: codegen (기존 Phase 4 재사용)
+  ├─ emitter.zig          # 출력 생성
+  │   입력: 청크 목록 + 링킹 정보
+  │   출력: JS 파일 + 소스맵
+  │   책임: exec_index 순서로 코드 배치, 런타임 로더 생성
+  │   의존: codegen (기존 Phase 4 재사용)
+  │
+  ├─ css_scanner.zig      # CSS @import 추출기
+  │   입력: CSS 소스 코드
+  │   출력: CssImportRecord[] (specifier + span)
+  │   책임: @import/@charset/주석 스킵, 첫 non-import 규칙에서 중단
+  │
+  └─ css_emitter.zig      # CSS 번들 생성
+      입력: 모듈 그래프 + 엔트리 인덱스
+      출력: 연결된 CSS OutputFile
+      책임: DFS로 CSS 모듈 수집, exec_index 정렬, @import strip, 파일명 패턴
 ```
 
 설계 원칙:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ const result = buildSync({ entryPoints: ["src/index.ts"] });
 const result = await build({
   entryPoints: ["src/index.ts"],
   target: "es2020",                          // ES 다운레벨 타겟
-  loader: { ".png": "file", ".svg": "text" }, // 확장자별 로더
+  loader: { ".png": "file", ".svg": "text" }, // 확장자별 로더 (.css는 자동 번들링)
   conditions: ["import", "default"],          // package.json exports 조건
   resolveExtensions: [".ts", ".tsx", ".js"],  // 확장자 탐색 순서
   mainFields: ["module", "main"],             // package.json 필드 순서
@@ -202,6 +202,7 @@ zts --bundle <entry.ts> --plugin zts.config.js     # JS 플러그인
 --entry-names=<pattern>      엔트리 파일명 패턴 (기본: [name], 예: [name]-[hash])
 --chunk-names=<pattern>      공통 청크 파일명 패턴 (기본: [name]-[hash], 예: chunks/[name]-[hash])
 --asset-names=<pattern>      에셋 파일명 패턴 (기본: [name]-[hash], [dir]/[name]/[hash]/[ext] 지원)
+--css-names=<pattern>        CSS 출력 파일명 패턴 (기본: [name])
 --loader:.ext=type           확장자별 로더 지정 (file, dataurl, text, binary, copy, empty)
 --metafile=<path>            빌드 입출력 JSON (esbuild 호환, 기본: meta.json)
 --analyze                    번들 분석 출력 (metafile JSON을 stderr에 출력)
@@ -245,6 +246,7 @@ zts --bundle <entry.ts> --plugin zts.config.js     # JS 플러그인
 - `--platform=react-native` → RN 프리셋 자동 적용 (아래 참조)
 - `import.meta` → CJS+node: `require("url").pathToFileURL(__filename).href` / CJS+browser: `""`
 - `--watch` / `--serve` → 증분 빌드 (변경 모듈만 재파싱, 나머지 캐시)
+- `import './style.css'` → 별도 `.css` 파일 자동 생성 (CSS `@import` 인라이닝, `--minify` 시 Lightning CSS minify)
 
 ### React Native 프리셋 (`--platform=react-native`)
 - resolve-extensions (사용자 미지정 시):

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -249,7 +249,8 @@ pub const Plugin = struct {
 
 ## 로더 시스템 (esbuild/Rolldown 호환)
 
-현재 ZTS는 .ts/.tsx/.js/.jsx만 처리. 플러그인의 load 훅으로 구현:
+현재 ZTS는 .ts/.tsx/.js/.jsx/.css를 네이티브 처리. 그 외는 플러그인의 load 훅으로 구현:
+- **CSS**: `import './style.css'` → 별도 `.css` 파일 emit, `@import` 인라이닝, `--minify` 시 Lightning CSS
 - **JSON**: `import pkg from './package.json'` → `export default {...}` + named exports
 - **Text**: 파일 내용을 문자열로 `export default "..."`
 - **Base64**: 파일을 base64 인코딩 `export default "data:...;base64,..."`
@@ -257,9 +258,9 @@ pub const Plugin = struct {
 - **Binary**: 파일을 Uint8Array로 export
 - **File/Asset**: 파일을 출력 디렉토리에 복사, 해시 파일명 URL 반환
 - **Copy**: 파일을 그대로 복사
-- **Empty**: 빈 모듈로 처리 (tree-shaking 대상)
+- **Empty**: 빈 모듈로 처리 (tree-shaking 대상, `--loader:.css=empty`로 CSS 무시 가능)
 
-CLI: `--loader:.json=json --loader:.txt=text --loader:.png=file`
+CLI: `--loader:.json=json --loader:.txt=text --loader:.png=file --loader:.css=empty`
 
 ---
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -93,6 +93,8 @@ src/
     purity.zig              #   순수성 분석 (expression/statement/varDecl/class 공유)
     chunk.zig               #   Code splitting (BitSet, 공통 청크, cross-chunk)
     emitter.zig             #   출력 생성 (exec_index 순서, ESM/CJS/IIFE)
+    css_scanner.zig         #   CSS @import 추출기 (경량 상태 머신)
+    css_emitter.zig         #   CSS 번들 생성 (@import strip + 연결 + 파일명 패턴)
     emitter/                #   emitter 서브 모듈
       dev.zig               #     dev mode 번들링 (HMR, __zts_register)
       chunks.zig            #     code splitting + hash/naming

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -36,6 +36,9 @@ cd tests/e2e && bun test             # Playwright E2E (dev server)
 - `tests/integration/tests/watch-json.test.ts` — watch-json NDJSON 이벤트
 - `tests/integration/tests/compat-table.test.ts` — kangax compat-table ES5~ES2022 (237 subtests)
 - `tests/integration/tests/swc-compare.test.ts` — ZTS vs SWC 다운레벨링 비교 (29 cases × 9 targets)
+- `tests/integration/tests/css-bundle.test.ts` — CSS 번들링 (26개: @import 체인, 순환, 중복 제거, BOM, 대용량 등)
+- `tests/integration/tests/css-library-smoke.test.ts` — CSS 라이브러리 스모크 (Emotion, Styled-Components, 네이티브 CSS)
+- `tests/integration/tests/stage3-decorator-smoke.test.ts` — MobX 6 Stage 3 decorator 스모크
 - `tests/e2e/tests/smoke.test.ts` — E2E 스모크 (브라우저 실행)
 - `tests/e2e/tests/browser-smoke.test.ts` — 브라우저 번들 E2E
 


### PR DESCRIPTION
## Summary
- STRUCTURE.md: `css_scanner.zig`, `css_emitter.zig` 파일 목록 추가
- TESTING.md: CSS 번들링 통합 테스트 + 라이브러리 스모크 테스트 목록 추가
- CLAUDE.md: `--css-names` CLI 옵션 + CSS 자동 번들링 동작 설명
- BUNDLER.md: CSS 번들링 모듈 설계 (css_scanner, css_emitter 책임/입출력)
- PLUGINS.md: 로더 시스템에 CSS 로더 타입 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)