### PR TITLE
refactor(bundler): Phase 3b+3c — symbol-ref 기반 re-export 체인 + 문자열 resolveExportChain 제거 (#1328)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -624,6 +624,11 @@ pub fn populateSyntheticSymbols(
         if (eb.has_local_default_binding and std.mem.eql(u8, eb.exported_name, "default")) {
             const id = try table.declare("_default", .synthetic_default, eb.local_span);
             eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };
+        } else if (eb.kind == .re_export) {
+            // Phase 3b: .re_export마다 alias 심볼 생성. linker가 post-link 단계에서
+            // resolveExportChain 결과를 canonical_name으로 저장한다.
+            const id = try table.declareAnonymous(eb.exported_name, .re_export_alias, eb.local_span);
+            eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };
         }
     }
 }

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -501,6 +501,7 @@ pub const Bundler = struct {
         if (self.options.minify_identifiers) {
             try worker_linker.computeMangling();
         }
+        worker_linker.populateReExportAliases(worker_graph.modules.items);
         defer worker_linker.deinit();
 
         // emit (IIFE 포맷)
@@ -661,6 +662,9 @@ pub const Bundler = struct {
                     try l.computeMangling();
                 }
             }
+            // Phase 3b (#1328): re_export_alias 심볼의 canonical_name 채우기.
+            // computeRenames 이후에 호출해야 getCanonicalName이 최종 리네임을 반영.
+            l.populateReExportAliases(graph.modules.items);
             break :blk l;
         } else null;
         defer if (linker) |*l| l.deinit();

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -24,19 +24,6 @@ const stmt_info_mod = @import("../stmt_info.zig");
 const ExportBinding = @import("../binding_scanner.zig").ExportBinding;
 const symbol_mod = @import("../symbol.zig");
 const SymbolRef = symbol_mod.SymbolRef;
-
-/// #1328 Phase 3a: ExportBinding.symbol이 현재 모듈의 synthetic_default 심볼인지 확인.
-/// 현재 모듈의 `_default = <expr>` 할당을 참조할 수 있음을 의미.
-fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
-    return switch (ref) {
-        .bundler => |b| blk: {
-            if (b.module != mod.index) break :blk false;
-            const table = mod.symbol_table orelse break :blk false;
-            break :blk b.symbol.isNone() == false and table.getKind(b.symbol) == .synthetic_default;
-        },
-        .semantic => false,
-    };
-}
 const parent = @import("../emitter.zig");
 const EmitOptions = parent.EmitOptions;
 const resolveNodeName = parent.resolveNodeName;
@@ -45,6 +32,19 @@ const collectImportBindingNames = parent.collectImportBindingNames;
 const appendRunBeforeMainCalls = parent.appendRunBeforeMainCalls;
 const appendIndented = parent.appendIndented;
 const appendModuleCall = parent.appendModuleCall;
+
+/// ExportBinding.symbol이 현재 모듈의 synthetic_default 심볼인지 확인.
+/// 현재 모듈의 `_default = <expr>` 할당을 참조할 수 있음을 의미.
+fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
+    return switch (ref) {
+        .bundler => |b| blk: {
+            if (b.module != mod.index) break :blk false;
+            const table = mod.symbol_table orelse break :blk false;
+            break :blk !b.symbol.isNone() and table.getKind(b.symbol) == .synthetic_default;
+        },
+        .semantic => false,
+    };
+}
 
 pub const EsmEmitResult = struct {
     code: []const u8,

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -46,6 +46,22 @@ fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
     };
 }
 
+/// re_export_alias에 linker가 주입한 canonical_name을 반환. null이면
+/// alias 심볼이 아니거나 linker가 resolve하지 못한 경우.
+fn reExportAliasCanonicalName(ref: SymbolRef, mod: *const Module) ?[]const u8 {
+    return switch (ref) {
+        .bundler => |b| blk: {
+            if (b.module != mod.index) break :blk null;
+            if (b.symbol.isNone()) break :blk null;
+            const table = mod.symbol_table orelse break :blk null;
+            if (table.getKind(b.symbol) != .re_export_alias) break :blk null;
+            if (!table.hasCanonicalName(b.symbol)) break :blk null;
+            break :blk table.getCanonicalName(b.symbol);
+        },
+        .semantic => null,
+    };
+}
+
 pub const EsmEmitResult = struct {
     code: []const u8,
     mappings: ?[]const SourceMap.Mapping = null,
@@ -429,28 +445,23 @@ pub fn emitEsmWrappedModule(
             for (module.export_bindings) |eb| {
                 if (eb.kind == .local or eb.kind == .re_export) {
                     try appendExportGetter(&wrapped, allocator, eb.exported_name, blk: {
-                        // #1328 Phase 3a: symbol table이 synthetic_default로 채운 경우에만
-                        // _default 단축 경로 사용. 현재 모듈에 `_default = <expr>` 할당이
-                        // 실제로 emit되는 케이스를 binding_scanner가 정확히 표시한다.
-                        // 분류 오탈자(.re_export로 잘못 분류된 barrel `export { X }`)에서도
-                        // 이 분기로 잘못 들어가지 않는다 (#1321 방어).
+                        // Symbol table이 단축 경로의 source of truth.
+                        // binding_scanner가 `_default = <expr>`가 실제로 emit되는 default만
+                        // synthetic_default로 표시하고, 나머지 re-export는 re_export_alias로
+                        // 표현 → linker가 canonical_name을 채운다. barrel `export { X }`같은
+                        // kind 오분류에도 영향받지 않음 (#1321 방어).
                         if (isSyntheticDefault(eb.symbol, module)) {
                             break :blk if (metadata) |md| md.default_export_name else "_default";
+                        }
+                        if (reExportAliasCanonicalName(eb.symbol, module)) |canon| {
+                            break :blk canon;
                         }
                         // live binding override: import binding이 canonical name으로 변경된 경우
                         if (metadata) |md| {
                             if (md.export_getter_overrides.get(eb.local_name)) |override|
                                 break :blk override;
                         }
-                        // `export { X } from './mod'` 직접 re-export는 현재 모듈에 로컬 바인딩이 없어
-                        // getCanonicalName(this_mod, local_name)이 miss → 원본 이름 fallback 시
-                        // `--global-identifier`로 예약된 글로벌과 충돌 가능 (#1312).
                         if (linker) |l| {
-                            if (eb.kind == .re_export) {
-                                if (l.resolveExportChain(module.index, eb.exported_name, 0)) |canonical| {
-                                    break :blk l.resolveToLocalName(canonical);
-                                }
-                            }
                             const mi: u32 = @intFromEnum(module.index);
                             if (l.getCanonicalName(mi, eb.local_name)) |renamed|
                                 break :blk renamed;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1013,6 +1013,7 @@ pub const ModuleGraph = struct {
                         .local_span = sb.local_span,
                         .kind = eb_kind,
                         .import_record_index = sb.import_record_index,
+                        .has_local_default_binding = sb.has_local_default_binding,
                     };
                 }
                 module.export_bindings = ebindings;
@@ -1031,6 +1032,10 @@ pub const ModuleGraph = struct {
 
             // namespace access 수집은 별도 AST walk 필요
             binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &parser.ast, module.import_bindings) catch {};
+
+            // Phase 1-3b (#1328): 합성 심볼 테이블 초기화 + _default / re_export_alias 등록.
+            module.ensureSymbolTable(self.allocator);
+            binding_scanner_mod.populateSyntheticSymbols(&module.symbol_table.?, module.index, module.export_bindings) catch {};
 
             // CJS/ESM 감지 — inline scan 결과로 ScanResult 생성
             const scan_result = import_scanner.ScanResult{

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1121,6 +1121,34 @@ pub const Linker = struct {
         return self.safeIdentifierName(canonical, cmod);
     }
 
+    /// #1328 Phase 3b: 각 모듈의 `re_export_alias` 합성 심볼에 대해 체인 resolve를
+    /// 수행하고, 결과를 `canonical_name`에 저장한다. Phase 3c에서 emitter가 이 값을
+    /// 직접 읽어 문자열 기반 `resolveExportChain` 호출을 제거한다.
+    ///
+    /// link() 이후에 호출되어야 한다 — export_map과 canonical_names가 준비된 상태를 전제.
+    pub fn populateReExportAliases(self: *const Linker, modules: []Module) void {
+        for (modules, 0..) |*m, idx| {
+            const mod_idx: ModuleIndex = @enumFromInt(idx);
+            const table_ptr = if (m.symbol_table) |*t| t else continue;
+            for (m.export_bindings) |eb| {
+                if (eb.kind != .re_export) continue;
+                const sym_id = switch (eb.symbol) {
+                    .bundler => |b| blk: {
+                        if (b.module != mod_idx) break :blk null;
+                        if (b.symbol.isNone()) break :blk null;
+                        if (table_ptr.getKind(b.symbol) != .re_export_alias) break :blk null;
+                        break :blk b.symbol;
+                    },
+                    else => null,
+                } orelse continue;
+
+                const ref = self.resolveExportChain(mod_idx, eb.exported_name, 0) orelse continue;
+                const name = self.resolveToLocalName(ref);
+                table_ptr.setCanonicalName(sym_id, name);
+            }
+        }
+    }
+
     /// "default"는 JS 예약어 — 값 위치에 식별자로 사용 불가.
     /// codegen 합성 변수명(_default)의 canonical name으로 대체.
     fn safeIdentifierName(self: *const Linker, name: []const u8, module_index: u32) []const u8 {

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -200,6 +200,13 @@ pub const SymbolTable = struct {
         return if (s.canonical_name.len > 0) s.canonical_name else s.name;
     }
 
+    /// `setCanonicalName`이 호출된 적 있는지 여부. re_export_alias의 체인 resolve
+    /// 완료를 판정할 때 fallback("" → name) 때문에 `getCanonicalName`만으로는 구분
+    /// 불가하므로 별도 API.
+    pub fn hasCanonicalName(self: *const SymbolTable, id: SymbolId) bool {
+        return self.symbols.items[@intFromEnum(id)].canonical_name.len > 0;
+    }
+
     pub fn getRefCount(self: *const SymbolTable, id: SymbolId) u32 {
         return self.symbols.items[@intFromEnum(id)].ref_count;
     }

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -76,6 +76,9 @@ pub const SymbolKind = enum(u8) {
     synthetic_init,
     /// `import * as X` namespace 객체
     synthetic_namespace,
+    /// Re-export alias (`export { X } from './m'`, barrel 등).
+    /// 자기 자신은 값을 갖지 않고 `points_to`로 target export를 가리킴.
+    re_export_alias,
     /// Resolve 실패한 외부 import (node builtin 등)
     unresolved_external,
 };
@@ -133,6 +136,23 @@ pub const SymbolTable = struct {
             .span = span,
         });
         try self.by_name.put(name, id);
+        return id;
+    }
+
+    /// 이름 기반 조회 없이 익명 심볼 등록. re_export_alias처럼 같은 exported_name이
+    /// 여러 개 올 수 있거나, name으로 lookup이 필요 없는 경우에 사용.
+    pub fn declareAnonymous(
+        self: *SymbolTable,
+        name: []const u8,
+        kind: SymbolKind,
+        span: Span,
+    ) !SymbolId {
+        const id: SymbolId = @enumFromInt(@as(u32, @intCast(self.symbols.items.len)));
+        try self.symbols.append(self.allocator, .{
+            .name = name,
+            .kind = kind,
+            .span = span,
+        });
         return id;
     }
 

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -584,6 +584,7 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
                 .local_span = .{ .start = start, .end = self.currentSpan().start },
                 .kind = re.kind,
                 .import_record_index = re.import_record_index,
+                .has_local_default_binding = true,
             }) catch {};
         }
 

--- a/src/parser/scan_results.zig
+++ b/src/parser/scan_results.zig
@@ -75,6 +75,9 @@ pub const ScanExportBinding = struct {
     kind: ExportBindingKind,
     /// re-export 시 소스 모듈의 scan_import_records 인덱스
     import_record_index: ?u32 = null,
+    /// #1328 Phase 3a: `export default <expr>` 구문에서 나온 바인딩인지.
+    /// true = codegen이 로컬 `_default = <expr>` 할당을 emit한다.
+    has_local_default_binding: bool = false,
 };
 
 /// CJS/ESM 감지 결과.


### PR DESCRIPTION
## Summary
#1328 Phase 3b + 3c — symbol table을 re-export 해결의 단일 진실의 원천으로 완성.

## Phase 3b: linker가 alias canonical_name 주입
- \`SymbolKind.re_export_alias\`: 자기 값 없이 \`canonical_name\`으로 target export의 로컬 이름을 보관하는 프록시.
- \`SymbolTable.declareAnonymous\`: name lookup 없이 익명 심볼 등록 (re-export alias는 같은 exported_name 충돌 걱정 없이 표현).
- \`binding_scanner.populateSyntheticSymbols\`: \`.re_export\`마다 alias 선언 + \`ExportBinding.symbol\`에 bundler ref 저장.
- \`linker.populateReExportAliases(modules)\`: link + computeRenames 이후 각 alias를 \`resolveExportChain + resolveToLocalName\`으로 해결, \`setCanonicalName\`으로 저장.

## Phase 3c: esm_wrap 전환
- 문자열 기반 \`resolveExportChain\` 호출 분기 삭제.
- 신규 헬퍼 \`reExportAliasCanonicalName\`: SymbolRef가 현재 모듈의 re_export_alias일 때 linker가 주입한 canonical_name 반환.
- getter resolution: \`isSyntheticDefault\` → \`reExportAliasCanonicalName\` → metadata override → linker.getCanonicalName → local_name fallback.

## Parser ↔ graph 연결 fix
기존 Phase 1-3a는 JSON 모듈에서만 동작했음 (JS는 parser의 inline scan 경로 사용). 이번에 JS 경로도 연결:
- \`ScanExportBinding.has_local_default_binding\` 추가, parser가 \`export default\` 구문에서 true 설정.
- graph.zig의 JS 모듈 경로가 필드 전파 + \`populateSyntheticSymbols\` 호출 추가.

## SymbolTable API 확장
- \`hasCanonicalName(id)\`: \`getCanonicalName\`이 미설정 시 원본 name fallback → 체인 미resolve 케이스 구분 불가 → 별도 API.

## Test plan
- [x] \`#1321 barrel re-export default chain\` 회귀 테스트 통과
- [x] \`Platform.js 패턴 (export default X where X is import)\` 통과 (Phase 3a 추가분)
- [x] \`#1312 global-identifier re-export\` 통과
- [x] \`zig build test\` 전체 통과
- [x] RN ExampleApp 통합 테스트 통과

Refs #1328 · follows #1329/#1330/#1331 · completes Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)