### PR TITLE
refactor(bundler): Phase 4c-3c-2 — canonical_names writer mirror to Symbol

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -731,6 +731,7 @@ pub const Linker = struct {
             if (self.canonical_names.getPtr(upd.key)) |ptr| {
                 self.allocator.free(ptr.*);
                 ptr.* = upd.val;
+                self.mirrorSymbolCanonicalFromKey(upd.key, upd.val);
             }
         }
 
@@ -744,8 +745,13 @@ pub const Linker = struct {
                 if (name_map.get(sym_name)) |mangled| {
                     const key = makeExportKey(self.allocator, @intCast(i), sym_name) catch continue;
                     if (!self.canonical_names.contains(key)) {
-                        self.canonical_names.put(key, self.allocator.dupe(u8, mangled) catch continue) catch {
+                        const dup = self.allocator.dupe(u8, mangled) catch {
                             self.allocator.free(key);
+                            continue;
+                        };
+                        self.putCanonicalName(key, dup) catch {
+                            self.allocator.free(key);
+                            self.allocator.free(dup);
                         };
                     } else {
                         self.allocator.free(key);
@@ -762,7 +768,8 @@ pub const Linker = struct {
         return self.canonical_names_used.contains(name);
     }
 
-    /// canonical_names에 put하면서 역방향 맵도 동기화.
+    /// canonical_names에 put하면서 역방향 맵 + semantic.Symbol.canonical_name 동기화.
+    /// #1328 Phase 4c-3c-2: semantic 미러는 4c-3c-3에서 reader가 소비.
     fn putCanonicalName(self: *Linker, key: []const u8, value: []const u8) !void {
         if (self.canonical_names.fetchRemove(key)) |old| {
             _ = self.canonical_names_used.fetchRemove(old.value);
@@ -771,6 +778,24 @@ pub const Linker = struct {
         }
         try self.canonical_names.put(key, value);
         try self.canonical_names_used.put(value, {});
+        self.mirrorSymbolCanonicalFromKey(key, value);
+    }
+
+    /// canonical_names key (4B module_index + 0x00 + name)에서 semantic.Symbol을
+    /// 찾아 canonical_name을 설정. lookup 실패는 silently ignore — synthetic 심볼
+    /// 등 scope_maps[0]에 없는 경우 거울 빈 채로 두고 기존 string map만 유효.
+    fn mirrorSymbolCanonicalFromKey(self: *Linker, key: []const u8, value: []const u8) void {
+        if (key.len < 5) return;
+        var module_index: u32 = undefined;
+        @memcpy(std.mem.asBytes(&module_index), key[0..4]);
+        const name = key[5..];
+        if (module_index >= self.modules.len) return;
+        const m = &self.modules[module_index];
+        const sem = m.semantic orelse return;
+        if (sem.scope_maps.len == 0) return;
+        const sym_idx = sem.scope_maps[0].get(name) orelse return;
+        if (sym_idx >= sem.symbols.items.len) return;
+        sem.symbols.items[sym_idx].canonical_name = value;
     }
 
     /// 모듈의 중첩 스코프(비-모듈 스코프)에 해당 이름이 존재하는지 확인.

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1413,6 +1413,33 @@ test "getCanonicalByRef: alias symbol의 canonical_name 반환" {
     try std.testing.expect(name.len > 0);
 }
 
+// #1328 Phase 4c-3c-2: putCanonicalName 미러
+test "computeRenames: rename된 심볼의 canonical_name이 semantic.Symbol에 미러됨" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 같은 이름 'x'가 두 모듈에서 export → 충돌 → 한 쪽이 x$1
+    try writeFile(tmp.dir, "a.ts", "export { x as a } from './m1'; export { x as b } from './m2';");
+    try writeFile(tmp.dir, "m1.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "m2.ts", "export const x = 2;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.graph.deinit();
+    defer r.cache.deinit();
+
+    try r.linker.computeRenames();
+
+    // m1 또는 m2 중 하나의 'x' 심볼이 canonical_name을 갖춰야 함
+    var renamed_count: u32 = 0;
+    for (r.graph.modules.items) |m| {
+        const sem = m.semantic orelse continue;
+        if (sem.scope_maps.len == 0) continue;
+        const sym_idx = sem.scope_maps[0].get("x") orelse continue;
+        if (sem.symbols.items[sym_idx].hasCanonicalName()) renamed_count += 1;
+    }
+    try std.testing.expect(renamed_count >= 1);
+}
+
 test "populateImportSymbols: named import의 local_symbol이 현재 모듈 semantic ref" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Summary
모든 writer 경로(`putCanonicalName` + `computeMangling` in-place 업데이트 + 자유이름 path)에서 `semantic.Symbol.canonical_name`을 거울로 채움. 기존 `linker.canonical_names` string map은 그대로 병존 (reader는 4c-3c-3에서 전환).

## How
- `mirrorSymbolCanonicalFromKey(key, value)`: key 파싱 (4B mod_idx + 0x00 + name) → `scope_maps[0]` 조회 → `sem.symbols[i].canonical_name = value`
- `putCanonicalName`이 매번 mirror 호출
- `computeMangling`의 in-place value 교체 경로 + 자유이름 직접 put 경로도 mirror 통과 (직접 put는 putCanonicalName 경유로 변경)

## Risk
거울 병존이라 reader 동작 변화 0. mirror 실패는 silent (synthetic 심볼 등은 빈 채로 두고 string map fallback).

## Test plan
- [x] `zig build test` (신규 단위 테스트: 모듈간 'x' 충돌 후 한쪽 심볼 canonical_name 채워짐)
- [x] 통합 테스트 (baseline 1 fail 무관)

## Follow-up
- 4c-3c-3: reader가 `getCanonicalByRef` → `symbol.canonical_name` 직접 읽도록 전환, string map 제거
- 4c-3c-4: `canonical_names_used` 충돌 검사 재설계

Refs #1328, builds on #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)