### PR TITLE
feat(server): Control API — /reset-cache endpoint

### DIFF
--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -92,6 +92,15 @@ pub const IncrementalBundler = struct {
         if (self.resolve_cache) |*rc| rc.deinit();
     }
 
+    /// 외부에서 캐시 전체 무효화 (Control API `/reset-cache` 등).
+    /// 다음 rebuild()는 초기 빌드와 동일한 전체 재번들.
+    pub fn reset(self: *IncrementalBundler) void {
+        self.clearCache();
+        self.persistent_store.deinit();
+        self.persistent_store = module_store.PersistentModuleStore.init(self.allocator);
+        self.needs_full_rebuild = true;
+    }
+
     fn clearCache(self: *IncrementalBundler) void {
         var it = self.module_cache.iterator();
         while (it.next()) |entry| {

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -162,6 +162,8 @@ pub const DevServer = struct {
     sse_clients: SseClients = .{},
     /// 모노토닉 이벤트 시퀀스 (SSE payload의 id 필드).
     event_seq: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    /// Control API `/reset-cache`가 설정; watchLoop가 다음 iteration에서 소비.
+    cache_reset_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     plugins: []const plugin_mod.Plugin = &.{},
     proxy: []const ProxyRule = &.{},
     sourcemap_cache: struct {
@@ -553,6 +555,14 @@ pub const DevServer = struct {
 
         while (true) {
             const events = watcher.waitForChanges(watch_interval_ms) catch continue;
+
+            // Control API 경유 캐시 리셋 요청 처리 — 파일 변경 없어도 다음 rebuild를 전체 빌드로.
+            if (self.cache_reset_requested.swap(false, .acquire)) {
+                inc_bundler.reset();
+                self.publishEvent("cache_reset", "{\"type\":\"cache_reset\"}");
+                getLog().print("  [ctrl] cache reset via /reset-cache\n", .{}) catch {};
+            }
+
             if (events.len == 0) continue;
 
             var changed_paths: std.ArrayList([]const u8) = .empty;
@@ -783,6 +793,29 @@ pub const DevServer = struct {
             }
         }
 
+        // 방법 제한 전에 검사하는 라우트 (POST 허용 Control API)
+        {
+            const target_early = request.head.target;
+            const path_end_early = std.mem.indexOfScalar(u8, target_early, '?') orelse target_early.len;
+            const raw_path_early = target_early[0..path_end_early];
+
+            // /sse/events — GET (event-stream)
+            if (std.mem.eql(u8, raw_path_early, "/sse/events")) {
+                self.handleSse(request) catch {};
+                return;
+            }
+
+            // Control API: /reset-cache — 모든 HTTP method 허용
+            if (std.mem.eql(u8, raw_path_early, "/reset-cache")) {
+                self.cache_reset_requested.store(true, .release);
+                request.respond("{\"ok\":true,\"action\":\"reset_cache\"}", .{
+                    .status = .ok,
+                    .extra_headers = &json_headers,
+                }) catch {};
+                return;
+            }
+        }
+
         if (request.head.method != .GET and request.head.method != .HEAD) {
             try request.respond("405 Method Not Allowed", .{
                 .status = .method_not_allowed,
@@ -802,12 +835,6 @@ pub const DevServer = struct {
             });
             return;
         };
-
-        // /sse/events — Server-Sent Events 구독 (모든 platform, entry 유무 무관)
-        if (std.mem.eql(u8, raw_path, "/sse/events")) {
-            self.handleSse(request) catch {};
-            return;
-        }
 
         if (self.entry_point != null) {
             // /@react-refresh — react-refresh/runtime 가상 모듈 (Vite 방식)
@@ -1111,6 +1138,10 @@ pub const DevServer = struct {
         .{ .name = "Access-Control-Allow-Methods", .value = "GET, HEAD, OPTIONS" },
         .{ .name = "Access-Control-Allow-Headers", .value = "*" },
         .{ .name = "Cache-Control", .value = "no-cache, no-store, must-revalidate" },
+    };
+
+    const json_headers = cors_headers ++ [_]http.Header{
+        .{ .name = "Content-Type", .value = "application/json; charset=utf-8" },
     };
 };
 


### PR DESCRIPTION
## Summary

Phase 2 — 외부(LLM 에이전트, CI, CLI 등)에서 dev server 상태를 제어하는 HTTP 엔드포인트. 현재는 캐시 리셋만 제공하며 확장 가능한 구조.

## 추가된 엔드포인트

- \`ALL /reset-cache\` — 빌드 캐시 무효화 요청 (GET/POST 모두 허용)
  - \`cache_reset_requested\` 플래그 (atomic) 설정
  - watchLoop가 다음 iteration에서 소비 → \`inc_bundler.reset()\` 호출
  - SSE \`cache_reset\` 이벤트 브로드캐스트

## API 추가

- \`IncrementalBundler.reset()\` — \`module_cache\` + \`persistent_store\` 전부 무효화, 다음 rebuild는 초기 빌드와 동일.

## 사용 예
\`\`\`bash
curl -X POST http://localhost:12300/reset-cache
# {\"ok\":true,\"action\":\"reset_cache\"}

# SSE로 결과 확인
curl -N http://localhost:12300/sse/events
# event: cache_reset
# data: {\"type\":\"cache_reset\"}
\`\`\`

## 구조
- 플래그 기반 (atomic bool). HTTP 핸들러와 watchLoop 스레드 간 동기화 가장 간단.
- watchLoop는 500ms 주기로 polling → 최대 500ms 지연 (AC 허용 범위)

## 다음 Phase
- Phase 3: MCP 서버 (\`/mcp\`) — \`reset_cache\` 도구 + \`get_build_events\` 도구 (이벤트 ring buffer 필요)

Ref: [rollipop.dev control API](https://rollipop.dev/docs/features/sse) 호환.

## Test plan
- [x] \`zig build test\` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)