### PR TITLE
refactor(ast): /simplify — variableDeclarationKind inline + dead bound 제거

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -871,7 +871,7 @@ pub const Ast = struct {
 
     /// variable_declaration 노드의 kind를 typed enum으로 반환.
     /// node.tag == .variable_declaration 가정. extra[0]에 저장된 u32를 디코드.
-    pub fn variableDeclarationKind(self: *const Ast, node: Node) VariableDeclarationKind {
+    pub inline fn variableDeclarationKind(self: *const Ast, node: Node) VariableDeclarationKind {
         return VariableDeclarationKind.fromU32(self.extra_data.items[node.data.extra]);
     }
 

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -2773,10 +2773,8 @@ pub const SemanticAnalyzer = struct {
         const node = self.ast.getNode(idx);
         switch (node.tag) {
             .variable_declaration => {
-                const extra_start = node.data.extra;
-                const extras = self.ast.extra_data.items;
-                if (extra_start + 2 >= extras.len) return;
-                if (self.ast.variableDeclarationKind(node).isLexical()) return; // let/const/using는 block scoped
+                // 바운드 체크는 predeclareVarDecl 내부에서 수행.
+                if (self.ast.variableDeclarationKind(node).isLexical()) return; // let/const/using/await_using는 block scoped
                 try self.predeclareVarDecl(node);
             },
             // 함수 선언도 hoisting 대상 (var scope에 등록)


### PR DESCRIPTION
## Summary
PR #1319 후속 /simplify. 효율성/품질 리뷰 발견.

- `Ast.variableDeclarationKind` `inline fn` 전환 — 내부 `fromU32`/`isLexical`만 inline이고 outer가 빠지면 hot path 인라이닝 깨짐
- analyzer 미사용 로컬 + 중복 바운드 체크 제거 (predeclareVarDecl 내부에서 수행)
- 주석 `await_using` 누락 보완

2파일 +3/-5. 동작 변경 없음, 테스트 그린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)