### PR TITLE
fix(bundler): #1299 RN preset에 arrow → function 다운레벨 추가

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2036,6 +2036,35 @@ test "RN preset: arrow worklet params → __closure에서 제외 (#1283 Reanimat
     try std.testing.expect(std.mem.indexOf(u8, result.output, "(value,context){") != null);
 }
 
+test "RN preset: #1299 arrow → function 다운레벨 (Hermes object literal arrow ternary 버그 회피)" {
+    // 이슈 #1299: 큰 arrow function ternary가 object property value 위치에 있을 때
+    // Hermes 런타임이 후속 prop을 누락. Rollipop도 사용자 arrow를 사실상 모두
+    // function으로 변환하므로 동일 정책.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\const obj = {
+        \\  flushQueue: (true ? () => { return 1; } : () => { return 2; }),
+        \\  createNode(tag) { return tag; },
+        \\};
+        \\console.log(Object.keys(obj));
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // arrow 구문 (` => `)이 출력에 없어야 함 (모두 function으로 변환)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, " => ") == null);
+}
+
 test "RN preset: async/await은 보존 (Hermes native 지원)" {
     // #1267 회귀 방지: RN 프리셋이 async를 state machine으로 변환하지 않아야 함.
     var tmp = std.testing.tmpDir(.{});

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -460,15 +460,20 @@ fn getMinVersion(engine: Engine, feature: Feature) ?struct { major: u16, minor: 
 /// Hermes (React Native) 전용 Unsupported matrix.
 ///
 /// Hermes 0.12+ 기준:
-/// - class expression 거부 → class 전체를 function IIFE로 다운레벨 (class=true 하나로 private/static 모두 함께 처리됨)
+/// - class expression 거부 → class 전체를 function IIFE로 다운레벨
+/// - **arrow function**: 큰 arrow function ternary가 object literal property value 위치에
+///   있을 때 Hermes가 후속 prop을 누락하는 런타임 버그 (#1299). 정확한 트리거 추출이
+///   어렵고 Rolldown + `@react-native/babel-preset`도 사용자 코드 arrow를 사실상 모두
+///   function으로 변환하므로(검증 결과) 동일하게 전체 다운레벨.
 /// - using 선언 미지원
-/// - async/await, let/const, ?., ??, arrow, destructuring, generator 등은 native 지원 → 보존
+/// - async/await, let/const, ?., ??, destructuring, generator 등은 native 지원 → 보존
 /// - 특히 async는 #1267 state machine 버그 때문에 **반드시 보존해야 함**
 ///
-/// 관련 이슈: #1267, #1275, #1277, #1278, #1283
+/// 관련 이슈: #1267, #1275, #1277, #1278, #1283, #1299
 pub fn fromHermesPreset() UnsupportedFeatures {
     return .{
         .class = true,
+        .arrow = true,
         .using = true,
     };
 }


### PR DESCRIPTION
Closes #1299.

## Problem
Hermes 런타임이 **큰 arrow function ternary가 object literal property value 위치**에 있을 때 후속 prop을 누락. 실기기에서 \`API.flushQueue\` (큰 arrow ternary) 이후 18개 메서드 (createAnimatedNode, startAnimatingNode 등) 누락 확인 → TouchableOpacity 터치 시 crash.

## Root cause 분석
- hermesc 단계에선 zts output syntax 통과 → bytecode/runtime 단계 Hermes 버그
- 정확한 트리거 조건 (line count? token count?) spec 불명, 다른 패턴도 위험

## Fix
\`compat.fromHermesPreset()\`에 \`.arrow=true\` 추가. 기존 ES2015 arrow → function lowering이 자동 활성화 (\`var _this = this\` 캡처 포함).

## Rolldown 출력 검증 (보수적 fix 정당화)
- Rolldown 번들 arrow 1495개 보존 — 대부분 Rolldown 자체 emit \`() => name\` export proxy
- **사용자 코드 arrow는 사실상 모두 function으로 변환** (AppRegistryImpl, NativeAnimatedHelper 등)
- ZTS도 동일 정책

## bungae 검증
- arrow 2011 → 39 (남은 39개는 Rolldown helper-style export proxy)
- API 객체: \`API = { getValue: (cond ? function(...) {...} : function(...) {...}), ... }\` 정상 변환
- 이슈 #1299 트리거 패턴 회피 확인

## Test plan
- [x] 회귀 테스트 추가
- [x] \`zig build test\` 그린
- [x] 실제 bungae RN bundle 검증

## Related
- #1283 #1285 (RN preset)
- #1287 (parser arrow normalize)
- #1295 (namespace member access — 별건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)