### PR TITLE
fix(bundler): #1315 hoisted function bodies in __esm factory keep sourcemap mappings

### DIFF
--- a/src/bundler/bundler_test/function_map.zig
+++ b/src/bundler/bundler_test/function_map.zig
@@ -113,3 +113,47 @@ test "bundler function_map: class methods — ClassName#method format" {
     try std.testing.expect(std.mem.indexOf(u8, sm, "\"Widget#render\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, sm, "\"Widget.create\"") != null);
 }
+
+test "bundler sourcemap: hoisted function bodies in __esm factory have mappings (#1315)" {
+    // RN preset에서 함수 선언이 __esm factory의 hoisted assignment(`X = function(...)`)로
+    // 변환될 때, func_cg의 sm_builder mappings이 머지되지 않아 함수 본문 전체가 [NO MAP]
+    // 처리되던 버그.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "App.tsx",
+        \\function runWithTiming(fn) {
+        \\  var result = fn();
+        \\  return result;
+        \\}
+        \\export { runWithTiming };
+    );
+    try writeFile(tmp.dir, "entry.ts", "export * from './App';");
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .sourcemap = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    const sm = result.sourcemap orelse return error.TestUnexpectedResult;
+    // mappings 필드의 비어있지 않은 그룹(line) 수 — 버그 시 모듈 본문 line이 모두 빈 그룹.
+    // semicolon은 line 구분자, 빈 그룹("")은 mapping 없음.
+    const mappings_marker = "\"mappings\":\"";
+    const start = (std.mem.indexOf(u8, sm, mappings_marker) orelse return error.TestUnexpectedResult) + mappings_marker.len;
+    const end = std.mem.indexOfScalarPos(u8, sm, start, '"') orelse return error.TestUnexpectedResult;
+    const mappings_str = sm[start..end];
+
+    var non_empty: usize = 0;
+    var it = std.mem.splitScalar(u8, mappings_str, ';');
+    while (it.next()) |group| {
+        if (group.len > 0) non_empty += 1;
+    }
+    // 호이스팅된 함수 본문 3줄 + 모듈 외 줄들. 버그 시 함수 본문 mapping 누락으로 1~2개에 그침.
+    try std.testing.expect(non_empty >= 4);
+}

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -447,6 +447,9 @@ pub fn emitEsmWrappedModule(
     }
 
     // 5. body codegen (variable_declaration/class → 할당문만)
+    // func_code의 sourcemap 매핑을 병합 단계까지 보존 (호이스팅된 함수 정의 매핑, #1315)
+    var func_mappings: ?[]const SourceMap.Mapping = null;
+    var func_preamble_lines: u32 = 0;
     var body_cg = Codegen.initWithOptions(arena_alloc, esm_ast, .{
         .minify_whitespace = options.minify_whitespace,
         .module_format = .cjs,
@@ -488,6 +491,9 @@ pub fn emitEsmWrappedModule(
             try func_cg.addSourceFile(parent.sourcemapSourcePath(module.path, options));
         }
         func_code = try func_cg.generateStatements(root, body_func_stmts.items);
+        if (func_cg.sm_builder) |*sm| {
+            if (sm.mappings.items.len > 0) func_mappings = sm.mappings.items;
+        }
     }
     var body_code = try body_cg.generateStatements(root, body_stmts.items);
 
@@ -691,7 +697,10 @@ pub fn emitEsmWrappedModule(
             try wrapped.appendSlice(allocator, "__zts_g.$RefreshSig$=function(){var rt=__zts_g.__ReactRefresh||__zts_resolveRefresh();if(rt)return rt.createSignatureFunctionForTransform();return function(t){return t}};");
         }
         if (rbm_code.items.len > 0) try wrapped.appendSlice(allocator, rbm_code.items);
-        if (func_code.len > 0) try wrapped.appendSlice(allocator, func_code);
+        if (func_code.len > 0) {
+            func_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
+            try wrapped.appendSlice(allocator, func_code);
+        }
         if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
         if (star_init_buf.items.len > 0) try wrapped.appendSlice(allocator, star_init_buf.items);
         try wrapped.appendSlice(allocator, body_code);
@@ -738,6 +747,7 @@ pub fn emitEsmWrappedModule(
         // func_code를 preamble 앞에 배치: 순환 참조에서 preamble이 의존 모듈을 init할 때
         // 이 모듈의 함수가 이미 할당된 상태여야 한다. (#1092)
         if (func_code.len > 0) {
+            func_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
             try wrapped.append(allocator, '\t');
             try appendIndented(&wrapped, allocator, func_code);
         }
@@ -781,10 +791,11 @@ pub fn emitEsmWrappedModule(
     var mappings: ?[]const SourceMap.Mapping = null;
     {
         const hm = hoist_mappings orelse &[_]SourceMap.Mapping{};
+        const fm = func_mappings orelse &[_]SourceMap.Mapping{};
         const bm = if (body_cg.sm_builder) |*sm| sm.mappings.items else &[_]SourceMap.Mapping{};
-        const all_maps = [_][]const SourceMap.Mapping{ hm, bm };
-        const line_offsets = [_]u32{ hoist_preamble_lines, body_preamble_lines };
-        const total = hm.len + bm.len;
+        const all_maps = [_][]const SourceMap.Mapping{ hm, fm, bm };
+        const line_offsets = [_]u32{ hoist_preamble_lines, func_preamble_lines, body_preamble_lines };
+        const total = hm.len + fm.len + bm.len;
         if (total > 0) {
             // 각 줄의 첫 매핑이 column 0이 아니면, column 0 매핑을 추가.
             // DevTools가 col 0으로 소스맵을 역참조할 때 올바른 줄을 반환하도록.


### PR DESCRIPTION
## Summary
- \`__esm\` factory 내 호이스팅된 함수 정의(\`X = function(...){...}\`)는 별도의 \`func_cg\` codegen으로 emit되는데, 그 sm_builder mappings이 머지 단계에서 누락되어 함수 본문 전체가 \`[NO MAP]\` 처리되던 버그
- Chrome DevTools 콘솔이 콜백 내부 \`console.log\`를 원본 파일 대신 \`console.js\` 폴리필 위치로 표시하던 원인

## Fix
\`src/bundler/emitter/esm_wrap.zig\`:
- \`func_cg.sm_builder.mappings\`를 \`func_mappings\`로 capture
- \`func_code\` 삽입 직전 \`func_preamble_lines\`(생성 출력 내 시작 line offset) 캡처
- 머지 시 \`[hoist, func, body]\` 3-way 병합 (이전: \`[hoist, body]\`)

## Test plan
- [x] \`zig build test\` — 신규 회귀 테스트 \`bundler sourcemap: hoisted function bodies in __esm factory have mappings (#1315)\` 통과
- [x] 로컬 검증: \`runWithTiming = function(fn) {...}\` 본문 3줄이 \`App.tsx:3:9\`, \`App.tsx:4:2\`, \`App.tsx:5:2\` 매핑 (이전: 모두 \`[NO MAP]\`)
- [x] 기존 sourcemap/function_map 테스트 회귀 없음

Closes #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)