### PR TITLE
feat(worklet): auto-workletization for known function callees

### DIFF
--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -58,6 +58,21 @@ pub const Plugin = struct {
     /// 함수 노드 방문 훅. visitFunction 완료 후 호출.
     /// function_declaration, function_expression, arrow_function_expression 대상.
     onFunction: ?*const fn (ctx: ?*anyopaque, api: *AstTransformCtx, func: FunctionInfo) PluginError!void = null,
+
+    /// Auto-workletization: 특정 함수 호출의 인자를 자동으로 worklet 변환.
+    /// transformer가 call_expression을 방문할 때 callee 이름을 매칭하여
+    /// 해당 인자 위치의 function을 worklet으로 처리한다.
+    autoWorkletCallees: []const AutoWorkletCallee = &.{},
+};
+
+/// Auto-workletization 대상 함수 정의.
+/// call_expression의 callee 이름이 매칭되면 지정된 인자 위치의 함수를 worklet으로 변환.
+pub const AutoWorkletCallee = struct {
+    name: []const u8,
+    /// worklet으로 변환할 인자 인덱스 (0-based). 최대 4개.
+    arg_indices: [4]u8 = .{ 0, 0xFF, 0xFF, 0xFF },
+    /// true이면 obj.method() 형태의 method call도 매칭 (callee가 static_member_expression)
+    is_method: bool = false,
 };
 
 /// 플러그인 배열을 순회하며 훅을 실행하는 유틸리티.

--- a/src/transformer/ast_plugin.zig
+++ b/src/transformer/ast_plugin.zig
@@ -52,6 +52,9 @@ pub const FunctionInfo = struct {
     flags: u32,
     /// 소스 파일 경로 (__initData.location 등에 사용)
     source_path: []const u8,
+    /// auto-workletization으로 활성화된 경우 true.
+    /// 'worklet' 디렉티브 없이도 worklet 변환이 필요한 함수.
+    is_auto_worklet: bool = false,
 };
 
 // ================================================================

--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -95,6 +95,7 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
             });
 
             // Plugin dispatch: worklet 등 AST 플러그인 적용
+            const is_auto_worklet = self.auto_worklet_next;
             if (try self.dispatchFunctionPlugins(result, .{
                 .node_idx = result,
                 .node_tag = .function_expression,
@@ -111,6 +112,7 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
                 .original_body_idx = body_idx,
                 .flags = func_flags,
                 .source_path = self.options.jsx_filename,
+                .is_auto_worklet = is_auto_worklet,
             })) |replacement| {
                 return replacement;
             }

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -5,6 +5,10 @@
 //!
 //! function_declaration (statement 위치) → trailing_nodes로 뒤에 삽입
 //! function_expression (expression 위치) → IIFE factory로 감싸서 교체
+//!
+//! Auto-workletization:
+//!   scheduleOnUI, runOnUI, runOnJS 등 알려진 함수의 인자를 자동 worklet 변환.
+//!   'worklet' 디렉티브 없이도 FunctionInfo.is_auto_worklet == true이면 변환.
 
 const std = @import("std");
 const ast_mod = @import("../../parser/ast.zig");
@@ -15,27 +19,76 @@ const ast_plugin = @import("../ast_plugin.zig");
 const AstTransformCtx = ast_plugin.AstTransformCtx;
 const FunctionInfo = ast_plugin.FunctionInfo;
 const worklet_mod = @import("../transformer/worklet.zig");
-const Plugin = @import("../../bundler/plugin.zig").Plugin;
-const PluginError = @import("../../bundler/plugin.zig").PluginError;
+const plugin_mod = @import("../../bundler/plugin.zig");
+const Plugin = plugin_mod.Plugin;
+const PluginError = plugin_mod.PluginError;
+const AutoWorkletCallee = plugin_mod.AutoWorkletCallee;
 
 pub fn plugin() Plugin {
     return .{
         .name = "reanimated-worklet",
         .onFunction = onFunction,
+        .autoWorkletCallees = &auto_worklet_callees,
     };
 }
+
+/// Reanimated/Worklets auto-workletization 대상 함수 목록.
+/// Babel react-native-worklets/plugin과 동일.
+const auto_worklet_callees = [_]AutoWorkletCallee{
+    // Scheduling functions (arg 0)
+    .{ .name = "runOnUI" },
+    .{ .name = "runOnUISync" },
+    .{ .name = "runOnUIAsync" },
+    .{ .name = "scheduleOnUI" },
+    .{ .name = "executeOnUIRuntimeSync" },
+    .{ .name = "runOnJS" },
+    // Scheduling functions (arg 1)
+    .{ .name = "runOnRuntime", .arg_indices = .{ 1, 0xFF, 0xFF, 0xFF } },
+    .{ .name = "runOnRuntimeSync", .arg_indices = .{ 1, 0xFF, 0xFF, 0xFF } },
+    .{ .name = "runOnRuntimeAsync", .arg_indices = .{ 1, 0xFF, 0xFF, 0xFF } },
+    .{ .name = "scheduleOnRuntime", .arg_indices = .{ 1, 0xFF, 0xFF, 0xFF } },
+    // Hooks (arg 0)
+    .{ .name = "useFrameCallback" },
+    .{ .name = "useAnimatedStyle" },
+    .{ .name = "useAnimatedProps" },
+    .{ .name = "createAnimatedPropAdapter" },
+    .{ .name = "useDerivedValue" },
+    .{ .name = "useAnimatedScrollHandler" },
+    // useAnimatedReaction (args 0 and 1)
+    .{ .name = "useAnimatedReaction", .arg_indices = .{ 0, 1, 0xFF, 0xFF } },
+    // Animation callbacks
+    .{ .name = "withTiming", .arg_indices = .{ 2, 0xFF, 0xFF, 0xFF } },
+    .{ .name = "withSpring", .arg_indices = .{ 2, 0xFF, 0xFF, 0xFF } },
+    .{ .name = "withDecay", .arg_indices = .{ 1, 0xFF, 0xFF, 0xFF } },
+    .{ .name = "withRepeat", .arg_indices = .{ 3, 0xFF, 0xFF, 0xFF } },
+    // Gesture handler method callbacks (arg 0, method call)
+    .{ .name = "onBegin", .is_method = true },
+    .{ .name = "onStart", .is_method = true },
+    .{ .name = "onEnd", .is_method = true },
+    .{ .name = "onFinalize", .is_method = true },
+    .{ .name = "onUpdate", .is_method = true },
+    .{ .name = "onChange", .is_method = true },
+    .{ .name = "onTouchesDown", .is_method = true },
+    .{ .name = "onTouchesMove", .is_method = true },
+    .{ .name = "onTouchesUp", .is_method = true },
+    .{ .name = "onTouchesCancelled", .is_method = true },
+};
 
 fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) PluginError!void {
     _ = ctx;
 
     if (info.body_idx.isNone()) return;
-    if (!api.hasDirective(info.body_idx, "worklet")) return;
 
-    // 디렉티브 제거 + closure 분석 + init code 생성: 모두 pre-visit body 사용.
-    // pre-visit body는 TS 포함/ES5 미적용 → codegen이 TS 자동 스트리핑.
+    const has_directive = api.hasDirective(info.body_idx, "worklet");
+    if (!has_directive and !info.is_auto_worklet) return;
+
+    // pre-visit body 사용: TS 포함/ES5 미적용 → codegen이 TS 자동 스트리핑.
     // ES5 헬퍼가 없으므로 UI thread에서 remote function deadlock 방지.
     // define 치환 전 식별자(global, __DEV__, process)는 JS_GLOBALS에 등록되어 제외됨.
-    const stripped_body = try api.stripDirective(info.original_body_idx);
+    const stripped_body = if (has_directive)
+        try api.stripDirective(info.original_body_idx)
+    else
+        info.original_body_idx; // auto-worklet: 디렉티브 없으므로 strip 불필요
 
     const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
     defer {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -252,6 +252,11 @@ pub const Transformer = struct {
     /// super() 이후의 this 참조를 _this로 교체해야 한다.
     super_call_this_alias: bool = false,
 
+    /// auto-workletization 플래그.
+    /// visitCallExpression에서 callee 매칭 시 true로 설정하고,
+    /// dispatchFunctionPlugins에서 FunctionInfo.is_auto_worklet로 전달 후 false로 리셋.
+    auto_worklet_next: bool = false,
+
     /// 런타임 헬퍼 사용 추적.
     /// 각 변환이 헬퍼를 사용하면 해당 비트를 설정한다.
     /// 번들러 emitter가 이 비트맵을 읽어 필요한 헬퍼만 출력에 주입한다.
@@ -2057,6 +2062,7 @@ pub const Transformer = struct {
         });
 
         // Plugin dispatch: onFunction (AST 훅)
+        const is_auto_worklet = self.auto_worklet_next;
         if (try self.dispatchFunctionPlugins(result, .{
             .node_idx = result,
             .node_tag = node.tag,
@@ -2069,6 +2075,7 @@ pub const Transformer = struct {
             .original_body_idx = old_body_idx,
             .flags = self.readU32(e, 4),
             .source_path = self.options.jsx_filename,
+            .is_auto_worklet = is_auto_worklet,
         })) |replacement| {
             return replacement;
         }
@@ -2665,7 +2672,7 @@ pub const Transformer = struct {
         return self.prependStatementsToBody(body_idx, &.{var_decl});
     }
 
-    /// arrow_function_expression: extra = [params, body, flags]
+    /// arrow_function_expression: extra = [params_list, body, flags]
     /// flags: 0x01 = async
     fn visitArrowFunction(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
@@ -2676,7 +2683,51 @@ pub const Transformer = struct {
         const new_params = try self.visitNode(params_idx);
         const new_body = try self.visitNode(body_idx);
         const new_extra = try self.ast.addExtras(&.{ @intFromEnum(new_params), @intFromEnum(new_body), flags });
-        return self.ast.addNode(.{ .tag = .arrow_function_expression, .span = node.span, .data = .{ .extra = new_extra } });
+        const result = try self.ast.addNode(.{ .tag = .arrow_function_expression, .span = node.span, .data = .{ .extra = new_extra } });
+
+        // Plugin dispatch: auto-workletization 등 AST 플러그인 적용
+        const is_auto_worklet = self.auto_worklet_next;
+        if (is_auto_worklet or self.options.plugins.len > 0) {
+            // arrow params는 formal_parameters (list) 또는 none일 수 있다.
+            var orig_p_start: u32 = 0;
+            var orig_p_len: u32 = 0;
+            var new_p_start: u32 = 0;
+            var new_p_len: u32 = 0;
+
+            if (!params_idx.isNone()) {
+                const orig_params_node = self.ast.getNode(params_idx);
+                if (orig_params_node.tag == .formal_parameters) {
+                    orig_p_start = orig_params_node.data.list.start;
+                    orig_p_len = orig_params_node.data.list.len;
+                }
+            }
+            if (!new_params.isNone()) {
+                const new_params_node = self.ast.getNode(new_params);
+                if (new_params_node.tag == .formal_parameters) {
+                    new_p_start = new_params_node.data.list.start;
+                    new_p_len = new_params_node.data.list.len;
+                }
+            }
+
+            if (try self.dispatchFunctionPlugins(result, .{
+                .node_idx = result,
+                .node_tag = .arrow_function_expression,
+                .name = null,
+                .body_idx = new_body,
+                .params_start = new_p_start,
+                .params_len = new_p_len,
+                .original_params_start = orig_p_start,
+                .original_params_len = orig_p_len,
+                .original_body_idx = body_idx,
+                .flags = flags,
+                .source_path = self.options.jsx_filename,
+                .is_auto_worklet = is_auto_worklet,
+            })) |replacement| {
+                return replacement;
+            }
+        }
+
+        return result;
     }
 
     // ================================================================
@@ -2829,7 +2880,15 @@ pub const Transformer = struct {
         const args_len = self.readU32(e, 2);
         const flags = self.readU32(e, 3);
         const new_callee = try self.visitNode(callee_idx);
-        const new_args = try self.visitExtraList(args_start, args_len);
+
+        // Auto-workletization: callee 이름이 플러그인 목록에 매칭되면
+        // 해당 인자 위치의 function/arrow에 auto_worklet_next 플래그를 설정.
+        const auto_callee = self.matchAutoWorkletCallee(callee_idx);
+        const new_args = if (auto_callee != null)
+            try self.visitCallArgsWithAutoWorklet(args_start, args_len, auto_callee.?)
+        else
+            try self.visitExtraList(args_start, args_len);
+
         const new_extra = try self.ast.addExtras(&.{
             @intFromEnum(new_callee), new_args.start, new_args.len, flags,
         });
@@ -3259,6 +3318,104 @@ pub const Transformer = struct {
     pub const makeSigHandle = refresh.makeSigHandle;
     pub const maybeRegisterRefreshSignature = refresh.maybeRegisterRefreshSignature;
     pub const insertSigCallAtBodyStart = refresh.insertSigCallAtBodyStart;
+
+    // ================================================================
+    // Auto-workletization helpers
+    // ================================================================
+
+    const AutoWorkletCallee = @import("../bundler/plugin.zig").AutoWorkletCallee;
+
+    /// call_expression의 callee가 auto-workletization 대상 함수인지 매칭.
+    /// identifier_reference(직접 호출) 또는 static_member_expression(메서드 호출) 지원.
+    fn matchAutoWorkletCallee(self: *Transformer, callee_idx: NodeIndex) ?AutoWorkletCallee {
+        if (self.options.plugins.len == 0) return null;
+        if (callee_idx.isNone()) return null;
+
+        const callee_node = self.ast.getNode(callee_idx);
+        const callee_name: []const u8 = switch (callee_node.tag) {
+            // scheduleOnUI(...) 형태
+            .identifier_reference => self.ast.source[callee_node.span.start..callee_node.span.end],
+            // obj.onBegin(...) 형태 — 프로퍼티 이름만 추출
+            .static_member_expression => blk: {
+                const me = callee_node.data.extra;
+                if (me + 1 >= self.ast.extra_data.items.len) break :blk "";
+                const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
+                if (prop_idx.isNone()) break :blk "";
+                const prop = self.ast.getNode(prop_idx);
+                break :blk self.ast.source[prop.span.start..prop.span.end];
+            },
+            else => return null,
+        };
+        if (callee_name.len == 0) return null;
+
+        const is_method = callee_node.tag == .static_member_expression;
+        for (self.options.plugins) |p| {
+            for (p.autoWorkletCallees) |entry| {
+                if (entry.is_method == is_method and std.mem.eql(u8, entry.name, callee_name)) {
+                    return entry;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// auto-workletization이 필요한 call expression의 인자를 개별 방문.
+    /// 대상 인자 위치의 function/arrow 방문 전에 auto_worklet_next 플래그를 설정.
+    fn visitCallArgsWithAutoWorklet(self: *Transformer, args_start: u32, args_len: u32, callee: AutoWorkletCallee) Error!NodeList {
+        const scratch_top = self.scratch.items.len;
+        defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+        const pending_top = self.pending_nodes.items.len;
+        defer self.pending_nodes.shrinkRetainingCapacity(pending_top);
+
+        const trailing_top = self.trailing_nodes.items.len;
+        defer self.trailing_nodes.shrinkRetainingCapacity(trailing_top);
+
+        var i: u32 = 0;
+        while (i < args_len) : (i += 1) {
+            const raw_idx = self.ast.extra_data.items[args_start + i];
+            const arg_idx: NodeIndex = @enumFromInt(raw_idx);
+
+            // 이 인자가 auto-worklet 대상인지 확인
+            const should_auto = blk: {
+                for (callee.arg_indices) |idx| {
+                    if (idx == 0xFF) break;
+                    if (idx == @as(u8, @intCast(i))) break :blk true;
+                }
+                break :blk false;
+            };
+
+            if (should_auto and !arg_idx.isNone()) {
+                const arg_node = self.ast.getNode(arg_idx);
+                if (arg_node.tag == .function_expression or
+                    arg_node.tag == .arrow_function_expression)
+                {
+                    self.auto_worklet_next = true;
+                }
+            }
+
+            const new_child = try self.visitNode(arg_idx);
+            self.auto_worklet_next = false;
+
+            // pending_nodes 드레인
+            if (self.pending_nodes.items.len > pending_top) {
+                try self.scratch.appendSlice(self.allocator, self.pending_nodes.items[pending_top..]);
+                self.pending_nodes.shrinkRetainingCapacity(pending_top);
+            }
+
+            if (!new_child.isNone()) {
+                try self.scratch.append(self.allocator, new_child);
+            }
+
+            // trailing_nodes 드레인
+            if (self.trailing_nodes.items.len > trailing_top) {
+                try self.scratch.appendSlice(self.allocator, self.trailing_nodes.items[trailing_top..]);
+                self.trailing_nodes.shrinkRetainingCapacity(trailing_top);
+            }
+        }
+
+        return self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    }
 
     // ================================================================
     // Plugin dispatch helper

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1326,3 +1326,84 @@ test "Worklet: scope hoisting rename reflected in closure value" {
     try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "helper:") != null);
 }
+
+test "Worklet: auto-workletization for scheduleOnUI argument" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\function scheduleOnUI(fn) {}
+        \\scheduleOnUI(() => {
+        \\  console.log("auto worklet");
+        \\});
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // auto-worklet 변환: __workletHash가 주입되어야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__initData") != null);
+}
+
+test "Worklet: auto-workletization for runOnUI argument" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\function runOnUI(fn) { return fn; }
+        \\runOnUI(() => {
+        \\  return 42;
+        \\})();
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+}
+
+test "Worklet: auto-workletization skips non-function args" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\function scheduleOnUI(fn) {}
+        \\var x = 1;
+        \\scheduleOnUI(x);
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // 인자가 함수가 아니면 worklet 변환 없음
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
+}
+
+test "Worklet: auto-workletization with correct arg index (withDecay arg 1)" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\function withDecay(config, callback) {}
+        \\withDecay({}, () => {
+        \\  console.log("done");
+        \\});
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // withDecay의 두 번째 인자(index 1)가 worklet화
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+}
+
+test "Worklet: auto-workletization does not affect wrong arg index" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\function withDecay(config, callback) {}
+        \\withDecay(() => { return 1; }, null);
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // withDecay의 첫 번째 인자(index 0)는 auto-worklet 대상 아님
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
+}
+
+test "Worklet: method auto-workletization for gesture handler onBegin" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\var gesture = {};
+        \\gesture.onBegin((e) => {
+        \\  console.log(e);
+        \\});
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // obj.onBegin() 메서드 호출의 첫 번째 인자가 worklet화
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+}


### PR DESCRIPTION
## Summary
- `scheduleOnUI`, `runOnUI`, `runOnJS` 등 알려진 함수의 인자를 자동으로 worklet 변환
- `useAnimatedStyle`, `useDerivedValue` 등 React hooks 지원
- `.onBegin`, `.onUpdate` 등 gesture handler 메서드 호출 지원
- `AutoWorkletCallee` 설정을 Plugin struct에 추가하여 플러그인이 대상 함수 목록 제공
- Non-ES5 arrow function에도 plugin dispatch 추가

## Test plan
- [x] 6 new unit tests (auto-worklet various patterns)
- [x] All existing worklet tests pass
- [x] 138 integration tests pass

Closes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)