### PR TITLE
feat(watch): expose phaseDurations on WatchRebuildEvent (#1223 Phase 3)

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -3685,6 +3685,193 @@ describe("watch()", () => {
 });
 
 // ================================================================
+// Issue #1223: HMR perf — 재현 테스트
+// 폴링 워처(500ms), mtime-only 캐시, 디바운스 부재, 증분 미흡, 관측성 부재
+// ================================================================
+
+describe("Issue #1223 HMR perf 재현", () => {
+  // ---- Phase 3: 관측성 (phaseDurations) ----
+  test("phase3: WatchRebuildEvent에 phaseDurations 필드가 노출되어야 함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase3-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<any>();
+
+    const handle = watch({
+      entryPoints: [join(dir, "entry.ts")],
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuildDone(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+
+    const event = await rebuildP;
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(event.phaseDurations).toBeDefined();
+    expect(typeof event.phaseDurations.detect).toBe("number");
+    expect(typeof event.phaseDurations.parse).toBe("number");
+    expect(typeof event.phaseDurations.semantic).toBe("number");
+    expect(typeof event.phaseDurations.emit).toBe("number");
+    expect(typeof event.phaseDurations.delta).toBe("number");
+    expect(typeof event.phaseDurations.total).toBe("number");
+    expect(event.phaseDurations.total).toBeGreaterThan(0);
+  }, 10000);
+
+  // ---- Phase 1a: 워처 latency (목표 < 200ms, 현재 폴링 500ms) ----
+  test("phase1a: 변경 감지부터 onRebuild까지 200ms 이내여야 함 (현재 500ms 폴링)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1a-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<void>();
+
+    const handle = watch({
+      entryPoints: [join(dir, "entry.ts")],
+      onReady() {
+        readyDone();
+      },
+      onRebuild() {
+        rebuildDone();
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 50));
+
+    const t0 = performance.now();
+    writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+    await rebuildP;
+    const elapsed = performance.now() - t0;
+
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(elapsed).toBeLessThan(200);
+  }, 10000);
+
+  // ---- Phase 1b: content hash (mtime만 갱신, 내용 동일 → 알림 없음) ----
+  test("phase1b: 내용이 동일하면 onRebuild가 호출되지 않아야 함 (content hash)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1b-"));
+    const entry = join(dir, "entry.ts");
+    const src = "export const x = 1;";
+    writeFileSync(entry, src);
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    let rebuildCount = 0;
+
+    const handle = watch({
+      entryPoints: [entry],
+      onReady() {
+        readyDone();
+      },
+      onRebuild() {
+        rebuildCount++;
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 내용 동일, mtime만 갱신 (touch와 유사)
+    writeFileSync(entry, src);
+    await new Promise((r) => setTimeout(r, 1500));
+
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    // 현재: mtime만 봐서 무조건 리빌드 트리거 → rebuildCount=1
+    // 목표: content hash로 스킵 → rebuildCount=0
+    expect(rebuildCount).toBe(0);
+  }, 10000);
+
+  // ---- Phase 1c: 디바운스 (idle 상태에서 50ms 내 두 번 저장 → 1회 리빌드) ----
+  test("phase1c: 첫 리빌드 후 50ms 내 두 번 저장은 한 번으로 병합되어야 함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1c-"));
+    const entry = join(dir, "entry.ts");
+    writeFileSync(entry, "export const x = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    let rebuildCount = 0;
+    let firstRebuildResolve: (() => void) | null = null;
+    const firstRebuildP = new Promise<void>((r) => {
+      firstRebuildResolve = r;
+    });
+
+    const handle = watch({
+      entryPoints: [entry],
+      onReady() {
+        readyDone();
+      },
+      onRebuild() {
+        rebuildCount++;
+        if (rebuildCount === 1) firstRebuildResolve!();
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 첫 저장 → 첫 리빌드 완료까지 대기
+    writeFileSync(entry, "export const x = 2;");
+    await firstRebuildP;
+    expect(rebuildCount).toBe(1);
+
+    // idle 상태에서 50ms 내에 두 번 빠르게 저장
+    writeFileSync(entry, "export const x = 3;");
+    await new Promise((r) => setTimeout(r, 10));
+    writeFileSync(entry, "export const x = 4;");
+
+    // 디바운스(50ms) + 빌드 시간 충분히 대기
+    await new Promise((r) => setTimeout(r, 2000));
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    // 현재: 폴링으로 두 번 모두 감지 → rebuildCount=3
+    // 목표: 디바운스로 병합 → rebuildCount=2
+    expect(rebuildCount).toBe(2);
+  }, 15000);
+
+  // ---- Phase 2: 증분 그래프 (1개 변경 → 1개만 재파싱) ----
+  test("phase2: 의존 그래프에서 leaf 1개만 변경 시 reparsedModules=1 이어야 함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase2-"));
+    writeFileSync(join(dir, "a.ts"), 'import { b } from "./b"; export const a = b + 1;');
+    writeFileSync(join(dir, "b.ts"), 'import { c } from "./c"; export const b = c + 1;');
+    writeFileSync(join(dir, "c.ts"), "export const c = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<any>();
+
+    const handle = watch({
+      entryPoints: [join(dir, "a.ts")],
+      devMode: true,
+      collectModuleCodes: true,
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuildDone(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // leaf(c.ts)만 변경 → c만 재파싱되어야 함 (a, b는 캐시)
+    writeFileSync(join(dir, "c.ts"), "export const c = 999;");
+
+    const event = await rebuildP;
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(event.reparsedModules).toBe(1);
+  }, 10000);
+});
+
+// ================================================================
 // buildResult에 moduleCodes/modulePaths 노출 테스트
 // ================================================================
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -254,6 +254,21 @@ export interface WatchRebuildEvent {
   graphChanged?: boolean;
   updates?: Array<{ id: string; code: string }>;
   bytes?: number;
+  /** 단계별 빌드 시간 (밀리초). 성공한 리빌드에서만 노출. */
+  phaseDurations?: {
+    /** 변경 감지 (mtime 스캔) */
+    detect: number;
+    /** 파싱 (resolve + parse + finalize) */
+    parse: number;
+    /** 의미 분석 (scope hoisting + linking + tree-shaking) */
+    semantic: number;
+    /** 코드 생성 (transform + codegen) */
+    emit: number;
+    /** HMR delta 추출 */
+    delta: number;
+    /** 총 리빌드 시간 (detect → delta 합산) */
+    total: number;
+  };
 }
 
 export interface WatchHandle {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1093,6 +1093,16 @@ const WatchReadyEvent = struct {
     bytes: usize,
 };
 
+/// 단계별 빌드 시간 (밀리초). Issue #1223 관측성.
+const PhaseDurations = struct {
+    detect_ms: f64 = 0,
+    parse_ms: f64 = 0,
+    semantic_ms: f64 = 0,
+    emit_ms: f64 = 0,
+    delta_ms: f64 = 0,
+    total_ms: f64 = 0,
+};
+
 /// onRebuild 콜백에 전달할 이벤트 데이터
 const WatchRebuildEvent = struct {
     success: bool,
@@ -1101,6 +1111,7 @@ const WatchRebuildEvent = struct {
     graph_changed: bool = false,
     updates: ?[]const ModuleUpdate = null,
     bytes: usize = 0,
+    phase_durations: ?PhaseDurations = null,
     // 실패 시
     error_msg: ?[]const u8 = null,
 
@@ -1218,6 +1229,26 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
         var js_bytes: c.napi_value = undefined;
         _ = c.napi_create_int64(env, @intCast(event.bytes), &js_bytes);
         _ = c.napi_set_named_property(env, js_event, "bytes", js_bytes);
+
+        // phaseDurations: { detect, parse, semantic, emit, delta, total } (ms)
+        if (event.phase_durations) |pd| {
+            var js_pd: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_pd);
+            const fields = [_]struct { name: [:0]const u8, value: f64 }{
+                .{ .name = "detect", .value = pd.detect_ms },
+                .{ .name = "parse", .value = pd.parse_ms },
+                .{ .name = "semantic", .value = pd.semantic_ms },
+                .{ .name = "emit", .value = pd.emit_ms },
+                .{ .name = "delta", .value = pd.delta_ms },
+                .{ .name = "total", .value = pd.total_ms },
+            };
+            for (fields) |f| {
+                var js_num: c.napi_value = undefined;
+                _ = c.napi_create_double(env, f.value, &js_num);
+                _ = c.napi_set_named_property(env, js_pd, f.name.ptr, js_num);
+            }
+            _ = c.napi_set_named_property(env, js_event, "phaseDurations", js_pd);
+        }
     } else {
         // error: string
         if (event.error_msg) |msg| {
@@ -1396,7 +1427,9 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         // stop_flag 재확인 (sleep 후)
         if (async_data.stop_flag.load(.acquire)) break;
 
-        // mtime 변경 확인 + 변경 파일 수집
+        // mtime 변경 확인 + 변경 파일 수집 (detect 단계)
+        var total_timer = std.time.Timer.start() catch null;
+        var detect_timer = std.time.Timer.start() catch null;
         var changed = false;
         var changed_files: std.ArrayList([]const u8) = .empty;
         defer changed_files.deinit(allocator);
@@ -1410,6 +1443,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
                 changed_files.append(allocator, entry.key_ptr.*) catch {};
             }
         }
+        const detect_ns: u64 = if (detect_timer) |*t| t.read() else 0;
 
         if (!changed) continue;
 
@@ -1490,7 +1524,8 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             }
         }
 
-        // dev mode: HMR diff
+        // dev mode: HMR diff (delta 단계)
+        var delta_timer = std.time.Timer.start() catch null;
         if (rebuild_result.module_dev_codes) |dev_codes| {
             // 모듈 ID 집합 비교 — graph 변경 감지
             const graph_changed_flag = blk: {
@@ -1551,6 +1586,23 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
                 };
             }
         }
+        const delta_ns: u64 = if (delta_timer) |*t| t.read() else 0;
+        const total_ns: u64 = if (total_timer) |*t| t.read() else 0;
+
+        // 단계별 타이밍 기록 (관측성 — Issue #1223)
+        const ns_to_ms = struct {
+            fn f(ns: u64) f64 {
+                return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
+            }
+        }.f;
+        event.phase_durations = .{
+            .detect_ms = ns_to_ms(detect_ns),
+            .parse_ms = ns_to_ms(rebuild_result.timings.graph_ns),
+            .semantic_ms = ns_to_ms(rebuild_result.timings.link_ns + rebuild_result.timings.shake_ns),
+            .emit_ms = ns_to_ms(rebuild_result.timings.emit_ns),
+            .delta_ms = ns_to_ms(delta_ns),
+            .total_ms = ns_to_ms(total_ns),
+        };
 
         // rebuild 이벤트 전송
         if (c.napi_call_threadsafe_function(async_data.rebuild_tsfn, @ptrCast(event), c.napi_tsfn_blocking) != c.napi_ok) {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1230,7 +1230,6 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
         _ = c.napi_create_int64(env, @intCast(event.bytes), &js_bytes);
         _ = c.napi_set_named_property(env, js_event, "bytes", js_bytes);
 
-        // phaseDurations: { detect, parse, semantic, emit, delta, total } (ms)
         if (event.phase_durations) |pd| {
             var js_pd: c.napi_value = undefined;
             _ = c.napi_create_object(env, &js_pd);
@@ -1427,7 +1426,6 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         // stop_flag 재확인 (sleep 후)
         if (async_data.stop_flag.load(.acquire)) break;
 
-        // mtime 변경 확인 + 변경 파일 수집 (detect 단계)
         var total_timer = std.time.Timer.start() catch null;
         var detect_timer = std.time.Timer.start() catch null;
         var changed = false;
@@ -1524,7 +1522,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             }
         }
 
-        // dev mode: HMR diff (delta 단계)
+        // dev mode: HMR diff
         var delta_timer = std.time.Timer.start() catch null;
         if (rebuild_result.module_dev_codes) |dev_codes| {
             // 모듈 ID 집합 비교 — graph 변경 감지
@@ -1589,19 +1587,14 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         const delta_ns: u64 = if (delta_timer) |*t| t.read() else 0;
         const total_ns: u64 = if (total_timer) |*t| t.read() else 0;
 
-        // 단계별 타이밍 기록 (관측성 — Issue #1223)
-        const ns_to_ms = struct {
-            fn f(ns: u64) f64 {
-                return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
-            }
-        }.f;
+        const nsToMs = bundler_mod.BundleResult.nsToMs;
         event.phase_durations = .{
-            .detect_ms = ns_to_ms(detect_ns),
-            .parse_ms = ns_to_ms(rebuild_result.timings.graph_ns),
-            .semantic_ms = ns_to_ms(rebuild_result.timings.link_ns + rebuild_result.timings.shake_ns),
-            .emit_ms = ns_to_ms(rebuild_result.timings.emit_ns),
-            .delta_ms = ns_to_ms(delta_ns),
-            .total_ms = ns_to_ms(total_ns),
+            .detect_ms = nsToMs(detect_ns),
+            .parse_ms = nsToMs(rebuild_result.timings.graph_ns),
+            .semantic_ms = nsToMs(rebuild_result.timings.link_ns + rebuild_result.timings.shake_ns),
+            .emit_ms = nsToMs(rebuild_result.timings.emit_ns),
+            .delta_ms = nsToMs(delta_ns),
+            .total_ms = nsToMs(total_ns),
         };
 
         // rebuild 이벤트 전송

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -221,6 +221,20 @@ pub const BundleResult = struct {
     asset_outputs: ?[]OutputFile = null,
     /// metafile JSON (--metafile). allocator 소유.
     metafile_json: ?[]const u8 = null,
+    /// 파이프라인 단계별 타이밍 (ns). 항상 측정 — 워치 모드 관측성용.
+    timings: BundleTimings = .{},
+
+    /// 단계별 빌드 시간 (나노초).
+    pub const BundleTimings = struct {
+        /// resolve + parse + finalize (graph build)
+        graph_ns: u64 = 0,
+        /// scope hoisting + linking
+        link_ns: u64 = 0,
+        /// tree-shaking
+        shake_ns: u64 = 0,
+        /// transform + codegen
+        emit_ns: u64 = 0,
+    };
 
     /// dev mode에서 모듈별 HMR 업데이트 코드. types.ModuleDevCode의 별칭.
     pub const ModuleDevCode = types.ModuleDevCode;
@@ -492,7 +506,8 @@ pub const Bundler = struct {
         var t_shake: u64 = 0;
         var t_emit: u64 = 0;
 
-        var timer: ?std.time.Timer = if (timing) std.time.Timer.start() catch null else null;
+        // 타이머는 항상 동작 (watch 관측성용). Timer.read()는 ns 단위 syscall 한 번으로 저렴.
+        var timer: ?std.time.Timer = std.time.Timer.start() catch null;
 
         // 0. RN dev mode: InitializeCore prelude 자동 주입.
         // InitializeCore → setUpReactRefresh에서 injectIntoGlobalHook을 호출한다.
@@ -975,6 +990,12 @@ pub const Bundler = struct {
             .module_dev_codes = module_dev_codes,
             .asset_outputs = final_asset_outputs,
             .metafile_json = metafile_json,
+            .timings = .{
+                .graph_ns = t_graph,
+                .link_ns = t_link,
+                .shake_ns = t_shake,
+                .emit_ns = t_emit,
+            },
         };
     }
 };

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -236,6 +236,11 @@ pub const BundleResult = struct {
         emit_ns: u64 = 0,
     };
 
+    /// ns → ms 변환 헬퍼 (타이밍 노출 공용).
+    pub fn nsToMs(ns: u64) f64 {
+        return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
+    }
+
     /// dev mode에서 모듈별 HMR 업데이트 코드. types.ModuleDevCode의 별칭.
     pub const ModuleDevCode = types.ModuleDevCode;
 


### PR DESCRIPTION
## Summary
- Issue #1223 HMR perf 개선의 **Phase 3 (관측성)**
- `WatchRebuildEvent.phaseDurations`에 단계별 빌드 시간(ms) 노출
- Phase 1/2 최적화 전에 병목 실측 근거 확보 목적

## Changes
- `Bundler.bundle()`이 단계별 ns 타이밍을 항상 측정 (기존: `--timing`일 때만)
- `BundleResult.timings`: `{ graph_ns, link_ns, shake_ns, emit_ns }`
- `WatchRebuildEvent.phase_durations` (Zig) / `phaseDurations` (TS):
  - `detect`: mtime 스캔
  - `parse`: graph build (resolve + parse + finalize)
  - `semantic`: link + tree-shake
  - `emit`: transform + codegen
  - `delta`: HMR module-code diff
  - `total`: 전체 리빌드 시간
- Issue #1223 재현 테스트 5개 추가 (`describe("Issue #1223 HMR perf 재현")`)
  - `phase3` ✅ 본 PR로 통과
  - `phase1a/1b/2` ❌ 다음 PR(이벤트 워처/content hash/증분 그래프)에서 해결

## Test plan
- [x] `bun test index.test.ts -t "phase3"` 통과
- [x] `bun test index.test.ts -t "watch"` 10/10 회귀 없음
- [x] `zig build test` 통과

Related: #1223