### PR TITLE
feat(diagnostic): multi-span labels + redeclaration previously-here hint

### DIFF
--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -78,7 +78,8 @@ describe("@zts/wasm", () => {
   });
 
   test("파싱 에러", () => {
-    expect(() => transpile("const = ;")).toThrow("error:");
+    // miette 스타일 렌더: "× <message> [ZTS코드]"
+    expect(() => transpile("const = ;")).toThrow(/\[ZTS\d{4}\]/);
   });
 
   test("Flow 스트리핑", () => {

--- a/src/diagnostic.zig
+++ b/src/diagnostic.zig
@@ -13,10 +13,18 @@ const std = @import("std");
 const Span = @import("lexer/token.zig").Span;
 const ErrorCode = @import("error_codes.zig").Code;
 
+/// 진단 라벨 — 에러의 primary span(`Diagnostic.span`) 외 관련 위치를 가리킨다.
+/// 재선언 에러의 "previously declared here", 브래킷 매칭 에러의 "opening '{' is here" 등.
+pub const Label = struct {
+    span: Span,
+    /// 라벨 메시지. null이면 밑줄만 표시.
+    message: ?[]const u8 = null,
+};
+
 /// 통합 진단 정보.
 /// 파서와 시맨틱 분석기 모두 이 타입으로 에러를 보고한다.
 pub const Diagnostic = struct {
-    /// 에러 발생 위치
+    /// 에러 발생 위치 (primary span)
     span: Span,
     /// 에러 메시지 (예: "Expected ';'", "Identifier 'x' has already been declared")
     message: []const u8,
@@ -24,10 +32,9 @@ pub const Diagnostic = struct {
     code: ?ErrorCode = null,
     /// 실제로 발견된 토큰 (예: "'}'"). null이면 표시하지 않음.
     found: ?[]const u8 = null,
-    /// 관련 위치 (예: 여는 괄호 위치). null이면 표시하지 않음.
-    related_span: ?Span = null,
-    /// 관련 위치 설명 (예: "opening bracket is here"). null이면 표시하지 않음.
-    related_label: ?[]const u8 = null,
+    /// 추가 라벨 — primary span 외의 관련 위치.
+    /// 재선언/참조 연결 에러에서 "원본 선언 위치" 등을 가리킨다. arena 소유.
+    labels: []const Label = &.{},
     /// 힌트 메시지 (예: "Try inserting a semicolon here"). null이면 표시하지 않음.
     hint: ?[]const u8 = null,
     /// 에러 출처
@@ -53,8 +60,7 @@ pub const OwnedDiagnostic = struct {
     message: []const u8,
     code: ?ErrorCode = null,
     found: ?[]const u8 = null,
-    related_span: ?Span = null,
-    related_label: ?[]const u8 = null,
+    labels: []const Label = &.{},
     hint: ?[]const u8 = null,
     kind: Diagnostic.Kind = .parse,
 
@@ -67,8 +73,8 @@ pub const OwnedDiagnostic = struct {
         const found = if (d.found) |s| try allocator.dupe(u8, s) else null;
         errdefer if (found) |s| allocator.free(s);
 
-        const related_label = if (d.related_label) |s| try allocator.dupe(u8, s) else null;
-        errdefer if (related_label) |s| allocator.free(s);
+        const labels = try dupeLabels(d.labels, allocator);
+        errdefer freeLabels(labels, allocator);
 
         const hint = if (d.hint) |s| try allocator.dupe(u8, s) else null;
 
@@ -76,10 +82,9 @@ pub const OwnedDiagnostic = struct {
             .span = d.span,
             .code = d.code,
             .kind = d.kind,
-            .related_span = d.related_span,
             .message = message,
             .found = found,
-            .related_label = related_label,
+            .labels = labels,
             .hint = hint,
         };
     }
@@ -87,8 +92,8 @@ pub const OwnedDiagnostic = struct {
     pub fn deinit(self: OwnedDiagnostic, allocator: std.mem.Allocator) void {
         allocator.free(self.message);
         if (self.found) |s| allocator.free(s);
-        if (self.related_label) |s| allocator.free(s);
         if (self.hint) |s| allocator.free(s);
+        freeLabels(self.labels, allocator);
     }
 
     /// 같은 필드를 가진 Diagnostic 값으로 변환. 렌더러의 fromDiagnostic() 재사용용.
@@ -99,25 +104,47 @@ pub const OwnedDiagnostic = struct {
             .message = self.message,
             .code = self.code,
             .found = self.found,
-            .related_span = self.related_span,
-            .related_label = self.related_label,
+            .labels = self.labels,
             .hint = self.hint,
             .kind = self.kind,
         };
     }
 };
 
+fn dupeLabels(labels: []const Label, allocator: std.mem.Allocator) ![]const Label {
+    if (labels.len == 0) return &.{};
+    const buf = try allocator.alloc(Label, labels.len);
+    var filled: usize = 0;
+    errdefer {
+        for (buf[0..filled]) |l| if (l.message) |m| allocator.free(m);
+        allocator.free(buf);
+    }
+    for (labels) |l| {
+        const msg = if (l.message) |m| try allocator.dupe(u8, m) else null;
+        buf[filled] = .{ .span = l.span, .message = msg };
+        filled += 1;
+    }
+    return buf;
+}
+
+fn freeLabels(labels: []const Label, allocator: std.mem.Allocator) void {
+    for (labels) |l| if (l.message) |m| allocator.free(m);
+    if (labels.len > 0) allocator.free(labels);
+}
+
 // ─── 테스트 ───
 
 test "OwnedDiagnostic.init: duplicates all strings and frees on deinit" {
     const allocator = std.testing.allocator;
+    const sample_labels = [_]Label{
+        .{ .span = .{ .start = 0, .end = 1 }, .message = "previously declared here" },
+    };
     const d = Diagnostic{
         .span = .{ .start = 3, .end = 7 },
         .message = "Identifier 'x' has already been declared",
         .code = .identifier_redeclared,
         .found = "x",
-        .related_span = .{ .start = 0, .end = 1 },
-        .related_label = "previously declared here",
+        .labels = &sample_labels,
         .hint = "Use a different name",
         .kind = .semantic,
     };
@@ -125,17 +152,18 @@ test "OwnedDiagnostic.init: duplicates all strings and frees on deinit" {
     const owned = try OwnedDiagnostic.init(d, allocator);
     defer owned.deinit(allocator);
 
-    // 필드 값은 보존
     try std.testing.expectEqual(@as(u32, 3), owned.span.start);
     try std.testing.expectEqual(ErrorCode.identifier_redeclared, owned.code.?);
     try std.testing.expectEqualStrings("Identifier 'x' has already been declared", owned.message);
     try std.testing.expectEqualStrings("x", owned.found.?);
-    try std.testing.expectEqualStrings("previously declared here", owned.related_label.?);
+    try std.testing.expectEqual(@as(usize, 1), owned.labels.len);
+    try std.testing.expectEqualStrings("previously declared here", owned.labels[0].message.?);
     try std.testing.expectEqualStrings("Use a different name", owned.hint.?);
     try std.testing.expectEqual(Diagnostic.Kind.semantic, owned.kind);
 
-    // 문자열이 원본과 독립된 포인터인지 (allocator dup 검증)
+    // allocator dup 검증 — 원본과 독립된 포인터
     try std.testing.expect(owned.message.ptr != d.message.ptr);
+    try std.testing.expect(owned.labels.ptr != d.labels.ptr);
 }
 
 test "OwnedDiagnostic.init: all optional fields null" {
@@ -150,7 +178,6 @@ test "OwnedDiagnostic.init: all optional fields null" {
 
     try std.testing.expect(owned.code == null);
     try std.testing.expect(owned.found == null);
-    try std.testing.expect(owned.related_span == null);
-    try std.testing.expect(owned.related_label == null);
+    try std.testing.expectEqual(@as(usize, 0), owned.labels.len);
     try std.testing.expect(owned.hint == null);
 }

--- a/src/diagnostic_renderer.zig
+++ b/src/diagnostic_renderer.zig
@@ -72,9 +72,24 @@ pub fn render(
     try ansi.styled(writer, .cyan, diag.file_path, color);
     try writer.print(":{d}:{d}]\n", .{ err_line + 1, err_col + 1 });
 
+    // label이 이미 차지한 줄은 context에서 생략 (중복 방지)
+    const label_before_err = err_line > 0 and hasLabelOnLine(diag.labels, source_info, err_line - 1);
+    const label_after_err = err_line + 1 < source_info.line_offsets.len and hasLabelOnLine(diag.labels, source_info, err_line + 1);
+
     // ── 3. 컨텍스트 줄: 에러 줄 전 1줄 ──
-    if (err_line > 0) {
+    if (err_line > 0 and !label_before_err) {
         try renderSourceLine(writer, source_info, err_line - 1, gutter_width, color, options.unicode);
+    }
+
+    // primary 위쪽 label 먼저 출력 (줄 번호 오름차순 유지)
+    if (label_before_err) {
+        for (diag.labels) |label| {
+            const l_lc = source_info.getLineColumn(label.span.start);
+            if (l_lc.line == err_line - 1) {
+                try renderSourceLine(writer, source_info, l_lc.line, gutter_width, color, options.unicode);
+                try renderLabelUnderline(writer, source_info, label, l_lc.line, l_lc.column, gutter_width, color, options.unicode);
+            }
+        }
     }
 
     // ── 4. 에러 줄 ──
@@ -83,8 +98,16 @@ pub fn render(
     // ── 5. 밑줄 + 라벨 ──
     try renderUnderline(writer, source_info, diag, err_line, err_col, gutter_width, color, options.unicode);
 
-    // ── 6. 에러 줄 후 1줄 (있으면) ──
-    if (err_line + 1 < source_info.line_offsets.len) {
+    // ── 5.5. primary 아래쪽 label 출력 (err_line보다 뒤) ──
+    for (diag.labels) |label| {
+        const l_lc = source_info.getLineColumn(label.span.start);
+        if (l_lc.line <= err_line) continue; // 위쪽/같은 줄은 위에서 처리 또는 생략
+        try renderSourceLine(writer, source_info, l_lc.line, gutter_width, color, options.unicode);
+        try renderLabelUnderline(writer, source_info, label, l_lc.line, l_lc.column, gutter_width, color, options.unicode);
+    }
+
+    // ── 6. 에러 줄 후 1줄 (label이 이미 차지하지 않은 경우) ──
+    if (err_line + 1 < source_info.line_offsets.len and !label_after_err) {
         try renderSourceLine(writer, source_info, err_line + 1, gutter_width, color, options.unicode);
     }
 
@@ -278,6 +301,52 @@ fn renderUnderline(
         try writer.writeByte('^');
     }
     try ansi.setStyle(writer, .reset, color);
+    try writer.writeByte('\n');
+}
+
+/// labels 중 주어진 줄에 걸린 것이 하나라도 있는지.
+fn hasLabelOnLine(labels: []const rich_diagnostic.Label, source_info: SourceInfo, line: u32) bool {
+    for (labels) |label| {
+        if (source_info.getLineColumn(label.span.start).line == line) return true;
+    }
+    return false;
+}
+
+/// Secondary label의 밑줄: ─── (primary의 ^^^ 대비). 메시지가 있으면 밑줄 뒤에 이어 출력.
+fn renderLabelUnderline(
+    writer: anytype,
+    source_info: SourceInfo,
+    label: anytype,
+    line: u32,
+    col: u32,
+    gutter_width: u32,
+    color: bool,
+    unicode: bool,
+) !void {
+    const line_text = source_info.getLineText(line);
+    const span_len = if (label.span.end > label.span.start)
+        @min(label.span.end - label.span.start, @as(u32, @intCast(line_text.len)) -| col)
+    else
+        1;
+
+    try writeGutter(writer, gutter_width, null, color);
+    if (unicode) try writer.writeAll(" \xc2\xb7 ") else try writer.writeAll(" . "); // ·
+
+    var i: u32 = 0;
+    while (i < col) : (i += 1) {
+        if (i < line_text.len and line_text[i] == '\t') try writer.writeByte('\t') else try writer.writeByte(' ');
+    }
+
+    try ansi.setStyle(writer, .cyan, color);
+    const underline_char: []const u8 = if (unicode) "\xe2\x94\x80" else "-"; // ─
+    i = 0;
+    while (i < span_len) : (i += 1) try writer.writeAll(underline_char);
+    try ansi.setStyle(writer, .reset, color);
+
+    if (label.message) |msg| {
+        try writer.writeByte(' ');
+        try ansi.styled(writer, .cyan, msg, color);
+    }
     try writer.writeByte('\n');
 }
 

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -545,7 +545,7 @@ fn tryReinterpretAsTypedArrow(self: *Parser, paren_expr: NodeIndex) ParseError2!
     // Check for `=>` — if present, this is a typed arrow function
     if (self.current() != .arrow or self.scanner.token.has_newline_before) {
         // Not a typed arrow — restore and let the caller treat `:` as ternary separator
-        self.errors.shrinkRetainingCapacity(errors_before);
+        self.rollbackErrors(errors_before);
         self.restoreState(saved);
         return null;
     }
@@ -1079,7 +1079,7 @@ fn trySkipTypeArgsSpeculative(self: *Parser, comptime strict: bool, comptime fol
     self.ast.nodes.items.len = saved_nodes_len;
     self.ast.extra_data.items.len = saved_extra_len;
     self.restoreScratch(saved_scratch);
-    self.errors.shrinkRetainingCapacity(saved_errors_len);
+    self.rollbackErrors(saved_errors_len);
     self.restoreState(scanner_after);
     return type_args_ok;
 }
@@ -1966,7 +1966,7 @@ fn parseTSTypeAssertion(self: *Parser) ParseError2!NodeIndex {
         if (try self.isTypedArrowFunction()) {
             if (try self.parseTypedArrowParams(self.currentSpan().start, false)) |arrow| return arrow;
             self.restoreState(saved);
-            self.errors.shrinkRetainingCapacity(err_count);
+            self.rollbackErrors(err_count);
         }
 
         // 빈 파라미터 arrow: <Type>() => body
@@ -1984,7 +1984,7 @@ fn parseTSTypeAssertion(self: *Parser) ParseError2!NodeIndex {
                 });
             }
             self.restoreState(saved);
-            self.errors.shrinkRetainingCapacity(err_count);
+            self.rollbackErrors(err_count);
         }
 
         // 파라미터가 있는 arrow: <Type>(x, y) => body
@@ -2082,7 +2082,7 @@ fn tryParseGenericArrow(self: *Parser, is_async: bool) ParseError2!?NodeIndex {
         self.ast.nodes.items.len = saved_nodes_len;
         self.ast.extra_data.shrinkRetainingCapacity(saved_extra_len);
         self.restoreState(saved);
-        self.errors.shrinkRetainingCapacity(err_count);
+        self.rollbackErrors(err_count);
         return null;
     }
 
@@ -2103,7 +2103,7 @@ fn tryParseGenericArrow(self: *Parser, is_async: bool) ParseError2!?NodeIndex {
     if (self.current() != .r_paren) {
         self.restoreScratch(scratch_top);
         self.restoreState(saved);
-        self.errors.shrinkRetainingCapacity(err_count);
+        self.rollbackErrors(err_count);
         return null;
     }
     try self.advance(); // skip )
@@ -2119,7 +2119,7 @@ fn tryParseGenericArrow(self: *Parser, is_async: bool) ParseError2!?NodeIndex {
     if (self.current() != .arrow or self.scanner.token.has_newline_before) {
         self.restoreScratch(scratch_top);
         self.restoreState(saved);
-        self.errors.shrinkRetainingCapacity(err_count);
+        self.rollbackErrors(err_count);
         return null;
     }
 

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -160,7 +160,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
                 self.advance() catch break :blk false; // skip 'from'
                 const after_from = self.current();
                 self.restoreState(saved);
-                self.errors.shrinkRetainingCapacity(err_count);
+                self.rollbackErrors(err_count);
                 break :blk after_from != .string_literal;
             }))
         {

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -23,7 +23,8 @@ const NodeList = ast_mod.NodeList;
 const jsx = @import("jsx.zig");
 const ts = @import("ts.zig");
 const flow = @import("flow.zig");
-pub const Diagnostic = @import("../diagnostic.zig").Diagnostic;
+const diagnostic = @import("../diagnostic.zig");
+pub const Diagnostic = diagnostic.Diagnostic;
 const scan_results_mod = @import("scan_results.zig");
 pub const scan_results = scan_results_mod;
 
@@ -330,7 +331,9 @@ pub const Parser = struct {
 
     pub fn deinit(self: *Parser) void {
         self.ast.deinit();
+        for (self.errors.items) |err| if (err.labels.len > 0) self.allocator.free(err.labels);
         self.errors.deinit(self.allocator);
+        for (self.deferred_module_errors.items) |err| if (err.labels.len > 0) self.allocator.free(err.labels);
         self.deferred_module_errors.deinit(self.allocator);
         self.scratch.deinit(self.allocator);
         self.scan_import_records.deinit(self.allocator);
@@ -339,6 +342,16 @@ pub const Parser = struct {
         self.scan_import_binding_map.deinit(self.allocator);
         self.param_name_spans.deinit(self.allocator);
         self.bracket_stack.deinit(self.allocator);
+    }
+
+    /// Speculative 파싱 실패 시 errors를 mark까지 롤백한다. 제거되는 에러가
+    /// 소유한 labels 배열도 함께 free — `errors.shrinkRetainingCapacity` 대신 사용.
+    pub fn rollbackErrors(self: *Parser, mark: usize) void {
+        if (mark >= self.errors.items.len) return;
+        for (self.errors.items[mark..]) |err| {
+            if (err.labels.len > 0) self.allocator.free(err.labels);
+        }
+        self.errors.shrinkRetainingCapacity(mark);
     }
 
     // ================================================================
@@ -397,17 +410,23 @@ pub const Parser = struct {
     pub fn expect(self: *Parser, expected: Kind) !void {
         if (!try self.eat(expected)) {
             const opening = self.findMatchingOpenBracket(expected);
-            try self.errors.append(self.allocator, .{
-                .span = self.currentSpan(),
-                .message = expected.symbol(),
-                .found = self.current().symbol(),
-                .related_span = if (opening) |o| o.span else null,
-                .related_label = if (opening) |o| switch (o.kind) {
+            const labels: []const diagnostic.Label = if (opening) |o| blk: {
+                const label_msg: ?[]const u8 = switch (o.kind) {
                     .l_paren => "opening '(' is here",
                     .l_bracket => "opening '[' is here",
                     .l_curly => "opening '{' is here",
                     else => null,
-                } else null,
+                };
+                if (label_msg == null) break :blk &.{};
+                const buf = try self.allocator.alloc(diagnostic.Label, 1);
+                buf[0] = .{ .span = o.span, .message = label_msg };
+                break :blk buf;
+            } else &.{};
+            try self.errors.append(self.allocator, .{
+                .span = self.currentSpan(),
+                .message = expected.symbol(),
+                .found = self.current().symbol(),
+                .labels = labels,
             });
         }
     }
@@ -2128,7 +2147,7 @@ pub const Parser = struct {
         self.in_formal_parameters = false;
         if (self.current() != .r_paren) {
             self.restoreScratch(scratch_top);
-            self.errors.shrinkRetainingCapacity(errors_before);
+            self.rollbackErrors(errors_before);
             self.restoreState(saved);
             return null;
         }
@@ -2144,7 +2163,7 @@ pub const Parser = struct {
         // => 확인
         if (self.current() != .arrow or self.scanner.token.has_newline_before) {
             self.restoreScratch(scratch_top);
-            self.errors.shrinkRetainingCapacity(errors_before);
+            self.rollbackErrors(errors_before);
             self.restoreState(saved);
             return null;
         }

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -1932,25 +1932,19 @@ test "CoverGrammar: arrow params rest-init is error" {
 // ================================================================
 
 /// 테스트 헬퍼: 특정 message를 가진 에러가 있는지 확인한다.
-/// 추가로 found, related_label, hint 필드를 검증할 수 있다.
+/// found, labels, hint 필드를 검증할 수 있다.
 const ErrorCheck = struct {
-    /// 에러 message (정확 일치)
     message: ?[]const u8 = null,
-    /// 에러 message (부분 일치)
     message_contains: ?[]const u8 = null,
-    /// found 필드가 non-null이어야 하는지
     has_found: ?bool = null,
-    /// related_span이 non-null이어야 하는지
-    has_related_span: ?bool = null,
-    /// related_label 기대값 (정확 일치)
-    related_label: ?[]const u8 = null,
-    /// hint가 non-null이어야 하는지
+    /// labels 배열이 비어 있는지 여부
+    has_labels: ?bool = null,
+    /// 라벨 중 하나가 이 message와 일치해야 함
+    label_message: ?[]const u8 = null,
     has_hint: ?bool = null,
-    /// hint 기대값 (정확 일치)
     hint: ?[]const u8 = null,
 };
 
-/// 테스트 헬퍼: 소스를 파싱하고 조건에 맞는 에러가 있는지 검증한다.
 fn expectParseError(source: []const u8, check: ErrorCheck) !void {
     var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
@@ -1965,21 +1959,27 @@ fn expectParseError(source: []const u8, check: ErrorCheck) !void {
         const contains_match = if (check.message_contains) |c| std.mem.indexOf(u8, err.message, c) != null else true;
         if (!msg_match or !contains_match) continue;
 
-        // message 매칭된 에러를 찾음 — 나머지 필드 검증
         if (check.has_found) |hf| try std.testing.expectEqual(hf, err.found != null);
-        if (check.has_related_span) |hr| try std.testing.expectEqual(hr, err.related_span != null);
-        if (check.related_label) |rl| {
-            try std.testing.expect(err.related_label != null);
-            try std.testing.expectEqualStrings(rl, err.related_label.?);
+        if (check.has_labels) |hl| try std.testing.expectEqual(hl, err.labels.len > 0);
+        if (check.label_message) |lm| {
+            var found_label = false;
+            for (err.labels) |l| {
+                if (l.message) |m| {
+                    if (std.mem.eql(u8, m, lm)) {
+                        found_label = true;
+                        break;
+                    }
+                }
+            }
+            try std.testing.expect(found_label);
         }
         if (check.has_hint) |hh| try std.testing.expectEqual(hh, err.hint != null);
         if (check.hint) |h| {
             try std.testing.expect(err.hint != null);
             try std.testing.expectEqualStrings(h, err.hint.?);
         }
-        return; // 검증 성공
+        return;
     }
-    // 매칭되는 에러를 못 찾음
     return error.TestUnexpectedResult;
 }
 
@@ -2004,30 +2004,27 @@ test "ErrorMsg: expect() shows found for curly brace" {
     try expectParseError("if (true) {", .{ .message = "}", .has_found = true });
 }
 
-test "ErrorMsg: bracket matching shows related_span for paren" {
-    // `function f(a, b ]` → Expected ')' but found ']', opening '(' is here
+test "ErrorMsg: bracket matching label for paren" {
     try expectParseError("function f(a, b ]", .{
         .message = ")",
-        .has_related_span = true,
-        .related_label = "opening '(' is here",
+        .has_labels = true,
+        .label_message = "opening '(' is here",
     });
 }
 
-test "ErrorMsg: bracket matching shows related_span for curly" {
-    // `if (true) { var x = 1;` → EOF에서 '}' 기대, opening '{' is here
+test "ErrorMsg: bracket matching label for curly" {
     try expectParseError("if (true) { var x = 1;", .{
         .message = "}",
-        .has_related_span = true,
-        .related_label = "opening '{' is here",
+        .has_labels = true,
+        .label_message = "opening '{' is here",
     });
 }
 
-test "ErrorMsg: bracket matching shows related_span for bracket" {
-    // `var a = [1, 2` → EOF에서 ']' 기대, opening '[' is here
+test "ErrorMsg: bracket matching label for bracket" {
     try expectParseError("var a = [1, 2", .{
         .message = "]",
-        .has_related_span = true,
-        .related_label = "opening '[' is here",
+        .has_labels = true,
+        .label_message = "opening '[' is here",
     });
 }
 
@@ -2079,14 +2076,14 @@ test "ErrorMsg: nested brackets track correctly" {
 
     _ = try parser.parse();
     try std.testing.expect(parser.errors.items.len > 0);
-    var has_related = false;
+    var has_labels = false;
     for (parser.errors.items) |err| {
-        if (err.related_span != null) {
-            has_related = true;
+        if (err.labels.len > 0) {
+            has_labels = true;
             break;
         }
     }
-    try std.testing.expect(has_related);
+    try std.testing.expect(has_labels);
 }
 
 test "ErrorMsg: valid code has no errors (regression)" {

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -370,7 +370,7 @@ pub fn parseDecorator(self: *Parser) ParseError2!NodeIndex {
         self.ast.nodes.items.len = saved_nodes_len;
         self.ast.extra_data.items.len = saved_extra_len;
         self.restoreScratch(saved_scratch);
-        self.errors.shrinkRetainingCapacity(saved_errors_len);
+        self.rollbackErrors(saved_errors_len);
         if (!type_args_ok) {
             // 파싱 실패 시 상태 복원
             self.restoreState(saved_scanner);
@@ -552,7 +552,7 @@ fn parseTypeOrTypePredicate(self: *Parser) ParseError2!NodeIndex {
             }
             // 'is'가 아니면 일반 타입 — 상태 복원 후 parseType에 위임
             self.restoreState(saved);
-            self.errors.shrinkRetainingCapacity(err_count);
+            self.rollbackErrors(err_count);
         }
     }
 
@@ -732,7 +732,7 @@ fn parseTypeOperatorOrHigher(self: *Parser) ParseError2!NodeIndex {
                 // 외부 컨텍스트가 disallow가 아닌데 ? 가 오면 → extends는 조건부 타입의 것
                 if (!ctx_saved.disallow_conditional_types and self.current() == .question) {
                     self.restoreState(infer_saved);
-                    self.errors.shrinkRetainingCapacity(infer_err_count);
+                    self.rollbackErrors(infer_err_count);
                     constraint = NodeIndex.none;
                 }
             }
@@ -1198,7 +1198,7 @@ fn tryParseFunctionTypeWithBacktracking(self: *Parser, start: u32) ParseError2!?
         // () 뒤에 => 없음 — 복원
         self.ast.nodes.items.len = nodes_before;
         self.ast.extra_data.items.len = extras_before;
-        self.errors.shrinkRetainingCapacity(errors_before);
+        self.rollbackErrors(errors_before);
         self.restoreState(saved);
         return null;
     }
@@ -1228,12 +1228,12 @@ fn tryParseFunctionTypeWithBacktracking(self: *Parser, start: u32) ParseError2!?
             // 에러 발생 — 함수 타입이 아님, 복원하여 괄호 타입으로 폴백
             self.ast.nodes.items.len = inner_nodes;
             self.ast.extra_data.items.len = inner_extras;
-            self.errors.shrinkRetainingCapacity(inner_errors);
+            self.rollbackErrors(inner_errors);
             self.restoreState(inner_saved);
             // 외부 saved로도 복원
             self.ast.nodes.items.len = nodes_before;
             self.ast.extra_data.items.len = extras_before;
-            self.errors.shrinkRetainingCapacity(errors_before);
+            self.rollbackErrors(errors_before);
             self.restoreState(saved);
             return null;
         }
@@ -1278,7 +1278,7 @@ fn tryParseFunctionTypeWithBacktracking(self: *Parser, start: u32) ParseError2!?
     // 파라미터로 파싱 실패 — 복원
     self.ast.nodes.items.len = nodes_before;
     self.ast.extra_data.items.len = extras_before;
-    self.errors.shrinkRetainingCapacity(errors_before);
+    self.rollbackErrors(errors_before);
     self.restoreState(saved);
     return null;
 }
@@ -1719,7 +1719,7 @@ fn parseTupleElementInner(self: *Parser) ParseError2!NodeIndex {
             self.advance() catch break :blk false; // skip ?
             const after_question = self.current();
             self.restoreState(saved);
-            self.errors.shrinkRetainingCapacity(err_count);
+            self.rollbackErrors(err_count);
             break :blk after_question == .colon;
         });
         if (is_labeled) {
@@ -1769,7 +1769,7 @@ fn isMappedType(self: *Parser) ParseError2!bool {
     defer {
         self.restoreState(state);
         // lookahead 중 추가된 에러 되돌리기
-        self.errors.shrinkRetainingCapacity(err_count);
+        self.rollbackErrors(err_count);
     }
 
     try self.advance(); // skip {

--- a/src/rich_diagnostic.zig
+++ b/src/rich_diagnostic.zig
@@ -14,9 +14,12 @@
 
 const std = @import("std");
 const Span = @import("lexer/token.zig").Span;
-const Diagnostic = @import("diagnostic.zig").Diagnostic;
+const diag_mod = @import("diagnostic.zig");
+const Diagnostic = diag_mod.Diagnostic;
 const BundlerDiagnostic = @import("bundler/types.zig").BundlerDiagnostic;
 const error_codes = @import("error_codes.zig");
+
+pub const Label = diag_mod.Label;
 
 /// 통합 진단 정보. 렌더러가 이 타입을 받아 포맷팅한다.
 pub const RichDiagnostic = struct {
@@ -41,16 +44,6 @@ pub const RichDiagnostic = struct {
         @"error",
         warning,
         info,
-    };
-
-    /// 소스 코드의 특정 위치에 붙이는 라벨.
-    /// 주 span 외에 "여기서 선언됨", "여기서 참조됨" 등을 표시할 때 사용.
-    pub const Label = struct {
-        span: Span,
-        /// 라벨 메시지. null이면 밑줄만 표시.
-        message: ?[]const u8 = null,
-        /// primary=true: ^^^ (주 원인), false: --- (보조 정보)
-        primary: bool = false,
     };
 };
 
@@ -120,22 +113,16 @@ pub const SourceInfo = struct {
 // ─── 변환 함수 ───
 
 /// 파서/시맨틱 Diagnostic을 RichDiagnostic으로 변환한다.
-///
 /// Diagnostic에는 severity가 없으므로 항상 .error로 설정한다.
-/// related_span이 있으면 related_label을 RichDiagnostic.note로 전달한다.
-/// (멀티 스팬 labels는 allocator가 필요하므로, 단순 변환에서는 note로 대체)
 pub fn fromDiagnostic(d: Diagnostic, file_path: []const u8) RichDiagnostic {
-    // related_span이 있으면 note로 위치 정보를 포함
-    const note_text: ?[]const u8 = if (d.related_label) |label| label else null;
-
     return .{
         .severity = .@"error",
         .code = if (d.code) |c| c.format() else null,
         .message = d.message,
         .span = d.span,
         .file_path = file_path,
+        .labels = d.labels,
         .help = d.hint,
-        .note = note_text,
     };
 }
 
@@ -248,16 +235,18 @@ test "fromDiagnostic: uses explicit error code" {
     try std.testing.expectEqualStrings("ZTS0300", rich.code.?);
 }
 
-test "fromDiagnostic: includes related span as note" {
+test "fromDiagnostic: forwards labels" {
+    const labels = [_]Label{
+        .{ .span = .{ .start = 5, .end = 6 }, .message = "opening '{' is here" },
+    };
     const d = Diagnostic{
         .span = .{ .start = 20, .end = 25 },
         .message = "Unexpected '}'",
-        .related_span = .{ .start = 5, .end = 6 },
-        .related_label = "opening '{' is here",
+        .labels = &labels,
         .kind = .parse,
     };
     const rich = fromDiagnostic(d, "test.ts");
 
-    try std.testing.expect(rich.note != null);
-    try std.testing.expectEqualStrings("opening '{' is here", rich.note.?);
+    try std.testing.expectEqual(@as(usize, 1), rich.labels.len);
+    try std.testing.expectEqualStrings("opening '{' is here", rich.labels[0].message.?);
 }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -27,7 +27,8 @@ const SymbolId = symbol_mod.SymbolId;
 const SymbolKind = symbol_mod.SymbolKind;
 const Symbol = symbol_mod.Symbol;
 const checker = @import("checker.zig");
-pub const Diagnostic = @import("../diagnostic.zig").Diagnostic;
+const diagnostic = @import("../diagnostic.zig");
+pub const Diagnostic = diagnostic.Diagnostic;
 const ErrorCode = @import("../error_codes.zig").Code;
 
 const AllocError = std.mem.Allocator.Error;
@@ -207,6 +208,7 @@ pub const SemanticAnalyzer = struct {
         for (self.errors.items) |err| {
             self.allocator.free(err.message);
             if (err.hint) |hint| self.allocator.free(hint);
+            if (err.labels.len > 0) self.allocator.free(err.labels);
         }
         self.scopes.deinit(self.allocator);
         self.symbols.deinit(self.allocator);
@@ -593,7 +595,7 @@ pub const SemanticAnalyzer = struct {
         if (!is_annex_b_fn) {
             if (self.findSymbolInScope(target_scope, name_text)) |existing| {
                 if (!self.canRedeclare(existing.kind, kind, target_scope)) {
-                    try self.addError(decl_span, name_text);
+                    try self.addRedeclarationError(decl_span, name_text, existing.declaration_span);
                     return;
                 }
             }
@@ -682,7 +684,7 @@ pub const SemanticAnalyzer = struct {
                 // block scope의 let/const/class와 충돌하거나,
                 // block scope의 function-like 선언과도 충돌
                 if (existing.kind.isBlockScoped() or existing.kind.isFunctionLike()) {
-                    try self.addError(decl_span, name);
+                    try self.addRedeclarationError(decl_span, name, existing.declaration_span);
                     return true;
                 }
             }
@@ -707,7 +709,7 @@ pub const SemanticAnalyzer = struct {
         // { { var f; } let f; } → var의 origin=inner, let의 scope=outer → inner는 outer의 자식이므로 충돌
         // { let f; } 밖의 var f → var의 origin=global, let의 scope=block → 충돌 아님
         if (self.isScopeDescendantOf(sym.origin_scope, lexical_scope)) {
-            try self.addError(decl_span, name);
+            try self.addRedeclarationError(decl_span, name, sym.declaration_span);
             return true;
         }
         return false;
@@ -992,7 +994,26 @@ pub const SemanticAnalyzer = struct {
     // ================================================================
 
     fn addError(self: *SemanticAnalyzer, span: Span, name: []const u8) AllocError!void {
-        try self.addErrorMsgCode(span, try std.fmt.allocPrint(self.allocator, "Identifier '{s}' has already been declared", .{name}), .identifier_redeclared);
+        try self.addRedeclarationError(span, name, null);
+    }
+
+    /// 재선언 에러 + "previously declared here" secondary label.
+    /// existing_span이 null이면 label 없이 기본 에러.
+    fn addRedeclarationError(self: *SemanticAnalyzer, span: Span, name: []const u8, existing_span: ?Span) AllocError!void {
+        const msg = try std.fmt.allocPrint(self.allocator, "Identifier '{s}' has already been declared", .{name});
+        errdefer self.allocator.free(msg);
+        const labels: []const diagnostic.Label = if (existing_span) |ex| blk: {
+            const buf = try self.allocator.alloc(diagnostic.Label, 1);
+            buf[0] = .{ .span = ex, .message = "previously declared here" };
+            break :blk buf;
+        } else &.{};
+        try self.errors.append(self.allocator, .{
+            .span = span,
+            .message = msg,
+            .kind = .semantic,
+            .code = .identifier_redeclared,
+            .labels = labels,
+        });
     }
 
     fn addPrivateNameError(self: *SemanticAnalyzer, span: Span, name: []const u8) AllocError!void {
@@ -2221,7 +2242,7 @@ pub const SemanticAnalyzer = struct {
                 for (names.*[0..count.*]) |existing_span| {
                     const existing_text = self.ast.getText(existing_span);
                     if (std.mem.eql(u8, name_text, existing_text)) {
-                        try self.addError(node.span, name_text);
+                        try self.addRedeclarationError(node.span, name_text, existing_span);
                         return;
                     }
                 }
@@ -2282,7 +2303,7 @@ pub const SemanticAnalyzer = struct {
             for (catch_names) |catch_span| {
                 const catch_name = self.ast.getText(catch_span);
                 if (std.mem.eql(u8, sym_name, catch_name)) {
-                    try self.addError(sym.declaration_span, sym_name);
+                    try self.addRedeclarationError(sym.declaration_span, sym_name, catch_span);
                     return;
                 }
             }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -198,10 +198,14 @@ const TestResult = struct {
 /// 테스트 헬퍼: 소스 코드를 파싱 → transformer 실행.
 fn parseAndTransform(allocator: std.mem.Allocator, source: []const u8) !TestResult {
     const scanner_ptr = try allocator.create(Scanner);
+    errdefer allocator.destroy(scanner_ptr);
     scanner_ptr.* = try Scanner.init(allocator, source);
+    errdefer scanner_ptr.deinit();
 
     const parser_ptr = try allocator.create(Parser);
+    errdefer allocator.destroy(parser_ptr);
     parser_ptr.* = Parser.init(allocator, scanner_ptr);
+    errdefer parser_ptr.deinit();
 
     _ = try parser_ptr.parse();
 
@@ -270,10 +274,14 @@ test "Transformer: isTypeOnlyNode covers all TS type tags" {
 /// 테스트 헬퍼: TransformOptions를 지정하여 파싱 → transformer 실행.
 pub fn parseAndTransformWithOptions(allocator: std.mem.Allocator, source: []const u8, options: TransformOptions) !TestResult {
     const scanner_ptr = try allocator.create(Scanner);
+    errdefer allocator.destroy(scanner_ptr);
     scanner_ptr.* = try Scanner.init(allocator, source);
+    errdefer scanner_ptr.deinit();
 
     const parser_ptr = try allocator.create(Parser);
+    errdefer allocator.destroy(parser_ptr);
     parser_ptr.* = Parser.init(allocator, scanner_ptr);
+    errdefer parser_ptr.deinit();
 
     _ = try parser_ptr.parse();
 


### PR DESCRIPTION
## Summary
- `Diagnostic.labels: []Label` 도입 — primary span 외 관련 위치를 다중 표시
- 재선언 에러(ZTS1000) 가 원본 선언 위치에 **"previously declared here"** 라벨 표시
- `diagnostic_renderer`가 miette 스타일로 여러 줄을 한 snippet에 정렬 출력
- PR #1437 후행: WASM CI 테스트 regex를 `[ZTS\d{4}\]` 포맷에 맞춰 복구

## 예시 출력
입력: \`let x = 1;\nlet x = 2;\`

\`\`\`
  × Identifier 'x' has already been declared [ZTS1000]
  ╭─[test.ts:2:5]
1 │ let x = 1;
  ·     ─ previously declared here
2 │ let x = 2;
  ·     ^
  ╰────
\`\`\`

## 구조적 변경
| 파일 | 변경 |
|---|---|
| \`src/diagnostic.zig\` | \`Label\` struct, \`OwnedDiagnostic.labels\` dup/free 로직 |
| \`src/parser/parser.zig\` | \`rollbackErrors\` 헬퍼 + \`Parser.deinit\`에 labels-free 경로 |
| \`src/parser/{expression,module,ts}.zig\` | \`errors.shrinkRetainingCapacity\` 17곳 → \`rollbackErrors\` |
| \`src/parser/parser.zig:expect\` | bracket matching을 \`related_span\` → \`labels\` 사용으로 이행 |
| \`src/diagnostic_renderer.zig\` | \`renderLabelUnderline\` + \`hasLabelOnLine\`, 줄 중복 방지 로직 |
| \`src/semantic/analyzer.zig\` | \`addRedeclarationError\` — Symbol.declaration_span으로 label 생성 |
| \`src/rich_diagnostic.zig\` | \`Label\` alias, \`fromDiagnostic\`이 \`labels\` 통과 |
| \`src/parser/parser_test.zig\` | \`ErrorCheck\`의 \`has_related_span/related_label\` → \`has_labels/label_message\` |
| \`src/transformer/transformer_test.zig\` | 테스트 헬퍼 errdefer — parser label 할당 누수 경로 보정 |
| \`packages/wasm/index.test.ts\` | 파싱 에러 기대값 regex 복구 (CI 실패 해결) |

## 후속 계획 (원래 PR 2 범위 분리)
범위 관리를 위해 PR 2를 축소 — 나머지는 후속 PR에서:
- **PR 2.5**: 재선언 6종 labels — ZTS1100, ZTS1200, ZTS1202, ZTS1300, ZTS703, ZTS515
- **PR 3**: 참조-정의 연결 5종 labels — ZTS1101, ZTS1103, ZTS1104, ZTS1201, ZTS1204
- **PR 4**: \`help\`/\`url\` 메타데이터 (Code.help(), Code.docsUrl())

## Test plan
- [x] \`zig build test\` — 통과 (3017/3017)
- [x] NAPI 유닛 (\`packages/core && bun test\`) — 360 pass
- [x] WASM 유닛 (\`packages/wasm && bun test\`) — 28 pass (CI 실패 복구)
- [x] 통합 (\`tests/integration && bun test\`) — 2899 pass, 4 skip
- [x] 스모크: \`let x = 1;\nlet x = 2;\` 입력에 ZTS1000 + previously declared here 라벨 확인
- [ ] 플레이그라운드 확인 (CI 빌드 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)