### PR TITLE
refactor(bundler): Phase 4c-2 — populateImportSymbols + ib.symbol 첫 소비

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -502,6 +502,7 @@ pub const Bundler = struct {
             try worker_linker.computeMangling();
         }
         worker_linker.populateReExportAliases(worker_graph.modules.items);
+        worker_linker.populateImportSymbols(worker_graph.modules.items);
         worker_linker.populateSymbolRefCounts(worker_graph.modules.items);
         defer worker_linker.deinit();
 
@@ -666,6 +667,8 @@ pub const Bundler = struct {
             // Phase 3b (#1328): re_export_alias 심볼의 canonical_name 채우기.
             // computeRenames 이후에 호출해야 getCanonicalName이 최종 리네임을 반영.
             l.populateReExportAliases(graph.modules.items);
+            // Phase 4c-2 (#1328): ImportBinding.symbol을 source 모듈의 export SymbolRef로 채움.
+            l.populateImportSymbols(graph.modules.items);
             // Phase 4d (#1328): symbol-level ref_count 수집. tree-shaking companion metric.
             l.populateSymbolRefCounts(graph.modules.items);
             break :blk l;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1162,18 +1162,15 @@ pub const Linker = struct {
     pub fn populateSymbolRefCounts(_: *const Linker, modules: []Module) void {
         for (modules) |*importer| {
             for (importer.import_bindings) |ib| {
+                if (!ib.symbol.isValid()) continue;
+                const source_i = @intFromEnum(ib.symbol.moduleIndex());
+                if (source_i >= modules.len) continue;
                 switch (ib.symbol) {
                     .alias => |a| {
-                        if (a.symbol.isNone() or a.module.isNone()) continue;
-                        const source_i = @intFromEnum(a.module);
-                        if (source_i >= modules.len) continue;
                         const table_ptr = if (modules[source_i].alias_table) |*t| t else continue;
                         table_ptr.incRefCount(a.symbol);
                     },
                     .semantic => |s| {
-                        if (s.symbol.isNone() or s.module.isNone()) continue;
-                        const source_i = @intFromEnum(s.module);
-                        if (source_i >= modules.len) continue;
                         const sem_ptr = if (modules[source_i].semantic) |*sem| sem else continue;
                         const idx: u32 = @intFromEnum(s.symbol);
                         if (idx >= sem_ptr.symbols.items.len) continue;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1158,32 +1158,48 @@ pub const Linker = struct {
     /// 활용하도록 통합할 예정.
     ///
     /// link() + populateReExportAliases() 이후에 호출되어야 한다.
-    pub fn populateSymbolRefCounts(self: *const Linker, modules: []Module) void {
-        var key_buf: [4096]u8 = undefined;
+    /// #1338 Phase 4c-2: ib.symbol로 직접 전환 — export_map 해시 lookup 제거.
+    pub fn populateSymbolRefCounts(_: *const Linker, modules: []Module) void {
         for (modules) |*importer| {
             for (importer.import_bindings) |ib| {
-                if (ib.import_record_index >= importer.import_records.len) continue;
-                const source_mod_idx = importer.import_records[ib.import_record_index].resolved;
-                if (source_mod_idx.isNone()) continue;
-                const source_i = @intFromEnum(source_mod_idx);
-                if (source_i >= modules.len) continue;
-
-                const key = makeExportKeyBuf(&key_buf, source_i, ib.imported_name);
-                const entry = self.export_map.get(key) orelse continue;
-                switch (entry.binding.symbol) {
+                switch (ib.symbol) {
                     .alias => |a| {
-                        if (a.symbol.isNone()) continue;
+                        if (a.symbol.isNone() or a.module.isNone()) continue;
+                        const source_i = @intFromEnum(a.module);
+                        if (source_i >= modules.len) continue;
                         const table_ptr = if (modules[source_i].alias_table) |*t| t else continue;
                         table_ptr.incRefCount(a.symbol);
                     },
                     .semantic => |s| {
-                        // #1328 Phase 4e-2b: semantic 공간의 합성/정규 심볼 ref_count 증가.
-                        if (s.symbol.isNone()) continue;
+                        if (s.symbol.isNone() or s.module.isNone()) continue;
+                        const source_i = @intFromEnum(s.module);
+                        if (source_i >= modules.len) continue;
                         const sem_ptr = if (modules[source_i].semantic) |*sem| sem else continue;
                         const idx: u32 = @intFromEnum(s.symbol);
                         if (idx >= sem_ptr.symbols.items.len) continue;
                         sem_ptr.symbols.items[idx].reference_count += 1;
                     },
+                }
+            }
+        }
+    }
+
+    /// #1338 Phase 4c-2: 모든 모듈의 import_binding.symbol을 채운다.
+    /// 각 ImportBinding의 imported_name으로 source 모듈의 ExportBinding을 찾고
+    /// 그 SymbolRef를 복사. invalid 유지는 source 모듈이 해당 export를 갖지 않는 경우.
+    /// populateReExportAliases 이후에 호출되어야 alias canonical_name이 반영됨.
+    pub fn populateImportSymbols(_: *const Linker, modules: []Module) void {
+        for (modules) |*importer| {
+            for (importer.import_bindings) |*ib| {
+                if (ib.import_record_index >= importer.import_records.len) continue;
+                const source_mod_idx = importer.import_records[ib.import_record_index].resolved;
+                if (source_mod_idx.isNone()) continue;
+                const source_i = @intFromEnum(source_mod_idx);
+                if (source_i >= modules.len) continue;
+                // namespace import는 개별 심볼이 아닌 모듈 전체를 가리킴 — skip.
+                if (ib.kind == .namespace) continue;
+                if (modules[source_i].findExportBinding(ib.imported_name)) |eb| {
+                    ib.symbol = eb.symbol;
                 }
             }
         }

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1333,6 +1333,7 @@ test "populateSymbolRefCounts: import이 source default symbol의 ref_count 증�
     defer r.cache.deinit();
 
     r.linker.populateReExportAliases(r.graph.modules.items);
+    r.linker.populateImportSymbols(r.graph.modules.items);
     r.linker.populateSymbolRefCounts(r.graph.modules.items);
 
     // b.ts의 synthetic_default symbol이 참조되어 ref_count == 1.
@@ -1363,6 +1364,7 @@ test "populateSymbolRefCounts: 아무도 안 쓰는 export는 ref_count 0" {
     defer r.cache.deinit();
 
     r.linker.populateReExportAliases(r.graph.modules.items);
+    r.linker.populateImportSymbols(r.graph.modules.items);
     r.linker.populateSymbolRefCounts(r.graph.modules.items);
 
     const b = &r.graph.modules.items[1];


### PR DESCRIPTION
## 요약

RFC #1328 Phase 4c 두 번째 단계. Phase 2에서 도입됐으나 여태 미사용이던
\`ImportBinding.symbol\` 필드를 실제로 populate하고, 첫 consumer인
\`populateSymbolRefCounts\`를 SymbolRef 기반으로 전환.

## 변경

### 신규 API
- \`Linker.populateImportSymbols(modules)\`: 모든 import_binding의 \`imported_name\`으로 source 모듈의 \`findExportBinding\` (4c-1에서 도입) 호출 → \`ExportBinding.symbol\`을 \`ImportBinding.symbol\`에 복사.
- namespace import는 skip (모듈 전체 참조라 개별 SymbolRef 무의미).

### 소비자 전환
\`populateSymbolRefCounts\`: 기존 패턴
\`\`\`zig
const key = makeExportKeyBuf(&key_buf, source_i, ib.imported_name);
const entry = self.export_map.get(key) orelse continue;
switch (entry.binding.symbol) { ... }
\`\`\`
→ 전환 후:
\`\`\`zig
switch (ib.symbol) { ... }
\`\`\`
4KB \`key_buf\` 스택 할당 + HashMap lookup 제거.

### 파이프라인 순서
\`bundler.zig\`의 link 시퀀스:
1. \`link()\`
2. \`computeRenames\`
3. \`populateReExportAliases\`
4. **\`populateImportSymbols\`** ← 신규
5. \`populateSymbolRefCounts\`

테스트 1건에 새 단계 호출 추가. 동작 변경 없음 — 유닛 2917 / 통합 2878 pass.

## 후속 (4c-3)
\`getCanonicalName(module, name)\` → \`resolveRef(ref)\` 전환. 가장 invasive (~30 사이트). mangler/rename 경로 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)