### PR TITLE
refactor: /simplify — RN preset + #x in obj 중복 제거

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -297,12 +297,12 @@ interface BuildOptionsCommon {
 export type BuildOptions =
   | (BuildOptionsCommon & {
       /** React Native (Hermes) 프리셋. target은 Hermes 매트릭스로 강제됨. */
-      platform: "react-native";
+      platform: Extract<import("../shared/index").Platform, "react-native">;
       target?: never;
       browserslist?: never;
     })
   | (BuildOptionsCommon & {
-      platform?: "browser" | "node" | "neutral";
+      platform?: Exclude<import("../shared/index").Platform, "react-native">;
       /** ES 다운레벨 타겟 ("es5" ~ "esnext") */
       target?: import("../shared/index").Target;
       /** browserslist 쿼리 (string 또는 string[]). 지정 시 target보다 우선. */

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -26,6 +26,7 @@ const Linker = @import("linker.zig").Linker;
 const TreeShaker = @import("tree_shaker.zig").TreeShaker;
 const module_store = @import("module_store.zig");
 const transpile_mod = @import("../transpile.zig");
+const compat = @import("../transformer/transformer.zig").TransformOptions.compat;
 
 /// `--platform=react-native` 프리셋 부울 플래그.
 /// CLI(main.zig)와 NAPI(napi_entry.zig) 양쪽에서 단일 소스로 참조되어
@@ -72,7 +73,7 @@ pub const BundleOptions = struct {
     /// useDefineForClassFields=false (tsconfig)
     use_define_for_class_fields: bool = true,
     /// Unsupported features bitmask (ES/엔진 타겟에서 변환됨)
-    unsupported: @import("../transformer/transformer.zig").TransformOptions.compat.UnsupportedFeatures = .{},
+    unsupported: compat.UnsupportedFeatures = .{},
     /// package.json exports 커스텀 조건 (--conditions, esbuild 호환)
     conditions: []const []const u8 = &.{},
     /// 파이프라인 단계별 타이밍 출력 (--timing)
@@ -315,14 +316,18 @@ pub const Bundler = struct {
     /// 외부 소유 ResolveCache 포인터. non-null이면 이것을 사용하고 resolve_cache 필드는 무시.
     resolve_cache_ref: ?*ResolveCache = null,
 
+    /// platform=react-native → Hermes unsupported matrix로 덮어쓰기.
+    /// 사용자가 --target으로 지정한 값은 무시된다 (Hermes는 ES 버전으로 표현 불가능한
+    /// 부분 지원 조합이라 target 직교성이 깨짐). 관련 이슈: #1283.
+    fn applyPlatformPreset(opts: *BundleOptions) void {
+        if (opts.platform == .react_native) {
+            opts.unsupported = compat.fromHermesPreset();
+        }
+    }
+
     pub fn init(allocator: std.mem.Allocator, options: BundleOptions) Bundler {
         var opts = options;
-        // platform=react-native → Hermes unsupported matrix로 덮어쓰기.
-        // 사용자가 --target으로 지정한 값은 무시된다 (Hermes는 ES 버전으로 표현 불가능한
-        // 부분 지원 조합이라 target 직교성이 깨짐). 관련 이슈: #1283.
-        if (opts.platform == .react_native) {
-            opts.unsupported = @import("../transformer/transformer.zig").TransformOptions.compat.fromHermesPreset();
-        }
+        applyPlatformPreset(&opts);
         return .{
             .allocator = allocator,
             .options = opts,
@@ -344,9 +349,7 @@ pub const Bundler = struct {
     /// resolve_cache_ref 포인터를 저장하므로 얕은 복사 없이 원본을 직접 참조한다.
     pub fn initWithResolveCache(allocator: std.mem.Allocator, options: BundleOptions, rc: *ResolveCache) Bundler {
         var opts = options;
-        if (opts.platform == .react_native) {
-            opts.unsupported = @import("../transformer/transformer.zig").TransformOptions.compat.fromHermesPreset();
-        }
+        applyPlatformPreset(&opts);
         return .{
             .allocator = allocator,
             .options = opts,

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -457,8 +457,6 @@ fn getMinVersion(engine: Engine, feature: Feature) ?struct { major: u16, minor: 
     return null;
 }
 
-/// ESTarget → UnsupportedFeatures.
-/// 타겟 ES 버전보다 높은 버전에서 도입된 feature를 unsupported로 설정.
 /// Hermes (React Native) 전용 Unsupported matrix.
 ///
 /// Hermes 0.12+ 기준:
@@ -475,6 +473,8 @@ pub fn fromHermesPreset() UnsupportedFeatures {
     };
 }
 
+/// ESTarget → UnsupportedFeatures.
+/// 타겟 ES 버전보다 높은 버전에서 도입된 feature를 unsupported로 설정.
 pub fn fromESTarget(target: ESTarget) UnsupportedFeatures {
     const t = @intFromEnum(target);
     var bits: u32 = 0;

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -890,25 +890,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     });
                 }
                 // instance: _x.has(obj)
-                return buildWeakCollectionHas(self, pf.var_name, right_idx, node.span);
+                return buildWeakMapCall(self, pf.var_name, "has", right_idx, &.{}, node.span);
             }
 
             // private method 매핑 조회
             for (self.current_private_methods) |pm| {
                 if (!std.mem.eql(u8, pm.original_name, orig)) continue;
-                return buildWeakCollectionHas(self, pm.weakset_name, right_idx, node.span);
+                return buildWeakMapCall(self, pm.weakset_name, "has", right_idx, &.{}, node.span);
             }
 
             return null;
-        }
-
-        /// `_x.has(obj)` 표현식 생성 (WeakMap/WeakSet 공용).
-        fn buildWeakCollectionHas(self: *Transformer, var_name: []const u8, obj_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const wm_ref = try es_helpers.makeIdentifierRef(self, var_name);
-            const has_prop = try es_helpers.makeIdentifierRef(self, "has");
-            const callee = try es_helpers.makeStaticMember(self, wm_ref, has_prop, span);
-            const new_obj = try self.visitNode(obj_idx);
-            return es_helpers.makeCallExpr(self, callee, &.{new_obj}, span);
         }
 
         /// static private field set: __classStaticPrivateFieldSpecSet(receiver, ClassName, _descriptor, value)


### PR DESCRIPTION
PR #1284 + #1285 follow-up (/simplify).

## Changes
- \`buildWeakCollectionHas\` 삭제 → 기존 \`buildWeakMapCall\` 재사용
- \`Bundler.applyPlatformPreset()\` private helper로 RN override 추출 — init + initWithResolveCache 중복 제거
- bundler.zig 파일 상단 \`compat\` alias (긴 \`@import(...).TransformOptions.compat\` 경로 제거)
- compat.zig 주석 위치 버그 수정 (fromESTarget doc이 fromHermesPreset에 붙어 있던 것 복구)
- BuildOptions union의 platform literal → \`Extract/Exclude<Platform, "react-native">\`로 shared/index.ts \`Platform\` 타입 재사용

## Test plan
- [x] \`zig build test\` 그린
- [x] TS discriminated union 여전히 \`target\` 거부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)