### PR TITLE
fix(mangler): direct eval/with 스코프 바인딩 mangling 차단 (#1258)

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -975,6 +975,105 @@ test "Minify: nested scope variable not shadowed by mangled name (#494)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "ok") != null);
 }
 
+test "Minify: direct eval preserves visible local bindings (#1258)" {
+    // direct eval은 스코프 내 모든 바인딩을 동적으로 참조할 수 있으므로,
+    // eval을 포함한 함수 및 그 상위 스코프의 변수는 mangling되면 안 된다.
+    // rolldown/oxc 방식: ContainsDirectEval 플래그를 상위로 전파.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\function run() {
+        \\  const veryLongPasswordVar = "secret";
+        \\  return eval("veryLongPasswordVar");
+        \\}
+        \\console.log(run());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 선언부도 eval 인자와 같은 이름을 유지해야 런타임에 eval("veryLongPasswordVar")가 resolve된다.
+    // 단순 indexOf는 eval 인자 문자열에 걸려 pass되므로, 선언 패턴을 직접 확인.
+    const has_decl = std.mem.indexOf(u8, result.output, "veryLongPasswordVar=") != null or
+        std.mem.indexOf(u8, result.output, "veryLongPasswordVar =") != null;
+    try std.testing.expect(has_decl);
+}
+
+test "Minify: direct eval preserves outer scope bindings too (#1258)" {
+    // direct eval은 포함 함수의 모든 조상 스코프 바인딩을 볼 수 있으므로,
+    // top-level 함수 이름도 eval 발생 시 보존되어야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\function topLevelFunc() {
+        \\  return eval("topLevelFunc.name");
+        \\}
+        \\console.log(topLevelFunc());
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const has_decl = std.mem.indexOf(u8, result.output, "function topLevelFunc") != null;
+    try std.testing.expect(has_decl);
+}
+
+test "Minify: with statement preserves bindings in enclosing scope (#1258)" {
+    // with 블록은 내부 식별자가 객체 속성으로 동적 해석될 수 있으므로,
+    // with을 포함한 스코프와 상위 스코프 변수는 mangling되면 안 된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\function run(obj) {
+        \\  var greetingOuter = "hi";
+        \\  with (obj) {
+        \\    console.log(greetingOuter);
+        \\  }
+        \\}
+        \\run({ greetingOuter: "hello" });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const has_decl = std.mem.indexOf(u8, result.output, "greetingOuter=") != null or
+        std.mem.indexOf(u8, result.output, "greetingOuter =") != null;
+    try std.testing.expect(has_decl);
+}
+
 // ============================================================
 // Asset Loader Tests
 // ============================================================

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -612,6 +612,12 @@ pub const Linker = struct {
         for (self.modules) |m| {
             const sem = m.semantic orelse continue;
             if (sem.scope_maps.len == 0) continue;
+            // direct eval / with이 이 모듈 내부 어디든 있으면 top-level 바인딩도
+            // 동적으로 참조될 수 있으므로 전체 스킵 (#1258). rolldown/oxc 방식.
+            if (sem.scopes.len > 0) {
+                const root_scope = sem.scopes[0];
+                if (root_scope.subtree_has_direct_eval or root_scope.subtree_has_with) continue;
+            }
             var sit = sem.scope_maps[0].iterator();
             while (sit.next()) |entry| {
                 const sym_name = entry.key_ptr.*;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -614,10 +614,7 @@ pub const Linker = struct {
             if (sem.scope_maps.len == 0) continue;
             // direct eval / with이 이 모듈 내부 어디든 있으면 top-level 바인딩도
             // 동적으로 참조될 수 있으므로 전체 스킵 (#1258). rolldown/oxc 방식.
-            if (sem.scopes.len > 0) {
-                const root_scope = sem.scopes[0];
-                if (root_scope.subtree_has_direct_eval or root_scope.subtree_has_with) continue;
-            }
+            if (sem.scopes.len > 0 and sem.scopes[0].blocksMangling()) continue;
             var sit = sem.scope_maps[0].iterator();
             while (sit.next()) |entry| {
                 const sym_name = entry.key_ptr.*;

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -169,6 +169,14 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
 
                 // skip 판정
                 if (shouldSkip(sym, name)) continue;
+                // direct eval / with 스코프의 바인딩은 mangling 차단 (#1258)
+                if (!sym.scope_id.isNone()) {
+                    const s_idx = sym.scope_id.toIndex();
+                    if (s_idx < scopes.len) {
+                        const s = scopes[s_idx];
+                        if (s.subtree_has_direct_eval or s.subtree_has_with) continue;
+                    }
+                }
                 if (skip_symbols) |ss| {
                     if (sym_idx < ss.capacity() and ss.isSet(sym_idx)) continue;
                 }

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -172,10 +172,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
                 // direct eval / with 스코프의 바인딩은 mangling 차단 (#1258)
                 if (!sym.scope_id.isNone()) {
                     const s_idx = sym.scope_id.toIndex();
-                    if (s_idx < scopes.len) {
-                        const s = scopes[s_idx];
-                        if (s.subtree_has_direct_eval or s.subtree_has_with) continue;
-                    }
+                    if (s_idx < scopes.len and scopes[s_idx].blocksMangling()) continue;
                 }
                 if (skip_symbols) |ss| {
                     if (sym_idx < ss.capacity() and ss.isSet(sym_idx)) continue;

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -255,33 +255,22 @@ pub const SemanticAnalyzer = struct {
     // 스코프 관리
     // ================================================================
 
+    /// 현재 스코프부터 root까지 각 Scope의 bool 필드(`field_offset`에 해당)를 true로 set.
+    /// rolldown/oxc 방식: direct eval / with은 포함 스코프와 모든 상위 스코프의
+    /// 바인딩을 동적으로 참조할 수 있으므로 mangling 대상에서 제외되어야 한다.
+    fn markScopeFieldToRoot(self: *SemanticAnalyzer, comptime field: []const u8) void {
+        var cur = self.current_scope;
+        while (!cur.isNone()) {
+            const idx = cur.toIndex();
+            if (idx >= self.scopes.items.len) break;
+            const ptr = &@field(self.scopes.items[idx], field);
+            if (ptr.*) break; // 이미 전파됨
+            ptr.* = true;
+            cur = self.scopes.items[idx].parent;
+        }
+    }
+
     /// 새 스코프를 생성하고 진입한다. 반환값: 이전 스코프 ID (나갈 때 복원용).
-    /// 현재 스코프 및 모든 조상 스코프에 direct eval 플래그를 전파한다.
-    /// rolldown/oxc 방식: direct eval은 포함 스코프와 모든 상위 스코프의 바인딩을
-    /// 동적으로 참조할 수 있으므로, 해당 스코프들의 변수 mangling을 비활성화한다.
-    fn markDirectEvalToRoot(self: *SemanticAnalyzer) void {
-        var cur = self.current_scope;
-        while (!cur.isNone()) {
-            const idx = cur.toIndex();
-            if (idx >= self.scopes.items.len) break;
-            if (self.scopes.items[idx].subtree_has_direct_eval) break; // 이미 전파됨
-            self.scopes.items[idx].subtree_has_direct_eval = true;
-            cur = self.scopes.items[idx].parent;
-        }
-    }
-
-    /// `with` 문도 동일하게 상위로 전파.
-    fn markWithToRoot(self: *SemanticAnalyzer) void {
-        var cur = self.current_scope;
-        while (!cur.isNone()) {
-            const idx = cur.toIndex();
-            if (idx >= self.scopes.items.len) break;
-            if (self.scopes.items[idx].subtree_has_with) break;
-            self.scopes.items[idx].subtree_has_with = true;
-            cur = self.scopes.items[idx].parent;
-        }
-    }
-
     fn enterScope(self: *SemanticAnalyzer, kind: ScopeKind, is_strict: bool) AllocError!ScopeId {
         const parent = self.current_scope;
         const new_id: ScopeId = @enumFromInt(@as(u32, @intCast(self.scopes.items.len)));
@@ -1078,7 +1067,7 @@ pub const SemanticAnalyzer = struct {
             .with_statement => {
                 // with 블록은 동적 이름 lookup을 유발하므로 현재 스코프와
                 // 모든 상위 스코프의 바인딩 mangling을 차단.
-                self.markWithToRoot();
+                self.markScopeFieldToRoot("subtree_has_with");
                 try self.visitNode(node.data.binary.left);
                 try self.visitNode(node.data.binary.right);
             },
@@ -1265,7 +1254,7 @@ pub const SemanticAnalyzer = struct {
                             if (callee_node.tag == .identifier_reference) {
                                 const callee_name = self.ast.getSourceText(callee_node.span);
                                 if (std.mem.eql(u8, callee_name, "eval")) {
-                                    self.markDirectEvalToRoot();
+                                    self.markScopeFieldToRoot("subtree_has_direct_eval");
                                 }
                             }
                         }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -256,6 +256,32 @@ pub const SemanticAnalyzer = struct {
     // ================================================================
 
     /// 새 스코프를 생성하고 진입한다. 반환값: 이전 스코프 ID (나갈 때 복원용).
+    /// 현재 스코프 및 모든 조상 스코프에 direct eval 플래그를 전파한다.
+    /// rolldown/oxc 방식: direct eval은 포함 스코프와 모든 상위 스코프의 바인딩을
+    /// 동적으로 참조할 수 있으므로, 해당 스코프들의 변수 mangling을 비활성화한다.
+    fn markDirectEvalToRoot(self: *SemanticAnalyzer) void {
+        var cur = self.current_scope;
+        while (!cur.isNone()) {
+            const idx = cur.toIndex();
+            if (idx >= self.scopes.items.len) break;
+            if (self.scopes.items[idx].subtree_has_direct_eval) break; // 이미 전파됨
+            self.scopes.items[idx].subtree_has_direct_eval = true;
+            cur = self.scopes.items[idx].parent;
+        }
+    }
+
+    /// `with` 문도 동일하게 상위로 전파.
+    fn markWithToRoot(self: *SemanticAnalyzer) void {
+        var cur = self.current_scope;
+        while (!cur.isNone()) {
+            const idx = cur.toIndex();
+            if (idx >= self.scopes.items.len) break;
+            if (self.scopes.items[idx].subtree_has_with) break;
+            self.scopes.items[idx].subtree_has_with = true;
+            cur = self.scopes.items[idx].parent;
+        }
+    }
+
     fn enterScope(self: *SemanticAnalyzer, kind: ScopeKind, is_strict: bool) AllocError!ScopeId {
         const parent = self.current_scope;
         const new_id: ScopeId = @enumFromInt(@as(u32, @intCast(self.scopes.items.len)));
@@ -1050,6 +1076,9 @@ pub const SemanticAnalyzer = struct {
             .labeled_statement => try self.visitLabeledStatement(node),
             .break_statement, .continue_statement => try self.visitBreakContinue(node),
             .with_statement => {
+                // with 블록은 동적 이름 lookup을 유발하므로 현재 스코프와
+                // 모든 상위 스코프의 바인딩 mangling을 차단.
+                self.markWithToRoot();
                 try self.visitNode(node.data.binary.left);
                 try self.visitNode(node.data.binary.right);
             },
@@ -1225,6 +1254,22 @@ pub const SemanticAnalyzer = struct {
                 const e = node.data.extra;
                 if (self.ast.hasExtra(e, 2)) {
                     const callee_idx = self.ast.readExtraNode(e, 0);
+                    // direct eval 감지: callee가 단순 identifier "eval"이면
+                    // 현재 스코프~루트의 변수 mangling을 차단.
+                    // indirect eval ((0,eval)(...), globalThis.eval 등)은 ECMA 사양상
+                    // 전역에서 평가되므로 로컬 변수에 영향 없음 → 감지 제외.
+                    if (node.tag == .call_expression and !callee_idx.isNone()) {
+                        const callee_ni = @intFromEnum(callee_idx);
+                        if (callee_ni < self.ast.nodes.items.len) {
+                            const callee_node = self.ast.nodes.items[callee_ni];
+                            if (callee_node.tag == .identifier_reference) {
+                                const callee_name = self.ast.getSourceText(callee_node.span);
+                                if (std.mem.eql(u8, callee_name, "eval")) {
+                                    self.markDirectEvalToRoot();
+                                }
+                            }
+                        }
+                    }
                     try self.visitNode(callee_idx);
                     try self.visitNodeList(.{
                         .start = self.ast.readExtra(e, 1),

--- a/src/semantic/scope.zig
+++ b/src/semantic/scope.zig
@@ -76,4 +76,10 @@ pub const Scope = struct {
 
     /// 이 스코프에서 선언된 심볼 수 (디버깅/통계용)
     symbol_count: u16 = 0,
+
+    /// 이 스코프에 선언된 바인딩이 direct eval/with으로 인해
+    /// 동적 lookup 대상이 될 수 있는지. mangler가 이름 변경을 건너뛰는 기준.
+    pub fn blocksMangling(self: Scope) bool {
+        return self.subtree_has_direct_eval or self.subtree_has_with;
+    }
 };

--- a/src/semantic/scope.zig
+++ b/src/semantic/scope.zig
@@ -65,6 +65,15 @@ pub const Scope = struct {
     /// 이 스코프가 strict mode인지
     is_strict: bool,
 
+    /// 이 스코프 또는 자손 스코프에 direct `eval(...)` 호출이 있는지.
+    /// true이면 이 스코프에 선언된 바인딩은 mangling되면 안 된다
+    /// (eval이 동적으로 이름을 참조할 수 있음). rolldown/oxc 방식.
+    subtree_has_direct_eval: bool = false,
+
+    /// 이 스코프 또는 자손 스코프에 `with` 문이 있는지.
+    /// true이면 이 스코프 바인딩은 mangling 금지.
+    subtree_has_with: bool = false,
+
     /// 이 스코프에서 선언된 심볼 수 (디버깅/통계용)
     symbol_count: u16 = 0,
 };


### PR DESCRIPTION
## Summary

- `--minify-identifiers` 적용 시 `eval()` / `with` 때문에 **런타임 ReferenceError**가 발생하는 버그 수정
- rolldown/oxc 전략 채택: 스코프 플래그 기반, `ContainsDirectEval` 상위 전파
- 회귀 테스트 3개 추가 (2823 all pass)

Closes #1258.

## 재현 (fix 전)

\`\`\`js
function run() {
  const veryLongPasswordVar = "secret";
  return eval("veryLongPasswordVar");
}
\`\`\`

fix 전 출력:
\`\`\`js
function e(){const e="secret";return eval("veryLongPasswordVar");}
//          ^ mangled                    ^ 원본 그대로 → ReferenceError
\`\`\`

fix 후: `veryLongPasswordVar` 원본 보존 ✅

## 구현

1. `Scope`에 `subtree_has_direct_eval` / `subtree_has_with` 플래그 추가
2. Semantic analyzer가 `call_expression(callee=eval)` 및 `with_statement` 감지 시 current scope → root 체인으로 전파
3. `mangler.zig` binding 수집 + `linker.collectManglingCandidates` 두 경로 모두에서 플래그 set 스코프 스킵
4. **indirect eval** (`(0, eval)(...)`, `globalThis.eval`) 은 ECMA 사양상 전역 evaluation이라 로컬 바인딩 영향 없음 → 감지 제외 (esbuild/oxc/swc 동일)

## 참고

- rolldown/oxc: `oxc_semantic` `ScopeFlags::ContainsDirectEval`
- swc minifier: `ScopeData.has_eval` 상위 전파
- esbuild: `containsDirectEval` 함수 경계까지 차단

## Test plan

- [x] `zig build test` — 2823/2823 passed
- [x] 재현 스크립트 수동 검증 (eval 내부 / outer fn / normal regression)
- [ ] production 앱에서 `--minify-identifiers` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)