### PR TITLE
fix(emitter): resolve circular ref init order in __esm factory

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -128,10 +128,20 @@ pub fn emitEsmWrappedModule(
                     // body_func_stmts: factory body 최상단에 배치 → forward reference 보존
                     try body_func_stmts.append(allocator, raw_idx);
                 } else {
-                    // rolldown 방식: function은 __esm 밖으로 호이스팅.
-                    // __export의 lazy getter가 외부 스코프에서 함수명을 참조하므로
-                    // function이 외부 스코프에 있어야 함.
-                    // function 본문의 import binding은 호출 시점에 init 완료 후이므로 유효.
+                    // strictExecutionOrder=false: function을 __esm factory 밖으로 호이스팅.
+                    // 함수명을 hoisted_var_names에 추가하여 var 선언 생성 (export getter 접근용).
+                    const func_node = if (export_inner) |idx|
+                        esm_ast.nodes.items[@intFromEnum(idx)]
+                    else
+                        stmt_node;
+                    const fn_name_idx: NodeIndex = @enumFromInt(esm_ast.extra_data.items[func_node.data.extra]);
+                    if (!fn_name_idx.isNone()) {
+                        const fn_name_node = esm_ast.nodes.items[@intFromEnum(fn_name_idx)];
+                        if (fn_name_node.tag == .binding_identifier) {
+                            const raw_name = esm_ast.getText(fn_name_node.data.string_ref);
+                            try hoisted_var_names.append(allocator, resolveNodeName(metadata, @intFromEnum(fn_name_idx), raw_name));
+                        }
+                    }
                     try hoisted_stmts.append(allocator, raw_idx);
                 }
             },
@@ -677,9 +687,9 @@ pub fn emitEsmWrappedModule(
             try wrapped.appendSlice(allocator, "__zts_g.$RefreshSig$=function(){var rt=__zts_g.__ReactRefresh||__zts_resolveRefresh();if(rt)return rt.createSignatureFunctionForTransform();return function(t){return t}};");
         }
         if (rbm_code.items.len > 0) try wrapped.appendSlice(allocator, rbm_code.items);
+        if (func_code.len > 0) try wrapped.appendSlice(allocator, func_code);
         if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
         if (star_init_buf.items.len > 0) try wrapped.appendSlice(allocator, star_init_buf.items);
-        if (func_code.len > 0) try wrapped.appendSlice(allocator, func_code);
         try wrapped.appendSlice(allocator, body_code);
         if (reexport_buf.items.len > 0) try wrapped.appendSlice(allocator, reexport_buf.items);
         if (has_refresh) {
@@ -721,6 +731,12 @@ pub fn emitEsmWrappedModule(
             try wrapped.append(allocator, '\t');
             try appendIndented(&wrapped, allocator, rbm_code.items);
         }
+        // func_code를 preamble 앞에 배치: 순환 참조에서 preamble이 의존 모듈을 init할 때
+        // 이 모듈의 함수가 이미 할당된 상태여야 한다. (#1092)
+        if (func_code.len > 0) {
+            try wrapped.append(allocator, '\t');
+            try appendIndented(&wrapped, allocator, func_code);
+        }
         if (preamble_code) |p| {
             try wrapped.append(allocator, '\t');
             try appendIndented(&wrapped, allocator, p);
@@ -728,10 +744,6 @@ pub fn emitEsmWrappedModule(
         if (star_init_buf.items.len > 0) {
             try wrapped.append(allocator, '\t');
             try appendIndented(&wrapped, allocator, star_init_buf.items);
-        }
-        if (func_code.len > 0) {
-            try wrapped.append(allocator, '\t');
-            try appendIndented(&wrapped, allocator, func_code);
         }
         body_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
         if (body_code.len > 0) {

--- a/src/transformer/plugins/builtin.zig
+++ b/src/transformer/plugins/builtin.zig
@@ -21,8 +21,6 @@ pub fn collect(
 ) ![]const Plugin {
     var count: usize = 0;
     if (options.worklet) count += 1;
-    // 향후: if (options.nativewind) count += 1;
-    // 향후: if (options.styled_components) count += 1;
 
     if (count == 0) return base_plugins;
 

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -2237,4 +2237,166 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toContain("99");
   });
+
+  test("ESM 래핑 모듈의 export function이 re-export 시 정상 resolve된다 (#1092)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `import { isEnabled } from "./re-export";\nconsole.log(typeof isEnabled, isEnabled());`,
+        "re-export.ts": `export { isEnabled } from "./lib";`,
+        "lib.ts": `
+          let called = false;
+          export function isEnabled(): boolean {
+            called = true;
+            return called;
+          }
+        `,
+      },
+      "index.ts",
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("function true");
+  });
+
+  test("ESM 래핑 모듈의 named export function이 undefined가 아니다 (#1092)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `import { greet, VERSION } from "./lib";\nconsole.log(typeof greet, greet("world"), VERSION);`,
+        "lib.ts": `
+          export function greet(name: string) {
+            return "hello " + name;
+          }
+          export const VERSION = "1.0";
+        `,
+      },
+      "index.ts",
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("function hello world 1.0");
+  });
+
+  test("순환 참조에서 export function이 init 전에 호출되면 undefined가 아니어야 한다 (#1092)", async () => {
+    // EnableNewWebImplementation.ts ↔ utils.ts 순환 참조 재현
+    // A가 B를 import하고, B가 A를 import. A의 export function이 B에서 호출됨.
+    const result = await bundleAndRun(
+      {
+        "index.ts": `import { result } from "./b";\nconsole.log(result);`,
+        "a.ts": `
+          import { helper } from "./b";
+          export function isEnabled(): boolean {
+            return true;
+          }
+          export const aValue = helper();
+        `,
+        "b.ts": `
+          import { isEnabled } from "./a";
+          export function helper(): string {
+            return "helper";
+          }
+          export const result = typeof isEnabled === "function" ? "ok:" + isEnabled() : "FAIL:undefined";
+        `,
+      },
+      "index.ts",
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("ok:true");
+  });
+
+  test("순환 참조에서 export function이 re-export를 통해 참조되어도 동작한다 (#1092)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `import { check } from "./consumer";\nconsole.log(check());`,
+        "provider.ts": `
+          import { consumerHelper } from "./consumer";
+          export function isReady(): boolean {
+            return true;
+          }
+          export const providerVal = consumerHelper();
+        `,
+        "re-export.ts": `export { isReady } from "./provider";`,
+        "consumer.ts": `
+          import { isReady } from "./re-export";
+          export function consumerHelper(): string {
+            return "consumed";
+          }
+          export function check(): string {
+            return typeof isReady === "function" ? "ok:" + isReady() : "FAIL:undefined";
+          }
+        `,
+      },
+      "index.ts",
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("ok:true");
+  });
+
+  test("순환 참조 + strict_execution_order에서 export function이 undefined가 아니다 (#1092)", async () => {
+    // RN 플랫폼(strict_execution_order=true)에서 순환 참조 시
+    // preamble이 함수 할당 전에 의존 모듈을 init하면 undefined 발생
+    const result = await bundleAndRun(
+      {
+        "index.ts": `import { result } from "./b";\nconsole.log(result);`,
+        "a.ts": `
+          import { helper } from "./b";
+          export function isEnabled(): boolean {
+            return true;
+          }
+          export const aValue = helper();
+        `,
+        "b.ts": `
+          import { isEnabled } from "./a";
+          export function helper(): string {
+            return "helper";
+          }
+          export const result = typeof isEnabled === "function" ? "ok:" + isEnabled() : "FAIL:" + typeof isEnabled;
+        `,
+      },
+      "index.ts",
+      ["--platform=react-native"],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("ok:true");
+  });
+
+  test("순환 참조에서 export function이 모듈 init 시점에 즉시 호출되어도 동작한다 (#1092)", async () => {
+    // gesture-handler 실제 패턴: A.ts의 factory가 B.ts를 init하는데,
+    // B.ts가 A.ts의 함수를 top-level에서 즉시 호출
+    const result = await bundleAndRun(
+      {
+        "index.ts": `import { topLevelResult } from "./caller";\nconsole.log(topLevelResult);`,
+        "provider.ts": `
+          import { tagMessage } from "./utils";
+          let useNew = true;
+          let getCalled = false;
+          export function enableLegacy(v = true) {
+            console.warn(tagMessage("legacy deprecated"));
+            useNew = !v;
+          }
+          export function isNewEnabled(): boolean {
+            getCalled = true;
+            return useNew;
+          }
+        `,
+        "utils.ts": `
+          export function tagMessage(msg: string) {
+            return "[GH] " + msg;
+          }
+        `,
+        "caller.ts": `
+          import { isNewEnabled } from "./provider";
+          export const topLevelResult = typeof isNewEnabled === "function"
+            ? "ok:" + isNewEnabled()
+            : "FAIL:" + typeof isNewEnabled;
+        `,
+      },
+      "index.ts",
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("ok:true");
+  });
 });


### PR DESCRIPTION
## Summary
- `__esm` factory에서 `func_code`를 `preamble_code` 앞에 배치
- 순환 참조에서 모듈 A의 preamble이 모듈 B를 init할 때, A의 export function이 이미 할당된 상태를 보장
- `react-native-gesture-handler`의 `isNewWebImplementationEnabled` undefined 에러 수정

## Root cause
```
변경 전: rbm → preamble → star_init → func_code → body
변경 후: rbm → func_code → preamble → star_init → body
```
순환 참조 시 preamble에서 의존 모듈을 init하면, 상대 모듈이 이 모듈의 함수를 즉시 참조. func_code가 preamble 뒤에 있으면 아직 undefined.

## Test plan
- [x] `zig build test` — 전체 통과
- [x] 순환 참조 회귀 테스트 4개 추가 (browser + RN 플랫폼)
- [x] 기존 strict-execution-order 테스트 통과

Closes #1092

🤖 Generated with [Claude Code](https://claude.com/claude-code)