### PR TITLE
refactor(bundler): Phase 4c-4d (batch 5) — preamble fallback ib.local_name 마이그레이션

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -278,7 +278,7 @@ pub fn emitEsmWrappedModule(
     // init 안에서 _jsxDEV = ... (할당만)으로 처리해야 함.
     for (module.import_bindings) |ib| {
         if (ib.isSynthetic()) {
-            try hoisted_var_names.append(allocator, ib.local_name);
+            try hoisted_var_names.append(allocator, module.importBindingLocalName(ib));
         }
     }
 
@@ -625,7 +625,7 @@ pub fn emitEsmWrappedModule(
                         var found_preamble_var: ?[]const u8 = null;
                         for (module.import_bindings) |ib| {
                             if (ib.import_record_index == rec_idx and ib.importsDefault()) {
-                                found_preamble_var = l.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
+                                found_preamble_var = l.getCanonicalByRef(ib.local_symbol) orelse module.importBindingLocalName(ib);
                                 break;
                             }
                         }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -204,7 +204,7 @@ pub fn buildMetadataForAst(
             // resolve 미완료: external 또는 resolve 실패.
             if (rec.resolved.isNone()) {
                 if (rec.kind == .static_import or rec.kind == .side_effect or rec.kind == .re_export) {
-                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
+                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                     // synthetic binding(JSX runtime 등) + ESM-wrapped 모듈 조합에서는
                     // top-level에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨.
                     // init 함수 본문에서 `var`로 재선언하면 outer scope를 shadow → #1209.
@@ -283,7 +283,7 @@ pub fn buildMetadataForAst(
 
             // CJS 모듈에서 import하는 경우: preamble에서 require_xxx() 호출 생성
             if (canonical_mod < self.modules.len and self.modules[canonical_mod].wrap_kind == .cjs) {
-                const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
+                const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                 const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
                 const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
                 // ESM-wrapped + synthetic binding: top-level에 이미 var 선언됨 → 할당만
@@ -346,7 +346,7 @@ pub fn buildMetadataForAst(
             // 롤다운 shimMissingExports 호환: 소스 모듈에 해당 export가 없으면
             // strict mode ReferenceError 대신 undefined를 반환하도록 shim 생성.
             if (resolved == null and self.shim_missing_exports) {
-                const shim_name = self.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
+                const shim_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                 try preamble.write("var ");
                 try preamble.write(shim_name);
                 try preamble.write(" = void 0;\n");
@@ -361,7 +361,7 @@ pub fn buildMetadataForAst(
             if (resolved) |rb| {
                 const cjs_mod: u32 = @intCast(@intFromEnum(rb.canonical.module_index));
                 if (cjs_mod < self.modules.len and self.modules[cjs_mod].wrap_kind == .cjs) {
-                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse ib.local_name;
+                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                     const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, cjs_mod);
                     const interop_mode2: types.Interop = if (m.def_format.isEsm()) .node else .babel;
                     const effective_name = rb.canonical.export_name;


### PR DESCRIPTION
## Summary
`getCanonicalByRef(ib.local_symbol) orelse ib.local_name` 패턴 6 사이트 일괄 전환:
- linker/metadata.zig: 207, 286, 349, 364
- esm_wrap.zig: 281, 628

helper는 local_symbol invalid 시 ib.local_name field 반환이라 동작 등가.

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)