### PR TITLE
refactor(bundler): Phase 1 — SymbolTable 타입 + Module 통합 (#1328)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -18,6 +18,9 @@ const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Span = @import("../lexer/token.zig").Span;
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
+const symbol_mod = @import("symbol.zig");
+const SymbolTable = symbol_mod.SymbolTable;
+const SymbolKind = symbol_mod.SymbolKind;
 
 pub const ImportBinding = struct {
     kind: Kind,
@@ -580,6 +583,25 @@ pub fn collectNamespaceAccesses(
             ib.namespace_used_properties = props;
         } else {
             ib.namespace_used_properties = &.{};
+        }
+    }
+}
+
+/// #1328 Phase 1: export bindings를 훑어 bundler-local 합성 심볼을 테이블에 등록.
+/// Consumer는 아직 없음 — 정합성 검증 + 다음 phase 준비용 shadow population.
+///
+/// 현재 등록 대상:
+///   - `export default` (kind=.local, exported_name="default") → synthetic_default ("_default")
+///
+/// 향후 phase에서 `exports_<module>` / `init_<module>` / `__ns_*` 등을
+/// linker/emitter 진입 시점에 추가 등록한다.
+pub fn populateSyntheticSymbols(
+    table: *SymbolTable,
+    export_bindings: []const ExportBinding,
+) !void {
+    for (export_bindings) |eb| {
+        if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
+            _ = try table.declare("_default", .synthetic_default, eb.local_span);
         }
     }
 }

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -309,3 +309,40 @@ test "barrel re-export: mixed local and re-export" {
     try std.testing.expectEqualStrings("y", r.export_bindings[1].exported_name);
     try std.testing.expectEqual(ExportBinding.Kind.local, r.export_bindings[1].kind);
 }
+
+// #1328 Phase 1: synthetic symbol population
+
+test "populateSyntheticSymbols: export default 는 _default 등록" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndExtractBindings(alloc, "const x = 1; export default x;");
+    defer r.arena.deinit();
+    defer alloc.free(r.import_bindings);
+    defer alloc.free(r.export_bindings);
+    defer alloc.free(r.import_records);
+
+    const symbol = @import("symbol.zig");
+    var table = symbol.SymbolTable.init(alloc);
+    defer table.deinit();
+
+    try binding_scanner.populateSyntheticSymbols(&table, r.export_bindings);
+    const id = table.find("_default") orelse return error.NotFound;
+    try std.testing.expectEqual(symbol.SymbolKind.synthetic_default, table.getKind(id));
+    try std.testing.expectEqual(@as(u32, 1), table.count());
+}
+
+test "populateSyntheticSymbols: default 없으면 빈 테이블" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndExtractBindings(alloc, "export const x = 1;");
+    defer r.arena.deinit();
+    defer alloc.free(r.import_bindings);
+    defer alloc.free(r.export_bindings);
+    defer alloc.free(r.import_records);
+
+    const symbol = @import("symbol.zig");
+    var table = symbol.SymbolTable.init(alloc);
+    defer table.deinit();
+
+    try binding_scanner.populateSyntheticSymbols(&table, r.export_bindings);
+    try std.testing.expectEqual(@as(u32, 0), table.count());
+    try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -764,6 +764,11 @@ pub const ModuleGraph = struct {
             binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &(module.ast.?), module.import_bindings) catch {};
             module.export_bindings = binding_scanner_mod.extractExportBindings(arena_alloc, &(module.ast.?), scan_result.records, module.import_bindings) catch &.{};
 
+            // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
+            // Consumer 연결은 Phase 2+. 지금은 shadow population만.
+            module.ensureSymbolTable(self.allocator);
+            binding_scanner_mod.populateSyntheticSymbols(&module.symbol_table.?, module.export_bindings) catch {};
+
             module.state = .parsed;
             return;
         }

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -38,6 +38,7 @@ pub const subprocess_plugin = @import("subprocess_plugin.zig");
 pub const module_store = @import("module_store.zig");
 pub const css_scanner = @import("css_scanner.zig");
 pub const css_emitter = @import("css_emitter.zig");
+pub const symbol = @import("symbol.zig");
 
 // 공개 타입 re-export
 pub const ModuleIndex = types.ModuleIndex;
@@ -68,6 +69,10 @@ pub const Plugin = plugin.Plugin;
 pub const PluginRunner = plugin.PluginRunner;
 pub const SubprocessPlugin = subprocess_plugin.SubprocessPlugin;
 pub const PersistentModuleStore = module_store.PersistentModuleStore;
+pub const SymbolId = symbol.SymbolId;
+pub const SymbolRef = symbol.SymbolRef;
+pub const SymbolKind = symbol.SymbolKind;
+pub const SymbolTable = symbol.SymbolTable;
 pub const incremental = @import("incremental.zig");
 pub const IncrementalBundler = incremental.IncrementalBundler;
 
@@ -91,6 +96,7 @@ test {
     _ = plugin;
     _ = subprocess_plugin;
     _ = module_store;
+    _ = symbol;
 
     // test files
     _ = @import("bundler_test.zig");

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -22,6 +22,8 @@ const binding_scanner = @import("binding_scanner.zig");
 pub const ImportBinding = binding_scanner.ImportBinding;
 pub const ExportBinding = binding_scanner.ExportBinding;
 const stmt_info_mod = @import("stmt_info.zig");
+const symbol_mod = @import("symbol.zig");
+pub const SymbolTable = symbol_mod.SymbolTable;
 
 /// Semantic analyzer 결과. parse_arena가 소유하는 데이터의 참조.
 /// linker가 import→export 연결 + 이름 충돌 해결에 사용.
@@ -69,6 +71,9 @@ pub const Module = struct {
     import_bindings: []ImportBinding = &.{},
     /// export 바인딩 상세. graph allocator 소유 (소스 텍스트 참조).
     export_bindings: []ExportBinding = &.{},
+    /// Bundler-local 합성 심볼 테이블 (cross-module linking용). #1328 Phase 1.
+    /// graph allocator 소유. null = 미초기화 (asset/disabled 모듈 등).
+    symbol_table: ?SymbolTable = null,
 
     /// 내가 import하는 모듈들 (순방향)
     dependencies: std.ArrayList(ModuleIndex),
@@ -220,8 +225,17 @@ pub const Module = struct {
         self.dependencies.deinit(allocator);
         self.importers.deinit(allocator);
         self.dynamic_imports.deinit(allocator);
+        if (self.symbol_table) |*t| t.deinit();
         // parse_arena가 Scanner/Parser/AST/source 메모리를 전부 소유.
         // ast.deinit()는 불필요 — arena.deinit()이 일괄 해제.
         if (self.parse_arena) |*arena| arena.deinit();
+    }
+
+    /// Lazy 초기화. graph allocator로 합성 심볼 테이블을 만든다.
+    /// 이미 있으면 no-op.
+    pub fn ensureSymbolTable(self: *Module, allocator: std.mem.Allocator) void {
+        if (self.symbol_table == null) {
+            self.symbol_table = SymbolTable.init(allocator);
+        }
     }
 };

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -1,0 +1,263 @@
+//! Bundler Symbol Table — cross-module linking layer.
+//!
+//! Semantic은 단일 모듈의 선언/스코프 분석을 담당한다. 이 파일은 그 위에
+//! cross-module linking(import/export 체인, 합성 심볼)을 얹는 bundler-local
+//! 테이블이다. 역할 분리는 issue #1328의 "Semantic 공존 모델" 참조.
+//!
+//! 규약(R1):
+//!   consumer는 반드시 getter/setter 함수만 사용. 내부 필드
+//!   (`symbols`, `by_name` 등) 직접 접근 금지. 내부 레이아웃(AoS/SoA)
+//!   을 무손실로 교체하기 위한 캡슐화.
+
+const std = @import("std");
+const Span = @import("../lexer/token.zig").Span;
+const types = @import("types.zig");
+const semantic_symbol = @import("../semantic/symbol.zig");
+
+pub const ModuleIndex = types.ModuleIndex;
+pub const SemanticSymbolId = semantic_symbol.SymbolId;
+
+/// Bundler 합성 심볼 id. 모듈-로컬 고유.
+/// semantic의 SymbolId와는 별개 공간 — `SymbolRef`를 통해 통합 참조.
+pub const SymbolId = enum(u32) {
+    none = std.math.maxInt(u32),
+    _,
+
+    pub fn isNone(self: SymbolId) bool {
+        return self == .none;
+    }
+};
+
+/// Cross-module 심볼 참조. semantic/bundler 두 공간을 구분.
+/// issue #1328 "Semantic 공존 모델 — SymbolRef 옵션 1(union)".
+pub const SymbolRef = union(enum) {
+    /// semantic이 소유한 선언 심볼 (var/let/const/function/class/import/parameter/catch)
+    semantic: struct { module: ModuleIndex, symbol: SemanticSymbolId },
+    /// bundler가 만든 합성 심볼 (_default$N, exports_X, init_X, __ns_X)
+    bundler: struct { module: ModuleIndex, symbol: SymbolId },
+
+    pub const invalid: SymbolRef = .{ .bundler = .{ .module = .none, .symbol = .none } };
+
+    pub fn isValid(self: SymbolRef) bool {
+        return switch (self) {
+            .semantic => |s| !s.module.isNone() and !s.symbol.isNone(),
+            .bundler => |b| !b.module.isNone() and !b.symbol.isNone(),
+        };
+    }
+
+    pub fn moduleIndex(self: SymbolRef) ModuleIndex {
+        return switch (self) {
+            .semantic => |s| s.module,
+            .bundler => |b| b.module,
+        };
+    }
+
+    pub fn eql(a: SymbolRef, b: SymbolRef) bool {
+        return switch (a) {
+            .semantic => |sa| switch (b) {
+                .semantic => |sb| sa.module == sb.module and sa.symbol == sb.symbol,
+                .bundler => false,
+            },
+            .bundler => |ba| switch (b) {
+                .bundler => |bb| ba.module == bb.module and ba.symbol == bb.symbol,
+                .semantic => false,
+            },
+        };
+    }
+};
+
+/// 합성 심볼 종류.
+pub const SymbolKind = enum(u8) {
+    /// `export default ...` 합성 변수 (`_default`, `_default$N`)
+    synthetic_default,
+    /// CJS 래퍼의 `exports_<module>` 객체
+    synthetic_exports,
+    /// ESM 래퍼의 `init_<module>` 함수
+    synthetic_init,
+    /// `import * as X` namespace 객체
+    synthetic_namespace,
+    /// Resolve 실패한 외부 import (node builtin 등)
+    unresolved_external,
+};
+
+/// 합성 심볼 레코드 (AoS 레이아웃 — 성능상 필요 시 내부 SoA로 전환 가능, R2).
+pub const Symbol = struct {
+    name: []const u8,
+    kind: SymbolKind,
+    span: Span,
+    /// Re-export 체인에서 이 심볼이 가리키는 원본 (미해결/로컬은 invalid).
+    /// Phase 3에서 linker가 채움.
+    points_to: SymbolRef = SymbolRef.invalid,
+    /// Linker renaming 후 최종 emit 이름. 빈 문자열이면 `name` 사용.
+    canonical_name: []const u8 = "",
+    /// Tree-shaking용 usage count. Phase 3에서 수집 시작.
+    ref_count: u32 = 0,
+};
+
+/// 모듈별 합성 심볼 저장소.
+///
+/// R1: 외부는 getter/setter만 사용. `symbols`/`by_name` 직접 접근 금지.
+pub const SymbolTable = struct {
+    symbols: std.ArrayList(Symbol),
+    by_name: std.StringHashMap(SymbolId),
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator) SymbolTable {
+        return .{
+            .symbols = .empty,
+            .by_name = std.StringHashMap(SymbolId).init(allocator),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *SymbolTable) void {
+        self.symbols.deinit(self.allocator);
+        self.by_name.deinit();
+    }
+
+    // ── mutation ──────────────────────────────────────────────
+
+    /// 합성 심볼을 등록하고 새 id를 반환.
+    /// 같은 이름이 이미 있으면 기존 id 반환 (멱등) — bundler 합성은 모듈당 1개 전제.
+    pub fn declare(
+        self: *SymbolTable,
+        name: []const u8,
+        kind: SymbolKind,
+        span: Span,
+    ) !SymbolId {
+        if (self.by_name.get(name)) |existing| return existing;
+        const id: SymbolId = @enumFromInt(@as(u32, @intCast(self.symbols.items.len)));
+        try self.symbols.append(self.allocator, .{
+            .name = name,
+            .kind = kind,
+            .span = span,
+        });
+        try self.by_name.put(name, id);
+        return id;
+    }
+
+    pub fn setPointsTo(self: *SymbolTable, id: SymbolId, target: SymbolRef) void {
+        self.symbols.items[@intFromEnum(id)].points_to = target;
+    }
+
+    pub fn setCanonicalName(self: *SymbolTable, id: SymbolId, name: []const u8) void {
+        self.symbols.items[@intFromEnum(id)].canonical_name = name;
+    }
+
+    pub fn incRefCount(self: *SymbolTable, id: SymbolId) void {
+        self.symbols.items[@intFromEnum(id)].ref_count += 1;
+    }
+
+    // ── read ──────────────────────────────────────────────────
+
+    pub fn count(self: *const SymbolTable) u32 {
+        return @intCast(self.symbols.items.len);
+    }
+
+    pub fn find(self: *const SymbolTable, name: []const u8) ?SymbolId {
+        return self.by_name.get(name);
+    }
+
+    pub fn getName(self: *const SymbolTable, id: SymbolId) []const u8 {
+        return self.symbols.items[@intFromEnum(id)].name;
+    }
+
+    pub fn getKind(self: *const SymbolTable, id: SymbolId) SymbolKind {
+        return self.symbols.items[@intFromEnum(id)].kind;
+    }
+
+    pub fn getSpan(self: *const SymbolTable, id: SymbolId) Span {
+        return self.symbols.items[@intFromEnum(id)].span;
+    }
+
+    pub fn getPointsTo(self: *const SymbolTable, id: SymbolId) SymbolRef {
+        return self.symbols.items[@intFromEnum(id)].points_to;
+    }
+
+    /// canonical_name이 비어있으면 원본 name 반환.
+    pub fn getCanonicalName(self: *const SymbolTable, id: SymbolId) []const u8 {
+        const s = &self.symbols.items[@intFromEnum(id)];
+        return if (s.canonical_name.len > 0) s.canonical_name else s.name;
+    }
+
+    pub fn getRefCount(self: *const SymbolTable, id: SymbolId) u32 {
+        return self.symbols.items[@intFromEnum(id)].ref_count;
+    }
+};
+
+// ── tests ─────────────────────────────────────────────────────
+
+test "SymbolTable: declare + get 기본" {
+    var t = SymbolTable.init(std.testing.allocator);
+    defer t.deinit();
+
+    const id = try t.declare("_default", .synthetic_default, .{ .start = 0, .end = 0 });
+    try std.testing.expectEqualStrings("_default", t.getName(id));
+    try std.testing.expectEqual(SymbolKind.synthetic_default, t.getKind(id));
+    try std.testing.expectEqual(@as(u32, 1), t.count());
+}
+
+test "SymbolTable: declare 멱등 (같은 이름)" {
+    var t = SymbolTable.init(std.testing.allocator);
+    defer t.deinit();
+
+    const a = try t.declare("init_X", .synthetic_init, .{ .start = 0, .end = 0 });
+    const b = try t.declare("init_X", .synthetic_init, .{ .start = 0, .end = 0 });
+    try std.testing.expectEqual(a, b);
+    try std.testing.expectEqual(@as(u32, 1), t.count());
+}
+
+test "SymbolTable: find" {
+    var t = SymbolTable.init(std.testing.allocator);
+    defer t.deinit();
+
+    const id = try t.declare("exports_Foo", .synthetic_exports, .{ .start = 0, .end = 0 });
+    try std.testing.expectEqual(@as(?SymbolId, id), t.find("exports_Foo"));
+    try std.testing.expectEqual(@as(?SymbolId, null), t.find("missing"));
+}
+
+test "SymbolTable: canonical_name fallback" {
+    var t = SymbolTable.init(std.testing.allocator);
+    defer t.deinit();
+
+    const id = try t.declare("_default", .synthetic_default, .{ .start = 0, .end = 0 });
+    try std.testing.expectEqualStrings("_default", t.getCanonicalName(id));
+    t.setCanonicalName(id, "_default$2");
+    try std.testing.expectEqualStrings("_default$2", t.getCanonicalName(id));
+}
+
+test "SymbolTable: points_to + ref_count" {
+    var t = SymbolTable.init(std.testing.allocator);
+    defer t.deinit();
+
+    const id = try t.declare("_default", .synthetic_default, .{ .start = 0, .end = 0 });
+    try std.testing.expect(!t.getPointsTo(id).isValid());
+
+    const target: SymbolRef = .{ .bundler = .{
+        .module = @enumFromInt(7),
+        .symbol = @enumFromInt(3),
+    } };
+    t.setPointsTo(id, target);
+    try std.testing.expect(t.getPointsTo(id).isValid());
+    try std.testing.expect(t.getPointsTo(id).eql(target));
+
+    try std.testing.expectEqual(@as(u32, 0), t.getRefCount(id));
+    t.incRefCount(id);
+    t.incRefCount(id);
+    try std.testing.expectEqual(@as(u32, 2), t.getRefCount(id));
+}
+
+test "SymbolRef: semantic vs bundler 공간 구분" {
+    const sem: SymbolRef = .{ .semantic = .{
+        .module = @enumFromInt(1),
+        .symbol = @enumFromInt(2),
+    } };
+    const bnd: SymbolRef = .{ .bundler = .{
+        .module = @enumFromInt(1),
+        .symbol = @enumFromInt(2),
+    } };
+    // 같은 숫자라도 다른 공간이면 다른 ref
+    try std.testing.expect(!sem.eql(bnd));
+    try std.testing.expect(sem.eql(sem));
+    try std.testing.expect(!SymbolRef.invalid.isValid());
+}


### PR DESCRIPTION
## Summary
#1328 Symbol table 리팩터 Phase 1 — bundler-local 합성 심볼 테이블 골격.

- `src/bundler/symbol.zig` 신규: `SymbolId` / `SymbolRef(union semantic|bundler)` / `SymbolKind` / `Symbol` / `SymbolTable`
- R1 캡슐화: getter/setter API만 외부 노출. 내부 저장(AoS)은 필요 시 SoA로 무손실 교체 가능
- `Module.symbol_table: ?SymbolTable` lazy 필드 추가 + `ensureSymbolTable` 헬퍼 + `deinit` 처리
- `binding_scanner.populateSyntheticSymbols`: `export default` 발견 시 `_default` 합성 심볼을 테이블에 등록 (shadow population)
- `graph.zig`가 binding_scanner 직후 population 수행

## Scope
**Consumer 연결 없음.** esm_wrap / linker / codegen은 이 테이블을 아직 사용하지 않음. Phase 2에서 `ExportBinding.symbol` / `ImportBinding.symbol` 필드 추가와 함께 연결.

## Test plan
- [x] 단위 테스트 6건 (`symbol.zig`): declare/멱등/find/canonical fallback/points_to/공간 구분
- [x] 통합 테스트 2건 (`binding_scanner_test.zig`): export default 등록 / 미등록 케이스
- [x] `zig build test` 전체 통과
- [x] RN ExampleApp 통합 테스트 (`tests/integration/tests/es5-rn.test.ts`) — regression 없음

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)