### PR TITLE
fix(bundle): __async 중복 emit + feat(compat): browserslist 지원

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,9 @@
       "bin": {
         "zts": "./bin/zts.mjs",
       },
+      "dependencies": {
+        "browserslist": "^4.24.0",
+      },
       "optionalDependencies": {
         "lightningcss": "^1.28.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -158,7 +158,7 @@
         "rfdc": "^1.0.0",
         "rxjs": "^7.0.0",
         "safe-buffer": "^5.0.0",
-        "semver": "^7.0.0",
+        "semver": "^7.7.4",
         "signal-exit": "^4.0.0",
         "solid-js": "^1.0.0",
         "statuses": "^2.0.0",
@@ -300,11 +300,11 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.5.7", "", {}, "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@emotion/babel-plugin": ["@emotion/babel-plugin@11.13.5", "", { "dependencies": { "@babel/helper-module-imports": "^7.16.7", "@babel/runtime": "^7.18.3", "@emotion/hash": "^0.9.2", "@emotion/memoize": "^0.9.0", "@emotion/serialize": "^1.3.3", "babel-plugin-macros": "^3.1.0", "convert-source-map": "^1.5.0", "escape-string-regexp": "^4.0.0", "find-root": "^1.1.0", "source-map": "^0.5.7", "stylis": "4.2.0" } }, "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ=="],
 
@@ -552,7 +552,7 @@
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
+    "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
     "@oxc-transform/binding-darwin-arm64": ["@oxc-transform/binding-darwin-arm64@0.60.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-o/A9ccVKxDvjLRFBZUbXGMSLFfCbSacQaue8G4WUPHKwpZ1hiwqHAwYuFDlTyq43HRBnzWdr6W+/FawdYZK4Bg=="],
 
@@ -672,37 +672,37 @@
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.13", "", { "os": "android", "cpu": "arm64" }, "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.13", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm" }, "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "s390x" }, "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "x64" }, "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.13", "", { "os": "linux", "cpu": "x64" }, "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.13", "", { "os": "none", "cpu": "arm64" }, "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.13", "", { "dependencies": { "@emnapi/core": "1.9.1", "@emnapi/runtime": "1.9.1", "@napi-rs/wasm-runtime": "^1.1.2" }, "cpu": "none" }, "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "x64" }, "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
@@ -832,31 +832,31 @@
 
     "@swc/cli": ["@swc/cli@0.6.0", "", { "dependencies": { "@swc/counter": "^0.1.3", "@xhmikosr/bin-wrapper": "^13.0.5", "commander": "^8.3.0", "fast-glob": "^3.2.5", "minimatch": "^9.0.3", "piscina": "^4.3.1", "semver": "^7.3.8", "slash": "3.0.0", "source-map": "^0.7.3" }, "peerDependencies": { "@swc/core": "^1.2.66", "chokidar": "^4.0.1" }, "optionalPeers": ["chokidar"], "bin": { "swc": "bin/swc.js", "swcx": "bin/swcx.js", "spack": "bin/spack.js" } }, "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw=="],
 
-    "@swc/core": ["@swc/core@1.15.21", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.21", "@swc/core-darwin-x64": "1.15.21", "@swc/core-linux-arm-gnueabihf": "1.15.21", "@swc/core-linux-arm64-gnu": "1.15.21", "@swc/core-linux-arm64-musl": "1.15.21", "@swc/core-linux-ppc64-gnu": "1.15.21", "@swc/core-linux-s390x-gnu": "1.15.21", "@swc/core-linux-x64-gnu": "1.15.21", "@swc/core-linux-x64-musl": "1.15.21", "@swc/core-win32-arm64-msvc": "1.15.21", "@swc/core-win32-ia32-msvc": "1.15.21", "@swc/core-win32-x64-msvc": "1.15.21" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-fkk7NJcBscrR3/F8jiqlMptRHP650NxqDnspBMrRe5d8xOoCy9MLL5kOBLFXjFLfMo3KQQHhk+/jUULOMlR1uQ=="],
+    "@swc/core": ["@swc/core@1.15.24", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.24", "@swc/core-darwin-x64": "1.15.24", "@swc/core-linux-arm-gnueabihf": "1.15.24", "@swc/core-linux-arm64-gnu": "1.15.24", "@swc/core-linux-arm64-musl": "1.15.24", "@swc/core-linux-ppc64-gnu": "1.15.24", "@swc/core-linux-s390x-gnu": "1.15.24", "@swc/core-linux-x64-gnu": "1.15.24", "@swc/core-linux-x64-musl": "1.15.24", "@swc/core-win32-arm64-msvc": "1.15.24", "@swc/core-win32-ia32-msvc": "1.15.24", "@swc/core-win32-x64-msvc": "1.15.24" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-5Hj8aNasue7yusUt8LGCUe/AjM7RMAce8ZoyDyiFwx7Al+GbYKL+yE7g4sJk8vEr1dKIkTRARkNIJENc4CjkBQ=="],
 
-    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.21", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA=="],
+    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.24", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g=="],
 
-    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.21", "", { "os": "darwin", "cpu": "x64" }, "sha512-//fOVntgowz9+V90lVsNCtyyrtbHp3jWH6Rch7MXHXbcvbLmbCTmssl5DeedUWLLGiAAW1wksBdqdGYOTjaNLw=="],
+    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.24", "", { "os": "darwin", "cpu": "x64" }, "sha512-fMIb/Zfn929pw25VMBhV7Ji2Dl+lCWtUPNdYJQYOke+00E5fcQ9ynxtP8+qhUo/HZc+mYQb1gJxwHM9vty+lXg=="],
 
-    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.21", "", { "os": "linux", "cpu": "arm" }, "sha512-meNI4Sh6h9h8DvIfEc0l5URabYMSuNvyisLmG6vnoYAS43s8ON3NJR8sDHvdP7NJTrLe0q/x2XCn6yL/BeHcZg=="],
+    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.24", "", { "os": "linux", "cpu": "arm" }, "sha512-vOkjsyjjxnoYx3hMEWcGxQrMgnNrRm6WAegBXrN8foHtDAR+zpdhpGF5a4lj1bNPgXAvmysjui8cM1ov/Clkaw=="],
 
-    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-QrXlNQnHeXqU2EzLlnsPoWEh8/GtNJLvfMiPsDhk+ht6Xv8+vhvZ5YZ/BokNWSIZiWPKLAqR0M7T92YF5tmD3g=="],
+    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.24", "", { "os": "linux", "cpu": "arm64" }, "sha512-h/oNu+upkXJ6Cicnq7YGVj9PkdfarLCdQa8l/FlHYvfv8CEiMaeeTnpLU7gSBH/rGxosM6Qkfa/J9mThGF9CLA=="],
 
-    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.21", "", { "os": "linux", "cpu": "arm64" }, "sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g=="],
+    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.24", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg=="],
 
-    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.21", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q=="],
+    "@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.24", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QZEsZfisHTSJlmyChgDFNmKPb3W6Lhbfo/O76HhIngfEdnQNmukS38/VSe1feho+xkV5A5hETyCbx3sALBZKAQ=="],
 
-    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.21", "", { "os": "linux", "cpu": "s390x" }, "sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA=="],
+    "@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.24", "", { "os": "linux", "cpu": "s390x" }, "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw=="],
 
-    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.21", "", { "os": "linux", "cpu": "x64" }, "sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q=="],
+    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.24", "", { "os": "linux", "cpu": "x64" }, "sha512-IpLYfposPA/XLxYOKpRfeccl1p5dDa3+okZDHHTchBkXEaVCnq5MADPmIWwIYj1tudt7hORsEHccG5no6IUQRw=="],
 
-    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.21", "", { "os": "linux", "cpu": "x64" }, "sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w=="],
+    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.24", "", { "os": "linux", "cpu": "x64" }, "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg=="],
 
-    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.21", "", { "os": "win32", "cpu": "arm64" }, "sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ=="],
+    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.24", "", { "os": "win32", "cpu": "arm64" }, "sha512-Txj+qUH1z2bUd1P3JvwByfjKFti3cptlAxhWgmunBUUxy/IW3CXLZ6l6Gk4liANadKkU71nIU1X30Z5vpMT3BA=="],
 
-    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.21", "", { "os": "win32", "cpu": "ia32" }, "sha512-IkSZj8PX/N4HcaFhMQtzmkV8YSnuNoJ0E6OvMwFiOfejPhiKXvl7CdDsn1f4/emYEIDO3fpgZW9DTaCRMDxaDA=="],
+    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.24", "", { "os": "win32", "cpu": "ia32" }, "sha512-15D/nl3XwrhFpMv+MADFOiVwv3FvH9j8c6Rf8EXBT3Q5LoMh8YnDnSgPYqw1JzPnksvsBX6QPXLiPqmcR/Z4qQ=="],
 
-    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.21", "", { "os": "win32", "cpu": "x64" }, "sha512-zUyWso7OOENB6e1N1hNuNn8vbvLsTdKQ5WKLgt/JcBNfJhKy/6jmBmqI3GXk/MyvQKd5SLvP7A0F36p7TeDqvw=="],
+    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.24", "", { "os": "win32", "cpu": "x64" }, "sha512-PR0PlTlPra2JbaDphrOAzm6s0v9rA0F17YzB+XbWD95B4g2cWcZY9LAeTa4xll70VLw9Jr7xBrlohqlQmelMFQ=="],
 
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
@@ -2646,7 +2646,7 @@
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.13", "", { "dependencies": { "@oxc-project/types": "=0.123.0", "@rolldown/pluginutils": "1.0.0-rc.13" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-x64": "1.0.0-rc.13", "@rolldown/binding-freebsd-x64": "1.0.0-rc.13", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw=="],
+    "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
@@ -2758,7 +2758,7 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "source-map-support": ["source-map-support@0.2.10", "", { "dependencies": { "source-map": "0.1.32" } }, "sha512-gGKOSat73z0V8wBKo9AGxZZyekczBireh1hHktbt+kb9acsCB5OfVCF2DCWlztcQ3r5oNN7f2BL0B2xOcoJ/DQ=="],
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
@@ -3138,6 +3138,8 @@
 
     "@gerrit0/mini-shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
+    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack": ["@jsonjoy.com/json-pack@17.67.0", "", { "dependencies": { "@jsonjoy.com/base64": "17.67.0", "@jsonjoy.com/buffers": "17.67.0", "@jsonjoy.com/codegen": "17.67.0", "@jsonjoy.com/json-pointer": "17.67.0", "@jsonjoy.com/util": "17.67.0", "hyperdyperid": "^1.2.0", "thingies": "^2.5.0", "tree-dump": "^1.1.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w=="],
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util": ["@jsonjoy.com/util@17.67.0", "", { "dependencies": { "@jsonjoy.com/buffers": "17.67.0", "@jsonjoy.com/codegen": "17.67.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew=="],
@@ -3148,9 +3150,13 @@
 
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+
+    "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
-    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
     "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" } }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
 
@@ -3203,8 +3209,6 @@
     "@xhmikosr/bin-check/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "@zts/integration/@swc/cli": ["@swc/cli@0.8.1", "", { "dependencies": { "@swc/counter": "^0.1.3", "@xhmikosr/bin-wrapper": "^14.0.0", "commander": "^8.3.0", "minimatch": "^9.0.3", "piscina": "^4.3.1", "semver": "^7.3.8", "slash": "3.0.0", "source-map": "^0.7.3", "tinyglobby": "^0.2.13" }, "peerDependencies": { "@swc/core": "^1.2.66", "chokidar": "^5.0.0" }, "optionalPeers": ["chokidar"], "bin": { "swc": "bin/swc.js", "swcx": "bin/swcx.js", "spack": "bin/spack.js" } }, "sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ=="],
-
-    "@zts/integration/@swc/core": ["@swc/core@1.15.24", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.24", "@swc/core-darwin-x64": "1.15.24", "@swc/core-linux-arm-gnueabihf": "1.15.24", "@swc/core-linux-arm64-gnu": "1.15.24", "@swc/core-linux-arm64-musl": "1.15.24", "@swc/core-linux-ppc64-gnu": "1.15.24", "@swc/core-linux-s390x-gnu": "1.15.24", "@swc/core-linux-x64-gnu": "1.15.24", "@swc/core-linux-x64-musl": "1.15.24", "@swc/core-win32-arm64-msvc": "1.15.24", "@swc/core-win32-ia32-msvc": "1.15.24", "@swc/core-win32-x64-msvc": "1.15.24" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-5Hj8aNasue7yusUt8LGCUe/AjM7RMAce8ZoyDyiFwx7Al+GbYKL+yE7g4sJk8vEr1dKIkTRARkNIJENc4CjkBQ=="],
 
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
@@ -3400,7 +3404,7 @@
 
     "sort-keys/is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
 
-    "source-map-support/source-map": ["source-map@0.1.32", "", { "dependencies": { "amdefine": ">=0.0.4" } }, "sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ=="],
+    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "spdy-transport/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -3410,19 +3414,17 @@
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "terser/source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
-
     "traceur/commander": ["commander@2.9.0", "", { "dependencies": { "graceful-readlink": ">= 1.0.0" } }, "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A=="],
 
     "traceur/semver": ["semver@4.3.6", "", { "bin": { "semver": "./bin/semver" } }, "sha512-IrpJ+yoG4EOH8DFWuVg+8H1kW1Oaof0Wxe7cPcXW3x9BjkN/eVo54F15LyqemnDIUYskQWr9qvl/RihmSy6+xQ=="],
+
+    "traceur/source-map-support": ["source-map-support@0.2.10", "", { "dependencies": { "source-map": "0.1.32" } }, "sha512-gGKOSat73z0V8wBKo9AGxZZyekczBireh1hHktbt+kb9acsCB5OfVCF2DCWlztcQ3r5oNN7f2BL0B2xOcoJ/DQ=="],
 
     "ts-loader/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "verror/core-util-is": ["core-util-is@1.0.2", "", {}, "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="],
-
-    "vite/rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
     "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
@@ -3472,6 +3474,12 @@
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
 
+    "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
+    "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+
+    "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+
     "@swc/cli/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
     "@types/body-parser/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
@@ -3503,30 +3511,6 @@
     "@zts/integration/@swc/cli/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "@zts/integration/@swc/cli/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
-
-    "@zts/integration/@swc/core/@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.24", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g=="],
-
-    "@zts/integration/@swc/core/@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.24", "", { "os": "darwin", "cpu": "x64" }, "sha512-fMIb/Zfn929pw25VMBhV7Ji2Dl+lCWtUPNdYJQYOke+00E5fcQ9ynxtP8+qhUo/HZc+mYQb1gJxwHM9vty+lXg=="],
-
-    "@zts/integration/@swc/core/@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.24", "", { "os": "linux", "cpu": "arm" }, "sha512-vOkjsyjjxnoYx3hMEWcGxQrMgnNrRm6WAegBXrN8foHtDAR+zpdhpGF5a4lj1bNPgXAvmysjui8cM1ov/Clkaw=="],
-
-    "@zts/integration/@swc/core/@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.24", "", { "os": "linux", "cpu": "arm64" }, "sha512-h/oNu+upkXJ6Cicnq7YGVj9PkdfarLCdQa8l/FlHYvfv8CEiMaeeTnpLU7gSBH/rGxosM6Qkfa/J9mThGF9CLA=="],
-
-    "@zts/integration/@swc/core/@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.24", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg=="],
-
-    "@zts/integration/@swc/core/@swc/core-linux-ppc64-gnu": ["@swc/core-linux-ppc64-gnu@1.15.24", "", { "os": "linux", "cpu": "ppc64" }, "sha512-QZEsZfisHTSJlmyChgDFNmKPb3W6Lhbfo/O76HhIngfEdnQNmukS38/VSe1feho+xkV5A5hETyCbx3sALBZKAQ=="],
-
-    "@zts/integration/@swc/core/@swc/core-linux-s390x-gnu": ["@swc/core-linux-s390x-gnu@1.15.24", "", { "os": "linux", "cpu": "s390x" }, "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw=="],
-
-    "@zts/integration/@swc/core/@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.24", "", { "os": "linux", "cpu": "x64" }, "sha512-IpLYfposPA/XLxYOKpRfeccl1p5dDa3+okZDHHTchBkXEaVCnq5MADPmIWwIYj1tudt7hORsEHccG5no6IUQRw=="],
-
-    "@zts/integration/@swc/core/@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.24", "", { "os": "linux", "cpu": "x64" }, "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg=="],
-
-    "@zts/integration/@swc/core/@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.24", "", { "os": "win32", "cpu": "arm64" }, "sha512-Txj+qUH1z2bUd1P3JvwByfjKFti3cptlAxhWgmunBUUxy/IW3CXLZ6l6Gk4liANadKkU71nIU1X30Z5vpMT3BA=="],
-
-    "@zts/integration/@swc/core/@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.24", "", { "os": "win32", "cpu": "ia32" }, "sha512-15D/nl3XwrhFpMv+MADFOiVwv3FvH9j8c6Rf8EXBT3Q5LoMh8YnDnSgPYqw1JzPnksvsBX6QPXLiPqmcR/Z4qQ=="],
-
-    "@zts/integration/@swc/core/@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.24", "", { "os": "win32", "cpu": "x64" }, "sha512-PR0PlTlPra2JbaDphrOAzm6s0v9rA0F17YzB+XbWD95B4g2cWcZY9LAeTa4xll70VLw9Jr7xBrlohqlQmelMFQ=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -3696,47 +3680,13 @@
 
     "spdy-transport/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "terser/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "traceur/source-map-support/source-map": ["source-map@0.1.32", "", { "dependencies": { "amdefine": ">=0.0.4" } }, "sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ=="],
 
     "ts-loader/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "ts-loader/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
-
-    "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
-
-    "vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
-
-    "vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
-
-    "vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
-
-    "vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
-
-    "vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
-
-    "vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
-
-    "vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
-
-    "vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
-
-    "vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
-
-    "vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
-
-    "vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
-
-    "vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
-
-    "vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
-
-    "vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
-
-    "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
-
-    "vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
     "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -3796,6 +3746,8 @@
 
     "@astrojs/react/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
     "@swc/cli/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check": ["@xhmikosr/bin-check@8.2.1", "", { "dependencies": { "execa": "^9.6.1", "isexe": "^4.0.0" } }, "sha512-DNruLq+kalxcE7JeDxtqrN9kyWjLW8VqsQPLRTwD1t9ck/1rF4qBL0mX5Fe2/xLOMjo5wPb67BNX2kSAhzfLjA=="],
@@ -3850,12 +3802,6 @@
 
     "ts-loader/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
-
-    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
-
-    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
-
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check/execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
@@ -3889,8 +3835,6 @@
     "compat-table/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "jshint/htmlparser2/domutils/dom-serializer/entities": ["entities@1.1.2", "", {}, "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="],
-
-    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check/execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -4304,3 +4304,82 @@ describe("buildResult moduleCodes/modulePaths", () => {
     rmSync(dir, { recursive: true });
   });
 });
+
+// ─── browserslist 옵션 ───
+
+describe("@zts/core browserslist", () => {
+  test("browserslist: 모던 브라우저 쿼리는 변환 안 함", () => {
+    const src = "async function f() { return await Promise.resolve(1); }";
+    const r = transpile(src, { browserslist: "last 2 chrome versions" });
+    expect(r.code).toContain("async function f");
+    expect(r.code).not.toContain("__async");
+  });
+
+  test("browserslist: 오래된 브라우저 쿼리는 async 다운레벨", () => {
+    const src = "async function f() { return await Promise.resolve(1); }";
+    const r = transpile(src, { browserslist: "chrome 50, firefox 50" });
+    expect(r.code).toContain("__async");
+  });
+
+  test("browserslist: 여러 엔진 중 하나라도 미지원이면 다운레벨 (보수적)", () => {
+    // chrome 최신은 optional_chaining 지원, safari 12는 미지원 → ?. 제거
+    const src = "const x = a?.b;";
+    const r = transpile(src, { browserslist: "chrome 100, safari 12" });
+    expect(r.code).not.toContain("?.");
+  });
+
+  test("browserslist: 쿼리 배열 입력", () => {
+    const src = "const x = 1 ** 2;";
+    // chrome 40은 exponentiation 미지원, chrome 55는 지원 → union 결과 chrome 40 기준
+    const r = transpile(src, { browserslist: ["chrome 40"] });
+    expect(r.code).not.toContain("**");
+  });
+
+  test("browserslist: ios_saf는 ios 엔진으로 매핑", () => {
+    const src = "async function f() {}";
+    // ios 10은 async 미지원 → 변환
+    const r = transpile(src, { browserslist: "ios_saf 10" });
+    expect(r.code).toContain("__async");
+  });
+
+  test("browserslist: 매핑 불가능한 엔진(samsung)만 있으면 보수적으로 esnext", () => {
+    // samsung 브라우저는 ZTS Engine에 없음 → 빈 engines → 0 (esnext)
+    const src = "async function f() {}";
+    const r = transpile(src, { browserslist: "samsung 20" });
+    expect(r.code).toContain("async function");
+  });
+
+  test("browserslist는 target보다 우선", () => {
+    const src = "const x = a?.b;";
+    // target=es5지만 browserslist=modern → optional chaining 유지
+    const r = transpile(src, { target: "es5", browserslist: "chrome 100" });
+    expect(r.code).toContain("?.");
+  });
+
+  test("browserslist: 빈 결과(매칭 없음)도 크래시 없이 처리", () => {
+    // 존재하지 않는 버전 규칙 — browserslist가 throw 할 수도 있음
+    // 이 경우 사용자 책임 — 우리 코드에서 크래시만 안 나면 됨
+    const src = "const x = 1;";
+    expect(() => transpile(src, { browserslist: "defaults" })).not.toThrow();
+  });
+
+  test("browserslist: hermes 매핑 (RN 사용자 대응)", () => {
+    // browserslist는 hermes를 모르지만 우리 파서는 수동 매핑 지원
+    // 직접 hermes 키워드 쿼리는 browserslist가 모르므로 defaults 사용 예시
+    const src = "async function f() {}";
+    // hermes 0.12는 async transform 필요 (kangax fail) → __async 나와야 함
+    // 이 테스트는 browserslistToUnsupported 저수준 API 커버
+    const { browserslistToUnsupported } = require("../shared/index");
+    const bits = browserslistToUnsupported(["hermes 0.12"]);
+    // bit 12 = async_await
+    expect(bits & (1 << 12)).not.toBe(0);
+    void src;
+  });
+
+  test("browserslist: 같은 엔진의 여러 버전 — 가장 낮은 버전 기준", () => {
+    const { browserslistToUnsupported } = require("../shared/index");
+    // chrome 40(미지원) + chrome 100(지원) 동시 전달 — 40 때문에 async_await unsupported
+    const bits = browserslistToUnsupported(["chrome 40", "chrome 100"]);
+    expect(bits & (1 << 12)).not.toBe(0);
+  });
+});

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "url";
 
 export type { Target, Platform, TranspileOptions, TranspileResult } from "../shared/index";
 import type { TranspileOptions, TranspileResult } from "../shared/index";
-import { encodeFlags, ES_TARGET_BITS } from "../shared/index";
+import { encodeFlags, ES_TARGET_BITS, browserslistToUnsupported } from "../shared/index";
 
 // ─── NAPI Module ───
 
@@ -104,12 +104,34 @@ export function init(addonPath?: string): void {
 /**
  * TypeScript/JSX 소스 코드를 트랜스파일한다.
  */
+/**
+ * browserslist 모듈 lazy-load 캐시. CJS require 캐시도 동작하지만
+ * 매 transpile마다 require() 호출 자체를 피해 오버헤드 제거.
+ */
+let _browserslist: ((q: string | string[]) => string[]) | null = null;
+
+/**
+ * target | browserslist → UnsupportedFeatures bitmask.
+ * browserslist가 지정되면 우선. 둘 다 없으면 0 (esnext).
+ */
+function resolveUnsupported(options: TranspileOptions): number {
+  if (options.browserslist) {
+    if (!_browserslist) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      _browserslist = require("browserslist") as (q: string | string[]) => string[];
+    }
+    const entries = _browserslist(options.browserslist);
+    return browserslistToUnsupported(entries);
+  }
+  return options.target ? (ES_TARGET_BITS[options.target] ?? 0) : 0;
+}
+
 export function transpile(source: string, options: TranspileOptions = {}): TranspileResult {
   if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
   if (!source) throw new Error("@zts/core: empty source");
 
   const flags = encodeFlags(options);
-  const unsupported = options.target ? (ES_TARGET_BITS[options.target] ?? 0) : 0;
+  const unsupported = resolveUnsupported(options);
 
   return native.transpile(
     source,
@@ -175,6 +197,11 @@ export interface BuildOptions {
   mainFields?: string[];
   /** ES 다운레벨 타겟 ("es5" ~ "esnext") */
   target?: import("../shared/index").Target;
+  /**
+   * browserslist 쿼리 (transpile과 동일, target보다 우선).
+   * bundler에선 현재 미전달 — 후속 작업. 타입만 노출해 API 일관성 유지.
+   */
+  browserslist?: string | string[];
   /** 출력 디렉토리 (write: true 시 사용) */
   outdir?: string;
   /** 출력 파일 경로 (단일 엔트리 시, write: true 시 사용) */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,9 @@
     "build": "bun run build:napi && cp ../../zig-out/lib/zts.node . && bun run build:js",
     "test": "bun test"
   },
+  "dependencies": {
+    "browserslist": "^4.24.0"
+  },
   "optionalDependencies": {
     "lightningcss": "^1.28.0"
   }

--- a/packages/shared/compat-engines.ts
+++ b/packages/shared/compat-engines.ts
@@ -1,0 +1,319 @@
+/**
+ * Engine × Feature 지원 버전 테이블 (JS 미러).
+ *
+ * src/transformer/compat.zig의 compat_table을 거울 복사.
+ * browserslist → UnsupportedFeatures bitmask 계산에 사용.
+ *
+ * **주의**: compat.zig를 수정하면 이 파일도 함께 업데이트.
+ * 장기적으론 scripts/compat-from-kangax.ts를 확장해 자동 생성.
+ *
+ * Bit 레이아웃은 packages/shared/index.ts ES_TARGET_BITS와 동일 (0-22).
+ */
+
+export type Engine =
+  | "chrome"
+  | "firefox"
+  | "safari"
+  | "edge"
+  | "node"
+  | "deno"
+  | "ios"
+  | "opera"
+  | "hermes";
+
+/** compat.zig의 Feature enum과 동일 순서. bit 위치 = 배열 인덱스. */
+export const FEATURES = [
+  // ES2015 (bit 0-10)
+  "arrow",
+  "class",
+  "template_literal",
+  "destructuring",
+  "for_of",
+  "spread",
+  "object_extensions",
+  "default_params",
+  "block_scoping",
+  "generator",
+  "new_target",
+  // ES2016
+  "exponentiation",
+  // ES2017
+  "async_await",
+  // ES2018
+  "object_spread",
+  // ES2019
+  "optional_catch_binding",
+  // ES2020
+  "nullish_coalescing",
+  "optional_chaining",
+  // ES2021
+  "logical_assignment",
+  // ES2022
+  "class_static_block",
+  "class_private_method",
+  "class_private_field",
+  // ES2023
+  "hashbang",
+  // ES2025
+  "using",
+] as const;
+
+export type Feature = (typeof FEATURES)[number];
+
+/**
+ * feature × engine → 최소 지원 버전 [major, minor].
+ * 엔진에 키가 없으면 "해당 엔진에서 미지원" (compat.zig의 보수적 해석).
+ */
+export const SUPPORT: Partial<Record<Feature, Partial<Record<Engine, [number, number]>>>> = {
+  arrow: {
+    chrome: [45, 0],
+    firefox: [22, 0],
+    safari: [10, 0],
+    edge: [12, 0],
+    node: [4, 0],
+    deno: [1, 0],
+    ios: [10, 0],
+  },
+  class: {
+    chrome: [49, 0],
+    firefox: [45, 0],
+    safari: [10, 1],
+    edge: [13, 0],
+    node: [6, 0],
+    deno: [1, 0],
+    ios: [10, 3],
+  },
+  template_literal: {
+    chrome: [41, 0],
+    firefox: [34, 0],
+    safari: [9, 0],
+    edge: [12, 0],
+    node: [4, 0],
+    deno: [1, 0],
+    ios: [9, 0],
+  },
+  destructuring: {
+    chrome: [49, 0],
+    firefox: [41, 0],
+    safari: [8, 0],
+    edge: [14, 0],
+    node: [6, 0],
+    deno: [1, 0],
+    ios: [8, 0],
+  },
+  for_of: {
+    chrome: [38, 0],
+    firefox: [13, 0],
+    safari: [7, 0],
+    edge: [12, 0],
+    node: [0, 12],
+    deno: [1, 0],
+    ios: [7, 0],
+    hermes: [0, 7],
+  },
+  spread: {
+    chrome: [46, 0],
+    firefox: [27, 0],
+    safari: [10, 0],
+    edge: [13, 0],
+    node: [5, 0],
+    deno: [1, 0],
+    ios: [10, 0],
+    hermes: [0, 7],
+  },
+  object_extensions: {
+    chrome: [43, 0],
+    firefox: [34, 0],
+    safari: [9, 0],
+    edge: [12, 0],
+    node: [4, 0],
+    deno: [1, 0],
+    ios: [9, 0],
+    hermes: [0, 7],
+  },
+  default_params: {
+    chrome: [49, 0],
+    firefox: [15, 0],
+    safari: [10, 0],
+    edge: [14, 0],
+    node: [6, 0],
+    deno: [1, 0],
+    ios: [10, 0],
+  },
+  block_scoping: {
+    chrome: [49, 0],
+    firefox: [51, 0],
+    safari: [11, 0],
+    edge: [14, 0],
+    node: [6, 0],
+    deno: [1, 0],
+    ios: [11, 0],
+  },
+  generator: {
+    chrome: [50, 0],
+    firefox: [53, 0],
+    safari: [10, 0],
+    edge: [13, 0],
+    node: [6, 0],
+    deno: [1, 0],
+    ios: [10, 0],
+  },
+  new_target: {
+    chrome: [46, 0],
+    firefox: [41, 0],
+    safari: [10, 0],
+    edge: [14, 0],
+    node: [5, 0],
+    deno: [1, 0],
+    ios: [10, 0],
+  },
+  exponentiation: {
+    chrome: [52, 0],
+    firefox: [52, 0],
+    safari: [10, 1],
+    edge: [14, 0],
+    node: [7, 0],
+    deno: [1, 0],
+    ios: [10, 3],
+    hermes: [0, 7],
+  },
+  async_await: {
+    chrome: [55, 0],
+    firefox: [52, 0],
+    safari: [11, 0],
+    edge: [15, 0],
+    node: [7, 6],
+    deno: [1, 0],
+    ios: [11, 0],
+    // Hermes 미등재: kangax 0.12 데이터에서 core async는 통과하나 async arrow /
+    // async class method에서 subtest fail. esbuild의 js_table.go도 동일 판정
+    // ("Hermes failed 4 tests including: async arrow functions") — 보수적으로 제외.
+  },
+  object_spread: {
+    chrome: [60, 0],
+    firefox: [55, 0],
+    safari: [11, 1],
+    edge: [79, 0],
+    node: [8, 3],
+    deno: [1, 0],
+    ios: [11, 3],
+    hermes: [0, 7],
+  },
+  optional_catch_binding: {
+    chrome: [66, 0],
+    firefox: [58, 0],
+    safari: [11, 1],
+    edge: [79, 0],
+    node: [10, 0],
+    deno: [1, 0],
+    ios: [11, 3],
+    hermes: [0, 12],
+  },
+  nullish_coalescing: {
+    chrome: [80, 0],
+    firefox: [72, 0],
+    safari: [13, 1],
+    edge: [80, 0],
+    node: [14, 0],
+    deno: [1, 0],
+    ios: [13, 4],
+    hermes: [0, 7],
+  },
+  optional_chaining: {
+    chrome: [91, 0],
+    firefox: [74, 0],
+    safari: [13, 1],
+    edge: [91, 0],
+    node: [16, 9],
+    deno: [1, 9],
+    ios: [13, 4],
+    hermes: [0, 12],
+  },
+  logical_assignment: {
+    chrome: [85, 0],
+    firefox: [79, 0],
+    safari: [14, 0],
+    edge: [85, 0],
+    node: [15, 0],
+    deno: [1, 2],
+    ios: [14, 0],
+    hermes: [0, 7],
+  },
+  class_static_block: {
+    chrome: [94, 0],
+    firefox: [93, 0],
+    safari: [16, 4],
+    edge: [94, 0],
+    node: [16, 11],
+    deno: [1, 14],
+    ios: [16, 4],
+  },
+  class_private_method: {
+    chrome: [84, 0],
+    firefox: [90, 0],
+    safari: [15, 0],
+    edge: [84, 0],
+    node: [14, 6],
+    deno: [1, 0],
+    ios: [15, 0],
+  },
+  class_private_field: {
+    chrome: [74, 0],
+    firefox: [90, 0],
+    safari: [14, 1],
+    edge: [79, 0],
+    node: [12, 0],
+    deno: [1, 0],
+    ios: [14, 5],
+  },
+  hashbang: {
+    chrome: [74, 0],
+    firefox: [67, 0],
+    safari: [13, 1],
+    edge: [79, 0],
+    node: [12, 0],
+    deno: [1, 0],
+    ios: [13, 4],
+    hermes: [0, 7],
+  },
+  using: {
+    // ES2025 `using` / `await using` 선언. 2026-04 기준 어떤 엔진도 미지원이라
+    // SUPPORT 테이블은 비어있고, computeUnsupported는 모든 엔진에서 비트를 set.
+    // 엔진 지원이 시작되면 여기에 추가.
+  },
+};
+
+/** a >= b (major, minor 순). */
+function verGte(a: [number, number], b: [number, number]): boolean {
+  if (a[0] !== b[0]) return a[0] > b[0];
+  return a[1] >= b[1];
+}
+
+/** 특정 engine 버전에서 feature가 지원되는지. */
+function isSupported(feature: Feature, engine: Engine, ver: [number, number]): boolean {
+  const min = SUPPORT[feature]?.[engine];
+  if (!min) return false;
+  return verGte(ver, min);
+}
+
+export type EngineVersion = { engine: Engine; major: number; minor: number };
+
+/**
+ * 엔진 목록에 대해 unsupported feature bitmask 계산.
+ * 하나라도 미지원인 feature는 set (가장 보수적).
+ */
+export function computeUnsupportedFromEngines(engines: EngineVersion[]): number {
+  let bits = 0;
+  for (let i = 0; i < FEATURES.length; i++) {
+    const feature = FEATURES[i];
+    let anyUnsupported = false;
+    for (const ev of engines) {
+      if (!isSupported(feature, ev.engine, [ev.major, ev.minor])) {
+        anyUnsupported = true;
+        break;
+      }
+    }
+    if (anyUnsupported) bits |= 1 << i;
+  }
+  return bits;
+}

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -72,6 +72,11 @@ export interface TranspileOptions {
   platform?: Platform;
   /** ES 다운레벨 타겟 */
   target?: Target;
+  /**
+   * browserslist 쿼리 (예: "last 2 versions", ">1%, not dead").
+   * 지정 시 target보다 우선. core 패키지에서만 해석됨 (browserslist 의존).
+   */
+  browserslist?: string | string[];
 }
 
 export interface TranspileResult {
@@ -138,4 +143,59 @@ export function encodeFlags(opts: TranspileOptions = {}): number {
 export function targetToUnsupported(target?: Target): number {
   if (!target) return 0;
   return ES_TARGET_BITS[target] ?? 0;
+}
+
+// ─── browserslist → UnsupportedFeatures ───
+
+export type { Engine, EngineVersion, Feature } from "./compat-engines";
+export { computeUnsupportedFromEngines, FEATURES } from "./compat-engines";
+
+import type { Engine, EngineVersion } from "./compat-engines";
+import { computeUnsupportedFromEngines } from "./compat-engines";
+
+/** browserslist 결과 문자열 ("chrome 100", "ios_saf 14.5") → EngineVersion. */
+export function parseBrowserslistEntry(entry: string): EngineVersion | null {
+  // 형식: "<name> <version>" — version은 "100", "14.1", "100-101" 등
+  const m = entry.trim().match(/^(\S+)\s+([\d.]+)(?:-[\d.]+)?$/);
+  if (!m) return null;
+  const name = m[1].toLowerCase();
+  const versionStr = m[2];
+  const [majStr, minStr = "0"] = versionStr.split(".");
+  const major = parseInt(majStr, 10);
+  const minor = parseInt(minStr, 10);
+  if (Number.isNaN(major)) return null;
+
+  // browserslist 이름 → ZTS Engine 매핑
+  // 미매핑 엔진(op_mini, samsung, and_chr 등)은 null 반환 → 호출자가 filter.
+  const map: Record<string, Engine> = {
+    chrome: "chrome",
+    and_chr: "chrome", // Android Chrome
+    firefox: "firefox",
+    and_ff: "firefox",
+    safari: "safari",
+    ios_saf: "ios",
+    edge: "edge",
+    node: "node",
+    deno: "deno",
+    opera: "opera",
+    op_mob: "opera",
+    hermes: "hermes",
+  };
+  const engine = map[name];
+  if (!engine) return null;
+  return { engine, major, minor };
+}
+
+/**
+ * browserslist가 반환한 문자열 배열 → unsupported bitmask.
+ * 매핑 불가능한 엔진(samsung, kaios 등)은 무시 (ZTS가 타겟팅하지 않는 엔진).
+ */
+export function browserslistToUnsupported(entries: string[]): number {
+  const engines: EngineVersion[] = [];
+  for (const e of entries) {
+    const parsed = parseBrowserslistEntry(e);
+    if (parsed) engines.push(parsed);
+  }
+  if (engines.length === 0) return 0; // 매핑된 엔진 없음 → 보수적으로 esnext
+  return computeUnsupportedFromEngines(engines);
 }

--- a/scripts/compat-from-kangax.ts
+++ b/scripts/compat-from-kangax.ts
@@ -1,0 +1,222 @@
+#!/usr/bin/env bun
+/**
+ * kangax compat-table → ZTS 호환성 데이터 추출기 (초안).
+ *
+ * 목적:
+ *   - references/compat-table/의 kangax 데이터에서 ZTS가 관리하는 feature set을
+ *     읽어, src/transformer/compat.zig 엔트리를 재생성하기 위한 raw 데이터를
+ *     얻는다.
+ *   - 엔진 × feature × 최소 지원 버전 매핑을 JSON으로 덤프.
+ *   - **자동 덮어쓰기는 하지 않음.** 결과를 수동 비교 후 compat.zig에 반영.
+ *
+ * 정책 (esbuild 방식):
+ *   - feature의 모든 subtest가 true여야 해당 feature "지원"으로 판정
+ *   - 하나라도 false/누락이면 unsupported
+ *
+ * 출력: scripts/out/compat-kangax.json
+ *
+ * 사용:
+ *   bun run scripts/compat-from-kangax.ts [feature]
+ *   bun run scripts/compat-from-kangax.ts async_await    # 특정 feature 드릴다운
+ *
+ * 제한:
+ *   - 현재는 async/await, generator, hashbang 등 대표 샘플만 매핑.
+ *   - 전체 feature 매핑은 ZTS Feature enum과 kangax feature name 사이의
+ *     매핑 테이블을 추가로 채워야 한다.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..");
+const KANGAX_DIR = join(ROOT, "references/compat-table");
+
+if (!existsSync(KANGAX_DIR)) {
+  console.error(`kangax clone not found: ${KANGAX_DIR}`);
+  console.error(`  git clone https://github.com/compat-table/compat-table.git ${KANGAX_DIR}`);
+  process.exit(1);
+}
+
+// kangax 데이터 파일은 CommonJS 모듈로 module.exports = { tests: [...] } 형식.
+// require()로 그대로 로드 가능.
+/* eslint-disable @typescript-eslint/no-require-imports */
+const es6 = require(join(KANGAX_DIR, "data-es6.js"));
+const es2016plus = require(join(KANGAX_DIR, "data-es2016plus.js"));
+const esnext = require(join(KANGAX_DIR, "data-esnext.js"));
+
+type Test = {
+  name: string;
+  subtests?: Test[];
+  res?: Record<string, boolean | object>;
+};
+
+type Dataset = { tests: Test[] };
+
+const ALL: Dataset[] = [es6, es2016plus, esnext];
+
+// ZTS의 Feature enum (src/transformer/compat.zig) → kangax 테스트 이름 매핑.
+// 핵심 샘플만 포함. 전체 커버를 위해선 이 맵을 확장.
+const FEATURE_MAP: Record<string, string[]> = {
+  async_await: ["async functions"],
+  generator: ["generators"],
+  arrow: ["arrow functions"],
+  class: ["class"],
+  destructuring: ["destructuring, declarations", "destructuring, assignment"],
+  default_params: ["default function parameters"],
+  spread: ["spread (...) operator"],
+  for_of: ["for..of loops"],
+  template_literal: ["template literals"],
+  exponentiation: ["exponentiation (**) operator"],
+  object_spread: ["object rest/spread properties"],
+  optional_catch_binding: ["optional catch binding"],
+  nullish_coalescing: ["nullish coalescing operator (??)"],
+  optional_chaining: ["optional chaining operator (?.)"],
+  logical_assignment: ["Logical Assignment"],
+  class_static_block: ["Class static initialization blocks"],
+  class_private_method: ["private class methods"],
+  class_private_field: ["instance class fields"],
+  hashbang: ["Hashbang Grammar"],
+};
+
+// 우리가 관심 있는 엔진만 추출 (kangax env 키 기준).
+// 하나의 엔진이 여러 버전 포인트를 가지므로 최소 지원 버전을 취함.
+const ENGINE_PREFIXES = {
+  chrome: /^chrome(\d+)$/,
+  firefox: /^firefox(\d+)$/,
+  safari: /^safari(\d+(_\d+)*)/,
+  edge: /^edge(\d+)$/,
+  node: /^node(\d+(_\d+)*)$/,
+  deno: /^deno(\d+(_\d+)*)$/,
+  ios: /^ios(\d+(_\d+)*)$/,
+  hermes: /^hermes(\d+_\d+_\d+)$/,
+};
+
+type Engine = keyof typeof ENGINE_PREFIXES;
+
+/** kangax 버전 문자열 "0_12_0" → [0, 12, 0]. */
+function parseVer(v: string): number[] {
+  return v.split("_").map((n) => parseInt(n, 10));
+}
+
+/** a >= b. */
+function verGte(a: number[], b: number[]): boolean {
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av > bv) return true;
+    if (av < bv) return false;
+  }
+  return true;
+}
+
+/** 모든 subtest가 이 엔진/버전에서 통과하는지 (esbuild 방식). */
+function allSubtestsPass(test: Test, envKey: string): boolean {
+  const subtests = test.subtests ?? [test];
+  for (const sub of subtests) {
+    const r = sub.res?.[envKey];
+    if (r !== true) return false;
+  }
+  return true;
+}
+
+/** 엔진별 feature 최소 지원 버전 찾기. 지원 안 하면 null. */
+function findMinSupportedVersion(test: Test, engine: Engine): number[] | null {
+  const re = ENGINE_PREFIXES[engine];
+  const envs: string[] = [];
+  // 모든 subtest res 키에서 엔진 매칭 수집
+  const subs = test.subtests ?? [test];
+  const keySet = new Set<string>();
+  for (const sub of subs) {
+    for (const k of Object.keys(sub.res ?? {})) keySet.add(k);
+  }
+  for (const k of keySet) if (re.test(k)) envs.push(k);
+
+  // 버전 오름차순 정렬
+  envs.sort((a, b) => {
+    const av = parseVer(a.replace(re, "$1"));
+    const bv = parseVer(b.replace(re, "$1"));
+    for (let i = 0; i < Math.max(av.length, bv.length); i++) {
+      if ((av[i] ?? 0) !== (bv[i] ?? 0)) return (av[i] ?? 0) - (bv[i] ?? 0);
+    }
+    return 0;
+  });
+
+  for (const env of envs) {
+    if (allSubtestsPass(test, env)) {
+      return parseVer(env.replace(re, "$1"));
+    }
+  }
+  return null;
+}
+
+/** ZTS feature key에 해당하는 kangax test 찾기. */
+function findTests(names: string[]): Test[] {
+  const out: Test[] = [];
+  for (const ds of ALL) {
+    for (const t of ds.tests) {
+      if (names.includes(t.name)) out.push(t);
+    }
+  }
+  return out;
+}
+
+type EngineVer = { engine: Engine; version: number[] };
+type FeatureEntry = { feature: string; supported: EngineVer[]; matchedTests: string[] };
+
+function buildReport(): FeatureEntry[] {
+  const report: FeatureEntry[] = [];
+  for (const [feature, names] of Object.entries(FEATURE_MAP)) {
+    const tests = findTests(names);
+    const supported: EngineVer[] = [];
+    for (const engine of Object.keys(ENGINE_PREFIXES) as Engine[]) {
+      // 모든 매칭 테스트에서 지원되는 최소 버전의 max (가장 늦게 지원되는 쪽)
+      let worst: number[] | null = null;
+      let anyMissing = false;
+      for (const t of tests) {
+        const v = findMinSupportedVersion(t, engine);
+        if (!v) {
+          anyMissing = true;
+          break;
+        }
+        if (!worst || verGte(v, worst)) worst = v;
+      }
+      if (!anyMissing && worst) supported.push({ engine, version: worst });
+    }
+    report.push({ feature, supported, matchedTests: tests.map((t) => t.name) });
+  }
+  return report;
+}
+
+const targetFeature = process.argv[2];
+const report = buildReport();
+
+const outDir = join(ROOT, "scripts/out");
+mkdirSync(outDir, { recursive: true });
+const outPath = join(outDir, "compat-kangax.json");
+writeFileSync(outPath, JSON.stringify(report, null, 2));
+console.log(`Wrote ${outPath}\n`);
+
+if (targetFeature) {
+  const e = report.find((r) => r.feature === targetFeature);
+  if (!e) {
+    console.error(`feature not in FEATURE_MAP: ${targetFeature}`);
+    process.exit(1);
+  }
+  console.log(`## ${e.feature}`);
+  console.log(`matched tests: ${e.matchedTests.join(", ")}`);
+  console.log(`supported:`);
+  for (const s of e.supported) {
+    console.log(`  ${s.engine} ${s.version.join(".")}`);
+  }
+  const notSupported = Object.keys(ENGINE_PREFIXES).filter(
+    (eng) => !e.supported.find((s) => s.engine === eng),
+  );
+  if (notSupported.length) console.log(`unsupported (in kangax): ${notSupported.join(", ")}`);
+} else {
+  console.log("# Summary\n");
+  for (const e of report) {
+    const hermes = e.supported.find((s) => s.engine === "hermes");
+    const mark = hermes ? `hermes ${hermes.version.join(".")}+` : "hermes: UNSUPPORTED";
+    console.log(`${e.feature.padEnd(24)} ${mark}`);
+  }
+}

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -741,6 +741,153 @@ test "Bundler: UMD external dependencies in wrapper" {
     try std.testing.expect(std.mem.indexOf(u8, output, "React.useState") != null);
 }
 
+test "Async helper: single __async emit when target downlevels async (#1267 dup)" {
+    // target=es5 + async 사용 → __async/__generator helper 정확히 1회씩만 emit
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export async function run() { return await Promise.resolve(1); }
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const compat = @import("../../transformer/compat.zig");
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const count = std.mem.count(u8, result.output, "var __async");
+    try std.testing.expectEqual(@as(usize, 1), count);
+    const gcount = std.mem.count(u8, result.output, "var __generator");
+    try std.testing.expectEqual(@as(usize, 1), gcount);
+}
+
+test "Async helper: no emit when target supports async natively" {
+    // target esnext — async 사용해도 transform 안 하므로 __async 주입 금지
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export async function run() { return await Promise.resolve(1); }
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var __async") == null);
+}
+
+test "Async helper: no emit when code has no async/await (edge)" {
+    // target=es5이어도 async가 아예 없으면 __async 주입 안 함 (현재 수정 후 기대 동작)
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export function run() { return 1; }
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const compat = @import("../../transformer/compat.zig");
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 실제 사용 없음 → 주입 안 함 (code size 낭비 제거)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var __async") == null);
+}
+
+test "Async helper: multi-module with async in one — single emit (edge)" {
+    // 여러 모듈 중 한 곳만 async 사용 → helper 1회만 emit
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { helper } from './helper';
+        \\import { load } from './lazy';
+        \\console.log(helper(), load());
+    );
+    try writeFile(tmp.dir, "helper.ts", "export function helper() { return 'h'; }");
+    try writeFile(tmp.dir, "lazy.ts",
+        \\export async function load() { return await Promise.resolve('l'); }
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const compat = @import("../../transformer/compat.zig");
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, result.output, "var __async"));
+}
+
+test "Async helper: top-level await triggers emit (edge)" {
+    // top-level await도 async transform을 트리거해야 함
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export const val = await Promise.resolve(42);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const compat = @import("../../transformer/compat.zig");
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat.fromESTarget(.es5),
+        .format = .esm,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // top-level await는 현재 경고만 emit 가능 — 에러 없으면 OK.
+    // 핵심: 만약 transform이 발생하면 __async가 정확히 1번만 emit
+    const count = std.mem.count(u8, result.output, "var __async");
+    try std.testing.expect(count <= 1);
+}
+
+test "Async helper: async arrow function (edge)" {
+    // async arrow도 동일하게 주입
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export const run = async () => await Promise.resolve(1);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const compat = @import("../../transformer/compat.zig");
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, result.output, "var __async"));
+}
+
 test "Bundler: AMD external dependencies in wrapper" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1349,9 +1349,8 @@ fn emitBundleRuntimeHelpers(
     if (options.experimental_decorators) {
         try rt.appendDecoratorRuntime(output, allocator, options.minify_whitespace);
     }
-    if (options.unsupported.async_await) {
-        try rt.appendAsyncRuntime(output, allocator, options.minify_whitespace, options.unsupported.arrow);
-    }
+    // __async는 이후 appendRuntimeHelpers(collected_helpers)에서 실제 사용 여부 기반으로
+    // 주입됨 — 여기서 target 기반으로 또 주입하면 중복 emit 된다.
     // dev mode: HMR 런타임 주입 (__zts_modules, __zts_require, __zts_apply_update 등).
     // HMR 런타임이 $RefreshReg$/$RefreshSig$도 정의하므로 별도 스텁 불필요.
     if (options.dev_mode) {
@@ -1397,6 +1396,9 @@ pub fn emitChunkRuntimeHelpers(
             try output.appendSlice(allocator, if (options.minify_whitespace) rt.ES_DECORATOR_RUNTIME_MIN else rt.ES_DECORATOR_RUNTIME);
         }
     }
+    // splitting 모드에서는 collected_helpers가 null로 전달되므로 per-chunk 사용 여부를
+    // 알 수 없다 → target 기반으로 주입 (단일-번들 모드와 달리 이 경로에선 appendRuntimeHelpers
+    // 가 다시 호출되지 않으므로 중복 아님).
     if (options.unsupported.async_await) {
         try rt.appendAsyncRuntime(output, allocator, options.minify_whitespace, options.unsupported.arrow);
     }

--- a/tests/benchmark/package.json
+++ b/tests/benchmark/package.json
@@ -97,7 +97,7 @@
     "rfdc": "^1.0.0",
     "rxjs": "^7.0.0",
     "safe-buffer": "^5.0.0",
-    "semver": "^7.0.0",
+    "semver": "^7.7.4",
     "signal-exit": "^4.0.0",
     "solid-js": "^1.0.0",
     "statuses": "^2.0.0",


### PR DESCRIPTION
## Summary

1. **[Fix]** 단일-번들 모드에서 `var __async` helper가 두 번 emit되던 버그 수정 (#1267 조사 중 발견)
2. **[Feat]** `browserslist` 옵션 지원 추가 (`TranspileOptions.browserslist`)
3. **[Test]** 엄격한 엣지 케이스 16건 추가 (async helper 6 + browserslist 10)

## __async 중복 버그

`emitBundleRuntimeHelpers` (target 기반) 와 `appendRuntimeHelpers` (collected_helpers 기반) 두 경로에서 `__async`를 모두 주입 → 단일-번들 mode에서 선언 2회 출력.

Fix: 단일-번들 경로에서 target 기반 injection 제거. splitting 모드는 `collected_helpers=null`이라 target fallback 유지.

### 재현 (fix 전)
\`\`\`js
var __async = function(fn) { ... };
var __async = function(fn) { ... };  ← 중복
// --- entry.ts ---
\`\`\`

## browserslist 지원

- \`TranspileOptions.browserslist?: string | string[]\` + BuildOptions 동일
- 우선순위: browserslist > target > (없음 = esnext)
- 내부 구현: packages/shared/compat-engines.ts에 Engine × Feature 지원 테이블 (compat.zig 미러)
- `browserslist` 패키지는 lazy require + 캐싱

### 예시
\`\`\`ts
transpile(code, { browserslist: "last 2 versions" });
transpile(code, { browserslist: ["chrome 100", "safari 14"] });
\`\`\`

## 테스트 (16건 추가)

### async helper (6건)
- 단일 emit 검증 (#1267 dup)
- 미지원 target 미emit
- no-async 미emit
- multi-module 일부만 async → helper 1회
- top-level await
- async arrow

### browserslist (10건)
- 모던/레거시 쿼리
- 쿼리 배열 입력
- ios_saf → ios 매핑
- samsung 미매핑 → 보수적 esnext
- target보다 우선
- hermes 저수준 API
- 동일 엔진 여러 버전 (가장 낮은 기준)

## 알려진 제약 (follow-up)

- `compat-engines.ts` ↔ `src/transformer/compat.zig` 데이터 중복
- 장기적으로 `scripts/compat-from-kangax.ts`를 확장해 자동 생성 예정
- bundler 경로는 아직 browserslist를 직접 해석하지 않음 (타입만 노출, 실제 해석은 JS API 레이어)

## /simplify 반영

- splitting 모드 async injection 회귀 원복
- browserslist require 캐싱
- `using`, hermes async 주석에 WHY 명시

## Test plan

- [x] \`zig build test\` — 2856/2856 pass
- [x] \`bun test\` (NAPI) — 267/267 pass (기존 257 + 신규 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)