### PR TITLE
feat(server): graceful shutdown() API for DevServer

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -268,6 +268,8 @@ pub const DevServer = struct {
     cache_reset_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     /// MCP `get_build_events` 도구용 이벤트 히스토리 (최근 N개).
     event_ring: EventRing,
+    /// shutdown() 호출 시 set; acceptLoop가 다음 iteration에서 종료.
+    shutdown_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     plugins: []const plugin_mod.Plugin = &.{},
     proxy: []const ProxyRule = &.{},
     sourcemap_cache: struct {
@@ -502,7 +504,9 @@ pub const DevServer = struct {
 
     fn acceptLoop(self: *DevServer) void {
         while (true) {
+            if (self.shutdown_requested.load(.acquire)) return;
             const connection = self.tcp_server.?.accept() catch |err| {
+                if (self.shutdown_requested.load(.acquire)) return;
                 getLog().print("zts: accept failed: {}\n", .{err}) catch {};
                 continue;
             };
@@ -511,6 +515,19 @@ pub const DevServer = struct {
                 continue;
             };
             thread.detach();
+        }
+    }
+
+    /// 외부 (테스트 등)에서 acceptLoop을 종료시킨다.
+    /// macOS/Linux에서 close()는 블로킹 중인 accept()를 깨우지 않으므로
+    /// self-connect로 accept를 한 번 트리거 → acceptLoop가 다음 iteration에서
+    /// shutdown_requested 플래그를 보고 종료. 실제 socket close는 deinit에서.
+    pub fn shutdown(self: *DevServer) void {
+        self.shutdown_requested.store(true, .release);
+        if (self.tcp_server) |*s| {
+            const addr = s.listen_address;
+            const stream = std.net.tcpConnectToAddress(addr) catch return;
+            stream.close();
         }
     }
 

--- a/src/server/dev_server_test.zig
+++ b/src/server/dev_server_test.zig
@@ -34,3 +34,22 @@ test "sanitizePath: 백슬래시 차단" {
     try testing.expect(sanitizePath("/foo\\bar") == null);
     try testing.expect(sanitizePath("\\..\\etc\\passwd") == null);
 }
+
+test "DevServer.shutdown: 플래그 설정 + acceptLoop 종료 신호" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    var server = try dev_server.DevServer.init(testing.allocator, .{
+        .root_dir = tmp_path,
+        .port = 0,
+        .host = "127.0.0.1",
+    });
+    defer server.deinit();
+
+    // shutdown 호출 — start() 안 부른 상태에서도 안전해야 함 (tcp_server == null)
+    server.shutdown();
+    try testing.expect(server.shutdown_requested.load(.acquire));
+}


### PR DESCRIPTION
## Summary

\`acceptLoop\`가 무한 블로킹 → 외부에서 종료할 방법 없었음. 이번 PR로 graceful shutdown 가능.

## 추가
- \`DevServer.shutdown_requested\`: atomic bool 플래그
- \`DevServer.shutdown()\`: 플래그 설정 + self-connect로 \`accept()\` wake-up
- \`acceptLoop\`: iteration 시작 + accept 에러 시 플래그 체크 → return

## 왜 self-connect인가
\`close(listening_fd)\`는 macOS/Linux에서 블로킹 중인 \`accept()\`를 깨우지 않음 (다른 스레드에서 close 시 동작 미정의). 자기 자신에게 TCP 연결을 한 번 시도해 \`accept()\`가 반환하도록 → 다음 iteration에서 \`shutdown_requested\` 체크 → 종료.

## 활용
- CLI \`Ctrl+C\` graceful shutdown 핸들러
- 테스트 cleanup (단, Zig 0.15 test runner + detached handleConnection 스레드 상호작용 이슈로 통합 테스트 자체는 보류 — 추후 Bun 기반 외부 통합 테스트로 재시도)

## Test plan
- [x] \`zig build test\` 전체 통과
- [x] shutdown() 단위 테스트 (start 호출 전에도 안전 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)