### PR TITLE
fix(worklet): traverse nested function/arrow bodies for closure capture

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -278,15 +278,78 @@ fn walkBodyForClosureAnalysis(
             return;
         },
 
-        // 중첩 함수: 별도 스코프이므로 진입하지 않음 (Babel 동일).
-        // function_declaration만 이름을 외부 locals에 추가.
-        .function_declaration => {
+        // 중첩 함수: 별도 스코프로 body를 순회하여 외부 참조를 수집.
+        // __initData.code에 중첩 함수 body가 포함되므로, 그 안의 외부 참조도
+        // worklet closure에 포함해야 함 (Babel과 동일).
+        // function_declaration extra = [name, params_start, params_len, body, flags, ...]
+        .function_declaration, .function_expression, .function => {
             const e = node.data.extra;
-            const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
-            try collectBindingNames(self, name_idx, locals);
+            // function_declaration만 이름을 외부 locals에 추가
+            if (tag == .function_declaration) {
+                const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                try collectBindingNames(self, name_idx, locals);
+            }
+            if (!self.ast.hasExtra(e, 4)) return;
+            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 3]);
+            if (body_idx.isNone()) return;
+
+            var fn_locals = std.StringHashMap(void).init(self.allocator);
+            defer fn_locals.deinit();
+            // 함수 이름 자체도 fn scope 로컬 (자기 참조)
+            const fn_name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+            try collectBindingNames(self, fn_name_idx, &fn_locals);
+            // params → fn scope 로컬
+            const p_start = self.ast.extra_data.items[e + 1];
+            const p_len = self.ast.extra_data.items[e + 2];
+            var pi: u32 = 0;
+            while (pi < p_len) : (pi += 1) {
+                try collectBindingNames(self, @enumFromInt(self.ast.extra_data.items[p_start + pi]), &fn_locals);
+            }
+
+            var fn_refs = std.StringHashMap(NodeIndex).init(self.allocator);
+            defer fn_refs.deinit();
+            try walkBodyForClosureAnalysis(self, body_idx, &fn_locals, &fn_refs, depth + 1);
+            var fr_iter = fn_refs.iterator();
+            while (fr_iter.next()) |entry| {
+                if (!fn_locals.contains(entry.key_ptr.*) and !locals.contains(entry.key_ptr.*)) {
+                    refs.put(entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
+                }
+            }
             return;
         },
-        .function_expression, .arrow_function_expression, .function => return,
+        // arrow: extra = [params_list, body, flags]
+        .arrow_function_expression => {
+            const e = node.data.extra;
+            if (!self.ast.hasExtra(e, 2)) return;
+            const params_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+            if (body_idx.isNone()) return;
+
+            var fn_locals = std.StringHashMap(void).init(self.allocator);
+            defer fn_locals.deinit();
+            // arrow params → fn scope 로컬
+            if (!params_idx.isNone()) {
+                const params_node = self.ast.getNode(params_idx);
+                if (params_node.tag == .formal_parameters) {
+                    const plist = params_node.data.list;
+                    var pi: u32 = 0;
+                    while (pi < plist.len) : (pi += 1) {
+                        try collectBindingNames(self, @enumFromInt(self.ast.extra_data.items[plist.start + pi]), &fn_locals);
+                    }
+                }
+            }
+
+            var fn_refs = std.StringHashMap(NodeIndex).init(self.allocator);
+            defer fn_refs.deinit();
+            try walkBodyForClosureAnalysis(self, body_idx, &fn_locals, &fn_refs, depth + 1);
+            var fr_iter = fn_refs.iterator();
+            while (fr_iter.next()) |entry| {
+                if (!fn_locals.contains(entry.key_ptr.*) and !locals.contains(entry.key_ptr.*)) {
+                    refs.put(entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
+                }
+            }
+            return;
+        },
 
         // object method / getter / setter: body를 별도 스코프로 순회.
         // params는 method 로컬, body 내 외부 참조만 outer refs에 병합.

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1112,7 +1112,7 @@ test "Worklet: pre-visit body used for initData (no ES5 helpers in closure)" {
     try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
 }
 
-test "Worklet: nested function params do not leak into outer closure" {
+test "Worklet: nested function captures outer refs but params stay local" {
     var r = try transformWorklet(std.testing.allocator,
         \\var ext = 1;
         \\export function w() {
@@ -1124,8 +1124,10 @@ test "Worklet: nested function params do not leak into outer closure" {
     defer r.deinit();
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
-    // inner는 중첩 함수(별도 스코프), ext만 외부 참조
-    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
+    // ext는 inner body에서 참조하는 외부 변수 → worklet closure에 포함
+    try std.testing.expect(std.mem.indexOf(u8, code, "ext:ext}=this.__closure") != null);
+    // inner의 param x는 closure에 포함되면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, code, "x:x") == null);
 }
 
 test "Worklet: default param (c = 0) not in closure" {
@@ -1544,4 +1546,27 @@ test "Worklet: nested object with computed property and new expression" {
     defer std.testing.allocator.free(code);
     try std.testing.expect(std.mem.indexOf(u8, code, "key:key") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "Cls:Cls") != null);
+}
+
+test "Worklet: nested function and arrow capture outer imports" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\var isShared = (v) => v != null;
+        \\var helper = () => 42;
+        \\function w() {
+        \\  "worklet";
+        \\  function extract(x) {
+        \\    if (isShared(x)) return;
+        \\    var fn = () => helper();
+        \\  }
+        \\  return extract;
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // 중첩 function 안의 isShared와 arrow 안의 helper 모두 worklet closure에 포함
+    try std.testing.expect(std.mem.indexOf(u8, code, "isShared:isShared") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "helper:helper") != null);
+    // extract의 param x는 closure에 없어야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, " x:x") == null);
 }


### PR DESCRIPTION
## Summary
- 중첩 function/arrow body를 별도 스코프로 순회하여 free variable을 worklet closure에 전파
- 이전에는 중첩 함수를 완전히 건너뛰어 내부의 외부 참조가 누락됨 (isSharedValue, IS_JEST 등)
- function params와 body locals는 제외, 외부 참조만 상위 closure에 병합

## Test plan
- [x] Updated test: nested function captures outer refs
- [x] New test: nested function + arrow capture outer imports
- [x] All 2531 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)