### PR TITLE
fix(worklet): strip directive from visited body to preserve inner auto-worklet

### DIFF
--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -82,13 +82,18 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     const has_directive = api.hasDirective(info.body_idx, "worklet");
     if (!has_directive and !info.is_auto_worklet) return;
 
-    // pre-visit body 사용: TS 포함/ES5 미적용 → codegen이 TS 자동 스트리핑.
-    // ES5 헬퍼가 없으므로 UI thread에서 remote function deadlock 방지.
-    // define 치환 전 식별자(global, __DEV__, process)는 JS_GLOBALS에 등록되어 제외됨.
-    const stripped_body = if (has_directive)
-        try api.stripDirective(info.original_body_idx)
+    // JS thread 실행용 body: 방문 완료된 body에서 디렉티브 strip.
+    // (auto-worklet 등 inner 변환이 보존됨)
+    if (has_directive) {
+        _ = try api.stripDirective(info.body_idx);
+    }
+
+    // __initData.code용: pre-visit body 사용 (TS 포함/ES5 미적용).
+    // codegen이 TS 자동 스트리핑. ES5 헬퍼가 없으므로 UI thread deadlock 방지.
+    const code_body = if (has_directive)
+        try worklet_mod.stripWorkletDirective(api.transformer, info.original_body_idx)
     else
-        info.original_body_idx; // auto-worklet: 디렉티브 없으므로 strip 불필요
+        info.original_body_idx;
 
     const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
     defer {
@@ -99,7 +104,7 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     const func_name = info.name orelse "anonymous";
     const init_code = try api.generateCode(
         func_name,
-        stripped_body,
+        code_body,
         closure_vars,
         info.original_params_start,
         info.original_params_len,

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1407,3 +1407,24 @@ test "Worklet: method auto-workletization for gesture handler onBegin" {
     // obj.onBegin() 메서드 호출의 첫 번째 인자가 worklet화
     try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
+
+test "Worklet: auto-workletization inside worklet function body" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\function scheduleOnUI(fn) {}
+        \\function outer() {
+        \\  "worklet";
+        \\  scheduleOnUI(() => {
+        \\    console.log("inner");
+        \\  });
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // outer 함수의 __workletHash
+    try std.testing.expect(std.mem.indexOf(u8, code, "outer.__workletHash") != null);
+    // inner arrow도 auto-worklet 변환되어야 함 (IIFE로 wrapping)
+    // 이전 버그: stripDirective가 원본 body로 덮어써서 inner 변환이 손실
+    const count = std.mem.count(u8, code, "__workletHash");
+    try std.testing.expect(count >= 2); // outer + inner
+}


### PR DESCRIPTION
## Summary
- `stripDirective`가 원본(미방문) body를 사용하여 inner auto-worklet IIFE 변환이 손실되는 버그 수정
- JS thread용 body는 방문 완료된 body에서 strip, `__initData.code`는 원본 body에서 생성

## Root Cause
worklet 함수 내부의 `scheduleOnUI(() => {...})`가 auto-worklet 변환되었지만, 외부 worklet의 `stripDirective`가 원본 body로 덮어씀

## Test plan
- [x] New unit test: auto-workletization inside worklet function body
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)