### PR TITLE
feat(diagnostic): previously-declared-here labels for 6 redeclaration errors

### DIFF
--- a/src/diagnostic.zig
+++ b/src/diagnostic.zig
@@ -13,6 +13,10 @@ const std = @import("std");
 const Span = @import("lexer/token.zig").Span;
 const ErrorCode = @import("error_codes.zig").Code;
 
+/// 재선언 계열 에러의 secondary label 문구.
+/// ZTS1000/1100/1200/1202/1300/515/703 등에서 원본 선언 위치를 가리킬 때 재사용.
+pub const PREVIOUSLY_DECLARED_HERE = "previously declared here";
+
 /// 진단 라벨 — 에러의 primary span(`Diagnostic.span`) 외 관련 위치를 가리킨다.
 /// 재선언 에러의 "previously declared here", 브래킷 매칭 에러의 "opening '{' is here" 등.
 pub const Label = struct {

--- a/src/diagnostic_renderer.zig
+++ b/src/diagnostic_renderer.zig
@@ -98,10 +98,18 @@ pub fn render(
     // ── 5. 밑줄 + 라벨 ──
     try renderUnderline(writer, source_info, diag, err_line, err_col, gutter_width, color, options.unicode);
 
+    // ── 5.25. primary와 같은 줄에 걸린 label 출력 (primary 밑줄 바로 아래) ──
+    for (diag.labels) |label| {
+        const l_lc = source_info.getLineColumn(label.span.start);
+        if (l_lc.line == err_line) {
+            try renderLabelUnderline(writer, source_info, label, l_lc.line, l_lc.column, gutter_width, color, options.unicode);
+        }
+    }
+
     // ── 5.5. primary 아래쪽 label 출력 (err_line보다 뒤) ──
     for (diag.labels) |label| {
         const l_lc = source_info.getLineColumn(label.span.start);
-        if (l_lc.line <= err_line) continue; // 위쪽/같은 줄은 위에서 처리 또는 생략
+        if (l_lc.line <= err_line) continue;
         try renderSourceLine(writer, source_info, l_lc.line, gutter_width, color, options.unicode);
         try renderLabelUnderline(writer, source_info, label, l_lc.line, l_lc.column, gutter_width, color, options.unicode);
     }

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -526,6 +526,18 @@ pub const Parser = struct {
         });
     }
 
+    /// 재선언 계열 에러 + "previously declared here" secondary label.
+    pub fn addErrorCodeWithPrevious(self: *Parser, span: Span, message: []const u8, code: ErrorCode, previous_span: Span) !void {
+        const buf = try self.allocator.alloc(diagnostic.Label, 1);
+        buf[0] = .{ .span = previous_span, .message = diagnostic.PREVIOUSLY_DECLARED_HERE };
+        try self.errors.append(self.allocator, .{
+            .span = span,
+            .message = message,
+            .code = code,
+            .labels = buf,
+        });
+    }
+
     /// Unambiguous 모드에서 모듈 전용 에러를 지연 수집한다.
     /// module에서만 에러인 항목 (top-level return, await in module 등)에 사용.
     /// 파싱 후 resolveModuleKind()에서 모듈 확정 시 병합, 스크립트 확정 시 폐기.
@@ -970,7 +982,7 @@ pub const Parser = struct {
                 for (self.param_name_spans.items) |prev_span| {
                     const prev_name = self.ast.source[prev_span.start..prev_span.end];
                     if (std.mem.eql(u8, name, prev_name)) {
-                        try self.addErrorCode(node.span, "Duplicate parameter name", .duplicate_parameter);
+                        try self.addErrorCodeWithPrevious(node.span, "Duplicate parameter name", .duplicate_parameter, prev_span);
                         return;
                     }
                 }
@@ -1518,7 +1530,7 @@ pub const Parser = struct {
                 for (self.param_name_spans.items[0..j]) |prev_span| {
                     const prev_name = self.ast.source[prev_span.start..prev_span.end];
                     if (std.mem.eql(u8, name, prev_name)) {
-                        try self.addErrorCode(name_span, "Duplicate parameter name", .duplicate_parameter);
+                        try self.addErrorCodeWithPrevious(name_span, "Duplicate parameter name", .duplicate_parameter, prev_span);
                         break;
                     }
                 }

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -932,7 +932,7 @@ fn parseSwitchStatement(self: *Parser) ParseError2!NodeIndex {
     self.ctx.is_top_level = false;
 
     const scratch_top = self.saveScratch();
-    var has_default = false;
+    var first_default_span: ?Span = null;
     while (self.current() != .r_curly and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
 
@@ -941,10 +941,11 @@ fn parseSwitchStatement(self: *Parser) ParseError2!NodeIndex {
         const default_span = self.currentSpan();
         const case_node = try parseSwitchCase(self);
         if (is_default) {
-            if (has_default) {
-                try self.addErrorCode(default_span, "Only one default clause is allowed in a switch statement", .switch_duplicate_default);
+            if (first_default_span) |first| {
+                try self.addErrorCodeWithPrevious(default_span, "Only one default clause is allowed in a switch statement", .switch_duplicate_default, first);
+            } else {
+                first_default_span = default_span;
             }
-            has_default = true;
         }
         try self.scratch.append(self.allocator, case_node);
 

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -448,11 +448,8 @@ pub const SemanticAnalyzer = struct {
             const is_accessor_pair = (existing.kind == .getter and kind == .setter) or
                 (existing.kind == .setter and kind == .getter);
             if (!is_accessor_pair) {
-                try self.addErrorMsgCode(span, try std.fmt.allocPrint(
-                    self.allocator,
-                    "Private field '{s}' has already been declared",
-                    .{name},
-                ), .private_redeclared);
+                const msg = try std.fmt.allocPrint(self.allocator, "Private field '{s}' has already been declared", .{name});
+                try self.addErrorMsgCodeWithPrevious(span, msg, .private_redeclared, existing.span);
                 return;
             }
             // getter+setter 쌍 확인됨 → accessor_pair로 업데이트
@@ -997,21 +994,26 @@ pub const SemanticAnalyzer = struct {
         try self.addRedeclarationError(span, name, null);
     }
 
-    /// 재선언 에러 + "previously declared here" secondary label.
-    /// existing_span이 null이면 label 없이 기본 에러.
-    fn addRedeclarationError(self: *SemanticAnalyzer, span: Span, name: []const u8, existing_span: ?Span) AllocError!void {
+    /// ZTS1000 identifier_redeclared — "Identifier '{name}' has already been declared" 메시지.
+    fn addRedeclarationError(self: *SemanticAnalyzer, span: Span, name: []const u8, previous_span: ?Span) AllocError!void {
         const msg = try std.fmt.allocPrint(self.allocator, "Identifier '{s}' has already been declared", .{name});
-        errdefer self.allocator.free(msg);
-        const labels: []const diagnostic.Label = if (existing_span) |ex| blk: {
+        try self.addErrorMsgCodeWithPrevious(span, msg, .identifier_redeclared, previous_span);
+    }
+
+    /// 재선언 계열 에러 + "previously declared here" secondary label.
+    /// previous_span이 null이면 label 없이 기본 에러.
+    /// msg는 allocator 소유가 인계된다 (deinit에서 free).
+    fn addErrorMsgCodeWithPrevious(self: *SemanticAnalyzer, span: Span, msg: []const u8, code: ErrorCode, previous_span: ?Span) AllocError!void {
+        const labels: []const diagnostic.Label = if (previous_span) |ex| blk: {
             const buf = try self.allocator.alloc(diagnostic.Label, 1);
-            buf[0] = .{ .span = ex, .message = "previously declared here" };
+            buf[0] = .{ .span = ex, .message = diagnostic.PREVIOUSLY_DECLARED_HERE };
             break :blk buf;
         } else &.{};
         try self.errors.append(self.allocator, .{
             .span = span,
             .message = msg,
             .kind = .semantic,
-            .code = .identifier_redeclared,
+            .code = code,
             .labels = labels,
         });
     }
@@ -2133,8 +2135,9 @@ pub const SemanticAnalyzer = struct {
             const name = self.ast.getText(label_node.span);
 
             // 중복 label 체크 (같은 label 이름이 현재 스택에 있으면 에러)
-            if (self.findLabel(name) != null) {
-                try self.addErrorMsgCode(label_node.span, try std.fmt.allocPrint(self.allocator, "Label '{s}' has already been declared", .{name}), .label_redeclared);
+            if (self.findLabel(name)) |existing| {
+                const msg = try std.fmt.allocPrint(self.allocator, "Label '{s}' has already been declared", .{name});
+                try self.addErrorMsgCodeWithPrevious(label_node.span, msg, .label_redeclared, existing.span);
             }
 
             // body가 loop인지 판별 (continue label에 필요)
@@ -2668,15 +2671,12 @@ pub const SemanticAnalyzer = struct {
     /// TS에서는 function overload, namespace merge 등으로 같은 이름의 export가 합법.
     fn registerExportedName(self: *SemanticAnalyzer, name: []const u8, span: Span) AllocError!void {
         if (!self.is_module) return;
-        if (self.exported_names.get(name)) |_| {
+        if (self.exported_names.get(name)) |previous_span| {
             // TS 모드: duplicate export 체크 스킵 (oxc: !is_typescript() 조건)
             // JS 모드에서만 에러
             if (!self.is_ts) {
-                try self.addErrorMsgCode(span, try std.fmt.allocPrint(
-                    self.allocator,
-                    "Duplicate export name '{s}'",
-                    .{name},
-                ), .duplicate_export);
+                const msg = try std.fmt.allocPrint(self.allocator, "Duplicate export name '{s}'", .{name});
+                try self.addErrorMsgCodeWithPrevious(span, msg, .duplicate_export, previous_span);
             }
         } else {
             try self.exported_names.put(name, span);

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -20,7 +20,8 @@ const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
 const Span = @import("../lexer/token.zig").Span;
 
-const Diagnostic = @import("../diagnostic.zig").Diagnostic;
+const diagnostic = @import("../diagnostic.zig");
+const Diagnostic = diagnostic.Diagnostic;
 const ErrorCode = @import("../error_codes.zig").Code;
 
 const AllocError = std.mem.Allocator.Error;
@@ -90,9 +91,10 @@ pub fn checkDuplicateConstructors(
         const body_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_start + 2]);
         if (body_idx.isNone()) continue;
 
-        if (first_constructor_span) |_| {
+        if (first_constructor_span) |first| {
             // body가 있는 constructor가 2개 이상 → 에러
-            try addErrorCode(errors, allocator, node.span, try std.fmt.allocPrint(allocator, "A class may only have one constructor", .{}), .duplicate_constructor);
+            const msg = try std.fmt.allocPrint(allocator, "A class may only have one constructor", .{});
+            try addErrorCodeWithPrevious(errors, allocator, node.span, msg, .duplicate_constructor, first);
             return; // 첫 중복만 보고
         } else {
             first_constructor_span = node.span;
@@ -127,6 +129,13 @@ fn matchKeyName(ast: *const Ast, key_idx: NodeIndex, target: []const u8) bool {
 /// 에러를 errors 목록에 추가한다.
 fn addErrorCode(errors: *std.ArrayList(Diagnostic), allocator: std.mem.Allocator, span: Span, msg: []const u8, code: ErrorCode) AllocError!void {
     try errors.append(allocator, .{ .span = span, .message = msg, .kind = .semantic, .code = code });
+}
+
+/// 재선언 계열 에러 + "previously declared here" secondary label.
+fn addErrorCodeWithPrevious(errors: *std.ArrayList(Diagnostic), allocator: std.mem.Allocator, span: Span, msg: []const u8, code: ErrorCode, previous_span: Span) AllocError!void {
+    const buf = try allocator.alloc(diagnostic.Label, 1);
+    buf[0] = .{ .span = previous_span, .message = diagnostic.PREVIOUSLY_DECLARED_HERE };
+    try errors.append(allocator, .{ .span = span, .message = msg, .kind = .semantic, .code = code, .labels = buf });
 }
 
 // ====================================================================
@@ -209,11 +218,8 @@ fn checkPrivateKeyStaticConflict(
     if (declared.get(name)) |existing| {
         // 같은 이름이 이미 등록됨 → static 상태가 다르면 에러
         if (existing.is_static != is_static) {
-            try addErrorCode(errors, allocator, key_node.span, try std.fmt.allocPrint(
-                allocator,
-                "Private field '{s}' has already been declared",
-                .{name},
-            ), .private_redeclared);
+            const msg = try std.fmt.allocPrint(allocator, "Private field '{s}' has already been declared", .{name});
+            try addErrorCodeWithPrevious(errors, allocator, key_node.span, msg, .private_redeclared, existing.span);
         }
     } else {
         try declared.put(name, .{ .is_static = is_static, .span = key_node.span });
@@ -350,12 +356,9 @@ fn recordSeenName(
     errors: *std.ArrayList(Diagnostic),
     allocator: std.mem.Allocator,
 ) AllocError!void {
-    if (seen.get(name)) |_| {
-        try addErrorCode(errors, allocator, span, try std.fmt.allocPrint(
-            allocator,
-            "Duplicate parameter name '{s}'",
-            .{name},
-        ), .duplicate_parameter);
+    if (seen.get(name)) |previous_span| {
+        const msg = try std.fmt.allocPrint(allocator, "Duplicate parameter name '{s}'", .{name});
+        try addErrorCodeWithPrevious(errors, allocator, span, msg, .duplicate_parameter, previous_span);
     } else {
         try seen.put(name, span);
     }

--- a/src/semantic/checker_test.zig
+++ b/src/semantic/checker_test.zig
@@ -8,6 +8,15 @@ const Parser = @import("../parser/parser.zig").Parser;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const SemanticAnalyzer = @import("analyzer.zig").SemanticAnalyzer;
 
+/// 체커가 채운 에러의 allocator-owned 리소스(message/labels)를 free.
+fn deinitErrors(errs: *std.ArrayList(Diagnostic), allocator: std.mem.Allocator) void {
+    for (errs.items) |e| {
+        allocator.free(e.message);
+        if (e.labels.len > 0) allocator.free(e.labels);
+    }
+    errs.deinit(allocator);
+}
+
 test "checker: duplicate constructor is error" {
     var scanner = try Scanner.init(std.testing.allocator, "class C { constructor() {} constructor() {} }");
     defer scanner.deinit();
@@ -16,10 +25,7 @@ test "checker: duplicate constructor is error" {
     _ = try parser.parse();
 
     var errs: std.ArrayList(Diagnostic) = .empty;
-    defer {
-        for (errs.items) |e| std.testing.allocator.free(e.message);
-        errs.deinit(std.testing.allocator);
-    }
+    defer deinitErrors(&errs, std.testing.allocator);
 
     // class body를 찾아서 검사
     // AST 마지막 노드는 program, 그 안에 class_declaration이 있음
@@ -63,10 +69,7 @@ test "checker: static/instance private name conflict is error" {
     _ = try parser.parse();
 
     var errs: std.ArrayList(Diagnostic) = .empty;
-    defer {
-        for (errs.items) |e| std.testing.allocator.free(e.message);
-        errs.deinit(std.testing.allocator);
-    }
+    defer deinitErrors(&errs, std.testing.allocator);
 
     const ast = &parser.ast;
     for (ast.nodes.items) |node| {
@@ -108,10 +111,7 @@ test "checker: duplicate __proto__ is error" {
     _ = try parser.parse();
 
     var errs: std.ArrayList(Diagnostic) = .empty;
-    defer {
-        for (errs.items) |e| std.testing.allocator.free(e.message);
-        errs.deinit(std.testing.allocator);
-    }
+    defer deinitErrors(&errs, std.testing.allocator);
 
     const ast = &parser.ast;
     for (ast.nodes.items) |node| {


### PR DESCRIPTION
## Summary
- PR #1438 확장 — 재선언/중복 계열 **6종**이 원본 선언 위치를 secondary label로 가리킴
- `diagnostic.PREVIOUSLY_DECLARED_HERE` 공용 상수
- 같은 줄 label이 primary 밑줄 아래에 표시되도록 렌더러 개선 (PR #1438의 남은 제한 해결)

## 적용 에러 코드
| Code | 에러 | 원본 위치 출처 |
|---|---|---|
| ZTS1100 | `private_redeclared` | `class_private_declared.get(name).span` / `declared.get(name).span` |
| ZTS1200 | `duplicate_export` | `exported_names.get(name)` |
| ZTS1202 | `label_redeclared` | `findLabel(name).span` |
| ZTS1300 | `duplicate_constructor` | `first_constructor_span` |
| ZTS0703 | `switch_duplicate_default` | `has_default: bool` → `first_default_span: ?Span` |
| ZTS0515 | `duplicate_parameter` | `param_name_spans` / `seen.get(name)` |

## 예시 출력
\`\`\`
  × A class may only have one constructor [ZTS1300]
  ╭─[test.ts:1:28]
1 │ class C { constructor() {} constructor() {} }
  ·                            ^^^^^^^^^^^^^^^^^
  ·           ───────────────── previously declared here
  ╰────
\`\`\`

## 구조적 변경
| 파일 | 변경 |
|---|---|
| \`src/diagnostic.zig\` | \`PREVIOUSLY_DECLARED_HERE\` 상수 |
| \`src/diagnostic_renderer.zig\` | 같은 줄 label 렌더 (section 5.25) — single-line 재선언에서도 label 표시 |
| \`src/parser/parser.zig\` | \`addErrorCodeWithPrevious\` 헬퍼 + duplicate_parameter 2곳 |
| \`src/parser/statement.zig\` | \`has_default: bool\` → \`first_default_span: ?Span\` |
| \`src/semantic/analyzer.zig\` | \`addErrorMsgCodeWithPrevious\` 헬퍼 + 3곳 (private/label/export) |
| \`src/semantic/checker.zig\` | \`addErrorCodeWithPrevious\` 헬퍼 + 3곳 |
| \`src/semantic/checker_test.zig\` | \`deinitErrors\` 헬퍼로 cleanup 통일 |

## 후속
- **PR 3**: 참조-정의 연결 5종 (ZTS1101 private_undeclared, ZTS1103/1104 getter/setter_only, ZTS1201 export_not_defined, ZTS1204 undefined_label)
- **PR 4**: \`help\` / \`url\` 메타데이터

## Test plan
- [x] \`zig build test\` — 전체 통과
- [x] NAPI 유닛 — 360 pass
- [x] WASM 유닛 — 28 pass
- [x] 통합 — 2899 pass, 4 skip
- [x] WASM 스모크: 6종 에러 모두 "previously declared here" 라벨 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)