### PR TITLE
refactor: /simplify — arrow params wrap helper + codegen listSep

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -364,6 +364,12 @@ pub const Codegen = struct {
     // 출력 헬퍼
     // ================================================================
 
+    /// 리스트 구분자: minify_whitespace=true면 "," 아니면 ", ".
+    /// formal_parameters, arguments, array literal 등에서 공용.
+    inline fn listSep(self: *const Codegen) []const u8 {
+        return if (self.options.minify_whitespace) "," else ", ";
+    }
+
     fn write(self: *Codegen, s: []const u8) !void {
         try self.buf.appendSlice(self.allocator, s);
         // 줄/열 추적
@@ -947,7 +953,7 @@ pub const Codegen = struct {
             .export_specifier => try self.emitExportSpecifier(node),
 
             // Formal parameters
-            .formal_parameters, .function_body => try self.emitList(node, if (self.options.minify_whitespace) "," else ", "),
+            .formal_parameters, .function_body => try self.emitList(node, self.listSep()),
 
             .formal_parameter => try self.emitFormalParam(node),
 
@@ -1550,7 +1556,7 @@ pub const Codegen = struct {
 
     fn emitArray(self: *Codegen, node: Node) !void {
         try self.writeByte('[');
-        try self.emitList(node, if (self.options.minify_whitespace) "," else ", ");
+        try self.emitList(node, self.listSep());
         try self.writeByte(']');
     }
 
@@ -1815,7 +1821,7 @@ pub const Codegen = struct {
         try self.emitNode(callee);
         if (is_optional) try self.write("?.");
         try self.writeByte('(');
-        try self.emitNodeList(args_start, args_len, if (self.options.minify_whitespace) "," else ", ");
+        try self.emitNodeList(args_start, args_len, self.listSep());
         try self.writeByte(')');
     }
 
@@ -1980,7 +1986,7 @@ pub const Codegen = struct {
         try self.write("new ");
         try self.emitNode(callee);
         try self.writeByte('(');
-        try self.emitNodeList(args_start, args_len, if (self.options.minify_whitespace) "," else ", ");
+        try self.emitNodeList(args_start, args_len, self.listSep());
         try self.writeByte(')');
     }
 
@@ -2580,7 +2586,7 @@ pub const Codegen = struct {
             if (!first) try self.write(", ");
             try self.writeByte('{');
             if (!self.options.minify_whitespace) try self.writeByte(' ');
-            const sep: []const u8 = if (self.options.minify_whitespace) "," else ", ";
+            const sep: []const u8 = self.listSep();
             var named_first = true;
             for (spec_indices) |raw_idx| {
                 const spec: NodeIndex = @enumFromInt(raw_idx);

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -253,12 +253,7 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
                         .span = id_span,
                         .data = .{ .string_ref = id_span },
                     });
-                    const params_list = try self.ast.addNodeList(&.{param});
-                    const params_node = try self.ast.addNode(.{
-                        .tag = .formal_parameters,
-                        .span = id_span,
-                        .data = .{ .list = params_list },
-                    });
+                    const params_node = try self.wrapAsFormalParameters(&.{param}, id_span);
                     const body = try parseArrowBody(self, true, params_node);
                     {
                         const ae = try self.ast.addExtras(&.{ @intFromEnum(params_node), @intFromEnum(body), 0x01 });
@@ -290,12 +285,7 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
                     try self.advance(); // skip )
                     if (self.current() == .arrow and !self.scanner.token.has_newline_before) {
                         try self.advance(); // skip =>
-                        const empty_list = try self.ast.addNodeList(&.{});
-                        const params_node = try self.ast.addNode(.{
-                            .tag = .formal_parameters,
-                            .span = .{ .start = empty_paren_start, .end = empty_paren_start },
-                            .data = .{ .list = empty_list },
-                        });
+                        const params_node = try self.wrapAsFormalParameters(&.{}, .{ .start = empty_paren_start, .end = empty_paren_start });
                         const body = try parseArrowBody(self, true, params_node);
                         {
                             const ae = try self.ast.addExtras(&.{ @intFromEnum(params_node), @intFromEnum(body), 0x01 });
@@ -348,12 +338,7 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
                 .data = .{ .string_ref = id_span },
             });
             // 모든 arrow는 formal_parameters list로 정규화 (ESTree 계약)
-            const params_list = try self.ast.addNodeList(&.{param});
-            const params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = id_span,
-                .data = .{ .list = params_list },
-            });
+            const params_node = try self.wrapAsFormalParameters(&.{param}, id_span);
             const body = try parseArrowBody(self, false, params_node);
 
             {
@@ -378,12 +363,7 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
         try self.advance(); // skip )
         if (self.current() == .arrow and !self.scanner.token.has_newline_before) {
             try self.advance(); // skip =>
-            const empty_list = try self.ast.addNodeList(&.{});
-            const params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = .{ .start = arrow_start, .end = arrow_start },
-                .data = .{ .list = empty_list },
-            });
+            const params_node = try self.wrapAsFormalParameters(&.{}, .{ .start = arrow_start, .end = arrow_start });
             const body = try parseArrowBody(self, false, params_node);
             {
                 const ae = try self.ast.addExtras(&.{ @intFromEnum(params_node), @intFromEnum(body), 0 });

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1136,6 +1136,17 @@ pub const Parser = struct {
         }
     }
 
+    /// 단일 파라미터 NodeIndex를 `formal_parameters` list 노드로 감싼다.
+    /// 빈 arrow(`() =>`)와 단일 식별자(`x =>`) 공용 헬퍼.
+    pub fn wrapAsFormalParameters(self: *Parser, params: []const NodeIndex, span: Span) !NodeIndex {
+        const list = try self.ast.addNodeList(params);
+        return try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = span,
+            .data = .{ .list = list },
+        });
+    }
+
     /// arrow function 파라미터를 cover grammar으로 검증 + **formal_parameters 노드로 정규화**.
     ///
     /// 입력: parseAssignmentExpression으로 파싱된 원형 (identifier / parenthesized / sequence / spread / formal_parameters).
@@ -1147,12 +1158,7 @@ pub const Parser = struct {
     pub fn coverExpressionToArrowParams(self: *Parser, idx: NodeIndex) ParseError2!NodeIndex {
         if (idx.isNone()) {
             // `() => ...` 같은 빈 arrow
-            const empty_list = try self.ast.addNodeList(&.{});
-            return try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = .{ .start = 0, .end = 0 },
-                .data = .{ .list = empty_list },
-            });
+            return self.wrapAsFormalParameters(&.{}, .{ .start = 0, .end = 0 });
         }
         const node = self.ast.getNode(idx);
 
@@ -1201,12 +1207,7 @@ pub const Parser = struct {
             try self.scratch.append(self.allocator, idx);
         }
 
-        const params_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-        return try self.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = node.span,
-            .data = .{ .list = params_list },
-        });
+        return self.wrapAsFormalParameters(self.scratch.items[scratch_top..], node.span);
     }
 
     /// 키워드를 바인딩 위치에서 사용할 때의 검증.

--- a/src/transformer/worklet_test.zig
+++ b/src/transformer/worklet_test.zig
@@ -360,9 +360,9 @@ test "Worklet: arrow function params not in closure (ES5 lowering)" {
 }
 
 test "Worklet: arrow function params not in closure (arrow 보존, ES5 lowering 없음)" {
-    // #1283 후속: RN Hermes 프리셋은 arrow를 보존 — worklet 변환 시점에
-    // params wrapper가 formal_parameters가 아닌 parenthesized/sequence로 남는다.
-    // 그래도 value/context는 closure에 포함되지 않아야 한다.
+    // #1283 후속: RN Hermes 프리셋은 arrow를 보존 — parser가 모든 arrow의 params를
+    // formal_parameters list로 정규화하므로 worklet plugin이 파라미터를 올바르게
+    // 인식해야 한다. value/context는 closure에 포함되면 안 됨.
     const plugins = [_]Plugin{worklet_plugin_mod.plugin()};
     var r = try parseAndTransformWithOptions(
         std.testing.allocator,


### PR DESCRIPTION
#1287 + #1289 + #1293 follow-up.

## Changes
- \`Parser.wrapAsFormalParameters(params, span)\` 신설 — 8개 arrow 생성 지점의 중복 코드 통일
- \`Codegen.listSep()\` inline fn 신설 — \`", "\`/\`","\` 삼항식 5곳 공용화
- worklet_test.zig 잘못된 주석 정정 (정규화 후 현재 불변식 반영)

## Deferred
- analyzer/es2015_arrow/checker의 parenthesized/sequence dead 분기 제거 — 별도 PR (semantic 영향 검증 필요)

## Test plan
- [x] \`zig build test\` 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)