### PR TITLE
test: watch/serve 메모리 스트레스 시뮬레이션 + ndjson 헬퍼 공통화

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -332,7 +332,7 @@ SWC 비교 테스트: 29 cases × 9 targets 전부 통과.
 | 항목 | 난이도 | 현재 상태 | 설명 |
 |------|--------|----------|------|
 | **통합 테스트 확대** | L | 143 패키지 스모크만 | 실제 프로젝트(Next.js, Remix, Vite 앱)로 E2E 번들링 검증 |
-| **watch/serve 장시간 안정성** | M | 기본 동작 | 8시간+ watch 시 메모리 릭, 파일 잠금, OS 이벤트 누락 검증 |
+| **watch/serve 장시간 안정성** | M | 부분 완료 | 150회 연속 rebuild 시뮬레이션 스트레스 테스트(`tests/integration/tests/watch-stress.test.ts`)로 RSS 기울기 <20KB/rebuild 검증 (실측 0.05). 실시간 8시간+ 실측은 수동 릴리즈 전 검증으로 유지 |
 | ~~**에러 메시지 품질**~~ | ✅ | 완료 | ANSI 컬러 출력 + Levenshtein "did you mean?" 제안 (ansi.zig, levenshtein.zig) |
 | ~~**source map 품질 검증**~~ | ✅ | 완료 | Playwright + CDP로 Chromium이 `sourceMappingURL`을 파싱하고 TS 파일명 breakpoint가 해석되는 E2E (`tests/e2e/tests/sourcemap-e2e.test.ts`) |
 | ~~**Node.js 호환성 edge case**~~ | ✅ | 완료 | `import.meta.{url,dirname,filename}` CJS/ESM 실행 검증, 심볼릭링크·상대경로 entry 번들 통합 테스트 (`tests/integration/tests/node-compat.test.ts`) |

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -129,6 +129,94 @@ export async function runNode(file: string): Promise<{ stdout: string; stderr: s
   return { stdout: stdout.trim(), stderr };
 }
 
+// ─── watch-json 테스트 공용 헬퍼 ───
+
+/// `zts --watch-json ...`을 shell 경유로 spawn하고 stdout을 jsonOutPath로 리다이렉트.
+/// bun test가 child process stdout pipe를 제대로 처리 못 해서 파일 리다이렉트 방식 사용.
+export function spawnWatchJson(
+  args: string[],
+  jsonOutPath: string,
+): import("node:child_process").ChildProcess {
+  const { spawn: spawnChild } = require("node:child_process");
+  const quoted = args.map((a) => `"${a}"`).join(" ");
+  return spawnChild("sh", ["-c", `"${ZTS_BIN}" ${quoted} > "${jsonOutPath}" 2>/dev/null`]);
+}
+
+/// watch 프로세스를 kill하고 종료를 기다림. 2초 후 SIGKILL fallback — 좀비 방지.
+export function killAndWait(proc: import("node:child_process").ChildProcess): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (proc.exitCode !== null) {
+      resolve();
+      return;
+    }
+    const timeout = setTimeout(() => {
+      try {
+        proc.kill("SIGKILL");
+      } catch {}
+      resolve();
+    }, 2000);
+    proc.on("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    proc.kill();
+  });
+}
+
+/** 증분 파싱 상태 — waitForNdjsonLines의 offset/parsedCount를 호출부에서 유지하기 위함. */
+export interface NdjsonTail<T = Record<string, unknown>> {
+  parsed: T[];
+  offset: number;
+}
+
+/** NdjsonTail 초기 상태. */
+export function createNdjsonTail<T = Record<string, unknown>>(): NdjsonTail<T> {
+  return { parsed: [], offset: 0 };
+}
+
+/// ndjson 파일을 폴링하며 `tail`에 새 라인을 누적 파싱. `minLines` 충족 시 반환.
+/// 루프에서 호출하면 매번 전체 파일이 아닌 offset 이후만 재파싱 (O(N²) 방지).
+export async function waitForNdjsonLines<T = Record<string, unknown>>(
+  path: string,
+  minLines: number,
+  tail: NdjsonTail<T>,
+  opts: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<T[]> {
+  const timeoutMs = opts.timeoutMs ?? 10000;
+  const pollMs = opts.pollMs ?? 100;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const buf = readFileSync(path, "utf8");
+      if (buf.length > tail.offset) {
+        // \n 기준 라인 분리. 부분 라인은 다음 폴링에서 처리.
+        const newContent = buf.slice(tail.offset);
+        const lastNl = newContent.lastIndexOf("\n");
+        if (lastNl >= 0) {
+          const complete = newContent.slice(0, lastNl);
+          tail.offset += lastNl + 1;
+          for (const line of complete.split("\n")) {
+            if (!line) continue;
+            try {
+              tail.parsed.push(JSON.parse(line) as T);
+            } catch {
+              // 부분 라인이나 쓰기 중간 상태 — 스킵 (offset은 이미 이동)
+            }
+          }
+        }
+      }
+      if (tail.parsed.length >= minLines) return tail.parsed;
+    } catch {
+      /* 파일 아직 없음 */
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  throw new Error(
+    `timeout waiting for ${minLines} ndjson lines in ${path} (got ${tail.parsed.length})`,
+  );
+}
+
 export async function runZtsInDir(
   dir: string,
   args: string[],

--- a/tests/integration/tests/watch-json.test.ts
+++ b/tests/integration/tests/watch-json.test.ts
@@ -1,8 +1,13 @@
 import { describe, test, expect } from "bun:test";
-import { createFixture, ZTS_BIN } from "./helpers";
+import {
+  createFixture,
+  createNdjsonTail,
+  killAndWait,
+  spawnWatchJson,
+  waitForNdjsonLines,
+} from "./helpers";
 import { join } from "node:path";
 import { readFileSync, writeFileSync } from "node:fs";
-import { spawn, type ChildProcess } from "node:child_process";
 
 /**
  * --watch-json 통합 테스트
@@ -10,67 +15,7 @@ import { spawn, type ChildProcess } from "node:child_process";
  * --watch-json은 --watch + NDJSON stdout 출력 모드.
  * stdout에는 NDJSON 이벤트만 출력되어야 하며,
  * 인간용 상태 메시지나 raw 번들 내용이 섞이면 안 됨.
- *
- * bun test에서 child process stdout pipe가 제대로 동작하지 않는 이슈가 있어
- * shell 경유 파일 리다이렉트 방식으로 NDJSON 출력을 검증한다.
  */
-
-/** zts --watch-json을 shell 경유로 spawn하고 stdout을 파일로 리다이렉트 */
-function spawnWatchJson(args: string[], jsonOutPath: string): ChildProcess {
-  const quotedArgs = args.map((a) => `"${a}"`).join(" ");
-  return spawn("sh", ["-c", `"${ZTS_BIN}" ${quotedArgs} > "${jsonOutPath}" 2>/dev/null`]);
-}
-
-/** NDJSON 출력 파일에서 특정 라인이 나타날 때까지 폴링 */
-async function waitForNdjsonLines(
-  jsonOutPath: string,
-  minLines: number,
-  timeoutMs = 10000,
-): Promise<Record<string, unknown>[]> {
-  const deadline = Date.now() + timeoutMs;
-  let lastContent = "";
-  while (Date.now() < deadline) {
-    try {
-      const content = readFileSync(jsonOutPath, "utf8").trim();
-      lastContent = content;
-      if (content) {
-        const parsed: Record<string, unknown>[] = [];
-        for (const line of content.split("\n").filter(Boolean)) {
-          try {
-            parsed.push(JSON.parse(line));
-          } catch {
-            break; // partial line — 다음 폴링에서 재시도
-          }
-        }
-        if (parsed.length >= minLines) {
-          return parsed;
-        }
-      }
-    } catch {
-      // 파일이 아직 없음 — 다음 폴링에서 재시도
-    }
-    await new Promise((r) => setTimeout(r, 200));
-  }
-  throw new Error(
-    `Timeout waiting for ${minLines} NDJSON line(s). Content: ${JSON.stringify(lastContent)}`,
-  );
-}
-
-/** 프로세스를 kill하고 종료를 기다림 */
-function killAndWait(proc: ChildProcess): Promise<void> {
-  return new Promise<void>((resolve) => {
-    if (proc.exitCode !== null) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 2000);
-    proc.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    proc.kill();
-  });
-}
 
 describe("--watch-json", () => {
   test("initial build emits ready event with files and bytes", { timeout: 30000 }, async () => {
@@ -84,9 +29,10 @@ describe("--watch-json", () => {
       ["--bundle", join(dir, "entry.ts"), "-o", outFile, "--watch-json"],
       jsonOut,
     );
+    const tail = createNdjsonTail();
 
     try {
-      const events = await waitForNdjsonLines(jsonOut, 1);
+      const events = await waitForNdjsonLines(jsonOut, 1, tail);
       const ready = events[0];
 
       expect(ready.type).toBe("ready");
@@ -118,9 +64,10 @@ describe("--watch-json", () => {
         ["--bundle", join(dir, "entry.ts"), "-o", outFile, "--watch-json"],
         jsonOut,
       );
+      const tail = createNdjsonTail();
 
       try {
-        const events = await waitForNdjsonLines(jsonOut, 1);
+        const events = await waitForNdjsonLines(jsonOut, 1, tail);
         const ready = events[0];
 
         // 첫 번째 stdout 라인이 valid JSON이어야 함
@@ -145,10 +92,11 @@ describe("--watch-json", () => {
       ["--bundle", join(dir, "entry.ts"), "-o", outFile, "--watch-json"],
       jsonOut,
     );
+    const tail = createNdjsonTail();
 
     try {
       // 1) ready 이벤트 수신
-      const readyEvents = await waitForNdjsonLines(jsonOut, 1);
+      const readyEvents = await waitForNdjsonLines(jsonOut, 1, tail);
       expect(readyEvents[0].type).toBe("ready");
 
       // 2) 파일 변경 (watch 폴링 간격 500ms 이후 감지됨)
@@ -156,7 +104,7 @@ describe("--watch-json", () => {
       writeFileSync(join(dir, "entry.ts"), `export const v = "changed";`);
 
       // 3) rebuild 이벤트 수신 (ready + rebuild = 2 lines)
-      const events = await waitForNdjsonLines(jsonOut, 2, 15000);
+      const events = await waitForNdjsonLines(jsonOut, 2, tail, { timeoutMs: 15000 });
       const rebuild = events[1];
       expect(rebuild.type).toBe("rebuild");
       expect(rebuild.success).toBe(true);
@@ -180,9 +128,10 @@ describe("--watch-json", () => {
     const jsonOut = join(dir, "ndjson.txt");
 
     const proc = spawnWatchJson(["--bundle", join(dir, "entry.ts"), "--watch-json"], jsonOut);
+    const tail = createNdjsonTail();
 
     try {
-      const events = await waitForNdjsonLines(jsonOut, 1);
+      const events = await waitForNdjsonLines(jsonOut, 1, tail);
       const ready = events[0];
 
       // stdout 첫 줄이 valid JSON이어야 하고, raw JS 코드가 아님
@@ -220,9 +169,10 @@ describe("--watch-json", () => {
       ],
       jsonOut,
     );
+    const tail = createNdjsonTail();
 
     try {
-      const events = await waitForNdjsonLines(jsonOut, 1);
+      const events = await waitForNdjsonLines(jsonOut, 1, tail);
       const ready = events[0];
 
       expect(ready.type).toBe("ready");
@@ -254,9 +204,10 @@ describe("--watch-json", () => {
       ],
       jsonOut,
     );
+    const tail = createNdjsonTail();
 
     try {
-      const readyEvents = await waitForNdjsonLines(jsonOut, 1);
+      const readyEvents = await waitForNdjsonLines(jsonOut, 1, tail);
       expect(readyEvents[0].type).toBe("ready");
       // entry 파일 1개만 그래프에 있지만 watch-folder로 config.json도 감시 대상에 추가됨
       expect((readyEvents[0].files as number) >= 2).toBe(true);
@@ -265,7 +216,7 @@ describe("--watch-json", () => {
       await new Promise((r) => setTimeout(r, 1000));
       writeFileSync(join(assetsDir, "config.json"), `{"k":2}`);
 
-      const events = await waitForNdjsonLines(jsonOut, 2, 15000);
+      const events = await waitForNdjsonLines(jsonOut, 2, tail, { timeoutMs: 15000 });
       const rebuild = events[1];
       expect(rebuild.type).toBe("rebuild");
       expect(rebuild.success).toBe(true);

--- a/tests/integration/tests/watch-stress.test.ts
+++ b/tests/integration/tests/watch-stress.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect } from "bun:test";
+import {
+  createFixture,
+  createNdjsonTail,
+  killAndWait,
+  spawnWatchJson,
+  waitForNdjsonLines,
+} from "./helpers";
+import { join } from "node:path";
+import { writeFileSync } from "node:fs";
+
+/**
+ * Watch 메모리 누수 시뮬레이션 스트레스 테스트.
+ *
+ * 실시간 8시간+ 실측은 CI에 부적합하므로, 누수가 "실제 시간"보다 "rebuild 횟수"에
+ * 비례한다는 전제로 압축하여 빠르게 N회 rebuild를 수행하고 RSS 궤적을 측정한다.
+ */
+
+/** `ps -o rss= -p <pid>`로 RSS(KB)를 샘플링. Linux/macOS 공용. */
+async function sampleRSS(pid: number): Promise<number> {
+  const proc = Bun.spawn({
+    cmd: ["ps", "-o", "rss=", "-p", String(pid)],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  const rss = Number.parseInt(stdout.trim(), 10);
+  if (Number.isNaN(rss)) {
+    throw new Error(`failed to parse RSS for pid ${pid}: ${JSON.stringify(stdout)}`);
+  }
+  return rss;
+}
+
+/** shell 부모 PID의 자식(zts) 찾기. Linux/macOS 공용. */
+async function findZtsChildPid(parentPid: number): Promise<number> {
+  const proc = Bun.spawn({
+    cmd: ["pgrep", "-P", String(parentPid), "zts"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+  const pid = Number.parseInt(stdout.trim().split("\n")[0], 10);
+  if (Number.isNaN(pid)) {
+    throw new Error(`failed to find zts child of pid ${parentPid}`);
+  }
+  return pid;
+}
+
+/** samples = [{x,y}...] 에서 최소제곱법 기울기(y per x). */
+function linearSlope(samples: Array<{ x: number; y: number }>): number {
+  const n = samples.length;
+  const mx = samples.reduce((s, p) => s + p.x, 0) / n;
+  const my = samples.reduce((s, p) => s + p.y, 0) / n;
+  let num = 0;
+  let den = 0;
+  for (const p of samples) {
+    num += (p.x - mx) * (p.y - my);
+    den += (p.x - mx) * (p.x - mx);
+  }
+  return den === 0 ? 0 : num / den;
+}
+
+describe("watch 메모리 스트레스 (시뮬레이션)", () => {
+  test(
+    "연속 rebuild N회 후 RSS 궤적이 임계값 내",
+    { timeout: 10 * 60 * 1000 /* 10분 — CI 느린 러너 여유 */ },
+    async () => {
+      const ITERATIONS = 150;
+      const SAMPLE_EVERY = 15;
+      // 임계: 실측 0.05 KB/rebuild 대비 넉넉하되 누수는 탐지 가능한 범위.
+      // 실제 누수 발생 시 수십 KB/회 수준이 통상.
+      const SLOPE_THRESHOLD_KB = 2;
+      const TOTAL_GROWTH_MAX_KB = 2048; // 2MB — warmup 후 정상 변동 흡수
+
+      const { dir, cleanup } = await createFixture({
+        "entry.ts": `export const v = 0;\nexport const extra = "padding";\n`,
+      });
+      const outFile = join(dir, "out.js");
+      const entryFile = join(dir, "entry.ts");
+      const jsonOut = join(dir, "ndjson.txt");
+
+      const proc = spawnWatchJson(["--bundle", entryFile, "-o", outFile, "--watch-json"], jsonOut);
+      const tail = createNdjsonTail();
+
+      try {
+        await waitForNdjsonLines(jsonOut, 1, tail, { timeoutMs: 15000 });
+
+        const ztsPid = await findZtsChildPid(proc.pid!);
+        const samples: Array<{ x: number; y: number }> = [];
+        samples.push({ x: 0, y: await sampleRSS(ztsPid) });
+
+        for (let i = 1; i <= ITERATIONS; i++) {
+          // content hash 변화 유도 — 변수 값을 iter마다 바꿈
+          writeFileSync(entryFile, `export const v = ${i};\nexport const extra = "padding";\n`);
+          await waitForNdjsonLines(jsonOut, 1 + i, tail, { timeoutMs: 10000 });
+
+          if (i % SAMPLE_EVERY === 0) {
+            samples.push({ x: i, y: await sampleRSS(ztsPid) });
+          }
+        }
+
+        const first = samples[0].y;
+        const last = samples[samples.length - 1].y;
+        const max = Math.max(...samples.map((s) => s.y));
+        const slope = linearSlope(samples);
+        const totalGrowth = max - first;
+
+        const trace = samples.map((s) => `${s.x}:${s.y}KB`).join(", ");
+        const summary = `iters=${ITERATIONS} first=${first}KB last=${last}KB max=${max}KB slope=${slope.toFixed(2)}KB/rebuild growth=${totalGrowth}KB`;
+
+        // 실패 시 디버깅 편의. 성공 시에도 CI 로그에 궤적 한 줄 남겨 트렌드 모니터링.
+        console.log(`[watch-stress] ${summary}`);
+        console.log(`[watch-stress] trace: ${trace}`);
+
+        // 2가지 지표로 누수 판정 — 기울기 + 전체 성장량. 계단식 누수(한 번에 확 증가 후 평평)는
+        // slope가 낮을 수 있어 totalGrowth도 함께 체크.
+        if (slope >= SLOPE_THRESHOLD_KB || totalGrowth > TOTAL_GROWTH_MAX_KB) {
+          throw new Error(`RSS 궤적이 임계값 초과\n${summary}\ntrace: ${trace}`);
+        }
+        expect(slope).toBeLessThan(SLOPE_THRESHOLD_KB);
+        expect(totalGrowth).toBeLessThanOrEqual(TOTAL_GROWTH_MAX_KB);
+      } finally {
+        await killAndWait(proc);
+        await cleanup();
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

ROADMAP 1단계 "안정성" 중 \`watch/serve 장시간 안정성\` 항목을 **시뮬레이션 기반 스트레스 테스트**로 커버. 실시간 8시간+ 실측은 CI에 부적합하므로, 누수가 "실시간"보다 "rebuild 횟수"에 비례한다는 전제로 빠르게 N회 rebuild를 돌리고 RSS 궤적을 측정.

## 새 테스트

**\`tests/integration/tests/watch-stress.test.ts\`** — 1 test (~80s, timeout 10분)
- 150회 연속 rebuild, RSS 샘플링 (15회마다)
- 기울기(slope) < 2 KB/rebuild + 전체 성장량 < 2 MB 검증 (이중 지표 — 계단식 누수도 탐지)
- 로컬 실측: first=3616KB max=3632KB slope=0.05KB/rebuild growth=16KB ✅

## 공용 헬퍼 이관

기존 \`watch-json.test.ts\`와의 3개 함수 중복을 \`helpers.ts\`로 제거:
- \`spawnWatchJson\` — shell 경유 --watch-json spawn + stdout 파일 리다이렉트
- \`killAndWait\` — SIGTERM + 2초 후 SIGKILL fallback (좀비 방지)
- \`waitForNdjsonLines\` + \`createNdjsonTail\` — **증분 파싱** 상태로 O(N²) 재파싱 제거, 폴링 간격 옵션화

\`watch-json.test.ts\`는 공용 헬퍼 import로 ~70줄 감소.

## docs/ROADMAP.md

\`watch/serve 장시간 안정성\` 항목을 "부분 완료"로 전환 + 테스트 파일 경로 명시. 실시간 8시간+ 실측은 수동 릴리즈 전 검증으로 유지.

## /simplify 반영

- Helpers 중복 제거 (reuse)
- O(N²) 파싱 제거 (efficiency)
- Threshold 20→2 KB/rebuild + totalGrowth 보조 지표 (quality — 실측 0.05 대비 400배 → 40배 여유로 강화)
- CI 타임아웃 5분 → 10분 (느린 러너 여유)
- SIGKILL fallback + 폴링 100ms

## Test plan

- [x] \`cd tests/integration && bun test tests/watch-stress.test.ts tests/watch-json.test.ts\` — 7 pass
- [x] 전체 통합 테스트 — 2880 pass, 0 fail
- [x] 로컬 실행 ~80s (CI 마진 300s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)