### PR TITLE
fix(transformer): object literal method shorthand 를 key:function 으로 lowering (#1385)

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -796,6 +796,62 @@ test "ES2015: computed no transform on esnext" {
     try std.testing.expectEqualStrings("var o={[k]:v};", r.output);
 }
 
+// --- ES2015: object method shorthand (#1385) ---
+
+test "ES2015: object method shorthand → key:function" {
+    var r = try e2eTarget(std.testing.allocator, "var o={m(){return 1;}};", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var o={m:function(){return 1;}};", r.output);
+}
+
+test "ES2015: object method shorthand + shorthand property mix" {
+    var r = try e2eTarget(std.testing.allocator, "var o={x,m(){return 1;}};", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var o={x:x,m:function(){return 1;}};", r.output);
+}
+
+test "ES2015: object getter/setter preserved (ES5 supports)" {
+    var r = try e2eTarget(std.testing.allocator, "var o={get x(){return 1;},set x(v){},m(){return 2;}};", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var o={get x(){return 1;},set x(v){},m:function(){return 2;}};", r.output);
+}
+
+test "ES2015: object computed method → bracket assignment with function" {
+    var r = try e2eTarget(std.testing.allocator, "var o={[k](){return 1;}};", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var _a;var o=(_a={},_a[k]=function(){return 1;},_a);", r.output);
+}
+
+test "ES2015: object Symbol.dispose computed method" {
+    var r = try e2eTarget(std.testing.allocator, "var o={[Symbol.dispose](){}};", .es5);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var _a;var o=(_a={},_a[Symbol.dispose]=function(){},_a);", r.output);
+}
+
+test "ES2015: object method no transform on esnext" {
+    var r = try e2eTarget(std.testing.allocator, "var o={m(){return 1;}};", .esnext);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var o={m(){return 1;}};", r.output);
+}
+
+test "ES2015: object async method → state machine wrapped in function" {
+    var r = try e2eTarget(std.testing.allocator, "var o={async a(){return 1;}};", .es5);
+    defer r.deinit();
+    // a: function() { ... __async(...) ... }
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "a:function()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__async") != null);
+    // 메서드 shorthand 원형이 남아 있으면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "async a(") == null);
+}
+
+test "ES2015: object generator method → state machine wrapped in function" {
+    var r = try e2eTarget(std.testing.allocator, "var o={*g(){yield 1;}};", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "g:function()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__generator") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "*g(") == null);
+}
+
 // --- ES2015: default/rest parameters ---
 
 test "ES2015: default parameter" {

--- a/src/transformer/es2015.zig
+++ b/src/transformer/es2015.zig
@@ -29,6 +29,7 @@
 pub const es2015_template = @import("es2015_template.zig");
 pub const es2015_shorthand = @import("es2015_shorthand.zig");
 pub const es2015_computed = @import("es2015_computed.zig");
+pub const es2015_object_methods = @import("es2015_object_methods.zig");
 pub const es2015_params = @import("es2015_params.zig");
 pub const es2015_spread = @import("es2015_spread.zig");
 pub const es2015_arrow = @import("es2015_arrow.zig");
@@ -42,6 +43,7 @@ test {
     _ = es2015_template;
     _ = es2015_shorthand;
     _ = es2015_computed;
+    _ = es2015_object_methods;
     _ = es2015_params;
     _ = es2015_spread;
     _ = es2015_arrow;

--- a/src/transformer/es2015_object_methods.zig
+++ b/src/transformer/es2015_object_methods.zig
@@ -1,0 +1,133 @@
+//! ES2015 다운레벨링: object literal method shorthand
+//!
+//! --target < es2015 (object_extensions unsupported) 일 때 활성화.
+//! { m() {} } → { m: function() {} }
+//! { async a() {} } → { a: function() {} }  (body는 async lowering)
+//! { *g() {} } → { g: function*() {} }      (이후 generator lowering)
+//! { [k]() {} } → { [k]: function() {} }    (computed_property_key 유지 → es2015_computed가 후처리)
+//!
+//! getter/setter는 ES5도 지원하므로 변환하지 않음.
+//!
+//! 동작 방식:
+//!   1. object_expression 내 member 리스트를 순회
+//!   2. method_definition(getter/setter 제외)를 object_property + function_expression으로 교체
+//!   3. computed key는 computed_property_key 노드를 그대로 보존 → 이후 ES2015Computed가 sequence expression으로 변환
+//!
+//! 스펙:
+//! - https://tc39.es/ecma262/#sec-method-definitions (ES2015 PropertyDefinition: MethodDefinition)
+//!
+//! 참고:
+//! - SWC: crates/swc_ecma_compat_es2015/src/shorthand_property.rs (단, SWC는 shorthand prop만, method는 별도)
+//! - esbuild: internal/js_parser/js_parser.go (lowerMethodShorthand 유사 경로)
+
+const std = @import("std");
+const ast_mod = @import("../parser/ast.zig");
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const NodeList = ast_mod.NodeList;
+
+pub fn ES2015ObjectMethods(comptime Transformer: type) type {
+    return struct {
+        /// object_expression 멤버 중 변환 대상 method_definition이 있는지 확인.
+        /// getter/setter(flags 0x02/0x04)는 ES5도 지원하므로 제외.
+        pub fn hasObjectMethod(self: *const Transformer, node: Node) bool {
+            const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
+            for (members) |raw_idx| {
+                const m = self.ast.getNode(@enumFromInt(raw_idx));
+                if (m.tag != .method_definition) continue;
+                const flags = self.ast.extra_data.items[m.data.extra + 3];
+                // getter(0x02) / setter(0x04) 는 ES5 지원 → 변환 제외
+                if ((flags & 0x02) != 0 or (flags & 0x04) != 0) continue;
+                return true;
+            }
+            return false;
+        }
+
+        /// method_definition → object_property { key: function_expression } 로 변환한 object_expression 반환.
+        /// function_expression은 async/generator 플래그를 보존하므로, 상위 visitNode가
+        /// async_await/generator unsupported일 경우 자동으로 추가 lowering을 수행한다.
+        pub fn lowerObjectMethods(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            const span = node.span;
+            const members_start = node.data.list.start;
+            const members_len = node.data.list.len;
+
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+            // visitNode가 extra_data를 재할당할 수 있으므로 인덱스 루프 사용.
+            var i: u32 = 0;
+            while (i < members_len) : (i += 1) {
+                const raw_idx = self.ast.extra_data.items[members_start + i];
+                const m_idx: NodeIndex = @enumFromInt(raw_idx);
+                const m = self.ast.getNode(m_idx);
+
+                if (m.tag != .method_definition) {
+                    // 일반 property / spread → 기존 방문 경로
+                    const new_m = try self.visitNode(m_idx);
+                    if (!new_m.isNone()) try self.scratch.append(self.allocator, new_m);
+                    continue;
+                }
+
+                const me = m.data.extra;
+                const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
+                const params_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
+                const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 2]);
+                const flags: u32 = self.ast.extra_data.items[me + 3];
+
+                // getter/setter는 원본 그대로 방문 (ES5 지원)
+                if ((flags & 0x02) != 0 or (flags & 0x04) != 0) {
+                    const new_m = try self.visitNode(m_idx);
+                    if (!new_m.isNone()) try self.scratch.append(self.allocator, new_m);
+                    continue;
+                }
+
+                // function_expression 플래그 재매핑
+                // method flags: bit3=async(0x08), bit4=generator(0x10)
+                // function flags: bit0=async(0x01), bit1=generator(0x02)
+                var fn_flags: u32 = 0;
+                if ((flags & 0x08) != 0) fn_flags |= ast_mod.FunctionFlags.is_async;
+                if ((flags & 0x10) != 0) fn_flags |= ast_mod.FunctionFlags.is_generator;
+
+                const none = @intFromEnum(NodeIndex.none);
+
+                // function_expression: [name, params, body, flags, return_type]
+                const fn_extra = try self.ast.addExtras(&.{
+                    none,
+                    @intFromEnum(params_idx),
+                    @intFromEnum(body_idx),
+                    fn_flags,
+                    none,
+                });
+                const fn_expr = try self.ast.addNode(.{
+                    .tag = .function_expression,
+                    .span = m.span,
+                    .data = .{ .extra = fn_extra },
+                });
+
+                // 상위 visitNode를 통해 async/generator lowering 적용
+                const new_fn = try self.visitNode(fn_expr);
+
+                // key도 방문 (computed_property_key 내부 expr 등)
+                const new_key = try self.visitNode(key_idx);
+
+                const prop = try self.ast.addNode(.{
+                    .tag = .object_property,
+                    .span = m.span,
+                    .data = .{ .binary = .{ .left = new_key, .right = new_fn, .flags = 0 } },
+                });
+                try self.scratch.append(self.allocator, prop);
+            }
+
+            const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+            return self.ast.addNode(.{
+                .tag = .object_expression,
+                .span = span,
+                .data = .{ .list = new_list },
+            });
+        }
+    };
+}
+
+test "ES2015 object methods module compiles" {
+    _ = ES2015ObjectMethods;
+}

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -37,6 +37,7 @@ const es2022 = @import("es2022.zig");
 const es2015_template = @import("es2015_template.zig");
 const es2015_shorthand = @import("es2015_shorthand.zig");
 const es2015_computed = @import("es2015_computed.zig");
+const es2015_object_methods = @import("es2015_object_methods.zig");
 const es2015_params = @import("es2015_params.zig");
 const es2015_spread = @import("es2015_spread.zig");
 const es2015_arrow = @import("es2015_arrow.zig");
@@ -627,13 +628,26 @@ pub const Transformer = struct {
                 return self.visitListNode(node);
             },
 
-            // object_expression: spread(ES2018) 또는 computed property(ES2015) 다운레벨링
+            // object_expression: spread(ES2018) / method shorthand / computed property(ES2015) 다운레벨링
             .object_expression => {
                 // Plugin visitor 훅 — 기본 방문 전 선취권 (null 반환 시 default 진행)
                 if (try self.dispatchVisitor(.on_object_expression, idx)) |replacement| return replacement;
                 if (self.options.unsupported.object_spread) {
                     if (es2018.ES2018(Transformer).hasSpreadProperty(self, node)) {
                         return es2018.ES2018(Transformer).lowerObjectSpread(self, node);
+                    }
+                }
+                // method shorthand → { key: function() {} } 를 먼저 처리.
+                // function_expression 내부 async/generator lowering까지 visitNode 경로로 수행한 뒤,
+                // computed key가 남아 있으면 아래 ES2015Computed가 후속 처리한다.
+                if (self.options.unsupported.object_extensions) {
+                    if (es2015_object_methods.ES2015ObjectMethods(Transformer).hasObjectMethod(self, node)) {
+                        const lowered = try es2015_object_methods.ES2015ObjectMethods(Transformer).lowerObjectMethods(self, node);
+                        const lowered_node = self.ast.getNode(lowered);
+                        if (es2015_computed.ES2015Computed(Transformer).hasComputedProperty(self, lowered_node)) {
+                            return es2015_computed.ES2015Computed(Transformer).lowerComputedProperties(self, lowered_node);
+                        }
+                        return lowered;
                     }
                 }
                 if (self.options.unsupported.object_extensions) {


### PR DESCRIPTION
## Summary
- `--target=es5` 등 object_extensions 미지원 타겟에서 object literal method shorthand `{ m(){} }` 가 그대로 emit 되어 ES5 파서가 SyntaxError 를 내던 문제 수정.
- `object_expression` 다운레벨 경로에 `es2015_object_methods` 를 추가: `method_definition` → `object_property { key: function_expression }`.
- `function_expression` 에 async/generator 플래그가 보존되므로 `es2017` / `es2015_generator` lowering 이 자동 적용.
- getter/setter 는 ES5 가 지원하므로 **변환하지 않음**.
- computed method 는 후속 `ES2015Computed` 가 bracket assignment 로 처리.

## Before / After

Input:
```ts
const o = { m() { return 1; }, async a() { return 2; }, *g() { yield 3; }, [k]() {} };
```

Before (`--target=es5`):
```js
var o = { m() { return 1; }, async a() { return 2; }, *g() { yield 3; }, [k]() {} };
// ↑ ES5 SyntaxError
```

After (`--target=es5`):
```js
var _a;
var o = (_a = {
  m: function () { return 1; },
  a: function () { return __async(function () { return __generator(...); }).call(this); },
  g: function () { return __generator(...); }
}, _a[k] = function () {}, _a);
```

`--target=esnext` 에서는 기존 method shorthand 그대로 유지.

## Test plan
- [x] `zig build test` — 유닛 테스트 추가 (plain/async/generator/computed/Symbol.dispose/getter-setter 보존/esnext no-op)
- [x] `cd tests/integration && bun test` — 2879 pass, 0 fail
- [x] 번개 재현 ohah/bungae#57 `objectMethodShorthand`

Closes #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)