### PR TITLE
fix(bundler): #1312 re-export getter resolves to canonical local name

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -924,6 +924,43 @@ test "Arrow param shadows hoisted top-level rename (effect TDZ repro)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "(size) => size") != null);
 }
 
+test "Re-export resolves to canonical local (not global-identifier reserved, #1312)" {
+    // `export { X } from './mod'` 직접 re-export가 `--global-identifier=X` 예약 때문에
+    // 원본 이름 X로 emit되어 글로벌 참조로 오염되는 버그.
+    // fix 후: re-export chain을 따라 source 모듈의 canonical 이름 (X$1)으로 resolve.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "URLSearchParams.ts",
+        \\export class URLSearchParams { constructor() { this.tag = "local"; } }
+    );
+    try writeFile(tmp.dir, "URL.ts",
+        \\export { URLSearchParams } from './URLSearchParams';
+        \\export class URL { constructor() { this.tag = "url"; } }
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\import * as M from './URL';
+        \\console.log(new M.URLSearchParams().tag);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const globals = [_][]const u8{"URLSearchParams"};
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .global_identifiers = &globals,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    // URL.ts의 re-export getter가 canonical local name `URLSearchParams$1`을 반환해야 함.
+    // (bare `URLSearchParams` 참조는 `--global-identifier` 글로벌과 충돌)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "URLSearchParams: () => URLSearchParams$1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "URLSearchParams: () => URLSearchParams,") == null);
+}
+
 test "Bundler: AMD external dependencies in wrapper" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -421,7 +421,15 @@ pub fn emitEsmWrappedModule(
                             if (md.export_getter_overrides.get(eb.local_name)) |override|
                                 break :blk override;
                         }
+                        // `export { X } from './mod'` 직접 re-export는 현재 모듈에 로컬 바인딩이 없어
+                        // getCanonicalName(this_mod, local_name)이 miss → 원본 이름 fallback 시
+                        // `--global-identifier`로 예약된 글로벌과 충돌 가능 (#1312).
                         if (linker) |l| {
+                            if (eb.kind == .re_export) {
+                                if (l.resolveExportChain(module.index, eb.exported_name, 0)) |canonical| {
+                                    break :blk l.resolveToLocalName(canonical);
+                                }
+                            }
                             const mi: u32 = @intFromEnum(module.index);
                             if (l.getCanonicalName(mi, eb.local_name)) |renamed|
                                 break :blk renamed;


### PR DESCRIPTION
## Summary
- `export { X } from './mod'` 직접 re-export가 `--global-identifier=X`로 예약된 글로벌 이름과 충돌 (#1312)
- 현재 모듈에 로컬 바인딩이 없는 re-export를 `getCanonicalName(this_mod, local_name)`으로 조회 → miss → 원본 이름 fallback → 글로벌 참조로 오염
- RN `polyfillGlobal` lazy getter 체인에서 재진입 유발 → `URLSearchParams = undefined` → TypeError

## Fix
`src/bundler/emitter/esm_wrap.zig`의 `__export` getter 생성 로직에서 `.re_export` binding일 때 `linker.resolveExportChain` + `resolveToLocalName`으로 source 모듈의 canonical local name을 resolve.

## 번들 변화 (재현 케이스)
```diff
 __export(exports_URL, {
-    URLSearchParams: () => URLSearchParams,   // ❌ 글로벌 참조
+    URLSearchParams: () => URLSearchParams$1, // ✅ source 모듈의 canonical local
     URL: () => URL,
 });
```

## Test plan
- [x] `zig build test` — 신규 재현 테스트 `Re-export resolves to canonical local (not global-identifier reserved, #1312)` 통과
- [x] 기존 bundler/emitter 테스트 회귀 없음
- [x] CLI 재현: `zts --bundle entry.ts --platform=react-native --global-identifier=URLSearchParams` 에서 getter가 `URLSearchParams\$1` 참조

Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)