### PR TITLE
fix(linker): use canonical export name for CJS re-export default resolution

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -344,15 +344,19 @@ pub fn buildMetadataForAst(
                 continue;
             }
 
-            // export * from CJS 패턴: canonical이 CJS 모듈을 가리키면
+            // re-export → CJS 패턴: canonical이 CJS 모듈을 가리키면
             // rename 대신 CJS preamble을 생성한다.
+            // canonical.export_name을 사용하여 re-export 체인을 올바르게 추적:
+            // import fn from './reexport' (default) → reexport: import { x } from 'cjs'; export default x
+            // → canonical = { cjs, "x" } → req_cjs().x (not .default)
             if (resolved) |rb| {
                 const cjs_mod: u32 = @intCast(@intFromEnum(rb.canonical.module_index));
                 if (cjs_mod < self.modules.len and self.modules[cjs_mod].wrap_kind == .cjs) {
                     const preamble_name = self.getCanonicalName(module_index, ib.local_name) orelse ib.local_name;
                     const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, cjs_mod);
                     const interop_mode2: types.Interop = if (m.def_format.isEsm()) .node else .babel;
-                    try preamble.writeCjsImport(preamble_name, ib.imported_name, req_var, false, interop_mode2);
+                    const effective_name = rb.canonical.export_name;
+                    try preamble.writeCjsImport(preamble_name, effective_name, req_var, false, interop_mode2);
                     continue;
                 }
             }

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -2796,4 +2796,29 @@ describe("dev 모드: re-export 소스 모듈 init", () => {
     expect(closureMatch![1]).not.toContain(" x");
     expect(closureMatch![1]).not.toContain(" y");
   });
+
+  test("default re-export from CJS: import fn from './reexport' resolves to named export (#1152)", async () => {
+    // import { findNodeHandle } from 'cjs-module'; export default findNodeHandle;
+    // → consumer: import fn from './reexport' → should resolve to cjs.findNodeHandle, not cjs.default
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+import myFn from "./reexport";
+console.log(typeof myFn + ":" + myFn());
+`,
+        "reexport.ts": `
+import { helper } from "./cjs-lib";
+export default helper;
+`,
+        "cjs-lib.ts": `
+module.exports = { helper: function() { return "ok"; } };
+`,
+      },
+      "index.ts",
+      [],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("function:ok");
+  });
 });


### PR DESCRIPTION
## Summary
- default import이 re-export 체인을 통해 CJS 모듈로 resolve될 때, `ib.imported_name`("default") 대신 `canonical.export_name`(실제 named export)을 사용
- `require_cjs().default` → `require_cjs().findNodeHandle` 수정

## Test plan
- [x] New integration test: default re-export from CJS
- [x] All 139 tests pass

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)