### PR TITLE
fix(worklet): expand object method shorthand in __initData.code

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -115,6 +115,9 @@ pub const CodegenOptions = struct {
     dev_module_id: ?[]const u8 = null,
     /// import.meta.glob 레코드. codegen이 glob 호출을 객체 리터럴로 직접 출력.
     import_records: []const @import("../bundler/types.zig").ImportRecord = &.{},
+    /// object literal method shorthand (`{ foo() {} }`)를 `{ foo: function() {} }`로 확장.
+    /// Reanimated worklet __initData.code 직렬화용 — getter/setter는 제외.
+    expand_object_method_shorthand: bool = false,
 };
 
 /// keepNames 엔트리. codegen이 수집하고 emitter가 __name() 호출로 변환.
@@ -152,6 +155,8 @@ pub const Codegen = struct {
     next_comment_idx: usize = 0,
     /// for문 init 위치에서 variable_declaration 출력 시 세미콜론 생략
     in_for_init: bool = false,
+    /// object_expression 리터럴을 출력 중인지 추적 (method shorthand 확장용).
+    in_object_expression: bool = false,
     /// for-in var initializer hoisting: emitVariableDeclarator에서 init 스킵
     skip_var_init: bool = false,
     /// namespace IIFE 내부에서 export된 변수의 참조를 ns.name으로 치환하기 위한 상태.
@@ -1357,6 +1362,12 @@ pub const Codegen = struct {
             try self.write("{}");
             return;
         }
+        const is_obj_expr = node.tag == .object_expression;
+        const prev_in_obj = self.in_object_expression;
+        if (is_obj_expr) self.in_object_expression = true;
+        defer if (is_obj_expr) {
+            self.in_object_expression = prev_in_obj;
+        };
         if (self.options.minify_whitespace) {
             try self.writeByte('{');
             try self.emitList(node, ",");
@@ -1997,11 +2008,34 @@ pub const Codegen = struct {
         try self.emitMemberDecorators(deco_start, deco_len);
 
         // flags: bit0=static, bit1=getter, bit2=setter, bit3=async, bit4=generator(*)
+        const is_getter = flags & 0x02 != 0;
+        const is_setter = flags & 0x04 != 0;
+        const expand_shorthand = self.options.expand_object_method_shorthand and
+            self.in_object_expression and !is_getter and !is_setter;
+
+        if (expand_shorthand) {
+            // `{ foo() {} }` → `{ foo: function() {} }` (Reanimated worklet 호환)
+            try self.emitNode(key);
+            if (self.options.minify_whitespace) {
+                try self.writeByte(':');
+            } else {
+                try self.write(": ");
+            }
+            if (flags & 0x08 != 0) try self.write("async ");
+            try self.write("function");
+            if (flags & 0x10 != 0) try self.writeByte('*');
+            try self.writeByte('(');
+            try self.emitNodeList(params_start, params_len, ",");
+            try self.writeByte(')');
+            try self.emitNode(body);
+            return;
+        }
+
         if (flags & 0x01 != 0) try self.write("static ");
         if (flags & 0x08 != 0) try self.write("async ");
-        if (flags & 0x02 != 0) {
+        if (is_getter) {
             try self.write("get ");
-        } else if (flags & 0x04 != 0) {
+        } else if (is_setter) {
             try self.write("set ");
         }
         if (flags & 0x10 != 0) try self.writeByte('*');

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -831,6 +831,9 @@ pub fn generateInitCode(
     const codegen_mod = @import("../../codegen/codegen.zig");
     var codegen = codegen_mod.Codegen.initWithOptions(self.allocator, &self.ast, .{
         .minify_whitespace = true,
+        // Reanimated worklet runtime은 object method shorthand를 인식하지 못하므로
+        // `{ foo() {} }` → `{ foo: function() {} }`로 확장. Metro/Babel과 동일한 출력.
+        .expand_object_method_shorthand = true,
     });
     const code = codegen.generate(program) catch return error.OutOfMemory;
     // codegen의 buf는 codegen이 소유 → 복제 필요

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1479,6 +1479,26 @@ test "Worklet: closure analysis includes refs inside object getters/setters/meth
     try std.testing.expect(std.mem.indexOf(u8, code, "outerFn:outerFn}=this.__closure") != null);
 }
 
+test "Worklet: __initData.code expands object method shorthand to `key: function`" {
+    // Reanimated worklet runtime은 method shorthand를 인식하지 못하므로
+    // __initData.code 내부의 object literal은 longhand(function expression)로 직렬화되어야 함.
+    var r = try transformWorklet(std.testing.allocator,
+        \\function w() {
+        \\  "worklet";
+        \\  return { start(tag, type) { return tag; }, stop(tag) { return tag; } };
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // __initData.code의 직렬화된 바디에 `start:function(` / `stop:function(`가 포함되어야 함.
+    try std.testing.expect(std.mem.indexOf(u8, code, "start:function(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "stop:function(") != null);
+    // 원본 shorthand (`start(tag,type){`)는 __initData.code 안에는 남지 않아야 함.
+    // (원본 함수 본문 자체는 visit 후 ES5 다운레벨이 적용되지 않으면 남을 수 있으므로
+    // 존재 검사만으로 충분히 회귀 감지 가능.)
+}
+
 test "Worklet: recursive function self-reference excluded from __closure" {
     var r = try transformWorklet(std.testing.allocator,
         \\function recurse(n) {


### PR DESCRIPTION
## Summary
- Reanimated worklet runtime이 object method shorthand(`{ foo() {} }`)를 인식하지 못해 LayoutAnimation(SlideInRight/FadeOut) 초기화 시 JSI getObject assert 실패로 SIGABRT 발생.
- Codegen에 `expand_object_method_shorthand` 옵션 추가, worklet `__initData.code` 생성 시 활성화해 `{ foo: function() {} }` 형태로 출력. Metro/Babel(`@babel/plugin-transform-shorthand-properties`)과 동일.
- getter/setter는 그대로 유지.

Fixes #1169

## Test plan
- [x] `zig build test` — 신규 유닛 테스트 `Worklet: __initData.code expands object method shorthand to \`key: function\`` 포함, 모두 통과
- [x] bungae ExampleApp `build:bungae --platform ios` 번들 출력에서 `start:function(`로 변환 확인, `start(tag` shorthand 0건
- [ ] 실기기/시뮬레이터에서 SlideInRight + FadeOut 레이아웃 애니메이션 크래시 미재현 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)