### PR TITLE
refactor: /simplify — transformer destructuring 분기 통합 + 주석/오타 정리

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2101,7 +2101,7 @@ test "RN preset: #1299 let/const → var 다운레벨 (Hermes block scoping)" {
 
 test "RN preset: #1299 arrow → function 다운레벨 (Hermes object literal arrow ternary 버그 회피)" {
     // 이슈 #1299: 큰 arrow function ternary가 object property value 위치에 있을 때
-    // Hermes 런타임이 후속 prop을 누락. Rollipop도 사용자 arrow를 사실상 모두
+    // Hermes 런타임이 후속 prop을 누락. Rolldown + @react-native/babel-preset도 사용자 arrow를 사실상 모두
     // function으로 변환하므로 동일 정책.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -459,7 +459,7 @@ fn getMinVersion(engine: Engine, feature: Feature) ?struct { major: u16, minor: 
 
 /// Hermes (React Native) 전용 Unsupported matrix.
 ///
-/// 정책: **사실상 ES5 다운레벨**이지만 `fromESTarget(.es5)`를 직접 쓰지 않고 필드를
+/// 정책: **ESNext → ES5 전체 다운레벨**. `fromESTarget(.es5)`를 직접 쓰지 않고 필드를
 /// 명시적으로 나열한다. Hermes는 일부 ES2015+ feature를 native 지원하지만 edge case가
 /// 누적되어 (#1267 #1283 #1299 #1302 등) 보수적으로 전체 다운레벨이 안전. 동시에
 /// 미래에 특정 feature를 보존하고 싶을 때(예: #1267 회귀 감수해서 async 다시 보존)
@@ -470,6 +470,7 @@ fn getMinVersion(engine: Engine, feature: Feature) ?struct { major: u16, minor: 
 ///   `_state.sent()` 버그가 도질 수 있음 — 발생 시 false로 토글 검토.
 /// - 모든 ES2015+ feature 다운레벨이 Rolldown + `@react-native/babel-preset` 출력과
 ///   가장 가까움 (검증 결과).
+/// - `UnsupportedFeatures`에 새 필드가 추가되면 여기도 검토 필요 (자동 반영 안 됨).
 ///
 /// 관련 이슈: #1267 #1275 #1277 #1278 #1283 #1299 #1302
 pub fn fromHermesPreset() UnsupportedFeatures {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1935,6 +1935,13 @@ pub const Transformer = struct {
     // ================================================================
 
     /// variable_declaration: extra_data = [kind_flags, list.start, list.len]
+    /// binding이 destructuring pattern (object/array)인지 판별.
+    inline fn isBindingPattern(self: *const Transformer, idx: NodeIndex) bool {
+        if (idx.isNone()) return false;
+        const tag = self.ast.getNode(idx).tag;
+        return tag == .object_pattern or tag == .array_pattern;
+    }
+
     fn visitVariableDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
         // ES2015: destructuring pattern → 개별 declarator로 분해
         // ES2018: object rest (...rest) → __rest 호출 (target < es2018)
@@ -1985,17 +1992,14 @@ pub const Transformer = struct {
                     // 단 destructuring pattern (`let {x}`, `let [x]`)은 init 추가 금지 —
                     // for-of/for-in의 left에서 매 반복 iter value를 받으며, `{x} = void 0` 같은
                     // statement는 block_statement로 잘못 파싱되어 syntax error (#1302).
-                    const binding = if (!new_name.isNone()) self.ast.getNode(new_name) else null;
-                    const is_destructuring = binding != null and (binding.?.tag == .object_pattern or binding.?.tag == .array_pattern);
+                    const is_destructuring = isBindingPattern(self, new_name);
                     const none = @intFromEnum(NodeIndex.none);
-                    if (is_destructuring) {
-                        const new_decl = try self.addExtraNode(.variable_declarator, decl.span, &.{ @intFromEnum(new_name), none, none });
-                        try self.scratch.append(self.allocator, new_decl);
-                    } else {
-                        const void_init = try es_helpers.makeVoidZero(self, node.span);
-                        const new_decl = try self.addExtraNode(.variable_declarator, decl.span, &.{ @intFromEnum(new_name), none, @intFromEnum(void_init) });
-                        try self.scratch.append(self.allocator, new_decl);
-                    }
+                    const init_node: u32 = if (is_destructuring)
+                        none
+                    else
+                        @intFromEnum(try es_helpers.makeVoidZero(self, node.span));
+                    const new_decl = try self.addExtraNode(.variable_declarator, decl.span, &.{ @intFromEnum(new_name), none, init_node });
+                    try self.scratch.append(self.allocator, new_decl);
                 } else {
                     const new_init = try self.visitNode(init_idx);
                     const none = @intFromEnum(NodeIndex.none);


### PR DESCRIPTION
#1303/#1304 follow-up (/simplify).

## Changes
- transformer.zig destructuring 분기 통합 (init_node 변수로 중복 제거)
- `isBindingPattern` inline helper 추출
- compat.zig doc: "ES5 매트릭스" 정확한 표현 (ES2023/2025 포함)
- plugin_misc.zig 오타 정리 (Rollipop → Rolldown)

Deferred (별도 PR):
- fromHermesPreset vs fromESTarget(.es5) 동치 테스트
- 테스트 helper `runRNBundle` 추출 (반복 패턴 3건)

## Test plan
- [x] \`zig build test\` 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)