### PR TITLE
refactor: /simplify #1271 — HookResult alias + lcss 정리

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -315,48 +315,33 @@ export interface ZtsPlugin {
   setup(build: PluginBuild): void;
 }
 
+/** 플러그인 훅 반환값: 동기/비동기 모두 허용. null/undefined로 패스스루. */
+type HookResult<T> = T | null | undefined | Promise<T | null | undefined>;
+
 export interface PluginBuild {
   onResolve(
     options: { filter: RegExp },
     callback: (args: {
       path: string;
       importer: string | null;
-    }) =>
-      | { path: string; external?: boolean }
-      | null
-      | undefined
-      | Promise<{ path: string; external?: boolean } | null | undefined>,
+    }) => HookResult<{ path: string; external?: boolean }>,
   ): void;
   onLoad(
     options: { filter: RegExp },
-    callback: (args: {
-      path: string;
-    }) =>
-      | { contents: string; loader?: string }
-      | null
-      | undefined
-      | Promise<{ contents: string; loader?: string } | null | undefined>,
+    callback: (args: { path: string }) => HookResult<{ contents: string; loader?: string }>,
   ): void;
   onTransform(
     options: { filter: RegExp },
-    callback: (args: {
-      code: string;
-      path: string;
-    }) => { code: string } | null | undefined | Promise<{ code: string } | null | undefined>,
+    callback: (args: { code: string; path: string }) => HookResult<{ code: string }>,
   ): void;
   onRenderChunk(
     options: { filter: RegExp },
-    callback: (args: {
-      code: string;
-      chunk: string;
-    }) => { code: string } | null | undefined | Promise<{ code: string } | null | undefined>,
+    callback: (args: { code: string; chunk: string }) => HookResult<{ code: string }>,
   ): void;
   onGenerateBundle(callback: (outputs: OutputFile[]) => void | Promise<void>): void;
   onAstFunction(
     options: { filter: RegExp },
-    callback: (
-      info: AstFunctionInfo,
-    ) => AstFunctionResult | null | undefined | Promise<AstFunctionResult | null | undefined>,
+    callback: (info: AstFunctionInfo) => HookResult<AstFunctionResult>,
   ): void;
 }
 
@@ -541,7 +526,7 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
 function postProcessCssOutputs(result: BuildResult, options: BuildOptions): void {
   if (!options.minify) return;
 
-  let lcss: typeof import("lightningcss") | null = null;
+  let lcss: typeof import("lightningcss");
   try {
     lcss = require("lightningcss");
   } catch {
@@ -551,7 +536,7 @@ function postProcessCssOutputs(result: BuildResult, options: BuildOptions): void
   for (const file of result.outputFiles) {
     if (!file.path.endsWith(".css")) continue;
     try {
-      const transformed = lcss!.transform({
+      const transformed = lcss.transform({
         code: Buffer.from(file.text),
         minify: true,
         filename: file.path,


### PR DESCRIPTION
## Summary

PR #1271 /simplify 리뷰 반영 — 즉시 조치 가능 2건.

## 변경

- **HookResult<T> type alias**: 플러그인 훅 5개의 반복 `T | null | undefined | Promise<T | null | undefined>` 패턴을 공통 타입으로 추출. 타입 시그니처 ~30% 간결.
- **lcss non-null assertion 제거**: `lcss!.transform()` 대신 선언 타입을 non-nullable로 유지하고 try/catch early-return에 의존. TS narrow이 이후 사용까지 유지돼 `!` 불필요.

## 스킵 (판정: 범위 밖)
- `tsd` / `expect-type`으로 컴파일 타임 타입 검증 — 라이브러리 추가/대규모 테스트 재작성 필요, follow-up
- 테스트 헬퍼 추출 — 각 시나리오 독립적이라 현재 수준 수용 가능

## Test plan

- [x] `tsc --emitDeclarationOnly` — 에러 없음, dist/core/index.d.ts emit
- [x] `bun test` — 359/359 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)