### PR TITLE
fix(worklet): skip getter/setter methods in worklet transformation

### DIFF
--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -130,9 +130,16 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
             try api.addTrailingStatement(stmt);
         }
     } else if (info.node_tag == .method_definition) {
+        // getter/setter worklet은 지원하지 않음 — 일반 함수로 변환하면 시맨틱이 깨지므로 skip.
+        // (Babel도 동일하게 getter/setter worklet을 지원하지 않음)
+        {
+            const t = api.transformer;
+            const method_flags = t.ast.extra_data.items[t.ast.getNode(info.node_idx).data.extra + 4];
+            if ((method_flags & 0x02) != 0 or (method_flags & 0x04) != 0) return; // getter or setter
+        }
+
         // object method: { build(props) { 'worklet'; ... } }
         // → { build: (function() { var build = function(props) { ... }; build.__workletHash = ...; return build; })() }
-        // method_definition을 object_property(key: IIFE)로 교체.
         const func_expr = try buildFunctionExprFromMethod(api, info);
         const iife = try buildWorkletIIFE(api, func_expr, func_name, stmts);
 

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1327,6 +1327,20 @@ test "Worklet: object method with outer closure vars captured" {
     try std.testing.expect(std.mem.indexOf(u8, code, "config:config}=this.__closure") != null);
 }
 
+test "Worklet: getter/setter with worklet directive is not transformed (unsupported)" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\var obj = { get x() {
+        \\  "worklet";
+        \\  return 1;
+        \\} };
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // getter worklet은 지원하지 않으므로 변환 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
+}
+
 test "Worklet: scope hoisting rename reflected in closure value" {
     const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
     var r = try parseAndTransformWithOptions(


### PR DESCRIPTION
## Summary
- getter/setter에 worklet 디렉티브가 있어도 변환하지 않음 (silent failure 방지)
- 일반 함수로 변환하면 getter/setter 시맨틱이 깨지므로 skip이 안전

🤖 Generated with [Claude Code](https://claude.com/claude-code)