### PR TITLE
fix(worklet): codegen TS stripping for pre-visit worklet body

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -778,7 +778,22 @@ pub const Codegen = struct {
             .ts_enum_declaration => try self.emitEnumIIFE(node),
             .ts_module_declaration => try self.emitNamespaceIIFE(node),
 
-            // TS 노드는 transformer에서 제거됨 — 여기 도달하면 strip_types=false
+            // TS expression 노드: operand만 출력 (type 부분 스트리핑).
+            // worklet __initData.code가 pre-visit body를 사용하므로 TS 노드가 남아있을 수 있음.
+            .ts_as_expression,
+            .ts_satisfies_expression,
+            .ts_non_null_expression,
+            .ts_type_assertion,
+            .ts_instantiation_expression,
+            => try self.emitNode(node.data.unary.operand),
+
+            // TS 타입 전용 노드: 출력 안 함
+            .ts_type_alias_declaration,
+            .ts_interface_declaration,
+            .ts_import_equals_declaration,
+            => {},
+
+            // 그 외 — 소스 텍스트 그대로 출력
             else => try self.writeNodeSpan(node),
         }
     }

--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -46,19 +46,11 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
 
             const param_list = try arrowParamsToList(self, params_idx);
 
-            // worklet directive가 있으면 ES5 lowering 비활성화
-            const is_worklet = self.options.plugins.len > 0 and
-                @import("transformer/worklet.zig").isWorkletDirectiveGeneric(self, body_idx, "worklet");
-            const saved_unsupported = self.options.unsupported;
-            if (is_worklet) self.options.unsupported = .{};
-
             // arrow body 안의 this/arguments를 캡처하기 위해 depth 증가.
             // visitNode에서 this → _this, arguments → _arguments로 치환된다.
             self.arrow_this_depth += 1;
             var new_body = try self.visitNode(body_idx);
             self.arrow_this_depth -= 1;
-
-            if (is_worklet) self.options.unsupported = saved_unsupported;
 
             // expression body → { return expr; }
             const func_body = blk: {

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -31,24 +31,24 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     if (info.body_idx.isNone()) return;
     if (!api.hasDirective(info.body_idx, "worklet")) return;
 
-    // 디렉티브 제거 (post-visit body — TS 스트리핑 완료)
-    const stripped_body = try api.stripDirective(info.body_idx);
+    // 디렉티브 제거 (pre-visit body — ES5 헬퍼 없는 원본)
+    const stripped_body = try api.stripDirective(info.original_body_idx);
 
-    // Closure 변수 추출 (post-visit body — ES5 변환 포함된 실제 body)
-    const closure_vars = try api.getClosureVars(info.body_idx, info.params_start, info.params_len);
+    // Closure 변수 추출 (pre-visit body — ES5 헬퍼가 아닌 원본 참조만 캡처)
+    const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
     defer {
         for (closure_vars) |cv| api.getAllocator().free(cv.name);
         api.getAllocator().free(closure_vars);
     }
 
-    // Init code 생성 (post-visit body — TS 스트리핑 완료)
+    // Init code 생성 (pre-visit body — codegen이 TS 노드를 자동 스트리핑)
     const func_name = info.name orelse "anonymous";
     const init_code = try api.generateCode(
         func_name,
         stripped_body,
         closure_vars,
-        info.params_start,
-        info.params_len,
+        info.original_params_start,
+        info.original_params_len,
         info.flags,
     );
     defer api.getAllocator().free(init_code);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1997,17 +1997,8 @@ pub const Transformer = struct {
         const pp = try self.visitParamsCollectProperties(params_start, params_len);
 
         // 바디 방문
-        // worklet directive가 있으면 ES5 lowering 비활성화 — Hermes UI runtime이
-        // spread/rest/arrow를 네이티브 지원하므로 ES5 헬퍼 주입 불필요.
-        // ES5 헬퍼는 worklet이 아닌 일반 함수라 UI thread에서 remote function으로
-        // 직렬화되어 동기 호출 시 deadlock 발생.
         const old_body_idx = self.readNodeIdx(e, 3);
-        const is_worklet = self.options.plugins.len > 0 and
-            worklet_mod.isWorkletDirectiveGeneric(self, old_body_idx, "worklet");
-        const saved_unsupported = self.options.unsupported;
-        if (is_worklet) self.options.unsupported = .{};
         var new_body = try self.visitNode(old_body_idx);
-        if (is_worklet) self.options.unsupported = saved_unsupported;
 
         // parameter property가 있으면 바디 앞에 this.x = x 문 삽입
         if (pp.prop_count > 0 and !new_body.isNone()) {


### PR DESCRIPTION
## Summary
- ES5 skip 접근 되돌림 (35개 미변환 worklet 유발)
- 대신: pre-visit body + codegen TS 노드 스트리핑
- codegen에 TS expression 노드 처리 추가 (operand만 출력)
- 결과: `fn(...args)` (ES6+ spread), `as string` 없음 (TS 제거), `__toConsumableArray` 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)