### PR TITLE
refactor(bundler): Phase 4c-4d — ib.local_name → ib.local_symbol 직접 사용

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -720,7 +720,7 @@ pub fn buildFinalExports(
 pub fn buildCrossModuleConstValues(
     self: *const Linker,
     m: *const Module,
-    sem: @import("../module.zig").ModuleSemanticData,
+    _: @import("../module.zig").ModuleSemanticData,
 ) !std.AutoHashMapUnmanaged(u32, @import("../../semantic/symbol.zig").ConstValue) {
     var const_values: std.AutoHashMapUnmanaged(u32, @import("../../semantic/symbol.zig").ConstValue) = .{};
     for (m.import_bindings) |ib| {
@@ -746,10 +746,9 @@ pub fn buildCrossModuleConstValues(
         const cv = target_sem.symbols.items[target_sym_idx].const_value;
         if (cv.kind == .none or !cv.isSafeToInline()) continue;
         // import binding의 local symbol에 매핑
-        if (sem.scope_maps.len > 0) {
-            if (sem.scope_maps[0].get(ib.local_name)) |local_sym| {
-                try const_values.put(self.allocator, @intCast(local_sym), cv);
-            }
+        if (ib.local_symbol.isValid()) {
+            const local_sym: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+            try const_values.put(self.allocator, local_sym, cv);
         }
     }
     return const_values;

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -433,9 +433,9 @@ pub const TreeShaker = struct {
             var arr = try self.allocator.alloc(?u32, sem.symbols.items.len);
             for (arr) |*a| a.* = null;
             for (mod.import_bindings, 0..) |ib, ib_idx| {
-                if (sem.scope_maps[0].get(ib.local_name)) |sym_idx| {
-                    if (sym_idx < arr.len) arr[sym_idx] = @intCast(ib_idx);
-                }
+                if (!ib.local_symbol.isValid()) continue;
+                const sym_idx: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+                if (sym_idx < arr.len) arr[sym_idx] = @intCast(ib_idx);
             }
             maps[i] = arr;
         }
@@ -898,10 +898,9 @@ pub const TreeShaker = struct {
 
     fn isImportBindingUsed(self: *const TreeShaker, m: Module, ib: ImportBinding) bool {
         if (m.semantic) |sem| {
-            if (sem.scope_maps.len > 0) {
-                if (sem.scope_maps[0].get(ib.local_name)) |sym_idx| {
-                    if (sym_idx < sem.symbols.items.len and sem.symbols.items[sym_idx].reference_count > 0) return true;
-                }
+            if (ib.local_symbol.isValid()) {
+                const sym_idx: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+                if (sym_idx < sem.symbols.items.len and sem.symbols.items[sym_idx].reference_count > 0) return true;
             }
         } else return true;
 

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -59,6 +59,7 @@ fn buildAndShakeWithOpts(
 
     var linker = Linker.init(allocator, graph.modules.items, .esm);
     try linker.link();
+    linker.populateImportSymbols(graph.modules.items);
 
     var shaker = try TreeShaker.init(allocator, graph.modules.items, &linker);
     try shaker.analyze(&.{entry});
@@ -204,6 +205,7 @@ test "tree-shaking: empty module graph" {
     var linker = Linker.init(std.testing.allocator, graph.modules.items, .esm);
     defer linker.deinit();
     try linker.link();
+    linker.populateImportSymbols(graph.modules.items);
 
     var shaker = try TreeShaker.init(std.testing.allocator, graph.modules.items, &linker);
     defer shaker.deinit();


### PR DESCRIPTION
## Summary
`scope_maps[0].get(ib.local_name)` 해시 hop을 `ib.local_symbol`(SymbolRef) 직접 인덱스로 단축. ib.local_symbol은 4c-3b-α의 `populateImportSymbols`가 채움.

## 전환 (3 사이트)
- tree_shaker.zig:436 (sym_to_ib map 구축)
- tree_shaker.zig:902 (isImportBindingUsed)
- linker/metadata.zig:750 (buildCrossModuleConstValues)

## 부수
- tree_shaker_test.zig 셋업 두 곳에 `linker.populateImportSymbols(...)` 호출 추가 — 프로덕션 경로(bundler.zig)와 동일 순서를 테스트도 따르게 함.

## Test plan
- [x] `zig build test` (tree_shaker 회귀 fix 포함)
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)