### PR TITLE
refactor(bundler): Phase 4c-3b-β — import preamble 5곳 getCanonicalByRef 전환

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -621,13 +621,12 @@ pub fn emitEsmWrappedModule(
                     .cjs => {
                         // preamble에서 이미 __toESM으로 바인딩된 변수가 있으면
                         // 중복 require 호출 없이 해당 변수를 참조한다.
-                        const mi: u32 = @intFromEnum(module.index);
                         var found_preamble_var: ?[]const u8 = null;
                         for (module.import_bindings) |ib| {
                             if (ib.import_record_index == rec_idx and
                                 std.mem.eql(u8, ib.imported_name, "default"))
                             {
-                                found_preamble_var = l.getCanonicalName(mi, ib.local_name) orelse ib.local_name;
+                                found_preamble_var = l.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
                                 break;
                             }
                         }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -204,7 +204,7 @@ pub fn buildMetadataForAst(
             // resolve 미완료: external 또는 resolve 실패.
             if (rec.resolved.isNone()) {
                 if (rec.kind == .static_import or rec.kind == .side_effect or rec.kind == .re_export) {
-                    const preamble_name = self.getCanonicalName(module_index, ib.local_name) orelse ib.local_name;
+                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
                     // synthetic binding(JSX runtime 등) + ESM-wrapped 모듈 조합에서는
                     // top-level에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨.
                     // init 함수 본문에서 `var`로 재선언하면 outer scope를 shadow → #1209.
@@ -283,7 +283,7 @@ pub fn buildMetadataForAst(
 
             // CJS 모듈에서 import하는 경우: preamble에서 require_xxx() 호출 생성
             if (canonical_mod < self.modules.len and self.modules[canonical_mod].wrap_kind == .cjs) {
-                const preamble_name = self.getCanonicalName(module_index, ib.local_name) orelse ib.local_name;
+                const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
                 const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
                 const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
                 // ESM-wrapped + synthetic binding: top-level에 이미 var 선언됨 → 할당만
@@ -346,7 +346,7 @@ pub fn buildMetadataForAst(
             // 롤다운 shimMissingExports 호환: 소스 모듈에 해당 export가 없으면
             // strict mode ReferenceError 대신 undefined를 반환하도록 shim 생성.
             if (resolved == null and self.shim_missing_exports) {
-                const shim_name = self.getCanonicalName(module_index, ib.local_name) orelse ib.local_name;
+                const shim_name = self.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
                 try preamble.write("var ");
                 try preamble.write(shim_name);
                 try preamble.write(" = void 0;\n");
@@ -361,7 +361,7 @@ pub fn buildMetadataForAst(
             if (resolved) |rb| {
                 const cjs_mod: u32 = @intCast(@intFromEnum(rb.canonical.module_index));
                 if (cjs_mod < self.modules.len and self.modules[cjs_mod].wrap_kind == .cjs) {
-                    const preamble_name = self.getCanonicalName(module_index, ib.local_name) orelse ib.local_name;
+                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
                     const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, cjs_mod);
                     const interop_mode2: types.Interop = if (m.def_format.isEsm()) .node else .babel;
                     const effective_name = rb.canonical.export_name;


### PR DESCRIPTION
## Summary
- metadata.zig: 207, 286, 349, 364 — `ib.local_symbol` 기반 facade 전환
- esm_wrap.zig: 630 — 동일 전환 (이제 불필요해진 `mi` 지역변수 제거)

## Why
4c-3b-α에서 채운 `ib.local_symbol`의 첫 실사용. import preamble/rename 경로가 문자열 `(module_index, name)` 대신 SymbolRef로 canonical을 조회 → 4c-3c의 canonical storage 재배치 선결조건.

## 의미 등가
`ib.local_symbol`은 현재 모듈 semantic symbol — 기존 `getCanonicalName(module_index, ib.local_name)`과 의미 동일. invalid일 땐 양쪽 모두 `ib.local_name` fallback.

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (기존 1 fail은 main baseline, 무관)

Refs #1328, builds on #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)