### PR TITLE
feat(diagnostic): reference-to-definition labels (getter/setter/label)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -420,18 +420,12 @@ pub const SemanticAnalyzer = struct {
                     ), .private_method_assign);
                 },
                 .getter => if (ref.usage == .write) {
-                    try self.addErrorMsgCode(ref.span, try std.fmt.allocPrint(
-                        self.allocator,
-                        "Cannot set private member '{s}'. It only has a getter.",
-                        .{ref.name},
-                    ), .private_getter_only);
+                    const msg = try std.fmt.allocPrint(self.allocator, "Cannot set private member '{s}'. It only has a getter.", .{ref.name});
+                    try self.addErrorMsgCodeWithLabel(ref.span, msg, .private_getter_only, info.?.span, "getter declared here");
                 },
                 .setter => if (ref.usage == .read) {
-                    try self.addErrorMsgCode(ref.span, try std.fmt.allocPrint(
-                        self.allocator,
-                        "Cannot read private member '{s}'. It only has a setter.",
-                        .{ref.name},
-                    ), .private_setter_only);
+                    const msg = try std.fmt.allocPrint(self.allocator, "Cannot read private member '{s}'. It only has a setter.", .{ref.name});
+                    try self.addErrorMsgCodeWithLabel(ref.span, msg, .private_setter_only, info.?.span, "setter declared here");
                 },
                 .field, .accessor_pair => {},
             }
@@ -1004,17 +998,28 @@ pub const SemanticAnalyzer = struct {
     /// previous_span이 null이면 label 없이 기본 에러.
     /// msg는 allocator 소유가 인계된다 (deinit에서 free).
     fn addErrorMsgCodeWithPrevious(self: *SemanticAnalyzer, span: Span, msg: []const u8, code: ErrorCode, previous_span: ?Span) AllocError!void {
-        const labels: []const diagnostic.Label = if (previous_span) |ex| blk: {
-            const buf = try self.allocator.alloc(diagnostic.Label, 1);
-            buf[0] = .{ .span = ex, .message = diagnostic.PREVIOUSLY_DECLARED_HERE };
-            break :blk buf;
-        } else &.{};
+        if (previous_span) |ex| {
+            return self.addErrorMsgCodeWithLabel(span, msg, code, ex, diagnostic.PREVIOUSLY_DECLARED_HERE);
+        }
         try self.errors.append(self.allocator, .{
             .span = span,
             .message = msg,
             .kind = .semantic,
             .code = code,
-            .labels = labels,
+        });
+    }
+
+    /// 참조-정의 연결 에러에서 정의 위치에 임의 label 메시지를 단다.
+    /// msg/label_msg는 호출자 책임 — label_msg는 정적 문자열 권장 (free하지 않음).
+    fn addErrorMsgCodeWithLabel(self: *SemanticAnalyzer, span: Span, msg: []const u8, code: ErrorCode, label_span: Span, label_msg: []const u8) AllocError!void {
+        const buf = try self.allocator.alloc(diagnostic.Label, 1);
+        buf[0] = .{ .span = label_span, .message = label_msg };
+        try self.errors.append(self.allocator, .{
+            .span = span,
+            .message = msg,
+            .kind = .semantic,
+            .code = code,
+            .labels = buf,
         });
     }
 
@@ -2168,7 +2173,8 @@ pub const SemanticAnalyzer = struct {
         if (self.findLabel(name)) |entry| {
             // continue는 loop label만 가능
             if (node.tag == .continue_statement and !entry.is_loop) {
-                try self.addErrorMsgCode(label_node.span, try std.fmt.allocPrint(self.allocator, "Cannot continue to non-loop label '{s}'", .{name}), .continue_non_loop_label);
+                const msg = try std.fmt.allocPrint(self.allocator, "Cannot continue to non-loop label '{s}'", .{name});
+                try self.addErrorMsgCodeWithLabel(label_node.span, msg, .continue_non_loop_label, entry.span, "label declared here (not a loop)");
             }
         } else {
             // label이 존재하지 않음


### PR DESCRIPTION
## Summary
- 참조 에러 3종이 **정의 위치**를 secondary label로 가리킴
- analyzer.zig에 범용 헬퍼 \`addErrorMsgCodeWithLabel\` 추가 (임의 label 메시지)
- 기존 \`addErrorMsgCodeWithPrevious\`는 thin wrapper로 재배치

## 적용 에러 코드
| Code | 에러 | Label 메시지 | 정의 위치 출처 |
|---|---|---|---|
| ZTS1103 | \`private_getter_only\` | "getter declared here" | \`info.?.span\` (class_private_declared) |
| ZTS1104 | \`private_setter_only\` | "setter declared here" | \`info.?.span\` (class_private_declared) |
| ZTS1203 | \`continue_non_loop_label\` | "label declared here (not a loop)" | \`findLabel().entry.span\` |

## 예시 출력
\`\`\`
  × Cannot set private member '#x'. It only has a getter. [ZTS1103]
  ╭─[test.ts:3:14]
2 │   get #x() { return 1; }
  ·       ── getter declared here
3 │   f() { this.#x = 2; }
  ·              ^^
4 │ }
  ╰────
\`\`\`

## 스킵된 에러 — PR 4 대상
다음 3종은 참조 타겟 자체가 존재하지 않는 에러라 secondary label 대상이 아님.
PR 4에서 \`help\` / \`url\` 메타데이터로 보충:
- ZTS1101 \`private_undeclared\` — 선언이 enclosing class에 없음
- ZTS1201 \`export_not_defined\` — 모듈 scope에 선언 없음
- ZTS1204 \`undefined_label\` — label 자체 없음

## 구조 요지
\`\`\`zig
// 신규: 임의 label 메시지 지원
fn addErrorMsgCodeWithLabel(self, span, msg, code, label_span, label_msg) !void { ... }

// 기존을 wrapper로 재배치
fn addErrorMsgCodeWithPrevious(self, span, msg, code, previous_span: ?Span) !void {
    if (previous_span) |ex| return addErrorMsgCodeWithLabel(..., ex, PREVIOUSLY_DECLARED_HERE);
    // else label 없는 append
}
\`\`\`

## Test plan
- [x] \`zig build test\` 전체 통과
- [x] NAPI 360 pass / WASM 28 pass / 통합 2899 pass
- [x] 스모크: 3종 에러 모두 정의 위치 label 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)