### PR TITLE
refactor(util): extract util/wyhash.zig helpers (#1229 Part 1)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -26,22 +26,9 @@ const watch_debounce_max_ms: u64 = 500;
 /// 파일 내용 해시 최대 크기 (소스 파일 기준 충분).
 const watch_hash_max_bytes: usize = 10 * 1024 * 1024;
 
-/// 파일 내용의 content hash (Wyhash 64-bit, 스트리밍).
-/// 전체 내용을 힙에 올리지 않고 64KB 버퍼로 순회하여 대용량 파일에서도 메모리 부담 없음.
+/// 파일 내용의 content hash (Wyhash 64-bit, 스트리밍). `util.wyhash` 위임.
 fn hashFileContent(path: []const u8) ?u64 {
-    const file = std.fs.cwd().openFile(path, .{}) catch return null;
-    defer file.close();
-    var hasher = std.hash.Wyhash.init(0);
-    var buf: [64 * 1024]u8 = undefined;
-    var total: usize = 0;
-    while (true) {
-        const n = file.read(&buf) catch return null;
-        if (n == 0) break;
-        total += n;
-        if (total > watch_hash_max_bytes) return null;
-        hasher.update(buf[0..n]);
-    }
-    return hasher.final();
+    return zts_lib.util.wyhash.hashFileStreaming(path, watch_hash_max_bytes);
 }
 
 /// FileWatcher에 path를 등록하고 content_hash_map에 해시 엔트리 생성/갱신.

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -16,6 +16,7 @@
 //!   - references/rolldown/crates/rolldown/src/chunk_graph/
 
 const std = @import("std");
+const wyhash = @import("../util/wyhash.zig");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 pub const ChunkIndex = types.ChunkIndex;
@@ -105,7 +106,7 @@ pub const BitSet = struct {
 
     /// 해시값을 계산한다 (HashMap 키로 사용).
     pub fn hash(self: BitSet) u64 {
-        return @import("../util/wyhash.zig").hashU64(self.entries);
+        return wyhash.hashU64(self.entries);
     }
 };
 

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -105,7 +105,7 @@ pub const BitSet = struct {
 
     /// 해시값을 계산한다 (HashMap 키로 사용).
     pub fn hash(self: BitSet) u64 {
-        return std.hash.Wyhash.hash(0, self.entries);
+        return @import("../util/wyhash.zig").hashU64(self.entries);
     }
 };
 

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -17,6 +17,7 @@
 //!   - references/bun/src/bundler/LinkerContext.zig
 
 const std = @import("std");
+const wyhash = @import("../util/wyhash.zig");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const ModuleType = types.ModuleType;
@@ -1710,7 +1711,7 @@ fn base64Encode(allocator: std.mem.Allocator, data: []const u8) ![]const u8 {
     return buf;
 }
 
-const contentHash = @import("../util/wyhash.zig").hashHex8;
+const contentHash = wyhash.hashHex8;
 
 /// asset naming 패턴 적용: [name] [hash] 치환 + 확장자 추가.
 fn applyAssetNamingPattern(

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1710,14 +1710,7 @@ fn base64Encode(allocator: std.mem.Allocator, data: []const u8) ![]const u8 {
     return buf;
 }
 
-/// 파일 내용의 content hash (Wyhash → 16진수 8자리).
-/// emitter.zig의 content hash와 동일 알고리즘 (Wyhash + 32-bit truncate).
-fn contentHash(data: []const u8) [8]u8 {
-    const hash_val = std.hash.Wyhash.hash(0, data);
-    var buf: [8]u8 = undefined;
-    _ = std.fmt.bufPrint(&buf, "{x:0>8}", .{@as(u32, @truncate(hash_val))}) catch unreachable;
-    return buf;
-}
+const contentHash = @import("../util/wyhash.zig").hashHex8;
 
 /// asset naming 패턴 적용: [name] [hash] 치환 + 확장자 추가.
 fn applyAssetNamingPattern(

--- a/src/root.zig
+++ b/src/root.zig
@@ -22,6 +22,7 @@ pub const bundler = @import("bundler/mod.zig");
 pub const server = @import("server/mod.zig");
 pub const transpile = @import("transpile.zig");
 pub const string_escape = @import("string_escape.zig");
+pub const util = @import("util/mod.zig");
 
 test {
     _ = lexer;
@@ -34,6 +35,7 @@ test {
     _ = bundler;
     _ = server;
     _ = @import("test_arena.zig");
+    _ = util.wyhash;
 
     // diagnostic system
     _ = ansi_mod;

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -11,6 +11,7 @@
 //!   'worklet' 디렉티브 없이도 FunctionInfo.is_auto_worklet == true이면 변환.
 
 const std = @import("std");
+const wyhash = @import("../../util/wyhash.zig");
 const ast_mod = @import("../../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
@@ -218,7 +219,7 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     );
     defer api.getAllocator().free(init_code);
 
-    const hash = @as(u32, @truncate(@import("../../util/wyhash.zig").hashU64(init_code)));
+    const hash = @as(u32, @truncate(wyhash.hashU64(init_code)));
 
     const stmts = try worklet_mod.buildWorkletPropertyAssignments(
         api.transformer,

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -218,7 +218,7 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
     );
     defer api.getAllocator().free(init_code);
 
-    const hash = @as(u32, @truncate(std.hash.Wyhash.hash(0, init_code)));
+    const hash = @as(u32, @truncate(@import("../../util/wyhash.zig").hashU64(init_code)));
 
     const stmts = try worklet_mod.buildWorkletPropertyAssignments(
         api.transformer,

--- a/src/util/mod.zig
+++ b/src/util/mod.zig
@@ -1,0 +1,3 @@
+//! 공용 유틸리티 모음.
+
+pub const wyhash = @import("wyhash.zig");

--- a/src/util/wyhash.zig
+++ b/src/util/wyhash.zig
@@ -51,7 +51,6 @@ test "hashHex8 format" {
     for (out) |c| {
         try std.testing.expect((c >= '0' and c <= '9') or (c >= 'a' and c <= 'f'));
     }
-    // low 32-bit와 일치하는지 확인
     const expect_u32 = @as(u32, @truncate(hashU64("abc")));
     var expect_buf: [8]u8 = undefined;
     _ = std.fmt.bufPrint(&expect_buf, "{x:0>8}", .{expect_u32}) catch unreachable;

--- a/src/util/wyhash.zig
+++ b/src/util/wyhash.zig
@@ -1,0 +1,84 @@
+//! Wyhash 공통 헬퍼.
+//!
+//! `std.hash.Wyhash`의 반복 패턴을 한 곳에 모은다 — 64-bit one-shot,
+//! 8자리 hex 요약(content hash placeholder), 파일 스트리밍 해시.
+//! 스트리밍 스킵 해싱(`bundler/emitter/chunks.zig`)처럼 특수한 경우는
+//! 여기에 넣지 않는다.
+
+const std = @import("std");
+
+/// 64-bit Wyhash one-shot.
+pub fn hashU64(data: []const u8) u64 {
+    return std.hash.Wyhash.hash(0, data);
+}
+
+/// 하위 32-bit 절삭 후 16진수 8자리 (content hash placeholder).
+pub fn hashHex8(data: []const u8) [8]u8 {
+    const hash_val = std.hash.Wyhash.hash(0, data);
+    var buf: [8]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "{x:0>8}", .{@as(u32, @truncate(hash_val))}) catch unreachable;
+    return buf;
+}
+
+/// 파일 내용의 Wyhash-64. 파일을 64KB 버퍼로 순회하여 대용량에서도 메모리 부담 없음.
+/// `max_bytes` 초과 시 null. 열기/읽기 실패 시 null.
+pub fn hashFileStreaming(path: []const u8, max_bytes: usize) ?u64 {
+    const file = std.fs.cwd().openFile(path, .{}) catch return null;
+    defer file.close();
+    var hasher = std.hash.Wyhash.init(0);
+    var buf: [64 * 1024]u8 = undefined;
+    var total: usize = 0;
+    while (true) {
+        const n = file.read(&buf) catch return null;
+        if (n == 0) break;
+        total += n;
+        if (total > max_bytes) return null;
+        hasher.update(buf[0..n]);
+    }
+    return hasher.final();
+}
+
+// ─── 테스트 ───
+
+test "hashU64 deterministic" {
+    try std.testing.expectEqual(hashU64("hello"), hashU64("hello"));
+    try std.testing.expect(hashU64("hello") != hashU64("hellp"));
+}
+
+test "hashHex8 format" {
+    const out = hashHex8("abc");
+    try std.testing.expectEqual(@as(usize, 8), out.len);
+    for (out) |c| {
+        try std.testing.expect((c >= '0' and c <= '9') or (c >= 'a' and c <= 'f'));
+    }
+    // low 32-bit와 일치하는지 확인
+    const expect_u32 = @as(u32, @truncate(hashU64("abc")));
+    var expect_buf: [8]u8 = undefined;
+    _ = std.fmt.bufPrint(&expect_buf, "{x:0>8}", .{expect_u32}) catch unreachable;
+    try std.testing.expectEqualSlices(u8, &expect_buf, &out);
+}
+
+test "hashFileStreaming matches hashU64" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const contents = "hello world, wyhash streaming";
+    try tmp.dir.writeFile(.{ .sub_path = "t.txt", .data = contents });
+    const real = try tmp.dir.realpathAlloc(std.testing.allocator, "t.txt");
+    defer std.testing.allocator.free(real);
+    const got = hashFileStreaming(real, 1024 * 1024) orelse return error.HashFailed;
+    try std.testing.expectEqual(hashU64(contents), got);
+}
+
+test "hashFileStreaming respects max_bytes" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "big.txt", .data = "0123456789" });
+    const real = try tmp.dir.realpathAlloc(std.testing.allocator, "big.txt");
+    defer std.testing.allocator.free(real);
+    try std.testing.expect(hashFileStreaming(real, 5) == null);
+    try std.testing.expect(hashFileStreaming(real, 100) != null);
+}
+
+test "hashFileStreaming missing file returns null" {
+    try std.testing.expect(hashFileStreaming("/nonexistent/zts_wyhash_test.txt", 1024) == null);
+}


### PR DESCRIPTION
## Summary
- `src/util/wyhash.zig` 신설: `hashU64` / `hashHex8` / `hashFileStreaming`
- graph.zig / chunk.zig / worklet_plugin.zig / napi_entry.zig의 중복 Wyhash 호출 제거
- `bundler/emitter/chunks.zig`의 placeholder-skip 스트리밍 해싱은 특수 케이스로 남김

Closes part 1 of #1229. Part 2 (`FileWatcher.addPathTracked` + dev_server 리팩터)는 HMR 로직과 얽혀 있어 후속 PR로 분리.

## Test plan
- [x] \`zig build test\` 통과 (wyhash 유닛 테스트 4개 포함)
- [x] \`zig build\` 통과
- [ ] \`cd packages/core && bun test\` — NAPI 스모크
- [ ] \`/simplify\` 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)