### PR TITLE
feat(worklet): support object method worklet directive (#1143)

### DIFF
--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -129,22 +129,67 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
         for (stmts) |stmt| {
             try api.addTrailingStatement(stmt);
         }
+    } else if (info.node_tag == .method_definition) {
+        // object method: { build(props) { 'worklet'; ... } }
+        // → { build: (function() { var build = function(props) { ... }; build.__workletHash = ...; return build; })() }
+        // method_definition을 object_property(key: IIFE)로 교체.
+        const func_expr = try buildFunctionExprFromMethod(api, info);
+        const iife = try buildWorkletIIFE(api, func_expr, func_name, stmts);
+
+        // object_property: binary = [key, value]
+        // method_definition의 key를 재사용
+        const t = api.transformer;
+        const method_node = t.ast.getNode(info.node_idx);
+        const me = method_node.data.extra;
+        const key_idx: NodeIndex = @enumFromInt(t.ast.extra_data.items[me]);
+        const prop = try t.ast.addNode(.{
+            .tag = .object_property,
+            .span = method_node.span,
+            .data = .{ .binary = .{ .left = key_idx, .right = iife, .flags = 0 } },
+        });
+        api.replaced_node = prop;
     } else {
         // expression 위치 (function_expression/arrow): IIFE factory로 감싸서 교체
-        //
-        // 변환:
-        //   function fn() { "worklet"; body }
-        // →
-        //   (function() {
-        //     var fn = function fn() { body };
-        //     fn.__workletHash = 123;
-        //     fn.__closure = {};
-        //     fn.__initData = { code: "...", location: "..." };
-        //     return fn;
-        //   })()
         const iife = try buildWorkletIIFE(api, info.node_idx, func_name, stmts);
         api.replaced_node = iife;
     }
+}
+
+/// method_definition에서 function_expression을 추출한다.
+/// { build(props) { body } } → function build(props) { body }
+fn buildFunctionExprFromMethod(api: *AstTransformCtx, info: FunctionInfo) PluginError!NodeIndex {
+    const t = api.transformer;
+    const method_node = t.ast.getNode(info.node_idx);
+    const me = method_node.data.extra;
+
+    // method_definition extra = [key(0), params_start(1), params_len(2), body(3), flags(4), ...]
+    const name_span = if (info.name) |n| (t.ast.addString(n) catch return error.OutOfMemory) else Span{ .start = 0, .end = 0 };
+    const name_node = if (info.name != null) (t.ast.addNode(.{
+        .tag = .binding_identifier,
+        .span = name_span,
+        .data = .{ .string_ref = name_span },
+    }) catch return error.OutOfMemory) else NodeIndex.none;
+
+    // method flags → function flags (async=bit0 of method flags bit3, generator=bit4)
+    const method_flags = t.ast.extra_data.items[me + 4];
+    var func_flags: u32 = 0;
+    if ((method_flags & 0x08) != 0) func_flags |= 0x01; // async
+    if ((method_flags & 0x10) != 0) func_flags |= 0x02; // generator
+
+    const none = @intFromEnum(NodeIndex.none);
+    const func_extra = t.ast.addExtras(&.{
+        @intFromEnum(name_node),
+        info.params_start,
+        info.params_len,
+        @intFromEnum(info.body_idx),
+        func_flags,
+        none, // return type
+    }) catch return error.OutOfMemory;
+    return t.ast.addNode(.{
+        .tag = .function_expression,
+        .span = method_node.span,
+        .data = .{ .extra = func_extra },
+    }) catch return error.OutOfMemory;
 }
 
 /// function_expression worklet을 IIFE factory로 감싼다.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3011,10 +3011,45 @@ pub const Transformer = struct {
             NodeList{ .start = 0, .len = 0 }
         else
             try self.visitExtraList(self.readU32(e, 5), self.readU32(e, 6));
-        return self.addExtraNode(.method_definition, node.span, &.{
+        const old_body_idx = self.readNodeIdx(e, 3);
+        const result = try self.addExtraNode(.method_definition, node.span, &.{
             @intFromEnum(new_key), pp.new_params.start, pp.new_params.len, @intFromEnum(new_body),
             self.readU32(e, 4),    new_decos.start,     new_decos.len,
         });
+
+        // Plugin dispatch: worklet 등 AST 플러그인 적용
+        // method_definition은 object/class 내부에 있으므로 IIFE 교체는 불가.
+        // 대신 워크릿 플러그인이 method body 기반으로 function_expression을 생성하여
+        // object_property value로 교체할 수 있도록 정보를 전달한다.
+        const is_auto_worklet = self.auto_worklet_next;
+        // method 이름 추출 (key가 identifier인 경우)
+        const method_name: ?[]const u8 = blk: {
+            const key_idx = self.readNodeIdx(e, 0);
+            if (key_idx.isNone()) break :blk null;
+            const key_node = self.ast.getNode(key_idx);
+            if (key_node.tag == .identifier_reference) {
+                break :blk self.ast.source[key_node.span.start..key_node.span.end];
+            }
+            break :blk null;
+        };
+        if (try self.dispatchFunctionPlugins(result, .{
+            .node_idx = result,
+            .node_tag = .method_definition,
+            .name = method_name,
+            .body_idx = new_body,
+            .params_start = pp.new_params.start,
+            .params_len = pp.new_params.len,
+            .original_params_start = params_start,
+            .original_params_len = params_len,
+            .original_body_idx = old_body_idx,
+            .flags = flags,
+            .source_path = self.options.jsx_filename,
+            .is_auto_worklet = is_auto_worklet,
+        })) |replacement| {
+            return replacement;
+        }
+
+        return result;
     }
 
     // property_definition: extra = [key, init_val, flags, deco_start, deco_len]

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1295,7 +1295,7 @@ test "Worklet: computed property access in worklet body" {
     try std.testing.expect(std.mem.indexOf(u8, code, "obj: obj") != null);
 }
 
-test "Worklet: object method worklet directive remains (known limitation)" {
+test "Worklet: object method with worklet directive is transformed" {
     var r = try transformWorklet(std.testing.allocator,
         \\var logger = { warn(msg) {
         \\  "worklet";
@@ -1305,10 +1305,26 @@ test "Worklet: object method worklet directive remains (known limitation)" {
     defer r.deinit();
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
-    // object method worklet은 현재 미변환 — "worklet" 디렉티브가 남아있음
-    try std.testing.expect(std.mem.indexOf(u8, code, "\"worklet\"") != null);
-    // __workletHash는 없어야 함 (미변환)
-    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
+    // object method worklet → object_property + IIFE로 변환
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__initData") != null);
+    // method가 object_property value로 변환됨
+    try std.testing.expect(std.mem.indexOf(u8, code, "warn:") != null);
+}
+
+test "Worklet: object method with outer closure vars captured" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\var config = {};
+        \\var obj = { build(props) {
+        \\  "worklet";
+        \\  return config[props];
+        \\} };
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "config:config}=this.__closure") != null);
 }
 
 test "Worklet: scope hoisting rename reflected in closure value" {


### PR DESCRIPTION
## Summary
- `{ build(props) { 'worklet'; ... } }` → `{ build: (IIFE with __workletHash)() }`
- `visitMethodDefinition`에 `dispatchFunctionPlugins` 호출 추가
- method_definition → object_property + function_expression IIFE 변환
- `buildFunctionExprFromMethod` 헬퍼로 method에서 function_expression 추출

## Test plan
- [x] 2 new tests (method worklet, method with closure)
- [x] Updated "known limitation" test → now passing
- [x] All 2533 unit tests pass
- [x] All 139 integration tests pass

Closes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)