### PR TITLE
fix(worklet): use post-visit body for arrow closure analysis

### DIFF
--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -102,10 +102,12 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
                 .body_idx = func_body,
                 .params_start = param_list.start,
                 .params_len = param_list.len,
-                // 변환 전 원본 사용 — worklet closure 분석에 필요
+                // post-visit body 사용: ES5 변환(spread → __toConsumableArray 등)이
+                // 주입한 헬퍼를 closure 분석에서 캡처하기 위함.
+                // __initData.code도 post-visit body로 생성되므로 일관성 유지.
                 .original_params_start = param_list.start,
                 .original_params_len = param_list.len,
-                .original_body_idx = body_idx,
+                .original_body_idx = func_body,
                 .flags = func_flags,
                 .source_path = self.options.jsx_filename,
             })) |replacement| {


### PR DESCRIPTION
## Summary
- Arrow worklet의 closure 분석이 pre-visit body를 사용하여 ES5 헬퍼(`__toConsumableArray` 등)를 캡처하지 못하는 버그 수정
- `__initData.code`는 post-visit body로 생성되므로, closure 분석도 post-visit body를 사용해야 일관성 유지
- 이로 인해 `runOnUISync`의 inner worklet이 UI thread에서 실패 → "Expected microtaskQueueFinalizers to be defined" 에러 발생

## Test plan
- [x] `zig build test` — all passed
- [x] `bun test tests/bundle-smoke.test.ts -t "worklet"` — 6 pass
- [x] NAPI verification: `__toConsumableArray` now captured in closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)