### PR TITLE
feat(worklet): file-level 'worklet' directive (Phase 6.4 basic)

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1331,6 +1331,13 @@ pub const Transformer = struct {
         if (self.options.unsupported.block_scoping and (node.tag == .program or node.tag == .function_body)) {
             self.collectTopLevelVarNames(node.data.list.start, node.data.list.len);
         }
+        // File-level worklet directive: program 최상단에 `'worklet';` 있으면
+        // top-level 함수/클래스를 auto-worklet 대상으로 표시 (Babel 호환).
+        if (self.options.plugins.len > 0 and node.tag == .program and
+            hasWorkletDirective(self, node.data.list.start, node.data.list.len))
+        {
+            return try self.visitFileWorkletProgram(node);
+        }
         // ES2025: using/await using → try-finally 래핑
         if (self.options.unsupported.using) {
             const Using = es2025_using.ES2025Using(Transformer);
@@ -3551,6 +3558,81 @@ pub const Transformer = struct {
             // function_declaration/expression/method_definition: [name, params_start, params_len, body(3), ...]
             else => 3,
         };
+    }
+
+    /// file-level `'worklet'` directive가 있는 program: 각 top-level 함수/클래스 방문 전에
+    /// auto_worklet_next=true로 설정. 중첩 함수/클래스는 영향 없음 (auto_worklet_next는
+    /// 한 번 소비되면 리셋).
+    fn visitFileWorkletProgram(self: *Transformer, node: Node) Error!NodeIndex {
+        const list_start = node.data.list.start;
+        const list_len = node.data.list.len;
+
+        const scratch_top = self.scratch.items.len;
+        defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+        const pending_top = self.pending_nodes.items.len;
+        defer self.pending_nodes.shrinkRetainingCapacity(pending_top);
+        const trailing_top = self.trailing_nodes.items.len;
+        defer self.trailing_nodes.shrinkRetainingCapacity(trailing_top);
+
+        var i: u32 = 0;
+        while (i < list_len) : (i += 1) {
+            const raw = self.ast.extra_data.items[list_start + i];
+            const child_idx: NodeIndex = @enumFromInt(raw);
+            if (!child_idx.isNone()) {
+                const child = self.ast.getNode(child_idx);
+                switch (child.tag) {
+                    .function_declaration, .class_declaration, .variable_declaration, .export_named_declaration, .export_default_declaration => {
+                        self.auto_worklet_next = true;
+                    },
+                    else => {},
+                }
+            }
+
+            // pending_nodes를 child 앞에 삽입 (visitExtraList와 동일 패턴)
+            if (self.pending_nodes.items.len > pending_top) {
+                try self.scratch.appendSlice(self.allocator, self.pending_nodes.items[pending_top..]);
+                self.pending_nodes.shrinkRetainingCapacity(pending_top);
+            }
+
+            const new_child = try self.visitNode(child_idx);
+            self.auto_worklet_next = false;
+            if (!new_child.isNone()) try self.scratch.append(self.allocator, new_child);
+
+            // trailing_nodes를 child 뒤에 삽입 (__workletHash 할당문 등)
+            if (self.trailing_nodes.items.len > trailing_top) {
+                try self.scratch.appendSlice(self.allocator, self.trailing_nodes.items[trailing_top..]);
+                self.trailing_nodes.shrinkRetainingCapacity(trailing_top);
+            }
+        }
+
+        const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+        return self.ast.addNode(.{
+            .tag = node.tag,
+            .span = node.span,
+            .data = .{ .list = new_list },
+        });
+    }
+
+    /// 리스트에서 첫 번째 directive로 `'worklet'` 또는 `"worklet"`가 있는지 확인.
+    /// directive는 expression_statement + string_literal (첫 non-comment 문장).
+    fn hasWorkletDirective(self: *Transformer, list_start: u32, list_len: u32) bool {
+        var i: u32 = 0;
+        while (i < list_len) : (i += 1) {
+            const idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list_start + i]);
+            if (idx.isNone()) continue;
+            const stmt = self.ast.getNode(idx);
+            if (stmt.tag != .expression_statement) return false; // directive는 리스트 맨 앞
+            const inner_idx = stmt.data.unary.operand;
+            if (inner_idx.isNone()) return false;
+            const inner = self.ast.getNode(inner_idx);
+            if (inner.tag != .string_literal) return false;
+            const text = self.ast.source[inner.span.start..inner.span.end];
+            // text는 quote 포함 (`"worklet"` 또는 `'worklet'`)
+            if (std.mem.eql(u8, text, "\"worklet\"") or std.mem.eql(u8, text, "'worklet'")) return true;
+            // 다른 directive (예: "use strict")면 다음으로 진행
+        }
+        return false;
     }
 
     /// onFunction 플러그인 훅을 실행한다.

--- a/src/transformer/worklet_babel_parity_test.zig
+++ b/src/transformer/worklet_babel_parity_test.zig
@@ -2090,9 +2090,7 @@ test "babel:babel_plugin_for_file_workletization:workletizes_FunctionDeclaration
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: has worklet data (__workletHash present)
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_file_workletization:workletizes_assigned_FunctionDeclaration" {
@@ -2105,9 +2103,7 @@ test "babel:babel_plugin_for_file_workletization:workletizes_assigned_FunctionDe
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: has worklet data (__workletHash present)
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_file_workletization:workletizes_FunctionDeclaration_in_named_export" {
@@ -2130,9 +2126,7 @@ test "babel:babel_plugin_for_file_workletization:workletizes_FunctionExpression"
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: has worklet data (__workletHash present)
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_file_workletization:workletizes_FunctionExpression_in_named_export" {
@@ -2155,9 +2149,7 @@ test "babel:babel_plugin_for_file_workletization:workletizes_ArrowFunctionExpres
     defer r.deinit();
     const code = tt.generateCode(&r) catch return error.SkipZigTest;
     defer std.testing.allocator.free(code);
-    _ = &code;
-    // EXPECT: has worklet data (__workletHash present)
-    // (snapshot — skipped)
+    try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
 }
 
 test "babel:babel_plugin_for_file_workletization:workletizes_ArrowFunctionExpression_in_named_export" {


### PR DESCRIPTION
## Summary

#1173 Phase 6.4 (basic) — Babel의 file workletization 중 non-export/non-class 케이스 포팅.

program 최상단에 \`'worklet';\` directive가 있을 때 top-level 함수/클래스 선언을 자동 worklet화.

## 지원 패턴

\`\`\`js
'worklet';
function foo() {...}           // ✅ function declaration
const foo = function () {...}  // ✅ function expression init
const foo = function foo() {}  // ✅ named function expression init
const foo = (x) => {...}       // ✅ arrow init
class Foo {...}                // auto_worklet_next만 설정 (실질 변환은 Phase 5)
\`\`\`

## 미지원 (후속 Phase)

- `export function` / `export default function` IIFE factory 변환 (Phase 6.5)
- class declaration workletization (Phase 5 `__classFactory` 의존)
- implicit WorkletContextObject (Phase 6.5)
- CommonJS export 재배치

## Test plan
- [x] `zig build test` 통과
- [x] bungae ExampleApp iOS 번들 회귀 없음 (519 hash, 0 dir)

Refs #1173 Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)