### PR TITLE
fix(shared): ES_TARGET_BITS off-by-one — hashbang/using 비트 정정

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -83,18 +83,24 @@ export interface TranspileResult {
 
 // ─── ES Target → UnsupportedFeatures bitmask ───
 
+// compat.zig UnsupportedFeatures 비트 레이아웃:
+//   0-10 = ES2015 features, 11 = ES2016, 12 = ES2017, 13 = ES2018,
+//   14 = ES2019, 15-16 = ES2020, 17 = ES2021,
+//   18-20 = ES2022 (class_static_block, class_private_method, class_private_field),
+//   21 = ES2023 (hashbang), 22 = ES2025 (using).
+// 타겟 T에 대해 "T 이후 도입된" 모든 feature 비트를 set한다.
 export const ES_TARGET_BITS: Record<string, number> = {
-  es5: 0x3fffff, // bit 0-21: 모든 feature unsupported
-  es2015: 0x3ff800, // bit 11-21
-  es2016: 0x3ff000, // bit 12-21
-  es2017: 0x3fe000, // bit 13-21
-  es2018: 0x3fc000, // bit 14-21
-  es2019: 0x3f8000, // bit 15-21
-  es2020: 0x3e0000, // bit 17-21
-  es2021: 0x3c0000, // bit 18-21
-  es2022: 0x300000, // bit 20-21 (hashbang + using)
-  es2023: 0x200000, // bit 21 (using only)
-  es2024: 0x200000, // bit 21 (using only, ES2024에 구문 변환 기능 없음)
+  es5: 0x7fffff, // bit 0-22
+  es2015: 0x7ff800, // bit 11-22
+  es2016: 0x7ff000, // bit 12-22
+  es2017: 0x7fe000, // bit 13-22
+  es2018: 0x7fc000, // bit 14-22
+  es2019: 0x7f8000, // bit 15-22
+  es2020: 0x7e0000, // bit 17-22
+  es2021: 0x7c0000, // bit 18-22
+  es2022: 0x600000, // bit 21-22 (hashbang + using)
+  es2023: 0x400000, // bit 22 (using only)
+  es2024: 0x400000, // bit 22 (ES2024에 구문 변환 기능 없음)
   es2025: 0x0,
   esnext: 0x0,
 };


### PR DESCRIPTION
## Summary

NAPI CI의 hashbang 테스트 3개 실패 복구.

## 원인

\`45d1871\` (fix(transformer): downlevel class private fields below ES2022) 에서 \`UnsupportedFeatures\` struct에 \`class_private_field\` bit가 추가되며 이후 비트가 하나씩 밀림:

- \`hashbang\`: bit 20 → **21**
- \`using\`: bit 21 → **22**

\`packages/shared/index.ts\`의 \`ES_TARGET_BITS\` 테이블은 업데이트되지 않아, JS에서 \`target: "es2023"\`을 전달해도 실제로는 hashbang 비트가 set되어 strip되는 상태였음.

\`es2023\` + hashbang 입력 → CI는 \`"\\nconsole.log(1);\\n"\` (hashbang 제거됨) 반환.

## Fix

ES_TARGET_BITS 전체 항목 좌측 1비트 이동:

| target | 이전 | 이후 |
|---|---|---|
| es5 | 0x3fffff | 0x7fffff |
| es2022 | 0x300000 | 0x600000 |
| es2023 | 0x200000 | 0x400000 |
| esnext | 0x0 | 0x0 |

주석도 bit 레이아웃 설명으로 업데이트.

## Test plan

- [x] \`packages/core\` NAPI 전체 스위트 257/257 pass (fix 전 3/257 fail)
- [x] \`zig build test\` 2842/2842 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)