### PR TITLE
chore(bundler): /simplify Phase 4c-3b 후속 — 융합·helper·주석 정리

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -43,7 +43,7 @@ pub const ImportBinding = struct {
     /// #1328 Phase 4c-3b: 현재 모듈의 로컬 바인딩 심볼 (semantic scope).
     /// import preamble/rename 경로에서 "현재 모듈 기준" canonical 조회에 사용.
     /// `symbol`은 source 모듈 쪽을 가리키므로 local 경로에는 쓸 수 없다.
-    /// linker.populateImportLocalSymbols가 채움. invalid = synthetic binding 등
+    /// linker.populateImportSymbols가 채움. invalid = synthetic binding 등
     /// semantic scope에 로컬이 없는 경우.
     local_symbol: symbol_mod.SymbolRef = symbol_mod.SymbolRef.invalid,
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -503,7 +503,6 @@ pub const Bundler = struct {
         }
         worker_linker.populateReExportAliases(worker_graph.modules.items);
         worker_linker.populateImportSymbols(worker_graph.modules.items);
-        worker_linker.populateImportLocalSymbols(worker_graph.modules.items);
         worker_linker.populateSymbolRefCounts(worker_graph.modules.items);
         defer worker_linker.deinit();
 
@@ -668,11 +667,9 @@ pub const Bundler = struct {
             // Phase 3b (#1328): re_export_alias 심볼의 canonical_name 채우기.
             // computeRenames 이후에 호출해야 getCanonicalName이 최종 리네임을 반영.
             l.populateReExportAliases(graph.modules.items);
-            // Phase 4c-2 (#1328): ImportBinding.symbol을 source 모듈의 export SymbolRef로 채움.
+            // ImportBinding.symbol(source-side) + local_symbol(current-side) 채움.
             l.populateImportSymbols(graph.modules.items);
-            // Phase 4c-3b-α (#1328): ImportBinding.local_symbol을 현재 모듈 semantic ref로 채움.
-            l.populateImportLocalSymbols(graph.modules.items);
-            // Phase 4d (#1328): symbol-level ref_count 수집. tree-shaking companion metric.
+            // symbol-level ref_count 수집. tree-shaking companion metric.
             l.populateSymbolRefCounts(graph.modules.items);
             break :blk l;
         } else null;

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -987,10 +987,7 @@ fn makeStarGetterValue(
             // scope-hoisted: export의 local_name을 찾아 canonical name으로 변환
             for (src_mod.export_bindings) |src_eb| {
                 if (std.mem.eql(u8, src_eb.exported_name, name)) {
-                    const local = if (src_eb.kind == .local)
-                        l.getCanonicalByRef(src_eb.symbol) orelse src_eb.local_name
-                    else
-                        l.getCanonicalName(src_i, src_eb.local_name) orelse src_eb.local_name;
+                    const local = l.getCanonicalForExport(src_eb, src_i);
                     return try allocator.dupe(u8, local);
                 }
             }
@@ -1013,10 +1010,7 @@ fn makeStarGetterValue(
                 // .none: canonical 로컬 변수
                 for (canonical_mod.export_bindings) |ceb| {
                     if (std.mem.eql(u8, ceb.exported_name, resolved.export_name)) {
-                        const local = if (ceb.kind == .local)
-                            l.getCanonicalByRef(ceb.symbol) orelse ceb.local_name
-                        else
-                            l.getCanonicalName(canonical_mod_i, ceb.local_name) orelse ceb.local_name;
+                        const local = l.getCanonicalForExport(ceb, canonical_mod_i);
                         return try allocator.dupe(u8, local);
                     }
                 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -867,6 +867,17 @@ pub const Linker = struct {
         return self.canonical_names.get(key);
     }
 
+    /// ExportBinding의 canonical local name을 kind별 safe한 방법으로 조회.
+    /// `.local`은 `eb.symbol`(semantic) 기반 ref 조회; 그 외는 문자열 조회.
+    /// `.re_export` alias는 chain-resolved canonical을 쓰므로 final exports/scope
+    /// hoisting에서 원하는 "현재 모듈 rename"과 다름 → 문자열 경로 유지.
+    pub fn getCanonicalForExport(self: *const Linker, eb: ExportBinding, module_index: u32) []const u8 {
+        if (eb.kind == .local) {
+            return self.getCanonicalByRef(eb.symbol) orelse eb.local_name;
+        }
+        return self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
+    }
+
     /// SymbolRef 기반 canonical name 조회 facade. #1338 Phase 4c-3.
     /// alias: AliasTable이 이미 canonical_name을 소유 → 직접 반환.
     /// semantic: 심볼 이름 추출 후 기존 string 기반 canonical_names 조회
@@ -1207,13 +1218,34 @@ pub const Linker = struct {
         }
     }
 
-    /// #1338 Phase 4c-2: 모든 모듈의 import_binding.symbol을 채운다.
-    /// 각 ImportBinding의 imported_name으로 source 모듈의 ExportBinding을 찾고
-    /// 그 SymbolRef를 복사. invalid 유지는 source 모듈이 해당 export를 갖지 않는 경우.
-    /// populateReExportAliases 이후에 호출되어야 alias canonical_name이 반영됨.
+    /// 모든 모듈의 ImportBinding 심볼 필드를 채운다:
+    ///   - `symbol`: source 모듈의 export SymbolRef (cross-module redirect).
+    ///     invalid 유지는 source 모듈이 해당 export를 갖지 않는 경우.
+    ///   - `local_symbol`: 현재 모듈 semantic top-level 심볼 (current-side 조회용).
+    /// `populateReExportAliases` 이후에 호출되어야 alias canonical이 반영됨.
     pub fn populateImportSymbols(_: *const Linker, modules: []Module) void {
-        for (modules) |*importer| {
+        for (modules, 0..) |*importer, i| {
+            const sem_opt = importer.semantic;
+            const module_scope_opt = if (sem_opt) |sem|
+                if (sem.scope_maps.len > 0) sem.scope_maps[0] else null
+            else
+                null;
+            const mod_idx: bundler_symbol.ModuleIndex = @enumFromInt(i);
+
             for (importer.import_bindings) |*ib| {
+                // current-side: scope_maps[0]에서 로컬 심볼 조회
+                if (module_scope_opt) |module_scope| {
+                    if (!ib.isSynthetic()) {
+                        if (module_scope.get(ib.local_name)) |sym_idx| {
+                            ib.local_symbol = .{ .semantic = .{
+                                .module = mod_idx,
+                                .symbol = @enumFromInt(@as(u32, @intCast(sym_idx))),
+                            } };
+                        }
+                    }
+                }
+
+                // source-side: import_record 따라 source 모듈의 export 심볼 복사
                 if (ib.import_record_index >= importer.import_records.len) continue;
                 const source_mod_idx = importer.import_records[ib.import_record_index].resolved;
                 if (source_mod_idx.isNone()) continue;
@@ -1224,27 +1256,6 @@ pub const Linker = struct {
                 if (modules[source_i].findExportBinding(ib.imported_name)) |eb| {
                     ib.symbol = eb.symbol;
                 }
-            }
-        }
-    }
-
-    /// #1328 Phase 4c-3b-α: ImportBinding.local_symbol을 현재 모듈의 semantic
-    /// top-level 심볼 ref로 채운다. import preamble/rename 경로가 source-side
-    /// `ib.symbol` 대신 current-side SymbolRef로 canonical을 조회하게 하려는 준비.
-    /// 소비자는 4c-3b-β에서 붙는다 (이 PR에서는 필드 채움만).
-    pub fn populateImportLocalSymbols(_: *const Linker, modules: []Module) void {
-        for (modules, 0..) |*importer, i| {
-            const sem = importer.semantic orelse continue;
-            if (sem.scope_maps.len == 0) continue;
-            const module_scope = sem.scope_maps[0];
-            const mod_idx: bundler_symbol.ModuleIndex = @enumFromInt(i);
-            for (importer.import_bindings) |*ib| {
-                if (ib.isSynthetic()) continue;
-                const sym_idx = module_scope.get(ib.local_name) orelse continue;
-                ib.local_symbol = .{ .semantic = .{
-                    .module = mod_idx,
-                    .symbol = @enumFromInt(@as(u32, @intCast(sym_idx))),
-                } };
             }
         }
     }
@@ -1525,7 +1536,6 @@ pub const Linker = struct {
                         }
                     }
                 }
-                // .local else-blk: eb.symbol은 semantic → ref 기반 조회와 등가.
                 break :blk self.getCanonicalByRef(eb.symbol) orelse eb.local_name;
             };
 

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -700,12 +700,7 @@ pub fn buildFinalExports(
         if (std.mem.eql(u8, eb.exported_name, "*")) continue;
         if (!first) try buf.appendSlice(self.allocator, ",");
         first = false;
-        // .local: eb.symbol(semantic)로 ref 기반 조회, 외: 기존 문자열 경로 유지
-        // (re_export alias는 chain-resolve된 canonical을 쓰므로 final exports 의미가 달라짐).
-        const actual_name = if (eb.kind == .local)
-            self.getCanonicalByRef(eb.symbol) orelse eb.local_name
-        else
-            self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
+        const actual_name = self.getCanonicalForExport(eb, module_index);
         try buf.append(self.allocator, ' ');
         try buf.appendSlice(self.allocator, actual_name);
         if (!std.mem.eql(u8, actual_name, eb.exported_name)) {
@@ -1197,12 +1192,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
             if (!first) try buf.appendSlice(self.allocator, ",");
             first = false;
 
-            // canonical 이름 (리네임됐으면 변경된 이름)
-            // .local은 semantic ref, 그 외는 기존 문자열 경로 유지.
-            const actual_name = if (eb.kind == .local)
-                self.getCanonicalByRef(eb.symbol) orelse eb.local_name
-            else
-                self.getCanonicalName(module_index, eb.local_name) orelse eb.local_name;
+            const actual_name = self.getCanonicalForExport(eb, module_index);
 
             try buf.append(self.allocator, ' ');
             try buf.appendSlice(self.allocator, actual_name);

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1413,8 +1413,7 @@ test "getCanonicalByRef: alias symbol의 canonical_name 반환" {
     try std.testing.expect(name.len > 0);
 }
 
-// #1328 Phase 4c-3b-α: ImportBinding.local_symbol population
-test "populateImportLocalSymbols: named import의 local_symbol이 현재 모듈 semantic ref" {
+test "populateImportSymbols: named import의 local_symbol이 현재 모듈 semantic ref" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "a.ts", "import { x } from './b'; console.log(x);");
@@ -1425,7 +1424,7 @@ test "populateImportLocalSymbols: named import의 local_symbol이 현재 모듈 
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    r.linker.populateImportLocalSymbols(r.graph.modules.items);
+    r.linker.populateImportSymbols(r.graph.modules.items);
 
     const a = &r.graph.modules.items[0];
     var found = false;
@@ -1438,21 +1437,4 @@ test "populateImportLocalSymbols: named import의 local_symbol이 현재 모듈 
         }
     }
     try std.testing.expect(found);
-}
-
-test "populateImportLocalSymbols: synthetic binding은 skip" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.ts", "export const x = 1;");
-
-    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
-    defer r.linker.deinit();
-    defer r.graph.deinit();
-    defer r.cache.deinit();
-
-    // synthetic binding 주입 (sentinel span)
-    const a = &r.graph.modules.items[0];
-    _ = a;
-    // 호출 자체가 crash 없이 완료되면 통과 (synthetic은 scope에 없어도 skip).
-    r.linker.populateImportLocalSymbols(r.graph.modules.items);
 }


### PR DESCRIPTION
## /simplify 리뷰 반영

### 1. populateImportLocalSymbols → populateImportSymbols 융합
동일 이중 순회 제거. 한 패스에서 source-side + current-side 모두 채움.

### 2. `Linker.getCanonicalForExport(eb, module_index)` helper
4곳 중복된 `if (eb.kind == .local) ... else ...` 패턴 통합. 정책 응집.
- metadata.zig: buildFinalExports ×2
- esm_wrap.zig: makeStarGetterValue ×2

### 3. 주석 정리
call-site phase-tag 주석 제거. 필드 docstring만 유지.

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328 (4c-3b 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)