### PR TITLE
refactor(transformer): extract visitWithRefreshSuppressed neutral API

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -57,10 +57,10 @@ pub const RefreshState = struct {
     /// 프로그램 끝에 var _s = $RefreshSig$(); + _s(Component, "sig") 호출로 주입.
     signatures: std.ArrayList(RefreshSignature) = .empty,
 
-    /// 등록 억제 플래그 (plugin이 IIFE 내부 함수를 visit할 때 설정).
-    /// 중첩 function_declaration이 컴포넌트로 오인되어 ReferenceError 유발하는 것을 방지.
+    /// 등록 억제 플래그. 중첩 function_declaration이 컴포넌트로 오인되어
+    /// `_cN = <name>` ReferenceError 유발하는 것을 방지.
     ///
-    /// NOTE: 현재 worklet_plugin이 직접 이 플래그를 세팅하는 cross-plugin 접근이 있다 (#1195 후속 과제).
+    /// 외부에서 직접 세팅하지 말고 core의 `visitWithRefreshSuppressed` scope API를 사용할 것.
     suppress_registration: bool = false,
 };
 

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -900,13 +900,9 @@ fn buildClassFactoryAssignment(t: *Transformer, class_name: []const u8, stripped
     const call_extra = try t.ast.addExtras(&.{ @intFromEnum(wrapper_fn), call_args.start, call_args.len, 0 });
     const iife = try t.ast.addNode(.{ .tag = .call_expression, .span = zero_span, .data = .{ .extra = call_extra } });
 
-    // 중요: visit을 돌려 plugin의 onFunction이 IIFE 내부 function_declaration을 worklet화하도록.
-    // Fast Refresh 등록은 억제 — IIFE 내부 factory function은 최상위 바인딩이 아니므로
-    // `_cN = <name>` 참조 시 ReferenceError 발생.
-    const saved_suppress = t.plugins.refresh.suppress_registration;
-    t.plugins.refresh.suppress_registration = true;
-    const visited_iife = try t.visitNode(iife);
-    t.plugins.refresh.suppress_registration = saved_suppress;
+    // visit을 돌려 plugin의 onFunction이 IIFE 내부 function_declaration을 worklet화하도록.
+    // Fast Refresh 등록은 억제: IIFE 내부 factory는 최상위 바인딩이 아니라 `_cN = <name>`가 ReferenceError.
+    const visited_iife = try t.visitWithRefreshSuppressed(iife);
 
     // LHS: ClassName.ClassName__classFactory
     const obj_ref = try t.ast.addNode(.{

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1717,6 +1717,17 @@ pub const Transformer = struct {
         return self.visitNode(body_idx);
     }
 
+    /// Fast Refresh 등록이 억제된 scope 안에서 node를 visit한다.
+    /// IIFE 내부 factory처럼 최상위 바인딩이 아닌 함수 선언에 대해
+    /// `_cN = <name>` 참조 시 ReferenceError를 유발하지 않도록 refresh 등록을 건너뛴다.
+    /// 호출 scope 바깥의 suppress 상태는 save/restore된다.
+    pub fn visitWithRefreshSuppressed(self: *Transformer, node_idx: NodeIndex) Error!NodeIndex {
+        const saved = self.plugins.refresh.suppress_registration;
+        self.plugins.refresh.suppress_registration = true;
+        defer self.plugins.refresh.suppress_registration = saved;
+        return self.visitNode(node_idx);
+    }
+
     /// 노드가 define 치환 대상이면 새 string_literal 노드를 반환.
     /// 대상: identifier_reference 또는 static_member_expression 체인.
     fn tryDefineReplace(self: *Transformer, node: Node) ?Error!NodeIndex {


### PR DESCRIPTION
## Summary
#1195 (D097) follow-up — plugin_state 분리 시 남아있던 유일한 cross-plugin 위반을 해소.

### Before
worklet_plugin이 refresh state를 직접 save/restore (D097 규칙 1 위반):
```zig
const saved = t.plugins.refresh.suppress_registration;
t.plugins.refresh.suppress_registration = true;
const visited = try t.visitNode(iife);
t.plugins.refresh.suppress_registration = saved;
```

### After
core가 제공하는 **명명된 scope API**로 교체 (D097 규칙 2):
```zig
const visited = try t.visitWithRefreshSuppressed(iife);
```

`plugin_state.zig`의 NOTE도 업데이트 — 외부는 scope API를 사용하도록 안내.

## Test plan
- [x] `zig build test` 통과
- [x] grep 검증: `plugins.refresh` 접근이 core/refresh plugin 외부에 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)