### PR TITLE
refactor(bundler): Phase 4e-2b PoC — synthetic_default를 semantic 공간으로 이전

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -20,6 +20,8 @@ const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const symbol_mod = @import("symbol.zig");
 const SymbolTable = symbol_mod.SymbolTable;
+const semantic_symbol = @import("../semantic/symbol.zig");
+const SemanticSymbol = semantic_symbol.Symbol;
 
 pub const ImportBinding = struct {
     kind: Kind,
@@ -75,14 +77,28 @@ pub const ExportBinding = struct {
         re_export_all,
     };
 
-    /// 이 export 때문에 현재 모듈에 `_default` 합성 변수가 생기는지 symbol table로 확인.
-    /// linker.addNameOwner / metadata.default_export_name / esm_wrap 호이스팅·할당
-    /// 사이트의 단일 source of truth — scanner의 `populateSyntheticSymbols`가 이
-    /// predicate가 true가 될 조건에 대해 정확히 synthetic_default 심볼을 등록한다.
-    pub fn hasSyntheticDefault(self: ExportBinding, table: *const SymbolTable) bool {
+    /// 이 export 때문에 현재 모듈에 `_default` 합성 변수가 생기는지 확인.
+    /// #1328 Phase 4e-2b: symbol이 semantic/bundler 두 공간 중 하나에 등록될 수
+    /// 있으므로 둘 다 지원한다. `table`은 bundler 합성, `symbols`는 semantic
+    /// 배열 (ModuleSemanticData.symbols.items). 둘 중 하나만 있어도 호출 가능.
+    pub fn hasSyntheticDefault(
+        self: ExportBinding,
+        table: ?*const SymbolTable,
+        symbols: ?[]const SemanticSymbol,
+    ) bool {
         return switch (self.symbol) {
-            .bundler => |b| !b.symbol.isNone() and table.getKind(b.symbol) == .synthetic_default,
-            .semantic => false,
+            .bundler => |b| blk: {
+                const t = table orelse break :blk false;
+                break :blk !b.symbol.isNone() and t.getKind(b.symbol) == .synthetic_default;
+            },
+            .semantic => |s| blk: {
+                if (s.symbol.isNone()) break :blk false;
+                const syms = symbols orelse break :blk false;
+                const idx: u32 = @intFromEnum(s.symbol);
+                if (idx >= syms.len) break :blk false;
+                const sk = syms[idx].synthetic_kind orelse break :blk false;
+                break :blk sk == .default_export;
+            },
         };
     }
 };
@@ -606,29 +622,45 @@ pub fn collectNamespaceAccesses(
     }
 }
 
-/// export bindings를 훑어 bundler-local 합성 심볼을 등록하고 `ExportBinding.symbol`을
-/// 채운다. Cross-module re-export 연결은 linker가 `populateReExportAliases`에서 수행.
+/// export bindings를 훑어 합성 심볼을 등록하고 `ExportBinding.symbol`을 채운다.
+/// Cross-module re-export 연결은 linker가 `populateReExportAliases`에서 수행.
+///
+/// #1328 Phase 4e-2b: `synthetic_default`는 semantic 공간으로 이전됨.
+/// `sem_symbols`/`sem_names`가 주어지면 semantic에 등록하고 ExportBinding.symbol은
+/// `.semantic` variant. null이면 기존 bundler 경로 (테스트/semantic 분석 실패 fallback).
+/// `re_export_alias`는 semantic 의미와 맞지 않아 항상 bundler 공간에 유지 (RFC #1338).
 pub fn populateSyntheticSymbols(
     table: *SymbolTable,
     module_index: ModuleIndex,
     export_bindings: []ExportBinding,
+    sem_symbols: ?*std.ArrayList(SemanticSymbol),
+    sem_names: ?*std.AutoHashMap(u32, []const u8),
+    arena: std.mem.Allocator,
 ) !void {
     for (export_bindings) |*eb| {
         // codegen이 `_default = <expr>` 할당을 emit하는 export만 synthetic_default 등록.
-        // 조건: local_name이 실제 바인딩 이름("Foo" 등)이 아닌 합성 이름일 때 — 즉
-        //   - "_default": 익명 default (`export default 42`) 또는 리터럴
-        //   - "default": `export { default } from './x'` / `export default X`(X는 default-import)
-        //     → esm_wrap body가 `_default = <chain>` 할당
-        // `export default class Foo` 등 **클래스명 재사용** 케이스(local_name="Foo")는 제외 —
-        // codegen이 Foo를 그대로 쓰므로 _default가 emit되지 않는다.
         if ((eb.kind == .local or eb.kind == .re_export) and
             std.mem.eql(u8, eb.exported_name, "default") and
             (std.mem.eql(u8, eb.local_name, "_default") or std.mem.eql(u8, eb.local_name, "default")))
         {
+            if (sem_symbols) |syms_ptr| if (sem_names) |names_ptr| {
+                const sem_id = try semantic_symbol.extendSymbol(
+                    arena,
+                    syms_ptr,
+                    names_ptr,
+                    .variable_var,
+                    .default_export,
+                    "_default",
+                    eb.local_span,
+                );
+                eb.symbol = .{ .semantic = .{ .module = module_index, .symbol = sem_id } };
+                continue;
+            };
+            // Fallback (semantic 없음): bundler 공간에 등록.
             const id = try table.declare("_default", .synthetic_default, eb.local_span);
             eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };
         } else if (eb.kind == .re_export) {
-            // Phase 3b: .re_export마다 alias 심볼 생성. linker가 post-link 단계에서
+            // re_export_alias는 bundler 전용 — linker가 post-link 단계에서
             // resolveExportChain 결과를 canonical_name으로 저장한다.
             const id = try table.declareAnonymous(eb.exported_name, .re_export_alias, eb.local_span);
             eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -325,7 +325,7 @@ test "populateSyntheticSymbols: 리터럴 default만 _default 등록 (로컬 var
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, null, alloc);
     const id = table.find("_default") orelse return error.NotFound;
     try std.testing.expectEqual(symbol.SymbolKind.synthetic_default, table.getKind(id));
 }
@@ -342,7 +342,7 @@ test "populateSyntheticSymbols: `export default x`(x는 로컬)은 _default 미�
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, null, alloc);
     try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
 }
 
@@ -357,7 +357,7 @@ test "populateSyntheticSymbols: default 없으면 빈 테이블" {
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, null, alloc);
     try std.testing.expectEqual(@as(u32, 0), table.count());
     try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
 }
@@ -374,7 +374,7 @@ test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
     defer table.deinit();
 
     const m: types.ModuleIndex = @enumFromInt(7);
-    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings);
+    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings, null, null, alloc);
 
     // default export가 bundler ref로 채워졌는지
     try std.testing.expect(r.export_bindings[0].symbol.isValid());
@@ -399,7 +399,7 @@ test "populateSyntheticSymbols Phase 2: 비-default export는 invalid 유지" {
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, null, alloc);
 
     // 일반 named export는 Phase 2에선 아직 미연결 (Phase 3에서 semantic 심볼과 연결)
     try std.testing.expect(!r.export_bindings[0].symbol.isValid());

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -926,7 +926,7 @@ pub fn emitModule(
                         }
                     } else {
                         // tree-shaker 없으면 기존 방식 (모듈 내부 computeReachable)
-                        if (stmt_info_mod.build(arena_alloc, &transformer.ast, sem.symbols, sym_ids)) |maybe_infos| {
+                        if (stmt_info_mod.build(arena_alloc, &transformer.ast, sem.symbols.items, sym_ids)) |maybe_infos| {
                             if (maybe_infos) |infos| {
                                 var used_sym_buf: std.ArrayListUnmanaged(u32) = .empty;
                                 defer used_sym_buf.deinit(arena_alloc);
@@ -1203,7 +1203,7 @@ fn propagateCrossModulePurity(
     // 1단계: no_side_effects인 import binding의 local symbol_id를 수집한다.
     // 비트셋 대신 bool 배열 사용 — 스택 256개, 초과 시 arena fallback.
     var has_any_pure = false;
-    const sym_count = sem.symbols.len;
+    const sym_count = sem.symbols.items.len;
     if (sym_count == 0) return;
 
     var pure_flags_buf: [256]bool = .{false} ** 256;
@@ -1234,8 +1234,8 @@ fn propagateCrossModulePurity(
             resolved.canonical.export_name;
 
         const target_sym_idx = target_scope.get(target_sym_name) orelse continue;
-        if (target_sym_idx >= target_sem.symbols.len) continue;
-        if (!target_sem.symbols[target_sym_idx].decl_flags.no_side_effects) continue;
+        if (target_sym_idx >= target_sem.symbols.items.len) continue;
+        if (!target_sem.symbols.items[target_sym_idx].decl_flags.no_side_effects) continue;
 
         const local_sym_idx = module_scope.get(ib.local_name) orelse continue;
         if (local_sym_idx >= sym_count) continue;

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -24,6 +24,7 @@ const stmt_info_mod = @import("../stmt_info.zig");
 const ExportBinding = @import("../binding_scanner.zig").ExportBinding;
 const symbol_mod = @import("../symbol.zig");
 const SymbolRef = symbol_mod.SymbolRef;
+const semantic_symbol = @import("../../semantic/symbol.zig");
 const parent = @import("../emitter.zig");
 const EmitOptions = parent.EmitOptions;
 const resolveNodeName = parent.resolveNodeName;
@@ -44,10 +45,23 @@ fn localBundlerSymbol(ref: SymbolRef, mod: *const Module) ?symbol_mod.SymbolId {
 
 /// ExportBinding.symbol이 현재 모듈의 synthetic_default 심볼인지 확인.
 /// 현재 모듈의 `_default = <expr>` 할당을 참조할 수 있음을 의미.
+/// #1328 Phase 4e-2b: semantic 공간 등록도 지원.
 fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
-    const id = localBundlerSymbol(ref, mod) orelse return false;
-    const table = mod.symbol_table orelse return false;
-    return table.getKind(id) == .synthetic_default;
+    return switch (ref) {
+        .bundler => |b| blk: {
+            if (b.module != mod.index or b.symbol.isNone()) break :blk false;
+            const table = mod.symbol_table orelse break :blk false;
+            break :blk table.getKind(b.symbol) == .synthetic_default;
+        },
+        .semantic => |s| blk: {
+            if (s.module != mod.index or s.symbol.isNone()) break :blk false;
+            const sem = mod.semantic orelse break :blk false;
+            const idx: u32 = @intFromEnum(s.symbol);
+            if (idx >= sem.symbols.items.len) break :blk false;
+            const sk = sem.symbols.items[idx].synthetic_kind orelse break :blk false;
+            break :blk sk == .default_export;
+        },
+    };
 }
 
 /// re_export_alias에 linker가 주입한 canonical_name을 반환. null이면
@@ -254,9 +268,11 @@ pub fn emitEsmWrappedModule(
     // `export { default } from './x'` 같은 순수 re-export도 body에서 `_default = <chain>`
     // 할당을 만들어내므로 hoisted_var 선언 필요. symbol table에 synthetic_default가
     // 등록돼 있으면 _default 변수가 실제로 emit된다는 뜻.
-    if (module.symbol_table) |*t| {
+    {
+        const t_opt = if (module.symbol_table) |*t| t else null;
+        const syms_opt: ?[]const semantic_symbol.Symbol = if (module.semantic) |sem| sem.symbols.items else null;
         for (module.export_bindings) |eb| {
-            if (eb.kind == .re_export and eb.hasSyntheticDefault(t)) {
+            if (eb.kind == .re_export and eb.hasSyntheticDefault(t_opt, syms_opt)) {
                 const def_name = if (metadata) |md| md.default_export_name else "_default";
                 try hoisted_var_names.append(allocator, def_name);
                 break;
@@ -561,10 +577,10 @@ pub fn emitEsmWrappedModule(
     var reexport_buf: std.ArrayList(u8) = .empty;
     defer reexport_buf.deinit(allocator);
     const sym_table_opt = if (module.symbol_table) |*t| t else null;
+    const sem_syms_opt: ?[]const semantic_symbol.Symbol = if (module.semantic) |sem| sem.symbols.items else null;
     for (module.export_bindings) |eb| {
         if (eb.kind != .re_export) continue;
-        const t = sym_table_opt orelse continue;
-        if (!eb.hasSyntheticDefault(t)) continue;
+        if (!eb.hasSyntheticDefault(sym_table_opt, sem_syms_opt)) continue;
         const rec_idx = eb.import_record_index orelse continue;
         if (rec_idx >= module.import_records.len) continue;
         const source_mod_idx = module.import_records[rec_idx].resolved;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -735,7 +735,7 @@ pub const ModuleGraph = struct {
             analyzer.enable_stmt_info = true;
             if (analyzer.analyze()) |_| {
                 module.semantic = .{
-                    .symbols = analyzer.symbols.items,
+                    .symbols = analyzer.symbols,
                     .scopes = analyzer.scopes.items,
                     .scope_maps = analyzer.scope_maps.items,
                     .exported_names = analyzer.exported_names,
@@ -938,7 +938,7 @@ pub const ModuleGraph = struct {
         // OOM 시 semantic = null로 유지 (부분 데이터로 linker가 오동작하는 것 방지)
         if (analyze_ok) {
             module.semantic = .{
-                .symbols = analyzer.symbols.items,
+                .symbols = analyzer.symbols,
                 .scopes = analyzer.scopes.items,
                 .scope_maps = analyzer.scope_maps.items,
                 .exported_names = analyzer.exported_names,

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -766,9 +766,27 @@ pub const ModuleGraph = struct {
             module.export_bindings = binding_scanner_mod.extractExportBindings(arena_alloc, &(module.ast.?), scan_result.records, module.import_bindings) catch &.{};
 
             // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
-            // Consumer 연결은 Phase 2+. 지금은 shadow population만.
+            // Phase 4e-2b: synthetic_default는 semantic 공간에 등록 (가능하면).
             module.ensureSymbolTable(self.allocator);
-            binding_scanner_mod.populateSyntheticSymbols(&module.symbol_table.?, module.index, module.export_bindings) catch {};
+            if (module.semantic) |*sem| {
+                binding_scanner_mod.populateSyntheticSymbols(
+                    &module.symbol_table.?,
+                    module.index,
+                    module.export_bindings,
+                    &sem.symbols,
+                    &sem.synthetic_names,
+                    arena_alloc,
+                ) catch {};
+            } else {
+                binding_scanner_mod.populateSyntheticSymbols(
+                    &module.symbol_table.?,
+                    module.index,
+                    module.export_bindings,
+                    null,
+                    null,
+                    arena_alloc,
+                ) catch {};
+            }
 
             module.state = .parsed;
             return;
@@ -1035,8 +1053,27 @@ pub const ModuleGraph = struct {
             binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &parser.ast, module.import_bindings) catch {};
 
             // Phase 1-3b (#1328): 합성 심볼 테이블 초기화 + _default / re_export_alias 등록.
+            // Phase 4e-2b: synthetic_default는 semantic 공간에 등록 (가능하면).
             module.ensureSymbolTable(self.allocator);
-            binding_scanner_mod.populateSyntheticSymbols(&module.symbol_table.?, module.index, module.export_bindings) catch {};
+            if (module.semantic) |*sem| {
+                binding_scanner_mod.populateSyntheticSymbols(
+                    &module.symbol_table.?,
+                    module.index,
+                    module.export_bindings,
+                    &sem.symbols,
+                    &sem.synthetic_names,
+                    arena_alloc,
+                ) catch {};
+            } else {
+                binding_scanner_mod.populateSyntheticSymbols(
+                    &module.symbol_table.?,
+                    module.index,
+                    module.export_bindings,
+                    null,
+                    null,
+                    arena_alloc,
+                ) catch {};
+            }
 
             // CJS/ESM 감지 — inline scan 결과로 ScanResult 생성
             const scan_result = import_scanner.ScanResult{

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -742,6 +742,7 @@ pub const ModuleGraph = struct {
                     .symbol_ids = analyzer.symbol_ids.items,
                     .unresolved_references = analyzer.unresolved_references,
                     .ref_scope_pairs = analyzer.ref_scope_pairs.items,
+                    .synthetic_names = std.AutoHashMap(u32, []const u8).init(arena_alloc),
                 };
                 if (analyzer.stmt_declared.items.len > 0) {
                     module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
@@ -945,6 +946,7 @@ pub const ModuleGraph = struct {
                 .symbol_ids = analyzer.symbol_ids.items,
                 .unresolved_references = analyzer.unresolved_references,
                 .ref_scope_pairs = analyzer.ref_scope_pairs.items,
+                .synthetic_names = std.AutoHashMap(u32, []const u8).init(arena_alloc),
             };
             // TLA 감지: semantic analyzer가 스코프 체인을 추적하며 정확히 판별
             module.uses_top_level_await = analyzer.has_top_level_await;

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -353,7 +353,7 @@ test "graph: semantic data preserved after build" {
     try std.testing.expect(sem.exported_names.get("x") != null);
     try std.testing.expect(sem.exported_names.get("greet") != null);
     // symbols 배열이 비어있지 않아야 함
-    try std.testing.expect(sem.symbols.len > 0);
+    try std.testing.expect(sem.symbols.items.len > 0);
     // scopes 배열이 비어있지 않아야 함
     try std.testing.expect(sem.scopes.len > 0);
 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -21,6 +21,7 @@ const ExportBinding = @import("binding_scanner.zig").ExportBinding;
 const Span = @import("../lexer/token.zig").Span;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Ast = @import("../parser/ast.zig").Ast;
+const semantic_symbol = @import("../semantic/symbol.zig");
 
 /// namespace 접근 패턴에서 생성되는 변수 prefix.
 /// metadata.zig, codegen.zig, emitter.zig에서 공유.
@@ -391,12 +392,11 @@ pub const Linker = struct {
         // 충돌 시 _default$N으로 리네이밍되도록 등록한다.
         const owner: NameOwner = .{ .module_index = module_index, .exec_index = m.exec_index };
         const sym_table_opt = if (m.symbol_table) |*t| t else null;
+        const sem_syms_opt: ?[]const semantic_symbol.Symbol = if (m.semantic) |s| s.symbols.items else null;
         for (m.export_bindings) |eb| {
-            if (sym_table_opt) |t| {
-                if (eb.hasSyntheticDefault(t)) {
-                    try self.addNameOwner(name_to_owners, "_default", owner);
-                    continue;
-                }
+            if (eb.hasSyntheticDefault(sym_table_opt, sem_syms_opt)) {
+                try self.addNameOwner(name_to_owners, "_default", owner);
+                continue;
             }
             if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
                 // export default function foo → foo 이름으로 등록
@@ -1172,13 +1172,21 @@ pub const Linker = struct {
 
                 const key = makeExportKeyBuf(&key_buf, source_i, ib.imported_name);
                 const entry = self.export_map.get(key) orelse continue;
-                const sym = switch (entry.binding.symbol) {
-                    .bundler => |b| b,
-                    .semantic => continue,
-                };
-                if (sym.symbol.isNone()) continue;
-                const table_ptr = if (modules[source_i].symbol_table) |*t| t else continue;
-                table_ptr.incRefCount(sym.symbol);
+                switch (entry.binding.symbol) {
+                    .bundler => |b| {
+                        if (b.symbol.isNone()) continue;
+                        const table_ptr = if (modules[source_i].symbol_table) |*t| t else continue;
+                        table_ptr.incRefCount(b.symbol);
+                    },
+                    .semantic => |s| {
+                        // #1328 Phase 4e-2b: semantic 공간의 합성/정규 심볼 ref_count 증가.
+                        if (s.symbol.isNone()) continue;
+                        const sem_ptr = if (modules[source_i].semantic) |*sem| sem else continue;
+                        const idx: u32 = @intFromEnum(s.symbol);
+                        if (idx >= sem_ptr.symbols.items.len) continue;
+                        sem_ptr.symbols.items[idx].reference_count += 1;
+                    },
+                }
             }
         }
     }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -354,7 +354,7 @@ pub const Linker = struct {
             // 단, CJS 모듈을 import하면 preamble에서 `var X = require_xxx().X`로 변수가 생성되므로
             // 충돌 대상에 포함해야 한다.
             const sym_idx = scope_entry.value_ptr.*;
-            if (sym_idx < sem.symbols.len and sem.symbols[sym_idx].decl_flags.is_import) {
+            if (sym_idx < sem.symbols.items.len and sem.symbols.items[sym_idx].decl_flags.is_import) {
                 // import binding이 top-level 변수를 생성하는 경우에만 충돌 대상에 포함:
                 // - CJS preamble: var X = require_xxx().X
                 // - __esm 호이스팅: var X; (래퍼 밖으로 호이스팅)
@@ -628,7 +628,7 @@ pub const Linker = struct {
                 if (std.mem.eql(u8, sym_name, "default")) continue;
                 if (std.mem.eql(u8, sym_name, "arguments")) continue;
 
-                const ref_count: u32 = if (sym_idx < sem.symbols.len) sem.symbols[sym_idx].reference_count else 0;
+                const ref_count: u32 = if (sym_idx < sem.symbols.items.len) sem.symbols.items[sym_idx].reference_count else 0;
                 const prev = name_refs.get(sym_name) orelse 0;
                 try name_refs.put(sym_name, prev + ref_count);
             }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -10,6 +10,7 @@ const ExportBinding = @import("../binding_scanner.zig").ExportBinding;
 const Span = @import("../../lexer/token.zig").Span;
 const NodeIndex = @import("../../parser/ast.zig").NodeIndex;
 const Ast = @import("../../parser/ast.zig").Ast;
+const semantic_symbol = @import("../../semantic/symbol.zig");
 const linker_mod = @import("../linker.zig");
 const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
@@ -555,12 +556,11 @@ pub fn buildMetadataForAst(
     // collectModuleNames에서 등록한 _default 충돌의 canonical name을 조회.
     var default_export_name: []const u8 = "_default";
     const sym_table_opt = if (m.symbol_table) |*t| t else null;
+    const sem_syms_opt: ?[]const semantic_symbol.Symbol = if (m.semantic) |s| s.symbols.items else null;
     for (m.export_bindings) |eb| {
-        if (sym_table_opt) |t| {
-            if (eb.hasSyntheticDefault(t)) {
-                default_export_name = self.getCanonicalName(module_index, "_default") orelse "_default";
-                break;
-            }
+        if (eb.hasSyntheticDefault(sym_table_opt, sem_syms_opt)) {
+            default_export_name = self.getCanonicalName(module_index, "_default") orelse "_default";
+            break;
         }
         if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
             default_export_name = self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -510,23 +510,23 @@ pub fn buildMetadataForAst(
 
         // nested scope mangling (liveness 기반)
         // top-level은 computeMangling에서 처리됨 → nested만 수행
-        if (self.nested_mangling_enabled and sem.symbols.len > 0) {
+        if (self.nested_mangling_enabled and sem.symbols.items.len > 0) {
             const Mangler = @import("../../codegen/mangler.zig");
 
             // top-level scope + export/import 심볼은 skip
-            var skip_syms = try std.DynamicBitSet.initEmpty(self.allocator, sem.symbols.len);
+            var skip_syms = try std.DynamicBitSet.initEmpty(self.allocator, sem.symbols.items.len);
             defer skip_syms.deinit();
 
             // scope_maps[0] (module scope)의 모든 심볼을 skip
             var skip_it = module_scope.iterator();
             while (skip_it.next()) |skip_entry| {
                 const sym_i = skip_entry.value_ptr.*;
-                if (sym_i < sem.symbols.len) skip_syms.set(sym_i);
+                if (sym_i < sem.symbols.items.len) skip_syms.set(sym_i);
             }
 
             var nested_result = try Mangler.mangle(self.allocator, .{
                 .scopes = sem.scopes,
-                .symbols = sem.symbols,
+                .symbols = sem.symbols.items,
                 .scope_maps = sem.scope_maps,
                 .ref_scope_pairs = sem.ref_scope_pairs,
                 .source = m.source,
@@ -744,8 +744,8 @@ pub fn buildCrossModuleConstValues(
             }
         }
         const target_sym_idx = target_sem.scope_maps[0].get(local_name) orelse continue;
-        if (target_sym_idx >= target_sem.symbols.len) continue;
-        const cv = target_sem.symbols[target_sym_idx].const_value;
+        if (target_sym_idx >= target_sem.symbols.items.len) continue;
+        const cv = target_sem.symbols.items[target_sym_idx].const_value;
         if (cv.kind == .none or !cv.isSafeToInline()) continue;
         // import binding의 local symbol에 매핑
         if (sem.scope_maps.len > 0) {

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1336,10 +1336,18 @@ test "populateSymbolRefCounts: import이 source default symbol의 ref_count 증�
     r.linker.populateSymbolRefCounts(r.graph.modules.items);
 
     // b.ts의 synthetic_default symbol이 참조되어 ref_count == 1.
+    // #1328 Phase 4e-2b: _default는 semantic 공간에 등록됨.
     const b = &r.graph.modules.items[1];
-    const b_table = b.symbol_table orelse return error.NoSymbolTable;
-    const def_id = b_table.find("_default") orelse return error.DefaultNotRegistered;
-    try std.testing.expectEqual(@as(u32, 1), b_table.getRefCount(def_id));
+    const b_sem = b.semantic orelse return error.NoSemantic;
+    var found_ref: u32 = 0;
+    for (b_sem.symbols.items) |sym| {
+        const sk = sym.synthetic_kind orelse continue;
+        if (sk == .default_export) {
+            found_ref = sym.reference_count;
+            break;
+        }
+    } else return error.DefaultNotRegistered;
+    try std.testing.expectEqual(@as(u32, 1), found_ref);
 }
 
 test "populateSymbolRefCounts: 아무도 안 쓰는 export는 ref_count 0" {
@@ -1358,8 +1366,17 @@ test "populateSymbolRefCounts: 아무도 안 쓰는 export는 ref_count 0" {
     r.linker.populateSymbolRefCounts(r.graph.modules.items);
 
     const b = &r.graph.modules.items[1];
-    const b_table = b.symbol_table orelse return error.NoSymbolTable;
-    const def_id = b_table.find("_default") orelse return error.DefaultNotRegistered;
-    // default는 미참조
-    try std.testing.expectEqual(@as(u32, 0), b_table.getRefCount(def_id));
+    const b_sem = b.semantic orelse return error.NoSemantic;
+    var found_ref: u32 = 0;
+    var found_default = false;
+    for (b_sem.symbols.items) |sym| {
+        const sk = sym.synthetic_kind orelse continue;
+        if (sk == .default_export) {
+            found_ref = sym.reference_count;
+            found_default = true;
+            break;
+        }
+    }
+    if (!found_default) return error.DefaultNotRegistered;
+    try std.testing.expectEqual(@as(u32, 0), found_ref);
 }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -28,7 +28,11 @@ pub const SymbolTable = symbol_mod.SymbolTable;
 /// Semantic analyzer 결과. parse_arena가 소유하는 데이터의 참조.
 /// linker가 import→export 연결 + 이름 충돌 해결에 사용.
 pub const ModuleSemanticData = struct {
-    symbols: []const Symbol,
+    /// Semantic 심볼 배열. parse_arena가 backing 메모리를 소유.
+    /// #1328 Phase 4e-2 / RFC #1338: ArrayList로 보관하여 bundler가
+    /// `extendSymbol`로 합성 심볼을 post-semantic 단계에 추가할 수 있게 한다.
+    /// 읽기는 `.items` 사용.
+    symbols: std.ArrayList(Symbol),
     scopes: []const Scope,
     /// 스코프별 이름→심볼 인덱스 조회. scope_maps[scope_id].get("x") → symbol index.
     scope_maps: []const std.StringHashMap(usize),

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -45,6 +45,20 @@ pub const ModuleSemanticData = struct {
     unresolved_references: std.StringHashMap(void),
     /// mangler용 참조 scope 페어. liveness BitSet 계산에 사용.
     ref_scope_pairs: []const RefScopePair = &.{},
+
+    /// 합성 심볼(`Symbol.synthetic_kind != null`)의 이름 사이드카.
+    /// #1338 옵션 B: 합성 심볼만 이 맵에 기록 — 정규 심볼은 Symbol.name(source Span)만
+    /// 사용하므로 메모리 오버헤드 zero. key = symbol id(u32), value = 이름 문자열
+    /// (parse_arena가 소유하거나 정적 문자열).
+    synthetic_names: std.AutoHashMap(u32, []const u8),
+
+    /// 심볼 id에 해당하는 이름을 반환. 합성은 사이드카에서, 정규는 source Span에서.
+    pub fn symbolName(self: *const ModuleSemanticData, id: u32, source: []const u8) []const u8 {
+        if (self.synthetic_names.get(id)) |name| return name;
+        if (id >= self.symbols.items.len) return "";
+        const s = self.symbols.items[id];
+        return source[s.name.start..s.name.end];
+    }
 };
 
 pub const Module = struct {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -280,7 +280,7 @@ pub const TreeShaker = struct {
             module_stmt_infos[i] = stmt_info_mod.build(
                 self.allocator,
                 ast,
-                sem.symbols,
+                sem.symbols.items,
                 sem.symbol_ids,
             ) catch null;
         }
@@ -430,7 +430,7 @@ pub const TreeShaker = struct {
             if (!self.included.isSet(i)) continue;
             const sem = mod.semantic orelse continue;
             if (sem.scope_maps.len == 0 or mod.import_bindings.len == 0) continue;
-            var arr = try self.allocator.alloc(?u32, sem.symbols.len);
+            var arr = try self.allocator.alloc(?u32, sem.symbols.items.len);
             for (arr) |*a| a.* = null;
             for (mod.import_bindings, 0..) |ib, ib_idx| {
                 if (sem.scope_maps[0].get(ib.local_name)) |sym_idx| {
@@ -900,7 +900,7 @@ pub const TreeShaker = struct {
         if (m.semantic) |sem| {
             if (sem.scope_maps.len > 0) {
                 if (sem.scope_maps[0].get(ib.local_name)) |sym_idx| {
-                    if (sym_idx < sem.symbols.len and sem.symbols[sym_idx].reference_count > 0) return true;
+                    if (sym_idx < sem.symbols.items.len and sem.symbols.items[sym_idx].reference_count > 0) return true;
                 }
             }
         } else return true;

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -273,6 +273,33 @@ pub const Symbol = struct {
     }
 };
 
+/// Bundler가 post-semantic 단계에서 합성 심볼을 semantic 공간에 추가한다.
+/// #1328 Phase 4e-2 / RFC #1338.
+///
+/// `list`는 `ModuleSemanticData.symbols`의 ArrayList이어야 하고,
+/// `allocator`는 해당 모듈의 `parse_arena`여야 한다 (name/span 수명 일치).
+///
+/// 반환된 SymbolId로 `SymbolRef { .semantic = { module, id } }` 구성 가능.
+pub fn extendSymbol(
+    allocator: std.mem.Allocator,
+    list: *std.ArrayList(Symbol),
+    kind: SymbolKind,
+    synthetic: SyntheticKind,
+    name: Span,
+    declaration_span: Span,
+) !SymbolId {
+    const id: SymbolId = @enumFromInt(@as(u32, @intCast(list.items.len)));
+    try list.append(allocator, .{
+        .name = name,
+        .scope_id = ScopeId.none,
+        .kind = kind,
+        .decl_flags = kind.declFlags(),
+        .declaration_span = declaration_span,
+        .synthetic_kind = synthetic,
+    });
+    return id;
+}
+
 /// 참조 발생 시 (심볼 인덱스, 참조 스코프) 쌍.
 /// mangler의 liveness BitSet 계산에 사용: 심볼이 어느 스코프에서 참조되는지 추적.
 /// analyzer.resolveIdentifier에서 수집, mangler.mangleLiveness에서 소비.

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -193,6 +193,21 @@ pub const DeclFlags = packed struct(u16) {
     }
 };
 
+/// Bundler가 생성한 합성 심볼 종류. #1328 Phase 4e-2.
+/// 선언 소스가 AST에 없는 심볼 — linker가 cross-module 연결용으로 추가.
+/// `re_export_alias`/`unresolved_external`은 값 의미가 없어 semantic 공간에
+/// 얹지 않으며, bundler 전용 `AliasTable`에 남는다 (RFC #1338 결정).
+pub const SyntheticKind = enum(u8) {
+    /// `export default ...` 합성 변수 (`_default`, `_default$N`)
+    default_export,
+    /// CJS 래퍼의 `exports_<module>` 객체
+    cjs_exports,
+    /// ESM 래퍼의 `init_<module>` 함수
+    esm_init,
+    /// `import * as X` namespace 객체
+    namespace,
+};
+
 /// 컴파일 타임 상수 값. 번들러에서 크로스-모듈 인라인에 사용.
 /// `const x = false` → ConstValue{ .kind = .false_ }
 pub const ConstValue = struct {
@@ -242,9 +257,19 @@ pub const Symbol = struct {
     /// const/let 선언의 초기화 값이 리터럴이면 설정.
     const_value: ConstValue = .{},
 
+    /// Bundler가 추가한 합성 심볼 종류. null = AST 선언에서 온 정규 심볼.
+    /// #1328 Phase 4e-2: `extendSymbol`로 추가된 심볼만 non-null.
+    synthetic_kind: ?SyntheticKind = null,
+
     /// 이 심볼의 이름을 소스에서 읽는다.
+    /// 합성 심볼(`synthetic_kind != null`)은 `span`이 소스 범위 밖을 가리킬 수 있어
+    /// caller는 `isSynthetic()`을 먼저 확인해야 한다.
     pub fn nameText(self: *const Symbol, source: []const u8) []const u8 {
         return source[self.name.start..self.name.end];
+    }
+
+    pub fn isSynthetic(self: *const Symbol) bool {
+        return self.synthetic_kind != null;
     }
 };
 

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -276,28 +276,34 @@ pub const Symbol = struct {
 /// Bundler가 post-semantic 단계에서 합성 심볼을 semantic 공간에 추가한다.
 /// #1328 Phase 4e-2 / RFC #1338.
 ///
-/// `list`는 `ModuleSemanticData.symbols`의 ArrayList이어야 하고,
-/// `allocator`는 해당 모듈의 `parse_arena`여야 한다 (name/span 수명 일치).
+/// `list`는 `ModuleSemanticData.symbols`의 ArrayList, `names`는 같은 data의
+/// 합성 이름 사이드카 맵이어야 한다. `allocator`는 해당 모듈의 `parse_arena`.
+///
+/// 합성 심볼은 소스 범위의 name span을 갖지 않으므로 `Symbol.name`은
+/// 빈 Span으로 두고 실제 이름은 `synthetic_names` 맵에 저장한다.
+/// 조회는 `ModuleSemanticData.symbolName(id, source)` 경유 (옵션 B).
 ///
 /// 반환된 SymbolId로 `SymbolRef { .semantic = { module, id } }` 구성 가능.
 pub fn extendSymbol(
     allocator: std.mem.Allocator,
     list: *std.ArrayList(Symbol),
+    names: *std.AutoHashMap(u32, []const u8),
     kind: SymbolKind,
     synthetic: SyntheticKind,
-    name: Span,
+    name_text: []const u8,
     declaration_span: Span,
 ) !SymbolId {
-    const id: SymbolId = @enumFromInt(@as(u32, @intCast(list.items.len)));
+    const id_u32: u32 = @intCast(list.items.len);
     try list.append(allocator, .{
-        .name = name,
+        .name = .{ .start = 0, .end = 0 },
         .scope_id = ScopeId.none,
         .kind = kind,
         .decl_flags = kind.declFlags(),
         .declaration_span = declaration_span,
         .synthetic_kind = synthetic,
     });
-    return id;
+    try names.put(id_u32, name_text);
+    return @enumFromInt(id_u32);
 }
 
 /// 참조 발생 시 (심볼 인덱스, 참조 스코프) 쌍.


### PR DESCRIPTION
## 요약

RFC #1338 의 Phase 4e-2b PoC. bundler의 `synthetic_default` 합성 심볼을
semantic symbol 공간(SymbolRef.semantic variant)으로 이전한다.
4e-2a 확장 인프라(필드/API/ArrayList 전환) + 4e-2b 실제 migration을
커밋 단위로 분리해 bisect 가능한 PR로 구성.

Closes #1338의 Phase 4e-2b 항목. 남은 4e-2c/2d/2e는 후속 PR.

## 커밋 구조

1. `a40f7130` — SyntheticKind enum + Symbol.synthetic_kind 필드 (4e-2a 준비)
2. `a555bf46` — extendSymbol API + ModuleSemanticData.symbols ArrayList 전환 (4e-2a 본론, 14 consumer 업데이트)
3. `fba5c26c` — synthetic_names 사이드카 맵 + extendSymbol 시그니처 확장 (옵션 B)
4. `504641dc` — synthetic_default 실제 migration + 4개 consumer + 2개 회귀 테스트 업데이트

## 설계 결정

- **옵션 B (사이드카 맵)**: 합성 이름은 `ModuleSemanticData.synthetic_names: AutoHashMap(u32, []const u8)`에 저장. 정규 심볼은 zero 오버헤드.
- **옵션 Y (canonical_name 재사용)**: `_default\$N` 충돌은 linker의 기존 `canonical_names: StringHashMap`이 처리 — semantic.Symbol에 필드 추가하지 않음.
- **`re_export_alias` 제외**: 값 없는 cross-module hop은 semantic scope 의미와 맞지 않아 bundler 전용 유지. RFC #1338 결정.

## 측정 (RN ExampleApp, 568 modules, --target=es5)

| | main | PoC |
|---|---|---|
| avg total | 801.3 ms | **789.5 ms** |
| min | 790 | 778 |
| max | 816 | 795 |

예측대로 semantic 확장 오버헤드 무시 가능 (노이즈 범위 내 regression 없음, 오히려 소폭 개선).

## 테스트

- 전체 2917개 유닛 테스트 통과
- 통합 테스트 2879 pass / 0 fail (es5-rn RN ExampleApp 포함)
- #1321 barrel / Platform.js / #1312 global re-export 회귀 테스트 통과
- Phase 4d `populateSymbolRefCounts` 테스트 2개를 semantic 경로로 업데이트

## 후속 작업

- 4e-2c: `synthetic_exports` / `synthetic_init` / `synthetic_namespace` 이전
- 4e-2d: SymbolRef union → 단일 u32 평탄화 (re_export_alias는 별도 AliasId)
- 4e-2e: bundler SymbolTable을 `AliasTable`로 축소
- 4c (prereq 별도 이슈): export registry로 문자열 필드 제거

## Test plan

- [x] \`zig build test\` 통과 확인
- [x] \`cd tests/integration && bun test\` 통과 확인
- [x] RN ExampleApp \`--timing\` 측정으로 regression 없음 확인
- [ ] 리뷰어: semantic symbol에 post-analyze 쓰기가 semantic pass의 의도와 충돌하는지 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)