### PR TITLE
feat(bundler): Metro x_facebook_sources per-source function maps + RN preset

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -99,6 +99,9 @@ pub const BundleOptions = struct {
     sourcemap: bool = false,
     /// Sentry Debug ID (--sourcemap-debug-ids). 소스맵 + JS에 동일 UUID를 삽입.
     sourcemap_debug_ids: bool = false,
+    /// Metro x_facebook_sources function map (--sourcemap-function-map).
+    /// --platform=react-native 시 자동 활성화. Hermes 스택트레이스 심볼리케이션용.
+    sourcemap_function_map: bool = false,
     /// 출력 파일명 (소스맵 참조용)
     output_filename: []const u8 = "bundle.js",
     /// UTF-8 문자를 이스케이프하지 않고 그대로 출력 (--charset=utf8)
@@ -384,6 +387,7 @@ pub const Bundler = struct {
             .jsx_fragment = self.options.jsx_fragment,
             .jsx_import_source = self.options.jsx_import_source,
             .sourcemap_debug_ids = self.options.sourcemap_debug_ids,
+            .sourcemap_function_map = self.options.sourcemap_function_map,
             .root_dir = self.options.root_dir,
             .plugins = self.options.plugins,
             .polyfills = &.{}, // 호출자가 loadPolyfills()로 설정

--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -14,6 +14,7 @@
 //   splitting_dev.zig      — code splitting, dev mode, profiling
 //   minify_loader.zig      — minify, asset loader, scope hoist regression
 //   plugin_misc.zig        — plugin, worker, Flow, ESM live binding, JSX auto, RN, misc
+//   function_map.zig       — Metro x_facebook_sources function map 번들러 통합 테스트
 
 comptime {
     _ = @import("bundler_test/basic.zig");
@@ -29,4 +30,5 @@ comptime {
     _ = @import("bundler_test/splitting_dev.zig");
     _ = @import("bundler_test/minify_loader.zig");
     _ = @import("bundler_test/plugin_misc.zig");
+    _ = @import("bundler_test/function_map.zig");
 }

--- a/src/bundler/bundler_test/function_map.zig
+++ b/src/bundler/bundler_test/function_map.zig
@@ -1,0 +1,115 @@
+//! x_facebook_sources function map 번들러 통합 테스트.
+//! sourcemap_function_map 옵션 활성화 시 번들 소스맵에 Metro 호환
+//! x_facebook_sources 필드가 포함되는지 검증한다.
+
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+
+test "bundler function_map: single-file — x_facebook_sources in sourcemap" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "function hello() { return 42; }");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .sourcemap = true,
+        .sourcemap_function_map = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const sm = result.sourcemap orelse return error.TestUnexpectedResult;
+
+    // x_facebook_sources 필드 존재
+    try std.testing.expect(std.mem.indexOf(u8, sm, "x_facebook_sources") != null);
+    // function map 내 이름 포함
+    try std.testing.expect(std.mem.indexOf(u8, sm, "\"<global>\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sm, "\"hello\"") != null);
+    // Metro 형식: [[{names,mappings}]]
+    try std.testing.expect(std.mem.indexOf(u8, sm, "\"names\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sm, "\"mappings\"") != null);
+}
+
+test "bundler function_map: multi-file — per-source entries" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "math.ts", "export function add(a: number, b: number) { return a + b; }");
+    try writeFile(tmp.dir, "main.ts", "import { add } from './math';\nconst result = add(1, 2);");
+
+    const entry = try absPath(&tmp, "main.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .sourcemap = true,
+        .sourcemap_function_map = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const sm = result.sourcemap orelse return error.TestUnexpectedResult;
+
+    // x_facebook_sources 존재
+    try std.testing.expect(std.mem.indexOf(u8, sm, "x_facebook_sources") != null);
+    // math.ts에서 선언된 add 함수 이름이 맵에 포함
+    try std.testing.expect(std.mem.indexOf(u8, sm, "\"add\"") != null);
+}
+
+test "bundler function_map: disabled — no x_facebook_sources" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "function foo() {}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .sourcemap = true,
+        // sourcemap_function_map 기본값 = false
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const sm = result.sourcemap orelse return error.TestUnexpectedResult;
+
+    // x_facebook_sources 미포함
+    try std.testing.expect(std.mem.indexOf(u8, sm, "x_facebook_sources") == null);
+}
+
+test "bundler function_map: class methods — ClassName#method format" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "class Widget { render() {} static create() {} }");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .sourcemap = true,
+        .sourcemap_function_map = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const sm = result.sourcemap orelse return error.TestUnexpectedResult;
+
+    try std.testing.expect(std.mem.indexOf(u8, sm, "x_facebook_sources") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sm, "\"Widget#render\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sm, "\"Widget.create\"") != null);
+}

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -52,6 +52,9 @@ pub const EmitOptions = struct {
     /// Sentry Debug ID. --sourcemap-debug-ids 활성화 시 true.
     /// 번들 끝에 `//# debugId=<UUID>` 주석을 추가하고, 소스맵 JSON에 `"debugId"` 필드를 삽입.
     sourcemap_debug_ids: bool = false,
+    /// Metro x_facebook_sources function map 생성.
+    /// Hermes 스택트레이스 심볼리케이션용. RN 플랫폼에서 자동 활성화.
+    sourcemap_function_map: bool = false,
     /// dev mode: 각 모듈을 __zts_register() 팩토리로 래핑하고
     /// HMR 런타임을 주입한다. import.meta.hot API 지원.
     dev_mode: bool = false,
@@ -347,6 +350,7 @@ pub fn emitWithTreeShaking(
         for (results) |r| {
             if (r.code) |c| allocator.free(c);
             if (r.mappings) |m| allocator.free(m);
+            if (r.fn_map_json) |j| allocator.free(j);
         }
         allocator.free(results);
     }
@@ -371,7 +375,7 @@ pub fn emitWithTreeShaking(
         for (sorted.items, 0..) |m, i| {
             const is_entry = if (entry_idx) |ei| @intFromEnum(m.index) == ei else false;
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
-            results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines) catch null;
+            results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines, &results[i].fn_map_json) catch null;
         }
     }
 
@@ -404,6 +408,11 @@ pub fn emitWithTreeShaking(
         break :blk sm;
     } else null;
     defer if (bundle_sm) |*sm| sm.deinit();
+
+    // per-source function map JSON 목록 (sources 추가 순서와 1:1 대응).
+    // sourcemap + sourcemap_function_map 활성화 시에만 사용.
+    var per_source_fn_maps: std.ArrayList(?[]const u8) = .empty;
+    defer per_source_fn_maps.deinit(allocator);
 
     // output에 이미 추가된 prologue/banner/polyfill/runtime helper 줄 수 추적
     // (module_output과 별도로 output에 먼저 들어감 — 아래에서 합류 시 사용)
@@ -446,6 +455,10 @@ pub fn emitWithTreeShaking(
                     options.sources_content,
                     false,
                 );
+                // function map: source 추가 순서와 동기화
+                if (options.sourcemap_function_map) {
+                    try per_source_fn_maps.append(allocator, results[i].fn_map_json);
+                }
             }
         }
 
@@ -582,8 +595,22 @@ pub fn emitWithTreeShaking(
 
         // debugId 설정
         sm.debug_id = debug_id;
-        const json = try sm.generateJSON(options.output_filename);
-        sourcemap_json = try allocator.dupe(u8, json);
+
+        // function map: identity source(polyfill/runtime)는 null 패딩
+        if (options.sourcemap_function_map and per_source_fn_maps.items.len > 0) {
+            while (per_source_fn_maps.items.len < sm.sources.items.len) {
+                try per_source_fn_maps.append(allocator, null);
+            }
+            const json = try sm.generateJSONWithPerSourceFunctionMaps(
+                allocator,
+                options.output_filename,
+                per_source_fn_maps.items,
+            );
+            sourcemap_json = try allocator.dupe(u8, json);
+        } else {
+            const json = try sm.generateJSON(options.output_filename);
+            sourcemap_json = try allocator.dupe(u8, json);
+        }
     }
 
     // 소스맵 참조 추가
@@ -634,6 +661,8 @@ const ModuleEmitResult = struct {
     mappings: ?[]const SourceMap.Mapping = null,
     /// preamble(cjs_import_preamble 등)과 래핑 헤더로 인해 codegen 매핑과 어긋나는 줄 수.
     preamble_lines: u32 = 0,
+    /// function map JSON (`{"names":[...],"mappings":"..."}`). null이면 비활성 또는 함수 없음.
+    fn_map_json: ?[]const u8 = null,
 };
 
 /// JS 예약어이거나 유효한 식별자가 아니면 프로퍼티 키에 따옴표가 필요.
@@ -702,7 +731,7 @@ fn emitModuleThread(
     shaker: ?*const TreeShaker,
     result: *ModuleEmitResult,
 ) void {
-    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.preamble_lines) catch null;
+    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.preamble_lines, &result.fn_map_json) catch null;
 }
 
 /// 단일 모듈을 Transformer → Codegen 파이프라인으로 처리.
@@ -719,6 +748,7 @@ pub fn emitModule(
     helpers_out: ?*RuntimeHelpers,
     mappings_out: ?*?[]const SourceMap.Mapping,
     preamble_lines_out: ?*u32,
+    fn_map_json_out: ?*?[]const u8,
 ) !?[]const u8 {
     // Disabled 모듈 (platform=browser에서 Node 빌트인): 빈 __commonJS wrapper 출력.
     // esbuild 호환: var require_X = __commonJS({ "(disabled)"(exports, module) {} });
@@ -960,6 +990,8 @@ pub fn emitModule(
         .sources_content = options.sources_content,
         // keepNames: codegen이 rename된 함수/클래스를 수집
         .keep_names = options.keep_names,
+        // Metro function map: sourcemap 활성화 시에만 수집
+        .sourcemap_function_map = options.sourcemap and options.sourcemap_function_map,
         // JSX: Transformer가 이미 call_expression으로 lowering 완료.
         // codegen은 jsx_element/jsx_fragment를 만나지 않으므로 JSX 옵션 불필요.
         // dev mode: import.meta.hot → __zts_make_hot("dev_id")
@@ -991,6 +1023,18 @@ pub fn emitModule(
         if (cg.sm_builder) |*sm| {
             if (sm.mappings.items.len > 0) {
                 mout.* = try allocator.dupe(SourceMap.Mapping, sm.mappings.items);
+            }
+        }
+    }
+
+    // function map JSON 직렬화 (활성화 시, arena 해제 전에)
+    if (fn_map_json_out) |fmout| {
+        if (cg.fn_map_builder) |*fm| {
+            if (fm.namesSlice().len > 0) {
+                var json_buf: std.ArrayList(u8) = .empty;
+                try fm.appendJson(&json_buf);
+                fmout.* = try allocator.dupe(u8, json_buf.items);
+                json_buf.deinit(arena_alloc);
             }
         }
     }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -247,7 +247,7 @@ pub fn emitChunks(
             const m = &modules[mi];
 
             const is_entry = if (entry_mod_idx) |ei| mi == ei else false;
-            const raw_code = try emitModule(allocator, m, options, linker, is_entry, null, null, null, null, null) orelse continue;
+            const raw_code = try emitModule(allocator, m, options, linker, is_entry, null, null, null, null, null, null) orelse continue;
             defer allocator.free(raw_code);
 
             // 동적 import 경로 리라이트: import('./page') → import('./page.js')

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -218,24 +218,47 @@ pub const SourceMapBuilder = struct {
         return self.buf.items;
     }
 
-    /// 소스맵 JSON + x_facebook_sources를 함께 생성한다.
-    /// `fn_map`이 있으면 `"x_facebook_sources":[[{names,mappings}]]` 추가.
-    /// 단일 source 가정 — 복수 source는 PR#3(bundler integration)에서 처리.
+    /// 소스맵 JSON + x_facebook_sources를 함께 생성한다. 단일 source 전용.
+    /// `fn_map`의 내용을 `"x_facebook_sources":[[{names,mappings}]]`로 직렬화.
     pub fn generateJSONWithFunctionMap(
         self: *SourceMapBuilder,
         allocator: std.mem.Allocator,
         output_file: []const u8,
         fn_map: *const @import("function_map.zig").FunctionMapBuilder,
     ) ![]const u8 {
-        // 기존 JSON 생성 후 닫힘 `}` 직전에 x_facebook_sources 삽입.
+        var json_buf: std.ArrayList(u8) = .empty;
+        defer json_buf.deinit(allocator);
+        try fn_map.appendJson(&json_buf);
+        return self.generateJSONWithPerSourceFunctionMaps(allocator, output_file, &.{json_buf.items});
+    }
+
+    /// 소스맵 JSON + x_facebook_sources 배열을 함께 생성한다. 복수 source 지원.
+    /// source_fn_maps[i]는 sources[i]에 해당하는 function map JSON
+    /// (`{"names":[...],"mappings":"..."}`) 또는 null (function map 없음).
+    /// x_facebook_sources 포맷: sources 순서와 1:1 대응하는 배열.
+    /// 각 요소는 null 또는 [{names,mappings}] (Metro 스펙: 배열로 감싼 단일 객체).
+    pub fn generateJSONWithPerSourceFunctionMaps(
+        self: *SourceMapBuilder,
+        allocator: std.mem.Allocator,
+        output_file: []const u8,
+        source_fn_maps: []const ?[]const u8,
+    ) ![]const u8 {
         const base = try self.generateJSON(output_file);
-        // base 마지막 `}` 제거 후 x_facebook_sources 추가.
         std.debug.assert(base.len > 0 and base[base.len - 1] == '}');
         self.buf.shrinkRetainingCapacity(base.len - 1);
 
-        try self.buf.appendSlice(allocator, ",\"x_facebook_sources\":[[");
-        try fn_map.appendJson(&self.buf);
-        try self.buf.appendSlice(allocator, "]]");
+        try self.buf.appendSlice(allocator, ",\"x_facebook_sources\":[");
+        for (source_fn_maps, 0..) |fm_json, i| {
+            if (i > 0) try self.buf.append(allocator, ',');
+            if (fm_json) |json| {
+                try self.buf.append(allocator, '[');
+                try self.buf.appendSlice(allocator, json);
+                try self.buf.append(allocator, ']');
+            } else {
+                try self.buf.appendSlice(allocator, "null");
+            }
+        }
+        try self.buf.append(allocator, ']');
         try self.buf.append(allocator, '}');
         return self.buf.items;
     }

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -226,10 +226,14 @@ pub const SourceMapBuilder = struct {
         output_file: []const u8,
         fn_map: *const @import("function_map.zig").FunctionMapBuilder,
     ) ![]const u8 {
-        var json_buf: std.ArrayList(u8) = .empty;
-        defer json_buf.deinit(allocator);
-        try fn_map.appendJson(&json_buf);
-        return self.generateJSONWithPerSourceFunctionMaps(allocator, output_file, &.{json_buf.items});
+        const base = try self.generateJSON(output_file);
+        std.debug.assert(base.len > 0 and base[base.len - 1] == '}');
+        self.buf.shrinkRetainingCapacity(base.len - 1);
+        try self.buf.appendSlice(allocator, ",\"x_facebook_sources\":[[");
+        try fn_map.appendJson(&self.buf);
+        try self.buf.appendSlice(allocator, "]]");
+        try self.buf.append(allocator, '}');
+        return self.buf.items;
     }
 
     /// 소스맵 JSON + x_facebook_sources 배열을 함께 생성한다. 복수 source 지원.

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,6 +33,9 @@ const CliOptions = struct {
     sourcemap: bool = false,
     /// Sentry Debug ID (--sourcemap-debug-ids). 소스맵 + JS에 동일 UUID를 삽입.
     sourcemap_debug_ids: bool = false,
+    /// Metro x_facebook_sources function map (--sourcemap-function-map).
+    /// --platform=react-native 시 자동 활성화.
+    sourcemap_function_map: bool = false,
     ascii_only: bool = false,
     quote_style: lib.codegen.QuoteStyle = .double,
     watch: bool = false,
@@ -299,6 +302,8 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             opts.sourcemap = true;
         } else if (std.mem.eql(u8, arg, "--sourcemap-debug-ids")) {
             opts.sourcemap_debug_ids = true;
+        } else if (std.mem.eql(u8, arg, "--sourcemap-function-map")) {
+            opts.sourcemap_function_map = true;
         } else if (std.mem.eql(u8, arg, "--project") or std.mem.eql(u8, arg, "-p")) {
             if (i + 1 < args.len) {
                 i += 1;
@@ -1266,6 +1271,8 @@ pub fn main() !void {
             if (opts.jsx_runtime == null) {
                 opts.jsx_runtime = .automatic;
             }
+            // Metro function map: Hermes 스택트레이스 심볼리케이션 — RN에서 기본 활성화
+            opts.sourcemap_function_map = true;
 
             // RN 에셋 기본 로더: Metro assetExts 호환.
             // 사용자 --loader 오버라이드가 loader_list 앞에 이미 있으므로
@@ -1370,6 +1377,7 @@ pub fn main() !void {
             .main_fields = opts.main_fields_list.items,
             .sourcemap = opts.sourcemap,
             .sourcemap_debug_ids = opts.sourcemap_debug_ids,
+            .sourcemap_function_map = opts.sourcemap_function_map,
             .output_filename = if (opts.output_file) |of| std.fs.path.basename(of) else "bundle.js",
             .outbase = opts.outbase,
             .packages_external = opts.packages_external,


### PR DESCRIPTION
## Summary

- `EmitOptions.sourcemap_function_map` / `BundleOptions.sourcemap_function_map` 플래그 추가
- `emitModule`에서 codegen의 `fn_map_builder`를 JSON으로 직렬화하여 `ModuleEmitResult.fn_map_json`에 전달
- `emitBundle`에서 sources 순서에 맞게 per-source function map 목록 추적, identity source(polyfill/runtime)는 `null` 패딩
- `SourceMapBuilder.generateJSONWithPerSourceFunctionMaps`: 복수 source 지원 신규 API — Metro 형식 `x_facebook_sources` 배열 생성
- `--sourcemap-function-map` CLI 플래그 (main.zig)
- `--platform=react-native` 프리셋에서 `sourcemap_function_map` 자동 활성화
- 번들러 통합 테스트 4개 (`bundler_test/function_map.zig`)

## Test plan

- [x] `zig build test` — 전체 테스트 통과, 메모리 릭 없음
- [x] single-file: `x_facebook_sources` 필드 + `<global>` / 함수명 포함 검증
- [x] multi-file: per-source entries 확인 (`add` 함수)
- [x] opt-out: `sourcemap_function_map=false` 시 `x_facebook_sources` 미포함
- [x] class method: `ClassName#method`, `ClassName.method` 포맷 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)