### PR TITLE
refactor(bundler): Phase 4c-3 — getCanonicalByRef facade 도입

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -877,19 +877,19 @@ pub const Linker = struct {
         const mod_i = @intFromEnum(ref.moduleIndex());
         if (mod_i >= self.modules.len) return null;
         const m = &self.modules[mod_i];
-        switch (ref) {
-            .alias => |a| {
-                const t = if (m.alias_table) |*at| at else return null;
-                return if (t.hasCanonicalName(a.symbol)) t.getCanonicalName(a.symbol) else null;
+        return switch (ref) {
+            .alias => |a| blk: {
+                const t = if (m.alias_table) |*at| at else break :blk null;
+                break :blk if (t.hasCanonicalName(a.symbol)) t.getCanonicalName(a.symbol) else null;
             },
-            .semantic => |s| {
-                const sem = m.semantic orelse return null;
+            .semantic => |s| blk: {
+                const sem = m.semantic orelse break :blk null;
                 const idx: u32 = @intFromEnum(s.symbol);
-                if (idx >= sem.symbols.items.len) return null;
+                if (idx >= sem.symbols.items.len) break :blk null;
                 const name = sem.symbols.items[idx].nameText(m.source);
-                return self.getCanonicalName(mod_i, name);
+                break :blk self.getCanonicalName(mod_i, name);
             },
-        }
+        };
     }
 
     // ================================================================

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -22,6 +22,7 @@ const Span = @import("../lexer/token.zig").Span;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Ast = @import("../parser/ast.zig").Ast;
 const semantic_symbol = @import("../semantic/symbol.zig");
+const bundler_symbol = @import("symbol.zig");
 
 /// namespace 접근 패턴에서 생성되는 변수 prefix.
 /// metadata.zig, codegen.zig, emitter.zig에서 공유.
@@ -864,6 +865,31 @@ pub const Linker = struct {
         var key_buf: [4096]u8 = undefined;
         const key = makeExportKeyBuf(&key_buf, module_index, name);
         return self.canonical_names.get(key);
+    }
+
+    /// SymbolRef 기반 canonical name 조회 facade. #1338 Phase 4c-3.
+    /// alias: AliasTable이 이미 canonical_name을 소유 → 직접 반환.
+    /// semantic: 심볼 이름 추출 후 기존 string 기반 canonical_names 조회
+    ///   (4c-3 후속에서 semantic.Symbol에 canonical_name 필드 이전 예정).
+    /// 리네임 안 됐으면 null — caller가 원본 이름으로 fallback.
+    pub fn getCanonicalByRef(self: *const Linker, ref: bundler_symbol.SymbolRef) ?[]const u8 {
+        if (!ref.isValid()) return null;
+        const mod_i = @intFromEnum(ref.moduleIndex());
+        if (mod_i >= self.modules.len) return null;
+        const m = &self.modules[mod_i];
+        switch (ref) {
+            .alias => |a| {
+                const t = if (m.alias_table) |*at| at else return null;
+                return if (t.hasCanonicalName(a.symbol)) t.getCanonicalName(a.symbol) else null;
+            },
+            .semantic => |s| {
+                const sem = m.semantic orelse return null;
+                const idx: u32 = @intFromEnum(s.symbol);
+                if (idx >= sem.symbols.items.len) return null;
+                const name = sem.symbols.items[idx].nameText(m.source);
+                return self.getCanonicalName(mod_i, name);
+            },
+        }
     }
 
     // ================================================================

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1382,3 +1382,33 @@ test "populateSymbolRefCounts: 아무도 안 쓰는 export는 ref_count 0" {
     if (!found_default) return error.DefaultNotRegistered;
     try std.testing.expectEqual(@as(u32, 0), found_ref);
 }
+
+// #1338 Phase 4c-3: SymbolRef 기반 canonical name facade
+test "getCanonicalByRef: alias symbol의 canonical_name 반환" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "export { default as Foo } from './b';");
+    try writeFile(tmp.dir, "b.ts", "export default 42;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    r.linker.populateReExportAliases(r.graph.modules.items);
+    r.linker.populateImportSymbols(r.graph.modules.items);
+
+    // a.ts의 barrel re-export alias symbol 찾기
+    const a = &r.graph.modules.items[0];
+    var alias_ref: ?@import("symbol.zig").SymbolRef = null;
+    for (a.export_bindings) |eb| {
+        if (eb.kind == .re_export and std.mem.eql(u8, eb.exported_name, "Foo")) {
+            alias_ref = eb.symbol;
+            break;
+        }
+    }
+    const ref = alias_ref orelse return error.AliasNotFound;
+    // alias는 canonical_name이 resolve된 상태 — facade가 non-null 반환해야 함
+    const name = r.linker.getCanonicalByRef(ref) orelse return error.NoCanonical;
+    try std.testing.expect(name.len > 0);
+}


### PR DESCRIPTION
## 요약

RFC #1328 Phase 4c 세 번째 단계. 문자열 기반 \`getCanonicalName(module, name)\` 호출지를 SymbolRef 기반으로 점진 교체하기 위한 **facade API**를 도입.

## 범위 재조정

원 계획은 \`canonical_names: StringHashMap\` 자체를 SymbolRef 기반 storage로 교체하는 대수술이었으나 리스크 평가 결과 mangler 재작성이 수반되어 단일 PR로 부적합. **facade + 점진 migration** 전략으로 전환.

## 변경

### 추가
\`\`\`zig
pub fn getCanonicalByRef(self: *const Linker, ref: SymbolRef) ?[]const u8
\`\`\`
- \`.alias\`: \`AliasTable\`이 이미 \`canonical_name\` 소유 — 직접 조회
- \`.semantic\`: 심볼 이름 추출 후 기존 \`canonical_names\` HashMap 위임 (storage 그대로)

### 회귀 테스트
barrel re-export에서 alias canonical_name 조회 — 1건 추가.

## 4c 남은 단계

| 단계 | 내용 |
|---|---|
| **4c-3b** | \`getCanonicalName\` consumer ~30 사이트 → \`getCanonicalByRef\` 점진 전환 |
| **4c-3c** | \`semantic.Symbol\`에 \`canonical_name\` 필드 이전 + \`canonical_names\` HashMap 제거 (mangler 재작성) |
| **4c-4** | \`ExportBinding\`/\`ImportBinding\`의 \`local_name\`/\`imported_name\` 제거 |

## 테스트
- 유닛 2918 pass
- 통합 2878 pass (pre-existing #1340 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)