### PR TITLE
chore(bundler): /simplify Phase 4c-4d 후속 — SymbolRef.semanticIndex 헬퍼

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -937,8 +937,7 @@ pub fn emitModule(
                                         } else {
                                             for (module.export_bindings) |eb| {
                                                 if (std.mem.eql(u8, eb.exported_name, name)) {
-                                                    if (eb.symbol == .semantic) {
-                                                        const sym_idx: u32 = @intFromEnum(eb.symbol.semantic.symbol);
+                                                    if (eb.symbol.semanticIndex()) |sym_idx| {
                                                         used_sym_buf.append(arena_alloc, sym_idx) catch {};
                                                     }
                                                     break;

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -958,8 +958,7 @@ pub fn computeAllUsedNames(
 
             // 크로스-모듈 BFS 도달성
             if (s.getModuleStmtInfos(mod_idx)) |ts_infos| {
-                if (eb.symbol == .semantic) {
-                    const sym_idx: u32 = @intFromEnum(eb.symbol.semantic.symbol);
+                if (eb.symbol.semanticIndex()) |sym_idx| {
                     if (ts_infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
                         if (!s.isStmtReachable(mod_idx, stmt_idx)) continue;
                     }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -272,8 +272,7 @@ pub fn buildMetadataForAst(
                         break :blk ns_name;
                     };
 
-                    if (ib.local_symbol == .semantic) {
-                        const sym_idx: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+                    if (ib.local_symbol.semanticIndex()) |sym_idx| {
                         const rename = try std.fmt.allocPrint(self.allocator, "{s}.{s}", .{ ns_var, ib.imported_name });
                         try owned_nested_renames.append(self.allocator, rename);
                         try renames.put(sym_idx, rename);
@@ -322,8 +321,7 @@ pub fn buildMetadataForAst(
             // __esm 타겟도 동일: rolldown 방식으로 변수가 래퍼 밖에 호이스팅되므로
             // canonical name으로 직접 치환 가능. exports_xxx rename은 변수 덮어쓰기 버그 유발.
             if (ib.kind == .namespace) {
-                if (ib.local_symbol != .semantic) continue;
-                const ns_sym_id: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+                const ns_sym_id = ib.local_symbol.semanticIndex() orelse continue;
                 const local_name = m.importBindingLocalName(ib);
                 const effective_syms = override_symbol_ids orelse sem.symbol_ids;
 
@@ -442,8 +440,7 @@ pub fn buildMetadataForAst(
             // 항상 renames에 등록하여 codegen이 target 변수를 참조하도록 함.
             // 중첩 스코프 충돌은 resolveNestedShadowConflicts에서 이미 처리됨.
             if (!isReservedName(target_name)) {
-                if (ib.local_symbol == .semantic) {
-                    const sym_idx: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+                if (ib.local_symbol.semanticIndex()) |sym_idx| {
                     try renames.put(sym_idx, target_name);
                     // __esm → __esm live binding: __export getter override 등록 +
                     // 자체 rename 루프에서 덮어쓰기 방지
@@ -750,8 +747,7 @@ pub fn buildCrossModuleConstValues(
         const cv = target_sem.symbols.items[target_sym_idx].const_value;
         if (cv.kind == .none or !cv.isSafeToInline()) continue;
         // import binding의 local symbol에 매핑
-        if (ib.local_symbol.isValid()) {
-            const local_sym: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+        if (ib.local_symbol.semanticIndex()) |local_sym| {
             try const_values.put(self.allocator, local_sym, cv);
         }
     }
@@ -1151,13 +1147,12 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
             if (ib.import_record_index >= m.import_records.len) continue;
             const rec = m.import_records[ib.import_record_index];
             if (rec.resolved.isNone()) continue;
-            if (ib.local_symbol != .semantic) continue;
+            const sym_idx = ib.local_symbol.semanticIndex() orelse continue;
 
             const target_name = self.getCanonicalByRef(ib.symbol) orelse ib.imported_name;
             const local_name = m.importBindingLocalName(ib);
 
             if (!std.mem.eql(u8, local_name, target_name)) {
-                const sym_idx: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
                 try renames.put(sym_idx, target_name);
             }
         }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -227,24 +227,25 @@ pub const Module = struct {
         return sem.symbols.items[idx].nameText(self.source);
     }
 
-    /// ImportBinding의 현재 모듈 로컬 이름. local_symbol을 우선 derive,
-    /// 미설정(synthetic 등) 시 ib.local_name 필드 fallback.
-    /// #1328 Phase 4c-4d: esbuild 패턴 — 이름은 Symbol 소유, binding은 Ref.
-    pub fn importBindingLocalName(self: *const Module, ib: ImportBinding) []const u8 {
-        if (ib.local_symbol == .semantic) {
-            if (self.symbolName(ib.local_symbol.semantic.symbol)) |n| return n;
-        }
-        return ib.local_name;
+    /// SymbolRef가 semantic을 가리키면 Symbol.nameText, 아니면 null.
+    fn refName(self: *const Module, ref: symbol_mod.SymbolRef) ?[]const u8 {
+        const idx = ref.semanticIndex() orelse return null;
+        const sem = self.semantic orelse return null;
+        if (idx >= sem.symbols.items.len) return null;
+        return sem.symbols.items[idx].nameText(self.source);
     }
 
-    /// ExportBinding의 로컬 이름. .local은 eb.symbol(semantic)에서 derive.
-    /// 그 외 kind는 eb.local_name 필드 fallback (re_export는 source 이름,
-    /// re_export_namespace는 ns alias, re_export_star는 "*").
+    /// ImportBinding의 현재 모듈 로컬 이름. local_symbol에서 derive 가능하면
+    /// Symbol.nameText, 아니면 ib.local_name 필드 fallback.
+    pub fn importBindingLocalName(self: *const Module, ib: ImportBinding) []const u8 {
+        return self.refName(ib.local_symbol) orelse ib.local_name;
+    }
+
+    /// ExportBinding의 로컬 이름. `.local` + semantic ref면 Symbol.nameText에서
+    /// derive, 그 외엔 eb.local_name 필드 그대로 반환.
     pub fn exportBindingLocalName(self: *const Module, eb: ExportBinding) []const u8 {
-        if (eb.kind == .local and eb.symbol == .semantic) {
-            if (self.symbolName(eb.symbol.semantic.symbol)) |n| return n;
-        }
-        return eb.local_name;
+        if (eb.kind != .local) return eb.local_name;
+        return self.refName(eb.symbol) orelse eb.local_name;
     }
 
     /// exported_name에 해당하는 SymbolRef 반환. 없으면 invalid.

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -51,6 +51,15 @@ pub const SymbolRef = union(enum) {
         };
     }
 
+    /// `.semantic`이면 SymbolId를 u32로 반환. `.alias`나 invalid면 null.
+    /// `if (ref == .semantic) @intFromEnum(ref.semantic.symbol)` 반복 패턴 단축.
+    pub fn semanticIndex(self: SymbolRef) ?u32 {
+        return switch (self) {
+            .semantic => |s| if (s.symbol.isNone()) null else @intFromEnum(s.symbol),
+            .alias => null,
+        };
+    }
+
     pub fn eql(x: SymbolRef, y: SymbolRef) bool {
         return switch (x) {
             .semantic => |xs| switch (y) {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -433,8 +433,7 @@ pub const TreeShaker = struct {
             var arr = try self.allocator.alloc(?u32, sem.symbols.items.len);
             for (arr) |*a| a.* = null;
             for (mod.import_bindings, 0..) |ib, ib_idx| {
-                if (!ib.local_symbol.isValid()) continue;
-                const sym_idx: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+                const sym_idx = ib.local_symbol.semanticIndex() orelse continue;
                 if (sym_idx < arr.len) arr[sym_idx] = @intCast(ib_idx);
             }
             maps[i] = arr;
@@ -493,8 +492,7 @@ pub const TreeShaker = struct {
                 for (m.export_bindings) |eb| {
                     if (eb.kind.isReExportAll()) continue;
                     if (!self.entry_set.isSet(i) and !self.isExportUsed(mi, eb.exported_name)) continue;
-                    if (eb.symbol != .semantic) continue;
-                    const sym_idx: u32 = @intFromEnum(eb.symbol.semantic.symbol);
+                    const sym_idx = eb.symbol.semanticIndex() orelse continue;
                     if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
                         try self.enqueue(@intCast(i), stmt_idx, reachable_stmts, &queue);
                     }
@@ -539,8 +537,7 @@ pub const TreeShaker = struct {
             if (sem.scope_maps.len == 0) continue;
             for (m.export_bindings) |eb| {
                 if (eb.kind.isReExportAll()) continue;
-                if (eb.symbol != .semantic) continue;
-                const sym_idx: u32 = @intFromEnum(eb.symbol.semantic.symbol);
+                const sym_idx = eb.symbol.semanticIndex() orelse continue;
                 if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
                     if (reachable_stmts[i] != null and reachable_stmts[i].?.isSet(stmt_idx)) {
                         try self.markExportUsed(@intCast(i), eb.exported_name);
@@ -898,8 +895,7 @@ pub const TreeShaker = struct {
 
     fn isImportBindingUsed(self: *const TreeShaker, m: Module, ib: ImportBinding) bool {
         if (m.semantic) |sem| {
-            if (ib.local_symbol.isValid()) {
-                const sym_idx: u32 = @intFromEnum(ib.local_symbol.semantic.symbol);
+            if (ib.local_symbol.semanticIndex()) |sym_idx| {
                 if (sym_idx < sem.symbols.items.len and sem.symbols.items[sym_idx].reference_count > 0) return true;
             }
         } else return true;


### PR DESCRIPTION
## /simplify 리뷰 반영

### 1. `SymbolRef.semanticIndex() ?u32` 추가
12 사이트의 `if (x == .semantic) @intFromEnum(x.semantic.symbol)` (또는 `isValid()` + 직접 access) 패턴을 한 줄로 통합. `.alias`/invalid는 자동 null.

### 2. Module.refName(ref) private helper 추출
`importBindingLocalName` / `exportBindingLocalName` 양쪽 공유. 두 헬퍼가 같은 derive 로직을 공유.

### 3. 주석 정리
- module.zig: phase tag(`#1328 Phase 4c-4d`) 제거
- `exportBindingLocalName` docstring을 함수 행동 기준으로 수정 (kind별 local_name 의미를 나열하던 부정확 부분 삭제)

### 전환된 사이트
- tree_shaker.zig 4
- linker/metadata.zig 5
- emitter.zig 1
- emitter/chunks.zig 1

`isValid()` vs `== .semantic` 혼재 문제도 해소 (모두 semanticIndex 경유).

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328 (4c-4d 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)