### PR TITLE
fix(worklet): handle assignment_target_identifier in arrow param exclusion

### DIFF
--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -95,6 +95,7 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
             });
 
             // Plugin dispatch: worklet 등 AST 플러그인 적용
+            // Plugin dispatch: worklet 등 AST 플러그인 적용
             if (try self.dispatchFunctionPlugins(result, .{
                 .node_idx = result,
                 .node_tag = .function_expression,

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -189,7 +189,10 @@ fn collectBindingNames(self: *Transformer, idx: NodeIndex, locals: *std.StringHa
     const node = self.ast.getNode(idx);
 
     switch (node.tag) {
-        .binding_identifier => {
+        // arrow params without type annotations are parsed as expressions then
+        // converted via coverExpressionToAssignmentTarget:
+        //   identifier_reference → assignment_target_identifier
+        .binding_identifier, .identifier_reference, .assignment_target_identifier => {
             const name = self.ast.getText(node.data.string_ref);
             if (name.len > 0) {
                 locals.put(name, {}) catch return error.OutOfMemory;

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1067,3 +1067,33 @@ test "Worklet: globalThis property not collected as closure var (unary_expressio
     // fn만 closure에 있어야 함
     try std.testing.expect(std.mem.indexOf(u8, code, "__closure = { fn: fn }") != null);
 }
+
+test "Worklet: arrow function params not in closure (ES5 lowering)" {
+    const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
+    var r = try parseAndTransformWithOptions(std.testing.allocator,
+        "var ext = 1; export const pf = (value, context) => { \"worklet\"; return ext + value + context; };",
+        .{ .plugins = &plugins, .jsx_filename = "test.ts", .unsupported = TransformOptions.compat.fromESTarget(.es5) },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // value, context는 파라미터이므로 closure에 포함되면 안 됨
+    // ext만 closure에 있어야 함
+    if (std.mem.indexOf(u8, code, "__closure = { ext: ext }") == null) {
+        std.debug.print("\n=== ACTUAL CODE ===\n{s}\n=== END ===\n", .{code});
+    }
+    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = { ext: ext }") != null);
+}
+
+test "Worklet: arrow function with typed var params not in closure (ES5 lowering)" {
+    const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
+    var r = try parseAndTransformWithOptions(std.testing.allocator,
+        "type Fn = any; var ext = 1; export const pf: Fn = (value, context) => { \"worklet\"; return ext + value + context; };",
+        .{ .plugins = &plugins, .jsx_filename = "test.ts", .unsupported = TransformOptions.compat.fromESTarget(.es5) },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // type annotation이 변수에 있고 params에는 없는 경우에도 params는 제외되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = { ext: ext }") != null);
+}


### PR DESCRIPTION
## Summary
- 타입 없는 arrow params(`(value, context) => { 'worklet'; ... }`)가 `assignment_target_identifier`로 파싱되는데, `collectBindingNames`가 이 태그를 처리하지 않아 파라미터가 `__closure`에 포함됨
- IIFE wrapper scope에서 파라미터 변수 접근 → `ReferenceError: Property 'context' doesn't exist`
- `collectBindingNames`에 `assignment_target_identifier` 추가
- 유닛 테스트 2개 추가 (arrow params + ES5 lowering)

## Test plan
- [x] `zig build test` — all passed (2 new tests)
- [x] `zig build napi` — NAPI verification: closure only contains `ext`, not `value`/`context`

🤖 Generated with [Claude Code](https://claude.com/claude-code)