### PR TITLE
fix(worklet): RN auto-enable + strip directive from method IIFE body (#1169)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2083,8 +2083,12 @@ fn parseBuildOptions(
         .react_refresh = getObjectBool(env, opts_obj, "reactRefresh", false),
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
         .configurable_exports = getObjectBool(env, opts_obj, "configurableExports", false),
-        .strict_execution_order = getObjectBool(env, opts_obj, "strictExecutionOrder", false),
-        .worklet_transform = getObjectBool(env, opts_obj, "workletTransform", false),
+        // RN 프리셋: platform=react-native이면 CLI와 동일하게 auto-enable.
+        // (CLI main.zig의 --platform=react-native 분기 참조 — worklet transform 없이는
+        // react-native-reanimated/worklets 내부 worklet 함수들이 serialize되지 않아
+        // LayoutAnimation 등에서 JSI getObject assert 실패로 크래시 발생.)
+        .strict_execution_order = getObjectBool(env, opts_obj, "strictExecutionOrder", false) or platform == .react_native,
+        .worklet_transform = getObjectBool(env, opts_obj, "workletTransform", false) or platform == .react_native,
         .global_identifiers = global_identifiers orelse &.{},
         .polyfills = polyfills orelse &.{},
         .run_before_main = run_before_main orelse &.{},

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2036,8 +2036,8 @@ fn parseBuildOptions(
         .metafile = getObjectBool(env, opts_obj, "metafile", false),
         .keep_names = getObjectBool(env, opts_obj, "keepNames", false),
         .shim_missing_exports = getObjectBool(env, opts_obj, "shimMissingExports", false),
-        .flow = getObjectBool(env, opts_obj, "flow", false),
-        .jsx_in_js = getObjectBool(env, opts_obj, "jsxInJs", false),
+        .flow = getObjectBool(env, opts_obj, "flow", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.flow),
+        .jsx_in_js = getObjectBool(env, opts_obj, "jsxInJs", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.jsx_in_js),
         .charset_utf8 = getObjectBool(env, opts_obj, "charsetUtf8", false),
         .use_define_for_class_fields = getObjectBool(env, opts_obj, "useDefineForClassFields", true),
         .experimental_decorators = getObjectBool(env, opts_obj, "experimentalDecorators", false),
@@ -2082,13 +2082,13 @@ fn parseBuildOptions(
         .root_dir = root_dir,
         .react_refresh = getObjectBool(env, opts_obj, "reactRefresh", false),
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
-        .configurable_exports = getObjectBool(env, opts_obj, "configurableExports", false),
-        // RN 프리셋: platform=react-native이면 CLI와 동일하게 auto-enable.
-        // (CLI main.zig의 --platform=react-native 분기 참조 — worklet transform 없이는
-        // react-native-reanimated/worklets 내부 worklet 함수들이 serialize되지 않아
-        // LayoutAnimation 등에서 JSI getObject assert 실패로 크래시 발생.)
-        .strict_execution_order = getObjectBool(env, opts_obj, "strictExecutionOrder", false) or platform == .react_native,
-        .worklet_transform = getObjectBool(env, opts_obj, "workletTransform", false) or platform == .react_native,
+        // RN 프리셋(bundler.zig의 RN_BOOL_PRESET 단일 소스): platform=react-native이면
+        // 사용자가 명시하지 않아도 CLI와 동일하게 auto-enable. worklet_transform 없이는
+        // node_modules/react-native-reanimated의 'worklet' directive가 serialize되지
+        // 않아 LayoutAnimation 등에서 JSI getObject assert 실패로 크래시 발생.
+        .configurable_exports = getObjectBool(env, opts_obj, "configurableExports", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.configurable_exports),
+        .strict_execution_order = getObjectBool(env, opts_obj, "strictExecutionOrder", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.strict_execution_order),
+        .worklet_transform = getObjectBool(env, opts_obj, "workletTransform", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.worklet_transform),
         .global_identifiers = global_identifiers orelse &.{},
         .polyfills = polyfills orelse &.{},
         .run_before_main = run_before_main orelse &.{},

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -27,6 +27,18 @@ const TreeShaker = @import("tree_shaker.zig").TreeShaker;
 const module_store = @import("module_store.zig");
 const transpile_mod = @import("../transpile.zig");
 
+/// `--platform=react-native` 프리셋 부울 플래그.
+/// CLI(main.zig)와 NAPI(napi_entry.zig) 양쪽에서 단일 소스로 참조되어
+/// 향후 플래그 추가/변경 시 한 곳만 수정하면 된다.
+pub const ReactNativeBoolPreset = struct {
+    flow: bool = true, // RN .js 파일은 Flow + JSX 혼용
+    jsx_in_js: bool = true,
+    configurable_exports: bool = true, // RN/Hermes: defineProperty에 configurable: true 필요
+    strict_execution_order: bool = true, // Babel worklet 호환: 함수 호이스팅 방지
+    worklet_transform: bool = true, // Reanimated worklet 네이티브 변환
+};
+pub const RN_BOOL_PRESET: ReactNativeBoolPreset = .{};
+
 pub const BundleOptions = struct {
     entry_points: []const []const u8,
     format: EmitOptions.Format = .esm,

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -63,6 +63,7 @@ pub const ChunkGraph = chunk.ChunkGraph;
 pub const Bundler = bundler_core.Bundler;
 pub const BundleOptions = bundler_core.BundleOptions;
 pub const BundleResult = bundler_core.BundleResult;
+pub const RN_BOOL_PRESET = bundler_core.RN_BOOL_PRESET;
 pub const Plugin = plugin.Plugin;
 pub const PluginRunner = plugin.PluginRunner;
 pub const SubprocessPlugin = subprocess_plugin.SubprocessPlugin;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1247,11 +1247,12 @@ pub fn main() !void {
             if (opts.main_fields_list.items.len == 0) {
                 try opts.main_fields_list.appendSlice(allocator, &.{ "react-native", "browser", "module", "main" });
             }
-            opts.flow = true;
-            opts.jsx_in_js = true; // RN의 .js 파일은 Flow + JSX 혼용
-            opts.configurable_exports = true; // RN/Hermes: defineProperty에 configurable: true 필요
-            opts.strict_execution_order = true; // Babel worklet 변환 호환: 함수 호이스팅 방지
-            opts.worklet_transform = true; // Reanimated worklet 네이티브 변환
+            const rn_preset = lib.bundler.RN_BOOL_PRESET;
+            opts.flow = rn_preset.flow;
+            opts.jsx_in_js = rn_preset.jsx_in_js;
+            opts.configurable_exports = rn_preset.configurable_exports;
+            opts.strict_execution_order = rn_preset.strict_execution_order;
+            opts.worklet_transform = rn_preset.worklet_transform;
             // Metro는 automatic JSX transform 사용 — 사용자가 명시하지 않았으면 자동 설정
             if (opts.jsx_runtime == null) {
                 opts.jsx_runtime = .automatic;

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -84,11 +84,13 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
 
     // 두 body를 별도 strip해야 함 (각각 다른 AST):
     // 1) visited body (info.body_idx): JS thread 실행용. inner 변환(auto-worklet 등) 보존.
-    //    반환값은 불필요 — side effect(modified_body 패치)만 사용.
+    //    function_declaration/expression은 dispatcher가 modified_body로 result 노드를 패치하지만,
+    //    method_definition은 직접 function_expression을 새로 빌드하므로 stripped body를 명시 전달.
     // 2) original body (info.original_body_idx): __initData.code용 (TS 포함/ES5 미적용).
-    if (has_directive) {
-        _ = try api.stripDirective(info.body_idx);
-    }
+    const stripped_body = if (has_directive)
+        try api.stripDirective(info.body_idx)
+    else
+        info.body_idx;
     const code_body = if (has_directive)
         try worklet_mod.stripWorkletDirective(api.transformer, info.original_body_idx)
     else
@@ -140,7 +142,7 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
 
         // object method: { build(props) { 'worklet'; ... } }
         // → { build: (function() { var build = function(props) { ... }; build.__workletHash = ...; return build; })() }
-        const func_expr = try buildFunctionExprFromMethod(api, info);
+        const func_expr = try buildFunctionExprFromMethod(api, info, stripped_body);
         const iife = try buildWorkletIIFE(api, func_expr, func_name, stmts);
 
         // object_property: binary = [key, value]
@@ -164,7 +166,8 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
 
 /// method_definition에서 function_expression을 추출한다.
 /// { build(props) { body } } → function build(props) { body }
-fn buildFunctionExprFromMethod(api: *AstTransformCtx, info: FunctionInfo) PluginError!NodeIndex {
+/// body_idx: directive가 제거된 stripped body (caller가 전달).
+fn buildFunctionExprFromMethod(api: *AstTransformCtx, info: FunctionInfo, body_idx: NodeIndex) PluginError!NodeIndex {
     const t = api.transformer;
     const method_node = t.ast.getNode(info.node_idx);
     const me = method_node.data.extra;
@@ -188,7 +191,7 @@ fn buildFunctionExprFromMethod(api: *AstTransformCtx, info: FunctionInfo) Plugin
         @intFromEnum(name_node),
         info.params_start,
         info.params_len,
-        @intFromEnum(info.body_idx),
+        @intFromEnum(body_idx),
         func_flags,
         none, // return type
     }) catch return error.OutOfMemory;

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1479,6 +1479,24 @@ test "Worklet: closure analysis includes refs inside object getters/setters/meth
     try std.testing.expect(std.mem.indexOf(u8, code, "outerFn:outerFn}=this.__closure") != null);
 }
 
+test "Worklet: object method worklet strips directive from IIFE body" {
+    // method_definition 경로에서 stripped body를 사용하지 않으면
+    // IIFE 내부 function 바디에 `'worklet'` directive가 잔존 (Reanimated runtime 크래시).
+    var r = try transformWorklet(std.testing.allocator,
+        \\var ERROR_MESSAGES = {
+        \\  invalidColor(color) {
+        \\    "worklet";
+        \\    return "Invalid color: " + color;
+        \\  }
+        \\};
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "\"worklet\";") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "invalidColor.__workletHash") != null);
+}
+
 test "Worklet: recursive function self-reference excluded from __closure" {
     var r = try transformWorklet(std.testing.allocator,
         \\function recurse(n) {


### PR DESCRIPTION
## Summary

Reanimated LayoutAnimation(SlideInRight/FadeOut) SIGABRT의 두 근본 원인을 한 PR에서 수정. 초기 가설이었던 object method shorthand 확장(#1170)은 무관으로 확인되어 철회.

### Root cause 1 — NAPI 경로에서 RN 프리셋 미적용
CLI (`--platform=react-native`)는 `worklet_transform` / `strict_execution_order`를 자동 활성화하는데 NAPI는 사용자가 명시 전달하지 않으면 기본값 false. bungae(+ZTS NAPI) 빌드 시 node_modules/react-native-reanimated/** 의 `'worklet'` directive가 아예 변환되지 않아 `__workletHash`/`__initData`가 할당되지 않고 Reanimated valueUnpacker가 JSI `getObject` assert 실패 → SIGABRT.

→ `packages/core/src/napi_entry.zig`에서 `platform == .react_native`이면 auto-enable.

### Root cause 2 — method_definition 경로의 directive strip 누락
`worklet_plugin.zig`의 method_definition 분기가 `stripDirective(info.body_idx)` 반환값을 버리고 원본 `info.body_idx`로 function_expression을 재구성 → IIFE 내부 함수 바디에 `'worklet'` directive 잔존. `createLayoutAnimationManager`가 반환하는 `{ start(){...}, stop(){...} }`, reanimated의 `ERROR_MESSAGES = { invalidColor(color) {...} }` 등이 해당.

→ `stripDirective` 결과를 `stripped_body`로 캡처하고 `buildFunctionExprFromMethod`에 명시 전달.

## Bundle comparison (bungae ExampleApp iOS release)

| metric           | before | after | Metro | Rollipop |
|------------------|--------|-------|-------|----------|
| `__workletHash=` |      3 |   517 |   534 |      519 |
| `__initData`     |    519 |   519 |   535 |      544 |
| raw `"worklet";` |    477 |     0 |     0 |        0 |

수정 후 worklet 변환 밀도는 Metro/Rollipop과 동등 수준. raw directive도 완전 제거.

(`__initData` dedup 부재로 인한 번들 크기 차이는 별도 최적화 이슈로 분리 예정.)

## Test plan
- [x] `zig build test` — 신규 유닛 테스트 포함 통과
- [x] bungae ExampleApp `build:bungae --platform ios`에서 raw `"worklet";` = 0 확인
- [ ] 실기기에서 SlideInRight + FadeOut 크래시 미재현 확인

Fixes #1169 #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)