### PR TITLE
fix(worklet): skip function_expression to avoid syntax error

### DIFF
--- a/src/transformer/ast_plugin.zig
+++ b/src/transformer/ast_plugin.zig
@@ -34,6 +34,8 @@ pub const worklet_mod = @import("transformer/worklet.zig");
 pub const FunctionInfo = struct {
     /// 변환된 함수 노드의 인덱스
     node_idx: NodeIndex,
+    /// 노드 태그 (function_declaration / function_expression / arrow_function_expression)
+    node_tag: Tag,
     /// 함수 이름 (null = 익명 함수/화살표)
     name: ?[]const u8,
     /// 함수 body 노드 인덱스 (block_statement/function_body)

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -27,9 +27,13 @@ pub fn plugin() Plugin {
 fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) PluginError!void {
     _ = ctx;
 
-    // "worklet" 디렉티브 확인
     if (info.body_idx.isNone()) return;
     if (!api.hasDirective(info.body_idx, "worklet")) return;
+
+    // function_expression/arrow는 인자/할당 위치에 있을 수 있으므로
+    // trailing_nodes로 property assignment를 삽입하면 문법이 깨진다.
+    // function_declaration(statement 위치)만 trailing_nodes 방식 지원.
+    if (info.node_tag != .function_declaration) return;
 
     // 디렉티브 제거
     const stripped_body = try api.stripDirective(info.body_idx);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2061,6 +2061,7 @@ pub const Transformer = struct {
             var api = AstTransformCtx{ .transformer = self, .modified_body = null };
             const func_info = FunctionInfo{
                 .node_idx = result,
+                .node_tag = node.tag,
                 .name = self.getFunctionName(self.ast.getNode(result)),
                 .body_idx = new_body,
                 .params_start = pp.new_params.start,


### PR DESCRIPTION
## Summary
- `function_expression`/`arrow` 위치의 worklet 변환 스킵
- `trailing_nodes`는 statement 위치에서만 동작하므로, call 인자 등 expression 위치에서는 문법 에러 발생
- `function_declaration`만 worklet 변환 적용
- `FunctionInfo`에 `node_tag` 필드 추가

## 원인
```javascript
// 변환 전
createSerializable(function guard() { "worklet"; ... })

// 잘못된 변환 (인자 위치에 statement 삽입)
createSerializable(function guard() { ... }, guard.__workletHash = 123;, ...)
//                                          ^^^^^^^^^ 문법 에러!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)