### PR TITLE
refactor(bundler): Phase 4c-1 — Export Registry 헬퍼 도입

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -851,11 +851,12 @@ pub const Linker = struct {
     }
 
     /// export의 실제 local_name을 조회. default export에서 "default" → "greet" 등.
+    /// #1338 Phase 4c-1: linker.export_map 해시 대신 Module 레지스트리 사용.
+    /// 모듈당 export 선형 스캔 (< 20개 수준).
     pub fn getExportLocalName(self: *const Linker, module_index: u32, exported_name: []const u8) ?[]const u8 {
-        var key_buf: [4096]u8 = undefined;
-        const key = makeExportKeyBuf(&key_buf, module_index, exported_name);
-        const entry = self.export_map.get(key) orelse return null;
-        return entry.binding.local_name;
+        if (module_index >= self.modules.len) return null;
+        const eb = self.modules[module_index].findExportBinding(exported_name) orelse return null;
+        return eb.local_name;
     }
 
     /// 특정 모듈+이름에 대한 canonical name 조회. 리네임 안 됐으면 null (원본 유지).

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -208,6 +208,23 @@ pub const Module = struct {
         return sem.symbols.items;
     }
 
+    /// exported_name으로 ExportBinding을 찾는다. #1338 Phase 4c-1 Export Registry.
+    /// 선형 스캔 — 일반적으로 모듈당 export 수가 < 20 수준이라 충분히 빠름.
+    /// 성능 프로파일에서 병목이 되면 내부적으로 HashMap 구축 가능 (R1 캡슐화).
+    pub fn findExportBinding(self: *const Module, exported_name: []const u8) ?*const ExportBinding {
+        for (self.export_bindings) |*eb| {
+            if (std.mem.eql(u8, eb.exported_name, exported_name)) return eb;
+        }
+        return null;
+    }
+
+    /// exported_name에 해당하는 SymbolRef 반환. 없으면 invalid.
+    /// #1338 Phase 4c-1: 문자열 기반 lookup을 SymbolRef로 승격하기 위한 진입점.
+    pub fn findExportSymbol(self: *const Module, exported_name: []const u8) symbol_mod.SymbolRef {
+        if (self.findExportBinding(exported_name)) |eb| return eb.symbol;
+        return symbol_mod.SymbolRef.invalid;
+    }
+
     /// CJS importee에 대한 interop 모드 결정 (Rolldown 방식).
     /// importer(self)가 ESM 정의 형식이면 Node 모드, 아니면 Babel 모드.
     pub fn interop(self: *const Module, importee: *const Module) ?types.Interop {


### PR DESCRIPTION
## 요약

RFC #1328의 Phase 4c 시작. 원 motivation인 "문자열 기반 모델 제거"의
첫 단계로 Module에 exported_name 기반 lookup 헬퍼를 추가. 이후 4c-2/3에서
\`linker.export_map\` / \`canonical_names\`의 string-keyed 경로를 이 헬퍼 +
SymbolRef 기반으로 점진 교체.

## 변경

### Module 헬퍼 추가
- \`Module.findExportBinding(exported_name) ?*const ExportBinding\`: 선형 스캔 (<20 exports/모듈)
- \`Module.findExportSymbol(exported_name) SymbolRef\`: SymbolRef 반환 (없으면 invalid)

### Consumer 전환 (1건, 패턴 demo)
- \`Linker.getExportLocalName\`: 기존 \`export_map.get(key)\` → \`Module.findExportBinding\` 경유. \`key_buf\` 스택 할당(4KB) 제거.

## 4c 전체 계획 (RFC #1328 코멘트 참조)

| 단계 | 범위 | 내용 |
|---|---|---|
| **4c-1** | ~10 사이트 | Export Registry 헬퍼 추가 (이 PR) |
| 4c-2 | ~20 사이트 | \`ImportBinding.symbol\` SymbolRef 소비 전환 |
| 4c-3 | ~30 사이트 | \`getCanonicalName(module, name)\` → \`resolveRef(ref)\` (가장 invasive) |
| 4c-4 | ~40 사이트 | \`local_name\`/\`imported_name\` 필드 제거, #1328 완전 closed |

## 테스트

- \`zig build test\`: 2917 pass
- 통합 테스트: 2878 pass (pre-existing #1340 제외)

## Test plan

- [x] \`zig build test\`
- [x] \`cd tests/integration && bun test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)