### PR TITLE
feat(plugin): onResolve에 { disabled: true } 반환 허용

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -364,6 +364,30 @@ describe("@zts/core build + plugins", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("onResolve disabled: true → 빈 모듈로 대체 (Metro empty / webpack false 매핑)", async () => {
+    // entry가 'should-be-empty'를 import. plugin이 disabled로 매핑.
+    writeFileSync(
+      join(dir, "entry-disabled.ts"),
+      `import * as m from "should-be-empty"; console.log(typeof m);`,
+    );
+    const disabledPlugin: ZtsPlugin = {
+      name: "disabled-resolver",
+      setup(build) {
+        build.onResolve({ filter: /^should-be-empty$/ }, () => ({
+          disabled: true,
+        }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, "entry-disabled.ts")],
+      plugins: [disabledPlugin],
+    });
+    expect(result.errors.length).toBe(0);
+    // disabled 모듈은 빈 객체 export → typeof는 "object"
+    expect(result.outputFiles[0].text).toMatch(/should-be-empty|module\.exports\s*=/);
+  });
+
   test("onResolve + onLoad 플러그인 (CSS → JS 변환)", async () => {
     const cssPlugin: ZtsPlugin = {
       name: "css-plugin",

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -406,10 +406,15 @@ type HookResult<T> = T | null | undefined | Promise<T | null | undefined>;
 export interface PluginBuild {
   onResolve(
     options: { filter: RegExp },
-    callback: (args: {
-      path: string;
-      importer: string | null;
-    }) => HookResult<{ path: string; external?: boolean }>,
+    callback: (args: { path: string; importer: string | null }) => HookResult<{
+      path?: string;
+      /** import 문을 그대로 유지 — 런타임이 해석 (esbuild 호환). */
+      external?: boolean;
+      /** 모듈을 빈 객체(`module.exports = {}`)로 대체.
+       * Metro `resolveRequest`가 `{ type: 'empty' }` 반환할 때, webpack `resolve.fallback`이
+       * `false`일 때 매핑용. `path` 생략 시 specifier가 식별자로 사용됨. */
+      disabled?: boolean;
+    }>,
   ): void;
   onLoad(
     options: { filter: RegExp },

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -524,6 +524,9 @@ const NapiPlugin = struct {
     const PluginResponse = struct {
         resolved_path: ?[]const u8 = null,
         is_external: bool = false,
+        /// 빈 모듈로 처리 (Metro `{ type: 'empty' }`, webpack `false` 폴백 매핑용).
+        /// resolveId가 `{ disabled: true }` 반환 시 ZTS가 `module.exports = {}` 처리.
+        is_disabled: bool = false,
         code: ?[]const u8 = null,
         /// AST plugin: 제거할 디렉티브 이름
         strip_directive: ?[]const u8 = null,
@@ -557,6 +560,7 @@ const NapiPlugin = struct {
             resp.resolved_path = path;
         }
         resp.is_external = getObjectBool(env, js_result, "external", false);
+        resp.is_disabled = getObjectBool(env, js_result, "disabled", false);
         if (getObjectString(env, js_result, "contents", native_alloc)) |contents| {
             resp.code = contents;
         }
@@ -740,6 +744,17 @@ const NapiPlugin = struct {
         defer {
             if (resp.resolved_path) |p| native_alloc.free(p);
             if (resp.code) |co| native_alloc.free(co);
+        }
+
+        // disabled: 빈 모듈로 처리. path는 식별용 — resolved_path 또는 specifier 그대로.
+        // Metro `{ type: 'empty' }` 매핑, webpack `resolve.fallback: false`와 동등.
+        if (resp.is_disabled) {
+            const id_path = resp.resolved_path orelse specifier;
+            return .{
+                .path = alloc.dupe(u8, id_path) catch return error.OutOfMemory,
+                .module_type = .javascript,
+                .disabled = true,
+            };
         }
 
         if (resp.resolved_path) |path| {


### PR DESCRIPTION
## Summary
ZTS 플러그인 onResolve가 \`{ disabled: true }\`를 반환하면 빈 모듈로 처리. Metro \`resolveRequest\`의 \`{ type: 'empty' }\`, webpack \`resolve.fallback: false\` 매핑용.

## API
\`\`\`ts
build.onResolve({ filter: /^missing-mod\$/ }, () => ({
  disabled: true,  // → module.exports = {}
}));
\`\`\`

기존 \`ResolveResult.disabled\` 플래그를 JS 플러그인 API로 노출. 새 인프라 없음.

## 배경 (이슈 #1423)
- esbuild \`namespace\`는 Rollup/Vite 진영엔 없음 — esbuild 전용
- ZTS는 Rollup/Vite 호환 우선 → \`namespace\` 미지원 결정
- virtual module은 Rollup 표준 \`\\0\` prefix
- empty 모듈은 \`disabled\` flag로 표준화 (이 PR)

## 호환 매트릭스 (개정)

| 패턴 | ZTS 지원 |
|---|---|
| Rollup \`\\0\` prefix virtual | ✅ (자동, fs lookup skip) |
| ZTS \`disabled: true\` empty | ✅ (이 PR) |
| esbuild \`namespace\` | ❌ (Rollup/Vite 진영 따라감) |

## Test plan
- [x] \`zig build napi\` 통과
- [x] index.test.ts: disabled 케이스 1개 추가 — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)