### PR TITLE
refactor(bundler): Phase 4e-2c — synthetic wrapper 심볼 semantic 통합

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -626,7 +626,7 @@ pub fn collectNamespaceAccesses(
 /// Cross-module re-export 연결은 linker가 `populateReExportAliases`에서 수행.
 ///
 /// #1328 Phase 4e-2b: `synthetic_default`는 semantic 공간으로 이전됨.
-/// `sem_symbols`/`sem_names`가 주어지면 semantic에 등록하고 ExportBinding.symbol은
+/// `sem_symbols`가 주어지면 semantic에 등록하고 ExportBinding.symbol은
 /// `.semantic` variant. null이면 기존 bundler 경로 (테스트/semantic 분석 실패 fallback).
 /// `re_export_alias`는 semantic 의미와 맞지 않아 항상 bundler 공간에 유지 (RFC #1338).
 pub fn populateSyntheticSymbols(
@@ -634,7 +634,6 @@ pub fn populateSyntheticSymbols(
     module_index: ModuleIndex,
     export_bindings: []ExportBinding,
     sem_symbols: ?*std.ArrayList(SemanticSymbol),
-    sem_names: ?*std.AutoHashMap(u32, []const u8),
     arena: std.mem.Allocator,
 ) !void {
     for (export_bindings) |*eb| {
@@ -643,11 +642,10 @@ pub fn populateSyntheticSymbols(
             std.mem.eql(u8, eb.exported_name, "default") and
             (std.mem.eql(u8, eb.local_name, "_default") or std.mem.eql(u8, eb.local_name, "default")))
         {
-            if (sem_symbols) |syms_ptr| if (sem_names) |names_ptr| {
+            if (sem_symbols) |syms_ptr| {
                 const sem_id = try semantic_symbol.extendSymbol(
                     arena,
                     syms_ptr,
-                    names_ptr,
                     .variable_var,
                     .default_export,
                     "_default",
@@ -655,7 +653,7 @@ pub fn populateSyntheticSymbols(
                 );
                 eb.symbol = .{ .semantic = .{ .module = module_index, .symbol = sem_id } };
                 continue;
-            };
+            }
             // Fallback (semantic 없음): bundler 공간에 등록.
             const id = try table.declare("_default", .synthetic_default, eb.local_span);
             eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -325,7 +325,7 @@ test "populateSyntheticSymbols: 리터럴 default만 _default 등록 (로컬 var
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, null, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, alloc);
     const id = table.find("_default") orelse return error.NotFound;
     try std.testing.expectEqual(symbol.SymbolKind.synthetic_default, table.getKind(id));
 }
@@ -342,7 +342,7 @@ test "populateSyntheticSymbols: `export default x`(x는 로컬)은 _default 미�
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, null, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, alloc);
     try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
 }
 
@@ -357,7 +357,7 @@ test "populateSyntheticSymbols: default 없으면 빈 테이블" {
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, null, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, alloc);
     try std.testing.expectEqual(@as(u32, 0), table.count());
     try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
 }
@@ -374,7 +374,7 @@ test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
     defer table.deinit();
 
     const m: types.ModuleIndex = @enumFromInt(7);
-    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings, null, null, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings, null, alloc);
 
     // default export가 bundler ref로 채워졌는지
     try std.testing.expect(r.export_bindings[0].symbol.isValid());
@@ -399,7 +399,7 @@ test "populateSyntheticSymbols Phase 2: 비-default export는 invalid 유지" {
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, null, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, alloc);
 
     // 일반 named export는 Phase 2에선 아직 미연결 (Phase 3에서 semantic 심볼과 연결)
     try std.testing.expect(!r.export_bindings[0].symbol.isValid());

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -728,7 +728,7 @@ pub fn appendModuleCall(output: *std.ArrayList(u8), allocator: std.mem.Allocator
     const call_name = if (mod.wrap_kind == .cjs)
         types.makeRequireVarName(allocator, mod.path) catch return
     else
-        types.makeInitVarName(allocator, mod.path) catch return;
+        mod.allocInitName(allocator) catch return;
     defer allocator.free(call_name);
     if (mod.wrap_kind != .cjs and mod.uses_top_level_await) {
         try output.appendSlice(allocator, "await ");

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -91,9 +91,9 @@ pub fn emitEsmWrappedModule(
 ) !EsmEmitResult {
     const basename = module.wrapperId();
 
-    const init_name = try types.makeInitVarName(allocator, module.path);
+    const init_name = try module.allocInitName(allocator);
     defer allocator.free(init_name);
-    const exports_name = try types.makeExportsVarName(allocator, module.path);
+    const exports_name = try module.allocExportsName(allocator);
     defer allocator.free(exports_name);
 
     // AST top-level 문장을 분류
@@ -435,7 +435,7 @@ pub fn emitEsmWrappedModule(
                     // export * as ns from './dep' → namespace re-export
                     // getter는 소스 모듈의 exports 객체 자체를 참조
                     const getter_val = switch (src_mod.wrap_kind) {
-                        .esm, .none => try types.makeExportsVarName(allocator, src_mod.path),
+                        .esm, .none => try src_mod.allocExportsName(allocator),
                         .cjs => blk: {
                             const rv = try types.makeRequireVarName(allocator, src_mod.path);
                             defer allocator.free(rv);
@@ -617,9 +617,9 @@ pub fn emitEsmWrappedModule(
                             try reexport_buf.appendSlice(allocator, source_mod.dev_id);
                             try reexport_buf.appendSlice(allocator, "\"].exports))");
                         } else {
-                            const iv = try types.makeInitVarName(allocator, source_mod.path);
+                            const iv = try source_mod.allocInitName(allocator);
                             defer allocator.free(iv);
-                            const ev = try types.makeExportsVarName(allocator, source_mod.path);
+                            const ev = try source_mod.allocExportsName(allocator);
                             defer allocator.free(ev);
                             try reexport_buf.appendSlice(allocator, iv);
                             try reexport_buf.appendSlice(allocator, "(), __toCommonJS(");
@@ -904,7 +904,7 @@ fn appendWrappedInitCall(
                 try buf.appendSlice(allocator, src_mod.dev_id);
                 try buf.appendSlice(allocator, "\"].fn();\n");
             } else {
-                const iv = try types.makeInitVarName(allocator, src_mod.path);
+                const iv = try src_mod.allocInitName(allocator);
                 defer allocator.free(iv);
                 try buf.appendSlice(allocator, iv);
                 try buf.appendSlice(allocator, "();\n");
@@ -1009,7 +1009,7 @@ fn makeStarGetterValue(
                 const canonical_mod = &l.modules[canonical_mod_i];
                 // canonical 모듈이 래핑되어 있으면 exports_xxx.name 형태
                 if (canonical_mod.wrap_kind == .esm) {
-                    const ev = try types.makeExportsVarName(allocator, canonical_mod.path);
+                    const ev = try canonical_mod.allocExportsName(allocator);
                     defer allocator.free(ev);
                     return try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, name });
                 }
@@ -1030,7 +1030,7 @@ fn makeStarGetterValue(
             return try allocator.dupe(u8, name);
         },
         .esm => {
-            const ev = try types.makeExportsVarName(allocator, src_mod.path);
+            const ev = try src_mod.allocExportsName(allocator);
             defer allocator.free(ev);
             return try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, name });
         },

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -336,6 +336,7 @@ pub const ModuleGraph = struct {
         }
 
         self.promoteExportsKinds();
+        self.registerWrapperSymbols();
         self.propagateTopLevelAwait();
     }
 
@@ -1404,6 +1405,42 @@ pub const ModuleGraph = struct {
                     m.wrap_kind = .esm;
                 }
             }
+        }
+    }
+
+    /// #1338 Phase 4e-2c: wrap_kind 확정 후 모든 래핑 모듈에 대해 `init_<path>`
+    /// + `exports_<path>` 합성 심볼을 semantic 공간에 등록한다. Emitter/linker가
+    /// `module.init_symbol`/`exports_symbol`로 이름을 조회해 중복 할당을 피한다.
+    /// OOM/semantic 없음 → 조용히 skip (fallback: makeInitVarName 재할당).
+    fn registerWrapperSymbols(self: *ModuleGraph) void {
+        const semantic_sym = @import("../semantic/symbol.zig");
+        for (self.modules.items) |*m| {
+            if (m.wrap_kind == .none) continue;
+            // incremental rebuild: 이미 등록된 모듈은 skip.
+            if (m.init_symbol != null or m.exports_symbol != null) continue;
+            const sem_ptr = if (m.semantic) |*s| s else continue;
+            const arena = if (m.parse_arena) |*a| a.allocator() else continue;
+
+            const init_name = types.makeInitVarName(arena, m.path) catch continue;
+            const exports_name = types.makeExportsVarName(arena, m.path) catch continue;
+
+            m.init_symbol = semantic_sym.extendSymbol(
+                arena,
+                &sem_ptr.symbols,
+                .function_decl,
+                .esm_init,
+                init_name,
+                Span.EMPTY,
+            ) catch null;
+
+            m.exports_symbol = semantic_sym.extendSymbol(
+                arena,
+                &sem_ptr.symbols,
+                .variable_var,
+                .cjs_exports,
+                exports_name,
+                Span.EMPTY,
+            ) catch null;
         }
     }
 

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -742,7 +742,6 @@ pub const ModuleGraph = struct {
                     .symbol_ids = analyzer.symbol_ids.items,
                     .unresolved_references = analyzer.unresolved_references,
                     .ref_scope_pairs = analyzer.ref_scope_pairs.items,
-                    .synthetic_names = std.AutoHashMap(u32, []const u8).init(arena_alloc),
                 };
                 if (analyzer.stmt_declared.items.len > 0) {
                     module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
@@ -774,7 +773,6 @@ pub const ModuleGraph = struct {
                     module.index,
                     module.export_bindings,
                     &sem.symbols,
-                    &sem.synthetic_names,
                     arena_alloc,
                 ) catch {};
             } else {
@@ -782,7 +780,6 @@ pub const ModuleGraph = struct {
                     &module.symbol_table.?,
                     module.index,
                     module.export_bindings,
-                    null,
                     null,
                     arena_alloc,
                 ) catch {};
@@ -964,7 +961,6 @@ pub const ModuleGraph = struct {
                 .symbol_ids = analyzer.symbol_ids.items,
                 .unresolved_references = analyzer.unresolved_references,
                 .ref_scope_pairs = analyzer.ref_scope_pairs.items,
-                .synthetic_names = std.AutoHashMap(u32, []const u8).init(arena_alloc),
             };
             // TLA 감지: semantic analyzer가 스코프 체인을 추적하며 정확히 판별
             module.uses_top_level_await = analyzer.has_top_level_await;
@@ -1061,7 +1057,6 @@ pub const ModuleGraph = struct {
                     module.index,
                     module.export_bindings,
                     &sem.symbols,
-                    &sem.synthetic_names,
                     arena_alloc,
                 ) catch {};
             } else {
@@ -1069,7 +1064,6 @@ pub const ModuleGraph = struct {
                     &module.symbol_table.?,
                     module.index,
                     module.export_bindings,
-                    null,
                     null,
                     arena_alloc,
                 ) catch {};

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -34,6 +34,7 @@ const json_to_esm = @import("json_to_esm.zig");
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
+const semantic_symbol = @import("../semantic/symbol.zig");
 const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
 const stmt_info_mod = @import("stmt_info.zig");
 const Span = @import("../lexer/token.zig").Span;
@@ -1408,12 +1409,11 @@ pub const ModuleGraph = struct {
         }
     }
 
-    /// #1338 Phase 4e-2c: wrap_kind 확정 후 모든 래핑 모듈에 대해 `init_<path>`
-    /// + `exports_<path>` 합성 심볼을 semantic 공간에 등록한다. Emitter/linker가
-    /// `module.init_symbol`/`exports_symbol`로 이름을 조회해 중복 할당을 피한다.
-    /// OOM/semantic 없음 → 조용히 skip (fallback: makeInitVarName 재할당).
+    /// wrap_kind 확정 후 모든 래핑 모듈에 `init_<path>` + `exports_<path>` 합성
+    /// 심볼을 semantic 공간에 등록한다. Emitter/linker가 Module.getInitName/
+    /// getExportsName으로 이름을 조회해 중복 할당을 피한다.
+    /// OOM/semantic 없음 → 조용히 skip, fallback 경로가 기존 동작 유지.
     fn registerWrapperSymbols(self: *ModuleGraph) void {
-        const semantic_sym = @import("../semantic/symbol.zig");
         for (self.modules.items) |*m| {
             if (m.wrap_kind == .none) continue;
             // incremental rebuild: 이미 등록된 모듈은 skip.
@@ -1424,7 +1424,7 @@ pub const ModuleGraph = struct {
             const init_name = types.makeInitVarName(arena, m.path) catch continue;
             const exports_name = types.makeExportsVarName(arena, m.path) catch continue;
 
-            m.init_symbol = semantic_sym.extendSymbol(
+            m.init_symbol = semantic_symbol.extendSymbol(
                 arena,
                 &sem_ptr.symbols,
                 .function_decl,
@@ -1433,7 +1433,7 @@ pub const ModuleGraph = struct {
                 Span.EMPTY,
             ) catch null;
 
-            m.exports_symbol = semantic_sym.extendSymbol(
+            m.exports_symbol = semantic_symbol.extendSymbol(
                 arena,
                 &sem_ptr.symbols,
                 .variable_var,

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -308,7 +308,7 @@ pub fn buildMetadataForAst(
                         try preamble.write(target_mod.dev_id);
                         try preamble.write("\"].fn();\n");
                     } else {
-                        const init_name = try types.makeInitVarName(self.allocator, target_mod.path);
+                        const init_name = try target_mod.allocInitName(self.allocator);
                         defer self.allocator.free(init_name);
                         try preamble.write(init_name);
                         try preamble.write("();\n");
@@ -641,7 +641,7 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
                 if (require_rewrites.get(rec.specifier)) |old| {
                     self.allocator.free(old);
                 }
-                const exports_name = try types.makeExportsVarName(self.allocator, m.path);
+                const exports_name = try m.allocExportsName(self.allocator);
                 defer self.allocator.free(exports_name);
                 const call_expr = try std.fmt.allocPrint(self.allocator, "__toCommonJS({s})", .{exports_name});
                 try require_rewrites.put(self.allocator, rec.specifier, call_expr);
@@ -671,9 +671,9 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
                 const call_expr = try types.fmtDevRequireExpr(self.allocator, target_mod.dev_id);
                 try require_rewrites.put(self.allocator, rec.specifier, call_expr);
             } else {
-                const init_name = try types.makeInitVarName(self.allocator, target_mod.path);
+                const init_name = try target_mod.allocInitName(self.allocator);
                 defer self.allocator.free(init_name);
-                const exports_name = try types.makeExportsVarName(self.allocator, target_mod.path);
+                const exports_name = try target_mod.allocExportsName(self.allocator);
                 defer self.allocator.free(exports_name);
                 const call_expr = try std.fmt.allocPrint(self.allocator, "({s}(), __toCommonJS({s}))", .{ init_name, exports_name });
                 try require_rewrites.put(self.allocator, rec.specifier, call_expr);

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -46,18 +46,10 @@ pub const ModuleSemanticData = struct {
     /// mangler용 참조 scope 페어. liveness BitSet 계산에 사용.
     ref_scope_pairs: []const RefScopePair = &.{},
 
-    /// 합성 심볼(`Symbol.synthetic_kind != null`)의 이름 사이드카.
-    /// #1338 옵션 B: 합성 심볼만 이 맵에 기록 — 정규 심볼은 Symbol.name(source Span)만
-    /// 사용하므로 메모리 오버헤드 zero. key = symbol id(u32), value = 이름 문자열
-    /// (parse_arena가 소유하거나 정적 문자열).
-    synthetic_names: std.AutoHashMap(u32, []const u8),
-
-    /// 심볼 id에 해당하는 이름을 반환. 합성은 사이드카에서, 정규는 source Span에서.
+    /// 심볼 id에 해당하는 이름을 반환. `Symbol.nameText` 래퍼.
     pub fn symbolName(self: *const ModuleSemanticData, id: u32, source: []const u8) []const u8 {
-        if (self.synthetic_names.get(id)) |name| return name;
         if (id >= self.symbols.items.len) return "";
-        const s = self.symbols.items[id];
-        return source[s.name.start..s.name.end];
+        return self.symbols.items[id].nameText(source);
     }
 };
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -169,6 +169,40 @@ pub const Module = struct {
         ready,
     };
 
+    /// wrap 모듈의 `init_<path>` 이름을 반환. 미등록/미래핑이면 null.
+    /// 반환 slice는 parse_arena가 소유 — 모듈 수명 내 유효.
+    pub fn getInitName(self: *const Module) ?[]const u8 {
+        const id = self.init_symbol orelse return null;
+        const sem = self.semantic orelse return null;
+        const idx: u32 = @intFromEnum(id);
+        if (idx >= sem.symbols.items.len) return null;
+        const name = sem.symbols.items[idx].synthetic_name;
+        return if (name.len > 0) name else null;
+    }
+
+    /// wrap 모듈의 `exports_<path>` 이름을 반환. 미등록/미래핑이면 null.
+    pub fn getExportsName(self: *const Module) ?[]const u8 {
+        const id = self.exports_symbol orelse return null;
+        const sem = self.semantic orelse return null;
+        const idx: u32 = @intFromEnum(id);
+        if (idx >= sem.symbols.items.len) return null;
+        const name = sem.symbols.items[idx].synthetic_name;
+        return if (name.len > 0) name else null;
+    }
+
+    /// `getInitName()`의 할당 버전 — 등록된 경우 dupe, 아니면 fresh 생성.
+    /// 기존 `types.makeInitVarName(alloc, path)` 호출지의 drop-in 대체.
+    pub fn allocInitName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
+        if (self.getInitName()) |n| return allocator.dupe(u8, n);
+        return types.makeInitVarName(allocator, self.path);
+    }
+
+    /// `getExportsName()`의 할당 버전.
+    pub fn allocExportsName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
+        if (self.getExportsName()) |n| return allocator.dupe(u8, n);
+        return types.makeExportsVarName(allocator, self.path);
+    }
+
     /// CJS importee에 대한 interop 모드 결정 (Rolldown 방식).
     /// importer(self)가 ESM 정의 형식이면 Node 모드, 아니면 Babel 모드.
     pub fn interop(self: *const Module, importee: *const Module) ?types.Interop {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -85,6 +85,13 @@ pub const Module = struct {
     /// graph allocator 소유. null = 미초기화 (asset/disabled 모듈 등).
     symbol_table: ?SymbolTable = null,
 
+    /// #1338 Phase 4e-2c: wrap_kind != .none 모듈의 `init_<path>` 함수 심볼 id
+    /// (semantic 공간). null = 미래핑 모듈 또는 semantic 없음 (fallback emit).
+    /// 이름은 `semantic.symbols[id].synthetic_name`.
+    init_symbol: ?@import("../semantic/symbol.zig").SymbolId = null,
+    /// #1338 Phase 4e-2c: wrap_kind != .none 모듈의 `exports_<path>` 객체 심볼 id.
+    exports_symbol: ?@import("../semantic/symbol.zig").SymbolId = null,
+
     /// 내가 import하는 모듈들 (순방향)
     dependencies: std.ArrayList(ModuleIndex),
     /// 나를 import하는 모듈들 (역방향, D078 HMR용)

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -15,8 +15,10 @@ const ModuleType = types.ModuleType;
 const ImportRecord = types.ImportRecord;
 const Ast = @import("../parser/ast.zig").Ast;
 const Span = @import("../lexer/token.zig").Span;
-const Symbol = @import("../semantic/symbol.zig").Symbol;
-const RefScopePair = @import("../semantic/symbol.zig").RefScopePair;
+const semantic_symbol = @import("../semantic/symbol.zig");
+const Symbol = semantic_symbol.Symbol;
+const RefScopePair = semantic_symbol.RefScopePair;
+const SemanticSymbolId = semantic_symbol.SymbolId;
 const Scope = @import("../semantic/scope.zig").Scope;
 const binding_scanner = @import("binding_scanner.zig");
 pub const ImportBinding = binding_scanner.ImportBinding;
@@ -85,12 +87,11 @@ pub const Module = struct {
     /// graph allocator 소유. null = 미초기화 (asset/disabled 모듈 등).
     symbol_table: ?SymbolTable = null,
 
-    /// #1338 Phase 4e-2c: wrap_kind != .none 모듈의 `init_<path>` 함수 심볼 id
-    /// (semantic 공간). null = 미래핑 모듈 또는 semantic 없음 (fallback emit).
-    /// 이름은 `semantic.symbols[id].synthetic_name`.
-    init_symbol: ?@import("../semantic/symbol.zig").SymbolId = null,
-    /// #1338 Phase 4e-2c: wrap_kind != .none 모듈의 `exports_<path>` 객체 심볼 id.
-    exports_symbol: ?@import("../semantic/symbol.zig").SymbolId = null,
+    /// wrap_kind != .none 모듈의 `init_<path>` 함수 심볼 id (semantic 공간).
+    /// null = 미래핑 또는 semantic 없음 (fallback: makeInitVarName 재할당).
+    init_symbol: ?SemanticSymbolId = null,
+    /// wrap_kind != .none 모듈의 `exports_<path>` 객체 심볼 id.
+    exports_symbol: ?SemanticSymbolId = null,
 
     /// 내가 import하는 모듈들 (순방향)
     dependencies: std.ArrayList(ModuleIndex),
@@ -169,10 +170,10 @@ pub const Module = struct {
         ready,
     };
 
-    /// wrap 모듈의 `init_<path>` 이름을 반환. 미등록/미래핑이면 null.
+    /// 등록된 합성 심볼의 이름(synthetic_name)을 반환. 미등록이면 null.
     /// 반환 slice는 parse_arena가 소유 — 모듈 수명 내 유효.
-    pub fn getInitName(self: *const Module) ?[]const u8 {
-        const id = self.init_symbol orelse return null;
+    fn syntheticName(self: *const Module, maybe_id: ?SemanticSymbolId) ?[]const u8 {
+        const id = maybe_id orelse return null;
         const sem = self.semantic orelse return null;
         const idx: u32 = @intFromEnum(id);
         if (idx >= sem.symbols.items.len) return null;
@@ -180,14 +181,12 @@ pub const Module = struct {
         return if (name.len > 0) name else null;
     }
 
-    /// wrap 모듈의 `exports_<path>` 이름을 반환. 미등록/미래핑이면 null.
+    pub fn getInitName(self: *const Module) ?[]const u8 {
+        return self.syntheticName(self.init_symbol);
+    }
+
     pub fn getExportsName(self: *const Module) ?[]const u8 {
-        const id = self.exports_symbol orelse return null;
-        const sem = self.semantic orelse return null;
-        const idx: u32 = @intFromEnum(id);
-        if (idx >= sem.symbols.items.len) return null;
-        const name = sem.symbols.items[idx].synthetic_name;
-        return if (name.len > 0) name else null;
+        return self.syntheticName(self.exports_symbol);
     }
 
     /// `getInitName()`의 할당 버전 — 등록된 경우 dupe, 아니면 fresh 생성.
@@ -197,7 +196,6 @@ pub const Module = struct {
         return types.makeInitVarName(allocator, self.path);
     }
 
-    /// `getExportsName()`의 할당 버전.
     pub fn allocExportsName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
         if (self.getExportsName()) |n| return allocator.dupe(u8, n);
         return types.makeExportsVarName(allocator, self.path);

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -295,6 +295,9 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
         const slot_id = maybe_slot orelse continue;
         const new_name = slot_names[slot_id] orelse continue;
         const sym = symbols[sym_idx];
+        // Bundler 합성 심볼(#1338)은 source AST에 식별자 참조가 없고 span이 (0,0).
+        // rename은 parser AST의 identifier 노드를 바꾸는 것이라 무의미 — skip.
+        if (sym.isSynthetic()) continue;
         const orig_name = source[sym.name.start..sym.name.end];
 
         if (std.mem.eql(u8, orig_name, new_name)) continue;

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -261,10 +261,14 @@ pub const Symbol = struct {
     /// #1328 Phase 4e-2: `extendSymbol`로 추가된 심볼만 non-null.
     synthetic_kind: ?SyntheticKind = null,
 
-    /// 이 심볼의 이름을 소스에서 읽는다.
-    /// 합성 심볼(`synthetic_kind != null`)은 `span`이 소스 범위 밖을 가리킬 수 있어
-    /// caller는 `isSynthetic()`을 먼저 확인해야 한다.
+    /// 합성 심볼의 이름 (소스 span이 없으므로 직접 저장). 정규 심볼은 빈 문자열.
+    /// #1338 Phase 4e-2c: HashMap 사이드카 대체 — ArrayList 수명과 일치시켜
+    /// incremental rebuild 시 arena 불일치 방지.
+    synthetic_name: []const u8 = "",
+
+    /// 이 심볼의 이름을 반환. 합성은 `synthetic_name`, 정규는 source Span에서.
     pub fn nameText(self: *const Symbol, source: []const u8) []const u8 {
+        if (self.synthetic_name.len > 0) return self.synthetic_name;
         return source[self.name.start..self.name.end];
     }
 
@@ -276,18 +280,17 @@ pub const Symbol = struct {
 /// Bundler가 post-semantic 단계에서 합성 심볼을 semantic 공간에 추가한다.
 /// #1328 Phase 4e-2 / RFC #1338.
 ///
-/// `list`는 `ModuleSemanticData.symbols`의 ArrayList, `names`는 같은 data의
-/// 합성 이름 사이드카 맵이어야 한다. `allocator`는 해당 모듈의 `parse_arena`.
+/// `list`는 `ModuleSemanticData.symbols`의 ArrayList이어야 하고,
+/// `allocator`는 해당 모듈의 `parse_arena`여야 한다.
 ///
-/// 합성 심볼은 소스 범위의 name span을 갖지 않으므로 `Symbol.name`은
-/// 빈 Span으로 두고 실제 이름은 `synthetic_names` 맵에 저장한다.
-/// 조회는 `ModuleSemanticData.symbolName(id, source)` 경유 (옵션 B).
+/// 합성 심볼은 소스 범위의 name span이 없으므로 `Symbol.name`은 빈 Span,
+/// 실제 이름은 `Symbol.synthetic_name` 필드에 직접 저장한다 (ArrayList 수명
+/// 과 일치 — incremental rebuild 시 HashMap 수명 문제 회피).
 ///
 /// 반환된 SymbolId로 `SymbolRef { .semantic = { module, id } }` 구성 가능.
 pub fn extendSymbol(
     allocator: std.mem.Allocator,
     list: *std.ArrayList(Symbol),
-    names: *std.AutoHashMap(u32, []const u8),
     kind: SymbolKind,
     synthetic: SyntheticKind,
     name_text: []const u8,
@@ -301,8 +304,8 @@ pub fn extendSymbol(
         .decl_flags = kind.declFlags(),
         .declaration_span = declaration_span,
         .synthetic_kind = synthetic,
+        .synthetic_name = name_text,
     });
-    try names.put(id_u32, name_text);
     return @enumFromInt(id_u32);
 }
 


### PR DESCRIPTION
## 요약

RFC #1338 Phase 4e-2c. Wrap 모듈(\`wrap_kind != .none\`)의 \`init_<path>\` 함수
+ \`exports_<path>\` 객체 합성 심볼을 semantic 공간에 등록하고, 모든 consumer가
단일 source of truth로 조회하도록 전환. 겸해서 4e-2b의 \`synthetic_names\`
HashMap 사이드카가 incremental rebuild에서 segfault 유발하던 문제를
\`Symbol.synthetic_name\` 필드로 교체해 수명 단순화.

## 커밋 구조

1. \`6154e41b\` — synthetic_names HashMap → Symbol.synthetic_name 필드
   - 4e-2b 사이드카 재설계. ArrayList 수명과 완전 일치 → rebuild 안전.
2. \`5544eb73\` — registerWrapperSymbols: wrap 모듈 init/exports 심볼 등록
   - promoteExportsKinds 직후 sweep. semantic 없음/OOM → fallback.
3. \`3c062abd\` — 11개 call site → Module.allocInitName/allocExportsName 치환
   - drop-in 대체, defer free 호환성 유지.

## 테스트

- 유닛 2917 전부 통과 (incremental rebuild 포함 — 4e-2b 사이드카 이슈 해소 확인)
- 통합 2878 pass, 0 fail (pre-existing #1340 제외 시)
- RN ExampleApp 번들 정상 (568 modules, es5)

## 설계 결정

- **Symbol 필드 vs 사이드카 맵**: 옵션 A(필드) 선택. 메모리 +16바이트/심볼 감수 대신 ArrayList 수명 일치로 incremental rebuild 안전성 확보. 4e-2b에서 옵션 B(HashMap)로 갔다가 wrap 등록 시점(promoteExportsKinds 이후) 때문에 arena 불일치 노출.
- **등록 위치**: \`promoteExportsKinds\` 직후 sweep. wrap_kind가 그 시점에 확정되므로 안전.
- **Fallback 유지**: semantic 없거나 OOM 시 기존 \`makeInitVarName\` 경로로 자동 전환 — regression free.

## 후속

- 4e-2d: SymbolRef union → 단일 u32 평탄화
- 4e-2e: bundler SymbolTable 축소 (re_export_alias / unresolved_external 전용)

## Test plan

- [x] \`zig build test\` 통과
- [x] \`cd tests/integration && bun test\` 통과 (pre-existing #1340 제외)
- [x] Incremental rebuild segfault 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)