### PR TITLE
refactor(bundler): Phase 4c-4d — emitter/chunks의 eb.local_name → eb.symbol 단축

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -937,8 +937,9 @@ pub fn emitModule(
                                         } else {
                                             for (module.export_bindings) |eb| {
                                                 if (std.mem.eql(u8, eb.exported_name, name)) {
-                                                    if (sem.scope_maps[0].get(eb.local_name)) |sym_idx| {
-                                                        used_sym_buf.append(arena_alloc, @intCast(sym_idx)) catch {};
+                                                    if (eb.symbol == .semantic) {
+                                                        const sym_idx: u32 = @intFromEnum(eb.symbol.semantic.symbol);
+                                                        used_sym_buf.append(arena_alloc, sym_idx) catch {};
                                                     }
                                                     break;
                                                 }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -957,13 +957,10 @@ pub fn computeAllUsedNames(
 
             // 크로스-모듈 BFS 도달성
             if (s.getModuleStmtInfos(mod_idx)) |ts_infos| {
-                if (m.semantic) |sem| {
-                    if (sem.scope_maps.len > 0) {
-                        if (sem.scope_maps[0].get(eb.local_name)) |sym_idx| {
-                            if (ts_infos.declaredStmtBySymbol(@intCast(sym_idx))) |stmt_idx| {
-                                if (!s.isStmtReachable(mod_idx, stmt_idx)) continue;
-                            }
-                        }
+                if (eb.symbol == .semantic) {
+                    const sym_idx: u32 = @intFromEnum(eb.symbol.semantic.symbol);
+                    if (ts_infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
+                        if (!s.isStmtReachable(mod_idx, stmt_idx)) continue;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
#1363에서 모든 .local ExportBinding이 SymbolRef를 보유하게 됐으므로 `scope_maps[0].get(eb.local_name)` 해시 hop을 `eb.symbol.semantic.symbol` 직접 인덱스로 단축.

## 전환
- emitter.zig:940 (used_sym_buf 채움)
- chunks.zig:962 (cross-module BFS reachability)

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)