### PR TITLE
fix(es5): insert class fields after super() call, before constructor body

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1339,9 +1339,13 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
         /// super() 호출이 있는 constructor body를 후처리:
         /// 1. body 앞에 var _this; 선언 추가
-        /// 2. body 끝에 return _this; 추가
+        /// 2. super() 직후에 instance fields 삽입
+        /// 3. 나머지 constructor body
+        /// 4. body 끝에 return _this; 추가
+        ///
+        /// ES6 스펙: class fields는 super() 직후, constructor body 이전에 초기화.
         /// lowerSuperCall이 _this = __callSuper(...) 대입식을 생성하므로,
-        /// super()가 if/else 등 어디에 있든 정상 동작한다.
+        /// 해당 대입식을 포함하는 statement를 찾아 그 직후에 fields를 삽입한다.
         fn postProcessSuperCallBody(self: *Transformer, body: NodeIndex, instance_fields: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const body_node = self.ast.getNode(body);
             if (body_node.tag != .block_statement) return body;
@@ -1359,14 +1363,35 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // var _this; (초기화 없는 선언) — extra_data grow 가능
             try self.scratch.append(self.allocator, try self.buildVarDecl("_this", .none, span));
 
-            // 기존 body statements — extra_data grow 후 다시 접근
-            for (self.ast.extra_data.items[stmts_start .. stmts_start + stmts_len]) |raw_idx| {
+            // super() 호출을 포함하는 statement를 찾는다.
+            // lowerSuperCall이 _this = __callSuper(...)로 변환하므로,
+            // expression_statement > assignment_expression(LHS=identifier) 패턴을 탐색.
+            // if/else 안에 있을 수도 있으므로 재귀 탐색.
+            var super_call_end: u32 = stmts_len; // fallback: fields를 body 끝에 배치
+            {
+                var i: u32 = 0;
+                while (i < stmts_len) : (i += 1) {
+                    const stmt_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[stmts_start + i]);
+                    if (containsSuperCallAssignment(self, stmt_idx)) {
+                        super_call_end = i + 1;
+                        break;
+                    }
+                }
+            }
+
+            // body stmts: super() 호출까지 (포함)
+            for (self.ast.extra_data.items[stmts_start .. stmts_start + super_call_end]) |raw_idx| {
                 try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
             }
 
-            // instance fields: _this에 할당 (super() 이후에 실행되어야 함)
+            // instance fields: super() 직후, constructor body 이전
             for (instance_fields) |field_stmt| {
                 try self.scratch.append(self.allocator, try replaceThisWithThisAlias(self, field_stmt, span));
+            }
+
+            // body stmts: super() 이후 나머지 constructor body
+            for (self.ast.extra_data.items[stmts_start + super_call_end .. stmts_start + stmts_len]) |raw_idx| {
+                try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
             }
 
             // return _this;
@@ -1383,6 +1408,42 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .list = new_list },
             });
+        }
+
+        /// lowerSuperCall이 생성하는 `_this = __callSuper(...)` 대입을 포함하는지 재귀 탐색.
+        /// LHS=bare identifier + RHS=call_expression 패턴으로 매칭.
+        /// (member expression `_this.x = ...` 과 구분)
+        fn containsSuperCallAssignment(self: *Transformer, node_idx: NodeIndex) bool {
+            if (node_idx.isNone()) return false;
+            const node = self.ast.getNode(node_idx);
+
+            switch (node.tag) {
+                .expression_statement => {
+                    const expr_idx = node.data.unary.operand;
+                    if (expr_idx.isNone()) return false;
+                    const expr = self.ast.getNode(expr_idx);
+                    if (expr.tag == .assignment_expression) {
+                        const left = self.ast.getNode(expr.data.binary.left);
+                        if (left.tag != .identifier_reference) return false;
+                        const right = self.ast.getNode(expr.data.binary.right);
+                        return right.tag == .call_expression;
+                    }
+                    return false;
+                },
+                .if_statement, .conditional_expression => {
+                    if (containsSuperCallAssignment(self, node.data.ternary.b)) return true;
+                    if (containsSuperCallAssignment(self, node.data.ternary.c)) return true;
+                    return false;
+                },
+                .block_statement => {
+                    const list = node.data.list;
+                    for (self.ast.extra_data.items[list.start .. list.start + list.len]) |raw_idx| {
+                        if (containsSuperCallAssignment(self, @enumFromInt(raw_idx))) return true;
+                    }
+                    return false;
+                },
+                else => return false,
+            }
         }
 
         /// 빈 function declaration (constructor가 없는 경우)

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1305,6 +1305,100 @@ console.log(new Child(true).v + ":" + new Child(false).v);`,
     expect(result.runOutput).toBe("10:20");
   });
 
+  test("ES5 class fields: super() 직후 초기화되어 constructor body에서 접근 가능", async () => {
+    // class fields는 super() 직후, constructor body 이전에 초기화되어야 함.
+    // 이전 버그: fields가 constructor body 뒤에 배치되어
+    // constructor에서 this.handlers에 접근하면 undefined 에러 발생.
+    // (react-native-gesture-handler BaseGesture 패턴)
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+let nextId = 0;
+class Gesture {}
+class BaseGesture extends Gesture {
+  gestureId = -1;
+  handlerTag = -1;
+  config: Record<string, unknown> = {};
+  handlers = { gestureId: -1, handlerTag: -1, isWorklet: [] as boolean[] };
+
+  constructor() {
+    super();
+    this.gestureId = nextId++;
+    this.handlers.gestureId = this.gestureId;
+  }
+}
+class ContinuousBase extends BaseGesture {}
+class PanGesture extends ContinuousBase {}
+const p = new PanGesture();
+console.log(p.gestureId + ":" + p.handlers.gestureId + ":" + (p instanceof Gesture));
+`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("0:0:true");
+  });
+
+  test("ES5 class fields: conditional super() + fields 올바른 순서", async () => {
+    // if/else 안의 super() 뒤에도 class fields가 올바르게 초기화되어야 함.
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+class Base { v: number; constructor(v: number) { this.v = v; } }
+class Child extends Base {
+  items: number[] = [];
+  constructor(x: boolean) {
+    if (x) { super(1); } else { super(2); }
+    this.items.push(this.v);
+  }
+}
+const a = new Child(true);
+const b = new Child(false);
+console.log(a.items.join(",") + ":" + b.items.join(","));
+`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("1:2");
+  });
+
+  test("ES5 class fields: 다단계 상속 체인에서 fields + constructor body 순서", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+class A {
+  a = "a";
+}
+class B extends A {
+  b = "b";
+  constructor() {
+    super();
+    this.b = this.b.toUpperCase(); // field 초기화 후 접근
+  }
+}
+class C extends B {
+  c = "c";
+}
+const obj = new C();
+console.log(obj.a + obj.b + obj.c);
+`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("aBc");
+  });
+
   test("ES5 destructuring 파라미터: function({ ref, ...props }) 올바른 변환", async () => {
     const result = await bundleAndRun(
       {


### PR DESCRIPTION
## Summary
- Class field initializers were placed after constructor body instead of immediately after `super()` call
- This caused `TypeError: Cannot set property 'gestureId' of undefined` in react-native-gesture-handler's BaseGesture pattern
- Fixed `postProcessSuperCallBody` to find the `_this = __callSuper(...)` statement and insert fields right after it
- Added `containsSuperCallAssignment` helper for recursive search (handles if/else conditional super)

## ES6 spec order
```
super() → field initializers → constructor body → return
```

## Test plan
- [x] 3 new regression tests (gesture-handler pattern, conditional super + fields, multi-level chain)
- [x] All 138 integration tests pass
- [x] Zig unit tests pass

Closes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)