### PR TITLE
refactor(bundler): Phase 4c-3c-4b — canonical_names string map 제거

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -182,10 +182,12 @@ pub const Linker = struct {
 
     diagnostics: std.ArrayList(BundlerDiagnostic),
 
-    /// 이름 충돌 해결 결과: (module_index, export_name) → canonical_name.
-    /// 충돌 없으면 원본 이름 유지 (엔트리 없음).
-    canonical_names: std.StringHashMap([]const u8),
-    /// canonical_names 값의 역방향 조회용. 리네임 후보가 기존 할당과 충돌하는지 O(1) 확인.
+    /// canonical_name 문자열 소유 리스트. semantic.Symbol/AliasTable의
+    /// `canonical_name` 슬라이스가 가리키는 backing 저장소. linker.deinit에서
+    /// 일괄 해제. #1328 Phase 4c-3c-4b: 기존 `canonical_names: StringHashMap` 대체.
+    canonical_strings: std.ArrayList([]const u8) = .empty,
+    /// 충돌 검사용 set. 리네임 후보가 기존 canonical로 사용 중인지 O(1) 확인.
+    /// 키는 canonical_strings가 소유 — 이 맵은 borrowed.
     canonical_names_used: std.StringHashMap(void),
 
     /// 자동 수집된 예약 글로벌 이름. 모든 모듈의 unresolved references를 합친 것.
@@ -256,7 +258,6 @@ pub const Linker = struct {
             .export_map = std.StringHashMap(ExportEntry).init(allocator),
             .resolved_bindings = std.AutoHashMap(BindingKey, ResolvedBinding).init(allocator),
             .diagnostics = .empty,
-            .canonical_names = std.StringHashMap([]const u8).init(allocator),
             .canonical_names_used = std.StringHashMap(void).init(allocator),
             .reserved_globals = std.StringHashMap(void).init(allocator),
             .global_identifiers = global_identifiers,
@@ -270,13 +271,9 @@ pub const Linker = struct {
         }
         self.export_map.deinit();
         self.resolved_bindings.deinit();
-        // canonical_names의 키(makeExportKey 할당)와 값(fmt.allocPrint 할당) 해제
-        var cit = self.canonical_names.iterator();
-        while (cit.next()) |entry| {
-            self.allocator.free(entry.key_ptr.*);
-            self.allocator.free(entry.value_ptr.*);
-        }
-        self.canonical_names.deinit();
+        // canonical_strings: Symbol.canonical_name backing 저장소 일괄 해제.
+        for (self.canonical_strings.items) |s| self.allocator.free(s);
+        self.canonical_strings.deinit(self.allocator);
         self.canonical_names_used.deinit();
         self.reserved_globals.deinit();
         for (self.nested_name_sets) |*set| {
@@ -464,8 +461,7 @@ pub const Linker = struct {
                     // 후보 이름도 예약어/다른 top-level/nested scope와 충돌할 수 있으므로 검증.
                     var suffix: u32 = 1;
                     const candidate = try self.findAvailableCandidate(name, owner.module_index, &suffix, name_to_owners);
-                    const key = try makeExportKey(self.allocator, owner.module_index, name);
-                    try self.putCanonicalName(key, candidate);
+                    try self.putCanonicalName(owner.module_index, name, candidate);
                 }
                 continue;
             }
@@ -490,8 +486,7 @@ pub const Linker = struct {
                 // 충돌 없는 후보 이름 검색
                 const candidate = try self.findAvailableCandidate(name, owner.module_index, &suffix, name_to_owners);
 
-                const key = try makeExportKey(self.allocator, owner.module_index, name);
-                try self.putCanonicalName(key, candidate);
+                try self.putCanonicalName(owner.module_index, name, candidate);
                 suffix += 1;
             }
         }
@@ -561,12 +556,11 @@ pub const Linker = struct {
                     // target module의 canonical name을 한 단계 더 rename
                     const cmod: u32 = @intCast(@intFromEnum(resolved.canonical.module_index));
                     const export_local = self.getExportLocalName(cmod, resolved.canonical.export_name) orelse resolved.canonical.export_name;
-                    const key = try makeExportKey(self.allocator, cmod, export_local);
 
                     // 새 이름: target_name$N (기존 이름 충돌 없는 것)
                     var suffix: u32 = 1;
                     const candidate = try self.findAvailableCandidate(target_name, cmod, &suffix, name_to_owners);
-                    try self.putCanonicalName(key, candidate);
+                    try self.putCanonicalName(cmod, export_local, candidate);
                 }
             }
         }
@@ -681,9 +675,9 @@ pub const Linker = struct {
                 }
             }
         }
-        var cit = self.canonical_names.valueIterator();
-        while (cit.next()) |v| {
-            try all_names.put(v.*, {});
+        // 이미 할당된 canonical 이름들도 충돌 후보에서 제외.
+        for (self.canonical_strings.items) |v| {
+            try all_names.put(v, {});
         }
 
         var name_map = std.StringHashMap([]const u8).init(self.allocator);
@@ -713,49 +707,35 @@ pub const Linker = struct {
             }
         }
 
-        // 3. canonical_names 업데이트 — 기존 rename된 이름도 mangling
-        var update_list: std.ArrayList(struct { key: []const u8, val: []const u8 }) = .empty;
-        defer update_list.deinit(self.allocator);
-
-        var cnit = self.canonical_names.iterator();
-        while (cnit.next()) |cn_entry| {
-            const current_name = cn_entry.value_ptr.*;
-            if (name_map.get(current_name)) |mangled| {
-                try update_list.append(self.allocator, .{
-                    .key = cn_entry.key_ptr.*,
-                    .val = try self.allocator.dupe(u8, mangled),
-                });
-            }
-        }
-        for (update_list.items) |upd| {
-            if (self.canonical_names.getPtr(upd.key)) |ptr| {
-                self.allocator.free(ptr.*);
-                ptr.* = upd.val;
-                self.mirrorSymbolCanonicalFromKey(upd.key, upd.val);
+        // 3. 기존 canonical_name이 mangling 대상이면 새 이름으로 교체.
+        //    Symbol을 직접 순회 — name_map은 (원본 또는 기존 canonical) → mangled.
+        for (self.modules) |m| {
+            const sem = m.semantic orelse continue;
+            for (sem.symbols.items) |*sym| {
+                if (sym.canonical_name.len == 0) continue;
+                if (name_map.get(sym.canonical_name)) |mangled| {
+                    const dup = try self.allocator.dupe(u8, mangled);
+                    _ = self.canonical_names_used.fetchRemove(sym.canonical_name);
+                    try self.canonical_strings.append(self.allocator, dup);
+                    try self.canonical_names_used.put(dup, {});
+                    sym.canonical_name = dup;
+                }
             }
         }
 
-        // 4. 아직 canonical_names에 없는 이름도 추가 (충돌 없던 이름)
+        // 4. 아직 canonical 미설정인 top-level 심볼에 mangled 이름 적용.
         for (self.modules, 0..) |m, i| {
             const sem = m.semantic orelse continue;
             if (sem.scope_maps.len == 0) continue;
             var sit = sem.scope_maps[0].iterator();
             while (sit.next()) |scope_entry| {
                 const sym_name = scope_entry.key_ptr.*;
+                const sym_idx = scope_entry.value_ptr.*;
+                if (sym_idx >= sem.symbols.items.len) continue;
+                if (sem.symbols.items[sym_idx].canonical_name.len > 0) continue;
                 if (name_map.get(sym_name)) |mangled| {
-                    const key = makeExportKey(self.allocator, @intCast(i), sym_name) catch continue;
-                    if (!self.canonical_names.contains(key)) {
-                        const dup = self.allocator.dupe(u8, mangled) catch {
-                            self.allocator.free(key);
-                            continue;
-                        };
-                        self.putCanonicalName(key, dup) catch {
-                            self.allocator.free(key);
-                            self.allocator.free(dup);
-                        };
-                    } else {
-                        self.allocator.free(key);
-                    }
+                    const dup = self.allocator.dupe(u8, mangled) catch continue;
+                    self.putCanonicalName(@intCast(i), sym_name, dup) catch {};
                 }
             }
         }
@@ -768,46 +748,42 @@ pub const Linker = struct {
         return self.canonical_names_used.contains(name);
     }
 
-    /// canonical_names에 put하면서 역방향 맵 + semantic.Symbol.canonical_name 동기화.
-    /// #1328 Phase 4c-3c-2: semantic 미러는 4c-3c-3에서 reader가 소비.
-    fn putCanonicalName(self: *Linker, key: []const u8, value: []const u8) !void {
-        if (self.canonical_names.fetchRemove(key)) |old| {
-            _ = self.canonical_names_used.fetchRemove(old.value);
-            self.allocator.free(old.key);
-            self.allocator.free(old.value);
+    /// (module_index, local_name)의 canonical_name을 설정. 호출자는 이미
+    /// duped value를 넘기며 이 함수가 ownership(canonical_strings)을 가져간다.
+    /// scope_maps[0] → synthetic_name 순으로 Symbol을 찾아 직접 기록.
+    /// Symbol을 못 찾으면 value를 free하고 ownership 등록도 안 함 (silently noop).
+    fn putCanonicalName(self: *Linker, module_index: u32, name: []const u8, value: []const u8) !void {
+        const sym = self.findSymbolMutable(module_index, name) orelse {
+            self.allocator.free(value);
+            return;
+        };
+        if (sym.canonical_name.len > 0) {
+            _ = self.canonical_names_used.fetchRemove(sym.canonical_name);
+            // 기존 value는 canonical_strings가 소유 — deinit에서 일괄 해제.
         }
-        try self.canonical_names.put(key, value);
+        try self.canonical_strings.append(self.allocator, value);
         try self.canonical_names_used.put(value, {});
-        self.mirrorSymbolCanonicalFromKey(key, value);
+        sym.canonical_name = value;
     }
 
-    /// canonical_names key (4B module_index + 0x00 + name)에서 semantic.Symbol을
-    /// 찾아 canonical_name을 설정. scope_maps[0] 조회 실패 시 synthetic_name으로
-    /// 선형 탐색 (synthetic 심볼은 scope_maps에 등록되지 않음 — extendSymbol 참조).
-    /// 양쪽 모두 실패는 silently ignore.
-    fn mirrorSymbolCanonicalFromKey(self: *Linker, key: []const u8, value: []const u8) void {
-        if (key.len < 5) return;
-        var module_index: u32 = undefined;
-        @memcpy(std.mem.asBytes(&module_index), key[0..4]);
-        const name = key[5..];
-        if (module_index >= self.modules.len) return;
+    /// scope_maps[0] → synthetic_name fallback으로 mutable Symbol 찾기.
+    fn findSymbolMutable(self: *Linker, module_index: u32, name: []const u8) ?*semantic_symbol.Symbol {
+        if (module_index >= self.modules.len) return null;
         const m = &self.modules[module_index];
-        const sem = m.semantic orelse return;
+        const sem = m.semantic orelse return null;
         if (sem.scope_maps.len > 0) {
             if (sem.scope_maps[0].get(name)) |sym_idx| {
                 if (sym_idx < sem.symbols.items.len) {
-                    sem.symbols.items[sym_idx].canonical_name = value;
-                    return;
+                    return &sem.symbols.items[sym_idx];
                 }
             }
         }
-        // Synthetic fallback: scope_maps에 없으므로 synthetic_name으로 매칭.
         for (sem.symbols.items) |*sym| {
             if (sym.synthetic_kind != null and std.mem.eql(u8, sym.synthetic_name, name)) {
-                sym.canonical_name = value;
-                return;
+                return sym;
             }
         }
+        return null;
     }
 
     /// 모듈의 중첩 스코프(비-모듈 스코프)에 해당 이름이 존재하는지 확인.
@@ -898,13 +874,9 @@ pub const Linker = struct {
     }
 
     /// 특정 모듈+이름에 대한 canonical name 조회. 리네임 안 됐으면 null (원본 유지).
-    /// scope_maps[0] → synthetic_name 순으로 Symbol 탐색. 둘 다 미발견이거나
-    /// canonical_name 미설정 시 string map fallback.
+    /// scope_maps[0] → synthetic_name 순으로 Symbol 탐색.
     pub fn getCanonicalName(self: *const Linker, module_index: u32, name: []const u8) ?[]const u8 {
-        if (self.lookupSymbolCanonical(module_index, name)) |c| return c;
-        var key_buf: [4096]u8 = undefined;
-        const key = makeExportKeyBuf(&key_buf, module_index, name);
-        return self.canonical_names.get(key);
+        return self.lookupSymbolCanonical(module_index, name);
     }
 
     /// (module, name) → Symbol.canonical_name 조회. scope_maps[0] 우선,
@@ -1667,14 +1639,9 @@ pub const Linker = struct {
     /// canonical_names를 초기화한다. 키와 값의 메모리를 해제하고 맵을 비운다.
     /// per-chunk rename에서 이전 청크의 결과를 제거할 때 사용.
     pub fn clearCanonicalNames(self: *Linker) void {
-        var cit = self.canonical_names.iterator();
-        while (cit.next()) |entry| {
-            self.allocator.free(entry.key_ptr.*);
-            self.allocator.free(entry.value_ptr.*);
-        }
-        self.canonical_names.clearRetainingCapacity();
+        for (self.canonical_strings.items) |s| self.allocator.free(s);
+        self.canonical_strings.clearRetainingCapacity();
         self.canonical_names_used.clearRetainingCapacity();
-        // semantic 거울도 초기화 — 4c-3c-3 reader가 symbol 우선 읽으므로 stale 방지.
         for (self.modules) |m| {
             const sem = m.semantic orelse continue;
             for (sem.symbols.items) |*sym| {

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -261,7 +261,7 @@ test "rename: no conflict — no rename" {
     defer r.cache.deinit();
 
     // x는 b.ts에만 있으므로 충돌 없음 → canonical_names 비어 있음
-    try std.testing.expectEqual(@as(u32, 0), r.linker.canonical_names.count());
+    try std.testing.expectEqual(@as(u32, 0), r.linker.canonical_strings.items.len);
 }
 
 test "rename: two modules same name — second gets $1" {
@@ -277,13 +277,12 @@ test "rename: two modules same name — second gets $1" {
 
     // b.ts(exec_index 낮음)가 원본 유지, a.ts가 count$1
     // 또는 a.ts가 원본이고 b.ts가 $1 (exec_index에 따라)
-    try std.testing.expect(r.linker.canonical_names.count() > 0);
+    try std.testing.expect(r.linker.canonical_strings.items.len > 0);
 
     // 하나는 리네임됨
     var has_rename = false;
-    var cit = r.linker.canonical_names.valueIterator();
-    while (cit.next()) |val| {
-        if (std.mem.startsWith(u8, val.*, "count$")) has_rename = true;
+    for (r.linker.canonical_strings.items) |val| {
+        if (std.mem.startsWith(u8, val, "count$")) has_rename = true;
     }
     try std.testing.expect(has_rename);
 }
@@ -302,9 +301,8 @@ test "rename: three modules same name — $1 and $2" {
 
     // 3개 중 2개 리네임
     var rename_count: u32 = 0;
-    var cit = r.linker.canonical_names.valueIterator();
-    while (cit.next()) |val| {
-        if (std.mem.startsWith(u8, val.*, "name$")) rename_count += 1;
+    for (r.linker.canonical_strings.items) |val| {
+        if (std.mem.startsWith(u8, val, "name$")) rename_count += 1;
     }
     try std.testing.expectEqual(@as(u32, 2), rename_count);
 }
@@ -320,7 +318,7 @@ test "rename: different names — no conflict" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    try std.testing.expectEqual(@as(u32, 0), r.linker.canonical_names.count());
+    try std.testing.expectEqual(@as(u32, 0), r.linker.canonical_strings.items.len);
 }
 
 test "rename: getCanonicalName returns renamed" {
@@ -368,9 +366,8 @@ test "rename: non-exported top-level variables also detected (C1)" {
 
     // helper가 두 모듈에서 충돌 → 하나가 리네임됨
     var has_helper_rename = false;
-    var cit = r.linker.canonical_names.valueIterator();
-    while (cit.next()) |val| {
-        if (std.mem.startsWith(u8, val.*, "helper$")) has_helper_rename = true;
+    for (r.linker.canonical_strings.items) |val| {
+        if (std.mem.startsWith(u8, val, "helper$")) has_helper_rename = true;
     }
     try std.testing.expect(has_helper_rename);
 }
@@ -389,12 +386,11 @@ test "rename: nested scope conflict avoidance (hasNestedBinding)" {
 
     // x가 충돌. 리네임된 쪽이 x$1을 건너뛰고 x$2가 되어야 함
     // (nested scope에 x$1이 이미 있으므로)
-    var cit = r.linker.canonical_names.valueIterator();
-    while (cit.next()) |val| {
-        if (std.mem.startsWith(u8, val.*, "x$")) {
+    for (r.linker.canonical_strings.items) |val| {
+        if (std.mem.startsWith(u8, val, "x$")) {
             // x$1이 아닌 다른 값이어야 함 (nested scope에 x$1 있으므로)
             // 단, semantic analyzer가 parameter를 어떤 scope에 넣는지에 따라 다를 수 있음
-            try std.testing.expect(val.*.len > 0);
+            try std.testing.expect(val.len > 0);
         }
     }
 }
@@ -412,9 +408,8 @@ test "rename: default export local name conflict (L5)" {
 
     // foo가 두 모듈에서 충돌 (a.ts: default export의 local name, b.ts: named export)
     var has_foo_rename = false;
-    var cit = r.linker.canonical_names.valueIterator();
-    while (cit.next()) |val| {
-        if (std.mem.startsWith(u8, val.*, "foo$")) has_foo_rename = true;
+    for (r.linker.canonical_strings.items) |val| {
+        if (std.mem.startsWith(u8, val, "foo$")) has_foo_rename = true;
     }
     try std.testing.expect(has_foo_rename);
 }
@@ -583,11 +578,11 @@ test "clearCanonicalNames: 초기화 후 비어있음" {
     try linker.computeRenames();
 
     // rename 결과가 있어야 함
-    try std.testing.expect(linker.canonical_names.count() > 0);
+    try std.testing.expect(linker.canonical_strings.items.len > 0);
 
     // 초기화 후 비어있어야 함
     linker.clearCanonicalNames();
-    try std.testing.expectEqual(@as(usize, 0), linker.canonical_names.count());
+    try std.testing.expectEqual(@as(usize, 0), linker.canonical_strings.items.len);
 }
 
 // ============================================================
@@ -722,9 +717,8 @@ test "rename: multiple export default identifiers use original names — no coll
 
     // x, y, z는 각각 다른 이름이므로 충돌 없음 → _default$ 리네임 0개
     var rename_count: u32 = 0;
-    var cit = r.linker.canonical_names.valueIterator();
-    while (cit.next()) |val| {
-        if (std.mem.startsWith(u8, val.*, "_default$")) rename_count += 1;
+    for (r.linker.canonical_strings.items) |val| {
+        if (std.mem.startsWith(u8, val, "_default$")) rename_count += 1;
     }
     try std.testing.expectEqual(@as(u32, 0), rename_count);
 }
@@ -878,9 +872,8 @@ test "rename: mixed function + expression defaults — identifier collision" {
 
     // expr1, expr2 모두 val → 하나가 val$1로 리네임
     var val_rename_count: u32 = 0;
-    var cit = r.linker.canonical_names.valueIterator();
-    while (cit.next()) |v| {
-        if (std.mem.startsWith(u8, v.*, "val$")) val_rename_count += 1;
+    for (r.linker.canonical_strings.items) |v| {
+        if (std.mem.startsWith(u8, v, "val$")) val_rename_count += 1;
     }
     try std.testing.expectEqual(@as(u32, 1), val_rename_count);
 }
@@ -900,9 +893,8 @@ test "rename: default identifier reuses name — no _default collision" {
 
     // x, y는 다른 이름이므로 충돌 없음 → _default$ 리네임 0개
     var rename_count: u32 = 0;
-    var cit = r.linker.canonical_names.valueIterator();
-    while (cit.next()) |val| {
-        if (std.mem.startsWith(u8, val.*, "_default$")) rename_count += 1;
+    for (r.linker.canonical_strings.items) |val| {
+        if (std.mem.startsWith(u8, val, "_default$")) rename_count += 1;
     }
     try std.testing.expectEqual(@as(u32, 0), rename_count);
 }


### PR DESCRIPTION
## Summary
`linker.canonical_names: StringHashMap`을 완전 제거. semantic.Symbol.canonical_name이 source of truth.

## 변경
- `canonical_names` 제거 → `canonical_strings: ArrayList([]const u8)` (ownership-only, deinit 일괄 해제)
- `putCanonicalName(module_index, name, value)` 시그니처 단순화 — key 빌드 내부화. 호출자 4곳 업데이트
- `findSymbolMutable`: scope_maps[0] → synthetic_name fallback
- `computeMangling` 재작성: canonical_names 순회 → symbols.items 직접 순회
- reader: string map fallback 제거 (Symbol만 봄)
- `clearCanonicalNames`: canonical_strings + 전체 symbol.canonical_name 초기화

## 테스트 마이그레이션
- `canonical_names.count()` → `canonical_strings.items.len`
- `valueIterator()` → `for (canonical_strings.items)`

## Test plan
- [x] `zig build test` (전체 통과)
- [x] 통합 테스트 (baseline 1 fail 무관)

## 4c-3c 종결
- ✅ 4c-3c-1: Symbol.canonical_name 필드 (#1352)
- ✅ 4c-3c-2: writer mirror (#1353)
- ✅ 4c-3c-3: reader 전환 (#1354)
- ✅ 4c-3c-4a: synthetic mirror 보강 (#1355)
- ✅ 4c-3c-4b: string map 제거 (이 PR)

남은 4c-4: 4개 문자열 필드(`local_name`/`imported_name`) 제거 후 #1328 closed.

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)