### PR TITLE
fix(cli): realpathAlloc leak + bundler 합성 노드 회귀 가드

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -961,6 +961,58 @@ test "Re-export resolves to canonical local (not global-identifier reserved, #13
     try std.testing.expect(std.mem.indexOf(u8, result.output, "URLSearchParams: () => URLSearchParams,") == null);
 }
 
+// ============================================================
+// #1404/#1407 회귀 가드 — 합성 노드 span 의 STRING_TABLE_BIT 처리
+// 번들러 단계에서 binding_scanner / linker 가 합성 identifier 의 이름을 추출할 때
+// `self.ast.source[..]` 직접 접근하면 OOB → SIGBUS. getText 일괄 치환 후 안전.
+// ============================================================
+
+test "Synthetic span: barrel re-export of async function — no SIGBUS at es5 (#1404/#1407)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "export { run } from './a';");
+    try writeFile(tmp.dir, "a.ts",
+        \\export async function run() {
+        \\  for await (const v of g()) use(v);
+        \\}
+        \\async function* g() { yield 1; }
+        \\function use(_: any) {}
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const compat = @import("../../transformer/compat.zig");
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__asyncValues") != null);
+}
+
+test "Synthetic span: object method shorthand + computed key — no SIGBUS at es5 (#1404/#1407)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export const o = { async fn() { return 1; }, ["k"]: 2 };
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const compat = @import("../../transformer/compat.zig");
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+}
+
 test "Bundler: AMD external dependencies in wrapper" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/main.zig
+++ b/src/main.zig
@@ -1590,7 +1590,11 @@ pub fn main() !void {
         if (!opts.allow_overwrite) {
             const entry_abs = abs_entry;
             if (opts.output_file) |out_path| {
-                const out_abs = std.fs.cwd().realpathAlloc(allocator, out_path) catch out_path;
+                // realpath 결과는 owned. fallback (out_path) 은 caller-owned 이므로
+                // 분기해서 owned 만 free.
+                const out_abs_owned = std.fs.cwd().realpathAlloc(allocator, out_path) catch null;
+                defer if (out_abs_owned) |p| allocator.free(p);
+                const out_abs = out_abs_owned orelse out_path;
                 if (std.mem.eql(u8, entry_abs, out_abs)) {
                     try stderr.print("zts: output file '{s}' would overwrite input file (use --allow-overwrite to permit)\n", .{out_path});
                     return error.TranspileFailed;


### PR DESCRIPTION
## Summary
PR #1407 (소스 deref audit) 진행 중 발견된 부수 항목 2건 처리.

### 1. realpathAlloc leak (cli)
\`src/main.zig:1593\` \`out_abs\` 가 owned/caller-owned 분기 안 돼 단순 free 불가 → 매 \`--bundle -o\` 호출 시 1건 leak. owned (realpathAlloc 결과) 만 free.

\`\`\`
error(gpa): memory address 0x... leaked:
  in mem.Allocator.dupe → fs.Dir.realpathAlloc → main.main
\`\`\`

### 2. bundler 회귀 가드 (#1404/#1407 후속)
\`bundler_test/basic.zig\` 에 합성 노드가 bundler 경로 (binding_scanner) 통과 시 SIGBUS 안 나는지 가드 2건:
- barrel re-export of async function at es5
- object method shorthand + computed key (원 #1404 케이스, bundler path)

## Test plan
- [x] \`zig build test\`
- [x] bungae ExampleApp 풀 번들 — leak 0건 확인 (\`grep gpa\` 결과 비어 있음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)