### PR TITLE
refactor(ast): /simplify — variable kind enum 후속 정리

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -16,7 +16,6 @@ const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
-const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const Span = @import("../lexer/token.zig").Span;
 const module_parser = @import("../parser/module.zig");
 const Kind = @import("../lexer/token.zig").Kind;
@@ -2399,7 +2398,7 @@ pub const Codegen = struct {
     fn emitVariableDeclaration(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         const extras = self.ast.extra_data.items[e .. e + 3];
-        const kind = VariableDeclarationKind.fromU32(extras[0]);
+        const kind = self.ast.variableDeclarationKind(node);
         const list_start = extras[1];
         const list_len = extras[2];
 

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1023,7 +1023,7 @@ pub const VariableDeclarationKind = enum(u32) {
     using = 3,
     await_using = 4,
 
-    pub fn fromU32(v: u32) VariableDeclarationKind {
+    pub inline fn fromU32(v: u32) VariableDeclarationKind {
         return switch (v) {
             0 => .@"var",
             1 => .let,
@@ -1034,11 +1034,11 @@ pub const VariableDeclarationKind = enum(u32) {
         };
     }
 
-    pub fn isLexical(self: VariableDeclarationKind) bool {
+    pub inline fn isLexical(self: VariableDeclarationKind) bool {
         return self != .@"var";
     }
 
-    pub fn isUsing(self: VariableDeclarationKind) bool {
+    pub inline fn isUsing(self: VariableDeclarationKind) bool {
         return self == .using or self == .await_using;
     }
 };

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -804,7 +804,7 @@ fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) ParseError2!v
     // initializer가 있으면 에러 (예외: sloppy var + for-in + BindingIdentifier만)
     // Annex B.3.5: for (var BindingIdentifier Initializer in Expression) — 허용
     // BindingPattern (array/object destructuring)은 Annex B에서도 항상 금지
-    const is_var = kind == .@"var";
+    const is_var = !kind.isLexical();
     const is_for_in = self.current() == .kw_in;
     if (is_for_in and is_var) {
         // TS 모드에서는 for-in var initializer를 허용 (esbuild 호환).

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1536,17 +1536,11 @@ pub const SemanticAnalyzer = struct {
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
         if (extra_start + 2 >= extras.len) return;
-        const kind = VariableDeclarationKind.fromU32(extras[extra_start]);
+        const kind = self.ast.variableDeclarationKind(node);
         const decl_start = extras[extra_start + 1];
         const decl_len = extras[extra_start + 2];
 
-        const sym_kind: SymbolKind = switch (kind) {
-            .@"var" => .variable_var,
-            .let => .variable_let,
-            .@"const" => .variable_const,
-            // using/await_using은 기존 동작을 유지하여 variable_var로 분류.
-            .using, .await_using => .variable_var,
-        };
+        const sym_kind = symbolKindFor(kind);
 
         if (decl_start + decl_len > extras.len) return;
         const decl_indices = extras[decl_start .. decl_start + decl_len];
@@ -1628,6 +1622,16 @@ pub const SemanticAnalyzer = struct {
             },
             else => {},
         }
+    }
+
+    /// VariableDeclarationKind → SymbolKind 매핑.
+    /// using/await_using은 lexical이지만 현재 분석기 구조상 var 분류 유지 (별도 처리 패스 도입 시 변경).
+    fn symbolKindFor(kind: VariableDeclarationKind) SymbolKind {
+        return switch (kind) {
+            .@"var", .using, .await_using => .variable_var,
+            .let => .variable_let,
+            .@"const" => .variable_const,
+        };
     }
 
     /// function flags → SymbolKind 변환.
@@ -2310,21 +2314,15 @@ pub const SemanticAnalyzer = struct {
     // ================================================================
 
     fn visitVariableDeclaration(self: *SemanticAnalyzer, node: Node) AllocError!void {
-        // extra: [kind_flags, declarators.start, declarators.len]
+        // extra: [kind, declarators.start, declarators.len]
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
         if (extra_start + 2 >= extras.len) return; // 바운드 방어
-        const kind = VariableDeclarationKind.fromU32(extras[extra_start]);
+        const kind = self.ast.variableDeclarationKind(node);
         const decl_start = extras[extra_start + 1];
         const decl_len = extras[extra_start + 2];
 
-        const sym_kind: SymbolKind = switch (kind) {
-            .@"var" => .variable_var,
-            .let => .variable_let,
-            .@"const" => .variable_const,
-            // using/await_using도 기존 else 분기와 동일하게 variable_var.
-            .using, .await_using => .variable_var,
-        };
+        const sym_kind = symbolKindFor(kind);
 
         // 각 declarator에서 바인딩 이름 추출
         // variable_declarator의 data는 extra: [name, type_ann, init_expr]
@@ -2778,8 +2776,7 @@ pub const SemanticAnalyzer = struct {
                 const extra_start = node.data.extra;
                 const extras = self.ast.extra_data.items;
                 if (extra_start + 2 >= extras.len) return;
-                const kind = VariableDeclarationKind.fromU32(extras[extra_start]);
-                if (kind != .@"var") return; // let/const는 block scoped
+                if (self.ast.variableDeclarationKind(node).isLexical()) return; // let/const/using는 block scoped
                 try self.predeclareVarDecl(node);
             },
             // 함수 선언도 hoisting 대상 (var scope에 등록)

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -35,10 +35,9 @@ const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
 const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 
-/// let/const/using/await_using을 모두 var로 다운레벨링.
-/// (block scoping, using disposal 전부 var로 치환된 뒤 다른 패스에서 처리)
-pub fn lowerKind(kind: VariableDeclarationKind) VariableDeclarationKind {
-    _ = kind;
+/// block scoping 다운레벨 시 모든 lexical(let/const/using/await_using)을 var로 치환.
+/// (using disposal 등 의미 보존은 별도 패스가 처리)
+pub inline fn lowerKind(_: VariableDeclarationKind) VariableDeclarationKind {
     return .@"var";
 }
 
@@ -57,8 +56,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             const init = self.ast.getNode(init_idx);
             if (init.tag != .variable_declaration) return names;
 
-            const kind = self.ast.variableDeclarationKind(init);
-            if (kind == .@"var") return names; // var는 무시, let/const/using/await_using만
+            if (!self.ast.variableDeclarationKind(init).isLexical()) return names;
 
             const e = init.data.extra;
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1956,7 +1956,7 @@ pub const Transformer = struct {
             }
         }
         const e = node.data.extra;
-        const orig_kind = VariableDeclarationKind.fromU32(self.readU32(e, 0));
+        const orig_kind = self.ast.variableDeclarationKind(node);
         const kind = if (self.options.unsupported.block_scoping)
             es2015_block_scoping.lowerKind(orig_kind)
         else
@@ -2663,8 +2663,7 @@ pub const Transformer = struct {
             if (stmt.tag != .variable_declaration) continue;
 
             const ve = stmt.data.extra;
-            const kind = self.ast.variableDeclarationKind(stmt);
-            if (kind == .@"var") continue; // var는 무시, let/const/using/await_using만
+            if (!self.ast.variableDeclarationKind(stmt).isLexical()) continue;
 
             const decl_start = self.readU32(ve, 1);
             const decl_len = self.readU32(ve, 2);


### PR DESCRIPTION
## Summary
PR #1318 후속 /simplify. 3개 리뷰 에이전트(reuse/quality/efficiency) 발견 정리.

## 변경
- `lowerKind` 파라미터 무시 명시 + `inline`
- `fromU32`/`isLexical`/`isUsing` `inline fn` 전환 (hot path 인라이닝 보장)
- raw `fromU32(extras[0])` → `Ast.variableDeclarationKind(node)` 헬퍼 사용 4곳
- 중복된 kind→SymbolKind switch 2벌 → `symbolKindFor` 헬퍼로 통합
- `kind == .@"var"` → `!kind.isLexical()` 명확화
- 매직넘버 잔재 주석 제거, 사용 안 되는 import 제거

동작 변경 없음, -34 / +27 줄.

## Test plan
- [x] zig build test
- [x] cd tests/integration && bun test (baseline 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)