### PR TITLE
fix(worklet): drop empty sourceMap field — causes Reanimated UI Runtime init failure

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -983,29 +983,11 @@ fn buildInitDataObject(self: *Transformer, init_code: []const u8, source_locatio
         try self.scratch.append(self.allocator, prop);
     }
 
-    // sourceMap property — Babel plugin이 dev 빌드에서 항상 주입하는 필드.
-    // ZTS는 현재 worklet body 수준의 source map을 생성하지 않으므로 빈 문자열.
-    // Reanimated runtime이 필드 존재 자체를 전제하는 경우를 대비해 빈 값이라도 설정.
-    {
-        const key_span = try self.ast.addString("sourceMap");
-        const key = try self.ast.addNode(.{
-            .tag = .identifier_reference,
-            .span = key_span,
-            .data = .{ .string_ref = key_span },
-        });
-        const empty_str_span = try self.ast.addString("\"\"");
-        const value = try self.ast.addNode(.{
-            .tag = .string_literal,
-            .span = empty_str_span,
-            .data = .{ .string_ref = empty_str_span },
-        });
-        const prop = try self.ast.addNode(.{
-            .tag = .object_property,
-            .span = zero_span,
-            .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
-        });
-        try self.scratch.append(self.allocator, prop);
-    }
+    // NOTE: sourceMap 필드는 실제 source map 데이터를 생성할 때만 추가해야 함.
+    // 빈 문자열을 주입하면 Reanimated 네이티브가 JSON 파싱 시도 → 파싱 실패로
+    // UI Runtime 초기화가 abort되어 _microtaskQueueFinalizers 등이 세팅 안 됨.
+    // Babel plugin도 sourceMap 생성 성공 시에만 주입 (workletFactory.ts:187-191).
+    // ZTS는 worklet 수준 source map 미지원 → 필드 생략.
 
     const obj_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     return self.ast.addNode(.{

--- a/src/transformer/worklet_test.zig
+++ b/src/transformer/worklet_test.zig
@@ -976,9 +976,12 @@ test "Worklet: __initData.code shorthand for multiple closure vars" {
     try std.testing.expect(std.mem.indexOf(u8, code, "{a,b,c}=this.__closure") != null);
 }
 
-test "Worklet: __initData includes sourceMap field (Babel parity)" {
-    // Babel plugin은 dev 빌드에서 __initData.sourceMap을 항상 주입.
-    // ZTS는 worklet 수준 sourceMap 미생성이라 빈 문자열이라도 필드 존재 보장.
+test "Worklet: __initData does NOT emit sourceMap when none generated" {
+    // Babel plugin은 실제 source map 생성 성공 시에만 sourceMap 필드를 주입
+    // (workletFactory.ts:187). 빈 문자열을 넣으면 Reanimated 네이티브가
+    // JSON 파싱 실패 → UI Runtime 초기화 abort →
+    // `Expected microtaskQueueFinalizers to be defined` 에러로 이어짐.
+    // ZTS는 worklet 수준 source map 미지원 → 필드 생략이 정답.
     var r = try transformWorklet(std.testing.allocator,
         \\function w() {
         \\  "worklet";
@@ -988,6 +991,5 @@ test "Worklet: __initData includes sourceMap field (Babel parity)" {
     defer r.deinit();
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
-    try std.testing.expect(std.mem.indexOf(u8, code, "sourceMap:") != null);
-    try std.testing.expect(std.mem.indexOf(u8, code, "sourceMap: \"\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "sourceMap") == null);
 }


### PR DESCRIPTION
## Summary
PR #1205에서 추가한 `__initData.sourceMap: ""` 빈 문자열 필드가 Reanimated 네이티브 초기화를 깨뜨려 앱 부팅이 실패하던 문제 수정.

### Observed error
```
[runtime not ready]: Error: Exception in HostFunction: [Reanimated]
Expected microtaskQueueFinalizers to be defined.
Perhaps Worklets failed to initialize the UI Runtime?
```

## Root cause
Reanimated 네이티브가 `__initData.sourceMap`이 존재하면 JSON 파싱 시도. 빈 문자열은 invalid JSON → 파싱 실패 → `installTurboModule` abort → `setupMicrotasks` worklet 실행 안 됨 → `globalThis._microtaskQueueFinalizers` 세팅 안 됨 → 다음 네이티브 모듈 초기화 시 위 assertion 실패.

## Fix
Babel plugin 동작과 일치시킴: **실제 source map 생성 성공 시에만** sourceMap 필드 주입. ZTS는 worklet-level source map 미지원이므로 필드를 **생략**.

## Test plan
- [x] `zig build test` 전체 통과
- [x] 관련 worklet_test 테스트를 "field 생략 확인"으로 반전
- [ ] 번개 ExampleApp 앱 부팅 확인

Refs #1193 follow-up (partial revert of #1205)

🤖 Generated with [Claude Code](https://claude.com/claude-code)