### PR TITLE
refactor(transformer): move refresh state into PluginState.refresh (Phase 1b)

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -10,6 +10,7 @@
 //!    를 통해서만 plugin 상태에 접근.
 //! 이 규칙을 지키면 추후 visitor-hook 아키텍처로 전환 시 비용이 저렴하다.
 
+const std = @import("std");
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 
@@ -31,6 +32,39 @@ pub const WorkletState = struct {
     plugin_version_span: ?Span = null,
 };
 
+pub const RefreshRegistration = struct {
+    /// _c / _c2 핸들 변수의 string_table Span (재사용)
+    handle_span: Span,
+    /// 컴포넌트 이름 (문자열)
+    name: []const u8,
+};
+
+pub const RefreshSignature = struct {
+    /// _s / _s2 핸들 변수의 string_table Span
+    handle_span: Span,
+    /// 컴포넌트 이름 (문자열)
+    component_name: []const u8,
+    /// Hook 시그니처 문자열 ("useState{[foo, setFoo](0)}\nuseEffect{}")
+    signature: []const u8,
+};
+
+pub const RefreshState = struct {
+    /// 감지된 컴포넌트 등록 목록.
+    /// transform 완료 후 프로그램 끝에 $RefreshReg$ 호출로 주입.
+    registrations: std.ArrayList(RefreshRegistration) = .empty,
+
+    /// Hook 시그니처 등록 목록.
+    /// 프로그램 끝에 var _s = $RefreshSig$(); + _s(Component, "sig") 호출로 주입.
+    signatures: std.ArrayList(RefreshSignature) = .empty,
+
+    /// 등록 억제 플래그 (plugin이 IIFE 내부 함수를 visit할 때 설정).
+    /// 중첩 function_declaration이 컴포넌트로 오인되어 ReferenceError 유발하는 것을 방지.
+    ///
+    /// NOTE: 현재 worklet_plugin이 직접 이 플래그를 세팅하는 cross-plugin 접근이 있다 (#1195 후속 과제).
+    suppress_registration: bool = false,
+};
+
 pub const PluginState = struct {
     worklet: WorkletState = .{},
+    refresh: RefreshState = .{},
 };

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -903,10 +903,10 @@ fn buildClassFactoryAssignment(t: *Transformer, class_name: []const u8, stripped
     // 중요: visit을 돌려 plugin의 onFunction이 IIFE 내부 function_declaration을 worklet화하도록.
     // Fast Refresh 등록은 억제 — IIFE 내부 factory function은 최상위 바인딩이 아니므로
     // `_cN = <name>` 참조 시 ReferenceError 발생.
-    const saved_suppress = t.suppress_refresh_registration;
-    t.suppress_refresh_registration = true;
+    const saved_suppress = t.plugins.refresh.suppress_registration;
+    t.plugins.refresh.suppress_registration = true;
     const visited_iife = try t.visitNode(iife);
-    t.suppress_refresh_registration = saved_suppress;
+    t.plugins.refresh.suppress_registration = saved_suppress;
 
     // LHS: ClassName.ClassName__classFactory
     const obj_ref = try t.ast.addNode(.{

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -312,18 +312,6 @@ pub const Transformer = struct {
     /// 소스의 줄 오프셋 테이블 (Scanner에서 전달). jsxDEV source info 계산용.
     line_offsets: []const u32 = &.{},
 
-    /// React Fast Refresh: 감지된 컴포넌트 등록 목록.
-    /// transform 완료 후 프로그램 끝에 $RefreshReg$ 호출로 주입.
-    refresh_registrations: std.ArrayList(RefreshRegistration) = .empty,
-
-    /// Fast Refresh 등록 억제 플래그 (plugin이 IIFE 내부 함수를 visit할 때 설정).
-    /// 중첩 function_declaration이 컴포넌트로 오인되어 ReferenceError 유발하는 것을 방지.
-    suppress_refresh_registration: bool = false,
-
-    /// React Fast Refresh: Hook 시그니처 등록 목록.
-    /// 프로그램 끝에 var _s = $RefreshSig$(); + _s(Component, "sig") 호출로 주입.
-    refresh_signatures: std.ArrayList(RefreshSignature) = .empty,
-
     /// 후행 노드 버퍼 (함수 뒤에 프로퍼티 할당문 삽입용).
     /// pending_nodes가 자식 앞에 삽입되는 것과 대칭: trailing_nodes는 자식 뒤에 삽입.
     /// visitExtraList가 각 자식 방문 후 이 버퍼를 드레인하여 리스트에 삽입한다.
@@ -361,21 +349,10 @@ pub const Transformer = struct {
         member_idx: NodeIndex = NodeIndex.none, // method_definition 노드 (ES2015 경로에서 사용)
     };
 
-    pub const RefreshRegistration = struct {
-        /// _c / _c2 핸들 변수의 string_table Span (재사용)
-        handle_span: Span,
-        /// 컴포넌트 이름 (문자열)
-        name: []const u8,
-    };
-
-    pub const RefreshSignature = struct {
-        /// _s / _s2 핸들 변수의 string_table Span
-        handle_span: Span,
-        /// 컴포넌트 이름 (문자열)
-        component_name: []const u8,
-        /// Hook 시그니처 문자열 ("useState{[foo, setFoo](0)}\nuseEffect{}")
-        signature: []const u8,
-    };
+    // RefreshRegistration / RefreshSignature 타입 정의는 plugin_state.zig로 이사.
+    // 외부 모듈 (refresh.zig 등)에서 `Transformer.RefreshRegistration`로 접근 가능하도록 alias 제공.
+    pub const RefreshRegistration = plugin_state.RefreshRegistration;
+    pub const RefreshSignature = plugin_state.RefreshSignature;
 
     pub fn init(allocator: std.mem.Allocator, source_ast: *const Ast, options: TransformOptions) Error!Transformer {
         // experimentalDecorators → useDefineForClassFields=false 강제
@@ -411,9 +388,9 @@ pub const Transformer = struct {
         self.pending_nodes.deinit(self.allocator);
         self.symbol_ids.deinit(self.allocator);
         if (self.define_spans.len > 0) self.allocator.free(self.define_spans);
-        self.refresh_registrations.deinit(self.allocator);
-        for (self.refresh_signatures.items) |s| self.allocator.free(s.signature);
-        self.refresh_signatures.deinit(self.allocator);
+        self.plugins.refresh.registrations.deinit(self.allocator);
+        for (self.plugins.refresh.signatures.items) |s| self.allocator.free(s.signature);
+        self.plugins.refresh.signatures.deinit(self.allocator);
         self.trailing_nodes.deinit(self.allocator);
         self.generator_label_stack.deinit(self.allocator);
         self.generator_temp_var_spans.deinit(self.allocator);
@@ -476,7 +453,7 @@ pub const Transformer = struct {
         }
 
         // React Fast Refresh: 컴포넌트 등록 코드를 프로그램 끝에 추가 ($RefreshReg$만, $RefreshSig$ 제거)
-        if (self.options.react_refresh and self.refresh_registrations.items.len > 0) {
+        if (self.options.react_refresh and self.plugins.refresh.registrations.items.len > 0) {
             return try self.appendRefreshRegistrations(root);
         }
 

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -45,7 +45,7 @@ pub fn getFunctionName(self: *Transformer, func_node: Node) ?[]const u8 {
 /// visitFunction에서 호출.
 pub fn maybeRegisterRefreshComponent(self: *Transformer, new_func_idx: NodeIndex) Error!void {
     if (!self.options.react_refresh) return;
-    if (self.suppress_refresh_registration) return;
+    if (self.plugins.refresh.suppress_registration) return;
 
     const func_node = self.ast.getNode(new_func_idx);
     // function_expression의 이름은 함수 내부 스코프에서만 접근 가능하므로
@@ -56,7 +56,7 @@ pub fn maybeRegisterRefreshComponent(self: *Transformer, new_func_idx: NodeIndex
 
     // 핸들 변수명 생성 + 등록 (프로그램 끝에서 일괄 주입)
     const handle_span = try self.makeRefreshHandle();
-    try self.refresh_registrations.append(self.allocator, .{
+    try self.plugins.refresh.registrations.append(self.allocator, .{
         .handle_span = handle_span,
         .name = name,
     });
@@ -64,7 +64,7 @@ pub fn maybeRegisterRefreshComponent(self: *Transformer, new_func_idx: NodeIndex
 
 /// _c, _c2, _c3, ... 핸들 변수명 생성
 pub fn makeRefreshHandle(self: *Transformer) Error!Span {
-    const idx = self.refresh_registrations.items.len;
+    const idx = self.plugins.refresh.registrations.items.len;
     if (idx == 0) {
         return self.ast.addString("_c");
     }
@@ -90,7 +90,7 @@ pub fn appendRefreshRegistrations(self: *Transformer, root: NodeIndex) Error!Nod
     }
 
     // _c = App; _c2 = Helper; 할당문 (함수 선언 뒤에 실행)
-    for (self.refresh_registrations.items) |reg| {
+    for (self.plugins.refresh.registrations.items) |reg| {
         const assign_stmt = try self.buildRefreshAssignment(reg);
         try self.scratch.append(self.allocator, assign_stmt);
     }
@@ -103,7 +103,7 @@ pub fn appendRefreshRegistrations(self: *Transformer, root: NodeIndex) Error!Nod
 
     // $RefreshReg$(_c, "ComponentName"); 호출들
     const refresh_reg_span = try self.ast.addString("$RefreshReg$");
-    for (self.refresh_registrations.items) |reg| {
+    for (self.plugins.refresh.registrations.items) |reg| {
         const reg_stmt = try self.buildRefreshRegCall(reg, refresh_reg_span);
         try self.scratch.append(self.allocator, reg_stmt);
     }
@@ -148,7 +148,7 @@ pub fn buildRefreshVarDeclaration(self: *Transformer) Error!NodeIndex {
     defer self.scratch.shrinkRetainingCapacity(scratch_top);
     const none = @intFromEnum(NodeIndex.none);
 
-    for (self.refresh_registrations.items) |reg| {
+    for (self.plugins.refresh.registrations.items) |reg| {
         const binding = try self.ast.addNode(.{
             .tag = .binding_identifier,
             .span = reg.handle_span,
@@ -469,7 +469,7 @@ pub fn findHookCallsInNodeDepth(self: *Transformer, idx: NodeIndex, sig_buf: *st
 
 /// _s / _s2 핸들 변수명 생성
 pub fn makeSigHandle(self: *Transformer) Error!Span {
-    const idx = self.refresh_signatures.items.len;
+    const idx = self.plugins.refresh.signatures.items.len;
     if (idx == 0) {
         return self.ast.addString("_s");
     }
@@ -492,7 +492,7 @@ pub fn maybeRegisterRefreshSignature(
     const signature = try self.scanHookSignature(old_body_idx) orelse return;
 
     const handle_span = try self.makeSigHandle();
-    try self.refresh_signatures.append(self.allocator, .{
+    try self.plugins.refresh.signatures.append(self.allocator, .{
         .handle_span = handle_span,
         .component_name = name,
         .signature = signature,


### PR DESCRIPTION
## Summary
Transformer core의 React Fast Refresh state 3개 + 관련 타입 2개를 `PluginState.refresh` 및 `plugin_state.zig`로 이사. 기능 동등 리팩터.

- `refresh_registrations` → `plugins.refresh.registrations`
- `refresh_signatures` → `plugins.refresh.signatures`
- `suppress_refresh_registration` → `plugins.refresh.suppress_registration`
- `RefreshRegistration` / `RefreshSignature` 타입을 plugin_state.zig로 이사, Transformer에는 alias 유지

## Known cross-plugin violation
`worklet_plugin.zig`가 `plugins.refresh.suppress_registration`을 직접 세팅. plugin_state.zig doc-string에 NOTE로 명시했고, 후속 과제로 중립 API(`t.suppressRefreshInScope(...)` 등)로 뽑아낼 예정. 이번 PR 범위 밖.

Refs #1195 (Phase 1b — refresh 이사)

## Test plan
- [x] `zig build test` 전체 통과

다음 Phase 1c: DECISIONS.md에 규칙 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)