### PR TITLE
refactor(bundler): Phase 4c-4c — ImportBinding.importsDefault() helper

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -60,6 +60,14 @@ pub const ImportBinding = struct {
     pub fn isSynthetic(self: ImportBinding) bool {
         return self.local_span.start >= SYNTHETIC_SPAN_BASE;
     }
+
+    /// `import x from './m'` (kind=.default) 또는 `import { default as X }`
+    /// (kind=.named, imported_name="default") 어느 쪽이든 source의 default를
+    /// import하는 케이스 통칭.
+    pub fn importsDefault(self: ImportBinding) bool {
+        return self.kind == .default or
+            (self.kind == .named and std.mem.eql(u8, self.imported_name, "default"));
+    }
 };
 
 pub const ExportBinding = struct {

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -623,9 +623,7 @@ pub fn emitEsmWrappedModule(
                         // 중복 require 호출 없이 해당 변수를 참조한다.
                         var found_preamble_var: ?[]const u8 = null;
                         for (module.import_bindings) |ib| {
-                            if (ib.import_record_index == rec_idx and
-                                std.mem.eql(u8, ib.imported_name, "default"))
-                            {
+                            if (ib.import_record_index == rec_idx and ib.importsDefault()) {
                                 found_preamble_var = l.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
                                 break;
                             }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -213,7 +213,7 @@ pub fn buildMetadataForAst(
                         // UMD/AMD: factory 매개변수에서 직접 참조
                         const param_name = try types.specifierToParamName(self.allocator, rec.specifier);
                         defer self.allocator.free(param_name);
-                        if (ib.kind == .namespace or std.mem.eql(u8, ib.imported_name, "default")) {
+                        if (ib.kind == .namespace or ib.importsDefault()) {
                             // import * as React / import React → factory param 직접 사용
                             if (!std.mem.eql(u8, preamble_name, param_name)) {
                                 try preamble.write("var ");


### PR DESCRIPTION
## Summary
`ib.kind == .default || ib.imported_name == \"default\"` 패턴을 `ib.importsDefault()` method로 통합. 두 케이스 모두 \"source 모듈의 default를 import\"한다는 의미:
- `import x from './m'` — kind=.default
- `import { default as X } from './m'` — kind=.named, imported_name=\"default\"

## 전환
- linker/metadata.zig:216 (UMD/AMD factory param 직접 참조 분기)
- esm_wrap.zig:627 (CJS preamble 변수 중복 방지)

PreambleWriter의 string-keyed API 2곳은 ImportBinding 없이 raw string만 받으므로 대상 외.

## Why
`imported_name` 필드 제거 (4c-4d) 선결조건 — 단일 변경 지점 마련. 향후 source export의 SymbolRef로 default 판정으로 교체 가능.

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)