### PR TITLE
fix(transpile): arena-owned 리소스 defer-order segfault (CLI --minify 크래시)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ Rollup/Vite 어댑터: `vitePlugin({...})` (모든 훅 async 지원).
 5. 구현 전 Test262/유닛 테스트 먼저
 6. Zig 초보자에게 설명 포함
 
+## Memory ownership
+- **Arena 안 리소스는 개별 deinit 금지**. `arena_alloc`으로 만든 `DynamicBitSet`/`ArrayList` 등은 `arena.deinit()`이 일괄 해제. 개별 `defer X.deinit()`을 함께 걸면 `arena.deinit()` 이후에 실행되어 해제된 메모리 접근 → segfault (#1287).
+- 성공 경로에서 `arena.deinit()`을 명시 호출하지 말 것. `defer arena.deinit()` 하나로 충분.
+- `errdefer arena.deinit()`만 쓰고 성공 경로는 따로 관리하는 패턴은 위험 — defer 순서 실수 유발.
+
 PR 제목: `feat(lexer): add numeric literal tokenization` 형식.
 
 ## References

--- a/src/codegen/codegen_test/helpers.zig
+++ b/src/codegen/codegen_test/helpers.zig
@@ -62,6 +62,7 @@ pub const SourceMapTestResult = struct {
 };
 
 /// 소스맵 활성화 e2e. 매핑 결과에 접근 가능.
+/// 소유권: 반환된 arena는 caller 소유 (`defer r.arena.deinit()` 필수).
 pub fn e2eSourceMap(backing_allocator: std.mem.Allocator, source: []const u8) !SourceMapTestResult {
     var arena = std.heap.ArenaAllocator.init(backing_allocator);
     errdefer arena.deinit();
@@ -115,6 +116,11 @@ pub fn e2eJSX(allocator: std.mem.Allocator, source: []const u8) !TestResult {
 /// 풀 옵션 e2e. ext로 확장자 지정 (".ts" 기본, ".tsx"면 JSX 모드).
 /// Arena로 전체 파이프라인을 실행. output은 arena 메모리를 가리키므로
 /// TestResult.deinit() 전에 사용해야 한다.
+///
+/// 소유권: 반환된 TestResult.arena는 **caller 소유**. caller가 반드시
+/// `defer r.arena.deinit();` 호출 필요. 성공 경로에선 errdefer가 실행되지
+/// 않으므로 caller defer가 유일한 해제 경로. 누락 시 arena 누수 (테스트 전용
+/// 이라 프로덕션 영향은 없음).
 pub fn e2eFull(backing_allocator: std.mem.Allocator, source: []const u8, t_options: TransformOptions, cg_options: CodegenOptions, ext: []const u8) !TestResult {
     var arena = std.heap.ArenaAllocator.init(backing_allocator);
     errdefer arena.deinit();

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -164,7 +164,7 @@ pub fn transpileWithCallback(
     on_error: ?ErrorCallback,
 ) TranspileError!TranspileResult {
     var arena = std.heap.ArenaAllocator.init(allocator);
-    errdefer arena.deinit();
+    defer arena.deinit();
     const arena_alloc = arena.allocator();
 
     // 1. 파싱
@@ -251,9 +251,9 @@ pub fn transpileWithCallback(
         @import("transformer/minify.zig").minify(&transformer.ast);
     }
 
-    // 5. Mangling 메타데이터 구성
+    // 5. Mangling 메타데이터 구성. skip_nodes는 arena-owned이라 별도 deinit 불필요
+    // (함수 종료 시 arena.deinit으로 일괄 해제).
     var mangle_metadata: ?LinkingMetadata = null;
-    defer if (mangle_metadata) |*mm| mm.skip_nodes.deinit();
 
     if (mangle_result) |*mr| {
         const node_count = transformer.ast.nodes.items.len;
@@ -343,9 +343,9 @@ pub fn transpileWithCallback(
         break :blk buf.items;
     } else output;
 
-    // Arena 밖으로 복제
+    // Arena 밖으로 복제 (arena는 함수 종료 시 defer로 해제 — line 167).
+    // mangle_metadata.skip_nodes는 arena-owned이므로 별도 deinit 불필요.
     const result_code = allocator.dupe(u8, final_output) catch return error.OutOfMemory;
-    arena.deinit();
     return .{
         .code = result_code,
         .sourcemap = sourcemap_json,


### PR DESCRIPTION
Fixes segfault reported in #1287 "Known limitation" 섹션.

## Problem
\`zts --minify\` 실행 시 seemingly unrelated segfault:
\`\`\`
Segmentation fault at address ...
std/bit_set.zig:729 in resize
std/bit_set.zig:787 in deinit
transpile.zig:256 in transpileWithCallback
\`\`\`

## Root cause
\`transpileWithCallback\`의 defer/deinit 순서 버그:
- Line 167: \`errdefer arena.deinit()\` (에러 시만)
- Line 256: \`defer if (mangle_metadata) |*mm| mm.skip_nodes.deinit()\`
- Line 348: **명시** \`arena.deinit()\` (성공 경로)

성공 경로 실행 순서:
1. Line 348 명시 \`arena.deinit()\` — arena 메모리 전체 해제
2. 함수 exit → line 256 defer 실행 → \`skip_nodes.deinit()\` → **freed arena 메모리 접근** → segfault

## Fix
- \`errdefer\` → \`defer arena.deinit()\` (성공/실패 공통)
- 명시 \`arena.deinit()\` 제거
- \`defer skip_nodes.deinit()\` 제거 — arena-owned이라 arena.deinit이 일괄 해제

## 부수 변경
- **CLAUDE.md "Memory ownership" 섹션 추가**: "arena 안 리소스는 개별 deinit 금지" 컨벤션 명시. 재발 방지.
- **Test helper 주석 보강**: \`e2eFull\`/\`e2eSourceMap\`에 "caller가 \`defer r.arena.deinit()\` 호출해야 함" 소유권 명시.

## Audit
전체 \`ArenaAllocator\` 사용 15곳 전수조사 — 다른 Critical 건은 없음. 일부 Suspicious (`graph.zig` parse_arena 4곳)는 현재 안전하지만 defensive errdefer 추가 여지 → **#1288로 분리**.

## Test plan
- [x] \`zig build test\` 그린
- [x] \`zts /tmp/input.js --minify\` 실행 시 정상 출력 (segfault 없음)
- [x] 다양한 입력으로 minify 반복 확인

## Related
- #1287 (이 버그를 Known limitation으로 언급했던 PR)
- #1288 (graph.zig parse_arena follow-up, defensive errdefer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)