### PR TITLE
fix(worklet): skip ES5 lowering inside worklet function bodies

### DIFF
--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -46,11 +46,19 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
 
             const param_list = try arrowParamsToList(self, params_idx);
 
+            // worklet directive가 있으면 ES5 lowering 비활성화
+            const is_worklet = self.options.plugins.len > 0 and
+                @import("transformer/worklet.zig").isWorkletDirectiveGeneric(self, body_idx, "worklet");
+            const saved_unsupported = self.options.unsupported;
+            if (is_worklet) self.options.unsupported = .{};
+
             // arrow body 안의 this/arguments를 캡처하기 위해 depth 증가.
             // visitNode에서 this → _this, arguments → _arguments로 치환된다.
             self.arrow_this_depth += 1;
             var new_body = try self.visitNode(body_idx);
             self.arrow_this_depth -= 1;
+
+            if (is_worklet) self.options.unsupported = saved_unsupported;
 
             // expression body → { return expr; }
             const func_body = blk: {

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -31,24 +31,24 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     if (info.body_idx.isNone()) return;
     if (!api.hasDirective(info.body_idx, "worklet")) return;
 
-    // 디렉티브 제거 (원본 body에서 — ES5 헬퍼 없는 pre-visit body)
-    const stripped_body = try api.stripDirective(info.original_body_idx);
+    // 디렉티브 제거 (post-visit body — TS 스트리핑 완료)
+    const stripped_body = try api.stripDirective(info.body_idx);
 
-    // Closure 변수 추출 (원본 body + params 사용 — Babel과 동일하게 변환 전 AST 분석)
-    const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
+    // Closure 변수 추출 (post-visit body — ES5 변환 포함된 실제 body)
+    const closure_vars = try api.getClosureVars(info.body_idx, info.params_start, info.params_len);
     defer {
         for (closure_vars) |cv| api.getAllocator().free(cv.name);
         api.getAllocator().free(closure_vars);
     }
 
-    // Init code 생성 (pre-visit body — Hermes가 spread/rest 네이티브 지원)
+    // Init code 생성 (post-visit body — TS 스트리핑 완료)
     const func_name = info.name orelse "anonymous";
     const init_code = try api.generateCode(
         func_name,
         stripped_body,
         closure_vars,
-        info.original_params_start,
-        info.original_params_len,
+        info.params_start,
+        info.params_len,
         info.flags,
     );
     defer api.getAllocator().free(init_code);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1997,8 +1997,17 @@ pub const Transformer = struct {
         const pp = try self.visitParamsCollectProperties(params_start, params_len);
 
         // 바디 방문
+        // worklet directive가 있으면 ES5 lowering 비활성화 — Hermes UI runtime이
+        // spread/rest/arrow를 네이티브 지원하므로 ES5 헬퍼 주입 불필요.
+        // ES5 헬퍼는 worklet이 아닌 일반 함수라 UI thread에서 remote function으로
+        // 직렬화되어 동기 호출 시 deadlock 발생.
         const old_body_idx = self.readNodeIdx(e, 3);
+        const is_worklet = self.options.plugins.len > 0 and
+            worklet_mod.isWorkletDirectiveGeneric(self, old_body_idx, "worklet");
+        const saved_unsupported = self.options.unsupported;
+        if (is_worklet) self.options.unsupported = .{};
         var new_body = try self.visitNode(old_body_idx);
+        if (is_worklet) self.options.unsupported = saved_unsupported;
 
         // parameter property가 있으면 바디 앞에 this.x = x 문 삽입
         if (pp.prop_count > 0 and !new_body.isNone()) {


### PR DESCRIPTION
## Summary
- Worklet body에서 ES5 lowering 비활성화: Hermes UI runtime이 ES6+ 네이티브 지원
- ES5 헬퍼(__toConsumableArray)는 non-worklet → remote function 직렬화 → runOnUISync deadlock
- visitFunction/lowerArrowFunction에서 worklet directive 감지 시 unsupported 임시 비활성화
- worklet_plugin: closure/initData 모두 post-visit body(TS 스트리핑 완료, ES5 미적용) 사용

## Verified
- closure: {} (ES5 헬퍼 없음)
- initData: ...args (원본 spread), __toConsumableArray 없음, TS 문법 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)