### PR TITLE
fix(worklet): exclude method params and body locals from closure refs

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -303,9 +303,10 @@ fn walkBodyForClosureAnalysis(
             var method_refs = std.StringHashMap(NodeIndex).init(self.allocator);
             defer method_refs.deinit();
             try walkBodyForClosureAnalysis(self, body_idx, &method_locals, &method_refs, depth + 1);
+            // method_refs - method_locals - outer_locals = method의 외부 참조
             var mr_iter = method_refs.iterator();
             while (mr_iter.next()) |entry| {
-                if (!locals.contains(entry.key_ptr.*)) {
+                if (!method_locals.contains(entry.key_ptr.*) and !locals.contains(entry.key_ptr.*)) {
                     refs.put(entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
                 }
             }


### PR DESCRIPTION
## Summary
- method body refs 병합 시 `method_locals` 체크 추가
- setter param (`newValue`)과 getter body local (`uiValueGetter`)이 `__closure`에 잘못 포함되는 버그 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)