### PR TITLE
feat(resolver): blockList — Metro 호환 해석 차단

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -220,6 +220,16 @@ interface BuildOptionsCommon {
    * 값이 문자열이면 해당 specifier로 재해석, `false`면 빈 모듈로 대체.
    * 예: `{ crypto: "crypto-browserify", fs: false }` */
   fallback?: Record<string, string | false>;
+  /** 해석 차단 패턴 (Metro `resolver.blockList` / webpack `IgnorePlugin` 호환).
+   * 매칭되는 절대 경로는 resolver가 해석 실패시켜 번들 그래프에 포함되지 않는다.
+   * - `RegExp`: `.source`를 추출해 패턴으로 사용
+   * - `string`: regex 문자열 그대로 사용
+   *
+   * 지원 구문: 리터럴, `.*`, `^`, `$`, `\x` 이스케이프. `|`, `[]`, `()`, `+?`, `\w\d`는 미지원.
+   *
+   * `platform: "react-native"` 시 Metro 기본 패턴들(`__tests__`, iOS/Android 빌드 폴더 등)이
+   * 자동 prepend된다. 사용자 패턴은 그 뒤에 append. */
+  blockList?: (RegExp | string)[];
   inject?: string[];
   jobs?: number;
   plugins?: ZtsPlugin[];
@@ -579,6 +589,14 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   delete napiOptions.outdir;
   delete napiOptions.plugins;
   delete napiOptions.allowOverwrite;
+  // blockList: RegExp는 .source로 추출해 string[]으로 넘긴다 (NAPI는 string만).
+  if (options.blockList) {
+    napiOptions.blockList = options.blockList.map((p) => {
+      if (p instanceof RegExp) return p.source;
+      if (typeof p === "string") return p;
+      throw new TypeError(`blockList entries must be RegExp or string, got ${typeof p}`);
+    });
+  }
   // browserslist → unsupported bitmask. transpile과 동일한 resolveUnsupported 재사용.
   if (options.browserslist) {
     napiOptions.unsupported = resolveUnsupported({ browserslist: options.browserslist });

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2282,6 +2282,13 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
+    // blockList: string[] (JS 쪽에서 RegExp는 .source로 변환해서 전달)
+    const block_list = getObjectStringArray(env, opts_obj, "blockList", native_alloc);
+    if (block_list) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
     // nodePaths: string[]
     const node_paths = getObjectStringArray(env, opts_obj, "nodePaths", native_alloc);
     if (node_paths) |arr| {
@@ -2298,6 +2305,15 @@ fn parseBuildOptions(
         .define = define_entries,
         .alias = alias_entries,
         .fallback = fallback_entries,
+        .block_list = blk: {
+            const user = block_list orelse &.{};
+            if (platform == .react_native) {
+                const merged = std.mem.concat(native_alloc, []const u8, &.{ bundler_mod.RN_DEFAULT_BLOCK_LIST, user }) catch return null;
+                if (!trackArr(owned_string_arrays, merged)) return null;
+                break :blk merged;
+            }
+            break :blk user;
+        },
         .minify_whitespace = if (minify) true else getObjectBool(env, opts_obj, "minifyWhitespace", false),
         .minify_identifiers = if (minify) true else getObjectBool(env, opts_obj, "minifyIdentifiers", false),
         .minify_syntax = if (minify) true else getObjectBool(env, opts_obj, "minifySyntax", false),

--- a/src/bundler/block_list.zig
+++ b/src/bundler/block_list.zig
@@ -1,0 +1,139 @@
+//! resolver blockList — 해석 단계에서 특정 경로를 차단하는 패턴 매칭.
+//!
+//! Metro/webpack의 blocklist 호환. Metro는 RegExp를 쓰지만 실전 패턴 대부분은
+//! 단순 케이스로 커버 가능해서 최소 매처만 구현한다.
+//!
+//! **지원 구문** (JS regex 서브셋):
+//! - 리터럴 문자
+//! - `.*` : 임의 문자열 (그리디, 개행 포함 X)
+//! - `^` : 시작 앵커 (패턴 맨 앞에서만)
+//! - `$` : 끝 앵커 (패턴 맨 뒤에서만)
+//! - `\/`, `\.`, `\\` : 이스케이프 (JS regex source 직접 받을 때 보존됨)
+//!
+//! **미지원**: `|`, `[]`, `()`, `+`, `?`, `{n,m}`, `\w`, `\d`, lookaround 등.
+//! 이런 패턴이 필요하면 `onResolve` 플러그인 훅으로 우회.
+
+const std = @import("std");
+
+/// `pattern`이 `text`의 어딘가와 매칭되는지 판정.
+/// `^`/`$`가 없으면 substring 매칭(어딘가 포함되면 OK). 있으면 그 위치 고정.
+pub fn matches(pattern: []const u8, text: []const u8) bool {
+    if (pattern.len == 0) return false;
+
+    const anchored_start = pattern.len > 0 and pattern[0] == '^';
+    const anchored_end = pattern.len > 0 and pattern[pattern.len - 1] == '$'
+        // `\$`는 리터럴 $ — 마지막 $ 앞에 역슬래시면 앵커 아님
+    and !(pattern.len >= 2 and pattern[pattern.len - 2] == '\\');
+
+    const p_start: usize = if (anchored_start) 1 else 0;
+    const p_end: usize = if (anchored_end) pattern.len - 1 else pattern.len;
+    const p = pattern[p_start..p_end];
+
+    if (anchored_start and anchored_end) {
+        return matchAt(p, text, 0, text.len) == text.len;
+    } else if (anchored_start) {
+        const r = matchAt(p, text, 0, text.len);
+        return r != null_match;
+    } else if (anchored_end) {
+        // 뒤에서부터 가능한 시작 지점을 훑으며 end 위치가 text.len인지 본다.
+        var start: usize = 0;
+        while (start <= text.len) : (start += 1) {
+            const r = matchAt(p, text, start, text.len);
+            if (r == text.len) return true;
+        }
+        return false;
+    } else {
+        // substring: 어떤 시작 지점에서든 매칭되면 true
+        var start: usize = 0;
+        while (start <= text.len) : (start += 1) {
+            if (matchAt(p, text, start, text.len) != null_match) return true;
+        }
+        return false;
+    }
+}
+
+const null_match: usize = std.math.maxInt(usize);
+
+/// `pattern`을 `text[start..]`에 맞춰 본다. 매칭 성공 시 끝 위치(text 인덱스) 반환, 실패 시 null_match.
+fn matchAt(pattern: []const u8, text: []const u8, start: usize, text_end: usize) usize {
+    var pi: usize = 0;
+    var ti: usize = start;
+
+    while (pi < pattern.len) {
+        // `.*` — 0개 이상 임의 문자. 그리디: 최대한 먹고 역추적.
+        if (pi + 1 < pattern.len and pattern[pi] == '.' and pattern[pi + 1] == '*') {
+            const rest = pattern[pi + 2 ..];
+            // rest가 text의 가능한 접미사들과 매칭되는지 — 큰 것부터 시도.
+            var take: usize = text_end - ti;
+            while (true) : (take -= 1) {
+                const r = matchAt(rest, text, ti + take, text_end);
+                if (r != null_match) return r;
+                if (take == 0) break;
+            }
+            return null_match;
+        }
+
+        // 이스케이프: 다음 문자를 리터럴로 취급
+        if (pattern[pi] == '\\' and pi + 1 < pattern.len) {
+            if (ti >= text_end) return null_match;
+            if (pattern[pi + 1] != text[ti]) return null_match;
+            pi += 2;
+            ti += 1;
+            continue;
+        }
+
+        // `.` 단일 — 임의 1문자
+        if (pattern[pi] == '.') {
+            if (ti >= text_end) return null_match;
+            pi += 1;
+            ti += 1;
+            continue;
+        }
+
+        // 리터럴
+        if (ti >= text_end) return null_match;
+        if (pattern[pi] != text[ti]) return null_match;
+        pi += 1;
+        ti += 1;
+    }
+
+    return ti;
+}
+
+// ============ tests ============
+
+test "matches: substring" {
+    try std.testing.expect(matches("/ios/", "/app/ios/main.m"));
+    try std.testing.expect(!matches("/ios/", "/app/android/main.m"));
+}
+
+test "matches: escape slash (JS regex source 그대로)" {
+    try std.testing.expect(matches("\\/ios\\/", "/app/ios/main.m"));
+    try std.testing.expect(!matches("\\/ios\\/", "/app/ipad/main.m"));
+}
+
+test "matches: suffix anchor" {
+    try std.testing.expect(matches("\\.bak$", "file.bak"));
+    try std.testing.expect(matches("\\.bak$", "/tmp/file.bak"));
+    try std.testing.expect(!matches("\\.bak$", "file.bak.txt"));
+}
+
+test "matches: prefix anchor" {
+    try std.testing.expect(matches("^/src/", "/src/app.ts"));
+    try std.testing.expect(!matches("^/src/", "/app/src/main.ts"));
+}
+
+test "matches: .* 임의 문자열" {
+    try std.testing.expect(matches("node_modules\\/.*\\/node_modules", "foo/node_modules/pkg/node_modules/bar"));
+    try std.testing.expect(!matches("node_modules\\/.*\\/node_modules", "foo/node_modules/pkg"));
+}
+
+test "matches: Metro 기본 패턴들" {
+    try std.testing.expect(matches("\\/__tests__\\/", "/app/src/__tests__/foo.test.ts"));
+    try std.testing.expect(matches("\\/android\\/app\\/build\\/", "/project/android/app/build/foo"));
+    try std.testing.expect(matches("\\/ios\\/Pods\\/", "/project/ios/Pods/bar"));
+}
+
+test "matches: empty pattern rejects" {
+    try std.testing.expect(!matches("", "anything"));
+}

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -44,6 +44,16 @@ pub const RN_BOOL_PRESET: ReactNativeBoolPreset = .{};
 /// RN 코어가 제공하는 표준 경로 (Metro와 동일).
 pub const RN_DEFAULT_ASSET_REGISTRY: []const u8 = "react-native/Libraries/Image/AssetRegistry";
 
+/// RN 프리셋의 기본 blockList 패턴. Metro의 `metro-config/defaults/exclusionList.js`와 동등.
+/// 사용자가 추가 패턴 주면 이 기본값에 append된다.
+pub const RN_DEFAULT_BLOCK_LIST: []const []const u8 = &.{
+    "\\/android\\/app\\/build\\/",
+    "\\/ios\\/Pods\\/",
+    "\\/ios\\/build\\/",
+    "\\/__tests__\\/",
+    "\\/__fixtures__\\/",
+};
+
 pub const BundleOptions = struct {
     entry_points: []const []const u8,
     format: EmitOptions.Format = .esm,
@@ -88,6 +98,8 @@ pub const BundleOptions = struct {
     alias: []const types.AliasEntry = &.{},
     /// Fallback (webpack resolve.fallback / Metro extraNodeModules). 해석 실패 시에만 적용.
     fallback: []const types.FallbackEntry = &.{},
+    /// Metro resolver.blockList 호환 — 매칭되는 절대 경로는 해석 차단.
+    block_list: []const []const u8 = &.{},
     /// Metro AssetRegistry 모듈 경로. null이면 일반 URL 문자열 export (웹/esbuild 방식).
     /// 설정 시 file/copy 로더가 `module.exports = require("<path>").registerAsset({...})` 형태로 래핑.
     /// RN 플랫폼 프리셋에서 "react-native/Libraries/Image/AssetRegistry"로 자동 설정.
@@ -348,6 +360,7 @@ pub const Bundler = struct {
                 .preserve_symlinks = options.preserve_symlinks,
                 .alias = options.alias,
                 .fallback = options.fallback,
+                .block_list = options.block_list,
                 .resolve_extensions = options.resolve_extensions,
                 .main_fields = options.main_fields,
                 .packages_external = options.packages_external,

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -135,6 +135,7 @@ pub const IncrementalBundler = struct {
                 .preserve_symlinks = self.options.preserve_symlinks,
                 .alias = self.options.alias,
                 .fallback = self.options.fallback,
+                .block_list = self.options.block_list,
                 .resolve_extensions = self.options.resolve_extensions,
                 .main_fields = self.options.main_fields,
             });

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -40,6 +40,7 @@ pub const css_scanner = @import("css_scanner.zig");
 pub const css_emitter = @import("css_emitter.zig");
 pub const symbol = @import("symbol.zig");
 pub const asset_meta = @import("asset_meta.zig");
+pub const block_list = @import("block_list.zig");
 
 // 공개 타입 re-export
 pub const ModuleIndex = types.ModuleIndex;
@@ -67,6 +68,7 @@ pub const BundleOptions = bundler_core.BundleOptions;
 pub const BundleResult = bundler_core.BundleResult;
 pub const RN_BOOL_PRESET = bundler_core.RN_BOOL_PRESET;
 pub const RN_DEFAULT_ASSET_REGISTRY = bundler_core.RN_DEFAULT_ASSET_REGISTRY;
+pub const RN_DEFAULT_BLOCK_LIST = bundler_core.RN_DEFAULT_BLOCK_LIST;
 pub const Plugin = plugin.Plugin;
 pub const PluginRunner = plugin.PluginRunner;
 pub const SubprocessPlugin = subprocess_plugin.SubprocessPlugin;
@@ -118,6 +120,7 @@ test {
     _ = @import("module_test.zig");
     _ = @import("plugin_test.zig");
     _ = asset_meta;
+    _ = block_list;
     _ = incremental;
     _ = @import("incremental_test.zig");
 }

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -119,6 +119,8 @@ pub const ResolveCache = struct {
         alias: []const resolver_mod.AliasEntry = &.{},
         /// webpack resolve.fallback / Metro extraNodeModules 호환.
         fallback: []const resolver_mod.FallbackEntry = &.{},
+        /// Metro resolver.blockList 호환 — 해석 차단 패턴.
+        block_list: []const []const u8 = &.{},
         resolve_extensions: []const []const u8 = &.{},
         main_fields: []const []const u8 = &.{},
         /// --packages=external: 모든 bare import를 external 처리
@@ -140,6 +142,7 @@ pub const ResolveCache = struct {
         r.preserve_symlinks = preserve_symlinks;
         r.alias = alias;
         r.fallback = options.fallback;
+        r.block_list = options.block_list;
         r.custom_extensions = options.resolve_extensions;
         r.main_fields = options.main_fields;
         r.node_paths = options.node_paths;

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -199,6 +199,9 @@ pub const Resolver = struct {
     /// alias와 달리 일반 해석이 **실패했을 때만** 적용. 정확 매칭만 지원 (webpack과 동일).
     /// `to == null`이면 빈 모듈(disabled result)로 대체.
     fallback: []const FallbackEntry = &.{},
+    /// blockList — Metro resolver.blockList 호환. 매칭되는 절대 경로는 ModuleNotFound 처리.
+    /// 패턴 구문은 `block_list.zig` 참조 (regex 최소 서브셋).
+    block_list: []const []const u8 = &.{},
     /// 커스텀 확장자 탐색 순서 (--resolve-extensions). 비어있으면 default_extensions 사용.
     /// RN 예: .ios.ts, .ios.tsx, .native.ts, .native.tsx, .ts, .tsx, .js, .jsx, .json
     custom_extensions: []const []const u8 = &.{},
@@ -260,6 +263,20 @@ pub const Resolver = struct {
     }
 
     pub fn resolve(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
+        const result = try self.resolveInner(source_dir, specifier);
+        if (self.block_list.len > 0 and !result.disabled) {
+            const bl = @import("block_list.zig");
+            for (self.block_list) |pat| {
+                if (bl.matches(pat, result.path)) {
+                    self.allocator.free(result.path);
+                    return error.ModuleNotFound;
+                }
+            }
+        }
+        return result;
+    }
+
+    fn resolveInner(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
         // alias 치환 (resolve 맨 처음에 적용, esbuild 동작과 동일)
         const effective_specifier = if (self.alias.len > 0)
             (applyAlias(self.allocator, self.alias, specifier) catch return error.OutOfMemory) orelse specifier

--- a/src/main.zig
+++ b/src/main.zig
@@ -75,6 +75,9 @@ const CliOptions = struct {
     /// --fallback:NAME=PATH (webpack resolve.fallback). 일반 해석 실패 시에만 적용.
     /// PATH 대신 "false"로 쓰면 빈 모듈로 대체.
     fallback_list: std.ArrayList(FallbackEntry) = .empty,
+    /// --block-list=PATTERN (반복). Metro resolver.blockList 호환.
+    /// JS regex source 스타일 문자열 (`\/ios\/`, `\.bak$` 등).
+    block_list: std.ArrayList([]const u8) = .empty,
     public_path: ?[]const u8 = null,
     banner_js: ?[]const u8 = null,
     footer_js: ?[]const u8 = null,
@@ -205,6 +208,7 @@ const CliOptions = struct {
         self.conditions_list.deinit(alloc);
         self.alias_list.deinit(alloc);
         self.fallback_list.deinit(alloc);
+        self.block_list.deinit(alloc);
         self.loader_list.deinit(alloc);
         for (self.inject_list.items) |p| alloc.free(p);
         self.inject_list.deinit(alloc);
@@ -513,6 +517,8 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
                 try stderr.print("zts: --alias requires FROM=TO format: {s}\n", .{arg});
                 std.process.exit(1);
             }
+        } else if (std.mem.startsWith(u8, arg, "--block-list=")) {
+            try opts.block_list.append(allocator, arg["--block-list=".len..]);
         } else if (std.mem.startsWith(u8, arg, "--fallback:")) {
             // --fallback:crypto=crypto-browserify (webpack resolve.fallback 호환)
             // --fallback:fs=false → 빈 모듈
@@ -1345,6 +1351,8 @@ pub fn main() !void {
             if (opts.asset_registry == null and !opts.asset_registry_explicit_off) {
                 opts.asset_registry = lib.bundler.RN_DEFAULT_ASSET_REGISTRY;
             }
+            // RN blockList 기본 패턴을 사용자 목록 앞에 prepend (Metro 동작과 동일).
+            try opts.block_list.insertSlice(allocator, 0, lib.bundler.RN_DEFAULT_BLOCK_LIST);
             // Metro는 automatic JSX transform 사용 — 사용자가 명시하지 않았으면 자동 설정
             if (opts.jsx_runtime == null) {
                 opts.jsx_runtime = .automatic;
@@ -1420,6 +1428,7 @@ pub fn main() !void {
             .preserve_symlinks = opts.preserve_symlinks,
             .alias = opts.alias_list.items,
             .fallback = opts.fallback_list.items,
+            .block_list = opts.block_list.items,
             .public_path = opts.public_path orelse "",
             .banner_js = opts.banner_js,
             .footer_js = opts.footer_js,

--- a/tests/integration/tests/block-list.test.ts
+++ b/tests/integration/tests/block-list.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from "bun:test";
+import { createFixture, runZts } from "./helpers";
+import { join } from "node:path";
+
+/**
+ * --block-list / blockList 통합 테스트.
+ *
+ * Metro resolver.blockList 호환 — 매칭되는 절대 경로는 해석 차단.
+ */
+describe("--block-list", () => {
+  test("패턴에 매칭되는 경로는 해석 실패", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import { x } from "./backup"; console.log(x);`,
+      "backup.ts": `export const x = "backup";`,
+    });
+    const outFile = join(dir, "out.js");
+    try {
+      const { stderr } = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        "--block-list=\\/backup",
+      ]);
+      expect(stderr.toLowerCase()).toContain("cannot resolve");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("block-list 없으면 정상 해석", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import { x } from "./backup"; console.log(x);`,
+      "backup.ts": `export const x = "backup";`,
+    });
+    const outFile = join(dir, "out.js");
+    try {
+      const { exitCode, stderr } = await runZts(["--bundle", join(dir, "entry.ts"), "-o", outFile]);
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("Cannot resolve");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("RN 프리셋 → __tests__ 자동 차단", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import { x } from "./__tests__/foo"; console.log(x);`,
+      "__tests__/foo.ts": `export const x = "test";`,
+    });
+    const outFile = join(dir, "out.js");
+    try {
+      const { stderr } = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        "--platform=react-native",
+      ]);
+      // RN 프리셋의 기본 blockList가 __tests__ 차단
+      expect(stderr.toLowerCase()).toContain("cannot resolve");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("접미사 앵커 ($) — .bak 파일 차단", async () => {
+    const { dir, cleanup } = await createFixture({
+      "entry.ts": `import { x } from "./stuff.bak"; console.log(x);`,
+      "stuff.bak.ts": `export const x = "bak";`,
+    });
+    const outFile = join(dir, "out.js");
+    try {
+      const { stderr } = await runZts([
+        "--bundle",
+        join(dir, "entry.ts"),
+        "-o",
+        outFile,
+        "--block-list=\\.bak\\.ts$",
+      ]);
+      expect(stderr.toLowerCase()).toContain("cannot resolve");
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Metro \`resolver.blockList\` / webpack \`IgnorePlugin\` 호환 해석 차단 기능 추가. 매칭되는 절대 경로는 resolver가 해석 실패시켜 번들 그래프에 포함 안 됨.

## API
\`\`\`ts
build({
  blockList: [
    /\/ios\//,              // RegExp
    "\\/backup\\.ts$",      // string (regex source)
  ],
})
\`\`\`

CLI: \`--block-list=PATTERN\` (반복)

## 지원 구문 (JS regex 서브셋)
- 리터럴 문자
- \`.*\` 임의 문자열 (그리디)
- \`^\` 시작 앵커 / \`$\` 끝 앵커
- \`\\x\` 이스케이프

미지원: \`|\`, \`[]\`, \`()\`, \`+?\`, \`\\w\\d\`, lookaround. 복잡한 패턴은 \`onResolve\` 플러그인으로 우회.

## RN 프리셋 기본 패턴 (자동 prepend)
\`\`\`
/\\/android\\/app\\/build\\//
/\\/ios\\/Pods\\//
/\\/ios\\/build\\//
/\\/__tests__\\//
/\\/__fixtures__\\//
\`\`\`
Metro \`metro-config/defaults/exclusionList.js\`와 동등.

## Test plan
- [x] \`zig build\` / \`zig build napi\` 통과
- [x] 유닛 테스트 7개 (substring/prefix/suffix anchor/.*/Metro 기본 패턴)
- [x] 통합 테스트 4개 (차단 확인/RN 자동/suffix 앵커)

## /simplify 반영
- \`ArrayList.insert(0)\` 루프 → \`insertSlice\` 단일 호출
- 수동 alloc+memcpy → \`std.mem.concat\`
- JS 타입 검증 추가 (RegExp/string 외 TypeError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)