### PR TITLE
refactor(bundler): Phase 4d — Symbol.ref_count 수집 시작 (#1328)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -502,6 +502,7 @@ pub const Bundler = struct {
             try worker_linker.computeMangling();
         }
         worker_linker.populateReExportAliases(worker_graph.modules.items);
+        worker_linker.populateSymbolRefCounts(worker_graph.modules.items);
         defer worker_linker.deinit();
 
         // emit (IIFE 포맷)
@@ -665,6 +666,8 @@ pub const Bundler = struct {
             // Phase 3b (#1328): re_export_alias 심볼의 canonical_name 채우기.
             // computeRenames 이후에 호출해야 getCanonicalName이 최종 리네임을 반영.
             l.populateReExportAliases(graph.modules.items);
+            // Phase 4d (#1328): symbol-level ref_count 수집. tree-shaking companion metric.
+            l.populateSymbolRefCounts(graph.modules.items);
             break :blk l;
         } else null;
         defer if (linker) |*l| l.deinit();

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1151,6 +1151,42 @@ pub const Linker = struct {
         }
     }
 
+    /// #1328 Phase 4d: 모든 모듈의 import_bindings를 훑어 source 모듈 export 심볼의
+    /// `ref_count`를 증가시킨다. Tree-shaking의 companion metric — "몇 개 모듈이 이
+    /// export를 참조하나"를 symbol level에서 집계.
+    ///
+    /// 현재 tree_shaker가 statement-level reachability로 수행하는 분석과 별개로,
+    /// symbol 기반 usage 데이터를 축적한다. Phase 4e 이후 tree-shaker가 이 값을
+    /// 활용하도록 통합할 예정.
+    ///
+    /// link() + populateReExportAliases() 이후에 호출되어야 한다.
+    pub fn populateSymbolRefCounts(self: *const Linker, modules: []Module) void {
+        _ = self;
+        for (modules) |*importer| {
+            for (importer.import_bindings) |ib| {
+                if (ib.import_record_index >= importer.import_records.len) continue;
+                const source_mod_idx = importer.import_records[ib.import_record_index].resolved;
+                if (source_mod_idx.isNone()) continue;
+                const source_i = @intFromEnum(source_mod_idx);
+                if (source_i >= modules.len) continue;
+
+                const source_mod = &modules[source_i];
+                const table_ptr = if (source_mod.symbol_table) |*t| t else continue;
+
+                for (source_mod.export_bindings) |eb| {
+                    if (!std.mem.eql(u8, eb.exported_name, ib.imported_name)) continue;
+                    switch (eb.symbol) {
+                        .bundler => |b| {
+                            if (!b.symbol.isNone()) table_ptr.incRefCount(b.symbol);
+                        },
+                        .semantic => {},
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
     /// "default"는 JS 예약어 — 값 위치에 식별자로 사용 불가.
     /// codegen 합성 변수명(_default)의 canonical name으로 대체.
     fn safeIdentifierName(self: *const Linker, name: []const u8, module_index: u32) []const u8 {

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1318,3 +1318,48 @@ test "semantic: non-shorthand {x: y} does not reference x" {
         }
     }
 }
+
+// #1328 Phase 4d: populateSymbolRefCounts
+
+test "populateSymbolRefCounts: import이 source default symbol의 ref_count 증가" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import x from './b'; console.log(x);");
+    try writeFile(tmp.dir, "b.ts", "export default 42;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    r.linker.populateReExportAliases(r.graph.modules.items);
+    r.linker.populateSymbolRefCounts(r.graph.modules.items);
+
+    // b.ts의 synthetic_default symbol이 참조되어 ref_count == 1.
+    const b = &r.graph.modules.items[1];
+    const b_table = b.symbol_table orelse return error.NoSymbolTable;
+    const def_id = b_table.find("_default") orelse return error.DefaultNotRegistered;
+    try std.testing.expectEqual(@as(u32, 1), b_table.getRefCount(def_id));
+}
+
+test "populateSymbolRefCounts: 아무도 안 쓰는 export는 ref_count 0" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // entry는 named만 씀, default는 import 안 함
+    try writeFile(tmp.dir, "a.ts", "import { y } from './b'; console.log(y);");
+    try writeFile(tmp.dir, "b.ts", "export default 42; export const y = 1;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    r.linker.populateReExportAliases(r.graph.modules.items);
+    r.linker.populateSymbolRefCounts(r.graph.modules.items);
+
+    const b = &r.graph.modules.items[1];
+    const b_table = b.symbol_table orelse return error.NoSymbolTable;
+    const def_id = b_table.find("_default") orelse return error.DefaultNotRegistered;
+    // default는 미참조
+    try std.testing.expectEqual(@as(u32, 0), b_table.getRefCount(def_id));
+}


### PR DESCRIPTION
## Summary
#1328 Phase 4d — symbol-level usage count 수집 파이프라인. 현재 tree_shaker의 statement-level reachability 분석과 별개로 축적되는 companion metric. Phase 4e(semantic 통합) 이후 tree_shaker가 활용하도록 통합 예정.

## 변경
- \`Linker.populateSymbolRefCounts(modules)\` 신규 API: 모든 모듈의 \`import_bindings\`를 훑어 source 모듈의 대응 export 심볼 \`ref_count\`를 증가.
- bundler-space 심볼(\`synthetic_default\` / \`re_export_alias\`)만 카운트. semantic 심볼은 기존 \`semantic.reference_count\` 경로 사용.
- \`bundler.zig\`의 메인/worker 링킹 경로 모두에서 \`populateReExportAliases\` 직후 호출.

## Test plan
- [x] 단위 테스트 2건 (linker_test.zig): default import가 ref_count 증가 / 미참조 default는 0 유지
- [x] \`zig build test\` 통과
- [x] RN ExampleApp 통합 테스트 regression 없음

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)