### PR TITLE
chore(transformer): unicode brace escape 유틸 재사용

### DIFF
--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -94,8 +94,8 @@ fn rewritePattern(
         if (c == '\\') {
             // `\u{XXXX}` brace unicode escape → surrogate pair / BMP escape
             if (opts.unicode_brace and i + 2 < pattern.len and pattern[i + 1] == 'u' and pattern[i + 2] == '{') {
-                if (parseBraceHex(pattern, i + 2)) |r| {
-                    try appendCodepointEscape(allocator, out, r.cp);
+                if (unicode_escape_lower.parseBraceHex(pattern, i + 2)) |r| {
+                    try unicode_escape_lower.appendCodepoint(out, allocator, r.cp);
                     i = r.end;
                     continue;
                 }
@@ -157,46 +157,6 @@ fn rewritePattern(
                 i += 1;
             },
         }
-    }
-}
-
-fn hexVal(c: u8) ?u32 {
-    return switch (c) {
-        '0'...'9' => @as(u32, c - '0'),
-        'a'...'f' => @as(u32, c - 'a' + 10),
-        'A'...'F' => @as(u32, c - 'A' + 10),
-        else => null,
-    };
-}
-
-/// `\u{` 바로 다음의 `{` 위치를 받아 hex 를 파싱. 닫는 `}` 까지 포함한 end 반환.
-fn parseBraceHex(s: []const u8, start_brace: usize) ?struct { cp: u32, end: usize } {
-    var i: usize = start_brace + 1;
-    var cp: u32 = 0;
-    var any: bool = false;
-    while (i < s.len and s[i] != '}') : (i += 1) {
-        const h = hexVal(s[i]) orelse return null;
-        cp = (cp << 4) | h;
-        if (cp > 0x10FFFF) return null;
-        any = true;
-    }
-    if (!any or i >= s.len or s[i] != '}') return null;
-    return .{ .cp = cp, .end = i + 1 };
-}
-
-fn appendHexUnit(allocator: std.mem.Allocator, out: *std.ArrayList(u8), unit: u32) !void {
-    var buf: [6]u8 = undefined;
-    _ = std.fmt.bufPrint(&buf, "\\u{X:0>4}", .{unit}) catch unreachable;
-    try out.appendSlice(allocator, &buf);
-}
-
-fn appendCodepointEscape(allocator: std.mem.Allocator, out: *std.ArrayList(u8), cp: u32) !void {
-    if (cp <= 0xFFFF) {
-        try appendHexUnit(allocator, out, cp);
-    } else {
-        const v = cp - 0x10000;
-        try appendHexUnit(allocator, out, 0xD800 | (v >> 10));
-        try appendHexUnit(allocator, out, 0xDC00 | (v & 0x3FF));
     }
 }
 

--- a/src/transformer/unicode_escape_lower.zig
+++ b/src/transformer/unicode_escape_lower.zig
@@ -49,7 +49,7 @@ fn hexVal(c: u8) ?u32 {
 
 /// `\u{` 가 content[pos-1] (이미 `\` 에서 시작해 pos가 'u'의 위치 + 2) 에서 시작한다고 가정하고,
 /// 닫는 `}` 까지 파싱한 codepoint 와 `}` 직후 인덱스를 반환. 실패 시 null.
-fn parseBraceHex(content: []const u8, start_brace: usize) ?struct { cp: u32, end: usize } {
+pub fn parseBraceHex(content: []const u8, start_brace: usize) ?struct { cp: u32, end: usize } {
     // content[start_brace] == '{'
     var i: usize = start_brace + 1;
     var cp: u32 = 0;
@@ -65,13 +65,13 @@ fn parseBraceHex(content: []const u8, start_brace: usize) ?struct { cp: u32, end
     return .{ .cp = cp, .end = i + 1 };
 }
 
-fn appendUnit(out: *std.ArrayList(u8), allocator: std.mem.Allocator, unit: u32) !void {
+pub fn appendUnit(out: *std.ArrayList(u8), allocator: std.mem.Allocator, unit: u32) !void {
     var buf: [6]u8 = undefined;
     _ = std.fmt.bufPrint(&buf, "\\u{X:0>4}", .{unit}) catch unreachable;
     try out.appendSlice(allocator, &buf);
 }
 
-fn appendCodepoint(out: *std.ArrayList(u8), allocator: std.mem.Allocator, cp: u32) !void {
+pub fn appendCodepoint(out: *std.ArrayList(u8), allocator: std.mem.Allocator, cp: u32) !void {
     if (cp <= 0xFFFF) {
         try appendUnit(out, allocator, cp);
     } else {


### PR DESCRIPTION
## Summary
- \`src/transformer/regex_lower.zig\` 에 중복 정의되어 있던 \`parseBraceHex\` / \`appendHexUnit\` / \`appendCodepointEscape\` (+ 지원 함수 \`hexVal\`) 를 제거.
- \`src/transformer/unicode_escape_lower.zig\` 의 \`parseBraceHex\` / \`appendCodepoint\` / \`appendUnit\` 을 \`pub\` 으로 노출하여 공유.
- unicode_escape_lower 측 네이밍과 인자 순서 (\`out, allocator, ...\`) 를 유지 — 4 케이스 (BMP/supplementary) 를 다루는 더 일반적 모듈.

## Behavior
- 동작 변경 없음. 두 구현은 byte-level 로 동일 출력 (\`\\u{X:0>4}\` 포맷, surrogate pair 계산 동일).

## Test plan
- [x] \`zig build test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)