### PR TITLE
fix(transformer): unicode brace escape \u{X} → surrogate pair lowering (#1388)

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2194,3 +2194,60 @@ test "regex: esnext no-op (#1387)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "/a.b/s") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "(?<y>") != null);
 }
+
+// --- unicode brace escape `\u{X}` (#1388) ---
+
+test "unicode_escape: astral string '\\u{1F600}' → surrogate pair (es5)" {
+    var r = try e2eTarget(std.testing.allocator, "const e = '\\u{1F600}';", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\uD83D\\uDE00") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\u{") == null);
+}
+
+test "unicode_escape: BMP string '\\u{41}' → '\\u0041' (es5)" {
+    var r = try e2eTarget(std.testing.allocator, "const e = '\\u{41}';", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\u0041") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\u{") == null);
+}
+
+test "unicode_escape: template literal astral (es2015 target — template 보존)" {
+    // es5는 template literal 자체를 문자열 concat으로 downlevel 하므로, template_element 보존을
+    // 위해 es2015 target 으로 확인. unicode_brace_escape 는 es2015 에서도 처리됨 (esVersion=es2015).
+    // ESTarget.es2015 → feature 도입 버전이 <= es2015 인 feature 는 unsupported가 아니지만,
+    // unicode_brace_escape 의 도입 버전이 es2015 라 es2015+ 에서는 no-op. 대신 es2015 하위 버전이
+    // ESTarget enum에 없으므로 es5 를 쓰되 문자열 리터럴로만 확인한다.
+    // (template 내부 lowering 은 이미 es2015_template 가 하위에서 처리하며, 그 이후 내려오는
+    //  문자열은 string_literal 경로로 들어간다.)
+    var r = try e2eTarget(std.testing.allocator, "const e = `\\u{1F600}`;", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\uD83D\\uDE00") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\u{") == null);
+}
+
+test "unicode_escape: plain '{abc}' 영향 없음 (es5)" {
+    var r = try e2eTarget(std.testing.allocator, "const e = '{abc}';", .es5);
+    defer r.deinit();
+    // quote style 은 기본 double.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"{abc}\"") != null);
+}
+
+test "unicode_escape: regex /[\\u{1F600}]/u → surrogate pair + u strip (es5)" {
+    var r = try e2eTarget(std.testing.allocator, "const r = /[\\u{1F600}]/u;", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\uD83D\\uDE00") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\u{") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "/u") == null);
+}
+
+test "unicode_escape: esnext 문자열 no-op" {
+    var r = try e2eTarget(std.testing.allocator, "const e = '\\u{1F600}';", .esnext);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\u{1F600}") != null);
+}
+
+test "unicode_escape: es2015 no-op" {
+    var r = try e2eTarget(std.testing.allocator, "const e = '\\u{1F600}';", .es2015);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\\u{1F600}") != null);
+}

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -95,11 +95,14 @@ pub const Feature = enum(u5) {
     regex_sticky, // /y flag (ES2015)
     regex_dotall, // /s flag (ES2018) — `.` → `[\s\S]` + flag strip
     regex_named_groups, // (?<name>...) (ES2018) — positional group으로 strip
+    /// `\u{X}` brace unicode escape (ES2015). 문자열/template 내부는 surrogate pair로,
+    /// regex 의 `u` flag + `\u{X}` 도 surrogate pair + flag strip (#1388).
+    unicode_brace_escape,
 
     /// 이 feature가 도입된 ES 버전.
     pub fn esVersion(self: Feature) ESTarget {
         return switch (self) {
-            .arrow, .class, .template_literal, .destructuring, .for_of, .spread, .object_extensions, .default_params, .block_scoping, .generator, .new_target, .regex_sticky => .es2015,
+            .arrow, .class, .template_literal, .destructuring, .for_of, .spread, .object_extensions, .default_params, .block_scoping, .generator, .new_target, .regex_sticky, .unicode_brace_escape => .es2015,
             .exponentiation => .es2016,
             .async_await => .es2017,
             .object_spread, .regex_dotall, .regex_named_groups => .es2018,
@@ -157,8 +160,9 @@ pub const UnsupportedFeatures = packed struct(u32) {
     regex_sticky: bool = false,
     regex_dotall: bool = false,
     regex_named_groups: bool = false,
+    unicode_brace_escape: bool = false,
 
-    _: u5 = 0,
+    _: u4 = 0,
 
     // Feature enum과 UnsupportedFeatures 필드 순서 1:1 대응 검증.
     // Feature 추가/재배치 시 여기서 컴파일 에러가 발생한다.
@@ -487,6 +491,17 @@ const compat_table = [_]CompatEntry{
     .{ .feature = .regex_dotall, .engine = .ios, .major = 11, .minor = 3 },
     // hermes: 미지원
 
+    // ── ES2015: unicode_brace_escape (`\u{XXXX}`) ──
+    // 문자열/regex의 brace unicode escape. ES2015 도입.
+    .{ .feature = .unicode_brace_escape, .engine = .chrome, .major = 44 },
+    .{ .feature = .unicode_brace_escape, .engine = .firefox, .major = 53 },
+    .{ .feature = .unicode_brace_escape, .engine = .safari, .major = 10 },
+    .{ .feature = .unicode_brace_escape, .engine = .edge, .major = 12 },
+    .{ .feature = .unicode_brace_escape, .engine = .node, .major = 4 },
+    .{ .feature = .unicode_brace_escape, .engine = .deno, .major = 1 },
+    .{ .feature = .unicode_brace_escape, .engine = .ios, .major = 10 },
+    .{ .feature = .unicode_brace_escape, .engine = .hermes, .major = 0 },
+
     // ── ES2018: regex_named_groups ──
     .{ .feature = .regex_named_groups, .engine = .chrome, .major = 64 },
     .{ .feature = .regex_named_groups, .engine = .firefox, .major = 78 },
@@ -566,6 +581,7 @@ pub fn fromHermesPreset() UnsupportedFeatures {
         .regex_sticky = true,
         .regex_dotall = true,
         .regex_named_groups = true,
+        .unicode_brace_escape = true,
     };
 }
 

--- a/src/transformer/es2015_template.zig
+++ b/src/transformer/es2015_template.zig
@@ -163,6 +163,18 @@ pub fn buildRawStringLiteral(self: anytype, text: []const u8) !NodeIndex {
 
     buf.appendAssumeCapacity('"');
 
+    // unicode brace escape lowering (#1388) — target 이 `\u{X}` 미지원이면 surrogate pair 로 치환.
+    if (self.options.unsupported.unicode_brace_escape) {
+        const unicode_escape_lower = @import("unicode_escape_lower.zig");
+        if (try unicode_escape_lower.lowerContent(self.allocator, buf.items[1 .. buf.items.len - 1])) |lowered| {
+            defer self.allocator.free(lowered);
+            buf.clearRetainingCapacity();
+            try buf.append(self.allocator, '"');
+            try buf.appendSlice(self.allocator, lowered);
+            try buf.append(self.allocator, '"');
+        }
+    }
+
     const str_span = try self.ast.addString(buf.items);
     return self.ast.addNode(.{
         .tag = .string_literal,
@@ -210,6 +222,17 @@ pub fn buildStringLiteral(self: anytype, text: []const u8) !NodeIndex {
     }
 
     buf.appendAssumeCapacity('"');
+
+    if (self.options.unsupported.unicode_brace_escape) {
+        const unicode_escape_lower = @import("unicode_escape_lower.zig");
+        if (try unicode_escape_lower.lowerContent(self.allocator, buf.items[1 .. buf.items.len - 1])) |lowered| {
+            defer self.allocator.free(lowered);
+            buf.clearRetainingCapacity();
+            try buf.append(self.allocator, '"');
+            try buf.appendSlice(self.allocator, lowered);
+            try buf.append(self.allocator, '"');
+        }
+    }
 
     const str_span = try self.ast.addString(buf.items);
     return self.ast.addNode(.{

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -6,7 +6,7 @@
 //!     → positional group으로만 보존. `match.groups` 객체는 포기.
 //!   - /y (sticky, ES2015): 미지원 타겟에서 flag strip (런타임 동작 변경 있음 — 경고)
 //!
-//! `u` flag + `\u{...}` brace 는 범위 밖 (#1388).
+//! - `u` flag + `\u{...}` brace (ES2015): `\u{X}` → surrogate pair / BMP escape + `u` flag strip (#1388)
 //!
 //! 참고:
 //! - esbuild: internal/js_parser/js_parser.go — visitRegExpLiteral / js_lexer regex scanner
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const compat = @import("compat.zig");
+const unicode_escape_lower = @import("unicode_escape_lower.zig");
 
 pub const Options = struct {
     unsupported: compat.UnsupportedFeatures,
@@ -40,26 +41,32 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
 
     const has_s = std.mem.indexOfScalar(u8, flags, 's') != null;
     const has_y = std.mem.indexOfScalar(u8, flags, 'y') != null;
+    const has_u = std.mem.indexOfScalar(u8, flags, 'u') != null;
 
     const need_dotall = has_s and opts.unsupported.regex_dotall;
     const need_named = opts.unsupported.regex_named_groups and hasNamedGroup(pattern);
     const need_sticky = has_y and opts.unsupported.regex_sticky;
+    // `u` flag 자체는 runtime 지원 대상이 아니지만, `\u{X}` brace escape 는 `u` flag 하에서만
+    // 허용된다. brace escape 를 surrogate pair 로 내리면서 flag 도 함께 strip 한다.
+    const need_unicode = has_u and opts.unsupported.unicode_brace_escape;
 
-    if (!need_dotall and !need_named and !need_sticky) return .{ .text = null };
+    if (!need_dotall and !need_named and !need_sticky and !need_unicode) return .{ .text = null };
 
-    // /pattern/flags 를 단일 버퍼로 조립. dotAll 치환을 고려해 +4 여유.
+    // /pattern/flags 를 단일 버퍼로 조립. dotAll/unicode 치환을 고려해 +8 여유.
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
-    try out.ensureTotalCapacity(allocator, raw.len + 4);
+    try out.ensureTotalCapacity(allocator, raw.len + 8);
     try out.append(allocator, '/');
     try rewritePattern(allocator, &out, pattern, .{
         .dotall = need_dotall,
         .strip_named = need_named,
+        .unicode_brace = need_unicode,
     });
     try out.append(allocator, '/');
     for (flags) |c| {
         if (need_dotall and c == 's') continue;
         if (need_sticky and c == 'y') continue;
+        if (need_unicode and c == 'u') continue;
         try out.append(allocator, c);
     }
     return .{ .text = try out.toOwnedSlice(allocator) };
@@ -68,6 +75,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
 const PatternOpts = struct {
     dotall: bool,
     strip_named: bool,
+    unicode_brace: bool,
 };
 
 /// pattern 내부를 character class / escape 를 고려하며 순회하여 변환.
@@ -82,8 +90,16 @@ fn rewritePattern(
     while (i < pattern.len) {
         const c = pattern[i];
 
-        // escape: 그대로 복사.
+        // escape
         if (c == '\\') {
+            // `\u{XXXX}` brace unicode escape → surrogate pair / BMP escape
+            if (opts.unicode_brace and i + 2 < pattern.len and pattern[i + 1] == 'u' and pattern[i + 2] == '{') {
+                if (parseBraceHex(pattern, i + 2)) |r| {
+                    try appendCodepointEscape(allocator, out, r.cp);
+                    i = r.end;
+                    continue;
+                }
+            }
             try out.append(allocator, c);
             if (i + 1 < pattern.len) {
                 try out.append(allocator, pattern[i + 1]);
@@ -141,6 +157,46 @@ fn rewritePattern(
                 i += 1;
             },
         }
+    }
+}
+
+fn hexVal(c: u8) ?u32 {
+    return switch (c) {
+        '0'...'9' => @as(u32, c - '0'),
+        'a'...'f' => @as(u32, c - 'a' + 10),
+        'A'...'F' => @as(u32, c - 'A' + 10),
+        else => null,
+    };
+}
+
+/// `\u{` 바로 다음의 `{` 위치를 받아 hex 를 파싱. 닫는 `}` 까지 포함한 end 반환.
+fn parseBraceHex(s: []const u8, start_brace: usize) ?struct { cp: u32, end: usize } {
+    var i: usize = start_brace + 1;
+    var cp: u32 = 0;
+    var any: bool = false;
+    while (i < s.len and s[i] != '}') : (i += 1) {
+        const h = hexVal(s[i]) orelse return null;
+        cp = (cp << 4) | h;
+        if (cp > 0x10FFFF) return null;
+        any = true;
+    }
+    if (!any or i >= s.len or s[i] != '}') return null;
+    return .{ .cp = cp, .end = i + 1 };
+}
+
+fn appendHexUnit(allocator: std.mem.Allocator, out: *std.ArrayList(u8), unit: u32) !void {
+    var buf: [6]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "\\u{X:0>4}", .{unit}) catch unreachable;
+    try out.appendSlice(allocator, &buf);
+}
+
+fn appendCodepointEscape(allocator: std.mem.Allocator, out: *std.ArrayList(u8), cp: u32) !void {
+    if (cp <= 0xFFFF) {
+        try appendHexUnit(allocator, out, cp);
+    } else {
+        const v = cp - 0x10000;
+        try appendHexUnit(allocator, out, 0xD800 | (v >> 10));
+        try appendHexUnit(allocator, out, 0xDC00 | (v & 0x3FF));
     }
 }
 
@@ -229,6 +285,29 @@ test "regex: dotAll + sticky 함께" {
     const out = (try runLower("/a.b/sy", .{ .regex_dotall = true, .regex_sticky = true })).?;
     defer testing.allocator.free(out);
     try testing.expectEqualStrings("/a[\\s\\S]b/", out);
+}
+
+test "regex: u + \\u{1F600} → surrogate pair + u strip" {
+    const out = (try runLower("/\\u{1F600}/u", .{ .unicode_brace_escape = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/\\uD83D\\uDE00/", out);
+}
+
+test "regex: u + BMP \\u{41} → \\u0041 + u strip" {
+    const out = (try runLower("/\\u{41}/u", .{ .unicode_brace_escape = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/\\u0041/", out);
+}
+
+test "regex: u flag 없으면 no-op" {
+    const out = try runLower("/\\u0041/", .{ .unicode_brace_escape = true });
+    try testing.expect(out == null);
+}
+
+test "regex: u + character class" {
+    const out = (try runLower("/[\\u{1F600}]/u", .{ .unicode_brace_escape = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/[\\uD83D\\uDE00]/", out);
 }
 
 test "regex: esnext (미지원 없음) no-op" {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -49,6 +49,7 @@ const es2015_class = @import("es2015_class.zig");
 const es2015_generator = @import("es2015_generator.zig");
 const es2025_using = @import("es2025_using.zig");
 const regex_lower = @import("regex_lower.zig");
+const unicode_escape_lower = @import("unicode_escape_lower.zig");
 const es2022_tla = @import("es2022_tla.zig");
 const jsx_lowering_mod = @import("jsx_lowering.zig");
 const es_helpers = @import("es_helpers.zig");
@@ -1089,12 +1090,30 @@ pub const Transformer = struct {
             .boolean_literal,
             .null_literal,
             .numeric_literal,
-            .string_literal,
             .bigint_literal,
             => self.copyNodeDirect(node),
+            .string_literal => blk: {
+                if (!self.options.unsupported.unicode_brace_escape) break :blk self.copyNodeDirect(node);
+                const raw = self.ast.getText(node.span);
+                // raw는 따옴표를 포함. content 만 변환 후 다시 조립.
+                if (raw.len < 2) break :blk self.copyNodeDirect(node);
+                const quote = raw[0];
+                if (quote != '"' and quote != '\'') break :blk self.copyNodeDirect(node);
+                const content = raw[1 .. raw.len - 1];
+                const lowered = (try unicode_escape_lower.lowerContent(self.allocator, content)) orelse break :blk self.copyNodeDirect(node);
+                defer self.allocator.free(lowered);
+                const new_raw = try std.fmt.allocPrint(self.allocator, "{c}{s}{c}", .{ quote, lowered, quote });
+                defer self.allocator.free(new_raw);
+                const new_span = try self.ast.addString(new_raw);
+                break :blk try self.ast.addNode(.{
+                    .tag = .string_literal,
+                    .span = new_span,
+                    .data = .{ .string_ref = new_span },
+                });
+            },
             .regexp_literal => blk: {
                 const u = self.options.unsupported;
-                if (!(u.regex_dotall or u.regex_named_groups or u.regex_sticky)) {
+                if (!(u.regex_dotall or u.regex_named_groups or u.regex_sticky or u.unicode_brace_escape)) {
                     break :blk self.copyNodeDirect(node);
                 }
                 const raw = self.ast.getText(node.span);
@@ -1151,13 +1170,24 @@ pub const Transformer = struct {
                 }
                 return self.copyNodeDirect(node);
             },
+            .template_element => blk: {
+                if (!self.options.unsupported.unicode_brace_escape) break :blk self.copyNodeDirect(node);
+                const raw = self.ast.getText(node.span);
+                const lowered = (try unicode_escape_lower.lowerContent(self.allocator, raw)) orelse break :blk self.copyNodeDirect(node);
+                defer self.allocator.free(lowered);
+                const new_span = try self.ast.addString(lowered);
+                break :blk try self.ast.addNode(.{
+                    .tag = .template_element,
+                    .span = new_span,
+                    .data = node.data,
+                });
+            },
             .private_identifier,
             .empty_statement,
             .debugger_statement,
             .directive,
             .hashbang,
             .super_expression,
-            .template_element,
             .elision,
             .jsx_empty_expression,
             .jsx_identifier,

--- a/src/transformer/unicode_escape_lower.zig
+++ b/src/transformer/unicode_escape_lower.zig
@@ -1,0 +1,175 @@
+//! Unicode brace escape (`\u{XXXX}`) 다운레벨링 (#1388)
+//!
+//! ES2015 brace unicode escape을 ES5 호환 surrogate pair 형태로 변환.
+//!   - U+0000 ~ U+FFFF  → `\uXXXX`
+//!   - U+10000 ~ U+10FFFF → `\uHHHH\uLLLL` (high/low surrogate)
+//!
+//! 적용 대상:
+//!   - 문자열 리터럴 (`"..."` / `'...'`)
+//!   - template literal 조각 (template_element의 raw 텍스트)
+//!   - regex literal 의 `u` flag 에서의 `\u{...}` (flag strip 은 regex_lower 쪽에서)
+//!
+//! `\\u{...}` 처럼 backslash 자체가 escape 된 경우는 변환하지 않는다.
+//! 닫는 `}` 가 없거나 16진수가 아니면 원본 유지 (lexer가 이미 검증하지만 방어적 처리).
+//!
+//! 참고:
+//! - TC39 ECMA-262 sec-literals-string-literals (UnicodeEscapeSequence)
+//! - esbuild: internal/js_printer/js_printer.go — printQuotedUTF16
+
+const std = @import("std");
+
+/// content에 `\u{...}` 가 하나 이상 있으면 true. 빠른 스캔 용도.
+pub fn containsBraceEscape(content: []const u8) bool {
+    var i: usize = 0;
+    while (i + 3 < content.len) : (i += 1) {
+        if (content[i] == '\\' and content[i + 1] == 'u' and content[i + 2] == '{') {
+            // `\\u{` (escaped backslash) 는 제외.
+            if (i > 0 and countTrailingBackslashes(content[0..i]) % 2 == 1) continue;
+            return true;
+        }
+    }
+    return false;
+}
+
+fn countTrailingBackslashes(s: []const u8) usize {
+    var n: usize = 0;
+    var i: usize = s.len;
+    while (i > 0 and s[i - 1] == '\\') : (i -= 1) n += 1;
+    return n;
+}
+
+fn hexVal(c: u8) ?u32 {
+    return switch (c) {
+        '0'...'9' => @as(u32, c - '0'),
+        'a'...'f' => @as(u32, c - 'a' + 10),
+        'A'...'F' => @as(u32, c - 'A' + 10),
+        else => null,
+    };
+}
+
+/// `\u{` 가 content[pos-1] (이미 `\` 에서 시작해 pos가 'u'의 위치 + 2) 에서 시작한다고 가정하고,
+/// 닫는 `}` 까지 파싱한 codepoint 와 `}` 직후 인덱스를 반환. 실패 시 null.
+fn parseBraceHex(content: []const u8, start_brace: usize) ?struct { cp: u32, end: usize } {
+    // content[start_brace] == '{'
+    var i: usize = start_brace + 1;
+    var cp: u32 = 0;
+    var any: bool = false;
+    while (i < content.len and content[i] != '}') : (i += 1) {
+        const h = hexVal(content[i]) orelse return null;
+        cp = (cp << 4) | h;
+        if (cp > 0x10FFFF) return null;
+        any = true;
+    }
+    if (!any) return null;
+    if (i >= content.len or content[i] != '}') return null;
+    return .{ .cp = cp, .end = i + 1 };
+}
+
+fn appendUnit(out: *std.ArrayList(u8), allocator: std.mem.Allocator, unit: u32) !void {
+    var buf: [6]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "\\u{X:0>4}", .{unit}) catch unreachable;
+    try out.appendSlice(allocator, &buf);
+}
+
+fn appendCodepoint(out: *std.ArrayList(u8), allocator: std.mem.Allocator, cp: u32) !void {
+    if (cp <= 0xFFFF) {
+        try appendUnit(out, allocator, cp);
+    } else {
+        // UTF-16 surrogate pair.
+        const v = cp - 0x10000;
+        const hi: u32 = 0xD800 | (v >> 10);
+        const lo: u32 = 0xDC00 | (v & 0x3FF);
+        try appendUnit(out, allocator, hi);
+        try appendUnit(out, allocator, lo);
+    }
+}
+
+/// content 전체에 대해 `\u{X}` 를 surrogate pair / BMP escape 로 치환.
+/// 변환이 없으면 null 반환. 성공 시 owned slice 반환.
+pub fn lowerContent(allocator: std.mem.Allocator, content: []const u8) !?[]u8 {
+    if (!containsBraceEscape(content)) return null;
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.ensureTotalCapacity(allocator, content.len + 8);
+
+    var i: usize = 0;
+    while (i < content.len) {
+        const c = content[i];
+        if (c == '\\' and i + 2 < content.len and content[i + 1] == 'u' and content[i + 2] == '{') {
+            if (parseBraceHex(content, i + 2)) |r| {
+                try appendCodepoint(&out, allocator, r.cp);
+                i = r.end;
+                continue;
+            }
+            // 파싱 실패: 원본 `\` 복사 후 한 칸 전진.
+            try out.append(allocator, c);
+            i += 1;
+            continue;
+        }
+        if (c == '\\' and i + 1 < content.len) {
+            // escape 시퀀스는 통째로 보존 (`\\`, `\n`, `\uXXXX` 등).
+            try out.append(allocator, c);
+            try out.append(allocator, content[i + 1]);
+            i += 2;
+            continue;
+        }
+        try out.append(allocator, c);
+        i += 1;
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+// ─── 테스트 ───
+
+const testing = std.testing;
+
+fn expectLower(input: []const u8, expected: []const u8) !void {
+    const got = (try lowerContent(testing.allocator, input)) orelse {
+        try testing.expectEqualStrings(expected, input);
+        return;
+    };
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings(expected, got);
+}
+
+test "unicode_escape: BMP `\\u{41}` → `\\u0041`" {
+    try expectLower("\\u{41}", "\\u0041");
+}
+
+test "unicode_escape: astral `\\u{1F600}` → surrogate pair" {
+    try expectLower("\\u{1F600}", "\\uD83D\\uDE00");
+}
+
+test "unicode_escape: mixed" {
+    try expectLower("hi \\u{1F600}!", "hi \\uD83D\\uDE00!");
+}
+
+test "unicode_escape: no brace escape → null" {
+    const got = try lowerContent(testing.allocator, "plain \\u0041 text");
+    try testing.expect(got == null);
+}
+
+test "unicode_escape: `\\\\u{41}` (escaped backslash) 는 변환 X" {
+    // 입력: `\\u{41}` (즉 `\u{41}` 을 문자 그대로 쓴 것)
+    const got = try lowerContent(testing.allocator, "\\\\u{41}");
+    try testing.expect(got == null);
+}
+
+test "unicode_escape: plain `{abc}` 영향 없음" {
+    const got = try lowerContent(testing.allocator, "{abc}");
+    try testing.expect(got == null);
+}
+
+test "unicode_escape: 빈 `\\u{}` 는 원본 유지" {
+    // 방어적: lexer가 이미 거부하지만, 들어오면 그대로 둔다.
+    try expectLower("\\u{}", "\\u{}");
+}
+
+test "unicode_escape: upper-case hex" {
+    try expectLower("\\u{FF}", "\\u00FF");
+}
+
+test "unicode_escape: max codepoint 10FFFF" {
+    try expectLower("\\u{10FFFF}", "\\uDBFF\\uDFFF");
+}


### PR DESCRIPTION
## Summary

ES2015 brace unicode escape `\u{XXXX}` 가 ES5/구 타겟에서 그대로 emit되어 ES5 파서 SyntaxError를 일으키던 문제 해결 (#1388). 문자열 리터럴 · template literal · regex `u` flag 세 경로 모두 커버.

- 문자열/template_element: `\u{X}` → `\uXXXX` (BMP) 또는 `\uHHHH\uLLLL` (surrogate pair, U+10000 이상)
- regex: `u` flag + `\u{X}` → surrogate pair + `u` flag strip (#1387 `regex_lower` 의 네 번째 케이스)
- compat: `unicode_brace_escape` feature (ES2015) 신설. Chrome 44 / FF 53 / Safari 10 / Node 4 기준
- ES2015 template downlevel 경로 (`es2015_template.buildStringLiteral` / `buildRawStringLiteral`) 도 lowering 적용 — template → string concat 으로 합성된 string_literal 은 재방문되지 않으므로 helper 내부에서 직접 처리.

## Before / After

```js
// input
const e = "\u{1F600}";
const b = "\u{41}";
const t = `hi \u{1F600}`;
const r = /[\u{1F600}]/u;
```

```js
// --target=es5 (before → SyntaxError 유발)
var e = "\u{1F600}";
var b = "\u{41}";
var t = `hi \u{1F600}`;
var r = /[\u{1F600}]/u;

// --target=es5 (after)
var e = "\uD83D\uDE00";
var b = "\u0041";
var t = "hi \uD83D\uDE00";
var r = /[\uD83D\uDE00]/;
```

`--target=esnext` / `es2015` 에서는 no-op.

## 주의

- regex 의 `u` flag 를 strip 하면 character class semantics 가 달라질 수 있다 (`[\uD83D\uDE00]` 는 기술적으로 "high surrogate or low surrogate" 로 해석됨). esbuild 도 같은 보수적 처리를 한다 — 대부분의 "U+1F600 매칭" 용법에서 실제 이모지 문자열은 surrogate pair 로 저장되므로 매칭은 기대대로 동작.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `unicode_escape_lower.zig` 유닛 테스트 (BMP / astral / 빈 escape / escaped backslash / max codepoint)
- [x] `regex_lower.zig` u flag 테스트 (surrogate pair, BMP, u 없을 때 no-op, character class)
- [x] `es_downlevel.zig` e2e (문자열 / template / regex / esnext no-op / es2015 no-op / plain `{abc}` 영향 없음)
- [x] CLI 실측 — `zts /tmp/test1388.ts --target=es5` 로 위 before/after 확인

Closes #1388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)