### PR TITLE
fix(worklet): apply worklet transform to reanimated/worklets in node_modules

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -698,8 +698,13 @@ pub fn emitModule(
     const is_user_code = std.mem.indexOf(u8, module.path, "/node_modules/") == null;
     const apply_refresh = options.react_refresh and is_user_code;
     const builtin = @import("../transformer/plugins/builtin.zig");
+    // worklet 변환은 react-native/@react-native 코어만 제외, 나머지 node_modules는 포함
+    // (reanimated/worklets 내부에도 "worklet" 디렉티브가 있으므로)
+    const exclude_worklet = options.worklet_transform and
+        (std.mem.indexOf(u8, module.path, "/node_modules/react-native/") != null or
+        std.mem.indexOf(u8, module.path, "/node_modules/@react-native/") != null);
     const merged_plugins = builtin.collect(.{
-        .worklet = options.worklet_transform and is_user_code,
+        .worklet = options.worklet_transform and !exclude_worklet,
     }, options.plugins, arena_alloc) catch return error.OutOfMemory;
 
     var transformer = try Transformer.init(arena_alloc, ast, .{


### PR DESCRIPTION
## Summary
- worklet 변환 필터를 Babel worklet 플러그인과 동일하게 변경
- `react-native/`, `@react-native/` 코어만 제외
- `react-native-reanimated/`, `react-native-worklets/` 등 node_modules 내 worklet 디렉티브도 변환

Reanimated 내부 코드(`initializeUI` 등)에 `"worklet"` 디렉티브가 있어 변환이 필요함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)