### PR TITLE
chore(transformer): for-of/for-await loop var assign helper 통합

### DIFF
--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -147,7 +147,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
 
             // !(_a = ...)
             const paren_inc = try es_helpers.makeParenExpr(self, inc_assign, span);
-            const not_inc = try makeUnaryNot(self, paren_inc, span);
+            const not_inc = try es_helpers.makeUnaryNot(self, paren_inc, span);
 
             // --- update: _a = true ---
             const inc_ref_update = try makeRefFromSpan(self, inc_span, span);
@@ -167,7 +167,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
             const step_value = try es_helpers.makeStaticMember(self, step_ref_body, value_prop, span);
 
             // var x = _e.value
-            const elem_assign = try buildLoopVarAssign(self, left, step_value, span);
+            const elem_assign = try es_helpers.buildForOfLoopVarAssign(self, left, step_value, span);
 
             // prepend to body
             const final_body = if (!new_body.isNone())
@@ -249,7 +249,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
 
             // !_a
             const inc_ref_finally = try makeRefFromSpan(self, inc_span, span);
-            const not_inc_finally = try makeUnaryNot(self, inc_ref_finally, span);
+            const not_inc_finally = try es_helpers.makeUnaryNot(self, inc_ref_finally, span);
 
             // _d.return != null
             const iter_ref_finally = try makeRefFromSpan(self, iter_span, span);
@@ -388,90 +388,10 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
             });
         }
 
-        fn makeUnaryNot(self: *Transformer, operand: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const extra = try self.ast.addExtras(&.{
-                @intFromEnum(operand),
-                @intFromEnum(token_mod.Kind.bang),
-            });
-            return self.ast.addNode(.{
-                .tag = .unary_expression,
-                .span = span,
-                .data = .{ .extra = extra },
-            });
-        }
-
         fn makeVarDeclFromSpan(self: *Transformer, name_span: Span, init: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const binding = try es_helpers.makeBindingIdentifier(self, name_span);
             const declarator = try es_helpers.makeDeclarator(self, binding, init, span);
             return es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", span);
-        }
-
-        /// for-of의 left를 기반으로 var 선언 또는 대입문 생성.
-        ///
-        /// Destructuring pattern(`const [a,b]` / `const {a,b}`) 은 ES5 `var` 내부
-        /// 에 올 수 없으므로 임시 변수 + element/prop 접근 declarator 로 전개한다.
-        /// 즉 `var [a, b] = _e.value` → `var _t = _e.value, a = _t[0], b = _t[1]`.
-        fn buildLoopVarAssign(self: *Transformer, left: NodeIndex, elem: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            if (left.isNone()) return NodeIndex.none;
-            const left_node = self.ast.getNode(left);
-
-            if (left_node.tag == .variable_declaration) {
-                const le = left_node.data.extra;
-                const list_start = self.readU32(le, 1);
-                const list_len = self.readU32(le, 2);
-                if (list_len == 0) return NodeIndex.none;
-
-                const first_decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list_start]);
-                const first_decl = self.ast.getNode(first_decl_idx);
-                if (first_decl.tag != .variable_declarator) return NodeIndex.none;
-
-                const binding_idx: NodeIndex = self.readNodeIdx(first_decl.data.extra, 0);
-                if (binding_idx.isNone()) return NodeIndex.none;
-                const binding_node = self.ast.getNode(binding_idx);
-
-                if (binding_node.tag == .array_pattern or binding_node.tag == .object_pattern) {
-                    // Destructuring pattern — 임시 변수 _t 도입 후 패턴을 declarator로 전개
-                    const temp_span = try es_helpers.makeTempVarSpan(self);
-                    const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
-                    const temp_decl = try es_helpers.makeDeclarator(self, temp_binding, elem, span);
-
-                    const scratch_top = self.scratch.items.len;
-                    defer self.scratch.shrinkRetainingCapacity(scratch_top);
-                    try self.scratch.append(self.allocator, temp_decl);
-
-                    const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(Transformer);
-                    try es2015_destruct.emitPatternDeclarators(self, binding_node, temp_span, span);
-
-                    return es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top..], .@"var", span);
-                }
-
-                const binding_name = try self.visitNode(binding_idx);
-                const declarator = try es_helpers.makeDeclarator(self, binding_name, elem, span);
-                return es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", span);
-            } else if (left_node.tag == .array_assignment_target or left_node.tag == .object_assignment_target) {
-                // Assignment destructuring: `for ([a,b] of ...)` → _t = elem; a = _t[0]; ...
-                // 기존 lowerDestructuringAssignment 경로(시퀀스 expression)를 재사용.
-                const assign = try self.ast.addNode(.{
-                    .tag = .assignment_expression,
-                    .span = span,
-                    .data = .{ .binary = .{ .left = left, .right = elem, .flags = 0 } },
-                });
-                const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(Transformer);
-                const lowered_seq = try es2015_destruct.lowerDestructuringAssignment(self, self.ast.getNode(assign));
-                return es_helpers.makeExprStmt(self, lowered_seq, span);
-            } else {
-                const new_left = try self.visitNode(left);
-                const assign = try self.ast.addNode(.{
-                    .tag = .assignment_expression,
-                    .span = span,
-                    .data = .{ .binary = .{ .left = new_left, .right = elem, .flags = 0 } },
-                });
-                return self.ast.addNode(.{
-                    .tag = .expression_statement,
-                    .span = span,
-                    .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
-                });
-            }
         }
     };
 }

--- a/src/transformer/es2018_for_await.zig
+++ b/src/transformer/es2018_for_await.zig
@@ -120,7 +120,7 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
             const step_done = try es_helpers.makeStaticMember(self, paren_step, done_prop, span);
 
             // !(...)
-            const not_done = try makeUnaryNot(self, step_done, span);
+            const not_done = try es_helpers.makeUnaryNot(self, step_done, span);
 
             // =====================================================
             // 3. while body: var v = _step.value; body;
@@ -131,7 +131,7 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
 
             const new_body = try self.visitNode(body);
 
-            const elem_stmt = try buildLoopVarAssign(self, left, step_value, span);
+            const elem_stmt = try es_helpers.buildForOfLoopVarAssign(self, left, step_value, span);
 
             const while_body_block = if (!new_body.isNone())
                 try self.prependStatementsToBody(new_body, &.{elem_stmt})
@@ -221,7 +221,7 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
             const step_ref_f2 = try es_helpers.makeIdentifierRefFromSpan(self, step_span);
             const done_prop2 = try es_helpers.makeIdentifierRef(self, "done");
             const step_done2 = try es_helpers.makeStaticMember(self, step_ref_f2, done_prop2, span);
-            const not_step_done = try makeUnaryNot(self, step_done2, span);
+            const not_step_done = try es_helpers.makeUnaryNot(self, step_done2, span);
 
             // _step && !_step.done
             const and1 = try self.ast.addNode(.{
@@ -348,97 +348,6 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .list = wrapper_list },
             });
-        }
-
-        // ================================================================
-        // 헬퍼
-        // ================================================================
-
-        fn makeUnaryNot(self: *Transformer, operand: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const extra = try self.ast.addExtras(&.{
-                @intFromEnum(operand),
-                @intFromEnum(token_mod.Kind.bang),
-            });
-            return self.ast.addNode(.{
-                .tag = .unary_expression,
-                .span = span,
-                .data = .{ .extra = extra },
-            });
-        }
-
-        /// for-await 의 left (variable_declaration 또는 expression) → `<left> = _step.value;` 문장.
-        ///
-        /// variable_declaration:
-        ///   var v = _step.value;
-        ///   (const/let 도 var 로 강등 — ES2015 미만 block-scoping 미지원 타겟에서도 안전.
-        ///    TDZ 의미는 잃지만, 실전 코드에서 for-await head 가 TDZ 를 기대하는 경우는 없음.)
-        ///
-        /// expression:
-        ///   (left) = _step.value;
-        ///
-        /// 현재는 head binding 이 단순 identifier 인 경우만 완전 지원.
-        /// destructuring pattern (`for await (const [k, v] of iter)`) 은 binding identifier 를
-        /// 그대로 body 로 옮기므로 ES2015 destructuring 미지원 타겟에서는 후속 destructuring
-        /// lowering 이 필요하다. (#1383)
-        fn buildLoopVarAssign(self: *Transformer, left: NodeIndex, elem: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            if (left.isNone()) {
-                // for await (;;) 은 문법적으로 불가하지만 방어.
-                return es_helpers.makeExprStmt(self, elem, span);
-            }
-            const left_node = self.ast.getNode(left);
-
-            if (left_node.tag == .variable_declaration) {
-                const le = left_node.data.extra;
-                const list_start = self.readU32(le, 1);
-                const list_len = self.readU32(le, 2);
-                if (list_len == 0) return es_helpers.makeExprStmt(self, elem, span);
-
-                const first_decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list_start]);
-                const first_decl = self.ast.getNode(first_decl_idx);
-                if (first_decl.tag != .variable_declarator) return es_helpers.makeExprStmt(self, elem, span);
-
-                const binding_idx: NodeIndex = self.readNodeIdx(first_decl.data.extra, 0);
-                if (binding_idx.isNone()) return es_helpers.makeExprStmt(self, elem, span);
-                const binding_node = self.ast.getNode(binding_idx);
-
-                if (binding_node.tag == .array_pattern or binding_node.tag == .object_pattern) {
-                    // Destructuring — 임시 변수 + element/prop 접근 declarator로 전개
-                    // (`var [a, b] = _step.value` 는 ES5에서 문법 오류)
-                    const temp_span = try es_helpers.makeTempVarSpan(self);
-                    const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
-                    const temp_decl = try es_helpers.makeDeclarator(self, temp_binding, elem, span);
-
-                    const scratch_top = self.scratch.items.len;
-                    defer self.scratch.shrinkRetainingCapacity(scratch_top);
-                    try self.scratch.append(self.allocator, temp_decl);
-
-                    const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(Transformer);
-                    try es2015_destruct.emitPatternDeclarators(self, binding_node, temp_span, span);
-
-                    return es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top..], .@"var", span);
-                }
-
-                const binding_name = try self.visitNode(binding_idx);
-                const declarator = try es_helpers.makeDeclarator(self, binding_name, elem, span);
-                return es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", span);
-            } else if (left_node.tag == .array_assignment_target or left_node.tag == .object_assignment_target) {
-                const assign = try self.ast.addNode(.{
-                    .tag = .assignment_expression,
-                    .span = span,
-                    .data = .{ .binary = .{ .left = left, .right = elem, .flags = 0 } },
-                });
-                const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(Transformer);
-                const lowered_seq = try es2015_destruct.lowerDestructuringAssignment(self, self.ast.getNode(assign));
-                return es_helpers.makeExprStmt(self, lowered_seq, span);
-            } else {
-                const new_left = try self.visitNode(left);
-                const assign = try self.ast.addNode(.{
-                    .tag = .assignment_expression,
-                    .span = span,
-                    .data = .{ .binary = .{ .left = new_left, .right = elem, .flags = 0 } },
-                });
-                return es_helpers.makeExprStmt(self, assign, span);
-            }
         }
     };
 }

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -291,6 +291,89 @@ pub fn makeExprStmt(self: anytype, expr: NodeIndex, span: Span) !NodeIndex {
     });
 }
 
+/// `!operand` unary expression 노드 생성.
+pub fn makeUnaryNot(self: anytype, operand: NodeIndex, span: Span) !NodeIndex {
+    const extra = try self.ast.addExtras(&.{
+        @intFromEnum(operand),
+        @intFromEnum(token_mod.Kind.bang),
+    });
+    return self.ast.addNode(.{
+        .tag = .unary_expression,
+        .span = span,
+        .data = .{ .extra = extra },
+    });
+}
+
+/// for-of / for-await-of 의 left 를 loop body 에 prepend 할 statement 로 변환.
+///
+/// - `variable_declaration` (const/let/var) → `var <binding> = elem;` (kind 는 항상 `.var` 로 강등)
+///   TDZ 의미는 잃지만 for-of / for-await head 가 TDZ 를 기대하는 경우는 실전에 없음.
+/// - Destructuring pattern (`[a, b]` / `{a, b}`) → 임시 변수 + element/prop 접근 declarator 로 전개.
+///   `var [a, b] = elem` 이 ES5 `var` 에서 문법 오류이므로 `var _t = elem, a = _t[0], b = _t[1]` 형태로 전개.
+/// - `array_assignment_target` / `object_assignment_target` → `lowerDestructuringAssignment` 로 sequence expr 생성 후 expression_statement 로 감쌈.
+/// - 그 외 (단순 identifier 등) → `<left> = elem;` expression_statement.
+///
+/// 그래머상 불가능한 방어 케이스 (left=none, list_len=0, first 가 declarator 가 아님 등) 에서도
+/// 항상 유효한 statement 를 반환 (`elem;`).
+pub fn buildForOfLoopVarAssign(self: anytype, left: NodeIndex, elem: NodeIndex, span: Span) !NodeIndex {
+    if (left.isNone()) return makeExprStmt(self, elem, span);
+    const left_node = self.ast.getNode(left);
+
+    if (left_node.tag == .variable_declaration) {
+        const le = left_node.data.extra;
+        const list_start = self.readU32(le, 1);
+        const list_len = self.readU32(le, 2);
+        if (list_len == 0) return makeExprStmt(self, elem, span);
+
+        const first_decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list_start]);
+        const first_decl = self.ast.getNode(first_decl_idx);
+        if (first_decl.tag != .variable_declarator) return makeExprStmt(self, elem, span);
+
+        const binding_idx: NodeIndex = self.readNodeIdx(first_decl.data.extra, 0);
+        if (binding_idx.isNone()) return makeExprStmt(self, elem, span);
+        const binding_node = self.ast.getNode(binding_idx);
+
+        if (binding_node.tag == .array_pattern or binding_node.tag == .object_pattern) {
+            // Destructuring pattern — 임시 변수 _t 도입 후 패턴을 declarator 로 전개
+            const temp_span = try makeTempVarSpan(self);
+            const temp_binding = try makeBindingIdentifier(self, temp_span);
+            const temp_decl = try makeDeclarator(self, temp_binding, elem, span);
+
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+            try self.scratch.append(self.allocator, temp_decl);
+
+            const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(@TypeOf(self.*));
+            try es2015_destruct.emitPatternDeclarators(self, binding_node, temp_span, span);
+
+            return makeVarDeclaration(self, self.scratch.items[scratch_top..], .@"var", span);
+        }
+
+        const binding_name = try self.visitNode(binding_idx);
+        const declarator = try makeDeclarator(self, binding_name, elem, span);
+        return makeVarDeclaration(self, &.{declarator}, .@"var", span);
+    } else if (left_node.tag == .array_assignment_target or left_node.tag == .object_assignment_target) {
+        // Assignment destructuring: `for ([a,b] of ...)` → _t = elem; a = _t[0]; ...
+        // 기존 lowerDestructuringAssignment 경로(sequence expression) 재사용.
+        const assign = try self.ast.addNode(.{
+            .tag = .assignment_expression,
+            .span = span,
+            .data = .{ .binary = .{ .left = left, .right = elem, .flags = 0 } },
+        });
+        const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(@TypeOf(self.*));
+        const lowered_seq = try es2015_destruct.lowerDestructuringAssignment(self, self.ast.getNode(assign));
+        return makeExprStmt(self, lowered_seq, span);
+    } else {
+        const new_left = try self.visitNode(left);
+        const assign = try self.ast.addNode(.{
+            .tag = .assignment_expression,
+            .span = span,
+            .data = .{ .binary = .{ .left = new_left, .right = elem, .flags = 0 } },
+        });
+        return makeExprStmt(self, assign, span);
+    }
+}
+
 // ============================================================
 // Object spread lowering 공용 헬퍼
 // ============================================================


### PR DESCRIPTION
## Summary
- \`src/transformer/es2015_for_of.zig\` 와 \`src/transformer/es2018_for_await.zig\` 에 거의 동일하게 존재하던 \`buildLoopVarAssign\` 을 \`es_helpers.buildForOfLoopVarAssign\` 으로 통합.
- 역시 두 파일에 동일 구현으로 존재하던 \`makeUnaryNot\` 을 \`es_helpers.makeUnaryNot\` 으로 통합.
- for-of 말단 else 의 inline \`expression_statement\` 생성은 \`es_helpers.makeExprStmt\` 로 교체해 일관화.

## Behavior
- 동작 변경 없음. 양쪽 모두 \`var\` 로 강등하는 기존 동작을 그대로 유지 (const/let TDZ 의미 상실은 이미 두 파일 모두 공통이었음).
- 그래머상 도달 불가한 방어 경로 (\`left.isNone()\`, \`list_len==0\` 등) 는 for-await 동작 (\`elem;\` expression statement 반환) 으로 일관화. 이 경로는 실제 파서가 생성할 수 없어 observable 차이 없음.

## Test plan
- [x] \`zig build test\`
- [x] \`cd tests/integration && bun test\` (2879 pass / 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)