### PR TITLE
fix(worklet): dupe closure var names to prevent use-after-free

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -807,7 +807,10 @@ fn serializeFunctionInfo(
     try buf.appendSlice(alloc, ",\"closureVars\":[");
     if (has_directives) {
         const closure_vars = api.getClosureVars(func.original_body_idx, func.original_params_start, func.original_params_len) catch &.{};
-        defer if (closure_vars.len > 0) api.getAllocator().free(closure_vars);
+        defer if (closure_vars.len > 0) {
+            for (closure_vars) |cv| api.getAllocator().free(cv.name);
+            api.getAllocator().free(closure_vars);
+        };
         for (closure_vars, 0..) |cv, i| {
             if (i > 0) try buf.append(alloc, ',');
             try buf.append(alloc, '"');

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -36,7 +36,10 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
 
     // Closure 변수 추출 (원본 body + params 사용 — Babel과 동일하게 변환 전 AST 분석)
     const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
-    defer api.getAllocator().free(closure_vars);
+    defer {
+        for (closure_vars) |cv| api.getAllocator().free(cv.name);
+        api.getAllocator().free(closure_vars);
+    }
 
     // Init code 생성
     const func_name = info.name orelse "anonymous";

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -163,13 +163,15 @@ pub fn collectClosureVars(
     try walkBodyForClosureAnalysis(self, body_idx, &locals, &refs, 0);
 
     // 4. refs - locals - globals = closure vars
+    // name을 복제: string_table 슬라이스는 이후 addString 호출로 무효화될 수 있음
     var result: std.ArrayList(ClosureVar) = .empty;
     var iter = refs.iterator();
     while (iter.next()) |entry| {
         const name = entry.key_ptr.*;
         if (locals.contains(name)) continue;
         if (isGlobal(name)) continue;
-        try result.append(self.allocator, .{ .name = name, .ref_idx = entry.value_ptr.* });
+        const duped = self.allocator.dupe(u8, name) catch return error.OutOfMemory;
+        try result.append(self.allocator, .{ .name = duped, .ref_idx = entry.value_ptr.* });
     }
 
     // 정렬 (결정론적 출력)


### PR DESCRIPTION
## Summary
- `collectClosureVars`가 반환하는 name 슬라이스가 `ast.string_table`을 직접 가리킴
- 이후 `generateInitCode`/`buildClosureObject`에서 `addString` 호출 시 `string_table` 재할당 → name 슬라이스 무효화 → 0xaa 바이트 출력
- Fix: name을 `allocator.dupe`로 복제, 모든 caller에서 해제

## Verified
- CLI 번들 빌드: 0 mismatches, 0 garbled bytes
- Hermes 컴파일: 성공 (에러 0)
- `zig build test`: 0 failures, 0 leaks
- `bun test tests/bundle-smoke.test.ts -t "worklet"`: 6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)