### PR TITLE
fix(worklet): arrow ExpressionBody의 implicit return을 __initData.code에 보존

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -959,11 +959,31 @@ pub fn generateInitCode(
 ) Error![]const u8 {
     const zero_span = Span{ .start = 0, .end = 0 };
 
-    // closure destructuring: const { v1, v2 } = this.__closure;
-    var new_body_idx = body_idx;
+    // arrow ExpressionBody 보정: body가 block/function_body가 아니면
+    // `{ return expr; }`로 감싸 implicit return 의미를 복원한다.
+    // (es2015_arrow는 visited body만 래핑하고 original_body_idx는 pre-visit expression을 그대로 넘기므로,
+    //  __initData.code 경로에서 return이 누락되어 UI thread가 undefined를 반환하는 문제를 수정.)
+    var new_body_idx = blk: {
+        if (body_idx.isNone()) break :blk body_idx;
+        const body_node = self.ast.getNode(body_idx);
+        if (body_node.tag == .block_statement or body_node.tag == .function_body or body_node.tag == .program) {
+            break :blk body_idx;
+        }
+        const ret_stmt = try self.ast.addNode(.{
+            .tag = .return_statement,
+            .span = body_node.span,
+            .data = .{ .unary = .{ .operand = body_idx, .flags = 0 } },
+        });
+        const list = try self.ast.addNodeList(&.{ret_stmt});
+        break :blk try self.ast.addNode(.{
+            .tag = .block_statement,
+            .span = body_node.span,
+            .data = .{ .list = list },
+        });
+    };
     if (closure_vars.len > 0) {
         const destr_stmt = try buildClosureDestructuring(self, closure_vars, zero_span);
-        new_body_idx = try self.prependStatementsToBody(body_idx, &.{destr_stmt});
+        new_body_idx = try self.prependStatementsToBody(new_body_idx, &.{destr_stmt});
     }
 
     // synthetic function: function funcName(params) { ...body... }

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -966,7 +966,7 @@ pub fn generateInitCode(
     var new_body_idx = blk: {
         if (body_idx.isNone()) break :blk body_idx;
         const body_node = self.ast.getNode(body_idx);
-        if (body_node.tag == .block_statement or body_node.tag == .function_body or body_node.tag == .program) {
+        if (body_node.tag == .block_statement or body_node.tag == .function_body) {
             break :blk body_idx;
         }
         const ret_stmt = try self.ast.addNode(.{

--- a/src/transformer/worklet_babel_parity_test.zig
+++ b/src/transformer/worklet_babel_parity_test.zig
@@ -2794,6 +2794,14 @@ test "ZTS: __workletClass with es5 target produces lowered IIFE class" {
     try std.testing.expect(std.mem.indexOf(u8, code, "Clazz__classFactory") != null);
 }
 
+fn containsReturnExpr(code: []const u8) bool {
+    const variants = [_][]const u8{ "return{", "return {", "return(", "return (" };
+    for (variants) |v| {
+        if (std.mem.indexOf(u8, code, v) != null) return true;
+    }
+    return false;
+}
+
 test "ZTS: arrow ExpressionBody preserves implicit return in __initData.code (issue #1191)" {
     // useAnimatedStyle(() => ({ ... })) 같은 arrow + expression body 형태가
     // __initData.code에 return 없이 직렬화되어 UI thread가 undefined를 반환하던 버그 회귀 방지.
@@ -2805,12 +2813,7 @@ test "ZTS: arrow ExpressionBody preserves implicit return in __initData.code (is
     defer r.deinit();
     const code = try tt.generateCode(&r);
     defer std.testing.allocator.free(code);
-    // __initData.code 문자열 안의 function body에 `return{` 또는 `return (` 가 포함되어야 한다.
-    const has_return = std.mem.indexOf(u8, code, "return{") != null or
-        std.mem.indexOf(u8, code, "return {") != null or
-        std.mem.indexOf(u8, code, "return(") != null or
-        std.mem.indexOf(u8, code, "return (") != null;
-    try std.testing.expect(has_return);
+    try std.testing.expect(containsReturnExpr(code));
 }
 
 test "ZTS: arrow ExpressionBody with closure preserves implicit return (issue #1191)" {
@@ -2825,12 +2828,6 @@ test "ZTS: arrow ExpressionBody with closure preserves implicit return (issue #1
     defer r.deinit();
     const code = try tt.generateCode(&r);
     defer std.testing.allocator.free(code);
-    // closure destructuring이 삽입된 뒤에도 return이 살아있어야 함.
-    const has_closure = std.mem.indexOf(u8, code, "this.__closure") != null;
-    const has_return = std.mem.indexOf(u8, code, "return{") != null or
-        std.mem.indexOf(u8, code, "return {") != null or
-        std.mem.indexOf(u8, code, "return(") != null or
-        std.mem.indexOf(u8, code, "return (") != null;
-    try std.testing.expect(has_closure);
-    try std.testing.expect(has_return);
+    try std.testing.expect(std.mem.indexOf(u8, code, "this.__closure") != null);
+    try std.testing.expect(containsReturnExpr(code));
 }

--- a/src/transformer/worklet_babel_parity_test.zig
+++ b/src/transformer/worklet_babel_parity_test.zig
@@ -2793,3 +2793,44 @@ test "ZTS: __workletClass with es5 target produces lowered IIFE class" {
     try std.testing.expect(std.mem.indexOf(u8, code, "__classCallCheck") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "Clazz__classFactory") != null);
 }
+
+test "ZTS: arrow ExpressionBody preserves implicit return in __initData.code (issue #1191)" {
+    // useAnimatedStyle(() => ({ ... })) 같은 arrow + expression body 형태가
+    // __initData.code에 return 없이 직렬화되어 UI thread가 undefined를 반환하던 버그 회귀 방지.
+    var r = try tt.transformWorklet(std.testing.allocator,
+        \\const animatedStyle = useAnimatedStyle(() => ({
+        \\  transform: [{ scale: scale.value }],
+        \\}));
+    );
+    defer r.deinit();
+    const code = try tt.generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // __initData.code 문자열 안의 function body에 `return{` 또는 `return (` 가 포함되어야 한다.
+    const has_return = std.mem.indexOf(u8, code, "return{") != null or
+        std.mem.indexOf(u8, code, "return {") != null or
+        std.mem.indexOf(u8, code, "return(") != null or
+        std.mem.indexOf(u8, code, "return (") != null;
+    try std.testing.expect(has_return);
+}
+
+test "ZTS: arrow ExpressionBody with closure preserves implicit return (issue #1191)" {
+    var r = try tt.transformWorklet(std.testing.allocator,
+        \\function Box(){
+        \\  const scale = useSharedValue(1);
+        \\  const animatedStyle = useAnimatedStyle(() => ({
+        \\    transform: [{ scale: scale.value }],
+        \\  }));
+        \\}
+    );
+    defer r.deinit();
+    const code = try tt.generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // closure destructuring이 삽입된 뒤에도 return이 살아있어야 함.
+    const has_closure = std.mem.indexOf(u8, code, "this.__closure") != null;
+    const has_return = std.mem.indexOf(u8, code, "return{") != null or
+        std.mem.indexOf(u8, code, "return {") != null or
+        std.mem.indexOf(u8, code, "return(") != null or
+        std.mem.indexOf(u8, code, "return (") != null;
+    try std.testing.expect(has_closure);
+    try std.testing.expect(has_return);
+}


### PR DESCRIPTION
## Summary
- `useAnimatedStyle(() => ({...}))`, `useDerivedValue(() => expr)` 같이 arrow + expression body 형태의 worklet이 UI thread에서 `undefined`를 반환하던 버그 수정 (#1191)
- `generateInitCode` 초입에서 body가 block/function_body/program이 아니면 `{ return expr; }`로 래핑 — arrow ExpressionBody의 implicit return 의미를 `__initData.code` 직렬화 경로에 복원
- 회귀 방지 유닛 테스트 2건 추가 (closure 유/무)

## Root Cause
`es2015_arrow.zig`는 visited body만 `{ return expr; }`로 래핑하고, `original_body_idx`로 pre-visit expression 노드를 그대로 넘긴다. `generateInitCode`는 이 원본을 function body로 사용하는데, `prependStatementsToBody`는 block-wrap만 수행할 뿐 `return`을 붙이지 않아 ExpressionStatement로 직렬화됨 → UI thread `undefined`.

## Test plan
- [x] `zig build test` 전체 통과 (Babel parity 169 tests + 추가 2건)
- [ ] 번개 ExampleApp ReanimatedDemo에서 scale/rotate/색상 애니메이션 정상 동작 확인

Fixes #1191

🤖 Generated with [Claude Code](https://claude.com/claude-code)