### PR TITLE
fix(worklet): inject user's react-native-worklets version into __pluginVersion

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -227,6 +227,9 @@ export interface BuildOptions {
   collectModuleCodes?: boolean;
   /** Object.defineProperty에 configurable: true 추가 (RN/Hermes 호환) */
   configurableExports?: boolean;
+  /** worklet의 `__pluginVersion` 값 (Reanimated dev mode jsVersion 대조용).
+   * 사용자 환경의 react-native-worklets 패키지 version을 전달해야 런타임 에러 없음. */
+  workletPluginVersion?: string;
   /** scope hoisting 시 예약할 전역 식별자 */
   globalIdentifiers?: string[];
   /** 번들 시작 시 즉시 실행 폴리필 경로 */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2089,6 +2089,7 @@ fn parseBuildOptions(
         .configurable_exports = getObjectBool(env, opts_obj, "configurableExports", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.configurable_exports),
         .strict_execution_order = getObjectBool(env, opts_obj, "strictExecutionOrder", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.strict_execution_order),
         .worklet_transform = getObjectBool(env, opts_obj, "workletTransform", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.worklet_transform),
+        .worklet_plugin_version = ownStr(env, opts_obj, "workletPluginVersion", owned_strings),
         .global_identifiers = global_identifiers orelse &.{},
         .polyfills = polyfills orelse &.{},
         .run_before_main = run_before_main orelse &.{},

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -165,6 +165,10 @@ pub const BundleOptions = struct {
     strict_execution_order: bool = false,
     /// Reanimated worklet 네이티브 변환. --platform=react-native에서 자동 활성화.
     worklet_transform: bool = false,
+    /// worklet의 `__pluginVersion` 값. null이면 ZTS 기본 상수 사용.
+    /// Reanimated dev mode runtime이 jsVersion과 대조하므로 사용자의 react-native-worklets
+    /// 패키지 버전을 그대로 전달해야 런타임 mismatch 에러 없음.
+    worklet_plugin_version: ?[]const u8 = null,
     /// 증분 빌드용 모�� 파싱 캐시. null이면 매번 전체 파싱.
     /// IncrementalBundler가 소유하고 빌드 간 보존한다.
     module_store: ?*@import("module_store.zig").PersistentModuleStore = null,
@@ -365,6 +369,7 @@ pub const Bundler = struct {
             .configurable_exports = self.options.configurable_exports,
             .strict_execution_order = self.options.strict_execution_order,
             .worklet_transform = self.options.worklet_transform,
+            .worklet_plugin_version = self.options.worklet_plugin_version,
         };
     }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -62,6 +62,8 @@ pub const EmitOptions = struct {
     react_refresh: bool = false,
     /// Reanimated worklet 네이티브 변환.
     worklet_transform: bool = false,
+    /// worklet의 `__pluginVersion` 값. null이면 ZTS 기본 상수.
+    worklet_plugin_version: ?[]const u8 = null,
     /// dev mode에서 per-module codes 수집 여부.
     /// false면 output만 생성하고 module_dev_codes를 건너뛴다 (초기 빌드용, 메모리 절감).
     /// true면 HMR 업데이트용 module_dev_codes를 수집한다 (rebuild용).
@@ -722,6 +724,7 @@ pub fn emitModule(
         .jsx_fragment = options.jsx_fragment,
         .jsx_import_source = options.jsx_import_source,
         .jsx_filename = module.path,
+        .worklet_plugin_version = options.worklet_plugin_version,
     });
     // symbol_ids 전파: semantic analyzer가 생성한 원본 AST의 symbol_ids를
     // transformer가 ast 기준으로 재매핑

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -115,6 +115,13 @@ pub const TransformOptions = struct {
     /// 예: `globals: ['__DEV__']` → worklet 내 `__DEV__` 참조가 __closure에 포함 안 됨.
     worklet_globals: []const []const u8 = &.{},
 
+    /// worklet 함수의 `__pluginVersion` 값. null이면 기본 ZTS 상수 사용.
+    /// Reanimated dev mode (`serializable.native.ts:464`)에서 `jsVersion`과 대조하여
+    /// 불일치 시 throw — 따라서 사용자의 `react-native-worklets` 패키지 버전을
+    /// 맞춰 전달해야 런타임 에러 없음. 번들러가 `node_modules/react-native-worklets/package.json`
+    /// 에서 자동 감지해 전달 권장.
+    worklet_plugin_version: ?[]const u8 = null,
+
     pub const compat = @import("compat.zig");
 };
 
@@ -199,6 +206,10 @@ pub const Transformer = struct {
     /// define value의 string_table Span 캐시. options.define과 동일 인덱스.
     /// transform() 시작 시 한 번 빌드하여, tryDefineReplace에서 addString 중복 호출을 방지.
     define_spans: []Span = &.{},
+
+    /// `__pluginVersion`에 주입할 따옴표로 감싼 문자열 리터럴 span (pre-computed).
+    /// worklet당 매번 allocPrint하는 오버헤드 제거 — init에서 한 번만 생성.
+    worklet_plugin_version_span: ?Span = null,
 
     /// ES 다운레벨링 임시 변수 카운터.
     /// `foo() ?? bar` → `(_a = foo()) != null ? _a : bar`에서 _a, _b, _c, ... 생성에 사용.
@@ -431,6 +442,13 @@ pub const Transformer = struct {
             for (self.options.define, 0..) |entry, i| {
                 self.define_spans[i] = self.ast.addString(entry.value) catch return Error.OutOfMemory;
             }
+        }
+
+        // worklet __pluginVersion 문자열 리터럴 span 사전 계산 (매 worklet당 할당 방지)
+        if (self.options.worklet_plugin_version) |v| {
+            const quoted = std.fmt.allocPrint(self.allocator, "\"{s}\"", .{v}) catch return Error.OutOfMemory;
+            defer self.allocator.free(quoted);
+            self.worklet_plugin_version_span = self.ast.addString(quoted) catch return Error.OutOfMemory;
         }
 
         // 파서의 마지막 노드가 루트 (program). parser_node_count - 1.

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -665,9 +665,11 @@ pub fn buildWorkletPropertyAssignments(
     const stack_stmt = try buildPropAssignment(self, func_name_span, "__stackDetails", empty_array, func_node_idx);
 
     // 5. funcName.__pluginVersion = "<version>";
-    // Babel react-native-worklets/plugin이 packageVersion을 심볼로 주입하는 동작과 동일.
-    // (Reanimated devtools/tooling이 worklet plugin 버전을 식별하는 용도)
-    const version_span = try self.ast.addString("\"" ++ WORKLET_PLUGIN_VERSION ++ "\"");
+    // Reanimated dev mode가 jsVersion과 대조 (serializable.native.ts:464) —
+    // 불일치 시 WorkletsError throw. 번들러가 사용자 react-native-worklets 버전을
+    // 전달하지 않으면 WORKLET_PLUGIN_VERSION fallback.
+    // 매 worklet당 allocPrint 방지를 위해 Transformer.init에서 pre-computed span 사용.
+    const version_span = self.worklet_plugin_version_span orelse try self.ast.addString("\"" ++ WORKLET_PLUGIN_VERSION ++ "\"");
     const version_node = try self.ast.addNode(.{
         .tag = .string_literal,
         .span = version_span,


### PR DESCRIPTION
## Problem

Reanimated dev mode runtime (\`serializable.native.ts:464\`)이 worklet의 \`__pluginVersion\`을 패키지의 \`jsVersion\`과 대조:

\`\`\`ts
if (__DEV__) {
  const babelVersion = value.__pluginVersion;
  if (babelVersion !== undefined && babelVersion !== jsVersion) {
    throw new WorkletsError(\`Mismatch between JS code version and plugin version...\`);
  }
}
\`\`\`

ZTS가 고정 문자열 \`"zts-0.0.1"\`을 주입해서 **\`__DEV__\` 빌드의 모든 worklet이 에러를 던지는 문제**. 개발 환경에서 Reanimated 사용 시 앱이 동작 안 함.

## Fix

번들러가 사용자 환경의 \`node_modules/react-native-worklets/package.json\` 버전을 감지해 \`workletPluginVersion\` 옵션으로 ZTS에 전달. Node resolution algorithm(require.resolve) 사용 — 모노레포(Yarn workspaces, pnpm) 호이스팅 자동 대응.

## Verification

bungae ExampleApp iOS 번들:
\`\`\`
__pluginVersion="0.8.1"  // 사용자의 react-native-worklets 실제 버전
\`\`\`
이전: \`__pluginVersion="zts-0.0.1"\` (mismatch) → 현재: matches \`jsVersion\`.

## Test plan
- [x] \`zig build test\` 통과
- [x] bungae ExampleApp 빌드 확인 (버전 감지됨)
- [ ] 실기기 dev mode에서 worklet 실행 시 WorkletsError 미발생 확인 (사용자 검증 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)