### PR TITLE
fix(bundler): ESM+Node 출력에 createRequire shim 조건부 주입 (closes #1456)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1291,6 +1291,11 @@ fn emitBundleRuntimeHelpers(
         if (m.wrap_kind == .esm) needs_esm_wrap_runtime = true;
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
+        // Node ESM 출력에 CJS wrapper가 섞이면 wrapper 내부 `require()`가 런타임에 미정의.
+        // createRequire shim은 runtime helper 정의보다 먼저 와야 `__commonJS` 래퍼가 참조 가능 (#1456).
+        if (needs_cjs_runtime and options.platform == .node and options.format == .esm) {
+            try rt.appendRequireShim(output, allocator, options.minify_whitespace);
+        }
         // __toESM, __copyProps, __defProp은 CJS/ESM 양쪽에서 공유
         try rt.appendCjsRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
     }
@@ -1334,6 +1339,10 @@ pub fn emitChunkRuntimeHelpers(
         }
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
+        // 단일 번들 경로와 동일: Node ESM + CJS wrap이면 createRequire shim 필요 (#1456)
+        if (needs_cjs_runtime and options.platform == .node and options.format == .esm) {
+            try rt.appendRequireShim(output, allocator, options.minify_whitespace);
+        }
         try rt.appendCjsRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
     }
     if (needs_esm_wrap_runtime) {

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -12,6 +12,17 @@ const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
 // CJS Interop
 // ============================================================
 
+/// Node ESM 환경에서 전역 `require` 부재 문제를 `createRequire(import.meta.url)`로 해결하는 shim.
+/// 참고: esbuild `internal/linker/linker.go`의 `needsCreateRequireShim`.
+pub const REQUIRE_SHIM = "import { createRequire } from \"node:module\";\nconst require = createRequire(import.meta.url);\n";
+pub const REQUIRE_SHIM_MIN = "import{createRequire}from\"node:module\";const require=createRequire(import.meta.url);";
+
+/// ESM 번들에 CJS wrapper가 섞일 때 preamble에 require shim을 주입.
+/// 호출부에서 `platform=node + format=esm + CJS wrap 존재` 조건을 판정하고 호출한다.
+pub fn appendRequireShim(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool) !void {
+    try buf.appendSlice(allocator, if (minify) REQUIRE_SHIM_MIN else REQUIRE_SHIM);
+}
+
 /// __commonJS 팩토리 함수 (esbuild 호환)
 pub const CJS_RUNTIME = "var __commonJS = (cb, mod) => function __require() {\n\treturn mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;\n};\n";
 pub const CJS_RUNTIME_MIN = "var __commonJS=(cb,mod)=>function __require(){return mod||(0,cb[Object.keys(cb)[0]])((mod={exports:{}}).exports,mod),mod.exports};";

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -120,11 +120,13 @@ export async function runZts(
   return runCmd([ZTS_BIN, ...args]);
 }
 
-/// Node로 JS 파일을 실행. exit != 0 시 stderr를 포함한 에러 throw (디버깅 편의).
+/// Node로 JS 파일을 실행. exit != 0 시 stdout/stderr를 포함한 에러 throw (디버깅 편의).
 export async function runNode(file: string): Promise<{ stdout: string; stderr: string }> {
   const { stdout, stderr, exitCode } = await runCmd(["node", file]);
   if (exitCode !== 0) {
-    throw new Error(`node '${file}' exited ${exitCode}\n--- stderr ---\n${stderr}`);
+    throw new Error(
+      `node '${file}' exited ${exitCode}\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+    );
   }
   return { stdout: stdout.trim(), stderr };
 }

--- a/tests/integration/tests/node-compat.test.ts
+++ b/tests/integration/tests/node-compat.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { createFixture, runNode, runZts, runZtsInDir } from "./helpers";
 import { join, basename } from "node:path";
-import { realpathSync, symlinkSync } from "node:fs";
+import { readFileSync, readdirSync, realpathSync, symlinkSync } from "node:fs";
 
 /// CJS/Node 프리셋으로 번들하고 outFile 경로 반환. 번들 실패 시 throw.
 async function bundleCjsNode(dir: string, entry: string, outName = "out.cjs"): Promise<string> {
@@ -134,6 +134,99 @@ describe("Node.js 호환 edge case", () => {
       const run = await runNode(outFile);
       expect(run.stdout).toMatch(/^file:\/\//);
       expect(run.stdout).toContain(basename(outFile));
+    });
+  });
+
+  describe("ESM+CJS interop (#1456)", () => {
+    test("shim injected for platform=node + CJS wrap", async () => {
+      const f = await createFixture({
+        "app.ts": `import dep from 'cjs-dep';\nconsole.log(dep.hostname);`,
+        "package.json": `{"type": "module"}`,
+        "node_modules/cjs-dep/package.json": `{"name":"cjs-dep","main":"index.cjs"}`,
+        "node_modules/cjs-dep/index.cjs": `const os = require('os');\nmodule.exports = { hostname: os.hostname() };`,
+      });
+      cleanup = f.cleanup;
+      const outFile = join(f.dir, "out.mjs");
+      const bundle = await runZts([
+        "--bundle",
+        join(f.dir, "app.ts"),
+        "--format=esm",
+        "--platform=node",
+        "-o",
+        outFile,
+      ]);
+      if (bundle.exitCode !== 0) throw new Error(`zts bundle failed: ${bundle.stderr}`);
+      const bundled = readFileSync(outFile, "utf8");
+      expect(bundled).toContain('import { createRequire } from "node:module"');
+      const run = await runNode(outFile);
+      expect(run.stdout.length).toBeGreaterThan(0);
+    });
+
+    test("shim NOT injected for pure ESM", async () => {
+      const f = await createFixture({ "app.ts": `export const v = 1;\nconsole.log(v);` });
+      cleanup = f.cleanup;
+      const outFile = join(f.dir, "out.mjs");
+      const bundle = await runZts([
+        "--bundle",
+        join(f.dir, "app.ts"),
+        "--format=esm",
+        "--platform=node",
+        "-o",
+        outFile,
+      ]);
+      if (bundle.exitCode !== 0) throw new Error(`zts bundle failed: ${bundle.stderr}`);
+      expect(readFileSync(outFile, "utf8")).not.toContain("createRequire");
+    });
+
+    test("shim NOT injected for platform=browser", async () => {
+      const f = await createFixture({
+        "app.ts": `import dep from 'cjs-dep';\nconsole.log(dep.x);`,
+        "node_modules/cjs-dep/package.json": `{"name":"cjs-dep","main":"index.cjs"}`,
+        "node_modules/cjs-dep/index.cjs": `module.exports = { x: 1 };`,
+      });
+      cleanup = f.cleanup;
+      const outFile = join(f.dir, "out.mjs");
+      const bundle = await runZts([
+        "--bundle",
+        join(f.dir, "app.ts"),
+        "--format=esm",
+        "--platform=browser",
+        "-o",
+        outFile,
+      ]);
+      if (bundle.exitCode !== 0) throw new Error(`zts bundle failed: ${bundle.stderr}`);
+      const bundled = readFileSync(outFile, "utf8");
+      expect(bundled).not.toContain("node:module");
+      expect(bundled).not.toContain("createRequire");
+    });
+
+    test("code splitting: shim injected in chunk containing CJS wrap", async () => {
+      const f = await createFixture({
+        "app.ts": `const lazy = import('./lazy');\nlazy.then((m) => console.log(m.run()));`,
+        "lazy.ts": `import dep from 'cjs-dep';\nexport function run() { return dep.x; }`,
+        "package.json": `{"type": "module"}`,
+        "node_modules/cjs-dep/package.json": `{"name":"cjs-dep","main":"index.cjs"}`,
+        "node_modules/cjs-dep/index.cjs": `module.exports = { x: 42 };`,
+      });
+      cleanup = f.cleanup;
+
+      const outDir = join(f.dir, "dist");
+      const bundle = await runZts([
+        "--bundle",
+        join(f.dir, "app.ts"),
+        "--format=esm",
+        "--platform=node",
+        "--splitting",
+        "--outdir",
+        outDir,
+      ]);
+      if (bundle.exitCode !== 0) throw new Error(`zts bundle failed: ${bundle.stderr}`);
+
+      const outputs = readdirSync(outDir).filter((n) => n.endsWith(".js") || n.endsWith(".mjs"));
+      const hasShim = outputs.some((n) =>
+        readFileSync(join(outDir, n), "utf8").includes("createRequire(import.meta.url)"),
+      );
+      expect(hasShim).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

[#1456](https://github.com/ohah/zts/issues/1456) 해결 — Node.js ESM+\`type: "module"\` 환경에서 ZTS의 ESM 번들이 CJS 모듈(\`__commonJS\` wrapper)을 포함할 때 wrapper 내부 \`require()\`가 \`ReferenceError: require is not defined\`로 실패하던 문제.

esbuild와 동일한 방식으로 preamble에 \`createRequire\` shim을 **조건부** 주입:
\`\`\`js
import { createRequire } from "node:module";
const require = createRequire(import.meta.url);
\`\`\`

## 주입 조건

- \`needs_cjs_runtime\` (번들에 \`wrap_kind == .cjs\` 모듈 존재)
- \`options.platform == .node\`
- \`options.format == .esm\`

모두 만족 시에만 주입 (순수 ESM, browser platform, CJS 출력에는 미주입).

## 변경

- \`src/bundler/runtime_helpers.zig\`: \`REQUIRE_SHIM\` / \`REQUIRE_SHIM_MIN\` 상수 + \`appendRequireShim()\` 헬퍼 (기존 \`append*Runtime\` 패턴 일관)
- \`src/bundler/emitter.zig\`: 단일 번들(\`emitBundleRuntimeHelpers\`) + 코드 스플리팅(\`emitChunkRuntimeHelpers\`) 양쪽에 동일 주입
- \`tests/integration/tests/node-compat.test.ts\`: 4개 테스트 추가
  - platform=node + CJS wrap → shim 주입 + Node 실행 성공
  - 순수 ESM → 미주입
  - platform=browser + CJS wrap → 미주입
  - \`--splitting\` + CJS wrap → 해당 청크에 주입
- \`tests/integration/tests/helpers.ts\`: \`runNode\` 실패 시 stdout도 에러 메시지에 포함 (디버깅 편의)

## /simplify 반영

- \`appendRequireShim\` 헬퍼로 중복 제거 (reuse)
- \`emitChunkRuntimeHelpers\` 누락 수정 (splitting 경로)
- runtime_helpers.zig doc의 leaky한 조건 중복 제거
- 중복 WHAT 주석 축약

## Test plan

- [x] 원 이슈(#1456) 재현 스니펫 실행 성공 확인 (\`const os = require('os')\` in ESM+type:module)
- [x] \`bun test tests/node-compat.test.ts\` — 10 pass, 0 fail (기존 6 + 새 4)
- [x] 전체 통합 테스트 — 2884 pass, 0 fail
- [x] \`zig build\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1456