### PR TITLE
fix(worklet): handle assignment_expression in param binding names

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -235,8 +235,8 @@ fn collectBindingNames(self: *Transformer, idx: NodeIndex, locals: *std.StringHa
         .rest_element, .spread_element => {
             try collectBindingNames(self, node.data.unary.operand, locals);
         },
-        .assignment_pattern => {
-            // default value: left = pattern, right = default
+        .assignment_pattern, .assignment_expression => {
+            // default value: left = pattern/identifier, right = default
             try collectBindingNames(self, node.data.binary.left, locals);
         },
         else => {},


### PR DESCRIPTION
Arrow default parameter (c = 0)가 assignment_expression으로 처리되어 collectBindingNames에서 누락 → closure에 파라미터 포함 → ReferenceError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)