### PR TITLE
feat(resolve): fallback 옵션 (webpack/Metro 호환)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -210,6 +210,10 @@ interface BuildOptionsCommon {
   jsxImportSource?: string;
   define?: Record<string, string>;
   alias?: Record<string, string>;
+  /** Fallback resolution — 일반 해석이 **실패했을 때만** 적용됨 (webpack `resolve.fallback` / Metro `resolver.extraNodeModules` 호환).
+   * 값이 문자열이면 해당 specifier로 재해석, `false`면 빈 모듈로 대체.
+   * 예: `{ crypto: "crypto-browserify", fs: false }` */
+  fallback?: Record<string, string | false>;
   inject?: string[];
   jobs?: number;
   plugins?: ZtsPlugin[];

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -275,6 +275,58 @@ fn getObjectKeyValuePairs(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8
     return result[0..count];
 }
 
+/// fallback 옵션용 — 값이 boolean false이면 null 저장, 문자열이면 그대로. 그 외엔 스킵.
+fn getObjectKeyValuePairsWithNullable(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]struct { []const u8, ?[]const u8 } {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+
+    var prop_names: c.napi_value = undefined;
+    if (c.napi_get_property_names(env, val, &prop_names) != c.napi_ok) return null;
+    var len: u32 = 0;
+    _ = c.napi_get_array_length(env, prop_names, &len);
+    if (len == 0) return null;
+
+    const Pair = struct { []const u8, ?[]const u8 };
+    const result = alloc.alloc(Pair, len) catch return null;
+    var count: u32 = 0;
+    for (0..len) |i| {
+        var prop_key: c.napi_value = undefined;
+        if (c.napi_get_element(env, prop_names, @intCast(i), &prop_key) != c.napi_ok) continue;
+        const k = getStringArg(env, prop_key, alloc) orelse continue;
+
+        var prop_val: c.napi_value = undefined;
+        if (c.napi_get_property(env, val, prop_key, &prop_val) != c.napi_ok) {
+            alloc.free(k);
+            continue;
+        }
+        var val_type: c.napi_valuetype = undefined;
+        _ = c.napi_typeof(env, prop_val, &val_type);
+
+        if (val_type == c.napi_boolean) {
+            var b: bool = false;
+            _ = c.napi_get_value_bool(env, prop_val, &b);
+            // false만 의미 있음 (빈 모듈). true는 "기본값"으로 해석 — 스킵.
+            if (b) {
+                alloc.free(k);
+                continue;
+            }
+            result[count] = .{ k, null };
+            count += 1;
+        } else {
+            const v = getStringArg(env, prop_val, alloc) orelse {
+                alloc.free(k);
+                continue;
+            };
+            result[count] = .{ k, v };
+            count += 1;
+        }
+    }
+    if (count == 0) {
+        alloc.free(result);
+        return null;
+    }
+    return result[0..count];
+}
+
 fn resolveEntryPoint(alloc: std.mem.Allocator, path: []const u8) ?[]const u8 {
     const resolved = std.fs.cwd().realpathAlloc(alloc, path) catch return alloc.dupe(u8, path) catch null;
     return resolved;
@@ -1416,6 +1468,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         .custom_conditions = bundle_opts.conditions,
         .preserve_symlinks = bundle_opts.preserve_symlinks,
         .alias = bundle_opts.alias,
+        .fallback = bundle_opts.fallback,
         .resolve_extensions = bundle_opts.resolve_extensions,
         .main_fields = bundle_opts.main_fields,
         .packages_external = bundle_opts.packages_external,
@@ -2093,6 +2146,21 @@ fn parseBuildOptions(
         alias_entries = als;
     }
 
+    // fallback: { "crypto": "crypto-browserify", "fs": false } → []FallbackEntry
+    // 값이 `false`면 빈 모듈, 문자열이면 해당 specifier로 재해석.
+    const fallback_pairs = getObjectKeyValuePairsWithNullable(env, opts_obj, "fallback", native_alloc);
+    var fallback_entries: []const bundler_mod.types.FallbackEntry = &.{};
+    if (fallback_pairs) |pairs| {
+        const fbs = native_alloc.alloc(bundler_mod.types.FallbackEntry, pairs.len) catch return null;
+        for (pairs, 0..) |pair, idx| {
+            if (!trackStr(owned_strings, pair[0])) return null;
+            if (pair[1]) |v| if (!trackStr(owned_strings, v)) return null;
+            fbs[idx] = .{ .from = pair[0], .to = pair[1] };
+        }
+        native_alloc.free(pairs);
+        fallback_entries = fbs;
+    }
+
     // loader: { ".png": "file", ".svg": "text" } → []LoaderOverride
     const loader_pairs = getObjectKeyValuePairs(env, opts_obj, "loader", native_alloc);
     var loader_overrides: []const bundler_mod.types.LoaderOverride = &.{};
@@ -2207,6 +2275,7 @@ fn parseBuildOptions(
         .external = external orelse &.{},
         .define = define_entries,
         .alias = alias_entries,
+        .fallback = fallback_entries,
         .minify_whitespace = if (minify) true else getObjectBool(env, opts_obj, "minifyWhitespace", false),
         .minify_identifiers = if (minify) true else getObjectBool(env, opts_obj, "minifyIdentifiers", false),
         .minify_syntax = if (minify) true else getObjectBool(env, opts_obj, "minifySyntax", false),

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -82,6 +82,8 @@ pub const BundleOptions = struct {
     preserve_symlinks: bool = false,
     /// import 경로 별칭 (--alias:K=V). resolve 시 specifier 앞부분을 치환.
     alias: []const types.AliasEntry = &.{},
+    /// Fallback (webpack resolve.fallback / Metro extraNodeModules). 해석 실패 시에만 적용.
+    fallback: []const types.FallbackEntry = &.{},
     /// 에셋/청크 URL prefix (--public-path). 동적 import 경로에 적용.
     public_path: []const u8 = "",
     /// 번들 출력 앞에 삽입할 텍스트 (--banner:js)
@@ -337,6 +339,7 @@ pub const Bundler = struct {
                 .custom_conditions = options.conditions,
                 .preserve_symlinks = options.preserve_symlinks,
                 .alias = options.alias,
+                .fallback = options.fallback,
                 .resolve_extensions = options.resolve_extensions,
                 .main_fields = options.main_fields,
                 .packages_external = options.packages_external,

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -134,6 +134,7 @@ pub const IncrementalBundler = struct {
                 .custom_conditions = self.options.conditions,
                 .preserve_symlinks = self.options.preserve_symlinks,
                 .alias = self.options.alias,
+                .fallback = self.options.fallback,
                 .resolve_extensions = self.options.resolve_extensions,
                 .main_fields = self.options.main_fields,
             });

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -117,6 +117,8 @@ pub const ResolveCache = struct {
         custom_conditions: []const []const u8 = &.{},
         preserve_symlinks: bool = false,
         alias: []const resolver_mod.AliasEntry = &.{},
+        /// webpack resolve.fallback / Metro extraNodeModules 호환.
+        fallback: []const resolver_mod.FallbackEntry = &.{},
         resolve_extensions: []const []const u8 = &.{},
         main_fields: []const []const u8 = &.{},
         /// --packages=external: 모든 bare import를 external 처리
@@ -137,6 +139,7 @@ pub const ResolveCache = struct {
         var r = Resolver.init(allocator);
         r.preserve_symlinks = preserve_symlinks;
         r.alias = alias;
+        r.fallback = options.fallback;
         r.custom_extensions = options.resolve_extensions;
         r.main_fields = options.main_fields;
         r.node_paths = options.node_paths;

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -59,6 +59,7 @@ const ts_extension_map: []const struct { from: []const u8, to: []const []const u
 const index_files: []const []const u8 = &.{ "index.ts", "index.tsx", "index.js", "index.jsx" };
 
 pub const AliasEntry = types.AliasEntry;
+pub const FallbackEntry = types.FallbackEntry;
 
 /// 디렉토리 엔트리 캐시 (esbuild 방식).
 /// 디렉토리를 처음 접근할 때 readdir()로 파일 목록을 통째로 읽어 캐시.
@@ -194,6 +195,10 @@ pub const Resolver = struct {
     /// 정확 매칭: "react" → "preact/compat"
     /// 접두사 매칭: "react/hooks" → "preact/compat/hooks"
     alias: []const AliasEntry = &.{},
+    /// Fallback 엔트리 (webpack `resolve.fallback` / Metro `extraNodeModules` 호환).
+    /// alias와 달리 일반 해석이 **실패했을 때만** 적용. 정확 매칭만 지원 (webpack과 동일).
+    /// `to == null`이면 빈 모듈(disabled result)로 대체.
+    fallback: []const FallbackEntry = &.{},
     /// 커스텀 확장자 탐색 순서 (--resolve-extensions). 비어있으면 default_extensions 사용.
     /// RN 예: .ios.ts, .ios.tsx, .native.ts, .native.tsx, .ts, .tsx, .js, .jsx, .json
     custom_extensions: []const []const u8 = &.{},
@@ -234,6 +239,26 @@ pub const Resolver = struct {
         return null;
     }
 
+    /// fallback 매핑을 specifier에 적용. bare 해석 실패 시에만 호출됨.
+    /// 정확 매칭만 (webpack/Metro 동작). to=null이면 빈 모듈, to=path/name이면 재해석.
+    fn applyFallback(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!?ResolveResult {
+        for (self.fallback) |entry| {
+            if (!std.mem.eql(u8, specifier, entry.from)) continue;
+            if (entry.to) |target| {
+                // target을 새로운 specifier로 보고 재해석. fallback 재귀는 막기 위해
+                // 임시로 fallback을 비워 resolve한다 (잘못된 fallback chain 방지).
+                const saved = self.fallback;
+                self.fallback = &.{};
+                defer self.fallback = saved;
+                return try self.resolve(source_dir, target);
+            }
+            // target=null → 빈 모듈 (webpack `false`)
+            const path_dup = self.allocator.dupe(u8, specifier) catch return error.OutOfMemory;
+            return .{ .path = path_dup, .module_type = .javascript, .disabled = true };
+        }
+        return null;
+    }
+
     pub fn resolve(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
         // alias 치환 (resolve 맨 처음에 적용, esbuild 동작과 동일)
         const effective_specifier = if (self.alias.len > 0)
@@ -250,7 +275,12 @@ pub const Resolver = struct {
 
         // bare specifier → node_modules 탐색
         if (!isRelativeOrAbsolute(effective_specifier)) {
-            return self.resolveNodeModules(source_dir, effective_specifier);
+            return self.resolveNodeModules(source_dir, effective_specifier) catch |err| {
+                if (err == error.ModuleNotFound and self.fallback.len > 0) {
+                    if (try self.applyFallback(source_dir, effective_specifier)) |r| return r;
+                }
+                return err;
+            };
         }
 
         // 경로 조합

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -53,6 +53,14 @@ pub const AliasEntry = struct {
     to: []const u8,
 };
 
+/// Fallback 엔트리 (webpack `resolve.fallback` / Metro `resolver.extraNodeModules` 호환).
+/// alias와 달리 일반 해석이 **실패했을 때만** 적용된다 — 설치된 실제 패키지가 있으면 그것이 우선.
+/// `to == null`이면 빈 모듈로 대체 (webpack `false` 의미).
+pub const FallbackEntry = struct {
+    from: []const u8,
+    to: ?[]const u8,
+};
+
 // ============================================================
 // Import 종류
 // ============================================================

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,6 +72,9 @@ const CliOptions = struct {
     timing: bool = false,
     preserve_symlinks: bool = false,
     alias_list: std.ArrayList(AliasEntry) = .empty,
+    /// --fallback:NAME=PATH (webpack resolve.fallback). 일반 해석 실패 시에만 적용.
+    /// PATH 대신 "false"로 쓰면 빈 모듈로 대체.
+    fallback_list: std.ArrayList(FallbackEntry) = .empty,
     public_path: ?[]const u8 = null,
     banner_js: ?[]const u8 = null,
     footer_js: ?[]const u8 = null,
@@ -176,6 +179,7 @@ const CliOptions = struct {
     };
 
     const AliasEntry = BundleOptions.AliasEntry;
+    const FallbackEntry = @import("zts_lib").bundler.types.FallbackEntry;
     const LoaderOverride = @import("zts_lib").bundler.types.LoaderOverride;
     const LoaderEnum = @import("zts_lib").bundler.types.Loader;
     const LegalCommentsEnum = @import("zts_lib").bundler.types.LegalComments;
@@ -195,6 +199,7 @@ const CliOptions = struct {
         self.define_list.deinit(alloc);
         self.conditions_list.deinit(alloc);
         self.alias_list.deinit(alloc);
+        self.fallback_list.deinit(alloc);
         self.loader_list.deinit(alloc);
         for (self.inject_list.items) |p| alloc.free(p);
         self.inject_list.deinit(alloc);
@@ -501,6 +506,20 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
                 });
             } else {
                 try stderr.print("zts: --alias requires FROM=TO format: {s}\n", .{arg});
+                std.process.exit(1);
+            }
+        } else if (std.mem.startsWith(u8, arg, "--fallback:")) {
+            // --fallback:crypto=crypto-browserify (webpack resolve.fallback 호환)
+            // --fallback:fs=false → 빈 모듈
+            const kv = arg["--fallback:".len..];
+            if (std.mem.indexOf(u8, kv, "=")) |eq_pos| {
+                const value = kv[eq_pos + 1 ..];
+                try opts.fallback_list.append(allocator, .{
+                    .from = kv[0..eq_pos],
+                    .to = if (std.mem.eql(u8, value, "false")) null else value,
+                });
+            } else {
+                try stderr.print("zts: --fallback requires NAME=PATH or NAME=false: {s}\n", .{arg});
                 std.process.exit(1);
             }
         } else if (std.mem.startsWith(u8, arg, "--public-path=")) {
@@ -1386,6 +1405,7 @@ pub fn main() !void {
             .timing = opts.timing,
             .preserve_symlinks = opts.preserve_symlinks,
             .alias = opts.alias_list.items,
+            .fallback = opts.fallback_list.items,
             .public_path = opts.public_path orelse "",
             .banner_js = opts.banner_js,
             .footer_js = opts.footer_js,
@@ -1738,6 +1758,7 @@ pub fn main() !void {
                 .custom_conditions = bundle_opts.conditions,
                 .preserve_symlinks = bundle_opts.preserve_symlinks,
                 .alias = bundle_opts.alias,
+                .fallback = bundle_opts.fallback,
                 .resolve_extensions = bundle_opts.resolve_extensions,
                 .main_fields = bundle_opts.main_fields,
                 .packages_external = bundle_opts.packages_external,

--- a/tests/integration/tests/resolve-fallback.test.ts
+++ b/tests/integration/tests/resolve-fallback.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "bun:test";
+import { createFixture, runZts, bundleAndRun } from "./helpers";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+/**
+ * --fallback (webpack resolve.fallback / Metro extraNodeModules 호환) 통합 테스트.
+ *
+ * 핵심 시맨틱:
+ * 1. 설치된 실제 패키지가 있으면 fallback 무시 — alias와의 차이점
+ * 2. 해석 실패 시에만 fallback 적용
+ * 3. `=false`이면 빈 모듈 (webpack "resolve.fallback에 false")
+ */
+describe("--fallback", () => {
+  test("해석 실패 시 fallback으로 대체된다", async () => {
+    const { bundleOutput, runOutput, exitCode, cleanup } = await bundleAndRun(
+      {
+        "entry.ts": `import { shim } from "missing-mod"; console.log(shim);`,
+        "shim.ts": `export const shim = "from-shim";`,
+      },
+      "entry.ts",
+      ["--fallback:missing-mod=./shim.ts"],
+    );
+    try {
+      expect(exitCode).toBe(0);
+      expect(runOutput).toBe("from-shim");
+      expect(bundleOutput).toBeDefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("설치된 실제 모듈이 있으면 fallback 무시 (alias와 구별되는 핵심 시맨틱)", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import { real } from "real-mod"; console.log(real);`,
+      "node_modules/real-mod/package.json": `{"name":"real-mod","main":"index.js"}`,
+      "node_modules/real-mod/index.js": `export const real = "from-real";`,
+      "shim.ts": `export const real = "from-shim";`,
+    });
+    const outFile = join(dir, "out.js");
+    try {
+      const { exitCode, stderr } = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        `--fallback:real-mod=${join(dir, "shim.ts")}`,
+      ]);
+      expect(exitCode).toBe(0);
+      const output = readFileSync(outFile, "utf8");
+      // fallback은 실패 시에만 적용 — 실제 패키지의 "from-real"이 나와야 함
+      expect(output).toContain("from-real");
+      expect(output).not.toContain("from-shim");
+      expect(stderr).not.toContain("error");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("--fallback:NAME=false — 빈 모듈로 대체", async () => {
+    const { bundleOutput, runOutput, exitCode, cleanup } = await bundleAndRun(
+      {
+        "entry.ts": `import * as m from "missing-mod"; console.log(typeof m);`,
+      },
+      "entry.ts",
+      ["--fallback:missing-mod=false"],
+    );
+    try {
+      expect(exitCode).toBe(0);
+      // 빈 모듈은 CJS 빈 객체 → typeof는 "object"
+      expect(runOutput).toBe("object");
+      expect(bundleOutput).toBeDefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("fallback 없이는 해석 실패 — 에러", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import { x } from "missing-mod"; console.log(x);`,
+    });
+    const outFile = join(dir, "out.js");
+    try {
+      const { stderr } = await runZts(["--bundle", join(dir, "entry.ts"), "-o", outFile]);
+      expect(stderr.toLowerCase()).toContain("cannot resolve");
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
\`resolve.fallback\` (webpack) / \`resolver.extraNodeModules\` (Metro)와 동일 시맨틱의 옵션 추가. alias와 달리 **일반 해석이 실패했을 때만** 적용되므로 설치된 실제 패키지가 있으면 그것이 우선 — Node 빌트인 폴리필, optional peer dep shim 같은 유스케이스에 적합.

## API
\`\`\`js
// JS API
build({
  fallback: {
    crypto: 'crypto-browserify',   // 해석 실패 시 재해석
    fs: false,                      // 빈 모듈로
  }
})

// CLI
zts --bundle entry.ts --fallback:crypto=crypto-browserify --fallback:fs=false
\`\`\`

## 왜 alias가 아닌 별도 옵션인가
- \`alias\`: **무조건** 치환 → 실제 패키지 설치돼도 덮어씀
- \`fallback\`: 실패 시에만 → 실제 패키지 우선, 없을 때만 shim

webpack 5에서 Node 빌트인 자동 폴리필 제거 후 마이그레이션의 1번 걸림돌. Metro에서도 동일한 패턴.

## Test plan
- [x] \`zig build\` / \`zig build napi\` 통과
- [x] 통합 테스트 4/4 통과 — 실제 패키지 우선 시맨틱 검증 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)