### PR TITLE
chore: CSS deps bump + @emotion/react · Tailwind v4 스모크 테스트

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,17 @@
     "": {
       "name": "zts",
       "devDependencies": {
-        "@emotion/css": "^11.13.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@tailwindcss/postcss": "^4.2.2",
         "lodash-es": "^4.17.21",
         "mobx": "^6.13.0",
         "oxfmt": "^0.41.0",
         "oxlint": "^1.56.0",
         "react": "^19.0.0",
-        "styled-components": "^6.1.0",
-        "vite": "^6.3.0",
+        "styled-components": "^6.4.0",
+        "tailwindcss": "^4.2.2",
+        "vite": "^8.0.8",
       },
     },
     "documents": {
@@ -219,6 +222,8 @@
     },
   },
   "packages": {
+    "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
+
     "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],
 
     "@ark/util": ["@ark/util@0.56.0", "", {}, "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="],
@@ -313,11 +318,15 @@
 
     "@emotion/memoize": ["@emotion/memoize@0.9.0", "", {}, "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="],
 
+    "@emotion/react": ["@emotion/react@11.14.0", "", { "dependencies": { "@babel/runtime": "^7.18.3", "@emotion/babel-plugin": "^11.13.5", "@emotion/cache": "^11.14.0", "@emotion/serialize": "^1.3.3", "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0", "@emotion/utils": "^1.4.2", "@emotion/weak-memoize": "^0.4.0", "hoist-non-react-statics": "^3.3.1" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA=="],
+
     "@emotion/serialize": ["@emotion/serialize@1.3.3", "", { "dependencies": { "@emotion/hash": "^0.9.2", "@emotion/memoize": "^0.9.0", "@emotion/unitless": "^0.10.0", "@emotion/utils": "^1.4.2", "csstype": "^3.0.2" } }, "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA=="],
 
     "@emotion/sheet": ["@emotion/sheet@1.4.0", "", {}, "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="],
 
     "@emotion/unitless": ["@emotion/unitless@0.10.0", "", {}, "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="],
+
+    "@emotion/use-insertion-effect-with-fallbacks": ["@emotion/use-insertion-effect-with-fallbacks@1.2.0", "", { "peerDependencies": { "react": ">=16.8.0" } }, "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg=="],
 
     "@emotion/utils": ["@emotion/utils@1.4.2", "", {}, "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="],
 
@@ -882,6 +891,8 @@
     "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ=="],
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA=="],
+
+    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "postcss": "^8.5.6", "tailwindcss": "4.2.2" } }, "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
@@ -1859,6 +1870,8 @@
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
+    "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
+
     "hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
@@ -2525,6 +2538,8 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "readable-stream": ["readable-stream@1.1.14", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.1", "isarray": "0.0.1", "string_decoder": "~0.10.x" } }, "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ=="],
@@ -2997,7 +3012,7 @@
 
     "vinyl": ["vinyl@2.2.1", "", { "dependencies": { "clone": "^2.1.1", "clone-buffer": "^1.0.0", "clone-stats": "^1.0.0", "cloneable-readable": "^1.0.0", "remove-trailing-separator": "^1.0.1", "replace-ext": "^1.0.0" } }, "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw=="],
 
-    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+    "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
@@ -3407,6 +3422,8 @@
 
     "verror/core-util-is": ["core-util-is@1.0.2", "", {}, "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="],
 
+    "vite/rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
+
     "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "webpack-bundle-analyzer/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
@@ -3687,6 +3704,40 @@
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
+
+    "vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
+
+    "vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
+
+    "vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
+
+    "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
+
+    "vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
+
     "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -3799,6 +3850,12 @@
 
     "ts-loader/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check/execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
@@ -3832,6 +3889,8 @@
     "compat-table/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "jshint/htmlparser2/domutils/dom-serializer/entities": ["entities@1.1.2", "", {}, "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check/execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "test:integration": "bun test --cwd tests/integration",
     "test:e2e": "bun run --cwd tests/e2e test",
     "test:all": "bun run test:integration && bun run test:e2e",
-    "postinstall": "zig build -Doptimize=ReleaseFast && zig build napi",
-    "build:zts": "zig build -Doptimize=ReleaseFast && zig build napi",
+    "build:zts": "zig build -Doptimize=ReleaseFast",
     "lint": "oxlint --ignore-pattern '**/fixtures/**' packages/ tests/integration tests/e2e tests/benchmark",
     "lint:fix": "oxlint --fix --ignore-pattern '**/fixtures/**' packages/ tests/integration tests/e2e tests/benchmark",
     "fmt": "oxfmt format packages/ tests/integration tests/e2e tests/benchmark",
@@ -25,13 +24,16 @@
     "playwright:install": "cd tests/e2e && bunx playwright install --with-deps chromium"
   },
   "devDependencies": {
-    "@emotion/css": "^11.13.0",
+    "@emotion/css": "^11.13.5",
+    "@emotion/react": "^11.14.0",
+    "@tailwindcss/postcss": "^4.2.2",
     "lodash-es": "^4.17.21",
     "mobx": "^6.13.0",
     "oxfmt": "^0.41.0",
     "oxlint": "^1.56.0",
     "react": "^19.0.0",
-    "styled-components": "^6.1.0",
-    "vite": "^6.3.0"
+    "styled-components": "^6.4.0",
+    "tailwindcss": "^4.2.2",
+    "vite": "^8.0.8"
   }
 }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1070,7 +1070,8 @@ test "Worklet: globalThis property not collected as closure var (unary_expressio
 
 test "Worklet: arrow function params not in closure (ES5 lowering)" {
     const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
-    var r = try parseAndTransformWithOptions(std.testing.allocator,
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
         "var ext = 1; export const pf = (value, context) => { \"worklet\"; return ext + value + context; };",
         .{ .plugins = &plugins, .jsx_filename = "test.ts", .unsupported = TransformOptions.compat.fromESTarget(.es5) },
     );
@@ -1083,7 +1084,8 @@ test "Worklet: arrow function params not in closure (ES5 lowering)" {
 
 test "Worklet: arrow function with typed var params not in closure (ES5 lowering)" {
     const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
-    var r = try parseAndTransformWithOptions(std.testing.allocator,
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
         "type Fn = any; var ext = 1; export const pf: Fn = (value, context) => { \"worklet\"; return ext + value + context; };",
         .{ .plugins = &plugins, .jsx_filename = "test.ts", .unsupported = TransformOptions.compat.fromESTarget(.es5) },
     );

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -2476,7 +2476,14 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     cleanup = fixture.cleanup;
 
     const outFile = join(fixture.dir, "out.js");
-    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, "--platform=react-native", "--target=es5"]);
+    const bundle = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+      "--platform=react-native",
+      "--target=es5",
+    ]);
     expect(bundle.exitCode).toBe(0);
 
     const code = readFileSync(outFile, "utf-8");
@@ -2488,7 +2495,9 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     expect(code).toMatch(/move\S*\.__closure\s*=\s*\{[^}]*offset/);
     // "worklet" 디렉티브는 제거되어야 함 (__initData.code 안은 제외)
     const lines = code.split("\n");
-    const directiveLines = lines.filter(l => /^\s*"worklet"/.test(l) && !l.includes("__initData"));
+    const directiveLines = lines.filter(
+      (l) => /^\s*"worklet"/.test(l) && !l.includes("__initData"),
+    );
     expect(directiveLines.length).toBe(0);
   });
 
@@ -2509,7 +2518,14 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     cleanup = fixture.cleanup;
 
     const outFile = join(fixture.dir, "out.js");
-    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, "--platform=react-native", "--target=es5"]);
+    const bundle = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+      "--platform=react-native",
+      "--target=es5",
+    ]);
     expect(bundle.exitCode).toBe(0);
 
     const code = readFileSync(outFile, "utf-8");
@@ -2517,7 +2533,9 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     expect(code).toContain("__workletHash");
     expect(code).toContain("__initData");
     // "worklet" 디렉티브가 남아있으면 안 됨 (__initData.code 제외)
-    const rawLines = code.split("\n").filter(l => /^\s*"worklet"/.test(l) && !l.includes("__initData") && !l.includes("code:"));
+    const rawLines = code
+      .split("\n")
+      .filter((l) => /^\s*"worklet"/.test(l) && !l.includes("__initData") && !l.includes("code:"));
     expect(rawLines.length).toBe(0);
   });
 
@@ -2548,7 +2566,14 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     cleanup = fixture.cleanup;
 
     const outFile = join(fixture.dir, "out.js");
-    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, "--platform=react-native", "--target=es5"]);
+    const bundle = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+      "--platform=react-native",
+      "--target=es5",
+    ]);
     expect(bundle.exitCode).toBe(0);
 
     const code = readFileSync(outFile, "utf-8");
@@ -2588,16 +2613,23 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     cleanup = fixture.cleanup;
 
     const outFile = join(fixture.dir, "out.js");
-    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, "--platform=react-native", "--target=es5"]);
+    const bundle = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+      "--platform=react-native",
+      "--target=es5",
+    ]);
     expect(bundle.exitCode).toBe(0);
 
     const code = readFileSync(outFile, "utf-8");
     // inline arrow worklet도 __workletHash가 주입되어야 함
     expect(code).toContain("__workletHash");
     // "worklet" 디렉티브가 변환 안 된 채 남아있으면 안 됨
-    const untransformed = code.split("\n").filter(l =>
-      /^\s*"worklet"/.test(l) && !l.includes("__initData") && !l.includes("code:")
-    );
+    const untransformed = code
+      .split("\n")
+      .filter((l) => /^\s*"worklet"/.test(l) && !l.includes("__initData") && !l.includes("code:"));
     expect(untransformed.length).toBe(0);
   });
 
@@ -2618,7 +2650,14 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     cleanup = fixture.cleanup;
 
     const outFile = join(fixture.dir, "out.js");
-    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, "--platform=react-native", "--target=es5"]);
+    const bundle = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+      "--platform=react-native",
+      "--target=es5",
+    ]);
     expect(bundle.exitCode).toBe(0);
 
     const code = readFileSync(outFile, "utf-8");
@@ -2645,7 +2684,14 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     cleanup = fixture.cleanup;
 
     const outFile = join(fixture.dir, "out.js");
-    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, "--platform=react-native", "--target=es5"]);
+    const bundle = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+      "--platform=react-native",
+      "--target=es5",
+    ]);
     expect(bundle.exitCode).toBe(0);
 
     const code = readFileSync(outFile, "utf-8");

--- a/tests/integration/tests/css-library-smoke.test.ts
+++ b/tests/integration/tests/css-library-smoke.test.ts
@@ -20,7 +20,9 @@ function hasPackage(name: string): boolean {
 }
 
 const hasEmotion = hasPackage("@emotion/css");
+const hasEmotionReact = hasPackage("@emotion/react");
 const hasStyledComponents = hasPackage("styled-components");
+const hasTailwind = hasPackage("tailwindcss");
 
 async function linkNodeModules(dir: string, packages: string[]) {
   const nmDir = join(dir, "node_modules");
@@ -163,6 +165,118 @@ describe.skipIf(!hasEmotion)("CSS Library Smoke — Emotion", () => {
     const js = await readFile(outFile, "utf-8");
     // cx 함수가 번들에 포함
     expect(js).toContain("merge");
+  });
+});
+
+// ─── @emotion/react (JSX + css prop) ───
+
+describe.skipIf(!hasEmotionReact)("CSS Library Smoke — @emotion/react", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it("@emotion/react styled component bundle (React externalized)", async () => {
+    const fixture = await createFixture({
+      "index.tsx": `
+        import styled from "@emotion/styled";
+        import { css } from "@emotion/react";
+        const Box = styled.div\`color: hotpink; padding: 8px;\`;
+        const mixin = css\`background: yellow;\`;
+        console.log(typeof Box, typeof mixin);
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    await linkNodeModules(fixture.dir, [
+      "@emotion/react",
+      "@emotion/styled",
+      "@emotion/cache",
+      "@emotion/serialize",
+      "@emotion/sheet",
+      "@emotion/utils",
+      "@emotion/hash",
+      "@emotion/unitless",
+      "@emotion/memoize",
+      "@emotion/use-insertion-effect-with-fallbacks",
+      "@emotion/weak-memoize",
+      "@emotion/is-prop-valid",
+      "@babel/runtime",
+      "hoist-non-react-statics",
+      "react-is",
+      "stylis",
+    ]);
+
+    const outFile = join(fixture.dir, "out.js");
+    const bundle = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.tsx"),
+      "-o",
+      outFile,
+      "--external",
+      "react",
+      "--external",
+      "react-dom",
+    ]);
+    expect(bundle.exitCode).toBe(0);
+
+    const js = await readFile(outFile, "utf-8");
+    expect(js).toContain("serializeStyles");
+    expect(js.length).toBeGreaterThan(10000);
+  });
+});
+
+// ─── Tailwind CSS v4 ───
+
+describe.skipIf(!hasTailwind)("CSS Library Smoke — Tailwind CSS v4", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it("bundles CSS importing tailwindcss/preflight.css", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './app.css';\nconsole.log("tailwind");`,
+      "app.css": `@import "tailwindcss/preflight.css";\n.btn { padding: 0.5rem 1rem; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    await linkNodeModules(fixture.dir, ["tailwindcss"]);
+
+    const outFile = join(fixture.dir, "out.js");
+    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile]);
+    expect(bundle.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    // preflight.css는 box-sizing 리셋 포함
+    expect(css).toContain("box-sizing");
+    expect(css).toContain(".btn");
+    expect(css).not.toContain("@import");
+  });
+
+  it("bundles tailwindcss/theme.css (CSS variables)", async () => {
+    const fixture = await createFixture({
+      "index.ts": `import './app.css';`,
+      "app.css": `@import "tailwindcss/theme.css";\n.primary { color: var(--color-blue-500); }`,
+    });
+    cleanup = fixture.cleanup;
+
+    await linkNodeModules(fixture.dir, ["tailwindcss"]);
+
+    const outFile = join(fixture.dir, "out.js");
+    const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "-o", outFile]);
+    expect(bundle.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, "index.css"), "utf-8");
+    // theme.css는 --color-* design token 정의
+    expect(css).toContain("--color-");
+    expect(css).toContain("var(--color-blue-500)");
   });
 });
 


### PR DESCRIPTION
## Summary
- **Deps bump**: `@emotion/css` 11.13→11.13.5, `styled-components` 6.1→6.4, `vite` 6.3→8.0.8
- **신규 devDependency**: `@emotion/react`, `tailwindcss`, `@tailwindcss/postcss`
- **postinstall 스크립트 제거**: 자동 `zig build`를 수동 전환 (`build:zts`도 NAPI 제외로 단순화)
- **css-library-smoke.test.ts 확장**:
  - `@emotion/react` + `@emotion/styled` 번들 스모크 (React externalized)
  - Tailwind v4 `@import "tailwindcss/preflight.css"` / `theme.css` — Lightning CSS 파이프라인 통과 검증
- 부수: `bundle-smoke.test.ts` oxfmt 정리 (별도 커밋)

## Test plan
- [x] `bun test tests/css-library-smoke.test.ts` — 9 pass (기존 6 + 신규 3)
- [ ] CI integration 워크플로우에서 새 deps 설치 + 스모크 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)