### PR TITLE
fix(napi): use original body/params for closure analysis

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -806,7 +806,7 @@ fn serializeFunctionInfo(
     // closureVars: 디렉티브가 있을 때만 계산 (스코프 분석은 비용이 크므로)
     try buf.appendSlice(alloc, ",\"closureVars\":[");
     if (has_directives) {
-        const closure_vars = api.getClosureVars(func.body_idx, func.params_start, func.params_len) catch &.{};
+        const closure_vars = api.getClosureVars(func.original_body_idx, func.original_params_start, func.original_params_len) catch &.{};
         defer if (closure_vars.len > 0) api.getAllocator().free(closure_vars);
         for (closure_vars, 0..) |v, i| {
             if (i > 0) try buf.append(alloc, ',');


### PR DESCRIPTION
## Root cause
`serializeFunctionInfo`에서 변환 후 body/params로 closure 분석 → globalThis property가 closure에 잡힘.
worklet_plugin은 original_body/params를 사용하도록 수정했지만 NAPI 경로는 누락.

🤖 Generated with [Claude Code](https://claude.com/claude-code)