### PR TITLE
fix(worklet): if_statement/try_statement/for_in use ternary data format

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -367,13 +367,11 @@ fn walkBodyForClosureAnalysis(
             try walkBodyForClosureAnalysis(self, node.data.ternary.c, locals, refs, depth + 1);
         },
 
-        // if 문: extra = [condition, consequent, alternate]
+        // if 문: ternary = { a: condition, b: consequent, c: alternate }
         .if_statement => {
-            const e = node.data.extra;
-            if (!self.ast.hasExtra(e, 3)) return;
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e]), locals, refs, depth + 1);
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e + 1]), locals, refs, depth + 1);
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e + 2]), locals, refs, depth + 1);
+            try walkBodyForClosureAnalysis(self, node.data.ternary.a, locals, refs, depth + 1);
+            try walkBodyForClosureAnalysis(self, node.data.ternary.b, locals, refs, depth + 1);
+            try walkBodyForClosureAnalysis(self, node.data.ternary.c, locals, refs, depth + 1);
         },
 
         // for 문: extra = [init, test, update, body]
@@ -386,22 +384,18 @@ fn walkBodyForClosureAnalysis(
             try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e + 3]), locals, refs, depth + 1);
         },
 
-        // for-in/for-of: extra = [left, right, body]
-        .for_in_statement, .for_of_statement => {
-            const e = node.data.extra;
-            if (!self.ast.hasExtra(e, 3)) return;
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e]), locals, refs, depth + 1);
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e + 1]), locals, refs, depth + 1);
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e + 2]), locals, refs, depth + 1);
+        // for-in/for-of: ternary = { a: left, b: right, c: body }
+        .for_in_statement, .for_of_statement, .for_await_of_statement => {
+            try walkBodyForClosureAnalysis(self, node.data.ternary.a, locals, refs, depth + 1);
+            try walkBodyForClosureAnalysis(self, node.data.ternary.b, locals, refs, depth + 1);
+            try walkBodyForClosureAnalysis(self, node.data.ternary.c, locals, refs, depth + 1);
         },
 
-        // try 문: extra = [block, handler, finalizer]
+        // try 문: ternary = { a: block, b: handler, c: finalizer }
         .try_statement => {
-            const e = node.data.extra;
-            if (!self.ast.hasExtra(e, 3)) return;
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e]), locals, refs, depth + 1);
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e + 1]), locals, refs, depth + 1);
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e + 2]), locals, refs, depth + 1);
+            try walkBodyForClosureAnalysis(self, node.data.ternary.a, locals, refs, depth + 1);
+            try walkBodyForClosureAnalysis(self, node.data.ternary.b, locals, refs, depth + 1);
+            try walkBodyForClosureAnalysis(self, node.data.ternary.c, locals, refs, depth + 1);
         },
 
         // catch 절: binary = [param, body]

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -944,3 +944,22 @@ test "Worklet: function_expression worklet produces IIFE factory (#1100)" {
     // return으로 반환
     try std.testing.expect(std.mem.indexOf(u8, code, "return myWorklet") != null);
 }
+
+test "Worklet: property access not collected as closure var (if_statement ternary)" {
+    const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
+    var r = try parseAndTransformWithOptions(std.testing.allocator,
+        \\function calc(current, previous) {
+        \\  "worklet";
+        \\  if (previous === undefined) {
+        \\    return current.force;
+        \\  } else {
+        \\    return current.force - previous.force;
+        \\  }
+        \\}
+    , .{ .plugins = &plugins, .jsx_filename = "test.ts" });
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // 'force'는 property access이므로 closure에 포함되면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
+}


### PR DESCRIPTION
## Summary
- `if_statement`, `try_statement`, `for_in_statement`, `for_of_statement`, `for_await_of_statement`의 data format이 `extra`가 아닌 `ternary`
- `walkBodyForClosureAnalysis`에서 잘못된 data 접근으로 property access의 property name(`force` from `current.force`)이 closure 변수로 수집됨
- 회귀 테스트 추가: property access가 closure에 포함되지 않는지 확인

## Root cause
```
// 잘못된 코드 (extra format)
const e = node.data.extra;
extra_data.items[e]     // ← 엉뚱한 인덱스 참조!
extra_data.items[e + 1]
extra_data.items[e + 2]

// 올바른 코드 (ternary format)
node.data.ternary.a  // condition
node.data.ternary.b  // consequent
node.data.ternary.c  // alternate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)