### PR TITLE
refactor(bundler): Phase 2 — Import/ExportBinding.symbol 필드 추가 (#1328)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -35,6 +35,10 @@ pub const ImportBinding = struct {
     /// namespace import에서 실제 접근된 프로퍼티 목록 (v.object → "object")
     /// null = 전체 사용 (동적 접근, namespace 탈출 등 fallback)
     namespace_used_properties: ?[]const []const u8 = null,
+    /// #1328 Phase 2: source 모듈의 export 심볼 참조. invalid = 미해결.
+    /// Phase 3에서 linker가 cross-module resolve로 채움. 기존 문자열 로직은
+    /// 병존 (Phase 4에서 제거).
+    symbol: symbol_mod.SymbolRef = symbol_mod.SymbolRef.invalid,
 
     pub const Kind = enum {
         default,
@@ -60,6 +64,11 @@ pub const ExportBinding = struct {
     kind: Kind,
     /// re-export 시 소스 모듈의 ImportRecord 인덱스
     import_record_index: ?u32 = null,
+    /// #1328 Phase 2: 이 export가 가리키는 심볼.
+    ///   - .local: 현재 모듈의 심볼 (semantic 선언 또는 bundler 합성 `_default`)
+    ///   - .re_export: source 모듈의 export 심볼 (Phase 3에서 linker가 채움)
+    /// invalid = 미해결. 기존 문자열 로직은 병존 (Phase 4에서 제거).
+    symbol: symbol_mod.SymbolRef = symbol_mod.SymbolRef.invalid,
 
     pub const Kind = enum {
         local,
@@ -587,21 +596,25 @@ pub fn collectNamespaceAccesses(
     }
 }
 
-/// #1328 Phase 1: export bindings를 훑어 bundler-local 합성 심볼을 테이블에 등록.
-/// Consumer는 아직 없음 — 정합성 검증 + 다음 phase 준비용 shadow population.
+/// #1328 Phase 1-2: export bindings를 훑어 bundler-local 합성 심볼을 테이블에
+/// 등록하고, 대응하는 ExportBinding.symbol을 채운다.
 ///
 /// 현재 등록 대상:
 ///   - `export default` (kind=.local, exported_name="default") → synthetic_default ("_default")
+///     대응 ExportBinding.symbol은 .bundler SymbolRef로 연결.
 ///
+/// Cross-module re-export 연결은 Phase 3에서 linker가 담당.
 /// 향후 phase에서 `exports_<module>` / `init_<module>` / `__ns_*` 등을
 /// linker/emitter 진입 시점에 추가 등록한다.
 pub fn populateSyntheticSymbols(
     table: *SymbolTable,
-    export_bindings: []const ExportBinding,
+    module_index: ModuleIndex,
+    export_bindings: []ExportBinding,
 ) !void {
-    for (export_bindings) |eb| {
+    for (export_bindings) |*eb| {
         if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
-            _ = try table.declare("_default", .synthetic_default, eb.local_span);
+            const id = try table.declare("_default", .synthetic_default, eb.local_span);
+            eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };
         }
     }
 }

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -324,7 +324,7 @@ test "populateSyntheticSymbols: export default 는 _default 등록" {
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, r.export_bindings);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
     const id = table.find("_default") orelse return error.NotFound;
     try std.testing.expectEqual(symbol.SymbolKind.synthetic_default, table.getKind(id));
     try std.testing.expectEqual(@as(u32, 1), table.count());
@@ -342,7 +342,52 @@ test "populateSyntheticSymbols: default 없으면 빈 테이블" {
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, r.export_bindings);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
     try std.testing.expectEqual(@as(u32, 0), table.count());
     try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
+}
+
+test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndExtractBindings(alloc, "const x = 1; export default x;");
+    defer r.arena.deinit();
+    defer alloc.free(r.import_bindings);
+    defer alloc.free(r.export_bindings);
+    defer alloc.free(r.import_records);
+
+    const symbol = @import("symbol.zig");
+    var table = symbol.SymbolTable.init(alloc);
+    defer table.deinit();
+
+    const m: types.ModuleIndex = @enumFromInt(7);
+    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings);
+
+    // default export가 bundler ref로 채워졌는지
+    try std.testing.expect(r.export_bindings[0].symbol.isValid());
+    try std.testing.expectEqual(m, r.export_bindings[0].symbol.moduleIndex());
+    switch (r.export_bindings[0].symbol) {
+        .bundler => |b| {
+            try std.testing.expectEqualStrings("_default", table.getName(b.symbol));
+            try std.testing.expectEqual(symbol.SymbolKind.synthetic_default, table.getKind(b.symbol));
+        },
+        .semantic => return error.UnexpectedSpace,
+    }
+}
+
+test "populateSyntheticSymbols Phase 2: 비-default export는 invalid 유지" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndExtractBindings(alloc, "export const x = 1;");
+    defer r.arena.deinit();
+    defer alloc.free(r.import_bindings);
+    defer alloc.free(r.export_bindings);
+    defer alloc.free(r.import_records);
+
+    const symbol = @import("symbol.zig");
+    var table = symbol.SymbolTable.init(alloc);
+    defer table.deinit();
+
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
+
+    // 일반 named export는 Phase 2에선 아직 미연결 (Phase 3에서 semantic 심볼과 연결)
+    try std.testing.expect(!r.export_bindings[0].symbol.isValid());
 }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -767,7 +767,7 @@ pub const ModuleGraph = struct {
             // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
             // Consumer 연결은 Phase 2+. 지금은 shadow population만.
             module.ensureSymbolTable(self.allocator);
-            binding_scanner_mod.populateSyntheticSymbols(&module.symbol_table.?, module.export_bindings) catch {};
+            binding_scanner_mod.populateSyntheticSymbols(&module.symbol_table.?, module.index, module.export_bindings) catch {};
 
             module.state = .parsed;
             return;


### PR DESCRIPTION
## Summary
#1328 Phase 2 — ExportBinding/ImportBinding에 SymbolRef 필드 추가 + \`export default\` 케이스 연결.

- `ImportBinding.symbol: SymbolRef = .invalid` 필드 추가
- `ExportBinding.symbol: SymbolRef = .invalid` 필드 추가
- `populateSyntheticSymbols(table, module_index, export_bindings)` 확장: \`export default\` 발견 시 synthetic \_default 등록 + 대응 ExportBinding.symbol = .bundler ref 설정
- 기존 `local_name`/`imported_name` 문자열 필드는 그대로 유지 (병존, Phase 4에서 제거)

## Scope
Consumer(esm_wrap/linker/codegen) 변경 없음. 아직 symbol 필드를 읽는 곳이 없으므로 기존 동작 불변.

## Test plan
- [x] Phase 2 테스트 2건 추가: `ExportBinding.symbol`이 bundler ref로 채워짐 / 비-default는 invalid 유지
- [x] 기존 binding_scanner 테스트 전부 통과 (시그니처 변경 반영)
- [x] `zig build test` 통과
- [x] RN ExampleApp 통합 테스트 regression 없음

Refs #1328 · follows Phase 1 (PR #1329)

🤖 Generated with [Claude Code](https://claude.com/claude-code)