### PR TITLE
fix(worklet): traverse object method/getter/setter bodies in closure analysis

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -277,6 +277,40 @@ fn walkBodyForClosureAnalysis(
             return;
         },
 
+        // object method / getter / setter: __initData.code에 body가 포함되므로
+        // body 내 외부 참조도 closure에 포함해야 함.
+        // 파라미터는 method 자체의 로컬이므로 별도 추적하여 refs에서 제외.
+        // method_definition extra = [key, params_start, params_len, body, flags, ...]
+        .method_definition => {
+            const e = node.data.extra;
+            if (!self.ast.hasExtra(e, 4)) return;
+            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 3]);
+            if (body_idx.isNone()) return;
+
+            // method params를 임시 로컬로 수집 (method 스코프 내에서만 유효)
+            var method_locals = std.StringHashMap(void).init(self.allocator);
+            defer method_locals.deinit();
+            const p_start = self.ast.extra_data.items[e + 1];
+            const p_len = self.ast.extra_data.items[e + 2];
+            var mi: u32 = 0;
+            while (mi < p_len) : (mi += 1) {
+                try collectBindingNames(self, @enumFromInt(self.ast.extra_data.items[p_start + mi]), &method_locals);
+            }
+
+            // body를 순회하되, method params를 임시로 outer locals에 추가하여
+            // method 파라미터가 closure 변수로 잘못 포함되지 않도록 함
+            var ml_iter = method_locals.iterator();
+            while (ml_iter.next()) |entry| {
+                locals.put(entry.key_ptr.*, {}) catch return error.OutOfMemory;
+            }
+            try walkBodyForClosureAnalysis(self, body_idx, locals, refs, depth + 1);
+            // method params를 다시 제거 (다른 method에 영향 주지 않도록)
+            var ml_iter2 = method_locals.iterator();
+            while (ml_iter2.next()) |entry| {
+                _ = locals.remove(entry.key_ptr.*);
+            }
+        },
+
         // 변수 선언: 이름 → locals, 초기값 → refs
         .variable_declaration => {
             const e = node.data.extra;

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1428,3 +1428,21 @@ test "Worklet: auto-workletization inside worklet function body" {
     const count = std.mem.count(u8, code, "__workletHash");
     try std.testing.expect(count >= 2); // outer + inner
 }
+
+test "Worklet: closure analysis includes refs inside object getters/setters/methods" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\function outerFn() { return 42; }
+        \\function w() {
+        \\  "worklet";
+        \\  return { get v() { return outerFn(); }, set v(x) { outerFn(); }, m() { outerFn(); } };
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // outerFn이 __closure에 포함되어야 함 (getter/setter/method body에서 참조)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "outerFn") != null);
+    // __initData.code에서 this.__closure로 destructure
+    try std.testing.expect(std.mem.indexOf(u8, code, "outerFn:outerFn}=this.__closure") != null);
+}


### PR DESCRIPTION
## Summary
- `walkBodyForClosureAnalysis`가 `method_definition` 노드를 건너뛰어 getter/setter/method body 내 외부 참조가 `__closure`에서 누락되는 버그 수정
- method params를 임시 locals로 추가하여 파라미터가 closure로 잘못 포함되지 않도록 처리

## Test plan
- [x] New unit test: closure refs inside getters/setters/methods
- [x] All existing tests pass

Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)