### PR TITLE
refactor(bundler): Phase 4c-4e — eb.symbol fill-in을 scan 시점으로 이전

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -650,6 +650,10 @@ pub fn populateSyntheticSymbols(
     export_bindings: []ExportBinding,
     sem_symbols: *std.ArrayList(SemanticSymbol),
     arena: std.mem.Allocator,
+    /// 모듈 top-level scope (scope_maps[0]). 일반 .local export의 eb.symbol을
+    /// scope_maps에서 lookup해 미리 채우는 데 사용. null이면 skip — linker가
+    /// 후속 패스에서 fallback 처리.
+    module_scope: ?std.StringHashMap(usize),
 ) !void {
     for (export_bindings) |*eb| {
         // codegen이 `_default = <expr>` 할당을 emit하는 export만 synthetic_default 등록.
@@ -671,6 +675,15 @@ pub fn populateSyntheticSymbols(
             // resolveExportChain 결과를 canonical_name으로 저장한다.
             const id = try table.declare(eb.exported_name);
             eb.symbol = .{ .alias = .{ .module = module_index, .symbol = id } };
+        } else if (eb.kind == .local) {
+            // 일반 .local export: scope_maps[0]에서 로컬 심볼 lookup → semantic ref.
+            // synthetic_default 케이스는 위에서 이미 처리됨.
+            const scope = module_scope orelse continue;
+            const sym_idx = scope.get(eb.local_name) orelse continue;
+            eb.symbol = .{ .semantic = .{
+                .module = module_index,
+                .symbol = @enumFromInt(@as(u32, @intCast(sym_idx))),
+            } };
         }
     }
 }

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -335,7 +335,7 @@ test "populateSyntheticSymbols: 리터럴 default만 _default 등록 (로컬 var
     var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
     defer sem_syms.deinit(alloc);
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc, null);
     const idx = findDefaultSymbol(sem_syms.items) orelse return error.NotFound;
     try std.testing.expectEqualStrings("_default", sem_syms.items[idx].synthetic_name);
 }
@@ -353,7 +353,7 @@ test "populateSyntheticSymbols: `export default x`(x는 로컬)은 _default 미�
     var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
     defer sem_syms.deinit(alloc);
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc, null);
     try std.testing.expectEqual(@as(?usize, null), findDefaultSymbol(sem_syms.items));
 }
 
@@ -370,7 +370,7 @@ test "populateSyntheticSymbols: default 없으면 빈 테이블" {
     var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
     defer sem_syms.deinit(alloc);
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc, null);
     try std.testing.expectEqual(@as(u32, 0), table.count());
     try std.testing.expectEqual(@as(usize, 0), sem_syms.items.len);
 }
@@ -389,7 +389,7 @@ test "populateSyntheticSymbols Phase 2: ExportBinding.symbol 연결" {
     defer sem_syms.deinit(alloc);
 
     const m: types.ModuleIndex = @enumFromInt(7);
-    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings, &sem_syms, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, m, r.export_bindings, &sem_syms, alloc, null);
 
     try std.testing.expect(r.export_bindings[0].symbol.isValid());
     try std.testing.expectEqual(m, r.export_bindings[0].symbol.moduleIndex());
@@ -417,7 +417,7 @@ test "populateSyntheticSymbols Phase 2: 비-default export는 invalid 유지" {
     var sem_syms: std.ArrayList(semantic_symbol.Symbol) = .empty;
     defer sem_syms.deinit(alloc);
 
-    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc);
+    try binding_scanner.populateSyntheticSymbols(&table, @enumFromInt(0), r.export_bindings, &sem_syms, alloc, null);
 
     try std.testing.expect(!r.export_bindings[0].symbol.isValid());
 }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -769,12 +769,15 @@ pub const ModuleGraph = struct {
             // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
             module.ensureAliasTable(self.allocator);
             if (module.semantic) |*sem| {
+                const scope0: ?std.StringHashMap(usize) =
+                    if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
                 binding_scanner_mod.populateSyntheticSymbols(
                     &module.alias_table.?,
                     module.index,
                     module.export_bindings,
                     &sem.symbols,
                     arena_alloc,
+                    scope0,
                 ) catch {};
             }
 
@@ -1045,12 +1048,15 @@ pub const ModuleGraph = struct {
             // + semantic 공간에 synthetic_default 등록.
             module.ensureAliasTable(self.allocator);
             if (module.semantic) |*sem| {
+                const scope0: ?std.StringHashMap(usize) =
+                    if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
                 binding_scanner_mod.populateSyntheticSymbols(
                     &module.alias_table.?,
                     module.index,
                     module.export_bindings,
                     &sem.symbols,
                     arena_alloc,
+                    scope0,
                 ) catch {};
             }
 

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1287,21 +1287,6 @@ pub const Linker = struct {
                     ib.symbol = eb.symbol;
                 }
             }
-
-            // .local export 중 binding_scanner가 채우지 않은(`_default` 합성/`re_export`
-            // 외) 일반 케이스의 eb.symbol을 scope_maps[0] 조회로 채움.
-            if (module_scope_opt) |module_scope| {
-                for (importer.export_bindings) |*eb| {
-                    if (eb.kind != .local) continue;
-                    if (eb.symbol.isValid()) continue; // 이미 채워짐
-                    if (module_scope.get(eb.local_name)) |sym_idx| {
-                        eb.symbol = .{ .semantic = .{
-                            .module = mod_idx,
-                            .symbol = @enumFromInt(@as(u32, @intCast(sym_idx))),
-                        } };
-                    }
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
binding_scanner.populateSyntheticSymbols가 .local export의 eb.symbol도 scope_maps[0]에서 lookup해 채우게 확장. linker.populateImportSymbols의 후속 fill loop 제거.

## Why
이제 모든 .local ExportBinding의 eb.symbol이 scan 단계에서 채워짐. linker 패스는 cross-module(.alias re_export) 작업만. 이로써 `ExportBinding.local_name` 필드의 외부 consumer는 0 — binding_scanner 내부 synthetic_default classification만 사용. 다음 단계(필드 물리 제거)의 선결조건.

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)