### PR TITLE
chore: remove duplicate comment and debug print

### DIFF
--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -95,7 +95,6 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
             });
 
             // Plugin dispatch: worklet 등 AST 플러그인 적용
-            // Plugin dispatch: worklet 등 AST 플러그인 적용
             if (try self.dispatchFunctionPlugins(result, .{
                 .node_idx = result,
                 .node_tag = .function_expression,

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1078,10 +1078,6 @@ test "Worklet: arrow function params not in closure (ES5 lowering)" {
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
     // value, context는 파라미터이므로 closure에 포함되면 안 됨
-    // ext만 closure에 있어야 함
-    if (std.mem.indexOf(u8, code, "__closure = { ext: ext }") == null) {
-        std.debug.print("\n=== ACTUAL CODE ===\n{s}\n=== END ===\n", .{code});
-    }
     try std.testing.expect(std.mem.indexOf(u8, code, "__closure = { ext: ext }") != null);
 }
 


### PR DESCRIPTION
- es2015_arrow.zig: 중복 주석 제거
- transformer_test.zig: 디버깅용 `std.debug.print` 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)