### PR TITLE
feat(transformer): #1278-2 static #field 다운레벨링 (class 보존 경로)

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -843,6 +843,40 @@ test "#1275: private method만 있고 원본 constructor 없을 때 새 construc
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodInit(this,_priv)") != null);
 }
 
+test "#1278-2: static #field → descriptor + StaticPrivateFieldSpecGet/Set" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  static #map = new Map();
+        \\  static get(k) { return this.#map.get(k); }
+        \\  static set(k, v) { this.#map.set(k, v); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // descriptor 객체 선언 (class 밖)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _map={writable:true,value:new Map()}") != null);
+    // static private field property_definition은 body에서 제거
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static #map") == null);
+    // helper 경유 접근 (class name은 'Foo')
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classStaticPrivateFieldSpecGet(this,Foo,_map)") != null);
+    // this.#map 구문은 class 본문 어디에도 남지 않아야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "this.#map") == null);
+}
+
+test "#1278-2: instance #field + static #field 혼합" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Mixed {
+        \\  #inst = 1;
+        \\  static #stc = 2;
+        \\  use() { return this.#inst + Mixed.#stc; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _inst=new WeakMap") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _stc={writable:true,value:2}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_inst.get(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classStaticPrivateFieldSpecGet(Mixed,Mixed,_stc)") != null);
+}
+
 test "#1278-1: standalone _method_fn 내부의 this.#field가 WeakMap get으로 변환" {
     // private method 본문이 다른 private field를 참조할 때, standalone 함수로
     // 추출된 후에도 참조가 WeakMap 접근으로 변환돼야 한다. 버그 수정 전에는

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -127,7 +127,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             // static private field → descriptor 객체 선언: var _x = { writable: true, value: initValue }
             for (cm.static_private_fields.items) |pf| {
-                try self.scratch.append(self.allocator, try buildStaticPrivateFieldDescriptorDecl(self, pf.name, pf.init, span));
+                try self.scratch.append(self.allocator, try es_helpers.buildStaticPrivateFieldDescriptor(self, pf.name, pf.init, span));
                 self.runtime_helpers.class_static_private_field = true;
             }
             for (cm.private_methods.items) |pm| {
@@ -414,7 +414,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             // static private field → descriptor 객체 선언
             for (cm.static_private_fields.items) |pf| {
-                try self.scratch.append(self.allocator, try buildStaticPrivateFieldDescriptorDecl(self, pf.name, pf.init, span));
+                try self.scratch.append(self.allocator, try es_helpers.buildStaticPrivateFieldDescriptor(self, pf.name, pf.init, span));
                 self.runtime_helpers.class_static_private_field = true;
             }
             for (cm.private_methods.items) |pm| {
@@ -861,51 +861,6 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const new_value = try self.visitNode(value_idx);
             self.runtime_helpers.class_static_private_field = true;
             return es_helpers.makeCallExpr(self, helper, &.{ new_obj, class_ref, desc_ref, new_value }, span);
-        }
-
-        /// static private field descriptor 선언: var _x = { writable: true, value: initValue }
-        fn buildStaticPrivateFieldDescriptorDecl(self: *Transformer, var_name: []const u8, init_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            // { writable: true, value: initValue }
-            const scratch_top = self.scratch.items.len;
-            defer self.scratch.shrinkRetainingCapacity(scratch_top);
-
-            // writable: true
-            const writable_key = try es_helpers.makeIdentifierRef(self, "writable");
-            const true_span = try self.ast.addString("true");
-            const true_val = try self.ast.addNode(.{
-                .tag = .boolean_literal,
-                .span = true_span,
-                .data = .{ .none = 1 },
-            });
-            const writable_node = try self.ast.addNode(.{
-                .tag = .object_property,
-                .span = span,
-                .data = .{ .binary = .{ .left = writable_key, .right = true_val, .flags = 0 } },
-            });
-            try self.scratch.append(self.allocator, writable_node);
-
-            // value: initValue (or void 0)
-            const value_key = try es_helpers.makeIdentifierRef(self, "value");
-            const value_init = if (!init_idx.isNone()) try self.visitNode(init_idx) else try es_helpers.makeVoidZero(self, span);
-            const value_node = try self.ast.addNode(.{
-                .tag = .object_property,
-                .span = span,
-                .data = .{ .binary = .{ .left = value_key, .right = value_init, .flags = 0 } },
-            });
-            try self.scratch.append(self.allocator, value_node);
-
-            // object_expression
-            const props_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-            const obj = try self.ast.addNode(.{
-                .tag = .object_expression,
-                .span = span,
-                .data = .{ .list = props_list },
-            });
-
-            // var _x = { writable: true, value: ... }
-            const binding = try es_helpers.makeBindingIdentifier(self, try self.ast.addString(var_name));
-            const declarator = try es_helpers.makeDeclarator(self, binding, obj, span);
-            return es_helpers.makeVarDeclaration(self, &.{declarator}, 0, span);
         }
 
         /// accessor method_definition에서 function expression 생성.

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -173,6 +173,7 @@ pub fn ES2022(comptime Transformer: type) type {
             lower_methods: bool,
             lower_fields: bool,
             has_super: bool,
+            class_name_text: ?[]const u8,
         ) Transformer.Error!bool {
             const body_node = self.ast.getNode(body_idx);
             const body_start = body_node.data.list.start;
@@ -216,7 +217,10 @@ pub fn ES2022(comptime Transformer: type) type {
                         if (key_node.tag != .private_identifier) continue;
 
                         const flags = self.readU32(pe, 2);
-                        if ((flags & 0x01) != 0) continue; // TODO: static private field
+                        const is_static = (flags & 0x01) != 0;
+                        // static private field는 class 이름 기반 brand check 헬퍼를 사용하므로
+                        // 익명 class에서는 다운레벨할 수 없다 (클래스 자체 참조가 없음).
+                        if (is_static and class_name_text == null) continue;
 
                         const init_val: NodeIndex = self.readNodeIdx(pe, 1);
                         const orig_name = self.ast.source[key_node.span.start..key_node.span.end];
@@ -228,6 +232,8 @@ pub fn ES2022(comptime Transformer: type) type {
                         try field_mappings.append(self.allocator, .{
                             .original_name = orig_name,
                             .var_name = var_name,
+                            .is_static = is_static,
+                            .class_name = if (is_static) class_name_text else null,
                         });
                         try field_member_raw.append(self.allocator, raw_idx);
                         try field_init_idx.append(self.allocator, init_val);
@@ -246,9 +252,16 @@ pub fn ES2022(comptime Transformer: type) type {
             defer self.current_private_methods = saved_private_methods;
             defer self.current_private_fields = saved_private_fields;
 
-            for (field_mappings.items) |m| {
-                const wm_decl = try es_helpers.buildWeakCollectionDecl(self, "WeakMap", m.var_name, span);
-                try pre_stmts.append(self.allocator, wm_decl);
+            for (field_mappings.items, field_init_idx.items) |m, init_val| {
+                if (m.is_static) {
+                    // static: `var _x = { writable: true, value: init };` — init이 descriptor 내부.
+                    const desc = try es_helpers.buildStaticPrivateFieldDescriptor(self, m.var_name, init_val, span);
+                    try pre_stmts.append(self.allocator, desc);
+                    self.runtime_helpers.class_static_private_field = true;
+                } else {
+                    const wm_decl = try es_helpers.buildWeakCollectionDecl(self, "WeakMap", m.var_name, span);
+                    try pre_stmts.append(self.allocator, wm_decl);
+                }
             }
             for (method_mappings.items) |m| {
                 const ws_decl = try es_helpers.buildWeakCollectionDecl(self, "WeakSet", m.weakset_name, span);
@@ -288,8 +301,11 @@ pub fn ES2022(comptime Transformer: type) type {
                     const fm = field_mappings.items[field_mapping_idx];
                     const fi = field_init_idx.items[field_mapping_idx];
                     field_mapping_idx += 1;
-                    const init_stmt = try buildPrivateFieldSetInit(self, fm.var_name, fi, span);
-                    try ctor_init_stmts.append(self.allocator, init_stmt);
+                    // static은 descriptor가 init 값을 이미 담고 있으므로 ctor 주입 없음, body에서 제거만.
+                    if (!fm.is_static) {
+                        const init_stmt = try buildPrivateFieldSetInit(self, fm.var_name, fi, span);
+                        try ctor_init_stmts.append(self.allocator, init_stmt);
+                    }
                     continue;
                 }
 

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -14,6 +14,45 @@ const NodeList = ast_mod.NodeList;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 
+/// static private field descriptor 선언 생성: `var _x = { writable: true, value: initValue };`
+/// __classStaticPrivateFieldSpecGet/Set 헬퍼가 descriptor 객체의 value/get/set 슬롯을 읽는다.
+pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, init_idx: NodeIndex, span: Span) !NodeIndex {
+    const scratch_top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    const writable_key = try makeIdentifierRef(self, "writable");
+    const true_span = try self.ast.addString("true");
+    const true_val = try self.ast.addNode(.{
+        .tag = .boolean_literal,
+        .span = true_span,
+        .data = .{ .none = 1 },
+    });
+    try self.scratch.append(self.allocator, try self.ast.addNode(.{
+        .tag = .object_property,
+        .span = span,
+        .data = .{ .binary = .{ .left = writable_key, .right = true_val, .flags = 0 } },
+    }));
+
+    const value_key = try makeIdentifierRef(self, "value");
+    const value_init = if (!init_idx.isNone()) try self.visitNode(init_idx) else try makeVoidZero(self, span);
+    try self.scratch.append(self.allocator, try self.ast.addNode(.{
+        .tag = .object_property,
+        .span = span,
+        .data = .{ .binary = .{ .left = value_key, .right = value_init, .flags = 0 } },
+    }));
+
+    const props_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    const obj = try self.ast.addNode(.{
+        .tag = .object_expression,
+        .span = span,
+        .data = .{ .list = props_list },
+    });
+
+    const binding = try makeBindingIdentifier(self, try self.ast.addString(var_name));
+    const declarator = try makeDeclarator(self, binding, obj, span);
+    return makeVarDeclaration(self, &.{declarator}, 0, span);
+}
+
 /// class member의 key가 `constructor` 이름인지 판별.
 /// identifier_reference/binding_identifier만 허용 (string literal key 등은 constructor로 취급 안 함).
 pub fn isConstructorKey(self: anytype, key_idx: NodeIndex) bool {

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -70,6 +70,13 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
 
         if (lower_pm or lower_pf) {
             const has_super = !self.readNodeIdx(e, 1).isNone();
+            // static private field helper는 class 이름으로 receiver brand check를 한다.
+            // 익명 class는 접근 helper가 `undefined`를 참조하게 되므로 static private field
+            // 자체가 emit되지 않는 한 문제 없음.
+            const class_name_text: ?[]const u8 = if (self.getClassNameSpan(new_name)) |s|
+                self.ast.getText(s)
+            else
+                null;
             var new_body: NodeIndex = .none;
             const had_any = try es2022.ES2022(Transformer).lowerPrivateMembers(
                 self,
@@ -82,6 +89,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                 lower_pm,
                 lower_pf,
                 has_super,
+                class_name_text,
             );
             if (had_any) {
                 current_body_idx = new_body;


### PR DESCRIPTION
Refs #1278 (3건 중 2건), closes #1277

## Problem
\`--target=es2015..es2021\` (class 구문 보존 경로)에서 \`static #field\`가 그대로 emit됨 → Hermes 0.12 등 static private field 미지원 런타임에서 파싱 에러.

es5 경로는 이미 descriptor + \`__classStaticPrivateFieldSpec*\` 헬퍼로 변환했지만, class 보존 경로에는 해당 로직이 없었다.

\`\`\`js
class Foo { static #map = new Map(); static get(k) { return this.#map.get(k); } }
\`\`\`
→ (이전) 변환 없이 그대로 emit ❌
→ (수정 후)
\`\`\`js
var _map = { writable: true, value: new Map() };
class Foo {
  static get(k) { return __classStaticPrivateFieldSpecGet(this, Foo, _map).get(k); }
}
\`\`\`

## Fix
- \`lowerPrivateMembers\`가 static private field도 수집 + descriptor 선언 생성
- 기존 dispatch(\`lowerPrivateFieldGet/Set\`)가 mapping.is_static/class_name을 보고 static helper로 자동 분기 — 인프라 재사용
- \`buildStaticPrivateFieldDescriptor\`를 \`es_helpers\`로 승격 (es5/es2022 경로 공유)
- 익명 class는 class 이름 참조가 불가능하므로 static 수집 skip

## Test plan
- [x] 회귀 테스트 2건 추가 (static-only, instance+static 혼합)
- [x] \`zig build test\` 그린
- [x] 원본 이슈 repro (\`FuseboxReactDevToolsDispatcher\`): descriptor + helper 경로로 정상 변환 확인

## Related
- #1278 (static block 다운레벨 미활성화 — 후속 PR)
- Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)