### PR TITLE
refactor(worklet): use original body for closure analysis (Babel-compatible)

### DIFF
--- a/src/transformer/ast_plugin.zig
+++ b/src/transformer/ast_plugin.zig
@@ -38,15 +38,16 @@ pub const FunctionInfo = struct {
     node_tag: Tag,
     /// 함수 이름 (null = 익명 함수/화살표)
     name: ?[]const u8,
-    /// 함수 body 노드 인덱스 (block_statement/function_body)
+    /// 함수 body 노드 인덱스 (변환 후)
     body_idx: NodeIndex,
     /// 파라미터 extra_data 시작 위치 (변환 후)
     params_start: u32,
     /// 파라미터 수 (변환 후)
     params_len: u32,
-    /// 원본 파라미터 (변환 전, rest params 등 포함)
+    /// 원본 (변환 전) — Babel과 동일하게 변환 전 AST로 closure 분석
     original_params_start: u32,
     original_params_len: u32,
+    original_body_idx: NodeIndex,
     /// 함수 플래그 (bit 0=async, bit 1=generator)
     flags: u32,
     /// 소스 파일 경로 (__initData.location 등에 사용)

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -34,8 +34,8 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     // 디렉티브 제거
     const stripped_body = try api.stripDirective(info.body_idx);
 
-    // Closure 변수 추출 (원본 params 사용 — rest params 등 변환 전 상태)
-    const closure_vars = try api.getClosureVars(stripped_body, info.original_params_start, info.original_params_len);
+    // Closure 변수 추출 (원본 body + params 사용 — Babel과 동일하게 변환 전 AST 분석)
+    const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
     defer api.getAllocator().free(closure_vars);
 
     // Init code 생성

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2068,6 +2068,7 @@ pub const Transformer = struct {
                 .params_len = pp.new_params.len,
                 .original_params_start = params_start,
                 .original_params_len = params_len,
+                .original_body_idx = old_body_idx,
                 .flags = self.readU32(e, 4),
                 .source_path = self.options.jsx_filename,
             };

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -151,53 +151,16 @@ pub fn collectClosureVars(
         }
     }
 
-    // 1.5. body 직접 자식의 var/let/const 이름 수집 (synthetic 노드 포함)
-    // transformer가 생성한 노드(rest params 변환 등)의 extra_data가
-    // walkBodyForClosureAnalysis에서 정상 파싱되지 않을 수 있으므로 별도 수집.
-    {
-        const body = self.ast.getNode(body_idx);
-        if (body.tag == .block_statement or body.tag == .function_body) {
-            const list = body.data.list;
-            var bi: u32 = 0;
-            while (bi < list.len) : (bi += 1) {
-                const stmt_raw = self.ast.extra_data.items[list.start + bi];
-                const stmt_idx: NodeIndex = @enumFromInt(stmt_raw);
-                if (stmt_idx.isNone()) continue;
-                const stmt = self.ast.getNode(stmt_idx);
-                if (stmt.tag == .variable_declaration) {
-                    const ve = stmt.data.extra;
-                    if (self.ast.hasExtra(ve, 3)) {
-                        const vl_start = self.ast.extra_data.items[ve + 1];
-                        const vl_len = self.ast.extra_data.items[ve + 2];
-                        var vi: u32 = 0;
-                        while (vi < vl_len) : (vi += 1) {
-                            if (vl_start + vi >= self.ast.extra_data.items.len) break;
-                            const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[vl_start + vi]);
-                            if (decl_idx.isNone()) continue;
-                            const decl = self.ast.getNode(decl_idx);
-                            if (decl.tag == .variable_declarator and self.ast.hasExtra(decl.data.extra, 3)) {
-                                const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[decl.data.extra]);
-                                try collectBindingNames(self, name_idx, &locals);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     // 2-3. body 순회: 지역 선언 → locals, 식별자 참조 → refs
     try walkBodyForClosureAnalysis(self, body_idx, &locals, &refs, 0);
 
-    // 4. refs - locals - globals - runtime helpers = closure vars
+    // 4. refs - locals - globals = closure vars
     var result: std.ArrayList([]const u8) = .empty;
     var iter = refs.iterator();
     while (iter.next()) |entry| {
         const name = entry.key_ptr.*;
         if (locals.contains(name)) continue;
         if (isGlobal(name)) continue;
-        // 런타임 헬퍼(__toConsumableArray, __classCallCheck 등) 제외
-        if (name.len >= 2 and name[0] == '_' and name[1] == '_') continue;
         try result.append(self.allocator, name);
     }
 


### PR DESCRIPTION
## Summary
- closure 분석을 **변환 전 원본 AST** (original body + params)로 수행
- Babel worklet 플러그인과 동일한 방식
- `__` 런타임 헬퍼 필터 제거 (불필요)
- 1.5 단계 body var 수집 제거 (불필요)
- 코드 35줄 감소

🤖 Generated with [Claude Code](https://claude.com/claude-code)