### PR TITLE
feat(bundler): --platform=react-native → Hermes unsupported matrix 강제 오버라이드

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -171,10 +171,13 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
 
 export type { OutputFile, Diagnostic };
 
-export interface BuildOptions {
+/**
+ * Common build options shared by all platforms.
+ * `platform` + `target` 조합은 `BuildOptions` 에서 discriminated union으로 제한됨.
+ */
+interface BuildOptionsCommon {
   entryPoints: string[];
   format?: "esm" | "cjs" | "iife" | "umd" | "amd";
-  platform?: "browser" | "node" | "neutral" | "react-native";
   external?: string[];
   minify?: boolean;
   minifyWhitespace?: boolean;
@@ -218,10 +221,6 @@ export interface BuildOptions {
   resolveExtensions?: string[];
   /** package.json 필드 순서 (예: ["module", "main"]) */
   mainFields?: string[];
-  /** ES 다운레벨 타겟 ("es5" ~ "esnext") */
-  target?: import("../shared/index").Target;
-  /** browserslist 쿼리 (string 또는 string[]). 지정 시 target보다 우선. */
-  browserslist?: string | string[];
   /** 출력 디렉토리 (write: true 시 사용) */
   outdir?: string;
   /** 출력 파일 경로 (단일 엔트리 시, write: true 시 사용) */
@@ -288,6 +287,27 @@ export interface BuildOptions {
   /** watch 모드 리빌드 콜백 */
   onRebuild?: (event: WatchRebuildEvent) => void;
 }
+
+/**
+ * BuildOptions: 사용자 공개 API.
+ *
+ * `platform === "react-native"` 일 때는 Hermes 호환 매트릭스가 강제되므로
+ * `target` / `browserslist`를 전달할 수 없다 (런타임에서도 무시됨).
+ */
+export type BuildOptions =
+  | (BuildOptionsCommon & {
+      /** React Native (Hermes) 프리셋. target은 Hermes 매트릭스로 강제됨. */
+      platform: "react-native";
+      target?: never;
+      browserslist?: never;
+    })
+  | (BuildOptionsCommon & {
+      platform?: "browser" | "node" | "neutral";
+      /** ES 다운레벨 타겟 ("es5" ~ "esnext") */
+      target?: import("../shared/index").Target;
+      /** browserslist 쿼리 (string 또는 string[]). 지정 시 target보다 우선. */
+      browserslist?: string | string[];
+    });
 
 export interface WatchReadyEvent {
   files: number;

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -316,11 +316,18 @@ pub const Bundler = struct {
     resolve_cache_ref: ?*ResolveCache = null,
 
     pub fn init(allocator: std.mem.Allocator, options: BundleOptions) Bundler {
+        var opts = options;
+        // platform=react-native → Hermes unsupported matrix로 덮어쓰기.
+        // 사용자가 --target으로 지정한 값은 무시된다 (Hermes는 ES 버전으로 표현 불가능한
+        // 부분 지원 조합이라 target 직교성이 깨짐). 관련 이슈: #1283.
+        if (opts.platform == .react_native) {
+            opts.unsupported = @import("../transformer/transformer.zig").TransformOptions.compat.fromHermesPreset();
+        }
         return .{
             .allocator = allocator,
-            .options = options,
+            .options = opts,
             .resolve_cache = ResolveCache.init(allocator, .{
-                .platform = options.platform,
+                .platform = opts.platform,
                 .external_patterns = options.external,
                 .custom_conditions = options.conditions,
                 .preserve_symlinks = options.preserve_symlinks,
@@ -336,9 +343,13 @@ pub const Bundler = struct {
     /// 외부에서 소유하는 ResolveCache를 사용하는 생성자.
     /// resolve_cache_ref 포인터를 저장하므로 얕은 복사 없이 원본을 직접 참조한다.
     pub fn initWithResolveCache(allocator: std.mem.Allocator, options: BundleOptions, rc: *ResolveCache) Bundler {
+        var opts = options;
+        if (opts.platform == .react_native) {
+            opts.unsupported = @import("../transformer/transformer.zig").TransformOptions.compat.fromHermesPreset();
+        }
         return .{
             .allocator = allocator,
-            .options = options,
+            .options = opts,
             .resolve_cache = rc.*, // resolve_cache_ref가 우선이므로 이 값은 사용 안 됨
             .resolve_cache_ref = rc,
         };

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1911,3 +1911,117 @@ test "let → var: 초기화 없는 let에 void 0 추가 확인" {
     // var(0) → var(0) 그대로
     try std.testing.expectEqual(@as(u32, 0), block_scoping.lowerKindFlags(0));
 }
+
+// ============================================================
+// RN preset: platform=react-native → Hermes unsupported matrix 강제 적용
+// ============================================================
+
+test "RN preset: class → function IIFE 강제 다운레벨 (Hermes class expression 호환)" {
+    // Hermes는 __esm wrap 내부의 `X = class X {}` 형태 class expression을 거부한다.
+    // platform=react-native 프리셋은 자동으로 `unsupported.class = true`를 설정해
+    // class를 function + prototype으로 다운레벨한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\import { AppError } from './err.js';
+        \\console.log(new AppError('x'));
+    );
+    try writeFile(tmp.dir, "err.js",
+        \\export class AppError extends Error {
+        \\  constructor(msg) { super(msg); }
+        \\}
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // class expression이 emit되지 않아야 함 (Hermes 호환의 핵심)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "= class AppError") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=class AppError") == null);
+    // class → function 변환 런타임 헬퍼가 주입돼야 함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__classCallCheck") != null);
+}
+
+test "RN preset: 사용자 unsupported.class=false여도 RN에서 자동 true 오버라이드" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\class Foo { greet() { return 'hi'; } }
+        \\new Foo().greet();
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    // 사용자가 의도적으로 class 보존을 요청해도 RN 프리셋이 오버라이드
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .unsupported = .{ .class = false },
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // RN에서는 class가 남아 있으면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "= class Foo") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=class Foo") == null);
+}
+
+test "RN preset: browser 플랫폼에서는 class 그대로 보존" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\class Foo { greet() { return 'hi'; } }
+        \\new Foo().greet();
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // browser는 class 문법 지원 → 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class Foo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__classCallCheck") == null);
+}
+
+test "RN preset: async/await은 보존 (Hermes native 지원)" {
+    // #1267 회귀 방지: RN 프리셋이 async를 state machine으로 변환하지 않아야 함.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\export async function f() { return await Promise.resolve(1); }
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // async/await 그대로 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "async function") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "await ") != null);
+    // state machine 헬퍼 없어야 함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__generator") == null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -62,6 +62,8 @@ const CliOptions = struct {
     unsupported: lib.transformer.TransformOptions.compat.UnsupportedFeatures = .{},
     /// --target에서 파싱한 ES 타겟. top-level await 등 타겟 제한 검증에 사용.
     es_target: ?lib.transformer.TransformOptions.compat.ESTarget = null,
+    /// 사용자가 --target을 명시적으로 전달했는지 (RN 프리셋 경고용).
+    target_explicit: bool = false,
     conditions_list: std.ArrayList([]const u8) = .empty,
     timing: bool = false,
     preserve_symlinks: bool = false,
@@ -459,6 +461,7 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
         } else if (std.mem.startsWith(u8, arg, "--target=")) {
             const val = arg["--target=".len..];
             const compat = lib.transformer.TransformOptions.compat;
+            opts.target_explicit = true;
             // ES 타겟 먼저 시도 (es5, es2015, ..., esnext)
             if (std.meta.stringToEnum(compat.ESTarget, val)) |es| {
                 opts.unsupported = compat.fromESTarget(es);
@@ -1233,6 +1236,14 @@ pub fn main() !void {
             try stderr.print("zts: warning: --platform=react-native --dev without --rn-platform may cause unresolved platform-specific modules (e.g. DevTools). Use --rn-platform=ios or --rn-platform=android.\n", .{});
         }
         if (opts.platform == .react_native) {
+            // Hermes는 ES 버전으로 표현 불가능한 부분 지원 조합이라 target 직교성이 깨진다.
+            // platform=react-native면 Hermes 매트릭스가 unsupported를 강제한다.
+            if (opts.target_explicit) {
+                try stderr.print("zts: warning: --target ignored when --platform=react-native (Hermes matrix applied)\n", .{});
+            }
+            opts.unsupported = lib.transformer.TransformOptions.compat.fromHermesPreset();
+            opts.es_target = null;
+
             if (opts.resolve_extensions_list.items.len == 0) {
                 // Metro/롤다운 호환: ts → tsx 순서 (sourceExtensions 기본 순서)
                 const native_and_base = &[_][]const u8{

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -459,6 +459,22 @@ fn getMinVersion(engine: Engine, feature: Feature) ?struct { major: u16, minor: 
 
 /// ESTarget → UnsupportedFeatures.
 /// 타겟 ES 버전보다 높은 버전에서 도입된 feature를 unsupported로 설정.
+/// Hermes (React Native) 전용 Unsupported matrix.
+///
+/// Hermes 0.12+ 기준:
+/// - class expression 거부 → class 전체를 function IIFE로 다운레벨 (class=true 하나로 private/static 모두 함께 처리됨)
+/// - using 선언 미지원
+/// - async/await, let/const, ?., ??, arrow, destructuring, generator 등은 native 지원 → 보존
+/// - 특히 async는 #1267 state machine 버그 때문에 **반드시 보존해야 함**
+///
+/// 관련 이슈: #1267, #1275, #1277, #1278, #1283
+pub fn fromHermesPreset() UnsupportedFeatures {
+    return .{
+        .class = true,
+        .using = true,
+    };
+}
+
 pub fn fromESTarget(target: ESTarget) UnsupportedFeatures {
     const t = @intFromEnum(target);
     var bits: u32 = 0;


### PR DESCRIPTION
Closes #1283 (#1277도 간접 해소).

## Problem
Hermes는 ES 버전으로 표현 불가능한 부분 지원 조합을 갖는다 (class expression 거부 + let/const/async native 지원). \`--target=es2022\`로 빌드해도 \`__esm\` wrap 내부의 \`X = class X {}\`가 Hermes 파싱 에러를 유발.

ES5 타겟으로 돌리면 class는 function으로 변환되지만, async/await까지 state machine으로 바뀌면서 #1267 같은 Hermes 런타임 버그 발생. 즉 **어떤 ES 타겟으로도 Hermes 완전 호환 불가**.

## Fix
\`--platform=react-native\`를 Hermes 전용 프리셋으로 동작시킴:
- \`compat.fromHermesPreset()\` — \`class=true\` (+ \`using=true\`) 만 셋팅, 나머지 전부 Hermes native 지원
- Bundler.init에서 platform 체크 후 \`options.unsupported\`를 덮어씀 (라이브러리 사용자도 혜택)
- CLI는 \`--target\` 명시 시 경고만 출력하고 무시
- TS BuildOptions를 discriminated union으로 리팩터링 → \`platform="react-native"\`면 \`target/browserslist\` 필드가 \`never\` 타입 (TS 컴파일 에러)

## 출력 예시
\`\`\`js
// Before (Hermes ❌)
AppError = class AppError extends Error {
  constructor(msg) { super(msg); }
};

// After (Hermes ✅)
AppError = (function(_super) {
  function AppError(msg) {
    __classCallCheck(this, AppError);
    var _this;
    _this = __callSuper(this, _super, [msg]);
    return _this;
  }
  __extends(AppError, _super);
  return AppError;
})(Error);
\`\`\`
Rolldown/rollipop의 \`@react-native/babel-preset\` 출력과 동일 시맨틱.

## Test plan
- [x] RN preset 회귀 테스트 4건 (class→function / user override 무효 / browser 보존 / async 보존)
- [x] \`zig build test\` 그린
- [x] TS discriminated union: \`platform="react-native"\` + \`target="es2022"\` 조합에서 컴파일 에러 확인 (\`Type '"es2022"' is not assignable to type 'never'\`)
- [x] 경고 메시지 출력 확인: \`zts: warning: --target ignored when --platform=react-native (Hermes matrix applied)\`

## Related
- #1267 (async state machine — 이제 RN 프리셋에선 보존되어 native async로 동작)
- #1275/#1277/#1278 (private class 다운레벨 시리즈 — RN 프리셋에서 자동 적용됨)
- Follow-up: ESM scope hoisting 근본해결 2 (별도 이슈로 분리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)