### PR TITLE
fix(bundler): #1291 require()로 참조되는 모듈을 tree-shake에서 보호

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1471,3 +1471,44 @@ test "TreeShaking: class extends call expression preserved (#1261 edge)" {
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "EXTENDS_CALL_MARKER") != null);
 }
+
+test "TreeShaking: #1291 require()로 참조되는 UMD 모듈은 tree-shake하지 않음" {
+    // UMD 패턴의 `module.exports = factory()`가 IIFE 내부에 있어 import_scanner가
+    // CJS 신호를 놓쳐 exports_kind=.none이 되면, hasAnyUsedExport=false로 판정된다.
+    // 하지만 require() 참조가 있으면 모듈 전체 반환이 필요하므로 제거 금지 — 이 불변식을 검증.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "umd.js",
+        \\(function(root, factory) {
+        \\    if (typeof exports === 'object' && typeof module === 'object') {
+        \\        module.exports = factory();
+        \\    } else if (typeof define === 'function' && define.amd) {
+        \\        define([], factory);
+        \\    } else {
+        \\        root["Lib"] = factory();
+        \\    }
+        \\})(self, function() {
+        \\    return { MARKER_UMD_PAYLOAD: 42 };
+        \\});
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\const lib = require('./umd.js');
+        \\console.log(lib);
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // UMD 모듈이 번들에 포함돼야 함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MARKER_UMD_PAYLOAD") != null);
+    // require_umd 정의도 있어야 함 (참조가 있는데 정의 없으면 런타임 ReferenceError)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_umd") != null);
+}

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -238,11 +238,28 @@ pub const TreeShaker = struct {
             if (!changed) break;
         }
 
+        // #1291: require()로 참조되는 모듈 인덱스 집합 사전 계산.
+        // require()는 모듈 전체를 반환하므로 개별 export 추적이 불가능 — 제거하면
+        // 참조 지점에서 ReferenceError 발생 (예: UMD 모듈이 exports_kind=.none으로
+        // 판정돼 hasAnyUsedExport=false여도 require 참조가 있으면 보존해야 함).
+        var require_targets = try std.DynamicBitSet.initEmpty(self.allocator, self.modules.len);
+        defer require_targets.deinit();
+        for (self.modules, 0..) |m, i| {
+            if (!self.included.isSet(i)) continue;
+            for (m.import_records) |rec| {
+                if (rec.kind != .require) continue;
+                if (rec.resolved.isNone()) continue;
+                const t = @intFromEnum(rec.resolved);
+                if (t < self.modules.len) require_targets.set(t);
+            }
+        }
+
         // fixpoint 후 미사용 sideEffects=false 모듈 제거 (1회만 수행, oscillation 방지)
         for (self.modules, 0..) |m, i| {
             if (!self.included.isSet(i)) continue;
             if (self.entry_set.isSet(i) or m.side_effects or m.wrap_kind.isWrapped()) continue;
             if (dyn_import_targets.isSet(i)) continue; // #1260: dynamic import target 보호
+            if (require_targets.isSet(i)) continue; // #1291: require 참조 모듈 보호
             if (!self.hasAnyUsedExport(@intCast(i))) {
                 self.included.unset(i);
             }
@@ -289,11 +306,25 @@ pub const TreeShaker = struct {
         try self.buildSymToIbMaps();
         try self.crossModuleBFS(module_stmt_infos, reachable_stmts);
 
-        // 미사용 sideEffects=false 모듈 제거
+        // 미사용 sideEffects=false 모듈 제거.
+        // require_targets 사전 계산: require()로 참조되는 모듈은 export 단위 추적 불가 → 보호.
+        var require_targets2 = try std.DynamicBitSet.initEmpty(self.allocator, self.modules.len);
+        defer require_targets2.deinit();
+        for (self.modules, 0..) |m, i| {
+            if (!self.included.isSet(i)) continue;
+            for (m.import_records) |rec| {
+                if (rec.kind != .require) continue;
+                if (rec.resolved.isNone()) continue;
+                const t = @intFromEnum(rec.resolved);
+                if (t < self.modules.len) require_targets2.set(t);
+            }
+        }
+
         for (self.modules, 0..) |m, i| {
             if (!self.included.isSet(i)) continue;
             if (self.entry_set.isSet(i) or m.side_effects or m.wrap_kind.isWrapped()) continue;
             if (dyn_import_targets.isSet(i)) continue; // #1260: dynamic import target 보호
+            if (require_targets2.isSet(i)) continue; // #1291: require 참조 모듈 보호
             if (!self.hasAnyUsedExport(@intCast(i)) and !self.hasAnyUsedExportDirect(@intCast(i))) {
                 self.included.unset(i);
             }


### PR DESCRIPTION
Closes #1291 (bungae 실빌드 검증 필요).

## Problem
UMD 패턴 모듈(react-devtools-core/dist/backend.js, 18301줄 webpack UMD)이 \`--target=es2021\`에서 번들에 포함되지 않아 런타임 \`ReferenceError: Property 'require_react_devtools_core_dist_backend' doesn't exist\`. \`--target=es5\`에선 정상.

## Root cause 추정 (이슈 댓글 진단)
1. UMD의 \`module.exports = factory()\`가 IIFE 내부에 있어 \`exports_kind=.none\`
2. \`hasAnyUsedExport=false\` + \`side_effects=false\` → tree_shaker의 제거 단계에서 unset
3. require 참조는 남지만 정의 누락

## Fix
tree_shaker의 두 제거 loop에 **\`require()\` 참조 모듈 보호 불변식** 추가. require는 모듈 전체를 반환하므로 개별 export 단위 추적이 불가능 → require 참조가 있으면 무조건 포함.

변경 범위:
- \`tree_shaker.zig\`: require_targets bitset 사전 계산 + 제거 단계에서 skip (2곳)

## 한계
이슈의 실제 재현 조건(bungae 빌드)과 동일한 **최소 repro 확보 실패**. UMD 패턴 minimal case는 현재 코드에서도 이미 정상 처리 (require 전파 경로가 동작). 

이 수정은 **defensive 불변식 보강** — "require로 참조되는데 정의 누락"은 어떤 경우에도 옳지 않은 상태라 제거 단계에서 가드. 유사 symptom 전반 해소 기대.

## Test plan
- [x] 회귀 테스트 추가 (UMD + IIFE 내부 module.exports + require 참조)
- [x] \`zig build test\` 그린
- [ ] **bungae 실빌드 검증 필요**: 이 수정 후에도 증상 재현되면 다른 원인 (import_scanner의 IIFE 내부 CJS 감지 등) 추가 조사

## Related
- #1283 (Hermes RN preset)
- #1285 (platform=react-native 프리셋)

🤖 Generated with [Claude Code](https://claude.com/claude-code)