### PR TITLE
fix(transformer): #1278-3 private member + static block 공존 시 static block 누락

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -877,6 +877,24 @@ test "#1278-2: instance #field + static #field 혼합" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__classStaticPrivateFieldSpecGet(Mixed,Mixed,_stc)") != null);
 }
 
+test "#1278-3: private member + static block 공존 시 static block 다운레벨" {
+    // private member가 있으면 body가 이미 visit된 상태가 되므로,
+    // lowerStaticBlocks를 이중 visit 없이 실행해야 한다.
+    var r = try e2eTarget(std.testing.allocator,
+        \\class A {
+        \\  #x = 1;
+        \\  static { console.log('sb'); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // static block은 IIFE로 클래스 밖에
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log(\"sb\")") != null);
+    // class body에는 static {} 구문 남아있지 않아야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static {") == null);
+    // private field는 여전히 WeakMap으로 변환
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _x=new WeakMap") != null);
+}
+
 test "#1278-1: standalone _method_fn 내부의 this.#field가 WeakMap get으로 변환" {
     // private method 본문이 다른 private field를 참조할 때, standalone 함수로
     // 추출된 후에도 참조가 WeakMap 접근으로 변환돼야 한다. 버그 수정 전에는

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -51,12 +51,15 @@ pub fn ES2022(comptime Transformer: type) type {
         ///   2. static_block이 아닌 멤버 → 그대로 방문하여 새 body에 추가
         ///   3. static_block → body에서 제거하고 IIFE로 변환, static_blocks에 수집
         ///   4. 호출자가 class 노드를 pending_nodes에 넣고, static_blocks의 IIFE를 그 뒤에 추가
+        /// already_visited=true: body가 이미 다른 변환 Pass에서 visit된 상태 — 멤버를 재방문하지
+        /// 않고 그대로 유지한다 (`lowerPrivateMembers` 뒤에 호출될 때 이중 변환 회피).
         pub fn lowerStaticBlocks(
             self: *Transformer,
             body_idx: NodeIndex,
             new_body_out: *NodeIndex,
             static_block_iifes: *std.ArrayList(NodeIndex),
             class_name_span: ?Span,
+            already_visited: bool,
         ) Transformer.Error!bool {
             const body_node = self.ast.getNode(body_idx);
             const body_start = body_node.data.list.start;
@@ -94,8 +97,9 @@ pub fn ES2022(comptime Transformer: type) type {
                     // static block → IIFE로 변환
                     const iife = try buildStaticBlockIIFE(self, member, class_name_span);
                     try static_block_iifes.append(self.allocator, iife);
+                } else if (already_visited) {
+                    try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
                 } else {
-                    // 일반 멤버 → 그대로 방문
                     const new_member = try self.visitNode(@enumFromInt(raw_idx));
 
                     // pending_nodes 드레인

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -99,9 +99,8 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         }
 
         // ES2022 다운레벨링: static block → IIFE (target < es2022)
-        // had_private_methods/had_private_fields가 true이면 이미 body를
-        // visit 했으므로, lowerStaticBlocks(파서 노드 기반)를 건너뛴다.
-        if (self.options.unsupported.class_static_block and !had_private_methods and !had_private_fields) {
+        // private member가 이미 body를 visit한 경우 `already_visited=true`로 재방문을 막는다.
+        if (self.options.unsupported.class_static_block) {
             var new_body: NodeIndex = .none;
             var static_block_iifes: std.ArrayList(NodeIndex) = .empty;
             defer static_block_iifes.deinit(self.allocator);
@@ -109,12 +108,14 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
             // 클래스 이름 추출 → static block 안의 this 치환에 사용.
             const class_name_span = self.getClassNameSpan(new_name);
 
+            const already_visited = had_private_methods or had_private_fields;
             const had_static_blocks = try es2022.ES2022(Transformer).lowerStaticBlocks(
                 self,
                 current_body_idx,
                 &new_body,
                 &static_block_iifes,
                 class_name_span,
+                already_visited,
             );
 
             if (had_static_blocks) {


### PR DESCRIPTION
Closes #1278

## Problem
class가 private member를 가지면 \`class_decorator.zig\`의 가드 \`!had_private_methods and !had_private_fields\`가 \`lowerStaticBlocks\`를 스킵해서 \`static { ... }\`가 그대로 emit됐다. Hermes 등 static block 미지원 런타임에서 파싱 에러.

원인: private Pass가 이미 body를 visit한 상태이므로 \`lowerStaticBlocks\`가 같은 body를 다시 visit하면 이중 변환 발생 → 가드로 막아둔 TODO성 shortcut.

## Fix
\`lowerStaticBlocks\`에 \`already_visited: bool\` 추가. true면 body 멤버 재방문을 건너뛰고 \`static_block\`만 IIFE로 추출. private Pass 결과는 그대로 유지되고 static block만 추출·이동됨.

가드 제거하고 \`already_visited = had_private_*\` 전달로 대체.

## Test plan
- [x] 회귀 테스트 추가: private field + static block 공존
- [x] \`zig build test\` 그린
- [x] audit repro (\`#field + static #field + #method + static block\` 혼합): 세 가지 다운레벨 모두 정상 동작 확인

## Related
- Closes #1278 (3건 모두 처리 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)