### PR TITLE
docs: SSE/Control API/MCP 가이드 + EN 누락 페이지 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Rollup/Vite 어댑터: `vitePlugin({...})` (모든 훅 async 지원).
 - `--platform=node` → Node 빌트인 자동 external
 - `--platform=react-native` → RN 프리셋: `.ios.*`/`.android.*`/`.native.*` 확장자, `react-native` main-field/exports 조건, `--flow` 자동
 - `--watch`/`--serve` → 증분 빌드, `--watch-json`은 NDJSON 이벤트 stdout 출력 (외부 HMR 연동)
+- Dev server 외부 인터페이스: `/sse/events` (SSE 빌드 이벤트), `/reset-cache` (Control API), `/mcp` (Model Context Protocol — Claude Code 등 LLM 에이전트 연동)
 - ES 다운레벨: `es5`~`es2025`/`esnext` (ES2023 hashbang strip, ES2025 `using` 다운레벨)
 - `import './x.css'` → 별도 CSS 파일 자동 생성 (Lightning CSS minify)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -102,6 +102,12 @@
 - **SIMD 확장** — 렉서에 `@Vector(16, u8)` 부분 적용 완료 (공백/식별자 스캔). 추가 확장 여지 있음
 - **WASM 공개 AST API** — AST 안정화 후
 
+## ✅ 최근 추가 (Dev Server 확장)
+
+- **SSE 이벤트 스트림** (`/sse/events`) — `server_ready`, `watch_change`, `bundle_build_*`, `cache_reset` 실시간 브로드캐스트 (rollipop 호환)
+- **Control API** (`/reset-cache`) — 외부에서 캐시 무효화 트리거
+- **MCP 서버** (`/mcp`) — JSON-RPC 2.0, `initialize`/`tools/list`/`tools/call`. 도구: `reset_cache`, `get_build_events`. Claude Code 등 LLM 에이전트가 `.mcp.json`으로 직접 연결 가능
+
 ## 의존성 관계
 ```
 AST 안정화 ──────────────┬──→ WASM 공개 AST API

--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -79,6 +79,7 @@ export default defineConfig({
             { label: "플러그인 레시피", slug: "guides/plugin-recipes", translations: { en: "Plugin Recipes" } },
             { label: "마이그레이션", slug: "guides/migration", translations: { en: "Migration" } },
             { label: "React Native", slug: "guides/react-native" },
+            { label: "Dev Server (SSE/MCP)", slug: "guides/dev-server" },
           ],
         },
         {

--- a/documents/src/content/docs/en/guides/dev-server.md
+++ b/documents/src/content/docs/en/guides/dev-server.md
@@ -1,0 +1,195 @@
+---
+title: Dev Server
+description: SSE event stream, Control API, and MCP server in the ZTS dev server
+---
+
+`zts --serve --bundle <entry>` starts a dev server that exposes **3 interfaces for external automation/observability** in addition to standard HTTP/HMR.
+
+| Endpoint | Purpose | Compatible |
+|---|---|---|
+| `/sse/events` | Server-Sent Events stream — real-time build/watch events | rollipop |
+| `/reset-cache` | Control API — invalidate cache externally | rollipop |
+| `/mcp` | MCP (Model Context Protocol) JSON-RPC | Claude Code, MCP clients |
+
+## Quick start
+
+```bash
+zts --serve --bundle src/index.tsx --port 12300
+```
+
+```bash
+# Subscribe to SSE events
+curl -N http://localhost:12300/sse/events
+
+# Reset cache
+curl -X POST http://localhost:12300/reset-cache
+
+# Call MCP tool
+curl -X POST http://localhost:12300/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+## SSE event stream
+
+### `GET /sse/events`
+
+Response: `Content-Type: text/event-stream`, keep-alive connection.
+
+Each event uses standard SSE format:
+```
+event: <type>
+data: <json>
+
+```
+
+### Event types
+
+| Type | When | Payload |
+|---|---|---|
+| `server_ready` | Server start | `{type, host, port}` |
+| `watch_change` | File change detected | `{type, file}` |
+| `bundle_build_started` | Build started | `{type, id}` |
+| `bundle_build_done` | Build succeeded | `{type, id, totalModules, duration}` |
+| `bundle_build_failed` | Build failed | `{type, id}` |
+| `cache_reset` | Cache invalidated (manual/MCP) | `{type}` |
+
+### Browser example
+
+```ts
+const es = new EventSource("http://localhost:12300/sse/events");
+es.addEventListener("bundle_build_done", (e) => {
+  const { duration, totalModules } = JSON.parse(e.data);
+  console.log(`Built ${totalModules} modules in ${duration}ms`);
+});
+```
+
+### Node example
+
+```ts
+const res = await fetch("http://localhost:12300/sse/events");
+const reader = res.body!.getReader();
+const decoder = new TextDecoder();
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  process.stdout.write(decoder.decode(value));
+}
+```
+
+## Control API
+
+### `ALL /reset-cache`
+
+Invalidate the entire build cache. Next build is a full rebuild (all modules re-parsed/transformed).
+
+Both GET and POST allowed.
+
+Response:
+```json
+{"ok":true,"action":"reset_cache"}
+```
+
+When the cache is actually reset, a `cache_reset` event is published to SSE.
+
+## MCP (Model Context Protocol)
+
+LLM agents (Claude Code etc.) interact with the dev bundler via the standard MCP protocol. **JSON-RPC 2.0 over HTTP**.
+
+### Registration (`.mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "zts": {
+      "type": "http",
+      "url": "http://localhost:12300/mcp"
+    }
+  }
+}
+```
+
+Start the dev server first, then start the MCP client (Claude Code etc.).
+
+### Supported methods
+
+| Method | Description |
+|---|---|
+| `initialize` | Protocol handshake (version 2024-11-05) |
+| `tools/list` | Returns tool list with JSON Schema |
+| `tools/call` | Execute a tool |
+| `notifications/initialized` | Client ready notification |
+
+### Tools
+
+#### `reset_cache`
+
+Invalidate build cache. Same effect as Control API `/reset-cache`.
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1,
+  "method": "tools/call",
+  "params": { "name": "reset_cache", "arguments": {} }
+}
+```
+
+#### `get_build_events`
+
+Returns build events collected during the specified duration (ms) as a JSON array.
+
+| Argument | Type | Default | Range |
+|---|---|---|---|
+| `duration` | number | 10000 | 1000~60000 (ms) |
+
+```json
+{
+  "jsonrpc": "2.0", "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_build_events",
+    "arguments": { "duration": 5000 }
+  }
+}
+```
+
+Response (`content[0].text` is a JSON string):
+```json
+[
+  {"seq":42,"type":"watch_change","data":{"type":"watch_change","file":"src/App.tsx"}},
+  {"seq":43,"type":"bundle_build_started","data":{"type":"bundle_build_started","id":"43"}},
+  {"seq":44,"type":"bundle_build_done","data":{"type":"bundle_build_done","id":"43","totalModules":42,"duration":123.45}}
+]
+```
+
+### LLM workflow example
+
+```
+1. get_build_events(2000) — capture current build state
+2. (LLM modifies code)
+3. get_build_events(10000) → wait for bundle_build_done or bundle_build_failed
+4. If failed, read error message, fix → back to 2
+5. If needed, reset_cache to clear cached state
+```
+
+## MCP error codes
+
+| Code | Meaning |
+|---|---|
+| `-32600` | Invalid Request (not POST / body > 64KB / etc.) |
+| `-32601` | Method not found |
+| `-32602` | Unknown tool |
+| `-32700` | Parse error (invalid JSON) |
+
+## Limits
+
+- **Body size**: MCP request body max 64KB. Returns HTTP 413 if exceeded.
+- **HTTP method**: `/mcp` accepts POST only. GET etc. → 405.
+- **Event buffer**: `get_build_events` reads from a 256-entry ring buffer. Older events are overwritten.
+- **SSE concurrent connections**: 64. Additional connections rejected.
+
+## See also
+
+- [Server-Sent Events (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+- [Model Context Protocol](https://modelcontextprotocol.io)
+- [rollipop SSE/MCP](https://rollipop.dev/docs/features/sse) — compatible surface

--- a/documents/src/content/docs/en/guides/migration.md
+++ b/documents/src/content/docs/en/guides/migration.md
@@ -1,0 +1,212 @@
+---
+title: Migration Guide
+description: How to migrate from esbuild, Vite, and webpack to ZTS.
+---
+
+## Migrating from esbuild
+
+ZTS supports nearly identical CLI options to esbuild. In most cases, replace `esbuild` with `zts`.
+
+### CLI option mapping
+
+| esbuild | ZTS | Note |
+|---------|-----|------|
+| `esbuild src/index.ts --bundle` | `zts --bundle src/index.ts` | Same |
+| `--outfile=dist/out.js` | `-o dist/out.js` | Short form supported |
+| `--outdir=dist` | `--outdir dist` | Same |
+| `--format=esm` | `--format=esm` | Same (esm/cjs/iife) |
+| `--platform=node` | `--platform=node` | Same |
+| `--minify` | `--minify` | Same |
+| `--sourcemap` | `--sourcemap` | Same |
+| `--splitting` | `--splitting` | Same |
+| `--target=es2020` | `--target=es2020` | Same |
+| `--external:react` | `--external react` | Space instead of `:` |
+| `--define:X=Y` | `--define:X=Y` | Same |
+| `--loader:.css=text` | `--loader:.css=text` | Same |
+| `--watch` | `--watch` or `-w` | Same |
+| `--serve` | `--serve` | Same |
+| `--metafile=meta.json` | `--metafile=meta.json` | Same |
+| `--legal-comments=eof` | `--legal-comments=eof` | Same |
+| `--keep-names` | `--keep-names` | Same |
+| `--drop:console` | `--drop=console` | `=` instead of `:` |
+| `--inject:./shim.js` | `--inject:./shim.js` | Same |
+| `--alias:react=preact/compat` | `--alias:react=preact/compat` | Same |
+| `--entry-names=[name]-[hash]` | `--entry-names=[name]-[hash]` | Same |
+| `--chunk-names=chunks/[hash]` | `--chunk-names=chunks/[hash]` | Same |
+| `--asset-names=assets/[hash]` | `--asset-names=assets/[hash]` | Same |
+
+### esbuild Build API migration
+
+```typescript
+// esbuild
+import * as esbuild from 'esbuild';
+await esbuild.build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  outdir: 'dist',
+  format: 'esm',
+  minify: true,
+});
+
+// ZTS — almost identical
+import { build } from '@zts/plugin';
+await build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  outdir: 'dist',
+  format: 'esm',
+  minify: true,
+});
+```
+
+### esbuild plugin migration
+
+ZTS plugins use Rollup/Vite-style hooks.
+
+```typescript
+// esbuild plugin
+const myPlugin = {
+  name: 'my-plugin',
+  setup(build) {
+    build.onResolve({ filter: /^virtual:/ }, args => ({
+      path: args.path,
+      namespace: 'virtual',
+    }));
+    build.onLoad({ filter: /.*/, namespace: 'virtual' }, args => ({
+      contents: 'export default 42',
+      loader: 'js',
+    }));
+  },
+};
+
+// ZTS plugin — Rollup/Vite style
+const myPlugin = {
+  name: 'my-plugin',
+  resolveId(source) {
+    if (source.startsWith('virtual:')) {
+      return { path: '\0' + source };
+    }
+    return null;
+  },
+  load(id) {
+    if (id.startsWith('\0virtual:')) {
+      return { contents: 'export default 42' };
+    }
+    return null;
+  },
+};
+```
+
+### Unsupported esbuild options
+
+| esbuild option | Alternative |
+|-------------|------|
+| `--format=umd` | Not supported. Use IIFE + manual UMD wrapper |
+| `--mangle-props` | Not supported |
+| `--analyze` (detailed tree) | `--analyze` (JSON output, tree format planned) |
+
+## Migrating from Vite
+
+Vite is a combination of dev server + production bundler (Rollup/Rolldown). ZTS is a standalone bundler and doesn't replace all Vite features.
+
+### Vite production build replacement
+
+```bash
+# Vite
+vite build
+
+# ZTS
+zts --bundle src/main.ts --outdir dist --format=esm --splitting --minify --sourcemap
+```
+
+### vite.config.ts mapping
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    minify: true,
+    sourcemap: true,
+    rollupOptions: {
+      external: ['react', 'react-dom'],
+    },
+  },
+});
+
+// ZTS CLI equivalent
+// zts --bundle src/main.ts --outdir dist --minify --sourcemap --external react --external react-dom
+```
+
+### Vite plugin → ZTS plugin
+
+Vite/Rollup plugin hooks (`resolveId`, `load`, `transform`) work identically in ZTS.
+
+```typescript
+// zts.config.ts
+import { defineConfig } from '@zts/plugin';
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'svg-loader',
+      load(id) {
+        if (id.endsWith('.svg')) {
+          const fs = require('fs');
+          const svg = fs.readFileSync(id, 'utf8');
+          return { contents: `export default ${JSON.stringify(svg)}` };
+        }
+        return null;
+      },
+    },
+  ],
+});
+```
+
+### Unsupported Vite features
+
+| Vite feature | ZTS alternative |
+|----------|---------|
+| `import.meta.glob` | Not supported (planned) |
+| `import.meta.env` | `--define:import.meta.env.MODE="production"` |
+| CSS Modules | Lightning CSS plugin |
+| `@vitejs/plugin-react` | `--jsx=automatic` (automatic React JSX) |
+| HMR (`import.meta.hot`) | `--serve --bundle` (supported) |
+| HTML entry | Not supported. Use JS entry |
+
+## Migrating from webpack
+
+webpack configuration is complex, but ZTS handles most of it via CLI options.
+
+### webpack.config.js → ZTS CLI
+
+```javascript
+// webpack.config.js
+module.exports = {
+  entry: './src/index.ts',
+  output: { path: 'dist', filename: 'bundle.js' },
+  resolve: { extensions: ['.ts', '.tsx', '.js'] },
+  module: {
+    rules: [
+      { test: /\.tsx?$/, use: 'ts-loader' },
+      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+      { test: /\.svg$/, type: 'asset/resource' },
+    ],
+  },
+  optimization: { minimize: true },
+};
+
+// ZTS equivalent
+// zts --bundle src/index.ts -o dist/bundle.js --minify --loader:.svg=file --loader:.css=text
+```
+
+### webpack loaders → ZTS loaders/plugins
+
+| webpack loader | ZTS equivalent |
+|-------------|---------|
+| `ts-loader` / `babel-loader` | Not needed (ZTS handles TS/JSX directly) |
+| `css-loader` + `style-loader` | `--loader:.css=text` or Lightning CSS plugin |
+| `file-loader` / `asset/resource` | `--loader:.png=file` |
+| `url-loader` / `asset/inline` | `--loader:.png=dataurl` |
+| `raw-loader` / `asset/source` | `--loader:.txt=text` |
+| `svg-loader` | `--loader:.svg=text` or plugin |

--- a/documents/src/content/docs/en/guides/plugin-recipes.md
+++ b/documents/src/content/docs/en/guides/plugin-recipes.md
@@ -1,0 +1,332 @@
+---
+title: Plugin Recipes
+description: A collection of commonly used ZTS plugin examples.
+---
+
+Ready-to-use plugin examples for real-world scenarios. All plugins are written in `zts.config.ts` and used with `--plugin zts.config.ts`.
+
+## CSS — Lightning CSS
+
+Transpile and bundle CSS with [Lightning CSS](https://lightningcss.dev/). Supports CSS Modules, vendor prefixes, and nesting syntax.
+
+```bash
+npm install lightningcss
+```
+
+```typescript
+// zts.config.ts
+import { defineConfig } from "@zts/plugin";
+import { transform, bundleAsync } from "lightningcss";
+import { readFileSync } from "fs";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "lightningcss",
+      load(id) {
+        if (!id.endsWith(".css")) return null;
+        const code = readFileSync(id);
+        const result = transform({
+          filename: id,
+          code,
+          minify: true,
+          targets: { chrome: 80 << 16 }, // chrome 80+
+        });
+        const css = result.code.toString();
+        // Convert CSS to JS module — inject style tag
+        return {
+          contents: `
+const style = document.createElement('style');
+style.textContent = ${JSON.stringify(css)};
+document.head.appendChild(style);
+export default ${JSON.stringify(css)};
+`,
+        };
+      },
+    },
+  ],
+});
+```
+
+```bash
+zts --bundle src/index.ts --plugin zts.config.ts -o dist/bundle.js
+```
+
+## CSS Modules
+
+Process CSS Modules with Lightning CSS to hash class names.
+
+```typescript
+// zts.config.ts
+import { defineConfig } from "@zts/plugin";
+import { transformStyleAttribute, transform } from "lightningcss";
+import { readFileSync } from "fs";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "css-modules",
+      load(id) {
+        if (!id.endsWith(".module.css")) return null;
+        const code = readFileSync(id);
+        const result = transform({
+          filename: id,
+          code,
+          minify: true,
+          cssModules: true,
+        });
+        const css = result.code.toString();
+        const exports = result.exports ?? {};
+        // Build class name mapping object
+        const classMap = Object.fromEntries(
+          Object.entries(exports).map(([k, v]) => [k, v.name])
+        );
+        return {
+          contents: `
+const style = document.createElement('style');
+style.textContent = ${JSON.stringify(css)};
+document.head.appendChild(style);
+export default ${JSON.stringify(classMap)};
+`,
+        };
+      },
+    },
+  ],
+});
+```
+
+```typescript
+// Usage
+import styles from './Button.module.css';
+const el = document.createElement('div');
+el.className = styles.container; // → hashed class name
+```
+
+## PostCSS + Tailwind CSS
+
+Process Tailwind CSS via PostCSS.
+
+```bash
+npm install postcss tailwindcss @tailwindcss/postcss
+```
+
+```typescript
+// zts.config.ts
+import { defineConfig } from "@zts/plugin";
+import postcss from "postcss";
+import tailwindcss from "@tailwindcss/postcss";
+import { readFileSync } from "fs";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "postcss-tailwind",
+      async load(id) {
+        if (!id.endsWith(".css")) return null;
+        const css = readFileSync(id, "utf8");
+        const result = await postcss([tailwindcss()]).process(css, {
+          from: id,
+        });
+        return {
+          contents: `
+const style = document.createElement('style');
+style.textContent = ${JSON.stringify(result.css)};
+document.head.appendChild(style);
+export default ${JSON.stringify(result.css)};
+`,
+        };
+      },
+    },
+  ],
+});
+```
+
+## SVG → React component
+
+Convert SVG files to React components.
+
+```typescript
+// zts.config.ts
+import { defineConfig } from "@zts/plugin";
+import { readFileSync } from "fs";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "svg-react",
+      load(id) {
+        if (!id.endsWith(".svg")) return null;
+        const svg = readFileSync(id, "utf8");
+        // Convert SVG attributes to React props
+        const component = svg
+          .replace(/class=/g, "className=")
+          .replace(/fill-rule=/g, "fillRule=")
+          .replace(/clip-rule=/g, "clipRule=")
+          .replace(/stroke-width=/g, "strokeWidth=")
+          .replace(/stroke-linecap=/g, "strokeLinecap=")
+          .replace(/stroke-linejoin=/g, "strokeLinejoin=");
+        return {
+          contents: `
+export default function SvgIcon(props) {
+  return ${component.replace(/<svg/, "<svg {...props}")};
+}
+export const src = ${JSON.stringify(svg)};
+`,
+        };
+      },
+    },
+  ],
+});
+```
+
+```tsx
+// Usage
+import Logo from './logo.svg';
+const App = () => <Logo width={32} height={32} />;
+```
+
+## YAML loader
+
+Import YAML files as parsed JSON.
+
+```bash
+npm install yaml
+```
+
+```typescript
+// zts.config.ts
+import { defineConfig } from "@zts/plugin";
+import { parse } from "yaml";
+import { readFileSync } from "fs";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "yaml",
+      load(id) {
+        if (!id.endsWith(".yaml") && !id.endsWith(".yml")) return null;
+        const text = readFileSync(id, "utf8");
+        const data = parse(text);
+        return {
+          contents: `export default ${JSON.stringify(data)};`,
+        };
+      },
+    },
+  ],
+});
+```
+
+## GraphQL loader
+
+Import `.graphql` / `.gql` files as strings.
+
+```typescript
+// zts.config.ts
+import { defineConfig } from "@zts/plugin";
+import { readFileSync } from "fs";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "graphql",
+      load(id) {
+        if (!id.endsWith(".graphql") && !id.endsWith(".gql")) return null;
+        const query = readFileSync(id, "utf8");
+        return {
+          contents: `export default ${JSON.stringify(query)};`,
+        };
+      },
+    },
+  ],
+});
+```
+
+## Environment variables (dotenv)
+
+Inject `.env` values at build time.
+
+```typescript
+// zts.config.ts
+import { defineConfig } from "@zts/plugin";
+import { readFileSync, existsSync } from "fs";
+
+function loadEnv(path = ".env"): Record<string, string> {
+  if (!existsSync(path)) return {};
+  const content = readFileSync(path, "utf8");
+  const env: Record<string, string> = {};
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const [key, ...rest] = trimmed.split("=");
+    env[key.trim()] = rest.join("=").trim().replace(/^["']|["']$/g, "");
+  }
+  return env;
+}
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "dotenv",
+      transform(code, id) {
+        if (!id.endsWith(".ts") && !id.endsWith(".js")) return null;
+        if (!code.includes("import.meta.env")) return null;
+        const env = loadEnv();
+        let result = code;
+        for (const [key, value] of Object.entries(env)) {
+          result = result.replaceAll(
+            `import.meta.env.${key}`,
+            JSON.stringify(value)
+          );
+        }
+        return result;
+      },
+    },
+  ],
+});
+```
+
+## Virtual module
+
+Inject runtime info as a virtual module.
+
+```typescript
+// zts.config.ts
+import { defineConfig } from "@zts/plugin";
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "virtual-build-info",
+      resolveId(source) {
+        if (source === "virtual:build-info") {
+          return { path: "\0virtual:build-info" };
+        }
+        return null;
+      },
+      load(id) {
+        if (id === "\0virtual:build-info") {
+          return {
+            contents: `
+export const buildTime = ${JSON.stringify(new Date().toISOString())};
+export const nodeVersion = ${JSON.stringify(process.version)};
+export const gitHash = ${JSON.stringify(
+              require("child_process")
+                .execSync("git rev-parse --short HEAD")
+                .toString()
+                .trim()
+            )};
+`,
+          };
+        }
+        return null;
+      },
+    },
+  ],
+});
+```
+
+```typescript
+// Usage
+import { buildTime, gitHash } from "virtual:build-info";
+console.log(`Built at ${buildTime} (${gitHash})`);
+```

--- a/documents/src/content/docs/guides/dev-server.md
+++ b/documents/src/content/docs/guides/dev-server.md
@@ -1,0 +1,195 @@
+---
+title: Dev Server
+description: ZTS dev server의 SSE 이벤트 스트림, Control API, MCP 서버
+---
+
+`zts --serve --bundle <entry>`로 시작하는 dev 서버는 일반 HTTP/HMR 외에 **외부 자동화/관측 도구를 위한 3가지 인터페이스**를 제공한다.
+
+| 엔드포인트 | 용도 | 호환 |
+|---|---|---|
+| `/sse/events` | Server-Sent Events 스트림 — 실시간 빌드/watch 이벤트 | rollipop |
+| `/reset-cache` | Control API — 외부에서 캐시 무효화 | rollipop |
+| `/mcp` | MCP (Model Context Protocol) JSON-RPC | Claude Code, MCP 클라이언트 |
+
+## 빠른 시작
+
+```bash
+zts --serve --bundle src/index.tsx --port 12300
+```
+
+```bash
+# SSE 이벤트 구독
+curl -N http://localhost:12300/sse/events
+
+# 캐시 리셋
+curl -X POST http://localhost:12300/reset-cache
+
+# MCP 도구 호출
+curl -X POST http://localhost:12300/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+## SSE 이벤트 스트림
+
+### `GET /sse/events`
+
+응답: `Content-Type: text/event-stream`, 연결 유지(keep-alive).
+
+각 이벤트는 표준 SSE 형식:
+```
+event: <type>
+data: <json>
+
+```
+
+### 이벤트 타입
+
+| Type | When | Payload |
+|---|---|---|
+| `server_ready` | 서버 시작 | `{type, host, port}` |
+| `watch_change` | 파일 변경 감지 | `{type, file}` |
+| `bundle_build_started` | 빌드 시작 | `{type, id}` |
+| `bundle_build_done` | 빌드 성공 | `{type, id, totalModules, duration}` |
+| `bundle_build_failed` | 빌드 실패 | `{type, id}` |
+| `cache_reset` | 캐시 초기화 (수동/MCP) | `{type}` |
+
+### 사용 예 (브라우저)
+
+```ts
+const es = new EventSource("http://localhost:12300/sse/events");
+es.addEventListener("bundle_build_done", (e) => {
+  const { duration, totalModules } = JSON.parse(e.data);
+  console.log(`Built ${totalModules} modules in ${duration}ms`);
+});
+```
+
+### 사용 예 (Node)
+
+```ts
+const res = await fetch("http://localhost:12300/sse/events");
+const reader = res.body!.getReader();
+const decoder = new TextDecoder();
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  process.stdout.write(decoder.decode(value));
+}
+```
+
+## Control API
+
+### `ALL /reset-cache`
+
+빌드 캐시 전체 무효화 요청. 다음 빌드는 초기 빌드와 동일 (모든 모듈 재파싱/재변환).
+
+GET, POST 모두 허용.
+
+응답:
+```json
+{"ok":true,"action":"reset_cache"}
+```
+
+캐시가 실제로 리셋되면 SSE에 `cache_reset` 이벤트가 발행된다.
+
+## MCP (Model Context Protocol)
+
+LLM 에이전트(Claude Code 등)가 표준 MCP 프로토콜로 dev 번들러와 직접 상호작용. **JSON-RPC 2.0 over HTTP**.
+
+### 등록 (`.mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "zts": {
+      "type": "http",
+      "url": "http://localhost:12300/mcp"
+    }
+  }
+}
+```
+
+dev 서버를 먼저 띄운 뒤 MCP 클라이언트(Claude Code 등) 시작.
+
+### 지원 메서드
+
+| Method | 설명 |
+|---|---|
+| `initialize` | 프로토콜 핸드셰이크 (버전 2024-11-05) |
+| `tools/list` | 도구 목록 + JSON Schema 반환 |
+| `tools/call` | 도구 실행 |
+| `notifications/initialized` | 클라이언트 준비 완료 통지 |
+
+### 도구
+
+#### `reset_cache`
+
+빌드 캐시를 무효화. Control API `/reset-cache`와 동일 효과.
+
+```json
+{
+  "jsonrpc": "2.0", "id": 1,
+  "method": "tools/call",
+  "params": { "name": "reset_cache", "arguments": {} }
+}
+```
+
+#### `get_build_events`
+
+지정된 시간(ms) 동안 수집된 빌드 이벤트를 JSON 배열로 반환.
+
+| 인자 | 타입 | 기본 | 범위 |
+|---|---|---|---|
+| `duration` | number | 10000 | 1000~60000 (ms) |
+
+```json
+{
+  "jsonrpc": "2.0", "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_build_events",
+    "arguments": { "duration": 5000 }
+  }
+}
+```
+
+응답 (`content[0].text`는 JSON 문자열):
+```json
+[
+  {"seq":42,"type":"watch_change","data":{"type":"watch_change","file":"src/App.tsx"}},
+  {"seq":43,"type":"bundle_build_started","data":{"type":"bundle_build_started","id":"43"}},
+  {"seq":44,"type":"bundle_build_done","data":{"type":"bundle_build_done","id":"43","totalModules":42,"duration":123.45}}
+]
+```
+
+### LLM 워크플로우 예
+
+```
+1. get_build_events(2000)으로 현재 빌드 상태 캡처
+2. (LLM이 코드 수정)
+3. get_build_events(10000) → bundle_build_done 또는 bundle_build_failed 대기
+4. failed면 에러 메시지 읽고 수정 → 2번으로
+5. 필요 시 reset_cache로 캐시 초기화
+```
+
+## 에러 코드 (MCP)
+
+| Code | Meaning |
+|---|---|
+| `-32600` | Invalid Request (POST 아님 / body 64KB 초과 등) |
+| `-32601` | Method not found |
+| `-32602` | Unknown tool |
+| `-32700` | Parse error (JSON 오류) |
+
+## 제약
+
+- **Body 크기**: MCP 요청 body는 최대 64KB. 초과 시 HTTP 413.
+- **HTTP method**: `/mcp`는 POST만. GET 등은 405.
+- **이벤트 버퍼**: `get_build_events`가 참조하는 ring buffer는 최근 256개. 그 이상은 덮어쓰임.
+- **SSE 동시 연결**: 64개. 초과 시 거부.
+
+## 관련
+
+- [Server-Sent Events (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+- [Model Context Protocol](https://modelcontextprotocol.io)
+- [rollipop SSE/MCP](https://rollipop.dev/docs/features/sse) — 호환 surface


### PR DESCRIPTION
## Summary

PR #1216~#1224에서 추가한 dev server 외부 인터페이스(SSE / Control API / MCP) 문서화 + 영문 사이트에 누락된 가이드 보충.

## 신규 문서
- **guides/dev-server.md (KO + EN)** — Dev Server 전체 가이드
  - SSE 이벤트 타입 6종 (server_ready, watch_change, bundle_build_*, cache_reset)
  - Control API: \`/reset-cache\` GET/POST
  - MCP: initialize/tools/list/tools/call, 도구 (reset_cache, get_build_events)
  - 클라이언트 사용 예: 브라우저 EventSource, Node fetch, \`.mcp.json\`, LLM 워크플로우
  - 에러 코드 + 제약 (body 64KB, ring buffer 256, SSE 64 connections)

## EN 누락 페이지 추가
- **en/guides/migration.md** — esbuild/Vite/webpack → ZTS (기존 KO 1:1 번역)
- **en/guides/plugin-recipes.md** — 8개 플러그인 레시피 (Lightning CSS, CSS Modules, PostCSS+Tailwind, SVG→React, YAML, GraphQL, dotenv, virtual module)

## 업데이트
- \`documents/astro.config.mjs\` — 사이드바에 \"Dev Server (SSE/MCP)\" 추가
- \`CLAUDE.md\` — Dev server 외부 인터페이스 1줄 요약
- \`docs/ROADMAP.md\` — 최근 추가 섹션 (SSE/Control API/MCP)

## Test plan
- [x] \`bun run astro build\` — 324 페이지 빌드 성공
- [x] All internal links valid (Astro 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)