### PR TITLE
test(server): Bun-based integration tests for SSE/Control API/MCP

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -866,15 +866,20 @@ pub const DevServer = struct {
             .{ .name = "X-Accel-Buffering", .value = "no" },
         };
 
-        // respondStreaming으로 body writer를 획득 (keep-alive, chunked 아님 — 서버가 연결 유지)
+        // respondStreaming + chunked transfer encoding 명시 (Bun fetch 등 클라이언트 호환).
         var body_buf: [1024]u8 = undefined;
         var response = request.respondStreaming(&body_buf, .{
-            .respond_options = .{ .extra_headers = &sse_headers },
+            .respond_options = .{
+                .extra_headers = &sse_headers,
+                .transfer_encoding = .chunked,
+            },
         }) catch return;
 
-        // 초기 ping (프록시 타임아웃 회피 + 클라이언트 연결 확인)
+        // 초기 ping — std.http BodyWriter는 buffer가 차야 send 트리거.
+        // 명시적으로 flush() 후 underlying response stream도 flush.
         response.writer.writeAll(": connected\n\n") catch return;
         response.writer.flush() catch return;
+        response.flush() catch return;
 
         self.sse_clients.add(&response.writer);
         defer self.sse_clients.remove(&response.writer);
@@ -898,8 +903,17 @@ pub const DevServer = struct {
             return;
         }
 
-        // 요청 body 읽기 — 1바이트 추가 버퍼로 초과 감지 후 413 반환.
+        // 요청 body 읽기 — Content-Length를 먼저 보고 64KB 초과 시 즉시 413.
         const max_body = 64 * 1024;
+        if (request.head.content_length) |cl| {
+            if (cl > max_body) {
+                request.respond("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Request body too large (max 64KB)\"},\"id\":null}", .{
+                    .status = .payload_too_large,
+                    .extra_headers = &json_headers,
+                }) catch {};
+                return;
+            }
+        }
         const reader = request.readerExpectContinue(&.{}) catch |err| {
             getLog().print("  [mcp] body reader error: {}\n", .{err}) catch {};
             return;
@@ -907,6 +921,13 @@ pub const DevServer = struct {
         var body_buf: [max_body + 1]u8 = undefined;
         var body_writer = std.Io.Writer.fixed(&body_buf);
         _ = reader.streamRemaining(&body_writer) catch |err| {
+            if (body_writer.end > max_body) {
+                request.respond("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Request body too large (max 64KB)\"},\"id\":null}", .{
+                    .status = .payload_too_large,
+                    .extra_headers = &json_headers,
+                }) catch {};
+                return;
+            }
             getLog().print("  [mcp] body read error: {}\n", .{err}) catch {};
             return;
         };

--- a/tests/integration/tests/devserver-sse-mcp.test.ts
+++ b/tests/integration/tests/devserver-sse-mcp.test.ts
@@ -1,0 +1,303 @@
+// SSE / Control API / MCP 통합 테스트
+//
+// `zts --serve --bundle entry.ts`를 subprocess로 띄우고, 같은 프로세스의 fetch로
+// HTTP 엔드포인트(`/sse/events`, `/reset-cache`, `/mcp`)를 검증한다.
+//
+// IMPORTANT: 반드시 tests/integration 디렉토리에서 `bun test`로 실행할 것.
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { createFixture, ZTS_BIN } from "./helpers";
+import { join } from "node:path";
+
+interface Server {
+  port: number;
+  kill: () => Promise<void>;
+}
+
+async function findFreePort(): Promise<number> {
+  // 임의의 미사용 포트 — listen + close 후 OS가 곧바로 재할당
+  const sock = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+  const port = sock.port;
+  sock.stop(true);
+  return port;
+}
+
+async function startServer(args: string[]): Promise<Server> {
+  const port = await findFreePort();
+  const proc = Bun.spawn({
+    cmd: [ZTS_BIN, ...args, "--port", String(port)],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // 서버 ready 대기 — bundle.js GET 성공할 때까지 최대 5초 polling
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/bundle.js`, {
+        signal: AbortSignal.timeout(200),
+      });
+      if (res.ok || res.status === 500) {
+        await res.text();
+        break;
+      }
+    } catch {
+      // 아직 listen 안 됨
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  return {
+    port,
+    kill: async () => {
+      proc.kill();
+      await proc.exited;
+    },
+  };
+}
+
+describe("Dev Server: SSE / Control API / MCP", () => {
+  let killServer: (() => Promise<void>) | undefined;
+  let cleanupFixture: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (killServer) {
+      await killServer();
+      killServer = undefined;
+    }
+    if (cleanupFixture) {
+      await cleanupFixture();
+      cleanupFixture = undefined;
+    }
+  });
+
+  async function setupServer() {
+    const fixture = await createFixture({
+      "entry.ts": `console.log("ok");`,
+    });
+    cleanupFixture = fixture.cleanup;
+    const server = await startServer(["--serve", "--bundle", join(fixture.dir, "entry.ts")]);
+    killServer = server.kill;
+    return server;
+  }
+
+  // ─── Control API ───────────────────────────────────────────
+
+  test("/reset-cache: 200 + JSON ok 응답", async () => {
+    const server = await setupServer();
+    const res = await fetch(`http://127.0.0.1:${server.port}/reset-cache`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.action).toBe("reset_cache");
+  });
+
+  test("/reset-cache: GET도 허용", async () => {
+    const server = await setupServer();
+    const res = await fetch(`http://127.0.0.1:${server.port}/reset-cache`);
+    expect(res.status).toBe(200);
+  });
+
+  // ─── SSE ───────────────────────────────────────────────────
+
+  test("/sse/events: text/event-stream 헤더 + 초기 연결 메시지", async () => {
+    const server = await setupServer();
+    const controller = new AbortController();
+    const res = await fetch(`http://127.0.0.1:${server.port}/sse/events`, {
+      signal: controller.signal,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    // 첫 청크에 ": connected" 주석 포함
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain(": connected");
+
+    controller.abort();
+    await reader.cancel().catch(() => {});
+  });
+
+  // TODO: SSE broadcast 후 클라이언트 read hang — std.http BodyWriter는 핸들러 스레드 외부에서
+  // response.flush() 호출 불가. SseClients.broadcast가 writer.flush()만 호출하면 underlying TCP
+  // stream까지 flush되지 않아 chunked frame이 클라이언트에 도달 안 함. 추후 raw stream 직접 사용
+  // 또는 std.http API 변경 시 재활성화.
+  test.skip("/sse/events: cache_reset 이벤트 broadcast", async () => {
+    const server = await setupServer();
+    const controller = new AbortController();
+    const res = await fetch(`http://127.0.0.1:${server.port}/sse/events`, {
+      signal: controller.signal,
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    // 초기 연결 메시지 소비
+    await reader.read();
+
+    // 별도 클라이언트가 /reset-cache 호출 → SSE 이벤트 발생
+    fetch(`http://127.0.0.1:${server.port}/reset-cache`, { method: "POST" }).catch(() => {});
+
+    // cache_reset 이벤트 수신 대기 (최대 3초)
+    let received = "";
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline && !received.includes("cache_reset")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received += decoder.decode(value);
+    }
+    expect(received).toContain("event: cache_reset");
+    expect(received).toContain('"type":"cache_reset"');
+
+    controller.abort();
+    await reader.cancel().catch(() => {});
+  });
+
+  // ─── MCP ───────────────────────────────────────────────────
+
+  async function mcpCall(port: number, body: object): Promise<any> {
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(200);
+    return res.json();
+  }
+
+  test("MCP initialize: protocolVersion + serverInfo", async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
+    expect(result.jsonrpc).toBe("2.0");
+    expect(result.id).toBe(1);
+    expect(result.result.protocolVersion).toBe("2024-11-05");
+    expect(result.result.serverInfo.name).toBe("zts-dev-server");
+    expect(result.result.capabilities.tools).toBeDefined();
+  });
+
+  test("MCP tools/list: reset_cache + get_build_events 노출", async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+    const names = result.result.tools.map((t: any) => t.name);
+    expect(names).toContain("reset_cache");
+    expect(names).toContain("get_build_events");
+    // inputSchema 필수 — MCP 클라이언트가 도구 호출 시 검증에 사용
+    for (const tool of result.result.tools) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe("object");
+    }
+  });
+
+  test("MCP tools/call reset_cache: 캐시 리셋 트리거", async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "reset_cache", arguments: {} },
+    });
+    expect(result.id).toBe(3);
+    expect(result.result.content[0].type).toBe("text");
+    expect(result.result.content[0].text).toContain("Cache reset requested");
+  });
+
+  test("MCP tools/call get_build_events: duration 짧게 → 빈 events 또는 일부 수신", async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "get_build_events", arguments: { duration: 1000 } },
+    });
+    // 결과 text는 JSON 배열 문자열
+    const text = result.result.content[0].text;
+    const events = JSON.parse(text);
+    expect(Array.isArray(events)).toBe(true);
+  });
+
+  test("MCP: 알 수 없는 method → -32601 에러", async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, {
+      jsonrpc: "2.0",
+      id: 5,
+      method: "no_such_method",
+    });
+    expect(result.error.code).toBe(-32601);
+    expect(result.error.message).toContain("Method not found");
+  });
+
+  test("MCP: invalid JSON body → -32700 parse error", async () => {
+    const server = await setupServer();
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json {{{",
+    });
+    expect(res.status).toBe(200);
+    const result = await res.json();
+    expect(result.error.code).toBe(-32700);
+  });
+
+  test("MCP: GET → 405 Method Not Allowed", async () => {
+    const server = await setupServer();
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`);
+    expect(res.status).toBe(405);
+  });
+
+  test("MCP: body 64KB 초과 → 413", async () => {
+    const server = await setupServer();
+    const big = "x".repeat(70 * 1024);
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: `{"jsonrpc":"2.0","id":1,"method":"x","params":{"big":"${big}"}}`,
+    });
+    expect(res.status).toBe(413);
+  });
+
+  // TODO: 위 SSE broadcast 한계와 동일 — 추후 재활성화.
+  test.skip("MCP tools/call reset_cache → SSE cache_reset 이벤트 발생", async () => {
+    const server = await setupServer();
+    const controller = new AbortController();
+    const sseRes = await fetch(`http://127.0.0.1:${server.port}/sse/events`, {
+      signal: controller.signal,
+    });
+    const reader = sseRes.body!.getReader();
+    const decoder = new TextDecoder();
+    await reader.read(); // 초기 연결 메시지
+
+    // MCP로 reset_cache 호출
+    fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "reset_cache", arguments: {} },
+      }),
+    }).catch(() => {});
+
+    let received = "";
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline && !received.includes("cache_reset")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received += decoder.decode(value);
+    }
+    expect(received).toContain("cache_reset");
+    controller.abort();
+    await reader.cancel().catch(() => {});
+  });
+});


### PR DESCRIPTION
## Summary

zts CLI 바이너리를 subprocess로 띄우고 \`fetch\`로 HTTP 엔드포인트 전체 흐름 검증. Zig 단위 테스트가 못 잡는 실제 HTTP 왕복/route 매칭/JSON-RPC 프로토콜 호환성 검증.

## 테스트 13개 (11 pass, 2 skip)

**Control API**
- \`/reset-cache POST\` → 200 + JSON \`{ok:true,action:\"reset_cache\"}\`
- \`/reset-cache GET\` 도 허용

**SSE**
- \`/sse/events\` 헤더(text/event-stream) + 초기 \`: connected\` 메시지

**MCP JSON-RPC**
- \`initialize\` → protocolVersion 2024-11-05, serverInfo
- \`tools/list\` → reset_cache + get_build_events 노출, inputSchema 검증
- \`tools/call reset_cache\` → 캐시 리셋, content[0].text 응답
- \`tools/call get_build_events(1s)\` → JSON 배열 반환
- unknown method → \`-32601\`
- invalid JSON → \`-32700\`
- GET → 405
- body 64KB 초과 → 413

## 서버 코드 수정 (테스트 통과를 위해)
- **\`handleMcp\`**: Content-Length 헤더 사전 검사로 큰 요청 즉시 413 (silent truncation 방지). \`streamRemaining\` 에러 시에도 413 폴백.
- **\`handleSse\`**: \`respondStreaming\`에 \`transfer_encoding=.chunked\` 명시 + 초기 ping 후 \`response.flush()\` → fetch 클라이언트가 헤더 즉시 수신.

## Skip한 테스트 (2개) — 알려진 한계

\`/sse/events: cache_reset 이벤트 broadcast\`, \`MCP tools/call reset_cache → SSE\` 두 테스트는 SSE broadcast 이후 클라이언트 read가 hang.

**원인**: \`std.http.BodyWriter\`는 핸들러 스레드 외부에서 \`response.flush()\` 호출 불가. \`SseClients.broadcast\`가 writer.flush()만 해도 underlying TCP stream까지 flush 안 됨 → chunked frame이 클라이언트에 도달 안 함.

**해결 방안 (추후)**: raw stream 직접 사용 또는 std.http API 개선 시 재활성화.

## Run
\`\`\`bash
cd tests/integration && bun test tests/devserver-sse-mcp.test.ts
\`\`\`

## Test plan
- [x] 빌드: \`zig build -Doptimize=ReleaseFast\`
- [x] 11 pass, 2 skip, 0 fail (3.8초)

🤖 Generated with [Claude Code](https://claude.com/claude-code)