### PR TITLE
refactor(server): TrackedFileSet — watcher + content-hash 캡슐화 (#1229 Part 2)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -14,6 +14,7 @@ const transpile_mod = zts_lib.transpile;
 const bundler_mod = zts_lib.bundler;
 const Bundler = bundler_mod.Bundler;
 const FileWatcher = zts_lib.server.FileWatcher;
+const TrackedFileSet = zts_lib.server.TrackedFileSet;
 
 /// Issue #1223 Phase 1: 워처 튜닝 상수.
 /// - watch_poll_timeout_ms: stop_flag 체크 주기 (이벤트 워처에서도 주기적으로 깨어나기 위함).
@@ -25,32 +26,6 @@ const watch_debounce_max_ms: u64 = 500;
 
 /// 파일 내용 해시 최대 크기 (소스 파일 기준 충분).
 const watch_hash_max_bytes: usize = 10 * 1024 * 1024;
-
-/// 파일 내용의 content hash (Wyhash 64-bit, 스트리밍). `util.wyhash` 위임.
-fn hashFileContent(path: []const u8) ?u64 {
-    return zts_lib.util.wyhash.hashFileStreaming(path, watch_hash_max_bytes);
-}
-
-/// FileWatcher에 path를 등록하고 content_hash_map에 해시 엔트리 생성/갱신.
-/// overwrite=false면 기존 엔트리의 해시는 보존(리빌드 후 재-싱크 용도).
-fn addAndCacheHash(
-    w: *FileWatcher,
-    hmap: *std.StringHashMap(u64),
-    alloc: std.mem.Allocator,
-    path: []const u8,
-    overwrite: bool,
-) bool {
-    w.addPath(path) catch return false;
-    if (!overwrite and hmap.contains(path)) return true;
-    const h = hashFileContent(path) orelse 0;
-    if (hmap.getEntry(path)) |e| {
-        e.value_ptr.* = h;
-    } else {
-        const key = alloc.dupe(u8, path) catch return true;
-        hmap.put(key, h) catch alloc.free(key);
-    }
-    return true;
-}
 
 /// 이벤트 배열의 path들을 중복 제거 set에 병합.
 /// FileWatcher.waitForChanges 결과는 다음 호출에서 무효화되므로 path를 dupe.
@@ -1406,8 +1381,9 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     defer persistent_resolve_cache.deinit();
 
     // Issue #1223 Phase 1: 이벤트 기반 파일 워처 (kqueue/inotify, mtime 폴백).
+    // TrackedFileSet이 FileWatcher와 내용 해시 캐시를 함께 소유 (#1229 Part 2).
     // 실패 시 워치 스레드 진입 직전에 종료한다.
-    var watcher = FileWatcher.init(allocator) catch |err| {
+    var tracked = TrackedFileSet.init(allocator, watch_hash_max_bytes) catch |err| {
         const event = allocator.create(WatchRebuildEvent) catch {
             _ = c.napi_release_threadsafe_function(async_data.ready_tsfn, c.napi_tsfn_release);
             _ = c.napi_release_threadsafe_function(async_data.rebuild_tsfn, c.napi_tsfn_release);
@@ -1424,27 +1400,17 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         async_data.deinit();
         return;
     };
-    defer watcher.deinit();
-
-    // content hash 캐시: mtime 변동으로 깨우되 실제 내용 변화만 리빌드 트리거.
-    var content_hash_map = std.StringHashMap(u64).init(allocator);
-    defer {
-        var it = content_hash_map.keyIterator();
-        while (it.next()) |k| allocator.free(k.*);
-        content_hash_map.deinit();
-    }
+    defer tracked.deinit();
 
     var initial_watch_count: usize = 0;
     if (bundle_opts.entry_points.len > 0 and
-        addAndCacheHash(&watcher, &content_hash_map, allocator, bundle_opts.entry_points[0], true))
+        tracked.addPath(bundle_opts.entry_points[0], true))
     {
         initial_watch_count += 1;
     }
     if (result.module_paths) |paths| {
         for (paths) |p| {
-            if (addAndCacheHash(&watcher, &content_hash_map, allocator, p, true)) {
-                initial_watch_count += 1;
-            }
+            if (tracked.addPath(p, true)) initial_watch_count += 1;
         }
     }
 
@@ -1495,7 +1461,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
 
     // Issue #1223 Phase 1: 이벤트 기반 워처 + 디바운스 + content hash 필터링.
     while (!async_data.stop_flag.load(.acquire)) {
-        const first_events = watcher.waitForChanges(watch_poll_timeout_ms) catch &[_]zts_lib.server.ChangeEvent{};
+        const first_events = tracked.waitForChanges(watch_poll_timeout_ms) catch &[_]zts_lib.server.ChangeEvent{};
         if (async_data.stop_flag.load(.acquire)) break;
 
         var total_timer: ?std.time.Timer = std.time.Timer.start() catch null;
@@ -1515,7 +1481,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         // 첫 이벤트로부터 watch_debounce_max_ms 초과 시 강제 종료.
         var debounce_timer: ?std.time.Timer = std.time.Timer.start() catch null;
         while (!async_data.stop_flag.load(.acquire)) {
-            const more = watcher.waitForChanges(watch_debounce_ms) catch break;
+            const more = tracked.waitForChanges(watch_debounce_ms) catch break;
             if (more.len == 0) break;
             collectTouched(&touched, allocator, more);
             if (debounce_timer) |*t| {
@@ -1529,17 +1495,9 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         defer changed_files.deinit(allocator);
         var tkit = touched.keyIterator();
         while (tkit.next()) |pkey| {
-            const path = pkey.*;
-            const new_hash = hashFileContent(path) orelse continue;
-            const old_hash = content_hash_map.get(path);
-            if (old_hash != null and old_hash.? == new_hash) continue;
-            if (content_hash_map.getEntry(path)) |entry| {
-                entry.value_ptr.* = new_hash;
-            } else {
-                const key_copy = allocator.dupe(u8, path) catch continue;
-                content_hash_map.put(key_copy, new_hash) catch allocator.free(key_copy);
+            if (tracked.markIfChanged(pkey.*)) {
+                changed_files.append(allocator, pkey.*) catch {};
             }
-            changed_files.append(allocator, path) catch {};
         }
         const detect_ns: u64 = if (detect_timer) |*t| t.read() else 0;
 
@@ -1715,25 +1673,22 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             for (paths) |p| desired.put(p, {}) catch {};
         }
 
-        // stale 엔트리 제거 — 워처와 content_hash_map 모두에서.
+        // stale 엔트리 제거 — 워처와 해시 캐시 양쪽에서.
         {
             var stale: std.ArrayList([]const u8) = .empty;
             defer stale.deinit(allocator);
-            var hit = content_hash_map.keyIterator();
+            var hit = tracked.keyIterator();
             while (hit.next()) |k| {
                 if (!desired.contains(k.*)) stale.append(allocator, k.*) catch {};
             }
-            for (stale.items) |k| {
-                watcher.removePath(k);
-                if (content_hash_map.fetchRemove(k)) |kv| allocator.free(kv.key);
-            }
+            for (stale.items) |k| tracked.removePath(k);
         }
 
         // 추가된 경로만 addPath + 해시. 기존 경로는 kqueue/inotify에 이미 등록됨.
         var dit = desired.keyIterator();
         while (dit.next()) |pkey| {
-            if (content_hash_map.contains(pkey.*)) continue;
-            _ = addAndCacheHash(&watcher, &content_hash_map, allocator, pkey.*, false);
+            if (tracked.contains(pkey.*)) continue;
+            _ = tracked.addPath(pkey.*, false);
         }
     }
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -13,7 +13,6 @@ const zts_lib = @import("zts_lib");
 const transpile_mod = zts_lib.transpile;
 const bundler_mod = zts_lib.bundler;
 const Bundler = bundler_mod.Bundler;
-const FileWatcher = zts_lib.server.FileWatcher;
 const TrackedFileSet = zts_lib.server.TrackedFileSet;
 
 /// Issue #1223 Phase 1: 워처 튜닝 상수.
@@ -1381,7 +1380,6 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     defer persistent_resolve_cache.deinit();
 
     // Issue #1223 Phase 1: 이벤트 기반 파일 워처 (kqueue/inotify, mtime 폴백).
-    // TrackedFileSet이 FileWatcher와 내용 해시 캐시를 함께 소유 (#1229 Part 2).
     // 실패 시 워치 스레드 진입 직전에 종료한다.
     var tracked = TrackedFileSet.init(allocator, watch_hash_max_bytes) catch |err| {
         const event = allocator.create(WatchRebuildEvent) catch {

--- a/src/server/mod.zig
+++ b/src/server/mod.zig
@@ -2,11 +2,13 @@ pub const DevServer = @import("dev_server.zig").DevServer;
 pub const FileWatcher = @import("file_watcher.zig").FileWatcher;
 pub const ChangeEvent = @import("file_watcher.zig").ChangeEvent;
 pub const ChangeKind = @import("file_watcher.zig").ChangeKind;
+pub const TrackedFileSet = @import("tracked_file_set.zig").TrackedFileSet;
 pub const mime = @import("mime.zig");
 
 test {
     _ = @import("dev_server.zig");
     _ = @import("file_watcher.zig");
+    _ = @import("tracked_file_set.zig");
     _ = @import("mime.zig");
 
     // test files

--- a/src/server/tracked_file_set.zig
+++ b/src/server/tracked_file_set.zig
@@ -1,0 +1,172 @@
+//! 파일 워처 + 내용 해시 캐시를 묶은 상위 자료구조.
+//!
+//! `FileWatcher`는 OS 수준 변경만 알려준다 (kqueue/inotify/mtime). 저장·touch
+//! 이벤트가 실제 내용 변경과 일치하지 않는 경우가 많아(atomic-write 후 재작성,
+//! 에디터 touch 등), NAPI watch 모드는 파일별로 Wyhash-64 해시를 캐싱해서
+//! "내용이 진짜 바뀐 파일"만 리빌드로 보낸다.
+//!
+//! 기존엔 napi_entry.zig에 `addAndCacheHash` 로컬 헬퍼 + 해시맵 수동 관리로
+//! 흩어져 있었다. 이 모듈은 그 패턴을 캡슐화한다 (#1229 Part 2).
+
+const std = @import("std");
+const file_watcher = @import("file_watcher.zig");
+const FileWatcher = file_watcher.FileWatcher;
+const ChangeEvent = file_watcher.ChangeEvent;
+const wyhash = @import("../util/wyhash.zig");
+
+/// FileWatcher + path→content-hash 맵.
+///
+/// key 소유: `addPath` 시 경로 문자열을 dupe해서 해시맵 키로 가진다.
+/// FileWatcher도 내부적으로 dupe하므로 두 쪽이 별도 복사본을 소유한다 —
+/// `removePath`에서 맞춰 해제한다.
+pub const TrackedFileSet = struct {
+    allocator: std.mem.Allocator,
+    watcher: FileWatcher,
+    hashes: std.StringHashMap(u64),
+    max_bytes: usize,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, max_bytes: usize) !Self {
+        return .{
+            .allocator = allocator,
+            .watcher = try FileWatcher.init(allocator),
+            .hashes = std.StringHashMap(u64).init(allocator),
+            .max_bytes = max_bytes,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.watcher.deinit();
+        var it = self.hashes.keyIterator();
+        while (it.next()) |k| self.allocator.free(k.*);
+        self.hashes.deinit();
+    }
+
+    /// 감시 대상 등록 + 해시 캐시 갱신.
+    /// `overwrite=false`면 기존 해시를 보존한다 (증분 재-싱크 용도).
+    /// 반환값: watcher 등록 성공 여부.
+    pub fn addPath(self: *Self, path: []const u8, overwrite: bool) bool {
+        self.watcher.addPath(path) catch return false;
+        if (!overwrite and self.hashes.contains(path)) return true;
+        const h = wyhash.hashFileStreaming(path, self.max_bytes) orelse 0;
+        if (self.hashes.getEntry(path)) |e| {
+            e.value_ptr.* = h;
+        } else {
+            const key = self.allocator.dupe(u8, path) catch return true;
+            self.hashes.put(key, h) catch self.allocator.free(key);
+        }
+        return true;
+    }
+
+    /// 워처 + 해시 캐시 양쪽에서 제거.
+    pub fn removePath(self: *Self, path: []const u8) void {
+        self.watcher.removePath(path);
+        if (self.hashes.fetchRemove(path)) |kv| self.allocator.free(kv.key);
+    }
+
+    pub fn contains(self: *const Self, path: []const u8) bool {
+        return self.hashes.contains(path);
+    }
+
+    pub fn keyIterator(self: *Self) std.StringHashMap(u64).KeyIterator {
+        return self.hashes.keyIterator();
+    }
+
+    /// 파일의 현재 내용 해시를 캐시와 비교. 내용이 바뀌었으면 캐시 갱신 후 true.
+    /// 읽기 실패/크기 초과 시 false.
+    pub fn markIfChanged(self: *Self, path: []const u8) bool {
+        const new_hash = wyhash.hashFileStreaming(path, self.max_bytes) orelse return false;
+        const old_hash = self.hashes.get(path);
+        if (old_hash != null and old_hash.? == new_hash) return false;
+        if (self.hashes.getEntry(path)) |entry| {
+            entry.value_ptr.* = new_hash;
+        } else {
+            const key_copy = self.allocator.dupe(u8, path) catch return false;
+            self.hashes.put(key_copy, new_hash) catch {
+                self.allocator.free(key_copy);
+                return false;
+            };
+        }
+        return true;
+    }
+
+    pub fn watchCount(self: *const Self) usize {
+        return self.watcher.watchCount();
+    }
+
+    pub fn waitForChanges(self: *Self, timeout_ms: u32) ![]const ChangeEvent {
+        return self.watcher.waitForChanges(timeout_ms);
+    }
+};
+
+// ─── 테스트 ───
+
+const testing = std.testing;
+
+test "addPath registers watcher + caches hash" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "a.txt", .data = "hello" });
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "a.txt");
+    defer testing.allocator.free(path);
+
+    var set = try TrackedFileSet.init(testing.allocator, 1024 * 1024);
+    defer set.deinit();
+
+    try testing.expect(set.addPath(path, true));
+    try testing.expect(set.contains(path));
+    try testing.expectEqual(@as(usize, 1), set.watchCount());
+}
+
+test "markIfChanged detects content change, same content returns false" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "a.txt", .data = "v1" });
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "a.txt");
+    defer testing.allocator.free(path);
+
+    var set = try TrackedFileSet.init(testing.allocator, 1024 * 1024);
+    defer set.deinit();
+
+    _ = set.addPath(path, true);
+    try testing.expect(!set.markIfChanged(path)); // 같은 내용
+
+    try tmp.dir.writeFile(.{ .sub_path = "a.txt", .data = "v2-different" });
+    try testing.expect(set.markIfChanged(path)); // 바뀜
+    try testing.expect(!set.markIfChanged(path)); // 캐시 갱신됨
+}
+
+test "overwrite=false preserves existing hash" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "a.txt", .data = "v1" });
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "a.txt");
+    defer testing.allocator.free(path);
+
+    var set = try TrackedFileSet.init(testing.allocator, 1024 * 1024);
+    defer set.deinit();
+
+    _ = set.addPath(path, true);
+    const h1 = set.hashes.get(path).?;
+
+    // 파일 내용 변경, overwrite=false — 캐시된 해시가 유지되어야 함 (재-싱크 시맨틱)
+    try tmp.dir.writeFile(.{ .sub_path = "a.txt", .data = "v2" });
+    _ = set.addPath(path, false);
+    try testing.expectEqual(h1, set.hashes.get(path).?);
+}
+
+test "removePath clears from both watcher and hash cache" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "a.txt", .data = "x" });
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "a.txt");
+    defer testing.allocator.free(path);
+
+    var set = try TrackedFileSet.init(testing.allocator, 1024 * 1024);
+    defer set.deinit();
+
+    _ = set.addPath(path, true);
+    set.removePath(path);
+    try testing.expect(!set.contains(path));
+}

--- a/src/server/tracked_file_set.zig
+++ b/src/server/tracked_file_set.zig
@@ -48,14 +48,17 @@ pub const TrackedFileSet = struct {
     /// 반환값: watcher 등록 성공 여부.
     pub fn addPath(self: *Self, path: []const u8, overwrite: bool) bool {
         self.watcher.addPath(path) catch return false;
-        if (!overwrite and self.hashes.contains(path)) return true;
-        const h = wyhash.hashFileStreaming(path, self.max_bytes) orelse 0;
-        if (self.hashes.getEntry(path)) |e| {
-            e.value_ptr.* = h;
+        const gop = self.hashes.getOrPut(path) catch return true;
+        if (gop.found_existing) {
+            if (!overwrite) return true;
         } else {
-            const key = self.allocator.dupe(u8, path) catch return true;
-            self.hashes.put(key, h) catch self.allocator.free(key);
+            const key = self.allocator.dupe(u8, path) catch {
+                _ = self.hashes.remove(path);
+                return true;
+            };
+            gop.key_ptr.* = key;
         }
+        gop.value_ptr.* = wyhash.hashFileStreaming(path, self.max_bytes) orelse 0;
         return true;
     }
 
@@ -77,17 +80,17 @@ pub const TrackedFileSet = struct {
     /// 읽기 실패/크기 초과 시 false.
     pub fn markIfChanged(self: *Self, path: []const u8) bool {
         const new_hash = wyhash.hashFileStreaming(path, self.max_bytes) orelse return false;
-        const old_hash = self.hashes.get(path);
-        if (old_hash != null and old_hash.? == new_hash) return false;
-        if (self.hashes.getEntry(path)) |entry| {
-            entry.value_ptr.* = new_hash;
+        const gop = self.hashes.getOrPut(path) catch return false;
+        if (gop.found_existing) {
+            if (gop.value_ptr.* == new_hash) return false;
         } else {
-            const key_copy = self.allocator.dupe(u8, path) catch return false;
-            self.hashes.put(key_copy, new_hash) catch {
-                self.allocator.free(key_copy);
+            const key = self.allocator.dupe(u8, path) catch {
+                _ = self.hashes.remove(path);
                 return false;
             };
+            gop.key_ptr.* = key;
         }
+        gop.value_ptr.* = new_hash;
         return true;
     }
 


### PR DESCRIPTION
## Summary
- `src/server/tracked_file_set.zig` 신설 — `FileWatcher` + `path→Wyhash-64` 해시 맵을 하나로 묶음
- `packages/core/src/napi_entry.zig`의 `addAndCacheHash` / `hashFileContent` 로컬 헬퍼 제거
- 변경 감지 루프(getEntry/put/dupe/free 수작업 17줄) → \`if (tracked.markIfChanged(p)) ...\` 1줄
- stale 정리도 \`tracked.removePath\` 한 곳에서

## Scope
이슈 #1229의 두 항목 중 Part 2만 포함. dev_server.zig는 해시 캐시를 쓰지 않아 \`addPathTracked\`의 혜택이 없고, 이슈 자체에서도 HMR 로직과 얽혀 별도 리뷰 단위로 분리를 권고 — 후속 PR로 남김.

Part 1 (\`util/wyhash.zig\`): #1235 (merged).
Closes #1229.

## Test plan
- [x] \`zig build test\` 통과 (TrackedFileSet 유닛 테스트 4개 포함)
- [x] \`zig build napi\`
- [x] \`cd packages/core && bun test\` — 320 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)