### PR TITLE
chore(transformer): /simplify #1404 후속 — 누락 사이트 + 매직 넘버 + 회귀 테스트

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -556,7 +556,7 @@ pub const Codegen = struct {
     fn addSourceMapping(self: *Codegen, span: Span) !void {
         if (self.sm_builder) |*sm| {
             // 합성 노드(string_table) 또는 빈 span → 소스맵 매핑 스킵
-            if (span.start & 0x8000_0000 != 0 or (span.start == 0 and span.end == 0)) return;
+            if (span.start & Ast.STRING_TABLE_BIT != 0 or (span.start == 0 and span.end == 0)) return;
             // byte offset → 줄/열 변환 (Scanner의 line_offsets 사용)
             const lc = self.getOriginalLineColumn(span.start);
             try sm.addMapping(.{

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1912,6 +1912,18 @@ test "ES2018: for-await-of with synthetic call — no SIGBUS in worklet auto-det
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__asyncValues") != null);
 }
 
+test "ES2015: object method shorthand + computed key — no SIGBUS (#1404 원본)" {
+    var r = try e2eTarget(std.testing.allocator, "const o = { async fn() { return 1; }, [\"k\"]: 2 };", .es5);
+    defer r.deinit();
+    try std.testing.expect(r.output.len > 0);
+}
+
+test "ES2015: generator method shorthand + computed method — no SIGBUS (#1404)" {
+    var r = try e2eTarget(std.testing.allocator, "const o = { *gen() { yield 1; }, [\"k\"]() { return 2; } };", .es5);
+    defer r.deinit();
+    try std.testing.expect(r.output.len > 0);
+}
+
 // --- spread edge cases ---
 
 test "ES2015: spread in new with apply" {

--- a/src/transformer/ast_plugin.zig
+++ b/src/transformer/ast_plugin.zig
@@ -246,7 +246,7 @@ pub const AstTransformCtx = struct {
 
         // 소스 텍스트 참조 → string_table로 복사 (span이 src_ast.source를 참조하므로)
         var new_span = src_node.span;
-        if (src_node.span.start & 0x8000_0000 == 0 and
+        if (src_node.span.start & ast_mod.Ast.STRING_TABLE_BIT == 0 and
             src_node.span.start < src_node.span.end and
             src_node.span.end <= @as(u32, @intCast(src_ast.source.len)))
         {

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -55,7 +55,7 @@ pub fn isConstructorKey(self: anytype, key_idx: NodeIndex) bool {
     if (key_idx.isNone()) return false;
     const key = self.ast.getNode(key_idx);
     if (key.tag != .identifier_reference and key.tag != .binding_identifier) return false;
-    const text = self.ast.source[key.data.string_ref.start..key.data.string_ref.end];
+    const text = self.ast.getText(key.data.string_ref);
     return std.mem.eql(u8, text, "constructor");
 }
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1828,7 +1828,7 @@ pub const Transformer = struct {
         const obj = self.ast.getNode(obj_idx);
         if (obj.tag != .identifier_reference) return false;
 
-        const obj_text = self.ast.source[obj.data.string_ref.start..obj.data.string_ref.end];
+        const obj_text = self.ast.getText(obj.data.string_ref);
         return std.mem.eql(u8, obj_text, "console");
     }
 

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -397,7 +397,7 @@ pub fn findHookCallsInNodeDepth(self: *Transformer, idx: NodeIndex, sig_buf: *st
                             if (!first_arg_idx.isNone() and @intFromEnum(first_arg_idx) < self.ast.nodes.items.len) {
                                 const first_arg = self.ast.getNode(first_arg_idx);
                                 if (first_arg.span.start < first_arg.span.end and
-                                    first_arg.span.start & 0x8000_0000 == 0)
+                                    first_arg.span.start & Ast.STRING_TABLE_BIT == 0)
                                 {
                                     try sig_buf.append(self.allocator, '(');
                                     try sig_buf.appendSlice(self.allocator, self.ast.getText(first_arg.span));
@@ -444,7 +444,7 @@ pub fn findHookCallsInNodeDepth(self: *Transformer, idx: NodeIndex, sig_buf: *st
             var lhs_text: ?[]const u8 = null;
             if (!lhs_idx.isNone() and @intFromEnum(lhs_idx) < self.ast.nodes.items.len) {
                 const lhs = self.ast.getNode(lhs_idx);
-                if (lhs.span.start < lhs.span.end and lhs.span.start & 0x8000_0000 == 0) {
+                if (lhs.span.start < lhs.span.end and lhs.span.start & Ast.STRING_TABLE_BIT == 0) {
                     lhs_text = self.ast.getText(lhs.span);
                 }
             }


### PR DESCRIPTION
## Summary
PR #1405 (#1404 fix) 머지 후 /simplify 검토에서 추가 cleanup 발견.

### 누락된 OOB 위험 사이트 2건 (동일 패턴)
- \`transformer.zig:1831\` \`isConsoleLog\` 의 \`obj.data.string_ref\` 직접 접근
- \`es_helpers.zig:58\` \`isConstructorKey\` 의 \`key.data.string_ref\` 직접 접근

### 매직 넘버 \`0x8000_0000\` → \`Ast.STRING_TABLE_BIT\` 상수화
- \`transformer/refresh.zig:400,447\`
- \`transformer/ast_plugin.zig:249\`
- \`codegen/codegen.zig:559\`

### 회귀 테스트 보강
- object method shorthand + computed key (async) — #1404 원본 케이스
- generator method shorthand + computed method

## Follow-up (별도 이슈 등록 예정)
- bundler/binding_scanner.zig 12+ 사이트
- bundler/import_scanner.zig + linker/metadata.zig
- semantic/analyzer.zig 25+, semantic/checker.zig 6
- codegen/codegen.zig 10+ 사이트 (sourcemap 외)

## Test plan
- [x] \`zig build test\`
- [x] \`cd tests/integration && bun test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)