### PR TITLE
fix(codegen): assign ns var for export default of namespace import

### DIFF
--- a/src/bundler/bundler_test/default_deconflict.zig
+++ b/src/bundler/bundler_test/default_deconflict.zig
@@ -535,3 +535,109 @@ test "Circular: entry depends on circular pair" {
     const a_pos = std.mem.indexOf(u8, result.output, "\"a\"") orelse return error.TestUnexpectedResult;
     try std.testing.expect(a_pos < entry_pos);
 }
+
+// ============================================================
+// #1208: export default X where X is namespace import
+// ============================================================
+
+test "Default: export default from namespace import assigns ns var" {
+    // `import * as X from './lib'; export default X;` 패턴.
+    // ZTS가 var X$N을 호이스팅하지만 값 할당이 누락되던 버그 회귀 방지.
+    // Reanimated/GestureDetector가 `Reanimated.default.createAnimatedComponent`로
+    // 접근할 때 default getter가 undefined 반환 → 드래그 동작 실패 (#1208).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import Animated from './mod';
+        \\console.log(Animated.foo);
+    );
+    try writeFile(tmp.dir, "mod.ts",
+        \\import * as X from './lib';
+        \\export default X;
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export const foo = 'barvalue';
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // ns var 할당이 반드시 존재해야 한다 (X = X_ns; 형태).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "X_ns") != null);
+    // default getter가 X를 반환 (minified 또는 non-minified 둘 다 허용)
+    // default getter는 arrow 또는 function expression (platform/minify에 따라 다름)
+    const has_default_getter = std.mem.indexOf(u8, result.output, "\"default\": () => X") != null or
+        std.mem.indexOf(u8, result.output, "\"default\":()=>X") != null or
+        std.mem.indexOf(u8, result.output, "\"default\": function() { return X; }") != null;
+    try std.testing.expect(has_default_getter);
+    // 할당 라인 확인: `X = X_ns;`
+    const has_assign = std.mem.indexOf(u8, result.output, "X = X_ns;") != null or
+        std.mem.indexOf(u8, result.output, "X=X_ns;") != null;
+    try std.testing.expect(has_assign);
+}
+
+test "Default: export default namespace — IIFE bundle resolves member access" {
+    // default getter에서 반환된 namespace object의 member access가 올바르게 값을 반환해야.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import Pkg from './mod';
+        \\console.log(Pkg.answer);
+    );
+    try writeFile(tmp.dir, "mod.ts",
+        \\import * as Stuff from './lib';
+        \\export default Stuff;
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export const answer = 42;
+        \\export const other = 'skip';
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // answer가 번들에 포함되어야 (trees-haker가 default 경유 namespace 접근도 보존)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "answer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "42") != null);
+}
+
+test "Default: regular export default identifier still self-ref (no regression)" {
+    // namespace가 아닌 일반 identifier는 self-ref 최적화가 그대로 유지되어야 함.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import x from './mod';
+        \\console.log(x);
+    );
+    try writeFile(tmp.dir, "mod.ts",
+        \\const value = 'hello';
+        \\export default value;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // regular default는 _ns suffix 없어야 — self-ref 최적화 유지
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "value_ns") == null);
+}

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1447,6 +1447,10 @@ pub const Codegen = struct {
         if (inner_node.tag != .identifier_reference) return false;
         if (self.options.linking_metadata) |md| {
             if (self.resolveSymbolId(inner, md)) |sid| {
+                // namespace import(`import * as X`)는 rename 이름(`X$N`)에 값이 할당되지 않고
+                // 별도 ns var(`X_ns`)에 object literal이 저장된다. 따라서 self-ref 아님 —
+                // `export default X`는 반드시 `X$N = X_ns` 할당이 필요.
+                if (md.ns_inline_objects.get(sid) != null) return false;
                 if (md.renames.get(sid)) |renamed| {
                     return std.mem.eql(u8, renamed, def_name);
                 }
@@ -2661,11 +2665,14 @@ pub const Codegen = struct {
                             try self.emitNode(inner);
                             try self.writeByte(';');
                         } else if (!self.isExportDefaultSelfRef(inner, def_name)) {
-                            // mangling으로 이름이 바뀐 경우 (View → View$44) 할당 필요.
-                            try self.write(def_name);
-                            try self.writeByte('=');
-                            try self.emitNode(inner);
-                            try self.writeByte(';');
+                            // namespace import이면 ns var name을 직접 사용 (rename과 다름).
+                            if (!(try self.tryEmitNsVarAssignment(def_name, inner))) {
+                                // mangling으로 이름이 바뀐 경우 (View → View$44) 할당 필요.
+                                try self.write(def_name);
+                                try self.writeByte('=');
+                                try self.emitNode(inner);
+                                try self.writeByte(';');
+                            }
                         }
                     }
                 }
@@ -2689,7 +2696,14 @@ pub const Codegen = struct {
                 } else {
                     const def_name = self.options.linking_metadata.?.default_export_name;
                     if (!self.isExportDefaultSelfRef(inner, def_name)) {
-                        try self.emitDefaultVarAssignment(def_name, inner);
+                        // namespace import(`export default X` where `X` is `import * as X`):
+                        // 실제 값은 `X_ns` (ns_inline_objects의 var_name)에 저장되므로
+                        // inner의 rename이 아닌 ns var에서 읽어야 한다.
+                        if (try self.tryEmitNsVarAssignment(def_name, inner)) {
+                            // 완료
+                        } else {
+                            try self.emitDefaultVarAssignment(def_name, inner);
+                        }
                     }
                 }
             }
@@ -2705,6 +2719,29 @@ pub const Codegen = struct {
                 try self.writeByte(';');
             }
         }
+    }
+
+    /// inner가 namespace import (`import * as X`) 를 참조하면 `<def_name> = <X_ns>;` 할당을 emit.
+    /// 성공 시 true, namespace import가 아니면 false (caller가 기본 emit 수행).
+    /// `var Animated$6;` 선언과 `Animated_ns = {...}` 객체 사이 연결을 복원해 default getter가
+    /// 올바른 namespace 객체를 반환하도록 한다 (#1208).
+    fn tryEmitNsVarAssignment(self: *Codegen, def_name: []const u8, inner: NodeIndex) !bool {
+        const md = self.options.linking_metadata orelse return false;
+        const inner_node = self.ast.getNode(inner);
+        if (inner_node.tag != .identifier_reference) return false;
+        const sid = self.resolveSymbolId(inner, md) orelse return false;
+        const entry = md.ns_inline_objects.get(sid) orelse return false;
+
+        if (!self.options.esm_var_assign_only) try self.write("var ");
+        try self.write(def_name);
+        if (self.options.minify_whitespace) {
+            try self.writeByte('=');
+        } else {
+            try self.write(" = ");
+        }
+        try self.write(entry.var_name);
+        try self.writeByte(';');
+        return true;
     }
 
     /// `var <name> = <inner>;` 출력 (export default 변환용).


### PR DESCRIPTION
## Summary
`import * as X from './lib'; export default X;` 패턴에서 default getter가 undefined를 반환하던 버그 수정. Reanimated GestureDetector가 `Reanimated.default.createAnimatedComponent`에 의존하는데 undefined면 fallback으로 Wrap plain component 사용 → gesture 이벤트 전달 실패 → 드래그 동작 안 함.

### Before
```js
var Animated$6;                                      // 선언만
__export(..., {"default": () => Animated$6});        // getter는 생성
var init_mod = __esm({...
  var Animated_ns = {get FlatList() {...}, ...};    // ns 객체는 생성됨
  // ❌ Animated$6 = Animated_ns; 누락 → default getter undefined 반환
});
```

### After
```js
var init_mod = __esm({...
  var Animated_ns = {get FlatList() {...}, ...};
  Animated$6 = Animated_ns;                          // ✅ 명시적 할당
});
```

## Root cause
ZTS linker는 namespace import value 저장을 위해 별도 `X_ns` 변수를 만들지만, `export default X` 처리 시 codegen의 self-ref 최적화가 inner `X` 와 rename된 `X$N`을 같은 이름이라 판단 → 할당 스킵 → `X$N`에 영원히 값 안 들어감.

## Fix
- `isExportDefaultSelfRef`: inner symbol이 `ns_inline_objects`에 있으면 self-ref로 취급하지 않음
- `emitExportDefault`: namespace import 케이스에 `tryEmitNsVarAssignment` 호출 → `<def_name> = <ns_var_name>;` 명시적 할당

## Test plan
- [x] `zig build test` 전체 통과
- [x] 새 테스트 3개:
  - namespace import default에 ns var 할당 존재
  - default getter 경유 member access 보존
  - 일반 identifier는 self-ref 최적화 유지 (regression guard)

Fixes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)