### PR TITLE
refactor(transpile): migrate options from per-field args to JSON payload

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from "url";
 
 export type { Target, Platform, TranspileOptions, TranspileResult } from "../shared/index";
 import type { TranspileOptions, TranspileResult } from "../shared/index";
-import { encodeFlags, ES_TARGET_BITS, browserslistToUnsupported } from "../shared/index";
+import { buildOptionsJson, ES_TARGET_BITS, browserslistToUnsupported } from "../shared/index";
 
 // ─── NAPI Module ───
 
@@ -51,12 +51,8 @@ interface NativeModule {
   transpile(
     source: string,
     filename: string,
-    flags: number,
-    unsupported: number,
-    jsxFactory: string,
-    jsxFragment: string,
-    jsxImportSource: string,
-  ): { code: string; map?: string };
+    optionsJson: string,
+  ): { code: string; map?: string; errors?: string };
   buildSync(options: Record<string, unknown>): NativeBuildResult;
   build(options: Record<string, unknown>): Promise<NativeBuildResult>;
   watch(options: Record<string, unknown>): NativeWatchHandle;
@@ -153,19 +149,8 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
   if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
   if (!source) throw new Error("@zts/core: empty source");
 
-  const flags = encodeFlags(options);
-  const unsupported = resolveUnsupported(options);
-
-  return native.transpile(
-    source,
-    options.filename ?? "input.ts",
-    flags,
-    unsupported,
-    options.jsxFactory ?? "",
-    options.jsxFragment ?? "",
-    options.jsxImportSource ?? "",
-    options.sourceRoot ?? "",
-  );
+  const optionsJson = buildOptionsJson(options, resolveUnsupported(options));
+  return native.transpile(source, options.filename ?? "input.ts", optionsJson);
 }
 
 // ─── Build API ───

--- a/packages/core/napi.test.mjs
+++ b/packages/core/napi.test.mjs
@@ -18,16 +18,9 @@ const require = createRequire(import.meta.url);
 const addonPath = join(__dirname, "../../zig-out/lib/zts.node");
 const native = require(addonPath);
 
-// 플래그 비트마스크 상수 (encodeFlags 비트 레이아웃 참조)
-const F = {
-  SOURCEMAP: 1 << 0,
-  JSX_AUTOMATIC: 1 << 4,
-  DROP_CONSOLE: 1 << 6,
-  CJS: 1 << 12,
-  USE_DEFINE: 1 << 16, // useDefineForClassFields (기본 true)
-  SOURCES_CONTENT: 1 << 22, // sourcesContent (기본 true)
-};
-const DEFAULT_FLAGS = F.USE_DEFINE | F.SOURCES_CONTENT;
+// 옵션은 단일 JSON payload (camelCase, Zig TranspileOptionsDto와 매핑).
+// 기본값(useDefineForClassFields, sourcesContent 등)은 Zig 측에서 처리하므로 생략 가능.
+const call = (src, filename, opts = {}) => native.transpile(src, filename, JSON.stringify(opts));
 
 describe("@zts/core NAPI (Node.js)", () => {
   it("모듈이 transpile 함수를 export한다", () => {
@@ -35,44 +28,24 @@ describe("@zts/core NAPI (Node.js)", () => {
   });
 
   it("기본 TypeScript 트랜스파일", () => {
-    const flags = DEFAULT_FLAGS; // useDefineForClassFields + sourcesContent
-    const result = native.transpile("const x: number = 1;", "input.ts", flags, 0, "", "", "");
+    const result = call("const x: number = 1;", "input.ts");
     assert.ok(result.code.includes("const x = 1;"));
     assert.equal(result.map, undefined);
   });
 
   it("인터페이스 스트리핑", () => {
-    const flags = DEFAULT_FLAGS;
-    const result = native.transpile(
-      "interface Foo { bar: string; }\nconst x = 1;",
-      "input.ts",
-      flags,
-      0,
-      "",
-      "",
-      "",
-    );
+    const result = call("interface Foo { bar: string; }\nconst x = 1;", "input.ts");
     assert.ok(!result.code.includes("interface"));
     assert.ok(result.code.includes("const x = 1;"));
   });
 
   it("타입 어노테이션 제거", () => {
-    const flags = DEFAULT_FLAGS;
-    const result = native.transpile(
-      "function add(a: number, b: number): number { return a + b; }",
-      "input.ts",
-      flags,
-      0,
-      "",
-      "",
-      "",
-    );
+    const result = call("function add(a: number, b: number): number { return a + b; }", "input.ts");
     assert.ok(!result.code.includes(": number"));
   });
 
   it("소스맵 생성", () => {
-    const flags = F.SOURCEMAP | DEFAULT_FLAGS; // sourcemap + defaults
-    const result = native.transpile("const x: number = 1;", "input.ts", flags, 0, "", "", "");
+    const result = call("const x: number = 1;", "input.ts", { sourcemap: true });
     assert.ok(result.code.includes("const x = 1;"));
     assert.ok(result.map !== undefined);
     const map = JSON.parse(result.map);
@@ -81,111 +54,53 @@ describe("@zts/core NAPI (Node.js)", () => {
   });
 
   it("CJS 포맷", () => {
-    const flags = F.CJS | DEFAULT_FLAGS; // cjs + defaults
-    const result = native.transpile(
-      'export const x = 1; export default "hello";',
-      "input.ts",
-      flags,
-      0,
-      "",
-      "",
-      "",
-    );
+    const result = call('export const x = 1; export default "hello";', "input.ts", { format: "cjs" });
     assert.ok(result.code.includes("exports"));
   });
 
   it("JSX 트랜스파일 (classic)", () => {
-    const flags = DEFAULT_FLAGS;
-    const result = native.transpile(
-      '<div className="app">hello</div>',
-      "app.tsx",
-      flags,
-      0,
-      "",
-      "",
-      "",
-    );
+    const result = call('<div className="app">hello</div>', "app.tsx");
     assert.ok(result.code.includes("React.createElement"));
   });
 
   it("JSX 트랜스파일 (automatic)", () => {
-    const flags = F.JSX_AUTOMATIC | DEFAULT_FLAGS; // automatic jsx
-    const result = native.transpile(
-      '<div className="app">hello</div>',
-      "app.tsx",
-      flags,
-      0,
-      "",
-      "",
-      "",
-    );
+    const result = call('<div className="app">hello</div>', "app.tsx", { jsx: "automatic" });
     assert.ok(result.code.includes("jsx"));
   });
 
   it("jsxFactory 커스텀", () => {
-    const flags = DEFAULT_FLAGS;
-    const result = native.transpile("<div />", "app.tsx", flags, 0, "h", "", "");
+    const result = call("<div />", "app.tsx", { jsxFactory: "h" });
     assert.ok(result.code.includes("h("));
     assert.ok(!result.code.includes("React.createElement"));
   });
 
   it("jsxImportSource 커스텀", () => {
-    const flags = F.JSX_AUTOMATIC | DEFAULT_FLAGS; // automatic jsx
-    const result = native.transpile("<div />", "app.tsx", flags, 0, "", "", "preact");
+    const result = call("<div />", "app.tsx", { jsx: "automatic", jsxImportSource: "preact" });
     assert.ok(result.code.includes("preact"));
   });
 
   it("ES5 다운레벨링", () => {
-    const flags = DEFAULT_FLAGS;
-    const unsupported = 0x3fffff; // es5 (bit 0-21)
-    const result = native.transpile(
-      "const x = () => 1;",
-      "input.ts",
-      flags,
-      unsupported,
-      "",
-      "",
-      "",
-    );
+    const result = call("const x = () => 1;", "input.ts", { target: "es5" });
     assert.ok(!result.code.includes("=>"));
     assert.ok(result.code.includes("function"));
   });
 
   it("drop console", () => {
-    const flags = F.DROP_CONSOLE | DEFAULT_FLAGS; // drop_console + defaults
-    const result = native.transpile(
-      'console.log("hello"); const x = 1;',
-      "input.ts",
-      flags,
-      0,
-      "",
-      "",
-      "",
-    );
+    const result = call('console.log("hello"); const x = 1;', "input.ts", { dropConsole: true });
     assert.ok(!result.code.includes("console.log"));
     assert.ok(result.code.includes("const x = 1;"));
   });
 
   it("파싱 에러 시 throw", () => {
-    const flags = DEFAULT_FLAGS;
     assert.throws(
-      () => native.transpile("const = ;", "input.ts", flags, 0, "", "", ""),
+      () => call("const = ;", "input.ts"),
       (err) => err.message.includes("ParseError"),
     );
   });
 
   it("반복 호출 안정성", () => {
-    const flags = DEFAULT_FLAGS;
     for (let i = 0; i < 100; i++) {
-      const result = native.transpile(
-        `const x${i}: number = ${i};`,
-        "input.ts",
-        flags,
-        0,
-        "",
-        "",
-        "",
-      );
+      const result = call(`const x${i}: number = ${i};`, "input.ts");
       assert.ok(result.code.includes(`const x${i} = ${i};`));
     }
   });

--- a/packages/core/napi.test.mjs
+++ b/packages/core/napi.test.mjs
@@ -54,7 +54,9 @@ describe("@zts/core NAPI (Node.js)", () => {
   });
 
   it("CJS 포맷", () => {
-    const result = call('export const x = 1; export default "hello";', "input.ts", { format: "cjs" });
+    const result = call('export const x = 1; export default "hello";', "input.ts", {
+      format: "cjs",
+    });
     assert.ok(result.code.includes("exports"));
   });
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -81,24 +81,19 @@ fn getStringArg(env: c.napi_env, value: c.napi_value, alloc: std.mem.Allocator) 
     return buf[0..actual];
 }
 
-fn getUint32Arg(env: c.napi_env, value: c.napi_value) u32 {
-    var val: u32 = 0;
-    _ = c.napi_get_value_uint32(env, value, &val);
-    return val;
-}
-
 // ─── transpile 함수 ───
 
-/// transpile(source, filename, flags, unsupported, jsxFactory, jsxFragment, jsxImportSource, sourceRoot)
+/// transpile(source, filename, optionsJson)
+/// optionsJson: TranspileOptionsDto JSON payload (camelCase 키)
 /// → { code: string, map?: string, errors?: string }
 fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argc: usize = 8;
-    var argv: [8]c.napi_value = undefined;
+    var argc: usize = 3;
+    var argv: [3]c.napi_value = undefined;
     if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
         return throwError(env, "failed to get arguments");
     }
-    if (argc < 4) {
-        return throwError(env, "transpile requires at least 4 arguments");
+    if (argc < 2) {
+        return throwError(env, "transpile requires at least 2 arguments (source, filename)");
     }
 
     // source (필수)
@@ -114,34 +109,15 @@ fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     };
     defer native_alloc.free(filename);
 
-    // flags, unsupported
-    const flags = getUint32Arg(env, argv[2]);
-    const unsupported = getUint32Arg(env, argv[3]);
+    // optionsJson (선택) + 파싱된 문자열의 수명을 위한 arena
+    var opts_arena = std.heap.ArenaAllocator.init(native_alloc);
+    defer opts_arena.deinit();
+    const opts_alloc = opts_arena.allocator();
 
-    // 선택적 문자열 옵션
-    const jsx_factory = if (argc > 4) getStringArg(env, argv[4], native_alloc) else null;
-    defer if (jsx_factory) |f| native_alloc.free(f);
-    const jsx_fragment = if (argc > 5) getStringArg(env, argv[5], native_alloc) else null;
-    defer if (jsx_fragment) |f| native_alloc.free(f);
-    const jsx_import_source = if (argc > 6) getStringArg(env, argv[6], native_alloc) else null;
-    defer if (jsx_import_source) |f| native_alloc.free(f);
-    const source_root = if (argc > 7) getStringArg(env, argv[7], native_alloc) else null;
-    defer if (source_root) |f| native_alloc.free(f);
+    const opts_json: []const u8 = if (argc > 2) (getStringArg(env, argv[2], opts_alloc) orelse "{}") else "{}";
 
-    // 옵션 구성
-    var options = transpile_mod.decodeFlags(flags);
-    options.unsupported = @bitCast(unsupported);
-    if (jsx_factory) |f| if (f.len > 0) {
-        options.jsx_factory = f;
-    };
-    if (jsx_fragment) |f| if (f.len > 0) {
-        options.jsx_fragment = f;
-    };
-    if (jsx_import_source) |f| if (f.len > 0) {
-        options.jsx_import_source = f;
-    };
-    if (source_root) |f| if (f.len > 0) {
-        options.source_root = f;
+    const options = transpile_mod.optionsFromJson(opts_alloc, opts_json) catch {
+        return throwError(env, "invalid options JSON");
     };
 
     // 트랜스파일 실행

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -146,10 +146,14 @@ export function targetToUnsupported(target?: Target): number {
  *   지정 시 Zig에서 `target` 기반 fallback보다 우선.
  * - `define`은 `[{ key, value }]` 배열로 직렬화 (Zig DefineEntry와 호환).
  */
-export function buildOptionsJson(opts: TranspileOptions = {}, unsupportedOverride?: number): string {
+export function buildOptionsJson(
+  opts: TranspileOptions = {},
+  unsupportedOverride?: number,
+): string {
   const payload: Record<string, unknown> = {};
   if (opts.target) payload.target = opts.target;
-  if (unsupportedOverride !== undefined && unsupportedOverride !== 0) payload.unsupported = unsupportedOverride;
+  if (unsupportedOverride !== undefined && unsupportedOverride !== 0)
+    payload.unsupported = unsupportedOverride;
   if (opts.flow) payload.flow = true;
   if (opts.jsxInJs) payload.jsxInJs = true;
   if (opts.jsx === "automatic") payload.jsx = "automatic";

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -130,39 +130,54 @@ export const ES_TARGET_BITS: Record<string, number> = {
   esnext: 0x0,
 };
 
-// ─── 옵션 인코딩 (Zig decodeFlags와 동일한 비트 레이아웃) ───
-
-export function encodeFlags(opts: TranspileOptions = {}): number {
-  let flags = 0;
-  if (opts.sourcemap) flags |= 1 << 0;
-  if (opts.minifyWhitespace || opts.minify) flags |= 1 << 1;
-  if (opts.minifyIdentifiers || opts.minify) flags |= 1 << 2;
-  if (opts.minifySyntax || opts.minify) flags |= 1 << 3;
-  if (opts.jsx === "automatic") flags |= 1 << 4;
-  if (opts.jsx === "automatic-dev") flags |= 1 << 5;
-  if (opts.dropConsole) flags |= 1 << 6;
-  if (opts.dropDebugger) flags |= 1 << 7;
-  if (opts.asciiOnly) flags |= 1 << 8;
-  if (opts.flow) flags |= 1 << 9;
-  if (opts.experimentalDecorators) flags |= 1 << 10;
-  if (opts.emitDecoratorMetadata) flags |= 1 << 11;
-  if (opts.format === "cjs") flags |= 1 << 12;
-  if (opts.quotes === "single") flags |= 1 << 14;
-  if (opts.quotes === "preserve") flags |= 2 << 14;
-  if (opts.useDefineForClassFields !== false) flags |= 1 << 16;
-  if (opts.charsetUtf8) flags |= 1 << 17;
-  if (opts.platform === "node") flags |= 1 << 18;
-  if (opts.platform === "neutral") flags |= 2 << 18;
-  if (opts.platform === "react-native") flags |= 3 << 18;
-  if (opts.jsxInJs) flags |= 1 << 20;
-  if (opts.sourcemapDebugIds) flags |= 1 << 21;
-  if (opts.sourcesContent !== false) flags |= 1 << 22;
-  return flags;
-}
-
 export function targetToUnsupported(target?: Target): number {
   if (!target) return 0;
   return ES_TARGET_BITS[target] ?? 0;
+}
+
+// ─── JSON payload 구성 (Zig optionsFromJson과 1:1 매핑) ───
+
+/**
+ * TranspileOptions를 Zig `TranspileOptionsDto` JSON으로 직렬화한다.
+ *
+ * - 기본값은 생략 (payload 크기 최소화)
+ * - enum 키는 Zig enum name과 일치 (예: "react-native" → "react_native")
+ * - browserslist 해석 결과는 `unsupportedOverride` 숫자로 주입 가능.
+ *   지정 시 Zig에서 `target` 기반 fallback보다 우선.
+ * - `define`은 `[{ key, value }]` 배열로 직렬화 (Zig DefineEntry와 호환).
+ */
+export function buildOptionsJson(opts: TranspileOptions = {}, unsupportedOverride?: number): string {
+  const payload: Record<string, unknown> = {};
+  if (opts.target) payload.target = opts.target;
+  if (unsupportedOverride !== undefined && unsupportedOverride !== 0) payload.unsupported = unsupportedOverride;
+  if (opts.flow) payload.flow = true;
+  if (opts.jsxInJs) payload.jsxInJs = true;
+  if (opts.jsx === "automatic") payload.jsx = "automatic";
+  else if (opts.jsx === "automatic-dev") payload.jsx = "automatic_dev";
+  else if (opts.jsx === "classic") payload.jsx = "classic";
+  if (opts.jsxFactory) payload.jsxFactory = opts.jsxFactory;
+  if (opts.jsxFragment) payload.jsxFragment = opts.jsxFragment;
+  if (opts.jsxImportSource) payload.jsxImportSource = opts.jsxImportSource;
+  if (opts.dropConsole) payload.dropConsole = true;
+  if (opts.dropDebugger) payload.dropDebugger = true;
+  if (opts.asciiOnly) payload.asciiOnly = true;
+  if (opts.charsetUtf8) payload.charsetUtf8 = true;
+  if (opts.experimentalDecorators) payload.experimentalDecorators = true;
+  if (opts.emitDecoratorMetadata) payload.emitDecoratorMetadata = true;
+  if (opts.useDefineForClassFields === false) payload.useDefineForClassFields = false;
+  if (opts.format) payload.format = opts.format;
+  if (opts.quotes) payload.quotes = opts.quotes;
+  if (opts.platform === "react-native") payload.platform = "react_native";
+  else if (opts.platform) payload.platform = opts.platform;
+  if (opts.minifyWhitespace || opts.minify) payload.minifyWhitespace = true;
+  if (opts.minifyIdentifiers || opts.minify) payload.minifyIdentifiers = true;
+  if (opts.minifySyntax || opts.minify) payload.minifySyntax = true;
+  if (opts.sourcemap) payload.sourcemap = true;
+  if (opts.sourcemapDebugIds) payload.sourcemapDebugIds = true;
+  // sourcesContent Zig 기본 true — false일 때만 명시 전달
+  if (opts.sourcesContent === false) payload.sourcesContent = false;
+  if (opts.sourceRoot) payload.sourceRoot = opts.sourceRoot;
+  return JSON.stringify(payload);
 }
 
 // ─── browserslist → UnsupportedFeatures ───

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -12,7 +12,7 @@
 
 export type { Target, Platform, TranspileOptions, TranspileResult } from "../shared/index";
 import type { TranspileOptions, TranspileResult } from "../shared/index";
-import { encodeFlags, targetToUnsupported } from "../shared/index";
+import { buildOptionsJson, targetToUnsupported } from "../shared/index";
 
 // ─── WASM Instance ───
 
@@ -25,16 +25,8 @@ interface WasmExports {
     srcLen: number,
     filePtr: number,
     fileLen: number,
-    flags: number,
-    unsupported: number,
-    jsxFactoryPtr: number,
-    jsxFactoryLen: number,
-    jsxFragmentPtr: number,
-    jsxFragmentLen: number,
-    jsxImportSourcePtr: number,
-    jsxImportSourceLen: number,
-    sourceRootPtr: number,
-    sourceRootLen: number,
+    optsJsonPtr: number,
+    optsJsonLen: number,
   ): bigint;
   get_error_ptr(): number;
   get_error_len(): number;
@@ -175,31 +167,11 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
 
   const [srcPtr, srcLen] = writeString(source);
   const [filePtr, fileLen] = options.filename ? writeString(options.filename) : [0, 0];
-  const [factoryPtr, factoryLen] = writeOptionalString(options.jsxFactory);
-  const [fragmentPtr, fragmentLen] = writeOptionalString(options.jsxFragment);
-  const [importSourcePtr, importSourceLen] = writeOptionalString(options.jsxImportSource);
-  const [sourceRootPtr, sourceRootLen] = writeOptionalString(options.sourceRoot);
-
-  const flags = encodeFlags(options);
-  const unsupported = targetToUnsupported(options.target);
+  const optsJson = buildOptionsJson(options, targetToUnsupported(options.target));
+  const [optsPtr, optsLen] = writeString(optsJson);
 
   try {
-    const packed = wasm.transpile(
-      srcPtr,
-      srcLen,
-      filePtr,
-      fileLen,
-      flags,
-      unsupported,
-      factoryPtr,
-      factoryLen,
-      fragmentPtr,
-      fragmentLen,
-      importSourcePtr,
-      importSourceLen,
-      sourceRootPtr,
-      sourceRootLen,
-    );
+    const packed = wasm.transpile(srcPtr, srcLen, filePtr, fileLen, optsPtr, optsLen);
 
     const outPtr = Number(packed >> 32n);
     const outLen = Number(packed & 0xffffffffn);
@@ -225,9 +197,6 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
   } finally {
     wasm.dealloc(srcPtr, srcLen);
     if (filePtr) wasm.dealloc(filePtr, fileLen);
-    if (factoryPtr) wasm.dealloc(factoryPtr, factoryLen);
-    if (fragmentPtr) wasm.dealloc(fragmentPtr, fragmentLen);
-    if (importSourcePtr) wasm.dealloc(importSourcePtr, importSourceLen);
-    if (sourceRootPtr) wasm.dealloc(sourceRootPtr, sourceRootLen);
+    wasm.dealloc(optsPtr, optsLen);
   }
 }

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -90,9 +90,7 @@ const decodeFlags = transpile_mod.decodeFlags;
 
 /// 소스 코드를 트랜스파일한다.
 ///
-/// flags: 비트마스크 옵션 (decodeFlags 참고)
-/// unsupported: UnsupportedFeatures packed u32 (ES 다운레벨링 타겟)
-/// 문자열 옵션: jsx_factory, jsx_fragment, jsx_import_source, source_root (ptr+len 쌍)
+/// opts_json: TranspileOptionsDto JSON payload (ptr+len). camelCase 키. 빈 문자열이면 기본값.
 ///
 /// 반환값: packed u64 (상위 32비트: 포인터, 하위 32비트: 길이, 0=에러)
 export fn transpile(
@@ -100,16 +98,8 @@ export fn transpile(
     src_len: u32,
     file_ptr: u32,
     file_len: u32,
-    flags: u32,
-    unsupported: u32,
-    jsx_factory_ptr: u32,
-    jsx_factory_len: u32,
-    jsx_fragment_ptr: u32,
-    jsx_fragment_len: u32,
-    jsx_import_source_ptr: u32,
-    jsx_import_source_len: u32,
-    source_root_ptr: u32,
-    source_root_len: u32,
+    opts_json_ptr: u32,
+    opts_json_len: u32,
 ) u64 {
     clearError();
 
@@ -124,20 +114,20 @@ export fn transpile(
     else
         "input.ts";
 
-    var options = decodeFlags(flags);
+    // JSON 옵션 파싱은 arena에 위임 — 파싱 결과의 문자열 수명을 트랜스파일 끝까지 유지.
+    var opts_arena = std.heap.ArenaAllocator.init(wasm_alloc);
+    defer opts_arena.deinit();
+    const opts_alloc = opts_arena.allocator();
 
-    // UnsupportedFeatures는 packed struct(u32) — 직접 bitcast
-    options.unsupported = @bitCast(unsupported);
+    const opts_json: []const u8 = if (opts_json_ptr != 0 and opts_json_len > 0)
+        @as([*]const u8, @ptrFromInt(opts_json_ptr))[0..opts_json_len]
+    else
+        "{}";
 
-    // 문자열 옵션 (빈 문자열이면 기본값 유지)
-    const factory = readStr(jsx_factory_ptr, jsx_factory_len);
-    if (factory.len > 0) options.jsx_factory = factory;
-    const fragment = readStr(jsx_fragment_ptr, jsx_fragment_len);
-    if (fragment.len > 0) options.jsx_fragment = fragment;
-    const import_source = readStr(jsx_import_source_ptr, jsx_import_source_len);
-    if (import_source.len > 0) options.jsx_import_source = import_source;
-    const source_root = readStr(source_root_ptr, source_root_len);
-    if (source_root.len > 0) options.source_root = source_root;
+    const options = transpile_mod.optionsFromJson(opts_alloc, opts_json) catch {
+        setError("invalid options JSON");
+        return 0;
+    };
 
     var result = transpile_mod.transpileWithCallback(wasm_alloc, source, file_path, options, &formatErrors) catch |err| {
         // formatErrors 콜백이 이미 상세 메시지를 last_error_buf에 저장했을 수 있음.

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -64,50 +64,105 @@ pub const TranspileOptions = struct {
     es_target: ?@import("transformer/compat.zig").ESTarget = null,
 };
 
-/// WASM/FFI 진입점 공용 플래그 디코더.
-/// 비트마스크 → TranspileOptions 변환 (비트 레이아웃은 packages/wasm, packages/core 참조).
-pub fn decodeFlags(flags: u32) TranspileOptions {
-    return .{
-        .sourcemap = flags & (1 << 0) != 0,
-        .minify_whitespace = flags & (1 << 1) != 0,
-        .minify_identifiers = flags & (1 << 2) != 0,
-        .minify_syntax = flags & (1 << 3) != 0,
-        .jsx_runtime = if (flags & (1 << 5) != 0)
-            .automatic_dev
-        else if (flags & (1 << 4) != 0)
-            .automatic
-        else
-            .classic,
-        .drop_console = flags & (1 << 6) != 0,
-        .drop_debugger = flags & (1 << 7) != 0,
-        .ascii_only = flags & (1 << 8) != 0,
-        .flow = flags & (1 << 9) != 0,
-        .experimental_decorators = flags & (1 << 10) != 0,
-        .emit_decorator_metadata = flags & (1 << 11) != 0,
-        .module_format = switch ((flags >> 12) & 0x3) {
-            0 => .esm,
-            1 => .cjs,
-            else => .esm,
-        },
-        .quote_style = switch ((flags >> 14) & 0x3) {
-            0 => .double,
-            1 => .single,
-            2 => .preserve,
-            else => .double,
-        },
-        .use_define_for_class_fields = flags & (1 << 16) != 0,
-        .charset_utf8 = flags & (1 << 17) != 0,
-        .platform = switch ((flags >> 18) & 0x3) {
-            0 => .browser,
-            1 => .node,
-            2 => .neutral,
-            3 => .react_native,
-            else => .browser,
-        },
-        .jsx_in_js = flags & (1 << 20) != 0,
-        .sourcemap_debug_ids = flags & (1 << 21) != 0,
-        .sources_content = flags & (1 << 22) != 0,
+/// WASM/NAPI 진입점 공용 JSON payload DTO.
+/// TS 쪽 TranspileOptions와 camelCase 필드명으로 매핑된다.
+/// 모든 필드가 optional이라 누락되어도 기본값 유지.
+///
+/// JSON에서 enum은 Zig enum name과 정확히 일치하는 string이어야 한다:
+///   - platform: "browser" | "node" | "neutral" | "react_native"
+///   - format: "esm" | "cjs"
+///   - quotes: "double" | "single" | "preserve"
+///   - jsx: "classic" | "automatic" | "automatic_dev"
+///   - target: "es5" | "es2015"..."es2025" | "esnext"
+/// JS 래퍼가 필요 시 하이픈/대시를 언더스코어로 변환해 전달한다.
+const TranspileOptionsDto = struct {
+    target: ?[]const u8 = null,
+    unsupported: ?u32 = null,
+    flow: ?bool = null,
+    jsxInJs: ?bool = null,
+    jsx: ?[]const u8 = null,
+    jsxFactory: ?[]const u8 = null,
+    jsxFragment: ?[]const u8 = null,
+    jsxImportSource: ?[]const u8 = null,
+    dropConsole: ?bool = null,
+    dropDebugger: ?bool = null,
+    asciiOnly: ?bool = null,
+    charsetUtf8: ?bool = null,
+    experimentalDecorators: ?bool = null,
+    emitDecoratorMetadata: ?bool = null,
+    useDefineForClassFields: ?bool = null,
+    format: ?[]const u8 = null,
+    quotes: ?[]const u8 = null,
+    platform: ?[]const u8 = null,
+    minifyWhitespace: ?bool = null,
+    minifyIdentifiers: ?bool = null,
+    minifySyntax: ?bool = null,
+    sourcemap: ?bool = null,
+    sourcemapDebugIds: ?bool = null,
+    sourcesContent: ?bool = null,
+    sourceRoot: ?[]const u8 = null,
+    define: ?[]const DefineEntry = null,
+};
+
+/// JSON payload를 파싱해 `TranspileOptions`로 변환한다.
+/// allocator는 arena 권장 — 반환된 값의 문자열/슬라이스 수명을 책임진다.
+///
+/// 오류: JSON 파싱 실패 / 알 수 없는 enum 문자열 → error 반환.
+pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !TranspileOptions {
+    const parsed = std.json.parseFromSliceLeaky(TranspileOptionsDto, allocator, json, .{ .ignore_unknown_fields = true }) catch return error.InvalidOptions;
+
+    var opts: TranspileOptions = .{};
+    const compat = @import("transformer/compat.zig");
+    const codegen = @import("codegen/codegen.zig");
+
+    if (parsed.target) |t| opts.es_target = std.meta.stringToEnum(compat.ESTarget, t);
+    if (parsed.unsupported) |u| {
+        opts.unsupported = @bitCast(u);
+    } else if (opts.es_target) |t| {
+        opts.unsupported = compat.fromESTarget(t);
+    }
+    if (parsed.flow) |v| opts.flow = v;
+    if (parsed.jsxInJs) |v| opts.jsx_in_js = v;
+    if (parsed.jsx) |s| {
+        if (std.meta.stringToEnum(codegen.JsxRuntime, s)) |e| opts.jsx_runtime = e;
+    }
+    if (parsed.jsxFactory) |s| if (s.len > 0) {
+        opts.jsx_factory = s;
     };
+    if (parsed.jsxFragment) |s| if (s.len > 0) {
+        opts.jsx_fragment = s;
+    };
+    if (parsed.jsxImportSource) |s| if (s.len > 0) {
+        opts.jsx_import_source = s;
+    };
+    if (parsed.dropConsole) |v| opts.drop_console = v;
+    if (parsed.dropDebugger) |v| opts.drop_debugger = v;
+    if (parsed.asciiOnly) |v| opts.ascii_only = v;
+    if (parsed.charsetUtf8) |v| opts.charset_utf8 = v;
+    if (parsed.experimentalDecorators) |v| opts.experimental_decorators = v;
+    if (parsed.emitDecoratorMetadata) |v| opts.emit_decorator_metadata = v;
+    if (parsed.useDefineForClassFields) |v| opts.use_define_for_class_fields = v;
+    if (parsed.format) |s| {
+        if (std.meta.stringToEnum(codegen.ModuleFormat, s)) |e| opts.module_format = e;
+    }
+    if (parsed.quotes) |s| {
+        if (std.meta.stringToEnum(codegen.QuoteStyle, s)) |e| opts.quote_style = e;
+    }
+    if (parsed.platform) |s| {
+        if (std.meta.stringToEnum(codegen.Platform, s)) |e| opts.platform = e;
+    }
+    if (parsed.minifyWhitespace) |v| opts.minify_whitespace = v;
+    if (parsed.minifyIdentifiers) |v| opts.minify_identifiers = v;
+    if (parsed.minifySyntax) |v| opts.minify_syntax = v;
+    if (parsed.sourcemap) |v| opts.sourcemap = v;
+    if (parsed.sourcemapDebugIds) |v| opts.sourcemap_debug_ids = v;
+    if (parsed.sourcesContent) |v| opts.sources_content = v;
+    if (parsed.sourceRoot) |s| if (s.len > 0) {
+        opts.source_root = s;
+    };
+    if (parsed.define) |d| opts.define = d;
+
+    return opts;
 }
 
 pub const TranspileError = error{


### PR DESCRIPTION
## Summary
Closes #1443.

WASM/NAPI 진입점이 옵션을 per-field로 받던 구조(WASM 14인자, NAPI 8인자)를 **단일 JSON payload**로 전환. esbuild/rolldown 관용구 도입.

## 동기 (Issue #1443)
기존 구조는 새 옵션 하나 추가마다 **5곳 동시 수정** 필요 → 누락 반복 버그 확정적:
- \`es_target\` → 플레이그라운드에서 ZTS0001 영구 스킵 (PR #1443에서 패치)
- \`source_root\` → 항상 빈 값 (PR #1443에서 패치)
- \`define\` → 전달 경로 **없음**

## 전후 비교

### WASM export 시그니처
\`\`\`
# Before (14 인자)
transpile(src_ptr, src_len, file_ptr, file_len, flags, unsupported,
          jsx_factory_ptr, jsx_factory_len, jsx_fragment_ptr, jsx_fragment_len,
          jsx_import_source_ptr, jsx_import_source_len, source_root_ptr, source_root_len) -> u64

# After (6 인자)
transpile(src_ptr, src_len, file_ptr, file_len, opts_json_ptr, opts_json_len) -> u64
\`\`\`

### NAPI 시그니처
\`\`\`
# Before (8 인자)
transpile(source, filename, flags, unsupported, jsxFactory, jsxFragment, jsxImportSource, sourceRoot)

# After (3 인자)
transpile(source, filename, optionsJson)
\`\`\`

## 변경 요지

| 파일 | 변경 |
|---|---|
| \`src/transpile.zig\` | \`decodeFlags\` (비트마스크) 제거 → \`TranspileOptionsDto\` + \`optionsFromJson\` |
| \`packages/shared/index.ts\` | \`encodeFlags\` 제거 → \`buildOptionsJson(opts, unsupportedOverride?)\` |
| \`packages/wasm/*\` | JSON 기반 전환, writeString 4회 → 1회 |
| \`packages/core/*\` | JSON 기반 전환, getStringArg 4회 → 1회 |
| \`packages/core/napi.test.mjs\` | 플래그 bit 상수 → \`call(src, file, opts)\` JSON 헬퍼로 전면 rewrite |

순 diff: **+201 / −296 = −95줄**

## 이점
- 새 옵션 추가 시 변경점: **5곳 → 2곳** (Zig \`TranspileOptions\` + TS \`TranspileOptions\`)
- WASM export ABI **영구 고정** — 인자 추가로 인한 break 없음
- \`define\` 배열 전달 경로 확보 (\`[]DefineEntry\` JSON 자동 직렬화)
- Zig 기본값(\`useDefineForClassFields\`, \`sourcesContent\` 등)을 Zig에서 소유 → TS ↔ Zig 불일치 버그 방지

## 성능
- 추가 오버헤드: per-call JSON 파싱 + arena alloc = ~100ns (전체 트랜스파일 대비 <0.01%)
- WASM memory write 3회 감소로 상쇄 또는 개선
- 유닛 테스트 \`--timing\` 출력: 1k/5k/10k 라인에서 이전과 동일 (+/- 노이즈)

## Fallback 정책
- \`unsupported\` 명시 > \`target\` 기반 자동 유도 (browserslist 해석 결과가 \`unsupported\`로 주입됨)
- 알 수 없는 enum 문자열은 silent ignore → 기본값 유지 (WASM/NAPI graceful degradation)

## /simplify 반영
- Dead code \`getUint32Arg\` 제거 (bitmask 시대 잔재)
- \`TranspileOptionsDto\`는 private (외부 사용 0)
- JS 래퍼의 중복 설명 주석 정리

## Test plan
- [x] \`zig build test\` — 3017/3017 pass
- [x] NAPI 유닛 — 360 pass
- [x] WASM 유닛 — 28 pass
- [x] 통합 — 2899 pass, 4 skip
- [x] 스모크: ZTS0001 \`target: es2021\` + TLA → 에러 표시 정상
- [x] \`packages/core/dist\` 재빌드 후 CLI 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)