### PR TITLE
feat(diagnostic): expose semantic errors through TranspileResult

### DIFF
--- a/documents/src/components/Playground.tsx
+++ b/documents/src/components/Playground.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import Editor from "@monaco-editor/react";
+import type { TranspileResult } from "../../../packages/shared/index";
 
 const EXAMPLES: { label: string; code: string }[] = [
   {
@@ -84,7 +85,7 @@ const DEFAULT_CODE = EXAMPLES[0].code;
 type TranspileFn = (
   source: string,
   options?: Record<string, unknown>,
-) => { code: string; map?: string };
+) => TranspileResult;
 
 interface Options {
   filename: string;
@@ -176,7 +177,9 @@ function doTranspile(
       jsxFragment: opts.jsxFragment || undefined,
       jsxImportSource: opts.jsxImportSource || undefined,
     });
-    return { output: result.code, sourcemap: result.map || "", error: "" };
+    // tsc 호환: 시맨틱 에러가 있어도 code는 함께 반환된다.
+    // result.errors가 있으면 에러 마커를 표시하되 변환 결과는 유지.
+    return { output: result.code, sourcemap: result.map || "", error: result.errors || "" };
   } catch (err) {
     return { output: "", sourcemap: "", error: String(err) };
   }

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -15,6 +15,9 @@ const zts_lib = @import("zts_lib");
 /// 죽는다 — 그 전에 ZTS 배너 + 이슈 URL을 찍어 사용자가 신고하기 쉽게 한다.
 pub const panic = zts_lib.crash_handler.panic;
 const transpile_mod = zts_lib.transpile;
+const rich_diagnostic = zts_lib.rich_diagnostic;
+const diagnostic_renderer = zts_lib.diagnostic_renderer;
+const napi_render_opts: diagnostic_renderer.RenderOptions = .{ .color = false, .unicode = true };
 const bundler_mod = zts_lib.bundler;
 const Bundler = bundler_mod.Bundler;
 const TrackedFileSet = zts_lib.server.TrackedFileSet;
@@ -169,6 +172,24 @@ fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
             return throwError(env, "failed to create sourcemap string");
         }
         _ = c.napi_set_named_property(env, js_result, "map", js_map);
+    }
+
+    // errors (선택적, tsc 호환): 시맨틱 에러가 있으면 CLI와 동일한 포맷으로
+    // 렌더링하여 string으로 노출. WASM 바인딩과 일치하는 schema.
+    if (result.diagnostics.len > 0) {
+        const source_info: rich_diagnostic.SourceInfo = .{
+            .source = source,
+            .line_offsets = result.line_offsets,
+        };
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(native_alloc);
+        diagnostic_renderer.renderAll(buf.writer(native_alloc), result.diagnostics, source_info, filename, napi_render_opts) catch {};
+        if (buf.items.len > 0) {
+            var js_errors: c.napi_value = undefined;
+            if (c.napi_create_string_utf8(env, buf.items.ptr, buf.items.len, &js_errors) == c.napi_ok) {
+                _ = c.napi_set_named_property(env, js_result, "errors", js_errors);
+            }
+        }
     }
 
     return js_result;

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -84,6 +84,12 @@ export interface TranspileResult {
   code: string;
   /** 소스맵 JSON (sourcemap: true 시) */
   map?: string;
+  /**
+   * 시맨틱 에러가 있을 때 CLI와 동일한 포맷으로 렌더된 전체 에러 텍스트.
+   * tsc 호환 정책: 에러가 있어도 code는 함께 반환된다.
+   * 플레이그라운드/IDE는 이 필드를 파싱해 마커로 표시한다.
+   */
+  errors?: string;
 }
 
 // ─── ES Target → UnsupportedFeatures bitmask ───

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -11,7 +11,7 @@
  */
 
 export type { Target, Platform, TranspileOptions, TranspileResult } from "../shared/index";
-import type { TranspileOptions } from "../shared/index";
+import type { TranspileOptions, TranspileResult } from "../shared/index";
 import { encodeFlags, targetToUnsupported } from "../shared/index";
 
 // ─── WASM Instance ───
@@ -199,22 +199,25 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
     const outPtr = Number(packed >> 32n);
     const outLen = Number(packed & 0xffffffffn);
 
+    // tsc 호환: 시맨틱 에러는 code와 함께 반환되므로 성공 경로에서도 확인.
+    // 핫패스(에러 없음)에서는 get_error_len 한 번만 호출 — 0이면 ptr/readString 스킵.
+    const errLen = wasm.get_error_len();
+    const errMsg = errLen === 0 ? "" : readString(wasm.get_error_ptr(), errLen);
+
     if (outPtr === 0) {
-      const errPtr = wasm.get_error_ptr();
-      const errLen = wasm.get_error_len();
-      const errMsg = errPtr ? readString(errPtr, errLen) : "unknown error";
-      throw new Error(`zts-wasm: ${errMsg}`);
+      throw new Error(`zts-wasm: ${errMsg || "unknown error"}`);
     }
 
     const raw = readString(outPtr, outLen);
     wasm.dealloc(outPtr, outLen);
 
     const nullIdx = options.sourcemap ? raw.indexOf("\0") : -1;
-    if (nullIdx !== -1) {
-      return { code: raw.slice(0, nullIdx), map: raw.slice(nullIdx + 1) };
-    }
+    const result: TranspileResult = nullIdx !== -1
+      ? { code: raw.slice(0, nullIdx), map: raw.slice(nullIdx + 1) }
+      : { code: raw };
 
-    return { code: raw };
+    if (errMsg) result.errors = errMsg;
+    return result;
   } finally {
     wasm.dealloc(srcPtr, srcLen);
     if (filePtr) wasm.dealloc(filePtr, fileLen);

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -212,9 +212,8 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
     wasm.dealloc(outPtr, outLen);
 
     const nullIdx = options.sourcemap ? raw.indexOf("\0") : -1;
-    const result: TranspileResult = nullIdx !== -1
-      ? { code: raw.slice(0, nullIdx), map: raw.slice(nullIdx + 1) }
-      : { code: raw };
+    const result: TranspileResult =
+      nullIdx !== -1 ? { code: raw.slice(0, nullIdx), map: raw.slice(nullIdx + 1) } : { code: raw };
 
     if (errMsg) result.errors = errMsg;
     return result;

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -10,11 +10,15 @@
 //!   4. 결과 읽기 후 dealloc()으로 해제
 
 const std = @import("std");
-const transpile_mod = @import("zts_lib").transpile;
+const zts_lib = @import("zts_lib");
+const transpile_mod = zts_lib.transpile;
 const TranspileOptions = transpile_mod.TranspileOptions;
-const Scanner = @import("zts_lib").lexer.Scanner;
-const Diagnostic = @import("zts_lib").diagnostic.Diagnostic;
-const compat = @import("zts_lib").transformer.transformer.TransformOptions.compat;
+const Scanner = zts_lib.lexer.Scanner;
+const Diagnostic = zts_lib.diagnostic.Diagnostic;
+const OwnedDiagnostic = zts_lib.diagnostic.OwnedDiagnostic;
+const rich_diagnostic = zts_lib.rich_diagnostic;
+const diagnostic_renderer = zts_lib.diagnostic_renderer;
+const compat = zts_lib.transformer.transformer.TransformOptions.compat;
 
 /// Bun 스타일 crash report: WASM에는 signal이 없지만 panic은 여전히 터질 수 있다.
 /// 호스트 콘솔(WASI stderr)로 배너 + 이슈 URL 출력.
@@ -36,70 +40,30 @@ fn clearError() void {
     last_error_buf = null;
 }
 
-/// 파서/시맨틱 에러를 SWC/tsc 스타일로 포맷하여 last_error_buf에 저장.
-/// 형식: "<file>:<line>:<col>: error: <message>\n  <line_num> | <source_line>\n    | <caret>"
-fn formatErrors(source: []const u8, file_path: []const u8, scanner: *const Scanner, errors: []const Diagnostic) void {
-    if (errors.len == 0) return;
+const wasm_render_opts: diagnostic_renderer.RenderOptions = .{ .color = false, .unicode = true };
+
+/// 진단 목록을 렌더링해 last_error_buf에 저장한다. Diagnostic(파서 콜백)과
+/// OwnedDiagnostic(transpile 성공 반환 시 시맨틱 에러) 양쪽 호출자 공용.
+fn bufferDiagnostics(
+    source: []const u8,
+    file_path: []const u8,
+    line_offsets: []const u32,
+    diagnostics: anytype,
+) void {
+    if (diagnostics.len == 0) return;
+    const source_info: rich_diagnostic.SourceInfo = .{ .source = source, .line_offsets = line_offsets };
     var buf: std.ArrayList(u8) = .empty;
     const writer = buf.writer(wasm_alloc);
-    // 첫 번째 에러만 표시 — 후속 에러는 복구 과정의 노이즈인 경우가 많음
-    formatSingleError(writer, source, file_path, scanner, errors[0]) catch return;
+    diagnostic_renderer.renderAll(writer, diagnostics, source_info, file_path, wasm_render_opts) catch {};
     if (buf.items.len > 0) {
         if (last_error_buf) |old| wasm_alloc.free(old);
         last_error_buf = buf.toOwnedSlice(wasm_alloc) catch null;
     }
 }
 
-fn formatSingleError(writer: anytype, source: []const u8, file_path: []const u8, scanner: *const Scanner, err: Diagnostic) !void {
-    const lc = scanner.getLineColumn(err.span.start);
-    const line_num = lc.line + 1;
-    const col_num = lc.column + 1;
-
-    // 에러 헤더: "file:line:col: error: message"
-    const kind_label: []const u8 = switch (err.kind) {
-        .parse => "error",
-        .semantic => "error[semantic]",
-    };
-    if (err.found) |found| {
-        try writer.print("{s}:{d}:{d}: {s}: Expected '{s}' but found '{s}'\n", .{ file_path, line_num, col_num, kind_label, err.message, found });
-    } else {
-        try writer.print("{s}:{d}:{d}: {s}: {s}\n", .{ file_path, line_num, col_num, kind_label, err.message });
-    }
-
-    // 해당 줄 텍스트 추출
-    const line_start = if (lc.line < scanner.line_offsets.items.len) scanner.line_offsets.items[lc.line] else 0;
-    var line_end = line_start;
-    while (line_end < source.len and source[line_end] != '\n' and source[line_end] != '\r') {
-        line_end += 1;
-    }
-    const line_text = source[line_start..line_end];
-
-    // 소스 줄 출력
-    try writer.print("  {d} | {s}\n", .{ line_num, line_text });
-
-    // 캐럿 위치 출력
-    var num_width: usize = 0;
-    var n = line_num;
-    while (n > 0) : (n /= 10) {
-        num_width += 1;
-    }
-    var i: usize = 0;
-    while (i < num_width + 2) : (i += 1) try writer.writeByte(' ');
-    try writer.writeAll("| ");
-    i = 0;
-    while (i < lc.column) : (i += 1) {
-        if (line_start + i < source.len and source[line_start + i] == '\t')
-            try writer.writeByte('\t')
-        else
-            try writer.writeByte(' ');
-    }
-    const err_len = if (err.span.end > err.span.start)
-        @min(err.span.end - err.span.start, line_end - (line_start + lc.column))
-    else
-        1;
-    i = 0;
-    while (i < err_len) : (i += 1) try writer.writeByte('^');
-    try writer.writeByte('\n');
+/// 파서 콜백 — 파서/시맨틱 에러를 last_error_buf에 저장.
+fn formatErrors(source: []const u8, file_path: []const u8, scanner: *const Scanner, errors: []const Diagnostic) void {
+    bufferDiagnostics(source, file_path, scanner.line_offsets.items, errors);
 }
 
 fn readStr(ptr: u32, len: u32) []const u8 {
@@ -187,7 +151,14 @@ export fn transpile(
         return 0;
     };
 
-    // 소스맵이 있으면 코드 뒤에 구분자(\0)와 소스맵을 붙여서 반환
+    // 시맨틱 에러는 result와 함께 반환된다 (tsc 호환). JS는 get_error_ptr로 조회.
+    if (result.diagnostics.len > 0) {
+        bufferDiagnostics(source, file_path, result.line_offsets, result.diagnostics);
+    }
+
+    // 소스맵이 있으면 코드 뒤에 구분자(\0)와 소스맵을 붙여서 반환.
+    // sourcemap 없는 경로는 result.code 포인터만 JS로 ownership transfer하고
+    // 나머지(diagnostics/line_offsets)는 여기서 해제해야 누수가 없다.
     const output = if (result.sourcemap) |sm| blk: {
         const total = result.code.len + 1 + sm.len;
         const combined = wasm_alloc.alloc(u8, total) catch {
@@ -200,7 +171,13 @@ export fn transpile(
         @memcpy(combined[result.code.len + 1 ..], sm);
         result.deinit(wasm_alloc);
         break :blk combined;
-    } else result.code;
+    } else blk: {
+        // code만 JS로 넘기고 부가 버퍼는 해제.
+        for (result.diagnostics) |d| d.deinit(wasm_alloc);
+        if (result.diagnostics.len > 0) wasm_alloc.free(result.diagnostics);
+        if (result.line_offsets.len > 0) wasm_alloc.free(result.line_offsets);
+        break :blk result.code;
+    };
 
     const ptr: u32 = @intFromPtr(output.ptr);
     const len: u32 = @intCast(output.len);

--- a/src/diagnostic.zig
+++ b/src/diagnostic.zig
@@ -9,6 +9,7 @@
 //!   - kind로 에러 출처를 구분 (parse, semantic)
 //!   - CLI에서 동일한 코드 프레임 포맷으로 출력 가능
 
+const std = @import("std");
 const Span = @import("lexer/token.zig").Span;
 const ErrorCode = @import("error_codes.zig").Code;
 
@@ -39,3 +40,117 @@ pub const Diagnostic = struct {
         semantic,
     };
 };
+
+/// Arena 수명을 탈출한 Diagnostic. 모든 문자열 필드가 allocator 소유.
+///
+/// 파서/시맨틱 에러는 Parser/Analyzer의 arena에 살지만, WASM/NAPI/CLI가
+/// transpile() 반환 이후에도 에러 정보를 참조해야 하므로 arena 해제 전에
+/// allocator로 복사해 OwnedDiagnostic 배열로 result에 담는다.
+///
+/// deinit()은 각 문자열 필드를 allocator로 free한다.
+pub const OwnedDiagnostic = struct {
+    span: Span,
+    message: []const u8,
+    code: ?ErrorCode = null,
+    found: ?[]const u8 = null,
+    related_span: ?Span = null,
+    related_label: ?[]const u8 = null,
+    hint: ?[]const u8 = null,
+    kind: Diagnostic.Kind = .parse,
+
+    /// Diagnostic을 allocator 소유로 복사해 OwnedDiagnostic을 만든다.
+    /// 실패 시 이미 복사된 필드를 되돌려 free하고 error.OutOfMemory 반환.
+    pub fn init(d: Diagnostic, allocator: std.mem.Allocator) !OwnedDiagnostic {
+        const message = try allocator.dupe(u8, d.message);
+        errdefer allocator.free(message);
+
+        const found = if (d.found) |s| try allocator.dupe(u8, s) else null;
+        errdefer if (found) |s| allocator.free(s);
+
+        const related_label = if (d.related_label) |s| try allocator.dupe(u8, s) else null;
+        errdefer if (related_label) |s| allocator.free(s);
+
+        const hint = if (d.hint) |s| try allocator.dupe(u8, s) else null;
+
+        return .{
+            .span = d.span,
+            .code = d.code,
+            .kind = d.kind,
+            .related_span = d.related_span,
+            .message = message,
+            .found = found,
+            .related_label = related_label,
+            .hint = hint,
+        };
+    }
+
+    pub fn deinit(self: OwnedDiagnostic, allocator: std.mem.Allocator) void {
+        allocator.free(self.message);
+        if (self.found) |s| allocator.free(s);
+        if (self.related_label) |s| allocator.free(s);
+        if (self.hint) |s| allocator.free(s);
+    }
+
+    /// 같은 필드를 가진 Diagnostic 값으로 변환. 렌더러의 fromDiagnostic() 재사용용.
+    /// 반환값은 self의 포인터만 빌리므로 self의 수명 안에서만 유효.
+    pub fn asDiagnostic(self: OwnedDiagnostic) Diagnostic {
+        return .{
+            .span = self.span,
+            .message = self.message,
+            .code = self.code,
+            .found = self.found,
+            .related_span = self.related_span,
+            .related_label = self.related_label,
+            .hint = self.hint,
+            .kind = self.kind,
+        };
+    }
+};
+
+// ─── 테스트 ───
+
+test "OwnedDiagnostic.init: duplicates all strings and frees on deinit" {
+    const allocator = std.testing.allocator;
+    const d = Diagnostic{
+        .span = .{ .start = 3, .end = 7 },
+        .message = "Identifier 'x' has already been declared",
+        .code = .identifier_redeclared,
+        .found = "x",
+        .related_span = .{ .start = 0, .end = 1 },
+        .related_label = "previously declared here",
+        .hint = "Use a different name",
+        .kind = .semantic,
+    };
+
+    const owned = try OwnedDiagnostic.init(d, allocator);
+    defer owned.deinit(allocator);
+
+    // 필드 값은 보존
+    try std.testing.expectEqual(@as(u32, 3), owned.span.start);
+    try std.testing.expectEqual(ErrorCode.identifier_redeclared, owned.code.?);
+    try std.testing.expectEqualStrings("Identifier 'x' has already been declared", owned.message);
+    try std.testing.expectEqualStrings("x", owned.found.?);
+    try std.testing.expectEqualStrings("previously declared here", owned.related_label.?);
+    try std.testing.expectEqualStrings("Use a different name", owned.hint.?);
+    try std.testing.expectEqual(Diagnostic.Kind.semantic, owned.kind);
+
+    // 문자열이 원본과 독립된 포인터인지 (allocator dup 검증)
+    try std.testing.expect(owned.message.ptr != d.message.ptr);
+}
+
+test "OwnedDiagnostic.init: all optional fields null" {
+    const allocator = std.testing.allocator;
+    const d = Diagnostic{
+        .span = .{ .start = 0, .end = 1 },
+        .message = "Expected ';'",
+    };
+
+    const owned = try OwnedDiagnostic.init(d, allocator);
+    defer owned.deinit(allocator);
+
+    try std.testing.expect(owned.code == null);
+    try std.testing.expect(owned.found == null);
+    try std.testing.expect(owned.related_span == null);
+    try std.testing.expect(owned.related_label == null);
+    try std.testing.expect(owned.hint == null);
+}

--- a/src/diagnostic_renderer.zig
+++ b/src/diagnostic_renderer.zig
@@ -22,8 +22,10 @@
 
 const std = @import("std");
 const ansi = @import("ansi.zig");
-const RichDiagnostic = @import("rich_diagnostic.zig").RichDiagnostic;
-const SourceInfo = @import("rich_diagnostic.zig").SourceInfo;
+const rich_diagnostic = @import("rich_diagnostic.zig");
+const RichDiagnostic = rich_diagnostic.RichDiagnostic;
+const SourceInfo = rich_diagnostic.SourceInfo;
+const Diagnostic = @import("diagnostic.zig").Diagnostic;
 
 pub const RenderOptions = struct {
     /// ANSI 컬러 코드 활성화 여부. isTty()로 자동 감지 가능.
@@ -110,6 +112,23 @@ pub fn render(
 
     // 빈 줄로 구분
     try writer.writeByte('\n');
+}
+
+/// 여러 Diagnostic을 순차로 렌더링한다. CLI/WASM/NAPI가 공용으로 쓰는 진입점.
+/// OwnedDiagnostic 등 `asDiagnostic()` 메서드가 있는 타입도 같은 함수로 받는다.
+/// 첫 에러 렌더 실패 시 루프를 중단한다 (writer가 망가진 상태).
+pub fn renderAll(
+    writer: anytype,
+    diagnostics: anytype,
+    source_info: SourceInfo,
+    file_path: []const u8,
+    options: RenderOptions,
+) !void {
+    for (diagnostics) |d| {
+        const diag: Diagnostic = if (@TypeOf(d) == Diagnostic) d else d.asDiagnostic();
+        const rich = rich_diagnostic.fromDiagnostic(diag, file_path);
+        try render(writer, rich, source_info, options);
+    }
 }
 
 /// 소스 코드 없이 간단하게 렌더링한다.

--- a/src/main.zig
+++ b/src/main.zig
@@ -908,7 +908,7 @@ fn transpileFile(
     }
 
     // 시맨틱 에러가 있었으면 exit 1 (tsc 호환: output은 생성하되 에러 코드 반환)
-    if (result.has_errors) return error.TranspileFailed;
+    if (result.diagnostics.len > 0) return error.TranspileFailed;
 
     // --timing
     if (options.timing) {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -21,6 +21,7 @@ const Mangler = @import("codegen/mod.zig").mangler;
 const LinkingMetadata = @import("bundler/linker.zig").LinkingMetadata;
 const rt = @import("bundler/runtime_helpers.zig");
 const Diagnostic = @import("diagnostic.zig").Diagnostic;
+const OwnedDiagnostic = @import("diagnostic.zig").OwnedDiagnostic;
 
 pub const TranspileOptions = struct {
     // --- 파싱 ---
@@ -133,12 +134,20 @@ pub const TranspileResult = struct {
     sourcemap: ?[]const u8 = null,
     /// 런타임 헬퍼 포함 여부
     has_helpers: bool = false,
-    /// 시맨틱 에러 여부 (tsc 호환: 에러가 있어도 output 생성)
-    has_errors: bool = false,
+    /// 시맨틱 에러 목록 (tsc 호환: codegen과 함께 반환).
+    /// allocator 소유. 각 항목은 arena에서 복사된 OwnedDiagnostic.
+    /// 파서 에러는 throw 경로라 여기 담기지 않는다 — on_error 콜백 참조.
+    diagnostics: []const OwnedDiagnostic = &.{},
+    /// 소스의 줄 시작 오프셋. diagnostics 렌더링에 필요.
+    /// allocator 소유. diagnostics가 비었으면 비어 있을 수 있다.
+    line_offsets: []const u32 = &.{},
 
     pub fn deinit(self: *TranspileResult, allocator: std.mem.Allocator) void {
         allocator.free(self.code);
         if (self.sourcemap) |sm| allocator.free(sm);
+        for (self.diagnostics) |d| d.deinit(allocator);
+        if (self.diagnostics.len > 0) allocator.free(self.diagnostics);
+        if (self.line_offsets.len > 0) allocator.free(self.line_offsets);
     }
 };
 
@@ -346,10 +355,39 @@ pub fn transpileWithCallback(
     // Arena 밖으로 복제 (arena는 함수 종료 시 defer로 해제 — line 167).
     // mangle_metadata.skip_nodes는 arena-owned이므로 별도 deinit 불필요.
     const result_code = allocator.dupe(u8, final_output) catch return error.OutOfMemory;
+    errdefer allocator.free(result_code);
+
+    // 시맨틱 에러 복사: arena → allocator. 실패 시 이미 복사된 항목들 roll back.
+    const semantic_errors = analyzer.errors.items;
+    const owned_diagnostics: []const OwnedDiagnostic = if (semantic_errors.len == 0) &.{} else blk: {
+        const buf = allocator.alloc(OwnedDiagnostic, semantic_errors.len) catch return error.OutOfMemory;
+        var filled: usize = 0;
+        errdefer {
+            for (buf[0..filled]) |d| d.deinit(allocator);
+            allocator.free(buf);
+        }
+        for (semantic_errors) |d| {
+            buf[filled] = try OwnedDiagnostic.init(d, allocator);
+            filled += 1;
+        }
+        break :blk buf;
+    };
+    errdefer {
+        for (owned_diagnostics) |d| d.deinit(allocator);
+        if (owned_diagnostics.len > 0) allocator.free(owned_diagnostics);
+    }
+
+    // line_offsets도 복사 (diagnostics 렌더링용). 에러 없으면 생략.
+    const owned_line_offsets: []const u32 = if (semantic_errors.len == 0)
+        &.{}
+    else
+        allocator.dupe(u32, scanner.line_offsets.items) catch return error.OutOfMemory;
+
     return .{
         .code = result_code,
         .sourcemap = sourcemap_json,
         .has_helpers = has_helpers,
-        .has_errors = analyzer.errors.items.len > 0,
+        .diagnostics = owned_diagnostics,
+        .line_offsets = owned_line_offsets,
     };
 }


### PR DESCRIPTION
## Summary
- 플레이그라운드/NAPI에서 `ZTS1000~1399` 시맨틱 에러가 누락되던 문제 수정 — tsc 호환 정책으로 에러와 함께 codegen이 진행되는데 WASM/NAPI는 성공 시 에러를 버리고 있었다
- `OwnedDiagnostic` 추가 (arena 탈출용), `TranspileResult.diagnostics/line_offsets` 필드로 에러 데이터 공급
- `diagnostic_renderer.renderAll()` 공용 진입점 — CLI/WASM/NAPI 렌더링 로직 중복 제거

## 변경 파일
| 파일 | 변경 |
|---|---|
| `src/diagnostic.zig` | `OwnedDiagnostic` struct (init/deinit/asDiagnostic) |
| `src/transpile.zig` | `TranspileResult.diagnostics`/`line_offsets` 필드 + arena 복사 |
| `src/diagnostic_renderer.zig` | `renderAll()` 공용 진입점 (anytype duck-typing) |
| `src/main.zig` | `has_errors` → `diagnostics.len > 0` |
| `packages/wasm/src/wasm_entry.zig` | `formatSingleError` 삭제, `renderAll` 사용 → `[ZTS코드]` 포함 |
| `packages/core/src/napi_entry.zig` | `result.errors` 필드로 CLI 포맷 노출 |
| `packages/shared/index.ts` | `TranspileResult.errors?: string` |
| `packages/wasm/index.ts` | 성공 경로에서도 에러 확인, 핫패스 최적화 (call 2→1) |
| `documents/src/components/Playground.tsx` | `result.errors` monaco 마커 표시 |

## 핫패스 영향
- 에러 없는 성공 경로: WASM export 호출 2회 → **1회** (`get_error_len` 먼저, 0이면 `get_error_ptr`/`readString` 스킵)
- `diagnostics`/`line_offsets`는 에러 없으면 빈 slice — 할당 0

## 제한 / 후속 PR
- 파서 에러는 여전히 NAPI가 `Error: ParseError` 문자열만 throw — context 없는 `ErrorCallback` 제약 때문. PR 2/3에서 해결.
- `labels` (다중 span), `help`, `url` 등 miette급 메타데이터는 다음 PR.

## Test plan
- [x] `zig build test` — 통과
- [x] NAPI 유닛 (`packages/core && bun test`) — 360 pass
- [x] 통합 (`tests/integration && bun test`) — 2899 pass, 4 skip
- [x] WASM 스모크: `const x = 1; const x = 2;` → `ZTS1000` 코드 + miette 프레임 노출 확인
- [x] NAPI 스모크: 동일 소스에서 `result.errors` 확인, 파서 에러는 throw
- [ ] 플레이그라운드에서 수동 확인 (CI 빌드 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)