### PR TITLE
fix(bundler): #1340 export { default as X } from re-export 시 source wrap 누락

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1385,6 +1385,36 @@ pub const ModuleGraph = struct {
             }
         }
 
+        // Pass 2.5: 래핑된 모듈의 re_export source는 lazy 체인 보존을 위해
+        // __esm 래핑 (#1340). barrel `export { default as X } from './m'` 패턴에서
+        // m이 scope-hoist되면 barrel의 init body가 비고 `_default = ...` 할당이
+        // 누락된다. re_export만 cascade — static_import는 binding rewrite로 해결됨.
+        // wrap_kind 변경이 또 다른 모듈을 promote할 수 있어 iterative 수행.
+        {
+            var changed = true;
+            while (changed) {
+                changed = false;
+                for (self.modules.items) |m| {
+                    if (m.wrap_kind == .none) continue;
+                    for (m.export_bindings) |eb| {
+                        if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
+                        const rec_idx = eb.import_record_index orelse continue;
+                        if (rec_idx >= m.import_records.len) continue;
+                        const target_mod_idx = m.import_records[rec_idx].resolved;
+                        if (target_mod_idx.isNone()) continue;
+                        const target_idx = @intFromEnum(target_mod_idx);
+                        if (target_idx >= self.modules.items.len) continue;
+                        var target = &self.modules.items[target_idx];
+                        if (target.wrap_kind != .none) continue;
+                        if (target.exports_kind == .esm or target.exports_kind == .esm_with_dynamic_fallback) {
+                            target.wrap_kind = .esm;
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+
         // Pass 3: 모든 ESM 모듈을 __esm 래핑 (RN + dev mode).
         // - RN: circular dep 체인에서 초기화 순서 보장 (Rolldown 호환 lazy loading)
         // - dev mode: HMR을 위해 모든 모듈이 개별 팩토리 함수로 래핑되어야 함

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1071,7 +1071,7 @@ describe("_default 합성 변수 충돌 방지", () => {
     }
   });
 
-  test("export { default as X } from re-export가 __esm 래퍼에서 할당된다 (#705)", async () => {
+  test("export { default as X } from re-export가 __esm 래퍼에서 할당된다 (#705, #1340)", async () => {
     const fixture = await createFixture({
       "index.ts": `const b = require("./barrel"); console.log(b.Foo);`,
       "barrel.ts": `export { default as Foo } from "./foo";`,
@@ -1081,11 +1081,14 @@ describe("_default 합성 변수 충돌 방지", () => {
 
     const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts")]);
     expect(bundle.exitCode).toBe(0);
-    // __esm body에 할당문이 있어야 한다
-    expect(bundle.stdout).toContain("= _default");
+    // foo가 __esm으로 래핑되어 init_foo 안에서 _default 할당이 일어나야 한다
+    expect(bundle.stdout).toMatch(/init_foo\s*=\s*__esm/);
+    expect(bundle.stdout).toMatch(/_default\$?\d*\s*=\s*"fooValue"/);
+    // barrel의 init body가 init_foo()를 호출해야 한다 (lazy 체인 보존)
+    expect(bundle.stdout).toMatch(/init_barrel\s*=\s*__esm[\s\S]*?init_foo\(\)/);
   });
 
-  test("export { default } from re-export가 __esm 래퍼에서 할당된다 (#705)", async () => {
+  test("export { default } from re-export가 __esm 래퍼에서 할당된다 (#705, #1340)", async () => {
     const fixture = await createFixture({
       "index.ts": `const b = require("./barrel"); console.log(b.default);`,
       "barrel.ts": `export { default } from "./foo";`,
@@ -1095,7 +1098,11 @@ describe("_default 합성 변수 충돌 방지", () => {
 
     const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts")]);
     expect(bundle.exitCode).toBe(0);
-    expect(bundle.stdout).toContain("= _default");
+    // foo가 __esm으로 래핑되고 init_foo 안에서 _default 할당이 있어야 함
+    expect(bundle.stdout).toMatch(/init_foo\s*=\s*__esm/);
+    expect(bundle.stdout).toMatch(/_default\$?\d*\s*=\s*"fooValue"/);
+    // barrel의 init body가 init_foo()를 호출 (lazy 체인 보존)
+    expect(bundle.stdout).toMatch(/init_barrel\s*=\s*__esm[\s\S]*?init_foo\(\)/);
   });
 
   test("export default <identifier>가 mangling 시 할당문을 생성한다", async () => {


### PR DESCRIPTION
## Root Cause (#1340)
\`barrel\`이 \`export { default as Foo } from "./foo"\`로 foo를 re-export할 때:
- foo의 \`exports_kind == .esm\`이고 wrap_kind는 \`.none\` (scope-hoist)으로 결정됨
- barrel은 require로 들어와서 \`__esm\` 래핑되지만 init body가 비어있음 (init_foo 호출 누락)
- foo의 \`_default$1 = "fooValue"\`가 top-level var로 eager 실행 → lazy 체인 깨짐

#705 두 테스트 중 \`as Foo\` 케이스가 commit 시점부터 실패한 원인.

## Fix
graph.zig wrap_kind 결정에 **Pass 2.5** 추가 — 래핑된 모듈의 re_export source가 ESM이면 \`.esm\`으로 cascade. wrap_kind 변화가 또 다른 모듈을 promote할 수 있어 iterative until stable.

\`re_export\` / \`re_export_star\` / \`re_export_namespace\`만 cascade — \`static_import\`는 binding rewrite 메커니즘으로 해결돼 wrap 강제 불필요.

## After fix
\`\`\`js
var _default$1;
var init_foo = __esm({ "foo.ts"() {
  _default$1 = "fooValue";
} });
var init_barrel = __esm({ "barrel.ts"() {
  init_foo();
} });
\`\`\`

## Test plan
- [x] \`zig build test\`
- [x] 통합 테스트 — 이전 baseline 1 fail → **0 fail**
- 두 #705 테스트의 assertion 정정 (의미 기반으로): (a) init_foo 존재 (b) \`_default = \`값\` 할당 (c) init_barrel이 init_foo() 호출

Closes #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)