### PR TITLE
fix(diagnostic): docsUrl uses lowercase 'zts' to match deployed site routes

### DIFF
--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -215,10 +215,11 @@ pub const Code = enum(u16) {
     }
 
     /// 이 코드에 해당하는 문서 URL. comptime const 반환, 할당 없음.
+    /// 문서 사이트 라우트는 소문자 `zts` 폴더를 사용 (사이트 빌더가 소문자 slug).
     pub fn docsUrl(self: Code) []const u8 {
         @setEvalBranchQuota(100_000);
         return switch (self) {
-            inline else => |v| comptime std.fmt.comptimePrint(docs_url_base ++ "ZTS{d:0>4}/", .{@intFromEnum(v)}),
+            inline else => |v| comptime std.fmt.comptimePrint(docs_url_base ++ "zts{d:0>4}/", .{@intFromEnum(v)}),
         };
     }
 


### PR DESCRIPTION
## Summary
PR #1441에서 \`Code.docsUrl\`가 대문자 경로(\`ZTS0001/\`)를 생성했는데, 실제 배포된 문서 사이트는 소문자 slug(\`zts0001/\`)만 서빙 → 에러 메시지의 "url: ..." 링크가 **404**.

## 검증
\`\`\`
curl -I https://ohah.github.io/zts/reference/errors/ZTS1000/  → 404
curl -I https://ohah.github.io/zts/reference/errors/zts1000/  → 200
\`\`\`

## 수정
\`error_codes.zig\`의 \`docsUrl\` 한 글자 수정: \`ZTS{d:0>4}/\` → \`zts{d:0>4}/\`.

\`Code.format()\`의 대문자 "ZTS…" 반환은 **헤더/마커 표시용**이므로 그대로 유지. URL path만 소문자로 정렬.

## Test plan
- [x] 유닛 테스트 통과
- [x] 스모크: \`url: https://ohah.github.io/zts/reference/errors/zts1000/\` 확인
- [ ] 머지 후 실제 사이트에서 링크 클릭 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)