### PR TITLE
refactor: /simplify follow-up + build API browserslist 구현

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -4376,6 +4376,38 @@ describe("@zts/core browserslist", () => {
     void src;
   });
 
+  test("browserslist: build API도 해석 (BuildOptions.browserslist)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-bs-build-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      "export async function run() { return await Promise.resolve(1); }",
+    );
+    // 오래된 쿼리 → async 다운레벨
+    const r = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      browserslist: "chrome 50",
+    });
+    const code = r.outputFiles[0].text;
+    expect(code).toContain("__async");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("browserslist: build API — 모던 타겟은 async 유지", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-bs-build2-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      "export async function run() { return await Promise.resolve(1); }",
+    );
+    const r = buildSync({
+      entryPoints: [join(dir, "entry.ts")],
+      browserslist: "last 2 chrome versions",
+    });
+    const code = r.outputFiles[0].text;
+    expect(code).toContain("async function");
+    expect(code).not.toContain("__async");
+    rmSync(dir, { recursive: true });
+  });
+
   test("browserslist: 같은 엔진의 여러 버전 — 가장 낮은 버전 기준", () => {
     const { browserslistToUnsupported } = require("../shared/index");
     // chrome 40(미지원) + chrome 100(지원) 동시 전달 — 40 때문에 async_await unsupported

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -197,8 +197,8 @@ export interface BuildOptions {
   mainFields?: string[];
   /** ES 다운레벨 타겟 ("es5" ~ "esnext") */
   target?: import("../shared/index").Target;
-  // browserslist는 build API에서 아직 구현되지 않았다. transpile API에서만 사용 가능.
-  // 구현 완료 후 이 위치에 필드를 추가한다.
+  /** browserslist 쿼리 (string 또는 string[]). 지정 시 target보다 우선. */
+  browserslist?: string | string[];
   /** 출력 디렉토리 (write: true 시 사용) */
   outdir?: string;
   /** 출력 파일 경로 (단일 엔트리 시, write: true 시 사용) */
@@ -510,6 +510,11 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   delete napiOptions.outdir;
   delete napiOptions.plugins;
   delete napiOptions.allowOverwrite;
+  // browserslist → unsupported bitmask. transpile과 동일한 resolveUnsupported 재사용.
+  if (options.browserslist) {
+    napiOptions.unsupported = resolveUnsupported({ browserslist: options.browserslist });
+    delete napiOptions.browserslist;
+  }
   return napiOptions;
 }
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -197,11 +197,8 @@ export interface BuildOptions {
   mainFields?: string[];
   /** ES 다운레벨 타겟 ("es5" ~ "esnext") */
   target?: import("../shared/index").Target;
-  /**
-   * browserslist 쿼리 (transpile과 동일, target보다 우선).
-   * bundler에선 현재 미전달 — 후속 작업. 타입만 노출해 API 일관성 유지.
-   */
-  browserslist?: string | string[];
+  // browserslist는 build API에서 아직 구현되지 않았다. transpile API에서만 사용 가능.
+  // 구현 완료 후 이 위치에 필드를 추가한다.
   /** 출력 디렉토리 (write: true 시 사용) */
   outdir?: string;
   /** 출력 파일 경로 (단일 엔트리 시, write: true 시 사용) */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2064,7 +2064,12 @@ fn parseBuildOptions(
     const compat = @import("zts_lib").transformer.transformer.TransformOptions.compat;
     const target_str = getObjectString(env, opts_obj, "target", native_alloc);
     if (target_str) |s| if (!trackStr(owned_strings, s)) return null;
-    const unsupported: compat.UnsupportedFeatures = if (target_str) |s|
+    // JS side (browserslist 해석 등)에서 미리 계산한 unsupported bitmask가 있으면 우선.
+    // 0이면 미설정으로 간주 — 어차피 unsupported=0은 esnext와 동일해서 target 기반 경로로 fallback해도 결과 동일.
+    const unsupported_override = getObjectUint32(env, opts_obj, "unsupported", 0);
+    const unsupported: compat.UnsupportedFeatures = if (unsupported_override != 0)
+        @bitCast(unsupported_override)
+    else if (target_str) |s|
         if (std.meta.stringToEnum(compat.ESTarget, s)) |t| compat.fromESTarget(t) else .{}
     else
         .{};

--- a/scripts/compat-from-kangax.ts
+++ b/scripts/compat-from-kangax.ts
@@ -76,6 +76,11 @@ const FEATURE_MAP: Record<string, string[]> = {
   class_private_method: ["private class methods"],
   class_private_field: ["instance class fields"],
   hashbang: ["Hashbang Grammar"],
+  // ZTS compat.zig에 있으나 이전 커밋에서 누락된 feature (FEATURE_MAP 커버리지 확장).
+  block_scoping: ["const", "let"],
+  new_target: ["new.target"],
+  object_extensions: ["object literal extensions"],
+  // using: ES2025, kangax 미등재 — SUPPORT 테이블 비어있음.
 };
 
 // 우리가 관심 있는 엔진만 추출 (kangax env 키 기준).

--- a/tests/benchmark/tree-shake-size.ts
+++ b/tests/benchmark/tree-shake-size.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env bun
+/**
+ * Tree-shake size benchmark — ZTS vs esbuild / rolldown / rspack.
+ *
+ * 동일 입력에 대해 각 번들러의 최종 출력 크기를 raw / gzip 기준으로 비교.
+ * 각 fixture는 "전체 크기" 대비 "사용된 export만" 크기가 얼마나 줄어드는지를 측정.
+ *
+ * 실행: bun run tree-shake-size.ts
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
+
+const ROOT = resolve(__dirname, "../..");
+const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
+const BENCH_BIN = join(__dirname, "node_modules/.bin");
+
+function findBin(name: string): string | null {
+  const p = join(BENCH_BIN, name);
+  return existsSync(p) ? p : null;
+}
+
+// ============================================================
+// Fixtures
+// ============================================================
+
+type Fixture = {
+  name: string;
+  description: string;
+  build(dir: string): string;
+  liveMarkers: string[]; // 출력에 있어야 함
+  deadMarkers: string[]; // 출력에 없어야 함 (올바른 tree-shake 시)
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: "synthetic-10",
+    description: "lib.ts의 10개 export 중 1개만 import",
+    build(dir) {
+      const parts: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        parts.push(
+          `export function fn${i}() { return "PAYLOAD_${i}_" + ${"x".repeat(40)}.length; }`,
+        );
+      }
+      writeFileSync(join(dir, "lib.ts"), parts.join("\n"));
+      writeFileSync(join(dir, "entry.ts"), `import { fn5 } from './lib';\nconsole.log(fn5());\n`);
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "fx", type: "module", sideEffects: false }),
+      );
+      return join(dir, "entry.ts");
+    },
+    liveMarkers: ["PAYLOAD_5"],
+    deadMarkers: Array.from({ length: 10 }, (_, i) => `PAYLOAD_${i}`).filter(
+      (m) => m !== "PAYLOAD_5",
+    ),
+  },
+  {
+    name: "barrel-chain",
+    description: "barrel → a/b/c (총 6 export) 중 1개만 used",
+    build(dir) {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `import { used_a } from './barrel';\nconsole.log(used_a());\n`,
+      );
+      writeFileSync(
+        join(dir, "barrel.ts"),
+        `export { used_a, unused_a } from './a';\nexport { used_b, unused_b } from './b';\nexport { used_c, unused_c } from './c';\n`,
+      );
+      for (const letter of ["a", "b", "c"]) {
+        writeFileSync(
+          join(dir, `${letter}.ts`),
+          `export function used_${letter}() { return "USED_${letter.toUpperCase()}_${"x".repeat(80)}"; }\nexport function unused_${letter}() { return "UNUSED_${letter.toUpperCase()}_${"x".repeat(80)}"; }\n`,
+        );
+      }
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "fx", type: "module", sideEffects: false }),
+      );
+      return join(dir, "entry.ts");
+    },
+    liveMarkers: ["USED_A_"],
+    deadMarkers: ["UNUSED_A_", "USED_B_", "UNUSED_B_", "USED_C_", "UNUSED_C_"],
+  },
+  {
+    name: "utils-partial",
+    description: "20개 유틸 중 2개만 사용 (lodash 유사 패턴)",
+    build(dir) {
+      const parts: string[] = [];
+      for (let i = 0; i < 20; i++) {
+        parts.push(
+          `export function util${i}(x: number): number { return x + ${i} + "${"pad".repeat(20)}".length; }`,
+        );
+      }
+      writeFileSync(join(dir, "utils.ts"), parts.join("\n"));
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `import { util3, util17 } from './utils';\nconsole.log(util3(1) + util17(2));\n`,
+      );
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name: "fx", type: "module", sideEffects: false }),
+      );
+      return join(dir, "entry.ts");
+    },
+    liveMarkers: ["util3", "util17"],
+    deadMarkers: ["util0 ", "util1 ", "util19 "].filter((m) => !["util3 ", "util17 "].includes(m)),
+  },
+];
+
+// ============================================================
+// Bundler runners — 각자 fixture dir + entry를 받아 output 경로 반환
+// ============================================================
+
+type Runner = { name: string; run(dir: string, entry: string): string | null };
+
+const runners: Runner[] = [
+  {
+    name: "ZTS",
+    run(dir, entry) {
+      const out = join(dir, "zts.js");
+      const r = spawnSync(ZTS_BIN, ["--bundle", entry, "--minify", "-o", out], {
+        encoding: "utf8",
+      });
+      if (r.status !== 0) return null;
+      return out;
+    },
+  },
+  {
+    name: "esbuild",
+    run(dir, entry) {
+      const bin = findBin("esbuild");
+      if (!bin) return null;
+      const out = join(dir, "esbuild.js");
+      const r = spawnSync(
+        bin,
+        [entry, "--bundle", "--minify", "--loader:.ts=ts", "--format=iife", `--outfile=${out}`],
+        { encoding: "utf8" },
+      );
+      if (r.status !== 0) return null;
+      return out;
+    },
+  },
+  {
+    name: "rolldown",
+    run(dir, entry) {
+      const bin = findBin("rolldown");
+      if (!bin) return null;
+      const outDir = join(dir, "rolldown-out");
+      mkdirSync(outDir, { recursive: true });
+      const r = spawnSync(bin, [entry, "--dir", outDir, "--minify"], { encoding: "utf8" });
+      if (r.status !== 0) return null;
+      // rolldown은 dir에 파일을 쏟아냄 — 가장 큰 파일을 entry로 가정
+      const files = readdirSync(outDir).filter((f) => f.endsWith(".js") || f.endsWith(".mjs"));
+      if (files.length === 0) return null;
+      const totalPath = files
+        .map((f) => ({ f, size: statSync(join(outDir, f)).size }))
+        .sort((a, b) => b.size - a.size)[0].f;
+      return join(outDir, totalPath);
+    },
+  },
+  {
+    name: "rspack",
+    run(dir, entry) {
+      const bin = findBin("rspack");
+      if (!bin) return null;
+      const outDir = join(dir, "rspack-out");
+      mkdirSync(outDir, { recursive: true });
+      const config = join(dir, "rspack.config.js");
+      writeFileSync(
+        config,
+        `module.exports = {
+  mode: 'production',
+  entry: ${JSON.stringify(entry)},
+  output: { path: ${JSON.stringify(outDir)}, filename: 'rspack.js' },
+  resolve: { extensions: ['.ts', '.js'] },
+  module: { rules: [{ test: /\\.ts$/, type: 'javascript/auto', use: { loader: 'builtin:swc-loader', options: { jsc: { parser: { syntax: 'typescript' } } } } }] },
+};`,
+      );
+      const r = spawnSync(bin, ["build", "--config", config], { cwd: dir, encoding: "utf8" });
+      if (r.status !== 0) return null;
+      return join(outDir, "rspack.js");
+    },
+  },
+];
+
+// ============================================================
+// Runner
+// ============================================================
+
+type Row = { bundler: string; raw: number; gzip: number; ok: boolean };
+
+function measure(path: string, fixture: Fixture): { raw: number; gzip: number; ok: boolean } {
+  const buf = readFileSync(path);
+  const src = buf.toString("utf8");
+  const liveOk = fixture.liveMarkers.every((m) => src.includes(m));
+  const deadOk = fixture.deadMarkers.every((m) => !src.includes(m));
+  return { raw: buf.length, gzip: gzipSync(buf).length, ok: liveOk && deadOk };
+}
+
+function pct(part: number, whole: number): string {
+  if (whole === 0) return "-";
+  return ((100 * part) / whole).toFixed(1) + "%";
+}
+
+function runFixture(fx: Fixture): Row[] {
+  const dir = mkdtempSync(join(tmpdir(), `zts-ts-${fx.name}-`));
+  try {
+    const entry = fx.build(dir);
+    const rows: Row[] = [];
+    for (const r of runners) {
+      const out = r.run(dir, entry);
+      if (!out || !existsSync(out)) {
+        rows.push({ bundler: r.name, raw: 0, gzip: 0, ok: false });
+        continue;
+      }
+      const m = measure(out, fx);
+      rows.push({ bundler: r.name, ...m });
+    }
+    return rows;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function printTable(fx: Fixture, rows: Row[]) {
+  console.log(`\n### ${fx.name} — ${fx.description}\n`);
+  console.log("| Bundler | Raw | Gzip | Correct | vs ZTS (raw) |");
+  console.log("|---|---:|---:|:---:|---:|");
+  const zts = rows.find((r) => r.bundler === "ZTS");
+  for (const r of rows) {
+    const raw = r.raw ? `${r.raw} B` : "—";
+    const gzip = r.gzip ? `${r.gzip} B` : "—";
+    const ok = r.ok ? "✓" : "✗";
+    const rel = zts && zts.raw && r.raw ? pct(r.raw, zts.raw) : "-";
+    console.log(`| ${r.bundler} | ${raw} | ${gzip} | ${ok} | ${rel} |`);
+  }
+}
+
+function main() {
+  if (!existsSync(ZTS_BIN)) {
+    console.error(`ZTS binary not found: ${ZTS_BIN}\nrun: zig build`);
+    process.exit(1);
+  }
+  console.log("# Tree-shake size benchmark\n");
+  console.log(
+    `Correct = 모든 live marker 포함 + dead marker 제외.\nvs ZTS (raw) = 해당 번들러 크기 / ZTS 크기.\n`,
+  );
+  for (const fx of fixtures) {
+    const rows = runFixture(fx);
+    printTable(fx, rows);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

PR #1269 후속 /simplify 반영 + build API의 browserslist 지원 구현.

## 변경사항

### 1. /simplify 재검토 반영
- **`scripts/compat-from-kangax.ts`**: FEATURE_MAP에 누락된 3개 추가 (block_scoping, new_target, object_extensions)
- **`tests/benchmark/tree-shake-size.ts`**: 미커밋 상태로 방치되던 벤치 스크립트 포함

### 2. BuildOptions.browserslist 실제 구현
이전엔 타입만 노출한 dead option이라 오해 소지. 실제 번들링에 반영되도록:

- `prepareNapiOptions`에서 browserslist 쿼리 → unsupported bitmask 해석
- `napi_entry.zig`에 `opts.unsupported` (u32) 직접 우선 수용 경로 추가 (JS 측 해석 결과 전달)

### 예시
\`\`\`ts
buildSync({
  entryPoints: ["./src/index.ts"],
  browserslist: "last 2 chrome versions",  // async 유지
});
buildSync({
  entryPoints: ["./src/index.ts"],
  browserslist: "chrome 50",  // async 다운레벨
});
\`\`\`

회귀 테스트 2개 추가.

## Test plan

- [x] \`zig build test\` — 2856/2856 pass
- [x] \`bun test\` (NAPI) — 269/269 pass (기존 267 + 신규 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)