### PR TITLE
chore(core): add postinstall script to auto-copy NAPI binary

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "build:js": "bun build index.ts --outdir dist --format esm --target node",
     "build:dts": "bun x tsc --emitDeclarationOnly",
     "build": "bun run build:napi && cp ../../zig-out/lib/zts.node . && bun run build:js && bun run build:dts",
+    "postinstall": "[ -f ../../zig-out/lib/zts.node ] && cp ../../zig-out/lib/zts.node . || true",
     "test": "bun test"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary
- `bun install` 시 `zig-out/lib/zts.node`이 있으면 `packages/core/`에 자동 복사
- 수동 `cp` 단계 생략 가능

## Test plan
- [ ] `zig build napi` 후 `bun install` → `packages/core/zts.node` 갱신 확인
- [ ] `zig-out/` 없는 상태에서 `bun install` → 에러 없이 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)