### PR TITLE
feat(worklet): Layout Animation auto-worklet via .withCallback() (Phase 2)

### DIFF
--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -73,6 +73,13 @@ pub const AutoWorkletCallee = struct {
     arg_indices: [4]u8 = .{ 0, 0xFF, 0xFF, 0xFF },
     /// true이면 obj.method() 형태의 method call도 매칭 (callee가 static_member_expression)
     is_method: bool = false,
+    /// 수신자(receiver) 검증 방식.
+    /// - any: 이름만 매칭 (기본)
+    /// - layout_animation: `X.withCallback(cb)` 형태에서 X가 Layout Animation 클래스인지 추가 검증.
+    ///   FadeIn/SlideIn/Bounce* 등의 알려진 클래스 및 new/chain 형태 허용.
+    receiver_kind: ReceiverKind = .any,
+
+    pub const ReceiverKind = enum { any, layout_animation };
 };
 
 /// 플러그인 배열을 순회하며 훅을 실행하는 유틸리티.

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -72,6 +72,63 @@ const auto_worklet_callees = [_]AutoWorkletCallee{
     .{ .name = "onTouchesMove", .is_method = true },
     .{ .name = "onTouchesUp", .is_method = true },
     .{ .name = "onTouchesCancelled", .is_method = true },
+    // Layout Animation callback — receiver 검증 필수 (임의 .withCallback() 오인 방지).
+    // `FadeIn.withCallback(cb)`, `new FadeIn().withCallback(cb)`, `FadeIn.build().withCallback(cb)` 등.
+    .{ .name = "withCallback", .is_method = true, .receiver_kind = .layout_animation },
+};
+
+/// Layout Animation 클래스 이름 집합.
+/// Reanimated의 EntryExit 애니메이션 + Layout Transition.
+/// Babel plugin(src/layoutAnimationAutoworkletization.ts)과 동일.
+pub const LAYOUT_ANIMATION_CLASSES = [_][]const u8{
+    // EntryExit animations
+    "BounceIn",            "BounceInDown",      "BounceInLeft",
+    "BounceInRight",       "BounceInUp",        "BounceOut",
+    "BounceOutDown",       "BounceOutLeft",     "BounceOutRight",
+    "BounceOutUp",         "FadeIn",            "FadeInDown",
+    "FadeInLeft",          "FadeInRight",       "FadeInUp",
+    "FadeOut",             "FadeOutDown",       "FadeOutLeft",
+    "FadeOutRight",        "FadeOutUp",         "FlipInEasyX",
+    "FlipInEasyY",         "FlipInXDown",       "FlipInXUp",
+    "FlipInYLeft",         "FlipInYRight",      "FlipOutEasyX",
+    "FlipOutEasyY",        "FlipOutXDown",      "FlipOutXUp",
+    "FlipOutYLeft",        "FlipOutYRight",     "LightSpeedInLeft",
+    "LightSpeedInRight",   "LightSpeedOutLeft", "LightSpeedOutRight",
+    "PinwheelIn",          "PinwheelOut",       "RollInLeft",
+    "RollInRight",         "RollOutLeft",       "RollOutRight",
+    "RotateInDownLeft",    "RotateInDownRight", "RotateInUpLeft",
+    "RotateInUpRight",     "RotateOutDownLeft", "RotateOutDownRight",
+    "RotateOutUpLeft",     "RotateOutUpRight",  "SlideInDown",
+    "SlideInLeft",         "SlideInRight",      "SlideInUp",
+    "SlideOutDown",        "SlideOutLeft",      "SlideOutRight",
+    "SlideOutUp",          "StretchInX",        "StretchInY",
+    "StretchOutX",         "StretchOutY",       "ZoomIn",
+    "ZoomInDown",          "ZoomInEasyDown",    "ZoomInEasyUp",
+    "ZoomInLeft",          "ZoomInRight",       "ZoomInRotate",
+    "ZoomInUp",            "ZoomOut",           "ZoomOutDown",
+    "ZoomOutEasyDown",     "ZoomOutEasyUp",     "ZoomOutLeft",
+    "ZoomOutRight",        "ZoomOutRotate",     "ZoomOutUp",
+    // Layout transitions
+    "Layout",              "LinearTransition",  "SequencedTransition",
+    "FadingTransition",    "JumpingTransition", "CurvedTransition",
+    "EntryExitTransition",
+};
+
+/// Layout Animation 클래스의 체이닝 메서드 집합.
+/// `FadeIn.duration(300).withCallback(cb)` 같은 체인 추적용.
+pub const LAYOUT_ANIMATION_CHAINABLE_METHODS = [_][]const u8{
+    // Base
+    "build",              "duration",          "delay",                 "getDuration",
+    "randomDelay",        "getDelay",          "getDelayFunction",
+    // Complex
+         "easing",
+    "rotate",             "springify",         "damping",               "mass",
+    "stiffness",          "overshootClamping", "energyThreshold",       "restDisplacementThreshold",
+    "restSpeedThreshold", "withInitialValues", "getAnimationAndConfig",
+    // DefaultTransition
+    "easingX",
+    "easingY",            "easingWidth",       "easingHeight",          "entering",
+    "exiting",            "reverse",
 };
 
 fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) PluginError!void {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3386,12 +3386,70 @@ pub const Transformer = struct {
         const is_method = callee_node.tag == .static_member_expression;
         for (self.options.plugins) |p| {
             for (p.autoWorkletCallees) |entry| {
-                if (entry.is_method == is_method and std.mem.eql(u8, entry.name, callee_name)) {
-                    return entry;
+                if (entry.is_method != is_method) continue;
+                if (!std.mem.eql(u8, entry.name, callee_name)) continue;
+                // receiver_kind 검증 — layout_animation은 수신자(member.object)가 알려진 LA 클래스여야 함
+                if (entry.receiver_kind == .layout_animation) {
+                    const me = callee_node.data.extra;
+                    const obj_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
+                    if (!self.isLayoutAnimationReceiver(obj_idx)) continue;
                 }
+                return entry;
             }
         }
         return null;
+    }
+
+    /// Layout Animation receiver 여부 판정.
+    /// Babel plugin의 isLayoutAnimationsChainableOrNewOperator 포팅:
+    ///  - identifier가 알려진 LA 클래스명이면 true
+    ///  - new LAClass(...)면 true
+    ///  - LAClass.chainMethod()로 체이닝된 경우 재귀적으로 true (chainMethod는 build/duration 등)
+    fn isLayoutAnimationReceiver(self: *Transformer, node_idx: NodeIndex) bool {
+        if (node_idx.isNone()) return false;
+        const node = self.ast.getNode(node_idx);
+        const wp = @import("plugins/worklet_plugin.zig");
+
+        // Identifier — 클래스 이름 직접 매칭
+        if (node.tag == .identifier_reference) {
+            const name = self.ast.source[node.span.start..node.span.end];
+            for (wp.LAYOUT_ANIMATION_CLASSES) |c| {
+                if (std.mem.eql(u8, c, name)) return true;
+            }
+            return false;
+        }
+
+        // new LAClass(...)
+        if (node.tag == .new_expression) {
+            const ne = node.data.extra;
+            const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[ne]);
+            return self.isLayoutAnimationReceiver(callee_idx);
+        }
+
+        // LAChain.chainMethod() — 체이닝 메서드 호출
+        if (node.tag == .call_expression) {
+            const ce = node.data.extra;
+            const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[ce]);
+            const callee_node = self.ast.getNode(callee_idx);
+            if (callee_node.tag != .static_member_expression) return false;
+            const me = callee_node.data.extra;
+            const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
+            if (prop_idx.isNone()) return false;
+            const prop = self.ast.getNode(prop_idx);
+            const prop_name = self.ast.source[prop.span.start..prop.span.end];
+            var chainable = false;
+            for (wp.LAYOUT_ANIMATION_CHAINABLE_METHODS) |m| {
+                if (std.mem.eql(u8, m, prop_name)) {
+                    chainable = true;
+                    break;
+                }
+            }
+            if (!chainable) return false;
+            const obj_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
+            return self.isLayoutAnimationReceiver(obj_idx);
+        }
+
+        return false;
     }
 
     /// auto-workletization이 필요한 call expression의 인자를 개별 방문.

--- a/src/transformer/worklet_babel_parity_test.zig
+++ b/src/transformer/worklet_babel_parity_test.zig
@@ -1227,9 +1227,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_unchained_callback_fu
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_unchained_callback_functions_automatically_with_new_keyword" {
@@ -1241,9 +1239,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_unchained_callback_fu
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn" {
@@ -1255,9 +1251,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_2" {
@@ -1269,9 +1263,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_2" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on_known_chained_methods_before" {
@@ -1283,9 +1275,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on_known_chained_methods_before_with_new_keyword" {
@@ -1297,9 +1287,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_3" {
@@ -1311,9 +1299,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_3" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_4" {
@@ -1325,9 +1311,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_4" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on_known_chained_methods_after" {
@@ -1339,9 +1323,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on_known_chained_methods_after_with_new_keyword" {
@@ -1355,9 +1337,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_5" {
@@ -1369,9 +1349,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_5" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_6" {
@@ -1383,9 +1361,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_6" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_7" {
@@ -1397,9 +1373,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_7" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_8" {
@@ -1411,9 +1385,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_8" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on_unknown_objects_chained_after" {
@@ -1425,9 +1397,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on_unknown_objects_chained_after_with_new_keyword" {
@@ -1441,9 +1411,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_9" {
@@ -1455,9 +1423,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_9" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:doesn_10" {
@@ -1471,9 +1437,7 @@ test "babel:babel_plugin_for_Layout_Animations:doesn_10" {
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 0 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") == null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on_longer_chains_of_known_objects" {
@@ -1487,9 +1451,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on_longer_chains_of_known_objects_with_new_keyword" {
@@ -1504,9 +1466,7 @@ test "babel:babel_plugin_for_Layout_Animations:workletizes_callback_functions_on
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: 1 worklet(s) — __workletHash count
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_debugging:does_inject_location_for_worklets_in_dev_builds" {


### PR DESCRIPTION
## Summary

#1173 Phase 2 — Babel `react-native-worklets/plugin`의 layoutAnimationAutoworkletization 포팅.

FadeIn/SlideIn 등 알려진 Layout Animation 클래스의 `.withCallback()` 콜백을 자동 worklet화.

## 지원 패턴

```js
FadeIn.withCallback(cb)
new FadeIn().withCallback(cb)
FadeIn.build().withCallback(cb)
FadeIn.duration(300).withCallback(cb)    // 체이닝
FadeIn.duration(300).easing(bezier).withCallback(cb)  // 다중 체이닝
```

임의 `X.withCallback()` (X가 LA 클래스가 아닌 경우)은 변환하지 않음 (예: `AmogusIn.withCallback(cb)`).

## 구현

- `AutoWorkletCallee`에 `receiver_kind` 필드 추가. 단순 메서드 이름 매칭을 넘어 수신자 검증 지원.
- `withCallback`는 `receiver_kind = .layout_animation`으로 등록.
- `matchAutoWorkletCallee`에서 해당 경우 수신자(member.object)를 `isLayoutAnimationReceiver`로 재귀 검사.
- `LAYOUT_ANIMATION_CLASSES` (~76 names): BounceIn/FadeIn/FlipIn/LightSpeed/Pinwheel/Roll/Rotate/Slide/Stretch/Zoom + LayoutTransition.
- `LAYOUT_ANIMATION_CHAINABLE_METHODS` (~22 names): build/duration/delay/easing/springify 등.

## Parity 테스트

`for_Layout_Animations` 블록 20 assert 활성화 (worklet hash 존재/부재 검증). Babel plugin.test.ts의 동일 케이스 망라.

## Test plan
- [x] `zig build test` — 모두 통과
- [x] bungae ExampleApp iOS 번들 — 회귀 없음 (517 worklet hash, 0 raw directive)

Refs #1173 Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)