### PR TITLE
refactor(bundler): Phase 4e-2d-c — SymbolRef.bundler → .alias rename (#1338 마지막)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -84,7 +84,7 @@ pub const ExportBinding = struct {
         symbols: []const SemanticSymbol,
     ) bool {
         return switch (self.symbol) {
-            .bundler => false,
+            .alias => false,
             .semantic => |s| blk: {
                 if (s.symbol.isNone()) break :blk false;
                 const idx: u32 = @intFromEnum(s.symbol);
@@ -646,7 +646,7 @@ pub fn populateSyntheticSymbols(
             // re_export_alias는 bundler 전용 — linker가 post-link 단계에서
             // resolveExportChain 결과를 canonical_name으로 저장한다.
             const id = try table.declare(eb.exported_name);
-            eb.symbol = .{ .bundler = .{ .module = module_index, .symbol = id } };
+            eb.symbol = .{ .alias = .{ .module = module_index, .symbol = id } };
         }
     }
 }

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -394,7 +394,7 @@ test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
     try std.testing.expect(r.export_bindings[0].symbol.isValid());
     try std.testing.expectEqual(m, r.export_bindings[0].symbol.moduleIndex());
     switch (r.export_bindings[0].symbol) {
-        .bundler => return error.UnexpectedSpace,
+        .alias => return error.UnexpectedSpace,
         .semantic => |s| {
             const idx: u32 = @intFromEnum(s.symbol);
             try std.testing.expectEqualStrings("_default", sem_syms.items[idx].synthetic_name);

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -34,11 +34,11 @@ const appendRunBeforeMainCalls = parent.appendRunBeforeMainCalls;
 const appendIndented = parent.appendIndented;
 const appendModuleCall = parent.appendModuleCall;
 
-/// SymbolRef가 `mod` 소유의 bundler 심볼일 때 SymbolId를 반환. 다른 모듈/공간이거나
+/// SymbolRef가 `mod` 소유의 alias일 때 AliasId를 반환. 다른 모듈/공간이거나
 /// invalid면 null. 아래 두 helper의 공통 unpack 단계.
-fn localBundlerSymbol(ref: SymbolRef, mod: *const Module) ?symbol_mod.AliasId {
+fn localAliasId(ref: SymbolRef, mod: *const Module) ?symbol_mod.AliasId {
     return switch (ref) {
-        .bundler => |b| if (b.module == mod.index and !b.symbol.isNone()) b.symbol else null,
+        .alias => |a| if (a.module == mod.index and !a.symbol.isNone()) a.symbol else null,
         .semantic => null,
     };
 }
@@ -47,7 +47,7 @@ fn localBundlerSymbol(ref: SymbolRef, mod: *const Module) ?symbol_mod.AliasId {
 /// 현재 모듈의 `_default = <expr>` 할당을 참조할 수 있음을 의미.
 fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
     return switch (ref) {
-        .bundler => false,
+        .alias => false,
         .semantic => |s| blk: {
             if (s.module != mod.index or s.symbol.isNone()) break :blk false;
             const sem = mod.semantic orelse break :blk false;
@@ -62,7 +62,7 @@ fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
 /// re_export_alias에 linker가 주입한 canonical_name을 반환. null이면
 /// alias 심볼이 아니거나 linker가 resolve하지 못한 경우.
 fn reExportAliasCanonicalName(ref: SymbolRef, mod: *const Module) ?[]const u8 {
-    const id = localBundlerSymbol(ref, mod) orelse return null;
+    const id = localAliasId(ref, mod) orelse return null;
     const table = mod.alias_table orelse return null;
     if (!table.hasCanonicalName(id)) return null;
     return table.getCanonicalName(id);

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1133,10 +1133,10 @@ pub const Linker = struct {
             for (m.export_bindings) |eb| {
                 if (eb.kind != .re_export) continue;
                 const sym_id = switch (eb.symbol) {
-                    .alias => |b| blk: {
-                        if (b.module != mod_idx) break :blk null;
-                        if (b.symbol.isNone()) break :blk null;
-                        break :blk b.symbol;
+                    .alias => |a| blk: {
+                        if (a.module != mod_idx) break :blk null;
+                        if (a.symbol.isNone()) break :blk null;
+                        break :blk a.symbol;
                     },
                     else => null,
                 } orelse continue;
@@ -1170,10 +1170,10 @@ pub const Linker = struct {
                 const key = makeExportKeyBuf(&key_buf, source_i, ib.imported_name);
                 const entry = self.export_map.get(key) orelse continue;
                 switch (entry.binding.symbol) {
-                    .alias => |b| {
-                        if (b.symbol.isNone()) continue;
+                    .alias => |a| {
+                        if (a.symbol.isNone()) continue;
                         const table_ptr = if (modules[source_i].alias_table) |*t| t else continue;
-                        table_ptr.incRefCount(b.symbol);
+                        table_ptr.incRefCount(a.symbol);
                     },
                     .semantic => |s| {
                         // #1328 Phase 4e-2b: semantic 공간의 합성/정규 심볼 ref_count 증가.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1133,7 +1133,7 @@ pub const Linker = struct {
             for (m.export_bindings) |eb| {
                 if (eb.kind != .re_export) continue;
                 const sym_id = switch (eb.symbol) {
-                    .bundler => |b| blk: {
+                    .alias => |b| blk: {
                         if (b.module != mod_idx) break :blk null;
                         if (b.symbol.isNone()) break :blk null;
                         break :blk b.symbol;
@@ -1170,7 +1170,7 @@ pub const Linker = struct {
                 const key = makeExportKeyBuf(&key_buf, source_i, ib.imported_name);
                 const entry = self.export_map.get(key) orelse continue;
                 switch (entry.binding.symbol) {
-                    .bundler => |b| {
+                    .alias => |b| {
                         if (b.symbol.isNone()) continue;
                         const table_ptr = if (modules[source_i].alias_table) |*t| t else continue;
                         table_ptr.incRefCount(b.symbol);

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -40,25 +40,25 @@ pub const SymbolRef = union(enum) {
     pub fn isValid(self: SymbolRef) bool {
         return switch (self) {
             .semantic => |s| !s.module.isNone() and !s.symbol.isNone(),
-            .alias => |b| !b.module.isNone() and !b.symbol.isNone(),
+            .alias => |a| !a.module.isNone() and !a.symbol.isNone(),
         };
     }
 
     pub fn moduleIndex(self: SymbolRef) ModuleIndex {
         return switch (self) {
             .semantic => |s| s.module,
-            .alias => |b| b.module,
+            .alias => |a| a.module,
         };
     }
 
-    pub fn eql(a: SymbolRef, b: SymbolRef) bool {
-        return switch (a) {
-            .semantic => |sa| switch (b) {
-                .semantic => |sb| sa.module == sb.module and sa.symbol == sb.symbol,
+    pub fn eql(x: SymbolRef, y: SymbolRef) bool {
+        return switch (x) {
+            .semantic => |xs| switch (y) {
+                .semantic => |ys| xs.module == ys.module and xs.symbol == ys.symbol,
                 .alias => false,
             },
-            .alias => |ba| switch (b) {
-                .alias => |bb| ba.module == bb.module and ba.symbol == bb.symbol,
+            .alias => |xa| switch (y) {
+                .alias => |ya| xa.module == ya.module and xa.symbol == ya.symbol,
                 .semantic => false,
             },
         };

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -28,27 +28,26 @@ pub const AliasId = enum(u32) {
     }
 };
 
-/// Cross-module 심볼 참조. semantic 선언/합성 vs bundler alias 공간을 구분.
-/// 4e-2d-c에서 union 평탄화 예정.
+/// Cross-module 심볼 참조. semantic 선언/합성 vs re-export alias 공간을 구분.
 pub const SymbolRef = union(enum) {
     /// semantic이 소유한 선언/합성 심볼
     semantic: struct { module: ModuleIndex, symbol: SemanticSymbolId },
-    /// bundler alias (re-export chain)
-    bundler: struct { module: ModuleIndex, symbol: AliasId },
+    /// Cross-module re-export alias (값 없는 redirect)
+    alias: struct { module: ModuleIndex, symbol: AliasId },
 
-    pub const invalid: SymbolRef = .{ .bundler = .{ .module = .none, .symbol = .none } };
+    pub const invalid: SymbolRef = .{ .alias = .{ .module = .none, .symbol = .none } };
 
     pub fn isValid(self: SymbolRef) bool {
         return switch (self) {
             .semantic => |s| !s.module.isNone() and !s.symbol.isNone(),
-            .bundler => |b| !b.module.isNone() and !b.symbol.isNone(),
+            .alias => |b| !b.module.isNone() and !b.symbol.isNone(),
         };
     }
 
     pub fn moduleIndex(self: SymbolRef) ModuleIndex {
         return switch (self) {
             .semantic => |s| s.module,
-            .bundler => |b| b.module,
+            .alias => |b| b.module,
         };
     }
 
@@ -56,10 +55,10 @@ pub const SymbolRef = union(enum) {
         return switch (a) {
             .semantic => |sa| switch (b) {
                 .semantic => |sb| sa.module == sb.module and sa.symbol == sb.symbol,
-                .bundler => false,
+                .alias => false,
             },
-            .bundler => |ba| switch (b) {
-                .bundler => |bb| ba.module == bb.module and ba.symbol == bb.symbol,
+            .alias => |ba| switch (b) {
+                .alias => |bb| ba.module == bb.module and ba.symbol == bb.symbol,
                 .semantic => false,
             },
         };
@@ -161,12 +160,12 @@ test "AliasTable: ref_count" {
     try std.testing.expectEqual(@as(u32, 2), t.getRefCount(id));
 }
 
-test "SymbolRef: semantic vs bundler 공간 구분" {
+test "SymbolRef: semantic vs alias 공간 구분" {
     const sem: SymbolRef = .{ .semantic = .{
         .module = @enumFromInt(1),
         .symbol = @enumFromInt(2),
     } };
-    const bnd: SymbolRef = .{ .bundler = .{
+    const bnd: SymbolRef = .{ .alias = .{
         .module = @enumFromInt(1),
         .symbol = @enumFromInt(2),
     } };


### PR DESCRIPTION
## 요약

RFC #1338 Phase 4e-2의 마무리. 4e-2d-a/b에서 bundler SymbolTable이 AliasTable로
축소됐으므로 SymbolRef variant 이름을 정합성 맞춤.

평탄화 검토 결과 **union 유지**: semantic(선언+합성, 값 있음, scope 존재) vs
alias(redirect, 값 없음, linker가 canonical_name 주입) 두 공간은 의미가 달라
분리된 표현이 설계적으로 정확.

## 변경

- \`SymbolRef.bundler\` variant → \`SymbolRef.alias\`
- \`esm_wrap.localBundlerSymbol\` → \`localAliasId\` (반환 타입과 일치)
- 주석 "bundler 심볼/공간/alias" → "alias" 통일

9 사이트 수정 (symbol.zig 내부 switch 3 + linker 2 + binding_scanner 1 + test 1 + esm_wrap 2). 동작 변경 없음.

## 전체 Phase 4e-2 커밋 요약

| Sub-phase | PR | 설명 |
|---|---|---|
| 4e-2a | #1339 | semantic extension API + ArrayList |
| 4e-2b | #1339 | synthetic_default → semantic |
| 4e-2c | #1341 | synthetic_init/exports → semantic |
| 4e-2d-a | #1342 | dead variants + fallback 제거 |
| 4e-2d-b | #1343 | SymbolTable → AliasTable 축소 |
| 4e-2d-c | **이 PR** | SymbolRef variant rename |

## 남은 작업 (별도 RFC)

- **4c**: \`ExportBinding.local_name\`/\`imported_name\` 제거 (export registry 설계 필요)
- **4e-1**: tree_shaker가 \`semantic.reference_count\` + \`alias.ref_count\` 통합 활용

## 테스트

- \`zig build test\`: 2917 pass
- \`cd tests/integration && bun test\`: 2878 pass (pre-existing #1340 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)