### PR TITLE
feat(asset): Metro AssetRegistry 호환 출력 (RN 전용 레이어)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -204,6 +204,12 @@ interface BuildOptionsCommon {
   entryNames?: string;
   chunkNames?: string;
   assetNames?: string;
+  /** Metro AssetRegistry 모듈 경로 (React Native 전용 레이어).
+   * - `undefined`: 플랫폼 프리셋 결정 (`platform: "react-native"`이면 기본 경로 자동)
+   * - `string`: 해당 경로의 registerAsset을 사용해 `module.exports = require(path).registerAsset({...})`로 래핑
+   * - `false`: 비활성화 (웹과 동일한 URL 문자열 export)
+   * 기본 경로: `"react-native/Libraries/Image/AssetRegistry"` */
+  assetRegistry?: string | false;
   jsx?: "classic" | "automatic" | "automatic-dev";
   jsxFactory?: string;
   jsxFragment?: string;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2099,6 +2099,28 @@ fn parseBuildOptions(
     const entry_names = ownStr(env, opts_obj, "entryNames", owned_strings);
     const chunk_names = ownStr(env, opts_obj, "chunkNames", owned_strings);
     const asset_names = ownStr(env, opts_obj, "assetNames", owned_strings);
+    // assetRegistry: string (경로), null/undefined (플랫폼 프리셋 결정), false (명시적 off).
+    // false를 구분하기 위해 boolean 타입을 별도 체크.
+    const asset_registry: ?[]const u8 = blk: {
+        if (getNamedProperty(env, opts_obj, "assetRegistry")) |v| {
+            var t: c.napi_valuetype = undefined;
+            _ = c.napi_typeof(env, v, &t);
+            if (t == c.napi_boolean) {
+                var b: bool = false;
+                _ = c.napi_get_value_bool(env, v, &b);
+                if (!b) break :blk null; // false → off (RN preset도 덮음)
+            } else if (t == c.napi_string) {
+                const s = getStringArg(env, v, native_alloc) orelse break :blk null;
+                if (!trackStr(owned_strings, s)) return null;
+                break :blk s;
+            }
+        }
+        // 미지정 + RN 플랫폼 → 기본 경로. 그 외 → null.
+        if (platform == .react_native) {
+            break :blk bundler_mod.RN_DEFAULT_ASSET_REGISTRY;
+        }
+        break :blk null;
+    };
 
     // JSX
     const jsx_str = ownStr(env, opts_obj, "jsx", owned_strings);
@@ -2301,6 +2323,7 @@ fn parseBuildOptions(
         .entry_names = entry_names orelse "[name]",
         .chunk_names = chunk_names orelse "[name]-[hash]",
         .asset_names = asset_names orelse "[name]-[hash]",
+        .asset_registry = asset_registry,
         .jsx_runtime = jsx_runtime,
         .jsx_factory = jsx_factory orelse "React.createElement",
         .jsx_fragment = jsx_fragment orelse "React.Fragment",

--- a/src/bundler/asset_meta.zig
+++ b/src/bundler/asset_meta.zig
@@ -1,0 +1,166 @@
+//! 이미지 파일 헤더에서 dimension과 MIME 서브타입을 추출.
+//! 이미지 전체를 디코딩하지 않고 헤더 바이트만 읽는 최소 구현.
+//!
+//! 지원 포맷: PNG, JPEG, GIF, WEBP.
+//! 지원 안 함: SVG(벡터 — 치수 없음, XML 파싱 필요), BMP, HEIC.
+
+const std = @import("std");
+
+pub const Dimensions = struct {
+    width: u32,
+    height: u32,
+};
+
+pub const AssetType = enum {
+    png,
+    jpg,
+    gif,
+    webp,
+    unknown,
+
+    pub fn fromExtension(ext: []const u8) AssetType {
+        if (std.ascii.eqlIgnoreCase(ext, ".png")) return .png;
+        if (std.ascii.eqlIgnoreCase(ext, ".jpg") or std.ascii.eqlIgnoreCase(ext, ".jpeg")) return .jpg;
+        if (std.ascii.eqlIgnoreCase(ext, ".gif")) return .gif;
+        if (std.ascii.eqlIgnoreCase(ext, ".webp")) return .webp;
+        return .unknown;
+    }
+
+    /// RN AssetRegistry의 `type` 필드용 — 점 없는 확장자 이름.
+    pub fn typeName(self: AssetType, fallback_ext: []const u8) []const u8 {
+        return switch (self) {
+            .png => "png",
+            .jpg => "jpg",
+            .gif => "gif",
+            .webp => "webp",
+            .unknown => if (fallback_ext.len > 0 and fallback_ext[0] == '.') fallback_ext[1..] else fallback_ext,
+        };
+    }
+};
+
+/// 파일 바이트에서 이미지 dimension을 추출. 알려진 포맷이 아니면 null.
+pub fn extractDimensions(bytes: []const u8) ?Dimensions {
+    if (parsePng(bytes)) |d| return d;
+    if (parseGif(bytes)) |d| return d;
+    if (parseWebp(bytes)) |d| return d;
+    if (parseJpeg(bytes)) |d| return d;
+    return null;
+}
+
+/// PNG: signature(8) + IHDR chunk(13 bytes) starts at byte 8.
+/// IHDR: length(4) + "IHDR"(4) + width(4 BE) + height(4 BE) + ...
+fn parsePng(b: []const u8) ?Dimensions {
+    if (b.len < 24) return null;
+    const sig = [_]u8{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+    if (!std.mem.eql(u8, b[0..8], &sig)) return null;
+    if (!std.mem.eql(u8, b[12..16], "IHDR")) return null;
+    const w = std.mem.readInt(u32, b[16..20], .big);
+    const h = std.mem.readInt(u32, b[20..24], .big);
+    return .{ .width = w, .height = h };
+}
+
+/// GIF: "GIF87a"/"GIF89a"(6) + width(2 LE) + height(2 LE).
+fn parseGif(b: []const u8) ?Dimensions {
+    if (b.len < 10) return null;
+    if (!std.mem.startsWith(u8, b, "GIF87a") and !std.mem.startsWith(u8, b, "GIF89a")) return null;
+    const w = std.mem.readInt(u16, b[6..8], .little);
+    const h = std.mem.readInt(u16, b[8..10], .little);
+    return .{ .width = w, .height = h };
+}
+
+/// WEBP: "RIFF"(4) + size(4) + "WEBP"(4) + VP8/VP8L/VP8X chunk.
+fn parseWebp(b: []const u8) ?Dimensions {
+    if (b.len < 30) return null;
+    if (!std.mem.eql(u8, b[0..4], "RIFF")) return null;
+    if (!std.mem.eql(u8, b[8..12], "WEBP")) return null;
+
+    // VP8 (lossy): "VP8 " at 12, dimensions at offset 26-29 (14 bits each)
+    if (std.mem.eql(u8, b[12..16], "VP8 ")) {
+        const w_raw = std.mem.readInt(u16, b[26..28], .little);
+        const h_raw = std.mem.readInt(u16, b[28..30], .little);
+        return .{ .width = w_raw & 0x3FFF, .height = h_raw & 0x3FFF };
+    }
+    // VP8L (lossless): "VP8L" at 12, dimensions packed in 4 bytes at offset 21
+    if (std.mem.eql(u8, b[12..16], "VP8L")) {
+        if (b.len < 25) return null;
+        const packed_bits = std.mem.readInt(u32, b[21..25], .little);
+        const w = (packed_bits & 0x3FFF) + 1;
+        const h = ((packed_bits >> 14) & 0x3FFF) + 1;
+        return .{ .width = w, .height = h };
+    }
+    // VP8X (extended): "VP8X" + flags(4) + canvas_width-1(3 LE) + canvas_height-1(3 LE)
+    if (std.mem.eql(u8, b[12..16], "VP8X")) {
+        if (b.len < 30) return null;
+        const w = 1 + @as(u32, b[24]) + (@as(u32, b[25]) << 8) + (@as(u32, b[26]) << 16);
+        const h = 1 + @as(u32, b[27]) + (@as(u32, b[28]) << 8) + (@as(u32, b[29]) << 16);
+        return .{ .width = w, .height = h };
+    }
+    return null;
+}
+
+/// JPEG: SOI(0xFFD8) + 여러 marker segments. SOF0/SOF2(0xFFC0/0xFFC2) marker에 dimension.
+fn parseJpeg(b: []const u8) ?Dimensions {
+    if (b.len < 4) return null;
+    if (b[0] != 0xFF or b[1] != 0xD8) return null;
+
+    var i: usize = 2;
+    while (i + 9 < b.len) {
+        if (b[i] != 0xFF) return null;
+        // padding FF는 스킵
+        while (i < b.len and b[i] == 0xFF) i += 1;
+        if (i >= b.len) return null;
+        const marker = b[i];
+        i += 1;
+
+        // SOF0/SOF1/SOF2/SOF3 — dimension 있음 (JPEG baseline/extended/progressive/lossless)
+        if (marker == 0xC0 or marker == 0xC1 or marker == 0xC2 or marker == 0xC3) {
+            if (i + 7 >= b.len) return null;
+            // segment: length(2) + precision(1) + height(2 BE) + width(2 BE)
+            const h = std.mem.readInt(u16, b[i + 3 ..][0..2], .big);
+            const w = std.mem.readInt(u16, b[i + 5 ..][0..2], .big);
+            return .{ .width = w, .height = h };
+        }
+
+        // standalone markers (no segment): RST0-7, SOI, EOI 등
+        if ((marker >= 0xD0 and marker <= 0xD9) or marker == 0x01) continue;
+
+        // segment 건너뛰기
+        if (i + 1 >= b.len) return null;
+        const seg_len = std.mem.readInt(u16, b[i..][0..2], .big);
+        if (seg_len < 2) return null;
+        i += seg_len;
+    }
+    return null;
+}
+
+test "PNG dimensions" {
+    // 1x1 PNG (red pixel)
+    const bytes = [_]u8{
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 'I',  'H',  'D',  'R',
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    };
+    const d = extractDimensions(&bytes) orelse return error.ExpectedDims;
+    try std.testing.expectEqual(@as(u32, 1), d.width);
+    try std.testing.expectEqual(@as(u32, 1), d.height);
+}
+
+test "GIF dimensions" {
+    const bytes = [_]u8{ 'G', 'I', 'F', '8', '9', 'a', 0x0A, 0x00, 0x14, 0x00 };
+    const d = extractDimensions(&bytes) orelse return error.ExpectedDims;
+    try std.testing.expectEqual(@as(u32, 10), d.width);
+    try std.testing.expectEqual(@as(u32, 20), d.height);
+}
+
+test "unknown format returns null" {
+    const bytes = [_]u8{ 'J', 'U', 'N', 'K' };
+    try std.testing.expect(extractDimensions(&bytes) == null);
+}
+
+test "AssetType.fromExtension" {
+    try std.testing.expectEqual(AssetType.png, AssetType.fromExtension(".png"));
+    try std.testing.expectEqual(AssetType.png, AssetType.fromExtension(".PNG"));
+    try std.testing.expectEqual(AssetType.jpg, AssetType.fromExtension(".jpg"));
+    try std.testing.expectEqual(AssetType.jpg, AssetType.fromExtension(".jpeg"));
+    try std.testing.expectEqual(AssetType.unknown, AssetType.fromExtension(".xyz"));
+}

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -40,6 +40,10 @@ pub const ReactNativeBoolPreset = struct {
 };
 pub const RN_BOOL_PRESET: ReactNativeBoolPreset = .{};
 
+/// RN 프리셋에서 asset_registry 미지정 시 사용할 기본 AssetRegistry 모듈 경로.
+/// RN 코어가 제공하는 표준 경로 (Metro와 동일).
+pub const RN_DEFAULT_ASSET_REGISTRY: []const u8 = "react-native/Libraries/Image/AssetRegistry";
+
 pub const BundleOptions = struct {
     entry_points: []const []const u8,
     format: EmitOptions.Format = .esm,
@@ -84,6 +88,10 @@ pub const BundleOptions = struct {
     alias: []const types.AliasEntry = &.{},
     /// Fallback (webpack resolve.fallback / Metro extraNodeModules). 해석 실패 시에만 적용.
     fallback: []const types.FallbackEntry = &.{},
+    /// Metro AssetRegistry 모듈 경로. null이면 일반 URL 문자열 export (웹/esbuild 방식).
+    /// 설정 시 file/copy 로더가 `module.exports = require("<path>").registerAsset({...})` 형태로 래핑.
+    /// RN 플랫폼 프리셋에서 "react-native/Libraries/Image/AssetRegistry"로 자동 설정.
+    asset_registry: ?[]const u8 = null,
     /// 에셋/청크 URL prefix (--public-path). 동적 import 경로에 적용.
     public_path: []const u8 = "",
     /// 번들 출력 앞에 삽입할 텍스트 (--banner:js)
@@ -598,6 +606,7 @@ pub const Bundler = struct {
         graph.loader_overrides = self.options.loader_overrides;
         graph.public_path = self.options.public_path;
         graph.asset_names = self.options.asset_names;
+        graph.asset_registry = self.options.asset_registry;
         // --inject와 --run-before-main을 합쳐서 엔트리 의존성으로 추가 (실행 순서: inject → run-before-main → entry)
         const combined_inject = if (self.options.run_before_main.len > 0)
             try std.mem.concat(self.allocator, []const u8, &.{ self.options.inject, self.options.run_before_main })

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -71,6 +71,8 @@ pub const ModuleGraph = struct {
     public_path: []const u8 = "",
     /// 에셋 파일명 패턴 (--asset-names). asset 로더에서 사용.
     asset_names: []const u8 = "[name]-[hash]",
+    /// Metro AssetRegistry 모듈 경로. null이면 URL 문자열, 값이 있으면 registerAsset 래핑.
+    asset_registry: ?[]const u8 = null,
     /// 엔트리 포인트 기준 디렉토리. [dir] 패턴 치환에 사용.
     /// entry point들의 공통 부모 디렉토리 (esbuild --outbase에 해당).
     entry_dir: []const u8 = "",
@@ -1713,10 +1715,16 @@ pub const ModuleGraph = struct {
                         return;
                     };
 
-                module.source = std.fmt.allocPrint(arena_alloc, "\"{s}\"", .{url}) catch {
-                    module.state = .ready;
-                    return;
-                };
+                module.source = if (self.asset_registry) |registry_path|
+                    emitAssetRegistryCall(arena_alloc, registry_path, module.path, raw, &hash, ext, name_without_ext, url) catch {
+                        module.state = .ready;
+                        return;
+                    }
+                else
+                    std.fmt.allocPrint(arena_alloc, "\"{s}\"", .{url}) catch {
+                        module.state = .ready;
+                        return;
+                    };
             },
             .empty => {
                 module.source = "undefined";
@@ -1863,6 +1871,49 @@ fn applyAssetNamingPattern(
     // 확장자 추가
     try buf.appendSlice(allocator, ext);
     return buf.toOwnedSlice(allocator);
+}
+
+/// Metro AssetRegistry.registerAsset() 호출식을 생성.
+/// RN 런타임은 이 객체의 키를 정확히 요구하므로 shape를 Metro 1:1로 맞춘다.
+/// 스코프 주의: scales는 MVP에서 [1]로 고정. @2x/@3x 자동 그룹화는 후속 작업.
+fn emitAssetRegistryCall(
+    alloc: std.mem.Allocator,
+    registry_path: []const u8,
+    abs_path: []const u8,
+    bytes: []const u8,
+    hash: *const [8]u8,
+    ext: []const u8,
+    name_without_ext: []const u8,
+    url: []const u8,
+) ![]const u8 {
+    const asset_meta = @import("asset_meta.zig");
+    const dims = asset_meta.extractDimensions(bytes);
+    const width = if (dims) |d| d.width else 0;
+    const height = if (dims) |d| d.height else 0;
+    const asset_type = asset_meta.AssetType.fromExtension(ext);
+    const type_name = asset_type.typeName(ext);
+
+    // httpServerLocation: url의 앞부분(파일명 제외). dev server가 제공하는 path.
+    const http_loc = std.fs.path.dirname(url) orelse ".";
+    const fs_dir = std.fs.path.dirname(abs_path) orelse ".";
+
+    // hash는 8바이트 이진 → 16자리 hex 문자열
+    var hash_hex: [16]u8 = undefined;
+    _ = std.fmt.bufPrint(&hash_hex, "{x:0>16}", .{std.mem.readInt(u64, hash, .big)}) catch unreachable;
+
+    return try std.fmt.allocPrint(alloc,
+        \\module.exports = require("{s}").registerAsset({{
+        \\  "__packager_asset": true,
+        \\  "httpServerLocation": "{s}",
+        \\  "width": {d},
+        \\  "height": {d},
+        \\  "scales": [1],
+        \\  "hash": "{s}",
+        \\  "name": "{s}",
+        \\  "type": "{s}",
+        \\  "fileSystemLocation": "{s}"
+        \\}})
+    , .{ registry_path, http_loc, width, height, &hash_hex, name_without_ext, type_name, fs_dir });
 }
 
 /// asset 파일의 entry_dir 기준 상대 디렉토리 경로를 계산한다.

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -39,6 +39,7 @@ pub const module_store = @import("module_store.zig");
 pub const css_scanner = @import("css_scanner.zig");
 pub const css_emitter = @import("css_emitter.zig");
 pub const symbol = @import("symbol.zig");
+pub const asset_meta = @import("asset_meta.zig");
 
 // 공개 타입 re-export
 pub const ModuleIndex = types.ModuleIndex;
@@ -65,6 +66,7 @@ pub const Bundler = bundler_core.Bundler;
 pub const BundleOptions = bundler_core.BundleOptions;
 pub const BundleResult = bundler_core.BundleResult;
 pub const RN_BOOL_PRESET = bundler_core.RN_BOOL_PRESET;
+pub const RN_DEFAULT_ASSET_REGISTRY = bundler_core.RN_DEFAULT_ASSET_REGISTRY;
 pub const Plugin = plugin.Plugin;
 pub const PluginRunner = plugin.PluginRunner;
 pub const SubprocessPlugin = subprocess_plugin.SubprocessPlugin;
@@ -115,6 +117,7 @@ test {
     _ = @import("types_test.zig");
     _ = @import("module_test.zig");
     _ = @import("plugin_test.zig");
+    _ = asset_meta;
     _ = incremental;
     _ = @import("incremental_test.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -87,6 +87,11 @@ const CliOptions = struct {
     entry_names: []const u8 = "[name]",
     chunk_names: []const u8 = "[name]-[hash]",
     asset_names: []const u8 = "[name]-[hash]",
+    /// --asset-registry=PATH: Metro AssetRegistry 모듈 경로. null=일반 URL, ""(명시적 off),
+    /// RN 플랫폼은 미지정 시 기본 경로 자동 적용.
+    asset_registry: ?[]const u8 = null,
+    /// 사용자가 명시적으로 --no-asset-registry를 전달했는지 (RN 프리셋 자동 적용 억제용).
+    asset_registry_explicit_off: bool = false,
     loader_list: std.ArrayList(LoaderOverride) = .empty,
     metafile_path: ?[]const u8 = null,
     analyze: bool = false,
@@ -554,6 +559,11 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             opts.chunk_names = arg["--chunk-names=".len..];
         } else if (std.mem.startsWith(u8, arg, "--asset-names=")) {
             opts.asset_names = arg["--asset-names=".len..];
+        } else if (std.mem.startsWith(u8, arg, "--asset-registry=")) {
+            opts.asset_registry = arg["--asset-registry=".len..];
+        } else if (std.mem.eql(u8, arg, "--no-asset-registry")) {
+            opts.asset_registry = null;
+            opts.asset_registry_explicit_off = true;
         } else if (std.mem.startsWith(u8, arg, "--metafile=")) {
             opts.metafile_path = arg["--metafile=".len..];
         } else if (std.mem.eql(u8, arg, "--metafile")) {
@@ -1331,6 +1341,10 @@ pub fn main() !void {
             opts.configurable_exports = rn_preset.configurable_exports;
             opts.strict_execution_order = rn_preset.strict_execution_order;
             opts.worklet_transform = rn_preset.worklet_transform;
+            // RN: 사용자가 --asset-registry/--no-asset-registry를 명시하지 않았으면 Metro 표준 경로 자동 적용.
+            if (opts.asset_registry == null and !opts.asset_registry_explicit_off) {
+                opts.asset_registry = lib.bundler.RN_DEFAULT_ASSET_REGISTRY;
+            }
             // Metro는 automatic JSX transform 사용 — 사용자가 명시하지 않았으면 자동 설정
             if (opts.jsx_runtime == null) {
                 opts.jsx_runtime = .automatic;
@@ -1417,6 +1431,7 @@ pub fn main() !void {
             .entry_names = opts.entry_names,
             .chunk_names = opts.chunk_names,
             .asset_names = opts.asset_names,
+            .asset_registry = opts.asset_registry,
             .loader_overrides = opts.loader_list.items,
             .metafile = opts.metafile_path != null or opts.analyze,
             .analyze = opts.analyze,

--- a/tests/integration/tests/asset-registry.test.ts
+++ b/tests/integration/tests/asset-registry.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect } from "bun:test";
+import { createFixture, runZts } from "./helpers";
+import { join } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
+
+/**
+ * --asset-registry / assetRegistry 통합 테스트.
+ *
+ * Metro AssetRegistry 호환 출력:
+ *   module.exports = require("<registry>").registerAsset({
+ *     __packager_asset: true, httpServerLocation, width, height, scales,
+ *     hash, name, type, fileSystemLocation
+ *   })
+ */
+
+// 1x1 PNG 픽셀 (빨강)
+const PNG_1x1 = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+  0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0x99, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+  0x00, 0x00, 0x03, 0x00, 0x01, 0x5b, 0xf4, 0x7c, 0x3b, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+  0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+
+describe("--asset-registry", () => {
+  test("RN 플랫폼 프리셋 → 기본 registry 경로 자동 주입", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import logo from "./logo.png"; console.log(logo);`,
+    });
+    writeFileSync(join(dir, "logo.png"), PNG_1x1);
+
+    const outFile = join(dir, "out.js");
+    try {
+      const { exitCode, stderr } = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        "--platform=react-native",
+        "--loader:.png=file",
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("error:");
+      const bundle = readFileSync(outFile, "utf8");
+      expect(bundle).toContain("react-native/Libraries/Image/AssetRegistry");
+      expect(bundle).toContain("registerAsset");
+      expect(bundle).toContain("__packager_asset");
+      expect(bundle).toContain('"width": 1');
+      expect(bundle).toContain('"height": 1');
+      expect(bundle).toContain('"type": "png"');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("--asset-registry=PATH로 커스텀 registry 경로 지정 가능", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import logo from "./logo.png"; console.log(logo);`,
+    });
+    writeFileSync(join(dir, "logo.png"), PNG_1x1);
+
+    const outFile = join(dir, "out.js");
+    try {
+      const { exitCode } = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        "--loader:.png=file",
+        "--asset-registry=@my/custom-registry",
+      ]);
+      expect(exitCode).toBe(0);
+      const bundle = readFileSync(outFile, "utf8");
+      expect(bundle).toContain("@my/custom-registry");
+      expect(bundle).toContain("registerAsset");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("--no-asset-registry로 RN 프리셋 덮기 (URL 문자열만)", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import logo from "./logo.png"; console.log(logo);`,
+    });
+    writeFileSync(join(dir, "logo.png"), PNG_1x1);
+
+    const outFile = join(dir, "out.js");
+    try {
+      const { exitCode } = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        "--platform=react-native",
+        "--loader:.png=file",
+        "--no-asset-registry",
+      ]);
+      expect(exitCode).toBe(0);
+      const bundle = readFileSync(outFile, "utf8");
+      expect(bundle).not.toContain("registerAsset");
+      expect(bundle).not.toContain("__packager_asset");
+      // 그냥 URL 문자열로 export
+      expect(bundle).toMatch(/logo-[a-f0-9]+\.png/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("비-RN 플랫폼 + registry 미지정 → 일반 URL 문자열 (기존 동작 유지)", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import logo from "./logo.png"; console.log(logo);`,
+    });
+    writeFileSync(join(dir, "logo.png"), PNG_1x1);
+
+    const outFile = join(dir, "out.js");
+    try {
+      const { exitCode } = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        "--loader:.png=file",
+      ]);
+      expect(exitCode).toBe(0);
+      const bundle = readFileSync(outFile, "utf8");
+      expect(bundle).not.toContain("registerAsset");
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
RN 번들에서 이미지 import가 Metro의 `AssetRegistry.registerAsset({...})` 형식으로 출력되도록 지원. 웹용 loader는 그대로 유지되고, 그 위에 **RN 전용 래핑 레이어**만 추가.

## API
\`\`\`ts
build({
  platform: 'react-native',
  loader: { '.png': 'file' },
  // assetRegistry 미지정 → RN 프리셋이 기본 경로 자동 주입
  // 커스텀:  assetRegistry: '@my/custom-registry'
  // 명시적 off: assetRegistry: false  (일반 URL 문자열 export)
})
\`\`\`

CLI: \`--asset-registry=PATH\` / \`--no-asset-registry\`

## 출력 예
\`\`\`js
module.exports = require("react-native/Libraries/Image/AssetRegistry").registerAsset({
  "__packager_asset": true,
  "httpServerLocation": ".",
  "width": 100, "height": 100,
  "scales": [1],
  "hash": "abc123...",
  "name": "logo",
  "type": "png",
  "fileSystemLocation": "/abs/path"
});
\`\`\`

## 설계
- **축 분리**: 웹/범용 에셋 처리(`loader`, `publicPath`, `assetNames`)는 기존 그대로 / RN 전용 래핑(`assetRegistry`)은 별도 옵션
- 네이밍을 Metro 전문 용어(`AssetRegistry`)로 맞춰 웹 유저 혼란 방지

## 스코프 제한 (MVP)
- `scales: [1]` 고정 — `@2x`/`@3x` variant 자동 묶기는 후속 PR
- PNG/JPEG/GIF/WEBP만 dimension 추출 지원 (SVG/BMP/HEIC는 폭·높이 0)

## Test plan
- [x] \`zig build\` / \`zig build napi\` / \`zig build test\` 통과
- [x] 통합 테스트 4개 — RN 기본/커스텀 경로/명시적 off/비-RN 유지 검증
- [x] asset_meta 유닛 테스트 4개 — PNG/GIF dimension 추출 + AssetType enum
- [ ] 번개 실제 RN 프로젝트 연동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)