### PR TITLE
fix(transformer): #1278-1 standalone _method_fn 내부 this.#field 미변환

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -842,3 +842,21 @@ test "#1275: private method만 있고 원본 constructor 없을 때 새 construc
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, r.output, "constructor("));
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodInit(this,_priv)") != null);
 }
+
+test "#1278-1: standalone _method_fn 내부의 this.#field가 WeakMap get으로 변환" {
+    // private method 본문이 다른 private field를 참조할 때, standalone 함수로
+    // 추출된 후에도 참조가 WeakMap 접근으로 변환돼야 한다. 버그 수정 전에는
+    // `function _getField_fn() { return this.#field; }` 처럼 class body 밖에서
+    // private 구문이 남아 파싱 에러가 발생했다.
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #field = 42;
+        \\  #getField() { return this.#field; }
+        \\  use() { return this.#getField(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _getField_fn()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return _field.get(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "this.#field") == null);
+}

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -237,6 +237,15 @@ pub fn ES2022(comptime Transformer: type) type {
 
             if (method_mappings.items.len == 0 and field_mappings.items.len == 0) return false;
 
+            // standalone fn body visit과 Pass 2 body visit 모두 this.#field / this.#method() 참조를
+            // 변환해야 하므로 pre_stmts 생성 전에 컨텍스트를 설정한다.
+            const saved_private_methods = self.current_private_methods;
+            const saved_private_fields = self.current_private_fields;
+            self.current_private_methods = method_mappings.items;
+            self.current_private_fields = field_mappings.items;
+            defer self.current_private_methods = saved_private_methods;
+            defer self.current_private_fields = saved_private_fields;
+
             for (field_mappings.items) |m| {
                 const wm_decl = try es_helpers.buildWeakCollectionDecl(self, "WeakMap", m.var_name, span);
                 try pre_stmts.append(self.allocator, wm_decl);
@@ -247,14 +256,6 @@ pub fn ES2022(comptime Transformer: type) type {
                 const fn_decl = try es_helpers.buildStandaloneFunc(self, m.func_name, m.member_idx, span);
                 try pre_stmts.append(self.allocator, fn_decl);
             }
-
-            // Pass 2 body visit 중 this.#method()/this.#f 참조 변환에 필요한 컨텍스트.
-            const saved_private_methods = self.current_private_methods;
-            const saved_private_fields = self.current_private_fields;
-            self.current_private_methods = method_mappings.items;
-            self.current_private_fields = field_mappings.items;
-            defer self.current_private_methods = saved_private_methods;
-            defer self.current_private_fields = saved_private_fields;
 
             var body_nodes: std.ArrayList(NodeIndex) = .empty;
             defer body_nodes.deinit(self.allocator);


### PR DESCRIPTION
Refs #1278 (3건 중 1건)

## Problem
`--target=es2015..es2021` 에서 private method가 다른 private field를 참조할 때, standalone 함수로 추출된 본문에 `this.#field` 구문이 그대로 남아 파싱 에러가 발생했다.

\`\`\`js
class Foo {
  #field = 42;
  #getField() { return this.#field; }
}
\`\`\`
→ (이전) \`function _getField_fn() { return this.#field; }\` ❌
→ (수정 후) \`function _getField_fn() { return _field.get(this); }\` ✅

## Root cause
\`lowerPrivateMembers\` 에서 컨텍스트(\`current_private_fields\`/\`current_private_methods\`) 설정이 pre_stmts 생성 **이후**에 이루어졌는데, \`buildStandaloneFunc\`가 pre_stmts 생성 중에 method body를 visit하기 때문에 그 시점엔 컨텍스트가 비어 있었다.

## Fix
컨텍스트 설정을 pre_stmts 생성 앞으로 이동. WeakMap/WeakSet 선언은 컨텍스트와 무관하므로 이동해도 의미 변화 없음.

## Test plan
- [x] 회귀 테스트 추가: `#field`를 참조하는 `#method()` 다운레벨 검증
- [x] \`zig build test\` 그린

## Related
- #1278 (static #field 다운레벨 미구현, static block 다운레벨 미활성화 — 후속 PR에서 처리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)