### PR TITLE
test(transpile): verify Zig DTO ↔ TS TranspileOptions field sync

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -79,6 +79,11 @@ export interface TranspileOptions {
   browserslist?: string | string[];
   /** 소스맵의 sourceRoot 필드 (기본: 빈 문자열) */
   sourceRoot?: string;
+  /**
+   * 식별자 치환 쌍. `value`는 raw JSON (문자열은 반드시 따옴표 포함).
+   * 예: `[{ key: "process.env.NODE_ENV", value: "\"production\"" }]`
+   */
+  define?: Array<{ key: string; value: string }>;
 }
 
 export interface TranspileResult {
@@ -181,6 +186,7 @@ export function buildOptionsJson(
   // sourcesContent Zig 기본 true — false일 때만 명시 전달
   if (opts.sourcesContent === false) payload.sourcesContent = false;
   if (opts.sourceRoot) payload.sourceRoot = opts.sourceRoot;
+  if (opts.define && opts.define.length > 0) payload.define = opts.define;
   return JSON.stringify(payload);
 }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -49,4 +49,5 @@ test {
 
     // test files
     _ = @import("config_test.zig");
+    _ = @import("transpile_options_dto_test.zig");
 }

--- a/src/transpile_options_dto_test.zig
+++ b/src/transpile_options_dto_test.zig
@@ -1,0 +1,141 @@
+//! `TranspileOptionsDto` (Zig) ↔ `TranspileOptions` (TS) 필드 동기화 검증.
+//!
+//! #1446에서 Zig struct가 JSON schema의 단일 소스가 됐지만, TS 쪽의
+//! `TranspileOptions` interface는 JSDoc/union 유지를 위해 handwritten으로
+//! 남았다. 두 표현이 드리프트하지 않도록 CI에서 자동 검증한다.
+//!
+//! 검증 원칙:
+//!   - Zig DTO 필드는 전부 TS interface에 존재해야 함 (WASM/NAPI로 전달되려면
+//!     TS 사용자가 해당 필드를 쓸 수 있어야 함).
+//!   - TS에만 있고 Zig에 없는 필드는 allowlist에 있어야 함 (JS 래퍼가
+//!     자체 처리하는 필드들 — filename/browserslist/minify 등).
+
+const std = @import("std");
+const TranspileOptionsDto = @import("transpile.zig").TranspileOptionsDto;
+
+/// TS `TranspileOptions`에만 있는 (Zig로 전달되지 않거나 JS 래퍼가 해석하는)
+/// 필드. 리스트에 없는 TS-only 필드가 발견되면 테스트 실패 — 의도된 추가라면
+/// 이 리스트에 등록할 것.
+const ts_only_allowlist = [_][]const u8{
+    "filename", // CLI/API의 별도 인자로 전달, 옵션 DTO에 안 들어감
+    "browserslist", // JS 쪽에서 unsupported bitmask로 해석 후 주입
+    "minify", // minifyWhitespace/Identifiers/Syntax all-in-one alias
+};
+
+/// Zig DTO에만 있는 (JS 래퍼가 내부적으로만 쓰는) 필드.
+/// TS 공개 API에 노출할 필요가 없는 internal 전달 경로 — 리스트에 없는 필드가
+/// TS에 누락되면 드리프트로 간주하고 실패.
+const zig_only_allowlist = [_][]const u8{
+    "unsupported", // JS wrapper가 browserslist 해석 후 주입. 사용자가 직접 쓸 일 없음.
+};
+
+/// TS `packages/shared/index.ts`의 `TranspileOptions` interface에서 필드명을
+/// 추출한다. 간단 파서: `interface TranspileOptions {` 블록 본문의 각 줄에서
+/// 첫 식별자(optional `?` 직전의 `:`까지)를 긁는다. 주석(`//`, `/**`)과 빈 줄은
+/// 스킵.
+fn parseTsInterface(source: []const u8, list: *std.ArrayList([]const u8), allocator: std.mem.Allocator) !void {
+    const marker = "interface TranspileOptions {";
+    const body_start = (std.mem.indexOf(u8, source, marker) orelse return error.InterfaceNotFound) + marker.len;
+    var depth: usize = 1;
+    var i: usize = body_start;
+    while (i < source.len and depth > 0) : (i += 1) {
+        switch (source[i]) {
+            '{' => depth += 1,
+            '}' => depth -= 1,
+            else => {},
+        }
+    }
+    const body = source[body_start .. i - 1];
+
+    var line_iter = std.mem.splitScalar(u8, body, '\n');
+    while (line_iter.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (line.len == 0) continue;
+        if (std.mem.startsWith(u8, line, "//")) continue;
+        if (std.mem.startsWith(u8, line, "*")) continue;
+        if (std.mem.startsWith(u8, line, "/*")) continue;
+
+        // `fieldName?:` 또는 `fieldName:` 패턴. 첫 non-identifier 문자까지가 필드명.
+        var end: usize = 0;
+        while (end < line.len and (std.ascii.isAlphanumeric(line[end]) or line[end] == '_')) end += 1;
+        if (end == 0) continue;
+        const name = line[0..end];
+        // `:` 또는 `?:`가 이어져야 필드 선언.
+        const after = line[end..];
+        if (!std.mem.startsWith(u8, after, ":") and !std.mem.startsWith(u8, after, "?:")) continue;
+        try list.append(allocator, name);
+    }
+}
+
+fn contains(haystack: []const []const u8, needle: []const u8) bool {
+    for (haystack) |s| if (std.mem.eql(u8, s, needle)) return true;
+    return false;
+}
+
+test "schema diff: Zig DTO fields are covered by TS TranspileOptions" {
+    const allocator = std.testing.allocator;
+
+    // 저장소 루트에서 테스트 실행 가정 (zig build test 기본).
+    const ts_source = std.fs.cwd().readFileAlloc(allocator, "packages/shared/index.ts", 1 * 1024 * 1024) catch |err| {
+        // CI 외 환경에서 경로가 다를 수 있음 → skip 처리
+        if (err == error.FileNotFound) return error.SkipZigTest;
+        return err;
+    };
+    defer allocator.free(ts_source);
+
+    var ts_fields: std.ArrayList([]const u8) = .empty;
+    defer ts_fields.deinit(allocator);
+    try parseTsInterface(ts_source, &ts_fields, allocator);
+    try std.testing.expect(ts_fields.items.len > 0);
+
+    // 1. Zig DTO 필드가 TS에 모두 있는지 (internal 필드는 zig_only_allowlist에서 제외)
+    const zig_fields = @typeInfo(TranspileOptionsDto).@"struct".fields;
+    inline for (zig_fields) |f| {
+        const is_internal = comptime contains(&zig_only_allowlist, f.name);
+        if (!is_internal and !contains(ts_fields.items, f.name)) {
+            std.debug.print(
+                "\n[schema drift] Zig TranspileOptionsDto.{s} is missing from TS TranspileOptions in packages/shared/index.ts\n",
+                .{f.name},
+            );
+            return error.ZigFieldMissingFromTs;
+        }
+    }
+
+    // 2. TS에만 있는 필드는 allowlist에 있어야 함
+    for (ts_fields.items) |ts_name| {
+        // Zig에 있으면 OK
+        var found = false;
+        inline for (zig_fields) |f| {
+            if (std.mem.eql(u8, f.name, ts_name)) found = true;
+        }
+        if (found) continue;
+        if (contains(&ts_only_allowlist, ts_name)) continue;
+        std.debug.print(
+            "\n[schema drift] TS TranspileOptions.{s} is not in Zig DTO — add to ts_only_allowlist if intentional\n",
+            .{ts_name},
+        );
+        return error.TsFieldNotAllowlisted;
+    }
+}
+
+test "parseTsInterface: basic extraction" {
+    const source =
+        \\export interface Other { x: number }
+        \\export interface TranspileOptions {
+        \\  /** Filename */
+        \\  filename?: string;
+        \\  sourcemap?: boolean;
+        \\  // inline comment
+        \\  target?: Target;
+        \\  nested?: { inner: string };
+        \\}
+    ;
+    var list: std.ArrayList([]const u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try parseTsInterface(source, &list, std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), list.items.len);
+    try std.testing.expectEqualStrings("filename", list.items[0]);
+    try std.testing.expectEqualStrings("sourcemap", list.items[1]);
+    try std.testing.expectEqualStrings("target", list.items[2]);
+    try std.testing.expectEqualStrings("nested", list.items[3]);
+}


### PR DESCRIPTION
## Summary
Closes #1443 — 3-PR 시리즈의 마지막. Zig \`TranspileOptionsDto\`와 TS \`TranspileOptions\` interface가 드리프트하지 않도록 \`zig build test\`에서 자동 검증.

## 배경
- #1446: Zig가 JSON schema의 **단일 소스**로 승격 (biome 수준)
- #1447: \`zts.config.json\` 자동 로드 + \`\$schema\` 자동완성
- **본 PR**: Tier-1 안전망 (CI diff 테스트) — 2곳을 유지하되 자동 동기화 보장

## 검증 로직

\`\`\`zig
// parseTsInterface: "interface TranspileOptions {...}" 블록에서 필드명 추출
// Zig DTO 필드 (@typeInfo) vs TS 필드 양방향 diff

1. Zig → TS: 모든 DTO 필드가 TS에 있어야 함
   예외: zig_only_allowlist (internal 전달 경로)
   → [unsupported] (JS 래퍼가 browserslist에서 자동 주입)

2. TS → Zig: TS-only 필드는 allowlist에 있어야 함
   → [filename, browserslist, minify]  (JS 래퍼 자체 처리)
\`\`\`

## 이 PR이 실제로 잡은 드리프트

| 필드 | 문제 | 조치 |
|---|---|---|
| \`define\` | #1443에서 Zig DTO에 추가했지만 TS \`TranspileOptions\`에 누락 (JSON 전환 이득인데 노출 안 됨) | TS interface에 \`define?: Array<{key, value}>\` 추가 + \`buildOptionsJson\` 직렬화 |

즉 **CI 없었으면 silent bug**였을 사례 1건을 즉시 감지했습니다.

## 시뮬레이션 검증
- \`sourcemap?\` 라인을 TS에서 임시 주석 처리 → 테스트 즉시 \`[schema drift] Zig TranspileOptionsDto.sourcemap is missing...\` 로 FAIL ✓
- 복원 후 3019 + 360 + 2899 모두 PASS

## 업계 위치 업데이트
- **이전**: biome 수준 (codegen), swc보다 나음
- **이후**: biome 수준 + **자동 드리프트 검증** — Zig 생태계에 napi-rs가 없는 제약 하에서 이론적 최대에 근접

## 변경
| 파일 | 변경 |
|---|---|
| \`src/transpile_options_dto_test.zig\` | 신설 — parseTsInterface + diff 검증 2개 테스트 |
| \`src/root.zig\` | 신규 test 파일 import |
| \`packages/shared/index.ts\` | \`TranspileOptions.define\` 필드 추가 + \`buildOptionsJson\` 직렬화 |

## Test plan
- [x] \`zig build test\` — 새 diff 테스트 pass
- [x] 드리프트 시뮬레이션으로 테스트 동작 확인
- [x] NAPI / WASM / 통합 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)