### PR TITLE
refactor(worklet): remove dead guard on ref_idx in buildClosureObject

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -647,9 +647,8 @@ fn buildClosureObject(self: *Transformer, closure_vars: []const ClosureVar) Erro
             .data = .{ .string_ref = name_span },
         });
         // 원본 참조의 symbol_id 복사 → scope hoisting rename 시 자동 갱신
-        if (!cv.ref_idx.isNone()) {
-            self.copySymbolId(cv.ref_idx, value);
-        }
+        // (ref_idx는 walkBodyForClosureAnalysis에서 항상 유효한 identifier_reference 노드)
+        self.copySymbolId(cv.ref_idx, value);
         // explicit key-value: { hue2rgb: hue2rgb } → rename 시 { hue2rgb: hue2rgb$1 }
         const prop = try self.ast.addNode(.{
             .tag = .object_property,


### PR DESCRIPTION
## Summary
- `buildClosureObject`에서 `if (!cv.ref_idx.isNone())` guard 제거
- `ref_idx`는 `walkBodyForClosureAnalysis`에서 항상 유효한 `identifier_reference` NodeIndex이므로 `.isNone()` 체크는 도달 불가
- dead code 제거 + invariant 문서화 주석 추가

## Test plan
- [x] `zig build test` passed
- [x] `zig build napi` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)