### PR TITLE
docs(CLAUDE.md): /simplify는 PR 전, label/assignee 필수, Test262 규칙 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ Rollup/Vite 어댑터: `vitePlugin({...})` (모든 훅 async 지원).
 1. 작업 단위 작게 (하나의 PR = 하나의 기능)
 2. 독립 작업은 서브에이전트로 병렬
 3. main 직접 push 금지 — feature branch → PR → merge
-4. PR 후 `/simplify` 필수 (파일 간 상호작용까지 검토)
-5. 구현 전 Test262/유닛 테스트 먼저
+4. PR 올리기 **전** `/simplify` 필수 (파일 간 상호작용까지 검토 → 이후 PR 생성)
+5. `gh pr create` 시 `--label`, `--assignee` 항상 지정
 6. Zig 초보자에게 설명 포함
 
 ## Memory ownership


### PR DESCRIPTION
## Summary
Development Workflow 규칙 정정.

- 4번: \`/simplify\`를 "PR 후" → **"PR 올리기 전"**으로 수정. 구현 → simplify → PR create 순서가 올바른 흐름.
- 5번 신설: \`gh pr create\` 시 \`--label\`, \`--assignee\` 항상 지정.
- 구현 전 Test262/유닛 테스트 규칙은 삭제 (실제 운영과 맞지 않아 제거).

## Test plan
- [x] 메타 변경. 코드 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)