### PR TITLE
fix(worklet): suppress Fast Refresh reg inside factory IIFE

### DIFF
--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -901,7 +901,12 @@ fn buildClassFactoryAssignment(t: *Transformer, class_name: []const u8, stripped
     const iife = try t.ast.addNode(.{ .tag = .call_expression, .span = zero_span, .data = .{ .extra = call_extra } });
 
     // 중요: visit을 돌려 plugin의 onFunction이 IIFE 내부 function_declaration을 worklet화하도록.
+    // Fast Refresh 등록은 억제 — IIFE 내부 factory function은 최상위 바인딩이 아니므로
+    // `_cN = <name>` 참조 시 ReferenceError 발생.
+    const saved_suppress = t.suppress_refresh_registration;
+    t.suppress_refresh_registration = true;
     const visited_iife = try t.visitNode(iife);
+    t.suppress_refresh_registration = saved_suppress;
 
     // LHS: ClassName.ClassName__classFactory
     const obj_ref = try t.ast.addNode(.{

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -323,6 +323,10 @@ pub const Transformer = struct {
     /// transform 완료 후 프로그램 끝에 $RefreshReg$ 호출로 주입.
     refresh_registrations: std.ArrayList(RefreshRegistration) = .empty,
 
+    /// Fast Refresh 등록 억제 플래그 (plugin이 IIFE 내부 함수를 visit할 때 설정).
+    /// 중첩 function_declaration이 컴포넌트로 오인되어 ReferenceError 유발하는 것을 방지.
+    suppress_refresh_registration: bool = false,
+
     /// React Fast Refresh: Hook 시그니처 등록 목록.
     /// 프로그램 끝에 var _s = $RefreshSig$(); + _s(Component, "sig") 호출로 주입.
     refresh_signatures: std.ArrayList(RefreshSignature) = .empty,

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -45,6 +45,7 @@ pub fn getFunctionName(self: *Transformer, func_node: Node) ?[]const u8 {
 /// visitFunction에서 호출.
 pub fn maybeRegisterRefreshComponent(self: *Transformer, new_func_idx: NodeIndex) Error!void {
     if (!self.options.react_refresh) return;
+    if (self.suppress_refresh_registration) return;
 
     const func_node = self.ast.getNode(new_func_idx);
     // function_expression의 이름은 함수 내부 스코프에서만 접근 가능하므로


### PR DESCRIPTION
## Summary
- \`<Class>__classFactory\` IIFE 내부 function_declaration이 PascalCase라는 이유로 Fast Refresh 컴포넌트로 오인되어 \`_cN = <name>\` 참조 시 ReferenceError 발생
- Transformer에 \`suppress_refresh_registration\` 플래그 추가, worklet plugin이 IIFE visit 전후로 토글

## Test plan
- [x] zig build test (2716/2716)
- [x] bungae ExampleApp 번들 재생성 — \`_c4 = WorkletMarkedClass__classFactory\` 더 이상 emit 안 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)