### PR TITLE
refactor(bundler): Phase 4c-3b-γ — export binding 6곳 getCanonicalByRef 전환

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -987,7 +987,10 @@ fn makeStarGetterValue(
             // scope-hoisted: export의 local_name을 찾아 canonical name으로 변환
             for (src_mod.export_bindings) |src_eb| {
                 if (std.mem.eql(u8, src_eb.exported_name, name)) {
-                    const local = l.getCanonicalName(src_i, src_eb.local_name) orelse src_eb.local_name;
+                    const local = if (src_eb.kind == .local)
+                        l.getCanonicalByRef(src_eb.symbol) orelse src_eb.local_name
+                    else
+                        l.getCanonicalName(src_i, src_eb.local_name) orelse src_eb.local_name;
                     return try allocator.dupe(u8, local);
                 }
             }
@@ -1010,7 +1013,10 @@ fn makeStarGetterValue(
                 // .none: canonical 로컬 변수
                 for (canonical_mod.export_bindings) |ceb| {
                     if (std.mem.eql(u8, ceb.exported_name, resolved.export_name)) {
-                        const local = l.getCanonicalName(canonical_mod_i, ceb.local_name) orelse ceb.local_name;
+                        const local = if (ceb.kind == .local)
+                            l.getCanonicalByRef(ceb.symbol) orelse ceb.local_name
+                        else
+                            l.getCanonicalName(canonical_mod_i, ceb.local_name) orelse ceb.local_name;
                         return try allocator.dupe(u8, local);
                     }
                 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1525,7 +1525,8 @@ pub const Linker = struct {
                         }
                     }
                 }
-                break :blk self.getCanonicalName(@intCast(mod_i), eb.local_name) orelse eb.local_name;
+                // .local else-blk: eb.symbol은 semantic → ref 기반 조회와 등가.
+                break :blk self.getCanonicalByRef(eb.symbol) orelse eb.local_name;
             };
 
             const safe_local = self.safeIdentifierName(actual_local, @intCast(mod_i));

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -561,7 +561,7 @@ pub fn buildMetadataForAst(
             break;
         }
         if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
-            default_export_name = self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
+            default_export_name = self.getCanonicalByRef(eb.symbol) orelse eb.local_name;
             break;
         }
     }
@@ -700,7 +700,12 @@ pub fn buildFinalExports(
         if (std.mem.eql(u8, eb.exported_name, "*")) continue;
         if (!first) try buf.appendSlice(self.allocator, ",");
         first = false;
-        const actual_name = self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
+        // .local: eb.symbol(semantic)로 ref 기반 조회, 외: 기존 문자열 경로 유지
+        // (re_export alias는 chain-resolve된 canonical을 쓰므로 final exports 의미가 달라짐).
+        const actual_name = if (eb.kind == .local)
+            self.getCanonicalByRef(eb.symbol) orelse eb.local_name
+        else
+            self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
         try buf.append(self.allocator, ' ');
         try buf.appendSlice(self.allocator, actual_name);
         if (!std.mem.eql(u8, actual_name, eb.exported_name)) {
@@ -1193,7 +1198,11 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
             first = false;
 
             // canonical 이름 (리네임됐으면 변경된 이름)
-            const actual_name = self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
+            // .local은 semantic ref, 그 외는 기존 문자열 경로 유지.
+            const actual_name = if (eb.kind == .local)
+                self.getCanonicalByRef(eb.symbol) orelse eb.local_name
+            else
+                self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
 
             try buf.append(self.allocator, ' ');
             try buf.appendSlice(self.allocator, actual_name);


### PR DESCRIPTION
## Summary
- metadata.zig:564 / 703 / 1196, linker.zig:1528, esm_wrap.zig:990 / 1013 전환
- `.local` 가드 후 `eb.symbol` (semantic) 기반 `getCanonicalByRef` 사용
- 그 외 kind는 기존 문자열 경로 유지

## Why
`eb.symbol`은 kind별 의미가 다름:
- `.local` → semantic SymbolRef (현재 모듈), 기존 `getCanonicalName(mod, local_name)`과 의미 등가
- `.re_export` → alias SymbolRef, canonical이 chain-resolved라 기존 문자열 경로와 동작 다름
- `.re_export_all` → invalid

`.local`에서만 전환해 의미 보존.

## 미변환 (의도)
esm_wrap.zig:475 — `.re_export`에서 alias canonical이 비어있을 때 현재 모듈 rename으로 fallback 필요 (#1312의 `URLSearchParams\$1` 시나리오). 단순 kind 가드로 해결 안 됨. 4c-3c에서 alias canonical-population 재설계와 함께 처리.

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)
- [x] #1312 회귀 테스트 통과 확인

Refs #1328, builds on #1348, #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)