### PR TITLE
refactor(worklet): extract dispatchFunctionPlugins helper + fix original_body_idx

### DIFF
--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -29,9 +29,7 @@ const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const Tag = Node.Tag;
-const ast_plugin = @import("ast_plugin.zig");
-const AstTransformCtx = ast_plugin.AstTransformCtx;
-const FunctionInfo = ast_plugin.FunctionInfo;
+const FunctionInfo = @import("ast_plugin.zig").FunctionInfo;
 
 pub fn ES2015Arrow(comptime Transformer: type) type {
     return struct {
@@ -96,38 +94,22 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
                 .data = .{ .extra = new_extra },
             });
 
-            // Plugin dispatch: arrow → function_expression 변환 후 worklet 등 AST 플러그인 적용.
-            // visitFunction과 동일한 onFunction 훅 호출.
-            if (self.options.plugins.len > 0) {
-                var api = AstTransformCtx{ .transformer = self, .modified_body = null };
-                const func_info = FunctionInfo{
-                    .node_idx = result,
-                    .node_tag = .function_expression,
-                    .name = null, // arrow는 항상 익명
-                    .body_idx = func_body,
-                    .params_start = param_list.start,
-                    .params_len = param_list.len,
-                    .original_params_start = param_list.start,
-                    .original_params_len = param_list.len,
-                    .original_body_idx = func_body,
-                    .flags = func_flags,
-                    .source_path = self.options.jsx_filename,
-                };
-                for (self.options.plugins) |p| {
-                    if (p.onFunction) |hook| {
-                        hook(p.context, &api, func_info) catch |err| switch (err) {
-                            error.OutOfMemory => return error.OutOfMemory,
-                            error.PluginFailed => {},
-                        };
-                    }
-                }
-                if (api.modified_body) |new_body_idx| {
-                    const result_extra = self.ast.getNode(result).data.extra;
-                    self.ast.extra_data.items[result_extra + 3] = @intFromEnum(new_body_idx);
-                }
-                if (api.replaced_node) |replacement| {
-                    return replacement;
-                }
+            // Plugin dispatch: worklet 등 AST 플러그인 적용
+            if (try self.dispatchFunctionPlugins(result, .{
+                .node_idx = result,
+                .node_tag = .function_expression,
+                .name = null,
+                .body_idx = func_body,
+                .params_start = param_list.start,
+                .params_len = param_list.len,
+                // 변환 전 원본 사용 — worklet closure 분석에 필요
+                .original_params_start = param_list.start,
+                .original_params_len = param_list.len,
+                .original_body_idx = body_idx,
+                .flags = func_flags,
+                .source_path = self.options.jsx_filename,
+            })) |replacement| {
+                return replacement;
             }
 
             return result;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2057,38 +2057,20 @@ pub const Transformer = struct {
         });
 
         // Plugin dispatch: onFunction (AST 훅)
-        if (self.options.plugins.len > 0) {
-            var api = AstTransformCtx{ .transformer = self, .modified_body = null };
-            const func_info = FunctionInfo{
-                .node_idx = result,
-                .node_tag = node.tag,
-                .name = self.getFunctionName(self.ast.getNode(result)),
-                .body_idx = new_body,
-                .params_start = pp.new_params.start,
-                .params_len = pp.new_params.len,
-                .original_params_start = params_start,
-                .original_params_len = params_len,
-                .original_body_idx = old_body_idx,
-                .flags = self.readU32(e, 4),
-                .source_path = self.options.jsx_filename,
-            };
-            for (self.options.plugins) |p| {
-                if (p.onFunction) |hook| {
-                    hook(p.context, &api, func_info) catch |err| switch (err) {
-                        error.OutOfMemory => return error.OutOfMemory,
-                        error.PluginFailed => {},
-                    };
-                }
-            }
-            // 플러그인이 body를 수정했으면 result 노드의 extra_data를 패치
-            if (api.modified_body) |new_body_idx| {
-                const result_extra = self.ast.getNode(result).data.extra;
-                self.ast.extra_data.items[result_extra + 3] = @intFromEnum(new_body_idx);
-            }
-            // 플러그인이 함수 노드 전체를 교체했으면 (function_expression → IIFE 등)
-            if (api.replaced_node) |replacement| {
-                return replacement;
-            }
+        if (try self.dispatchFunctionPlugins(result, .{
+            .node_idx = result,
+            .node_tag = node.tag,
+            .name = self.getFunctionName(self.ast.getNode(result)),
+            .body_idx = new_body,
+            .params_start = pp.new_params.start,
+            .params_len = pp.new_params.len,
+            .original_params_start = params_start,
+            .original_params_len = params_len,
+            .original_body_idx = old_body_idx,
+            .flags = self.readU32(e, 4),
+            .source_path = self.options.jsx_filename,
+        })) |replacement| {
+            return replacement;
         }
 
         // React Fast Refresh: PascalCase 함수 → 컴포넌트 등록
@@ -3277,4 +3259,29 @@ pub const Transformer = struct {
     pub const makeSigHandle = refresh.makeSigHandle;
     pub const maybeRegisterRefreshSignature = refresh.maybeRegisterRefreshSignature;
     pub const insertSigCallAtBodyStart = refresh.insertSigCallAtBodyStart;
+
+    // ================================================================
+    // Plugin dispatch helper
+    // ================================================================
+
+    /// onFunction 플러그인 훅을 실행한다.
+    /// 플러그인이 함수를 교체하면 새 NodeIndex를 반환, 아니면 null.
+    /// body 수정 시 result 노드의 extra_data를 직접 패치한다.
+    pub fn dispatchFunctionPlugins(self: *Transformer, result: NodeIndex, func_info: FunctionInfo) Error!?NodeIndex {
+        if (self.options.plugins.len == 0) return null;
+        var api = AstTransformCtx{ .transformer = self, .modified_body = null };
+        for (self.options.plugins) |p| {
+            if (p.onFunction) |hook| {
+                hook(p.context, &api, func_info) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.PluginFailed => {},
+                };
+            }
+        }
+        if (api.modified_body) |new_body_idx| {
+            const result_extra = self.ast.getNode(result).data.extra;
+            self.ast.extra_data.items[result_extra + 3] = @intFromEnum(new_body_idx);
+        }
+        return api.replaced_node;
+    }
 };


### PR DESCRIPTION
## Summary
- `visitFunction`과 `lowerArrowFunction`에서 중복된 plugin dispatch 코드(~20줄)를 `dispatchFunctionPlugins()` 헬퍼로 추출
- `lowerArrowFunction`의 `original_body_idx`가 변환 후 body를 사용하던 버그 수정 → 변환 전 `body_idx` 사용

## Test plan
- [x] `zig build test` passed
- [x] `zig build napi` passed
- [x] `bun test tests/es5-rn.test.ts` — 30 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)