### PR TITLE
refactor(ast): variable_declaration kind를 typed enum으로 추출

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1904,12 +1904,13 @@ test "let → var: 초기화 없는 let에 void 0 추가 확인" {
     // 트랜스포머가 void 0을 생성하는지 codegen_test에서 직접 검증 (4개 테스트 추가됨).
     // 여기서는 변환 로직의 핵심 경로만 확인.
     const block_scoping = @import("../../transformer/es2015_block_scoping.zig");
-    // let(1) → var(0)
-    try std.testing.expectEqual(@as(u32, 0), block_scoping.lowerKindFlags(1));
-    // const(2) → var(0)
-    try std.testing.expectEqual(@as(u32, 0), block_scoping.lowerKindFlags(2));
-    // var(0) → var(0) 그대로
-    try std.testing.expectEqual(@as(u32, 0), block_scoping.lowerKindFlags(0));
+    const VDK = @import("../../parser/ast.zig").VariableDeclarationKind;
+    // let → var
+    try std.testing.expectEqual(VDK.@"var", block_scoping.lowerKind(.let));
+    // const → var
+    try std.testing.expectEqual(VDK.@"var", block_scoping.lowerKind(.@"const"));
+    // var → var 그대로
+    try std.testing.expectEqual(VDK.@"var", block_scoping.lowerKind(.@"var"));
 }
 
 // ============================================================

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -16,6 +16,7 @@ const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const Span = @import("../lexer/token.zig").Span;
 const module_parser = @import("../parser/module.zig");
 const Kind = @import("../lexer/token.zig").Kind;
@@ -2398,7 +2399,7 @@ pub const Codegen = struct {
     fn emitVariableDeclaration(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         const extras = self.ast.extra_data.items[e .. e + 3];
-        const kind_flags = extras[0];
+        const kind = VariableDeclarationKind.fromU32(extras[0]);
         const list_start = extras[1];
         const list_len = extras[2];
 
@@ -2443,13 +2444,12 @@ pub const Codegen = struct {
             // destructuring → fall through to normal path (var 키워드 유지)
         }
 
-        const keyword = switch (kind_flags) {
-            0 => "var ",
-            1 => "let ",
-            2 => "const ",
-            3 => "using ",
-            4 => "await using ",
-            else => "var ",
+        const keyword = switch (kind) {
+            .@"var" => "var ",
+            .let => "let ",
+            .@"const" => "const ",
+            .using => "using ",
+            .await_using => "await using ",
         };
         try self.write(keyword);
         try self.emitNodeList(list_start, list_len, ",");

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -869,6 +869,12 @@ pub const Ast = struct {
         self.nodes.items[@intFromEnum(index)].tag = new_tag;
     }
 
+    /// variable_declaration 노드의 kind를 typed enum으로 반환.
+    /// node.tag == .variable_declaration 가정. extra[0]에 저장된 u32를 디코드.
+    pub fn variableDeclarationKind(self: *const Ast, node: Node) VariableDeclarationKind {
+        return VariableDeclarationKind.fromU32(self.extra_data.items[node.data.extra]);
+    }
+
     /// extra_data에 값을 추가하고 시작 인덱스를 반환한다.
     pub fn addExtra(self: *Ast, value: u32) !u32 {
         const index: u32 = @intCast(self.extra_data.items.len);
@@ -1006,4 +1012,33 @@ pub const ArrowFlags = struct {
 /// extra: [tag, template, flags]
 pub const TaggedTemplateFlags = struct {
     pub const is_pure: u32 = 0x01; // @__PURE__
+};
+
+/// variable_declaration의 kind. extra[0]에 u32로 저장.
+/// 매직넘버(0~4) 대신 typed enum 사용. 값은 wire-compat 유지를 위해 고정.
+pub const VariableDeclarationKind = enum(u32) {
+    @"var" = 0,
+    let = 1,
+    @"const" = 2,
+    using = 3,
+    await_using = 4,
+
+    pub fn fromU32(v: u32) VariableDeclarationKind {
+        return switch (v) {
+            0 => .@"var",
+            1 => .let,
+            2 => .@"const",
+            3 => .using,
+            4 => .await_using,
+            else => .@"var", // 미지값은 var로 fallback (parser fallback과 일치)
+        };
+    }
+
+    pub fn isLexical(self: VariableDeclarationKind) bool {
+        return self != .@"var";
+    }
+
+    pub fn isUsing(self: VariableDeclarationKind) bool {
+        return self == .using or self == .await_using;
+    }
 };

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -14,6 +14,7 @@ const std = @import("std");
 const ast_mod = @import("ast.zig");
 const Tag = ast_mod.Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const Span = @import("../lexer/token.zig").Span;
 const Parser = @import("parser.zig").Parser;
 const ParseError2 = @import("parser.zig").ParseError2;
@@ -1205,7 +1206,7 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
         });
         // variable_declaration: extra = [kind_flags, list_start, list_len]
         const decl_list = try self.ast.addNodeList(&.{declarator});
-        const var_extra = try self.ast.addExtras(&.{ 2, decl_list.start, decl_list.len }); // 2 = const
+        const var_extra = try self.ast.addExtras(&.{ @intFromEnum(VariableDeclarationKind.@"const"), decl_list.start, decl_list.len });
         const const_decl = try self.ast.addNode(.{
             .tag = .variable_declaration,
             .span = span,

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -134,7 +134,7 @@ pub const Parser = struct {
     allow_new_target: bool = false,
     /// constructor 안인지
     is_constructor: bool = false,
-    /// await using 파싱 중인지 (parseAwaitUsingDeclaration → parseVariableDeclaration에서 kind_flags=4로 설정)
+    /// await using 파싱 중인지 (parseAwaitUsingDeclaration → parseVariableDeclaration에서 kind=.await_using으로 설정)
     is_await_using: bool = false,
     /// strict mode 여부 (D054: "use strict" directive 또는 module mode)
     is_strict_mode: bool = false,

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -31,6 +31,72 @@ test "Parser: variable declaration" {
     try std.testing.expect(parser.errors.items.len == 0);
 }
 
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
+
+fn firstVariableDeclaration(parser: *Parser) ast_mod.Node {
+    // 첫 번째 variable_declaration 노드를 찾음 (program/block/function 위치 무관).
+    for (parser.ast.nodes.items) |node| {
+        if (node.tag == .variable_declaration) return node;
+    }
+    unreachable;
+}
+
+fn parseAndGetKind(src: []const u8) !VariableDeclarationKind {
+    var scanner = try Scanner.init(std.testing.allocator, src);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len == 0);
+    const decl = firstVariableDeclaration(&parser);
+    return parser.ast.variableDeclarationKind(decl);
+}
+
+test "Parser: variableDeclarationKind — var" {
+    try std.testing.expectEqual(VariableDeclarationKind.@"var", try parseAndGetKind("var x = 1;"));
+}
+
+test "Parser: variableDeclarationKind — let" {
+    try std.testing.expectEqual(VariableDeclarationKind.let, try parseAndGetKind("let x = 1;"));
+}
+
+test "Parser: variableDeclarationKind — const" {
+    try std.testing.expectEqual(VariableDeclarationKind.@"const", try parseAndGetKind("const x = 1;"));
+}
+
+test "Parser: variableDeclarationKind — using" {
+    try std.testing.expectEqual(VariableDeclarationKind.using, try parseAndGetKind("{ using x = null; }"));
+}
+
+test "Parser: variableDeclarationKind — await using" {
+    try std.testing.expectEqual(VariableDeclarationKind.await_using, try parseAndGetKind("async function f() { await using x = null; }"));
+}
+
+test "VariableDeclarationKind: isLexical / isUsing helpers" {
+    try std.testing.expect(!VariableDeclarationKind.@"var".isLexical());
+    try std.testing.expect(VariableDeclarationKind.let.isLexical());
+    try std.testing.expect(VariableDeclarationKind.@"const".isLexical());
+    try std.testing.expect(VariableDeclarationKind.using.isLexical());
+    try std.testing.expect(VariableDeclarationKind.await_using.isLexical());
+
+    try std.testing.expect(!VariableDeclarationKind.let.isUsing());
+    try std.testing.expect(VariableDeclarationKind.using.isUsing());
+    try std.testing.expect(VariableDeclarationKind.await_using.isUsing());
+}
+
+test "VariableDeclarationKind: wire-compat numeric values" {
+    // 모든 consumer가 의존하는 wire 값. 변경 금지.
+    try std.testing.expectEqual(@as(u32, 0), @intFromEnum(VariableDeclarationKind.@"var"));
+    try std.testing.expectEqual(@as(u32, 1), @intFromEnum(VariableDeclarationKind.let));
+    try std.testing.expectEqual(@as(u32, 2), @intFromEnum(VariableDeclarationKind.@"const"));
+    try std.testing.expectEqual(@as(u32, 3), @intFromEnum(VariableDeclarationKind.using));
+    try std.testing.expectEqual(@as(u32, 4), @intFromEnum(VariableDeclarationKind.await_using));
+}
+
+test "VariableDeclarationKind: fromU32 unknown values fall back to var" {
+    try std.testing.expectEqual(VariableDeclarationKind.@"var", VariableDeclarationKind.fromU32(99));
+}
+
 test "Parser: binary expression" {
     var scanner = try Scanner.init(std.testing.allocator, "1 + 2 * 3;");
     defer scanner.deinit();

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -12,6 +12,7 @@ const ast_mod = @import("ast.zig");
 const Node = ast_mod.Node;
 const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const token_mod = @import("../lexer/token.zig");
 const Kind = token_mod.Kind;
 const Span = token_mod.Span;
@@ -496,18 +497,18 @@ fn parseWithStatement(self: *Parser) ParseError2!NodeIndex {
 
 fn parseVariableDeclaration(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
-    const kind_flags: u32 = switch (self.current()) {
-        .kw_var => 0,
-        .kw_let => 1,
-        .kw_const => 2,
-        .kw_using => if (self.is_await_using) @as(u32, 4) else @as(u32, 3), // 3=using, 4=await using
-        else => 0,
+    const kind: VariableDeclarationKind = switch (self.current()) {
+        .kw_var => .@"var",
+        .kw_let => .let,
+        .kw_const => .@"const",
+        .kw_using => if (self.is_await_using) .await_using else .using,
+        else => .@"var",
     };
     try self.advance(); // skip var/let/const/using
 
     // let/const 선언에서 바인딩 이름 'let'은 금지 (ECMAScript 14.3.1.1)
     // 'let let = 1' → SyntaxError (non-strict에서도)
-    if (kind_flags != 0 and self.current() == .kw_let) {
+    if (kind.isLexical() and self.current() == .kw_let) {
         try self.addErrorCode(self.currentSpan(), "'let' is not allowed as variable name in lexical declaration", .let_in_lexical);
     }
 
@@ -517,7 +518,7 @@ fn parseVariableDeclaration(self: *Parser) ParseError2!NodeIndex {
         // const without initializer → SyntaxError (ECMAScript 14.3.1)
         // for-in/for-of에서는 const 이니셜라이저 불필요 (for (const x of ...))
         // TS declare에서도 불필요 (declare const x: number)
-        if (kind_flags == 2 and !decl.isNone() and !self.for_loop_init and !self.ctx.in_ambient) {
+        if (kind == .@"const" and !decl.isNone() and !self.for_loop_init and !self.ctx.in_ambient) {
             const decl_node = self.ast.getNode(decl);
             if (decl_node.tag == .variable_declarator) {
                 const init_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[decl_node.data.extra + 2]);
@@ -542,7 +543,7 @@ fn parseVariableDeclaration(self: *Parser) ParseError2!NodeIndex {
     const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
     // extra_data: [kind_flags, list.start, list.len]
-    const extra_start = try self.ast.addExtra(kind_flags);
+    const extra_start = try self.ast.addExtra(@intFromEnum(kind));
     _ = try self.ast.addExtra(list.start);
     _ = try self.ast.addExtra(list.len);
 
@@ -782,7 +783,7 @@ fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) ParseError2!v
     if (init_node.tag != .variable_declaration) return;
 
     const extras = self.ast.extra_data.items;
-    const kind_flags = extras[init_node.data.extra];
+    const kind = self.ast.variableDeclarationKind(init_node);
     const list_start = extras[init_node.data.extra + 1];
     const decl_len = extras[init_node.data.extra + 2];
 
@@ -803,7 +804,7 @@ fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) ParseError2!v
     // initializer가 있으면 에러 (예외: sloppy var + for-in + BindingIdentifier만)
     // Annex B.3.5: for (var BindingIdentifier Initializer in Expression) — 허용
     // BindingPattern (array/object destructuring)은 Annex B에서도 항상 금지
-    const is_var = kind_flags == 0;
+    const is_var = kind == .@"var";
     const is_for_in = self.current() == .kw_in;
     if (is_for_in and is_var) {
         // TS 모드에서는 for-in var initializer를 허용 (esbuild 호환).

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -16,6 +16,7 @@ const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const Span = @import("../lexer/token.zig").Span;
 const scope_mod = @import("scope.zig");
 const ScopeId = scope_mod.ScopeId;
@@ -1535,15 +1536,16 @@ pub const SemanticAnalyzer = struct {
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
         if (extra_start + 2 >= extras.len) return;
-        const kind_flags = extras[extra_start];
+        const kind = VariableDeclarationKind.fromU32(extras[extra_start]);
         const decl_start = extras[extra_start + 1];
         const decl_len = extras[extra_start + 2];
 
-        const sym_kind: SymbolKind = switch (kind_flags) {
-            0 => .variable_var,
-            1 => .variable_let,
-            2 => .variable_const,
-            else => .variable_var,
+        const sym_kind: SymbolKind = switch (kind) {
+            .@"var" => .variable_var,
+            .let => .variable_let,
+            .@"const" => .variable_const,
+            // using/await_using은 기존 동작을 유지하여 variable_var로 분류.
+            .using, .await_using => .variable_var,
         };
 
         if (decl_start + decl_len > extras.len) return;
@@ -2312,15 +2314,16 @@ pub const SemanticAnalyzer = struct {
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
         if (extra_start + 2 >= extras.len) return; // 바운드 방어
-        const kind_flags = extras[extra_start];
+        const kind = VariableDeclarationKind.fromU32(extras[extra_start]);
         const decl_start = extras[extra_start + 1];
         const decl_len = extras[extra_start + 2];
 
-        const sym_kind: SymbolKind = switch (kind_flags) {
-            0 => .variable_var,
-            1 => .variable_let,
-            2 => .variable_const,
-            else => .variable_var,
+        const sym_kind: SymbolKind = switch (kind) {
+            .@"var" => .variable_var,
+            .let => .variable_let,
+            .@"const" => .variable_const,
+            // using/await_using도 기존 else 분기와 동일하게 variable_var.
+            .using, .await_using => .variable_var,
         };
 
         // 각 declarator에서 바인딩 이름 추출
@@ -2775,8 +2778,8 @@ pub const SemanticAnalyzer = struct {
                 const extra_start = node.data.extra;
                 const extras = self.ast.extra_data.items;
                 if (extra_start + 2 >= extras.len) return;
-                const kind_flags = extras[extra_start];
-                if (kind_flags != 0) return; // let/const는 block scoped
+                const kind = VariableDeclarationKind.fromU32(extras[extra_start]);
+                if (kind != .@"var") return; // let/const는 block scoped
                 try self.predeclareVarDecl(node);
             },
             // 함수 선언도 hoisting 대상 (var scope에 등록)

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -33,10 +33,13 @@ const Tag = Node.Tag;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 
-/// let(1), const(2), using(3), await_using(4)이면 var(0)으로 변환.
-pub fn lowerKindFlags(kind_flags: u32) u32 {
-    return if (kind_flags >= 1 and kind_flags <= 4) 0 else kind_flags;
+/// let/const/using/await_using을 모두 var로 다운레벨링.
+/// (block scoping, using disposal 전부 var로 치환된 뒤 다른 패스에서 처리)
+pub fn lowerKind(kind: VariableDeclarationKind) VariableDeclarationKind {
+    _ = kind;
+    return .@"var";
 }
 
 pub fn ES2015BlockScoping(comptime Transformer: type) type {
@@ -54,9 +57,10 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             const init = self.ast.getNode(init_idx);
             if (init.tag != .variable_declaration) return names;
 
+            const kind = self.ast.variableDeclarationKind(init);
+            if (kind == .@"var") return names; // var는 무시, let/const/using/await_using만
+
             const e = init.data.extra;
-            const kind_flags = self.readU32(e, 0);
-            if (kind_flags == 0) return names; // var(0)는 무시, let(1)/const(2)/using(3)/await_using(4)만
 
             const list_start = self.readU32(e, 1);
             const list_len = self.readU32(e, 2);
@@ -287,7 +291,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             const loop_name_span = try self.ast.addString(loop_name);
             const loop_binding = try es_helpers.makeBindingIdentifier(self, loop_name_span);
             const loop_decl = try es_helpers.makeDeclarator(self, loop_binding, func_expr, span);
-            const loop_var = try es_helpers.makeVarDeclaration(self, &.{loop_decl}, 0, span);
+            const loop_var = try es_helpers.makeVarDeclaration(self, &.{loop_decl}, .@"var", span);
 
             // --- _loop(i, j, ...) 호출 ---
             const scratch_top2 = self.scratch.items.len;
@@ -811,9 +815,9 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
 
 test "ES2015 block scoping module compiles" {
     const std_lib = @import("std");
-    try std_lib.testing.expectEqual(@as(u32, 0), lowerKindFlags(0)); // var → var
-    try std_lib.testing.expectEqual(@as(u32, 0), lowerKindFlags(1)); // let → var
-    try std_lib.testing.expectEqual(@as(u32, 0), lowerKindFlags(2)); // const → var
-    try std_lib.testing.expectEqual(@as(u32, 0), lowerKindFlags(3)); // using → var
-    try std_lib.testing.expectEqual(@as(u32, 0), lowerKindFlags(4)); // await_using → var
+    try std_lib.testing.expectEqual(VariableDeclarationKind.@"var", lowerKind(.@"var")); // var → var
+    try std_lib.testing.expectEqual(VariableDeclarationKind.@"var", lowerKind(.let)); // let → var
+    try std_lib.testing.expectEqual(VariableDeclarationKind.@"var", lowerKind(.@"const")); // const → var
+    try std_lib.testing.expectEqual(VariableDeclarationKind.@"var", lowerKind(.using)); // using → var
+    try std_lib.testing.expectEqual(VariableDeclarationKind.@"var", lowerKind(.await_using)); // await_using → var
 }

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -236,7 +236,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             // var ClassName = IIFE;
             const declarator = try es_helpers.makeDeclarator(self, new_name, iife_call, span);
-            const var_decl = try es_helpers.makeVarDeclaration(self, &.{declarator}, 0, span);
+            const var_decl = try es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", span);
             try self.pending_nodes.append(self.allocator, var_decl);
 
             // static fields → IIFE 밖 (init에서 ClassName 자기참조 시 이미 할당된 상태)

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -633,7 +633,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             // 2) for-in의 left를 var _ref 로 교체
             const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
             const temp_decl = try es_helpers.makeDeclarator(self, temp_binding, NodeIndex.none, span);
-            const new_left = try es_helpers.makeVarDeclaration(self, &.{temp_decl}, 0, span);
+            const new_left = try es_helpers.makeVarDeclaration(self, &.{temp_decl}, .@"var", span);
 
             // 3) right를 visit
             const new_right = try self.visitNode(right);

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -114,7 +114,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
             const iter_declarator = try es_helpers.makeDeclarator(self, iter_binding, iter_call, span);
             const step_binding = try es_helpers.makeBindingIdentifier(self, step_span);
             const step_declarator = try es_helpers.makeDeclarator(self, step_binding, .none, span);
-            const for_init = try es_helpers.makeVarDeclaration(self, &.{ iter_declarator, step_declarator }, 0, span);
+            const for_init = try es_helpers.makeVarDeclaration(self, &.{ iter_declarator, step_declarator }, .@"var", span);
 
             // --- test: !(_a = (_e = _d.next()).done) ---
 
@@ -403,7 +403,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
         fn makeVarDeclFromSpan(self: *Transformer, name_span: Span, init: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const binding = try es_helpers.makeBindingIdentifier(self, name_span);
             const declarator = try es_helpers.makeDeclarator(self, binding, init, span);
-            return es_helpers.makeVarDeclaration(self, &.{declarator}, 0, span);
+            return es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", span);
         }
 
         /// for-of의 left를 기반으로 var 선언 또는 대입문 생성.
@@ -425,7 +425,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                 const binding_name = try self.visitNode(binding_idx);
 
                 const declarator = try es_helpers.makeDeclarator(self, binding_name, elem, span);
-                return es_helpers.makeVarDeclaration(self, &.{declarator}, 0, span);
+                return es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", span);
             } else {
                 const new_left = try self.visitNode(left);
                 const assign = try self.ast.addNode(.{

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -203,7 +203,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                     try self.scratch.append(self.allocator, declarator);
                 }
                 self.generator_temp_var_spans.clearRetainingCapacity();
-                var_decl_node = try es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top2..], 0, span);
+                var_decl_node = try es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top2..], .@"var", span);
             }
 
             return .{ .body = switch_node, .var_decl = var_decl_node };

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -216,7 +216,7 @@ pub fn ES2015Params(comptime Transformer: type) type {
             const destruct_decl = try es_helpers.makeVarDeclaration(
                 self,
                 &.{try es_helpers.makeDeclarator(self, visited_pattern, temp_ref2, span)},
-                0,
+                .@"var",
                 span,
             );
             try body_stmts.append(self.allocator, destruct_decl);
@@ -244,7 +244,7 @@ pub fn ES2015Params(comptime Transformer: type) type {
 
             const declarators = self.scratch.items[scratch_top..];
             if (declarators.len > 0) {
-                const decl = try es_helpers.makeVarDeclaration(self, declarators, 0, span);
+                const decl = try es_helpers.makeVarDeclaration(self, declarators, .@"var", span);
                 try body_stmts.append(self.allocator, decl);
             }
 
@@ -326,7 +326,7 @@ pub fn ES2015Params(comptime Transformer: type) type {
 
             // var rest = [].slice.call(arguments, N)
             const declarator = try es_helpers.makeDeclarator(self, binding, call_node, span);
-            return es_helpers.makeVarDeclaration(self, &.{declarator}, 0, span);
+            return es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", span);
         }
 
         /// identifier 노드를 복제한다 (같은 이름의 새 노드).

--- a/src/transformer/es2025_using.zig
+++ b/src/transformer/es2025_using.zig
@@ -53,6 +53,7 @@ const NodeList = ast_mod.NodeList;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 
 pub fn ES2025Using(comptime Transformer: type) type {
     return struct {
@@ -68,8 +69,7 @@ pub fn ES2025Using(comptime Transformer: type) type {
                 if (node.tag == .variable_declaration) {
                     const e = node.data.extra;
                     if (self.ast.hasExtra(e, 3)) {
-                        const kind_flags = self.ast.extra_data.items[e];
-                        if (kind_flags == 3 or kind_flags == 4) return true;
+                        if (self.ast.variableDeclarationKind(node).isUsing()) return true;
                     }
                 }
             }
@@ -104,10 +104,10 @@ pub fn ES2025Using(comptime Transformer: type) type {
                     if (node.tag == .variable_declaration) {
                         const e = node.data.extra;
                         if (self.ast.hasExtra(e, 3)) {
-                            const kind_flags = self.ast.extra_data.items[e];
-                            if (kind_flags == 3 or kind_flags == 4) {
+                            const kind = self.ast.variableDeclarationKind(node);
+                            if (kind.isUsing()) {
                                 if (first_using_idx == len) first_using_idx = i;
-                                if (kind_flags == 4) has_await_using = true;
+                                if (kind == .await_using) has_await_using = true;
                             }
                         }
                     }
@@ -155,7 +155,7 @@ pub fn ES2025Using(comptime Transformer: type) type {
             });
             const stack_decl_list = try self.ast.addNodeList(&.{stack_declarator});
             const stack_decl = try self.addExtraNode(.variable_declaration, zero_span, &.{
-                0, // var
+                @intFromEnum(VariableDeclarationKind.@"var"),
                 stack_decl_list.start,
                 stack_decl_list.len,
             });
@@ -173,15 +173,15 @@ pub fn ES2025Using(comptime Transformer: type) type {
                     if (node.tag == .variable_declaration) {
                         const e = node.data.extra;
                         if (self.ast.hasExtra(e, 3)) {
-                            const kind_flags = self.ast.extra_data.items[e];
-                            if (kind_flags == 3 or kind_flags == 4) {
+                            const kind = self.ast.variableDeclarationKind(node);
+                            if (kind.isUsing()) {
                                 const decl_list_start = self.readU32(e, 1);
                                 const decl_list_len = self.readU32(e, 2);
                                 try transformUsingDeclarators(
                                     self,
                                     decl_list_start,
                                     decl_list_len,
-                                    kind_flags == 4,
+                                    kind == .await_using,
                                     stack_span,
                                     node.span,
                                 );
@@ -278,7 +278,7 @@ pub fn ES2025Using(comptime Transformer: type) type {
                 });
                 const new_decl_list = try self.ast.addNodeList(&.{new_decl});
                 const var_decl = try self.addExtraNode(.variable_declaration, span, &.{
-                    0, // var
+                    @intFromEnum(VariableDeclarationKind.@"var"),
                     new_decl_list.start,
                     new_decl_list.len,
                 });
@@ -316,7 +316,7 @@ pub fn ES2025Using(comptime Transformer: type) type {
 
             const var_list = try self.ast.addNodeList(&.{ error_declarator, has_error_declarator });
             const var_decl = try self.addExtraNode(.variable_declaration, span, &.{
-                0, // var
+                @intFromEnum(VariableDeclarationKind.@"var"),
                 var_list.start,
                 var_list.len,
             });

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -11,6 +11,7 @@ const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 
@@ -45,7 +46,7 @@ pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, in
 
     const binding = try makeBindingIdentifier(self, try self.ast.addString(var_name));
     const declarator = try makeDeclarator(self, binding, obj, span);
-    return makeVarDeclaration(self, &.{declarator}, 0, span);
+    return makeVarDeclaration(self, &.{declarator}, .@"var", span);
 }
 
 /// class member의 key가 `constructor` 이름인지 판별.
@@ -270,11 +271,10 @@ pub fn makeDeclarator(self: anytype, binding: NodeIndex, init: NodeIndex, span: 
     });
 }
 
-/// variable_declaration 노드 생성 (var 키워드, declarators 배열).
-/// kind_flags: 0 = var, 1 = let, 2 = const
-pub fn makeVarDeclaration(self: anytype, declarators: []const NodeIndex, kind_flags: u32, span: Span) !NodeIndex {
+/// variable_declaration 노드 생성 (var/let/const/using/await_using 키워드, declarators 배열).
+pub fn makeVarDeclaration(self: anytype, declarators: []const NodeIndex, kind: VariableDeclarationKind, span: Span) !NodeIndex {
     const decl_list = try self.ast.addNodeList(declarators);
-    const var_extra = try self.ast.addExtras(&.{ kind_flags, decl_list.start, decl_list.len });
+    const var_extra = try self.ast.addExtras(&.{ @intFromEnum(kind), decl_list.start, decl_list.len });
     return self.ast.addNode(.{
         .tag = .variable_declaration,
         .span = span,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -21,6 +21,7 @@ const Data = Node.Data;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const module_parser = @import("../parser/module.zig");
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
@@ -1842,8 +1843,8 @@ pub const Transformer = struct {
         const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
         self.scratch.shrinkRetainingCapacity(scratch_top);
         // variable_declaration: extra = [kind_flags, list.start, list.len]
-        // kind_flags=2: const
-        const var_extra = try self.ast.addExtras(&.{ 2, list.start, list.len });
+        // kind = .const
+        const var_extra = try self.ast.addExtras(&.{ @intFromEnum(VariableDeclarationKind.@"const"), list.start, list.len });
         return try self.ast.addNode(.{
             .tag = .variable_declaration,
             .span = node.span,
@@ -1955,16 +1956,16 @@ pub const Transformer = struct {
             }
         }
         const e = node.data.extra;
-        const orig_kind = self.readU32(e, 0);
-        const kind_flags = if (self.options.unsupported.block_scoping)
-            es2015_block_scoping.lowerKindFlags(orig_kind)
+        const orig_kind = VariableDeclarationKind.fromU32(self.readU32(e, 0));
+        const kind = if (self.options.unsupported.block_scoping)
+            es2015_block_scoping.lowerKind(orig_kind)
         else
             orig_kind;
 
         // let/const → var 변환 시: 초기화 없는 declarator에 = void 0 추가.
         // let은 블록 스코프로 매 반복 새 바인딩이지만, var는 hoisted되어 이전 값 유지.
         // Metro(Babel)와 동일하게 명시적 undefined 초기화로 의미론 보존.
-        const needs_void_init = self.options.unsupported.block_scoping and (orig_kind >= 1 and orig_kind <= 4);
+        const needs_void_init = self.options.unsupported.block_scoping and orig_kind.isLexical();
 
         const list_start = self.readU32(e, 1);
         const list_len = self.readU32(e, 2);
@@ -2009,11 +2010,11 @@ pub const Transformer = struct {
             }
 
             const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-            return self.addExtraNode(.variable_declaration, node.span, &.{ kind_flags, new_list.start, new_list.len });
+            return self.addExtraNode(.variable_declaration, node.span, &.{ @intFromEnum(kind), new_list.start, new_list.len });
         }
 
         const new_list = try self.visitExtraList(list_start, list_len);
-        return self.addExtraNode(.variable_declaration, node.span, &.{ kind_flags, new_list.start, new_list.len });
+        return self.addExtraNode(.variable_declaration, node.span, &.{ @intFromEnum(kind), new_list.start, new_list.len });
     }
 
     /// variable_declarator: extra_data = [name, type_ann, init]
@@ -2662,8 +2663,8 @@ pub const Transformer = struct {
             if (stmt.tag != .variable_declaration) continue;
 
             const ve = stmt.data.extra;
-            const kind_flags = self.readU32(ve, 0);
-            if (kind_flags == 0) continue; // var(0)은 무시, let(1)/const(2)/using(3)/await_using(4)만
+            const kind = self.ast.variableDeclarationKind(stmt);
+            if (kind == .@"var") continue; // var는 무시, let/const/using/await_using만
 
             const decl_start = self.readU32(ve, 1);
             const decl_len = self.readU32(ve, 2);
@@ -2723,7 +2724,7 @@ pub const Transformer = struct {
 
         const decl_list = try self.ast.addNodeList(&.{declarator});
         return self.addExtraNode(.variable_declaration, span, &.{
-            0, // var
+            @intFromEnum(VariableDeclarationKind.@"var"),
             decl_list.start,
             decl_list.len,
         });
@@ -2757,7 +2758,7 @@ pub const Transformer = struct {
 
         const decl_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
         const var_decl = try self.addExtraNode(.variable_declaration, span, &.{
-            0, // var
+            @intFromEnum(VariableDeclarationKind.@"var"),
             decl_list.start,
             decl_list.len,
         });


### PR DESCRIPTION
## Summary
`variable_declaration` 노드의 kind(var/let/const/using/await using)를 매직넘버 0~4 비교에서 `VariableDeclarationKind` typed enum으로 정규화. 동작 변경 없음, 타입 안전성 강화.

## 배경
어제 PR #1283 후속(#1317)에서 발견한 정규화 가치 케이스 중 #4. 매직넘버 비교가 12+ 파일에 흩어져 있어 신규 kind 추가/누락 시 silent 버그 위험이 있었음. enum exhaustive switch로 컴파일 타임 차단.

## 변경
- `ast.zig`: `VariableDeclarationKind` enum (wire 값 0~4 고정) + `isLexical()` / `isUsing()` 헬퍼 + `Ast.variableDeclarationKind()` 메서드
- parser/transformer/codegen/semantic 전체 마이그레이션
- `lowerKindFlags(u32)` → `lowerKind(VariableDeclarationKind)` 시그니처 변경
- `makeVarDeclaration` 호출부 모두 enum 사용

## 테스트
- 신규 8개 unit test: 5가지 kind 파서 매핑, isLexical/isUsing, wire-compat 수치, fromU32 fallback
- `zig build test` 그린
- 통합 테스트 baseline과 fail 수 동일 (2861 pass / 18 fail)

## Test plan
- [x] zig build test
- [x] cd tests/integration && bun test (baseline 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)