### PR TITLE
fix(transformer): #1302 for-of destructuring + block_scoping void 0 init 추가 안 함

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2036,6 +2036,35 @@ test "RN preset: arrow worklet params → __closure에서 제외 (#1283 Reanimat
     try std.testing.expect(std.mem.indexOf(u8, result.output, "(value,context){") != null);
 }
 
+test "RN preset: #1302 for-of destructuring + const→var는 void 0 init 추가 안 함" {
+    // for-of/for-in의 left는 매 반복 iter value를 binding하므로 init 불필요.
+    // block_scoping이 무조건 `void 0` init 추가하면 `{x} = void 0` invalid statement 생성.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\const updates = [{id:1, instance:2, color:3}];
+        \\for (const { id, instance, color } of updates) {
+        \\  console.log(id);
+        \\}
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // for-of left의 destructuring init은 추가하지 않음
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "} = void 0;") == null);
+    // for-of 자체는 var로 정상 변환
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "for (var {") != null);
+}
+
 test "RN preset: #1299 let/const → var 다운레벨 (Hermes block scoping)" {
     // `for (let q = 0, ...)` 같은 패턴이 object literal 평가를 깨뜨려 후속 prop 누락.
     // arrow → function 변환만으로 회피되지 않음. Rolldown도 block-scoping 변환.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1982,10 +1982,20 @@ pub const Transformer = struct {
 
                 if (init_idx.isNone()) {
                     // let x; → var x = void 0;
-                    const void_init = try es_helpers.makeVoidZero(self, node.span);
+                    // 단 destructuring pattern (`let {x}`, `let [x]`)은 init 추가 금지 —
+                    // for-of/for-in의 left에서 매 반복 iter value를 받으며, `{x} = void 0` 같은
+                    // statement는 block_statement로 잘못 파싱되어 syntax error (#1302).
+                    const binding = if (!new_name.isNone()) self.ast.getNode(new_name) else null;
+                    const is_destructuring = binding != null and (binding.?.tag == .object_pattern or binding.?.tag == .array_pattern);
                     const none = @intFromEnum(NodeIndex.none);
-                    const new_decl = try self.addExtraNode(.variable_declarator, decl.span, &.{ @intFromEnum(new_name), none, @intFromEnum(void_init) });
-                    try self.scratch.append(self.allocator, new_decl);
+                    if (is_destructuring) {
+                        const new_decl = try self.addExtraNode(.variable_declarator, decl.span, &.{ @intFromEnum(new_name), none, none });
+                        try self.scratch.append(self.allocator, new_decl);
+                    } else {
+                        const void_init = try es_helpers.makeVoidZero(self, node.span);
+                        const new_decl = try self.addExtraNode(.variable_declarator, decl.span, &.{ @intFromEnum(new_name), none, @intFromEnum(void_init) });
+                        try self.scratch.append(self.allocator, new_decl);
+                    }
                 } else {
                     const new_init = try self.visitNode(init_idx);
                     const none = @intFromEnum(NodeIndex.none);


### PR DESCRIPTION
Closes #1302.

## Problem
\`for (const { id, instance, color } of updates)\` + block_scoping (hermes target) → 잘못된 코드:
\`\`\`js
{ id:id, instance:instance, color:color } = void 0;   // ❌
for (var { id:id, instance:instance, color:color } of updates) {...}
\`\`\`

Hermes \`';' expected\` SyntaxError.

## Root cause
\`transformer.zig:visitVariableDeclaration\`이 init 없는 declarator에 무조건 \`void 0\` 추가. for-of/for-in의 left는 iter value를 binding받으므로 init 불필요 + destructuring + void 0 조합은 ambiguous statement (block_statement로 파싱) → SyntaxError.

## Fix
destructuring pattern + init=none이면 void 0 추가 skip. for-loop 컨텍스트 검사 없이 destructuring 자체로 판단 (다른 destructuring 케이스도 동일 이유로 init 추가 의미 없음).

## Test plan
- [x] 회귀 테스트 추가
- [x] \`zig build test\` 그린
- [x] minimal repro 정상 변환
- [x] **bungae RN bundle**: \`} = void 0;\` 잔존 0개

## Related
- #1299 #1301 (block_scoping 도입)
- #1283 (Hermes RN preset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)