### PR TITLE
fix(worklet): generate initData code from pre-visit body

### DIFF
--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -31,8 +31,8 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     if (info.body_idx.isNone()) return;
     if (!api.hasDirective(info.body_idx, "worklet")) return;
 
-    // 디렉티브 제거
-    const stripped_body = try api.stripDirective(info.body_idx);
+    // 디렉티브 제거 (원본 body에서 — ES5 헬퍼 없는 pre-visit body)
+    const stripped_body = try api.stripDirective(info.original_body_idx);
 
     // Closure 변수 추출 (원본 body + params 사용 — Babel과 동일하게 변환 전 AST 분석)
     const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
@@ -41,14 +41,14 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
         api.getAllocator().free(closure_vars);
     }
 
-    // Init code 생성
+    // Init code 생성 (pre-visit body — Hermes가 spread/rest 네이티브 지원)
     const func_name = info.name orelse "anonymous";
     const init_code = try api.generateCode(
         func_name,
         stripped_body,
         closure_vars,
-        info.params_start,
-        info.params_len,
+        info.original_params_start,
+        info.original_params_len,
         info.flags,
     );
     defer api.getAllocator().free(init_code);


### PR DESCRIPTION
## Summary
- `stripDirective`와 `generateCode`가 `info.body_idx`(post-visit)를 사용하여 `__initData.code`에 ES5 헬퍼 포함됨
- closure 분석은 `info.original_body_idx`(pre-visit)를 사용하여 ES5 헬퍼 미포함
- 불일치로 UI thread에서 `__toConsumableArray` undefined → deadlock
- 모든 worklet code 생성을 `original_body_idx`로 통일

## Verified
```
closure: {} (empty)
initData: ...args (spread) — no __toConsumableArray
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)