### PR TITLE
fix(semantic): rest 파라미터 binding(spread_element)을 함수 스코프에 등록 (#1457)

### DIFF
--- a/src/bundler/bundler_test/default_deconflict.zig
+++ b/src/bundler/bundler_test/default_deconflict.zig
@@ -786,3 +786,45 @@ test "Default: regular export default identifier still self-ref (no regression)"
     // regular default는 _ns suffix 없어야 — self-ref 최적화 유지
     try std.testing.expect(std.mem.indexOf(u8, result.output, "value_ns") == null);
 }
+
+test "Deconflict: rest parameter shadows renamed function (#1457)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\import { t as ignore } from "./shadow.js";
+        \\import { t as fn } from "./pipe.js";
+        \\globalThis.__out = [ignore, fn(99, 10, 20, 30)];
+    );
+    try writeFile(tmp.dir, "shadow.js", "export const t = \"x\";");
+    try writeFile(tmp.dir, "pipe.js",
+        \\export function t(e, ...t) {
+        \\  return [e, t.length, t.map((x) => x * 2)];
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const fn_marker = "function ";
+    const fn_start = std.mem.indexOf(u8, result.output, fn_marker) orelse return error.TestUnexpectedResult;
+    const name_start = fn_start + fn_marker.len;
+    const paren = std.mem.indexOfScalarPos(u8, result.output, name_start, '(') orelse return error.TestUnexpectedResult;
+    const fn_name = result.output[name_start..paren];
+    // pipe.js의 함수 t는 shadow.js의 t와 충돌해 rename된다.
+    try std.testing.expect(!std.mem.eql(u8, fn_name, "t"));
+
+    const length_ref = try std.fmt.allocPrint(std.testing.allocator, "{s}.length", .{fn_name});
+    defer std.testing.allocator.free(length_ref);
+    const map_ref = try std.fmt.allocPrint(std.testing.allocator, "{s}.map", .{fn_name});
+    defer std.testing.allocator.free(map_ref);
+    // 함수 내부의 rest 파라미터 `t`가 renamed 함수명으로 잘못 rewrite되면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, length_ref) == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, map_ref) == null);
+}

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -919,7 +919,7 @@ pub const SemanticAnalyzer = struct {
             .assignment_pattern, .assignment_target_with_default => {
                 self.setSymbolIdForPredeclaredBinding(node.data.binary.left);
             },
-            .binding_rest_element, .rest_element, .assignment_target_rest => {
+            .binding_rest_element, .rest_element, .assignment_target_rest, .spread_element => {
                 self.setSymbolIdForPredeclaredBinding(node.data.unary.operand);
             },
             else => {},
@@ -1605,7 +1605,7 @@ pub const SemanticAnalyzer = struct {
                 // default value(right)는 순회하지 않고, 바인딩 이름(left)만 추출
                 try self.predeclareBindingNames(node.data.binary.left, kind);
             },
-            .binding_rest_element, .rest_element, .assignment_target_rest => {
+            .binding_rest_element, .rest_element, .assignment_target_rest, .spread_element => {
                 try self.predeclareBindingNames(node.data.unary.operand, kind);
             },
             else => {},
@@ -1639,7 +1639,7 @@ pub const SemanticAnalyzer = struct {
                 try self.visitBindingPatternExpressions(node.data.binary.left);
                 try self.visitNode(node.data.binary.right);
             },
-            .binding_rest_element, .rest_element, .assignment_target_rest => {
+            .binding_rest_element, .rest_element, .assignment_target_rest, .spread_element => {
                 try self.visitBindingPatternExpressions(node.data.unary.operand);
             },
             else => {},
@@ -2286,7 +2286,7 @@ pub const SemanticAnalyzer = struct {
                 // binary: { left = pattern, right = default }
                 try self.collectAndCheckCatchBindings(node.data.binary.left, names, count);
             },
-            .rest_element => {
+            .rest_element, .spread_element => {
                 try self.collectAndCheckCatchBindings(node.data.unary.operand, names, count);
             },
             else => {},
@@ -2734,7 +2734,10 @@ pub const SemanticAnalyzer = struct {
                 // 기본값 순회 — 식별자 참조를 포함할 수 있음 (e.g. function f(a = imported))
                 try self.visitNode(node.data.binary.right);
             },
-            .binding_rest_element, .rest_element, .assignment_target_rest => {
+            // parser/binding.zig는 파라미터 위치의 `...x`를 spread_element로 만든다 — binding
+            // 컨텍스트의 rest로 함께 처리하지 않으면 rest 파라미터가 함수 스코프에 등록되지 않아
+            // 함수 내부에서 outer 동명 심볼로 잘못 resolve된다.
+            .binding_rest_element, .rest_element, .assignment_target_rest, .spread_element => {
                 // unary: { operand = binding }
                 try self.registerBinding(node.data.unary.operand, kind);
             },

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -789,12 +789,10 @@ const projects: ProjectConfig[] = [
     pkg: "ts-results-es",
     entry: `import { Ok } from 'ts-results-es';\nconst r = new Ok(42).map(n => n + 1);\nconsole.log(r.isOk(), r.value);`,
   },
-  // remeda: purry 함수 오버로딩 패턴이 번들러 scope hoisting과 충돌
-  // → 단순 import만 테스트
   {
     name: "remeda",
     pkg: "remeda",
-    entry: `import { unique } from 'remeda';\nconsole.log(typeof unique);`,
+    entry: `import { pipe, map, filter } from 'remeda';\nconst r = pipe([1,2,3,4,5], filter((x: number) => x > 1), map((x: number) => x * 2));\nconsole.log(JSON.stringify(r));`,
   },
   {
     name: "nanostores",


### PR DESCRIPTION
## Summary

- parser는 파라미터 위치의 `...x`를 `spread_element` 태그로 만드는데, semantic analyzer의 binding-pattern walker(`registerBinding` 외 4개)가 이 태그를 처리하지 않아 rest 파라미터가 함수 스코프에 등록되지 않았다.
- 함수 이름과 동일한 이름의 rest 파라미터가 outer scope의 함수로 잘못 resolve되어, 번들러 rename 후 함수 내부의 rest 참조가 함수 자기 자신을 가리켰다.
- remeda `pipe()`/`purry` 패턴이 정확히 이 버그를 재현 (`function t(e, ...t)` → `t`가 `t\$1`로 rename되면 내부 `t.length`/`t.map`이 `t\$1.length`/`t\$1.map`이 되어 throw).

## Fix

`src/semantic/analyzer.zig`의 5개 binding-pattern walker(`setSymbolIdForPredeclaredBinding`, `predeclareBindingNames`, `visitBindingPatternExpressions`, `collectAndCheckCatchBindings`, `registerBinding`)의 rest 처리 arm에 `.spread_element`를 추가해 inner operand를 동일하게 처리.

## Tests

- 회귀 테스트 추가: `Deconflict: rest parameter shadows renamed function (#1457)` — 함수 이름을 출력에서 동적 추출하여 `<fn_name>.length`/`<fn_name>.map` 부재 검사 (renamer suffix 스킴 변경에도 견고).
- `tests/benchmark/smoke.ts`의 remeda 우회(`import { unique }`) 제거 → 실제 `pipe(filter, map)` 케이스로 복구. ZTS 빌드/실행 OK + esbuild/rolldown 출력과 MATCH 확인.

## Test plan

- [x] `zig build test` 전체 통과
- [x] remeda 스모크: ZTS↔esbuild↔rolldown 출력 일치
- [x] 회귀 검증: fp-ts / lodash-es / rxjs / immer / preact 스모크 모두 OUTPUT MATCH
- [x] 이슈 본문 재현 케이스 직접 실행: `[4,6,8,10]` 정상 출력

## Follow-up (별도 issue 권장)

`registerBinding` 등 6개 binding-pattern walker가 동일 switch 구조를 반복(이번처럼 한 케이스를 빠뜨리기 쉬운 구조). `walkBindingPattern(idx, ctx, leafFn, defaultValueFn)` 콜백 기반 visitor로 통합하면 같은 종류의 누락을 구조적으로 방지 가능. 본 PR 범위 밖.

Closes #1457

🤖 Generated with [Claude Code](https://claude.com/claude-code)