### PR TITLE
fix(core): browserslist를 optional로 전환 + Bun 정적 resolve 회피

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -105,10 +105,32 @@ export function init(addonPath?: string): void {
  * TypeScript/JSX 소스 코드를 트랜스파일한다.
  */
 /**
- * browserslist 모듈 lazy-load 캐시. CJS require 캐시도 동작하지만
- * 매 transpile마다 require() 호출 자체를 피해 오버헤드 제거.
+ * browserslist 모듈 lazy-load 캐시.
+ *
+ * Bun/esbuild 같은 번들러는 `require("browserslist")`를 **정적 분석**해서
+ * 의존성을 강제 해결하려 한다. browserslist는 optional이므로 (missing 시
+ * target으로 graceful fallback) Function 생성자로 require를 감싸 정적
+ * resolve를 회피한다. 사용자가 `browserslist` 옵션을 전달했지만 패키지가
+ * 설치되어 있지 않으면 친절한 에러 throw.
  */
 let _browserslist: ((q: string | string[]) => string[]) | null = null;
+let _browserslistResolved = false;
+
+function loadBrowserslist(): ((q: string | string[]) => string[]) | null {
+  if (_browserslistResolved) return _browserslist;
+  _browserslistResolved = true;
+  try {
+    // ESM 환경이라 Node/Bun의 createRequire로 런타임 require를 얻는다.
+    // 동적 문자열 key를 넘겨 Bun 번들러의 정적 분석을 회피 → browserslist
+    // 미설치여도 zts 자체는 로드 가능 (optional dep).
+    const req = createRequire(import.meta.url);
+    const name = "browserslist";
+    _browserslist = req(name) as (q: string | string[]) => string[];
+  } catch {
+    _browserslist = null;
+  }
+  return _browserslist;
+}
 
 /**
  * target | browserslist → UnsupportedFeatures bitmask.
@@ -116,12 +138,13 @@ let _browserslist: ((q: string | string[]) => string[]) | null = null;
  */
 function resolveUnsupported(options: TranspileOptions): number {
   if (options.browserslist) {
-    if (!_browserslist) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      _browserslist = require("browserslist") as (q: string | string[]) => string[];
+    const bl = loadBrowserslist();
+    if (!bl) {
+      throw new Error(
+        "@zts/core: 'browserslist' option requires the 'browserslist' package. Install it: bun add browserslist",
+      );
     }
-    const entries = _browserslist(options.browserslist);
-    return browserslistToUnsupported(entries);
+    return browserslistToUnsupported(bl(options.browserslist));
   }
   return options.target ? (ES_TARGET_BITS[options.target] ?? 0) : 0;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,10 +27,8 @@
     "build": "bun run build:napi && cp ../../zig-out/lib/zts.node . && bun run build:js && bun run build:dts",
     "test": "bun test"
   },
-  "dependencies": {
-    "browserslist": "^4.24.0"
-  },
   "optionalDependencies": {
+    "browserslist": "^4.24.0",
     "lightningcss": "^1.28.0"
   }
 }


### PR DESCRIPTION
## Summary

bungae 등 zts를 **로컬 path/submodule로 참조하는 consumer**에서 발생한 설치 에러 수정:

\`\`\`
error: Could not resolve: "browserslist". Maybe you need to "bun install"?
  at bungae/zts/packages/core/index.ts:121:31
error: postinstall script from "bungae" exited with 1
\`\`\`

## 원인

1. \`require("browserslist")\`를 Bun 번들러가 **정적 분석**해 의존성을 강제 해결하려 함
2. 사용자 top-level \`node_modules\`에 \`browserslist\`가 없으면 resolve 실패

## 수정

### browserslist = optional dependency
\`browserslist\`는 **opt-in** 기능 (사용자가 \`{ browserslist: "..." }\` 옵션 전달 시에만 사용). 사용 안 하면 필요 없음. 따라서 semantically optional이 맞음.

- \`dependencies\` → \`optionalDependencies\`
- 미설치여도 zts 로드 가능, \`target\` 옵션으로 fallback
- 사용자가 \`browserslist\` 옵션을 전달했는데 패키지 없으면 명확한 에러 throw

### Bun 정적 resolve 회피
이전 \`new Function("m", "return require(m)")\` 트릭은 **ESM 스코프에 \`require\` 바인딩이 없어 실패**. \`createRequire\`로 대체:

\`\`\`ts
const req = createRequire(import.meta.url);
const name = "browserslist";  // 동적 string → 번들러 정적 분석 회피
_browserslist = req(name);
\`\`\`

## Test plan

- [x] \`zig build test\` — 2856/2856 pass
- [x] \`bun test\` — 359/359 pass (browserslist 19건 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)