### PR TITLE
fix(transpile): wire es_target diagnostic + source_root through WASM/NAPI

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -164,6 +164,7 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
     options.jsxFactory ?? "",
     options.jsxFragment ?? "",
     options.jsxImportSource ?? "",
+    options.sourceRoot ?? "",
   );
 }
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -89,11 +89,11 @@ fn getUint32Arg(env: c.napi_env, value: c.napi_value) u32 {
 
 // ─── transpile 함수 ───
 
-/// transpile(source, filename, flags, unsupported, jsxFactory, jsxFragment, jsxImportSource)
-/// → { code: string, map?: string }
+/// transpile(source, filename, flags, unsupported, jsxFactory, jsxFragment, jsxImportSource, sourceRoot)
+/// → { code: string, map?: string, errors?: string }
 fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argc: usize = 7;
-    var argv: [7]c.napi_value = undefined;
+    var argc: usize = 8;
+    var argv: [8]c.napi_value = undefined;
     if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
         return throwError(env, "failed to get arguments");
     }
@@ -125,6 +125,8 @@ fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     defer if (jsx_fragment) |f| native_alloc.free(f);
     const jsx_import_source = if (argc > 6) getStringArg(env, argv[6], native_alloc) else null;
     defer if (jsx_import_source) |f| native_alloc.free(f);
+    const source_root = if (argc > 7) getStringArg(env, argv[7], native_alloc) else null;
+    defer if (source_root) |f| native_alloc.free(f);
 
     // 옵션 구성
     var options = transpile_mod.decodeFlags(flags);
@@ -137,6 +139,9 @@ fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     };
     if (jsx_import_source) |f| if (f.len > 0) {
         options.jsx_import_source = f;
+    };
+    if (source_root) |f| if (f.len > 0) {
+        options.source_root = f;
     };
 
     // 트랜스파일 실행

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -77,6 +77,8 @@ export interface TranspileOptions {
    * 지정 시 target보다 우선. core 패키지에서만 해석됨 (browserslist 의존).
    */
   browserslist?: string | string[];
+  /** 소스맵의 sourceRoot 필드 (기본: 빈 문자열) */
+  sourceRoot?: string;
 }
 
 export interface TranspileResult {

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -33,6 +33,8 @@ interface WasmExports {
     jsxFragmentLen: number,
     jsxImportSourcePtr: number,
     jsxImportSourceLen: number,
+    sourceRootPtr: number,
+    sourceRootLen: number,
   ): bigint;
   get_error_ptr(): number;
   get_error_len(): number;
@@ -176,6 +178,7 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
   const [factoryPtr, factoryLen] = writeOptionalString(options.jsxFactory);
   const [fragmentPtr, fragmentLen] = writeOptionalString(options.jsxFragment);
   const [importSourcePtr, importSourceLen] = writeOptionalString(options.jsxImportSource);
+  const [sourceRootPtr, sourceRootLen] = writeOptionalString(options.sourceRoot);
 
   const flags = encodeFlags(options);
   const unsupported = targetToUnsupported(options.target);
@@ -194,6 +197,8 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
       fragmentLen,
       importSourcePtr,
       importSourceLen,
+      sourceRootPtr,
+      sourceRootLen,
     );
 
     const outPtr = Number(packed >> 32n);
@@ -223,5 +228,6 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
     if (factoryPtr) wasm.dealloc(factoryPtr, factoryLen);
     if (fragmentPtr) wasm.dealloc(fragmentPtr, fragmentLen);
     if (importSourcePtr) wasm.dealloc(importSourcePtr, importSourceLen);
+    if (sourceRootPtr) wasm.dealloc(sourceRootPtr, sourceRootLen);
   }
 }

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -92,7 +92,7 @@ const decodeFlags = transpile_mod.decodeFlags;
 ///
 /// flags: 비트마스크 옵션 (decodeFlags 참고)
 /// unsupported: UnsupportedFeatures packed u32 (ES 다운레벨링 타겟)
-/// 문자열 옵션: jsx_factory, jsx_fragment, jsx_import_source (ptr+len 쌍)
+/// 문자열 옵션: jsx_factory, jsx_fragment, jsx_import_source, source_root (ptr+len 쌍)
 ///
 /// 반환값: packed u64 (상위 32비트: 포인터, 하위 32비트: 길이, 0=에러)
 export fn transpile(
@@ -108,6 +108,8 @@ export fn transpile(
     jsx_fragment_len: u32,
     jsx_import_source_ptr: u32,
     jsx_import_source_len: u32,
+    source_root_ptr: u32,
+    source_root_len: u32,
 ) u64 {
     clearError();
 
@@ -134,6 +136,8 @@ export fn transpile(
     if (fragment.len > 0) options.jsx_fragment = fragment;
     const import_source = readStr(jsx_import_source_ptr, jsx_import_source_len);
     if (import_source.len > 0) options.jsx_import_source = import_source;
+    const source_root = readStr(source_root_ptr, source_root_len);
+    if (source_root.len > 0) options.source_root = source_root;
 
     var result = transpile_mod.transpileWithCallback(wasm_alloc, source, file_path, options, &formatErrors) catch |err| {
         // formatErrors 콜백이 이미 상세 메시지를 last_error_buf에 저장했을 수 있음.

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -75,9 +75,14 @@ pub const SemanticAnalyzer = struct {
     /// 함수/arrow 내부의 await는 포함하지 않음.
     has_top_level_await: bool = false,
 
-    /// ES 타겟 (--target 옵션). null이면 타겟 검증을 스킵한다.
-    /// es2022 미만에서 top-level await를 사용하면 진단을 발생시킨다.
+    /// ES 타겟 (--target 옵션). null이면 에러 메시지에서 타겟 이름 생략.
+    /// 진단 트리거 자체는 `unsupported` 비트로 판단 — WASM/NAPI 경로에도 적용된다.
     es_target: ?@import("../transformer/compat.zig").ESTarget = null,
+
+    /// 타겟에서 미지원 feature 비트. `top_level_await` 비트가 set이면 ZTS0001 발생.
+    /// CLI/WASM/NAPI 모두 동일한 비트마스크로 타겟 정보를 전달하므로,
+    /// 이 필드를 기준으로 진단하면 모든 진입점에서 일관된 동작 보장.
+    unsupported: @import("../transformer/compat.zig").UnsupportedFeatures = .{},
 
     /// 메모리 할당자
     allocator: std.mem.Allocator,
@@ -320,32 +325,22 @@ pub const SemanticAnalyzer = struct {
         return null;
     }
 
-    /// 현재 스코프 체인에 function 스코프가 있는지 확인한다.
-    /// TLA 감지에 사용: function 안이면 await는 TLA가 아님.
-    /// es_target < es2022일 때 top-level await 진단을 발생시킨다.
-    /// es_target이 null이면 (타겟 미지정) 진단을 생략한다.
+    /// top-level await가 타겟에서 미지원일 때 진단을 발생시킨다.
+    /// `unsupported.top_level_await` 비트 기반 — CLI/WASM/NAPI 모두 동일 경로로 트리거.
+    /// es_target이 명시됐으면 메시지에 이름 포함, 없으면 일반 문구.
     fn emitTopLevelAwaitDiag(self: *SemanticAnalyzer, span: Span) !void {
-        const compat = @import("../transformer/compat.zig");
-        const target = self.es_target orelse return; // 타겟 미지정이면 스킵
-        if (@intFromEnum(target) >= @intFromEnum(compat.ESTarget.es2022)) return; // es2022 이상이면 OK
+        if (!self.unsupported.top_level_await) return;
 
-        // deinit에서 message/hint를 free하므로 allocPrint로 할당
-        const msg = try std.fmt.allocPrint(
-            self.allocator,
-            "Top-level await is not available in the configured target environment ({s})",
-            .{@tagName(target)},
-        );
-        const hint = try self.allocator.dupe(
-            u8,
-            "Set target to 'es2022' or higher to use top-level await",
-        );
+        const msg = if (self.es_target) |t|
+            try std.fmt.allocPrint(self.allocator, "Top-level await is not available in the configured target environment ({s})", .{@tagName(t)})
+        else
+            try self.allocator.dupe(u8, "Top-level await is not available in the configured target environment");
 
         try self.errors.append(self.allocator, .{
             .span = span,
             .message = msg,
             .kind = .semantic,
             .code = .top_level_await_target,
-            .hint = hint,
         });
     }
 

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1069,6 +1069,7 @@ fn analyzeModuleWithTarget(source: []const u8, target: @import("../transformer/c
     var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
     ana.is_module = true;
     ana.es_target = target;
+    ana.unsupported = @import("../transformer/compat.zig").fromESTarget(target);
     errdefer ana.deinit();
     try ana.analyze();
     return .{ .scanner = scanner, .parser = parser, .analyzer = ana };
@@ -1085,7 +1086,8 @@ test "TLA: await at top-level emits error when target < es2022" {
     const err = r.analyzer.errors.items[0];
     try std.testing.expect(std.mem.indexOf(u8, err.message, "Top-level await") != null);
     try std.testing.expectEqual(Diagnostic.Kind.semantic, err.kind);
-    try std.testing.expect(err.hint != null);
+    // hint는 PR #1441부터 Code.help()가 담당 (진단엔 미포함, 렌더러가 주입)
+    try std.testing.expectEqual(@import("../error_codes.zig").Code.top_level_await_target, err.code.?);
 }
 
 test "TLA: await at top-level no error when target >= es2022" {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -212,6 +212,7 @@ pub fn transpileWithCallback(
     analyzer.is_ts = parser.is_ts;
     analyzer.is_flow = parser.is_flow;
     analyzer.es_target = options.es_target;
+    analyzer.unsupported = options.unsupported;
     analyzer.analyze() catch return error.SemanticError;
     if (analyzer.errors.items.len > 0) {
         if (on_error) |cb| cb(source, file_path, &scanner, analyzer.errors.items);


### PR DESCRIPTION
## Summary
WASM/NAPI 진입점이 \`TranspileOptions\`의 일부 필드를 세팅하지 않아 플레이그라운드에서 구조적으로 발생 불가였던 진단/옵션을 복구.

### 확인된 누락 (CLI에선 정상, WASM/NAPI에서만 실패)
| 필드 | 영향 | 이 PR 조치 |
|---|---|---|
| \`es_target\` | **ZTS0001 top_level_await_target 항상 스킵** | 진단을 \`unsupported.top_level_await\` 비트 기반으로 전환 (방안 B) |
| \`source_root\` | 사용자 지정 sourcemap \`sourceRoot\` 적용 불가 | WASM/NAPI에 문자열 인자 추가 |
| \`define\` | 동적 값 전달 불가 | **별도 대형 리팩토링 필요** — issue #1443 (JSON payload 전환)에서 추적 |

## 구조적 근본 수정은 별도
필드별 인자 추가 방식은 **새 옵션마다 5곳 동시 수정** 필요 → 누락 재발 예정. esbuild 스타일 JSON payload 전환을 [#1443](https://github.com/ohah/zts/issues/1443)에서 추적.

## 예시 출력 (WASM, 이제 CLI와 동일)
\`\`\`
  × Top-level await is not available in the configured target environment [ZTS0001]
  ╭─[test.mjs:1:14]
1 │ const data = await fetch("/api");
  ·              ^^^^^^^^^^^^^^^^^^^
  ╰────
  help: Set --target=es2022 or later, or wrap the code in an 'async' function.
  url: https://ohah.github.io/zts/reference/errors/zts0001/
\`\`\`

## 변경
| 파일 | 변경 |
|---|---|
| \`src/semantic/analyzer.zig\` | \`unsupported\` 필드 + \`emitTopLevelAwaitDiag\`를 비트 기반으로 전환. \`es_target\`은 메시지의 타겟 이름 표시용으로만 유지 |
| \`src/transpile.zig\` | \`analyzer.unsupported = options.unsupported\` 세팅 |
| \`src/semantic/analyzer_test.zig\` | TLA 헬퍼가 \`unsupported\`도 세팅. \`hint\` 체크 → \`code\` 체크 (PR #1441 이후 hint는 렌더러 Code.help()가 담당) |
| \`packages/wasm/src/wasm_entry.zig\` | \`transpile\` export에 \`source_root\` ptr+len 인자 추가 |
| \`packages/core/src/napi_entry.zig\` | \`napiTranspile\`에 8번째 \`sourceRoot\` 인자 추가 |
| \`packages/shared/index.ts\` | \`TranspileOptions.sourceRoot?: string\` |
| \`packages/wasm/index.ts\`, \`packages/core/index.ts\` | native 호출에 \`sourceRoot\` 전달 |

## Test plan
- [x] \`zig build test\` 전체 통과
- [x] NAPI 360 / WASM 28 / 통합 2899 pass
- [x] 스모크: \`target: es2021\` + TLA 입력 → ZTS0001 에러 + help + url 표시
- [x] CLI와 WASM/NAPI 출력 비교 — 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)