### PR TITLE
test: Vite 앱 build + 브라우저 실행 E2E (vite-plugin-zts)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -331,7 +331,7 @@ SWC 비교 테스트: 29 cases × 9 targets 전부 통과.
 
 | 항목 | 난이도 | 현재 상태 | 설명 |
 |------|--------|----------|------|
-| **통합 테스트 확대** | L | 143 패키지 스모크만 | 실제 프로젝트(Next.js, Remix, Vite 앱)로 E2E 번들링 검증 |
+| **통합 테스트 확대** | L | 부분 완료 | ✅ Vite: multi-module TS/TSX 앱을 `vite-plugin-zts`로 프로덕션 번들 → Playwright 브라우저 실행 E2E (`tests/e2e/tests/vite-app-e2e.test.ts`). Remix/Next.js는 자체 빌드 시스템 의존이라 프레임워크 어댑터 레이어가 선행되어야 함 — 별도 로드맵(생태계 3단계)으로 이동 |
 | **watch/serve 장시간 안정성** | M | 부분 완료 | 150회 연속 rebuild 시뮬레이션 스트레스 테스트(`tests/integration/tests/watch-stress.test.ts`)로 RSS 기울기 <20KB/rebuild 검증 (실측 0.05). 실시간 8시간+ 실측은 수동 릴리즈 전 검증으로 유지 |
 | ~~**에러 메시지 품질**~~ | ✅ | 완료 | ANSI 컬러 출력 + Levenshtein "did you mean?" 제안 (ansi.zig, levenshtein.zig) |
 | ~~**source map 품질 검증**~~ | ✅ | 완료 | Playwright + CDP로 Chromium이 `sourceMappingURL`을 파싱하고 TS 파일명 breakpoint가 해석되는 E2E (`tests/e2e/tests/sourcemap-e2e.test.ts`) |

--- a/tests/e2e/tests/vite-app-e2e.test.ts
+++ b/tests/e2e/tests/vite-app-e2e.test.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+/**
+ * Multi-module Vite 앱을 vite-plugin-zts로 빌드 → 브라우저 실행 E2E.
+ *
+ * 기존 tests/integration/tests/vite-plugin-zts.test.ts는 단일 파일 transform 단위 검증.
+ * 본 테스트는 다중 TS/TSX 모듈 앱을 실제 `vite build`로 프로덕션 번들한 뒤 Playwright
+ * 브라우저에서 로드해 동작까지 확인 — real-world E2E.
+ *
+ * Vite config에서 vite-plugin-zts(TS 소스)를 import하므로 Bun을 통해 실행해야 한다.
+ * Playwright 자체는 Node에서 돌지만, 빌드/preview 서브프로세스는 `bun x --bun vite …` 경유.
+ */
+
+const PROJECT_ROOT = resolve(__dirname, "../../..");
+const TEST_PORT = 3996;
+
+const FILES: Record<string, string> = {
+  "index.html": `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>vite+zts e2e</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>`,
+  "src/main.tsx": `
+import { greet } from "./util";
+import { mountApp } from "./app";
+
+const name: string = "ZTS";
+const message = greet(name);
+mountApp(document.getElementById("root")!, message);
+`,
+  "src/util.ts": `
+export const PREFIX = "hello from";
+export function greet(name: string): string {
+  return \`\${PREFIX} \${name}\`;
+}
+`,
+  "src/app.tsx": `
+export function mountApp(el: HTMLElement, message: string): void {
+  el.innerHTML = \`<h1 data-testid="greeting">\${message}</h1>\`;
+}
+`,
+  "package.json": JSON.stringify({ type: "module" }),
+};
+
+function makeViteConfig(pluginDir: string): string {
+  return `import { zts } from "${pluginDir.replace(/\\/g, "/")}/src/index.ts";
+export default { plugins: [zts()], build: { minify: true, sourcemap: true } };
+`;
+}
+
+let fixtureDir: string;
+let previewServer: ChildProcess | null = null;
+
+test.beforeAll(async () => {
+  fixtureDir = await mkdtemp(join(tmpdir(), "zts-vite-e2e-"));
+
+  for (const [name, content] of Object.entries(FILES)) {
+    const filePath = join(fixtureDir, name);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, content.trimStart());
+  }
+
+  const pluginDir = join(PROJECT_ROOT, "packages/vite-plugin-zts");
+  await writeFile(join(fixtureDir, "vite.config.ts"), makeViteConfig(pluginDir));
+
+  // `bun x --bun vite build` — Bun 런타임으로 실행하여 vite 플러그인의 TS 소스 import 가능
+  const build = spawnSync("bun", ["x", "--bun", "vite", "build"], {
+    cwd: fixtureDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (build.status !== 0) {
+    throw new Error(
+      `vite build failed (exit ${build.status})\n--- stdout ---\n${build.stdout}\n--- stderr ---\n${build.stderr}`,
+    );
+  }
+
+  previewServer = spawn("bun", ["x", "--bun", "vite", "preview", "--port", String(TEST_PORT)], {
+    cwd: fixtureDir,
+    stdio: "pipe",
+  });
+  await new Promise((r) => setTimeout(r, 2500));
+});
+
+test.afterAll(async () => {
+  if (previewServer) {
+    previewServer.kill();
+    await new Promise((r) => previewServer!.on("close", r));
+  }
+  if (fixtureDir) {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test.describe("Vite app build (vite-plugin-zts) E2E", () => {
+  test("다중 모듈 TS/TSX 앱이 번들되고 브라우저에서 정상 실행된다", async ({ page }) => {
+    await page.goto(`http://localhost:${TEST_PORT}/`);
+    await expect(page.getByTestId("greeting")).toHaveText("hello from ZTS");
+  });
+
+  test("빌드 출력에 TS 타입 어노테이션이 남아있지 않다", async ({ request }) => {
+    const indexHtml = await (await request.get(`http://localhost:${TEST_PORT}/`)).text();
+    const scriptMatch = indexHtml.match(/src="(\/assets\/[^"]+\.js)"/);
+    expect(scriptMatch).not.toBeNull();
+
+    const js = await (await request.get(`http://localhost:${TEST_PORT}${scriptMatch![1]}`)).text();
+    expect(js).toContain("hello from");
+    expect(js).not.toMatch(/: string\b/);
+    expect(js).not.toMatch(/: HTMLElement\b/);
+  });
+});


### PR DESCRIPTION
## Summary

ROADMAP 1단계 "안정성" 중 \`통합 테스트 확대\` 항목을 Vite 프로덕션 앱 E2E로 커버. 기존 \`vite-plugin-zts.test.ts\`는 단일 파일 transform 유닛 수준이었는데, 본 테스트는 **다중 TS/TSX 모듈 앱을 실제 \`vite build\`로 프로덕션 번들 → Playwright 브라우저에서 실행**까지 확인.

## 새 테스트

\`tests/e2e/tests/vite-app-e2e.test.ts\` — 2 tests
1. 다중 TS/TSX 모듈 앱이 번들되고 브라우저 DOM에 정상 렌더링
2. 빌드 출력 .js에 TS 타입 어노테이션 미잔존

fixture 구조: \`index.html\` + \`src/main.tsx\` → \`src/util.ts\` + \`src/app.tsx\` (3개 모듈 체인)

## 구현 노트

- Playwright는 Node 런타임이라 \`vite-plugin-zts\`의 TS 소스 import가 직접 불가
- → \`vite build\` / \`vite preview\`를 \`bun x --bun vite …\` 서브프로세스로 실행
- \`vite.config.ts\`를 fixture에 생성하여 Bun 런타임에서 TS 플러그인 import

## Remix / Next.js 범위 결정

프레임워크 자체 빌드 시스템(Remix compiler, Next.js webpack/Turbopack)에 의존하여 **"ZTS로 번들"이 구조적으로 어려움**. 프레임워크 어댑터 레이어가 선행되어야 하므로 ROADMAP **생태계 3단계(프레임워크 통합)**로 이동. ZTS는 "esbuild/Vite 대체" 포지셔닝과 가장 잘 맞는 **Vite 방향**에 집중.

## docs/ROADMAP.md

\`통합 테스트 확대\` 항목을 "부분 완료"로 전환 + Remix/Next.js는 생태계 3단계로 옮긴다는 주석 명시.

## Test plan

- [x] \`cd tests/e2e && bunx playwright test tests/vite-app-e2e.test.ts\` — 2 pass (~3.3s)
- [x] 기존 e2e 전체 — 108 pass, 2 fail (smoke.test.ts의 HMR/에러 오버레이, **이 PR과 무관한 기존 이슈**)
- [x] Vite build + preview가 Bun 런타임에서 정상 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)