### PR TITLE
fix(worklet): exclude function self-reference from __closure

### DIFF
--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -94,13 +94,32 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     else
         info.original_body_idx;
 
-    const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
+    const all_closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
     defer {
-        for (closure_vars) |cv| api.getAllocator().free(cv.name);
-        api.getAllocator().free(closure_vars);
+        for (all_closure_vars) |cv| api.getAllocator().free(cv.name);
+        api.getAllocator().free(all_closure_vars);
     }
 
     const func_name = info.name orelse "anonymous";
+
+    // 함수 자기 참조 제외: 재귀 함수에서 자신의 이름이 closure에 포함되면 순환 참조 발생.
+    // function_declaration/expression의 이름은 body 내에서 자기 참조 가능 (JS 스펙).
+    var closure_vars_count: usize = 0;
+    for (all_closure_vars) |cv| {
+        if (!std.mem.eql(u8, cv.name, func_name)) closure_vars_count += 1;
+    }
+    const closure_vars = if (closure_vars_count < all_closure_vars.len) blk: {
+        const filtered = api.getAllocator().alloc(worklet_mod.ClosureVar, closure_vars_count) catch return error.OutOfMemory;
+        var fi: usize = 0;
+        for (all_closure_vars) |cv| {
+            if (!std.mem.eql(u8, cv.name, func_name)) {
+                filtered[fi] = cv;
+                fi += 1;
+            }
+        }
+        break :blk filtered;
+    } else all_closure_vars;
+    defer if (closure_vars.ptr != all_closure_vars.ptr) api.getAllocator().free(closure_vars);
     const init_code = try api.generateCode(
         func_name,
         code_body,

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1446,3 +1446,17 @@ test "Worklet: closure analysis includes refs inside object getters/setters/meth
     // __initData.code에서 this.__closure로 destructure
     try std.testing.expect(std.mem.indexOf(u8, code, "outerFn:outerFn}=this.__closure") != null);
 }
+
+test "Worklet: recursive function self-reference excluded from __closure" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\function recurse(n) {
+        \\  "worklet";
+        \\  if (n > 0) recurse(n - 1);
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // 자기 참조는 closure에 포함되면 안 됨 (순환 참조 방지)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
+}


### PR DESCRIPTION
## Summary
- 재귀 worklet 함수의 자기 참조가 `__closure`에 포함되어 `cyclic object to serializable` 에러 발생하는 버그 수정
- 함수 이름은 JS 스펙상 body 내에서 자기 참조 가능하므로 closure 캡처 불필요

## Test plan
- [x] New unit test: recursive function self-reference excluded
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)