### PR TITLE
feat(watch): watchFolders 옵션 지원

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -282,6 +282,13 @@ interface BuildOptionsCommon {
   polyfills?: string[];
   /** 엔트리 모듈 직전에 실행할 모듈 경로 */
   runBeforeMain?: string[];
+  /** 번들 그래프 밖의 디렉토리를 감시 루트에 추가 (Metro watchFolders 호환).
+   * 절대/상대 경로 모두 허용. 지정된 경로는 재귀 스캔되어 감시 대상에 포함된다. */
+  watchFolders?: string[];
+  /** watchFolders 스캔 시 포함할 파일 glob 화이트리스트 (루트 기준 상대 경로). */
+  watchInclude?: string[];
+  /** watchFolders 스캔 시 제외할 파일 glob (루트 기준 상대 경로). */
+  watchExclude?: string[];
   /** watch 모드 빌드 완료 콜백 */
   onReady?: (event: WatchReadyEvent) => void;
   /** watch 모드 리빌드 콜백 */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1318,8 +1318,32 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
     _ = c.napi_call_function(env, js_undefined, js_func, 1, &call_args, &js_result);
 }
 
-/// watch 워커 스레드: 초기 빌드 → ready 이벤트 → 폴링 루프 → rebuild 이벤트
-/// watchFolders 루트를 재귀 스캔해 tracked에 등록. include/exclude glob은 루트 기준 상대.
+/// 경로 세그먼트에 node_modules/.git가 있으면 true (부분문자열 아닌 '/' 경계 매칭).
+fn hasSkippedSegment(rel: []const u8) bool {
+    var it = std.mem.splitScalar(u8, rel, '/');
+    while (it.next()) |seg| {
+        if (std.mem.eql(u8, seg, "node_modules")) return true;
+        if (std.mem.eql(u8, seg, ".git")) return true;
+    }
+    return false;
+}
+
+/// include가 지정되면 최소 하나 매칭 필요, exclude 매칭은 즉시 제외.
+fn passesWatchGlobFilter(rel: []const u8, include: []const []const u8, exclude: []const []const u8) bool {
+    const matchGlob = zts_lib.bundler.resolve_cache.matchGlob;
+    if (include.len > 0) {
+        var any = false;
+        for (include) |pat| if (matchGlob(pat, rel)) {
+            any = true;
+            break;
+        };
+        if (!any) return false;
+    }
+    for (exclude) |pat| if (matchGlob(pat, rel)) return false;
+    return true;
+}
+
+/// watchFolders 루트를 재귀 스캔해 tracked에 등록.
 fn addWatchRootFiles(
     allocator: std.mem.Allocator,
     root: []const u8,
@@ -1328,7 +1352,6 @@ fn addWatchRootFiles(
     tracked: *zts_lib.server.TrackedFileSet,
     count: *usize,
 ) void {
-    const matchGlob = zts_lib.bundler.resolve_cache.matchGlob;
     var dir = std.fs.cwd().openDir(root, .{ .iterate = true }) catch return;
     defer dir.close();
     var walker = dir.walk(allocator) catch return;
@@ -1336,28 +1359,10 @@ fn addWatchRootFiles(
 
     while (walker.next() catch null) |entry| {
         if (entry.kind != .file) continue;
-        const rel = entry.path;
-        if (std.mem.indexOf(u8, rel, "node_modules") != null) continue;
-        if (std.mem.indexOf(u8, rel, ".git/") != null) continue;
+        if (hasSkippedSegment(entry.path)) continue;
+        if (!passesWatchGlobFilter(entry.path, include, exclude)) continue;
 
-        if (include.len > 0) {
-            var any = false;
-            for (include) |pat| if (matchGlob(pat, rel)) {
-                any = true;
-                break;
-            };
-            if (!any) continue;
-        }
-        if (exclude.len > 0) {
-            var skip = false;
-            for (exclude) |pat| if (matchGlob(pat, rel)) {
-                skip = true;
-                break;
-            };
-            if (skip) continue;
-        }
-
-        const full_path = std.fs.path.join(allocator, &.{ root, rel }) catch continue;
+        const full_path = std.fs.path.join(allocator, &.{ root, entry.path }) catch continue;
         defer allocator.free(full_path);
         if (tracked.addPath(full_path, true)) count.* += 1;
     }

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1102,6 +1102,12 @@ const WatchAsyncData = struct {
     ready_tsfn: c.napi_threadsafe_function,
     rebuild_tsfn: c.napi_threadsafe_function,
     stop_flag: std.atomic.Value(bool),
+    /// Metro watchFolders 호환. 그래프 밖 감시 루트(절대/상대 경로).
+    watch_roots: []const []const u8 = &.{},
+    /// watch_roots 스캔 시 포함할 파일 glob (루트 기준 상대).
+    watch_include: []const []const u8 = &.{},
+    /// watch_roots 스캔 시 제외할 파일 glob (루트 기준 상대).
+    watch_exclude: []const []const u8 = &.{},
 
     fn deinit(self: *WatchAsyncData) void {
         // 소유된 문자열 해제
@@ -1313,6 +1319,50 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
 }
 
 /// watch 워커 스레드: 초기 빌드 → ready 이벤트 → 폴링 루프 → rebuild 이벤트
+/// watchFolders 루트를 재귀 스캔해 tracked에 등록. include/exclude glob은 루트 기준 상대.
+fn addWatchRootFiles(
+    allocator: std.mem.Allocator,
+    root: []const u8,
+    include: []const []const u8,
+    exclude: []const []const u8,
+    tracked: *zts_lib.server.TrackedFileSet,
+    count: *usize,
+) void {
+    const matchGlob = zts_lib.bundler.resolve_cache.matchGlob;
+    var dir = std.fs.cwd().openDir(root, .{ .iterate = true }) catch return;
+    defer dir.close();
+    var walker = dir.walk(allocator) catch return;
+    defer walker.deinit();
+
+    while (walker.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const rel = entry.path;
+        if (std.mem.indexOf(u8, rel, "node_modules") != null) continue;
+        if (std.mem.indexOf(u8, rel, ".git/") != null) continue;
+
+        if (include.len > 0) {
+            var any = false;
+            for (include) |pat| if (matchGlob(pat, rel)) {
+                any = true;
+                break;
+            };
+            if (!any) continue;
+        }
+        if (exclude.len > 0) {
+            var skip = false;
+            for (exclude) |pat| if (matchGlob(pat, rel)) {
+                skip = true;
+                break;
+            };
+            if (skip) continue;
+        }
+
+        const full_path = std.fs.path.join(allocator, &.{ root, rel }) catch continue;
+        defer allocator.free(full_path);
+        if (tracked.addPath(full_path, true)) count.* += 1;
+    }
+}
+
 fn watchWorkerThread(async_data: *WatchAsyncData) void {
     const allocator = native_alloc;
     const bundle_opts = async_data.options;
@@ -1423,6 +1473,18 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         for (paths) |p| {
             if (tracked.addPath(p, true)) initial_watch_count += 1;
         }
+    }
+
+    // watchFolders: 번들 그래프 밖 루트를 재귀 스캔해 tracked에 추가
+    for (async_data.watch_roots) |root| {
+        addWatchRootFiles(
+            allocator,
+            root,
+            async_data.watch_include,
+            async_data.watch_exclude,
+            &tracked,
+            &initial_watch_count,
+        );
     }
 
     // 초기 빌드 결과를 파일에 쓰기 (onReady 전에 완료해야 서버가 읽을 수 있음)
@@ -1767,6 +1829,26 @@ fn napiWatch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_va
         .rebuild_tsfn = undefined,
         .stop_flag = std.atomic.Value(bool).init(false),
     };
+
+    // watchFolders/watchInclude/watchExclude 파싱 (parseBuildOptions 바깥에서 수집)
+    inline for (.{
+        .{ "watchFolders", "watch_roots" },
+        .{ "watchInclude", "watch_include" },
+        .{ "watchExclude", "watch_exclude" },
+    }) |pair| {
+        if (getObjectStringArray(env, argv[0], pair[0], native_alloc)) |arr| {
+            const ok = blk: {
+                for (arr) |s| async_data.owned_strings.append(native_alloc, s) catch break :blk false;
+                async_data.owned_string_arrays.append(native_alloc, arr) catch break :blk false;
+                break :blk true;
+            };
+            if (!ok) {
+                native_alloc.destroy(async_data);
+                return throwError(env, "OutOfMemory");
+            }
+            @field(async_data.*, pair[1]) = arr;
+        }
+    }
 
     // 옵션 파싱
     var opts = parseBuildOptions(env, argv[0], &async_data.owned_strings, &async_data.owned_string_arrays) orelse {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1318,32 +1318,8 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
     _ = c.napi_call_function(env, js_undefined, js_func, 1, &call_args, &js_result);
 }
 
-/// 경로 세그먼트에 node_modules/.git가 있으면 true (부분문자열 아닌 '/' 경계 매칭).
-fn hasSkippedSegment(rel: []const u8) bool {
-    var it = std.mem.splitScalar(u8, rel, '/');
-    while (it.next()) |seg| {
-        if (std.mem.eql(u8, seg, "node_modules")) return true;
-        if (std.mem.eql(u8, seg, ".git")) return true;
-    }
-    return false;
-}
-
-/// include가 지정되면 최소 하나 매칭 필요, exclude 매칭은 즉시 제외.
-fn passesWatchGlobFilter(rel: []const u8, include: []const []const u8, exclude: []const []const u8) bool {
-    const matchGlob = zts_lib.bundler.resolve_cache.matchGlob;
-    if (include.len > 0) {
-        var any = false;
-        for (include) |pat| if (matchGlob(pat, rel)) {
-            any = true;
-            break;
-        };
-        if (!any) return false;
-    }
-    for (exclude) |pat| if (matchGlob(pat, rel)) return false;
-    return true;
-}
-
-/// watchFolders 루트를 재귀 스캔해 tracked에 등록.
+/// watchFolders 루트를 재귀 스캔해 TrackedFileSet에 등록.
+/// tracked.addPath가 내부에서 key를 dupe하므로 visitor는 false로 walker가 free하게 둔다.
 fn addWatchRootFiles(
     allocator: std.mem.Allocator,
     root: []const u8,
@@ -1352,20 +1328,20 @@ fn addWatchRootFiles(
     tracked: *zts_lib.server.TrackedFileSet,
     count: *usize,
 ) void {
-    var dir = std.fs.cwd().openDir(root, .{ .iterate = true }) catch return;
-    defer dir.close();
-    var walker = dir.walk(allocator) catch return;
-    defer walker.deinit();
-
-    while (walker.next() catch null) |entry| {
-        if (entry.kind != .file) continue;
-        if (hasSkippedSegment(entry.path)) continue;
-        if (!passesWatchGlobFilter(entry.path, include, exclude)) continue;
-
-        const full_path = std.fs.path.join(allocator, &.{ root, entry.path }) catch continue;
-        defer allocator.free(full_path);
-        if (tracked.addPath(full_path, true)) count.* += 1;
-    }
+    const Ctx = struct { tracked: *zts_lib.server.TrackedFileSet, count: *usize };
+    const visit = struct {
+        fn f(ctx: Ctx, full_path: []const u8) bool {
+            if (ctx.tracked.addPath(full_path, true)) ctx.count.* += 1;
+            return false;
+        }
+    }.f;
+    zts_lib.server.watch_scan.scanRoot(
+        allocator,
+        root,
+        .{ .include = include, .exclude = exclude },
+        Ctx{ .tracked = tracked, .count = count },
+        visit,
+    ) catch {};
 }
 
 fn watchWorkerThread(async_data: *WatchAsyncData) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2307,33 +2307,8 @@ fn collectMtimes(
     }
 }
 
-/// 경로에 node_modules/.git 세그먼트가 포함되어 있으면 true.
-/// 부분문자열이 아닌 '/' 경계 매칭 — `my_node_modules_doc.txt`는 스킵되지 않는다.
-fn hasSkippedSegment(rel: []const u8) bool {
-    var it = std.mem.splitScalar(u8, rel, '/');
-    while (it.next()) |seg| {
-        if (std.mem.eql(u8, seg, "node_modules")) return true;
-        if (std.mem.eql(u8, seg, ".git")) return true;
-    }
-    return false;
-}
-
-/// include가 지정되면 최소 하나 매칭 필요, exclude 매칭은 즉시 제외.
-fn passesWatchGlobFilter(rel: []const u8, include: []const []const u8, exclude: []const []const u8) bool {
-    const matchGlob = @import("zts_lib").bundler.resolve_cache.matchGlob;
-    if (include.len > 0) {
-        var any = false;
-        for (include) |pat| if (matchGlob(pat, rel)) {
-            any = true;
-            break;
-        };
-        if (!any) return false;
-    }
-    for (exclude) |pat| if (matchGlob(pat, rel)) return false;
-    return true;
-}
-
-/// watchFolder 루트를 재귀 스캔해 파일 mtime을 수집. include/exclude는 루트 기준 상대.
+/// watchFolder 루트를 재귀 스캔해 파일 mtime을 mtime_map에 등록.
+/// visitor는 true 반환으로 full_path 소유권을 map 키로 이전한다.
 fn collectWatchRootMtimes(
     allocator: std.mem.Allocator,
     root: []const u8,
@@ -2341,32 +2316,25 @@ fn collectWatchRootMtimes(
     exclude: []const []const u8,
     mtime_map: *std.StringHashMap(i128),
 ) !void {
-    var dir = try std.fs.cwd().openDir(root, .{ .iterate = true });
-    defer dir.close();
-
-    var walker = try dir.walk(allocator);
-    defer walker.deinit();
-
-    while (try walker.next()) |entry| {
-        if (entry.kind != .file) continue;
-        if (hasSkippedSegment(entry.path)) continue;
-        if (!passesWatchGlobFilter(entry.path, include, exclude)) continue;
-
-        const full_path = try std.fs.path.join(allocator, &.{ root, entry.path });
-        const gop = mtime_map.getOrPut(full_path) catch {
-            allocator.free(full_path);
-            continue;
-        };
-        if (gop.found_existing) {
-            allocator.free(full_path);
-            continue;
+    const Ctx = struct { map: *std.StringHashMap(i128) };
+    const visit = struct {
+        fn f(ctx: Ctx, full_path: []const u8) bool {
+            const gop = ctx.map.getOrPut(full_path) catch return false;
+            if (gop.found_existing) return false;
+            gop.value_ptr.* = getFileMtime(full_path) catch {
+                _ = ctx.map.remove(full_path);
+                return false;
+            };
+            return true;
         }
-        gop.value_ptr.* = getFileMtime(full_path) catch {
-            _ = mtime_map.remove(full_path);
-            allocator.free(full_path);
-            continue;
-        };
-    }
+    }.f;
+    try @import("zts_lib").server.watch_scan.scanRoot(
+        allocator,
+        root,
+        .{ .include = include, .exclude = exclude },
+        Ctx{ .map = mtime_map },
+        visit,
+    );
 }
 
 /// 에러 코드 프레임 출력 (D012).

--- a/src/main.zig
+++ b/src/main.zig
@@ -2307,9 +2307,33 @@ fn collectMtimes(
     }
 }
 
-/// --watch-folder로 지정된 루트를 재귀 스캔해 모든 파일의 mtime을 수집한다.
-/// include/exclude glob은 루트 기준 상대 경로에 대해 매칭한다 (둘 다 비어있으면 전부 포함).
-/// node_modules, .git 은 기본 제외.
+/// 경로에 node_modules/.git 세그먼트가 포함되어 있으면 true.
+/// 부분문자열이 아닌 '/' 경계 매칭 — `my_node_modules_doc.txt`는 스킵되지 않는다.
+fn hasSkippedSegment(rel: []const u8) bool {
+    var it = std.mem.splitScalar(u8, rel, '/');
+    while (it.next()) |seg| {
+        if (std.mem.eql(u8, seg, "node_modules")) return true;
+        if (std.mem.eql(u8, seg, ".git")) return true;
+    }
+    return false;
+}
+
+/// include가 지정되면 최소 하나 매칭 필요, exclude 매칭은 즉시 제외.
+fn passesWatchGlobFilter(rel: []const u8, include: []const []const u8, exclude: []const []const u8) bool {
+    const matchGlob = @import("zts_lib").bundler.resolve_cache.matchGlob;
+    if (include.len > 0) {
+        var any = false;
+        for (include) |pat| if (matchGlob(pat, rel)) {
+            any = true;
+            break;
+        };
+        if (!any) return false;
+    }
+    for (exclude) |pat| if (matchGlob(pat, rel)) return false;
+    return true;
+}
+
+/// watchFolder 루트를 재귀 스캔해 파일 mtime을 수집. include/exclude는 루트 기준 상대.
 fn collectWatchRootMtimes(
     allocator: std.mem.Allocator,
     root: []const u8,
@@ -2317,11 +2341,7 @@ fn collectWatchRootMtimes(
     exclude: []const []const u8,
     mtime_map: *std.StringHashMap(i128),
 ) !void {
-    const matchGlob = @import("zts_lib").bundler.resolve_cache.matchGlob;
-
-    var dir = std.fs.cwd().openDir(root, .{ .iterate = true }) catch |err| {
-        return err;
-    };
+    var dir = try std.fs.cwd().openDir(root, .{ .iterate = true });
     defer dir.close();
 
     var walker = try dir.walk(allocator);
@@ -2329,37 +2349,20 @@ fn collectWatchRootMtimes(
 
     while (try walker.next()) |entry| {
         if (entry.kind != .file) continue;
-        const rel = entry.path;
-        if (std.mem.indexOf(u8, rel, "node_modules") != null) continue;
-        if (std.mem.indexOf(u8, rel, ".git/") != null) continue;
+        if (hasSkippedSegment(entry.path)) continue;
+        if (!passesWatchGlobFilter(entry.path, include, exclude)) continue;
 
-        if (include.len > 0) {
-            var any = false;
-            for (include) |pat| if (matchGlob(pat, rel)) {
-                any = true;
-                break;
-            };
-            if (!any) continue;
-        }
-        if (exclude.len > 0) {
-            var skip = false;
-            for (exclude) |pat| if (matchGlob(pat, rel)) {
-                skip = true;
-                break;
-            };
-            if (skip) continue;
-        }
-
-        const full_path = try std.fs.path.join(allocator, &.{ root, rel });
-        if (mtime_map.contains(full_path)) {
-            allocator.free(full_path);
-            continue;
-        }
-        const mtime = getFileMtime(full_path) catch {
+        const full_path = try std.fs.path.join(allocator, &.{ root, entry.path });
+        const gop = mtime_map.getOrPut(full_path) catch {
             allocator.free(full_path);
             continue;
         };
-        mtime_map.put(full_path, mtime) catch {
+        if (gop.found_existing) {
+            allocator.free(full_path);
+            continue;
+        }
+        gop.value_ptr.* = getFileMtime(full_path) catch {
+            _ = mtime_map.remove(full_path);
             allocator.free(full_path);
             continue;
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -152,6 +152,14 @@ const CliOptions = struct {
     node_paths_list: std.ArrayList([]const u8) = .empty,
     /// --watch-delay=MS: watch 리빌드 디바운스 지연 (밀리초)
     watch_delay_ms: u32 = 100,
+    /// --watch-folder=DIR (반복): 번들 그래프 밖의 디렉토리를 감시 루트에 추가.
+    /// Metro의 watchFolders에 대응. 내부 표현은 roots + include/exclude로 일반화되어
+    /// 나중에 Rollup/Vite의 watch.include/exclude 스펙도 같은 필드로 매핑된다.
+    watch_roots_list: std.ArrayList([]const u8) = .empty,
+    /// --watch-include=GLOB (반복): roots 스캔 시 포함할 파일 glob 화이트리스트.
+    watch_include_list: std.ArrayList([]const u8) = .empty,
+    /// --watch-exclude=GLOB (반복): roots 스캔 시 제외할 파일 glob.
+    watch_exclude_list: std.ArrayList([]const u8) = .empty,
     /// --clean: 빌드 전 출력 디렉토리 정리
     clean: bool = false,
     /// --jobs=N: 병렬 워커 스레드 수 (0=기본값/CPU코어수, 1=단일스레드)
@@ -202,6 +210,10 @@ const CliOptions = struct {
         self.drop_labels_list.deinit(alloc);
         self.pure_list.deinit(alloc);
         self.node_paths_list.deinit(alloc);
+        for (self.watch_roots_list.items) |p| alloc.free(p);
+        self.watch_roots_list.deinit(alloc);
+        self.watch_include_list.deinit(alloc);
+        self.watch_exclude_list.deinit(alloc);
     }
 };
 
@@ -578,6 +590,17 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
                 try stderr.print("zts: --watch-delay requires a number (ms): {s}\n", .{val});
                 std.process.exit(1);
             };
+        } else if (std.mem.startsWith(u8, arg, "--watch-folder=")) {
+            const raw = arg["--watch-folder=".len..];
+            const abs = std.fs.cwd().realpathAlloc(allocator, raw) catch {
+                try stderr.print("zts: cannot resolve --watch-folder path: {s}\n", .{raw});
+                std.process.exit(1);
+            };
+            try opts.watch_roots_list.append(allocator, abs);
+        } else if (std.mem.startsWith(u8, arg, "--watch-include=")) {
+            try opts.watch_include_list.append(allocator, arg["--watch-include=".len..]);
+        } else if (std.mem.startsWith(u8, arg, "--watch-exclude=")) {
+            try opts.watch_exclude_list.append(allocator, arg["--watch-exclude=".len..]);
         } else if (std.mem.eql(u8, arg, "--clean")) {
             opts.clean = true;
         } else if (std.mem.startsWith(u8, arg, "--jobs=")) {
@@ -1746,6 +1769,19 @@ pub fn main() !void {
                 }
             }
 
+            // --watch-folder: 번들 그래프 밖 루트를 재귀 스캔해 감시 대상에 추가
+            for (opts.watch_roots_list.items) |root| {
+                collectWatchRootMtimes(
+                    allocator,
+                    root,
+                    opts.watch_include_list.items,
+                    opts.watch_exclude_list.items,
+                    &mtime_map,
+                ) catch |err| {
+                    try stderr.print("[watch] failed to scan --watch-folder '{s}': {}\n", .{ root, err });
+                };
+            }
+
             // config 파일도 감시 대상에 추가
             for (opts.plugin_paths.items) |config_path| {
                 const abs_config = std.fs.cwd().realpathAlloc(allocator, config_path) catch continue;
@@ -2264,6 +2300,65 @@ fn collectMtimes(
         };
 
         // full_path를 키로 소유권 이전
+        mtime_map.put(full_path, mtime) catch {
+            allocator.free(full_path);
+            continue;
+        };
+    }
+}
+
+/// --watch-folder로 지정된 루트를 재귀 스캔해 모든 파일의 mtime을 수집한다.
+/// include/exclude glob은 루트 기준 상대 경로에 대해 매칭한다 (둘 다 비어있으면 전부 포함).
+/// node_modules, .git 은 기본 제외.
+fn collectWatchRootMtimes(
+    allocator: std.mem.Allocator,
+    root: []const u8,
+    include: []const []const u8,
+    exclude: []const []const u8,
+    mtime_map: *std.StringHashMap(i128),
+) !void {
+    const matchGlob = @import("zts_lib").bundler.resolve_cache.matchGlob;
+
+    var dir = std.fs.cwd().openDir(root, .{ .iterate = true }) catch |err| {
+        return err;
+    };
+    defer dir.close();
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        const rel = entry.path;
+        if (std.mem.indexOf(u8, rel, "node_modules") != null) continue;
+        if (std.mem.indexOf(u8, rel, ".git/") != null) continue;
+
+        if (include.len > 0) {
+            var any = false;
+            for (include) |pat| if (matchGlob(pat, rel)) {
+                any = true;
+                break;
+            };
+            if (!any) continue;
+        }
+        if (exclude.len > 0) {
+            var skip = false;
+            for (exclude) |pat| if (matchGlob(pat, rel)) {
+                skip = true;
+                break;
+            };
+            if (skip) continue;
+        }
+
+        const full_path = try std.fs.path.join(allocator, &.{ root, rel });
+        if (mtime_map.contains(full_path)) {
+            allocator.free(full_path);
+            continue;
+        }
+        const mtime = getFileMtime(full_path) catch {
+            allocator.free(full_path);
+            continue;
+        };
         mtime_map.put(full_path, mtime) catch {
             allocator.free(full_path);
             continue;

--- a/src/server/mod.zig
+++ b/src/server/mod.zig
@@ -4,12 +4,14 @@ pub const ChangeEvent = @import("file_watcher.zig").ChangeEvent;
 pub const ChangeKind = @import("file_watcher.zig").ChangeKind;
 pub const TrackedFileSet = @import("tracked_file_set.zig").TrackedFileSet;
 pub const mime = @import("mime.zig");
+pub const watch_scan = @import("watch_scan.zig");
 
 test {
     _ = @import("dev_server.zig");
     _ = @import("file_watcher.zig");
     _ = @import("tracked_file_set.zig");
     _ = @import("mime.zig");
+    _ = @import("watch_scan.zig");
 
     // test files
     _ = @import("dev_server_test.zig");

--- a/src/server/watch_scan.zig
+++ b/src/server/watch_scan.zig
@@ -1,0 +1,88 @@
+//! watchFolders 루트를 재귀 스캔하는 공통 walker.
+//!
+//! CLI watch(mtime 폴링)와 NAPI watch(TrackedFileSet) 두 구현이 같은 필터링 규칙을
+//! 쓰기 위해 여기로 추출. 저장소 타입이 달라 실제 "어디에 저장할지"는 visitor 콜백에
+//! 위임한다.
+
+const std = @import("std");
+const matchGlob = @import("../bundler/resolve_cache.zig").matchGlob;
+
+pub const Filter = struct {
+    /// 지정되면 최소 하나와 매칭되어야 통과. 비어있으면 모두 통과.
+    include: []const []const u8 = &.{},
+    /// 하나라도 매칭되면 제외.
+    exclude: []const []const u8 = &.{},
+};
+
+/// 경로 세그먼트가 node_modules/.git인 경우 true. 부분문자열 아닌 '/' 경계 매칭.
+pub fn hasSkippedSegment(rel: []const u8) bool {
+    var it = std.mem.splitScalar(u8, rel, '/');
+    while (it.next()) |seg| {
+        if (std.mem.eql(u8, seg, "node_modules")) return true;
+        if (std.mem.eql(u8, seg, ".git")) return true;
+    }
+    return false;
+}
+
+pub fn passesFilter(rel: []const u8, filter: Filter) bool {
+    if (filter.include.len > 0) {
+        var any = false;
+        for (filter.include) |pat| if (matchGlob(pat, rel)) {
+            any = true;
+            break;
+        };
+        if (!any) return false;
+    }
+    for (filter.exclude) |pat| if (matchGlob(pat, rel)) return false;
+    return true;
+}
+
+/// `root` 아래 파일을 재귀 스캔, 필터 통과한 것마다 `visit(ctx, full_path)` 호출.
+/// visitor는 `true` 반환 시 `full_path` 메모리 소유권을 가져간다 (walker는 free 안 함).
+/// `false` 반환 시 walker가 즉시 free — transient view로만 사용할 때 유용.
+pub fn scanRoot(
+    allocator: std.mem.Allocator,
+    root: []const u8,
+    filter: Filter,
+    context: anytype,
+    comptime visit: fn (ctx: @TypeOf(context), full_path: []const u8) bool,
+) !void {
+    var dir = try std.fs.cwd().openDir(root, .{ .iterate = true });
+    defer dir.close();
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (hasSkippedSegment(entry.path)) continue;
+        if (!passesFilter(entry.path, filter)) continue;
+
+        const full_path = try std.fs.path.join(allocator, &.{ root, entry.path });
+        const taken = visit(context, full_path);
+        if (!taken) allocator.free(full_path);
+    }
+}
+
+test "hasSkippedSegment: '/' 경계 매칭" {
+    const t = std.testing;
+    try t.expect(hasSkippedSegment("a/node_modules/b.js"));
+    try t.expect(hasSkippedSegment("node_modules/x.js"));
+    try t.expect(hasSkippedSegment(".git/HEAD"));
+    try t.expect(!hasSkippedSegment("my_node_modules_doc.txt"));
+    try t.expect(!hasSkippedSegment("src/.gitignore"));
+}
+
+test "passesFilter: include/exclude 조합" {
+    const t = std.testing;
+    const f1: Filter = .{};
+    try t.expect(passesFilter("a.ts", f1));
+
+    const f2: Filter = .{ .include = &.{"*.ts"} };
+    try t.expect(passesFilter("a.ts", f2));
+    try t.expect(!passesFilter("a.js", f2));
+
+    const f3: Filter = .{ .exclude = &.{"*.test.ts"} };
+    try t.expect(passesFilter("a.ts", f3));
+    try t.expect(!passesFilter("a.test.ts", f3));
+}

--- a/tests/integration/tests/watch-json.test.ts
+++ b/tests/integration/tests/watch-json.test.ts
@@ -233,4 +233,45 @@ describe("--watch-json", () => {
       await cleanup();
     }
   });
+
+  test("--watch-folder: 그래프 밖 파일 변경도 rebuild 트리거", { timeout: 30000 }, async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `export const v = "initial";`,
+      "assets/config.json": `{"k":1}`,
+    });
+    const outFile = join(dir, "out.js");
+    const jsonOut = join(dir, "ndjson.txt");
+    const assetsDir = join(dir, "assets");
+
+    const proc = spawnWatchJson(
+      [
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        "--watch-json",
+        `--watch-folder=${assetsDir}`,
+      ],
+      jsonOut,
+    );
+
+    try {
+      const readyEvents = await waitForNdjsonLines(jsonOut, 1);
+      expect(readyEvents[0].type).toBe("ready");
+      // entry 파일 1개만 그래프에 있지만 watch-folder로 config.json도 감시 대상에 추가됨
+      expect((readyEvents[0].files as number) >= 2).toBe(true);
+
+      // 그래프 밖 파일 변경
+      await new Promise((r) => setTimeout(r, 1000));
+      writeFileSync(join(assetsDir, "config.json"), `{"k":2}`);
+
+      const events = await waitForNdjsonLines(jsonOut, 2, 15000);
+      const rebuild = events[1];
+      expect(rebuild.type).toBe("rebuild");
+      expect(rebuild.success).toBe(true);
+    } finally {
+      await killAndWait(proc);
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Metro `watchFolders` 호환 옵션 추가 — 번들 그래프 밖 루트를 감시 대상에 포함
- 내부 모델을 `roots + include/exclude glob`으로 일반화 → 나중에 Rollup/Vite `watch.include/exclude` 스펙도 동일 필드로 매핑 가능
- CLI: `--watch-folder=DIR`, `--watch-include=GLOB`, `--watch-exclude=GLOB`
- NAPI/JS: `BuildOptions.watchFolders / watchInclude / watchExclude`

## Design note
Metro류(경로 배열)와 Rollup류(glob 필터) 스펙을 둘 다 수용하려고 내부는 일반화된 표현을 쓴다. 어댑터 레이어에서:
- Metro `watchFolders` → `roots`
- Rollup `watch.include/exclude` → `include`/`exclude` (roots=cwd)

## Scope (MVP)
- roots 내 파일 mtime/해시 체크 기반 — 신규 파일 추가/삭제 감지는 후속
- CLI watch 경로와 NAPI watch 경로 둘 다 구현

## Test plan
- [x] `zig build` / `zig build napi` 통과
- [x] `bun test tests/watch-json.test.ts` — 그래프 밖 파일 변경 → rebuild 수신 검증 (6/6 pass)
- [ ] 번개쪽 실제 RN watchFolders 유스케이스 연동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)