### PR TITLE
refactor(transformer): unify closure analysis via ctx-owned cache

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -803,14 +803,11 @@ fn serializeFunctionInfo(
     }
     try buf.append(alloc, ']');
 
-    // closureVars: 디렉티브가 있을 때만 계산 (스코프 분석은 비용이 크므로)
+    // closureVars: 디렉티브가 있을 때만 계산 (스코프 분석은 비용이 크므로).
+    // ctx 캐시 덕분에 worklet_plugin이 먼저 계산했다면 재사용 (#1114).
     try buf.appendSlice(alloc, ",\"closureVars\":[");
     if (has_directives) {
-        const closure_vars = api.getClosureVars(func.original_body_idx, func.original_params_start, func.original_params_len, func.name) catch &.{};
-        defer if (closure_vars.len > 0) {
-            for (closure_vars) |cv| api.getAllocator().free(cv.name);
-            api.getAllocator().free(closure_vars);
-        };
+        const closure_vars = api.getClosureVars(&func) catch &.{};
         for (closure_vars, 0..) |cv, i| {
             if (i > 0) try buf.append(alloc, ',');
             try buf.append(alloc, '"');

--- a/src/transformer/ast_plugin.zig
+++ b/src/transformer/ast_plugin.zig
@@ -75,6 +75,12 @@ pub const AstTransformCtx = struct {
     /// function_expression worklet → IIFE factory 변환 등에 사용.
     replaced_node: ?NodeIndex = null,
 
+    /// 현재 함수 방문의 closure 분석 캐시.
+    /// dispatchFunctionPlugins마다 ctx가 새로 만들어지므로 최대 1개 함수에 대한 결과.
+    /// 여러 플러그인(worklet_plugin, napi_entry 등)이 같은 closure 결과를 공유한다.
+    /// ctx 소유권 — dispatcher가 종료 시 deinitClosureCache() 호출로 해제.
+    closure_cache: ?[]const worklet_mod.ClosureVar = null,
+
     // --- 디렉티브 ---
 
     /// 함수 body의 첫 문장이 지정된 디렉티브인지 확인.
@@ -93,17 +99,37 @@ pub const AstTransformCtx = struct {
 
     // --- 스코프 분석 ---
 
-    /// 함수 body에서 closure 변수(외부 참조)를 추출.
-    /// func_name: 함수 이름 (자기 참조 제외용). null이면 무시.
-    /// 반환된 슬라이스는 caller가 getAllocator().free()로 해제해야 한다.
+    /// 함수의 closure 변수(외부 참조)를 추출.
+    /// 항상 **변환 전 원본** body/params로 분석 (Babel 호환) — 호출부 실수 방지.
+    /// 같은 ctx에서 반복 호출 시 캐시 반환 (issue #1114).
+    /// 반환된 슬라이스는 ctx가 소유 — 호출부가 free하지 말 것.
     pub fn getClosureVars(
         self: *AstTransformCtx,
-        body_idx: NodeIndex,
-        params_start: u32,
-        params_len: u32,
-        func_name: ?[]const u8,
+        info: *const FunctionInfo,
     ) Error![]const worklet_mod.ClosureVar {
-        return worklet_mod.collectClosureVars(self.transformer, body_idx, params_start, params_len, func_name);
+        if (self.closure_cache) |cached| return cached;
+        const vars = try worklet_mod.collectClosureVars(
+            self.transformer,
+            info.original_body_idx,
+            info.original_params_start,
+            info.original_params_len,
+            info.name,
+        );
+        self.closure_cache = vars;
+        return vars;
+    }
+
+    /// 캐시된 closure 결과 해제. dispatcher가 dispatchFunctionPlugins 종료 시 호출.
+    pub fn deinitClosureCache(self: *AstTransformCtx) void {
+        if (self.closure_cache) |vars| {
+            const alloc = self.getAllocator();
+            for (vars) |cv| {
+                alloc.free(cv.name);
+                if (cv.class_factory_base) |b| alloc.free(b);
+            }
+            alloc.free(vars);
+            self.closure_cache = null;
+        }
     }
 
     // --- AST 노드 생성 (Transformer/Ast 위임) ---

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -205,14 +205,8 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
         break :blk name;
     };
 
-    const closure_vars = try api.getClosureVars(info.original_body_idx, info.original_params_start, info.original_params_len, info.name);
-    defer {
-        for (closure_vars) |cv| {
-            api.getAllocator().free(cv.name);
-            if (cv.class_factory_base) |b| api.getAllocator().free(b);
-        }
-        api.getAllocator().free(closure_vars);
-    }
+    // ctx가 캐시 소유 — 해제는 dispatcher의 deinitClosureCache()가 담당 (#1114).
+    const closure_vars = try api.getClosureVars(&info);
 
     const init_code = try api.generateCode(
         func_name,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3729,6 +3729,7 @@ pub const Transformer = struct {
     pub fn dispatchFunctionPlugins(self: *Transformer, result: NodeIndex, func_info: FunctionInfo) Error!?NodeIndex {
         if (self.options.plugins.len == 0) return null;
         var api = AstTransformCtx{ .transformer = self, .modified_body = null };
+        defer api.deinitClosureCache();
         for (self.options.plugins) |p| {
             if (p.onFunction) |hook| {
                 hook(p.context, &api, func_info) catch |err| switch (err) {


### PR DESCRIPTION
## Summary

- `getClosureVars(body, params_start, params_len, name)` → `getClosureVars(info: *const FunctionInfo)` — 호출부 실수 방지
- `AstTransformCtx.closure_cache`로 같은 함수 방문 내 재계산 방지 (worklet_plugin + napi_entry가 결과 공유)
- dispatcher가 ctx 생명주기에 맞춰 `deinitClosureCache()` 호출 — 두 호출부의 수동 free 제거

## 배경
`getClosureVars`가 raw body_idx/params를 인자로 받아 두 호출부(worklet_plugin, napi_entry)가 각자 원본 필드를 넘겨야 했음. #1113은 napi 쪽이 변환 후 body를 넘겨 `globalThis.__callGuardDEV`가 closure에 포함되는 버그 발생. 시그니처로 강제 + 캐시 공유로 드리프트 불가능하게.

Closes #1114

## Test plan
- [x] `zig build test` 통과
- [x] `cd packages/core && bun test` 통과 (315 pass)
- 기존 worklet/closure 테스트가 리팩터링을 검증 (API 소비자 둘 다 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)