### PR TITLE
fix(bundler): avoid duplicate init call for CJS side-effect import

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -887,3 +887,49 @@ test "sideEffects: side-effect-only import to ESM module under __esm wrap invoke
     const index_init_block = result.output[index_init_start .. index_init_end_off + 2];
     try std.testing.expect(std.mem.indexOf(u8, index_init_block, "init_sideeffect()") != null);
 }
+
+test "sideEffects: CJS side-effect import must not be duplicated in barrel init (#1193)" {
+    // #1193 fix 후속: CJS 타겟은 body rewrite가 이미 require_xxx()를 주입하므로
+    // side-effect import 전용 preamble 루프는 ESM 타겟만 처리해야 한다.
+    // 중복 호출은 side-effect가 두 번 실행되는 동작 회귀를 일으킬 수 있음.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { x } from './node_modules/pkg';
+        \\console.log(x);
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/package.json",
+        \\{"name":"pkg","main":"./index.js","sideEffects":["./sideeffect.js"]}
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\import './sideeffect';
+        \\export * from './values';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/values.js",
+        \\export const x = 1;
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/sideeffect.js",
+        \\globalThis.sideEffectRan = true;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const index_init_start = std.mem.indexOf(u8, result.output, "var init_pkg_index = __esm") orelse
+        return error.IndexInitMissing;
+    const index_init_end_off = std.mem.indexOfPos(u8, result.output, index_init_start, "})") orelse
+        return error.IndexInitMalformed;
+    const index_init_block = result.output[index_init_start .. index_init_end_off + 2];
+    const count = std.mem.count(u8, index_init_block, "require_pkg_sideeffect()");
+    try std.testing.expectEqual(@as(usize, 1), count);
+}

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -623,8 +623,10 @@ pub fn emitEsmWrappedModule(
             try appendWrappedInitCall(&star_init_buf, allocator, &l.modules[src_i], options);
         }
 
-        // Side-effect-only import (`import './x';`)도 barrel의 init에서 호출되어야
-        // 한다. export_bindings에는 포함되지 않으므로 별도 루프로 처리.
+        // Side-effect-only import (`import './x';`) → target이 ESM 래핑일 때만
+        // barrel의 preamble에 init 호출을 추가한다. export_bindings에는 포함되지
+        // 않아 기존 re-export loop가 건너뛰기 때문.
+        // CJS 타겟은 body rewrite가 이미 `require_xxx()`를 주입하므로 제외 (중복 방지).
         // 누락 시 RN 런타임에서 target 모듈의 top-level이 실행되지 않아
         // global setup(예: Reanimated LayoutAnimationsManager) 실패 (#1193).
         for (module.import_records) |rec| {
@@ -633,9 +635,11 @@ pub fn emitEsmWrappedModule(
             const src_i = @intFromEnum(rec.resolved);
             if (src_i >= l.modules.len) continue;
             if (re_export_inited.contains(src_i)) continue;
+            const src_mod = &l.modules[src_i];
+            if (src_mod.wrap_kind != .esm) continue;
             re_export_inited.put(src_i, {}) catch {};
 
-            try appendWrappedInitCall(&star_init_buf, allocator, &l.modules[src_i], options);
+            try appendWrappedInitCall(&star_init_buf, allocator, src_mod, options);
         }
     }
 


### PR DESCRIPTION
## Summary
PR #1200 follow-up — side-effect import preamble 루프가 CJS 타겟까지 처리해서 body rewrite의 `require_xxx()` 호출과 중복 생성되는 회귀 수정.

### Before (#1200 머지 직후)
```js
var init_pkg_index = __esm({
  "index.js"() {
    init_pkg_values();
    require_pkg_sideeffect();      // body rewrite (기존)
      require_pkg_sideeffect();    // side-effect preamble 루프 (중복!)
  }
});
```

### After
```js
var init_pkg_index = __esm({
  "index.js"() {
    init_pkg_values();
    require_pkg_sideeffect();      // body rewrite만
  }
});
```

## Root Cause
`emitter/esm_wrap.zig`의 side-effect import preamble 루프가 CJS/ESM 구분 없이 `appendWrappedInitCall`를 호출. CJS 타겟은 body rewrite가 이미 `require_xxx()`를 주입하므로 중복 발생. ESM 타겟만 preamble이 필요 (body rewrite가 call을 못 만들어줘서 #1200의 핵심 버그).

## Fix
루프에 `if (src_mod.wrap_kind != .esm) continue;` 추가.

## Test plan
- [x] Regression test: CJS 타겟 side-effect import의 `require_xxx()` 호출이 정확히 1회만 존재
- [x] 기존 #1200 ESM 케이스 테스트 통과 유지
- [x] `zig build test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)