### PR TITLE
fix(core): BuildOptions에 누락 옵션 3개 추가

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -273,6 +273,14 @@ interface BuildOptionsCommon {
   collectModuleCodes?: boolean;
   /** Object.defineProperty에 configurable: true 추가 (RN/Hermes 호환) */
   configurableExports?: boolean;
+  /** ESM 실행 순서 보장 — 함수 선언을 factory 내부 assignment로 다운그레이드해 호이스팅 방지.
+   * Rolldown의 strictExecutionOrder와 동일. React Native 플랫폼에서 자동 활성화. */
+  strictExecutionOrder?: boolean;
+  /** scope hoisting 활성화 (기본 true). 단일 chunk에서 모듈 경계를 제거하고 심볼을 평탄화. */
+  scopeHoist?: boolean;
+  /** Reanimated worklet 변환 — "worklet" 디렉티브 함수에 __workletHash/__closure/__initData 주입.
+   * React Native 플랫폼에서 자동 활성화. */
+  workletTransform?: boolean;
   /** worklet의 `__pluginVersion` 값 (Reanimated dev mode jsVersion 대조용).
    * 사용자 환경의 react-native-worklets 패키지 version을 전달해야 런타임 에러 없음. */
   workletPluginVersion?: string;


### PR DESCRIPTION
## Summary
NAPI(\`napi_entry.zig\`)와 CLI(\`main.zig\`)에서 이미 읽고 있었지만 \`packages/core/index.ts\`의 \`BuildOptionsCommon\` 인터페이스에서 누락되어 있던 옵션 3개를 추가.

- \`strictExecutionOrder\` — ESM 실행 순서 보장 (Rolldown 호환, RN 자동 활성화)
- \`scopeHoist\` — scope hoisting (기본 true)
- \`workletTransform\` — Reanimated worklet 변환 (RN 자동 활성화)

이전에는 JS API 사용자가 해당 옵션을 전달하면 TS 에러가 나는데 런타임은 처리되는 상태였음.

## Test plan
- [x] \`tsc --noEmit\` 통과
- [x] 런타임 동작 변화 없음 (타입만 노출)

🤖 Generated with [Claude Code](https://claude.com/claude-code)