### PR TITLE
refactor(bundler): Phase 4c-4d (batch 3) — chunks/tree_shaker eb.local_name 마이그레이션

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -903,10 +903,11 @@ pub fn computeAllUsedNames(
             const target_i: u32 = @intFromEnum(target);
             const gop = try reverse_map.getOrPut(allocator, target_i);
             if (!gop.found_existing) gop.value_ptr.* = .empty;
+            const ieb_local = importer.exportBindingLocalName(ieb);
             try gop.value_ptr.append(allocator, .{
                 .importer_module_index = imp_i,
-                .imported_name = ieb.local_name,
-                .local_name = ieb.local_name,
+                .imported_name = ieb_local,
+                .local_name = ieb_local,
                 .exported_name = ieb.exported_name,
                 .kind = switch (ieb.kind) {
                     .re_export_star => .re_export_star,
@@ -993,11 +994,12 @@ pub fn computeAllUsedNames(
                 if (is_dead) continue;
             }
 
-            names_buf.append(allocator, eb.local_name) catch {
+            const eb_local = m.exportBindingLocalName(eb);
+            names_buf.append(allocator, eb_local) catch {
                 all_used = true;
                 break;
             };
-            if (!std.mem.eql(u8, eb.exported_name, eb.local_name)) {
+            if (!std.mem.eql(u8, eb.exported_name, eb_local)) {
                 names_buf.append(allocator, eb.exported_name) catch {
                     all_used = true;
                     break;

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -742,7 +742,7 @@ pub const TreeShaker = struct {
                         self.included.set(src);
                         try self.seedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
                     } else {
-                        try self.seedExport(src, eb.local_name, queue, module_stmt_infos, reachable_stmts);
+                        try self.seedExport(src, m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);
                     }
                 }
             }
@@ -788,7 +788,7 @@ pub const TreeShaker = struct {
                 self.included.set(src);
                 try self.seedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
             } else {
-                try self.seedExport(src, eb.local_name, queue, module_stmt_infos, reachable_stmts);
+                try self.seedExport(src, m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);
             }
         }
         // namespace import 전파: import * as X에서 X가 사용되면 소스 모듈도 시드
@@ -947,7 +947,7 @@ pub const TreeShaker = struct {
                                 // named re-export: canonical 모듈도 include
                                 if (self.linker.resolveExportChain(
                                     m.import_records[rec_idx].resolved,
-                                    eb.local_name,
+                                    m.exportBindingLocalName(eb),
                                     0,
                                 )) |canonical| {
                                     const canon_idx = @intFromEnum(canonical.module_index);


### PR DESCRIPTION
## Summary
5 사이트 추가:
- chunks.zig:907-910 (RevEntry 구축)
- chunks.zig:996-1001 (export name 비교/append)
- tree_shaker.zig:745, 791, 950 (re-export seed/resolve)

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)