### PR TITLE
refactor(bundler): Phase 4c-4d — populateImportSymbols가 .local export 심볼도 채우게

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1283,6 +1283,21 @@ pub const Linker = struct {
                     ib.symbol = eb.symbol;
                 }
             }
+
+            // .local export 중 binding_scanner가 채우지 않은(`_default` 합성/`re_export`
+            // 외) 일반 케이스의 eb.symbol을 scope_maps[0] 조회로 채움.
+            if (module_scope_opt) |module_scope| {
+                for (importer.export_bindings) |*eb| {
+                    if (eb.kind != .local) continue;
+                    if (eb.symbol.isValid()) continue; // 이미 채워짐
+                    if (module_scope.get(eb.local_name)) |sym_idx| {
+                        eb.symbol = .{ .semantic = .{
+                            .module = mod_idx,
+                            .symbol = @enumFromInt(@as(u32, @intCast(sym_idx))),
+                        } };
+                    }
+                }
+            }
         }
     }
 

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -493,10 +493,10 @@ pub const TreeShaker = struct {
                 for (m.export_bindings) |eb| {
                     if (eb.kind.isReExportAll()) continue;
                     if (!self.entry_set.isSet(i) and !self.isExportUsed(mi, eb.exported_name)) continue;
-                    if (sem.scope_maps[0].get(eb.local_name)) |sym_idx| {
-                        if (infos.declaredStmtBySymbol(@intCast(sym_idx))) |stmt_idx| {
-                            try self.enqueue(@intCast(i), stmt_idx, reachable_stmts, &queue);
-                        }
+                    if (eb.symbol != .semantic) continue;
+                    const sym_idx: u32 = @intFromEnum(eb.symbol.semantic.symbol);
+                    if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
+                        try self.enqueue(@intCast(i), stmt_idx, reachable_stmts, &queue);
                     }
                 }
                 if (self.entry_set.isSet(i)) {
@@ -539,11 +539,11 @@ pub const TreeShaker = struct {
             if (sem.scope_maps.len == 0) continue;
             for (m.export_bindings) |eb| {
                 if (eb.kind.isReExportAll()) continue;
-                if (sem.scope_maps[0].get(eb.local_name)) |sym_idx| {
-                    if (infos.declaredStmtBySymbol(@intCast(sym_idx))) |stmt_idx| {
-                        if (reachable_stmts[i] != null and reachable_stmts[i].?.isSet(stmt_idx)) {
-                            try self.markExportUsed(@intCast(i), eb.exported_name);
-                        }
+                if (eb.symbol != .semantic) continue;
+                const sym_idx: u32 = @intFromEnum(eb.symbol.semantic.symbol);
+                if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
+                    if (reachable_stmts[i] != null and reachable_stmts[i].?.isSet(stmt_idx)) {
+                        try self.markExportUsed(@intCast(i), eb.exported_name);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
binding_scanner.populateExportSymbols는 synthetic_default + re_export 두 경로만 `eb.symbol`을 채움. 일반 `export const x` (.local) 케이스는 미설정 상태였음. linker.populateImportSymbols 끝에 export_bindings 순회를 추가해 누락된 .local 케이스를 보강.

## How
- `kind == .local && eb.symbol invalid` → `scope_maps[0].get(eb.local_name)` 결과로 semantic SymbolRef 생성·저장
- 모든 .local ExportBinding이 이제 SymbolRef를 보유 → `eb.symbol != .semantic` 가드가 의미 갖춤

## 활용 (이 PR에서 함께)
- tree_shaker.zig 두 사이트 (497, 543): `scope_maps[0].get(eb.local_name)` → `eb.symbol.semantic.symbol` 직접 인덱스로 단축

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)