### PR TITLE
fix(worklet): rest params, runtime helpers, and TS types in closure

### DIFF
--- a/src/transformer/ast_plugin.zig
+++ b/src/transformer/ast_plugin.zig
@@ -40,10 +40,13 @@ pub const FunctionInfo = struct {
     name: ?[]const u8,
     /// 함수 body 노드 인덱스 (block_statement/function_body)
     body_idx: NodeIndex,
-    /// 파라미터 extra_data 시작 위치
+    /// 파라미터 extra_data 시작 위치 (변환 후)
     params_start: u32,
-    /// 파라미터 수
+    /// 파라미터 수 (변환 후)
     params_len: u32,
+    /// 원본 파라미터 (변환 전, rest params 등 포함)
+    original_params_start: u32,
+    original_params_len: u32,
     /// 함수 플래그 (bit 0=async, bit 1=generator)
     flags: u32,
     /// 소스 파일 경로 (__initData.location 등에 사용)

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -34,8 +34,8 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     // 디렉티브 제거
     const stripped_body = try api.stripDirective(info.body_idx);
 
-    // Closure 변수 추출
-    const closure_vars = try api.getClosureVars(stripped_body, info.params_start, info.params_len);
+    // Closure 변수 추출 (원본 params 사용 — rest params 등 변환 전 상태)
+    const closure_vars = try api.getClosureVars(stripped_body, info.original_params_start, info.original_params_len);
     defer api.getAllocator().free(closure_vars);
 
     // Init code 생성

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2066,6 +2066,8 @@ pub const Transformer = struct {
                 .body_idx = new_body,
                 .params_start = pp.new_params.start,
                 .params_len = pp.new_params.len,
+                .original_params_start = params_start,
+                .original_params_len = params_len,
                 .flags = self.readU32(e, 4),
                 .source_path = self.options.jsx_filename,
             };

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -151,16 +151,53 @@ pub fn collectClosureVars(
         }
     }
 
+    // 1.5. body 직접 자식의 var/let/const 이름 수집 (synthetic 노드 포함)
+    // transformer가 생성한 노드(rest params 변환 등)의 extra_data가
+    // walkBodyForClosureAnalysis에서 정상 파싱되지 않을 수 있으므로 별도 수집.
+    {
+        const body = self.ast.getNode(body_idx);
+        if (body.tag == .block_statement or body.tag == .function_body) {
+            const list = body.data.list;
+            var bi: u32 = 0;
+            while (bi < list.len) : (bi += 1) {
+                const stmt_raw = self.ast.extra_data.items[list.start + bi];
+                const stmt_idx: NodeIndex = @enumFromInt(stmt_raw);
+                if (stmt_idx.isNone()) continue;
+                const stmt = self.ast.getNode(stmt_idx);
+                if (stmt.tag == .variable_declaration) {
+                    const ve = stmt.data.extra;
+                    if (self.ast.hasExtra(ve, 3)) {
+                        const vl_start = self.ast.extra_data.items[ve + 1];
+                        const vl_len = self.ast.extra_data.items[ve + 2];
+                        var vi: u32 = 0;
+                        while (vi < vl_len) : (vi += 1) {
+                            if (vl_start + vi >= self.ast.extra_data.items.len) break;
+                            const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[vl_start + vi]);
+                            if (decl_idx.isNone()) continue;
+                            const decl = self.ast.getNode(decl_idx);
+                            if (decl.tag == .variable_declarator and self.ast.hasExtra(decl.data.extra, 3)) {
+                                const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[decl.data.extra]);
+                                try collectBindingNames(self, name_idx, &locals);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // 2-3. body 순회: 지역 선언 → locals, 식별자 참조 → refs
     try walkBodyForClosureAnalysis(self, body_idx, &locals, &refs, 0);
 
-    // 4. refs - locals - globals = closure vars
+    // 4. refs - locals - globals - runtime helpers = closure vars
     var result: std.ArrayList([]const u8) = .empty;
     var iter = refs.iterator();
     while (iter.next()) |entry| {
         const name = entry.key_ptr.*;
         if (locals.contains(name)) continue;
         if (isGlobal(name)) continue;
+        // 런타임 헬퍼(__toConsumableArray, __classCallCheck 등) 제외
+        if (name.len >= 2 and name[0] == '_' and name[1] == '_') continue;
         try result.append(self.allocator, name);
     }
 
@@ -217,7 +254,7 @@ fn collectBindingNames(self: *Transformer, idx: NodeIndex, locals: *std.StringHa
                 }
             }
         },
-        .rest_element => {
+        .rest_element, .spread_element => {
             try collectBindingNames(self, node.data.unary.operand, locals);
         },
         .assignment_pattern => {

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -890,3 +890,57 @@ test "Worklet: worklet transform disabled when no plugins" {
     // plugins가 없으므로 worklet 변환 없음 — statement 1개 (함수만)
     try std.testing.expectEqual(@as(u32, 1), r.statementCount());
 }
+
+test "Worklet: rest params are not included in closure (#1104)" {
+    const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
+    var r = try parseAndTransformWithOptions(std.testing.allocator,
+        "function guard(fn, ...args) { \"worklet\"; return fn(...args); }",
+        .{
+            .plugins = &plugins,
+            .jsx_filename = "test.ts",
+            .unsupported = TransformOptions.compat.fromESTarget(.es5),
+        },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // rest param 'args'는 closure에 포함되면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
+}
+
+test "Worklet: directive found after rest params transform (#1102)" {
+    const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
+    var r = try parseAndTransformWithOptions(std.testing.allocator,
+        "function guard(fn, ...args) { \"worklet\"; return fn(...args); }",
+        .{
+            .plugins = &plugins,
+            .jsx_filename = "test.ts",
+            .unsupported = TransformOptions.compat.fromESTarget(.es5),
+        },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // worklet 변환이 적용되어야 함 (디렉티브가 rest params 뒤로 밀려도)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+    // "worklet" 디렉티브가 제거되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, "\"worklet\"") == null);
+}
+
+test "Worklet: function_expression worklet produces IIFE factory (#1100)" {
+    const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
+    var r = try parseAndTransformWithOptions(std.testing.allocator,
+        "var x = wrap(function myWorklet() { \"worklet\"; return 42; });",
+        .{ .plugins = &plugins, .jsx_filename = "test.ts" },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // IIFE factory로 감싸져야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+    // 원본 함수가 IIFE 안에서 var로 할당
+    try std.testing.expect(std.mem.indexOf(u8, code, "var myWorklet") != null);
+    // return으로 반환
+    try std.testing.expect(std.mem.indexOf(u8, code, "return myWorklet") != null);
+}


### PR DESCRIPTION
## Summary
- `spread_element` (rest params) 처리 추가 — `collectBindingNames`에서 누락
- `FunctionInfo`에 `original_params_start/len` 추가 — ES5 변환 전 원본 params로 closure 분석
- `__` 접두어 런타임 헬퍼(`__toConsumableArray` 등) closure에서 제외
- 회귀 테스트 3개 추가

## Root cause
파서가 rest params를 `rest_element`가 아닌 `spread_element`로 표현. `collectBindingNames`가 `spread_element`를 처리하지 않아 rest param이 locals에서 누락 → closure에 포함.

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)