### PR TITLE
refactor(bundler): Phase 4c-4d (start) — buildImportRenames의 imported_name 조회 SymbolRef화

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1150,11 +1150,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
             const rec = m.import_records[ib.import_record_index];
             if (rec.resolved.isNone()) continue;
 
-            const canonical_mod = @intFromEnum(rec.resolved);
-            const target_name = if (self.getCanonicalName(@intCast(canonical_mod), ib.imported_name)) |renamed|
-                renamed
-            else
-                ib.imported_name;
+            const target_name = self.getCanonicalByRef(ib.symbol) orelse ib.imported_name;
 
             if (!std.mem.eql(u8, ib.local_name, target_name)) {
                 // 모듈 스코프에서 import binding의 심볼 인덱스 찾기


### PR DESCRIPTION
## Summary
`getCanonicalName(canonical_mod, ib.imported_name)` → `getCanonicalByRef(ib.symbol)` 단일 사이트 전환 (metadata.zig:1154). 4c-2에서 채워둔 `ib.symbol`(source 모듈의 export SymbolRef)을 직접 사용.

## Why
4c-3c 완료로 모든 SymbolRef 기반 canonical 조회 인프라가 마련됨. 이제 string-keyed lookups를 점진 전환 가능. 이 PR은 그 첫 incremental 단계.

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

## Follow-up
- 다른 `getCanonicalName(...,  ib.imported_name)` / `getCanonicalName(..., eb.local_name)` 사이트들 점진 전환
- 4c-4의 정통적 \"필드 제거\"는 154 read site의 derive cost 평가 후 별 세션

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)