### PR TITLE
chore(bundler): /simplify #1340 후속 — helper 추출 + regex 정밀화

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -99,6 +99,11 @@ pub const ExportBinding = struct {
         pub fn isReExportAll(self: Kind) bool {
             return self == .re_export_star or self == .re_export_namespace;
         }
+
+        /// `.re_export` + `.re_export_*` 모두 포함 — 임의의 cross-module re-export.
+        pub fn isAnyReExport(self: Kind) bool {
+            return self == .re_export or self == .re_export_star or self == .re_export_namespace;
+        }
     };
 
     /// 이 export 때문에 현재 모듈에 `_default` 합성 변수가 생기는지 확인.

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1397,19 +1397,10 @@ pub const ModuleGraph = struct {
                 for (self.modules.items) |m| {
                     if (m.wrap_kind == .none) continue;
                     for (m.export_bindings) |eb| {
-                        if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
+                        if (!eb.kind.isAnyReExport()) continue;
                         const rec_idx = eb.import_record_index orelse continue;
-                        if (rec_idx >= m.import_records.len) continue;
-                        const target_mod_idx = m.import_records[rec_idx].resolved;
-                        if (target_mod_idx.isNone()) continue;
-                        const target_idx = @intFromEnum(target_mod_idx);
-                        if (target_idx >= self.modules.items.len) continue;
-                        var target = &self.modules.items[target_idx];
-                        if (target.wrap_kind != .none) continue;
-                        if (target.exports_kind == .esm or target.exports_kind == .esm_with_dynamic_fallback) {
-                            target.wrap_kind = .esm;
-                            changed = true;
-                        }
+                        const target = self.resolveImportTarget(m, rec_idx) orelse continue;
+                        if (promoteToEsmWrap(target)) changed = true;
                     }
                 }
             }
@@ -1461,6 +1452,26 @@ pub const ModuleGraph = struct {
                 Span.EMPTY,
             ) catch null;
         }
+    }
+
+    /// `m.import_records[rec_idx].resolved`를 따라 target Module 포인터를 얻는다.
+    /// bounds/none 체크 실패 시 null. wrap_kind 결정 패스들의 공통 진입점.
+    fn resolveImportTarget(self: *ModuleGraph, m: anytype, rec_idx: usize) ?*Module {
+        if (rec_idx >= m.import_records.len) return null;
+        const target_mod_idx = m.import_records[rec_idx].resolved;
+        if (target_mod_idx.isNone()) return null;
+        const target_idx = @intFromEnum(target_mod_idx);
+        if (target_idx >= self.modules.items.len) return null;
+        return &self.modules.items[target_idx];
+    }
+
+    /// `.none` 상태의 ESM 모듈을 `.esm`으로 promote. 이미 래핑됐거나 ESM이 아니면
+    /// no-op. 변경 발생 시 true (Pass 2.5 fixpoint loop의 changed 플래그용).
+    fn promoteToEsmWrap(target: *Module) bool {
+        if (target.wrap_kind != .none) return false;
+        if (target.exports_kind != .esm and target.exports_kind != .esm_with_dynamic_fallback) return false;
+        target.wrap_kind = .esm;
+        return true;
     }
 
     /// node_modules 내 .js 파일이 ESM/CJS 신호 없으면 CJS로 간주.

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1083,9 +1083,11 @@ describe("_default 합성 변수 충돌 방지", () => {
     expect(bundle.exitCode).toBe(0);
     // foo가 __esm으로 래핑되어 init_foo 안에서 _default 할당이 일어나야 한다
     expect(bundle.stdout).toMatch(/init_foo\s*=\s*__esm/);
-    expect(bundle.stdout).toMatch(/_default\$?\d*\s*=\s*"fooValue"/);
+    expect(bundle.stdout).toMatch(/_default(?:\$\d+)?\s*=\s*"fooValue"/);
     // barrel의 init body가 init_foo()를 호출해야 한다 (lazy 체인 보존)
-    expect(bundle.stdout).toMatch(/init_barrel\s*=\s*__esm[\s\S]*?init_foo\(\)/);
+    // init_barrel의 __esm body 안에 init_foo() 호출이 있는지 — body는 `__esm({...})` 안.
+    // {...} 닫힘 직전까지만 매칭하도록 anchor (다른 모듈 init이 끼어드는 false-positive 방지).
+    expect(bundle.stdout).toMatch(/init_barrel\s*=\s*__esm\(\{[\s\S]*?init_foo\(\)[\s\S]*?\}\)/);
   });
 
   test("export { default } from re-export가 __esm 래퍼에서 할당된다 (#705, #1340)", async () => {
@@ -1100,9 +1102,11 @@ describe("_default 합성 변수 충돌 방지", () => {
     expect(bundle.exitCode).toBe(0);
     // foo가 __esm으로 래핑되고 init_foo 안에서 _default 할당이 있어야 함
     expect(bundle.stdout).toMatch(/init_foo\s*=\s*__esm/);
-    expect(bundle.stdout).toMatch(/_default\$?\d*\s*=\s*"fooValue"/);
+    expect(bundle.stdout).toMatch(/_default(?:\$\d+)?\s*=\s*"fooValue"/);
     // barrel의 init body가 init_foo()를 호출 (lazy 체인 보존)
-    expect(bundle.stdout).toMatch(/init_barrel\s*=\s*__esm[\s\S]*?init_foo\(\)/);
+    // init_barrel의 __esm body 안에 init_foo() 호출이 있는지 — body는 `__esm({...})` 안.
+    // {...} 닫힘 직전까지만 매칭하도록 anchor (다른 모듈 init이 끼어드는 false-positive 방지).
+    expect(bundle.stdout).toMatch(/init_barrel\s*=\s*__esm\(\{[\s\S]*?init_foo\(\)[\s\S]*?\}\)/);
   });
 
   test("export default <identifier>가 mangling 시 할당문을 생성한다", async () => {


### PR DESCRIPTION
## /simplify 리뷰 반영

### Helper 추출
- `ExportBinding.Kind.isAnyReExport()` — `re_export` + `re_export_*` 통칭
- `ModuleGraph.resolveImportTarget(m, rec_idx)` — bounds + isNone + intCast 3중 체크 통합
- `ModuleGraph.promoteToEsmWrap(target) bool` — wrap_kind 승격 로직 한 곳

### 결과
Pass 2.5 본문이 4줄로 압축, 의도가 한 눈에 보임.

### 테스트 regex 정밀화
- `_default\$?\d*` → `_default(?:\$\d+)?` (`$` 있으면 digit 필수)
- init_barrel↔init_foo 매칭에 `__esm({...})` 경계 anchor 추가 (cross-module false-positive 방지)

## Test plan
- [x] `zig build test`
- [x] 통합 테스트 (0 fail)

Refs #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)