### PR TITLE
feat(diagnostics): Bun 스타일 crash report — panic handler + 신고 안내

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -10,6 +10,10 @@
 
 const std = @import("std");
 const zts_lib = @import("zts_lib");
+
+/// Bun 스타일 crash report: NAPI addon에서 panic이 터지면 Node 프로세스 전체가
+/// 죽는다 — 그 전에 ZTS 배너 + 이슈 URL을 찍어 사용자가 신고하기 쉽게 한다.
+pub const panic = zts_lib.crash_handler.panic;
 const transpile_mod = zts_lib.transpile;
 const bundler_mod = zts_lib.bundler;
 const Bundler = bundler_mod.Bundler;

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -16,6 +16,10 @@ const Scanner = @import("zts_lib").lexer.Scanner;
 const Diagnostic = @import("zts_lib").diagnostic.Diagnostic;
 const compat = @import("zts_lib").transformer.transformer.TransformOptions.compat;
 
+/// Bun 스타일 crash report: WASM에는 signal이 없지만 panic은 여전히 터질 수 있다.
+/// 호스트 콘솔(WASI stderr)로 배너 + 이슈 URL 출력.
+pub const panic = @import("zts_lib").crash_handler.panic;
+
 /// WASM에서는 wasm_allocator 사용 (memory.grow 기반)
 const wasm_alloc = std.heap.wasm_allocator;
 

--- a/src/crash_handler.zig
+++ b/src/crash_handler.zig
@@ -1,0 +1,137 @@
+//! ZTS crash report (Bun 스타일).
+//!
+//! `std.debug.FullPanic`에 꽂아 쓰는 커스텀 panic 핸들러 + 신고 안내 URL 출력.
+//! Phase 1 — panic handler 커스터마이징 + issue URL. POSIX signal (SIGBUS/SIGSEGV)
+//! 핸들러는 async-signal-safety 검증 필요해서 후속 PR로 분리.
+//!
+//! 사용법 (각 root 파일에서):
+//! ```zig
+//! const crash_handler = @import("zts_lib").crash_handler; // CLI root는 "crash_handler.zig" 직접 import
+//! pub const panic = crash_handler.panic;
+//! ```
+//!
+//! 선택적으로 `setContext(.{ .input_file = "...", .target = "es5" })`를 진입 시 호출하면
+//! panic 메시지에 컨텍스트가 함께 찍힌다. thread-local이라 스레드별 best-effort.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// GitHub issue tracker base. 새 이슈 URL로 직접 보내 라벨/제목 프리필.
+const ISSUE_NEW_URL = "https://github.com/ohah/zts/issues/new";
+
+/// 진입점에서 best-effort로 채워 두는 크래시 컨텍스트.
+/// panic 출력에 현재 변환 중인 파일/타겟을 포함시키기 위함.
+pub const Context = struct {
+    input_file: ?[]const u8 = null,
+    target: ?[]const u8 = null,
+    /// cli/napi/wasm 중 어디서 돌다 죽었는지.
+    entry: ?[]const u8 = null,
+};
+
+threadlocal var current_context: Context = .{};
+
+pub fn setContext(ctx: Context) void {
+    current_context = ctx;
+}
+
+pub fn clearContext() void {
+    current_context = .{};
+}
+
+pub fn getContext() Context {
+    return current_context;
+}
+
+/// FullPanic이 요구하는 시그니처. Zig 내부에서 safety panic도 여기로 모인다.
+fn panicFn(msg: []const u8, first_trace_addr: ?usize) noreturn {
+    @branchHint(.cold);
+
+    // stderr에 배너를 먼저 찍는다. 실패해도 무시 — 어쨌든 defaultPanic으로 넘어간다.
+    // deprecatedWriter는 `anytype` writer를 반환하므로 std.Io.Writer 전환 이슈가 없다.
+    const stderr_file = std.fs.File.stderr();
+    const w = stderr_file.deprecatedWriter();
+    printBanner(w, msg) catch {};
+
+    // 기본 panic 경로 (스택 트레이스 + abort)로 위임.
+    // defaultPanic은 내부에서 심볼 해석/스택 덤프 + posix.abort()를 수행.
+    std.debug.defaultPanic(msg, first_trace_addr);
+}
+
+fn printBanner(out: anytype, msg: []const u8) !void {
+    try out.writeAll("\n");
+    try out.print("zts: fatal: {s}\n", .{msg});
+
+    const ctx = current_context;
+    if (ctx.entry) |e| try out.print("  entry:  {s}\n", .{e});
+    if (ctx.input_file) |f| try out.print("  input:  {s}\n", .{f});
+    if (ctx.target) |t| try out.print("  target: {s}\n", .{t});
+    try out.print("  os/arch: {s}/{s}\n", .{ @tagName(builtin.os.tag), @tagName(builtin.cpu.arch) });
+    try out.print("  zig:     {s}\n", .{builtin.zig_version_string});
+
+    try out.writeAll(
+        \\
+        \\This is a bug in zts. Please file an issue with the stack trace below:
+        \\
+    );
+    try printIssueUrl(out, msg, ctx);
+    try out.writeAll("\n\n");
+}
+
+/// GitHub "new issue" URL에 title/labels 프리필.
+fn printIssueUrl(out: anytype, msg: []const u8, ctx: Context) !void {
+    try out.writeAll(ISSUE_NEW_URL);
+    try out.writeAll("?labels=crash&title=");
+
+    // 제목: "panic: <msg 첫 80자> (<entry>, input=<file>)"
+    try writeUrlEncoded(out, "panic: ");
+    const msg_cut = if (msg.len > 80) msg[0..80] else msg;
+    try writeUrlEncoded(out, msg_cut);
+    if (ctx.entry) |e| {
+        try writeUrlEncoded(out, " (");
+        try writeUrlEncoded(out, e);
+        if (ctx.input_file) |f| {
+            try writeUrlEncoded(out, ", input=");
+            try writeUrlEncoded(out, f);
+        }
+        try writeUrlEncoded(out, ")");
+    }
+}
+
+/// RFC3986 unreserved + 숫자/하이픈/밑줄/점/물결은 그대로, 그 외는 `%HH`.
+/// 공백은 `+`로.
+fn writeUrlEncoded(out: anytype, s: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (s) |c| {
+        switch (c) {
+            'A'...'Z', 'a'...'z', '0'...'9', '-', '_', '.', '~' => try out.writeByte(c),
+            ' ' => try out.writeByte('+'),
+            else => {
+                try out.writeByte('%');
+                try out.writeByte(hex[(c >> 4) & 0xF]);
+                try out.writeByte(hex[c & 0xF]);
+            },
+        }
+    }
+}
+
+/// 진입점에서 `pub const panic = crash_handler.panic;`로 사용.
+pub const panic = std.debug.FullPanic(panicFn);
+
+// ─── 테스트 ───
+
+test "writeUrlEncoded: unreserved passthrough + space as plus + percent encode" {
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try writeUrlEncoded(fbs.writer(), "Hello World/foo.ts");
+    try std.testing.expectEqualStrings("Hello+World%2Ffoo.ts", fbs.getWritten());
+}
+
+test "setContext/getContext roundtrip" {
+    setContext(.{ .input_file = "a.ts", .target = "es5", .entry = "cli" });
+    const c = getContext();
+    try std.testing.expectEqualStrings("a.ts", c.input_file.?);
+    try std.testing.expectEqualStrings("es5", c.target.?);
+    try std.testing.expectEqualStrings("cli", c.entry.?);
+    clearContext();
+    try std.testing.expect(getContext().input_file == null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,6 +14,10 @@ const emitter = lib.bundler.emitter;
 const SubprocessPlugin = lib.bundler.SubprocessPlugin;
 const plugin_mod = lib.bundler.plugin;
 
+/// Bun 스타일 crash report: panic 발생 시 배너 + 이슈 URL 출력 후 기본 경로로 abort.
+/// root 선언이라야 컴파일러가 safety panic을 여기로 보낸다.
+pub const panic = lib.crash_handler.panic;
+
 /// CLI 인자를 파싱한 결과를 담는 구조체.
 /// main()에서 개별 변수 30여 개로 흩어져 있던 옵션을 하나로 모은다.
 const CliOptions = struct {
@@ -992,6 +996,13 @@ pub fn main() !void {
 
     var opts = try parseCliArguments(args, allocator) orelse return;
     defer opts.deinit(allocator);
+
+    // crash report 컨텍스트: panic 시 어떤 입력/타겟에서 죽었는지 알려 준다.
+    lib.crash_handler.setContext(.{
+        .entry = "cli",
+        .input_file = opts.input_file,
+        .target = if (opts.es_target) |t| @tagName(t) else null,
+    });
 
     // zts.config.{js,ts,mjs,mts,cjs,cts} 자동 탐색 (--plugin 미지정 시)
     if (opts.plugin_paths.items.len == 0 and (opts.is_bundle or opts.is_serve)) {

--- a/src/root.zig
+++ b/src/root.zig
@@ -23,6 +23,7 @@ pub const server = @import("server/mod.zig");
 pub const transpile = @import("transpile.zig");
 pub const string_escape = @import("string_escape.zig");
 pub const util = @import("util/mod.zig");
+pub const crash_handler = @import("crash_handler.zig");
 
 test {
     _ = lexer;
@@ -43,6 +44,8 @@ test {
     _ = diagnostic_renderer;
     _ = levenshtein;
     _ = error_codes;
+
+    _ = crash_handler;
 
     // test files
     _ = @import("config_test.zig");


### PR DESCRIPTION
## Summary
- panic 발생 시 Bun 스타일로 `zts: fatal: <msg>` 배너 + 컨텍스트(진입점/입력파일/타겟/os-arch/zig 버전) + GitHub new-issue URL(라벨·제목 프리필)을 출력한 뒤 기존 `std.debug.defaultPanic` 경로로 위임.
- `src/crash_handler.zig` 신규 모듈 — `std.debug.FullPanic` 래핑 + thread-local `Context`.
- `main.zig` / `packages/core/src/napi_entry.zig` / `packages/wasm/src/wasm_entry.zig` 각 root에 `pub const panic = crash_handler.panic;` 연결. CLI 진입 시 `setContext`로 input/target 주입.

## Scope
**Phase 1만** 포함. POSIX signal(SIGBUS/SIGSEGV) 핸들러는 async-signal-safety(핸들러 안에서 malloc/printf 금지 등) 검증이 필요해 **별도 PR**로 분리 — 후속 이슈에서 다룸.

## Motivation
Zig 런타임은 Rust napi-rs / Go esbuild 처럼 panic을 자동으로 잡아주지 않아, 그대로 두면 `thread N panic:` 뒤의 원시 스택 트레이스만 노출됨. SWC/oxc 수준의 UX를 지향하는 툴에서 약점 — Bun도 같은 이유로 자체 crash_handler를 둔다.

## Sample output
```
zts: fatal: intentional test panic for crash_handler verification
  entry:  demo
  input:  foo.ts
  target: es5
  os/arch: macos/aarch64
  zig:     0.15.2

This is a bug in zts. Please file an issue with the stack trace below:
https://github.com/ohah/zts/issues/new?labels=crash&title=panic%3A+intentional+test+panic+...+%28demo%2C+input%3Dfoo.ts%29

thread 99547510 panic: intentional test panic ...
  (기존 std.debug.defaultPanic 스택 트레이스)
```

## Test plan
- [x] `zig build` / `zig build test` / `zig build napi` / `zig build wasm` 모두 성공
- [x] 의도적 `@panic` 트리거 시 배너·컨텍스트·URL 출력 확인 후 기존 스택 트레이스로 fallthrough
- [x] `writeUrlEncoded` / `setContext` 유닛 테스트 추가
- [ ] (후속) SIGBUS/SIGSEGV signal handler — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)