### PR TITLE
fix(sourcemap): register polyfills as sources + correct prologue mappings

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -643,7 +643,10 @@ pub const Bundler = struct {
         // 2.7. 폴리필 파일 내용 로딩 (--polyfill)
         var polyfill_entries: std.ArrayList(EmitOptions.PolyfillEntry) = .empty;
         defer {
-            for (polyfill_entries.items) |e| self.allocator.free(e.content);
+            for (polyfill_entries.items) |e| {
+                self.allocator.free(e.content);
+                if (e.path) |p| self.allocator.free(p);
+            }
             polyfill_entries.deinit(self.allocator);
         }
         for (self.options.polyfills) |poly_path| {
@@ -665,6 +668,7 @@ pub const Bundler = struct {
             try polyfill_entries.append(self.allocator, .{
                 .name = std.fs.path.basename(poly_path),
                 .content = content,
+                .path = try self.allocator.dupe(u8, poly_path),
             });
         }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -142,6 +142,8 @@ pub const EmitOptions = struct {
     pub const PolyfillEntry = struct {
         name: []const u8,
         content: []const u8,
+        /// 원본 폴리필 파일 경로. 소스맵 sources 등록용. null이면 sources에 등록하지 않는다.
+        path: ?[]const u8 = null,
     };
 
     pub const Format = types.Format;
@@ -254,17 +256,48 @@ pub fn emitWithTreeShaking(
 
     // 폴리필 주입 (--polyfill): IIFE로 감싸서 즉시 실행.
     // Metro/롤다운과 동일하게 모듈 그래프 밖에서 런타임 헬퍼보다 먼저 실행.
-    for (options.polyfills) |poly| {
+    const PolyfillRange = struct {
+        content_start_line: u32,
+        content_line_count: u32,
+        entry: *const EmitOptions.PolyfillEntry,
+    };
+    var polyfill_ranges: std.ArrayList(PolyfillRange) = .empty;
+    defer polyfill_ranges.deinit(allocator);
+
+    // output에 누적 추가된 줄 수를 인라인 추적 (전체 버퍼 재스캔 방지).
+    var output_line: u32 = @intCast(std.mem.count(u8, output.items, "\n"));
+
+    for (options.polyfills) |*poly| {
         if (!options.minify_whitespace) {
             try output.appendSlice(allocator, "// --- polyfill: ");
             try output.appendSlice(allocator, poly.name);
             try output.appendSlice(allocator, " ---\n");
+            output_line += 1;
         }
         try output.appendSlice(allocator, "(function(){");
-        if (!options.minify_whitespace) try output.append(allocator, '\n');
+        if (!options.minify_whitespace) {
+            try output.append(allocator, '\n');
+            output_line += 1;
+        }
+
+        const content_start = output_line;
         try output.appendSlice(allocator, poly.content);
-        if (!options.minify_whitespace) try output.append(allocator, '\n');
+        output_line += @intCast(std.mem.count(u8, poly.content, "\n"));
+        if (!options.minify_whitespace) {
+            try output.append(allocator, '\n');
+            output_line += 1;
+        }
+
+        if (options.sourcemap and poly.path != null) {
+            try polyfill_ranges.append(allocator, .{
+                .content_start_line = content_start,
+                .content_line_count = output_line - content_start,
+                .entry = poly,
+            });
+        }
+
         try output.appendSlice(allocator, "})();\n");
+        output_line += 1;
     }
 
     // 런타임 헬퍼 주입
@@ -509,24 +542,27 @@ pub fn emitWithTreeShaking(
             }
         }
 
-        // prologue 전체(banner/polyfill/runtime helper/HMR runtime)를 가상 소스 "<runtime>"으로 매핑.
-        // DevTools가 prologue 프레임을 자동으로 무시하고 유저 코드 프레임을 표시.
-        // prologue_lines가 0이면 prologue가 없으므로 스킵.
+        // prologue를 가상 소스 "<runtime>"으로 매핑하고 polyfill은 별도 source로 매핑.
+        // DevTools가 vendored 프레임을 ignoreList로 스킵 → 유저 코드 프레임을 노출.
         if (prologue_lines > 0) {
-            const runtime_src_idx = try sm.addSource("node_modules/.zts/runtime.js");
-            if (options.sources_content) {
-                try sm.addSourceContent("// zts bundle runtime (polyfills, helpers)\n");
-            }
+            const runtime_src_idx = try addIdentitySource(sm, "node_modules/.zts/runtime.js", "// zts bundle runtime (polyfills, helpers)\n", options.sources_content);
             try sm.addIgnoredSource(runtime_src_idx);
-            // identity mapping: prologue의 모든 줄을 <runtime>에 매핑
-            for (0..prologue_lines) |line| {
-                try sm.addMapping(.{
-                    .generated_line = @intCast(line),
-                    .generated_column = 0,
-                    .source_index = runtime_src_idx,
-                    .original_line = @intCast(line),
-                    .original_column = 0,
-                });
+
+            // polyfill content 라인을 건너뛰며 runtime identity 매핑 추가.
+            // polyfill_ranges는 삽입 순서가 곧 시작 라인 오름차순.
+            var cursor: u32 = 0;
+            for (polyfill_ranges.items) |r| {
+                try addIdentityMappings(sm, runtime_src_idx, cursor, r.content_start_line - cursor, cursor);
+                cursor = r.content_start_line + r.content_line_count;
+            }
+            if (cursor < prologue_lines) {
+                try addIdentityMappings(sm, runtime_src_idx, cursor, prologue_lines - cursor, cursor);
+            }
+
+            for (polyfill_ranges.items) |r| {
+                const src_idx = try addIdentitySource(sm, r.entry.path.?, r.entry.content, options.sources_content);
+                try sm.addIgnoredSource(src_idx);
+                try addIdentityMappings(sm, src_idx, r.content_start_line, r.content_line_count, 0);
             }
         }
 
@@ -1375,6 +1411,27 @@ pub fn collectImportBindingNames(
 // --- ESM wrap functions (emitter/esm_wrap.zig) ---
 const esm_wrap = @import("emitter/esm_wrap.zig");
 const emitEsmWrappedModule = esm_wrap.emitEsmWrappedModule;
+
+/// source 등록 + (선택) sourcesContent 등록을 한 번에. source_index 반환.
+fn addIdentitySource(sm: *SourceMap.SourceMapBuilder, path: []const u8, content: []const u8, include_content: bool) !u32 {
+    const idx = try sm.addSource(path);
+    if (include_content) try sm.addSourceContent(content);
+    return idx;
+}
+
+/// generated_line[gen_start..gen_start+count)를 (col=0, source_idx, original_line=orig_start+i, col=0)로 매핑.
+fn addIdentityMappings(sm: *SourceMap.SourceMapBuilder, source_idx: u32, gen_start: u32, count: u32, orig_start: u32) !void {
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        try sm.addMapping(.{
+            .generated_line = gen_start + i,
+            .generated_column = 0,
+            .source_index = source_idx,
+            .original_line = orig_start + i,
+            .original_column = 0,
+        });
+    }
+}
 
 // --- 포맷별 래핑 (prologue/epilogue) ---
 

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -74,6 +74,11 @@ pub const Mapping = struct {
     original_line: u32,
     /// 소스 파일의 열 (0-based)
     original_column: u32,
+
+    pub fn lessThan(_: void, a: Mapping, b: Mapping) bool {
+        if (a.generated_line != b.generated_line) return a.generated_line < b.generated_line;
+        return a.generated_column < b.generated_column;
+    }
 };
 
 // ============================================================
@@ -97,6 +102,12 @@ pub const SourceMapBuilder = struct {
     /// x_google_ignoreList: DevTools에서 무시할 소스 인덱스 목록.
     /// 폴리필, node_modules 등 프레임워크 코드를 자동으로 스킵하도록 한다.
     ignored_sources: std.ArrayList(u32) = .empty,
+    /// addMapping 호출 순서가 (generated_line, column) 오름차순인지 추적.
+    /// false면 encodeMappings에서 정렬한다. 일반 모듈 emit은 순차적이지만
+    /// emitter가 prologue 매핑을 모듈 매핑보다 늦게 추가할 수 있다.
+    is_sorted: bool = true,
+    last_gen_line: u32 = 0,
+    last_gen_col: u32 = 0,
 
     pub fn init(allocator: std.mem.Allocator) SourceMapBuilder {
         return .{
@@ -135,6 +146,13 @@ pub const SourceMapBuilder = struct {
 
     /// 매핑 추가.
     pub fn addMapping(self: *SourceMapBuilder, mapping: Mapping) !void {
+        if (self.is_sorted and self.mappings.items.len > 0) {
+            const out_of_order = mapping.generated_line < self.last_gen_line or
+                (mapping.generated_line == self.last_gen_line and mapping.generated_column < self.last_gen_col);
+            if (out_of_order) self.is_sorted = false;
+        }
+        self.last_gen_line = mapping.generated_line;
+        self.last_gen_col = mapping.generated_column;
         try self.mappings.append(self.allocator, mapping);
     }
 
@@ -228,6 +246,10 @@ pub const SourceMapBuilder = struct {
 
     /// mappings 필드를 VLQ 인코딩.
     fn encodeMappings(self: *SourceMapBuilder) !void {
+        if (!self.is_sorted) {
+            std.mem.sort(Mapping, self.mappings.items, {}, Mapping.lessThan);
+        }
+
         var prev_gen_col: i32 = 0;
         var prev_src_idx: i32 = 0;
         var prev_src_line: i32 = 0;
@@ -387,4 +409,39 @@ test "generateUuidV4 — format and version/variant" {
     // variant nibble ∈ {8, 9, a, b}
     const variant = buf[19];
     try std.testing.expect(variant == '8' or variant == '9' or variant == 'a' or variant == 'b');
+}
+
+test "encodeMappings — out-of-order insertions are sorted before VLQ encoding" {
+    // VLQ 스트림은 generated_line/column 오름차순이어야 하므로 호출 순서가 뒤섞이면
+    // 정렬되어야 한다. 정렬이 없으면 작은 line의 매핑이 인코딩 시 누락된다.
+    var sm = SourceMapBuilder.init(std.testing.allocator);
+    defer sm.deinit();
+
+    const a = try sm.addSource("module.js");
+    const b = try sm.addSource("polyfill.js");
+
+    // 모듈 매핑(line 5)을 먼저 추가
+    try sm.addMapping(.{ .generated_line = 5, .generated_column = 0, .source_index = a, .original_line = 0, .original_column = 0 });
+    // prologue identity 매핑(line 0~2)을 나중에 추가 — 정렬 안 되면 누락됨
+    try sm.addMapping(.{ .generated_line = 0, .generated_column = 0, .source_index = b, .original_line = 0, .original_column = 0 });
+    try sm.addMapping(.{ .generated_line = 1, .generated_column = 0, .source_index = b, .original_line = 1, .original_column = 0 });
+    try sm.addMapping(.{ .generated_line = 2, .generated_column = 0, .source_index = b, .original_line = 2, .original_column = 0 });
+
+    const json = try sm.generateJSON("out.js");
+    // mappings 필드 추출
+    const key = "\"mappings\":\"";
+    const start = std.mem.indexOf(u8, json, key).? + key.len;
+    const end = std.mem.indexOfScalarPos(u8, json, start, '"').?;
+    const mappings = json[start..end];
+
+    // 라인 0,1,2,3,4,5 → 첫 라인은 ";" 없이 시작
+    // line 0 mapping이 누락되면 첫 글자가 ";" 가 됨
+    try std.testing.expect(mappings.len > 0);
+    try std.testing.expect(mappings[0] != ';');
+    // 정확히 5개의 ";" 가 있어야 함 (line 5에 매핑 도달까지)
+    var semi: usize = 0;
+    for (mappings) |c| if (c == ';') {
+        semi += 1;
+    };
+    try std.testing.expectEqual(@as(usize, 5), semi);
 }


### PR DESCRIPTION
Closes #1221

## Summary
- 번들 prelude(banner + RN polyfill + runtime helper) 921 라인이 매핑 없이 출력되어 DevTools가 `index.bundle:493` 식으로 표시되던 문제 해결
- `console.js` / `error-guard.js` 등 inline polyfill을 별도 source로 등록 + `x_google_ignoreList`에 포함 → 유저 코드 프레임을 stack walk

## 근본 원인
1. `encodeMappings`는 insertion-order 의존인데 emitter가 prologue identity 매핑을 모듈 매핑 _이후_에 추가 → `prev_gen_line`이 이미 921 너머로 진행되어 prologue 매핑이 사실상 누락
2. polyfill을 sources 배열에 등록하는 로직 자체가 부재

## 변경
- `SourceMapBuilder`: `addMapping`에서 역방향 삽입 감지 → `is_sorted=false`, `encodeMappings`에서 필요할 때만 정렬 (일반 모듈 emit은 비용 0)
- emitter: polyfill마다 `addSource` + `addSourceContent` + `addIgnoredSource` + identity 매핑. `<runtime>` 매핑은 polyfill 라인 범위 사이 gap만 채움
- `output_line` 러닝 카운터로 polyfill 루프의 O(P·N) buffer 재스캔 제거
- `addIdentitySource` / `addIdentityMappings` 헬퍼 추출
- `PolyfillEntry.path: ?[]const u8` 추가

## Test plan
- [x] `zig build test` 통과 (회귀 테스트 추가: out-of-order mapping insertion 정렬 검증)
- [x] 번개 ExampleApp dev 빌드로 재현 → 수정 후: leading `;` 921→0, polyfill sources 등록됨, line 493 MAPPED, ignoreList에 polyfill 3개

🤖 Generated with [Claude Code](https://claude.com/claude-code)