### PR TITLE
refactor(ast): #1283 후 cover grammar 잔재 dead 분기 제거

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2134,17 +2134,11 @@ pub const Codegen = struct {
 
         if (flags & 0x01 != 0) try self.write("async ");
 
-        // params 출력 — esbuild 호환: 항상 괄호로 감싸기 (단일 파라미터도 괄호 추가)
+        // params 출력 — #1283 이후 항상 formal_parameters 노드. 괄호는 codegen이 부착.
         if (!params.isNone()) {
-            const param_node = self.ast.getNode(params);
-            if (param_node.tag == .parenthesized_expression) {
-                // 괄호 형태: (a, b) => a + b — parenthesized_expression이 이미 괄호를 포함
-                try self.emitNode(params);
-            } else {
-                try self.writeByte('(');
-                try self.emitNode(params);
-                try self.writeByte(')');
-            }
+            try self.writeByte('(');
+            try self.emitNode(params);
+            try self.writeByte(')');
         } else {
             try self.write("()");
         }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -2226,7 +2226,7 @@ pub const SemanticAnalyzer = struct {
                     count.* += 1;
                 }
             },
-            .array_pattern, .array_expression => {
+            .array_pattern => {
                 // list: binding elements
                 if (node.data.list.len == 0) return;
                 if (node.data.list.start + node.data.list.len > self.ast.extra_data.items.len) return;
@@ -2235,7 +2235,7 @@ pub const SemanticAnalyzer = struct {
                     try self.collectAndCheckCatchBindings(@enumFromInt(raw_idx), names, count);
                 }
             },
-            .object_pattern, .object_expression => {
+            .object_pattern => {
                 if (node.data.list.len == 0) return;
                 if (node.data.list.start + node.data.list.len > self.ast.extra_data.items.len) return;
                 const indices = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -435,11 +435,10 @@ fn collectArrowParamNames(
     const node = ast.getNode(idx);
 
     switch (node.tag) {
-        // 단일 파라미터 (post-cover-grammar)
         .binding_identifier => {
             try recordSeenName(ast.source[node.span.start..node.span.end], node.span, seen, errors, allocator);
         },
-        // parser가 정규화한 formal_parameters list (#1283 이후 기본 형태)
+        // parser가 정규화한 formal_parameters list (#1283 이후 항상 이 형태)
         .formal_parameters => {
             if (node.data.list.len == 0) return;
             if (node.data.list.start + node.data.list.len > ast.extra_data.items.len) return;
@@ -448,20 +447,6 @@ fn collectArrowParamNames(
                 try collectArrowParamNames(ast, @enumFromInt(raw_idx), seen, errors, allocator);
             }
         },
-        // cover grammar에서 변환된 파라미터 리스트 (legacy — 정규화 전 호출 시)
-        .parenthesized_expression, .sequence_expression => {
-            if (node.tag == .parenthesized_expression) {
-                try collectArrowParamNames(ast, node.data.unary.operand, seen, errors, allocator);
-            } else {
-                if (node.data.list.len == 0) return;
-                if (node.data.list.start + node.data.list.len > ast.extra_data.items.len) return;
-                const indices = ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                for (indices) |raw_idx| {
-                    try collectArrowParamNames(ast, @enumFromInt(raw_idx), seen, errors, allocator);
-                }
-            }
-        },
-        // identifier를 파라미터로 사용 (cover grammar 변환 전후 모두 처리)
         .identifier_reference, .assignment_target_identifier => {
             try recordSeenName(ast.source[node.span.start..node.span.end], node.span, seen, errors, allocator);
         },


### PR DESCRIPTION
## Summary
- 3fc3736e (#1283 arrow params formal_parameters 정규화) 이후 도달 불가능해진 dead 분기 3곳 정리
- 동작 변화 없음, 28→7줄

## 정리 대상
- `codegen.zig emitArrowFunction`: params가 `parenthesized_expression`인 분기 — 정규화 후 미도달
- `checker.zig collectArrowParamNames`: `parenthesized_expression`/`sequence_expression` legacy 분기 (주석에 명시)
- `analyzer.zig collectAndCheckCatchBindings`: `array_expression`/`object_expression` alias — `parseCatchClause`가 `parseBindingIdentifier`만 호출해 도달 불가

## Test plan
- [x] zig build
- [x] zig build test

🤖 Generated with [Claude Code](https://claude.com/claude-code)