### PR TITLE
feat(watch): expose reparsedModules + incremental-cache initial build (#1223 Phase 2)

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -3685,6 +3685,193 @@ describe("watch()", () => {
 });
 
 // ================================================================
+// Issue #1223: HMR perf — 재현 테스트
+// 폴링 워처(500ms), mtime-only 캐시, 디바운스 부재, 증분 미흡, 관측성 부재
+// ================================================================
+
+describe("Issue #1223 HMR perf 재현", () => {
+  // ---- Phase 3: 관측성 (phaseDurations) ----
+  test("phase3: WatchRebuildEvent에 phaseDurations 필드가 노출되어야 함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase3-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<any>();
+
+    const handle = watch({
+      entryPoints: [join(dir, "entry.ts")],
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuildDone(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+
+    const event = await rebuildP;
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(event.phaseDurations).toBeDefined();
+    expect(typeof event.phaseDurations.detect).toBe("number");
+    expect(typeof event.phaseDurations.parse).toBe("number");
+    expect(typeof event.phaseDurations.semantic).toBe("number");
+    expect(typeof event.phaseDurations.emit).toBe("number");
+    expect(typeof event.phaseDurations.delta).toBe("number");
+    expect(typeof event.phaseDurations.total).toBe("number");
+    expect(event.phaseDurations.total).toBeGreaterThan(0);
+  }, 10000);
+
+  // ---- Phase 1a: 워처 latency (목표 < 200ms, 현재 폴링 500ms) ----
+  test("phase1a: 변경 감지부터 onRebuild까지 200ms 이내여야 함 (현재 500ms 폴링)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1a-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<void>();
+
+    const handle = watch({
+      entryPoints: [join(dir, "entry.ts")],
+      onReady() {
+        readyDone();
+      },
+      onRebuild() {
+        rebuildDone();
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 50));
+
+    const t0 = performance.now();
+    writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+    await rebuildP;
+    const elapsed = performance.now() - t0;
+
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(elapsed).toBeLessThan(200);
+  }, 10000);
+
+  // ---- Phase 1b: content hash (mtime만 갱신, 내용 동일 → 알림 없음) ----
+  test("phase1b: 내용이 동일하면 onRebuild가 호출되지 않아야 함 (content hash)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1b-"));
+    const entry = join(dir, "entry.ts");
+    const src = "export const x = 1;";
+    writeFileSync(entry, src);
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    let rebuildCount = 0;
+
+    const handle = watch({
+      entryPoints: [entry],
+      onReady() {
+        readyDone();
+      },
+      onRebuild() {
+        rebuildCount++;
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 내용 동일, mtime만 갱신 (touch와 유사)
+    writeFileSync(entry, src);
+    await new Promise((r) => setTimeout(r, 1500));
+
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    // 현재: mtime만 봐서 무조건 리빌드 트리거 → rebuildCount=1
+    // 목표: content hash로 스킵 → rebuildCount=0
+    expect(rebuildCount).toBe(0);
+  }, 10000);
+
+  // ---- Phase 1c: 디바운스 (idle 상태에서 50ms 내 두 번 저장 → 1회 리빌드) ----
+  test("phase1c: 첫 리빌드 후 50ms 내 두 번 저장은 한 번으로 병합되어야 함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1c-"));
+    const entry = join(dir, "entry.ts");
+    writeFileSync(entry, "export const x = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    let rebuildCount = 0;
+    let firstRebuildResolve: (() => void) | null = null;
+    const firstRebuildP = new Promise<void>((r) => {
+      firstRebuildResolve = r;
+    });
+
+    const handle = watch({
+      entryPoints: [entry],
+      onReady() {
+        readyDone();
+      },
+      onRebuild() {
+        rebuildCount++;
+        if (rebuildCount === 1) firstRebuildResolve!();
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 첫 저장 → 첫 리빌드 완료까지 대기
+    writeFileSync(entry, "export const x = 2;");
+    await firstRebuildP;
+    expect(rebuildCount).toBe(1);
+
+    // idle 상태에서 50ms 내에 두 번 빠르게 저장
+    writeFileSync(entry, "export const x = 3;");
+    await new Promise((r) => setTimeout(r, 10));
+    writeFileSync(entry, "export const x = 4;");
+
+    // 디바운스(50ms) + 빌드 시간 충분히 대기
+    await new Promise((r) => setTimeout(r, 2000));
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    // 현재: 폴링으로 두 번 모두 감지 → rebuildCount=3
+    // 목표: 디바운스로 병합 → rebuildCount=2
+    expect(rebuildCount).toBe(2);
+  }, 15000);
+
+  // ---- Phase 2: 증분 그래프 (1개 변경 → 1개만 재파싱) ----
+  test("phase2: 의존 그래프에서 leaf 1개만 변경 시 reparsedModules=1 이어야 함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase2-"));
+    writeFileSync(join(dir, "a.ts"), 'import { b } from "./b"; export const a = b + 1;');
+    writeFileSync(join(dir, "b.ts"), 'import { c } from "./c"; export const b = c + 1;');
+    writeFileSync(join(dir, "c.ts"), "export const c = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<any>();
+
+    const handle = watch({
+      entryPoints: [join(dir, "a.ts")],
+      devMode: true,
+      collectModuleCodes: true,
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuildDone(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // leaf(c.ts)만 변경 → c만 재파싱되어야 함 (a, b는 캐시)
+    writeFileSync(join(dir, "c.ts"), "export const c = 999;");
+
+    const event = await rebuildP;
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(event.reparsedModules).toBe(1);
+  }, 10000);
+});
+
+// ================================================================
 // buildResult에 moduleCodes/modulePaths 노출 테스트
 // ================================================================
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -254,6 +254,21 @@ export interface WatchRebuildEvent {
   graphChanged?: boolean;
   updates?: Array<{ id: string; code: string }>;
   bytes?: number;
+  /** 단계별 빌드 시간 (밀리초). 성공한 리빌드에서만 노출. */
+  phaseDurations?: {
+    /** 변경 감지 (mtime 스캔) */
+    detect: number;
+    /** 파싱 (resolve + parse + finalize) */
+    parse: number;
+    /** 의미 분석 (scope hoisting + linking + tree-shaking) */
+    semantic: number;
+    /** 코드 생성 (transform + codegen) */
+    emit: number;
+    /** HMR delta 추출 */
+    delta: number;
+    /** 총 리빌드 시간 (detect → delta 합산) */
+    total: number;
+  };
 }
 
 export interface WatchHandle {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -269,6 +269,8 @@ export interface WatchRebuildEvent {
     /** 총 리빌드 시간 (detect → delta 합산) */
     total: number;
   };
+  /** 증분 그래프에서 재파싱된 모듈 수. 캐시 미스된 모듈만 카운트. 전체 빌드에서는 미노출. */
+  reparsedModules?: number;
 }
 
 export interface WatchHandle {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1177,6 +1177,8 @@ const WatchRebuildEvent = struct {
     updates: ?[]const ModuleUpdate = null,
     bytes: usize = 0,
     phase_durations: ?PhaseDurations = null,
+    /// 증분 그래프에서 재파싱된 모듈 수 (Issue #1223 Phase 2).
+    reparsed_modules: ?usize = null,
     // 실패 시
     error_msg: ?[]const u8 = null,
 
@@ -1313,6 +1315,12 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
             }
             _ = c.napi_set_named_property(env, js_event, "phaseDurations", js_pd);
         }
+
+        if (event.reparsed_modules) |n| {
+            var js_n: c.napi_value = undefined;
+            _ = c.napi_create_int64(env, @intCast(n), &js_n);
+            _ = c.napi_set_named_property(env, js_event, "reparsedModules", js_n);
+        }
     } else {
         // error: string
         if (event.error_msg) |msg| {
@@ -1335,8 +1343,17 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     const allocator = native_alloc;
     const bundle_opts = async_data.options;
 
-    // 초기 빌드
-    var bundler = Bundler.init(allocator, bundle_opts);
+    // Issue #1223 Phase 2: 초기 빌드에도 PersistentModuleStore 전달.
+    // 초기 빌드에서 store가 채워져야 첫 리빌드가 캐시 히트 경로로 진입한다.
+    const module_store_mod = bundler_mod.module_store;
+    const ResolveCache = bundler_mod.ResolveCache;
+    var persistent_store = module_store_mod.PersistentModuleStore.init(allocator);
+    defer persistent_store.deinit();
+
+    var initial_opts = bundle_opts;
+    initial_opts.module_store = &persistent_store;
+
+    var bundler = Bundler.init(allocator, initial_opts);
     var result = bundler.bundle() catch |err| {
         // 초기 빌드 실패 — rebuild 이벤트로 에러 전달
         const event = allocator.create(WatchRebuildEvent) catch {
@@ -1361,12 +1378,6 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         return;
     };
     defer result.deinit(allocator);
-
-    // 증분 빌드용 PersistentModuleStore + ResolveCache
-    const module_store_mod = bundler_mod.module_store;
-    const ResolveCache = bundler_mod.ResolveCache;
-    var persistent_store = module_store_mod.PersistentModuleStore.init(allocator);
-    defer persistent_store.deinit();
 
     // dev mode: per-module code 캐시 (HMR diff용)
     var module_code_cache = std.StringHashMap([]const u8).init(allocator);
@@ -1698,6 +1709,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             .delta_ms = nsToMs(delta_ns),
             .total_ms = nsToMs(total_ns),
         };
+        event.reparsed_modules = rebuild_result.reparsed_modules;
 
         // rebuild 이벤트 전송
         if (c.napi_call_threadsafe_function(async_data.rebuild_tsfn, @ptrCast(event), c.napi_tsfn_blocking) != c.napi_ok) {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1093,6 +1093,16 @@ const WatchReadyEvent = struct {
     bytes: usize,
 };
 
+/// 단계별 빌드 시간 (밀리초). Issue #1223 관측성.
+const PhaseDurations = struct {
+    detect_ms: f64 = 0,
+    parse_ms: f64 = 0,
+    semantic_ms: f64 = 0,
+    emit_ms: f64 = 0,
+    delta_ms: f64 = 0,
+    total_ms: f64 = 0,
+};
+
 /// onRebuild 콜백에 전달할 이벤트 데이터
 const WatchRebuildEvent = struct {
     success: bool,
@@ -1101,6 +1111,7 @@ const WatchRebuildEvent = struct {
     graph_changed: bool = false,
     updates: ?[]const ModuleUpdate = null,
     bytes: usize = 0,
+    phase_durations: ?PhaseDurations = null,
     // 실패 시
     error_msg: ?[]const u8 = null,
 
@@ -1218,6 +1229,26 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
         var js_bytes: c.napi_value = undefined;
         _ = c.napi_create_int64(env, @intCast(event.bytes), &js_bytes);
         _ = c.napi_set_named_property(env, js_event, "bytes", js_bytes);
+
+        // phaseDurations: { detect, parse, semantic, emit, delta, total } (ms)
+        if (event.phase_durations) |pd| {
+            var js_pd: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_pd);
+            const fields = [_]struct { name: [:0]const u8, value: f64 }{
+                .{ .name = "detect", .value = pd.detect_ms },
+                .{ .name = "parse", .value = pd.parse_ms },
+                .{ .name = "semantic", .value = pd.semantic_ms },
+                .{ .name = "emit", .value = pd.emit_ms },
+                .{ .name = "delta", .value = pd.delta_ms },
+                .{ .name = "total", .value = pd.total_ms },
+            };
+            for (fields) |f| {
+                var js_num: c.napi_value = undefined;
+                _ = c.napi_create_double(env, f.value, &js_num);
+                _ = c.napi_set_named_property(env, js_pd, f.name.ptr, js_num);
+            }
+            _ = c.napi_set_named_property(env, js_event, "phaseDurations", js_pd);
+        }
     } else {
         // error: string
         if (event.error_msg) |msg| {
@@ -1396,7 +1427,9 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         // stop_flag 재확인 (sleep 후)
         if (async_data.stop_flag.load(.acquire)) break;
 
-        // mtime 변경 확인 + 변경 파일 수집
+        // mtime 변경 확인 + 변경 파일 수집 (detect 단계)
+        var total_timer = std.time.Timer.start() catch null;
+        var detect_timer = std.time.Timer.start() catch null;
         var changed = false;
         var changed_files: std.ArrayList([]const u8) = .empty;
         defer changed_files.deinit(allocator);
@@ -1410,6 +1443,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
                 changed_files.append(allocator, entry.key_ptr.*) catch {};
             }
         }
+        const detect_ns: u64 = if (detect_timer) |*t| t.read() else 0;
 
         if (!changed) continue;
 
@@ -1490,7 +1524,8 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             }
         }
 
-        // dev mode: HMR diff
+        // dev mode: HMR diff (delta 단계)
+        var delta_timer = std.time.Timer.start() catch null;
         if (rebuild_result.module_dev_codes) |dev_codes| {
             // 모듈 ID 집합 비교 — graph 변경 감지
             const graph_changed_flag = blk: {
@@ -1551,6 +1586,23 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
                 };
             }
         }
+        const delta_ns: u64 = if (delta_timer) |*t| t.read() else 0;
+        const total_ns: u64 = if (total_timer) |*t| t.read() else 0;
+
+        // 단계별 타이밍 기록 (관측성 — Issue #1223)
+        const ns_to_ms = struct {
+            fn f(ns: u64) f64 {
+                return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
+            }
+        }.f;
+        event.phase_durations = .{
+            .detect_ms = ns_to_ms(detect_ns),
+            .parse_ms = ns_to_ms(rebuild_result.timings.graph_ns),
+            .semantic_ms = ns_to_ms(rebuild_result.timings.link_ns + rebuild_result.timings.shake_ns),
+            .emit_ms = ns_to_ms(rebuild_result.timings.emit_ns),
+            .delta_ms = ns_to_ms(delta_ns),
+            .total_ms = ns_to_ms(total_ns),
+        };
 
         // rebuild 이벤트 전송
         if (c.napi_call_threadsafe_function(async_data.rebuild_tsfn, @ptrCast(event), c.napi_tsfn_blocking) != c.napi_ok) {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -13,6 +13,23 @@ const zts_lib = @import("zts_lib");
 const transpile_mod = zts_lib.transpile;
 const bundler_mod = zts_lib.bundler;
 const Bundler = bundler_mod.Bundler;
+const FileWatcher = zts_lib.server.FileWatcher;
+
+/// Issue #1223 Phase 1: 워처 튜닝 상수.
+/// - watch_poll_timeout_ms: stop_flag 체크 주기 (이벤트 워처에서도 주기적으로 깨어나기 위함).
+/// - watch_debounce_ms: 첫 이벤트 이후 정적(idle) 구간 — 연속 저장 병합 윈도우.
+const watch_poll_timeout_ms: u32 = 200;
+const watch_debounce_ms: u32 = 50;
+
+/// 파일 내용의 content hash (Wyhash 64-bit).
+/// mtime 변동만으로 리빌드하지 않고, 실제 내용 변화만 감지한다.
+fn hashFileContent(allocator: std.mem.Allocator, path: []const u8) ?u64 {
+    const file = std.fs.cwd().openFile(path, .{}) catch return null;
+    defer file.close();
+    const content = file.readToEndAlloc(allocator, 128 * 1024 * 1024) catch return null;
+    defer allocator.free(content);
+    return std.hash.Wyhash.hash(0, content);
+}
 const BundleOptions = bundler_mod.BundleOptions;
 const Platform = zts_lib.codegen.codegen.Platform;
 const JsxRuntime = zts_lib.codegen.codegen.JsxRuntime;
@@ -1342,35 +1359,56 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     });
     defer persistent_resolve_cache.deinit();
 
-    // mtime 맵 초기화
-    var mtime_map = std.StringHashMap(i128).init(allocator);
+    // Issue #1223 Phase 1: 이벤트 기반 파일 워처 (kqueue/inotify, mtime 폴백).
+    // 실패 시 워치 스레드 진입 직전에 종료한다.
+    var watcher = FileWatcher.init(allocator) catch {
+        const event = allocator.create(WatchRebuildEvent) catch {
+            _ = c.napi_release_threadsafe_function(async_data.ready_tsfn, c.napi_tsfn_release);
+            _ = c.napi_release_threadsafe_function(async_data.rebuild_tsfn, c.napi_tsfn_release);
+            async_data.deinit();
+            return;
+        };
+        event.* = .{ .success = false, .error_msg = allocator.dupe(u8, "FileWatcherInitFailed") catch null };
+        if (c.napi_call_threadsafe_function(async_data.rebuild_tsfn, @ptrCast(event), c.napi_tsfn_blocking) != c.napi_ok) {
+            event.deinit();
+        }
+        _ = c.napi_release_threadsafe_function(async_data.ready_tsfn, c.napi_tsfn_release);
+        _ = c.napi_release_threadsafe_function(async_data.rebuild_tsfn, c.napi_tsfn_release);
+        async_data.deinit();
+        return;
+    };
+    defer watcher.deinit();
+
+    // content hash 캐시: mtime 변동으로 깨우되 실제 내용 변화만 리빌드 트리거.
+    var content_hash_map = std.StringHashMap(u64).init(allocator);
     defer {
-        var it = mtime_map.keyIterator();
+        var it = content_hash_map.keyIterator();
         while (it.next()) |k| allocator.free(k.*);
-        mtime_map.deinit();
+        content_hash_map.deinit();
     }
 
-    // 엔트리 파일을 감시 대상에 추가
+    // 감시 대상 등록: 엔트리 + 초기 빌드의 module_paths
+    var initial_watch_count: usize = 0;
+    const registerWatchPath = struct {
+        fn run(w: *FileWatcher, hmap: *std.StringHashMap(u64), alloc: std.mem.Allocator, path: []const u8) bool {
+            w.addPath(path) catch return false;
+            const key = alloc.dupe(u8, path) catch return true;
+            const h = hashFileContent(alloc, path) orelse 0;
+            hmap.put(key, h) catch alloc.free(key);
+            return true;
+        }
+    }.run;
+
     if (bundle_opts.entry_points.len > 0) {
-        const entry_path = bundle_opts.entry_points[0];
-        const entry_dupe = allocator.dupe(u8, entry_path) catch @as([]u8, "");
-        if (entry_dupe.len > 0) {
-            const entry_mtime = getFileMtime(entry_path) catch 0;
-            mtime_map.put(entry_dupe, entry_mtime) catch {
-                allocator.free(entry_dupe);
-            };
+        if (registerWatchPath(&watcher, &content_hash_map, allocator, bundle_opts.entry_points[0])) {
+            initial_watch_count += 1;
         }
     }
-
-    // 초기 빌드의 module_paths에서 mtime 수집
     if (result.module_paths) |paths| {
         for (paths) |p| {
-            const duped = allocator.dupe(u8, p) catch continue;
-            const mt = getFileMtime(p) catch continue;
-            mtime_map.put(duped, mt) catch {
-                allocator.free(duped);
-                continue;
-            };
+            if (registerWatchPath(&watcher, &content_hash_map, allocator, p)) {
+                initial_watch_count += 1;
+            }
         }
     }
 
@@ -1411,7 +1449,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     {
         const ready_event = allocator.create(WatchReadyEvent) catch return;
         ready_event.* = .{
-            .files = mtime_map.count(),
+            .files = initial_watch_count,
             .bytes = initial_bytes,
         };
         if (c.napi_call_threadsafe_function(async_data.ready_tsfn, @ptrCast(ready_event), c.napi_tsfn_blocking) != c.napi_ok) {
@@ -1419,31 +1457,66 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         }
     }
 
-    // 폴링 루프 — 500ms 간격으로 파일 변경 감지
+    // Issue #1223 Phase 1: 이벤트 기반 워처 + 디바운스 + content hash 필터링.
     while (!async_data.stop_flag.load(.acquire)) {
-        std.Thread.sleep(500 * std.time.ns_per_ms);
-
-        // stop_flag 재확인 (sleep 후)
+        // 첫 이벤트 대기 (stop_flag 체크를 위해 poll timeout 사용).
+        const first_events = watcher.waitForChanges(watch_poll_timeout_ms) catch &[_]zts_lib.server.ChangeEvent{};
         if (async_data.stop_flag.load(.acquire)) break;
 
         var total_timer = std.time.Timer.start() catch null;
         var detect_timer = std.time.Timer.start() catch null;
-        var changed = false;
+
+        // 이벤트 수집 — path 중복 제거용 set.
+        var touched: std.StringHashMap(void) = .init(allocator);
+        defer {
+            var kit = touched.keyIterator();
+            while (kit.next()) |k| allocator.free(k.*);
+            touched.deinit();
+        }
+        const collectTouched = struct {
+            fn run(set: *std.StringHashMap(void), alloc: std.mem.Allocator, evts: []const zts_lib.server.ChangeEvent) void {
+                for (evts) |e| {
+                    if (set.contains(e.path)) continue;
+                    const dup = alloc.dupe(u8, e.path) catch continue;
+                    set.put(dup, {}) catch alloc.free(dup);
+                }
+            }
+        }.run;
+        collectTouched(&touched, allocator, first_events);
+
+        if (touched.count() == 0) continue;
+
+        // 디바운스: 정적 구간(50ms)이 확보될 때까지 추가 이벤트를 병합.
+        while (!async_data.stop_flag.load(.acquire)) {
+            const more = watcher.waitForChanges(watch_debounce_ms) catch break;
+            if (more.len == 0) break;
+            collectTouched(&touched, allocator, more);
+        }
+        if (async_data.stop_flag.load(.acquire)) break;
+
+        // content hash 필터링: 내용이 실제로 변한 파일만 changed_files에 포함.
         var changed_files: std.ArrayList([]const u8) = .empty;
         defer changed_files.deinit(allocator);
-
-        var mit = mtime_map.iterator();
-        while (mit.next()) |entry| {
-            const current_mtime = getFileMtime(entry.key_ptr.*) catch continue;
-            if (current_mtime != entry.value_ptr.*) {
-                entry.value_ptr.* = current_mtime;
-                changed = true;
-                changed_files.append(allocator, entry.key_ptr.*) catch {};
+        var tkit = touched.keyIterator();
+        while (tkit.next()) |pkey| {
+            const path = pkey.*;
+            const new_hash = hashFileContent(allocator, path) orelse continue;
+            const old_hash = content_hash_map.get(path);
+            if (old_hash != null and old_hash.? == new_hash) continue; // 내용 동일 — 스킵
+            // 해시 업데이트 (기존 키 재사용).
+            if (content_hash_map.getEntry(path)) |entry| {
+                entry.value_ptr.* = new_hash;
+            } else {
+                const key_copy = allocator.dupe(u8, path) catch continue;
+                content_hash_map.put(key_copy, new_hash) catch {
+                    allocator.free(key_copy);
+                };
             }
+            changed_files.append(allocator, path) catch {};
         }
         const detect_ns: u64 = if (detect_timer) |*t| t.read() else 0;
 
-        if (!changed) continue;
+        if (changed_files.items.len == 0) continue;
 
         // 재번들 — 증분 빌드: persistent_store + persistent_resolve_cache 재사용
         var incremental_opts = bundle_opts;
@@ -1602,31 +1675,24 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             event.deinit();
         }
 
-        // watch 대상 재구축 — 삭제된 모듈 제거 + 새 모듈 추가
-        {
-            var kit = mtime_map.keyIterator();
-            while (kit.next()) |k| allocator.free(k.*);
-            mtime_map.clearRetainingCapacity();
-
-            // 엔트리 재추가
-            if (bundle_opts.entry_points.len > 0) {
-                const entry_path = bundle_opts.entry_points[0];
-                const re_entry = allocator.dupe(u8, entry_path) catch continue;
-                const re_mtime = getFileMtime(entry_path) catch 0;
-                mtime_map.put(re_entry, re_mtime) catch {
-                    allocator.free(re_entry);
-                    continue;
-                };
+        // watch 대상 재구축 — 삭제된 모듈 제거 + 새 모듈 추가.
+        // content_hash_map은 리빌드 시점에 새 파일의 해시만 보강(기존 엔트리는 유지).
+        watcher.clearPaths();
+        if (bundle_opts.entry_points.len > 0) {
+            watcher.addPath(bundle_opts.entry_points[0]) catch {};
+            if (!content_hash_map.contains(bundle_opts.entry_points[0])) {
+                const key = allocator.dupe(u8, bundle_opts.entry_points[0]) catch continue;
+                const h = hashFileContent(allocator, bundle_opts.entry_points[0]) orelse 0;
+                content_hash_map.put(key, h) catch allocator.free(key);
             }
-
-            if (rebuild_result.module_paths) |paths| {
-                for (paths) |p| {
-                    const duped = allocator.dupe(u8, p) catch continue;
-                    const mt = getFileMtime(p) catch continue;
-                    mtime_map.put(duped, mt) catch {
-                        allocator.free(duped);
-                        continue;
-                    };
+        }
+        if (rebuild_result.module_paths) |paths| {
+            for (paths) |p| {
+                watcher.addPath(p) catch continue;
+                if (!content_hash_map.contains(p)) {
+                    const key = allocator.dupe(u8, p) catch continue;
+                    const h = hashFileContent(allocator, p) orelse 0;
+                    content_hash_map.put(key, h) catch allocator.free(key);
                 }
             }
         }

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1230,7 +1230,6 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
         _ = c.napi_create_int64(env, @intCast(event.bytes), &js_bytes);
         _ = c.napi_set_named_property(env, js_event, "bytes", js_bytes);
 
-        // phaseDurations: { detect, parse, semantic, emit, delta, total } (ms)
         if (event.phase_durations) |pd| {
             var js_pd: c.napi_value = undefined;
             _ = c.napi_create_object(env, &js_pd);
@@ -1427,7 +1426,6 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         // stop_flag 재확인 (sleep 후)
         if (async_data.stop_flag.load(.acquire)) break;
 
-        // mtime 변경 확인 + 변경 파일 수집 (detect 단계)
         var total_timer = std.time.Timer.start() catch null;
         var detect_timer = std.time.Timer.start() catch null;
         var changed = false;
@@ -1524,7 +1522,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             }
         }
 
-        // dev mode: HMR diff (delta 단계)
+        // dev mode: HMR diff
         var delta_timer = std.time.Timer.start() catch null;
         if (rebuild_result.module_dev_codes) |dev_codes| {
             // 모듈 ID 집합 비교 — graph 변경 감지
@@ -1589,19 +1587,14 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         const delta_ns: u64 = if (delta_timer) |*t| t.read() else 0;
         const total_ns: u64 = if (total_timer) |*t| t.read() else 0;
 
-        // 단계별 타이밍 기록 (관측성 — Issue #1223)
-        const ns_to_ms = struct {
-            fn f(ns: u64) f64 {
-                return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
-            }
-        }.f;
+        const nsToMs = bundler_mod.BundleResult.nsToMs;
         event.phase_durations = .{
-            .detect_ms = ns_to_ms(detect_ns),
-            .parse_ms = ns_to_ms(rebuild_result.timings.graph_ns),
-            .semantic_ms = ns_to_ms(rebuild_result.timings.link_ns + rebuild_result.timings.shake_ns),
-            .emit_ms = ns_to_ms(rebuild_result.timings.emit_ns),
-            .delta_ms = ns_to_ms(delta_ns),
-            .total_ms = ns_to_ms(total_ns),
+            .detect_ms = nsToMs(detect_ns),
+            .parse_ms = nsToMs(rebuild_result.timings.graph_ns),
+            .semantic_ms = nsToMs(rebuild_result.timings.link_ns + rebuild_result.timings.shake_ns),
+            .emit_ms = nsToMs(rebuild_result.timings.emit_ns),
+            .delta_ms = nsToMs(delta_ns),
+            .total_ms = nsToMs(total_ns),
         };
 
         // rebuild 이벤트 전송

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -18,17 +18,65 @@ const FileWatcher = zts_lib.server.FileWatcher;
 /// Issue #1223 Phase 1: 워처 튜닝 상수.
 /// - watch_poll_timeout_ms: stop_flag 체크 주기 (이벤트 워처에서도 주기적으로 깨어나기 위함).
 /// - watch_debounce_ms: 첫 이벤트 이후 정적(idle) 구간 — 연속 저장 병합 윈도우.
+/// - watch_debounce_max_ms: 디바운스 최대 대기 시간 — 지속 변경되는 파일에 의한 기아 방지.
 const watch_poll_timeout_ms: u32 = 200;
 const watch_debounce_ms: u32 = 50;
+const watch_debounce_max_ms: u64 = 500;
 
-/// 파일 내용의 content hash (Wyhash 64-bit).
-/// mtime 변동만으로 리빌드하지 않고, 실제 내용 변화만 감지한다.
-fn hashFileContent(allocator: std.mem.Allocator, path: []const u8) ?u64 {
+/// 파일 내용 해시 최대 크기 (소스 파일 기준 충분).
+const watch_hash_max_bytes: usize = 10 * 1024 * 1024;
+
+/// 파일 내용의 content hash (Wyhash 64-bit, 스트리밍).
+/// 전체 내용을 힙에 올리지 않고 64KB 버퍼로 순회하여 대용량 파일에서도 메모리 부담 없음.
+fn hashFileContent(path: []const u8) ?u64 {
     const file = std.fs.cwd().openFile(path, .{}) catch return null;
     defer file.close();
-    const content = file.readToEndAlloc(allocator, 128 * 1024 * 1024) catch return null;
-    defer allocator.free(content);
-    return std.hash.Wyhash.hash(0, content);
+    var hasher = std.hash.Wyhash.init(0);
+    var buf: [64 * 1024]u8 = undefined;
+    var total: usize = 0;
+    while (true) {
+        const n = file.read(&buf) catch return null;
+        if (n == 0) break;
+        total += n;
+        if (total > watch_hash_max_bytes) return null;
+        hasher.update(buf[0..n]);
+    }
+    return hasher.final();
+}
+
+/// FileWatcher에 path를 등록하고 content_hash_map에 해시 엔트리 생성/갱신.
+/// overwrite=false면 기존 엔트리의 해시는 보존(리빌드 후 재-싱크 용도).
+fn addAndCacheHash(
+    w: *FileWatcher,
+    hmap: *std.StringHashMap(u64),
+    alloc: std.mem.Allocator,
+    path: []const u8,
+    overwrite: bool,
+) bool {
+    w.addPath(path) catch return false;
+    if (!overwrite and hmap.contains(path)) return true;
+    const h = hashFileContent(path) orelse 0;
+    if (hmap.getEntry(path)) |e| {
+        e.value_ptr.* = h;
+    } else {
+        const key = alloc.dupe(u8, path) catch return true;
+        hmap.put(key, h) catch alloc.free(key);
+    }
+    return true;
+}
+
+/// 이벤트 배열의 path들을 중복 제거 set에 병합.
+/// FileWatcher.waitForChanges 결과는 다음 호출에서 무효화되므로 path를 dupe.
+fn collectTouched(
+    set: *std.StringHashMap(void),
+    alloc: std.mem.Allocator,
+    evts: []const zts_lib.server.ChangeEvent,
+) void {
+    for (evts) |e| {
+        if (set.contains(e.path)) continue;
+        const dup = alloc.dupe(u8, e.path) catch continue;
+        set.put(dup, {}) catch alloc.free(dup);
+    }
 }
 const BundleOptions = bundler_mod.BundleOptions;
 const Platform = zts_lib.codegen.codegen.Platform;
@@ -1361,14 +1409,15 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
 
     // Issue #1223 Phase 1: 이벤트 기반 파일 워처 (kqueue/inotify, mtime 폴백).
     // 실패 시 워치 스레드 진입 직전에 종료한다.
-    var watcher = FileWatcher.init(allocator) catch {
+    var watcher = FileWatcher.init(allocator) catch |err| {
         const event = allocator.create(WatchRebuildEvent) catch {
             _ = c.napi_release_threadsafe_function(async_data.ready_tsfn, c.napi_tsfn_release);
             _ = c.napi_release_threadsafe_function(async_data.rebuild_tsfn, c.napi_tsfn_release);
             async_data.deinit();
             return;
         };
-        event.* = .{ .success = false, .error_msg = allocator.dupe(u8, "FileWatcherInitFailed") catch null };
+        const err_name: [:0]const u8 = @errorName(err);
+        event.* = .{ .success = false, .error_msg = allocator.dupe(u8, err_name) catch null };
         if (c.napi_call_threadsafe_function(async_data.rebuild_tsfn, @ptrCast(event), c.napi_tsfn_blocking) != c.napi_ok) {
             event.deinit();
         }
@@ -1387,26 +1436,15 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         content_hash_map.deinit();
     }
 
-    // 감시 대상 등록: 엔트리 + 초기 빌드의 module_paths
     var initial_watch_count: usize = 0;
-    const registerWatchPath = struct {
-        fn run(w: *FileWatcher, hmap: *std.StringHashMap(u64), alloc: std.mem.Allocator, path: []const u8) bool {
-            w.addPath(path) catch return false;
-            const key = alloc.dupe(u8, path) catch return true;
-            const h = hashFileContent(alloc, path) orelse 0;
-            hmap.put(key, h) catch alloc.free(key);
-            return true;
-        }
-    }.run;
-
-    if (bundle_opts.entry_points.len > 0) {
-        if (registerWatchPath(&watcher, &content_hash_map, allocator, bundle_opts.entry_points[0])) {
-            initial_watch_count += 1;
-        }
+    if (bundle_opts.entry_points.len > 0 and
+        addAndCacheHash(&watcher, &content_hash_map, allocator, bundle_opts.entry_points[0], true))
+    {
+        initial_watch_count += 1;
     }
     if (result.module_paths) |paths| {
         for (paths) |p| {
-            if (registerWatchPath(&watcher, &content_hash_map, allocator, p)) {
+            if (addAndCacheHash(&watcher, &content_hash_map, allocator, p, true)) {
                 initial_watch_count += 1;
             }
         }
@@ -1459,58 +1497,49 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
 
     // Issue #1223 Phase 1: 이벤트 기반 워처 + 디바운스 + content hash 필터링.
     while (!async_data.stop_flag.load(.acquire)) {
-        // 첫 이벤트 대기 (stop_flag 체크를 위해 poll timeout 사용).
         const first_events = watcher.waitForChanges(watch_poll_timeout_ms) catch &[_]zts_lib.server.ChangeEvent{};
         if (async_data.stop_flag.load(.acquire)) break;
 
-        var total_timer = std.time.Timer.start() catch null;
-        var detect_timer = std.time.Timer.start() catch null;
+        var total_timer: ?std.time.Timer = std.time.Timer.start() catch null;
+        var detect_timer: ?std.time.Timer = std.time.Timer.start() catch null;
 
-        // 이벤트 수집 — path 중복 제거용 set.
         var touched: std.StringHashMap(void) = .init(allocator);
         defer {
             var kit = touched.keyIterator();
             while (kit.next()) |k| allocator.free(k.*);
             touched.deinit();
         }
-        const collectTouched = struct {
-            fn run(set: *std.StringHashMap(void), alloc: std.mem.Allocator, evts: []const zts_lib.server.ChangeEvent) void {
-                for (evts) |e| {
-                    if (set.contains(e.path)) continue;
-                    const dup = alloc.dupe(u8, e.path) catch continue;
-                    set.put(dup, {}) catch alloc.free(dup);
-                }
-            }
-        }.run;
         collectTouched(&touched, allocator, first_events);
 
         if (touched.count() == 0) continue;
 
-        // 디바운스: 정적 구간(50ms)이 확보될 때까지 추가 이벤트를 병합.
+        // 디바운스: idle 50ms 확보까지 드레인. 지속 변경되는 파일로 인한 기아를 막기 위해
+        // 첫 이벤트로부터 watch_debounce_max_ms 초과 시 강제 종료.
+        var debounce_timer: ?std.time.Timer = std.time.Timer.start() catch null;
         while (!async_data.stop_flag.load(.acquire)) {
             const more = watcher.waitForChanges(watch_debounce_ms) catch break;
             if (more.len == 0) break;
             collectTouched(&touched, allocator, more);
+            if (debounce_timer) |*t| {
+                if (t.read() / std.time.ns_per_ms > watch_debounce_max_ms) break;
+            }
         }
         if (async_data.stop_flag.load(.acquire)) break;
 
-        // content hash 필터링: 내용이 실제로 변한 파일만 changed_files에 포함.
+        // content hash 필터링.
         var changed_files: std.ArrayList([]const u8) = .empty;
         defer changed_files.deinit(allocator);
         var tkit = touched.keyIterator();
         while (tkit.next()) |pkey| {
             const path = pkey.*;
-            const new_hash = hashFileContent(allocator, path) orelse continue;
+            const new_hash = hashFileContent(path) orelse continue;
             const old_hash = content_hash_map.get(path);
-            if (old_hash != null and old_hash.? == new_hash) continue; // 내용 동일 — 스킵
-            // 해시 업데이트 (기존 키 재사용).
+            if (old_hash != null and old_hash.? == new_hash) continue;
             if (content_hash_map.getEntry(path)) |entry| {
                 entry.value_ptr.* = new_hash;
             } else {
                 const key_copy = allocator.dupe(u8, path) catch continue;
-                content_hash_map.put(key_copy, new_hash) catch {
-                    allocator.free(key_copy);
-                };
+                content_hash_map.put(key_copy, new_hash) catch allocator.free(key_copy);
             }
             changed_files.append(allocator, path) catch {};
         }
@@ -1675,26 +1704,37 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             event.deinit();
         }
 
-        // watch 대상 재구축 — 삭제된 모듈 제거 + 새 모듈 추가.
-        // content_hash_map은 리빌드 시점에 새 파일의 해시만 보강(기존 엔트리는 유지).
-        watcher.clearPaths();
+        // Issue #1223 Phase 1: diff 기반 재-싱크.
+        // 모듈 경로가 변하지 않으면 kqueue/inotify 갱신 없이 기존 상태 재사용.
+        // 삭제된 모듈의 content_hash 엔트리도 함께 정리하여 무한 증가 방지.
+        var desired: std.StringHashMap(void) = .init(allocator);
+        defer desired.deinit();
         if (bundle_opts.entry_points.len > 0) {
-            watcher.addPath(bundle_opts.entry_points[0]) catch {};
-            if (!content_hash_map.contains(bundle_opts.entry_points[0])) {
-                const key = allocator.dupe(u8, bundle_opts.entry_points[0]) catch continue;
-                const h = hashFileContent(allocator, bundle_opts.entry_points[0]) orelse 0;
-                content_hash_map.put(key, h) catch allocator.free(key);
-            }
+            desired.put(bundle_opts.entry_points[0], {}) catch {};
         }
         if (rebuild_result.module_paths) |paths| {
-            for (paths) |p| {
-                watcher.addPath(p) catch continue;
-                if (!content_hash_map.contains(p)) {
-                    const key = allocator.dupe(u8, p) catch continue;
-                    const h = hashFileContent(allocator, p) orelse 0;
-                    content_hash_map.put(key, h) catch allocator.free(key);
-                }
+            for (paths) |p| desired.put(p, {}) catch {};
+        }
+
+        // stale 엔트리 제거 — 워처와 content_hash_map 모두에서.
+        {
+            var stale: std.ArrayList([]const u8) = .empty;
+            defer stale.deinit(allocator);
+            var hit = content_hash_map.keyIterator();
+            while (hit.next()) |k| {
+                if (!desired.contains(k.*)) stale.append(allocator, k.*) catch {};
             }
+            for (stale.items) |k| {
+                watcher.removePath(k);
+                if (content_hash_map.fetchRemove(k)) |kv| allocator.free(kv.key);
+            }
+        }
+
+        // 추가된 경로만 addPath + 해시. 기존 경로는 kqueue/inotify에 이미 등록됨.
+        var dit = desired.keyIterator();
+        while (dit.next()) |pkey| {
+            if (content_hash_map.contains(pkey.*)) continue;
+            _ = addAndCacheHash(&watcher, &content_hash_map, allocator, pkey.*, false);
         }
     }
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -221,6 +221,20 @@ pub const BundleResult = struct {
     asset_outputs: ?[]OutputFile = null,
     /// metafile JSON (--metafile). allocator 소유.
     metafile_json: ?[]const u8 = null,
+    /// 파이프라인 단계별 타이밍 (ns). 항상 측정 — 워치 모드 관측성용.
+    timings: BundleTimings = .{},
+
+    /// 단계별 빌드 시간 (나노초).
+    pub const BundleTimings = struct {
+        /// resolve + parse + finalize (graph build)
+        graph_ns: u64 = 0,
+        /// scope hoisting + linking
+        link_ns: u64 = 0,
+        /// tree-shaking
+        shake_ns: u64 = 0,
+        /// transform + codegen
+        emit_ns: u64 = 0,
+    };
 
     /// dev mode에서 모듈별 HMR 업데이트 코드. types.ModuleDevCode의 별칭.
     pub const ModuleDevCode = types.ModuleDevCode;
@@ -492,7 +506,8 @@ pub const Bundler = struct {
         var t_shake: u64 = 0;
         var t_emit: u64 = 0;
 
-        var timer: ?std.time.Timer = if (timing) std.time.Timer.start() catch null else null;
+        // 타이머는 항상 동작 (watch 관측성용). Timer.read()는 ns 단위 syscall 한 번으로 저렴.
+        var timer: ?std.time.Timer = std.time.Timer.start() catch null;
 
         // 0. RN dev mode: InitializeCore prelude 자동 주입.
         // InitializeCore → setUpReactRefresh에서 injectIntoGlobalHook을 호출한다.
@@ -975,6 +990,12 @@ pub const Bundler = struct {
             .module_dev_codes = module_dev_codes,
             .asset_outputs = final_asset_outputs,
             .metafile_json = metafile_json,
+            .timings = .{
+                .graph_ns = t_graph,
+                .link_ns = t_link,
+                .shake_ns = t_shake,
+                .emit_ns = t_emit,
+            },
         };
     }
 };

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -236,6 +236,11 @@ pub const BundleResult = struct {
         emit_ns: u64 = 0,
     };
 
+    /// ns → ms 변환 헬퍼 (타이밍 노출 공용).
+    pub fn nsToMs(ns: u64) f64 {
+        return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
+    }
+
     /// dev mode에서 모듈별 HMR 업데이트 코드. types.ModuleDevCode의 별칭.
     pub const ModuleDevCode = types.ModuleDevCode;
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -589,13 +589,12 @@ pub const Bundler = struct {
         graph.jsx_import_source = self.options.jsx_import_source;
         defer graph.deinit();
 
-        // graph.build() 또는 buildIncremental() 호출
-        var reparsed_count: usize = 0;
-        var incremental: bool = false;
+        // graph.build() 또는 buildIncremental() 호출.
+        // reparsed_count: 증분 경로(=store 전달)일 때만 set — null은 전체 파싱을 의미.
+        var reparsed_count: ?usize = null;
         if (self.options.module_store) |store| {
             const inc_result = try graph.buildIncremental(self.options.entry_points, store);
             reparsed_count = inc_result.reparsed_indices.len;
-            incremental = true;
             self.allocator.free(inc_result.reparsed_indices);
         } else {
             try graph.build(self.options.entry_points);
@@ -1008,7 +1007,7 @@ pub const Bundler = struct {
                 .shake_ns = t_shake,
                 .emit_ns = t_emit,
             },
-            .reparsed_modules = if (incremental) reparsed_count else null,
+            .reparsed_modules = reparsed_count,
         };
     }
 };

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -223,6 +223,9 @@ pub const BundleResult = struct {
     metafile_json: ?[]const u8 = null,
     /// 파이프라인 단계별 타이밍 (ns). 항상 측정 — 워치 모드 관측성용.
     timings: BundleTimings = .{},
+    /// 증분 빌드에서 실제로 재파싱된 모듈 수.
+    /// non-incremental 빌드에서는 `null` (전체 파싱). HMR 관측성용.
+    reparsed_modules: ?usize = null,
 
     /// 단계별 빌드 시간 (나노초).
     pub const BundleTimings = struct {
@@ -587,8 +590,12 @@ pub const Bundler = struct {
         defer graph.deinit();
 
         // graph.build() 또는 buildIncremental() 호출
+        var reparsed_count: usize = 0;
+        var incremental: bool = false;
         if (self.options.module_store) |store| {
             const inc_result = try graph.buildIncremental(self.options.entry_points, store);
+            reparsed_count = inc_result.reparsed_indices.len;
+            incremental = true;
             self.allocator.free(inc_result.reparsed_indices);
         } else {
             try graph.build(self.options.entry_points);
@@ -1001,6 +1008,7 @@ pub const Bundler = struct {
                 .shake_ns = t_shake,
                 .emit_ns = t_emit,
             },
+            .reparsed_modules = if (incremental) reparsed_count else null,
         };
     }
 };

--- a/src/server/mod.zig
+++ b/src/server/mod.zig
@@ -1,5 +1,7 @@
 pub const DevServer = @import("dev_server.zig").DevServer;
 pub const FileWatcher = @import("file_watcher.zig").FileWatcher;
+pub const ChangeEvent = @import("file_watcher.zig").ChangeEvent;
+pub const ChangeKind = @import("file_watcher.zig").ChangeKind;
 pub const mime = @import("mime.zig");
 
 test {


### PR DESCRIPTION
## Summary
Issue #1223 HMR perf 개선의 **Phase 2**. 역의존성 그래프 기반 증분 재방문 결과를 관측 가능하게 노출 + 첫 리빌드부터 캐시가 동작하도록 수정.

> ⚠️ 이 PR은 #1228 (Phase 1) 위에 stack되어 있습니다. #1228 머지 후 base를 main으로 전환.

## Changes
- `BundleResult.reparsed_modules: ?usize` 추가. `buildIncremental()` 경로에서 `reparsed_indices.len` 전달. non-incremental 빌드에서는 `null`.
- **초기 빌드에도 PersistentModuleStore 전달** — 기존에는 초기 빌드가 store 없이 동작해 첫 리빌드가 모든 모듈을 재파싱. 이제 첫 리빌드부터 캐시 히트.
- `WatchRebuildEvent.reparsedModules` 필드 + napi 직렬화 + TS 타입.

## 효과
재현 테스트 `phase2` (a → b → c 그래프에서 c만 변경):
| 단계 | reparsedModules |
|---|---|
| 이전 | `undefined` (필드 미노출) |
| `reparsed_indices` 노출만 | `3` (모두 재파싱 — 초기 store 비어있음) |
| + 초기 store 배선 | **`1`** (c만 재파싱) |

## Test plan
- [x] `bun test -t "Issue #1223"` **5/5 pass** (모든 phase 재현 해결)
- [x] `bun test -t "watch"` 10/10 회귀 없음
- [x] `zig build test` 통과

## 관련
- Closes #1223 (Phase 3 + 1 + 2 누적)
- Stacks on #1228 → #1227
- Follow-up: #1229 (util/wyhash 추출 + FileWatcher.addPathTracked)