### PR TITLE
refactor(transformer): move worklet state into PluginState.worklet

### DIFF
--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -95,7 +95,7 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
             });
 
             // Plugin dispatch: worklet 등 AST 플러그인 적용
-            const is_auto_worklet = self.auto_worklet_next;
+            const is_auto_worklet = self.plugins.worklet.auto_next;
             if (try self.dispatchFunctionPlugins(result, .{
                 .node_idx = result,
                 .node_tag = .function_expression,

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -1,0 +1,36 @@
+//! 플러그인별 runtime state를 모아두는 컨테이너.
+//!
+//! Transformer core에 산재하던 plugin-specific 필드를 이곳으로 이사하여,
+//! core는 ES spec 변환에, plugin은 자기 state에 집중할 수 있게 한다.
+//!
+//! ## 접근 규칙 (DECISIONS.md)
+//! 1. 각 plugin은 **자기 sub-struct만** 접근. cross-plugin 접근 금지.
+//!    예: refresh plugin이 `plugins.worklet.*`를 읽으면 안 됨.
+//! 2. Core는 명명된 hook point 함수(예: `visitBodyWorkletAware`, `dispatchFunctionPlugins`)
+//!    를 통해서만 plugin 상태에 접근.
+//! 이 규칙을 지키면 추후 visitor-hook 아키텍처로 전환 시 비용이 저렴하다.
+
+const token_mod = @import("../lexer/token.zig");
+const Span = token_mod.Span;
+
+pub const WorkletState = struct {
+    /// auto-workletization 플래그.
+    /// visitCallExpression에서 callee 매칭 시 true로 설정하고,
+    /// dispatchFunctionPlugins에서 FunctionInfo.is_auto_worklet로 전달 후 false로 리셋.
+    auto_next: bool = false,
+
+    /// 익명 worklet 함수 이름 생성 시 사용하는 sequential counter (Babel `null<N>` 호환).
+    anonymous_counter: u32 = 0,
+
+    /// worklet 함수 body 방문 중 깊이. > 0 이면 define 치환(`--define:global=...`) 억제.
+    /// worklet body는 UI 런타임에서 실행되므로 JS 전용 global polyfill 심볼로 치환하면 안 된다.
+    body_depth: u32 = 0,
+
+    /// `__pluginVersion`에 주입할 따옴표로 감싼 문자열 리터럴 span (pre-computed).
+    /// worklet당 매번 allocPrint하는 오버헤드 제거 — init에서 한 번만 생성.
+    plugin_version_span: ?Span = null,
+};
+
+pub const PluginState = struct {
+    worklet: WorkletState = .{},
+};

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -176,8 +176,8 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     var anon_name_buf: [256]u8 = undefined;
     var sanitize_buf: [128]u8 = undefined;
     const func_name = if (info.name) |n| n else blk: {
-        const idx = api.transformer.worklet_anonymous_counter;
-        api.transformer.worklet_anonymous_counter += 1;
+        const idx = api.transformer.plugins.worklet.anonymous_counter;
+        api.transformer.plugins.worklet.anonymous_counter += 1;
         const file_marker = sanitizeFilename(info.source_path, &sanitize_buf);
         const name = std.fmt.bufPrint(&anon_name_buf, "{s}_null{d}", .{ file_marker, idx }) catch return error.OutOfMemory;
         break :blk name;
@@ -487,7 +487,7 @@ fn visitFileWorkletProgram(t: *Transformer, node: Node) !NodeIndex {
                 continue;
             }
             switch (child.tag) {
-                .function_declaration, .class_declaration, .variable_declaration, .export_named_declaration, .export_default_declaration => t.auto_worklet_next = true,
+                .function_declaration, .class_declaration, .variable_declaration, .export_named_declaration, .export_default_declaration => t.plugins.worklet.auto_next = true,
                 else => {},
             }
         }
@@ -496,7 +496,7 @@ fn visitFileWorkletProgram(t: *Transformer, node: Node) !NodeIndex {
             t.pending_nodes.shrinkRetainingCapacity(pending_top);
         }
         const new_child = try t.visitNode(child_idx);
-        t.auto_worklet_next = false;
+        t.plugins.worklet.auto_next = false;
         if (!new_child.isNone()) try t.scratch.append(t.allocator, new_child);
         if (t.trailing_nodes.items.len > trailing_top) {
             try t.scratch.appendSlice(t.allocator, t.trailing_nodes.items[trailing_top..]);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1728,7 +1728,7 @@ pub const Transformer = struct {
     // define 글로벌 치환
     // ================================================================
 
-    /// 함수 body가 worklet이 될 예정이면 `worklet_body_depth`를 올린 상태로 body를 방문한다.
+    /// 함수 body가 worklet이 될 예정이면 `plugins.worklet.body_depth`를 올린 상태로 body를 방문한다.
     /// 반환된 body 내부에서는 `--define` 치환이 억제되어 UI 런타임에서도 심볼이 안전하게 유지된다.
     pub fn visitBodyWorkletAware(self: *Transformer, body_idx: NodeIndex) Error!NodeIndex {
         const is_worklet = self.plugins.worklet.auto_next or
@@ -2945,7 +2945,7 @@ pub const Transformer = struct {
         const new_callee = try self.visitNode(callee_idx);
 
         // Auto-workletization: callee 이름이 플러그인 목록에 매칭되면
-        // 해당 인자 위치의 function/arrow에 auto_worklet_next 플래그를 설정.
+        // 해당 인자 위치의 function/arrow에 plugins.worklet.auto_next 플래그를 설정.
         const auto_callee = self.matchAutoWorkletCallee(callee_idx);
         const new_args = if (auto_callee != null)
             try self.visitCallArgsWithAutoWorklet(args_start, args_len, auto_callee.?)
@@ -3516,7 +3516,7 @@ pub const Transformer = struct {
     }
 
     /// auto-workletization이 필요한 call expression의 인자를 개별 방문.
-    /// 대상 인자 위치의 function/arrow 방문 전에 auto_worklet_next 플래그를 설정.
+    /// 대상 인자 위치의 function/arrow 방문 전에 plugins.worklet.auto_next 플래그를 설정.
     fn visitCallArgsWithAutoWorklet(self: *Transformer, args_start: u32, args_len: u32, callee: AutoWorkletCallee) Error!NodeList {
         const scratch_top = self.scratch.items.len;
         defer self.scratch.shrinkRetainingCapacity(scratch_top);
@@ -3542,7 +3542,7 @@ pub const Transformer = struct {
             };
 
             // save/restore: 재귀적 visitNode 내부의 중첩 call_expression이
-            // auto_worklet_next를 오염시키지 않도록 보호.
+            // plugins.worklet.auto_next를 오염시키지 않도록 보호.
             const saved_auto = self.plugins.worklet.auto_next;
             if (should_auto and !arg_idx.isNone()) {
                 const arg_node = self.ast.getNode(arg_idx);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -23,6 +23,8 @@ const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const plugin_state = @import("plugin_state.zig");
+const PluginState = plugin_state.PluginState;
 const es2016 = @import("es2016.zig");
 const es2018 = @import("es2018.zig");
 const es2017_mod = @import("es2017.zig");
@@ -208,10 +210,6 @@ pub const Transformer = struct {
     /// transform() 시작 시 한 번 빌드하여, tryDefineReplace에서 addString 중복 호출을 방지.
     define_spans: []Span = &.{},
 
-    /// `__pluginVersion`에 주입할 따옴표로 감싼 문자열 리터럴 span (pre-computed).
-    /// worklet당 매번 allocPrint하는 오버헤드 제거 — init에서 한 번만 생성.
-    worklet_plugin_version_span: ?Span = null,
-
     /// ES 다운레벨링 임시 변수 카운터.
     /// `foo() ?? bar` → `(_a = foo()) != null ? _a : bar`에서 _a, _b, _c, ... 생성에 사용.
     temp_var_counter: u32 = 0,
@@ -274,18 +272,9 @@ pub const Transformer = struct {
     /// super() 이후의 this 참조를 _this로 교체해야 한다.
     super_call_this_alias: bool = false,
 
-    /// auto-workletization 플래그.
-    /// visitCallExpression에서 callee 매칭 시 true로 설정하고,
-    /// dispatchFunctionPlugins에서 FunctionInfo.is_auto_worklet로 전달 후 false로 리셋.
-    auto_worklet_next: bool = false,
-
-    /// 익명 worklet 함수 이름 생성 시 사용하는 sequential counter (Babel `null<N>` 호환).
-    /// 같은 파일 내에서 0부터 증가, worklet plugin이 fallback name 만들 때 사용.
-    worklet_anonymous_counter: u32 = 0,
-
-    /// worklet 함수 body 방문 중 깊이. > 0 이면 define 치환(`--define:global=...`) 억제.
-    /// worklet body는 UI 런타임에서 실행되므로 JS 전용 global polyfill 심볼로 치환하면 안 된다.
-    worklet_body_depth: u32 = 0,
+    /// 플러그인별 runtime state. 각 plugin은 자기 sub-struct만 접근.
+    /// 상세 규칙은 `plugin_state.zig` 참조.
+    plugins: PluginState = .{},
 
     /// 런타임 헬퍼 사용 추적.
     /// 각 변환이 헬퍼를 사용하면 해당 비트를 설정한다.
@@ -461,14 +450,14 @@ pub const Transformer = struct {
         if (self.options.worklet_plugin_version) |v| {
             const quoted = std.fmt.allocPrint(self.allocator, "\"{s}\"", .{v}) catch return Error.OutOfMemory;
             defer self.allocator.free(quoted);
-            self.worklet_plugin_version_span = self.ast.addString(quoted) catch return Error.OutOfMemory;
+            self.plugins.worklet.plugin_version_span = self.ast.addString(quoted) catch return Error.OutOfMemory;
         }
 
         // 파서의 마지막 노드가 루트 (program). parser_node_count - 1.
         const root_idx: NodeIndex = @enumFromInt(self.parser_node_count - 1);
         const saved_temp_counter = self.temp_var_counter;
         // worklet anonymous naming counter — Transformer 인스턴스 재사용 시 매 transform당 0부터 시작.
-        self.worklet_anonymous_counter = 0;
+        self.plugins.worklet.anonymous_counter = 0;
         var root = try self.visitNode(root_idx);
 
         // Pass 2: ES2015 params lowering 일괄 적용
@@ -584,7 +573,7 @@ pub const Transformer = struct {
         // 3단계: define 글로벌 치환
         // --------------------------------------------------------
         // worklet body 내부에서는 억제: UI 런타임은 bundler prelude의 polyfill 심볼을 모름.
-        if (self.options.define.len > 0 and self.worklet_body_depth == 0) {
+        if (self.options.define.len > 0 and self.plugins.worklet.body_depth == 0) {
             if (self.tryDefineReplace(node)) |new_node| {
                 return try new_node;
             }
@@ -1742,11 +1731,11 @@ pub const Transformer = struct {
     /// 함수 body가 worklet이 될 예정이면 `worklet_body_depth`를 올린 상태로 body를 방문한다.
     /// 반환된 body 내부에서는 `--define` 치환이 억제되어 UI 런타임에서도 심볼이 안전하게 유지된다.
     pub fn visitBodyWorkletAware(self: *Transformer, body_idx: NodeIndex) Error!NodeIndex {
-        const is_worklet = self.auto_worklet_next or
+        const is_worklet = self.plugins.worklet.auto_next or
             worklet_mod.isWorkletDirectiveGeneric(self, body_idx, "worklet");
-        if (is_worklet) self.worklet_body_depth += 1;
+        if (is_worklet) self.plugins.worklet.body_depth += 1;
         defer if (is_worklet) {
-            self.worklet_body_depth -= 1;
+            self.plugins.worklet.body_depth -= 1;
         };
         return self.visitNode(body_idx);
     }
@@ -2136,7 +2125,7 @@ pub const Transformer = struct {
         });
 
         // Plugin dispatch: onFunction (AST 훅)
-        const is_auto_worklet = self.auto_worklet_next;
+        const is_auto_worklet = self.plugins.worklet.auto_next;
         if (try self.dispatchFunctionPlugins(result, .{
             .node_idx = result,
             .node_tag = node.tag,
@@ -2760,7 +2749,7 @@ pub const Transformer = struct {
         const result = try self.ast.addNode(.{ .tag = .arrow_function_expression, .span = node.span, .data = .{ .extra = new_extra } });
 
         // Plugin dispatch: auto-workletization 등 AST 플러그인 적용
-        const is_auto_worklet = self.auto_worklet_next;
+        const is_auto_worklet = self.plugins.worklet.auto_next;
         if (is_auto_worklet or self.options.plugins.len > 0) {
             // arrow params는 formal_parameters (list) 또는 none일 수 있다.
             var orig_p_start: u32 = 0;
@@ -3095,7 +3084,7 @@ pub const Transformer = struct {
         // method_definition은 object/class 내부에 있으므로 IIFE 교체는 불가.
         // 대신 워크릿 플러그인이 method body 기반으로 function_expression을 생성하여
         // object_property value로 교체할 수 있도록 정보를 전달한다.
-        const is_auto_worklet = self.auto_worklet_next;
+        const is_auto_worklet = self.plugins.worklet.auto_next;
         // method 이름 추출 (key가 identifier인 경우)
         const method_name: ?[]const u8 = blk: {
             const key_idx = self.readNodeIdx(e, 0);
@@ -3554,18 +3543,18 @@ pub const Transformer = struct {
 
             // save/restore: 재귀적 visitNode 내부의 중첩 call_expression이
             // auto_worklet_next를 오염시키지 않도록 보호.
-            const saved_auto = self.auto_worklet_next;
+            const saved_auto = self.plugins.worklet.auto_next;
             if (should_auto and !arg_idx.isNone()) {
                 const arg_node = self.ast.getNode(arg_idx);
                 if (arg_node.tag == .function_expression or
                     arg_node.tag == .arrow_function_expression)
                 {
-                    self.auto_worklet_next = true;
+                    self.plugins.worklet.auto_next = true;
                 }
             }
 
             const new_child = try self.visitNode(arg_idx);
-            self.auto_worklet_next = saved_auto;
+            self.plugins.worklet.auto_next = saved_auto;
 
             // pending_nodes 드레인
             if (self.pending_nodes.items.len > pending_top) {

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -789,7 +789,7 @@ pub fn buildWorkletPropertyAssignments(
     // 불일치 시 WorkletsError throw. 번들러가 사용자 react-native-worklets 버전을
     // 전달하지 않으면 WORKLET_PLUGIN_VERSION fallback.
     // 매 worklet당 allocPrint 방지를 위해 Transformer.init에서 pre-computed span 사용.
-    const version_span = self.worklet_plugin_version_span orelse try self.ast.addString("\"" ++ WORKLET_PLUGIN_VERSION ++ "\"");
+    const version_span = self.plugins.worklet.plugin_version_span orelse try self.ast.addString("\"" ++ WORKLET_PLUGIN_VERSION ++ "\"");
     const version_node = try self.ast.addNode(.{
         .tag = .string_literal,
         .span = version_span,


### PR DESCRIPTION
## Summary
Transformer core에 산재하던 worklet-specific runtime state 4개를 별도 `PluginState.worklet` sub-struct로 이사. 기능 동등 리팩터.

- `plugin_state.zig` 신규: `PluginState { worklet: WorkletState }`
- `auto_worklet_next` → `plugins.worklet.auto_next`
- `worklet_anonymous_counter` → `plugins.worklet.anonymous_counter`
- `worklet_body_depth` → `plugins.worklet.body_depth`
- `worklet_plugin_version_span` → `plugins.worklet.plugin_version_span`

## 접근 규칙 (`plugin_state.zig` doc-string)
1. 각 plugin은 **자기 sub-struct만** 접근. cross-plugin 접근 금지.
2. Core는 명명된 hook point 함수로만 plugin 상태 접근.

이 규칙을 지키면 추후 visitor-hook 아키텍처 전환 비용이 저렴.

Refs #1195 (Phase 1a — worklet 이사)

## Test plan
- [x] `zig build test` 전체 통과
- [ ] 번개 ExampleApp 번들 smoke check (PR 머지 전)

Phase 1b(refresh 이사), 1c(DECISIONS 기록)는 별도 PR 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)