### PR TITLE
refactor(bundler): Phase 4e-2d-a — dead SymbolKind variants 제거

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -78,25 +78,18 @@ pub const ExportBinding = struct {
     };
 
     /// 이 export 때문에 현재 모듈에 `_default` 합성 변수가 생기는지 확인.
-    /// #1328 Phase 4e-2b: symbol이 semantic/bundler 두 공간 중 하나에 등록될 수
-    /// 있으므로 둘 다 지원한다. `table`은 bundler 합성, `symbols`는 semantic
-    /// 배열 (ModuleSemanticData.symbols.items). 둘 중 하나만 있어도 호출 가능.
+    /// #1338 Phase 4e-2d-a: synthetic_default는 항상 semantic 공간에 등록됨.
     pub fn hasSyntheticDefault(
         self: ExportBinding,
-        table: ?*const SymbolTable,
-        symbols: ?[]const SemanticSymbol,
+        symbols: []const SemanticSymbol,
     ) bool {
         return switch (self.symbol) {
-            .bundler => |b| blk: {
-                const t = table orelse break :blk false;
-                break :blk !b.symbol.isNone() and t.getKind(b.symbol) == .synthetic_default;
-            },
+            .bundler => false,
             .semantic => |s| blk: {
                 if (s.symbol.isNone()) break :blk false;
-                const syms = symbols orelse break :blk false;
                 const idx: u32 = @intFromEnum(s.symbol);
-                if (idx >= syms.len) break :blk false;
-                const sk = syms[idx].synthetic_kind orelse break :blk false;
+                if (idx >= symbols.len) break :blk false;
+                const sk = symbols[idx].synthetic_kind orelse break :blk false;
                 break :blk sk == .default_export;
             },
         };
@@ -625,15 +618,13 @@ pub fn collectNamespaceAccesses(
 /// export bindings를 훑어 합성 심볼을 등록하고 `ExportBinding.symbol`을 채운다.
 /// Cross-module re-export 연결은 linker가 `populateReExportAliases`에서 수행.
 ///
-/// #1328 Phase 4e-2b: `synthetic_default`는 semantic 공간으로 이전됨.
-/// `sem_symbols`가 주어지면 semantic에 등록하고 ExportBinding.symbol은
-/// `.semantic` variant. null이면 기존 bundler 경로 (테스트/semantic 분석 실패 fallback).
-/// `re_export_alias`는 semantic 의미와 맞지 않아 항상 bundler 공간에 유지 (RFC #1338).
+/// #1338 Phase 4e-2d-a: `synthetic_default`는 항상 semantic 공간에 등록.
+/// `re_export_alias`는 값 의미가 없어 bundler 전용 (RFC #1338).
 pub fn populateSyntheticSymbols(
     table: *SymbolTable,
     module_index: ModuleIndex,
     export_bindings: []ExportBinding,
-    sem_symbols: ?*std.ArrayList(SemanticSymbol),
+    sem_symbols: *std.ArrayList(SemanticSymbol),
     arena: std.mem.Allocator,
 ) !void {
     for (export_bindings) |*eb| {
@@ -642,21 +633,15 @@ pub fn populateSyntheticSymbols(
             std.mem.eql(u8, eb.exported_name, "default") and
             (std.mem.eql(u8, eb.local_name, "_default") or std.mem.eql(u8, eb.local_name, "default")))
         {
-            if (sem_symbols) |syms_ptr| {
-                const sem_id = try semantic_symbol.extendSymbol(
-                    arena,
-                    syms_ptr,
-                    .variable_var,
-                    .default_export,
-                    "_default",
-                    eb.local_span,
-                );
-                eb.symbol = .{ .semantic = .{ .module = module_index, .symbol = sem_id } };
-                continue;
-            }
-            // Fallback (semantic 없음): bundler 공간에 등록.
-            const id = try table.declare("_default", .synthetic_default, eb.local_span);
-            eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };
+            const sem_id = try semantic_symbol.extendSymbol(
+                arena,
+                sem_symbols,
+                .variable_var,
+                .default_export,
+                "_default",
+                eb.local_span,
+            );
+            eb.symbol = .{ .semantic = .{ .module = module_index, .symbol = sem_id } };
         } else if (eb.kind == .re_export) {
             // re_export_alias는 bundler 전용 — linker가 post-link 단계에서
             // resolveExportChain 결과를 canonical_name으로 저장한다.

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -9,6 +9,7 @@ const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const import_scanner = @import("import_scanner.zig");
 const symbol = @import("symbol.zig");
+const semantic_symbol = @import("../semantic/symbol.zig");
 
 // ============================================================
 // Tests
@@ -313,9 +314,16 @@ test "barrel re-export: mixed local and re-export" {
 
 // #1328 Phase 1: synthetic symbol population
 
+fn findDefaultSymbol(syms: []const semantic_symbol.Symbol) ?usize {
+    for (syms, 0..) |s, i| {
+        const sk = s.synthetic_kind orelse continue;
+        if (sk == .default_export) return i;
+    }
+    return null;
+}
+
 test "populateSyntheticSymbols: 리터럴 default만 _default 등록 (로컬 var 재사용은 제외)" {
     const alloc = std.testing.allocator;
-    // 리터럴 `export default 42` — codegen이 실제로 `_default = 42` emit.
     var r = try parseAndExtractBindings(alloc, "export default 42;");
     defer r.arena.deinit();
     defer alloc.free(r.import_bindings);
@@ -324,15 +332,16 @@ test "populateSyntheticSymbols: 리터럴 default만 _default 등록 (로컬 var
 
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
+    var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
+    defer sem_syms.deinit(alloc);
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, alloc);
-    const id = table.find("_default") orelse return error.NotFound;
-    try std.testing.expectEqual(symbol.SymbolKind.synthetic_default, table.getKind(id));
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc);
+    const idx = findDefaultSymbol(sem_syms.items) orelse return error.NotFound;
+    try std.testing.expectEqualStrings("_default", sem_syms.items[idx].synthetic_name);
 }
 
 test "populateSyntheticSymbols: `export default x`(x는 로컬)은 _default 미등록" {
     const alloc = std.testing.allocator;
-    // codegen이 x를 재사용하고 `_default` 변수를 만들지 않으므로 등록하지 않는다.
     var r = try parseAndExtractBindings(alloc, "const x = 1; export default x;");
     defer r.arena.deinit();
     defer alloc.free(r.import_bindings);
@@ -341,9 +350,11 @@ test "populateSyntheticSymbols: `export default x`(x는 로컬)은 _default 미�
 
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
+    var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
+    defer sem_syms.deinit(alloc);
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, alloc);
-    try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc);
+    try std.testing.expectEqual(@as(?usize, null), findDefaultSymbol(sem_syms.items));
 }
 
 test "populateSyntheticSymbols: default 없으면 빈 테이블" {
@@ -356,10 +367,12 @@ test "populateSyntheticSymbols: default 없으면 빈 테이블" {
 
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
+    var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
+    defer sem_syms.deinit(alloc);
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc);
     try std.testing.expectEqual(@as(u32, 0), table.count());
-    try std.testing.expectEqual(@as(?symbol.SymbolId, null), table.find("_default"));
+    try std.testing.expectEqual(@as(usize, 0), sem_syms.items.len);
 }
 
 test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
@@ -372,19 +385,22 @@ test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
 
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
+    var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
+    defer sem_syms.deinit(alloc);
 
     const m: types.ModuleIndex = @enumFromInt(7);
-    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings, null, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings, &sem_syms, alloc);
 
-    // default export가 bundler ref로 채워졌는지
     try std.testing.expect(r.export_bindings[0].symbol.isValid());
     try std.testing.expectEqual(m, r.export_bindings[0].symbol.moduleIndex());
     switch (r.export_bindings[0].symbol) {
-        .bundler => |b| {
-            try std.testing.expectEqualStrings("_default", table.getName(b.symbol));
-            try std.testing.expectEqual(symbol.SymbolKind.synthetic_default, table.getKind(b.symbol));
+        .bundler => return error.UnexpectedSpace,
+        .semantic => |s| {
+            const idx: u32 = @intFromEnum(s.symbol);
+            try std.testing.expectEqualStrings("_default", sem_syms.items[idx].synthetic_name);
+            const sk = sem_syms.items[idx].synthetic_kind orelse return error.NoSyntheticKind;
+            try std.testing.expectEqual(semantic_symbol.SyntheticKind.default_export, sk);
         },
-        .semantic => return error.UnexpectedSpace,
     }
 }
 
@@ -398,9 +414,10 @@ test "populateSyntheticSymbols Phase 2: 비-default export는 invalid 유지" {
 
     var table = symbol.SymbolTable.init(alloc);
     defer table.deinit();
+    var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
+    defer sem_syms.deinit(alloc);
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, null, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc);
 
-    // 일반 named export는 Phase 2에선 아직 미연결 (Phase 3에서 semantic 심볼과 연결)
     try std.testing.expect(!r.export_bindings[0].symbol.isValid());
 }

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -45,14 +45,9 @@ fn localBundlerSymbol(ref: SymbolRef, mod: *const Module) ?symbol_mod.SymbolId {
 
 /// ExportBinding.symbol이 현재 모듈의 synthetic_default 심볼인지 확인.
 /// 현재 모듈의 `_default = <expr>` 할당을 참조할 수 있음을 의미.
-/// #1328 Phase 4e-2b: semantic 공간 등록도 지원.
 fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
     return switch (ref) {
-        .bundler => |b| blk: {
-            if (b.module != mod.index or b.symbol.isNone()) break :blk false;
-            const table = mod.symbol_table orelse break :blk false;
-            break :blk table.getKind(b.symbol) == .synthetic_default;
-        },
+        .bundler => false,
         .semantic => |s| blk: {
             if (s.module != mod.index or s.symbol.isNone()) break :blk false;
             const sem = mod.semantic orelse break :blk false;
@@ -269,10 +264,9 @@ pub fn emitEsmWrappedModule(
     // 할당을 만들어내므로 hoisted_var 선언 필요. symbol table에 synthetic_default가
     // 등록돼 있으면 _default 변수가 실제로 emit된다는 뜻.
     {
-        const t_opt = if (module.symbol_table) |*t| t else null;
-        const syms_opt: ?[]const semantic_symbol.Symbol = if (module.semantic) |sem| sem.symbols.items else null;
+        const syms: []const semantic_symbol.Symbol = if (module.semantic) |sem| sem.symbols.items else &.{};
         for (module.export_bindings) |eb| {
-            if (eb.kind == .re_export and eb.hasSyntheticDefault(t_opt, syms_opt)) {
+            if (eb.kind == .re_export and eb.hasSyntheticDefault(syms)) {
                 const def_name = if (metadata) |md| md.default_export_name else "_default";
                 try hoisted_var_names.append(allocator, def_name);
                 break;
@@ -576,11 +570,10 @@ pub fn emitEsmWrappedModule(
     // 소스 모듈의 wrap_kind에 따라 적절한 할당문을 직접 생성.
     var reexport_buf: std.ArrayList(u8) = .empty;
     defer reexport_buf.deinit(allocator);
-    const sym_table_opt = if (module.symbol_table) |*t| t else null;
-    const sem_syms_opt: ?[]const semantic_symbol.Symbol = if (module.semantic) |sem| sem.symbols.items else null;
+    const sem_syms: []const semantic_symbol.Symbol = if (module.semantic) |sem| sem.symbols.items else &.{};
     for (module.export_bindings) |eb| {
         if (eb.kind != .re_export) continue;
-        if (!eb.hasSyntheticDefault(sym_table_opt, sem_syms_opt)) continue;
+        if (!eb.hasSyntheticDefault(sem_syms)) continue;
         const rec_idx = eb.import_record_index orelse continue;
         if (rec_idx >= module.import_records.len) continue;
         const source_mod_idx = module.import_records[rec_idx].resolved;

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -264,9 +264,8 @@ pub fn emitEsmWrappedModule(
     // 할당을 만들어내므로 hoisted_var 선언 필요. symbol table에 synthetic_default가
     // 등록돼 있으면 _default 변수가 실제로 emit된다는 뜻.
     {
-        const syms: []const semantic_symbol.Symbol = if (module.semantic) |sem| sem.symbols.items else &.{};
         for (module.export_bindings) |eb| {
-            if (eb.kind == .re_export and eb.hasSyntheticDefault(syms)) {
+            if (eb.kind == .re_export and eb.hasSyntheticDefault(module.semanticSymbols())) {
                 const def_name = if (metadata) |md| md.default_export_name else "_default";
                 try hoisted_var_names.append(allocator, def_name);
                 break;
@@ -570,10 +569,9 @@ pub fn emitEsmWrappedModule(
     // 소스 모듈의 wrap_kind에 따라 적절한 할당문을 직접 생성.
     var reexport_buf: std.ArrayList(u8) = .empty;
     defer reexport_buf.deinit(allocator);
-    const sem_syms: []const semantic_symbol.Symbol = if (module.semantic) |sem| sem.symbols.items else &.{};
     for (module.export_bindings) |eb| {
         if (eb.kind != .re_export) continue;
-        if (!eb.hasSyntheticDefault(sem_syms)) continue;
+        if (!eb.hasSyntheticDefault(module.semanticSymbols())) continue;
         const rec_idx = eb.import_record_index orelse continue;
         if (rec_idx >= module.import_records.len) continue;
         const source_mod_idx = module.import_records[rec_idx].resolved;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -767,7 +767,6 @@ pub const ModuleGraph = struct {
             module.export_bindings = binding_scanner_mod.extractExportBindings(arena_alloc, &(module.ast.?), scan_result.records, module.import_bindings) catch &.{};
 
             // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
-            // Phase 4e-2b: synthetic_default는 semantic 공간에 등록 (가능하면).
             module.ensureSymbolTable(self.allocator);
             if (module.semantic) |*sem| {
                 binding_scanner_mod.populateSyntheticSymbols(
@@ -775,14 +774,6 @@ pub const ModuleGraph = struct {
                     module.index,
                     module.export_bindings,
                     &sem.symbols,
-                    arena_alloc,
-                ) catch {};
-            } else {
-                binding_scanner_mod.populateSyntheticSymbols(
-                    &module.symbol_table.?,
-                    module.index,
-                    module.export_bindings,
-                    null,
                     arena_alloc,
                 ) catch {};
             }
@@ -1050,8 +1041,8 @@ pub const ModuleGraph = struct {
             // namespace access 수집은 별도 AST walk 필요
             binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &parser.ast, module.import_bindings) catch {};
 
-            // Phase 1-3b (#1328): 합성 심볼 테이블 초기화 + _default / re_export_alias 등록.
-            // Phase 4e-2b: synthetic_default는 semantic 공간에 등록 (가능하면).
+            // Phase 1-3b (#1328): 합성 심볼 테이블 초기화 + re_export_alias 등록
+            // + semantic 공간에 synthetic_default 등록.
             module.ensureSymbolTable(self.allocator);
             if (module.semantic) |*sem| {
                 binding_scanner_mod.populateSyntheticSymbols(
@@ -1059,14 +1050,6 @@ pub const ModuleGraph = struct {
                     module.index,
                     module.export_bindings,
                     &sem.symbols,
-                    arena_alloc,
-                ) catch {};
-            } else {
-                binding_scanner_mod.populateSyntheticSymbols(
-                    &module.symbol_table.?,
-                    module.index,
-                    module.export_bindings,
-                    null,
                     arena_alloc,
                 ) catch {};
             }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -391,10 +391,9 @@ pub const Linker = struct {
         // codegen이 현재 모듈에 `_default` 합성 변수를 만드는 모든 export를 수집.
         // 충돌 시 _default$N으로 리네이밍되도록 등록한다.
         const owner: NameOwner = .{ .module_index = module_index, .exec_index = m.exec_index };
-        const sym_table_opt = if (m.symbol_table) |*t| t else null;
-        const sem_syms_opt: ?[]const semantic_symbol.Symbol = if (m.semantic) |s| s.symbols.items else null;
+        const sem_syms: []const semantic_symbol.Symbol = if (m.semantic) |s| s.symbols.items else &.{};
         for (m.export_bindings) |eb| {
-            if (eb.hasSyntheticDefault(sym_table_opt, sem_syms_opt)) {
+            if (eb.hasSyntheticDefault(sem_syms)) {
                 try self.addNameOwner(name_to_owners, "_default", owner);
                 continue;
             }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -391,9 +391,8 @@ pub const Linker = struct {
         // codegen이 현재 모듈에 `_default` 합성 변수를 만드는 모든 export를 수집.
         // 충돌 시 _default$N으로 리네이밍되도록 등록한다.
         const owner: NameOwner = .{ .module_index = module_index, .exec_index = m.exec_index };
-        const sem_syms: []const semantic_symbol.Symbol = if (m.semantic) |s| s.symbols.items else &.{};
         for (m.export_bindings) |eb| {
-            if (eb.hasSyntheticDefault(sem_syms)) {
+            if (eb.hasSyntheticDefault(m.semanticSymbols())) {
                 try self.addNameOwner(name_to_owners, "_default", owner);
                 continue;
             }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -555,9 +555,8 @@ pub fn buildMetadataForAst(
 
     // collectModuleNames에서 등록한 _default 충돌의 canonical name을 조회.
     var default_export_name: []const u8 = "_default";
-    const sem_syms: []const semantic_symbol.Symbol = if (m.semantic) |s| s.symbols.items else &.{};
     for (m.export_bindings) |eb| {
-        if (eb.hasSyntheticDefault(sem_syms)) {
+        if (eb.hasSyntheticDefault(m.semanticSymbols())) {
             default_export_name = self.getCanonicalName(module_index, "_default") orelse "_default";
             break;
         }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -555,10 +555,9 @@ pub fn buildMetadataForAst(
 
     // collectModuleNames에서 등록한 _default 충돌의 canonical name을 조회.
     var default_export_name: []const u8 = "_default";
-    const sym_table_opt = if (m.symbol_table) |*t| t else null;
-    const sem_syms_opt: ?[]const semantic_symbol.Symbol = if (m.semantic) |s| s.symbols.items else null;
+    const sem_syms: []const semantic_symbol.Symbol = if (m.semantic) |s| s.symbols.items else &.{};
     for (m.export_bindings) |eb| {
-        if (eb.hasSyntheticDefault(sym_table_opt, sem_syms_opt)) {
+        if (eb.hasSyntheticDefault(sem_syms)) {
             default_export_name = self.getCanonicalName(module_index, "_default") orelse "_default";
             break;
         }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -201,6 +201,13 @@ pub const Module = struct {
         return types.makeExportsVarName(allocator, self.path);
     }
 
+    /// Semantic 심볼 배열 slice. semantic이 없으면 빈 slice.
+    /// `hasSyntheticDefault` 등 semantic-aware predicate 호출 시 편의.
+    pub fn semanticSymbols(self: *const Module) []const Symbol {
+        const sem = self.semantic orelse return &.{};
+        return sem.symbols.items;
+    }
+
     /// CJS importee에 대한 interop 모드 결정 (Rolldown 방식).
     /// importer(self)가 ESM 정의 형식이면 Node 모드, 아니면 Babel 모드.
     pub fn interop(self: *const Module, importee: *const Module) ?types.Interop {

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -66,21 +66,13 @@ pub const SymbolRef = union(enum) {
     }
 };
 
-/// 합성 심볼 종류.
+/// 합성 심볼 종류. #1338 Phase 4e-2d-a: 4e-2b/2c 마이그레이션 + fallback
+/// 제거 후 bundler 공간은 cross-module re-export 체인만 보관.
+/// 4e-2d-b에서 SymbolTable을 AliasTable로 축소 예정.
 pub const SymbolKind = enum(u8) {
-    /// `export default ...` 합성 변수 (`_default`, `_default$N`)
-    synthetic_default,
-    /// CJS 래퍼의 `exports_<module>` 객체
-    synthetic_exports,
-    /// ESM 래퍼의 `init_<module>` 함수
-    synthetic_init,
-    /// `import * as X` namespace 객체
-    synthetic_namespace,
     /// Re-export alias (`export { X } from './m'`, barrel 등).
     /// 자기 자신은 값을 갖지 않고 linker가 `canonical_name`에 체인 resolve 결과를 주입한다.
     re_export_alias,
-    /// Resolve 실패한 외부 import (node builtin 등)
-    unresolved_external,
 };
 
 /// 합성 심볼 레코드 (AoS 레이아웃 — 성능상 필요 시 내부 SoA로 전환 가능, R2).
@@ -221,9 +213,9 @@ test "SymbolTable: declare + get 기본" {
     var t = SymbolTable.init(std.testing.allocator);
     defer t.deinit();
 
-    const id = try t.declare("_default", .synthetic_default, .{ .start = 0, .end = 0 });
+    const id = try t.declare("_default", .re_export_alias, .{ .start = 0, .end = 0 });
     try std.testing.expectEqualStrings("_default", t.getName(id));
-    try std.testing.expectEqual(SymbolKind.synthetic_default, t.getKind(id));
+    try std.testing.expectEqual(SymbolKind.re_export_alias, t.getKind(id));
     try std.testing.expectEqual(@as(u32, 1), t.count());
 }
 
@@ -231,8 +223,8 @@ test "SymbolTable: declare 멱등 (같은 이름)" {
     var t = SymbolTable.init(std.testing.allocator);
     defer t.deinit();
 
-    const a = try t.declare("init_X", .synthetic_init, .{ .start = 0, .end = 0 });
-    const b = try t.declare("init_X", .synthetic_init, .{ .start = 0, .end = 0 });
+    const a = try t.declare("_default", .re_export_alias, .{ .start = 0, .end = 0 });
+    const b = try t.declare("_default", .re_export_alias, .{ .start = 0, .end = 0 });
     try std.testing.expectEqual(a, b);
     try std.testing.expectEqual(@as(u32, 1), t.count());
 }
@@ -241,8 +233,8 @@ test "SymbolTable: find" {
     var t = SymbolTable.init(std.testing.allocator);
     defer t.deinit();
 
-    const id = try t.declare("exports_Foo", .synthetic_exports, .{ .start = 0, .end = 0 });
-    try std.testing.expectEqual(@as(?SymbolId, id), t.find("exports_Foo"));
+    const id = try t.declare("_default", .re_export_alias, .{ .start = 0, .end = 0 });
+    try std.testing.expectEqual(@as(?SymbolId, id), t.find("_default"));
     try std.testing.expectEqual(@as(?SymbolId, null), t.find("missing"));
 }
 
@@ -250,7 +242,7 @@ test "SymbolTable: canonical_name fallback" {
     var t = SymbolTable.init(std.testing.allocator);
     defer t.deinit();
 
-    const id = try t.declare("_default", .synthetic_default, .{ .start = 0, .end = 0 });
+    const id = try t.declare("_default", .re_export_alias, .{ .start = 0, .end = 0 });
     try std.testing.expectEqualStrings("_default", t.getCanonicalName(id));
     t.setCanonicalName(id, "_default$2");
     try std.testing.expectEqualStrings("_default$2", t.getCanonicalName(id));
@@ -260,7 +252,7 @@ test "SymbolTable: points_to + ref_count" {
     var t = SymbolTable.init(std.testing.allocator);
     defer t.deinit();
 
-    const id = try t.declare("_default", .synthetic_default, .{ .start = 0, .end = 0 });
+    const id = try t.declare("_default", .re_export_alias, .{ .start = 0, .end = 0 });
     try std.testing.expect(!t.getPointsTo(id).isValid());
 
     const target: SymbolRef = .{ .bundler = .{

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -195,8 +195,8 @@ pub const DeclFlags = packed struct(u16) {
 
 /// Bundler가 생성한 합성 심볼 종류. #1328 Phase 4e-2.
 /// 선언 소스가 AST에 없는 심볼 — linker가 cross-module 연결용으로 추가.
-/// `re_export_alias`/`unresolved_external`은 값 의미가 없어 semantic 공간에
-/// 얹지 않으며, bundler 전용 `AliasTable`에 남는다 (RFC #1338 결정).
+/// `re_export_alias`는 값 의미가 없어 semantic 공간에 얹지 않으며 bundler
+/// 전용 `AliasTable`에 남는다 (RFC #1338 결정).
 pub const SyntheticKind = enum(u8) {
     /// `export default ...` 합성 변수 (`_default`, `_default$N`)
     default_export,
@@ -204,8 +204,6 @@ pub const SyntheticKind = enum(u8) {
     cjs_exports,
     /// ESM 래퍼의 `init_<module>` 함수
     esm_init,
-    /// `import * as X` namespace 객체
-    namespace,
 };
 
 /// 컴파일 타임 상수 값. 번들러에서 크로스-모듈 인라인에 사용.


### PR DESCRIPTION
## 요약

RFC #1338 Phase 4e-2d의 첫 단계. 4e-2b(synthetic_default) + 4e-2c(wrap symbols)
마이그레이션 완료로 unused가 된 code path를 정리. 리뷰 중 **synthetic_default
fallback 경로도 실무에서 발동 불가**(semantic은 analyze 성공 시 항상 생성)로
판명되어 함께 제거 — bundler \`SymbolKind\`는 \`re_export_alias\` 하나만 남음.

## 제거 대상

### bundler SymbolKind
- \`synthetic_exports\` / \`synthetic_init\` / \`synthetic_namespace\`: 4e-2c에서 \`init_<path>\`/\`exports_<path>\` 이름을 semantic 공간에 등록하도록 이전 완료, 등록 사이트 없음
- \`unresolved_external\`: 원래부터 미사용
- \`synthetic_default\`: fallback 제거로 불필요 — populateSyntheticSymbols의 \`sem_symbols: ?*\` → 필수 파라미터로 승격하면서 bundler 등록 경로 삭제

### semantic SyntheticKind
- \`namespace\`: 등록 사이트 없음

## API 단순화

- \`ExportBinding.hasSyntheticDefault(symbols)\`: \`table\` 파라미터 제거
- \`isSyntheticDefault(esm_wrap)\`: \`.bundler => false\`로 단순화
- \`graph.zig\`: \`module.semantic == null\` 분기 제거

## 테스트

- \`binding_scanner_test\` 5개 fallback 테스트를 semantic 공간 기반으로 재작성
- \`symbol.zig\` 테스트 2건에서 제거된 kind를 \`re_export_alias\`로 치환
- 동작 변경 없음 — 유닛 2917 / 통합 2878 pass (pre-existing #1340 제외)

## 남은 상태

- \`bundler.SymbolKind\`: \`re_export_alias\` 1개만
- \`SymbolRef\` union: \`.semantic\` (실사용) / \`.bundler\` (re_export_alias 전용)
- 다음 PR(4e-2d-b)에서 \`re_export_alias\`를 \`AliasTable\`로 분리하면 bundler SymbolTable 타입 자체를 제거 가능

## Test plan

- [x] \`zig build test\` 통과
- [x] \`cd tests/integration && bun test\` 통과 (pre-existing #1340 제외)
- [x] binding_scanner_test 재작성 — semantic 경로 커버리지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)