### PR TITLE
feat(codegen): Metro x_facebook_sources function map — contextual name 수집

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -116,6 +116,9 @@ pub const CodegenOptions = struct {
     dev_module_id: ?[]const u8 = null,
     /// import.meta.glob 레코드. codegen이 glob 호출을 객체 리터럴로 직접 출력.
     import_records: []const @import("../bundler/types.zig").ImportRecord = &.{},
+    /// Metro x_facebook_sources function map emit 활성화.
+    /// --platform=react-native 시 자동 활성화 (PR#3).
+    sourcemap_function_map: bool = false,
 };
 
 /// keepNames 엔트리. codegen이 수집하고 emitter가 __name() 호출로 변환.
@@ -132,6 +135,8 @@ const IMPORT_META_NODE_OBJECT = "{url:" ++ IMPORT_META_URL_NODE ++ ",dirname:__d
 
 const SourceMapBuilder = @import("sourcemap.zig").SourceMapBuilder;
 const Mapping = @import("sourcemap.zig").Mapping;
+const FunctionMapBuilder = @import("function_map.zig").FunctionMapBuilder;
+const RangeMapping = @import("function_map.zig").RangeMapping;
 
 pub const Codegen = struct {
     ast: *const Ast,
@@ -167,6 +172,15 @@ pub const Codegen = struct {
     // JSX 필드 제거: Transformer의 jsx_lowering이 JSX → call_expression 변환을 담당.
     // codegen은 더 이상 JSX AST 노드를 처리하지 않음.
 
+    /// Metro function map 빌더 (sourcemap_function_map 활성화 시).
+    fn_map_builder: ?FunctionMapBuilder = null,
+    /// function map 이름 스택. enter 시 push, exit 시 pop. last()가 현재 scope 이름.
+    fn_name_stack: std.ArrayList([]const u8) = .empty,
+    /// 다음 function/arrow/class에 적용할 contextual name.
+    /// parent emit(VariableDeclarator, Assignment, ObjectProperty 등)에서 설정,
+    /// emitFunction/emitArrow/emitClass 진입 시 소비 후 null 로 초기화.
+    pending_fn_name: ?[]const u8 = null,
+
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
     }
@@ -177,6 +191,7 @@ pub const Codegen = struct {
             builder.source_root = options.source_root;
             builder.sources_content = options.sources_content;
         }
+        const fm = if (options.sourcemap_function_map) FunctionMapBuilder.init(allocator) else null;
         return .{
             .ast = ast,
             .allocator = allocator,
@@ -184,6 +199,7 @@ pub const Codegen = struct {
             .options = options,
             .indent_level = 0,
             .sm_builder = sm,
+            .fn_map_builder = fm,
             .gen_line = 0,
             .gen_col = 0,
             // JSX 필드 제거: Transformer가 JSX lowering 담당
@@ -195,6 +211,8 @@ pub const Codegen = struct {
         self.declared_names.deinit(self.allocator);
         self.keep_names_entries.deinit(self.allocator);
         if (self.sm_builder) |*sm| sm.deinit();
+        if (self.fn_map_builder) |*fm| fm.deinit();
+        self.fn_name_stack.deinit(self.allocator);
     }
 
     /// 특정 statement 노드 목록만 코드로 생성한다 (__esm var 호이스팅용).
@@ -221,7 +239,11 @@ pub const Codegen = struct {
 
         // namespace var 중복 제거: top-level 선언 이름 사전 수집
         self.collectTopLevelDeclNames(root);
+
+        // function map: program 진입 시 <global> frame
+        if (self.fn_map_builder != null) try self.fnMapEnter("<global>");
         try self.emitNode(root);
+        if (self.fn_map_builder != null) try self.fnMapExit();
 
         // keepNames: 수집된 entries를 코드 끝에 __name() 호출로 append (복사 없음)
         for (self.keep_names_entries.items) |entry| {
@@ -328,6 +350,16 @@ pub const Codegen = struct {
         return null;
     }
 
+    /// 소스맵 JSON + x_facebook_sources를 함께 생성한다. generate() 후에 호출.
+    /// fn_map_builder가 없으면 generateSourceMap과 동일.
+    pub fn generateSourceMapWithFunctionMap(self: *Codegen, output_file: []const u8) !?[]const u8 {
+        const sm = &(self.sm_builder orelse return null);
+        if (self.fn_map_builder) |*fm| {
+            return try sm.generateJSONWithFunctionMap(self.allocator, output_file, fm);
+        }
+        return try sm.generateJSON(output_file);
+    }
+
     // ================================================================
     // 출력 헬퍼
     // ================================================================
@@ -353,6 +385,166 @@ pub const Codegen = struct {
         } else {
             self.gen_col += 1;
         }
+    }
+
+    // ================================================================
+    // Function Map 도우미
+    // ================================================================
+
+    /// 현재 generated position으로 새 이름 frame에 진입. fn_name_stack push.
+    /// 이름이 바뀔 때만 FunctionMapBuilder.push 호출 (중복 제거는 FunctionMapBuilder가 담당).
+    fn fnMapEnter(self: *Codegen, name: []const u8) !void {
+        if (self.fn_map_builder == null) return;
+        try self.fn_map_builder.?.push(.{
+            .name = name,
+            .line = self.gen_line + 1, // FunctionMapBuilder는 1-based
+            .column = self.gen_col,
+        });
+        try self.fn_name_stack.append(self.allocator, name);
+    }
+
+    /// 현재 generated position으로 frame 종료. fn_name_stack pop 후 부모 이름으로 복귀.
+    fn fnMapExit(self: *Codegen) !void {
+        if (self.fn_map_builder == null) return;
+        if (self.fn_name_stack.items.len == 0) return;
+        _ = self.fn_name_stack.pop();
+        if (self.fn_name_stack.items.len == 0) return;
+        const parent = self.fn_name_stack.items[self.fn_name_stack.items.len - 1];
+        try self.fn_map_builder.?.push(.{
+            .name = parent,
+            .line = self.gen_line + 1,
+            .column = self.gen_col,
+        });
+    }
+
+    /// 노드가 function/arrow/class 인지 확인.
+    fn isFunctionLike(self: *const Codegen, idx: NodeIndex) bool {
+        if (idx.isNone()) return false;
+        return switch (self.ast.getNode(idx).tag) {
+            .function_declaration, .function_expression, .function,
+            .arrow_function_expression,
+            .class_declaration, .class_expression => true,
+            else => false,
+        };
+    }
+
+    /// binding_identifier 노드에서 이름 추출.
+    fn resolveBindingName(self: *const Codegen, idx: NodeIndex) ?[]const u8 {
+        if (idx.isNone()) return null;
+        const n = self.ast.getNode(idx);
+        return switch (n.tag) {
+            .binding_identifier => self.ast.getText(n.data.string_ref),
+            else => null,
+        };
+    }
+
+    /// MemberExpression/identifier의 leaf 이름 추출 (assignment left 용).
+    /// `a.b.c` → "c", `a["str"]` → "str", `a[expr]` → null
+    fn resolveMemberLeafName(self: *const Codegen, idx: NodeIndex) ?[]const u8 {
+        if (idx.isNone()) return null;
+        const n = self.ast.getNode(idx);
+        return switch (n.tag) {
+            .identifier_reference,
+            .assignment_target_identifier,
+            .binding_identifier => self.ast.getText(n.data.string_ref),
+            .static_member_expression => blk: {
+                const e = n.data.extra;
+                if (!self.ast.hasExtra(e, 2)) break :blk null;
+                const property = self.ast.readExtraNode(e, 1);
+                break :blk self.resolveIdentifierText(property);
+            },
+            .computed_member_expression => blk: {
+                const e = n.data.extra;
+                if (!self.ast.hasExtra(e, 2)) break :blk null;
+                const property = self.ast.readExtraNode(e, 1);
+                break :blk self.resolveKeyName(property);
+            },
+            else => null,
+        };
+    }
+
+    /// object/method key 노드에서 이름 추출.
+    /// identifier → 이름, string_literal → 값(따옴표 제거), numeric → 텍스트,
+    /// computed(literal) → 값, computed(expr) → null
+    fn resolveKeyName(self: *const Codegen, idx: NodeIndex) ?[]const u8 {
+        if (idx.isNone()) return null;
+        const n = self.ast.getNode(idx);
+        return switch (n.tag) {
+            .identifier_reference,
+            .binding_identifier,
+            .private_identifier => self.ast.getText(n.data.string_ref),
+            .string_literal => self.resolveStringLiteralValue(n),
+            .numeric_literal => self.ast.getText(n.span),
+            .computed_property_key => blk: {
+                const inner = n.data.unary.operand;
+                if (inner.isNone()) break :blk null;
+                const inner_n = self.ast.getNode(inner);
+                // 리터럴만 이름으로 사용 (변수 참조는 런타임 값 → anonymous)
+                break :blk switch (inner_n.tag) {
+                    .string_literal => self.resolveStringLiteralValue(inner_n),
+                    .numeric_literal => self.ast.getText(inner_n.span),
+                    else => null,
+                };
+            },
+            else => null,
+        };
+    }
+
+    fn resolveIdentifierText(self: *const Codegen, idx: NodeIndex) ?[]const u8 {
+        if (idx.isNone()) return null;
+        const n = self.ast.getNode(idx);
+        return switch (n.tag) {
+            .identifier_reference,
+            .binding_identifier,
+            .private_identifier => self.ast.getText(n.data.string_ref),
+            else => null,
+        };
+    }
+
+    /// string_literal 노드에서 따옴표를 제거한 값 반환.
+    fn resolveStringLiteralValue(self: *const Codegen, n: Node) ?[]const u8 {
+        const text = self.ast.getText(n.span);
+        return if (text.len >= 2) text[1 .. text.len - 1] else null;
+    }
+
+    /// fn_name_stack top (현재 class 이름). <global>/<anonymous> 이면 null.
+    fn resolveParentClassName(self: *const Codegen) ?[]const u8 {
+        const stack = self.fn_name_stack.items;
+        if (stack.len == 0) return null;
+        const top = stack[stack.len - 1];
+        if (std.mem.eql(u8, top, "<global>") or std.mem.eql(u8, top, "<anonymous>")) return null;
+        return top;
+    }
+
+    /// method_definition 키 + flags → Metro 스타일 이름 생성.
+    /// getter → "get__name", setter → "set__name", constructor → class 이름.
+    /// 부모 class 이름이 있으면 "ClassName#method" / "ClassName.method" 형태.
+    fn resolveMethodName(self: *Codegen, key: NodeIndex, flags: u32) ![]const u8 {
+        const is_getter = flags & 0x02 != 0;
+        const is_setter = flags & 0x04 != 0;
+        const is_static = flags & 0x01 != 0;
+
+        // constructor → 부모 class 이름
+        if (self.resolveKeyName(key)) |k| {
+            if (std.mem.eql(u8, k, "constructor")) {
+                return self.resolveParentClassName() orelse "constructor";
+            }
+        }
+
+        const raw = self.resolveKeyName(key) orelse "<anonymous>";
+
+        const method_name: []const u8 = if (is_getter)
+            try std.fmt.allocPrint(self.allocator, "get__{s}", .{raw})
+        else if (is_setter)
+            try std.fmt.allocPrint(self.allocator, "set__{s}", .{raw})
+        else
+            raw;
+
+        if (self.resolveParentClassName()) |class_name| {
+            const sep: []const u8 = if (is_static) "." else "#";
+            return std.fmt.allocPrint(self.allocator, "{s}{s}{s}", .{ class_name, sep, method_name });
+        }
+        return method_name;
     }
 
     /// 소스맵 매핑 추가. 노드의 소스 span과 현재 출력 위치를 매핑.
@@ -1294,7 +1486,19 @@ pub const Codegen = struct {
             try self.writeByte('=');
         }
         try self.writeSpace();
-        try self.emitNode(node.data.binary.right);
+        const right = node.data.binary.right;
+        // contextual name: 단순 할당(=)이고 오른쪽이 function-like → left leaf 이름 사용.
+        // flags == 0: 트랜스포머 합성 = 노드, flags == Kind.eq: 파서 생성 = 노드.
+        const is_simple_assign = node.data.binary.flags == 0 or
+            @as(Kind, @enumFromInt(node.data.binary.flags)) == .eq;
+        if (self.fn_map_builder != null and is_simple_assign and self.isFunctionLike(right)) {
+            const saved = self.pending_fn_name;
+            self.pending_fn_name = self.resolveMemberLeafName(node.data.binary.left);
+            try self.emitNode(right);
+            self.pending_fn_name = saved;
+        } else {
+            try self.emitNode(right);
+        }
     }
 
     fn emitConditional(self: *Codegen, node: Node) !void {
@@ -1404,7 +1608,15 @@ pub const Codegen = struct {
             } else {
                 try self.write(": ");
             }
-            try self.emitNode(value);
+            // contextual name: 값이 function-like → key 이름 사용
+            if (self.fn_map_builder != null and self.isFunctionLike(value)) {
+                const saved = self.pending_fn_name;
+                self.pending_fn_name = self.resolveKeyName(key);
+                try self.emitNode(value);
+                self.pending_fn_name = saved;
+            } else {
+                try self.emitNode(value);
+            }
         }
     }
 
@@ -1852,6 +2064,20 @@ pub const Codegen = struct {
         const body: NodeIndex = @enumFromInt(extras[3]);
         const flags = extras[4];
 
+        // function map: contextual name 소비 후 진입
+        const saved_pending = self.pending_fn_name;
+        self.pending_fn_name = null;
+        if (self.fn_map_builder != null) {
+            const fn_name: []const u8 = if (!name.isNone())
+                self.ast.getText(self.ast.getNode(name).data.string_ref)
+            else
+                saved_pending orelse "<anonymous>";
+            try self.fnMapEnter(fn_name);
+        }
+        defer if (self.fn_map_builder != null) {
+            self.fnMapExit() catch {};
+        };
+
         // strict execution order: function declaration → 할당식으로 변환.
         // `function foo() {...}` → `foo = function() {...};`
         // var foo; 선언은 esm_wrap에서 hoisted_var_names로 이미 top-level에 배치됨.
@@ -1892,6 +2118,16 @@ pub const Codegen = struct {
         const body: NodeIndex = @enumFromInt(extras[e + 1]);
         const flags = extras[e + 2];
 
+        // function map: 화살표 함수는 항상 익명 — contextual name 사용
+        const saved_pending = self.pending_fn_name;
+        self.pending_fn_name = null;
+        if (self.fn_map_builder != null) {
+            try self.fnMapEnter(saved_pending orelse "<anonymous>");
+        }
+        defer if (self.fn_map_builder != null) {
+            self.fnMapExit() catch {};
+        };
+
         if (flags & 0x01 != 0) try self.write("async ");
 
         // params 출력 — esbuild 호환: 항상 괄호로 감싸기 (단일 파라미터도 괄호 추가)
@@ -1925,6 +2161,20 @@ pub const Codegen = struct {
         const body: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
         const deco_start = self.ast.extra_data.items[e + 6];
         const deco_len = self.ast.extra_data.items[e + 7];
+
+        // function map: class도 frame (Metro는 Class를 Function처럼 처리)
+        const saved_pending = self.pending_fn_name;
+        self.pending_fn_name = null;
+        if (self.fn_map_builder != null) {
+            const class_name: []const u8 = if (!name.isNone())
+                self.ast.getText(self.ast.getNode(name).data.string_ref)
+            else
+                saved_pending orelse "<anonymous>";
+            try self.fnMapEnter(class_name);
+        }
+        defer if (self.fn_map_builder != null) {
+            self.fnMapExit() catch {};
+        };
 
         // class는 block-scoped → __esm 콜백 밖 __export getter가 접근 불가.
         // variable_declaration과 동일하게 할당문으로 변환. (emitter가 var 선언을 밖에 배치)
@@ -1999,6 +2249,15 @@ pub const Codegen = struct {
         const deco_start = extras[5];
         const deco_len = extras[6];
 
+        // function map: ClassName#method / ClassName.method / get__name / set__name
+        if (self.fn_map_builder != null) {
+            const method_name = try self.resolveMethodName(key, flags);
+            try self.fnMapEnter(method_name);
+        }
+        defer if (self.fn_map_builder != null) {
+            self.fnMapExit() catch {};
+        };
+
         try self.emitMemberDecorators(deco_start, deco_len);
 
         // flags: bit0=static, bit1=getter, bit2=setter, bit3=async, bit4=generator(*)
@@ -2036,7 +2295,15 @@ pub const Codegen = struct {
             try self.writeSpace();
             try self.writeByte('=');
             try self.writeSpace();
-            try self.emitNode(value);
+            // contextual name: class property = function-like → key 이름 사용
+            if (self.fn_map_builder != null and self.isFunctionLike(value)) {
+                const saved = self.pending_fn_name;
+                self.pending_fn_name = self.resolveKeyName(key);
+                try self.emitNode(value);
+                self.pending_fn_name = saved;
+            } else {
+                try self.emitNode(value);
+            }
         }
         try self.writeByte(';');
     }
@@ -2207,7 +2474,15 @@ pub const Codegen = struct {
             try self.writeSpace();
             try self.writeByte('=');
             try self.writeSpace();
-            try self.emitNode(init_val);
+            // contextual name: binding_identifier = function/arrow/class → 변수명을 이름으로
+            if (self.fn_map_builder != null and self.isFunctionLike(init_val)) {
+                const saved = self.pending_fn_name;
+                self.pending_fn_name = self.resolveBindingName(name);
+                try self.emitNode(init_val);
+                self.pending_fn_name = saved;
+            } else {
+                try self.emitNode(init_val);
+            }
         }
     }
 
@@ -2727,7 +3002,15 @@ pub const Codegen = struct {
         }
         try self.write("export default ");
         const inner_idx = node.data.unary.operand;
-        try self.emitNode(inner_idx);
+        // contextual name: 익명 function/arrow/class → "default"
+        if (self.fn_map_builder != null and self.isFunctionLike(inner_idx)) {
+            const saved = self.pending_fn_name;
+            self.pending_fn_name = "default";
+            try self.emitNode(inner_idx);
+            self.pending_fn_name = saved;
+        } else {
+            try self.emitNode(inner_idx);
+        }
         // class/function 선언 뒤에는 세미콜론 불필요
         if (!inner_idx.isNone()) {
             const inner_tag = self.ast.getNode(inner_idx).tag;

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -421,9 +421,7 @@ pub const Codegen = struct {
     fn isFunctionLike(self: *const Codegen, idx: NodeIndex) bool {
         if (idx.isNone()) return false;
         return switch (self.ast.getNode(idx).tag) {
-            .function_declaration, .function_expression, .function,
-            .arrow_function_expression,
-            .class_declaration, .class_expression => true,
+            .function_declaration, .function_expression, .function, .arrow_function_expression, .class_declaration, .class_expression => true,
             else => false,
         };
     }
@@ -444,9 +442,7 @@ pub const Codegen = struct {
         if (idx.isNone()) return null;
         const n = self.ast.getNode(idx);
         return switch (n.tag) {
-            .identifier_reference,
-            .assignment_target_identifier,
-            .binding_identifier => self.ast.getText(n.data.string_ref),
+            .identifier_reference, .assignment_target_identifier, .binding_identifier => self.ast.getText(n.data.string_ref),
             .static_member_expression => blk: {
                 const e = n.data.extra;
                 if (!self.ast.hasExtra(e, 2)) break :blk null;
@@ -470,9 +466,7 @@ pub const Codegen = struct {
         if (idx.isNone()) return null;
         const n = self.ast.getNode(idx);
         return switch (n.tag) {
-            .identifier_reference,
-            .binding_identifier,
-            .private_identifier => self.ast.getText(n.data.string_ref),
+            .identifier_reference, .binding_identifier, .private_identifier => self.ast.getText(n.data.string_ref),
             .string_literal => self.resolveStringLiteralValue(n),
             .numeric_literal => self.ast.getText(n.span),
             .computed_property_key => blk: {
@@ -494,9 +488,7 @@ pub const Codegen = struct {
         if (idx.isNone()) return null;
         const n = self.ast.getNode(idx);
         return switch (n.tag) {
-            .identifier_reference,
-            .binding_identifier,
-            .private_identifier => self.ast.getText(n.data.string_ref),
+            .identifier_reference, .binding_identifier, .private_identifier => self.ast.getText(n.data.string_ref),
             else => null,
         };
     }

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -515,28 +515,34 @@ pub const Codegen = struct {
         const is_getter = flags & 0x02 != 0;
         const is_setter = flags & 0x04 != 0;
         const is_static = flags & 0x01 != 0;
-
-        // constructor → 부모 class 이름
-        if (self.resolveKeyName(key)) |k| {
-            if (std.mem.eql(u8, k, "constructor")) {
-                return self.resolveParentClassName() orelse "constructor";
-            }
-        }
+        const sep: []const u8 = if (is_static) "." else "#";
 
         const raw = self.resolveKeyName(key) orelse "<anonymous>";
 
-        const method_name: []const u8 = if (is_getter)
-            try std.fmt.allocPrint(self.allocator, "get__{s}", .{raw})
-        else if (is_setter)
-            try std.fmt.allocPrint(self.allocator, "set__{s}", .{raw})
+        // constructor → 부모 class 이름
+        if (std.mem.eql(u8, raw, "constructor")) {
+            return self.resolveParentClassName() orelse "constructor";
+        }
+
+        const class_name = self.resolveParentClassName();
+
+        if (is_getter) {
+            return if (class_name) |cn|
+                std.fmt.allocPrint(self.allocator, "{s}{s}get__{s}", .{ cn, sep, raw })
+            else
+                std.fmt.allocPrint(self.allocator, "get__{s}", .{raw});
+        }
+        if (is_setter) {
+            return if (class_name) |cn|
+                std.fmt.allocPrint(self.allocator, "{s}{s}set__{s}", .{ cn, sep, raw })
+            else
+                std.fmt.allocPrint(self.allocator, "set__{s}", .{raw});
+        }
+        // 일반 메서드: class 컨텍스트 없으면 기존 슬라이스 그대로 반환 (할당 불필요)
+        return if (class_name) |cn|
+            std.fmt.allocPrint(self.allocator, "{s}{s}{s}", .{ cn, sep, raw })
         else
             raw;
-
-        if (self.resolveParentClassName()) |class_name| {
-            const sep: []const u8 = if (is_static) "." else "#";
-            return std.fmt.allocPrint(self.allocator, "{s}{s}{s}", .{ class_name, sep, method_name });
-        }
-        return method_name;
     }
 
     /// 소스맵 매핑 추가. 노드의 소스 span과 현재 출력 위치를 매핑.
@@ -2067,7 +2073,7 @@ pub const Codegen = struct {
             try self.fnMapEnter(fn_name);
         }
         defer if (self.fn_map_builder != null) {
-            self.fnMapExit() catch {};
+            self.fnMapExit() catch {}; // defer는 오류 전파 불가 — OOM 시 상위 emit이 이미 실패했으므로 무시
         };
 
         // strict execution order: function declaration → 할당식으로 변환.
@@ -2117,7 +2123,7 @@ pub const Codegen = struct {
             try self.fnMapEnter(saved_pending orelse "<anonymous>");
         }
         defer if (self.fn_map_builder != null) {
-            self.fnMapExit() catch {};
+            self.fnMapExit() catch {}; // defer는 오류 전파 불가 — OOM 시 상위 emit이 이미 실패했으므로 무시
         };
 
         if (flags & 0x01 != 0) try self.write("async ");
@@ -2165,7 +2171,7 @@ pub const Codegen = struct {
             try self.fnMapEnter(class_name);
         }
         defer if (self.fn_map_builder != null) {
-            self.fnMapExit() catch {};
+            self.fnMapExit() catch {}; // defer는 오류 전파 불가 — OOM 시 상위 emit이 이미 실패했으므로 무시
         };
 
         // class는 block-scoped → __esm 콜백 밖 __export getter가 접근 불가.
@@ -2247,7 +2253,7 @@ pub const Codegen = struct {
             try self.fnMapEnter(method_name);
         }
         defer if (self.fn_map_builder != null) {
-            self.fnMapExit() catch {};
+            self.fnMapExit() catch {}; // defer는 오류 전파 불가 — OOM 시 상위 emit이 이미 실패했으므로 무시
         };
 
         try self.emitMemberDecorators(deco_start, deco_len);

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -10,6 +10,7 @@
 //   flow.zig               — Flow 타입 스트리핑
 //   engine_jsx.zig         — 엔진 타겟 + JSX 런타임 모드
 //   private_jsx_advanced.zig — private method, JSX text/dev/auto, ES2025
+//   function_map.zig       — Metro x_facebook_sources function map E2E 테스트
 
 comptime {
     _ = @import("codegen_test/helpers.zig");
@@ -22,4 +23,5 @@ comptime {
     _ = @import("codegen_test/engine_jsx.zig");
     _ = @import("codegen_test/private_jsx_advanced.zig");
     _ = @import("codegen_test/decorator.zig");
+    _ = @import("codegen_test/function_map.zig");
 }

--- a/src/codegen/codegen_test/function_map.zig
+++ b/src/codegen/codegen_test/function_map.zig
@@ -1,0 +1,128 @@
+//! function map 수집 통합 테스트.
+//! Codegen의 sourcemap_function_map 옵션 활성화 시
+//! x_facebook_sources JSON 구조와 contextual name을 검증한다.
+
+const std = @import("std");
+const h = @import("helpers.zig");
+const Codegen = h.Codegen;
+const Scanner = h.Scanner;
+const Parser = h.Scanner; // 사용 안 함
+const FunctionMapBuilder = @import("../function_map.zig").FunctionMapBuilder;
+
+/// function map 활성화 e2e: x_facebook_sources JSON 반환.
+fn e2eFunctionMap(backing_allocator: std.mem.Allocator, source: []const u8) !struct {
+    json: []const u8,
+    arena: std.heap.ArenaAllocator,
+} {
+    const helpers = @import("helpers.zig");
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
+    const allocator = arena.allocator();
+
+    var scanner = try helpers.Scanner.init(allocator, source);
+    var parser = @import("../../parser/parser.zig").Parser.init(allocator, &scanner);
+    parser.configureFromExtension(".ts");
+    _ = try parser.parse();
+
+    var t = try helpers.Transformer.init(allocator, &parser.ast, .{});
+    const root = try t.transform();
+
+    var cg = Codegen.initWithOptions(allocator, &t.ast, .{
+        .sourcemap = true,
+        .sourcemap_function_map = true,
+    });
+    cg.line_offsets = scanner.line_offsets.items;
+    try cg.addSourceFile("input.ts");
+    _ = try cg.generate(root);
+    const json = try cg.generateSourceMapWithFunctionMap("output.js") orelse "";
+    return .{ .json = json, .arena = arena };
+}
+
+test "function_map: function declaration — self name" {
+    var r = try e2eFunctionMap(std.testing.allocator, "function foo() {}");
+    defer r.arena.deinit();
+    // x_facebook_sources 존재
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "x_facebook_sources") != null);
+    // names에 <global>, foo 존재
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"<global>\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"foo\"") != null);
+}
+
+test "function_map: arrow function with variable contextual name" {
+    var r = try e2eFunctionMap(std.testing.allocator, "const bar = () => {};");
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"bar\"") != null);
+}
+
+test "function_map: assignment contextual name — member leaf" {
+    var r = try e2eFunctionMap(std.testing.allocator, "obj.render = function() {};");
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"render\"") != null);
+}
+
+test "function_map: object property contextual name" {
+    var r = try e2eFunctionMap(std.testing.allocator, "const o = { handleClick: () => {} };");
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"handleClick\"") != null);
+}
+
+test "function_map: class method — ClassName#method" {
+    var r = try e2eFunctionMap(std.testing.allocator, "class MyComp { render() {} }");
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"MyComp\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"MyComp#render\"") != null);
+}
+
+test "function_map: static method — ClassName.method" {
+    var r = try e2eFunctionMap(std.testing.allocator, "class Foo { static create() {} }");
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"Foo.create\"") != null);
+}
+
+test "function_map: getter/setter — get__name / set__name" {
+    var r = try e2eFunctionMap(std.testing.allocator, "class A { get value() {} set value(v) {} }");
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"A#get__value\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"A#set__value\"") != null);
+}
+
+test "function_map: export default anonymous function — default" {
+    var r = try e2eFunctionMap(std.testing.allocator, "export default function() {}");
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"default\"") != null);
+}
+
+test "function_map: string key property" {
+    var r = try e2eFunctionMap(std.testing.allocator,
+        \\const o = { "onClick": () => {} };
+    );
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"onClick\"") != null);
+}
+
+test "function_map: computed non-literal key — anonymous" {
+    var r = try e2eFunctionMap(std.testing.allocator, "const o = { [expr]: () => {} };");
+    defer r.arena.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.json, "\"<anonymous>\"") != null);
+}
+
+test "function_map: sourcemap_function_map=false — no x_facebook_sources" {
+    // 옵션 비활성화 시 x_facebook_sources 미포함
+    const helpers = @import("helpers.zig");
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var scanner = try helpers.Scanner.init(allocator, "function foo() {}");
+    var parser = @import("../../parser/parser.zig").Parser.init(allocator, &scanner);
+    parser.configureFromExtension(".ts");
+    _ = try parser.parse();
+    var t = try helpers.Transformer.init(allocator, &parser.ast, .{});
+    const root = try t.transform();
+    var cg = Codegen.initWithOptions(allocator, &t.ast, .{ .sourcemap = true });
+    cg.line_offsets = scanner.line_offsets.items;
+    try cg.addSourceFile("input.ts");
+    _ = try cg.generate(root);
+    const json = try cg.generateSourceMap("output.js") orelse "";
+    try std.testing.expect(std.mem.indexOf(u8, json, "x_facebook_sources") == null);
+}

--- a/src/codegen/codegen_test/function_map.zig
+++ b/src/codegen/codegen_test/function_map.zig
@@ -6,7 +6,6 @@ const std = @import("std");
 const h = @import("helpers.zig");
 const Codegen = h.Codegen;
 const Scanner = h.Scanner;
-const Parser = h.Scanner; // 사용 안 함
 const FunctionMapBuilder = @import("../function_map.zig").FunctionMapBuilder;
 
 /// function map 활성화 e2e: x_facebook_sources JSON 반환.
@@ -14,17 +13,16 @@ fn e2eFunctionMap(backing_allocator: std.mem.Allocator, source: []const u8) !str
     json: []const u8,
     arena: std.heap.ArenaAllocator,
 } {
-    const helpers = @import("helpers.zig");
     var arena = std.heap.ArenaAllocator.init(backing_allocator);
     errdefer arena.deinit();
     const allocator = arena.allocator();
 
-    var scanner = try helpers.Scanner.init(allocator, source);
-    var parser = @import("../../parser/parser.zig").Parser.init(allocator, &scanner);
+    var scanner = try Scanner.init(allocator, source);
+    var parser = h.Parser.init(allocator, &scanner);
     parser.configureFromExtension(".ts");
     _ = try parser.parse();
 
-    var t = try helpers.Transformer.init(allocator, &parser.ast, .{});
+    var t = try h.Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
 
     var cg = Codegen.initWithOptions(allocator, &t.ast, .{
@@ -108,16 +106,15 @@ test "function_map: computed non-literal key — anonymous" {
 
 test "function_map: sourcemap_function_map=false — no x_facebook_sources" {
     // 옵션 비활성화 시 x_facebook_sources 미포함
-    const helpers = @import("helpers.zig");
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    var scanner = try helpers.Scanner.init(allocator, "function foo() {}");
-    var parser = @import("../../parser/parser.zig").Parser.init(allocator, &scanner);
+    var scanner = try Scanner.init(allocator, "function foo() {}");
+    var parser = h.Parser.init(allocator, &scanner);
     parser.configureFromExtension(".ts");
     _ = try parser.parse();
-    var t = try helpers.Transformer.init(allocator, &parser.ast, .{});
+    var t = try h.Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
     var cg = Codegen.initWithOptions(allocator, &t.ast, .{ .sourcemap = true });
     cg.line_offsets = scanner.line_offsets.items;

--- a/src/codegen/function_map.zig
+++ b/src/codegen/function_map.zig
@@ -46,6 +46,8 @@ pub const FunctionMapBuilder = struct {
     last_line: i32 = 1, // Metro: new RelativeValue(1)
     last_column: i32 = 0,
     last_name_index: i32 = 0,
+    /// 마지막으로 emit된 이름. 연속으로 동일 이름 push 시 중복 제거 (Metro advanceToPos 패턴).
+    last_pushed_name: ?[]const u8 = null,
 
     pub fn init(allocator: std.mem.Allocator) FunctionMapBuilder {
         return .{ .allocator = allocator };
@@ -63,6 +65,11 @@ pub const FunctionMapBuilder = struct {
     /// 같은 위치에 동일 이름을 연속으로 push 하는 호출은 호출자가 미리 필터링해야 한다
     /// (Metro 도 top-of-stack name 비교로 중복을 막는다).
     pub fn push(self: *FunctionMapBuilder, mapping: RangeMapping) !void {
+        // 연속으로 동일 이름이면 스킵 (Metro advanceToPos: name !== tailName 체크와 동일).
+        if (self.last_pushed_name) |last| {
+            if (std.mem.eql(u8, last, mapping.name)) return;
+        }
+        self.last_pushed_name = mapping.name;
         const name_index = try self.internName(mapping.name);
 
         const new_line: i32 = @intCast(mapping.line);
@@ -165,14 +172,26 @@ test "two segments same line — AAA,UC" {
     try std.testing.expectEqualStrings("foo", names[1]);
 }
 
-test "name dedup — second push of same name reuses index" {
+test "name dedup — consecutive same name push is skipped" {
+    // 연속 동일 이름은 중복 매핑을 방지한다 (Metro advanceToPos 패턴).
     var b = FunctionMapBuilder.init(std.testing.allocator);
     defer b.deinit();
     try b.push(.{ .name = "foo", .line = 1, .column = 0 });
-    try b.push(.{ .name = "foo", .line = 1, .column = 5 });
+    try b.push(.{ .name = "foo", .line = 1, .column = 5 }); // 동일 이름 → 스킵
     try std.testing.expectEqual(@as(usize, 1), b.namesSlice().len);
-    // name_delta=0 → "AAA" + "," + VLQ(5)="K" + VLQ(0)="A" = "AAA,KA"
-    try std.testing.expectEqualStrings("AAA,KA", b.mappingsSlice());
+    try std.testing.expectEqualStrings("AAA", b.mappingsSlice());
+}
+
+test "name dedup — non-consecutive same name reuses names index" {
+    // <global>@L1,0 → foo@L1,5 → <global>@L1,15: names에 중복 없음
+    // 세그먼트3: col_delta=10→"U", name_delta=-1→VLQ(-1)=(1<<1)|1=3→"D" → ",UD"
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
+    try b.push(.{ .name = "foo", .line = 1, .column = 5 });
+    try b.push(.{ .name = "<global>", .line = 1, .column = 15 });
+    try std.testing.expectEqual(@as(usize, 2), b.namesSlice().len);
+    try std.testing.expectEqualStrings("AAA,KC,UD", b.mappingsSlice());
 }
 
 test "new line — semicolon + 3-field with line_delta" {

--- a/src/codegen/function_map.zig
+++ b/src/codegen/function_map.zig
@@ -30,21 +30,22 @@ pub const RangeMapping = struct {
 ///
 /// Metro `MappingEncoder` 의 Zig 포팅. 이름을 중복 제거하며 `push()` 호출이
 /// 증가 순서 (line asc, then column asc) 임을 가정한다 — Metro도 동일.
+///
+/// 소유권: `push()`에 전달하는 `name` 슬라이스는 빌더 생존 기간 동안
+/// 호출자가 소유해야 한다. 빌더는 이름을 복사하지 않고 참조만 저장한다.
 pub const FunctionMapBuilder = struct {
     allocator: std.mem.Allocator,
     /// 등장 순 이름 목록.
     names: std.ArrayList([]const u8) = .empty,
-    /// 이름 → names 인덱스 (중복 제거).
+    /// 이름 → names 인덱스 (중복 제거). 키는 외부 소유 슬라이스 참조.
     names_map: std.StringHashMapUnmanaged(u32) = .empty,
     /// VLQ mappings 버퍼.
     mappings: std.ArrayList(u8) = .empty,
 
     // RelativeValue 들 — 상대값 인코딩용.
-    last_line: i32 = 1, // 초기값 1 (Metro: new RelativeValue(1))
+    last_line: i32 = 1, // Metro: new RelativeValue(1)
     last_column: i32 = 0,
     last_name_index: i32 = 0,
-    /// 현재 라인에 이미 세그먼트를 쓴 적이 있는지. false면 다음 push 는 first-of-line.
-    has_segment_on_line: bool = false,
 
     pub fn init(allocator: std.mem.Allocator) FunctionMapBuilder {
         return .{ .allocator = allocator };
@@ -68,18 +69,17 @@ pub const FunctionMapBuilder = struct {
         const line_delta: i32 = new_line - self.last_line;
         self.last_line = new_line;
 
+        // 첫 세그먼트이거나 라인이 바뀐 경우 — first-of-line (3필드 인코딩).
         const first_of_line = self.mappings.items.len == 0 or line_delta > 0;
 
         if (line_delta > 0) {
-            // 라인 구분자 1개만 출력, 실제 라인 차이는 line_delta 필드로 전달됨.
+            // 세미콜론 1개 — 실제 라인 차이는 line_delta 필드로 전달.
             try self.mappings.append(self.allocator, ';');
             self.last_column = 0;
-        } else if (self.has_segment_on_line) {
-            // 같은 라인의 뒤 세그먼트 — 콤마 구분.
+        } else if (!first_of_line) {
             try self.mappings.append(self.allocator, ',');
         }
 
-        // [col_delta, name_delta] 공통.
         const new_column: i32 = @intCast(mapping.column);
         const col_delta = new_column - self.last_column;
         self.last_column = new_column;
@@ -92,11 +92,8 @@ pub const FunctionMapBuilder = struct {
         try sourcemap.encodeVLQ(self.allocator, &self.mappings, name_delta);
 
         if (first_of_line) {
-            // 세 번째 필드: 실제 라인 델타.
             try sourcemap.encodeVLQ(self.allocator, &self.mappings, line_delta);
         }
-
-        self.has_segment_on_line = true;
     }
 
     /// 현재까지의 mappings 를 반환. 소유권은 빌더에 남는다.
@@ -111,15 +108,15 @@ pub const FunctionMapBuilder = struct {
 
     /// JSON 직렬화: `{"names":[...],"mappings":"..."}` 를 `buf` 에 추가한다.
     /// sources 배열 외부 구조 (x_facebook_sources 전체 배열) 는 호출자가 감싼다.
-    pub fn appendJson(self: *const FunctionMapBuilder, allocator: std.mem.Allocator, buf: *std.ArrayList(u8)) !void {
-        try buf.appendSlice(allocator, "{\"names\":[");
+    pub fn appendJson(self: *const FunctionMapBuilder, buf: *std.ArrayList(u8)) !void {
+        try buf.appendSlice(self.allocator, "{\"names\":[");
         for (self.names.items, 0..) |n, i| {
-            if (i > 0) try buf.append(allocator, ',');
-            try appendJsonString(allocator, buf, n);
+            if (i > 0) try buf.append(self.allocator, ',');
+            try sourcemap.appendJsonStringTo(self.allocator, buf, n);
         }
-        try buf.appendSlice(allocator, "],\"mappings\":\"");
-        try buf.appendSlice(allocator, self.mappings.items);
-        try buf.appendSlice(allocator, "\"}");
+        try buf.appendSlice(self.allocator, "],\"mappings\":\"");
+        try buf.appendSlice(self.allocator, self.mappings.items);
+        try buf.appendSlice(self.allocator, "\"}");
     }
 
     fn internName(self: *FunctionMapBuilder, name: []const u8) !u32 {
@@ -133,30 +130,6 @@ pub const FunctionMapBuilder = struct {
     }
 };
 
-fn appendJsonString(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), s: []const u8) !void {
-    try buf.append(allocator, '"');
-    for (s) |c| {
-        switch (c) {
-            '"' => try buf.appendSlice(allocator, "\\\""),
-            '\\' => try buf.appendSlice(allocator, "\\\\"),
-            '\n' => try buf.appendSlice(allocator, "\\n"),
-            '\r' => try buf.appendSlice(allocator, "\\r"),
-            '\t' => try buf.appendSlice(allocator, "\\t"),
-            else => {
-                if (c < 0x20) {
-                    try buf.appendSlice(allocator, "\\u00");
-                    const hex = "0123456789abcdef";
-                    try buf.append(allocator, hex[c >> 4]);
-                    try buf.append(allocator, hex[c & 0x0f]);
-                } else {
-                    try buf.append(allocator, c);
-                }
-            },
-        }
-    }
-    try buf.append(allocator, '"');
-}
-
 // ============================================================
 // Tests — Metro MappingEncoder 의 동작을 trace 하여 기대값 고정.
 // ============================================================
@@ -169,8 +142,9 @@ test "empty builder produces empty mappings and names" {
 }
 
 test "first push on line 1 col 0 — AAA (col=0, name=0, line_delta=0)" {
-    // Metro: new RelativeValue(1) 초기. push line=1 → lineDelta=0 → firstOfLine(pos==0)
-    // startSegment(0) → append VLQ(0)="A", append name(0)="A", append lineDelta(0)="A"
+    // Metro RelativeValue 초기: line=1, col=0, name=0.
+    // push(line=1) → line_delta=0, first_of_line(len==0) → 3필드
+    // VLQ(0)+VLQ(0)+VLQ(0) = "AAA"
     var b = FunctionMapBuilder.init(std.testing.allocator);
     defer b.deinit();
     try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
@@ -178,10 +152,9 @@ test "first push on line 1 col 0 — AAA (col=0, name=0, line_delta=0)" {
     try std.testing.expectEqualStrings("<global>", b.namesSlice()[0]);
 }
 
-test "two segments same line different name — AAA,UC" {
-    // push(<global>, 1, 0) → "AAA"
-    // push(foo, 1, 10): line_delta=0, firstOfLine=false (has segment)
-    //   → "," + VLQ(10)="U" + VLQ(1)="C" → ",UC"
+test "two segments same line — AAA,UC" {
+    // push(<global>,1,0) → "AAA"
+    // push(foo,1,10): line_delta=0, not first → "," + VLQ(10)="U" + VLQ(1)="C"
     var b = FunctionMapBuilder.init(std.testing.allocator);
     defer b.deinit();
     try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
@@ -197,18 +170,14 @@ test "name dedup — second push of same name reuses index" {
     defer b.deinit();
     try b.push(.{ .name = "foo", .line = 1, .column = 0 });
     try b.push(.{ .name = "foo", .line = 1, .column = 5 });
-    // names 에 "foo" 하나뿐.
     try std.testing.expectEqual(@as(usize, 1), b.namesSlice().len);
-    // 두 번째 세그먼트의 name_delta = 0.
-    // "AAA" + "," + VLQ(5)="K" + VLQ(0)="A" → "AAA,KA"
+    // name_delta=0 → "AAA" + "," + VLQ(5)="K" + VLQ(0)="A" = "AAA,KA"
     try std.testing.expectEqualStrings("AAA,KA", b.mappingsSlice());
 }
 
-test "new line — semicolon + first-of-line 3-field segment with line_delta" {
-    // push(<global>, 1, 0) → "AAA"
-    // push(foo, 3, 2): line_delta=2, firstOfLine=true
-    //   → ";" (single, regardless of line diff) + VLQ(2)="E" + VLQ(1)="C" + VLQ(2)="E"
-    //   → ";ECE"
+test "new line — semicolon + 3-field with line_delta" {
+    // push(<global>,1,0) → "AAA"
+    // push(foo,3,2): line_delta=2 → ";" + VLQ(2)="E" + VLQ(1)="C" + VLQ(2)="E"
     var b = FunctionMapBuilder.init(std.testing.allocator);
     defer b.deinit();
     try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
@@ -217,9 +186,9 @@ test "new line — semicolon + first-of-line 3-field segment with line_delta" {
 }
 
 test "new line resets column delta base to 0" {
-    // push(<global>, 1, 0) → "AAA"
-    // push(foo, 2, 5): line_delta=1, col resets to 0 → col_delta=5
-    //   → ";" + VLQ(5)="K" + VLQ(1)="C" + VLQ(1)="C" → ";KCC"
+    // push(<global>,1,0) → "AAA"
+    // push(foo,2,5): line_delta=1, col resets → col_delta=5
+    //   → ";" + VLQ(5)="K" + VLQ(1)="C" + VLQ(1)="C" = ";KCC"
     var b = FunctionMapBuilder.init(std.testing.allocator);
     defer b.deinit();
     try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
@@ -235,7 +204,7 @@ test "appendJson serializes names and mappings" {
 
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try b.appendJson(std.testing.allocator, &buf);
+    try b.appendJson(&buf);
     try std.testing.expectEqualStrings(
         "{\"names\":[\"<global>\",\"foo\"],\"mappings\":\"AAA,UC\"}",
         buf.items,
@@ -243,24 +212,21 @@ test "appendJson serializes names and mappings" {
 }
 
 test "appendJson escapes special characters in names" {
-    // 이름에 따옴표/백슬래시가 섞인 경우 (eval 함수 이름 등 이론적 케이스).
     var b = FunctionMapBuilder.init(std.testing.allocator);
     defer b.deinit();
     try b.push(.{ .name = "a\"b", .line = 1, .column = 0 });
 
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try b.appendJson(std.testing.allocator, &buf);
+    try b.appendJson(&buf);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"a\\\"b\"") != null);
 }
 
 test "multiple lines with multiple segments" {
-    // L1: <global>@0   → "AAA"
-    // L1: foo@5        → ",KC"  (col_delta=5, name_delta=+1, 2필드)
-    // L2: bar@0        → new line → last_column 리셋 0, col_delta=0-0=0
-    //   → ";" + VLQ(0)="A" + VLQ(+1)="C" + VLQ(line_delta=1)="C"
-    //   → ";ACC"
-    // 기대: "AAA,KC;ACC"
+    // push(<global>,1,0) → "AAA"
+    // push(foo,1,5): same line → ",KC"  (col=5→VLQ"K", name+1→VLQ"C")
+    // push(bar,2,0): new line → last_column 리셋 0, col_delta=0
+    //   → ";" + VLQ(0)="A" + VLQ(1)="C" + VLQ(1)="C" = ";ACC"
     var b = FunctionMapBuilder.init(std.testing.allocator);
     defer b.deinit();
     try b.push(.{ .name = "<global>", .line = 1, .column = 0 });

--- a/src/codegen/function_map.zig
+++ b/src/codegen/function_map.zig
@@ -1,0 +1,270 @@
+//! Metro-compatible Function Map encoder (`x_facebook_sources` 확장).
+//!
+//! Metro 소스맵의 `x_facebook_sources[i]` 는 `sources[i]` 의 함수 이름 맵이다.
+//! 각 항목은 `{names: string[], mappings: string}` — generated position → name index.
+//!
+//! Hermes 스택트레이스 심볼리케이션에서 라인/컬럼뿐 아니라 enclosing function
+//! 이름까지 복원할 때 사용한다.
+//!
+//! VLQ 포맷 (Metro `MappingEncoder` 와 동일):
+//!   - 라인 첫 세그먼트: `[col_delta, name_delta, line_delta]` (3필드)
+//!   - 이후 세그먼트:    `[col_delta, name_delta]` (2필드)
+//!   - 라인 구분은 세미콜론 1개 (실제 라인 차이는 line_delta로 표현)
+//!   - 라인은 메모리상 1-based (초기값 1), 컬럼은 0-based
+//!
+//! 참고: references/metro/packages/metro-source-map/src/generateFunctionMap.js
+//!       references/metro/packages/metro-source-map/src/B64Builder.js
+
+const std = @import("std");
+const sourcemap = @import("sourcemap.zig");
+
+/// 단일 이름 매핑 엔트리 (raw form).
+/// `line` 은 1-based, `column` 은 0-based.
+pub const RangeMapping = struct {
+    name: []const u8,
+    line: u32,
+    column: u32,
+};
+
+/// Function map 빌더.
+///
+/// Metro `MappingEncoder` 의 Zig 포팅. 이름을 중복 제거하며 `push()` 호출이
+/// 증가 순서 (line asc, then column asc) 임을 가정한다 — Metro도 동일.
+pub const FunctionMapBuilder = struct {
+    allocator: std.mem.Allocator,
+    /// 등장 순 이름 목록.
+    names: std.ArrayList([]const u8) = .empty,
+    /// 이름 → names 인덱스 (중복 제거).
+    names_map: std.StringHashMapUnmanaged(u32) = .empty,
+    /// VLQ mappings 버퍼.
+    mappings: std.ArrayList(u8) = .empty,
+
+    // RelativeValue 들 — 상대값 인코딩용.
+    last_line: i32 = 1, // 초기값 1 (Metro: new RelativeValue(1))
+    last_column: i32 = 0,
+    last_name_index: i32 = 0,
+    /// 현재 라인에 이미 세그먼트를 쓴 적이 있는지. false면 다음 push 는 first-of-line.
+    has_segment_on_line: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator) FunctionMapBuilder {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *FunctionMapBuilder) void {
+        self.names.deinit(self.allocator);
+        self.names_map.deinit(self.allocator);
+        self.mappings.deinit(self.allocator);
+    }
+
+    /// 이름과 시작 위치로 매핑을 추가한다.
+    ///
+    /// `line` 1-based, `column` 0-based. 호출은 position 증가 순이어야 한다.
+    /// 같은 위치에 동일 이름을 연속으로 push 하는 호출은 호출자가 미리 필터링해야 한다
+    /// (Metro 도 top-of-stack name 비교로 중복을 막는다).
+    pub fn push(self: *FunctionMapBuilder, mapping: RangeMapping) !void {
+        const name_index = try self.internName(mapping.name);
+
+        const new_line: i32 = @intCast(mapping.line);
+        const line_delta: i32 = new_line - self.last_line;
+        self.last_line = new_line;
+
+        const first_of_line = self.mappings.items.len == 0 or line_delta > 0;
+
+        if (line_delta > 0) {
+            // 라인 구분자 1개만 출력, 실제 라인 차이는 line_delta 필드로 전달됨.
+            try self.mappings.append(self.allocator, ';');
+            self.last_column = 0;
+        } else if (self.has_segment_on_line) {
+            // 같은 라인의 뒤 세그먼트 — 콤마 구분.
+            try self.mappings.append(self.allocator, ',');
+        }
+
+        // [col_delta, name_delta] 공통.
+        const new_column: i32 = @intCast(mapping.column);
+        const col_delta = new_column - self.last_column;
+        self.last_column = new_column;
+
+        const new_name_index: i32 = @intCast(name_index);
+        const name_delta = new_name_index - self.last_name_index;
+        self.last_name_index = new_name_index;
+
+        try sourcemap.encodeVLQ(self.allocator, &self.mappings, col_delta);
+        try sourcemap.encodeVLQ(self.allocator, &self.mappings, name_delta);
+
+        if (first_of_line) {
+            // 세 번째 필드: 실제 라인 델타.
+            try sourcemap.encodeVLQ(self.allocator, &self.mappings, line_delta);
+        }
+
+        self.has_segment_on_line = true;
+    }
+
+    /// 현재까지의 mappings 를 반환. 소유권은 빌더에 남는다.
+    pub fn mappingsSlice(self: *const FunctionMapBuilder) []const u8 {
+        return self.mappings.items;
+    }
+
+    /// 이름 목록을 반환. 순서는 등장 순 (VLQ name_index 참조).
+    pub fn namesSlice(self: *const FunctionMapBuilder) []const []const u8 {
+        return self.names.items;
+    }
+
+    /// JSON 직렬화: `{"names":[...],"mappings":"..."}` 를 `buf` 에 추가한다.
+    /// sources 배열 외부 구조 (x_facebook_sources 전체 배열) 는 호출자가 감싼다.
+    pub fn appendJson(self: *const FunctionMapBuilder, allocator: std.mem.Allocator, buf: *std.ArrayList(u8)) !void {
+        try buf.appendSlice(allocator, "{\"names\":[");
+        for (self.names.items, 0..) |n, i| {
+            if (i > 0) try buf.append(allocator, ',');
+            try appendJsonString(allocator, buf, n);
+        }
+        try buf.appendSlice(allocator, "],\"mappings\":\"");
+        try buf.appendSlice(allocator, self.mappings.items);
+        try buf.appendSlice(allocator, "\"}");
+    }
+
+    fn internName(self: *FunctionMapBuilder, name: []const u8) !u32 {
+        const gop = try self.names_map.getOrPut(self.allocator, name);
+        if (!gop.found_existing) {
+            const idx: u32 = @intCast(self.names.items.len);
+            gop.value_ptr.* = idx;
+            try self.names.append(self.allocator, name);
+        }
+        return gop.value_ptr.*;
+    }
+};
+
+fn appendJsonString(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), s: []const u8) !void {
+    try buf.append(allocator, '"');
+    for (s) |c| {
+        switch (c) {
+            '"' => try buf.appendSlice(allocator, "\\\""),
+            '\\' => try buf.appendSlice(allocator, "\\\\"),
+            '\n' => try buf.appendSlice(allocator, "\\n"),
+            '\r' => try buf.appendSlice(allocator, "\\r"),
+            '\t' => try buf.appendSlice(allocator, "\\t"),
+            else => {
+                if (c < 0x20) {
+                    try buf.appendSlice(allocator, "\\u00");
+                    const hex = "0123456789abcdef";
+                    try buf.append(allocator, hex[c >> 4]);
+                    try buf.append(allocator, hex[c & 0x0f]);
+                } else {
+                    try buf.append(allocator, c);
+                }
+            },
+        }
+    }
+    try buf.append(allocator, '"');
+}
+
+// ============================================================
+// Tests — Metro MappingEncoder 의 동작을 trace 하여 기대값 고정.
+// ============================================================
+
+test "empty builder produces empty mappings and names" {
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try std.testing.expectEqualStrings("", b.mappingsSlice());
+    try std.testing.expectEqual(@as(usize, 0), b.namesSlice().len);
+}
+
+test "first push on line 1 col 0 — AAA (col=0, name=0, line_delta=0)" {
+    // Metro: new RelativeValue(1) 초기. push line=1 → lineDelta=0 → firstOfLine(pos==0)
+    // startSegment(0) → append VLQ(0)="A", append name(0)="A", append lineDelta(0)="A"
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
+    try std.testing.expectEqualStrings("AAA", b.mappingsSlice());
+    try std.testing.expectEqualStrings("<global>", b.namesSlice()[0]);
+}
+
+test "two segments same line different name — AAA,UC" {
+    // push(<global>, 1, 0) → "AAA"
+    // push(foo, 1, 10): line_delta=0, firstOfLine=false (has segment)
+    //   → "," + VLQ(10)="U" + VLQ(1)="C" → ",UC"
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
+    try b.push(.{ .name = "foo", .line = 1, .column = 10 });
+    try std.testing.expectEqualStrings("AAA,UC", b.mappingsSlice());
+    const names = b.namesSlice();
+    try std.testing.expectEqualStrings("<global>", names[0]);
+    try std.testing.expectEqualStrings("foo", names[1]);
+}
+
+test "name dedup — second push of same name reuses index" {
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "foo", .line = 1, .column = 0 });
+    try b.push(.{ .name = "foo", .line = 1, .column = 5 });
+    // names 에 "foo" 하나뿐.
+    try std.testing.expectEqual(@as(usize, 1), b.namesSlice().len);
+    // 두 번째 세그먼트의 name_delta = 0.
+    // "AAA" + "," + VLQ(5)="K" + VLQ(0)="A" → "AAA,KA"
+    try std.testing.expectEqualStrings("AAA,KA", b.mappingsSlice());
+}
+
+test "new line — semicolon + first-of-line 3-field segment with line_delta" {
+    // push(<global>, 1, 0) → "AAA"
+    // push(foo, 3, 2): line_delta=2, firstOfLine=true
+    //   → ";" (single, regardless of line diff) + VLQ(2)="E" + VLQ(1)="C" + VLQ(2)="E"
+    //   → ";ECE"
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
+    try b.push(.{ .name = "foo", .line = 3, .column = 2 });
+    try std.testing.expectEqualStrings("AAA;ECE", b.mappingsSlice());
+}
+
+test "new line resets column delta base to 0" {
+    // push(<global>, 1, 0) → "AAA"
+    // push(foo, 2, 5): line_delta=1, col resets to 0 → col_delta=5
+    //   → ";" + VLQ(5)="K" + VLQ(1)="C" + VLQ(1)="C" → ";KCC"
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
+    try b.push(.{ .name = "foo", .line = 2, .column = 5 });
+    try std.testing.expectEqualStrings("AAA;KCC", b.mappingsSlice());
+}
+
+test "appendJson serializes names and mappings" {
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
+    try b.push(.{ .name = "foo", .line = 1, .column = 10 });
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    try b.appendJson(std.testing.allocator, &buf);
+    try std.testing.expectEqualStrings(
+        "{\"names\":[\"<global>\",\"foo\"],\"mappings\":\"AAA,UC\"}",
+        buf.items,
+    );
+}
+
+test "appendJson escapes special characters in names" {
+    // 이름에 따옴표/백슬래시가 섞인 경우 (eval 함수 이름 등 이론적 케이스).
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "a\"b", .line = 1, .column = 0 });
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    try b.appendJson(std.testing.allocator, &buf);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"a\\\"b\"") != null);
+}
+
+test "multiple lines with multiple segments" {
+    // L1: <global>@0   → "AAA"
+    // L1: foo@5        → ",KC"  (col_delta=5, name_delta=+1, 2필드)
+    // L2: bar@0        → new line → last_column 리셋 0, col_delta=0-0=0
+    //   → ";" + VLQ(0)="A" + VLQ(+1)="C" + VLQ(line_delta=1)="C"
+    //   → ";ACC"
+    // 기대: "AAA,KC;ACC"
+    var b = FunctionMapBuilder.init(std.testing.allocator);
+    defer b.deinit();
+    try b.push(.{ .name = "<global>", .line = 1, .column = 0 });
+    try b.push(.{ .name = "foo", .line = 1, .column = 5 });
+    try b.push(.{ .name = "bar", .line = 2, .column = 0 });
+    try std.testing.expectEqualStrings("AAA,KC;ACC", b.mappingsSlice());
+}

--- a/src/codegen/mod.zig
+++ b/src/codegen/mod.zig
@@ -13,11 +13,14 @@ pub const Codegen = codegen.Codegen;
 pub const QuoteStyle = codegen.QuoteStyle;
 pub const sourcemap = @import("sourcemap.zig");
 pub const SourceMapBuilder = sourcemap.SourceMapBuilder;
+pub const function_map = @import("function_map.zig");
+pub const FunctionMapBuilder = function_map.FunctionMapBuilder;
 pub const mangler = @import("mangler.zig");
 
 test {
     _ = codegen;
     _ = sourcemap;
+    _ = function_map;
     _ = mangler;
 
     // test files

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -220,28 +220,7 @@ pub const SourceMapBuilder = struct {
 
     /// 문자열을 JSON 이스케이프하여 buf에 추가한다.
     fn appendJsonString(self: *SourceMapBuilder, s: []const u8) !void {
-        try self.buf.append(self.allocator, '"');
-        for (s) |c| {
-            switch (c) {
-                '"' => try self.buf.appendSlice(self.allocator, "\\\""),
-                '\\' => try self.buf.appendSlice(self.allocator, "\\\\"),
-                '\n' => try self.buf.appendSlice(self.allocator, "\\n"),
-                '\r' => try self.buf.appendSlice(self.allocator, "\\r"),
-                '\t' => try self.buf.appendSlice(self.allocator, "\\t"),
-                else => {
-                    if (c < 0x20) {
-                        // 제어 문자 → \u00XX
-                        try self.buf.appendSlice(self.allocator, "\\u00");
-                        const hex = "0123456789abcdef";
-                        try self.buf.append(self.allocator, hex[c >> 4]);
-                        try self.buf.append(self.allocator, hex[c & 0x0f]);
-                    } else {
-                        try self.buf.append(self.allocator, c);
-                    }
-                },
-            }
-        }
-        try self.buf.append(self.allocator, '"');
+        return appendJsonStringTo(self.allocator, &self.buf, s);
     }
 
     /// mappings 필드를 VLQ 인코딩.
@@ -289,6 +268,32 @@ pub const SourceMapBuilder = struct {
         }
     }
 };
+
+/// 문자열을 JSON 이스케이프하여 `buf`에 추가한다.
+/// `SourceMapBuilder.appendJsonString` 및 `FunctionMapBuilder.appendJson`에서 공유.
+pub fn appendJsonStringTo(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), s: []const u8) !void {
+    try buf.append(allocator, '"');
+    for (s) |c| {
+        switch (c) {
+            '"' => try buf.appendSlice(allocator, "\\\""),
+            '\\' => try buf.appendSlice(allocator, "\\\\"),
+            '\n' => try buf.appendSlice(allocator, "\\n"),
+            '\r' => try buf.appendSlice(allocator, "\\r"),
+            '\t' => try buf.appendSlice(allocator, "\\t"),
+            else => {
+                if (c < 0x20) {
+                    try buf.appendSlice(allocator, "\\u00");
+                    const hex = "0123456789abcdef";
+                    try buf.append(allocator, hex[c >> 4]);
+                    try buf.append(allocator, hex[c & 0x0f]);
+                } else {
+                    try buf.append(allocator, c);
+                }
+            },
+        }
+    }
+    try buf.append(allocator, '"');
+}
 
 // ============================================================
 // 테스트

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -218,6 +218,28 @@ pub const SourceMapBuilder = struct {
         return self.buf.items;
     }
 
+    /// 소스맵 JSON + x_facebook_sources를 함께 생성한다.
+    /// `fn_map`이 있으면 `"x_facebook_sources":[[{names,mappings}]]` 추가.
+    /// 단일 source 가정 — 복수 source는 PR#3(bundler integration)에서 처리.
+    pub fn generateJSONWithFunctionMap(
+        self: *SourceMapBuilder,
+        allocator: std.mem.Allocator,
+        output_file: []const u8,
+        fn_map: *const @import("function_map.zig").FunctionMapBuilder,
+    ) ![]const u8 {
+        // 기존 JSON 생성 후 닫힘 `}` 직전에 x_facebook_sources 삽입.
+        const base = try self.generateJSON(output_file);
+        // base 마지막 `}` 제거 후 x_facebook_sources 추가.
+        std.debug.assert(base.len > 0 and base[base.len - 1] == '}');
+        self.buf.shrinkRetainingCapacity(base.len - 1);
+
+        try self.buf.appendSlice(allocator, ",\"x_facebook_sources\":[[");
+        try fn_map.appendJson(&self.buf);
+        try self.buf.appendSlice(allocator, "]]");
+        try self.buf.append(allocator, '}');
+        return self.buf.items;
+    }
+
     /// 문자열을 JSON 이스케이프하여 buf에 추가한다.
     fn appendJsonString(self: *SourceMapBuilder, s: []const u8) !void {
         return appendJsonStringTo(self.allocator, &self.buf, s);


### PR DESCRIPTION
## Summary

- `CodegenOptions.sourcemap_function_map` 옵션 추가 — Metro 호환 `x_facebook_sources` 확장 필드 생성
- Hermes 스택트레이스 심볼리케이션에서 함수 이름까지 복원 가능
- `generateSourceMapWithFunctionMap()` API 추가
- Contextual name 100% 추론 구현:
  - function 선언/표현식 → 자기 이름 / anonymous
  - `const bar = () => {}` → "bar"
  - `obj.render = function() {}` → "render"
  - `{ handleClick: () => {} }` → "handleClick"
  - `class MyComp { render() {} }` → "MyComp#render"
  - `class Foo { static create() {} }` → "Foo.create"
  - getter/setter → "get__value" / "set__value"
  - `export default function() {}` → "default"
  - `{ [expr]: () => {} }` → "\<anonymous>" (비리터럴 computed key)
- E2E 통합 테스트 11개 추가 (`src/codegen/codegen_test/function_map.zig`)

**Bug Fix:**
- `Kind.eq` flags 비교 버그: 파서 생성 `=` 연산자의 flags 값은 0이 아닌 `@intFromEnum(Kind.eq)` (105)
- computed property `[identifier]` 는 anonymous 처리 (리터럴만 이름으로)

## Test plan

- [x] `zig build test` — 전체 테스트 통과
- [x] function_map.zig 11개 E2E 테스트 통과
  - function declaration, arrow+variable, assignment member leaf, object property
  - class method (ClassName#method), static method (ClassName.method)
  - getter/setter (get__/set__), export default, string key, computed anonymous
  - sourcemap_function_map=false → x_facebook_sources 미포함 확인

Closes #1247 (PR#2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)