### PR TITLE
refactor: /simplify — private var name + descriptor object literal 공용화

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -862,7 +862,7 @@ test "#1278-2: static #field → descriptor + StaticPrivateFieldSpecGet/Set" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "this.#map") == null);
 }
 
-test "#1278-2: instance #field + static #field 혼합" {
+test "#1278-2: static #field + instance #field 혼합 (brand check + WeakMap 공존)" {
     var r = try e2eTarget(std.testing.allocator,
         \\class Mixed {
         \\  #inst = 1;

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1095,15 +1095,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const key_node = self.ast.getNode(key);
                     if (key_node.tag == .private_identifier) {
                         const orig_name = self.ast.source[key_node.span.start..key_node.span.end]; // "#x"
-                        // "#x" → "_x"
-                        var name_buf: [128]u8 = undefined;
-                        name_buf[0] = '_';
-                        const name_rest = orig_name[1..]; // "x" (# 제거)
-                        @memcpy(name_buf[1 .. 1 + name_rest.len], name_rest);
-                        const var_name = name_buf[0 .. 1 + name_rest.len];
-
                         const field_info = PrivateFieldInfo{
-                            .name = try self.allocator.dupe(u8, var_name),
+                            .name = try es_helpers.makePrivateVarName(self.allocator, orig_name),
                             .original_name = orig_name,
                             .init = init_val,
                         };

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -166,6 +166,10 @@ pub fn ES2022(comptime Transformer: type) type {
         ///
         /// lower_methods / lower_fields: false면 해당 종류는 수집하지 않는다
         /// (예: ES2022 타겟에서 method만 다운레벨, field는 런타임 네이티브 유지).
+        ///
+        /// class_name_text: static private field helper가 receiver brand check에 사용할
+        /// 클래스 이름(원본 소스 텍스트). 익명 class면 null — 이 경우 static private field는
+        /// 수집에서 제외된다 (클래스 자체 참조가 불가능).
         pub fn lowerPrivateMembers(
             self: *Transformer,
             body_idx: NodeIndex,
@@ -228,10 +232,7 @@ pub fn ES2022(comptime Transformer: type) type {
 
                         const init_val: NodeIndex = self.readNodeIdx(pe, 1);
                         const orig_name = self.ast.source[key_node.span.start..key_node.span.end];
-                        const bare = orig_name[1..];
-                        const var_name = try self.allocator.alloc(u8, 1 + bare.len);
-                        var_name[0] = '_';
-                        @memcpy(var_name[1..], bare);
+                        const var_name = try es_helpers.makePrivateVarName(self.allocator, orig_name);
 
                         try field_mappings.append(self.allocator, .{
                             .original_name = orig_name,

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -41,12 +41,7 @@ pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, in
         .data = .{ .binary = .{ .left = value_key, .right = value_init, .flags = 0 } },
     }));
 
-    const props_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-    const obj = try self.ast.addNode(.{
-        .tag = .object_expression,
-        .span = span,
-        .data = .{ .list = props_list },
-    });
+    const obj = try makeObjectLiteral(self, self.scratch.items[scratch_top..], span);
 
     const binding = try makeBindingIdentifier(self, try self.ast.addString(var_name));
     const declarator = try makeDeclarator(self, binding, obj, span);
@@ -400,17 +395,23 @@ pub const PrivateMethodNames = struct {
     fn_name: []const u8,
 };
 
+/// "#bar" → "_bar" (allocator 소유). private field WeakMap/descriptor 변수명으로 사용.
+pub fn makePrivateVarName(allocator: std.mem.Allocator, orig_name: []const u8) ![]u8 {
+    const bare = orig_name[1..]; // # 제거
+    const buf = try allocator.alloc(u8, 1 + bare.len);
+    buf[0] = '_';
+    @memcpy(buf[1..], bare);
+    return buf;
+}
+
 /// "#bar" → { ws_name="_bar", fn_name="_bar_fn" }
-/// allocator로 직접 할당하여 버퍼 크기 제한 없음.
 pub fn makePrivateMethodNames(allocator: std.mem.Allocator, orig_name: []const u8) !PrivateMethodNames {
-    const bare_name = orig_name[1..]; // # 제거
-    const ws_name = try allocator.alloc(u8, 1 + bare_name.len);
-    ws_name[0] = '_';
-    @memcpy(ws_name[1..], bare_name);
-    const fn_name = try allocator.alloc(u8, 1 + bare_name.len + 3);
+    const ws_name = try makePrivateVarName(allocator, orig_name);
+    const bare = orig_name[1..];
+    const fn_name = try allocator.alloc(u8, 1 + bare.len + 3);
     fn_name[0] = '_';
-    @memcpy(fn_name[1 .. 1 + bare_name.len], bare_name);
-    @memcpy(fn_name[1 + bare_name.len ..], "_fn");
+    @memcpy(fn_name[1 .. 1 + bare.len], bare);
+    @memcpy(fn_name[1 + bare.len ..], "_fn");
     return .{ .ws_name = ws_name, .fn_name = fn_name };
 }
 


### PR DESCRIPTION
#1278 follow-up (/simplify).

## Changes
- \`es_helpers.makePrivateVarName\` 신설 → es2022.zig + es2015_class.zig의 \`"#"\` 제거 + \`"_"\` prefix alloc 중복 제거
- \`makePrivateMethodNames\`가 \`makePrivateVarName\` 재사용
- \`buildStaticPrivateFieldDescriptor\`가 기존 \`makeObjectLiteral\` 헬퍼 사용 — 중복 object_expression addNode 제거
- \`lowerPrivateMembers.class_name_text\` doc-comment 보강
- 테스트 제목 서브타이틀 분리

## Test plan
- [x] \`zig build test\` 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)