### PR TITLE
chore: update stale RN-preset comments after #1306/#1312 fixes

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -741,7 +741,7 @@ test "Bundler: UMD external dependencies in wrapper" {
     try std.testing.expect(std.mem.indexOf(u8, output, "React.useState") != null);
 }
 
-test "Async helper: single __async emit when target downlevels async (#1267 dup)" {
+test "Async helper: single __async emit when target downlevels async" {
     // target=es5 + async 사용 → __async/__generator helper 정확히 1회씩만 emit
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2129,9 +2129,9 @@ test "RN preset: #1299 arrow → function 다운레벨 (Hermes object literal ar
 }
 
 test "RN preset: async/await도 ES5 매트릭스로 다운레벨 (보수적 정책)" {
-    // #1267 회귀 가능성 감수. RN preset은 사실상 ES5 매트릭스 — async도 state
-    // machine으로 변환. 만약 #1267 도지면 fromHermesPreset()의 async_await만
-    // false로 토글 (필드별 명시적 작성으로 개별 조정 가능).
+    // RN preset은 사실상 ES5 매트릭스 — async도 state machine으로 변환.
+    // #1306에서 sent() throw-check 수정 후 rejected Promise 전파 정상 동작.
+    // 네이티브 async 보존이 필요하면 fromHermesPreset()의 async_await만 false로 토글.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.js",

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -461,18 +461,17 @@ fn getMinVersion(engine: Engine, feature: Feature) ?struct { major: u16, minor: 
 ///
 /// 정책: **ESNext → ES5 전체 다운레벨**. `fromESTarget(.es5)`를 직접 쓰지 않고 필드를
 /// 명시적으로 나열한다. Hermes는 일부 ES2015+ feature를 native 지원하지만 edge case가
-/// 누적되어 (#1267 #1283 #1299 #1302 등) 보수적으로 전체 다운레벨이 안전. 동시에
-/// 미래에 특정 feature를 보존하고 싶을 때(예: #1267 회귀 감수해서 async 다시 보존)
-/// 개별 필드만 false로 토글할 수 있어야 한다.
+/// 누적되어 (#1283 #1299 #1302 등) 보수적으로 전체 다운레벨이 안전. 미래에 특정
+/// feature를 보존하고 싶을 때 개별 필드만 false로 토글할 수 있어야 한다.
 ///
 /// 비고:
-/// - async_await=true: ES5와 동일하게 state machine으로 변환. 단 #1267에서 보고된
-///   `_state.sent()` 버그가 도질 수 있음 — 발생 시 false로 토글 검토.
+/// - async_await=true: ES5와 동일하게 state machine으로 변환 (#1306에서 sent() throw-check
+///   수정 후 정상 동작. 네이티브 async 보존은 벤치마크 필요 시 async_await=false 토글).
 /// - 모든 ES2015+ feature 다운레벨이 Rolldown + `@react-native/babel-preset` 출력과
 ///   가장 가까움 (검증 결과).
 /// - `UnsupportedFeatures`에 새 필드가 추가되면 여기도 검토 필요 (자동 반영 안 됨).
 ///
-/// 관련 이슈: #1267 #1275 #1277 #1278 #1283 #1299 #1302
+/// 관련 이슈: #1275 #1277 #1278 #1283 #1299 #1302 #1306
 pub fn fromHermesPreset() UnsupportedFeatures {
     return .{
         // ES2015


### PR DESCRIPTION
## Summary
- 관련 이슈 정리 후속: #1267(Promise.all 이슈)이 #1306 sent() throw-check 수정으로 해결됐고, #1310/#1311도 closed. 관련 주석에서 "회귀 가능성" 표현을 현재 상태로 업데이트.

## 변경
- \`src/transformer/compat.zig\` \`fromHermesPreset()\` doc: #1267 회귀 경고 → #1306 수정 반영
- \`src/bundler/bundler_test/plugin_misc.zig\` "RN preset" 테스트 주석 업데이트

실제 dead code는 없음 — RN 관련 active 코드(InitializeCore 주입, polyfillGlobal 이름 처리)는 모두 유효.

## Test plan
- [x] \`zig build test\` 통과 (주석만 변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)