### PR TITLE
refactor(semantic): Phase 4c-3c-1 — Symbol.canonical_name 필드 추가

### DIFF
--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -264,6 +264,12 @@ pub const Symbol = struct {
     /// incremental rebuild 시 arena 불일치 방지.
     synthetic_name: []const u8 = "",
 
+    /// 번들러 linker/mangler가 주입한 canonical (rename된) 이름. 빈 문자열 =
+    /// 미지정 (원본 이름 유지). 소유권은 linker (`self.allocator`) — Symbol은
+    /// non-owning slice만 보유. 따라서 linker가 살아있는 동안만 유효.
+    /// #1328 Phase 4c-3c: 기존 `linker.canonical_names: StringHashMap` 대체 준비.
+    canonical_name: []const u8 = "",
+
     /// 이 심볼의 이름을 반환. 합성은 `synthetic_name`, 정규는 source Span에서.
     pub fn nameText(self: *const Symbol, source: []const u8) []const u8 {
         if (self.synthetic_name.len > 0) return self.synthetic_name;
@@ -272,6 +278,11 @@ pub const Symbol = struct {
 
     pub fn isSynthetic(self: *const Symbol) bool {
         return self.synthetic_kind != null;
+    }
+
+    /// Linker가 canonical_name을 주입했는지 여부. 빈 문자열 = 미지정.
+    pub fn hasCanonicalName(self: *const Symbol) bool {
+        return self.canonical_name.len > 0;
     }
 };
 


### PR DESCRIPTION
## Summary
- `semantic.Symbol`에 `canonical_name: []const u8 = \"\"` 필드 추가
- `hasCanonicalName()` 헬퍼 추가

## Why
4c-3c는 `linker.canonical_names: StringHashMap` 제거를 목표로 함. 그 첫 단계로 canonical name 슬롯을 semantic.Symbol에 마련.

## 소유권
linker (`self.allocator`)가 canonical_name 문자열 소유. Symbol은 non-owning slice. linker 생존 기간에만 유효 — 기존 canonical_names map value 소유권 모델과 동일.

## Scope
필드/헬퍼만. writer/reader 미전환 → 런타임 동작 변화 0.

## Test plan
- [x] `zig build test`

## Follow-up
- 4c-3c-2: 3개 writer 경로(calculateRenames/resolveNestedShadowConflicts/computeMangling)가 symbol.canonical_name에 직접 쓰기. 거울 병존.
- 4c-3c-3: reader 전환, 거울 맵 제거.
- 4c-3c-4: canonical_names_used 충돌 검사 재설계.

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)