### PR TITLE
fix(worklet): add __stackDetails to prevent dev mode crash

### DIFF
--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -93,7 +93,7 @@ fn buildWorkletIIFE(
     api: *AstTransformCtx,
     func_node: NodeIndex,
     func_name: []const u8,
-    prop_stmts: [3]NodeIndex,
+    prop_stmts: [4]NodeIndex,
 ) PluginError!NodeIndex {
     const zero_span = Span{ .start = 0, .end = 0 };
     const t = api.transformer;
@@ -130,11 +130,11 @@ fn buildWorkletIIFE(
         .data = .{ .unary = .{ .operand = return_ref, .flags = 0 } },
     });
 
-    // factory body: [var_decl, prop_stmts[0], prop_stmts[1], prop_stmts[2], return_stmt]
+    // factory body: [var_decl, prop_stmts[0..3], return_stmt]
     const body_list = try t.ast.addNodeList(&.{
         var_decl,      prop_stmts[0],
         prop_stmts[1], prop_stmts[2],
-        return_stmt,
+        prop_stmts[3], return_stmt,
     });
     const body = try t.ast.addNode(.{
         .tag = .block_statement,

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -605,7 +605,7 @@ fn buildPropAssignment(self: *Transformer, func_name_span: Span, prop_name: []co
 
 /// worklet 함수에 대한 __workletHash, __closure, __initData 프로퍼티 할당문들을 생성한다.
 ///
-/// 반환: 3개의 expression_statement NodeIndex 배열 (caller가 trailing_nodes에 추가)
+/// 반환: 4개의 expression_statement NodeIndex 배열 (caller가 trailing_nodes에 추가)
 pub fn buildWorkletPropertyAssignments(
     self: *Transformer,
     func_name: []const u8,
@@ -616,7 +616,7 @@ pub fn buildWorkletPropertyAssignments(
     /// 원본 함수 노드 인덱스. 이 노드의 name span을 사용하면
     /// codegen의 scope hoisting rename이 자동 적용된다.
     func_node_idx: NodeIndex,
-) Error![3]NodeIndex {
+) Error![4]NodeIndex {
     // 원본 함수의 binding_identifier span 사용 (scope hoisting rename 호환)
     const func_name_span = blk: {
         if (!func_node_idx.isNone()) {
@@ -653,7 +653,17 @@ pub fn buildWorkletPropertyAssignments(
     const init_data_obj = try buildInitDataObject(self, init_code, source_location, zero_span);
     const init_data_stmt = try buildPropAssignment(self, func_name_span, "__initData", init_data_obj, func_node_idx);
 
-    return .{ hash_stmt, closure_stmt, init_data_stmt };
+    // 4. funcName.__stackDetails = [];
+    // Worklets runtime이 __DEV__ 모드에서 registerWorkletStackDetails(hash, __stackDetails)를
+    // 호출하므로, 빈 배열이라도 설정해야 crash 방지.
+    const empty_array = try self.ast.addNode(.{
+        .tag = .array_expression,
+        .span = zero_span,
+        .data = .{ .list = try self.ast.addNodeList(&.{}) },
+    });
+    const stack_stmt = try buildPropAssignment(self, func_name_span, "__stackDetails", empty_array, func_node_idx);
+
+    return .{ hash_stmt, closure_stmt, init_data_stmt, stack_stmt };
 }
 
 /// { var1: var1, var2: var2, ... } 객체 리터럴 노드를 생성한다.

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -781,7 +781,7 @@ test "Worklet: statement count includes property assignments" {
     );
     defer r.deinit();
     // 1 function declaration + 3 property assignments = 4 statements
-    try std.testing.expectEqual(@as(u32, 4), r.statementCount());
+    try std.testing.expectEqual(@as(u32, 5), r.statementCount());
 }
 
 test "Worklet: no closure vars produces empty closure object" {
@@ -824,7 +824,7 @@ test "Worklet: parameters are not closure vars" {
     );
     defer r.deinit();
     // function + 3 property assignments = 4 statements
-    try std.testing.expectEqual(@as(u32, 4), r.statementCount());
+    try std.testing.expectEqual(@as(u32, 5), r.statementCount());
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
     // x, y는 파라미터이므로 closure에 포함되지 않아야 함
@@ -861,7 +861,7 @@ test "Worklet: non-worklet function mixed with worklet function" {
     );
     defer r.deinit();
     // normal(1) + anim(1) + 3 property assignments = 5 statements
-    try std.testing.expectEqual(@as(u32, 5), r.statementCount());
+    try std.testing.expectEqual(@as(u32, 6), r.statementCount());
 }
 
 test "Worklet: globals are excluded from closure vars" {


### PR DESCRIPTION
## Summary
- Worklets runtime이 `__DEV__` 모드에서 `registerWorkletStackDetails(hash, __stackDetails)`를 호출
- ZTS worklet에 `__stackDetails`가 없어서 crash → `runOnUISync(setupCallGuard)` 실패 → `setupMicrotasks` 미도달 → "Expected microtaskQueueFinalizers to be defined"
- `__stackDetails = []` 추가하여 crash 방지
- Metro 번들과 비교하여 발견: Metro는 `__stackDetails = [new Error(), line, col]`을 설정

## Test plan
- [x] `zig build test` — all passed (statement count tests updated)
- [x] `zig build napi` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)