### PR TITLE
feat(diagnostic): help hints + docs URL per error code

### DIFF
--- a/src/diagnostic_renderer.zig
+++ b/src/diagnostic_renderer.zig
@@ -127,7 +127,7 @@ pub fn render(
         try writer.writeAll(" +----\n");
     }
 
-    // ── 8. help/note ──
+    // ── 8. help/note/url ──
     if (diag.help) |help_text| {
         try ansi.styled(writer, .bold_cyan, "  help", color);
         try writer.writeAll(": ");
@@ -138,6 +138,12 @@ pub fn render(
         try ansi.styled(writer, .bold_blue, "  note", color);
         try writer.writeAll(": ");
         try writer.writeAll(note_text);
+        try writer.writeByte('\n');
+    }
+    if (diag.url) |url_text| {
+        try ansi.styled(writer, .dim, "  url", color);
+        try writer.writeAll(": ");
+        try ansi.styled(writer, .dim, url_text, color);
         try writer.writeByte('\n');
     }
 
@@ -204,6 +210,12 @@ pub fn renderSimple(
         try ansi.styled(writer, .bold_blue, "  note", color);
         try writer.writeAll(": ");
         try writer.writeAll(note_text);
+        try writer.writeByte('\n');
+    }
+    if (diag.url) |url_text| {
+        try ansi.styled(writer, .dim, "  url", color);
+        try writer.writeAll(": ");
+        try ansi.styled(writer, .dim, url_text, color);
         try writer.writeByte('\n');
     }
 

--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -19,6 +19,9 @@
 //!   1200-1299  시맨틱: export/label
 //!   1300-1399  시맨틱: class/getter/setter/object
 
+/// 문서 사이트 에러 레퍼런스 base URL. Code.docsUrl이 여기에 코드를 붙여 전체 URL 생성.
+const docs_url_base = "https://ohah.github.io/zts/reference/errors/";
+
 /// 에러 코드. 각 항목은 고유한 번호를 가진다.
 pub const Code = enum(u16) {
     // ═══════════════════════════════════════════════════════
@@ -208,6 +211,41 @@ pub const Code = enum(u16) {
         @setEvalBranchQuota(100_000);
         return switch (self) {
             inline else => |v| comptime std.fmt.comptimePrint("ZTS{d:0>4}", .{@intFromEnum(v)}),
+        };
+    }
+
+    /// 이 코드에 해당하는 문서 URL. comptime const 반환, 할당 없음.
+    pub fn docsUrl(self: Code) []const u8 {
+        @setEvalBranchQuota(100_000);
+        return switch (self) {
+            inline else => |v| comptime std.fmt.comptimePrint(docs_url_base ++ "ZTS{d:0>4}/", .{@intFromEnum(v)}),
+        };
+    }
+
+    /// 에러 수정 힌트. 없으면 null.
+    /// comptime const 문자열만 반환 — 할당 없음. 렌더러가 "help: ..." 로 출력.
+    pub fn help(self: Code) ?[]const u8 {
+        return switch (self) {
+            // 시맨틱 재선언/참조 (PR 2/2.5/3에서 커버한 에러들)
+            .identifier_redeclared => "Use a different identifier, or change 'let'/'const' to 'var' if redeclaration is intended.",
+            .private_redeclared => "Private field names must be unique within a class. Rename one of the declarations.",
+            .private_undeclared => "Private fields must be declared in an enclosing class body before being referenced.",
+            .private_getter_only => "Private member has only a getter. Add a 'set' accessor to allow assignment.",
+            .private_setter_only => "Private member has only a setter. Add a 'get' accessor to allow reading.",
+            .duplicate_export => "Rename one of the exports, or use a single 'export { x as a, y as b }' form.",
+            .export_not_defined => "Ensure the exported name is declared in module scope before the export statement.",
+            .label_redeclared => "Label names must be unique within the enclosing function. Rename the inner label.",
+            .undefined_label => "The 'break'/'continue' label must match a label declared in an enclosing statement.",
+            .continue_non_loop_label => "'continue' requires the target label to be attached to a loop (for/while/do).",
+            .duplicate_constructor => "Merge the constructor bodies into a single 'constructor()' method.",
+            .duplicate_parameter => "Parameter names must be unique in strict mode and within destructuring patterns.",
+            .switch_duplicate_default => "A 'switch' can have at most one 'default' case — remove the duplicate.",
+            // 타겟
+            .top_level_await_target => "Set --target=es2022 or later, or wrap the code in an 'async' function.",
+            // 번들러
+            .unresolved_import => "Check the import path spelling and confirm the file exists.",
+            .missing_export => "Verify the exported name. Use 'export * from' or named re-exports if needed.",
+            else => null,
         };
     }
 

--- a/src/rich_diagnostic.zig
+++ b/src/rich_diagnostic.zig
@@ -39,6 +39,9 @@ pub const RichDiagnostic = struct {
     help: ?[]const u8 = null,
     /// 추가 정보 (예: "Top-level await is an ES2022 feature")
     note: ?[]const u8 = null,
+    /// 에러 문서 URL. 렌더러가 "url: ..." 줄로 표시.
+    /// RichDiagnostic 생성 시 호출자가 소유 문자열을 주입 (정적 또는 bufPrint 버퍼).
+    url: ?[]const u8 = null,
 
     pub const Severity = enum {
         @"error",
@@ -114,6 +117,8 @@ pub const SourceInfo = struct {
 
 /// 파서/시맨틱 Diagnostic을 RichDiagnostic으로 변환한다.
 /// Diagnostic에는 severity가 없으므로 항상 .error로 설정한다.
+/// Diagnostic에 hint가 없으면 Code.help()에서 자동 수정 힌트를 주입.
+/// code가 있으면 docsUrl도 자동 주입.
 pub fn fromDiagnostic(d: Diagnostic, file_path: []const u8) RichDiagnostic {
     return .{
         .severity = .@"error",
@@ -122,7 +127,8 @@ pub fn fromDiagnostic(d: Diagnostic, file_path: []const u8) RichDiagnostic {
         .span = d.span,
         .file_path = file_path,
         .labels = d.labels,
-        .help = d.hint,
+        .help = d.hint orelse if (d.code) |c| c.help() else null,
+        .url = if (d.code) |c| c.docsUrl() else null,
     };
 }
 


### PR DESCRIPTION
## Summary
모든 진단에 수정 힌트와 문서 URL을 자동 표시. oxc의 \`OxcDiagnostic.help\`/\`url\` 관용구 반영.

## 예시 출력
\`\`\`
  × Identifier 'x' has already been declared [ZTS1000]
  ╭─[test.ts:2:5]
1 │ let x = 1;
  ·     ─ previously declared here
2 │ let x = 2;
  ·     ^
  ╰────
  help: Use a different identifier, or change 'let'/'const' to 'var' if redeclaration is intended.
  url: https://ohah.github.io/zts/reference/errors/ZTS1000/
\`\`\`

## 추가
| 변경 | 위치 |
|---|---|
| \`Code.help()\` — 수정 힌트 (comptime const, 할당 없음) | \`src/error_codes.zig\` |
| \`Code.docsUrl()\` — 문서 URL (comptime 생성, \`docs_url_base\` 상수) | \`src/error_codes.zig\` |
| \`RichDiagnostic.url\` 필드 | \`src/rich_diagnostic.zig\` |
| \`fromDiagnostic\`이 code 기반 help/url 자동 주입 | \`src/rich_diagnostic.zig\` |
| 렌더러가 help 다음에 url 줄 출력 | \`src/diagnostic_renderer.zig\` |

## 힌트가 채워진 에러
- 재선언/참조 연결 13종 (ZTS1000/1100/1101/1103/1104/1200/1201/1202/1203/1204/1300/0515/0703)
- 타겟 1종 (ZTS0001 top_level_await_target)
- 번들러 2종 (ZTS0100 unresolved_import, ZTS0101 missing_export)

**나머지 에러**: null — 후속 PR에서 점진 확장. URL은 전체 코드 자동 생성.

## Fallback 정책
- \`Diagnostic.hint\`(호출자 제공)가 있으면 그 값이 우선
- 없고 \`code\`가 있으면 \`Code.help()\`가 fallback
- \`code\`가 있으면 \`url\`은 항상 자동 주입

## Test plan
- [x] \`zig build test\` 전체 통과
- [x] NAPI 360 / WASM 28 / 통합 2899 pass
- [x] 스모크: help/url 3종 확인 (ZTS1000/1101/1204)

## 후속 (있다면)
- 남은 에러 코드들의 help 메시지 채우기 (점진)
- severity 다계층 (Warning / Advice) — PR 2에서 이미 존재하는 \`Severity\` enum을 시맨틱 분석기에서 활용

🤖 Generated with [Claude Code](https://claude.com/claude-code)