### PR TITLE
docs(cli): 현재 CLI 스펙에 맞게 reference/cli.md 전면 갱신

### DIFF
--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -6,99 +6,180 @@ description: Complete list of ZTS CLI options
 ## Transpile
 
 ```bash
-zts <file.ts>                    # -> stdout
-zts <file.ts> -o <out.js>       # -> file
-zts <dir/> --outdir <out/>      # Recursive directory transpile
-zts - < input.ts                # stdin input
+zts <file.ts>                      # → stdout
+zts <file.ts> -o <out.js>          # → file
+zts <dir/> --outdir <out/>         # recursive directory
+zts - < input.ts                   # stdin
 ```
 
 ## Bundle
 
 ```bash
-zts --bundle <entry.ts>                              # -> stdout
-zts --bundle <entry.ts> -o out.js                    # -> file
-zts --bundle <entry.ts> --splitting --outdir dist    # Code splitting
-zts --bundle <entry.ts> --preserve-modules --outdir dist  # Per-module output
-zts --bundle <entry.ts> --plugin zts.config.js       # JS plugin
+zts --bundle <entry.ts>                               # → stdout
+zts --bundle <entry.ts> -o out.js                     # → file
+zts --bundle <entry.ts> --splitting --outdir dist     # code splitting
+zts --bundle <entry.ts> --preserve-modules --outdir dist  # per-module (library)
+zts --bundle <entry.ts> --plugin zts.config.js        # JS plugin
 ```
 
-## Common Options
+## I/O
 
 | Option | Description |
 |--------|-------------|
-| `--format=esm\|cjs\|iife` | Module format |
-| `--platform=browser\|node\|neutral\|react-native` | Target platform |
-| `--minify` | Minify output |
-| `--sourcemap` | Generate source maps |
-| `--ascii-only` | Escape non-ASCII to `\uXXXX` |
-| `--quotes=double\|single\|preserve` | Quote style |
-| `--drop=console` | Remove console.* calls |
-| `--drop=debugger` | Remove debugger statements |
-| `--define:KEY=VALUE` | Global substitution |
-| `--external <pkg>` | Exclude from bundle |
-| `--alias:FROM=TO` | Import path alias |
-| `--banner:js=<text>` | Prepend text to output |
-| `--footer:js=<text>` | Append text to output |
-| `--global-name=<name>` | IIFE export variable name |
-| `--public-path=<url>` | Asset URL prefix |
-| `--out-extension:.js=<ext>` | Change output extension |
+| `-o, --out-file <path>` | Output file path |
+| `--outdir <path>` | Output directory (required for dir input / splitting / preserve-modules) |
+| `--outbase=<dir>` | Base dir for computing output paths |
+| `--out-extension:.js=<ext>` | Change output extension (e.g. `.mjs`) |
+| `--allow-overwrite` | Allow overwriting input path |
+| `--clean` | Clear outdir before building |
 
-## JSX Options
+## Format / Platform
+
+| Option | Description |
+|--------|-------------|
+| `--format=esm\|cjs\|iife\|umd\|amd` | Module format (default: `esm`) |
+| `--platform=browser\|node\|neutral\|react-native` | Target platform |
+| `--rn-platform=ios\|android` | RN sub-platform (`.ios.*`/`.android.*` extensions) |
+| `--target=<spec>` | ES target: `es2015`–`esnext` or engine versions (`chrome80,safari14`) |
+| `--global-name=<name>` | IIFE export name |
+| `--global-identifier=<id>` | Global identifier override |
+
+## Minify
+
+| Option | Description |
+|--------|-------------|
+| `--minify` | Enable all three (shortcut) |
+| `--minify-whitespace` | Whitespace/semicolons/newlines only (debuggable) |
+| `--minify-syntax` | `true`→`!0`, paren removal, constant folding |
+| `--minify-identifiers` | Shorten local identifiers |
+| `--keep-names` | Preserve function/class `.name` |
+| `--charset=utf8\|ascii` | Output charset |
+| `--ascii-only` | Non-ASCII → `\uXXXX` (= `--charset=ascii`) |
+| `--quotes=double\|single\|preserve` | String quote style |
+| `--line-limit=<n>` | Max line length (wrap when minifying) |
+
+## Source Maps
+
+| Option | Description |
+|--------|-------------|
+| `--sourcemap` | External `.js.map` |
+| `--sourcemap=inline` | Inline data URL |
+| `--sourcemap=external` | External file, no comment |
+| `--sourcemap=hidden` | External only (omit comment) |
+| `--sourcemap-debug-ids` | Sentry debugId support |
+| `--sources-content=false` | Omit `sourcesContent` |
+| `--source-root=<path>` | `sourceRoot` field |
+
+## Transform / Replace
+
+| Option | Description |
+|--------|-------------|
+| `--define:KEY=VALUE` | Global replace (e.g. `process.env.NODE_ENV` → `"production"`) |
+| `--drop=console` | Remove `console.*` calls |
+| `--drop=debugger` | Remove `debugger` statements |
+| `--drop-labels=<list>` | Remove labeled blocks (e.g. `DEV,TEST`) |
+| `--pure:<name>` | Mark call as pure for DCE |
+| `--inject:<path>` | Auto-inject import (shim) |
+| `--polyfill=<list>` | Runtime polyfill injection |
+
+## JSX
 
 | Option | Description |
 |--------|-------------|
 | `--jsx=classic\|automatic\|automatic-dev` | JSX runtime |
-| `--jsx-dev` | Shorthand for `--jsx=automatic-dev` |
-| `--jsx-factory=<fn>` | Classic factory function |
-| `--jsx-fragment=<fn>` | Classic Fragment component |
-| `--jsx-import-source=<pkg>` | Automatic mode import source |
+| `--jsx-dev` | `--jsx=automatic-dev` shortcut |
+| `--jsx-factory=<fn>` | Classic factory (default: `React.createElement`) |
+| `--jsx-fragment=<fn>` | Classic Fragment |
+| `--jsx-import-source=<pkg>` | Automatic import source (default: `react`) |
+| `--jsx-in-js` | Allow JSX parsing in `.js` files |
+| `--jsx-side-effects` | Mark JSX elements as having side effects (skip DCE) |
 
-## Bundle-only Options
-
-| Option | Description |
-|--------|-------------|
-| `--splitting` | Code splitting |
-| `--preserve-modules` | Per-module output |
-| `--preserve-modules-root=<dir>` | Output root path |
-| `--entry-names=<pattern>` | Entry filename pattern |
-| `--chunk-names=<pattern>` | Chunk filename pattern |
-| `--asset-names=<pattern>` | Asset filename pattern |
-| `--loader:.ext=type` | Per-extension loader |
-| `--metafile=<path>` | Build metadata JSON |
-| `--analyze` | Bundle analysis output |
-| `--legal-comments=<mode>` | License comment handling |
-| `--inject:<path>` | Auto-import into all entries |
-| `--keep-names` | Preserve function/class .name |
-| `--shim-missing-exports` | Provide undefined for missing exports |
-| `--resolve-extensions=<exts>` | Extension resolution order |
-| `--main-fields=<fields>` | package.json field order |
-
-## React Native Options
+## TypeScript
 
 | Option | Description |
 |--------|-------------|
-| `--rn-platform=ios\|android` | RN sub-platform |
-| `--flow` | Flow type stripping |
+| `-p, --project <path>` | tsconfig.json path/directory |
+| `--tsconfig-raw=<json>` | Inline tsconfig JSON |
+| `--experimental-decorators` | Legacy decorator (`__decorateClass`) |
+| `--use-define-for-class-fields=false\|true` | Class field semantics |
 
-## Dev Server
+## Flow
 
 | Option | Description |
 |--------|-------------|
-| `--serve [dir]` | Static file server |
-| `--port <number>` | Port (default: 12300) |
-| `--host [addr]` | Bind address |
+| `--flow` | Flow type stripping (auto-detected via `@flow` pragma) |
+| `--ignore-annotations` | Ignore Flow comments/pragmas |
+
+## Bundle-specific
+
+| Option | Description |
+|--------|-------------|
+| `--bundle` | Enable bundle mode |
+| `--splitting` | Code splitting (requires `--outdir`) |
+| `--preserve-modules` | Per-module output (library build) |
+| `--preserve-modules-root=<dir>` | Root for output structure |
+| `--entry-names=<pattern>` | Entry name pattern (`[name]`, `[hash]`) |
+| `--chunk-names=<pattern>` | Chunk name pattern |
+| `--asset-names=<pattern>` | Asset name pattern |
+| `--loader:.ext=type` | Loader by extension (`file\|dataurl\|text\|binary\|copy\|json\|css\|js\|ts\|jsx\|tsx`) |
+| `--metafile` / `--metafile=<path>` | Build meta JSON (stdout or file) |
+| `--analyze` | Bundle analysis report |
+| `--legal-comments=<mode>` | License comments: `none\|inline\|eof\|linked\|external` |
+| `--banner:js=<text>` | Prepend text |
+| `--footer:js=<text>` | Append text |
+| `--public-path=<url>` | Asset URL prefix |
+| `--shim-missing-exports` | Shim missing exports with `undefined` |
+
+## Resolve
+
+| Option | Description |
+|--------|-------------|
+| `--external <pkg>` / `--external=<pkg,...>` | Exclude from bundle (repeatable) |
+| `--packages=external` | Mark all npm packages external |
+| `--alias:FROM=TO` | Import path alias |
+| `--conditions=<list>` | Custom export conditions (e.g. `production,custom`) |
+| `--resolve-extensions=<exts>` | Extension lookup order (e.g. `.ios.ts,.ts,.js`) |
+| `--main-fields=<fields>` | package.json field order (e.g. `react-native,browser,main`) |
+| `--node-paths=<dirs>` | Additional `NODE_PATH` directories |
+| `--preserve-symlinks` | Don't resolve symlinks |
+
+## Watch / Dev Server
+
+| Option | Description |
+|--------|-------------|
+| `-w, --watch` | Watch for file changes (incremental rebuild) |
+| `--watch-json` | NDJSON event output (for external HMR integration) |
+| `--watch-delay=<ms>` | Debounce delay |
+| `--serve [dir]` | Static file server (default: `.`) |
+| `--port <n>` | Server port |
+| `--host [addr]` | Binding address |
 | `--open` | Auto-open browser |
 | `--proxy /api=http://host:port` | API proxy |
+| `--dev` | Dev mode (HMR + fast rebuild) |
+| `--run-before-main=<cmd>` | Inject code to run before bundle entry |
 
-## Other
+**Dev server external interfaces:** `/sse/events` (SSE build events), `/reset-cache` (Control API), `/mcp` (Model Context Protocol — for LLM agents like Claude Code).
+
+## Plugins / Execution
 
 | Option | Description |
 |--------|-------------|
-| `-w, --watch` | Watch for file changes |
-| `--watch-json` | NDJSON event output |
-| `-p, --project <path>` | tsconfig.json path |
-| `--experimental-decorators` | Legacy decorators |
-| `--use-define-for-class-fields=false` | Class fields to constructor |
-| `--log-level=<level>` | Log level |
-| `--charset=utf8` | Keep non-ASCII characters |
-| `--preserve-symlinks` | Preserve symlinks |
+| `--plugin <path>` | JS/TS plugin or config file |
+| `--jobs=<n>` | Parallel thread count |
+
+## Diagnostics / Logging
+
+| Option | Description |
+|--------|-------------|
+| `--log-level=<level>` | `silent\|error\|warning\|info\|debug\|verbose` |
+| `--log-limit=<n>` | Max diagnostics shown |
+| `--timing` | Per-stage timing output |
+| `--tokenize` | Print tokens instead of transpiling |
+| `--test262 <dir>` | Run Test262 suite |
+| `-h, --help` | Show help |
+
+## See Also
+
+- JS API (`@zts/core`) in `packages/core/index.ts` provides the same options programmatically.
+- Use `vite-plugin-zts` or `vitePlugin()` for the Vite adapter.
+- Unsupported options and future plans: [docs/ROADMAP.md](https://github.com/ohah/zts/blob/main/docs/ROADMAP.md).

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -6,99 +6,180 @@ description: ZTS CLI 옵션 전체 목록
 ## 트랜스파일
 
 ```bash
-zts <file.ts>                    # → stdout
-zts <file.ts> -o <out.js>       # → 파일
-zts <dir/> --outdir <out/>      # 디렉토리 재귀 변환
-zts - < input.ts                # stdin 입력
+zts <file.ts>                      # → stdout
+zts <file.ts> -o <out.js>          # → 파일
+zts <dir/> --outdir <out/>         # 디렉토리 재귀 변환
+zts - < input.ts                   # stdin 입력
 ```
 
 ## 번들
 
 ```bash
-zts --bundle <entry.ts>                              # → stdout
-zts --bundle <entry.ts> -o out.js                    # → 파일
-zts --bundle <entry.ts> --splitting --outdir dist    # 코드 스플리팅
-zts --bundle <entry.ts> --preserve-modules --outdir dist  # 모듈별 출력
-zts --bundle <entry.ts> --plugin zts.config.js       # JS 플러그인
+zts --bundle <entry.ts>                               # → stdout
+zts --bundle <entry.ts> -o out.js                     # → 파일
+zts --bundle <entry.ts> --splitting --outdir dist     # 코드 스플리팅
+zts --bundle <entry.ts> --preserve-modules --outdir dist  # 모듈별 출력 (라이브러리)
+zts --bundle <entry.ts> --plugin zts.config.js        # JS 플러그인
 ```
 
-## 공통 옵션
+## 입출력
 
 | 옵션 | 설명 |
 |------|------|
-| `--format=esm\|cjs\|iife` | 모듈 포맷 |
-| `--platform=browser\|node\|neutral\|react-native` | 타겟 플랫폼 |
-| `--minify` | 출력 압축 |
-| `--sourcemap` | 소스맵 생성 |
-| `--ascii-only` | non-ASCII → `\uXXXX` |
-| `--quotes=double\|single\|preserve` | 따옴표 스타일 |
-| `--drop=console` | console.* 제거 |
-| `--drop=debugger` | debugger 문 제거 |
-| `--define:KEY=VALUE` | 글로벌 치환 |
-| `--external <pkg>` | 번들에서 제외 |
-| `--alias:FROM=TO` | import 경로 별칭 |
-| `--banner:js=<text>` | 출력 앞에 텍스트 |
-| `--footer:js=<text>` | 출력 뒤에 텍스트 |
-| `--global-name=<name>` | IIFE export 변수명 |
-| `--public-path=<url>` | 에셋 URL prefix |
-| `--out-extension:.js=<ext>` | 출력 확장자 변경 |
+| `-o, --out-file <path>` | 출력 파일 경로 |
+| `--outdir <path>` | 출력 디렉토리 (디렉토리 입력·`--splitting`·`--preserve-modules`) |
+| `--outbase=<dir>` | 출력 기준 디렉토리 (공통 prefix 계산) |
+| `--out-extension:.js=<ext>` | 출력 확장자 변경 (예: `.mjs`) |
+| `--allow-overwrite` | 입력과 같은 경로에 덮어쓰기 허용 |
+| `--clean` | 빌드 전 outdir 비우기 |
 
-## JSX 옵션
+## 모듈 포맷 / 플랫폼
+
+| 옵션 | 설명 |
+|------|------|
+| `--format=esm\|cjs\|iife\|umd\|amd` | 모듈 포맷 (기본: `esm`) |
+| `--platform=browser\|node\|neutral\|react-native` | 타겟 플랫폼 |
+| `--rn-platform=ios\|android` | RN 서브 플랫폼 (`.ios.*`/`.android.*` 확장자) |
+| `--target=<spec>` | ES 타겟: `es2015`~`esnext` 또는 엔진 버전 (`chrome80,safari14` 등) |
+| `--global-name=<name>` | IIFE export 변수명 |
+| `--global-identifier=<id>` | 글로벌 식별자 치환 |
+
+## 미니파이
+
+| 옵션 | 설명 |
+|------|------|
+| `--minify` | 세 가지 모두 켜기 (shortcut) |
+| `--minify-whitespace` | 공백/세미콜론/줄바꿈만 축약 (디버깅 가능) |
+| `--minify-syntax` | `true`→`!0`, 괄호 제거, constant folding |
+| `--minify-identifiers` | 지역 변수명 단축 |
+| `--keep-names` | 함수/클래스 `.name` 보존 |
+| `--charset=utf8\|ascii` | 출력 문자셋 |
+| `--ascii-only` | non-ASCII → `\uXXXX` (= `--charset=ascii`) |
+| `--quotes=double\|single\|preserve` | 문자열 따옴표 스타일 |
+| `--line-limit=<n>` | 한 줄 최대 길이 (minify 시 줄바꿈 삽입) |
+
+## 소스맵
+
+| 옵션 | 설명 |
+|------|------|
+| `--sourcemap` | `.js.map` 외부 파일 |
+| `--sourcemap=inline` | data URL 인라인 |
+| `--sourcemap=external` | sourceMappingURL 주석 없이 외부만 |
+| `--sourcemap=hidden` | 외부 파일 생성만 (주석 생략) |
+| `--sourcemap-debug-ids` | Sentry debugId 삽입 |
+| `--sources-content=false` | `sourcesContent` 필드 생략 |
+| `--source-root=<path>` | sourceRoot 필드 |
+
+## 변환 / 치환
+
+| 옵션 | 설명 |
+|------|------|
+| `--define:KEY=VALUE` | 글로벌 치환 (`process.env.NODE_ENV` → `"production"` 등) |
+| `--drop=console` | `console.*` 호출 제거 |
+| `--drop=debugger` | `debugger` 문 제거 |
+| `--drop-labels=<list>` | 특정 label 블록 제거 (예: `DEV,TEST`) |
+| `--pure:<name>` | 해당 호출을 pure로 표시해 DCE 대상화 |
+| `--inject:<path>` | 자동 import (shim) |
+| `--polyfill=<list>` | 런타임 폴리필 주입 |
+
+## JSX
 
 | 옵션 | 설명 |
 |------|------|
 | `--jsx=classic\|automatic\|automatic-dev` | JSX 런타임 |
-| `--jsx-dev` | `--jsx=automatic-dev` 단축 |
-| `--jsx-factory=<fn>` | classic factory |
+| `--jsx-dev` | `--jsx=automatic-dev` shortcut |
+| `--jsx-factory=<fn>` | classic factory (기본: `React.createElement`) |
 | `--jsx-fragment=<fn>` | classic Fragment |
-| `--jsx-import-source=<pkg>` | automatic import source |
+| `--jsx-import-source=<pkg>` | automatic import source (기본: `react`) |
+| `--jsx-in-js` | `.js` 파일에서도 JSX 파싱 허용 |
+| `--jsx-side-effects` | JSX 요소에 부수효과 있다고 표시 (DCE 회피) |
 
-## 번들 전용 옵션
+## TypeScript
 
 | 옵션 | 설명 |
 |------|------|
-| `--splitting` | 코드 스플리팅 |
-| `--preserve-modules` | 모듈별 출력 |
-| `--preserve-modules-root=<dir>` | 출력 기준 경로 |
-| `--entry-names=<pattern>` | 엔트리 파일명 패턴 |
+| `-p, --project <path>` | tsconfig.json 경로/디렉토리 |
+| `--tsconfig-raw=<json>` | tsconfig 내용 인라인 주입 |
+| `--experimental-decorators` | legacy decorator (`__decorateClass`) |
+| `--use-define-for-class-fields=false\|true` | 클래스 필드 의미론 |
+
+## Flow
+
+| 옵션 | 설명 |
+|------|------|
+| `--flow` | Flow 타입 스트리핑 (`@flow` pragma 자동 감지) |
+| `--ignore-annotations` | Flow 주석/pragma 무시 |
+
+## 번들 전용
+
+| 옵션 | 설명 |
+|------|------|
+| `--bundle` | 번들 모드 활성화 |
+| `--splitting` | 코드 스플리팅 (`--outdir` 필요) |
+| `--preserve-modules` | 모듈별 출력 (라이브러리 빌드) |
+| `--preserve-modules-root=<dir>` | 출력 구조 기준 디렉토리 |
+| `--entry-names=<pattern>` | 엔트리 파일명 패턴 (`[name]`, `[hash]`) |
 | `--chunk-names=<pattern>` | 청크 파일명 패턴 |
 | `--asset-names=<pattern>` | 에셋 파일명 패턴 |
-| `--loader:.ext=type` | 확장자별 로더 |
-| `--metafile=<path>` | 빌드 메타 JSON |
-| `--analyze` | 번들 분석 출력 |
-| `--legal-comments=<mode>` | 라이센스 주석 |
-| `--inject:<path>` | 자동 import |
-| `--keep-names` | 함수/클래스 .name 보존 |
-| `--shim-missing-exports` | 없는 export에 undefined |
-| `--resolve-extensions=<exts>` | 확장자 탐색 순서 |
-| `--main-fields=<fields>` | package.json 필드 순서 |
+| `--loader:.ext=type` | 확장자별 로더 (`file\|dataurl\|text\|binary\|copy\|json\|css\|js\|ts\|jsx\|tsx`) |
+| `--metafile` / `--metafile=<path>` | 빌드 메타 JSON (stdout 또는 파일) |
+| `--analyze` | 번들 분석 리포트 |
+| `--legal-comments=<mode>` | 라이선스 주석: `none\|inline\|eof\|linked\|external` |
+| `--banner:js=<text>` | 출력 앞 텍스트 |
+| `--footer:js=<text>` | 출력 뒤 텍스트 |
+| `--public-path=<url>` | 에셋 URL prefix |
+| `--shim-missing-exports` | 없는 export에 `undefined` shim |
 
-## React Native 옵션
-
-| 옵션 | 설명 |
-|------|------|
-| `--rn-platform=ios\|android` | RN 서브 플랫폼 |
-| `--flow` | Flow 타입 스트리핑 |
-
-## Dev Server
+## Resolve
 
 | 옵션 | 설명 |
 |------|------|
-| `--serve [dir]` | 정적 파일 서버 |
-| `--port <number>` | 포트 (기본: 12300) |
+| `--external <pkg>` / `--external=<pkg,...>` | 번들에서 제외 (반복 가능) |
+| `--packages=external` | 모든 npm 패키지를 external 처리 |
+| `--alias:FROM=TO` | import 경로 별칭 |
+| `--conditions=<list>` | 커스텀 export 조건 (예: `production,custom`) |
+| `--resolve-extensions=<exts>` | 확장자 탐색 순서 (예: `.ios.ts,.ts,.js`) |
+| `--main-fields=<fields>` | package.json 필드 순서 (예: `react-native,browser,main`) |
+| `--node-paths=<dirs>` | `NODE_PATH` 추가 탐색 경로 |
+| `--preserve-symlinks` | 심링크 실제 경로 해석 안 함 |
+
+## Watch / Dev Server
+
+| 옵션 | 설명 |
+|------|------|
+| `-w, --watch` | 파일 변경 감시 (증분 리빌드) |
+| `--watch-json` | NDJSON 이벤트 출력 (외부 HMR 연동) |
+| `--watch-delay=<ms>` | 디바운스 지연 |
+| `--serve [dir]` | 정적 파일 서버 (기본: `.`) |
+| `--port <n>` | 서버 포트 |
 | `--host [addr]` | 바인딩 주소 |
 | `--open` | 브라우저 자동 열기 |
 | `--proxy /api=http://host:port` | API 프록시 |
+| `--dev` | 개발 모드 (HMR + 빠른 리빌드) |
+| `--run-before-main=<cmd>` | 번들 엔트리 실행 전에 돌릴 코드 주입 |
 
-## 기타
+**Dev Server 외부 인터페이스:** `/sse/events` (SSE 빌드 이벤트), `/reset-cache` (Control API), `/mcp` (Model Context Protocol — Claude Code 등 LLM 에이전트 연동).
+
+## 플러그인 / 실행
 
 | 옵션 | 설명 |
 |------|------|
-| `-w, --watch` | 파일 변경 감시 |
-| `--watch-json` | NDJSON 이벤트 출력 |
-| `-p, --project <path>` | tsconfig.json 경로 |
-| `--experimental-decorators` | legacy decorator |
-| `--use-define-for-class-fields=false` | class field → constructor |
-| `--log-level=<level>` | 로그 레벨 |
-| `--charset=utf8` | non-ASCII 유지 |
-| `--preserve-symlinks` | 심링크 유지 |
+| `--plugin <path>` | JS/TS 플러그인 또는 설정 파일 |
+| `--jobs=<n>` | 병렬 스레드 수 |
+
+## 진단 / 로깅
+
+| 옵션 | 설명 |
+|------|------|
+| `--log-level=<level>` | `silent\|error\|warning\|info\|debug\|verbose` |
+| `--log-limit=<n>` | 표시할 진단 최대 개수 |
+| `--timing` | 단계별 실행 시간 출력 |
+| `--tokenize` | 토큰 출력 (트랜스파일 대신) |
+| `--test262 <dir>` | Test262 러너 실행 |
+| `-h, --help` | 도움말 |
+
+## 참고
+
+- JS API(`@zts/core`)는 `packages/core/index.ts`에서 동일한 옵션을 프로그램적으로 제공합니다.
+- Vite 어댑터는 `vite-plugin-zts` 또는 `vitePlugin()`으로 사용하세요.
+- 미지원 옵션 / 향후 계획은 [docs/ROADMAP.md](https://github.com/ohah/zts/blob/main/docs/ROADMAP.md) 참고.


### PR DESCRIPTION
## Summary
\`reference/cli.md\` (KO + EN)이 실제 \`src/main.zig\`의 CLI 처리에 30+개 플래그를 누락한 상태였음. 전면 동기화:

**새로 문서화된 주요 옵션:**
- 미니파이 세분화: \`--minify-{whitespace,syntax,identifiers}\` (D030 — 이미 구현되어 있었음)
- ES 타겟: \`--target=es2015~esnext\` / 엔진 버전 (\`chrome80,safari14\`)
- 추가 포맷: \`--format=umd\`, \`--format=amd\`
- I/O: \`--outbase\`, \`--allow-overwrite\`, \`--clean\`
- 변환: \`--drop-labels\`, \`--pure\`, \`--inject\`, \`--polyfill\`
- 소스맵 모드: \`inline\` / \`external\` / \`hidden\`, \`--sources-content\`, \`--source-root\`, \`--sourcemap-debug-ids\`
- JSX: \`--jsx-in-js\`, \`--jsx-side-effects\`
- Flow: \`--ignore-annotations\`
- Resolve: \`--packages=external\`, \`--node-paths\`
- Watch: \`--watch-delay\`, \`--dev\`, \`--run-before-main\`
- 진단: \`--log-limit\`, \`--timing\`
- 플러그인: \`--plugin\`, \`--jobs\`

13개 카테고리로 재정렬하여 가독성 개선.

## Test plan
- [x] Astro/Starlight 빌드 통과 (326 페이지, 링크 검증 OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)