### PR TITLE
refactor(bundler): RN preset을 ES5 매트릭스로 확장 (필드별 명시 작성)

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2059,10 +2059,10 @@ test "RN preset: #1302 for-of destructuring + const→var는 void 0 init 추가 
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // for-of left의 destructuring init은 추가하지 않음
+    // 잘못된 `{...} = void 0;` statement가 emit되지 않아야 함
+    // (RN preset에서 destructuring/for-of 자체도 다운레벨되므로 패턴이 더 변환되지만,
+    // 핵심 회귀 조건은 destructuring + no-init declarator에 void 0가 안 붙는 것)
     try std.testing.expect(std.mem.indexOf(u8, result.output, "} = void 0;") == null);
-    // for-of 자체는 var로 정상 변환
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "for (var {") != null);
 }
 
 test "RN preset: #1299 let/const → var 다운레벨 (Hermes block scoping)" {
@@ -2128,8 +2128,10 @@ test "RN preset: #1299 arrow → function 다운레벨 (Hermes object literal ar
     try std.testing.expect(std.mem.indexOf(u8, result.output, " => ") == null);
 }
 
-test "RN preset: async/await은 보존 (Hermes native 지원)" {
-    // #1267 회귀 방지: RN 프리셋이 async를 state machine으로 변환하지 않아야 함.
+test "RN preset: async/await도 ES5 매트릭스로 다운레벨 (보수적 정책)" {
+    // #1267 회귀 가능성 감수. RN preset은 사실상 ES5 매트릭스 — async도 state
+    // machine으로 변환. 만약 #1267 도지면 fromHermesPreset()의 async_await만
+    // false로 토글 (필드별 명시적 작성으로 개별 조정 가능).
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.js",
@@ -2147,9 +2149,6 @@ test "RN preset: async/await은 보존 (Hermes native 지원)" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // async/await 그대로 보존
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "async function") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "await ") != null);
-    // state machine 헬퍼 없어야 함
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__generator") == null);
+    // async function이 더 이상 native 형태로 남지 않음 (state machine으로 변환)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "async function f") == null);
 }

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -459,26 +459,53 @@ fn getMinVersion(engine: Engine, feature: Feature) ?struct { major: u16, minor: 
 
 /// Hermes (React Native) 전용 Unsupported matrix.
 ///
-/// Hermes 0.12+ 기준:
-/// - class expression 거부 → class 전체를 function IIFE로 다운레벨
-/// - **arrow function**: 큰 arrow function ternary가 object literal property value 위치에
-///   있을 때 Hermes가 후속 prop을 누락하는 런타임 버그 (#1299). 정확한 트리거 추출이
-///   어렵고 Rolldown + `@react-native/babel-preset`도 사용자 코드 arrow를 사실상 모두
-///   function으로 변환하므로(검증 결과) 동일하게 전체 다운레벨.
-/// - **block scoping (let/const)**: arrow → function 변환만으로 #1299 회피되지 않음.
-///   `for (let q = 0, ...)` 같은 패턴이 Hermes object literal 평가를 깨뜨려 후속 prop
-///   누락. Rolldown + `@babel/plugin-transform-block-scoping`도 var로 변환 (검증 결과).
-///   동일 정책으로 전체 다운레벨.
-/// - using 선언 미지원
-/// - async/await, ?., ??, destructuring, generator 등은 native 지원 → 보존
-/// - 특히 async는 #1267 state machine 버그 때문에 **반드시 보존해야 함**
+/// 정책: **사실상 ES5 다운레벨**이지만 `fromESTarget(.es5)`를 직접 쓰지 않고 필드를
+/// 명시적으로 나열한다. Hermes는 일부 ES2015+ feature를 native 지원하지만 edge case가
+/// 누적되어 (#1267 #1283 #1299 #1302 등) 보수적으로 전체 다운레벨이 안전. 동시에
+/// 미래에 특정 feature를 보존하고 싶을 때(예: #1267 회귀 감수해서 async 다시 보존)
+/// 개별 필드만 false로 토글할 수 있어야 한다.
 ///
-/// 관련 이슈: #1267, #1275, #1277, #1278, #1283, #1299
+/// 비고:
+/// - async_await=true: ES5와 동일하게 state machine으로 변환. 단 #1267에서 보고된
+///   `_state.sent()` 버그가 도질 수 있음 — 발생 시 false로 토글 검토.
+/// - 모든 ES2015+ feature 다운레벨이 Rolldown + `@react-native/babel-preset` 출력과
+///   가장 가까움 (검증 결과).
+///
+/// 관련 이슈: #1267 #1275 #1277 #1278 #1283 #1299 #1302
 pub fn fromHermesPreset() UnsupportedFeatures {
     return .{
-        .class = true,
+        // ES2015
         .arrow = true,
+        .class = true,
+        .template_literal = true,
+        .destructuring = true,
+        .for_of = true,
+        .spread = true,
+        .object_extensions = true,
+        .default_params = true,
         .block_scoping = true,
+        .generator = true,
+        .new_target = true,
+        // ES2016
+        .exponentiation = true,
+        // ES2017
+        .async_await = true,
+        // ES2018
+        .object_spread = true,
+        // ES2019
+        .optional_catch_binding = true,
+        // ES2020
+        .nullish_coalescing = true,
+        .optional_chaining = true,
+        // ES2021
+        .logical_assignment = true,
+        // ES2022
+        .class_static_block = true,
+        .class_private_method = true,
+        .class_private_field = true,
+        // ES2023
+        .hashbang = true,
+        // ES2025
         .using = true,
     };
 }


### PR DESCRIPTION
#1302 후속 정책 변경.

## Why
부분 다운레벨로 #1267 #1283 #1299 #1302 등 Hermes edge case 누적. 사실상 ES5로 전체 다운레벨이 가장 안전 (Rolldown + @react-native/babel-preset 출력과도 가장 가까움).

## Design
\`fromESTarget(.es5)\` 호출 대신 **필드별 명시 작성**. 미래 특정 feature 보존이 필요할 때(예: #1267 회귀 감수해서 \`async_await\`만 false 토글) 개별 조정 가능.

## Verification (bungae RN bundle)
모든 ES2015+ feature 잔존 0개:
- \`for (let\` : 0  
- \`const x =\` : 0
- async function (코드): 0 (잔존 4개는 React 에러 메시지 문자열)
- \`= class\` : 0
- \`static #\` : 0
- \`} = void 0;\` (#1302) : 0

## Test plan
- [x] \`zig build test\` 그린
- [x] 기존 RN preset 테스트 2건 정책 변경 반영 (async 보존 → 다운레벨, #1302)
- [x] bungae 실제 빌드 검증

## Trade-offs
- bundle 크기 약간 증가
- Hermes native arrow/let-const/optional-chaining 등의 성능 손실
- async/await의 #1267 state machine 버그 회귀 가능성 (도지면 \`async_await=false\` 토글)

## Related
- #1267 #1283 #1299 #1302
- Rolldown + @react-native/babel-preset 정책

🤖 Generated with [Claude Code](https://claude.com/claude-code)