### PR TITLE
refactor(bundler): Phase 4c-4d (batch 1) — m.exportBindingLocalName 마이그레이션

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -398,8 +398,9 @@ pub const Linker = struct {
             }
             if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
                 // export default function foo → foo 이름으로 등록
-                if (module_scope.get(eb.local_name) == null) {
-                    try self.addNameOwner(name_to_owners, eb.local_name, owner);
+                const local = m.exportBindingLocalName(eb);
+                if (module_scope.get(local) == null) {
+                    try self.addNameOwner(name_to_owners, local, owner);
                 }
             }
         }
@@ -598,10 +599,10 @@ pub const Linker = struct {
         for (self.modules) |m| {
             for (m.export_bindings) |eb| {
                 try exported.put(eb.exported_name, {});
-                try exported.put(eb.local_name, {});
+                try exported.put(m.exportBindingLocalName(eb), {});
             }
             for (m.import_bindings) |ib| {
-                try exported.put(ib.local_name, {});
+                try exported.put(m.importBindingLocalName(ib), {});
             }
         }
 

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -193,7 +193,7 @@ pub fn buildMetadataForAst(
         var exported_locals = std.StringHashMap(void).init(self.allocator);
         defer exported_locals.deinit();
         for (m.export_bindings) |eb| {
-            if (eb.kind == .local) try exported_locals.put(eb.local_name, {});
+            if (eb.kind == .local) try exported_locals.put(m.exportBindingLocalName(eb), {});
         }
 
         // import 바인딩 → canonical 이름

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -181,7 +181,7 @@ pub const TreeShaker = struct {
             if (has_local_reexport) {
                 var set = std.StringHashMap(void).init(self.allocator);
                 for (m.export_bindings) |eb| {
-                    if (eb.kind == .local) try set.put(eb.local_name, {});
+                    if (eb.kind == .local) try set.put(m.exportBindingLocalName(eb), {});
                 }
                 re_export_sets[i] = set;
             } else {


### PR DESCRIPTION
## Summary
#1365 헬퍼 도입 후 첫 사이트 전환 4곳. `eb.local_name`/`ib.local_name` 직접 read를 `m.exportBindingLocalName(eb)`/`m.importBindingLocalName(ib)`로 교체.

## 사이트
- linker/metadata.zig:196 (exported_locals 수집)
- linker.zig:401-403 (default export 충돌 owner 등록)
- linker.zig:601-605 (mangling 제외 이름 수집)
- tree_shaker.zig:184 (re_export_sets 구축)

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)