### PR TITLE
fix(es2015): spread iterator with __toConsumableArray helper

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -706,6 +706,29 @@ pub const USING_RUNTIME_ES5 =
 pub const USING_RUNTIME_ES5_MIN = "var __using=function(stack,value,async){if(value!=null){if(typeof value!==\"object\"&&typeof value!==\"function\")throw new TypeError(\"Object expected\");var dispose,inner;if(async)dispose=value[Symbol.asyncDispose];if(dispose===void 0){dispose=value[Symbol.dispose];if(async)inner=dispose}if(typeof dispose!==\"function\")throw new TypeError(\"Object not disposable\");if(inner)dispose=function(){try{inner.call(this)}catch(e){return Promise.reject(e)}};stack.push([async,dispose,value])}else if(async){stack.push([async])}return value};var __callDispose=function(stack,error,hasError){var E=typeof SuppressedError===\"function\"?SuppressedError:function(e,s,m){var err=new Error(m);err.error=e;err.suppressed=s;return err};var fail=function(e){error=hasError?new E(e,error,\"An error was suppressed during disposal\"):(hasError=true,e)};var next=function(it){while(it=stack.pop()){try{var result=it[1]&&it[1].call(it[2]);if(it[0])return Promise.resolve(result).then(next,function(e){fail(e);return next()})}catch(e){fail(e)}}if(hasError)throw error};return next()};";
 
 // ============================================================
+// Spread Array (ES2015)
+// ============================================================
+
+/// __toConsumableArray: spread 배열 변환 (SWC 호환).
+/// 배열이면 직접 복사, iterable이면 Array.from(), array-like면 수동 복사.
+/// [...map.values()] → [].concat(__toConsumableArray(map.values()))
+pub const SPREAD_ARRAY_RUNTIME =
+    \\var __arrayLikeToArray = function(arr, len) {
+    \\  if (len == null || len > arr.length) len = arr.length;
+    \\  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+    \\  return arr2;
+    \\};
+    \\var __toConsumableArray = function(arr) {
+    \\  if (Array.isArray(arr)) return __arrayLikeToArray(arr);
+    \\  if (typeof Symbol !== "undefined" && arr[Symbol.iterator] != null) return Array.from(arr);
+    \\  if (arr && typeof arr.length === "number") return __arrayLikeToArray(arr);
+    \\  throw new TypeError("Invalid attempt to spread non-iterable instance.");
+    \\};
+    \\
+;
+pub const SPREAD_ARRAY_RUNTIME_MIN = "var __arrayLikeToArray=function(arr,len){if(len==null||len>arr.length)len=arr.length;for(var i=0,arr2=new Array(len);i<len;i++)arr2[i]=arr[i];return arr2};var __toConsumableArray=function(arr){if(Array.isArray(arr))return __arrayLikeToArray(arr);if(typeof Symbol!==\"undefined\"&&arr[Symbol.iterator]!=null)return Array.from(arr);if(arr&&typeof arr.length===\"number\")return __arrayLikeToArray(arr);throw new TypeError(\"Invalid attempt to spread non-iterable instance.\")};";
+
+// ============================================================
 // Append Helper
 // ============================================================
 
@@ -761,6 +784,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
     if (helpers.es_decorator) {
         try buf.appendSlice(allocator, if (minify) ES_DECORATOR_RUNTIME_MIN else ES_DECORATOR_RUNTIME);
+    }
+    if (helpers.spread_array) {
+        try buf.appendSlice(allocator, if (minify) SPREAD_ARRAY_RUNTIME_MIN else SPREAD_ARRAY_RUNTIME);
     }
 }
 

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -827,20 +827,19 @@ test "ES2015: params no transform on esnext" {
 test "ES2015: spread in call" {
     var r = try e2eTarget(std.testing.allocator, "f(...arr);", .es5);
     defer r.deinit();
-    // 변수 spread: 배열 리터럴이 아니므로 [].concat()으로 래핑 (string 등 non-array 안전)
-    try std.testing.expectEqualStrings("f.apply(void 0,[].concat(arr));", r.output);
+    try std.testing.expectEqualStrings("f.apply(void 0,[].concat(__toConsumableArray(arr)));", r.output);
 }
 
 test "ES2015: spread in call with args" {
     var r = try e2eTarget(std.testing.allocator, "f(a,...arr);", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("f.apply(void 0,[].concat([a],arr));", r.output);
+    try std.testing.expectEqualStrings("f.apply(void 0,[].concat([a],__toConsumableArray(arr)));", r.output);
 }
 
 test "ES2015: spread in array" {
     var r = try e2eTarget(std.testing.allocator, "var x=[...arr,1];", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var x=[].concat(arr,[1]);", r.output);
+    try std.testing.expectEqualStrings("var x=[].concat(__toConsumableArray(arr),[1]);", r.output);
 }
 
 test "ES2015: spread no transform on esnext" {

--- a/src/transformer/es2015_spread.zig
+++ b/src/transformer/es2015_spread.zig
@@ -271,9 +271,11 @@ pub fn ES2015Spread(comptime Transformer: type) type {
                         try self.scratch.append(self.allocator, group_arr);
                         non_spread_top = self.scratch.items.len;
                     }
-                    // spread 값을 직접 추가 (concat 인자)
+                    // spread 값을 __toConsumableArray()로 감싸서 concat 인자로 추가.
+                    // Iterator/Iterable(Map.values() 등)을 배열로 안전하게 변환.
                     const visited = try self.visitNode(elem.data.unary.operand);
-                    try self.scratch.append(self.allocator, visited);
+                    const wrapped = try wrapWithToConsumableArray(self, visited, span);
+                    try self.scratch.append(self.allocator, wrapped);
                     non_spread_top = self.scratch.items.len;
                 } else {
                     const visited = try self.visitNode(@enumFromInt(raw_idx));
@@ -342,7 +344,8 @@ pub fn ES2015Spread(comptime Transformer: type) type {
                         has_non_spread = true;
                     }
                     const visited = try self.visitNode(arg.data.unary.operand);
-                    try self.scratch.append(self.allocator, visited);
+                    const wrapped = try wrapWithToConsumableArray(self, visited, span);
+                    try self.scratch.append(self.allocator, wrapped);
                     non_spread_top = self.scratch.items.len;
                     spread_count += 1;
                 } else {
@@ -387,6 +390,29 @@ pub fn ES2015Spread(comptime Transformer: type) type {
         }
 
         /// [].concat(args...) 호출을 생성한다.
+        /// spread 값을 __toConsumableArray(value) 호출로 감싼다.
+        /// Iterator/Iterable/array-like를 안전하게 배열로 변환. (SWC 호환)
+        fn wrapWithToConsumableArray(self: *Transformer, value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            self.runtime_helpers.spread_array = true;
+
+            const fn_span = try self.ast.addString("__toConsumableArray");
+            const callee = try self.ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = fn_span,
+                .data = .{ .string_ref = fn_span },
+            });
+
+            const args = try self.ast.addNodeList(&.{value});
+            const call_extra = try self.ast.addExtras(&.{
+                @intFromEnum(callee), args.start, args.len, 0,
+            });
+            return self.ast.addNode(.{
+                .tag = .call_expression,
+                .span = span,
+                .data = .{ .extra = call_extra },
+            });
+        }
+
         fn buildConcatCall(self: *Transformer, args: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
             // []
             const empty_list = try self.ast.addNodeList(&.{});

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -2399,4 +2399,60 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toContain("ok:true");
   });
+
+  test("ES5: [...map.values()] spread가 Iterator를 배열로 펼친다 (#1095)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          const m = new Map();
+          m.set("a", { test: () => true });
+          m.set("b", { test: () => true });
+          const arr = [...m.values()];
+          console.log("len:" + arr.length, "type:" + typeof arr[0].test);
+        `,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("len:2");
+    expect(result.runOutput).toContain("type:function");
+  });
+
+  test("ES5: [...set.values()] spread가 Iterator를 배열로 펼친다 (#1095)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          const s = new Set([10, 20, 30]);
+          const arr = [...s.values()];
+          console.log("len:" + arr.length, "sum:" + arr.reduce((a: number, b: number) => a + b, 0));
+        `,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("len:3");
+    expect(result.runOutput).toContain("sum:60");
+  });
+
+  test("ES5: [...generator()] spread가 Generator를 배열로 펼친다 (#1095)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          function* gen() { yield 1; yield 2; yield 3; }
+          const arr = [...gen()];
+          console.log("len:" + arr.length, "vals:" + arr.join(","));
+        `,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("len:3");
+    expect(result.runOutput).toContain("vals:1,2,3");
+  });
 });


### PR DESCRIPTION
## Summary
- `[...map.values()]` → `[].concat(map.values())` 변환이 Iterator를 배열로 안 펼치는 버그 수정
- SWC 호환 `__toConsumableArray` 런타임 헬퍼 추가
  - Array → 직접 복사
  - Iterable (Map, Set, Generator) → `Array.from()`
  - Array-like → 수동 복사
- semver `Comparator.prototype.test undefined` 에러 해결

## Test plan
- [x] `zig build test` — 전체 통과
- [x] ES5 spread 통합 테스트 3개 추가 (Map, Set, Generator)
- [x] 기존 spread 유닛 테스트 expected output 업데이트

Closes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)