### PR TITLE
docs: 롤리팝/번개 내부 레퍼런스 제거 — Rolldown 기준 표현으로 통일

### DIFF
--- a/docs/BUNDLER.md
+++ b/docs/BUNDLER.md
@@ -227,8 +227,8 @@ const Module = struct {
   - io_uring (Linux): inotify보다 시스템콜 오버헤드 적은 비동기 I/O (성능 최적화 시점)
 - **증분 재빌드**: 파일 변경 → 모듈 그래프에서 영향받는 모듈만 재빌드 → HMR 전송
 
-## React Native 지원 (Rollipop/bungae 방식 — Metro 레거시 불필요)
-- **참고**: Rollipop (bungae/reference/rollipop), bungae/oxc-bundler — Rolldown 위에서 Metro를 대체
+## React Native 지원 (Rolldown 방식 — Metro 레거시 불필요)
+- **방향**: 표준 ESM 번들러(Rolldown 계열) 위에 RN 특화 기능을 플러그인/코어 옵션으로 얹는 접근. Metro의 런타임 규약을 그대로 들고 가지 않음.
 - **불필요한 Metro 레거시** (구현하지 않음):
   - `__d` 래핑 — 표준 스코프 호이스팅으로 대체
   - Haste 모듈 시스템 — Node.js 표준 해석으로 대체
@@ -237,8 +237,8 @@ const Module = struct {
 - **필요한 RN 특화 기능**:
   - ~~`platformResolverPlugin`~~ — ✅ 코어 옵션으로 구현 (`--resolve-extensions`, `--main-fields`)
   - ~~`flowStripPlugin`~~ — ✅ ZTS 코어에서 직접 구현 (`--flow`, flow.zig)
-  - `preludePlugin` — polyfill/InitializeCore 주입 (Bungae에서 플러그인으로)
-  - `assetPlugin` — 이미지 등 에셋 처리 (Bungae에서 플러그인으로)
+  - `preludePlugin` — polyfill/InitializeCore 주입 (플러그인으로)
+  - `assetPlugin` — 이미지 등 에셋 처리 (플러그인으로)
   - ~~`hermesCompatPlugin`~~ — ✅ `--target=es5`로 대응
   - ~~`react-refresh`~~ — ✅ ZTS dev server에 내장
   - ~~글로벌 주입~~ — ✅ `--define:__DEV__=true` 등

--- a/docs/HMR.md
+++ b/docs/HMR.md
@@ -14,12 +14,12 @@ Dev 서버 + Hot Module Replacement 상세 설계 문서.
 - 웹 타겟: `import.meta.hot` (Vite 호환, ESM 네이티브)
 - RN 타겟: `module.hot` (Metro 호환, RN 내장 HMRClient 재사용)
 - 내부 HMR 엔진은 하나, API 표면만 다름
-- 번개(bungae) oxc-bundler가 동일 방식: `import.meta.hot` 기본 + metro-runtime HMRClient 교체 플러그인
+- Rolldown 계열도 동일 방식: `import.meta.hot` 기본 + metro-runtime HMRClient 교체 플러그인
 
 ### D058. HMR 프로토콜: Vite 호환 + Metro 어댑터
 - 웹: Vite HMR 프로토콜 (WebSocket JSON 메시지)
 - RN: Metro HMR 프로토콜 (`update-start` → `update` → `update-done`)
-- 롤리팝(rollipop)은 자체 프로토콜이지만 RN 업데이트마다 호환성 검증 필요 → Metro 호환이 유지보수 비용 낮음
+- 자체 프로토콜 방식은 RN 업데이트마다 호환성 검증 필요 → Metro 호환이 유지보수 비용 낮음
 
 ### D059. 동시성: `std.Thread.spawn` per-connection
 - esbuild goroutine과 유사
@@ -44,7 +44,6 @@ Dev 서버 + Hot Module Replacement 상세 설계 문서.
 │ Vite        │ import.meta.hot     │ ESM 네이티브                 │
 │ Rolldown    │ import.meta.hot     │ Vite 호환                    │
 │ Metro       │ module.hot (커스텀)  │ CJS + RN 내장 HMRClient     │
-│ 번개(oxc)   │ import.meta.hot     │ Rolldown DevEngine + 어댑터  │
 │ ZTS (결정)  │ import.meta.hot 기본 │ Vite 호환 + RN module.hot   │
 └─────────────┴─────────────────────┴─────────────────────────────┘
 ```
@@ -85,8 +84,7 @@ Dev 서버 + Hot Module Replacement 상세 설계 문서.
 ```
 
 ## 참고 프로젝트
-- **번개(bungae)**: `../bungae/` — oxc-bundler HMR (Rolldown DevEngine, `import.meta.hot`)
-- **롤리팝(rollipop)**: `../bungae/reference/rollipop/` — 자체 HMR 프로토콜
+- **Rolldown**: `references/rolldown/` — Rolldown DevEngine, `import.meta.hot`
 - **Metro**: `references/metro/packages/metro-runtime/` — `module.hot`, Metro HMR 프로토콜
 - **Vite**: `references/vite/packages/vite/src/client/` — `import.meta.hot`, Vite HMR 프로토콜
 - **esbuild**: `--serve` 모드 — 최소 구현 참고

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -102,7 +102,7 @@
 
 ## ✅ 최근 추가 (Dev Server 확장)
 
-- **SSE 이벤트 스트림** (`/sse/events`) — `server_ready`, `watch_change`, `bundle_build_*`, `cache_reset` 실시간 브로드캐스트 (rollipop 호환)
+- **SSE 이벤트 스트림** (`/sse/events`) — `server_ready`, `watch_change`, `bundle_build_*`, `cache_reset` 실시간 브로드캐스트 (Rolldown DevEngine 호환)
 - **Control API** (`/reset-cache`) — 외부에서 캐시 무효화 트리거
 - **MCP 서버** (`/mcp`) — JSON-RPC 2.0, `initialize`/`tools/list`/`tools/call`. 도구: `reset_cache`, `get_build_events`. Claude Code 등 LLM 에이전트가 `.mcp.json`으로 직접 연결 가능
 


### PR DESCRIPTION
## Summary

내부 프로젝트 이름(번개/롤리팝)으로 표기된 방법론/레퍼런스를 외부 독자가 바로 이해할 수 있도록 **Rolldown** 기준 표현으로 통일.

## 변경

- \`docs/BUNDLER.md\` RN 지원 섹션: "Rollipop/bungae 방식" → "Rolldown 방식"
- \`docs/HMR.md\`:
  - "번개(bungae) oxc-bundler가 동일 방식" → "Rolldown 계열도 동일 방식"
  - "롤리팝(rollipop)은 자체 프로토콜" → "자체 프로토콜 방식"
  - HMR API 비교 표의 "번개(oxc)" 행 삭제 (Rolldown 행과 실질 중복)
  - 참고 프로젝트 섹션의 bungae/rollipop 경로 → Rolldown 레퍼런스 경로
- \`docs/ROADMAP.md\`: "rollipop 호환" → "Rolldown DevEngine 호환"

문서 전역에서 \`Rollipop|bungae|롤리팝|번개|rollipop|oxc-bundler\` 검색 0건 확인.

## Test plan

- [x] grep 검색 — 잔존 참조 0건
- [x] 문서만 변경 — 테스트 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)