### PR TITLE
chore(bundler): /simplify Phase 4c-4e 후속 — SymbolRef.makeSemantic + 주석

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -639,11 +639,11 @@ pub fn collectNamespaceAccesses(
     }
 }
 
-/// export bindings를 훑어 합성 심볼을 등록하고 `ExportBinding.symbol`을 채운다.
-/// Cross-module re-export 연결은 linker가 `populateReExportAliases`에서 수행.
-///
-/// #1338 Phase 4e-2d-a: `synthetic_default`는 항상 semantic 공간에 등록.
-/// `re_export_alias`는 값 의미가 없어 bundler 전용 (RFC #1338).
+/// 모든 ExportBinding의 `symbol` 필드를 채운다. 세 경로:
+///   1. `_default = <expr>` 패턴 → semantic 합성 심볼(`default_export`) 등록
+///   2. `.re_export` → AliasTable에 alias 등록
+///   3. `.local` → `module_scope`에서 동명 심볼 lookup → semantic ref
+/// Cross-module re-export 체인 resolve는 linker가 `populateReExportAliases`에서 수행.
 pub fn populateSyntheticSymbols(
     table: *AliasTable,
     module_index: ModuleIndex,
@@ -680,10 +680,7 @@ pub fn populateSyntheticSymbols(
             // synthetic_default 케이스는 위에서 이미 처리됨.
             const scope = module_scope orelse continue;
             const sym_idx = scope.get(eb.local_name) orelse continue;
-            eb.symbol = .{ .semantic = .{
-                .module = module_index,
-                .symbol = @enumFromInt(@as(u32, @intCast(sym_idx))),
-            } };
+            eb.symbol = symbol_mod.SymbolRef.makeSemantic(module_index, sym_idx);
         }
     }
 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1267,10 +1267,7 @@ pub const Linker = struct {
                 if (module_scope_opt) |module_scope| {
                     if (!ib.isSynthetic()) {
                         if (module_scope.get(ib.local_name)) |sym_idx| {
-                            ib.local_symbol = .{ .semantic = .{
-                                .module = mod_idx,
-                                .symbol = @enumFromInt(@as(u32, @intCast(sym_idx))),
-                            } };
+                            ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(mod_idx, sym_idx);
                         }
                     }
                 }

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -37,6 +37,14 @@ pub const SymbolRef = union(enum) {
 
     pub const invalid: SymbolRef = .{ .alias = .{ .module = .none, .symbol = .none } };
 
+    /// `.semantic` 변형 생성. `sym_idx`는 usize/u32 모두 허용 (intCast).
+    pub fn makeSemantic(module: ModuleIndex, sym_idx: anytype) SymbolRef {
+        return .{ .semantic = .{
+            .module = module,
+            .symbol = @enumFromInt(@as(u32, @intCast(sym_idx))),
+        } };
+    }
+
     pub fn isValid(self: SymbolRef) bool {
         return switch (self) {
             .semantic => |s| !s.module.isNone() and !s.symbol.isNone(),


### PR DESCRIPTION
## /simplify 리뷰 반영

### 1. `SymbolRef.makeSemantic(module, sym_idx)` 생성자
`anytype` sym_idx로 usize/u32 모두 허용. 2 사이트 적용 (binding_scanner / linker). union variant `.semantic`과 이름 충돌해 method는 `makeSemantic`.

### 2. populateSyntheticSymbols docstring 갱신
4c-4e가 `.local` 채움 책임을 추가했는데 docstring은 여전히 synthetic 한정만 말했음 — 3 경로(synthetic_default / re_export alias / local) 명시.

## 미반영 (의도)
- graph.zig 두 callsite 중복: `*Module` 받는 형태로 묶으면 깔끔하나 arena_alloc 경계와 얽혀 별도 PR
- `module_scope: ?StringHashMap` 테스트 편의용 optional 유지
- 함수 이름 단일책임 분리는 별도 PR

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (baseline 1 fail 무관)

Refs #1328 (4c-4e 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)