### PR TITLE
refactor(worklet): move self-reference exclusion into collectClosureVars

### DIFF
--- a/src/transformer/ast_plugin.zig
+++ b/src/transformer/ast_plugin.zig
@@ -94,14 +94,16 @@ pub const AstTransformCtx = struct {
     // --- 스코프 분석 ---
 
     /// 함수 body에서 closure 변수(외부 참조)를 추출.
+    /// func_name: 함수 이름 (자기 참조 제외용). null이면 무시.
     /// 반환된 슬라이스는 caller가 getAllocator().free()로 해제해야 한다.
     pub fn getClosureVars(
         self: *AstTransformCtx,
         body_idx: NodeIndex,
         params_start: u32,
         params_len: u32,
+        func_name: ?[]const u8,
     ) Error![]const worklet_mod.ClosureVar {
-        return worklet_mod.collectClosureVars(self.transformer, body_idx, params_start, params_len);
+        return worklet_mod.collectClosureVars(self.transformer, body_idx, params_start, params_len, func_name);
     }
 
     // --- AST 노드 생성 (Transformer/Ast 위임) ---

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -94,32 +94,14 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     else
         info.original_body_idx;
 
-    const all_closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len);
-    defer {
-        for (all_closure_vars) |cv| api.getAllocator().free(cv.name);
-        api.getAllocator().free(all_closure_vars);
-    }
-
     const func_name = info.name orelse "anonymous";
 
-    // 함수 자기 참조 제외: 재귀 함수에서 자신의 이름이 closure에 포함되면 순환 참조 발생.
-    // function_declaration/expression의 이름은 body 내에서 자기 참조 가능 (JS 스펙).
-    var closure_vars_count: usize = 0;
-    for (all_closure_vars) |cv| {
-        if (!std.mem.eql(u8, cv.name, func_name)) closure_vars_count += 1;
+    const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len, info.name);
+    defer {
+        for (closure_vars) |cv| api.getAllocator().free(cv.name);
+        api.getAllocator().free(closure_vars);
     }
-    const closure_vars = if (closure_vars_count < all_closure_vars.len) blk: {
-        const filtered = api.getAllocator().alloc(worklet_mod.ClosureVar, closure_vars_count) catch return error.OutOfMemory;
-        var fi: usize = 0;
-        for (all_closure_vars) |cv| {
-            if (!std.mem.eql(u8, cv.name, func_name)) {
-                filtered[fi] = cv;
-                fi += 1;
-            }
-        }
-        break :blk filtered;
-    } else all_closure_vars;
-    defer if (closure_vars.ptr != all_closure_vars.ptr) api.getAllocator().free(closure_vars);
+
     const init_code = try api.generateCode(
         func_name,
         code_body,

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -135,7 +135,7 @@ const JS_GLOBALS = std.StaticStringMap(void).initComptime(.{
 /// 함수 body와 파라미터로부터 closure 변수(외부 참조)를 추출한다.
 ///
 /// 알고리즘:
-///   1. 파라미터 이름 → locals 집합에 추가
+///   1. 함수 이름 + 파라미터 이름 → locals 집합에 추가
 ///   2. body 내 지역 선언(var/let/const/function) 이름 → locals 집합에 추가
 ///   3. body 내 identifier_reference 이름 → refs 집합에 추가
 ///   4. refs - locals - JS_GLOBALS = closure 변수
@@ -144,11 +144,17 @@ pub fn collectClosureVars(
     body_idx: NodeIndex,
     params_start: u32,
     params_len: u32,
+    func_name: ?[]const u8,
 ) Error![]const ClosureVar {
     var locals = std.StringHashMap(void).init(self.allocator);
     defer locals.deinit();
     var refs = std.StringHashMap(NodeIndex).init(self.allocator);
     defer refs.deinit();
+
+    // 0. 함수 이름 → locals (자기 참조 제외: JS 스펙상 함수 이름은 body 내에서 접근 가능)
+    if (func_name) |name| {
+        if (name.len > 0) locals.put(name, {}) catch return error.OutOfMemory;
+    }
 
     // 1. 파라미터 이름 수집
     var pi: u32 = 0;


### PR DESCRIPTION
## Summary
- 함수 자기 참조 제외를 플러그인 후처리에서 `collectClosureVars` 내부로 이동
- `func_name` 파라미터를 `getClosureVars`/`collectClosureVars`에 추가
- 플러그인의 fragile한 2-pass 필터링 코드 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)