### PR TITLE
feat(watch): expose reparsedModules + incremental-cache initial build (#1223 Phase 2)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -269,6 +269,8 @@ export interface WatchRebuildEvent {
     /** 총 리빌드 시간 (detect → delta 합산) */
     total: number;
   };
+  /** 증분 그래프에서 재파싱된 모듈 수. 캐시 미스된 모듈만 카운트. 전체 빌드에서는 미노출. */
+  reparsedModules?: number;
 }
 
 export interface WatchHandle {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1177,6 +1177,8 @@ const WatchRebuildEvent = struct {
     updates: ?[]const ModuleUpdate = null,
     bytes: usize = 0,
     phase_durations: ?PhaseDurations = null,
+    /// 증분 그래프에서 재파싱된 모듈 수 (Issue #1223 Phase 2).
+    reparsed_modules: ?usize = null,
     // 실패 시
     error_msg: ?[]const u8 = null,
 
@@ -1313,6 +1315,12 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
             }
             _ = c.napi_set_named_property(env, js_event, "phaseDurations", js_pd);
         }
+
+        if (event.reparsed_modules) |n| {
+            var js_n: c.napi_value = undefined;
+            _ = c.napi_create_int64(env, @intCast(n), &js_n);
+            _ = c.napi_set_named_property(env, js_event, "reparsedModules", js_n);
+        }
     } else {
         // error: string
         if (event.error_msg) |msg| {
@@ -1335,8 +1343,17 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     const allocator = native_alloc;
     const bundle_opts = async_data.options;
 
-    // 초기 빌드
-    var bundler = Bundler.init(allocator, bundle_opts);
+    // Issue #1223 Phase 2: 초기 빌드에도 PersistentModuleStore 전달.
+    // 초기 빌드에서 store가 채워져야 첫 리빌드가 캐시 히트 경로로 진입한다.
+    const module_store_mod = bundler_mod.module_store;
+    const ResolveCache = bundler_mod.ResolveCache;
+    var persistent_store = module_store_mod.PersistentModuleStore.init(allocator);
+    defer persistent_store.deinit();
+
+    var initial_opts = bundle_opts;
+    initial_opts.module_store = &persistent_store;
+
+    var bundler = Bundler.init(allocator, initial_opts);
     var result = bundler.bundle() catch |err| {
         // 초기 빌드 실패 — rebuild 이벤트로 에러 전달
         const event = allocator.create(WatchRebuildEvent) catch {
@@ -1361,12 +1378,6 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         return;
     };
     defer result.deinit(allocator);
-
-    // 증분 빌드용 PersistentModuleStore + ResolveCache
-    const module_store_mod = bundler_mod.module_store;
-    const ResolveCache = bundler_mod.ResolveCache;
-    var persistent_store = module_store_mod.PersistentModuleStore.init(allocator);
-    defer persistent_store.deinit();
 
     // dev mode: per-module code 캐시 (HMR diff용)
     var module_code_cache = std.StringHashMap([]const u8).init(allocator);
@@ -1698,6 +1709,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             .delta_ms = nsToMs(delta_ns),
             .total_ms = nsToMs(total_ns),
         };
+        event.reparsed_modules = rebuild_result.reparsed_modules;
 
         // rebuild 이벤트 전송
         if (c.napi_call_threadsafe_function(async_data.rebuild_tsfn, @ptrCast(event), c.napi_tsfn_blocking) != c.napi_ok) {

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -589,13 +589,12 @@ pub const Bundler = struct {
         graph.jsx_import_source = self.options.jsx_import_source;
         defer graph.deinit();
 
-        // graph.build() 또는 buildIncremental() 호출
-        var reparsed_count: usize = 0;
-        var incremental: bool = false;
+        // graph.build() 또는 buildIncremental() 호출.
+        // reparsed_count: 증분 경로(=store 전달)일 때만 set — null은 전체 파싱을 의미.
+        var reparsed_count: ?usize = null;
         if (self.options.module_store) |store| {
             const inc_result = try graph.buildIncremental(self.options.entry_points, store);
             reparsed_count = inc_result.reparsed_indices.len;
-            incremental = true;
             self.allocator.free(inc_result.reparsed_indices);
         } else {
             try graph.build(self.options.entry_points);
@@ -1008,7 +1007,7 @@ pub const Bundler = struct {
                 .shake_ns = t_shake,
                 .emit_ns = t_emit,
             },
-            .reparsed_modules = if (incremental) reparsed_count else null,
+            .reparsed_modules = reparsed_count,
         };
     }
 };

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -223,6 +223,9 @@ pub const BundleResult = struct {
     metafile_json: ?[]const u8 = null,
     /// 파이프라인 단계별 타이밍 (ns). 항상 측정 — 워치 모드 관측성용.
     timings: BundleTimings = .{},
+    /// 증분 빌드에서 실제로 재파싱된 모듈 수.
+    /// non-incremental 빌드에서는 `null` (전체 파싱). HMR 관측성용.
+    reparsed_modules: ?usize = null,
 
     /// 단계별 빌드 시간 (나노초).
     pub const BundleTimings = struct {
@@ -587,8 +590,12 @@ pub const Bundler = struct {
         defer graph.deinit();
 
         // graph.build() 또는 buildIncremental() 호출
+        var reparsed_count: usize = 0;
+        var incremental: bool = false;
         if (self.options.module_store) |store| {
             const inc_result = try graph.buildIncremental(self.options.entry_points, store);
+            reparsed_count = inc_result.reparsed_indices.len;
+            incremental = true;
             self.allocator.free(inc_result.reparsed_indices);
         } else {
             try graph.build(self.options.entry_points);
@@ -1001,6 +1008,7 @@ pub const Bundler = struct {
                 .shake_ns = t_shake,
                 .emit_ns = t_emit,
             },
+            .reparsed_modules = if (incremental) reparsed_count else null,
         };
     }
 };


### PR DESCRIPTION
재생성: 이전 #1230은 base(#1228 Phase 1) merge 시 자동 close.

## Summary
Issue #1223 HMR perf 개선의 **Phase 2 (최종)**. 역의존성 그래프 기반 증분 재방문 결과 노출 + 첫 리빌드부터 캐시 동작.

## Changes
- `BundleResult.reparsed_modules: ?usize` (null = non-incremental)
- **초기 빌드에도 PersistentModuleStore 전달** — 첫 리빌드부터 캐시 히트
- `WatchRebuildEvent.reparsedModules` 노출

## 효과
재현 테스트 phase2 (a → b → c, c만 변경): `reparsedModules = 1` (c만 재파싱)

본 PR 머지 후 **Issue #1223 HMR perf 재현 5/5 모두 PASS**, main CI 복구.

Closes #1223