### PR TITLE
fix(worklet): dispatcher body-offset for arrow_function_expression (Phase 4)

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3517,6 +3517,17 @@ pub const Transformer = struct {
     // Plugin dispatch helper
     // ================================================================
 
+    /// 함수-유사 노드의 body가 extra_data에서 차지하는 슬롯 오프셋.
+    /// parser/ast.zig의 노드 extra 레이아웃 정의와 일치해야 한다.
+    fn functionBodyOffset(tag: @import("../parser/ast.zig").Node.Tag) u32 {
+        return switch (tag) {
+            // arrow: [params(0), body(1), flags]
+            .arrow_function_expression => 1,
+            // function_declaration/expression/method_definition: [name, params_start, params_len, body(3), ...]
+            else => 3,
+        };
+    }
+
     /// onFunction 플러그인 훅을 실행한다.
     /// 플러그인이 함수를 교체하면 새 NodeIndex를 반환, 아니면 null.
     /// body 수정 시 result 노드의 extra_data를 직접 패치한다.
@@ -3533,7 +3544,7 @@ pub const Transformer = struct {
         }
         if (api.modified_body) |new_body_idx| {
             const result_extra = self.ast.getNode(result).data.extra;
-            self.ast.extra_data.items[result_extra + 3] = @intFromEnum(new_body_idx);
+            self.ast.extra_data.items[result_extra + functionBodyOffset(func_info.node_tag)] = @intFromEnum(new_body_idx);
         }
         return api.replaced_node;
     }

--- a/src/transformer/worklet_babel_parity_test.zig
+++ b/src/transformer/worklet_babel_parity_test.zig
@@ -575,13 +575,37 @@ test "babel:babel_plugin_for_class_worklets:workletizes_setter" {
 }
 
 test "babel:babel_plugin_for_class_worklets:workletizes_class_field" {
-    // PHASE 2+ 에서 구현 예정 (미구현 기능 테스트)
-    return error.SkipZigTest;
+    var r = tt.transformWorklet(std.testing.allocator,
+        \\class Foo {
+        \\  bar = (x) => {
+        \\    'worklet';
+        \\    return x + 2;
+        \\  };
+        \\}
+    ) catch return error.SkipZigTest;
+    defer r.deinit();
+    const code = tt.generateCode(&r) catch return error.SkipZigTest;
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "'worklet';") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "\"worklet\";") == null);
 }
 
 test "babel:babel_plugin_for_class_worklets:workletizes_static_class_field" {
-    // PHASE 2+ 에서 구현 예정 (미구현 기능 테스트)
-    return error.SkipZigTest;
+    var r = tt.transformWorklet(std.testing.allocator,
+        \\class Foo {
+        \\  static bar = (x) => {
+        \\    'worklet';
+        \\    return x + 2;
+        \\  };
+        \\}
+    ) catch return error.SkipZigTest;
+    defer r.deinit();
+    const code = tt.generateCode(&r) catch return error.SkipZigTest;
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "'worklet';") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "\"worklet\";") == null);
 }
 
 test "babel:babel_plugin_for_class_worklets:workletizes_constructor" {


### PR DESCRIPTION
## Summary

#1173 Phase 4. Class field worklet(\`bar = (x) => { 'worklet'; ... }\`) 동작 시 plugin dispatch의 body 패치가 arrow의 잘못된 extra 슬롯을 덮어써 \`'worklet'\` directive가 잔존하던 버그 수정.

## 원인

`dispatchFunctionPlugins`의 `modified_body` 패치가 result extra offset **3**을 고정 사용.
- function_declaration/expression/method_definition: `[name, params_start, params_len, body(3), ...]` → OK
- **arrow_function_expression**: `[params(0), body(1), flags]` → offset 3은 body가 아니라 flags 다음(해당 없음)

결과: IIFE 래핑은 되었으나 내부 arrow body에 directive 잔존.

## 수정

`functionBodyOffset(tag)` 헬퍼 추가, 노드 타입별 올바른 offset 반환. `parser/ast.zig`의 node extra 레이아웃 정의와 1:1 대응.

## Parity 테스트
- `workletizes_class_field`, `workletizes_static_class_field` 활성화 (pass)
- bundle 회귀 없음 (517 hash, 0 directive)

Refs #1173 Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)