### PR TITLE
docs(en): 모든 에러 페이지 영문 마이그레이션 (126 pages)

### DIFF
--- a/documents/src/content/docs/en/reference/errors/index.md
+++ b/documents/src/content/docs/en/reference/errors/index.md
@@ -5,10 +5,199 @@ description: Full list of ZTS error codes
 
 ZTS assigns a unique code to every diagnostic. Click a code to see details and a reproduction.
 
-> Note: only error pages translated to English so far are listed below. The full Korean catalogue is at [한국어 → 에러 코드 레퍼런스](/zts/reference/errors).
+
+## Target / compatibility
+
+| Code | Message |
+|------|--------|
+| [`ZTS0001`](/zts/en/reference/errors/zts0001) | Top-level await is not available in the configured target environment |
 
 ## Bundler — import/export
 
 | Code | Message |
-|------|---------|
+|------|--------|
+| [`ZTS0100`](/zts/en/reference/errors/zts0100) | Could not resolve import |
+| [`ZTS0101`](/zts/en/reference/errors/zts0101) | Export not found in module |
+| [`ZTS0102`](/zts/en/reference/errors/zts0102) | Circular dependency detected |
+| [`ZTS0103`](/zts/en/reference/errors/zts0103) | Module resolution failed |
 | [`ZTS0104`](/zts/en/reference/errors/zts0104) | Re-export references the module itself (self-cycle) |
+
+## Bundler — files / loaders
+
+| Code | Message |
+|------|--------|
+| [`ZTS0200`](/zts/en/reference/errors/zts0200) | Failed to read file |
+| [`ZTS0201`](/zts/en/reference/errors/zts0201) | Failed to parse JSON |
+| [`ZTS0202`](/zts/en/reference/errors/zts0202) | No loader is configured for this file type |
+
+## Parser — import/export
+
+| Code | Message |
+|------|--------|
+| [`ZTS0300`](/zts/en/reference/errors/zts0300) | 'import' declaration is only allowed in module code |
+| [`ZTS0301`](/zts/en/reference/errors/zts0301) | 'import' declaration must be at the top level |
+| [`ZTS0302`](/zts/en/reference/errors/zts0302) | 'import defer/source' requires a binding |
+| [`ZTS0303`](/zts/en/reference/errors/zts0303) | String literal in import specifier requires 'as' binding |
+| [`ZTS0304`](/zts/en/reference/errors/zts0304) | Duplicate import attribute key |
+| [`ZTS0305`](/zts/en/reference/errors/zts0305) | 'export' declaration is only allowed in module code |
+| [`ZTS0306`](/zts/en/reference/errors/zts0306) | 'export' declaration must be at the top level |
+| [`ZTS0307`](/zts/en/reference/errors/zts0307) | String literal cannot be used as local binding in export |
+| [`ZTS0308`](/zts/en/reference/errors/zts0308) | Module source string expected |
+| [`ZTS0309`](/zts/en/reference/errors/zts0309) | 'export' is not allowed in statement position |
+| [`ZTS0310`](/zts/en/reference/errors/zts0310) | 'import' is not allowed in statement position |
+| [`ZTS0311`](/zts/en/reference/errors/zts0311) | 'import' cannot be used with 'new' |
+| [`ZTS0312`](/zts/en/reference/errors/zts0312) | 'import.meta' is only allowed in module code |
+| [`ZTS0313`](/zts/en/reference/errors/zts0313) | Expected 'import.meta', 'import.source', or 'import.defer' |
+| [`ZTS0314`](/zts/en/reference/errors/zts0314) | 'import.source'/'import.defer' requires arguments |
+
+## Parser — declarations / classes
+
+| Code | Message |
+|------|--------|
+| [`ZTS0400`](/zts/en/reference/errors/zts0400) | Anonymous function declaration cannot be invoked |
+| [`ZTS0401`](/zts/en/reference/errors/zts0401) | Function declaration is not allowed in statement position |
+| [`ZTS0402`](/zts/en/reference/errors/zts0402) | Function declaration is not allowed in statement position in strict mode |
+| [`ZTS0403`](/zts/en/reference/errors/zts0403) | Generator declaration is not allowed in statement position |
+| [`ZTS0404`](/zts/en/reference/errors/zts0404) | Async function declaration is not allowed in statement position |
+| [`ZTS0405`](/zts/en/reference/errors/zts0405) | Class declaration is not allowed in statement position |
+| [`ZTS0406`](/zts/en/reference/errors/zts0406) | Class constructor cannot be a getter, setter, generator, or async |
+| [`ZTS0407`](/zts/en/reference/errors/zts0407) | Class member cannot be named '#constructor' |
+| [`ZTS0408`](/zts/en/reference/errors/zts0408) | Class field cannot be named 'constructor' |
+| [`ZTS0409`](/zts/en/reference/errors/zts0409) | Static class field cannot be named 'prototype' |
+| [`ZTS0410`](/zts/en/reference/errors/zts0410) | Static class method cannot be named 'prototype' |
+| [`ZTS0411`](/zts/en/reference/errors/zts0411) | Class expected after decorator |
+| [`ZTS0412`](/zts/en/reference/errors/zts0412) | Class or export expected after decorator |
+| [`ZTS0413`](/zts/en/reference/errors/zts0413) | Labelled function declaration is not allowed in loop body |
+| [`ZTS0414`](/zts/en/reference/errors/zts0414) | Lexical declaration is not allowed in statement position |
+
+## Parser — bindings / identifiers
+
+| Code | Message |
+|------|--------|
+| [`ZTS0500`](/zts/en/reference/errors/zts0500) | Identifier expected |
+| [`ZTS0501`](/zts/en/reference/errors/zts0501) | Binding pattern expected |
+| [`ZTS0502`](/zts/en/reference/errors/zts0502) | Escaped reserved word cannot be used as identifier |
+| [`ZTS0503`](/zts/en/reference/errors/zts0503) | Escaped reserved word cannot be used as identifier in strict mode |
+| [`ZTS0504`](/zts/en/reference/errors/zts0504) | Reserved word cannot be used as identifier |
+| [`ZTS0505`](/zts/en/reference/errors/zts0505) | Reserved word in strict mode cannot be used as identifier |
+| [`ZTS0506`](/zts/en/reference/errors/zts0506) | Keywords cannot contain escape characters |
+| [`ZTS0507`](/zts/en/reference/errors/zts0507) | 'let' is not allowed as variable name in lexical declaration |
+| [`ZTS0508`](/zts/en/reference/errors/zts0508) | Const declarations must be initialized |
+| [`ZTS0509`](/zts/en/reference/errors/zts0509) | 'async' is not allowed as identifier in for-of left-hand side |
+| [`ZTS0510`](/zts/en/reference/errors/zts0510) | 'let' is not allowed as identifier in for-of left-hand side |
+| [`ZTS0511`](/zts/en/reference/errors/zts0511) | Only a single variable declaration is allowed in a for-in/for-of statement |
+| [`ZTS0512`](/zts/en/reference/errors/zts0512) | For-in/for-of loop variable declaration may not have an initializer |
+| [`ZTS0513`](/zts/en/reference/errors/zts0513) | Rest element must be last element |
+| [`ZTS0514`](/zts/en/reference/errors/zts0514) | Rest element may not have a trailing comma |
+| [`ZTS0515`](/zts/en/reference/errors/zts0515) | Duplicate parameter name |
+| [`ZTS0516`](/zts/en/reference/errors/zts0516) | Private name is not allowed in destructuring pattern |
+| [`ZTS0517`](/zts/en/reference/errors/zts0517) | Invalid assignment target |
+| [`ZTS0518`](/zts/en/reference/errors/zts0518) | Assignment to 'eval' or 'arguments' is not allowed in strict mode |
+
+## Parser — expressions / operators
+
+| Code | Message |
+|------|--------|
+| [`ZTS0600`](/zts/en/reference/errors/zts0600) | Expression expected |
+| [`ZTS0601`](/zts/en/reference/errors/zts0601) | Unary expression cannot be the left operand of '**' |
+| [`ZTS0602`](/zts/en/reference/errors/zts0602) | Cannot mix '??' with '&&' or '||' without parentheses |
+| [`ZTS0603`](/zts/en/reference/errors/zts0603) | Private name is not valid outside of 'in' expression |
+| [`ZTS0604`](/zts/en/reference/errors/zts0604) | Private name is not valid as right-hand side of 'in' expression |
+| [`ZTS0605`](/zts/en/reference/errors/zts0605) | Private fields cannot be deleted |
+| [`ZTS0606`](/zts/en/reference/errors/zts0606) | Private field access on super is not allowed |
+| [`ZTS0620`](/zts/en/reference/errors/zts0620) | 'super' is not allowed outside of a method |
+| [`ZTS0621`](/zts/en/reference/errors/zts0621) | 'super()' is only allowed in a class constructor |
+| [`ZTS0607`](/zts/en/reference/errors/zts0607) | Tagged template cannot be used in optional chain |
+| [`ZTS0608`](/zts/en/reference/errors/zts0608) | Property key expected |
+| [`ZTS0609`](/zts/en/reference/errors/zts0609) | Expected ':' after property key |
+| [`ZTS0610`](/zts/en/reference/errors/zts0610) | Invalid shorthand property initializer |
+| [`ZTS0611`](/zts/en/reference/errors/zts0611) | Reserved word cannot be used as shorthand property |
+| [`ZTS0612`](/zts/en/reference/errors/zts0612) | Reserved word in strict mode cannot be used as shorthand property |
+| [`ZTS0613`](/zts/en/reference/errors/zts0613) | 'yield' cannot be used as shorthand property in generator |
+| [`ZTS0614`](/zts/en/reference/errors/zts0614) | 'await' cannot be used as shorthand property in async/module |
+| [`ZTS0615`](/zts/en/reference/errors/zts0615) | Private identifier is not allowed as object property key |
+| [`ZTS0616`](/zts/en/reference/errors/zts0616) | 'arguments' is not allowed in class field initializer |
+| [`ZTS0617`](/zts/en/reference/errors/zts0617) | 'arguments' is not allowed in class static initializer |
+| [`ZTS0618`](/zts/en/reference/errors/zts0618) | String literal contains lone surrogate |
+| [`ZTS0619`](/zts/en/reference/errors/zts0619) | 'new.target' is not allowed outside of functions |
+
+## Parser — statements / control flow
+
+| Code | Message |
+|------|--------|
+| [`ZTS0700`](/zts/en/reference/errors/zts0700) | 'return' outside of function |
+| [`ZTS0701`](/zts/en/reference/errors/zts0701) | 'break' outside of loop or switch |
+| [`ZTS0702`](/zts/en/reference/errors/zts0702) | 'continue' outside of loop |
+| [`ZTS0703`](/zts/en/reference/errors/zts0703) | Only one default clause is allowed in a switch statement |
+| [`ZTS0704`](/zts/en/reference/errors/zts0704) | Case or default expected |
+| [`ZTS0705`](/zts/en/reference/errors/zts0705) | Catch or finally expected |
+| [`ZTS0706`](/zts/en/reference/errors/zts0706) | No line break is allowed after 'throw' |
+| [`ZTS0707`](/zts/en/reference/errors/zts0707) | Escaped reserved word cannot be used as label |
+| [`ZTS0708`](/zts/en/reference/errors/zts0708) | Escaped reserved word cannot be used as label in strict mode |
+| [`ZTS0709`](/zts/en/reference/errors/zts0709) | Reserved word in strict mode cannot be used as label |
+
+## Parser — strict mode
+
+| Code | Message |
+|------|--------|
+| [`ZTS0800`](/zts/en/reference/errors/zts0800) | 'with' is not allowed in strict mode |
+| [`ZTS0801`](/zts/en/reference/errors/zts0801) | Octal literals are not allowed in strict mode |
+| [`ZTS0802`](/zts/en/reference/errors/zts0802) | Octal escape sequences are not allowed in strict mode |
+| [`ZTS0803`](/zts/en/reference/errors/zts0803) | Deleting an identifier is not allowed in strict mode |
+| [`ZTS0804`](/zts/en/reference/errors/zts0804) | \"use strict\" not allowed in function with non-simple parameters |
+
+## Parser — await / yield / JSX / TS
+
+| Code | Message |
+|------|--------|
+| [`ZTS0900`](/zts/en/reference/errors/zts0900) | 'await' cannot be used as identifier in this context |
+| [`ZTS0901`](/zts/en/reference/errors/zts0901) | 'await' expression is not allowed in formal parameters |
+| [`ZTS0902`](/zts/en/reference/errors/zts0902) | 'await' is not allowed in class static initializer |
+| [`ZTS0903`](/zts/en/reference/errors/zts0903) | 'await' is not allowed in non-async function in module code |
+| [`ZTS0904`](/zts/en/reference/errors/zts0904) | 'await' is not allowed in arrow function parameters |
+| [`ZTS0905`](/zts/en/reference/errors/zts0905) | 'await' is not allowed in async arrow function parameters |
+| [`ZTS0906`](/zts/en/reference/errors/zts0906) | 'yield' expression is not allowed in formal parameters |
+| [`ZTS0907`](/zts/en/reference/errors/zts0907) | 'yield' is not allowed in arrow function parameters |
+| [`ZTS0908`](/zts/en/reference/errors/zts0908) | Invalid escape sequence in template literal |
+| [`ZTS0909`](/zts/en/reference/errors/zts0909) | Expected template continuation |
+| [`ZTS0910`](/zts/en/reference/errors/zts0910) | JSX tag name expected |
+| [`ZTS0911`](/zts/en/reference/errors/zts0911) | Spread expected |
+| [`ZTS0912`](/zts/en/reference/errors/zts0912) | Type expected |
+| [`ZTS0913`](/zts/en/reference/errors/zts0913) | Expected 'in' in mapped type |
+| [`ZTS0914`](/zts/en/reference/errors/zts0914) | Expected 'type' after 'opaque' |
+
+## Semantic — redeclaration
+
+| Code | Message |
+|------|--------|
+| [`ZTS1000`](/zts/en/reference/errors/zts1000) | Identifier has already been declared |
+| [`ZTS1001`](/zts/en/reference/errors/zts1001) | Cannot be used as a binding identifier in strict mode |
+
+## Semantic — private
+
+| Code | Message |
+|------|--------|
+| [`ZTS1100`](/zts/en/reference/errors/zts1100) | Private field has already been declared |
+| [`ZTS1101`](/zts/en/reference/errors/zts1101) | Private field must be declared in an enclosing class |
+| [`ZTS1102`](/zts/en/reference/errors/zts1102) | Cannot assign to private method |
+| [`ZTS1103`](/zts/en/reference/errors/zts1103) | Cannot set private member (getter only) |
+| [`ZTS1104`](/zts/en/reference/errors/zts1104) | Cannot read private member (setter only) |
+
+## Semantic — export / label
+
+| Code | Message |
+|------|--------|
+| [`ZTS1200`](/zts/en/reference/errors/zts1200) | Duplicate export name |
+| [`ZTS1201`](/zts/en/reference/errors/zts1201) | Export is not defined |
+| [`ZTS1202`](/zts/en/reference/errors/zts1202) | Label has already been declared |
+| [`ZTS1203`](/zts/en/reference/errors/zts1203) | Cannot continue to non-loop label |
+| [`ZTS1204`](/zts/en/reference/errors/zts1204) | Undefined label |
+
+## Semantic — class / other
+
+| Code | Message |
+|------|--------|
+| [`ZTS1300`](/zts/en/reference/errors/zts1300) | A class may only have one constructor |
+| [`ZTS1301`](/zts/en/reference/errors/zts1301) | Property name __proto__ appears more than once in object literal |
+| [`ZTS1302`](/zts/en/reference/errors/zts1302) | Getter must not have any formal parameters |
+| [`ZTS1303`](/zts/en/reference/errors/zts1303) | Setter must have exactly one formal parameter |

--- a/documents/src/content/docs/en/reference/errors/zts0001.md
+++ b/documents/src/content/docs/en/reference/errors/zts0001.md
@@ -1,0 +1,24 @@
+---
+title: 'ZTS0001: Top-level await is not available in the configured target environment'
+description: 'Top-level await is not available in the configured target environment'
+---
+
+## ZTS0001
+
+> Top-level await is not available in the configured target environment
+
+**Category**: Target / compatibility
+
+### Reproduction
+
+```ts
+export const data = await fetch("/api");
+```
+
+**Options**: `--target=es2021`
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#eyJjb2RlIjoiZXhwb3J0IGNvbnN0IGRhdGEgPSBhd2FpdCBmZXRjaChcIi9hcGlcIik7Iiwib3B0aW9ucyI6eyJ0YXJnZXQiOiJlczIwMjEifX0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0100.md
+++ b/documents/src/content/docs/en/reference/errors/zts0100.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0100: Could not resolve import'
+description: 'Could not resolve import'
+---
+
+## ZTS0100
+
+> Could not resolve import
+
+**Category**: Bundler — import/export
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0101.md
+++ b/documents/src/content/docs/en/reference/errors/zts0101.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0101: Export not found in module'
+description: 'Export not found in module'
+---
+
+## ZTS0101
+
+> Export not found in module
+
+**Category**: Bundler — import/export
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0102.md
+++ b/documents/src/content/docs/en/reference/errors/zts0102.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0102: Circular dependency detected'
+description: 'Circular dependency detected'
+---
+
+## ZTS0102
+
+> Circular dependency detected
+
+**Category**: Bundler — import/export
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0103.md
+++ b/documents/src/content/docs/en/reference/errors/zts0103.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0103: Module resolution failed'
+description: 'Module resolution failed'
+---
+
+## ZTS0103
+
+> Module resolution failed
+
+**Category**: Bundler — import/export
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0200.md
+++ b/documents/src/content/docs/en/reference/errors/zts0200.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0200: Failed to read file'
+description: 'Failed to read file'
+---
+
+## ZTS0200
+
+> Failed to read file
+
+**Category**: Bundler — files / loaders
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0201.md
+++ b/documents/src/content/docs/en/reference/errors/zts0201.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0201: Failed to parse JSON'
+description: 'Failed to parse JSON'
+---
+
+## ZTS0201
+
+> Failed to parse JSON
+
+**Category**: Bundler — files / loaders
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0202.md
+++ b/documents/src/content/docs/en/reference/errors/zts0202.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0202: No loader is configured for this file type'
+description: 'No loader is configured for this file type'
+---
+
+## ZTS0202
+
+> No loader is configured for this file type
+
+**Category**: Bundler — files / loaders
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0300.md
+++ b/documents/src/content/docs/en/reference/errors/zts0300.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0300: ''import'' declaration is only allowed in module code'
+description: '''import'' declaration is only allowed in module code'
+---
+
+## ZTS0300
+
+> 'import' declaration is only allowed in module code
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+import { foo } from "./bar";
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aW1wb3J0IHsgZm9vIH0gZnJvbSAiLi9iYXIiOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0301.md
+++ b/documents/src/content/docs/en/reference/errors/zts0301.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0301: ''import'' declaration must be at the top level'
+description: '''import'' declaration must be at the top level'
+---
+
+## ZTS0301
+
+> 'import' declaration must be at the top level
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+function f() { import { x } from "y"; }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24gZigpIHsgaW1wb3J0IHsgeCB9IGZyb20gInkiOyB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0302.md
+++ b/documents/src/content/docs/en/reference/errors/zts0302.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0302: ''import defer/source'' requires a binding'
+description: '''import defer/source'' requires a binding'
+---
+
+## ZTS0302
+
+> 'import defer/source' requires a binding
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+import defer "mod";
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aW1wb3J0IGRlZmVyICJtb2QiOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0303.md
+++ b/documents/src/content/docs/en/reference/errors/zts0303.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0303: String literal in import specifier requires ''as'' binding'
+description: 'String literal in import specifier requires ''as'' binding'
+---
+
+## ZTS0303
+
+> String literal in import specifier requires 'as' binding
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+import { "foo" } from "./mod";
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aW1wb3J0IHsgImZvbyIgfSBmcm9tICIuL21vZCI7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0304.md
+++ b/documents/src/content/docs/en/reference/errors/zts0304.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0304: Duplicate import attribute key'
+description: 'Duplicate import attribute key'
+---
+
+## ZTS0304
+
+> Duplicate import attribute key
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+import x from "./mod" with { type: "json", type: "json" };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aW1wb3J0IHggZnJvbSAiLi9tb2QiIHdpdGggeyB0eXBlOiAianNvbiIsIHR5cGU6ICJqc29uIiB9Ow==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0305.md
+++ b/documents/src/content/docs/en/reference/errors/zts0305.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0305: ''export'' declaration is only allowed in module code'
+description: '''export'' declaration is only allowed in module code'
+---
+
+## ZTS0305
+
+> 'export' declaration is only allowed in module code
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+export const x = 1;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZXhwb3J0IGNvbnN0IHggPSAxOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0306.md
+++ b/documents/src/content/docs/en/reference/errors/zts0306.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0306: ''export'' declaration must be at the top level'
+description: '''export'' declaration must be at the top level'
+---
+
+## ZTS0306
+
+> 'export' declaration must be at the top level
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+function f() { export const x = 1; }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24gZigpIHsgZXhwb3J0IGNvbnN0IHggPSAxOyB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0307.md
+++ b/documents/src/content/docs/en/reference/errors/zts0307.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0307: String literal cannot be used as local binding in export'
+description: 'String literal cannot be used as local binding in export'
+---
+
+## ZTS0307
+
+> String literal cannot be used as local binding in export
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+export { "foo" };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZXhwb3J0IHsgImZvbyIgfTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0308.md
+++ b/documents/src/content/docs/en/reference/errors/zts0308.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0308: Module source string expected'
+description: 'Module source string expected'
+---
+
+## ZTS0308
+
+> Module source string expected
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+import source x from;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aW1wb3J0IHNvdXJjZSB4IGZyb207)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0309.md
+++ b/documents/src/content/docs/en/reference/errors/zts0309.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0309: ''export'' is not allowed in statement position'
+description: '''export'' is not allowed in statement position'
+---
+
+## ZTS0309
+
+> 'export' is not allowed in statement position
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+(export { x });
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#KGV4cG9ydCB7IHggfSk7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0310.md
+++ b/documents/src/content/docs/en/reference/errors/zts0310.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0310: ''import'' is not allowed in statement position'
+description: '''import'' is not allowed in statement position'
+---
+
+## ZTS0310
+
+> 'import' is not allowed in statement position
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+(import { x } from "y");
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#KGltcG9ydCB7IHggfSBmcm9tICJ5Iik7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0311.md
+++ b/documents/src/content/docs/en/reference/errors/zts0311.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0311: ''import'' cannot be used with ''new'''
+description: '''import'' cannot be used with ''new'''
+---
+
+## ZTS0311
+
+> 'import' cannot be used with 'new'
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+const m = new import("./mod");
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbSA9IG5ldyBpbXBvcnQoIi4vbW9kIik7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0312.md
+++ b/documents/src/content/docs/en/reference/errors/zts0312.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0312: ''import.meta'' is only allowed in module code'
+description: '''import.meta'' is only allowed in module code'
+---
+
+## ZTS0312
+
+> 'import.meta' is only allowed in module code
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+console.log(import.meta.url);
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc29sZS5sb2coaW1wb3J0Lm1ldGEudXJsKTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0313.md
+++ b/documents/src/content/docs/en/reference/errors/zts0313.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0313: Expected ''import.meta'', ''import.source'', or ''import.defer'''
+description: 'Expected ''import.meta'', ''import.source'', or ''import.defer'''
+---
+
+## ZTS0313
+
+> Expected 'import.meta', 'import.source', or 'import.defer'
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+const x = import.foo;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IGltcG9ydC5mb287)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0314.md
+++ b/documents/src/content/docs/en/reference/errors/zts0314.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0314: ''import.source''/''import.defer'' requires arguments'
+description: '''import.source''/''import.defer'' requires arguments'
+---
+
+## ZTS0314
+
+> 'import.source'/'import.defer' requires arguments
+
+**Category**: Parser — import/export
+
+### Reproduction
+
+```ts
+const x = import.source();
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IGltcG9ydC5zb3VyY2UoKTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0400.md
+++ b/documents/src/content/docs/en/reference/errors/zts0400.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0400: Anonymous function declaration cannot be invoked'
+description: 'Anonymous function declaration cannot be invoked'
+---
+
+## ZTS0400
+
+> Anonymous function declaration cannot be invoked
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+export default function() {}()
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24oKSB7fSgp)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0401.md
+++ b/documents/src/content/docs/en/reference/errors/zts0401.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0401: Function declaration is not allowed in statement position'
+description: 'Function declaration is not allowed in statement position'
+---
+
+## ZTS0401
+
+> Function declaration is not allowed in statement position
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+if (true) function foo() {}
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aWYgKHRydWUpIGZ1bmN0aW9uIGZvbygpIHt9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0402.md
+++ b/documents/src/content/docs/en/reference/errors/zts0402.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0402: Function declaration is not allowed in statement position in strict mode'
+description: 'Function declaration is not allowed in statement position in strict mode'
+---
+
+## ZTS0402
+
+> Function declaration is not allowed in statement position in strict mode
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+"use strict"; if (true) function foo() {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBpZiAodHJ1ZSkgZnVuY3Rpb24gZm9vKCkge30=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0403.md
+++ b/documents/src/content/docs/en/reference/errors/zts0403.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0403: Generator declaration is not allowed in statement position'
+description: 'Generator declaration is not allowed in statement position'
+---
+
+## ZTS0403
+
+> Generator declaration is not allowed in statement position
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+if (true) function* foo() {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aWYgKHRydWUpIGZ1bmN0aW9uKiBmb28oKSB7fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0404.md
+++ b/documents/src/content/docs/en/reference/errors/zts0404.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0404: Async function declaration is not allowed in statement position'
+description: 'Async function declaration is not allowed in statement position'
+---
+
+## ZTS0404
+
+> Async function declaration is not allowed in statement position
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+if (true) async function foo() {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aWYgKHRydWUpIGFzeW5jIGZ1bmN0aW9uIGZvbygpIHt9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0405.md
+++ b/documents/src/content/docs/en/reference/errors/zts0405.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0405: Class declaration is not allowed in statement position'
+description: 'Class declaration is not allowed in statement position'
+---
+
+## ZTS0405
+
+> Class declaration is not allowed in statement position
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+if (true) class Foo {}
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aWYgKHRydWUpIGNsYXNzIEZvbyB7fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0406.md
+++ b/documents/src/content/docs/en/reference/errors/zts0406.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0406: Class constructor cannot be a getter, setter, generator, or async'
+description: 'Class constructor cannot be a getter, setter, generator, or async'
+---
+
+## ZTS0406
+
+> Class constructor cannot be a getter, setter, generator, or async
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+class Foo { async constructor() {} }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgRm9vIHsgYXN5bmMgY29uc3RydWN0b3IoKSB7fSB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0407.md
+++ b/documents/src/content/docs/en/reference/errors/zts0407.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0407: Class member cannot be named ''#constructor'''
+description: 'Class member cannot be named ''#constructor'''
+---
+
+## ZTS0407
+
+> Class member cannot be named '#constructor'
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+class Foo { #constructor() {} }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgRm9vIHsgI2NvbnN0cnVjdG9yKCkge30gfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0408.md
+++ b/documents/src/content/docs/en/reference/errors/zts0408.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0408: Class field cannot be named ''constructor'''
+description: 'Class field cannot be named ''constructor'''
+---
+
+## ZTS0408
+
+> Class field cannot be named 'constructor'
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+class Foo { constructor = 1; }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgRm9vIHsgY29uc3RydWN0b3IgPSAxOyB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0409.md
+++ b/documents/src/content/docs/en/reference/errors/zts0409.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0409: Static class field cannot be named ''prototype'''
+description: 'Static class field cannot be named ''prototype'''
+---
+
+## ZTS0409
+
+> Static class field cannot be named 'prototype'
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+class Foo { static prototype = 1; }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgRm9vIHsgc3RhdGljIHByb3RvdHlwZSA9IDE7IH0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0410.md
+++ b/documents/src/content/docs/en/reference/errors/zts0410.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0410: Static class method cannot be named ''prototype'''
+description: 'Static class method cannot be named ''prototype'''
+---
+
+## ZTS0410
+
+> Static class method cannot be named 'prototype'
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+class Foo { static prototype() {} }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgRm9vIHsgc3RhdGljIHByb3RvdHlwZSgpIHt9IH0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0411.md
+++ b/documents/src/content/docs/en/reference/errors/zts0411.md
@@ -1,0 +1,24 @@
+---
+title: 'ZTS0411: Class expected after decorator'
+description: 'Class expected after decorator'
+---
+
+## ZTS0411
+
+> Class expected after decorator
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+@dec let x = 1;
+```
+
+**Options**: `--experimental-decorators`
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#eyJjb2RlIjoiQGRlYyBsZXQgeCA9IDE7Iiwib3B0aW9ucyI6eyJleHBlcmltZW50YWxEZWNvcmF0b3JzIjp0cnVlfX0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0412.md
+++ b/documents/src/content/docs/en/reference/errors/zts0412.md
@@ -1,0 +1,24 @@
+---
+title: 'ZTS0412: Class or export expected after decorator'
+description: 'Class or export expected after decorator'
+---
+
+## ZTS0412
+
+> Class or export expected after decorator
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+@dec if (true) {}
+```
+
+**Options**: `--experimental-decorators`
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#eyJjb2RlIjoiQGRlYyBpZiAodHJ1ZSkge30iLCJvcHRpb25zIjp7ImV4cGVyaW1lbnRhbERlY29yYXRvcnMiOnRydWV9fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0413.md
+++ b/documents/src/content/docs/en/reference/errors/zts0413.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0413: Labelled function declaration is not allowed in loop body'
+description: 'Labelled function declaration is not allowed in loop body'
+---
+
+## ZTS0413
+
+> Labelled function declaration is not allowed in loop body
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+for (;;) label: function f() {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Zm9yICg7OykgbGFiZWw6IGZ1bmN0aW9uIGYoKSB7fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0414.md
+++ b/documents/src/content/docs/en/reference/errors/zts0414.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0414: Lexical declaration is not allowed in statement position'
+description: 'Lexical declaration is not allowed in statement position'
+---
+
+## ZTS0414
+
+> Lexical declaration is not allowed in statement position
+
+**Category**: Parser — declarations / classes
+
+### Reproduction
+
+```ts
+if (true) const x = 1;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#aWYgKHRydWUpIGNvbnN0IHggPSAxOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0500.md
+++ b/documents/src/content/docs/en/reference/errors/zts0500.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0500: Identifier expected'
+description: 'Identifier expected'
+---
+
+## ZTS0500
+
+> Identifier expected
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+const = 1;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgPSAxOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0501.md
+++ b/documents/src/content/docs/en/reference/errors/zts0501.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0501: Binding pattern expected'
+description: 'Binding pattern expected'
+---
+
+## ZTS0501
+
+> Binding pattern expected
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+function f({ ) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24gZih7ICkge30=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0502.md
+++ b/documents/src/content/docs/en/reference/errors/zts0502.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0502: Escaped reserved word cannot be used as identifier'
+description: 'Escaped reserved word cannot be used as identifier'
+---
+
+## ZTS0502
+
+> Escaped reserved word cannot be used as identifier
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+const \u0069f = 1;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgXHUwMDY5ZiA9IDE7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0503.md
+++ b/documents/src/content/docs/en/reference/errors/zts0503.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0503: Escaped reserved word cannot be used as identifier in strict mode'
+description: 'Escaped reserved word cannot be used as identifier in strict mode'
+---
+
+## ZTS0503
+
+> Escaped reserved word cannot be used as identifier in strict mode
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+"use strict"; const \u0070ackage = 1;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBjb25zdCBcdTAwNzBhY2thZ2UgPSAxOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0504.md
+++ b/documents/src/content/docs/en/reference/errors/zts0504.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0504: Reserved word cannot be used as identifier'
+description: 'Reserved word cannot be used as identifier'
+---
+
+## ZTS0504
+
+> Reserved word cannot be used as identifier
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+const if = 1;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgaWYgPSAxOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0505.md
+++ b/documents/src/content/docs/en/reference/errors/zts0505.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0505: Reserved word in strict mode cannot be used as identifier'
+description: 'Reserved word in strict mode cannot be used as identifier'
+---
+
+## ZTS0505
+
+> Reserved word in strict mode cannot be used as identifier
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+"use strict"; const package = 1;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBjb25zdCBwYWNrYWdlID0gMTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0506.md
+++ b/documents/src/content/docs/en/reference/errors/zts0506.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0506: Keywords cannot contain escape characters'
+description: 'Keywords cannot contain escape characters'
+---
+
+## ZTS0506
+
+> Keywords cannot contain escape characters
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+\u0069f (true) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#XHUwMDY5ZiAodHJ1ZSkge30=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0507.md
+++ b/documents/src/content/docs/en/reference/errors/zts0507.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0507: ''let'' is not allowed as variable name in lexical declaration'
+description: '''let'' is not allowed as variable name in lexical declaration'
+---
+
+## ZTS0507
+
+> 'let' is not allowed as variable name in lexical declaration
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+let let = 1;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#bGV0IGxldCA9IDE7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0508.md
+++ b/documents/src/content/docs/en/reference/errors/zts0508.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0508: Const declarations must be initialized'
+description: 'Const declarations must be initialized'
+---
+
+## ZTS0508
+
+> Const declarations must be initialized
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+const x;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeDs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0509.md
+++ b/documents/src/content/docs/en/reference/errors/zts0509.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0509: ''async'' is not allowed as identifier in for-of left-hand side'
+description: '''async'' is not allowed as identifier in for-of left-hand side'
+---
+
+## ZTS0509
+
+> 'async' is not allowed as identifier in for-of left-hand side
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+for (async of []) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Zm9yIChhc3luYyBvZiBbXSkge30=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0510.md
+++ b/documents/src/content/docs/en/reference/errors/zts0510.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0510: ''let'' is not allowed as identifier in for-of left-hand side'
+description: '''let'' is not allowed as identifier in for-of left-hand side'
+---
+
+## ZTS0510
+
+> 'let' is not allowed as identifier in for-of left-hand side
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+for (let of []) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Zm9yIChsZXQgb2YgW10pIHt9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0511.md
+++ b/documents/src/content/docs/en/reference/errors/zts0511.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0511: Only a single variable declaration is allowed in a for-in/for-of statement'
+description: 'Only a single variable declaration is allowed in a for-in/for-of statement'
+---
+
+## ZTS0511
+
+> Only a single variable declaration is allowed in a for-in/for-of statement
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+for (let a, b in obj) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Zm9yIChsZXQgYSwgYiBpbiBvYmopIHt9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0512.md
+++ b/documents/src/content/docs/en/reference/errors/zts0512.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0512: For-in/for-of loop variable declaration may not have an initializer'
+description: 'For-in/for-of loop variable declaration may not have an initializer'
+---
+
+## ZTS0512
+
+> For-in/for-of loop variable declaration may not have an initializer
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+for (let x = 1 of arr) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Zm9yIChsZXQgeCA9IDEgb2YgYXJyKSB7fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0513.md
+++ b/documents/src/content/docs/en/reference/errors/zts0513.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0513: Rest element must be last element'
+description: 'Rest element must be last element'
+---
+
+## ZTS0513
+
+> Rest element must be last element
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+function f(...a, b) {}
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24gZiguLi5hLCBiKSB7fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0514.md
+++ b/documents/src/content/docs/en/reference/errors/zts0514.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0514: Rest element may not have a trailing comma'
+description: 'Rest element may not have a trailing comma'
+---
+
+## ZTS0514
+
+> Rest element may not have a trailing comma
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+function f(...a,) {}
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24gZiguLi5hLCkge30=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0515.md
+++ b/documents/src/content/docs/en/reference/errors/zts0515.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0515: Duplicate parameter name'
+description: 'Duplicate parameter name'
+---
+
+## ZTS0515
+
+> Duplicate parameter name
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+"use strict"; function f(a, a) {}
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBmdW5jdGlvbiBmKGEsIGEpIHt9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0516.md
+++ b/documents/src/content/docs/en/reference/errors/zts0516.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0516: Private name is not allowed in destructuring pattern'
+description: 'Private name is not allowed in destructuring pattern'
+---
+
+## ZTS0516
+
+> Private name is not allowed in destructuring pattern
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+class C { #x = 1; f() { const { #x } = this; } }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7ICN4ID0gMTsgZigpIHsgY29uc3QgeyAjeCB9ID0gdGhpczsgfSB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0517.md
+++ b/documents/src/content/docs/en/reference/errors/zts0517.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0517: Invalid assignment target'
+description: 'Invalid assignment target'
+---
+
+## ZTS0517
+
+> Invalid assignment target
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+1 + 2 = 3;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#MSArIDIgPSAzOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0518.md
+++ b/documents/src/content/docs/en/reference/errors/zts0518.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0518: Assignment to ''eval'' or ''arguments'' is not allowed in strict mode'
+description: 'Assignment to ''eval'' or ''arguments'' is not allowed in strict mode'
+---
+
+## ZTS0518
+
+> Assignment to 'eval' or 'arguments' is not allowed in strict mode
+
+**Category**: Parser — bindings / identifiers
+
+### Reproduction
+
+```ts
+"use strict"; eval = 1;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBldmFsID0gMTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0600.md
+++ b/documents/src/content/docs/en/reference/errors/zts0600.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0600: Expression expected'
+description: 'Expression expected'
+---
+
+## ZTS0600
+
+> Expression expected
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const x = ;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IDs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0601.md
+++ b/documents/src/content/docs/en/reference/errors/zts0601.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0601: Unary expression cannot be the left operand of ''**'''
+description: 'Unary expression cannot be the left operand of ''**'''
+---
+
+## ZTS0601
+
+> Unary expression cannot be the left operand of '**'
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const x = -a ** 2;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IC1hICoqIDI7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0602.md
+++ b/documents/src/content/docs/en/reference/errors/zts0602.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0602: Cannot mix ''??'' with ''&&'' or ''||'' without parentheses'
+description: 'Cannot mix ''??'' with ''&&'' or ''||'' without parentheses'
+---
+
+## ZTS0602
+
+> Cannot mix '??' with '&&' or '||' without parentheses
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const x = a ?? b || c;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IGEgPz8gYiB8fCBjOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0603.md
+++ b/documents/src/content/docs/en/reference/errors/zts0603.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0603: Private name is not valid outside of ''in'' expression'
+description: 'Private name is not valid outside of ''in'' expression'
+---
+
+## ZTS0603
+
+> Private name is not valid outside of 'in' expression
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+class C { f() { #x; } }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IGYoKSB7ICN4OyB9IH0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0604.md
+++ b/documents/src/content/docs/en/reference/errors/zts0604.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0604: Private name is not valid as right-hand side of ''in'' expression'
+description: 'Private name is not valid as right-hand side of ''in'' expression'
+---
+
+## ZTS0604
+
+> Private name is not valid as right-hand side of 'in' expression
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+class C { #y; f() { "x" in #y; } }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7ICN5OyBmKCkgeyAieCIgaW4gI3k7IH0gfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0605.md
+++ b/documents/src/content/docs/en/reference/errors/zts0605.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0605: Private fields cannot be deleted'
+description: 'Private fields cannot be deleted'
+---
+
+## ZTS0605
+
+> Private fields cannot be deleted
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+class C { #x = 1; f() { delete this.#x; } }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7ICN4ID0gMTsgZigpIHsgZGVsZXRlIHRoaXMuI3g7IH0gfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0606.md
+++ b/documents/src/content/docs/en/reference/errors/zts0606.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0606: Private field access on super is not allowed'
+description: 'Private field access on super is not allowed'
+---
+
+## ZTS0606
+
+> Private field access on super is not allowed
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+class C extends B { f() { super.#x; } }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyBleHRlbmRzIEIgeyBmKCkgeyBzdXBlci4jeDsgfSB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0607.md
+++ b/documents/src/content/docs/en/reference/errors/zts0607.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0607: Tagged template cannot be used in optional chain'
+description: 'Tagged template cannot be used in optional chain'
+---
+
+## ZTS0607
+
+> Tagged template cannot be used in optional chain
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```js
+foo?.bar`hello`;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Zm9vPy5iYXJgaGVsbG9gOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0608.md
+++ b/documents/src/content/docs/en/reference/errors/zts0608.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0608: Property key expected'
+description: 'Property key expected'
+---
+
+## ZTS0608
+
+> Property key expected
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const o = { []: 1 };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbyA9IHsgW106IDEgfTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0609.md
+++ b/documents/src/content/docs/en/reference/errors/zts0609.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0609: Expected '':'' after property key'
+description: 'Expected '':'' after property key'
+---
+
+## ZTS0609
+
+> Expected ':' after property key
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const o = { x 1 };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbyA9IHsgeCAxIH07)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0610.md
+++ b/documents/src/content/docs/en/reference/errors/zts0610.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0610: Invalid shorthand property initializer'
+description: 'Invalid shorthand property initializer'
+---
+
+## ZTS0610
+
+> Invalid shorthand property initializer
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const o = { x = 1 };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbyA9IHsgeCA9IDEgfTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0611.md
+++ b/documents/src/content/docs/en/reference/errors/zts0611.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0611: Reserved word cannot be used as shorthand property'
+description: 'Reserved word cannot be used as shorthand property'
+---
+
+## ZTS0611
+
+> Reserved word cannot be used as shorthand property
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const o = { if };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbyA9IHsgaWYgfTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0612.md
+++ b/documents/src/content/docs/en/reference/errors/zts0612.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0612: Reserved word in strict mode cannot be used as shorthand property'
+description: 'Reserved word in strict mode cannot be used as shorthand property'
+---
+
+## ZTS0612
+
+> Reserved word in strict mode cannot be used as shorthand property
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+"use strict"; const o = { package };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBjb25zdCBvID0geyBwYWNrYWdlIH07)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0613.md
+++ b/documents/src/content/docs/en/reference/errors/zts0613.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0613: ''yield'' cannot be used as shorthand property in generator'
+description: '''yield'' cannot be used as shorthand property in generator'
+---
+
+## ZTS0613
+
+> 'yield' cannot be used as shorthand property in generator
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+function* g() { const o = { yield }; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24qIGcoKSB7IGNvbnN0IG8gPSB7IHlpZWxkIH07IH0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0614.md
+++ b/documents/src/content/docs/en/reference/errors/zts0614.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0614: ''await'' cannot be used as shorthand property in async/module'
+description: '''await'' cannot be used as shorthand property in async/module'
+---
+
+## ZTS0614
+
+> 'await' cannot be used as shorthand property in async/module
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+async function f() { const o = { await }; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#YXN5bmMgZnVuY3Rpb24gZigpIHsgY29uc3QgbyA9IHsgYXdhaXQgfTsgfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0615.md
+++ b/documents/src/content/docs/en/reference/errors/zts0615.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0615: Private identifier is not allowed as object property key'
+description: 'Private identifier is not allowed as object property key'
+---
+
+## ZTS0615
+
+> Private identifier is not allowed as object property key
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const o = { #x: 1 };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbyA9IHsgI3g6IDEgfTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0616.md
+++ b/documents/src/content/docs/en/reference/errors/zts0616.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0616: ''arguments'' is not allowed in class field initializer'
+description: '''arguments'' is not allowed in class field initializer'
+---
+
+## ZTS0616
+
+> 'arguments' is not allowed in class field initializer
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+class C { x = arguments; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IHggPSBhcmd1bWVudHM7IH0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0617.md
+++ b/documents/src/content/docs/en/reference/errors/zts0617.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0617: ''arguments'' is not allowed in class static initializer'
+description: '''arguments'' is not allowed in class static initializer'
+---
+
+## ZTS0617
+
+> 'arguments' is not allowed in class static initializer
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+class C { static { arguments; } }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IHN0YXRpYyB7IGFyZ3VtZW50czsgfSB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0618.md
+++ b/documents/src/content/docs/en/reference/errors/zts0618.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0618: String literal contains lone surrogate'
+description: 'String literal contains lone surrogate'
+---
+
+## ZTS0618
+
+> String literal contains lone surrogate
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const x = "\uD800";
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9ICJcdUQ4MDAiOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0619.md
+++ b/documents/src/content/docs/en/reference/errors/zts0619.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0619: ''new.target'' is not allowed outside of functions'
+description: '''new.target'' is not allowed outside of functions'
+---
+
+## ZTS0619
+
+> 'new.target' is not allowed outside of functions
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const x = new.target;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IG5ldy50YXJnZXQ7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0620.md
+++ b/documents/src/content/docs/en/reference/errors/zts0620.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0620: ''super'' is not allowed outside of a method'
+description: '''super'' is not allowed outside of a method'
+---
+
+## ZTS0620
+
+> 'super' is not allowed outside of a method
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+const x = super.foo;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IHN1cGVyLmZvbzs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0621.md
+++ b/documents/src/content/docs/en/reference/errors/zts0621.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0621: ''super()'' is only allowed in a class constructor'
+description: '''super()'' is only allowed in a class constructor'
+---
+
+## ZTS0621
+
+> 'super()' is only allowed in a class constructor
+
+**Category**: Parser — expressions / operators
+
+### Reproduction
+
+```ts
+class C { f() { super(); } }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IGYoKSB7IHN1cGVyKCk7IH0gfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0700.md
+++ b/documents/src/content/docs/en/reference/errors/zts0700.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0700: ''return'' outside of function'
+description: '''return'' outside of function'
+---
+
+## ZTS0700
+
+> 'return' outside of function
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+return 1;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#cmV0dXJuIDE7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0701.md
+++ b/documents/src/content/docs/en/reference/errors/zts0701.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0701: ''break'' outside of loop or switch'
+description: '''break'' outside of loop or switch'
+---
+
+## ZTS0701
+
+> 'break' outside of loop or switch
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+break;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#YnJlYWs7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0702.md
+++ b/documents/src/content/docs/en/reference/errors/zts0702.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0702: ''continue'' outside of loop'
+description: '''continue'' outside of loop'
+---
+
+## ZTS0702
+
+> 'continue' outside of loop
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+continue;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29udGludWU7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0703.md
+++ b/documents/src/content/docs/en/reference/errors/zts0703.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0703: Only one default clause is allowed in a switch statement'
+description: 'Only one default clause is allowed in a switch statement'
+---
+
+## ZTS0703
+
+> Only one default clause is allowed in a switch statement
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+switch(x) { default: break; default: break; }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#c3dpdGNoKHgpIHsgZGVmYXVsdDogYnJlYWs7IGRlZmF1bHQ6IGJyZWFrOyB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0704.md
+++ b/documents/src/content/docs/en/reference/errors/zts0704.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0704: Case or default expected'
+description: 'Case or default expected'
+---
+
+## ZTS0704
+
+> Case or default expected
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+switch(x) { foo; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#c3dpdGNoKHgpIHsgZm9vOyB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0705.md
+++ b/documents/src/content/docs/en/reference/errors/zts0705.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0705: Catch or finally expected'
+description: 'Catch or finally expected'
+---
+
+## ZTS0705
+
+> Catch or finally expected
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+try {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#dHJ5IHt9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0706.md
+++ b/documents/src/content/docs/en/reference/errors/zts0706.md
@@ -1,0 +1,24 @@
+---
+title: 'ZTS0706: No line break is allowed after ''throw'''
+description: 'No line break is allowed after ''throw'''
+---
+
+## ZTS0706
+
+> No line break is allowed after 'throw'
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+throw
+new Error();
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#dGhyb3cKbmV3IEVycm9yKCk7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0707.md
+++ b/documents/src/content/docs/en/reference/errors/zts0707.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0707: Escaped reserved word cannot be used as label'
+description: 'Escaped reserved word cannot be used as label'
+---
+
+## ZTS0707
+
+> Escaped reserved word cannot be used as label
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+\u0069f: while(true) { break \u0069f; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#XHUwMDY5Zjogd2hpbGUodHJ1ZSkgeyBicmVhayBcdTAwNjlmOyB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0708.md
+++ b/documents/src/content/docs/en/reference/errors/zts0708.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0708: Escaped reserved word cannot be used as label in strict mode'
+description: 'Escaped reserved word cannot be used as label in strict mode'
+---
+
+## ZTS0708
+
+> Escaped reserved word cannot be used as label in strict mode
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+"use strict"; \u0070ackage: while(true) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBcdTAwNzBhY2thZ2U6IHdoaWxlKHRydWUpIHt9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0709.md
+++ b/documents/src/content/docs/en/reference/errors/zts0709.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0709: Reserved word in strict mode cannot be used as label'
+description: 'Reserved word in strict mode cannot be used as label'
+---
+
+## ZTS0709
+
+> Reserved word in strict mode cannot be used as label
+
+**Category**: Parser — statements / control flow
+
+### Reproduction
+
+```ts
+"use strict"; package: while(true) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBwYWNrYWdlOiB3aGlsZSh0cnVlKSB7fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0800.md
+++ b/documents/src/content/docs/en/reference/errors/zts0800.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0800: ''with'' is not allowed in strict mode'
+description: '''with'' is not allowed in strict mode'
+---
+
+## ZTS0800
+
+> 'with' is not allowed in strict mode
+
+**Category**: Parser — strict mode
+
+### Reproduction
+
+```ts
+"use strict"; with(obj) {}
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyB3aXRoKG9iaikge30=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0801.md
+++ b/documents/src/content/docs/en/reference/errors/zts0801.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0801: Octal literals are not allowed in strict mode'
+description: 'Octal literals are not allowed in strict mode'
+---
+
+## ZTS0801
+
+> Octal literals are not allowed in strict mode
+
+**Category**: Parser — strict mode
+
+### Reproduction
+
+```ts
+"use strict"; const x = 0123;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBjb25zdCB4ID0gMDEyMzs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0802.md
+++ b/documents/src/content/docs/en/reference/errors/zts0802.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0802: Octal escape sequences are not allowed in strict mode'
+description: 'Octal escape sequences are not allowed in strict mode'
+---
+
+## ZTS0802
+
+> Octal escape sequences are not allowed in strict mode
+
+**Category**: Parser — strict mode
+
+### Reproduction
+
+```ts
+"use strict"; const x = "\07";
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBjb25zdCB4ID0gIlwwNyI7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0803.md
+++ b/documents/src/content/docs/en/reference/errors/zts0803.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0803: Deleting an identifier is not allowed in strict mode'
+description: 'Deleting an identifier is not allowed in strict mode'
+---
+
+## ZTS0803
+
+> Deleting an identifier is not allowed in strict mode
+
+**Category**: Parser — strict mode
+
+### Reproduction
+
+```ts
+"use strict"; var x = 1; delete x;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyB2YXIgeCA9IDE7IGRlbGV0ZSB4Ow==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0804.md
+++ b/documents/src/content/docs/en/reference/errors/zts0804.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0804: \"use strict\" not allowed in function with non-simple parameters'
+description: '\"use strict\" not allowed in function with non-simple parameters'
+---
+
+## ZTS0804
+
+> \"use strict\" not allowed in function with non-simple parameters
+
+**Category**: Parser — strict mode
+
+### Reproduction
+
+```ts
+function f(a = 1) { "use strict"; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24gZihhID0gMSkgeyAidXNlIHN0cmljdCI7IH0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0900.md
+++ b/documents/src/content/docs/en/reference/errors/zts0900.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0900: ''await'' cannot be used as identifier in this context'
+description: '''await'' cannot be used as identifier in this context'
+---
+
+## ZTS0900
+
+> 'await' cannot be used as identifier in this context
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+async function f() { const await = 1; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#YXN5bmMgZnVuY3Rpb24gZigpIHsgY29uc3QgYXdhaXQgPSAxOyB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0901.md
+++ b/documents/src/content/docs/en/reference/errors/zts0901.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0901: ''await'' expression is not allowed in formal parameters'
+description: '''await'' expression is not allowed in formal parameters'
+---
+
+## ZTS0901
+
+> 'await' expression is not allowed in formal parameters
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+async function f(x = await 1) {}
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#YXN5bmMgZnVuY3Rpb24gZih4ID0gYXdhaXQgMSkge30=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0902.md
+++ b/documents/src/content/docs/en/reference/errors/zts0902.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0902: ''await'' is not allowed in class static initializer'
+description: '''await'' is not allowed in class static initializer'
+---
+
+## ZTS0902
+
+> 'await' is not allowed in class static initializer
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+class C { static x = await 1; }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IHN0YXRpYyB4ID0gYXdhaXQgMTsgfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0903.md
+++ b/documents/src/content/docs/en/reference/errors/zts0903.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0903: ''await'' is not allowed in non-async function in module code'
+description: '''await'' is not allowed in non-async function in module code'
+---
+
+## ZTS0903
+
+> 'await' is not allowed in non-async function in module code
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+export {}; function f() { await 1; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZXhwb3J0IHt9OyBmdW5jdGlvbiBmKCkgeyBhd2FpdCAxOyB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0904.md
+++ b/documents/src/content/docs/en/reference/errors/zts0904.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0904: ''await'' is not allowed in arrow function parameters'
+description: '''await'' is not allowed in arrow function parameters'
+---
+
+## ZTS0904
+
+> 'await' is not allowed in arrow function parameters
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+async function f() { (await) => {} }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#YXN5bmMgZnVuY3Rpb24gZigpIHsgKGF3YWl0KSA9PiB7fSB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0905.md
+++ b/documents/src/content/docs/en/reference/errors/zts0905.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0905: ''await'' is not allowed in async arrow function parameters'
+description: '''await'' is not allowed in async arrow function parameters'
+---
+
+## ZTS0905
+
+> 'await' is not allowed in async arrow function parameters
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+const f = async (await) => {};
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgZiA9IGFzeW5jIChhd2FpdCkgPT4ge307)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0906.md
+++ b/documents/src/content/docs/en/reference/errors/zts0906.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0906: ''yield'' expression is not allowed in formal parameters'
+description: '''yield'' expression is not allowed in formal parameters'
+---
+
+## ZTS0906
+
+> 'yield' expression is not allowed in formal parameters
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+function* g(x = yield 1) {}
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24qIGcoeCA9IHlpZWxkIDEpIHt9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0907.md
+++ b/documents/src/content/docs/en/reference/errors/zts0907.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0907: ''yield'' is not allowed in arrow function parameters'
+description: '''yield'' is not allowed in arrow function parameters'
+---
+
+## ZTS0907
+
+> 'yield' is not allowed in arrow function parameters
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+function* g() { (yield) => {} }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZnVuY3Rpb24qIGcoKSB7ICh5aWVsZCkgPT4ge30gfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0908.md
+++ b/documents/src/content/docs/en/reference/errors/zts0908.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0908: Invalid escape sequence in template literal'
+description: 'Invalid escape sequence in template literal'
+---
+
+## ZTS0908
+
+> Invalid escape sequence in template literal
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+const x = `\unicode`;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IGBcdW5pY29kZWA7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0909.md
+++ b/documents/src/content/docs/en/reference/errors/zts0909.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0909: Expected template continuation'
+description: 'Expected template continuation'
+---
+
+## ZTS0909
+
+> Expected template continuation
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+const x = `hello ${
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IGBoZWxsbyAkew==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0910.md
+++ b/documents/src/content/docs/en/reference/errors/zts0910.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS0910: JSX tag name expected'
+description: 'JSX tag name expected'
+---
+
+## ZTS0910
+
+> JSX tag name expected
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+const x = < />;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgeCA9IDwgLz47)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0911.md
+++ b/documents/src/content/docs/en/reference/errors/zts0911.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0911: Spread expected'
+description: 'Spread expected'
+---
+
+## ZTS0911
+
+> Spread expected
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+const [x] = [...];
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgW3hdID0gWy4uLl07)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0912.md
+++ b/documents/src/content/docs/en/reference/errors/zts0912.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0912: Type expected'
+description: 'Type expected'
+---
+
+## ZTS0912
+
+> Type expected
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+type T = ;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#dHlwZSBUID0gOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0913.md
+++ b/documents/src/content/docs/en/reference/errors/zts0913.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS0913: Expected ''in'' in mapped type'
+description: 'Expected ''in'' in mapped type'
+---
+
+## ZTS0913
+
+> Expected 'in' in mapped type
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+type T = { [K]: string };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#dHlwZSBUID0geyBbS106IHN0cmluZyB9Ow==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts0914.md
+++ b/documents/src/content/docs/en/reference/errors/zts0914.md
@@ -1,0 +1,24 @@
+---
+title: 'ZTS0914: Expected ''type'' after ''opaque'''
+description: 'Expected ''type'' after ''opaque'''
+---
+
+## ZTS0914
+
+> Expected 'type' after 'opaque'
+
+**Category**: Parser — await / yield / JSX / TS
+
+### Reproduction
+
+```ts
+opaque type Foo = string;
+```
+
+**Options**: `--flow`
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#eyJjb2RlIjoib3BhcXVlIHR5cGUgRm9vID0gc3RyaW5nOyIsIm9wdGlvbnMiOnsiZmxvdyI6dHJ1ZSwiZmlsZW5hbWUiOiJpbnB1dC5qcyJ9fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1000.md
+++ b/documents/src/content/docs/en/reference/errors/zts1000.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS1000: Identifier has already been declared'
+description: 'Identifier has already been declared'
+---
+
+## ZTS1000
+
+> Identifier has already been declared
+
+**Category**: Semantic — redeclaration
+
+### Reproduction
+
+```ts
+export let x = 1; let x = 2;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZXhwb3J0IGxldCB4ID0gMTsgbGV0IHggPSAyOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1001.md
+++ b/documents/src/content/docs/en/reference/errors/zts1001.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1001: Cannot be used as a binding identifier in strict mode'
+description: 'Cannot be used as a binding identifier in strict mode'
+---
+
+## ZTS1001
+
+> Cannot be used as a binding identifier in strict mode
+
+**Category**: Semantic — redeclaration
+
+### Reproduction
+
+```ts
+"use strict"; let arguments = 1;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#InVzZSBzdHJpY3QiOyBsZXQgYXJndW1lbnRzID0gMTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1100.md
+++ b/documents/src/content/docs/en/reference/errors/zts1100.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS1100: Private field has already been declared'
+description: 'Private field has already been declared'
+---
+
+## ZTS1100
+
+> Private field has already been declared
+
+**Category**: Semantic — private
+
+### Reproduction
+
+```ts
+class C { #x; #x; }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7ICN4OyAjeDsgfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1101.md
+++ b/documents/src/content/docs/en/reference/errors/zts1101.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS1101: Private field must be declared in an enclosing class'
+description: 'Private field must be declared in an enclosing class'
+---
+
+## ZTS1101
+
+> Private field must be declared in an enclosing class
+
+**Category**: Semantic — private
+
+### Reproduction
+
+```ts
+class C { f() { this.#x; } }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IGYoKSB7IHRoaXMuI3g7IH0gfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1102.md
+++ b/documents/src/content/docs/en/reference/errors/zts1102.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1102: Cannot assign to private method'
+description: 'Cannot assign to private method'
+---
+
+## ZTS1102
+
+> Cannot assign to private method
+
+**Category**: Semantic — private
+
+### Reproduction
+
+```ts
+class C { #m() {} f() { this.#m = 1; } }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7ICNtKCkge30gZigpIHsgdGhpcy4jbSA9IDE7IH0gfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1103.md
+++ b/documents/src/content/docs/en/reference/errors/zts1103.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1103: Cannot set private member (getter only)'
+description: 'Cannot set private member (getter only)'
+---
+
+## ZTS1103
+
+> Cannot set private member (getter only)
+
+**Category**: Semantic — private
+
+### Reproduction
+
+```ts
+class C { get #x() { return 1; } f() { this.#x = 1; } }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IGdldCAjeCgpIHsgcmV0dXJuIDE7IH0gZigpIHsgdGhpcy4jeCA9IDE7IH0gfQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1104.md
+++ b/documents/src/content/docs/en/reference/errors/zts1104.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1104: Cannot read private member (setter only)'
+description: 'Cannot read private member (setter only)'
+---
+
+## ZTS1104
+
+> Cannot read private member (setter only)
+
+**Category**: Semantic — private
+
+### Reproduction
+
+```ts
+class C { set #x(v) {} f() { console.log(this.#x); } }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IHNldCAjeCh2KSB7fSBmKCkgeyBjb25zb2xlLmxvZyh0aGlzLiN4KTsgfSB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1200.md
+++ b/documents/src/content/docs/en/reference/errors/zts1200.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS1200: Duplicate export name'
+description: 'Duplicate export name'
+---
+
+## ZTS1200
+
+> Duplicate export name
+
+**Category**: Semantic — export / label
+
+### Reproduction
+
+```ts
+export const x = 1; export const x = 2;
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZXhwb3J0IGNvbnN0IHggPSAxOyBleHBvcnQgY29uc3QgeCA9IDI7)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1201.md
+++ b/documents/src/content/docs/en/reference/errors/zts1201.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1201: Export is not defined'
+description: 'Export is not defined'
+---
+
+## ZTS1201
+
+> Export is not defined
+
+**Category**: Semantic — export / label
+
+### Reproduction
+
+```ts
+export { y };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#ZXhwb3J0IHsgeSB9Ow==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1202.md
+++ b/documents/src/content/docs/en/reference/errors/zts1202.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1202: Label has already been declared'
+description: 'Label has already been declared'
+---
+
+## ZTS1202
+
+> Label has already been declared
+
+**Category**: Semantic — export / label
+
+### Reproduction
+
+```ts
+label: label: while(true) {}
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#bGFiZWw6IGxhYmVsOiB3aGlsZSh0cnVlKSB7fQ==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1203.md
+++ b/documents/src/content/docs/en/reference/errors/zts1203.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1203: Cannot continue to non-loop label'
+description: 'Cannot continue to non-loop label'
+---
+
+## ZTS1203
+
+> Cannot continue to non-loop label
+
+**Category**: Semantic — export / label
+
+### Reproduction
+
+```ts
+label: { continue label; }
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#bGFiZWw6IHsgY29udGludWUgbGFiZWw7IH0=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1204.md
+++ b/documents/src/content/docs/en/reference/errors/zts1204.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1204: Undefined label'
+description: 'Undefined label'
+---
+
+## ZTS1204
+
+> Undefined label
+
+**Category**: Semantic — export / label
+
+### Reproduction
+
+```ts
+break foo;
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#YnJlYWsgZm9vOw==)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1300.md
+++ b/documents/src/content/docs/en/reference/errors/zts1300.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS1300: A class may only have one constructor'
+description: 'A class may only have one constructor'
+---
+
+## ZTS1300
+
+> A class may only have one constructor
+
+**Category**: Semantic — class / other
+
+### Reproduction
+
+```ts
+class C { constructor() {} constructor() {} }
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y2xhc3MgQyB7IGNvbnN0cnVjdG9yKCkge30gY29uc3RydWN0b3IoKSB7fSB9)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1301.md
+++ b/documents/src/content/docs/en/reference/errors/zts1301.md
@@ -1,0 +1,22 @@
+---
+title: 'ZTS1301: Property name __proto__ appears more than once in object literal'
+description: 'Property name __proto__ appears more than once in object literal'
+---
+
+## ZTS1301
+
+> Property name __proto__ appears more than once in object literal
+
+**Category**: Semantic — class / other
+
+### Reproduction
+
+```ts
+const o = { __proto__: null, __proto__: null };
+```
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbyA9IHsgX19wcm90b19fOiBudWxsLCBfX3Byb3RvX186IG51bGwgfTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1302.md
+++ b/documents/src/content/docs/en/reference/errors/zts1302.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS1302: Getter must not have any formal parameters'
+description: 'Getter must not have any formal parameters'
+---
+
+## ZTS1302
+
+> Getter must not have any formal parameters
+
+**Category**: Semantic — class / other
+
+### Reproduction
+
+```ts
+const o = { get x(a) {} };
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbyA9IHsgZ2V0IHgoYSkge30gfTs=)
+
+### How to fix
+
+See the error message for cause and resolution.

--- a/documents/src/content/docs/en/reference/errors/zts1303.md
+++ b/documents/src/content/docs/en/reference/errors/zts1303.md
@@ -1,0 +1,23 @@
+---
+title: 'ZTS1303: Setter must have exactly one formal parameter'
+description: 'Setter must have exactly one formal parameter'
+---
+
+## ZTS1303
+
+> Setter must have exactly one formal parameter
+
+**Category**: Semantic — class / other
+
+### Reproduction
+
+```ts
+const o = { set x() {} };
+```
+
+
+[Reproduce in Playground →](https://ohah.github.io/zts/playground/#Y29uc3QgbyA9IHsgc2V0IHgoKSB7fSB9Ow==)
+
+### How to fix
+
+See the error message for cause and resolution.


### PR DESCRIPTION
## Summary
한국어 \`reference/errors\`의 126개 에러 페이지를 \`en/reference/errors\`로 일괄 변환. PR #1427에서 ZTS0104만 영문 추가했던 것을 전체 카탈로그로 확장.

## 변경
- 126개 페이지 신규 생성 (zts0001 ~ zts1303)
- frontmatter title/description은 영문 메시지 원본 유지
- boilerplate 영문화: \`**카테고리**\` → \`**Category**\`, \`### 재현 코드\` → \`### Reproduction\`, \`### 해결 방법\` → \`### How to fix\`, "이 에러의 원인과 해결 방법은..." → "See the error message for cause and resolution."
- 14개 카테고리 영문 매핑 (예: 파서: 식/연산자 → Parser — expressions / operators)
- \`en/reference/errors/index.md\`를 한국어와 동일 카탈로그로 재작성 (테이블 헤더 \`| Code | Message |\`, link path \`/zts/en/reference/errors/\`)

## 검증
- 한국어 잔존 검사: 영문 페이지 126개 중 한글 unicode 0건
- astro 빌드: 328 pages, all internal links valid

## Test plan
- [x] \`bun run build\` 통과
- [x] 영문 errors index에 모든 카테고리 표시
- [ ] 사이트 배포 후 영문 errors 페이지 클릭/검색 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)