### PR TITLE
refactor(bundler): Phase 3a — symbol table 기반 _default getter + #1321/Platform.js 회귀 fix (#1328)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -68,6 +68,11 @@ pub const ExportBinding = struct {
     ///   - .re_export: source 모듈의 export 심볼 (Phase 3에서 linker가 채움)
     /// invalid = 미해결. 기존 문자열 로직은 병존 (Phase 4에서 제거).
     symbol: symbol_mod.SymbolRef = symbol_mod.SymbolRef.invalid,
+    /// #1328 Phase 3a: `export default <expr>` 구문에서 나온 바인딩인지 여부.
+    /// true = codegen이 현재 모듈에 `_default = <expr>` 할당을 emit한다.
+    /// false (kind=.re_export) = `export { default } from './x'` 같은 순수 재-export로,
+    /// 현재 모듈에 로컬 default 바인딩이 없음 → esm_wrap은 체인 resolve로 내려보낸다.
+    has_local_default_binding: bool = false,
 
     pub const Kind = enum {
         local,
@@ -333,6 +338,7 @@ pub fn extractExportBindings(
                     .local_span = node.span,
                     .kind = kind,
                     .import_record_index = final_rec_idx,
+                    .has_local_default_binding = true,
                 });
             },
             .export_all_declaration => {
@@ -595,23 +601,27 @@ pub fn collectNamespaceAccesses(
     }
 }
 
-/// #1328 Phase 1-2: export bindings를 훑어 bundler-local 합성 심볼을 테이블에
+/// #1328 Phase 1-3a: export bindings를 훑어 bundler-local 합성 심볼을 테이블에
 /// 등록하고, 대응하는 ExportBinding.symbol을 채운다.
 ///
-/// 현재 등록 대상:
-///   - `export default` (kind=.local, exported_name="default") → synthetic_default ("_default")
-///     대응 ExportBinding.symbol은 .bundler SymbolRef로 연결.
+/// `_default` 합성 심볼은 `has_local_default_binding == true`인 모든 default
+/// export에 등록된다. 여기에는 다음이 포함된다:
+///   - `export default 42;` / `export default class Foo {}` (kind=.local)
+///   - `import X from './x'; export default X;` (kind=.re_export — #1321 커밋 분류)
+///     codegen이 `_default = X` 할당을 emit하므로 로컬 `_default` 참조 가능.
 ///
-/// Cross-module re-export 연결은 Phase 3에서 linker가 담당.
-/// 향후 phase에서 `exports_<module>` / `init_<module>` / `__ns_*` 등을
-/// linker/emitter 진입 시점에 추가 등록한다.
+/// 제외: `export { default } from './x'` (has_local_default_binding=false).
+/// 이 경우엔 로컬 `_default` 바인딩이 없어 esm_wrap이 re-export 체인 resolve로
+/// 내려보내야 한다.
+///
+/// Cross-module re-export 연결은 Phase 3b에서 linker가 담당.
 pub fn populateSyntheticSymbols(
     table: *SymbolTable,
     module_index: ModuleIndex,
     export_bindings: []ExportBinding,
 ) !void {
     for (export_bindings) |*eb| {
-        if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
+        if (eb.has_local_default_binding and std.mem.eql(u8, eb.exported_name, "default")) {
             const id = try table.declare("_default", .synthetic_default, eb.local_span);
             eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };
         }

--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -20,7 +20,6 @@ const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const symbol_mod = @import("symbol.zig");
 const SymbolTable = symbol_mod.SymbolTable;
-const SymbolKind = symbol_mod.SymbolKind;
 
 pub const ImportBinding = struct {
     kind: Kind,

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -8,6 +8,7 @@ const types = @import("types.zig");
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const import_scanner = @import("import_scanner.zig");
+const symbol = @import("symbol.zig");
 
 // ============================================================
 // Tests
@@ -320,7 +321,6 @@ test "populateSyntheticSymbols: export default 는 _default 등록" {
     defer alloc.free(r.export_bindings);
     defer alloc.free(r.import_records);
 
-    const symbol = @import("symbol.zig");
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
@@ -338,7 +338,6 @@ test "populateSyntheticSymbols: default 없으면 빈 테이블" {
     defer alloc.free(r.export_bindings);
     defer alloc.free(r.import_records);
 
-    const symbol = @import("symbol.zig");
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
@@ -355,7 +354,6 @@ test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
     defer alloc.free(r.export_bindings);
     defer alloc.free(r.import_records);
 
-    const symbol = @import("symbol.zig");
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
@@ -382,7 +380,6 @@ test "populateSyntheticSymbols Phase 2: 비-default export는 invalid 유지" {
     defer alloc.free(r.export_bindings);
     defer alloc.free(r.import_records);
 
-    const symbol = @import("symbol.zig");
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 

--- a/src/bundler/bundler_test/default_deconflict.zig
+++ b/src/bundler/bundler_test/default_deconflict.zig
@@ -86,6 +86,151 @@ test "Default: re-export default from another module" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"real-value\"") != null);
 }
 
+test "Default: barrel re-export default chain preserves bindings (#1321)" {
+    // #1321: `import X from './x'; export default X; export { Y };` 패턴에서
+    // binding_scanner가 X, Y 모두 local_name="default"로 .re_export 분류 →
+    // esm_wrap이 local_name=="default"만 보고 현재 모듈의 _default$N에 잘못 연결.
+    // react-native-svg에서 `default`와 `Shape`가 같은 _default$N을 참조하는 회귀.
+    // Phase 3a(#1328): has_local_default_binding 플래그가 barrel `export { X }` 케이스에
+    // false를 유지하므로 _default 단축 경로에 들어가지 않는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import Svg, { Shape, Path } from './index';
+        \\console.log(new Svg().kind, new Shape().kind, new Path().kind);
+    );
+    try writeFile(tmp.dir, "index.ts",
+        \\export * from './barrel';
+        \\export { default } from './barrel';
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import Svg from './Svg';
+        \\import Shape from './Shape';
+        \\import Path from './Path';
+        \\export default Svg;
+        \\export { Shape, Path };
+    );
+    try writeFile(tmp.dir, "Svg.ts", "export default class Svg { kind = 'Svg'; }");
+    try writeFile(tmp.dir, "Shape.ts", "export default class Shape { kind = 'Shape'; }");
+    try writeFile(tmp.dir, "Path.ts", "export default class Path { kind = 'Path'; }");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Shape: () => Shape") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Path: () => Path") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"default\": () => Svg") != null);
+}
+
+test "Default: export { X as default } where X is default-import (#1321 edge)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import V from './barrel';
+        \\console.log(V.tag);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import Real from './real';
+        \\export { Real as default };
+    );
+    try writeFile(tmp.dir, "real.ts", "export default { tag: 'REAL' };");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"REAL\"") != null);
+}
+
+test "Default: mixed default + named imports re-exported from single source (#1321 edge)" {
+    // `import X, { Y } from './a'; export default X; export { Y };`
+    // X는 .re_export + has_local_default_binding=true → _default 단축 경로 OK.
+    // Y는 .re_export + has_local_default_binding=false → 체인 resolve.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import D, { named } from './barrel';
+        \\console.log(D, named);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import Def, { named } from './src';
+        \\export default Def;
+        \\export { named };
+    );
+    try writeFile(tmp.dir, "src.ts",
+        \\export default 'DEFVAL';
+        \\export const named = 'NAMEDVAL';
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"DEFVAL\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"NAMEDVAL\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "named: () => named") != null);
+}
+
+test "Default: Platform.js 패턴 — export default X where X is default-import (#1328)" {
+    // RN Platform.js 회귀: `import Platform from './Platform.ios'; export default Platform;`
+    // binding_scanner가 .re_export로 분류하지만 codegen은 `_default = Platform` emit함.
+    // Phase 3a의 has_local_default_binding=true가 symbol table에 _default 등록 →
+    // esm_wrap이 `return _default$N;` 올바른 코드 생성. 기존 버그에선 `return default;`
+    // (reserved keyword) SyntaxError 발생.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import P from './Platform';
+        \\console.log(P.os);
+    );
+    try writeFile(tmp.dir, "Platform.ts",
+        \\import Impl from './Platform.ios';
+        \\export default Impl;
+    );
+    try writeFile(tmp.dir, "Platform.ios.ts", "export default { os: 'ios' };");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"ios\"") != null);
+    // getter가 예약어 `default`를 identifier로 참조하면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return default;") == null);
+}
+
 test "Default: default export with same-name local variable" {
     // Rollup default-identifier-deshadowing
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -22,6 +22,21 @@ const TreeShaker = @import("../tree_shaker.zig").TreeShaker;
 const statement_shaker = @import("../statement_shaker.zig");
 const stmt_info_mod = @import("../stmt_info.zig");
 const ExportBinding = @import("../binding_scanner.zig").ExportBinding;
+const symbol_mod = @import("../symbol.zig");
+const SymbolRef = symbol_mod.SymbolRef;
+
+/// #1328 Phase 3a: ExportBinding.symbol이 현재 모듈의 synthetic_default 심볼인지 확인.
+/// 현재 모듈의 `_default = <expr>` 할당을 참조할 수 있음을 의미.
+fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
+    return switch (ref) {
+        .bundler => |b| blk: {
+            if (b.module != mod.index) break :blk false;
+            const table = mod.symbol_table orelse break :blk false;
+            break :blk b.symbol.isNone() == false and table.getKind(b.symbol) == .synthetic_default;
+        },
+        .semantic => false,
+    };
+}
 const parent = @import("../emitter.zig");
 const EmitOptions = parent.EmitOptions;
 const resolveNodeName = parent.resolveNodeName;
@@ -414,8 +429,14 @@ pub fn emitEsmWrappedModule(
             for (module.export_bindings) |eb| {
                 if (eb.kind == .local or eb.kind == .re_export) {
                     try appendExportGetter(&wrapped, allocator, eb.exported_name, blk: {
-                        if (std.mem.eql(u8, eb.local_name, "default"))
+                        // #1328 Phase 3a: symbol table이 synthetic_default로 채운 경우에만
+                        // _default 단축 경로 사용. 현재 모듈에 `_default = <expr>` 할당이
+                        // 실제로 emit되는 케이스를 binding_scanner가 정확히 표시한다.
+                        // 분류 오탈자(.re_export로 잘못 분류된 barrel `export { X }`)에서도
+                        // 이 분기로 잘못 들어가지 않는다 (#1321 방어).
+                        if (isSyntheticDefault(eb.symbol, module)) {
                             break :blk if (metadata) |md| md.default_export_name else "_default";
+                        }
                         // live binding override: import binding이 canonical name으로 변경된 경우
                         if (metadata) |md| {
                             if (md.export_getter_overrides.get(eb.local_name)) |override|


### PR DESCRIPTION
## Summary
#1328 Phase 3a — symbol table을 \`_default\` getter 판단의 source of truth로 교체. #1321 barrel re-export collapse + Platform.js \`return default;\` SyntaxError 두 회귀를 구조적으로 해결.

## 변경

**binding_scanner:**
- \`ExportBinding.has_local_default_binding\` 플래그 추가. \`.export_default_declaration\` AST 노드에서만 true — codegen이 실제로 로컬 \`_default = <expr>\`를 emit하는 케이스와 정확히 일치.
- \`populateSyntheticSymbols\`가 \`has_local_default_binding\` 기준으로 \_default 등록. Platform.js 패턴(\`export default X\` where X is default-import, kind=.re\\_export) 포함.

**esm_wrap:**
- 문자열 \`local_name == \"default\"\` shortcut을 \`isSyntheticDefault(eb.symbol, module)\`로 교체.
- Symbol table이 진실의 원천 — barrel \`export { X }\` (X default-import, kind=.re\\_export, exported\\_name=\"X\")는 \`has_local_default_binding=false\`라 shortcut 우회 → 체인 resolve로 올바르게 내려감.

## 두 회귀가 해결되는 이유

| 케이스 | kind | exported | has\\_local\\_default\\_binding | 결과 |
|---|---|---|---|---|
| \`export default 42\` | .local | default | **true** | \_default 단축 ✓ |
| \`export default X\` (X is import, Platform.js) | .re\\_export | default | **true** | \_default 단축 ✓ |
| \`export { default } from './x'\` | .re\\_export | default | **false** | 체인 resolve ✓ |
| \`export { X }\` (X is default-import, #1321) | .re\\_export | **X** | **false** | 체인 resolve ✓ |

## Test plan
- [x] #1321 barrel 회귀 테스트 3건 복원 (barrel chain / \`export { X as default }\` / default+named mixed)
- [x] Platform.js 회귀 테스트 신규 추가 (\`return default;\` 부재 검증 포함)
- [x] \`zig build test\` 전체 통과
- [x] RN ExampleApp 통합 테스트 통과 (Platform.js 실제 케이스)

## 후속
- Phase 3b: linker가 .re\\_export에 대해 ExportBinding.symbol을 cross-module resolve로 채움
- Phase 3c: 문자열 fallback 전면 제거

Refs #1328 · follows PRs #1329, #1330 · closes Platform.js 회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)