### PR TITLE
refactor(bundler): Phase 4c-4d (batch 2) — eb.local_name 마이그레이션

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -465,17 +465,18 @@ pub fn emitEsmWrappedModule(
                         if (reExportAliasCanonicalName(eb.symbol, module)) |canon| {
                             break :blk canon;
                         }
+                        const local_name = module.exportBindingLocalName(eb);
                         // live binding override: import binding이 canonical name으로 변경된 경우
                         if (metadata) |md| {
-                            if (md.export_getter_overrides.get(eb.local_name)) |override|
+                            if (md.export_getter_overrides.get(local_name)) |override|
                                 break :blk override;
                         }
                         if (linker) |l| {
                             const mi: u32 = @intFromEnum(module.index);
-                            if (l.getCanonicalName(mi, eb.local_name)) |renamed|
+                            if (l.getCanonicalName(mi, local_name)) |renamed|
                                 break :blk renamed;
                         }
-                        break :blk eb.local_name;
+                        break :blk local_name;
                     }, options.configurable_exports);
                 }
             }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -561,7 +561,7 @@ pub fn buildMetadataForAst(
             break;
         }
         if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
-            default_export_name = self.getCanonicalByRef(eb.symbol) orelse eb.local_name;
+            default_export_name = self.getCanonicalByRef(eb.symbol) orelse m.exportBindingLocalName(eb);
             break;
         }
     }
@@ -737,7 +737,7 @@ pub fn buildCrossModuleConstValues(
         var local_name = canon.export_name;
         for (target_module.export_bindings) |eb| {
             if (std.mem.eql(u8, eb.exported_name, canon.export_name)) {
-                local_name = eb.local_name;
+                local_name = target_module.exportBindingLocalName(eb);
                 break;
             }
         }
@@ -1014,7 +1014,7 @@ pub fn buildDevMetadataForAst(
                             try buf.appendSlice(self.allocator, " = __zts_require(\"");
                             try buf.appendSlice(self.allocator, re_path);
                             try buf.appendSlice(self.allocator, "\").");
-                            try buf.appendSlice(self.allocator, eb.local_name);
+                            try buf.appendSlice(self.allocator, m.exportBindingLocalName(eb));
                             try buf.appendSlice(self.allocator, ";\n");
                             continue;
                         }
@@ -1025,7 +1025,7 @@ pub fn buildDevMetadataForAst(
             try buf.appendSlice(self.allocator, "exports.");
             try buf.appendSlice(self.allocator, eb.exported_name);
             try buf.appendSlice(self.allocator, " = ");
-            try buf.appendSlice(self.allocator, eb.local_name);
+            try buf.appendSlice(self.allocator, m.exportBindingLocalName(eb));
             try buf.appendSlice(self.allocator, ";\n");
         }
 


### PR DESCRIPTION
## Summary
5 사이트 추가 전환:
- linker/metadata.zig:564 (default_export_name fallback)
- linker/metadata.zig:740 (target_module export→local_name 매핑)
- linker/metadata.zig:1017, 1028 (dev mode CJS `exports.X = local` 출력)
- esm_wrap.zig:470/475/478 (export getter)

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)