### PR TITLE
fix(bundler): #1291 recoverable parser error는 모듈 스킵하지 않음

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1472,6 +1472,41 @@ test "TreeShaking: class extends call expression preserved (#1261 edge)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "EXTENDS_CALL_MARKER") != null);
 }
 
+test "#1291 실제 증상: \"use strict\" + non-simple params 있는 모듈이 graph에서 스킵됨" {
+    // 실제 이슈 재현: backend.js 같은 webpack UMD 번들이 내부 함수에
+    // `"use strict"` + destructuring params 조합을 가질 때 parser가 validation 에러를
+    // 내고 graph.zig가 모듈 전체를 스킵 → require 참조가 생기지만 정의는 없음.
+    //
+    // SyntaxError지만 V8/Hermes 런타임은 실행하므로 번들러는 경고로 처리해야 함
+    // (esbuild/rollup 동일 정책).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.js",
+        \\function foo({ a, b }) {
+        \\    "use strict";
+        \\    return a + b;
+        \\}
+        \\module.exports = foo;
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\const foo = require('./lib.js');
+        \\console.log(foo({ a: 1, b: 2 }));
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_lib = __commonJS") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = foo") != null);
+}
+
 test "TreeShaking: #1291 require()로 참조되는 UMD 모듈은 tree-shake하지 않음" {
     // UMD 패턴의 `module.exports = factory()`가 IIFE 내부에 있어 import_scanner가
     // CJS 신호를 놓쳐 exports_kind=.none이 되면, hasAnyUsedExport=false로 판정된다.

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -883,14 +883,19 @@ pub const ModuleGraph = struct {
         };
 
         if (parser.errors.items.len > 0) {
-            // 파싱 에러가 있으면 AST가 불완전 → transformer/codegen 크래시 방지
-            // 에러 메시지를 기록하고 이 모듈을 스킵
+            // 파싱 에러 기록. recoverable validation 에러(use_strict_non_simple 등)는
+            // AST가 정상이고 런타임도 실행하므로 모듈을 스킵하지 않는다 (#1291).
+            var has_fatal = false;
             for (parser.errors.items) |err| {
                 const msg = if (err.message.len > 0) err.message else "Parse error";
                 self.addDiag(.parse_error, .@"error", module.path, err.span, .parse, msg, null);
+                const recoverable = if (err.code) |c| c.isRecoverable() else false;
+                if (!recoverable) has_fatal = true;
             }
-            module.state = .ready;
-            return;
+            if (has_fatal) {
+                module.state = .ready;
+                return;
+            }
         }
 
         // Legal comments 수집 (eof/linked/external 모드용)

--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -210,6 +210,19 @@ pub const Code = enum(u16) {
         };
     }
 
+    /// Recoverable validation 에러인지 판정.
+    /// true면 AST 구조는 정상이고 런타임(V8/Hermes 등)도 실행하므로, 번들러는
+    /// 모듈을 스킵하지 말고 계속 진행해야 한다 (esbuild/rollup 동일 정책).
+    ///
+    /// 예: `"use strict"` + non-simple params는 ECMAScript 14.1.2상 SyntaxError
+    /// 이지만 모든 실제 엔진에서 실행됨 — webpack UMD 번들에 흔히 존재 (#1291).
+    pub fn isRecoverable(self: Code) bool {
+        return switch (self) {
+            .use_strict_non_simple => true,
+            else => false,
+        };
+    }
+
     /// 이 에러 코드의 기본 메시지를 반환한다.
     pub fn message(self: Code) []const u8 {
         return switch (self) {


### PR DESCRIPTION
Closes #1291.

## Root cause
webpack UMD 번들(예: react-devtools-core/dist/backend.js)이 내부 함수에 \`\"use strict\"\` + non-simple params(destructuring/default/rest) 조합을 포함. ECMAScript 14.1.2상 SyntaxError지만 V8/Hermes 등 **모든 실제 런타임은 실행**.

ZTS parser는 \`use_strict_non_simple\` 에러만 기록하고 AST는 정상 생성 — 하지만 \`graph.zig:885\`가 "parser error 있으면 모듈 전체 스킵" 처리해서 AST가 비어있는 상태로 남음. 결과: \`import_scanner\`의 \`module.exports\` 감지 실패 → \`tree_shaker\` 제거 → \`require\` 참조는 남지만 정의 누락.

## Fix
- \`error_codes.zig\`: \`Code.isRecoverable()\` 메서드 추가. \`use_strict_non_simple\`만 true (AST 구조 영향 없는 validation-only).
- \`graph.zig\`: parser error를 recoverable/fatal로 분리. recoverable만 있으면 모듈 유지. fatal 섞여 있으면 기존대로 스킵. diagnostic은 여전히 기록.

esbuild/rollup 동일 정책.

## Test plan
- [x] 회귀 테스트 추가 (`"use strict"` + destructuring params + require 참조)
- [x] \`zig build test\` 전체 그린
- [x] **실제 bungae RN 번들 검증**: \`require_react_devtools_core_dist_backend = __commonJS\` 정의 포함 확인 (이전 99개 → 100개)

## Related
- #1292 (tree_shaker require 참조 보호 — 방어적 불변식, 유지)
- #1283 (Hermes RN preset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)