### PR TITLE
refactor(bundler): Phase 4a — cjs_wrap 분리 + _default 판정 symbol table 단일화 (#1328)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -79,6 +79,27 @@ pub const ExportBinding = struct {
         re_export,
         re_export_all,
     };
+
+    /// Scanner 내부용 predicate: local_name=="default" 패턴으로 `_default = <chain>`
+    /// 할당을 esm_wrap body가 만드는 케이스. `populateSyntheticSymbols`가 이 조건에
+    /// 해당하는 export에 synthetic_default 합성 심볼을 등록한다.
+    fn emitsLocalDefault(self: ExportBinding) bool {
+        if (self.kind != .local and self.kind != .re_export) return false;
+        return std.mem.eql(u8, self.local_name, "default");
+    }
+
+    /// #1328 Phase 4a: 이 export 때문에 현재 모듈에 `_default` 합성 변수가 생기는지
+    /// symbol table로 확인. linker.addNameOwner / metadata.default_export_name /
+    /// esm_wrap 호이스팅·할당 사이트의 단일 source of truth.
+    ///
+    /// scanner의 `populateSyntheticSymbols`가 이 predicate가 true가 될 조건에 대해
+    /// 정확히 synthetic_default 심볼을 등록하므로, 판정은 symbol 조회 한 번으로 끝.
+    pub fn hasSyntheticDefault(self: ExportBinding, table: *const SymbolTable) bool {
+        return switch (self.symbol) {
+            .bundler => |b| !b.symbol.isNone() and table.getKind(b.symbol) == .synthetic_default,
+            .semantic => false,
+        };
+    }
 };
 
 /// AST에서 import 바인딩 상세를 추출한다.
@@ -621,7 +642,17 @@ pub fn populateSyntheticSymbols(
     export_bindings: []ExportBinding,
 ) !void {
     for (export_bindings) |*eb| {
-        if (eb.has_local_default_binding and std.mem.eql(u8, eb.exported_name, "default")) {
+        // codegen이 `_default = <expr>` 할당을 emit하는 export만 synthetic_default 등록.
+        // 조건: local_name이 실제 바인딩 이름("Foo" 등)이 아닌 합성 이름일 때 — 즉
+        //   - "_default": 익명 default (`export default 42`) 또는 리터럴
+        //   - "default": `export { default } from './x'` / `export default X`(X는 default-import)
+        //     → esm_wrap body가 `_default = <chain>` 할당
+        // `export default class Foo` 등 **클래스명 재사용** 케이스(local_name="Foo")는 제외 —
+        // codegen이 Foo를 그대로 쓰므로 _default가 emit되지 않는다.
+        if ((eb.kind == .local or eb.kind == .re_export) and
+            std.mem.eql(u8, eb.exported_name, "default") and
+            (std.mem.eql(u8, eb.local_name, "_default") or std.mem.eql(u8, eb.local_name, "default")))
+        {
             const id = try table.declare("_default", .synthetic_default, eb.local_span);
             eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };
         } else if (eb.kind == .re_export) {

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -313,9 +313,10 @@ test "barrel re-export: mixed local and re-export" {
 
 // #1328 Phase 1: synthetic symbol population
 
-test "populateSyntheticSymbols: export default 는 _default 등록" {
+test "populateSyntheticSymbols: 리터럴 default만 _default 등록 (로컬 var 재사용은 제외)" {
     const alloc = std.testing.allocator;
-    var r = try parseAndExtractBindings(alloc, "const x = 1; export default x;");
+    // 리터럴 `export default 42` — codegen이 실제로 `_default = 42` emit.
+    var r = try parseAndExtractBindings(alloc, "export default 42;");
     defer r.arena.deinit();
     defer alloc.free(r.import_bindings);
     defer alloc.free(r.export_bindings);
@@ -327,7 +328,22 @@ test "populateSyntheticSymbols: export default 는 _default 등록" {
     try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
     const id = table.find("_default") orelse return error.NotFound;
     try std.testing.expectEqual(symbol.SymbolKind.synthetic_default, table.getKind(id));
-    try std.testing.expectEqual(@as(u32, 1), table.count());
+}
+
+test "populateSyntheticSymbols: `export default x`(x는 로컬)은 _default 미등록" {
+    const alloc = std.testing.allocator;
+    // codegen이 x를 재사용하고 `_default` 변수를 만들지 않으므로 등록하지 않는다.
+    var r = try parseAndExtractBindings(alloc, "const x = 1; export default x;");
+    defer r.arena.deinit();
+    defer alloc.free(r.import_bindings);
+    defer alloc.free(r.export_bindings);
+    defer alloc.free(r.import_records);
+
+    var table = symbol.SymbolTable.init(alloc);
+    defer table.deinit();
+
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
+    try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
 }
 
 test "populateSyntheticSymbols: default 없으면 빈 테이블" {
@@ -348,7 +364,7 @@ test "populateSyntheticSymbols: default 없으면 빈 테이블" {
 
 test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
     const alloc = std.testing.allocator;
-    var r = try parseAndExtractBindings(alloc, "const x = 1; export default x;");
+    var r = try parseAndExtractBindings(alloc, "export default 42;");
     defer r.arena.deinit();
     defer alloc.free(r.import_bindings);
     defer alloc.free(r.export_bindings);

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1171,60 +1171,11 @@ pub fn emitModule(
     return try allocator.dupe(u8, code);
 }
 
-/// JSON 모듈을 CJS 형태로 출력: __commonJS 래핑 + module.exports = <JSON content>
-/// Disabled 모듈: platform=browser에서 Node 빌트인 모듈을 빈 __commonJS wrapper로 출력.
-/// esbuild 호환 형식: var require_util = __commonJS({ "(disabled)"(exports, module) {} });
-fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, minify: bool) !?[]const u8 {
-    const var_name = try types.makeRequireVarName(allocator, module.path);
-    defer allocator.free(var_name);
-
-    var buf: std.ArrayList(u8) = .empty;
-    if (minify) {
-        try buf.appendSlice(allocator, "var ");
-        try buf.appendSlice(allocator, var_name);
-        try buf.appendSlice(allocator, "=__commonJS({\"(disabled)\"(exports,module){}});");
-    } else {
-        try buf.appendSlice(allocator, "var ");
-        try buf.appendSlice(allocator, var_name);
-        try buf.appendSlice(allocator, " = __commonJS({\n\t\"(disabled)\"(exports, module) {\n\t}\n});\n");
-    }
-    return try buf.toOwnedSlice(allocator);
-}
-
-/// Asset 모듈을 출력한다 (CJS wrap 패턴).
-/// source에 값 표현식이 저장되어 있고, __commonJS wrapper로 래핑.
-/// linker가 `require_X()` 호출을 생성하므로, 모든 포맷에서 CJS 패턴을 사용.
-fn emitAssetModule(allocator: std.mem.Allocator, module: *const Module, options: EmitOptions) !?[]const u8 {
-    if (module.source.len == 0) return null;
-    return emitCjsWrapper(allocator, module.path, module.source, options.minify_whitespace);
-}
-
-/// __commonJS wrapper 출력 (Asset 모듈용).
-/// var require_X = __commonJS({ "filename"(exports, module) { module.exports = <source>; } });
-fn emitCjsWrapper(allocator: std.mem.Allocator, path: []const u8, source: []const u8, minify: bool) !?[]const u8 {
-    const var_name = try types.makeRequireVarName(allocator, path);
-    defer allocator.free(var_name);
-
-    var buf: std.ArrayList(u8) = .empty;
-    if (minify) {
-        try buf.appendSlice(allocator, "var ");
-        try buf.appendSlice(allocator, var_name);
-        try buf.appendSlice(allocator, "=__commonJS({\"");
-        try buf.appendSlice(allocator, std.fs.path.basename(path));
-        try buf.appendSlice(allocator, "\"(exports,module){module.exports=");
-        try buf.appendSlice(allocator, source);
-        try buf.appendSlice(allocator, "}});");
-    } else {
-        try buf.appendSlice(allocator, "var ");
-        try buf.appendSlice(allocator, var_name);
-        try buf.appendSlice(allocator, " = __commonJS({\n\t\"");
-        try buf.appendSlice(allocator, std.fs.path.basename(path));
-        try buf.appendSlice(allocator, "\"(exports, module) {\nmodule.exports=");
-        try buf.appendSlice(allocator, source);
-        try buf.appendSlice(allocator, ";\n\t}\n});\n");
-    }
-    return try buf.toOwnedSlice(allocator);
-}
+// --- CJS wrap functions (emitter/cjs_wrap.zig) ---
+const cjs_wrap = @import("emitter/cjs_wrap.zig");
+const emitDisabledModule = cjs_wrap.emitDisabledModule;
+const emitAssetModule = cjs_wrap.emitAssetModule;
+pub const emitCjsWrapper = cjs_wrap.emitCjsWrapper;
 
 /// Cross-module @__NO_SIDE_EFFECTS__ 전파.
 ///

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -1,0 +1,63 @@
+//! CJS 래퍼 (__commonJS) — Asset/Disabled 모듈용 팩토리 함수 emit.
+//!
+//! 일반 CJS 번들(module.wrap_kind == .cjs)의 __commonJS 래핑은 emitter.zig의
+//! emitModule이 직접 생성한다. 이 파일은 source가 이미 값 표현식 형태인 특수
+//! 케이스를 담당: asset (file/copy 로더) + disabled (browser 빌드의 Node 빌트인).
+
+const std = @import("std");
+const types = @import("../types.zig");
+const Module = @import("../module.zig").Module;
+const EmitOptions = @import("../emitter.zig").EmitOptions;
+
+/// Disabled 모듈: platform=browser에서 Node 빌트인 모듈을 빈 __commonJS wrapper로 출력.
+/// esbuild 호환 형식: `var require_util = __commonJS({ "(disabled)"(exports, module) {} });`
+pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, minify: bool) !?[]const u8 {
+    const var_name = try types.makeRequireVarName(allocator, module.path);
+    defer allocator.free(var_name);
+
+    var buf: std.ArrayList(u8) = .empty;
+    if (minify) {
+        try buf.appendSlice(allocator, "var ");
+        try buf.appendSlice(allocator, var_name);
+        try buf.appendSlice(allocator, "=__commonJS({\"(disabled)\"(exports,module){}});");
+    } else {
+        try buf.appendSlice(allocator, "var ");
+        try buf.appendSlice(allocator, var_name);
+        try buf.appendSlice(allocator, " = __commonJS({\n\t\"(disabled)\"(exports, module) {\n\t}\n});\n");
+    }
+    return try buf.toOwnedSlice(allocator);
+}
+
+/// Asset 모듈(file/copy 로더)을 CJS wrap 패턴으로 출력. source엔 값 표현식이 저장됨.
+/// linker가 `require_X()` 호출을 생성하므로, 모든 포맷에서 CJS 패턴을 사용.
+pub fn emitAssetModule(allocator: std.mem.Allocator, module: *const Module, options: EmitOptions) !?[]const u8 {
+    if (module.source.len == 0) return null;
+    return emitCjsWrapper(allocator, module.path, module.source, options.minify_whitespace);
+}
+
+/// `var require_X = __commonJS({ "filename"(exports, module) { module.exports = <source>; } });`
+/// 형태의 __commonJS wrapper를 생성.
+pub fn emitCjsWrapper(allocator: std.mem.Allocator, path: []const u8, source: []const u8, minify: bool) !?[]const u8 {
+    const var_name = try types.makeRequireVarName(allocator, path);
+    defer allocator.free(var_name);
+
+    var buf: std.ArrayList(u8) = .empty;
+    if (minify) {
+        try buf.appendSlice(allocator, "var ");
+        try buf.appendSlice(allocator, var_name);
+        try buf.appendSlice(allocator, "=__commonJS({\"");
+        try buf.appendSlice(allocator, std.fs.path.basename(path));
+        try buf.appendSlice(allocator, "\"(exports,module){module.exports=");
+        try buf.appendSlice(allocator, source);
+        try buf.appendSlice(allocator, "}});");
+    } else {
+        try buf.appendSlice(allocator, "var ");
+        try buf.appendSlice(allocator, var_name);
+        try buf.appendSlice(allocator, " = __commonJS({\n\t\"");
+        try buf.appendSlice(allocator, std.fs.path.basename(path));
+        try buf.appendSlice(allocator, "\"(exports, module) {\nmodule.exports=");
+        try buf.appendSlice(allocator, source);
+        try buf.appendSlice(allocator, ";\n\t}\n});\n");
+    }
+    return try buf.toOwnedSlice(allocator);
+}

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -251,13 +251,16 @@ pub fn emitEsmWrappedModule(
         }
     }
 
-    // re-export (export { default } from / export { default as X } from)는
-    // AST에 export_default_declaration 노드가 없으므로 export_bindings에서 확인.
-    for (module.export_bindings) |eb| {
-        if (eb.kind == .re_export and std.mem.eql(u8, eb.local_name, "default")) {
-            const def_name = if (metadata) |md| md.default_export_name else "_default";
-            try hoisted_var_names.append(allocator, def_name);
-            break;
+    // `export { default } from './x'` 같은 순수 re-export도 body에서 `_default = <chain>`
+    // 할당을 만들어내므로 hoisted_var 선언 필요. symbol table에 synthetic_default가
+    // 등록돼 있으면 _default 변수가 실제로 emit된다는 뜻.
+    if (module.symbol_table) |*t| {
+        for (module.export_bindings) |eb| {
+            if (eb.kind == .re_export and eb.hasSyntheticDefault(t)) {
+                const def_name = if (metadata) |md| md.default_export_name else "_default";
+                try hoisted_var_names.append(allocator, def_name);
+                break;
+            }
         }
     }
 
@@ -557,9 +560,11 @@ pub fn emitEsmWrappedModule(
     // 소스 모듈의 wrap_kind에 따라 적절한 할당문을 직접 생성.
     var reexport_buf: std.ArrayList(u8) = .empty;
     defer reexport_buf.deinit(allocator);
+    const sym_table_opt = if (module.symbol_table) |*t| t else null;
     for (module.export_bindings) |eb| {
         if (eb.kind != .re_export) continue;
-        if (!std.mem.eql(u8, eb.local_name, "default")) continue;
+        const t = sym_table_opt orelse continue;
+        if (!eb.hasSyntheticDefault(t)) continue;
         const rec_idx = eb.import_record_index orelse continue;
         if (rec_idx >= module.import_records.len) continue;
         const source_mod_idx = module.import_records[rec_idx].resolved;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -387,16 +387,18 @@ pub const Linker = struct {
             });
         }
 
-        // codegen이 "_default" 합성 변수를 생성하는 모든 경우를 수집하여
+        // codegen이 현재 모듈에 `_default` 합성 변수를 만드는 모든 export를 수집.
         // 충돌 시 _default$N으로 리네이밍되도록 등록한다.
-        // local_name == "default"이면 codegen이 합성 _default 변수를 만든다.
         const owner: NameOwner = .{ .module_index = module_index, .exec_index = m.exec_index };
+        const sym_table_opt = if (m.symbol_table) |*t| t else null;
         for (m.export_bindings) |eb| {
-            if (std.mem.eql(u8, eb.local_name, "default")) {
-                if (eb.kind == .local or eb.kind == .re_export) {
+            if (sym_table_opt) |t| {
+                if (eb.hasSyntheticDefault(t)) {
                     try self.addNameOwner(name_to_owners, "_default", owner);
+                    continue;
                 }
-            } else if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
+            }
+            if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
                 // export default function foo → foo 이름으로 등록
                 if (module_scope.get(eb.local_name) == null) {
                     try self.addNameOwner(name_to_owners, eb.local_name, owner);

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -554,12 +554,13 @@ pub fn buildMetadataForAst(
 
     // collectModuleNames에서 등록한 _default 충돌의 canonical name을 조회.
     var default_export_name: []const u8 = "_default";
+    const sym_table_opt = if (m.symbol_table) |*t| t else null;
     for (m.export_bindings) |eb| {
-        if (std.mem.eql(u8, eb.local_name, "default") and
-            (eb.kind == .local or eb.kind == .re_export))
-        {
-            default_export_name = self.getCanonicalName(module_index, "_default") orelse "_default";
-            break;
+        if (sym_table_opt) |t| {
+            if (eb.hasSyntheticDefault(t)) {
+                default_export_name = self.getCanonicalName(module_index, "_default") orelse "_default";
+                break;
+            }
         }
         if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
             default_export_name = self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;


### PR DESCRIPTION
## Summary
#1328 Phase 4a 두 단계:

### 4a-1: CJS emit helpers를 cjs_wrap.zig로 분리
emitter.zig에 인라인돼 있던 \`emitDisabledModule\` / \`emitAssetModule\` / \`emitCjsWrapper\` 3개 헬퍼를 \`src/bundler/emitter/cjs_wrap.zig\` 신규 파일로 추출. esm_wrap/cjs_wrap 대칭 구조. 순수 리팩터.

### 4a-2: \`_default\` 판정을 symbol table에 단일화
"이 export 때문에 현재 모듈에 \`_default = <expr>\`가 emit되나?"를 판정하는 4곳이 문자열 \`local_name == \"default\"\` 비교를 각자 복제하고 있었음. symbol table을 single source of truth로 교체:

- **esm_wrap:257** (hoisted_var_names)
- **esm_wrap:562** (re-export 할당문 생성)
- **linker:395** (\`addNameOwner\`)
- **metadata:558** (\`default_export_name\` 조회)

모두 \`ExportBinding.hasSyntheticDefault(table)\` predicate 하나로 통일.

### populateSyntheticSymbols 정확도 개선
등록 조건을 codegen 실제 동작과 맞춤:
- \`local_name ∈ {_default, default}\` + exported_name=\"default\"
- 클래스/함수명 재사용 케이스(\`export default class Foo\` → local_name=\"Foo\")는 **제외** — 이전 \`has_local_default_binding\` 기준은 과도했음 (실제 codegen은 Foo 재사용, _default emit 안 함).

검증으로 \`const x = 1; export default x;\`가 \`_default\` 변수 없이 x만 남긴다는 점 bundled output에서 확인.

## Test plan
- [x] \`zig build test\` 통과 (Phase 1 단위 테스트를 실제 동작에 맞게 업데이트)
- [x] RN ExampleApp 통합 테스트 통과
- [x] #1321 barrel 회귀 + Platform.js 회귀 + #1312 global-identifier 모두 유지

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)