### PR TITLE
feat(cli): auto-load zts.config.json with $schema autocomplete

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -74,6 +74,7 @@ export default defineConfig({
           translations: { en: "Guides" },
           items: [
             { label: "트랜스파일", slug: "guides/transpile", translations: { en: "Transpile" } },
+            { label: "설정 파일", slug: "guides/config-file", translations: { en: "Config File" } },
             { label: "번들링", slug: "guides/bundling", translations: { en: "Bundling" } },
             { label: "플러그인", slug: "guides/plugins", translations: { en: "Plugins" } },
             { label: "플러그인 레시피", slug: "guides/plugin-recipes", translations: { en: "Plugin Recipes" } },

--- a/documents/src/content/docs/en/guides/config-file.md
+++ b/documents/src/content/docs/en/guides/config-file.md
@@ -1,0 +1,84 @@
+---
+title: Config file (zts.config.json)
+description: Auto-loaded zts.config.json with editor autocomplete via $schema
+---
+
+The ZTS CLI auto-loads `zts.config.json` from the current directory. JSON-schema-aware editors (VSCode / IntelliJ / Zed) give you **autocomplete + type checking** via the `$schema` reference.
+
+## Quick start
+
+```json
+{
+  "$schema": "https://ohah.github.io/zts/schemas/transpile-options.schema.json",
+  "target": "es2022",
+  "sourcemap": true,
+  "minifySyntax": true,
+  "platform": "browser"
+}
+```
+
+Running `zts input.ts` in the same directory picks up these options automatically.
+
+```bash
+zts input.ts                  # uses values from config.json
+zts input.ts --quotes=double  # CLI argument overrides config (CLI > config)
+```
+
+## Option priority
+
+ZTS merges options in this order (**later wins**):
+
+1. Zig defaults
+2. `zts.config.json`
+3. `tsconfig.json` (selective: `compilerOptions.target`, etc.)
+4. CLI arguments
+
+You can override config values from the CLI but not the other way around. To temporarily disable the config, rename or delete the file.
+
+## Editor setup
+
+### VSCode
+
+Works out of the box — the `$schema` field is enough.
+
+### Local schema (offline)
+
+To use a local schema instead of the online URL (ZTS repo contributors only):
+
+```bash
+zig build schema
+```
+
+## Supported fields
+
+See the [Transpile Options reference](/zts/en/reference/options/) — the schema covers the same fields as the `TranspileOptions` TS interface.
+
+**Note**: bundler-only options (`external`, `alias`, `define`, etc.) are limited in `zts.config.json`. For complex bundler configs, use `zts.config.ts` (TypeScript config with plugin support).
+
+## zts.config.ts vs zts.config.json
+
+| | `zts.config.ts` | `zts.config.json` |
+|---|---|---|
+| Plugins | ✅ Full support | ❌ |
+| Dynamic values | ✅ (functions, imports) | ❌ |
+| JSON schema autocomplete | ❌ | ✅ |
+| CLI auto-discovery | `bundle`/`serve` only | **All commands** |
+| Learning curve | Medium | Low |
+
+**Recommendation**:
+- Simple transpile / small projects → `zts.config.json`
+- Plugins / dynamic config / bundling → `zts.config.ts`
+
+If both exist, `zts.config.ts` takes precedence on the bundle path.
+
+## Regenerating the schema
+
+When you upgrade ZTS, the URL stays the same but the option list may have changed. In VSCode, reopen the workspace or run "JSON: Clear Schema Cache" to force a refresh.
+
+ZTS repo contributors: after editing `src/transpile.zig`'s `TranspileOptionsDto`, run:
+
+```bash
+zig build schema
+```
+
+This regenerates `documents/public/schemas/transpile-options.schema.json`.

--- a/documents/src/content/docs/guides/config-file.md
+++ b/documents/src/content/docs/guides/config-file.md
@@ -1,0 +1,87 @@
+---
+title: 설정 파일 (zts.config.json)
+description: ZTS CLI가 자동 로드하는 zts.config.json 사용법과 에디터 자동완성
+---
+
+ZTS CLI는 현재 디렉토리의 `zts.config.json`을 자동으로 로드합니다. VSCode / IntelliJ / Zed 등 JSON-schema-aware 에디터에서 `$schema` 참조로 **자동완성 + 타입 검증**을 받을 수 있습니다.
+
+## 빠른 시작
+
+```json
+{
+  "$schema": "https://ohah.github.io/zts/schemas/transpile-options.schema.json",
+  "target": "es2022",
+  "sourcemap": true,
+  "minifySyntax": true,
+  "platform": "browser"
+}
+```
+
+파일을 저장하면 같은 디렉토리의 `zts input.ts` 실행 시 자동으로 위 옵션이 적용됩니다.
+
+```bash
+zts input.ts               # config.json 값 사용
+zts input.ts --quotes=double  # CLI 인자가 config 덮어씀 (CLI > config)
+```
+
+## 옵션 우선순위
+
+ZTS는 다음 순서로 옵션을 병합합니다 (**뒤가 우선**):
+
+1. Zig 기본값
+2. `zts.config.json`
+3. `tsconfig.json` (`compilerOptions.target` 등 일부 필드)
+4. CLI 인자
+
+CLI 인자로 `zts.config.json`의 값을 덮어쓸 수 있지만, 반대는 불가능합니다. config 파일을 일시 비활성화하려면 파일을 이름 변경하거나 삭제하세요.
+
+## $schema 에디터 설정
+
+### VSCode
+
+`$schema` 필드가 있으면 **추가 설정 없이** 자동 작동합니다. JSON 파일에서 바로 자동완성과 hover 설명이 나타납니다.
+
+### 로컬 schema 참조 (오프라인)
+
+온라인 schema 대신 로컬 파일을 쓰려면:
+
+```bash
+# 프로젝트 루트에 schema 파일 생성
+zig build schema
+```
+
+(ZTS 레포 내부에서만 사용 가능. npm 패키지 사용자는 URL 방식 권장.)
+
+## 지원 필드
+
+`zts.config.json`에서 사용할 수 있는 모든 필드는 [Transpile 옵션 레퍼런스](/zts/reference/options/)를 참조하세요. `TranspileOptions`와 동일합니다.
+
+**주의**: bundler 전용 옵션(`external`, `alias`, `define` 등)은 현재 `zts.config.json`에서 제한적으로 지원됩니다. bundler 설정이 많다면 `zts.config.ts` (TypeScript 설정 파일, 플러그인 지원)를 사용하세요.
+
+## zts.config.ts vs zts.config.json
+
+| | `zts.config.ts` | `zts.config.json` |
+|---|---|---|
+| 플러그인 | ✅ 전체 지원 | ❌ |
+| 동적 값 | ✅ (함수, import) | ❌ |
+| JSON schema 자동완성 | ❌ | ✅ |
+| CLI 자동 탐색 | bundle/serve만 | **모든 명령** |
+| 학습 비용 | 중 | 낮음 |
+
+**권장**:
+- 단순 트랜스파일 / 작은 프로젝트 → `zts.config.json`
+- 플러그인 / 동적 설정 / 번들 → `zts.config.ts`
+
+두 파일이 동시에 있으면 `zts.config.ts`가 우선합니다 (번들 경로).
+
+## 스키마 재생성
+
+ZTS 버전을 업그레이드하면 schema URL은 동일하지만 내부 옵션 목록이 갱신됐을 수 있습니다. VSCode에서 JSON 캐시를 강제로 새로고침하려면 워크스페이스를 다시 열거나 "JSON: Clear Schema Cache" 명령을 실행하세요.
+
+ZTS 저장소 내부 개발자는:
+
+```bash
+zig build schema
+```
+
+로 `documents/public/schemas/transpile-options.schema.json`을 재생성합니다 — `src/transpile.zig`의 `TranspileOptionsDto` struct가 변경되면 반드시 실행.

--- a/src/main.zig
+++ b/src/main.zig
@@ -248,6 +248,64 @@ fn parseEngineTargets(val: []const u8) ?lib.transformer.TransformOptions.compat.
     return compat.unsupportedFeatures(targets[0..count]);
 }
 
+/// `zts.config.json`이 cwd에 있으면 파싱해 opts의 defaults를 세팅한다.
+/// CLI 인자가 뒤에서 이 값을 덮어쓴다 → "CLI > config.json".
+/// transpile.zig의 `optionsFromJson`을 재사용하여 schema 일치를 보장.
+///
+/// 현재 매핑되는 필드: target/sourcemap/minify/jsx/platform/format/quotes/drop/flow
+/// 등 TranspileOptions에 대응하는 것들. bundler-only 필드(external, alias 등)는
+/// 여기서 처리하지 않는다.
+fn applyZtsConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
+    const f = try std.fs.cwd().openFile("zts.config.json", .{});
+    defer f.close();
+    const content = try f.readToEndAlloc(allocator, 1 * 1024 * 1024);
+    defer allocator.free(content);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const parsed = lib.transpile.optionsFromJson(arena_alloc, content) catch return error.InvalidConfig;
+
+    if (parsed.es_target) |t| {
+        opts.es_target = t;
+        opts.unsupported = lib.transformer.TransformOptions.compat.fromESTarget(t);
+    }
+    opts.unsupported = @bitCast(@as(u32, @bitCast(parsed.unsupported)) | @as(u32, @bitCast(opts.unsupported)));
+    if (parsed.flow) opts.flow = true;
+    if (parsed.jsx_in_js) opts.jsx_in_js = true;
+    opts.jsx_runtime = parsed.jsx_runtime;
+    // 문자열 필드는 config 수명이 함수 종료 후 해제됨 → dupe 필수.
+    if (parsed.jsx_factory.len > 0 and !std.mem.eql(u8, parsed.jsx_factory, "React.createElement")) {
+        opts.jsx_factory = try allocator.dupe(u8, parsed.jsx_factory);
+    }
+    if (parsed.jsx_fragment.len > 0 and !std.mem.eql(u8, parsed.jsx_fragment, "React.Fragment")) {
+        opts.jsx_fragment = try allocator.dupe(u8, parsed.jsx_fragment);
+    }
+    if (parsed.jsx_import_source.len > 0 and !std.mem.eql(u8, parsed.jsx_import_source, "react")) {
+        opts.jsx_import_source = try allocator.dupe(u8, parsed.jsx_import_source);
+    }
+    if (parsed.drop_console) opts.drop_console = true;
+    if (parsed.drop_debugger) opts.drop_debugger = true;
+    if (parsed.ascii_only) opts.ascii_only = true;
+    if (parsed.charset_utf8) opts.charset_utf8 = true;
+    if (parsed.experimental_decorators) opts.experimental_decorators = true;
+    if (parsed.emit_decorator_metadata) opts.emit_decorator_metadata = true;
+    if (parsed.use_define_for_class_fields == false) opts.use_define_for_class_fields = false;
+    opts.module_format = parsed.module_format;
+    opts.quote_style = parsed.quote_style;
+    opts.platform = parsed.platform;
+    if (parsed.minify_whitespace) opts.minify_whitespace = true;
+    if (parsed.minify_identifiers) opts.minify_identifiers = true;
+    if (parsed.minify_syntax) opts.minify_syntax = true;
+    if (parsed.sourcemap) opts.sourcemap = true;
+    if (parsed.sourcemap_debug_ids) opts.sourcemap_debug_ids = true;
+    if (!parsed.sources_content) opts.sources_content = false;
+    if (parsed.source_root.len > 0) {
+        opts.source_root = try allocator.dupe(u8, parsed.source_root);
+    }
+}
+
 /// CLI 인자를 파싱하여 CliOptions를 반환한다.
 /// --help 출력이나 파싱 에러로 프로그램을 종료해야 하면 null을 반환한다.
 fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?CliOptions {
@@ -260,6 +318,14 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
     }
 
     var opts = CliOptions{};
+    // zts.config.json이 있으면 defaults를 그쪽으로 초기화. CLI 인자는 뒤에서
+    // 파싱되며 이 값을 덮어쓴다 ("CLI > config" 우선순위).
+    applyZtsConfigJson(&opts, allocator) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => {
+            try stderr.print("[zts] zts.config.json load failed: {}\n", .{err});
+        },
+    };
 
     var i: usize = 1;
     while (i < args.len) : (i += 1) {


### PR DESCRIPTION
## Summary
PR #1446 후속 — CLI가 현재 디렉토리의 \`zts.config.json\`을 자동으로 로드. \`\$schema\` 참조를 통해 VSCode / IntelliJ / Zed에서 **자동완성 + 타입 검증**.

## 예시

\`\`\`json
{
  "\$schema": "https://ohah.github.io/zts/schemas/transpile-options.schema.json",
  "target": "es2022",
  "sourcemap": true,
  "minifySyntax": true
}
\`\`\`

\`\`\`bash
zts input.ts               # config 값 사용
zts input.ts --quotes=double  # CLI 인자가 config 덮어씀
\`\`\`

## 우선순위 (뒤가 우선)
1. Zig 기본값
2. \`zts.config.json\`
3. \`tsconfig.json\` (일부 필드)
4. CLI 인자

## 구현 포인트
- \`applyZtsConfigJson(opts, allocator)\` 헬퍼 — \`parseCliArguments\` 최상단에서 호출, \`CliOptions\` defaults를 세팅. CLI가 그 위에 덮어씀 → \`CLI > config\` 자동 보장.
- \`transpile.optionsFromJson\`을 **재사용** → WASM/NAPI/CLI 모두 동일 JSON parser. Zig struct 단일 소스가 schema + config 로더 + WASM/NAPI payload를 모두 담당.
- FileNotFound는 조용히 넘김 (파일 없으면 기존 동작 그대로). 파싱 에러만 경고 출력.

## 매핑되는 필드
target, unsupported, flow, jsxInJs, jsx, jsxFactory/Fragment/ImportSource, dropConsole/Debugger, asciiOnly, charsetUtf8, experimentalDecorators, emitDecoratorMetadata, useDefineForClassFields, format, quotes, platform, minify\*, sourcemap, sourcemapDebugIds, sourcesContent, sourceRoot.

(bundler 전용: external, alias, define 등은 별도 — \`zts.config.ts\` 권장)

## 문서
- \`guides/config-file.md\` (ko+en) 신설 — 빠른 시작, 우선순위, editor 설정, \`.ts\` vs \`.json\` 비교
- 사이드바 "설정 파일" / "Config File" 항목 추가

## 스모크 검증
| 케이스 | 결과 |
|---|---|
| \`{ target: es5 }\` | arrow function → \`function\` 다운레벨 |
| \`{ dropConsole: true }\` | \`console.log\` 제거 |
| \`{ quotes: "single" }\` + CLI \`--quotes=double\` | CLI 우선 (double 적용) |

## 후속
- **PR #3** (#1443 마무리): CI에서 schema ↔ TS \`TranspileOptions\` interface 필드 diff 검증

## Test plan
- [x] \`zig build test\` 통과
- [x] NAPI / 통합 테스트 모두 통과
- [x] Astro docs build — 332 pages, 내부 링크 valid
- [x] 수동 스모크 3가지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)