### PR TITLE
fix(worklet): use post-visit body for function declaration closure analysis

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2066,7 +2066,7 @@ pub const Transformer = struct {
             .params_len = pp.new_params.len,
             .original_params_start = params_start,
             .original_params_len = params_len,
-            .original_body_idx = old_body_idx,
+            .original_body_idx = new_body,
             .flags = self.readU32(e, 4),
             .source_path = self.options.jsx_filename,
         })) |replacement| {

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -905,9 +905,16 @@ test "Worklet: rest params are not included in closure (#1104)" {
     defer r.deinit();
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
-    // rest param 'args'는 closure에 포함되면 안 됨
+    // rest param 'args'와 'fn'은 closure에 포함되면 안 됨
+    // ES5 spread 헬퍼(__toConsumableArray)는 post-visit body에서 감지되어 closure에 포함
     try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__toConsumableArray") != null);
+    // fn, args는 파라미터/지역변수이므로 closure에 포함되면 안 됨
+    const closure_match = std.mem.indexOf(u8, code, "__closure = {") orelse unreachable;
+    const closure_end = std.mem.indexOfPos(u8, code, closure_match, "}") orelse unreachable;
+    const closure_content = code[closure_match..closure_end];
+    try std.testing.expect(std.mem.indexOf(u8, closure_content, " fn") == null);
+    try std.testing.expect(std.mem.indexOf(u8, closure_content, " args") == null);
 }
 
 test "Worklet: directive found after rest params transform (#1102)" {


### PR DESCRIPTION
## Summary
- `visitFunction`에서도 `original_body_idx`가 pre-visit body(`old_body_idx`)를 사용하여 ES5 헬퍼가 closure에 캡처되지 않는 동일한 버그 수정
- `callGuardDEV` 같은 regular function worklet에서 `...args` spread 사용 시 `__toConsumableArray`가 `__closure`에 없어 UI thread에서 실패
- `runOnUISync(setupCallGuard)` 실행 실패 → `setupMicrotasks` 미도달 → "Expected microtaskQueueFinalizers" 에러

## Test plan
- [x] `zig build test` — all passed (rest params test updated)
- [x] `bun test tests/bundle-smoke.test.ts -t "worklet"` — 6 pass
- [x] CLI verification: `__toConsumableArray` now in closure for regular function worklets

🤖 Generated with [Claude Code](https://claude.com/claude-code)