### PR TITLE
feat(worklet): substituteWebPlatformChecks option (Phase 6.2)

### DIFF
--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -121,6 +121,9 @@ pub const LAYOUT_ANIMATION_CLASSES = [_][]const u8{
     "EntryExitTransition",
 };
 
+/// Reanimated web 플랫폼 체크 함수 — `substituteWebPlatformChecks` 옵션에서 `true`로 치환 대상.
+pub const WEB_PLATFORM_CHECK_NAMES = [_][]const u8{ "isWeb", "shouldBeUseWeb" };
+
 /// Layout Animation 클래스의 체이닝 메서드 집합.
 /// `FadeIn.duration(300).withCallback(cb)` 같은 체인 추적용.
 pub const LAYOUT_ANIMATION_CHAINABLE_METHODS = [_][]const u8{

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -105,6 +105,11 @@ pub const TransformOptions = struct {
     /// transformer는 AST 훅(onFunction 등)만 사용.
     plugins: []const Plugin = &.{},
 
+    /// Reanimated worklet plugin의 substituteWebPlatformChecks 옵션 포팅.
+    /// true일 때 `isWeb()` / `shouldBeUseWeb()` 호출을 `true` 리터럴로 정적 치환.
+    /// web build에서 플랫폼 체크 코드가 항상 true로 평가되므로 dead code 제거 효과.
+    substitute_web_platform_checks: bool = false,
+
     pub const compat = @import("compat.zig");
 };
 
@@ -2879,6 +2884,26 @@ pub const Transformer = struct {
         const args_start = self.readU32(e, 1);
         const args_len = self.readU32(e, 2);
         const flags = self.readU32(e, 3);
+
+        // Reanimated web: `isWeb()` / `shouldBeUseWeb()` → `true` (dead code 제거 목적).
+        if (self.options.substitute_web_platform_checks and args_len == 0 and !callee_idx.isNone()) {
+            const callee_node = self.ast.getNode(callee_idx);
+            if (callee_node.tag == .identifier_reference) {
+                const name = self.ast.source[callee_node.span.start..callee_node.span.end];
+                const wp = @import("plugins/worklet_plugin.zig");
+                for (wp.WEB_PLATFORM_CHECK_NAMES) |n| {
+                    if (std.mem.eql(u8, n, name)) {
+                        const true_span = try self.ast.addString("true");
+                        return try self.ast.addNode(.{
+                            .tag = .boolean_literal,
+                            .span = true_span,
+                            .data = .{ .string_ref = true_span },
+                        });
+                    }
+                }
+            }
+        }
+
         const new_callee = try self.visitNode(callee_idx);
 
         // Auto-workletization: callee 이름이 플러그인 목록에 매칭되면

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -268,7 +268,7 @@ test "Transformer: isTypeOnlyNode covers all TS type tags" {
 }
 
 /// 테스트 헬퍼: TransformOptions를 지정하여 파싱 → transformer 실행.
-fn parseAndTransformWithOptions(allocator: std.mem.Allocator, source: []const u8, options: TransformOptions) !TestResult {
+pub fn parseAndTransformWithOptions(allocator: std.mem.Allocator, source: []const u8, options: TransformOptions) !TestResult {
     const scanner_ptr = try allocator.create(Scanner);
     scanner_ptr.* = try Scanner.init(allocator, source);
 

--- a/src/transformer/worklet_babel_parity_test.zig
+++ b/src/transformer/worklet_babel_parity_test.zig
@@ -1689,8 +1689,22 @@ test "babel:babel_plugin_for_web_configuration:includes_initData_when_omitNative
 }
 
 test "babel:babel_plugin_for_web_configuration:substitutes_isWeb_and_shouldBeUseWeb_with_true_when_substituteWebPlatformChecks_option_is_set_to_true" {
-    // PHASE 2+ 에서 구현 예정 (미구현 기능 테스트)
-    return error.SkipZigTest;
+    const Plugin = @import("transformer.zig").Plugin;
+    const worklet_plugin_mod = @import("plugins/worklet_plugin.zig");
+    const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
+    var r = try @import("transformer_test.zig").parseAndTransformWithOptions(std.testing.allocator,
+        \\const x = isWeb();
+        \\const y = shouldBeUseWeb();
+    , .{
+        .plugins = &plugins,
+        .substitute_web_platform_checks = true,
+        .jsx_filename = "test.ts",
+    });
+    defer r.deinit();
+    const code = tt.generateCode(&r) catch return error.SkipZigTest;
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "const x = true;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "const y = true;") != null);
 }
 
 test "babel:babel_plugin_for_web_configuration:doesn" {


### PR DESCRIPTION
## Summary

#1173 Phase 6.2 — Reanimated web 빌드용 `isWeb()` / `shouldBeUseWeb()` 정적 치환 옵션 포팅.

## 사용

\`\`\`zig
TransformOptions.substitute_web_platform_checks = true
\`\`\`

\`\`\`js
// 입력
const x = isWeb();
const y = shouldBeUseWeb();

// 출력
const x = true;
const y = true;
\`\`\`

## 구현

`visitCallExpression`에 guard 추가 — 인자 없는 호출 (`args_len == 0`) + callee가 identifier (`isWeb` 또는 `shouldBeUseWeb`)일 때 boolean_literal `true`로 치환.

## Parity 테스트
- `for_web_configuration:substitutes_isWeb_...` 활성화 (pass)

Refs #1173 Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)