### PR TITLE
test(watch): #1223 커버리지 보강 + content hash 한도 RN 대응 (256MB)

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -3869,6 +3869,243 @@ describe("Issue #1223 HMR perf 재현", () => {
 
     expect(event.reparsedModules).toBe(1);
   }, 10000);
+
+  // ---- phase2b: deep dependency chain (10단계) ----
+  test("phase2b: 10단계 체인에서 leaf 변경 시 reparsedModules=1", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase2b-"));
+    const N = 10;
+    for (let i = 0; i < N - 1; i++) {
+      writeFileSync(
+        join(dir, `m${i}.ts`),
+        `import { v${i + 1} } from "./m${i + 1}"; export const v${i} = v${i + 1} + 1;`,
+      );
+    }
+    writeFileSync(join(dir, `m${N - 1}.ts`), `export const v${N - 1} = 1;`);
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<any>();
+    const handle = watch({
+      entryPoints: [join(dir, "m0.ts")],
+      devMode: true,
+      collectModuleCodes: true,
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuildDone(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    writeFileSync(join(dir, `m${N - 1}.ts`), `export const v${N - 1} = 999;`);
+    const event = await rebuildP;
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(event.reparsedModules).toBe(1);
+  }, 15000);
+
+  // ---- phase2c: 체인 중간 모듈 변경 시 해당 모듈만 재파싱 ----
+  test("phase2c: 체인 중간(b)만 변경 — 상위(a)/하위(c) 캐시 유지", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase2c-"));
+    writeFileSync(join(dir, "a.ts"), 'import { b } from "./b"; export const a = b + 1;');
+    writeFileSync(join(dir, "b.ts"), 'import { c } from "./c"; export const b = c + 1;');
+    writeFileSync(join(dir, "c.ts"), "export const c = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<any>();
+    const handle = watch({
+      entryPoints: [join(dir, "a.ts")],
+      devMode: true,
+      collectModuleCodes: true,
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuildDone(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    writeFileSync(join(dir, "b.ts"), 'import { c } from "./c"; export const b = c + 42;');
+    const event = await rebuildP;
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(event.reparsedModules).toBe(1);
+  }, 10000);
+
+  // ---- phase1d: stale content_hash 엔트리 정리 ----
+  test("phase1d: import 제거 후 이전 파일 변경은 리빌드 트리거 안 함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1d-"));
+    const entry = join(dir, "entry.ts");
+    const extra = join(dir, "extra.ts");
+    writeFileSync(extra, "export const y = 1;");
+    writeFileSync(entry, 'import { y } from "./extra"; export const x = y;');
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const rebuilds: Array<{ changed?: string[] }> = [];
+    const handle = watch({
+      entryPoints: [entry],
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuilds.push(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 1차: entry에서 extra import 제거 → graph에서 extra 빠짐
+    writeFileSync(entry, "export const x = 1;");
+    await new Promise((r) => setTimeout(r, 1500));
+    const reb1 = rebuilds.length;
+    expect(reb1).toBeGreaterThanOrEqual(1);
+
+    // 2차: extra.ts 내용 변경 — 이미 그래프에서 빠졌으므로 리빌드 없어야 함
+    writeFileSync(extra, "export const y = 999;");
+    await new Promise((r) => setTimeout(r, 1500));
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    // extra 변경 후 추가 리빌드가 없어야 — watcher가 extra를 removePath 한 결과
+    expect(rebuilds.length).toBe(reb1);
+  }, 15000);
+
+  // ---- phase1e: 중복 이벤트 dedup (같은 파일 여러 번 touch → 1회 리빌드) ----
+  test("phase1e: 같은 파일 연속 touch 시 리빌드 1회만 발생", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1e-"));
+    const entry = join(dir, "entry.ts");
+    writeFileSync(entry, "export const x = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    let rebuildCount = 0;
+    const handle = watch({
+      entryPoints: [entry],
+      onReady() {
+        readyDone();
+      },
+      onRebuild() {
+        rebuildCount++;
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // 같은 파일에 동일 내용 5회 빠르게 write — 이벤트는 5개이지만 content hash로 dedup
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(entry, "export const x = 2;");
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    await new Promise((r) => setTimeout(r, 1500));
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(rebuildCount).toBe(1);
+  }, 10000);
+
+  // ---- phase1f: 디바운스 starvation cap (지속 변경되는 파일에도 리빌드 진행) ----
+  test("phase1f: 디바운스 윈도우를 계속 갱신해도 500ms 상한 내 리빌드 발생", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1f-"));
+    const entry = join(dir, "entry.ts");
+    writeFileSync(entry, "export const x = 1;");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<void>();
+    const handle = watch({
+      entryPoints: [entry],
+      onReady() {
+        readyDone();
+      },
+      onRebuild() {
+        rebuildDone();
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 50));
+
+    // 20ms마다 파일 수정 — 매번 debounce window(50ms) 내에 새 이벤트.
+    // starvation cap(500ms)이 없으면 영영 리빌드 안 됨.
+    let counter = 0;
+    const interval = setInterval(() => {
+      counter++;
+      writeFileSync(entry, `export const x = ${counter};`);
+    }, 20);
+
+    const t0 = performance.now();
+    await rebuildP;
+    const elapsed = performance.now() - t0;
+    clearInterval(interval);
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    // 500ms cap + 빌드 시간 여유 포함하여 상한 검증
+    expect(elapsed).toBeLessThan(1500);
+  }, 10000);
+
+  // ---- phase1g: 경계 — 빈 파일 해시 ----
+  test("phase1g: 빈 파일도 해시되어 리빌드 동작 정상", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1g-"));
+    const entry = join(dir, "entry.ts");
+    writeFileSync(entry, "");
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<any>();
+    const handle = watch({
+      entryPoints: [entry],
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuildDone(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+    writeFileSync(entry, "export const x = 1;");
+
+    const event = await rebuildP;
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(event.success).toBe(true);
+  }, 10000);
+
+  // ---- phase1h: 경계 — 대형 파일(>10MB) 해시 폴백 경로 ----
+  test("phase1h: 대형 파일(15MB)에서도 크래시 없이 리빌드 트리거", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-1223-phase1h-"));
+    const entry = join(dir, "entry.ts");
+    writeFileSync(entry, 'import "./big.json"; export const x = 1;');
+    // 15MB JSON 배열 — watch_hash_max_bytes(256MB) 이내라 정상 해시 경로 사용,
+    // 크래시/OOM 없이 동작해야 함을 보장.
+    const big = "[" + "0,".repeat(3_000_000) + "0]";
+    writeFileSync(join(dir, "big.json"), big);
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<any>();
+    const handle = watch({
+      entryPoints: [entry],
+      loader: { ".json": "json" },
+      onReady() {
+        readyDone();
+      },
+      onRebuild(event) {
+        rebuildDone(event);
+      },
+    });
+    await readyP;
+    await new Promise((r) => setTimeout(r, 100));
+
+    writeFileSync(entry, 'import "./big.json"; export const x = 2;');
+    const event = await rebuildP;
+    handle.stop();
+    rmSync(dir, { recursive: true });
+
+    expect(event.success).toBe(true);
+  }, 20000);
 });
 
 // ================================================================

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -23,8 +23,11 @@ const watch_poll_timeout_ms: u32 = 200;
 const watch_debounce_ms: u32 = 50;
 const watch_debounce_max_ms: u64 = 500;
 
-/// 파일 내용 해시 최대 크기 (소스 파일 기준 충분).
-const watch_hash_max_bytes: usize = 10 * 1024 * 1024;
+/// 파일 내용 해시 상한 (#1233). RN 등 대형 프로젝트의 vendor 번들/asset catalog/locale
+/// JSON이 수십 MB에 이를 수 있어 넉넉히 잡음. 초과 시 `util.wyhash.hashFileStreaming`이
+/// size+mtime 기반 pseudo-hash로 폴백한다 — 해당 파일이 영영 리빌드 트리거되지 않는 stale
+/// output 방지.
+const watch_hash_max_bytes: usize = 256 * 1024 * 1024;
 
 /// 이벤트 배열의 path들을 중복 제거 set에 병합.
 /// FileWatcher.waitForChanges 결과는 다음 호출에서 무효화되므로 path를 dupe.

--- a/src/util/wyhash.zig
+++ b/src/util/wyhash.zig
@@ -21,18 +21,25 @@ pub fn hashHex8(data: []const u8) [8]u8 {
 }
 
 /// 파일 내용의 Wyhash-64. 파일을 64KB 버퍼로 순회하여 대용량에서도 메모리 부담 없음.
-/// `max_bytes` 초과 시 null. 열기/읽기 실패 시 null.
+/// `max_bytes` 초과 시 size+mtime 기반 pseudo-hash로 폴백 (RN 등 vendor 번들/locale JSON 대응 — #1233).
+/// 열기/stat/읽기 실패 시 null.
 pub fn hashFileStreaming(path: []const u8, max_bytes: usize) ?u64 {
     const file = std.fs.cwd().openFile(path, .{}) catch return null;
     defer file.close();
+    const stat = file.stat() catch return null;
+    if (stat.size > max_bytes) {
+        // 거대 파일: 내용 스트리밍 비용을 피하고 size+mtime으로 pseudo-hash.
+        // mtime만 갱신될 때 false-positive가 생길 수 있지만 stale output보다 안전.
+        var h = std.hash.Wyhash.init(0);
+        h.update(std.mem.asBytes(&stat.size));
+        h.update(std.mem.asBytes(&stat.mtime));
+        return h.final();
+    }
     var hasher = std.hash.Wyhash.init(0);
     var buf: [64 * 1024]u8 = undefined;
-    var total: usize = 0;
     while (true) {
         const n = file.read(&buf) catch return null;
         if (n == 0) break;
-        total += n;
-        if (total > max_bytes) return null;
         hasher.update(buf[0..n]);
     }
     return hasher.final();
@@ -68,14 +75,17 @@ test "hashFileStreaming matches hashU64" {
     try std.testing.expectEqual(hashU64(contents), got);
 }
 
-test "hashFileStreaming respects max_bytes" {
+test "hashFileStreaming over-limit falls back to size+mtime pseudo-hash" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.writeFile(.{ .sub_path = "big.txt", .data = "0123456789" });
     const real = try tmp.dir.realpathAlloc(std.testing.allocator, "big.txt");
     defer std.testing.allocator.free(real);
-    try std.testing.expect(hashFileStreaming(real, 5) == null);
-    try std.testing.expect(hashFileStreaming(real, 100) != null);
+    // 한도 초과 — null 대신 pseudo-hash 반환 (size+mtime).
+    const fallback = hashFileStreaming(real, 5) orelse return error.HashFailed;
+    const full = hashFileStreaming(real, 100) orelse return error.HashFailed;
+    // 둘은 다른 알고리즘이므로 서로 달라야 함 (확률적 — 충돌 매우 희박).
+    try std.testing.expect(fallback != full);
 }
 
 test "hashFileStreaming missing file returns null" {


### PR DESCRIPTION
## Summary
Issue #1223 follow-up — 재현 테스트 커버리지 확장 + content hash 한도를 RN 규모에 맞게 상향.

## 버그 수정: 대형 파일 stale output
기존 \`watch_hash_max_bytes = 10MB\` 초과 시 \`hashFileContent\`가 \`null\`을 반환해 해당 파일이 영영 리빌드 트리거되지 않던 문제. RN의 vendor 번들 / locale JSON이 쉽게 10MB를 넘음.

**수정:**
- 한도 상향: 10MB → **256MB**
- 한도 초과 시 size+mtime 기반 **pseudo-hash 폴백** (null 반환하지 않음)
- \`stat()\` 선행 호출로 대형 파일은 O(1) 처리

## 커버리지 테스트 (신규 7개)
| 테스트 | 검증 내용 |
|---|---|
| phase2b | 10단계 체인에서 leaf 변경 → reparsedModules=1 |
| phase2c | 체인 중간 모듈 변경 → 해당 모듈만 재파싱 |
| phase1d | import 제거된 파일 변경은 리빌드 트리거 안 함 (stale 정리) |
| phase1e | 같은 파일 연속 touch → content hash dedup으로 1회 리빌드 |
| phase1f | 디바운스 starvation cap — 20ms 주기 변경에도 500ms 내 리빌드 |
| phase1g | 빈 파일 해시 경계 |
| phase1h | 대형 파일(15MB) 해시 경로 크래시 없음 |

## Test plan
- [x] Issue #1223 재현 테스트: **12/12 pass** (기존 5 + 신규 7)
- [x] 전체: **251/251 pass**

Related: #1223