### PR TITLE
refactor(bundler): Phase 4c-4a — ExportBinding.Kind 분리 (re_export_star/re_export_namespace)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -78,9 +78,19 @@ pub const ExportBinding = struct {
     symbol: symbol_mod.SymbolRef = symbol_mod.SymbolRef.invalid,
 
     pub const Kind = enum {
+        /// 현재 모듈에서 직접 선언/할당된 export.
         local,
+        /// source에서 명시적으로 가져온 named re-export (예: `export { x } from`).
         re_export,
-        re_export_all,
+        /// `export * from './m'` — 모든 export 합치기 (alias 없음).
+        re_export_star,
+        /// `export * as ns from './m'` — namespace 객체로 노출.
+        re_export_namespace,
+
+        /// `re_export_star`/`re_export_namespace` 통칭 (구 `re_export_all`).
+        pub fn isReExportAll(self: Kind) bool {
+            return self == .re_export_star or self == .re_export_namespace;
+        }
     };
 
     /// 이 export 때문에 현재 모듈에 `_default` 합성 변수가 생기는지 확인.
@@ -378,7 +388,7 @@ pub fn extractExportBindings(
                         .exported_name = name_text,
                         .local_name = name_text,
                         .local_span = node.span,
-                        .kind = .re_export_all,
+                        .kind = .re_export_namespace,
                         .import_record_index = rec_idx,
                     });
                 } else {
@@ -387,7 +397,7 @@ pub fn extractExportBindings(
                         .exported_name = "*",
                         .local_name = "*",
                         .local_span = node.span,
-                        .kind = .re_export_all,
+                        .kind = .re_export_star,
                         .import_record_index = rec_idx,
                     });
                 }

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -173,7 +173,7 @@ test "export binding: export all" {
 
     try std.testing.expectEqual(@as(usize, 1), r.export_bindings.len);
     try std.testing.expectEqualStrings("*", r.export_bindings[0].exported_name);
-    try std.testing.expectEqual(ExportBinding.Kind.re_export_all, r.export_bindings[0].kind);
+    try std.testing.expectEqual(ExportBinding.Kind.re_export_star, r.export_bindings[0].kind);
 }
 
 test "export binding: export function" {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -887,7 +887,7 @@ pub fn computeAllUsedNames(
 
         // export_bindings 중 re_export / re_export_all → 타겟 모듈로 역매핑
         for (importer.export_bindings) |ieb| {
-            if (ieb.kind != .re_export_all and ieb.kind != .re_export) continue;
+            if (!ieb.kind.isReExportAll() and ieb.kind != .re_export) continue;
             const rec_idx = ieb.import_record_index orelse continue;
             if (rec_idx >= importer.import_records.len) continue;
             const target = importer.import_records[rec_idx].resolved;
@@ -900,7 +900,7 @@ pub fn computeAllUsedNames(
                 .imported_name = ieb.local_name,
                 .local_name = ieb.local_name,
                 .exported_name = ieb.exported_name,
-                .kind = if (ieb.kind == .re_export_all) .re_export_all else .re_export,
+                .kind = if (ieb.kind.isReExportAll()) .re_export_all else .re_export,
             });
         }
 
@@ -940,7 +940,7 @@ pub fn computeAllUsedNames(
             &.{};
 
         for (m.export_bindings) |eb| {
-            if (eb.kind == .re_export_all) continue;
+            if (eb.kind.isReExportAll()) continue;
             if (!s.isExportUsed(mod_idx, eb.exported_name)) continue;
 
             // 크로스-모듈 BFS 도달성

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -395,7 +395,7 @@ pub fn emitEsmWrappedModule(
             defer visited.deinit();
 
             for (module.export_bindings) |eb| {
-                if (eb.kind != .re_export_all) continue;
+                if (!eb.kind.isReExportAll()) continue;
                 const rec_idx = eb.import_record_index orelse continue;
                 if (rec_idx >= module.import_records.len) continue;
                 const source_mod_idx = module.import_records[rec_idx].resolved;
@@ -664,7 +664,7 @@ pub fn emitEsmWrappedModule(
         defer re_export_inited.deinit();
 
         for (module.export_bindings) |eb| {
-            if (eb.kind != .re_export_all and eb.kind != .re_export) continue;
+            if (!eb.kind.isReExportAll() and eb.kind != .re_export) continue;
             const rec_idx = eb.import_record_index orelse continue;
             if (rec_idx >= module.import_records.len) continue;
             const source_mod_idx = module.import_records[rec_idx].resolved;
@@ -953,7 +953,7 @@ fn collectStarExportNames(
 
     // 직접 선언된 export 수집 (local + re_export + named re_export_all)
     for (m.export_bindings) |eb| {
-        if (eb.kind == .re_export_all and std.mem.eql(u8, eb.exported_name, "*")) continue;
+        if (eb.kind == .re_export_star) continue;
         if (!seen.contains(eb.exported_name)) {
             try seen.put(eb.exported_name, {});
         }
@@ -961,7 +961,7 @@ fn collectStarExportNames(
 
     // export * from 재귀 — 소스 모듈의 export도 수집
     for (m.export_bindings) |eb| {
-        if (eb.kind != .re_export_all) continue;
+        if (!eb.kind.isReExportAll()) continue;
         if (!std.mem.eql(u8, eb.exported_name, "*")) continue;
         const rec_idx = eb.import_record_index orelse continue;
         if (rec_idx >= m.import_records.len) continue;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -299,7 +299,7 @@ pub const Linker = struct {
         // 단순 그래프(re-export 없음)에서는 캐시 오버헤드가 이득보다 크므로 비활성.
         for (self.modules) |m| {
             for (m.export_bindings) |eb| {
-                if (eb.kind == .re_export or eb.kind == .re_export_all) {
+                if (eb.kind == .re_export or eb.kind.isReExportAll()) {
                     self.chain_cache_enabled = true;
                     break;
                 }
@@ -1112,7 +1112,7 @@ pub const Linker = struct {
         // 2. export * 확인 (re_export_all)
         const m = self.modules[mod_i];
         for (m.export_bindings) |eb| {
-            if (eb.kind != .re_export_all) continue;
+            if (!eb.kind.isReExportAll()) continue;
             if (eb.import_record_index) |rec_idx| {
                 if (rec_idx < m.import_records.len) {
                     const source_mod = m.import_records[rec_idx].resolved;
@@ -1420,7 +1420,7 @@ pub const Linker = struct {
         var ns_re_exports = std.StringHashMap(u32).init(self.allocator); // exported_name → source_mod
         defer ns_re_exports.deinit();
         for (target.export_bindings) |eb| {
-            if (eb.kind == .re_export_all and !std.mem.eql(u8, eb.exported_name, "*")) {
+            if (eb.kind == .re_export_namespace) {
                 if (eb.import_record_index) |rec_idx| {
                     if (rec_idx < target.import_records.len) {
                         const src = target.import_records[rec_idx].resolved;
@@ -1512,11 +1512,11 @@ pub const Linker = struct {
         for (m.export_bindings) |eb| {
             // 일반 export * from (exported_name == "*") → 재귀로 처리 (skip)
             // export * as ns (exported_name != "*") → named export로 포함
-            if (eb.kind == .re_export_all and std.mem.eql(u8, eb.exported_name, "*")) continue;
+            if (eb.kind == .re_export_star) continue;
             if (seen.contains(eb.exported_name)) continue;
             try seen.put(eb.exported_name, {});
 
-            const actual_local = if (eb.kind == .re_export_all and !std.mem.eql(u8, eb.exported_name, "*")) blk: {
+            const actual_local = if (eb.kind == .re_export_namespace) blk: {
                 // export * as ns — 소스 모듈의 인라인 객체를 생성 (재귀)
                 if (eb.import_record_index) |rec_idx| {
                     if (rec_idx < m.import_records.len) {
@@ -1533,7 +1533,7 @@ pub const Linker = struct {
                     const cmod_i = @intFromEnum(canonical.module_index);
                     if (cmod_i < self.modules.len) {
                         for (self.modules[cmod_i].export_bindings) |ceb| {
-                            if (ceb.kind == .re_export_all and
+                            if (ceb.kind.isReExportAll() and
                                 std.mem.eql(u8, ceb.exported_name, canonical.export_name) and
                                 !std.mem.eql(u8, ceb.exported_name, "*"))
                             {
@@ -1582,7 +1582,7 @@ pub const Linker = struct {
         // 직접 선언된 export { default }는 위 첫 루프에서 이미 수집됨.
         try seen.put("default", {});
         for (m.export_bindings) |eb| {
-            if (eb.kind != .re_export_all) continue;
+            if (!eb.kind.isReExportAll()) continue;
             if (!std.mem.eql(u8, eb.exported_name, "*")) continue; // export * as ns는 skip
             if (eb.import_record_index) |rec_idx| {
                 if (rec_idx < m.import_records.len) {

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -378,7 +378,7 @@ pub fn buildMetadataForAst(
                     const cmod: u32 = @intCast(@intFromEnum(rb.canonical.module_index));
                     if (cmod < self.modules.len) {
                         for (self.modules[cmod].export_bindings) |eb| {
-                            if (eb.kind == .re_export_all and
+                            if (eb.kind.isReExportAll() and
                                 std.mem.eql(u8, eb.exported_name, rb.canonical.export_name) and
                                 !std.mem.eql(u8, eb.exported_name, "*"))
                             {
@@ -696,7 +696,7 @@ pub fn buildFinalExports(
     try buf.appendSlice(self.allocator, "export {");
     var first = true;
     for (export_bindings) |eb| {
-        if (eb.kind == .re_export_all) continue;
+        if (eb.kind.isReExportAll()) continue;
         if (std.mem.eql(u8, eb.exported_name, "*")) continue;
         if (!first) try buf.appendSlice(self.allocator, ",");
         first = false;
@@ -998,7 +998,7 @@ pub fn buildDevMetadataForAst(
         defer buf.deinit(self.allocator);
 
         for (m.export_bindings) |eb| {
-            if (eb.kind == .re_export_all) continue;
+            if (eb.kind.isReExportAll()) continue;
             if (std.mem.eql(u8, eb.exported_name, "*")) continue;
 
             // exports.name = local_name;
@@ -1186,7 +1186,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
         try buf.appendSlice(self.allocator, "export {");
         var first = true;
         for (m.export_bindings) |eb| {
-            if (eb.kind == .re_export_all) continue;
+            if (eb.kind.isReExportAll()) continue;
             if (std.mem.eql(u8, eb.exported_name, "*")) continue;
 
             if (!first) try buf.appendSlice(self.allocator, ",");

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -491,7 +491,7 @@ pub const TreeShaker = struct {
                 if (sem.scope_maps.len == 0) continue;
                 const mi: u32 = @intCast(i);
                 for (m.export_bindings) |eb| {
-                    if (eb.kind == .re_export_all) continue;
+                    if (eb.kind.isReExportAll()) continue;
                     if (!self.entry_set.isSet(i) and !self.isExportUsed(mi, eb.exported_name)) continue;
                     if (sem.scope_maps[0].get(eb.local_name)) |sym_idx| {
                         if (infos.declaredStmtBySymbol(@intCast(sym_idx))) |stmt_idx| {
@@ -538,7 +538,7 @@ pub const TreeShaker = struct {
             const sem = m.semantic orelse continue;
             if (sem.scope_maps.len == 0) continue;
             for (m.export_bindings) |eb| {
-                if (eb.kind == .re_export_all) continue;
+                if (eb.kind.isReExportAll()) continue;
                 if (sem.scope_maps[0].get(eb.local_name)) |sym_idx| {
                     if (infos.declaredStmtBySymbol(@intCast(sym_idx))) |stmt_idx| {
                         if (reachable_stmts[i] != null and reachable_stmts[i].?.isSet(stmt_idx)) {
@@ -732,12 +732,12 @@ pub const TreeShaker = struct {
         }
         // re-export 처리
         for (m.export_bindings) |eb| {
-            if (eb.kind != .re_export and eb.kind != .re_export_all) continue;
+            if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
             if (eb.import_record_index) |rec_idx| {
                 if (rec_idx < m.import_records.len) {
                     const src = @intFromEnum(m.import_records[rec_idx].resolved);
                     if (src >= self.modules.len) continue;
-                    if (eb.kind == .re_export_all) {
+                    if (eb.kind.isReExportAll()) {
                         try self.markAllExportsUsed(@intCast(src));
                         self.included.set(src);
                         try self.seedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
@@ -779,12 +779,12 @@ pub const TreeShaker = struct {
         if (mod_idx >= self.modules.len) return;
         const m = self.modules[mod_idx];
         for (m.export_bindings) |eb| {
-            if (eb.kind != .re_export and eb.kind != .re_export_all) continue;
+            if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
             const rec_idx = eb.import_record_index orelse continue;
             if (rec_idx >= m.import_records.len) continue;
             const src = @intFromEnum(m.import_records[rec_idx].resolved);
             if (src >= self.modules.len) continue;
-            if (eb.kind == .re_export_all) {
+            if (eb.kind.isReExportAll()) {
                 self.included.set(src);
                 try self.seedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
             } else {
@@ -809,7 +809,7 @@ pub const TreeShaker = struct {
         for (self.modules, 0..) |m, i| {
             if (!self.included.isSet(i)) continue;
             for (m.export_bindings) |eb| {
-                if (eb.kind != .re_export and eb.kind != .re_export_all) continue;
+                if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
                 if (check_used and !self.isExportUsed(@intCast(i), eb.exported_name)) continue;
                 if (eb.import_record_index) |rec_idx| {
                     if (rec_idx < m.import_records.len) {
@@ -819,7 +819,7 @@ pub const TreeShaker = struct {
                                 self.included.set(src);
                                 changed = true;
                             }
-                            if (eb.kind == .re_export_all and !std.mem.eql(u8, eb.exported_name, "*")) {
+                            if (eb.kind == .re_export_namespace) {
                                 try self.markAllExportsUsed(@intCast(src));
                             } else if (!check_used) {
                                 try self.markAllExportsUsed(@intCast(src));
@@ -936,13 +936,13 @@ pub const TreeShaker = struct {
         const m = self.modules[module_index];
         for (m.export_bindings) |eb| {
             // re-export 소스 include는 "*" skip 전에 처리
-            if (eb.kind == .re_export_all or eb.kind == .re_export) {
+            if (eb.kind.isReExportAll() or eb.kind == .re_export) {
                 if (eb.import_record_index) |rec_idx| {
                     if (rec_idx < m.import_records.len) {
                         const source_mod = @intFromEnum(m.import_records[rec_idx].resolved);
                         if (source_mod < self.modules.len) {
                             if (!self.included.isSet(source_mod)) self.included.set(source_mod);
-                            if (eb.kind == .re_export_all) {
+                            if (eb.kind.isReExportAll()) {
                                 try self.markAllExportsUsed(@intCast(source_mod));
                             } else {
                                 // named re-export: canonical 모듈도 include
@@ -961,7 +961,7 @@ pub const TreeShaker = struct {
                         }
                     }
                 }
-                if (eb.kind == .re_export_all) continue;
+                if (eb.kind.isReExportAll()) continue;
             }
             if (std.mem.eql(u8, eb.exported_name, "*")) continue;
 
@@ -972,7 +972,7 @@ pub const TreeShaker = struct {
     fn hasAnyUsedExport(self: *const TreeShaker, module_index: u32) bool {
         if (module_index >= self.modules.len) return false;
         for (self.modules[module_index].export_bindings) |eb| {
-            if (eb.kind == .re_export_all) continue;
+            if (eb.kind.isReExportAll()) continue;
             if (std.mem.eql(u8, eb.exported_name, "*")) continue;
             if (self.isExportUsed(module_index, eb.exported_name)) return true;
         }

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -638,7 +638,7 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
                     .exported_name = name_text,
                     .local_name = name_text,
                     .local_span = .{ .start = start, .end = self.currentSpan().start },
-                    .kind = .re_export_all,
+                    .kind = .re_export_namespace,
                     .import_record_index = rec_idx,
                 }) catch {};
             } else {
@@ -647,7 +647,7 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
                     .exported_name = "*",
                     .local_name = "*",
                     .local_span = .{ .start = start, .end = self.currentSpan().start },
-                    .kind = .re_export_all,
+                    .kind = .re_export_star,
                     .import_record_index = rec_idx,
                 }) catch {};
             }

--- a/src/parser/scan_results.zig
+++ b/src/parser/scan_results.zig
@@ -56,11 +56,12 @@ pub const ScanImportBinding = struct {
     import_record_index: u32,
 };
 
-/// export 바인딩 종류.
+/// export 바인딩 종류. bundler ExportBinding.Kind와 1:1 (intCast 대응 유지).
 pub const ExportBindingKind = enum {
     local,
     re_export,
-    re_export_all,
+    re_export_star,
+    re_export_namespace,
 };
 
 /// 파서가 수집하는 export 바인딩. bundler ExportBinding의 경량 버전.


### PR DESCRIPTION
## Summary
`ExportBinding.Kind.re_export_all` 한 값으로 표현하던 `export * from`(no alias) vs `export * as ns from`(namespace)을 두 kind로 분리. 그동안 `exported_name == \"*\"` 문자열 sentinel로 구분하던 코드를 enum 비교로 일소.

- `.re_export_star`: `export * from './m'`
- `.re_export_namespace`: `export * as ns from './m'`
- `Kind.isReExportAll()`: 두 kind 통칭 (이전 `re_export_all` 의미)

## Why
4c-4 (#1328 closed)의 첫 단계 — `exported_name` 문자열 필드 제거를 위한 선결조건. sentinel 비교 사이트들이 enum 비교로 바뀌면서 `exported_name`에 대한 read 의존성이 줄어든다.

## 전환
- `kind == .re_export_all and exported_name == \"*\"` → `kind == .re_export_star`
- `kind == .re_export_all and exported_name != \"*\"` → `kind == .re_export_namespace`
- bare `kind == .re_export_all` → `kind.isReExportAll()`

## 영향
- src/parser/scan_results.zig의 `ExportBindingKind`도 sync (intCast 1:1 유지)
- chunks.zig 내부 `RevKind`는 함수-로컬 별도 enum이라 그대로 유지 (관련 sentinel 비교 1곳은 후속 4c-4b에서 처리)

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)