### PR TITLE
refactor(bundler): Phase 4c-4d — Module name 헬퍼 (esbuild 패턴)

### DIFF
--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -218,6 +218,35 @@ pub const Module = struct {
         return null;
     }
 
+    /// SymbolId → 이름. semantic Symbol.nameText 호출의 short-cut.
+    /// 인덱스 범위 밖이거나 semantic 없으면 null.
+    pub fn symbolName(self: *const Module, id: SemanticSymbolId) ?[]const u8 {
+        const sem = self.semantic orelse return null;
+        const idx: u32 = @intFromEnum(id);
+        if (idx >= sem.symbols.items.len) return null;
+        return sem.symbols.items[idx].nameText(self.source);
+    }
+
+    /// ImportBinding의 현재 모듈 로컬 이름. local_symbol을 우선 derive,
+    /// 미설정(synthetic 등) 시 ib.local_name 필드 fallback.
+    /// #1328 Phase 4c-4d: esbuild 패턴 — 이름은 Symbol 소유, binding은 Ref.
+    pub fn importBindingLocalName(self: *const Module, ib: ImportBinding) []const u8 {
+        if (ib.local_symbol == .semantic) {
+            if (self.symbolName(ib.local_symbol.semantic.symbol)) |n| return n;
+        }
+        return ib.local_name;
+    }
+
+    /// ExportBinding의 로컬 이름. .local은 eb.symbol(semantic)에서 derive.
+    /// 그 외 kind는 eb.local_name 필드 fallback (re_export는 source 이름,
+    /// re_export_namespace는 ns alias, re_export_star는 "*").
+    pub fn exportBindingLocalName(self: *const Module, eb: ExportBinding) []const u8 {
+        if (eb.kind == .local and eb.symbol == .semantic) {
+            if (self.symbolName(eb.symbol.semantic.symbol)) |n| return n;
+        }
+        return eb.local_name;
+    }
+
     /// exported_name에 해당하는 SymbolRef 반환. 없으면 invalid.
     /// #1338 Phase 4c-1: 문자열 기반 lookup을 SymbolRef로 승격하기 위한 진입점.
     pub fn findExportSymbol(self: *const Module, exported_name: []const u8) symbol_mod.SymbolRef {


### PR DESCRIPTION
## Summary
esbuild/rolldown/oxc 패턴 — 이름은 Symbol에 저장, 바인딩은 Ref로 참조, 출력 시 derive. 4c-3c로 SymbolRef 인프라가 갖춰졌으니 같은 모델로 마무리.

## 추가 헬퍼
- `Module.symbolName(id)`: `SymbolId → Symbol.nameText(self.source)` 단축
- `Module.importBindingLocalName(ib)`: ib.local_symbol → derive, fallback ib.local_name
- `Module.exportBindingLocalName(eb)`: .local + eb.symbol → derive, fallback eb.local_name

## Why Module-side
binding_scanner는 Module을 import할 수 없음 (circular dep). 헬퍼는 Module에 위치.

## Scope
헬퍼 도입만. 사이트 전환은 후속 PR.

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

## Follow-up
- 후속 PR로 ~140 read site를 헬퍼로 점진 전환
- 모든 read 마이그레이션 완료 후 binding 구조체에서 string 필드 제거

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)