### PR TITLE
feat(worklet): IIFE factory for function_expression worklets

### DIFF
--- a/src/transformer/ast_plugin.zig
+++ b/src/transformer/ast_plugin.zig
@@ -64,6 +64,10 @@ pub const AstTransformCtx = struct {
     /// dispatcher가 이 값을 확인하여 result 노드의 extra_data를 패치한다.
     modified_body: ?NodeIndex = null,
 
+    /// 플러그인이 함수 노드 전체를 교체한 경우 새 노드 인덱스.
+    /// function_expression worklet → IIFE factory 변환 등에 사용.
+    replaced_node: ?NodeIndex = null,
+
     // --- 디렉티브 ---
 
     /// 함수 body의 첫 문장이 지정된 디렉티브인지 확인.

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -1,13 +1,16 @@
 //! Reanimated Worklet Plugin
 //!
 //! "worklet" 디렉티브가 있는 함수를 감지하고,
-//! __workletHash, __closure, __initData 프로퍼티 할당을 함수 뒤에 주입한다.
+//! __workletHash, __closure, __initData 프로퍼티 할당을 주입한다.
 //!
-//! 사용:
-//!   const plugins = [_]Plugin{ worklet_plugin.plugin() };
-//!   var t = Transformer.init(alloc, ast, .{ .plugins = &plugins });
+//! function_declaration (statement 위치) → trailing_nodes로 뒤에 삽입
+//! function_expression (expression 위치) → IIFE factory로 감싸서 교체
 
 const std = @import("std");
+const ast_mod = @import("../../parser/ast.zig");
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const Span = @import("../../lexer/token.zig").Span;
 const ast_plugin = @import("../ast_plugin.zig");
 const AstTransformCtx = ast_plugin.AstTransformCtx;
 const FunctionInfo = ast_plugin.FunctionInfo;
@@ -15,7 +18,6 @@ const worklet_mod = @import("../transformer/worklet.zig");
 const Plugin = @import("../../bundler/plugin.zig").Plugin;
 const PluginError = @import("../../bundler/plugin.zig").PluginError;
 
-/// Worklet Plugin 인스턴스를 반환한다.
 pub fn plugin() Plugin {
     return .{
         .name = "reanimated-worklet",
@@ -23,17 +25,11 @@ pub fn plugin() Plugin {
     };
 }
 
-/// onFunction 훅 — "worklet" 디렉티브 감지 + 프로퍼티 할당 주입.
 fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) PluginError!void {
     _ = ctx;
 
     if (info.body_idx.isNone()) return;
     if (!api.hasDirective(info.body_idx, "worklet")) return;
-
-    // function_expression/arrow는 인자/할당 위치에 있을 수 있으므로
-    // trailing_nodes로 property assignment를 삽입하면 문법이 깨진다.
-    // function_declaration(statement 위치)만 trailing_nodes 방식 지원.
-    if (info.node_tag != .function_declaration) return;
 
     // 디렉티브 제거
     const stripped_body = try api.stripDirective(info.body_idx);
@@ -54,10 +50,8 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     );
     defer api.getAllocator().free(init_code);
 
-    // Hash 계산
     const hash = @as(u32, @truncate(std.hash.Wyhash.hash(0, init_code)));
 
-    // __workletHash, __closure, __initData 프로퍼티 할당 생성
     const stmts = try worklet_mod.buildWorkletPropertyAssignments(
         api.transformer,
         func_name,
@@ -67,8 +61,104 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
         info.source_path,
     );
 
-    // trailing statements로 함수 뒤에 삽입
-    for (stmts) |stmt| {
-        try api.addTrailingStatement(stmt);
+    if (info.node_tag == .function_declaration) {
+        // statement 위치: trailing_nodes로 함수 뒤에 삽입
+        for (stmts) |stmt| {
+            try api.addTrailingStatement(stmt);
+        }
+    } else {
+        // expression 위치 (function_expression/arrow): IIFE factory로 감싸서 교체
+        //
+        // 변환:
+        //   function fn() { "worklet"; body }
+        // →
+        //   (function() {
+        //     var fn = function fn() { body };
+        //     fn.__workletHash = 123;
+        //     fn.__closure = {};
+        //     fn.__initData = { code: "...", location: "..." };
+        //     return fn;
+        //   })()
+        const iife = try buildWorkletIIFE(api, info.node_idx, func_name, stmts);
+        api.replaced_node = iife;
     }
+}
+
+/// function_expression worklet을 IIFE factory로 감싼다.
+fn buildWorkletIIFE(
+    api: *AstTransformCtx,
+    func_node: NodeIndex,
+    func_name: []const u8,
+    prop_stmts: [3]NodeIndex,
+) PluginError!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const t = api.transformer;
+
+    // var funcName = <original function>;
+    const name_span = try t.ast.addString(func_name);
+    const binding = try t.ast.addNode(.{
+        .tag = .binding_identifier,
+        .span = name_span,
+        .data = .{ .string_ref = name_span },
+    });
+    const none = @intFromEnum(NodeIndex.none);
+    const declarator = try t.addExtraNode(.variable_declarator, zero_span, &.{
+        @intFromEnum(binding),
+        none, // type annotation
+        @intFromEnum(func_node), // init = original function
+    });
+    const decl_list = try t.ast.addNodeList(&.{declarator});
+    const var_decl = try t.addExtraNode(.variable_declaration, zero_span, &.{
+        0, // var
+        decl_list.start,
+        decl_list.len,
+    });
+
+    // return funcName;
+    const return_ref = try t.ast.addNode(.{
+        .tag = .identifier_reference,
+        .span = name_span,
+        .data = .{ .string_ref = name_span },
+    });
+    const return_stmt = try t.ast.addNode(.{
+        .tag = .return_statement,
+        .span = zero_span,
+        .data = .{ .unary = .{ .operand = return_ref, .flags = 0 } },
+    });
+
+    // factory body: [var_decl, prop_stmts[0], prop_stmts[1], prop_stmts[2], return_stmt]
+    const body_list = try t.ast.addNodeList(&.{
+        var_decl,     prop_stmts[0],
+        prop_stmts[1], prop_stmts[2],
+        return_stmt,
+    });
+    const body = try t.ast.addNode(.{
+        .tag = .block_statement,
+        .span = zero_span,
+        .data = .{ .list = body_list },
+    });
+
+    // function() { ... } (wrapper — 파라미터 없는 익명 함수)
+    const empty_params = try t.ast.addNodeList(&.{});
+    const wrapper_func = try t.addExtraNode(.function_expression, zero_span, &.{
+        none, // name (anonymous)
+        empty_params.start, empty_params.len,
+        @intFromEnum(body),
+        0, // flags
+        none, // return type
+    });
+
+    // (function() { ... })() — IIFE 호출
+    const call_args = try t.ast.addNodeList(&.{});
+    const call_extra = try t.ast.addExtras(&.{
+        @intFromEnum(wrapper_func),
+        call_args.start,
+        call_args.len,
+        0,
+    });
+    return t.ast.addNode(.{
+        .tag = .call_expression,
+        .span = zero_span,
+        .data = .{ .extra = call_extra },
+    });
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2082,6 +2082,10 @@ pub const Transformer = struct {
                 const result_extra = self.ast.getNode(result).data.extra;
                 self.ast.extra_data.items[result_extra + 3] = @intFromEnum(new_body_idx);
             }
+            // 플러그인이 함수 노드 전체를 교체했으면 (function_expression → IIFE 등)
+            if (api.replaced_node) |replacement| {
+                return replacement;
+            }
         }
 
         // React Fast Refresh: PascalCase 함수 → 컴포넌트 등록


### PR DESCRIPTION
## Summary
- `function_expression`/`arrow` 위치의 worklet을 IIFE factory로 감싸서 변환
- `function_declaration` (statement 위치) → 기존 `trailing_nodes` 방식 유지
- `AstTransformCtx`에 `replaced_node` 필드 추가로 함수 노드 전체 교체 지원

## 변환 예시
```javascript
// 입력
runOnUISync(function initializeUI() { "worklet"; registerError(); })

// 출력 (IIFE factory)
runOnUISync(function() {
  var initializeUI = function initializeUI() { registerError(); };
  initializeUI.__workletHash = 123;
  initializeUI.__closure = {};
  initializeUI.__initData = { code: "...", location: "..." };
  return initializeUI;
}())
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)