### PR TITLE
refactor(ast): Phase 2 — function/method params formal_parameters 노드로 정규화

### DIFF
--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -232,10 +232,11 @@ pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
                 if (ast.extra_data.items[me + 4] > 0) return true; // decorator
             },
             .method_definition => {
+                // method_definition: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
                 const me = member.data.extra;
-                if (me + 6 >= ast.extra_data.items.len) return true;
+                if (me + 5 >= ast.extra_data.items.len) return true;
                 if (computedKeyHasSideEffects(ast, me)) return true;
-                if (ast.extra_data.items[me + 6] > 0) return true; // decorator
+                if (ast.extra_data.items[me + 5] > 0) return true; // decorator
             },
             else => {},
         }

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2061,12 +2061,15 @@ pub const Codegen = struct {
 
     fn emitFunction(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
-        const extras = self.ast.extra_data.items[e .. e + 6];
+        // function_expression은 ret_type 없이 4 slots, function_declaration/function은 5 slots.
+        // 공통 [name(0), params(1), body(2), flags(3)]만 읽는다.
+        const extras = self.ast.extra_data.items[e .. e + 4];
         const name: NodeIndex = @enumFromInt(extras[0]);
-        const params_start = extras[1];
-        const params_len = extras[2];
-        const body: NodeIndex = @enumFromInt(extras[3]);
-        const flags = extras[4];
+        const params_list = self.ast.functionParamsList(node);
+        const params_start = params_list.start;
+        const params_len = params_list.len;
+        const body: NodeIndex = @enumFromInt(extras[2]);
+        const flags = extras[3];
 
         // function map: contextual name 소비 후 진입
         const saved_pending = self.pending_fn_name;
@@ -2238,14 +2241,15 @@ pub const Codegen = struct {
     // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
     fn emitMethodDef(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
-        const extras = self.ast.extra_data.items[e .. e + 7];
+        const extras = self.ast.extra_data.items[e .. e + 6];
         const key: NodeIndex = @enumFromInt(extras[0]);
-        const params_start = extras[1];
-        const params_len = extras[2];
-        const body: NodeIndex = @enumFromInt(extras[3]);
-        const flags = extras[4];
-        const deco_start = extras[5];
-        const deco_len = extras[6];
+        const params_list = self.ast.functionParamsList(node);
+        const params_start = params_list.start;
+        const params_len = params_list.len;
+        const body: NodeIndex = @enumFromInt(extras[2]);
+        const flags = extras[3];
+        const deco_start = extras[4];
+        const deco_len = extras[5];
 
         // function map: ClassName#method / ClassName.method / get__name / set__name
         if (self.fn_map_builder != null) {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2238,7 +2238,7 @@ pub const Codegen = struct {
         try self.emitNode(node.data.unary.operand);
     }
 
-    // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
+    // method_definition: extra = [key, params, body, flags, deco_start, deco_len]
     fn emitMethodDef(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         const extras = self.ast.extra_data.items[e .. e + 6];
@@ -3502,8 +3502,7 @@ pub const Codegen = struct {
             .function_declaration, .class_declaration => {
                 // function foo() {} → Foo.foo = foo;
                 const e = decl.data.extra;
-                const extras = self.ast.extra_data.items[e .. e + 6];
-                const name_idx: NodeIndex = @enumFromInt(extras[0]);
+                const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
                 if (!name_idx.isNone()) {
                     const fn_name_node = self.ast.getNode(name_idx);
                     const fn_name = self.ast.getText(fn_name_node.span);

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -875,6 +875,25 @@ pub const Ast = struct {
         return VariableDeclarationKind.fromU32(self.extra_data.items[node.data.extra]);
     }
 
+    /// 함수형 노드의 formal_parameters NodeList를 반환한다 (extra_data 인덱스 + len).
+    /// 지원 태그: function_declaration / function_expression / function /
+    /// arrow_function_expression / method_definition.
+    /// formal_parameters 노드가 없거나 잘못된 경우 빈 NodeList 반환.
+    /// consumer에서 registerParams/checkDuplicateParams 등 (start, len) 시그니처 호출에 사용.
+    pub fn functionParamsList(self: *const Ast, node: Node) NodeList {
+        const params_slot: u32 = switch (node.tag) {
+            .arrow_function_expression => 0,
+            .function_declaration, .function_expression, .function, .method_definition => 1,
+            else => return .{ .start = 0, .len = 0 },
+        };
+        if (node.data.extra + params_slot >= self.extra_data.items.len) return .{ .start = 0, .len = 0 };
+        const params_idx: NodeIndex = @enumFromInt(self.extra_data.items[node.data.extra + params_slot]);
+        if (params_idx.isNone() or @intFromEnum(params_idx) >= self.nodes.items.len) return .{ .start = 0, .len = 0 };
+        const params_node = self.getNode(params_idx);
+        if (params_node.tag != .formal_parameters) return .{ .start = 0, .len = 0 };
+        return params_node.data.list;
+    }
+
     /// 함수형 노드의 파라미터 슬라이스를 반환한다 (각 element는 NodeIndex의 raw u32).
     /// 지원 태그: function_declaration / function_expression / function /
     /// arrow_function_expression / method_definition.

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -595,14 +595,14 @@ pub const Node = struct {
                 .private_field_expression,
                 .computed_member_expression,
                 => .{ .kind = .extra, .child_offsets = &.{ 0, 1 } },
-                // function: extra = [name(0), params_start(1), params_len(2), body(3), flags, ret_type(5)]
-                .function_expression, .function_declaration, .function => .{ .kind = .extra, .child_offsets = &.{ 0, 3 }, .list_offsets = &.{.{ 1, 2 }} },
+                // function: extra = [name(0), params(1), body(2), flags(3), ret_type(4)]
+                .function_expression, .function_declaration, .function => .{ .kind = .extra, .child_offsets = &.{ 0, 1, 2 } },
                 // arrow: extra = [params(0), body(1), flags]
                 .arrow_function_expression => .{ .kind = .extra, .child_offsets = &.{ 0, 1 } },
                 // class: extra = [name(0), super(1), body(2), type_params(3), impl_start, impl_len, deco_start, deco_len]
                 .class_expression, .class_declaration => .{ .kind = .extra, .child_offsets = &.{ 0, 1, 2 } },
-                // method: extra = [key(0), params_start(1), params_len(2), body(3), flags, deco_start, deco_len]
-                .method_definition => .{ .kind = .extra, .child_offsets = &.{ 0, 3 }, .list_offsets = &.{.{ 1, 2 }} },
+                // method: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
+                .method_definition => .{ .kind = .extra, .child_offsets = &.{ 0, 1, 2 } },
                 // property_definition: extra = [key(0), init(1), flags, deco_start, deco_len]
                 .property_definition, .accessor_property => .{ .kind = .extra, .child_offsets = &.{ 0, 1 } },
                 // for_statement: extra = [init(0), test(1), update(2), body(3)]
@@ -878,28 +878,21 @@ pub const Ast = struct {
     /// 함수형 노드의 파라미터 슬라이스를 반환한다 (각 element는 NodeIndex의 raw u32).
     /// 지원 태그: function_declaration / function_expression / function /
     /// arrow_function_expression / method_definition.
-    /// arrow는 `formal_parameters` 노드를 unwrap, 나머지는 extra에 저장된 bare NodeList를 슬라이스.
+    /// 모두 `formal_parameters` 노드를 unwrap (arrow는 extra[0], 나머지는 extra[1]).
     /// formal_parameters 노드가 비어 있거나 params가 없으면 빈 슬라이스 반환.
     pub fn functionParams(self: *const Ast, node: Node) []const u32 {
-        return switch (node.tag) {
-            .arrow_function_expression => blk: {
-                const params_idx: NodeIndex = @enumFromInt(self.extra_data.items[node.data.extra]);
-                if (params_idx.isNone()) break :blk &[_]u32{};
-                const params_node = self.getNode(params_idx);
-                if (params_node.tag != .formal_parameters) break :blk &[_]u32{};
-                const list = params_node.data.list;
-                if (list.len == 0) break :blk &[_]u32{};
-                break :blk self.extra_data.items[list.start .. list.start + list.len];
-            },
-            .function_declaration, .function_expression, .function, .method_definition => blk: {
-                const e = node.data.extra;
-                const start = self.extra_data.items[e + 1];
-                const len = self.extra_data.items[e + 2];
-                if (len == 0) break :blk &[_]u32{};
-                break :blk self.extra_data.items[start .. start + len];
-            },
-            else => &[_]u32{},
+        const params_slot: u32 = switch (node.tag) {
+            .arrow_function_expression => 0,
+            .function_declaration, .function_expression, .function, .method_definition => 1,
+            else => return &[_]u32{},
         };
+        const params_idx: NodeIndex = @enumFromInt(self.extra_data.items[node.data.extra + params_slot]);
+        if (params_idx.isNone()) return &[_]u32{};
+        const params_node = self.getNode(params_idx);
+        if (params_node.tag != .formal_parameters) return &[_]u32{};
+        const list = params_node.data.list;
+        if (list.len == 0) return &[_]u32{};
+        return self.extra_data.items[list.start .. list.start + list.len];
     }
 
     /// extra_data에 값을 추가하고 시작 인덱스를 반환한다.

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -875,6 +875,16 @@ pub const Ast = struct {
         return VariableDeclarationKind.fromU32(self.extra_data.items[node.data.extra]);
     }
 
+    /// `formal_parameters` 노드를 생성한다. transformer가 function/method를 새로 만들 때
+    /// slot 1(arrow는 slot 0)에 넣을 NodeIndex를 반환 — caller는 `@intFromEnum(...)` 으로 extras에 기록.
+    pub fn addFormalParameters(self: *Ast, list: NodeList, span: Span) !NodeIndex {
+        return self.addNode(.{
+            .tag = .formal_parameters,
+            .span = span,
+            .data = .{ .list = list },
+        });
+    }
+
     /// 함수형 노드의 formal_parameters NodeList를 반환한다 (extra_data 인덱스 + len).
     /// 지원 태그: function_declaration / function_expression / function /
     /// arrow_function_expression / method_definition.

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -126,9 +126,9 @@ fn parseFunctionDeclarationWithFlags(self: *Parser, extra_flags: u32) ParseError
 
     const param_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
+    const params_node = try self.wrapAsFormalParametersFromList(param_list, .{ .start = 0, .end = 0 });
     const extra_start = try self.ast.addExtra(@intFromEnum(name));
-    _ = try self.ast.addExtra(param_list.start);
-    _ = try self.ast.addExtra(param_list.len);
+    _ = try self.ast.addExtra(@intFromEnum(params_node));
     _ = try self.ast.addExtra(@intFromEnum(body));
     _ = try self.ast.addExtra(flags);
     _ = try self.ast.addExtra(@intFromEnum(return_type));
@@ -236,9 +236,9 @@ fn parseFunctionDeclarationWithFlagsOptionalName(self: *Parser, extra_flags: u32
 
     const param_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
+    const params_node = try self.wrapAsFormalParametersFromList(param_list, .{ .start = 0, .end = 0 });
     const extra_start = try self.ast.addExtra(@intFromEnum(name));
-    _ = try self.ast.addExtra(param_list.start);
-    _ = try self.ast.addExtra(param_list.len);
+    _ = try self.ast.addExtra(@intFromEnum(params_node));
     _ = try self.ast.addExtra(@intFromEnum(body));
     _ = try self.ast.addExtra(flags);
     _ = try self.ast.addExtra(@intFromEnum(return_type));
@@ -318,9 +318,9 @@ pub fn parseFunctionExpressionWithFlags(self: *Parser, extra_flags: u32) ParseEr
 
     const param_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
+    const params_node = try self.wrapAsFormalParametersFromList(param_list, .{ .start = 0, .end = 0 });
     const extra_start = try self.ast.addExtra(@intFromEnum(name));
-    _ = try self.ast.addExtra(param_list.start);
-    _ = try self.ast.addExtra(param_list.len);
+    _ = try self.ast.addExtra(@intFromEnum(params_node));
     _ = try self.ast.addExtra(@intFromEnum(body));
     _ = try self.ast.addExtra(flags);
 
@@ -781,12 +781,12 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.allow_super_property = saved_super_prop_for_params;
         const param_list = try self.ast.addNodeList(self.scratch.items[param_top..]);
         self.restoreScratch(param_top);
+        const params_node = try self.wrapAsFormalParametersFromList(param_list, .{ .start = 0, .end = 0 });
 
-        // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
+        // method_definition: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
         const extra_start = try self.ast.addExtras(&.{
             @intFromEnum(key),
-            param_list.start,
-            param_list.len,
+            @intFromEnum(params_node),
             @intFromEnum(body),
             flags,
             decorators.start,

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1140,9 +1140,9 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
 
         // 1) function Name_withRef({...props}, ref) { body }
         const none = @intFromEnum(NodeIndex.none);
+        const params_node = try self.wrapAsFormalParametersFromList(params, .{ .start = 0, .end = 0 });
         const func_extra = try self.ast.addExtra(@intFromEnum(with_ref_name));
-        _ = try self.ast.addExtra(params.start);
-        _ = try self.ast.addExtra(params.len);
+        _ = try self.ast.addExtra(@intFromEnum(params_node));
         _ = try self.ast.addExtra(@intFromEnum(body));
         _ = try self.ast.addExtra(0); // flags
         _ = try self.ast.addExtra(none); // return_type
@@ -1226,9 +1226,9 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
 
     // ref가 없으면 일반 함수 선언
     const none = @intFromEnum(NodeIndex.none);
+    const params_node = try self.wrapAsFormalParametersFromList(params, .{ .start = 0, .end = 0 });
     const extra_start = try self.ast.addExtra(@intFromEnum(name));
-    _ = try self.ast.addExtra(params.start);
-    _ = try self.ast.addExtra(params.len);
+    _ = try self.ast.addExtra(@intFromEnum(params_node));
     _ = try self.ast.addExtra(@intFromEnum(body));
     _ = try self.ast.addExtra(0);
     _ = try self.ast.addExtra(none);

--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -205,12 +205,12 @@ pub fn parseObjectMethodBody(self: *Parser, start: u32, key: NodeIndex, flags: u
 
     const param_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
+    const params_node = try self.wrapAsFormalParametersFromList(param_list, .{ .start = 0, .end = 0 });
 
-    // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
-    // 클래스 메서드와 동일한 7개 필드 (객체 메서드는 decorator 없으므로 0, 0)
+    // method_definition: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
+    // 클래스 메서드와 동일한 6개 필드 (객체 메서드는 decorator 없으므로 0, 0)
     const extra_start = try self.ast.addExtra(@intFromEnum(key));
-    _ = try self.ast.addExtra(param_list.start);
-    _ = try self.ast.addExtra(param_list.len);
+    _ = try self.ast.addExtra(@intFromEnum(params_node));
     _ = try self.ast.addExtra(@intFromEnum(body));
     _ = try self.ast.addExtra(flags);
     _ = try self.ast.addExtra(0); // deco_start (no decorators)

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1147,6 +1147,17 @@ pub const Parser = struct {
         });
     }
 
+    /// 이미 만든 NodeList(extra_data에 연속 저장된 NodeIndex 리스트)를 formal_parameters 노드로 감싼다.
+    /// function/method/arrow가 공유하는 정규화 계약. arrow는 coverExpressionToArrowParams에서,
+    /// function/method는 parse* 함수들의 마지막 단계에서 사용.
+    pub fn wrapAsFormalParametersFromList(self: *Parser, list: NodeList, span: Span) !NodeIndex {
+        return try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = span,
+            .data = .{ .list = list },
+        });
+    }
+
     /// arrow function 파라미터를 cover grammar으로 검증 + **formal_parameters 노드로 정규화**.
     ///
     /// 입력: parseAssignmentExpression으로 파싱된 원형 (identifier / parenthesized / sequence / spread / formal_parameters).

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -970,7 +970,7 @@ pub const SemanticAnalyzer = struct {
     fn isFunctionWithNoSideEffects(self: *const SemanticAnalyzer, node: Node) bool {
         const e = node.data.extra;
         return switch (node.tag) {
-            .function_expression, .function_declaration => self.ast.hasExtra(e, 4) and (self.ast.readExtra(e, 4) & ast_mod.FunctionFlags.no_side_effects) != 0,
+            .function_expression, .function_declaration => self.ast.hasExtra(e, 3) and (self.ast.readExtra(e, 3) & ast_mod.FunctionFlags.no_side_effects) != 0,
             .arrow_function_expression => self.ast.hasExtra(e, 2) and (self.ast.readExtra(e, 2) & ast_mod.ArrowFlags.no_side_effects) != 0,
             else => false,
         };
@@ -1096,10 +1096,10 @@ pub const SemanticAnalyzer = struct {
 
             // ---- method_definition/property_definition 내부 순회 ----
             .method_definition => {
-                // extra: [key, params.start, params.len, body, flags]
+                // extra: [key, params, body, flags]
                 const extra_start = node.data.extra;
                 const extras = self.ast.extra_data.items;
-                if (extra_start + 3 < extras.len) {
+                if (extra_start + 2 < extras.len) {
                     // key 순회 — computed property ([expr])만 순회한다.
                     // non-computed key는 단순한 이름이므로 순회하지 않는다.
                     // 순회하면 identifier_reference로 방문되어 namespace import 이름이
@@ -1116,11 +1116,12 @@ pub const SemanticAnalyzer = struct {
                     // getter/setter 파라미터 개수 검증
                     try checker.checkGetterSetterParams(self.ast, node, &self.errors, self.allocator);
 
-                    const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 3]);
+                    const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 2]);
                     // 함수 본문을 function scope로 감싸서 순회
                     const scope_saved = try self.enterScope(.function, self.is_strict_mode);
-                    const params_start = extras[extra_start + 1];
-                    const params_len = extras[extra_start + 2];
+                    const params_list = self.ast.functionParamsList(node);
+                    const params_start = params_list.start;
+                    const params_len = params_list.len;
                     try self.registerParams(params_start, params_len);
                     // 메서드는 항상 UniqueFormalParameters — 중복 금지
                     try checker.checkDuplicateParams(self.ast, params_start, params_len, &self.errors, self.allocator);
@@ -1654,12 +1655,12 @@ pub const SemanticAnalyzer = struct {
     fn predeclareFuncDecl(self: *SemanticAnalyzer, node: Node) AllocError!void {
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
-        if (extra_start + 5 >= extras.len) return;
+        if (extra_start + 4 >= extras.len) return;
         const name_idx: NodeIndex = @enumFromInt(extras[extra_start]);
 
         if (!name_idx.isNone()) {
             const name_node = self.ast.getNode(name_idx);
-            try self.declareSymbolWithNode(name_node.span, functionSymbolKind(extras[extra_start + 4]), node.span, @intFromEnum(name_idx));
+            try self.declareSymbolWithNode(name_node.span, functionSymbolKind(extras[extra_start + 3]), node.span, @intFromEnum(name_idx));
         }
     }
 
@@ -1697,13 +1698,13 @@ pub const SemanticAnalyzer = struct {
     }
 
     fn visitFunctionDeclaration(self: *SemanticAnalyzer, node: Node) AllocError!void {
-        // extra: [name, params.start, params.len, body, flags, return_type]
+        // extra: [name, params, body, flags, return_type]
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
-        if (extra_start + 5 >= extras.len) return;
+        if (extra_start + 4 >= extras.len) return;
         const name_idx: NodeIndex = @enumFromInt(extras[extra_start]);
-        const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 3]);
-        const flags = extras[extra_start + 4];
+        const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 2]);
+        const flags = extras[extra_start + 3];
 
         const symbol_kind = functionSymbolKind(flags);
         const has_no_side_effects = (flags & ast_mod.FunctionFlags.no_side_effects) != 0;
@@ -1741,8 +1742,9 @@ pub const SemanticAnalyzer = struct {
         const saved_labels = self.saveLabelLen(); // label은 함수 경계를 넘지 못함
 
         // 파라미터를 function 스코프에 등록
-        const params_start = extras[extra_start + 1];
-        const params_len = extras[extra_start + 2];
+        const params_list = self.ast.functionParamsList(node);
+        const params_start = params_list.start;
+        const params_len = params_list.len;
         try self.registerParams(params_start, params_len);
 
         // 중복 파라미터 검증: generator/async는 항상 UniqueFormalParameters,
@@ -1769,22 +1771,23 @@ pub const SemanticAnalyzer = struct {
         const func_node = self.ast.getNode(func_idx);
         if (func_node.tag != .function_declaration) return;
         const fe = func_node.data.extra;
-        if (!self.ast.hasExtra(fe, 3)) return;
-        const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[fe + 3]);
+        if (!self.ast.hasExtra(fe, 2)) return;
+        const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[fe + 2]);
         if (body_idx.isNone()) return;
 
         const saved = try self.enterScope(.function, self.is_strict_mode);
-        try self.registerParams(self.ast.extra_data.items[fe + 1], self.ast.extra_data.items[fe + 2]);
+        const params_list = self.ast.functionParamsList(func_node);
+        try self.registerParams(params_list.start, params_list.len);
         try self.visitFunctionBodyInner(body_idx);
         self.exitScope(saved);
     }
 
     fn visitFunctionExpression(self: *SemanticAnalyzer, node: Node) AllocError!void {
-        // extra: [name, params.start, params.len, body, flags]
+        // extra: [name, params, body, flags]
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
-        if (extra_start + 4 >= extras.len) return;
-        const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 3]);
+        if (extra_start + 3 >= extras.len) return;
+        const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 2]);
 
         const saved = try self.enterScope(.function, self.is_strict_mode);
         const saved_labels = self.saveLabelLen();
@@ -1795,12 +1798,13 @@ pub const SemanticAnalyzer = struct {
         // (이름의 read-only 접근은 런타임에서 처리)
         _ = @as(NodeIndex, @enumFromInt(extras[extra_start])); // name_idx (사용하지 않음)
 
-        const params_start = extras[extra_start + 1];
-        const params_len = extras[extra_start + 2];
+        const params_list = self.ast.functionParamsList(node);
+        const params_start = params_list.start;
+        const params_len = params_list.len;
         try self.registerParams(params_start, params_len);
 
         // 중복 파라미터 검증: flags에서 async/generator 판별
-        const fn_flags = extras[extra_start + 4];
+        const fn_flags = extras[extra_start + 3];
         const FnFlags = ast_mod.FunctionFlags;
         const fn_is_async = (fn_flags & FnFlags.is_async) != 0;
         const fn_is_generator = (fn_flags & FnFlags.is_generator) != 0;
@@ -2041,14 +2045,14 @@ pub const SemanticAnalyzer = struct {
             const node = self.ast.getNode(idx);
             switch (node.tag) {
                 .method_definition => {
-                    // extra: [key, params.start, params.len, body, flags]
+                    // extra: [key, params, body, flags]
                     const extra_start = node.data.extra;
                     if (extra_start >= self.ast.extra_data.items.len) continue;
                     const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[extra_start]);
-                    // flags는 extra_start + 4: 0x02=getter, 0x04=setter
+                    // flags는 extra_start + 3: 0x02=getter, 0x04=setter
                     const kind: PrivateNameKind = blk: {
-                        if (extra_start + 4 < self.ast.extra_data.items.len) {
-                            const flags = self.ast.extra_data.items[extra_start + 4];
+                        if (extra_start + 3 < self.ast.extra_data.items.len) {
+                            const flags = self.ast.extra_data.items[extra_start + 3];
                             if (flags & 0x02 != 0) break :blk .getter;
                             if (flags & 0x04 != 0) break :blk .setter;
                         }

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -73,9 +73,9 @@ pub fn checkDuplicateConstructors(
         if (node.tag != .method_definition) continue;
 
         const extra_start = node.data.extra;
-        if (extra_start + 4 >= ast.extra_data.items.len) continue;
+        if (extra_start + 3 >= ast.extra_data.items.len) continue;
         const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_start]);
-        const flags = ast.extra_data.items[extra_start + 4];
+        const flags = ast.extra_data.items[extra_start + 3];
 
         // static 메서드는 constructor가 아님
         if ((flags & METHOD_FLAG_STATIC) != 0) continue;
@@ -86,8 +86,8 @@ pub fn checkDuplicateConstructors(
         if (!matchKeyName(ast, key_idx, "constructor")) continue;
 
         // TypeScript constructor overloads: body가 없는 시그니처는 허용.
-        // body(extra[3])가 .none이면 overload 시그니처이므로 스킵.
-        const body_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_start + 3]);
+        // body(extra[2])가 .none이면 overload 시그니처이므로 스킵.
+        const body_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_start + 2]);
         if (body_idx.isNone()) continue;
 
         if (first_constructor_span) |_| {
@@ -163,9 +163,9 @@ pub fn checkPrivateNameStaticConflict(
         switch (node.tag) {
             .method_definition => {
                 const extra_start = node.data.extra;
-                if (extra_start + 4 >= ast.extra_data.items.len) continue;
+                if (extra_start + 3 >= ast.extra_data.items.len) continue;
                 const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_start]);
-                const flags = ast.extra_data.items[extra_start + 4];
+                const flags = ast.extra_data.items[extra_start + 3];
                 const is_static = (flags & METHOD_FLAG_STATIC) != 0;
 
                 try checkPrivateKeyStaticConflict(ast, key_idx, is_static, &declared, errors, allocator);
@@ -293,10 +293,10 @@ pub fn checkGetterSetterParams(
     if (node.tag != .method_definition) return;
 
     const extra_start = node.data.extra;
-    if (extra_start + 4 >= ast.extra_data.items.len) return;
+    if (extra_start + 3 >= ast.extra_data.items.len) return;
 
-    const flags = ast.extra_data.items[extra_start + 4];
-    const params_len = ast.extra_data.items[extra_start + 2];
+    const flags = ast.extra_data.items[extra_start + 3];
+    const params_len: u32 = @intCast(ast.functionParams(node).len);
 
     if ((flags & METHOD_FLAG_GETTER) != 0 and params_len != 0) {
         try addErrorCode(errors, allocator, node.span, try std.fmt.allocPrint(allocator, "Getter must not have any formal parameters", .{}), .getter_no_params);

--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -79,11 +79,7 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
                 0;
 
             const none = @intFromEnum(NodeIndex.none);
-            const params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = node.span,
-                .data = .{ .list = param_list },
-            });
+            const params_node = try self.ast.addFormalParameters(param_list, node.span);
             const new_extra = try self.ast.addExtras(&.{
                 none, // name (anonymous)
                 @intFromEnum(params_node),

--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -72,17 +72,21 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
                 break :blk new_body;
             };
 
-            // function_expression: extra = [name, params_start, params_len, body, flags, return_type]
+            // function_expression: extra = [name(0), params(1), body(2), flags(3), return_type(4)]
             const func_flags: u32 = if (flags & ast_mod.ArrowFlags.is_async != 0)
                 ast_mod.FunctionFlags.is_async
             else
                 0;
 
             const none = @intFromEnum(NodeIndex.none);
+            const params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = node.span,
+                .data = .{ .list = param_list },
+            });
             const new_extra = try self.ast.addExtras(&.{
                 none, // name (anonymous)
-                param_list.start,
-                param_list.len,
+                @intFromEnum(params_node),
                 @intFromEnum(func_body),
                 func_flags,
                 none, // return_type

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -273,13 +273,8 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             }
             const params = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
 
-            // --- function expression ---
             const none = @intFromEnum(NodeIndex.none);
-            const params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = params },
-            });
+            const params_node = try self.ast.addFormalParameters(params, span);
             const func_extra = try self.ast.addExtras(&.{
                 none,                           @intFromEnum(params_node),
                 @intFromEnum(transformed_body), 0,            none,

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -277,7 +277,8 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             const params_node = try self.ast.addFormalParameters(params, span);
             const func_extra = try self.ast.addExtras(&.{
                 none,                           @intFromEnum(params_node),
-                @intFromEnum(transformed_body), 0,            none,
+                @intFromEnum(transformed_body), 0,
+                none,
             });
             const func_expr = try self.ast.addNode(.{
                 .tag = .function_expression,

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -275,8 +275,13 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
 
             // --- function expression ---
             const none = @intFromEnum(NodeIndex.none);
+            const params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = params },
+            });
             const func_extra = try self.ast.addExtras(&.{
-                none,                           params.start, params.len,
+                none,                           @intFromEnum(params_node),
                 @intFromEnum(transformed_body), 0,            none,
             });
             const func_expr = try self.ast.addNode(.{

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1543,11 +1543,15 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
 
             const empty_params = try self.ast.addNodeList(&.{});
+            const empty_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = empty_params },
+            });
             const none = @intFromEnum(NodeIndex.none);
             const func_extra = try self.ast.addExtras(&.{
                 @intFromEnum(name),
-                empty_params.start,
-                empty_params.len,
+                @intFromEnum(empty_params_node),
                 @intFromEnum(body),
                 0,
                 none,
@@ -1750,13 +1754,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const extras = self.ast.extra_data.items;
 
             const key_idx: NodeIndex = @enumFromInt(extras[me]);
-            const params_start = extras[me + 1];
-            const params_len = extras[me + 2];
-            const body_idx: NodeIndex = @enumFromInt(extras[me + 3]);
-            const flags = extras[me + 4];
+            const params_idx: NodeIndex = @enumFromInt(extras[me + 1]);
+            const body_idx: NodeIndex = @enumFromInt(extras[me + 2]);
+            const flags = extras[me + 3];
 
             // function expression 생성 — ES2015 params lowering은 Pass 2에서 일괄 처리
-            const new_params = try self.visitExtraList(params_start, params_len);
+            const params_list_unwrap: NodeList = if (!params_idx.isNone()) blk: {
+                const pn = self.ast.getNode(params_idx);
+                break :blk if (pn.tag == .formal_parameters) pn.data.list else .{ .start = 0, .len = 0 };
+            } else .{ .start = 0, .len = 0 };
+            const new_params = try self.visitExtraList(params_list_unwrap.start, params_list_unwrap.len);
 
             const is_async = flags & 0x08 != 0;
             const is_generator = flags & 0x10 != 0;
@@ -1796,10 +1803,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
             };
 
             const none = @intFromEnum(NodeIndex.none);
+            const new_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = new_params },
+            });
             const func_extra = try self.ast.addExtras(&.{
                 none, // anonymous
-                new_params.start,
-                new_params.len,
+                @intFromEnum(new_params_node),
                 @intFromEnum(new_body),
                 func_flags,
                 none,
@@ -1831,10 +1842,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .data = .{ .list = body_list },
             });
             const none = @intFromEnum(NodeIndex.none);
+            const params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = params },
+            });
             const func_extra = try self.ast.addExtras(&.{
                 none,
-                params.start,
-                params.len,
+                @intFromEnum(params_node),
                 @intFromEnum(wrapper_body),
                 0,
                 none,

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -218,9 +218,15 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const param_binding = try es_helpers.makeBindingIdentifier(self, try self.ast.addString(super_param_text));
                 break :blk try self.ast.addNodeList(&.{param_binding});
             } else try self.ast.addNodeList(&.{});
+            const wrapper_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = wrapper_params },
+            });
+            // function_expression: [name(0), params(1), body(2), flags(3), ret_type(4)]
             const wrapper_extra = try self.ast.addExtras(&.{
-                none,                    wrapper_params.start, wrapper_params.len,
-                @intFromEnum(iife_body), 0,                    none,
+                none, @intFromEnum(wrapper_params_node),
+                @intFromEnum(iife_body), 0, none,
             });
             const wrapper_fn = try self.ast.addNode(.{ .tag = .function_expression, .span = span, .data = .{ .extra = wrapper_extra } });
             const paren = try es_helpers.makeParenExpr(self, wrapper_fn, span);
@@ -467,7 +473,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const wrapper_params = if (has_super and super_span != null) blk: {
                 break :blk try self.ast.addNodeList(&.{try es_helpers.makeBindingIdentifier(self, try self.ast.addString(expr_super_param))});
             } else try self.ast.addNodeList(&.{});
-            const wrapper_extra = try self.ast.addExtras(&.{ none, wrapper_params.start, wrapper_params.len, @intFromEnum(iife_body), 0, none });
+            const wrapper_params_node2 = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = wrapper_params },
+            });
+            const wrapper_extra = try self.ast.addExtras(&.{ none, @intFromEnum(wrapper_params_node2), @intFromEnum(iife_body), 0, none });
             const wrapper_fn = try self.ast.addNode(.{ .tag = .function_expression, .span = span, .data = .{ .extra = wrapper_extra } });
             const paren = try es_helpers.makeParenExpr(self, wrapper_fn, span);
 
@@ -1456,11 +1467,15 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
 
             const empty_params = try self.ast.addNodeList(&.{});
+            const empty_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = empty_params },
+            });
             const none = @intFromEnum(NodeIndex.none);
             const func_extra = try self.ast.addExtras(&.{
                 @intFromEnum(name),
-                empty_params.start,
-                empty_params.len,
+                @intFromEnum(empty_params_node),
                 @intFromEnum(empty_body),
                 0,
                 none,

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -918,9 +918,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
         fn buildAccessorFunc(self: *Transformer, member_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const member = self.ast.getNode(member_idx);
             const me = member.data.extra;
-            const params_start = self.readU32(me, 1);
-            const params_len = self.readU32(me, 2);
-            const body_idx: NodeIndex = self.readNodeIdx(me, 3);
+            const params_list_old = self.ast.functionParamsList(member);
+            const params_start = params_list_old.start;
+            const params_len = params_list_old.len;
+            const body_idx: NodeIndex = self.readNodeIdx(me, 2);
 
             const new_params = try self.visitExtraList(params_start, params_len);
 
@@ -928,9 +929,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const new_body = try visitMethodBodyWithCtx(self, body_idx, span, nt_ctx);
 
             const none = @intFromEnum(NodeIndex.none);
+            const new_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = new_params },
+            });
             const func_extra = try self.ast.addExtras(&.{
-                none,                   new_params.start, new_params.len,
-                @intFromEnum(new_body), 0,                none,
+                none,                   @intFromEnum(new_params_node),
+                @intFromEnum(new_body), 0,                             none,
             });
             return self.ast.addNode(.{
                 .tag = .function_expression,
@@ -1089,14 +1095,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 if (member.tag == .method_definition) {
                     const me = member.data.extra;
                     const key: NodeIndex = self.readNodeIdx(me, 0);
-                    const flags = self.readU32(me, 4);
+                    const flags = self.readU32(me, 3);
                     const is_static = (flags & 0x01) != 0;
                     const is_abstract = (flags & 0x20) != 0;
                     const is_declare = (flags & 0x40) != 0;
                     const kind = (flags >> 1) & 0x03; // 0=method, 1=get, 2=set
 
                     // 본문 없는 메서드 스트리핑: abstract, declare, TS 오버로드 시그니처
-                    const method_body: NodeIndex = @enumFromInt(self.readU32(me, 3));
+                    const method_body: NodeIndex = @enumFromInt(self.readU32(me, 2));
                     if (is_abstract or is_declare or method_body.isNone()) continue;
 
                     if (!is_static and es_helpers.isConstructorKey(self, key)) {
@@ -1253,18 +1259,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // extra_data 슬라이스는 prependStatementsToBody 호출 시 재할당될 수 있으므로
             // 필요한 값을 미리 로컬에 복사
             const saved_name = self.ast.extra_data.items[fe];
-            const saved_params_start = self.ast.extra_data.items[fe + 1];
-            const saved_params_len = self.ast.extra_data.items[fe + 2];
-            const saved_flags = self.ast.extra_data.items[fe + 4];
-            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[fe + 3]);
+            const saved_params_idx = self.ast.extra_data.items[fe + 1];
+            const saved_flags = self.ast.extra_data.items[fe + 3];
+            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[fe + 2]);
 
             const new_body = try self.prependStatementsToBody(body_idx, stmts);
 
             const none = @intFromEnum(NodeIndex.none);
             const new_extra = try self.ast.addExtras(&.{
                 saved_name,
-                saved_params_start,
-                saved_params_len,
+                saved_params_idx,
                 @intFromEnum(new_body),
                 saved_flags,
                 none,
@@ -1283,9 +1287,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const ctor = self.ast.getNode(ctor_idx);
             const me = ctor.data.extra;
 
-            const params_start = self.readU32(me, 1);
-            const params_len = self.readU32(me, 2);
-            const body_idx: NodeIndex = self.readNodeIdx(me, 3);
+            const params_list_old = self.ast.functionParamsList(ctor);
+            const params_start = params_list_old.start;
+            const params_len = params_list_old.len;
+            const body_idx: NodeIndex = self.readNodeIdx(me, 2);
 
             // super_call_this_alias save/restore (lowerSuperCall이 설정)
             const saved_super_alias = self.super_call_this_alias;
@@ -1312,10 +1317,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
 
             const none = @intFromEnum(NodeIndex.none);
+            const new_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = new_params },
+            });
             const func_extra = try self.ast.addExtras(&.{
                 @intFromEnum(name),
-                new_params.start,
-                new_params.len,
+                @intFromEnum(new_params_node),
                 @intFromEnum(new_body),
                 0, // flags (no async/generator)
                 none, // return_type
@@ -1987,23 +1996,22 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const member = self.ast.getNode(@enumFromInt(raw_idx));
                 if (member.tag == .method_definition) {
                     const me = member.data.extra;
-                    const flags = self.readU32(me, 4);
+                    const flags = self.readU32(me, 3);
                     const is_static = (flags & 0x01) != 0;
                     const key: NodeIndex = self.readNodeIdx(me, 0);
+                    const params_list_m = self.ast.functionParamsList(member);
 
                     if (!is_static and es_helpers.isConstructorKey(self, key)) {
                         // constructor param decorator
-                        const params_start = self.readU32(me, 1);
-                        const params_len = self.readU32(me, 2);
-                        try self.collectParamDecorators(&ctor_param_decos, params_start, params_len);
+                        try self.collectParamDecorators(&ctor_param_decos, params_list_m.start, params_list_m.len);
                         continue;
                     }
 
                     // method decorator + param decorator
-                    const deco_start = self.readU32(me, 5);
-                    const deco_len = self.readU32(me, 6);
-                    const params_start = self.readU32(me, 1);
-                    const params_len = self.readU32(me, 2);
+                    const deco_start = self.readU32(me, 4);
+                    const deco_len = self.readU32(me, 5);
+                    const params_start = params_list_m.start;
+                    const params_len = params_list_m.len;
                     if (deco_len > 0 or params_len > 0) {
                         const new_key = try self.visitNode(key);
                         try self.collectMemberDecorators(

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1754,15 +1754,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const extras = self.ast.extra_data.items;
 
             const key_idx: NodeIndex = @enumFromInt(extras[me]);
-            const params_idx: NodeIndex = @enumFromInt(extras[me + 1]);
             const body_idx: NodeIndex = @enumFromInt(extras[me + 2]);
             const flags = extras[me + 3];
 
             // function expression 생성 — ES2015 params lowering은 Pass 2에서 일괄 처리
-            const params_list_unwrap: NodeList = if (!params_idx.isNone()) blk: {
-                const pn = self.ast.getNode(params_idx);
-                break :blk if (pn.tag == .formal_parameters) pn.data.list else .{ .start = 0, .len = 0 };
-            } else .{ .start = 0, .len = 0 };
+            const params_list_unwrap = self.ast.functionParamsList(member);
             const new_params = try self.visitExtraList(params_list_unwrap.start, params_list_unwrap.len);
 
             const is_async = flags & 0x08 != 0;

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -221,8 +221,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const wrapper_params_node = try self.ast.addFormalParameters(wrapper_params, span);
             // function_expression: [name(0), params(1), body(2), flags(3), ret_type(4)]
             const wrapper_extra = try self.ast.addExtras(&.{
-                none, @intFromEnum(wrapper_params_node),
-                @intFromEnum(iife_body), 0, none,
+                none,                    @intFromEnum(wrapper_params_node),
+                @intFromEnum(iife_body), 0,
+                none,
             });
             const wrapper_fn = try self.ast.addNode(.{ .tag = .function_expression, .span = span, .data = .{ .extra = wrapper_extra } });
             const paren = try es_helpers.makeParenExpr(self, wrapper_fn, span);
@@ -935,7 +936,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const new_params_node = try self.ast.addFormalParameters(new_params, span);
             const func_extra = try self.ast.addExtras(&.{
                 none,                   @intFromEnum(new_params_node),
-                @intFromEnum(new_body), 0,                             none,
+                @intFromEnum(new_body), 0,
+                none,
             });
             return self.ast.addNode(.{
                 .tag = .function_expression,

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -218,11 +218,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const param_binding = try es_helpers.makeBindingIdentifier(self, try self.ast.addString(super_param_text));
                 break :blk try self.ast.addNodeList(&.{param_binding});
             } else try self.ast.addNodeList(&.{});
-            const wrapper_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = wrapper_params },
-            });
+            const wrapper_params_node = try self.ast.addFormalParameters(wrapper_params, span);
             // function_expression: [name(0), params(1), body(2), flags(3), ret_type(4)]
             const wrapper_extra = try self.ast.addExtras(&.{
                 none, @intFromEnum(wrapper_params_node),
@@ -473,11 +469,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const wrapper_params = if (has_super and super_span != null) blk: {
                 break :blk try self.ast.addNodeList(&.{try es_helpers.makeBindingIdentifier(self, try self.ast.addString(expr_super_param))});
             } else try self.ast.addNodeList(&.{});
-            const wrapper_params_node2 = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = wrapper_params },
-            });
+            const wrapper_params_node2 = try self.ast.addFormalParameters(wrapper_params, span);
             const wrapper_extra = try self.ast.addExtras(&.{ none, @intFromEnum(wrapper_params_node2), @intFromEnum(iife_body), 0, none });
             const wrapper_fn = try self.ast.addNode(.{ .tag = .function_expression, .span = span, .data = .{ .extra = wrapper_extra } });
             const paren = try es_helpers.makeParenExpr(self, wrapper_fn, span);
@@ -940,11 +932,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const new_body = try visitMethodBodyWithCtx(self, body_idx, span, nt_ctx);
 
             const none = @intFromEnum(NodeIndex.none);
-            const new_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = new_params },
-            });
+            const new_params_node = try self.ast.addFormalParameters(new_params, span);
             const func_extra = try self.ast.addExtras(&.{
                 none,                   @intFromEnum(new_params_node),
                 @intFromEnum(new_body), 0,                             none,
@@ -1328,11 +1316,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
 
             const none = @intFromEnum(NodeIndex.none);
-            const new_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = new_params },
-            });
+            const new_params_node = try self.ast.addFormalParameters(new_params, span);
             const func_extra = try self.ast.addExtras(&.{
                 @intFromEnum(name),
                 @intFromEnum(new_params_node),
@@ -1467,11 +1451,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
 
             const empty_params = try self.ast.addNodeList(&.{});
-            const empty_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = empty_params },
-            });
+            const empty_params_node = try self.ast.addFormalParameters(empty_params, span);
             const none = @intFromEnum(NodeIndex.none);
             const func_extra = try self.ast.addExtras(&.{
                 @intFromEnum(name),
@@ -1543,11 +1523,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
 
             const empty_params = try self.ast.addNodeList(&.{});
-            const empty_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = empty_params },
-            });
+            const empty_params_node = try self.ast.addFormalParameters(empty_params, span);
             const none = @intFromEnum(NodeIndex.none);
             const func_extra = try self.ast.addExtras(&.{
                 @intFromEnum(name),
@@ -1799,11 +1775,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             };
 
             const none = @intFromEnum(NodeIndex.none);
-            const new_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = new_params },
-            });
+            const new_params_node = try self.ast.addFormalParameters(new_params, span);
             const func_extra = try self.ast.addExtras(&.{
                 none, // anonymous
                 @intFromEnum(new_params_node),
@@ -1838,11 +1810,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .data = .{ .list = body_list },
             });
             const none = @intFromEnum(NodeIndex.none);
-            const params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = params },
-            });
+            const params_node = try self.ast.addFormalParameters(params, span);
             const func_extra = try self.ast.addExtras(&.{
                 none,
                 @intFromEnum(params_node),

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -122,11 +122,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // 일반 function으로 변환 (generator 플래그 제거)
             const new_flags = flags & ~@as(u32, ast_mod.FunctionFlags.is_generator);
             const none = @intFromEnum(NodeIndex.none);
-            const new_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = new_params },
-            });
+            const new_params_node = try self.ast.addFormalParameters(new_params, span);
             const new_extra = try self.ast.addExtras(&.{
                 @intFromEnum(new_name),
                 @intFromEnum(new_params_node),
@@ -1959,11 +1955,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // function(_state) { ... }
             const params = try self.ast.addNodeList(&.{state_param});
             const none = @intFromEnum(NodeIndex.none);
-            const params_node_g = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = .{ .start = 0, .end = 0 },
-                .data = .{ .list = params },
-            });
+            const params_node_g = try self.ast.addFormalParameters(params, .{ .start = 0, .end = 0 });
             const func_extra = try self.ast.addExtras(&.{
                 none, // anonymous
                 @intFromEnum(params_node_g),

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1959,10 +1959,14 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // function(_state) { ... }
             const params = try self.ast.addNodeList(&.{state_param});
             const none = @intFromEnum(NodeIndex.none);
+            const params_node_g = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = .{ .start = 0, .end = 0 },
+                .data = .{ .list = params },
+            });
             const func_extra = try self.ast.addExtras(&.{
                 none, // anonymous
-                params.start,
-                params.len,
+                @intFromEnum(params_node_g),
                 @intFromEnum(body),
                 0, // flags
                 none,

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -70,16 +70,17 @@ const Operation = struct {
 pub fn ES2015Generator(comptime Transformer: type) type {
     return struct {
         /// generator function을 상태 머신으로 변환.
-        /// function*: extra = [name, params_start, params_len, body, flags, return_type]
+        /// function*: extra = [name(0), params(1), body(2), flags(3), return_type(4)]
         pub fn lowerGeneratorFunction(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const e = node.data.extra;
             const span = node.span;
 
             const name_idx: NodeIndex = self.readNodeIdx(e, 0);
-            const params_start = self.readU32(e, 1);
-            const params_len = self.readU32(e, 2);
-            const body_idx: NodeIndex = self.readNodeIdx(e, 3);
-            const flags = self.readU32(e, 4);
+            const params_list_old = self.ast.functionParamsList(node);
+            const params_start = params_list_old.start;
+            const params_len = params_list_old.len;
+            const body_idx: NodeIndex = self.readNodeIdx(e, 2);
+            const flags = self.readU32(e, 3);
 
             const new_name = try self.visitNode(name_idx);
 
@@ -121,10 +122,14 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // 일반 function으로 변환 (generator 플래그 제거)
             const new_flags = flags & ~@as(u32, ast_mod.FunctionFlags.is_generator);
             const none = @intFromEnum(NodeIndex.none);
+            const new_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = new_params },
+            });
             const new_extra = try self.ast.addExtras(&.{
                 @intFromEnum(new_name),
-                new_params.start,
-                new_params.len,
+                @intFromEnum(new_params_node),
                 @intFromEnum(new_body),
                 new_flags,
                 none,

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -68,11 +68,7 @@ pub fn ES2017(comptime Transformer: type) type {
             });
 
             const new_flags = flags & ~ast_mod.FunctionFlags.is_async;
-            const new_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = node.span,
-                .data = .{ .list = new_params },
-            });
+            const new_params_node = try self.ast.addFormalParameters(new_params, node.span);
             const new_extra = try self.ast.addExtras(&.{
                 @intFromEnum(new_name),
                 @intFromEnum(new_params_node),
@@ -180,11 +176,7 @@ pub fn ES2017(comptime Transformer: type) type {
 
             // 일반 function으로 변환 (async + generator 플래그 모두 제거)
             const new_flags = flags & ~(ast_mod.FunctionFlags.is_async | @as(u32, ast_mod.FunctionFlags.is_generator));
-            const new_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = new_params },
-            });
+            const new_params_node = try self.ast.addFormalParameters(new_params, span);
             const new_extra = try self.ast.addExtras(&.{
                 @intFromEnum(new_name),
                 @intFromEnum(new_params_node),

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -239,12 +239,16 @@ pub fn ES2017(comptime Transformer: type) type {
                 .data = .{ .list = body_list },
             });
 
-            // function_expression: extra = [name, params_start, params_len, body, flags, return_type]
+            // function_expression: extra = [name, params, body, flags, return_type]
             const none = @intFromEnum(NodeIndex.none);
+            const params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = params_list },
+            });
             const func_extra = try self.ast.addExtras(&.{
                 none, // anonymous
-                params_list.start,
-                params_list.len,
+                @intFromEnum(params_node),
                 @intFromEnum(func_body),
                 0, // flags (not async, not generator)
                 none, // return_type

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -239,13 +239,8 @@ pub fn ES2017(comptime Transformer: type) type {
                 .data = .{ .list = body_list },
             });
 
-            // function_expression: extra = [name, params, body, flags, return_type]
             const none = @intFromEnum(NodeIndex.none);
-            const params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = params_list },
-            });
+            const params_node = try self.ast.addFormalParameters(params_list, span);
             const func_extra = try self.ast.addExtras(&.{
                 none, // anonymous
                 @intFromEnum(params_node),

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -39,10 +39,11 @@ pub fn ES2017(comptime Transformer: type) type {
         pub fn lowerAsyncFunction(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const e = node.data.extra;
             const name_idx: NodeIndex = self.readNodeIdx(e, 0);
-            const params_start = self.readU32(e, 1);
-            const params_len = self.readU32(e, 2);
-            const body_idx: NodeIndex = self.readNodeIdx(e, 3);
-            const flags = self.readU32(e, 4);
+            const params_list = self.ast.functionParamsList(node);
+            const params_start = params_list.start;
+            const params_len = params_list.len;
+            const body_idx: NodeIndex = self.readNodeIdx(e, 2);
+            const flags = self.readU32(e, 3);
 
             const new_name = try self.visitNode(name_idx);
             const new_body = try self.visitBodyWorkletAware(body_idx);
@@ -67,10 +68,14 @@ pub fn ES2017(comptime Transformer: type) type {
             });
 
             const new_flags = flags & ~ast_mod.FunctionFlags.is_async;
+            const new_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = node.span,
+                .data = .{ .list = new_params },
+            });
             const new_extra = try self.ast.addExtras(&.{
                 @intFromEnum(new_name),
-                new_params.start,
-                new_params.len,
+                @intFromEnum(new_params_node),
                 @intFromEnum(wrapper_body),
                 new_flags,
                 @intFromEnum(NodeIndex.none),
@@ -134,10 +139,11 @@ pub fn ES2017(comptime Transformer: type) type {
             const span = node.span;
 
             const name_idx: NodeIndex = self.readNodeIdx(e, 0);
-            const params_start = self.readU32(e, 1);
-            const params_len = self.readU32(e, 2);
-            const body_idx: NodeIndex = self.readNodeIdx(e, 3);
-            const flags = self.readU32(e, 4);
+            const params_list = self.ast.functionParamsList(node);
+            const params_start = params_list.start;
+            const params_len = params_list.len;
+            const body_idx: NodeIndex = self.readNodeIdx(e, 2);
+            const flags = self.readU32(e, 3);
 
             const new_name = try self.visitNode(name_idx);
 
@@ -174,10 +180,14 @@ pub fn ES2017(comptime Transformer: type) type {
 
             // 일반 function으로 변환 (async + generator 플래그 모두 제거)
             const new_flags = flags & ~(ast_mod.FunctionFlags.is_async | @as(u32, ast_mod.FunctionFlags.is_generator));
+            const new_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = new_params },
+            });
             const new_extra = try self.ast.addExtras(&.{
                 @intFromEnum(new_name),
-                new_params.start,
-                new_params.len,
+                @intFromEnum(new_params_node),
                 @intFromEnum(wrapper_body),
                 new_flags,
                 @intFromEnum(NodeIndex.none),

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -407,11 +407,7 @@ pub fn ES2022(comptime Transformer: type) type {
                 .data = .{ .string_ref = ctor_name_span },
             });
             // method_definition: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
-            const ctor_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = params_list },
-            });
+            const ctor_params_node = try self.ast.addFormalParameters(params_list, span);
             const ctor_extra = try self.ast.addExtras(&.{
                 @intFromEnum(ctor_key),
                 @intFromEnum(ctor_params_node),
@@ -565,11 +561,7 @@ pub fn ES2022(comptime Transformer: type) type {
 
             // 빈 formal_parameters 노드 생성
             const empty_params_list = try self.ast.addNodeList(&.{});
-            const params = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = span,
-                .data = .{ .list = empty_params_list },
-            });
+            const params = try self.ast.addFormalParameters(empty_params_list, span);
 
             // arrow_function_expression: extra = [params, body, flags]
             // flags = 0 (non-async)

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -148,9 +148,9 @@ pub fn ES2022(comptime Transformer: type) type {
             const new_body = try self.prependStatementsToBody(body_idx, stmts);
 
             const new_me = try self.ast.addExtras(&.{
-                saved_key, saved_params,
-                @intFromEnum(new_body), saved_flags, saved_deco_start,
-                saved_deco_len,
+                saved_key,              saved_params,
+                @intFromEnum(new_body), saved_flags,
+                saved_deco_start,       saved_deco_len,
             });
             return self.ast.addNode(.{
                 .tag = .method_definition,

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -137,18 +137,18 @@ pub fn ES2022(comptime Transformer: type) type {
             const extras = self.ast.extra_data.items;
             const me = node.data.extra;
 
+            // method_definition: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
             const saved_key = extras[me];
-            const saved_ps = extras[me + 1];
-            const saved_pl = extras[me + 2];
-            const saved_flags = extras[me + 4];
-            const saved_deco_start = extras[me + 5];
-            const saved_deco_len = extras[me + 6];
-            const body_idx: NodeIndex = @enumFromInt(extras[me + 3]);
+            const saved_params = extras[me + 1];
+            const saved_flags = extras[me + 3];
+            const saved_deco_start = extras[me + 4];
+            const saved_deco_len = extras[me + 5];
+            const body_idx: NodeIndex = @enumFromInt(extras[me + 2]);
 
             const new_body = try self.prependStatementsToBody(body_idx, stmts);
 
             const new_me = try self.ast.addExtras(&.{
-                saved_key,              saved_ps,    saved_pl,
+                saved_key, saved_params,
                 @intFromEnum(new_body), saved_flags, saved_deco_start,
                 saved_deco_len,
             });
@@ -406,10 +406,15 @@ pub fn ES2022(comptime Transformer: type) type {
                 .span = ctor_name_span,
                 .data = .{ .string_ref = ctor_name_span },
             });
+            // method_definition: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
+            const ctor_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = span,
+                .data = .{ .list = params_list },
+            });
             const ctor_extra = try self.ast.addExtras(&.{
                 @intFromEnum(ctor_key),
-                params_list.start,
-                params_list.len,
+                @intFromEnum(ctor_params_node),
                 @intFromEnum(ctor_body),
                 0, 0, 0, // flags, deco_start, deco_len
             });

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -203,7 +203,7 @@ pub fn ES2022(comptime Transformer: type) type {
                         const me = member.data.extra;
                         const extras = self.ast.extra_data.items;
                         const key: NodeIndex = @enumFromInt(extras[me]);
-                        const flags = extras[me + 4];
+                        const flags = extras[me + 3];
                         const is_static = (flags & 0x01) != 0;
                         if (key.isNone() or is_static) continue;
                         const key_node = self.ast.getNode(key);

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -499,10 +499,14 @@ pub fn wrapInFunction(self: anytype, expr: NodeIndex, span: Span) !NodeIndex {
         .data = .{ .list = body_list },
     });
     const empty_params = try self.ast.addNodeList(&.{});
+    const empty_params_node = try self.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = span,
+        .data = .{ .list = empty_params },
+    });
     const func_extra = try self.ast.addExtras(&.{
         @intFromEnum(NodeIndex.none),
-        empty_params.start,
-        empty_params.len,
+        @intFromEnum(empty_params_node),
         @intFromEnum(body_block),
         0,
         @intFromEnum(NodeIndex.none),
@@ -517,10 +521,14 @@ pub fn wrapInFunction(self: anytype, expr: NodeIndex, span: Span) !NodeIndex {
 /// body를 감싸는 generator function expression 생성: function*() { ...body... }
 pub fn buildGeneratorWrapper(self: anytype, body: NodeIndex, span: Span) !NodeIndex {
     const empty_params = try self.ast.addNodeList(&.{});
+    const empty_params_node = try self.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = span,
+        .data = .{ .list = empty_params },
+    });
     const gen_extra = try self.ast.addExtras(&.{
         @intFromEnum(NodeIndex.none),
-        empty_params.start,
-        empty_params.len,
+        @intFromEnum(empty_params_node),
         @intFromEnum(body),
         ast_mod.FunctionFlags.is_generator,
         @intFromEnum(NodeIndex.none),

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -447,12 +447,7 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const name_node = try makeBindingIdentifier(self, name_span);
 
     const none = @intFromEnum(NodeIndex.none);
-    // function_declaration: extra = [name(0), params(1), body(2), flags(3), ret_type(4)]
-    const new_params_node = try self.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = span,
-        .data = .{ .list = new_params },
-    });
+    const new_params_node = try self.ast.addFormalParameters(new_params, span);
     const func_extra = try self.ast.addExtras(&.{
         @intFromEnum(name_node),
         @intFromEnum(new_params_node),
@@ -499,11 +494,7 @@ pub fn wrapInFunction(self: anytype, expr: NodeIndex, span: Span) !NodeIndex {
         .data = .{ .list = body_list },
     });
     const empty_params = try self.ast.addNodeList(&.{});
-    const empty_params_node = try self.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = span,
-        .data = .{ .list = empty_params },
-    });
+    const empty_params_node = try self.ast.addFormalParameters(empty_params, span);
     const func_extra = try self.ast.addExtras(&.{
         @intFromEnum(NodeIndex.none),
         @intFromEnum(empty_params_node),
@@ -521,11 +512,7 @@ pub fn wrapInFunction(self: anytype, expr: NodeIndex, span: Span) !NodeIndex {
 /// body를 감싸는 generator function expression 생성: function*() { ...body... }
 pub fn buildGeneratorWrapper(self: anytype, body: NodeIndex, span: Span) !NodeIndex {
     const empty_params = try self.ast.addNodeList(&.{});
-    const empty_params_node = try self.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = span,
-        .data = .{ .list = empty_params },
-    });
+    const empty_params_node = try self.ast.addFormalParameters(empty_params, span);
     const gen_extra = try self.ast.addExtras(&.{
         @intFromEnum(NodeIndex.none),
         @intFromEnum(empty_params_node),

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -431,13 +431,13 @@ pub fn buildWeakCollectionDecl(self: anytype, constructor_name: []const u8, var_
 }
 
 /// method_definition → standalone function declaration으로 추출.
-/// method_definition: extra = [key, params_start, params_len, body, flags, ...]
+/// method_definition: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
 pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeIndex, span: Span) !NodeIndex {
     const method_node = self.ast.getNode(method_idx);
-    const me = method_node.data.extra;
-    const params_start = self.ast.extra_data.items[me + 1];
-    const params_len = self.ast.extra_data.items[me + 2];
-    const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 3]);
+    const params_list_old = self.ast.functionParamsList(method_node);
+    const params_start = params_list_old.start;
+    const params_len = params_list_old.len;
+    const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[method_node.data.extra + 2]);
 
     const new_params = try self.visitExtraList(params_start, params_len);
 
@@ -447,10 +447,15 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const name_node = try makeBindingIdentifier(self, name_span);
 
     const none = @intFromEnum(NodeIndex.none);
+    // function_declaration: extra = [name(0), params(1), body(2), flags(3), ret_type(4)]
+    const new_params_node = try self.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = span,
+        .data = .{ .list = new_params },
+    });
     const func_extra = try self.ast.addExtras(&.{
         @intFromEnum(name_node),
-        new_params.start,
-        new_params.len,
+        @intFromEnum(new_params_node),
         @intFromEnum(new_body),
         0,
         none,

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -293,11 +293,10 @@ fn buildFunctionExprFromMethod(api: *AstTransformCtx, info: FunctionInfo, body_i
 
     const none = @intFromEnum(NodeIndex.none);
     // function_expression: extra = [name(0), params(1), body(2), flags(3), ret_type(4)]
-    const params_list_node = t.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = method_node.span,
-        .data = .{ .list = .{ .start = info.params_start, .len = info.params_len } },
-    }) catch return error.OutOfMemory;
+    const params_list_node = t.ast.addFormalParameters(
+        .{ .start = info.params_start, .len = info.params_len },
+        method_node.span,
+    ) catch return error.OutOfMemory;
     const func_extra = t.ast.addExtras(&.{
         @intFromEnum(name_node),
         @intFromEnum(params_list_node),
@@ -385,11 +384,7 @@ fn buildWorkletIIFE(
 
     // function() { ... } (wrapper — 파라미터 없는 익명 함수)
     const empty_params = try t.ast.addNodeList(&.{});
-    const empty_params_node = try t.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = zero_span,
-        .data = .{ .list = empty_params },
-    });
+    const empty_params_node = try t.ast.addFormalParameters(empty_params, zero_span);
     const wrapper_func = try t.addExtraNode(.function_expression, zero_span, &.{
         none, // name (anonymous)
         @intFromEnum(empty_params_node),
@@ -620,11 +615,7 @@ fn lowerWorkletContextObject(t: *Transformer, node: Node) !NodeIndex {
         });
         const body = try buildContextObjectFactoryBody(t, list_start, list_len);
         const empty_params = try t.ast.addNodeList(&.{});
-        const empty_params_node = try t.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = zero_span,
-            .data = .{ .list = empty_params },
-        });
+        const empty_params_node = try t.ast.addFormalParameters(empty_params, zero_span);
         const none = @intFromEnum(NodeIndex.none);
         const fn_node = try t.addExtraNode(.function_expression, zero_span, &.{
             none, @intFromEnum(empty_params_node), @intFromEnum(body), 0, none,
@@ -906,11 +897,7 @@ fn buildClassFactoryAssignment(t: *Transformer, class_name: []const u8, stripped
     });
     const body = try buildClassFactoryBody(t, class_name_span, stripped_body);
     const empty_params = try t.ast.addNodeList(&.{});
-    const empty_params_node = try t.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = zero_span,
-        .data = .{ .list = empty_params },
-    });
+    const empty_params_node = try t.ast.addFormalParameters(empty_params, zero_span);
     const none = @intFromEnum(NodeIndex.none);
     const inner_fn = try t.addExtraNode(.function_declaration, zero_span, &.{
         @intFromEnum(binding_node), @intFromEnum(empty_params_node),

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -236,6 +236,8 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
         for (stmts) |stmt| {
             try api.addTrailingStatement(stmt);
         }
+        // 함수 body에서 "worklet" directive 제거 (dispatcher가 result 노드 body slot 패치)
+        if (has_directive) api.modified_body = stripped_body;
     } else if (info.node_tag == .method_definition) {
         const t = api.transformer;
         const method_node = t.ast.getNode(info.node_idx);

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -901,7 +901,8 @@ fn buildClassFactoryAssignment(t: *Transformer, class_name: []const u8, stripped
     const none = @intFromEnum(NodeIndex.none);
     const inner_fn = try t.addExtraNode(.function_declaration, zero_span, &.{
         @intFromEnum(binding_node), @intFromEnum(empty_params_node),
-        @intFromEnum(body),         0,                  none,
+        @intFromEnum(body),         0,
+        none,
     });
 
     // IIFE: (function() { function <fn>(){...} return <fn>; })()

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -240,7 +240,7 @@ fn onFunction(ctx: ?*anyopaque, api: *AstTransformCtx, info: FunctionInfo) Plugi
         const t = api.transformer;
         const method_node = t.ast.getNode(info.node_idx);
         const me = method_node.data.extra;
-        const method_flags = t.ast.extra_data.items[me + 4];
+        const method_flags = t.ast.extra_data.items[me + 3];
         const func_expr = try buildFunctionExprFromMethod(api, info, stripped_body);
 
         if ((method_flags & (METHOD_FLAG_GETTER | METHOD_FLAG_SETTER)) != 0) {
@@ -275,7 +275,7 @@ fn buildFunctionExprFromMethod(api: *AstTransformCtx, info: FunctionInfo, body_i
     const method_node = t.ast.getNode(info.node_idx);
     const me = method_node.data.extra;
 
-    // method_definition extra = [key(0), params_start(1), params_len(2), body(3), flags(4), ...]
+    // method_definition extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
     const name_span = if (info.name) |n| (t.ast.addString(n) catch return error.OutOfMemory) else Span{ .start = 0, .end = 0 };
     const name_node = if (info.name != null) (t.ast.addNode(.{
         .tag = .binding_identifier,
@@ -284,16 +284,21 @@ fn buildFunctionExprFromMethod(api: *AstTransformCtx, info: FunctionInfo, body_i
     }) catch return error.OutOfMemory) else NodeIndex.none;
 
     // method flags → function flags (async=bit0 of method flags bit3, generator=bit4)
-    const method_flags = t.ast.extra_data.items[me + 4];
+    const method_flags = t.ast.extra_data.items[me + 3];
     var func_flags: u32 = 0;
     if ((method_flags & METHOD_FLAG_ASYNC) != 0) func_flags |= 0x01; // function async
     if ((method_flags & METHOD_FLAG_GENERATOR) != 0) func_flags |= 0x02; // function generator
 
     const none = @intFromEnum(NodeIndex.none);
+    // function_expression: extra = [name(0), params(1), body(2), flags(3), ret_type(4)]
+    const params_list_node = t.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = method_node.span,
+        .data = .{ .list = .{ .start = info.params_start, .len = info.params_len } },
+    }) catch return error.OutOfMemory;
     const func_extra = t.ast.addExtras(&.{
         @intFromEnum(name_node),
-        info.params_start,
-        info.params_len,
+        @intFromEnum(params_list_node),
         @intFromEnum(body_idx),
         func_flags,
         none, // return type
@@ -655,17 +660,16 @@ fn buildContextObjectFactoryBody(t: *Transformer, list_start: u32, list_len: u32
             // method → object_property with function_expression value.
             const me = member.data.extra;
             const key_idx: NodeIndex = @enumFromInt(t.ast.extra_data.items[me]);
-            const params_start = t.ast.extra_data.items[me + 1];
-            const params_len = t.ast.extra_data.items[me + 2];
-            const body_idx: NodeIndex = @enumFromInt(t.ast.extra_data.items[me + 3]);
-            const m_flags = t.ast.extra_data.items[me + 4];
+            const params_idx_raw = t.ast.extra_data.items[me + 1];
+            const body_idx: NodeIndex = @enumFromInt(t.ast.extra_data.items[me + 2]);
+            const m_flags = t.ast.extra_data.items[me + 3];
             // method → function expression flags: async/generator만 전파
             var fn_flags: u32 = 0;
             if ((m_flags & METHOD_FLAG_ASYNC) != 0) fn_flags |= 0x01;
             if ((m_flags & METHOD_FLAG_GENERATOR) != 0) fn_flags |= 0x02;
             const none = @intFromEnum(NodeIndex.none);
             const fn_expr = try t.addExtraNode(.function_expression, member.span, &.{
-                none, params_start, params_len, @intFromEnum(body_idx), fn_flags, none,
+                none, params_idx_raw, @intFromEnum(body_idx), fn_flags, none,
             });
             const new_prop = try t.ast.addNode(.{
                 .tag = .object_property,

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -383,10 +383,14 @@ fn buildWorkletIIFE(
 
     // function() { ... } (wrapper — 파라미터 없는 익명 함수)
     const empty_params = try t.ast.addNodeList(&.{});
+    const empty_params_node = try t.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = zero_span,
+        .data = .{ .list = empty_params },
+    });
     const wrapper_func = try t.addExtraNode(.function_expression, zero_span, &.{
         none, // name (anonymous)
-        empty_params.start,
-        empty_params.len,
+        @intFromEnum(empty_params_node),
         @intFromEnum(body),
         0, // flags
         none, // return type
@@ -614,9 +618,14 @@ fn lowerWorkletContextObject(t: *Transformer, node: Node) !NodeIndex {
         });
         const body = try buildContextObjectFactoryBody(t, list_start, list_len);
         const empty_params = try t.ast.addNodeList(&.{});
+        const empty_params_node = try t.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = zero_span,
+            .data = .{ .list = empty_params },
+        });
         const none = @intFromEnum(NodeIndex.none);
         const fn_node = try t.addExtraNode(.function_expression, zero_span, &.{
-            none, empty_params.start, empty_params.len, @intFromEnum(body), 0, none,
+            none, @intFromEnum(empty_params_node), @intFromEnum(body), 0, none,
         });
         const visited_fn = try t.visitNode(fn_node);
         const new_prop = try t.ast.addNode(.{
@@ -895,9 +904,14 @@ fn buildClassFactoryAssignment(t: *Transformer, class_name: []const u8, stripped
     });
     const body = try buildClassFactoryBody(t, class_name_span, stripped_body);
     const empty_params = try t.ast.addNodeList(&.{});
+    const empty_params_node = try t.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = zero_span,
+        .data = .{ .list = empty_params },
+    });
     const none = @intFromEnum(NodeIndex.none);
     const inner_fn = try t.addExtraNode(.function_declaration, zero_span, &.{
-        @intFromEnum(binding_node), empty_params.start, empty_params.len,
+        @intFromEnum(binding_node), @intFromEnum(empty_params_node),
         @intFromEnum(body),         0,                  none,
     });
 
@@ -915,7 +929,7 @@ fn buildClassFactoryAssignment(t: *Transformer, class_name: []const u8, stripped
     const iife_body_list = try t.ast.addNodeList(&.{ inner_fn, ret_stmt });
     const iife_body = try t.ast.addNode(.{ .tag = .block_statement, .span = zero_span, .data = .{ .list = iife_body_list } });
     const wrapper_fn = try t.addExtraNode(.function_expression, zero_span, &.{
-        none, empty_params.start, empty_params.len, @intFromEnum(iife_body), 0, none,
+        none, @intFromEnum(empty_params_node), @intFromEnum(iife_body), 0, none,
     });
     const call_args = try t.ast.addNodeList(&.{});
     const call_extra = try t.ast.addExtras(&.{ @intFromEnum(wrapper_fn), call_args.start, call_args.len, 0 });

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -891,7 +891,7 @@ pub const Transformer = struct {
                 if (self.options.unsupported.async_await) {
                     const extras = self.ast.extra_data.items;
                     const e = node.data.extra;
-                    if (e + 4 < extras.len and (extras[e + 4] & ast_mod.FunctionFlags.is_async) != 0) {
+                    if (e + 3 < extras.len and (extras[e + 3] & ast_mod.FunctionFlags.is_async) != 0) {
                         // async + generator 둘 다 unsupported → 직접 state machine 생성
                         if (self.options.unsupported.generator) {
                             return es2017_mod.ES2017(Transformer).lowerAsyncToStateMachine(self, node);
@@ -903,7 +903,7 @@ pub const Transformer = struct {
                 if (self.options.unsupported.generator) {
                     const extras = self.ast.extra_data.items;
                     const e = node.data.extra;
-                    if (e + 4 < extras.len and (extras[e + 4] & ast_mod.FunctionFlags.is_generator) != 0) {
+                    if (e + 3 < extras.len and (extras[e + 3] & ast_mod.FunctionFlags.is_generator) != 0) {
                         return es2015_generator.ES2015Generator(Transformer).lowerGeneratorFunction(self, node);
                     }
                 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3792,8 +3792,8 @@ pub const Transformer = struct {
         return switch (tag) {
             // arrow: [params(0), body(1), flags]
             .arrow_function_expression => 1,
-            // function_declaration/expression/method_definition: [name, params_start, params_len, body(3), ...]
-            else => 3,
+            // function_declaration/expression/method_definition: [name/key(0), params(1), body(2), flags(3), ...]
+            else => 2,
         };
     }
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2158,11 +2158,7 @@ pub const Transformer = struct {
         // Metro도 직접 스캔하지 않고 Babel/SWC에 위임. $RefreshReg$만 유지.
 
         const none = @intFromEnum(NodeIndex.none);
-        const new_params_node = try self.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = params_span,
-            .data = .{ .list = pp.new_params },
-        });
+        const new_params_node = try self.ast.addFormalParameters(pp.new_params, params_span);
         const result = try self.addExtraNode(node.tag, node.span, &.{
             @intFromEnum(new_name), @intFromEnum(new_params_node),
             @intFromEnum(new_body), self.readU32(e, 3),  none,
@@ -3132,11 +3128,7 @@ pub const Transformer = struct {
         else
             try self.visitExtraList(self.readU32(e, 4), self.readU32(e, 5));
         const old_body_idx = self.readNodeIdx(e, 2);
-        const new_params_node = try self.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = params_span,
-            .data = .{ .list = pp.new_params },
-        });
+        const new_params_node = try self.ast.addFormalParameters(pp.new_params, params_span);
         const result = try self.addExtraNode(.method_definition, node.span, &.{
             @intFromEnum(new_key), @intFromEnum(new_params_node), @intFromEnum(new_body),
             self.readU32(e, 3),    new_decos.start,               new_decos.len,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -473,25 +473,28 @@ pub const Transformer = struct {
             const node = self.ast.nodes.items[i];
             switch (node.tag) {
                 .function_declaration, .function_expression, .function, .method_definition => {
-                    // extra layout: [name_or_key, params_start, params_len, body, ...]
+                    // extra layout: [name_or_key(0), params(1), body(2), ...]
                     const e = node.data.extra;
-                    if (e + 3 >= self.ast.extra_data.items.len) continue;
-                    const params_start = self.ast.extra_data.items[e + 1];
-                    const params_len = self.ast.extra_data.items[e + 2];
-                    if (params_len == 0) continue;
-                    if (!es2015_params.ES2015Params(Transformer).hasDefaultOrRest(self, params_start, params_len)) continue;
+                    if (e + 2 >= self.ast.extra_data.items.len) continue;
+                    const params_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+                    if (params_idx.isNone() or @intFromEnum(params_idx) >= self.ast.nodes.items.len) continue;
+                    const params_node = self.ast.getNode(params_idx);
+                    if (params_node.tag != .formal_parameters) continue;
+                    const params_list = params_node.data.list;
+                    if (params_list.len == 0) continue;
+                    if (!es2015_params.ES2015Params(Transformer).hasDefaultOrRest(self, params_list.start, params_list.len)) continue;
 
-                    var lr = try es2015_params.ES2015Params(Transformer).lowerParamsPass2(self, params_start, params_len, node.span);
+                    var lr = try es2015_params.ES2015Params(Transformer).lowerParamsPass2(self, params_list.start, params_list.len, node.span);
                     defer lr.body_stmts.deinit(self.allocator);
 
-                    self.ast.extra_data.items[e + 1] = lr.new_params.start;
-                    self.ast.extra_data.items[e + 2] = lr.new_params.len;
+                    // formal_parameters 노드의 NodeList in-place 업데이트
+                    self.ast.nodes.items[@intFromEnum(params_idx)].data.list = lr.new_params;
 
                     if (lr.body_stmts.items.len > 0) {
-                        const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 3]);
+                        const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
                         if (!body_idx.isNone()) {
                             const new_body = try self.prependStatementsToBody(body_idx, lr.body_stmts.items);
-                            self.ast.extra_data.items[e + 3] = @intFromEnum(new_body);
+                            self.ast.extra_data.items[e + 2] = @intFromEnum(new_body);
                         }
                     }
                 },

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -490,11 +490,7 @@ pub const Transformer = struct {
                     // formal_parameters 노드를 새로 만들어 extras[e+1]에 연결.
                     // (여러 function 노드가 동일 params_idx를 공유할 수 있으므로 in-place mutation 금지:
                     //  prependToFunctionBody 등은 params_idx를 복사하여 새 function 노드를 만든다.)
-                    const new_params_node = try self.ast.addNode(.{
-                        .tag = .formal_parameters,
-                        .span = params_node.span,
-                        .data = .{ .list = lr.new_params },
-                    });
+                    const new_params_node = try self.ast.addFormalParameters(lr.new_params, params_node.span);
                     self.ast.extra_data.items[e + 1] = @intFromEnum(new_params_node);
 
                     if (lr.body_stmts.items.len > 0) {
@@ -895,24 +891,17 @@ pub const Transformer = struct {
             .function_declaration,
             .function_expression,
             => {
-                if (self.options.unsupported.async_await) {
-                    const extras = self.ast.extra_data.items;
-                    const e = node.data.extra;
-                    if (e + 3 < extras.len and (extras[e + 3] & ast_mod.FunctionFlags.is_async) != 0) {
-                        // async + generator 둘 다 unsupported → 직접 state machine 생성
-                        if (self.options.unsupported.generator) {
-                            return es2017_mod.ES2017(Transformer).lowerAsyncToStateMachine(self, node);
-                        }
-                        return es2017_mod.ES2017(Transformer).lowerAsyncFunction(self, node);
+                const e = node.data.extra;
+                const flags = self.readU32(e, 3);
+                if (self.options.unsupported.async_await and (flags & ast_mod.FunctionFlags.is_async) != 0) {
+                    // async + generator 둘 다 unsupported → 직접 state machine 생성
+                    if (self.options.unsupported.generator) {
+                        return es2017_mod.ES2017(Transformer).lowerAsyncToStateMachine(self, node);
                     }
+                    return es2017_mod.ES2017(Transformer).lowerAsyncFunction(self, node);
                 }
-                // ES2015: generator function → 상태 머신
-                if (self.options.unsupported.generator) {
-                    const extras = self.ast.extra_data.items;
-                    const e = node.data.extra;
-                    if (e + 3 < extras.len and (extras[e + 3] & ast_mod.FunctionFlags.is_generator) != 0) {
-                        return es2015_generator.ES2015Generator(Transformer).lowerGeneratorFunction(self, node);
-                    }
+                if (self.options.unsupported.generator and (flags & ast_mod.FunctionFlags.is_generator) != 0) {
+                    return es2015_generator.ES2015Generator(Transformer).lowerGeneratorFunction(self, node);
                 }
                 return self.visitFunction(node);
             },
@@ -1624,13 +1613,8 @@ pub const Transformer = struct {
             .span = span,
             .data = .{ .list = body_list },
         });
-        // function extra: [name, params, body, flags, return_type]
         const fn_params_list = try self.ast.addNodeList(&.{match_param});
-        const fn_params_node = try self.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = span,
-            .data = .{ .list = fn_params_list },
-        });
+        const fn_params_node = try self.ast.addFormalParameters(fn_params_list, span);
         const fn_extra = try self.ast.addExtras(&.{
             @intFromEnum(NodeIndex.none), // name (anonymous)
             @intFromEnum(fn_params_node),
@@ -2575,11 +2559,7 @@ pub const Transformer = struct {
         });
         const none = @intFromEnum(NodeIndex.none);
         const inner_empty_params = try self.ast.addNodeList(&.{});
-        const inner_params_node = try self.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = span,
-            .data = .{ .list = inner_empty_params },
-        });
+        const inner_params_node = try self.ast.addFormalParameters(inner_empty_params, span);
         const inner_func_extra = try self.ast.addExtras(&.{
             none, @intFromEnum(inner_params_node), @intFromEnum(inner_body), 0, none,
         });
@@ -2623,11 +2603,7 @@ pub const Transformer = struct {
             .data = .{ .string_ref = fn_name_binding_span },
         });
         const outer_empty_params = try self.ast.addNodeList(&.{});
-        const outer_params_node = try self.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = span,
-            .data = .{ .list = outer_empty_params },
-        });
+        const outer_params_node = try self.ast.addFormalParameters(outer_empty_params, span);
         const outer_func_extra = try self.ast.addExtras(&.{
             @intFromEnum(fn_name_binding), @intFromEnum(outer_params_node), @intFromEnum(outer_body), 0, none,
         });

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2161,7 +2161,8 @@ pub const Transformer = struct {
         const new_params_node = try self.ast.addFormalParameters(pp.new_params, params_span);
         const result = try self.addExtraNode(node.tag, node.span, &.{
             @intFromEnum(new_name), @intFromEnum(new_params_node),
-            @intFromEnum(new_body), self.readU32(e, 3),  none,
+            @intFromEnum(new_body), self.readU32(e, 3),
+            none,
         });
 
         // Plugin dispatch: onFunction (AST 훅)

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2042,7 +2042,7 @@ pub const Transformer = struct {
         // function foo(): void;  ← overload signature (body 없음)
         // function foo(x: number): void;  ← overload signature
         // function foo(x?: number) {}  ← 구현체 (body 있음)
-        if (self.readNodeIdx(e, 3).isNone()) return NodeIndex.none;
+        if (self.readNodeIdx(e, 2).isNone()) return NodeIndex.none;
 
         // 일반 함수는 자체 this 바인딩을 가지므로 depth 증가.
         // static block 안에서 function() { this.x } 의 this는 치환하면 안 됨.
@@ -2091,15 +2091,25 @@ pub const Transformer = struct {
         const new_name = try self.visitNode(self.readNodeIdx(e, 0));
 
         // 파라미터 방문 + parameter property 수집
-        const params_start = self.readU32(e, 1);
-        const params_len = self.readU32(e, 2);
+        const params_idx_old = self.readNodeIdx(e, 1);
+        var params_span = node.span;
+        var params_list_old = NodeList{ .start = 0, .len = 0 };
+        if (!params_idx_old.isNone()) {
+            const pnode = self.ast.getNode(params_idx_old);
+            if (pnode.tag == .formal_parameters) {
+                params_list_old = pnode.data.list;
+                params_span = pnode.span;
+            }
+        }
+        const params_start = params_list_old.start;
+        const params_len = params_list_old.len;
         const scratch_top = self.scratch.items.len;
         defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
         const pp = try self.visitParamsCollectProperties(params_start, params_len);
 
         // 바디 방문
-        const old_body_idx = self.readNodeIdx(e, 3);
+        const old_body_idx = self.readNodeIdx(e, 2);
         var new_body = try self.visitBodyWorkletAware(old_body_idx);
 
         // parameter property가 있으면 바디 앞에 this.x = x 문 삽입
@@ -2153,9 +2163,14 @@ pub const Transformer = struct {
         // Metro도 직접 스캔하지 않고 Babel/SWC에 위임. $RefreshReg$만 유지.
 
         const none = @intFromEnum(NodeIndex.none);
+        const new_params_node = try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = params_span,
+            .data = .{ .list = pp.new_params },
+        });
         const result = try self.addExtraNode(node.tag, node.span, &.{
-            @intFromEnum(new_name), pp.new_params.start, pp.new_params.len,
-            @intFromEnum(new_body), self.readU32(e, 4),  none,
+            @intFromEnum(new_name), @intFromEnum(new_params_node),
+            @intFromEnum(new_body), self.readU32(e, 3),  none,
         });
 
         // Plugin dispatch: onFunction (AST 훅)
@@ -2170,7 +2185,7 @@ pub const Transformer = struct {
             .original_params_start = params_start,
             .original_params_len = params_len,
             .original_body_idx = old_body_idx,
-            .flags = self.readU32(e, 4),
+            .flags = self.readU32(e, 3),
             .source_path = self.options.jsx_filename,
             .is_auto_worklet = is_auto_worklet,
         })) |replacement| {
@@ -3015,21 +3030,31 @@ pub const Transformer = struct {
         });
     }
 
-    // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
+    // method_definition: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
     // constructor의 parameter property (public x: number) 변환도 처리.
     // abstract 메서드 (flags bit5=0x20)는 런타임에 존재하면 안 되므로 완전히 제거.
     pub fn visitMethodDefinition(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
-        const flags = self.readU32(e, 4);
+        const flags = self.readU32(e, 3);
         // abstract 메서드는 타입 전용이므로 완전히 스트리핑
         if (self.options.strip_types and (flags & 0x20) != 0) return NodeIndex.none;
         // TS method overload signature: body가 없으면 제거
-        if (self.readNodeIdx(e, 3).isNone()) return NodeIndex.none;
+        if (self.readNodeIdx(e, 2).isNone()) return NodeIndex.none;
         const new_key = try self.visitNode(self.readNodeIdx(e, 0));
 
         // 파라미터 방문 — parameter property 감지
-        const params_start = self.readU32(e, 1);
-        const params_len = self.readU32(e, 2);
+        const params_idx_old = self.readNodeIdx(e, 1);
+        var params_span = node.span;
+        var params_list_old = NodeList{ .start = 0, .len = 0 };
+        if (!params_idx_old.isNone()) {
+            const pnode = self.ast.getNode(params_idx_old);
+            if (pnode.tag == .formal_parameters) {
+                params_list_old = pnode.data.list;
+                params_span = pnode.span;
+            }
+        }
+        const params_start = params_list_old.start;
+        const params_len = params_list_old.len;
         const pp = try self.visitParamsCollectProperties(params_start, params_len);
 
         // arrow this/arguments 캡처: method도 자체 this 바인딩을 가짐 (visitFunction과 동일)
@@ -3059,7 +3084,7 @@ pub const Transformer = struct {
         }
         defer self.new_target_ctx = saved_new_target_ctx;
 
-        var new_body = try self.visitBodyWorkletAware(self.readNodeIdx(e, 3));
+        var new_body = try self.visitBodyWorkletAware(self.readNodeIdx(e, 2));
 
         // parameter property가 있으면 바디 앞에 this.x = x 문 삽입
         if (pp.prop_count > 0 and !new_body.isNone()) {
@@ -3106,11 +3131,16 @@ pub const Transformer = struct {
         const new_decos = if (self.options.experimental_decorators)
             NodeList{ .start = 0, .len = 0 }
         else
-            try self.visitExtraList(self.readU32(e, 5), self.readU32(e, 6));
-        const old_body_idx = self.readNodeIdx(e, 3);
+            try self.visitExtraList(self.readU32(e, 4), self.readU32(e, 5));
+        const old_body_idx = self.readNodeIdx(e, 2);
+        const new_params_node = try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = params_span,
+            .data = .{ .list = pp.new_params },
+        });
         const result = try self.addExtraNode(.method_definition, node.span, &.{
-            @intFromEnum(new_key), pp.new_params.start, pp.new_params.len, @intFromEnum(new_body),
-            self.readU32(e, 4),    new_decos.start,     new_decos.len,
+            @intFromEnum(new_key), @intFromEnum(new_params_node), @intFromEnum(new_body),
+            self.readU32(e, 3),    new_decos.start,               new_decos.len,
         });
 
         // Plugin dispatch: worklet 등 AST 플러그인 적용

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -487,8 +487,15 @@ pub const Transformer = struct {
                     var lr = try es2015_params.ES2015Params(Transformer).lowerParamsPass2(self, params_list.start, params_list.len, node.span);
                     defer lr.body_stmts.deinit(self.allocator);
 
-                    // formal_parameters 노드의 NodeList in-place 업데이트
-                    self.ast.nodes.items[@intFromEnum(params_idx)].data.list = lr.new_params;
+                    // formal_parameters 노드를 새로 만들어 extras[e+1]에 연결.
+                    // (여러 function 노드가 동일 params_idx를 공유할 수 있으므로 in-place mutation 금지:
+                    //  prependToFunctionBody 등은 params_idx를 복사하여 새 function 노드를 만든다.)
+                    const new_params_node = try self.ast.addNode(.{
+                        .tag = .formal_parameters,
+                        .span = params_node.span,
+                        .data = .{ .list = lr.new_params },
+                    });
+                    self.ast.extra_data.items[e + 1] = @intFromEnum(new_params_node);
 
                     if (lr.body_stmts.items.len > 0) {
                         const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1617,12 +1617,16 @@ pub const Transformer = struct {
             .span = span,
             .data = .{ .list = body_list },
         });
-        // function extra: [name, params_start, params_len, body, flags, return_type]
+        // function extra: [name, params, body, flags, return_type]
         const fn_params_list = try self.ast.addNodeList(&.{match_param});
+        const fn_params_node = try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = span,
+            .data = .{ .list = fn_params_list },
+        });
         const fn_extra = try self.ast.addExtras(&.{
             @intFromEnum(NodeIndex.none), // name (anonymous)
-            fn_params_list.start,
-            fn_params_list.len,
+            @intFromEnum(fn_params_node),
             @intFromEnum(fn_body),
             0, // flags
             @intFromEnum(NodeIndex.none), // return type
@@ -2563,8 +2567,14 @@ pub const Transformer = struct {
             .data = .{ .list = inner_body_list },
         });
         const none = @intFromEnum(NodeIndex.none);
+        const inner_empty_params = try self.ast.addNodeList(&.{});
+        const inner_params_node = try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = span,
+            .data = .{ .list = inner_empty_params },
+        });
         const inner_func_extra = try self.ast.addExtras(&.{
-            none, 0, 0, @intFromEnum(inner_body), 0, none,
+            none, @intFromEnum(inner_params_node), @intFromEnum(inner_body), 0, none,
         });
         const inner_func = try self.ast.addNode(.{
             .tag = .function_expression,
@@ -2605,8 +2615,14 @@ pub const Transformer = struct {
             .span = fn_name_binding_span,
             .data = .{ .string_ref = fn_name_binding_span },
         });
+        const outer_empty_params = try self.ast.addNodeList(&.{});
+        const outer_params_node = try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = span,
+            .data = .{ .list = outer_empty_params },
+        });
         const outer_func_extra = try self.ast.addExtras(&.{
-            @intFromEnum(fn_name_binding), 0, 0, @intFromEnum(outer_body), 0, none,
+            @intFromEnum(fn_name_binding), @intFromEnum(outer_params_node), @intFromEnum(outer_body), 0, none,
         });
         const fn_decl = try self.ast.addNode(.{
             .tag = .function_declaration,

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -2209,11 +2209,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                             .data = .{ .list = body_list },
                         });
                         const setter_flags: u32 = 0x04 | (if (is_static) @as(u32, 0x01) else 0); // setter + static
-                        const setter_params_node = try self.ast.addNode(.{
-                            .tag = .formal_parameters,
-                            .span = zero_span,
-                            .data = .{ .list = setter_params },
-                        });
+                        const setter_params_node = try self.ast.addFormalParameters(setter_params, zero_span);
                         const setter = try self.addExtraNode(.method_definition, zero_span, &.{
                             @intFromEnum(setter_key),
                             @intFromEnum(setter_params_node),
@@ -2464,11 +2460,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 .data = .{ .string_ref = ctor_key_span },
             });
             const empty_params = try self.ast.addNodeList(&.{});
-            const empty_params_node = try self.ast.addNode(.{
-                .tag = .formal_parameters,
-                .span = zero_span,
-                .data = .{ .list = empty_params },
-            });
+            const empty_params_node = try self.ast.addFormalParameters(empty_params, zero_span);
             const empty_decos = try self.ast.addNodeList(&.{});
             const ctor_method = try self.addExtraNode(.method_definition, zero_span, &.{
                 @intFromEnum(ctor_key),
@@ -2710,11 +2702,10 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
         // __setFunctionName(function() { ... }, "#name")
         const setfn_callee = try makeIdentifier(self, "__setFunctionName");
         // function expression with original body
-        const fn_params_node = try self.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = zero_span,
-            .data = .{ .list = .{ .start = info.method_params_start, .len = info.method_params_len } },
-        });
+        const fn_params_node = try self.ast.addFormalParameters(
+            .{ .start = info.method_params_start, .len = info.method_params_len },
+            zero_span,
+        );
         const fn_expr = try self.addExtraNode(.function_expression, zero_span, &.{
             @intFromEnum(NodeIndex.none), // name (anonymous)
             @intFromEnum(fn_params_node),
@@ -3077,11 +3068,7 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
             .data = .{ .list = body_list },
         });
 
-        const set_fn_params_node = try self.ast.addNode(.{
-            .tag = .formal_parameters,
-            .span = zero_span,
-            .data = .{ .list = fn_params },
-        });
+        const set_fn_params_node = try self.ast.addFormalParameters(fn_params, zero_span);
         const set_fn = try self.addExtraNode(.function_expression, zero_span, &.{
             none, // name (anonymous)
             @intFromEnum(set_fn_params_node),
@@ -3440,11 +3427,7 @@ pub fn buildGetterMethod(self: *Transformer, key: NodeIndex, return_expr: NodeIn
         .data = .{ .list = body_list },
     });
     const empty_params = try self.ast.addNodeList(&.{});
-    const empty_params_node = try self.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = span,
-        .data = .{ .list = empty_params },
-    });
+    const empty_params_node = try self.ast.addFormalParameters(empty_params, span);
     const empty_decos = try self.ast.addNodeList(&.{});
     const getter_flags: u32 = 0x02 | (if (is_static) @as(u32, 0x01) else 0);
     return self.addExtraNode(.method_definition, span, &.{

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1006,8 +1006,9 @@ pub fn insertFieldAssignmentsIntoConstructor(
     // constructor method_definition을 새 body로 재생성
     // extra: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
     return self.addExtraNode(.method_definition, ctor_node.span, &.{
-        ctor_e0, ctor_e1,
-        @intFromEnum(new_body), ctor_e3, ctor_e4, ctor_e5,
+        ctor_e0,                ctor_e1,
+        @intFromEnum(new_body), ctor_e3,
+        ctor_e4,                ctor_e5,
     });
 }
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1108,10 +1108,15 @@ pub fn buildConstructorWithFieldAssignments(
         .data = .{ .string_ref = ctor_span },
     });
 
-    // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
+    // method_definition: extra = [key, params, body, flags, deco_start, deco_len]
     const empty_decos = try self.ast.addNodeList(&.{});
+    const params_node = try self.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = zero_span,
+        .data = .{ .list = params_list },
+    });
     return self.addExtraNode(.method_definition, zero_span, &.{
-        @intFromEnum(ctor_key), params_list.start, params_list.len,
+        @intFromEnum(ctor_key), @intFromEnum(params_node),
         @intFromEnum(body), 0, // flags=0 (non-static, normal method)
         empty_decos.start,  empty_decos.len,
     });
@@ -2209,10 +2214,14 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                             .data = .{ .list = body_list },
                         });
                         const setter_flags: u32 = 0x04 | (if (is_static) @as(u32, 0x01) else 0); // setter + static
+                        const setter_params_node = try self.ast.addNode(.{
+                            .tag = .formal_parameters,
+                            .span = zero_span,
+                            .data = .{ .list = setter_params },
+                        });
                         const setter = try self.addExtraNode(.method_definition, zero_span, &.{
                             @intFromEnum(setter_key),
-                            setter_params.start,
-                            setter_params.len,
+                            @intFromEnum(setter_params_node),
                             @intFromEnum(body),
                             setter_flags,
                             empty_decos.start,
@@ -2460,11 +2469,15 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 .data = .{ .string_ref = ctor_key_span },
             });
             const empty_params = try self.ast.addNodeList(&.{});
+            const empty_params_node = try self.ast.addNode(.{
+                .tag = .formal_parameters,
+                .span = zero_span,
+                .data = .{ .list = empty_params },
+            });
             const empty_decos = try self.ast.addNodeList(&.{});
             const ctor_method = try self.addExtraNode(.method_definition, zero_span, &.{
                 @intFromEnum(ctor_key),
-                empty_params.start,
-                empty_params.len,
+                @intFromEnum(empty_params_node),
                 @intFromEnum(ctor_body),
                 0, // flags (no static/getter/setter)
                 empty_decos.start,
@@ -2702,10 +2715,14 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
         // __setFunctionName(function() { ... }, "#name")
         const setfn_callee = try makeIdentifier(self, "__setFunctionName");
         // function expression with original body
+        const fn_params_node = try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = zero_span,
+            .data = .{ .list = .{ .start = info.method_params_start, .len = info.method_params_len } },
+        });
         const fn_expr = try self.addExtraNode(.function_expression, zero_span, &.{
             @intFromEnum(NodeIndex.none), // name (anonymous)
-            info.method_params_start,
-            info.method_params_len,
+            @intFromEnum(fn_params_node),
             @intFromEnum(info.method_body),
             0, // flags
             @intFromEnum(NodeIndex.none), // ret_type
@@ -3065,10 +3082,14 @@ pub fn buildAccessObject(self: *Transformer, info: Stage3MemberInfo) Error!NodeI
             .data = .{ .list = body_list },
         });
 
+        const set_fn_params_node = try self.ast.addNode(.{
+            .tag = .formal_parameters,
+            .span = zero_span,
+            .data = .{ .list = fn_params },
+        });
         const set_fn = try self.addExtraNode(.function_expression, zero_span, &.{
             none, // name (anonymous)
-            fn_params.start,
-            fn_params.len,
+            @intFromEnum(set_fn_params_node),
             @intFromEnum(fn_body),
             0, // flags
             none, // ret_type
@@ -3424,12 +3445,16 @@ pub fn buildGetterMethod(self: *Transformer, key: NodeIndex, return_expr: NodeIn
         .data = .{ .list = body_list },
     });
     const empty_params = try self.ast.addNodeList(&.{});
+    const empty_params_node = try self.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = span,
+        .data = .{ .list = empty_params },
+    });
     const empty_decos = try self.ast.addNodeList(&.{});
     const getter_flags: u32 = 0x02 | (if (is_static) @as(u32, 0x01) else 0);
     return self.addExtraNode(.method_definition, span, &.{
         @intFromEnum(key),
-        empty_params.start,
-        empty_params.len,
+        @intFromEnum(empty_params_node),
         @intFromEnum(getter_body),
         getter_flags,
         empty_decos.start,

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -682,8 +682,9 @@ pub fn classifyMethodDefinition(
     const class_members = ctx.class_members;
     const member_decorators = ctx.member_decorators;
     const me = member.data.extra;
-    const flags = self.readU32(me, 4);
+    const flags = self.readU32(me, 3);
     const is_static = (flags & 0x01) != 0;
+    const params_list_m = self.ast.functionParamsList(member);
 
     // constructor 감지
     const is_ctor = if (!is_static) blk: {
@@ -699,12 +700,10 @@ pub fn classifyMethodDefinition(
     if (is_ctor) {
         // constructor parameter decorator → class-level __decorateClass에 포함
         if (self.options.experimental_decorators) {
-            const params_start = self.readU32(me, 1);
-            const params_len = self.readU32(me, 2);
-            try self.collectParamDecorators(ctx.ctor_param_decos, params_start, params_len);
+            try self.collectParamDecorators(ctx.ctor_param_decos, params_list_m.start, params_list_m.len);
             // emitDecoratorMetadata: 원본 AST에서 constructor 파라미터 위치 저장
-            ctx.ctor_params_start.* = params_start;
-            ctx.ctor_params_len.* = params_len;
+            ctx.ctor_params_start.* = params_list_m.start;
+            ctx.ctor_params_len.* = params_list_m.len;
         }
 
         const new_member = try self.visitMethodDefinition(member);
@@ -718,10 +717,10 @@ pub fn classifyMethodDefinition(
 
     // 일반 메서드: member decorator + parameter decorator 수집 (single-pass)
     if (self.options.experimental_decorators) {
-        const deco_start = self.readU32(me, 5);
-        const deco_len = self.readU32(me, 6);
-        const params_start = self.readU32(me, 1);
-        const params_len = self.readU32(me, 2);
+        const deco_start = self.readU32(me, 4);
+        const deco_len = self.readU32(me, 5);
+        const params_start = params_list_m.start;
+        const params_len = params_list_m.len;
         if (deco_len > 0 or params_len > 0) {
             const new_key = try self.visitNode(self.readNodeIdx(me, 0));
             try self.collectMemberDecorators(
@@ -936,7 +935,7 @@ pub fn insertFieldAssignmentsIntoConstructor(
     fields: []const FieldAssignment,
     has_super: bool,
 ) Error!NodeIndex {
-    // method_definition: extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
+    // method_definition: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
     const ctor_node = self.ast.getNode(ctor_idx);
     const ce = ctor_node.data.extra;
     // extra_data에서 값만 미리 복사 (이후 AST 변형으로 슬라이스가 무효화될 수 있음)
@@ -946,8 +945,7 @@ pub fn insertFieldAssignmentsIntoConstructor(
     const ctor_e3 = self.ast.extra_data.items[ce + 3];
     const ctor_e4 = self.ast.extra_data.items[ce + 4];
     const ctor_e5 = self.ast.extra_data.items[ce + 5];
-    const ctor_e6 = self.ast.extra_data.items[ce + 6];
-    const body_idx: NodeIndex = @enumFromInt(ctor_e3);
+    const body_idx: NodeIndex = @enumFromInt(ctor_e2);
 
     if (body_idx.isNone()) return ctor_idx;
 
@@ -1006,10 +1004,10 @@ pub fn insertFieldAssignmentsIntoConstructor(
     });
 
     // constructor method_definition을 새 body로 재생성
+    // extra: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
     return self.addExtraNode(.method_definition, ctor_node.span, &.{
-        ctor_e0,                ctor_e1, ctor_e2,
-        @intFromEnum(new_body), ctor_e4, ctor_e5,
-        ctor_e6,
+        ctor_e0, ctor_e1,
+        @intFromEnum(new_body), ctor_e3, ctor_e4, ctor_e5,
     });
 }
 
@@ -1739,8 +1737,8 @@ pub fn hasAnyMemberDecorators(self: *Transformer, class_extra: u32) bool {
             const deco_len = self.readU32(me, 4);
             if (deco_len > 0) return true;
         } else if (member.tag == .method_definition) {
-            // extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
-            const deco_len = self.readU32(me, 6);
+            // extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
+            const deco_len = self.readU32(me, 5);
             if (deco_len > 0) return true;
         }
     }
@@ -1884,10 +1882,10 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
             const me = member.data.extra;
 
             if (member.tag == .method_definition) {
-                // extra = [key, params_start, params_len, body, flags, deco_start, deco_len]
-                const flags = self.readU32(me, 4);
-                const deco_start = self.readU32(me, 5);
-                const deco_len = self.readU32(me, 6);
+                // extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
+                const flags = self.readU32(me, 3);
+                const deco_start = self.readU32(me, 4);
+                const deco_len = self.readU32(me, 5);
                 const is_static = (flags & 0x01) != 0;
                 const is_getter = (flags & 0x02) != 0;
                 const is_setter = (flags & 0x04) != 0;
@@ -1935,9 +1933,10 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     var m_params_len: u32 = 0;
                     if (is_private_method) {
                         desc_name = try std.fmt.allocPrint(self.allocator, "_private_{s}_descriptor", .{var_n});
-                        m_body = try self.visitNode(self.readNodeIdx(me, 3));
-                        m_params_start = self.readU32(me, 1);
-                        m_params_len = self.readU32(me, 2);
+                        m_body = try self.visitNode(self.readNodeIdx(me, 2));
+                        const pl = self.ast.functionParamsList(member);
+                        m_params_start = pl.start;
+                        m_params_len = pl.len;
                     }
 
                     try member_infos.append(self.allocator, .{
@@ -1964,12 +1963,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     try new_members.append(self.allocator, getter);
                 } else {
                     // public method 또는 non-decorated → 그대로 추가
-                    const new_body = try self.visitNode(self.readNodeIdx(me, 3));
+                    const new_body = try self.visitNode(self.readNodeIdx(me, 2));
                     const empty_list = try self.ast.addNodeList(&.{});
                     const new_method = try self.addExtraNode(.method_definition, member.span, &.{
                         @intFromEnum(new_key),
                         self.readU32(me, 1),
-                        self.readU32(me, 2),
                         @intFromEnum(new_body),
                         flags,
                         empty_list.start,

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -2421,7 +2421,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
             for (new_members.items, 0..) |member_node_idx, mi| {
                 const m = self.ast.getNode(member_node_idx);
                 if (m.tag != .method_definition) continue;
-                const m_flags = self.readU32(m.data.extra, 4);
+                const m_flags = self.readU32(m.data.extra, 3);
                 if ((m_flags & 0x07) != 0) continue; // getter/setter/static이면 skip
                 const m_key_idx = self.readNodeIdx(m.data.extra, 0);
                 if (m_key_idx.isNone()) continue;
@@ -2430,15 +2430,15 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 if (!std.mem.eql(u8, self.ast.getText(m_key.data.string_ref), "constructor")) continue;
 
                 // prependStatementsToBody로 기존 body 앞에 삽입
-                const old_body_idx = self.readNodeIdx(m.data.extra, 3);
+                const old_body_idx = self.readNodeIdx(m.data.extra, 2);
                 const new_body_ctor = try self.prependStatementsToBody(old_body_idx, &.{run_init_stmt});
                 const empty_decos = try self.ast.addNodeList(&.{});
+                // method_definition: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
                 const new_ctor_method = try self.addExtraNode(.method_definition, m.span, &.{
                     self.readU32(m.data.extra, 0), // key
-                    self.readU32(m.data.extra, 1), // params_start
-                    self.readU32(m.data.extra, 2), // params_len
+                    self.readU32(m.data.extra, 1), // params (formal_parameters idx)
                     @intFromEnum(new_body_ctor),
-                    self.readU32(m.data.extra, 4), // flags
+                    self.readU32(m.data.extra, 3), // flags
                     empty_decos.start,
                     empty_decos.len,
                 });

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1108,13 +1108,8 @@ pub fn buildConstructorWithFieldAssignments(
         .data = .{ .string_ref = ctor_span },
     });
 
-    // method_definition: extra = [key, params, body, flags, deco_start, deco_len]
     const empty_decos = try self.ast.addNodeList(&.{});
-    const params_node = try self.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = zero_span,
-        .data = .{ .list = params_list },
-    });
+    const params_node = try self.ast.addFormalParameters(params_list, zero_span);
     return self.addExtraNode(.method_definition, zero_span, &.{
         @intFromEnum(ctor_key), @intFromEnum(params_node),
         @intFromEnum(body), 0, // flags=0 (non-static, normal method)

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -505,12 +505,13 @@ fn walkBodyForClosureAnalysis(
             if (tag == .function_declaration) {
                 try collectBindingNames(self, @enumFromInt(self.ast.extra_data.items[e]), locals);
             }
-            if (!self.ast.hasExtra(e, 4)) return;
-            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 3]);
+            if (!self.ast.hasExtra(e, 3)) return;
+            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
             if (body_idx.isNone()) return;
             // name + params → param_nodes (extra_data 슬라이스 + name 앞에 추가)
-            const p_start = self.ast.extra_data.items[e + 1];
-            const p_len = self.ast.extra_data.items[e + 2];
+            const plist = self.ast.functionParamsList(node);
+            const p_start = plist.start;
+            const p_len = plist.len;
             // name(e[0])은 항상 포함, params는 extra_data 슬라이스
             // 두 소스를 합치기 위해 단일 배열 사용은 불가 → 두 번 호출 대신 inline 처리
             var fn_locals = std.StringHashMap(void).init(self.allocator);
@@ -543,11 +544,12 @@ fn walkBodyForClosureAnalysis(
         },
         .method_definition => {
             const e = node.data.extra;
-            if (!self.ast.hasExtra(e, 4)) return;
-            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 3]);
+            if (!self.ast.hasExtra(e, 3)) return;
+            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
             if (body_idx.isNone()) return;
-            const p_start = self.ast.extra_data.items[e + 1];
-            const p_len = self.ast.extra_data.items[e + 2];
+            const plist = self.ast.functionParamsList(node);
+            const p_start = plist.start;
+            const p_len = plist.len;
             if (p_start + p_len <= self.ast.extra_data.items.len) {
                 try walkScopedBody(self, body_idx, self.ast.extra_data.items[p_start .. p_start + p_len], locals, refs, depth);
             }

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -1069,7 +1069,8 @@ pub fn generateInitCode(
     );
     const synthetic_func = try self.addExtraNode(.function_declaration, zero_span, &.{
         @intFromEnum(name_node),    @intFromEnum(params_node),
-        @intFromEnum(new_body_idx), flags,        none,
+        @intFromEnum(new_body_idx), flags,
+        none,
     });
 
     // 단일 문장 프로그램 생성

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -1063,8 +1063,13 @@ pub fn generateInitCode(
     });
     const none = @intFromEnum(NodeIndex.none);
 
+    const params_node = try self.ast.addNode(.{
+        .tag = .formal_parameters,
+        .span = zero_span,
+        .data = .{ .list = .{ .start = params_start, .len = params_len } },
+    });
     const synthetic_func = try self.addExtraNode(.function_declaration, zero_span, &.{
-        @intFromEnum(name_node),    params_start, params_len,
+        @intFromEnum(name_node),    @intFromEnum(params_node),
         @intFromEnum(new_body_idx), flags,        none,
     });
 

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -1063,11 +1063,10 @@ pub fn generateInitCode(
     });
     const none = @intFromEnum(NodeIndex.none);
 
-    const params_node = try self.ast.addNode(.{
-        .tag = .formal_parameters,
-        .span = zero_span,
-        .data = .{ .list = .{ .start = params_start, .len = params_len } },
-    });
+    const params_node = try self.ast.addFormalParameters(
+        .{ .start = params_start, .len = params_len },
+        zero_span,
+    );
     const synthetic_func = try self.addExtraNode(.function_declaration, zero_span, &.{
         @intFromEnum(name_node),    @intFromEnum(params_node),
         @intFromEnum(new_body_idx), flags,        none,

--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -1073,7 +1073,7 @@ class C {
 const x = "";
 ((b = class extends C {
 	static x = 1;
-},d = x) => {
+}, d = x) => {
 	var x;
 })();
 "
@@ -1091,7 +1091,7 @@ class C {
 const x = "";
 ((b = class extends C {
 	static x = 1;
-},d = x) => {
+}, d = x) => {
 	var x;
 })();
 "
@@ -10775,10 +10775,10 @@ let A = (() => {
 		static {
 			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
 			_x_decorators = [// uses class reference
-((t,c) => {
+((t, c) => {
 			})];
 			_y_decorators = [// uses 'this'
-((t,c) => {
+((t, c) => {
 			})];
 			__esDecorate(this, null, _x_decorators, { kind: "accessor", name: "x", static: true, private: false, access: { has: (obj) => "x" in obj, get: (obj) => obj.x, set: function(obj,value) {
 				obj.x = value;

--- a/tests/integration/tests/tsc/__snapshots__/es6-arrowFunction.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-arrowFunction.test.ts.snap
@@ -25,7 +25,7 @@ var arrow1 = (a) => {
 };
 var arrow2 = (a) => {
 };
-var arrow3 = (a,b) => {
+var arrow3 = (a, b) => {
 };
 "
 `;
@@ -36,7 +36,7 @@ var arrow1 = (a) => {
 };
 var arrow2 = (a) => {
 };
-var arrow3 = (a,b) => {
+var arrow3 = (a, b) => {
 };
 "
 `;
@@ -87,7 +87,7 @@ var arrow1 = (a) => {
 };
 var arrow2 = (a) => {
 };
-var arrow3 = (a,b) => {
+var arrow3 = (a, b) => {
 };
 "
 `;
@@ -98,7 +98,7 @@ var arrow1 = (a) => {
 };
 var arrow2 = (a) => {
 };
-var arrow3 = (a,b) => {
+var arrow3 = (a, b) => {
 };
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/es6-defaultParameters.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-defaultParameters.test.ts.snap
@@ -34,7 +34,7 @@ var lambda2 = (x, y="hello") => {
 };
 var lambda3 = (x, y="hello", ...rest) => {
 };
-var lambda4 = (y = "hello",...rest) => {
+var lambda4 = (y = "hello", ...rest) => {
 };
 var x = function(str="hello",...rest) {
 };
@@ -53,7 +53,7 @@ var lambda2 = (x, y="hello") => {
 };
 var lambda3 = (x, y="hello", ...rest) => {
 };
-var lambda4 = (y = "hello",...rest) => {
+var lambda4 = (y = "hello", ...rest) => {
 };
 var x = function(str="hello",...rest) {
 };

--- a/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
@@ -1005,13 +1005,13 @@ var x = [1, 2, \`abc\${ 123 }def\`];
 
 exports[`TSC: es6/templates templateStringInArrowFunction 1`] = `
 "// @target: es2015
-var x = (x) => \`abc\${ x }def\`;
+var x = (x) => \`abc\${x}def\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringInArrowFunctionES6 1`] = `
 "// @strict: false
-var x = (x) => \`abc\${ x }def\`;
+var x = (x) => \`abc\${x}def\`;
 "
 `;
 

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -6545,7 +6545,7 @@ exports[`TSC: expressions functionExpressionContextualTyping1 1`] = `
 var E = /* @__PURE__ */ ((E) => {E[E["red"]=0]="red";E[E["blue"]=1]="blue";return E;})(E || {});
 // A contextual signature S is extracted from a function type T as follows:
 //      If T is a function type with exactly one call signature, and if that call signature is non- generic, S is that signature.
-var a0 = (num,str) => {
+var a0 = (num, str) => {
 	num.toExponential();
 	return 0;
 };
@@ -6563,17 +6563,17 @@ var a1 = (a1) => {
 //        and if all of the signatures are identical ignoring return types,
 //        then S is a signature with the same parameters and a union of the return types.
 var b1;
-b1 = (k,h) => {
+b1 = (k, h) => {
 };
 var b2;
-b2 = (foo,bar) => {
+b2 = (foo, bar) => {
 	return foo + 1;
 };
-b2 = (foo,bar) => {
+b2 = (foo, bar) => {
 	return "hello";
 };
 var b3;
-b3 = (name,number) => {
+b3 = (name, number) => {
 };
 var b4 = (number = 1) => {
 	return "hello";
@@ -6593,12 +6593,12 @@ b6 = (i) => {
 	return i;
 };
 // Per spec, no contextual signature can be extracted in this case. (Otherwise clause)
-b7 = (j,m) => {
+b7 = (j, m) => {
 };
 // Per spec, no contextual signature can be extracted in this case. (Otherwise clause)
 class C {
 	constructor() {
-		var k = (j,k) => {
+		var k = (j, k) => {
 			return [j, k];
 		};
 	}
@@ -6618,7 +6618,7 @@ exports[`TSC: expressions functionExpressionContextualTyping2 1`] = `
 //      Otherwise, no contextual signature can be extracted from T and S is undefined.
 var a0;
 var a1;
-a1 = (foo,bar) => {
+a1 = (foo, bar) => {
 	return true;
 };
 // Error
@@ -7656,7 +7656,7 @@ function someGenerics2b(n) {
 }
 someGenerics2b((n, x) => n);
 someGenerics2b((n, t) => n);
-someGenerics2b((n,t) => n.substr(t * t));
+someGenerics2b((n, t) => n.substr(t * t));
 // Generic call with argument of function type whose parameter is not of type parameter type but body/return type uses type parameter
 function someGenerics3(producer) {
 }
@@ -7739,7 +7739,7 @@ new someGenerics2a((n) => n);
 new someGenerics2a((n) => n.substr(0));
 new someGenerics2b((n, x) => n);
 new someGenerics2b((n, t) => n);
-new someGenerics2b((n,t) => n.substr(t * t));
+new someGenerics2b((n, t) => n.substr(t * t));
 // Generic call with argument of function type whose parameter is not of type parameter type but body/return type uses type parameter
 new someGenerics3(() => "");
 new someGenerics3(() => undefined);
@@ -7853,7 +7853,7 @@ function someGenerics2b(n) {
 }
 someGenerics2b((n, x) => n);
 someGenerics2b((n, t) => n);
-someGenerics2b((n,t) => n.substr(t * t));
+someGenerics2b((n, t) => n.substr(t * t));
 // Generic call with argument of function type whose parameter is not of type parameter type but body/return type uses type parameter
 function someGenerics3(producer) {
 }
@@ -8473,7 +8473,7 @@ const a = () => undefined;
 	var a;
 })();
 const x = "";
-((b = a() ?? "d",d = x) => {
+((b = a() ?? "d", d = x) => {
 	var x;
 })();
 "
@@ -8896,7 +8896,7 @@ const a = () => undefined;
 	var a;
 })();
 const x = "";
-((b = a()?.d,d = x) => {
+((b = a()?.d, d = x) => {
 	var x;
 })();
 "


### PR DESCRIPTION
## Summary
- function/method extras layout 을 OLD `[name, params_start, params_len, body, flags, ret_type]` (6/7 슬롯) → NEW `[name, params_idx, body, flags, ret_type]` (5/6 슬롯) 로 정규화. arrow function 이 이미 쓰던 `formal_parameters` 노드 패턴으로 통일.
- 단일 `Ast.functionParamsList(node)` 헬퍼로 arrow/function/method 모두 균일하게 params 접근 가능.
- 18개 creation 사이트를 `Ast.addFormalParameters(list, span)` 헬퍼로 정리.

## Why
Phase 1 (PR #1322) 에서 헬퍼만 먼저 도입해 consumer 가 변환 layout 에 구애받지 않도록 준비했고, Phase 2 에서 실제 layout migration 을 수행. 이후로는 params 접근 경로가 하나라 새 consumer 추가 시 slot 오프셋 실수 여지 최소화.

## Major Fixes (migration 중 발견)
- `transformer.zig` async/generator flag 체크 slot 3 (NEW flags) 로 정정. 이전 `e+4` (NEW ret_type) 읽기로 false positive 발생해 `async function*` 허위 변환.
- `transformer.zig lowerAllFunctionParams` — 여러 function 노드가 `saved_params_idx` 복사로 동일 `formal_parameters` 공유하므로 in-place mutation 금지. 새 노드 생성으로 수정 (예: `class Base { constructor(...a) {} }` 의 rest param lowering 누락).
- `worklet_plugin.zig` function_declaration 경로에서 `api.modified_body = stripped_body` 누락 → directive 잔존 수정. + `functionBodyOffset` 이 OLD body slot 3 기준이라 NEW flags 슬롯을 body 로 오인하던 버그 수정. 이 두 줄이 worklet 12 단위 테스트 전부 해결.
- `bundler/purity.zig` method `me+6` bounds/decorator 체크 (OLD 7-slot) → NEW 6-slot 로 수정. statement_shaker 테스트 실패 원인.
- `codegen.zig` function_declaration/class_declaration 공통 분기의 `extras[e..e+6]` 슬라이스 → function 5슬롯 초과 방지.

## 후속 (이 PR 범위 밖)
- 헬퍼 시그니처의 `(params_start: u32, params_len: u32)` → `NodeList` 또는 `NodeIndex` 로 통일 (Phase 3 후보). 현재는 블래스트 반경 최소화 목적으로 과도기 유지.

## Test plan
- [x] 단위 테스트 2901/2901 통과
- [x] 통합 테스트 2879 pass / 0 fail (baseline 18 → 0)
- [x] TSC 스냅샷 arrow 파라미터 포맷 일관화 (`(a,b)` → `(a, b)`) 반영
- [ ] CI 녹색 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)