### PR TITLE
fix(napi): pass func_name to getClosureVars

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -806,7 +806,7 @@ fn serializeFunctionInfo(
     // closureVars: 디렉티브가 있을 때만 계산 (스코프 분석은 비용이 크므로)
     try buf.appendSlice(alloc, ",\"closureVars\":[");
     if (has_directives) {
-        const closure_vars = api.getClosureVars(func.original_body_idx, func.original_params_start, func.original_params_len) catch &.{};
+        const closure_vars = api.getClosureVars(func.original_body_idx, func.original_params_start, func.original_params_len, func.name) catch &.{};
         defer if (closure_vars.len > 0) {
             for (closure_vars) |cv| api.getAllocator().free(cv.name);
             api.getAllocator().free(closure_vars);


### PR DESCRIPTION
## Summary
- NAPI entry의 `getClosureVars` 호출에 `func_name` 인자 추가 (API 변경 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)