### PR TITLE
feat(transformer): #x in obj Ergonomic Brand Check 다운레벨링

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -912,3 +912,112 @@ test "#1278-1: standalone _method_fn 내부의 this.#field가 WeakMap get으로 
     try std.testing.expect(std.mem.indexOf(u8, r.output, "return _field.get(this)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "this.#field") == null);
 }
+
+// ES2022 Ergonomic Brand Checks: #x in obj
+// ================================================================
+// Spec: https://tc39.es/ecma262/#sec-relational-operators
+// Babel: @babel/plugin-transform-private-property-in-object
+// 동작: class가 다운레벨되어 private mapping이 있을 때만 변환.
+// - instance field  : #x in obj → _x.has(obj)    (WeakMap.has)
+// - private method  : #m in obj → _m.has(obj)    (WeakSet.has)
+// - static field    : #s in obj → obj === ClassName (brand check, class 이름 필요)
+
+test "#x in obj: instance private field → WeakMap.has" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #x = 1;
+        \\  static test(o) { return #x in o; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x.has(o)") != null);
+    // private 구문이 class body 밖으로 새어 나가지 않아야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#x in") == null);
+}
+
+test "#x in obj: private method → WeakSet.has" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #m() { return 1; }
+        \\  static test(o) { return #m in o; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_m.has(o)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#m in") == null);
+}
+
+test "#x in obj: static private field → class identity brand check" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  static #s = 1;
+        \\  static test(o) { return #s in o; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // static private field는 런타임에 별도 저장소가 없으므로 class 자체 비교로 brand check.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "o===Foo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#s in") == null);
+}
+
+test "#x in obj: 부정 !(#x in obj)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #x;
+        \\  static test(o) { return !(#x in o); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // 원본의 괄호는 보존되어 `!(_x.has(o))`. 시맨틱 동일.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x.has(o)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#x in") == null);
+}
+
+test "#x in obj: 체이닝 (#x in o && #y in o)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #x;
+        \\  #y;
+        \\  static test(o) { return (#x in o) && (#y in o); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x.has(o)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_y.has(o)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#x in") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#y in") == null);
+}
+
+test "#x in obj: if 문 안에서" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #x;
+        \\  static test(o) { if (#x in o) return 1; return 0; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(_x.has(o))") != null);
+}
+
+test "#x in obj: instance method 내부 (this 컨텍스트 아닌 일반 인자)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #x;
+        \\  test(o) { return #x in o; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x.has(o)") != null);
+}
+
+test "#x in obj: es2022 타겟에서는 보존 (native 지원)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #x;
+        \\  static test(o) { return #x in o; }
+        \\}
+    , .es2022);
+    defer r.deinit();
+    // es2022에서는 private field가 native 지원이므로 #x in o 그대로 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#x in o") != null);
+}

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -852,6 +852,65 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return es_helpers.makeCallExpr(self, helper, &.{ new_obj, class_ref, desc_ref }, span);
         }
 
+        /// ES2022 Ergonomic Brand Checks: `#x in obj` → 내부 표현으로 다운레벨.
+        ///
+        /// node는 binary_expression(op=in, left=private_identifier "#x", right=obj).
+        /// private mapping이 없으면 null 반환 (보존).
+        ///
+        /// - instance field  : `_x.has(obj)`   (WeakMap.has)
+        /// - private method  : `_m.has(obj)`   (WeakSet.has)
+        /// - static field    : `obj === ClassName` (class identity brand check)
+        ///
+        /// Spec: https://tc39.es/proposal-private-fields-in-in/
+        /// Babel: @babel/plugin-transform-private-property-in-object
+        pub fn lowerPrivateIn(self: *Transformer, node: Node) ?Transformer.Error!NodeIndex {
+            const left_idx = node.data.binary.left;
+            const right_idx = node.data.binary.right;
+            if (left_idx.isNone() or right_idx.isNone()) return null;
+            const left_node = self.ast.getNode(left_idx);
+            if (left_node.tag != .private_identifier) return null;
+
+            const orig = self.ast.source[left_node.span.start..left_node.span.end];
+
+            // instance field / static field 매핑 우선 조회
+            for (self.current_private_fields) |pf| {
+                if (!std.mem.eql(u8, pf.original_name, orig)) continue;
+                if (pf.is_static) {
+                    // static: obj === ClassName (class identity 비교)
+                    const new_obj = try self.visitNode(right_idx);
+                    const class_ref = try es_helpers.makeIdentifierRef(self, pf.class_name orelse "undefined");
+                    return self.ast.addNode(.{
+                        .tag = .binary_expression,
+                        .span = node.span,
+                        .data = .{ .binary = .{
+                            .left = new_obj,
+                            .right = class_ref,
+                            .flags = @intFromEnum(token_mod.Kind.eq3),
+                        } },
+                    });
+                }
+                // instance: _x.has(obj)
+                return buildWeakCollectionHas(self, pf.var_name, right_idx, node.span);
+            }
+
+            // private method 매핑 조회
+            for (self.current_private_methods) |pm| {
+                if (!std.mem.eql(u8, pm.original_name, orig)) continue;
+                return buildWeakCollectionHas(self, pm.weakset_name, right_idx, node.span);
+            }
+
+            return null;
+        }
+
+        /// `_x.has(obj)` 표현식 생성 (WeakMap/WeakSet 공용).
+        fn buildWeakCollectionHas(self: *Transformer, var_name: []const u8, obj_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            const wm_ref = try es_helpers.makeIdentifierRef(self, var_name);
+            const has_prop = try es_helpers.makeIdentifierRef(self, "has");
+            const callee = try es_helpers.makeStaticMember(self, wm_ref, has_prop, span);
+            const new_obj = try self.visitNode(obj_idx);
+            return es_helpers.makeCallExpr(self, callee, &.{new_obj}, span);
+        }
+
         /// static private field set: __classStaticPrivateFieldSpecSet(receiver, ClassName, _descriptor, value)
         fn buildStaticPrivateFieldSet(self: *Transformer, mapping: Transformer.PrivateFieldMapping, obj_idx: NodeIndex, value_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const helper = try es_helpers.makeIdentifierRef(self, "__classStaticPrivateFieldSpecSet");

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -712,6 +712,18 @@ pub const Transformer = struct {
                         return es2020.ES2020(Transformer).lowerNullishCoalescing(self, node);
                     }
                 }
+                // ES2022 Ergonomic Brand Checks: #x in obj → _x.has(obj) 등
+                // private mapping이 설정돼 있을 때만 변환 (class 다운레벨 경로가 활성화된 경우).
+                if (node.tag == .binary_expression and
+                    (self.current_private_fields.len > 0 or self.current_private_methods.len > 0))
+                {
+                    const op: token_mod.Kind = @enumFromInt(node.data.binary.flags);
+                    if (op == .kw_in) {
+                        if (es2015_class.ES2015Class(Transformer).lowerPrivateIn(self, node)) |result| {
+                            return result;
+                        }
+                    }
+                }
                 return self.visitBinaryNode(node);
             },
             .assignment_expression => {


### PR DESCRIPTION
## Problem
ES2022 \`#privateField in obj\` 구문이 class 다운레벨 경로에서 변환되지 않아, class body 밖으로 private 구문이 새어 나가 SyntaxError. \`--target=es5\` 에서도 같은 버그.

## Fix
\`lowerPrivateIn\` 추가 — private identifier가 \`in\`의 좌변에 올 때 mapping 조회 후:
- instance private field: \`_x.has(obj)\`
- private method:         \`_m.has(obj)\`  
- static private field:   \`obj === ClassName\`

transformer dispatch는 binary_expression + op=\`in\` + LHS=private_identifier 조건에서 mapping이 있을 때만 변환 (es2022에서는 native 보존).

## Test plan
- [x] 회귀 테스트 8건 (instance/method/static/negation/chain/if/instance-method/es2022-preserve)
- [x] \`zig build test\` 그린
- [x] 테스트 **선작성 후** 구현 (7/8 실패 확인 → 구현 → 전건 통과)

## Related
Babel \`@babel/plugin-transform-private-property-in-object\` 와 동일 시맨틱. #1278 follow-up. RN 프리셋 작업의 prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)