### PR TITLE
fix(worklet): shorthand destructuring + sourceMap field in __initData.code

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -983,6 +983,30 @@ fn buildInitDataObject(self: *Transformer, init_code: []const u8, source_locatio
         try self.scratch.append(self.allocator, prop);
     }
 
+    // sourceMap property — Babel plugin이 dev 빌드에서 항상 주입하는 필드.
+    // ZTS는 현재 worklet body 수준의 source map을 생성하지 않으므로 빈 문자열.
+    // Reanimated runtime이 필드 존재 자체를 전제하는 경우를 대비해 빈 값이라도 설정.
+    {
+        const key_span = try self.ast.addString("sourceMap");
+        const key = try self.ast.addNode(.{
+            .tag = .identifier_reference,
+            .span = key_span,
+            .data = .{ .string_ref = key_span },
+        });
+        const empty_str_span = try self.ast.addString("\"\"");
+        const value = try self.ast.addNode(.{
+            .tag = .string_literal,
+            .span = empty_str_span,
+            .data = .{ .string_ref = empty_str_span },
+        });
+        const prop = try self.ast.addNode(.{
+            .tag = .object_property,
+            .span = zero_span,
+            .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
+        });
+        try self.scratch.append(self.allocator, prop);
+    }
+
     const obj_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     return self.ast.addNode(.{
         .tag = .object_expression,
@@ -1087,6 +1111,8 @@ fn buildClosureDestructuring(self: *Transformer, closure_vars: []const ClosureVa
     const none = @intFromEnum(NodeIndex.none);
 
     // object binding pattern: { var1, var2, ... }
+    // codegen에서 binding_property.right가 NodeIndex.none이면 `{key}` shorthand로 출력됨.
+    // Babel/Metro 출력 (`const {X,Y}`)과 형태 일치 — Reanimated가 worklet code string을 파싱할 때 동일 형태 기대.
     for (closure_vars) |cv| {
         const name_span = try self.ast.addString(cv.name);
         const key = try self.ast.addNode(.{
@@ -1094,16 +1120,10 @@ fn buildClosureDestructuring(self: *Transformer, closure_vars: []const ClosureVa
             .span = name_span,
             .data = .{ .string_ref = name_span },
         });
-        const binding = try self.ast.addNode(.{
-            .tag = .binding_identifier,
-            .span = name_span,
-            .data = .{ .string_ref = name_span },
-        });
-        // shorthand binding property: { varName } → key = varName, value = varName binding
         const prop = try self.ast.addNode(.{
             .tag = .binding_property,
             .span = zero_span,
-            .data = .{ .binary = .{ .left = key, .right = binding, .flags = 0 } },
+            .data = .{ .binary = .{ .left = key, .right = NodeIndex.none, .flags = 0 } },
         });
         try self.scratch.append(self.allocator, prop);
     }

--- a/src/transformer/worklet_test.zig
+++ b/src/transformer/worklet_test.zig
@@ -401,9 +401,9 @@ test "Worklet: nested function captures outer refs but params stay local" {
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
     // ext는 inner body에서 참조하는 외부 변수 → worklet closure에 포함
-    try std.testing.expect(std.mem.indexOf(u8, code, "ext:ext}=this.__closure") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "ext}=this.__closure") != null);
     // inner의 param x는 closure에 포함되면 안 됨
-    try std.testing.expect(std.mem.indexOf(u8, code, "x:x") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "x: x") == null);
 }
 
 test "Worklet: default param (c = 0) not in closure" {
@@ -601,7 +601,7 @@ test "Worklet: object method with outer closure vars captured" {
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
     try std.testing.expect(std.mem.indexOf(u8, code, "__workletHash") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "config:config}=this.__closure") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "config}=this.__closure") != null);
 }
 
 test "Worklet: getter with worklet directive becomes factory body (Babel 호환)" {
@@ -769,7 +769,7 @@ test "Worklet: closure analysis includes refs inside object getters/setters/meth
     try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "outerFn") != null);
     // __initData.code에서 this.__closure로 destructure
-    try std.testing.expect(std.mem.indexOf(u8, code, "outerFn:outerFn}=this.__closure") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "outerFn}=this.__closure") != null);
 }
 
 test "Worklet: object method worklet strips directive from IIFE body" {
@@ -814,7 +814,7 @@ test "Worklet: TS type assertion (as) does not break closure analysis" {
     defer r.deinit();
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
-    try std.testing.expect(std.mem.indexOf(u8, code, "outer:outer}=this.__closure") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "outer}=this.__closure") != null);
 }
 
 test "Worklet: closure captures through ternary, template literal, array, spread" {
@@ -831,10 +831,10 @@ test "Worklet: closure captures through ternary, template literal, array, spread
     defer r.deinit();
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
-    try std.testing.expect(std.mem.indexOf(u8, code, "a:a") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "b:b") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "c:c") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "d:d") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "a: a") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "b: b") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "c: c") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "d: d") != null);
 }
 
 test "Worklet: closure captures through switch, for-in, try-catch" {
@@ -850,11 +850,11 @@ test "Worklet: closure captures through switch, for-in, try-catch" {
     defer r.deinit();
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
-    try std.testing.expect(std.mem.indexOf(u8, code, "val:val") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "obj:obj") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "fn2:fn2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "val: val") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "obj: obj") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "fn2: fn2") != null);
     // catch param 'e'는 closure가 아닌 로컬
-    try std.testing.expect(std.mem.indexOf(u8, code, "e:e") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "e: e") == null);
 }
 
 test "Worklet: method param shadowing does not leak to outer closure" {
@@ -885,8 +885,8 @@ test "Worklet: nested object with computed property and new expression" {
     defer r.deinit();
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
-    try std.testing.expect(std.mem.indexOf(u8, code, "key:key") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "Cls:Cls") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "key: key") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "Cls: Cls") != null);
 }
 
 test "Worklet: nested function and arrow capture outer imports" {
@@ -906,8 +906,8 @@ test "Worklet: nested function and arrow capture outer imports" {
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
     // 중첩 function 안의 isShared와 arrow 안의 helper 모두 worklet closure에 포함
-    try std.testing.expect(std.mem.indexOf(u8, code, "isShared:isShared") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "helper:helper") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "isShared: isShared") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "helper: helper") != null);
     // extract의 param x는 closure에 없어야 함
     try std.testing.expect(std.mem.indexOf(u8, code, " x:x") == null);
 }
@@ -939,4 +939,55 @@ test "Worklet: arrow with destructured param does not leak" {
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
     try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
+}
+
+// ============================================================
+// Babel parity: __initData.code destructuring shorthand + sourceMap field (#1193 follow-up)
+// ============================================================
+
+test "Worklet: __initData.code uses shorthand destructuring (const {X} = this.__closure)" {
+    // Babel react-native-worklets는 worklet code string에서 shorthand 형태로 emit.
+    // Reanimated runtime이 해당 형태를 기대하는 경우를 대비 parity 유지.
+    var r = try transformWorklet(std.testing.allocator,
+        \\var foo = 1;
+        \\function w() {
+        \\  "worklet";
+        \\  return foo + 1;
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "{foo}=this.__closure") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "{foo:foo}=this.__closure") == null);
+}
+
+test "Worklet: __initData.code shorthand for multiple closure vars" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\var a = 1, b = 2, c = 3;
+        \\function w() {
+        \\  "worklet";
+        \\  return a + b + c;
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "{a,b,c}=this.__closure") != null);
+}
+
+test "Worklet: __initData includes sourceMap field (Babel parity)" {
+    // Babel plugin은 dev 빌드에서 __initData.sourceMap을 항상 주입.
+    // ZTS는 worklet 수준 sourceMap 미생성이라 빈 문자열이라도 필드 존재 보장.
+    var r = try transformWorklet(std.testing.allocator,
+        \\function w() {
+        \\  "worklet";
+        \\  return 1;
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "sourceMap:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "sourceMap: \"\"") != null);
 }


### PR DESCRIPTION
## Summary
Metro(Babel + Reanimated plugin) 출력과 정확히 일치하도록 worklet code string 형식 수정. 드래그 실패 의심 원인 해소 시도.

### Before
```js
Apptsx_null5.__initData = {
  code: "function Apptsx_null5(e){const {translateX:translateX,translateY:translateY}=this.__closure;...}",
  location: "/..."
};
```

### After (Metro와 동일)
```js
Apptsx_null5.__initData = {
  code: "function Apptsx_null5(e){const {translateX,translateY}=this.__closure;...}",
  location: "/...",
  sourceMap: ""
};
```

## Changes
1. **Shorthand destructuring**: `buildClosureDestructuring` 의 binding_property.right를 NodeIndex.none으로 설정 → codegen이 `{X}` 형태로 shorthand 출력
2. **sourceMap field**: `buildInitDataObject` 에서 빈 문자열 필드 추가 (Babel plugin은 dev에서 항상 주입)

## Test plan
- [x] 기존 Worklet 테스트 assertion 업데이트 (`X:X` → `X: X`, destructuring 관련은 shorthand로)
- [x] 새 테스트 3개 추가 (shorthand 적용, 다중 var, sourceMap 필드)
- [x] `zig build test` 전체 통과
- [ ] 번개 ExampleApp에서 DragDemo 런타임 검증

Refs #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)