### PR TITLE
feat: vite-plugin-zts — Vite esbuild transform을 ZTS로 교체

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,22 @@ await build({
 > **async 훅 지원**: 모든 Rollup/Vite 훅은 `Promise`를 반환할 수 있다.
 > `async resolveId()`, `async load()`, `async transform()`, `async renderChunk()`, `async generateBundle()` 모두 동작.
 
+### vite-plugin-zts (Vite 플러그인)
+Vite의 esbuild transform을 ZTS로 교체하는 플러그인.
+```typescript
+// vite.config.ts
+import { defineConfig } from "vite";
+import { zts } from "vite-plugin-zts";
+
+export default defineConfig({
+  plugins: [zts()],
+});
+```
+옵션:
+- `include?: RegExp` — 변환할 파일 패턴 (기본: `/\.(tsx?|jsx)$/`)
+- `exclude?: RegExp` — 제외 패턴 (기본: `/node_modules/`)
+- `transpileOptions?: TranspileOptions` — ZTS transpile 옵션
+
 ### define/alias
 ```typescript
 buildSync({

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -328,6 +328,7 @@ SWC 비교 테스트: 29 cases × 9 targets 전부 통과.
 | **플러그인 예제** | S~M | 없음 | PostCSS, Tailwind, SVG, YAML 등 커뮤니티 플러그인 레퍼런스 |
 | ~~**import.meta.glob**~~ | ✅ | 완료 | Vite 호환 glob import (eager/import 옵션) |
 | **마이그레이션 가이드** | S | 없음 | esbuild → ZTS, Vite → ZTS 설정 대응표 |
+| ~~**vite-plugin-zts**~~ | ✅ | 완료 | Vite의 esbuild transform을 ZTS로 교체하는 플러그인 |
 | **프레임워크 통합** | XL | 없음 | Next.js/Remix/SvelteKit 플러그인 또는 어댑터 |
 | **Vite 호환 모드** | XL | 없음 | `vite.config.js` 읽어서 마이그레이션 비용 제로 (장기 목표) |
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -142,6 +142,7 @@ src/
     runner.zig              #   메타데이터 파서 + 테스트 실행기
 packages/
   core/                     # N-API 바인딩 (npm 패키지)
+  vite-plugin-zts/          # Vite 플러그인 (esbuild transform → ZTS 교체)
 tests/
   test262/                  # TC39 공식 Test262 (서브모듈)
   integration/              # Bun 기반 CLI 통합 테스트

--- a/packages/vite-plugin-zts/package.json
+++ b/packages/vite-plugin-zts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vite-plugin-zts",
+  "version": "0.1.0",
+  "description": "Use ZTS as the TypeScript/JSX transformer in Vite (replaces esbuild)",
+  "license": "MIT",
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "peerDependencies": {
+    "vite": ">=5.0.0"
+  },
+  "dependencies": {
+    "@zts/core": "workspace:*"
+  }
+}

--- a/packages/vite-plugin-zts/package.json
+++ b/packages/vite-plugin-zts/package.json
@@ -11,10 +11,10 @@
       "types": "./src/index.ts"
     }
   },
-  "peerDependencies": {
-    "vite": ">=5.0.0"
-  },
   "dependencies": {
     "@zts/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "vite": ">=5.0.0"
   }
 }

--- a/packages/vite-plugin-zts/src/index.ts
+++ b/packages/vite-plugin-zts/src/index.ts
@@ -1,0 +1,79 @@
+/**
+ * vite-plugin-zts — Vite의 esbuild transform을 ZTS로 교체하는 플러그인
+ *
+ * @example
+ * ```ts
+ * // vite.config.ts
+ * import { defineConfig } from "vite";
+ * import { zts } from "vite-plugin-zts";
+ *
+ * export default defineConfig({
+ *   plugins: [zts()],
+ * });
+ * ```
+ */
+
+import type { Plugin } from "vite";
+import { init, transpile } from "../../core/index";
+import type { TranspileOptions } from "../../core/index";
+
+export interface ZtsPluginOptions {
+  /**
+   * 변환할 파일 확장자 패턴 (기본: /\.(tsx?|jsx)$/)
+   */
+  include?: RegExp;
+  /**
+   * 제외할 파일 패턴 (기본: /node_modules/)
+   */
+  exclude?: RegExp;
+  /**
+   * ZTS transpile 옵션 (target, jsx 등)
+   */
+  transpileOptions?: Omit<TranspileOptions, "filename">;
+}
+
+const DEFAULT_INCLUDE = /\.(tsx?|jsx)$/;
+const DEFAULT_EXCLUDE = /node_modules/;
+
+export function zts(options: ZtsPluginOptions = {}): Plugin {
+  const include = options.include ?? DEFAULT_INCLUDE;
+  const exclude = options.exclude ?? DEFAULT_EXCLUDE;
+  const transpileOpts = options.transpileOptions ?? {};
+
+  let initialized = false;
+
+  return {
+    name: "vite-plugin-zts",
+
+    // esbuild transform 비활성화 — ZTS가 대신 처리
+    config() {
+      return {
+        esbuild: false,
+      };
+    },
+
+    buildStart() {
+      if (!initialized) {
+        init();
+        initialized = true;
+      }
+    },
+
+    transform(code, id) {
+      if (!include.test(id)) return null;
+      if (exclude.test(id)) return null;
+
+      const result = transpile(code, {
+        ...transpileOpts,
+        filename: id,
+      });
+
+      return {
+        code: result.code,
+        map: result.map ? JSON.parse(result.map) : null,
+      };
+    },
+  };
+}
+
+export default zts;

--- a/tests/integration/tests/vite-plugin-zts.test.ts
+++ b/tests/integration/tests/vite-plugin-zts.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { createFixture } from "./helpers";
+import { join, resolve } from "node:path";
+
+// vite-plugin-zts 스모크 테스트
+// Vite 빌드에서 ZTS가 esbuild 대신 TS/JSX를 트랜스파일하는지 검증
+
+const PROJECT_ROOT = resolve(import.meta.dir, "../../..");
+
+function hasPackage(name: string): boolean {
+  try {
+    const { statSync } = require("node:fs");
+    statSync(join(PROJECT_ROOT, "node_modules", name, "package.json"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const hasVite = hasPackage("vite");
+
+async function viteBuildLib(root: string, entry: string): Promise<{ output: any[] }> {
+  const vite = await import("vite");
+  const { zts } = await import(join(PROJECT_ROOT, "packages/vite-plugin-zts/src/index.ts"));
+
+  const result = await vite.build({
+    root,
+    plugins: [zts()],
+    build: {
+      lib: { entry, formats: ["es"], fileName: "out" },
+      outDir: "dist",
+      minify: false,
+      write: false,
+    },
+    logLevel: "silent",
+  });
+
+  const rollupOutput = Array.isArray(result) ? result[0] : result;
+  return { output: (rollupOutput as any).output ?? [] };
+}
+
+describe.skipIf(!hasVite)("vite-plugin-zts", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it("TypeScript transform → type annotations stripped", async () => {
+    const fixture = await createFixture({
+      "main.ts": `export const greeting: string = "hello from ZTS";\nexport const num: number = 42;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await viteBuildLib(fixture.dir, join(fixture.dir, "main.ts"));
+
+    const jsChunk = result.output.find((o: any) => o.type === "chunk");
+    expect(jsChunk).toBeDefined();
+    expect(jsChunk.code).toContain("hello from ZTS");
+    expect(jsChunk.code).not.toContain(": string");
+    expect(jsChunk.code).not.toContain(": number");
+  });
+
+  it("JSX transform → JSX syntax compiled to JS", async () => {
+    const fixture = await createFixture({
+      "main.tsx": `export const App = () => <div className="app">Hello JSX</div>;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const vite = await import("vite");
+    const { zts } = await import(join(PROJECT_ROOT, "packages/vite-plugin-zts/src/index.ts"));
+    const r = await vite.build({
+      root: fixture.dir,
+      plugins: [zts()],
+      build: {
+        lib: { entry: join(fixture.dir, "main.tsx"), formats: ["es"], fileName: "out" },
+        outDir: "dist",
+        minify: false,
+        write: false,
+        rollupOptions: { external: ["react", "react/jsx-runtime", "react/jsx-dev-runtime"] },
+      },
+      logLevel: "silent",
+    });
+    const rollupOutput = Array.isArray(r) ? r[0] : r;
+    const result = { output: (rollupOutput as any).output ?? [] };
+
+    const jsChunk = result.output.find((o: any) => o.type === "chunk");
+    expect(jsChunk).toBeDefined();
+    expect(jsChunk.code).not.toContain("<div");
+    expect(jsChunk.code).toContain("Hello JSX");
+  });
+
+  it("enum transform → enum compiled to object", async () => {
+    const fixture = await createFixture({
+      "main.ts": `export enum Color { Red, Green, Blue }\nexport const c = Color.Red;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await viteBuildLib(fixture.dir, join(fixture.dir, "main.ts"));
+
+    const jsChunk = result.output.find((o: any) => o.type === "chunk");
+    expect(jsChunk).toBeDefined();
+    expect(jsChunk.code).not.toContain("enum ");
+    expect(jsChunk.code).toContain("Color");
+  });
+
+  it("interface/type stripped without error", async () => {
+    const fixture = await createFixture({
+      "main.ts": `
+        interface User { name: string; age: number; }
+        type ID = string | number;
+        export const greet = (u: User): string => u.name;
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await viteBuildLib(fixture.dir, join(fixture.dir, "main.ts"));
+
+    const jsChunk = result.output.find((o: any) => o.type === "chunk");
+    expect(jsChunk).toBeDefined();
+    expect(jsChunk.code).not.toContain("interface");
+    expect(jsChunk.code).not.toContain("type ID");
+    expect(jsChunk.code).toContain("greet");
+  });
+});


### PR DESCRIPTION
## Summary
- `vite-plugin-zts` 패키지 추가: Vite의 esbuild transform을 ZTS `transpile()`로 교체
- `esbuild: false` 자동 설정, `.ts/.tsx/.jsx` 파일만 처리, `node_modules` 제외
- `vite-plugin-swc`와 동일한 사용 패턴

## 사용법
```ts
// vite.config.ts
import { defineConfig } from "vite";
import { zts } from "vite-plugin-zts";

export default defineConfig({
  plugins: [zts()],
});
```

## Test plan
- [x] 통합 테스트 4개 (TS strip, JSX, enum, interface/type)
- [x] Vite 8 + Rolldown 환경에서 lib 모드 빌드 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)