### PR TITLE
refactor(parser): rest 파라미터 태그 일관성 + cover grammar 정규화

### DIFF
--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -112,14 +112,16 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
 /// decorator/modifier 처리 후의 순수 바인딩 패턴 파싱.
 /// parseBindingPattern에서 decorator가 있을 때 내부 패턴을 파싱하기 위해 분리.
 fn parseBindingPatternInner(self: *Parser) ParseError2!NodeIndex {
-    // rest parameter: ...pattern
+    // 함수 파라미터의 rest binding: ...pattern.
+    // ESTree와 동일하게 binding 컨텍스트는 RestElement(=rest_element)로 emit한다 —
+    // SpreadElement는 표현식 컨텍스트(call args, array/object spread) 전용.
     if (self.current() == .dot3) {
         const rest_start = self.currentSpan().start;
         try self.advance(); // skip '...'
         const pattern = try parseBindingPattern(self);
         try self.checkBindingRestInit(pattern);
         return try self.ast.addNode(.{
-            .tag = .spread_element,
+            .tag = .rest_element,
             .span = .{ .start = rest_start, .end = self.currentSpan().start },
             .data = .{ .unary = .{ .operand = pattern, .flags = 0 } },
         });

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -633,17 +633,19 @@ pub const Parser = struct {
     }
 
     /// rest parameter가 마지막이 아니면 에러.
-    /// spread_element 뒤에 comma가 오면 rest가 마지막이 아닌 것.
+    /// rest 노드(rest_element는 binding 컨텍스트, spread_element는 cover grammar
+    /// reinterpret 경로) 뒤에 comma가 오면 rest가 마지막이 아닌 것.
     /// 단, ambient context (declare)에서 trailing comma (,...) → ) 는 허용.
     pub fn checkRestParameterLast(self: *Parser, param: NodeIndex) ParseError2!void {
-        if (!param.isNone() and self.ast.getNode(param).tag == .spread_element and self.current() == .comma) {
-            // ambient context에서 trailing comma (rest 뒤 comma + r_paren)는 허용
-            if (self.ctx.in_ambient) {
-                const next = try self.peekNextKind();
-                if (next == .r_paren) return;
-            }
-            try self.addErrorCode(self.currentSpan(), "Rest parameter must be last formal parameter", .rest_must_be_last);
+        if (param.isNone() or self.current() != .comma) return;
+        const tag = self.ast.getNode(param).tag;
+        if (tag != .rest_element and tag != .spread_element) return;
+        // ambient context에서 trailing comma (rest 뒤 comma + r_paren)는 허용
+        if (self.ctx.in_ambient) {
+            const next = try self.peekNextKind();
+            if (next == .r_paren) return;
         }
+        try self.addErrorCode(self.currentSpan(), "Rest parameter must be last formal parameter", .rest_must_be_last);
     }
 
     /// 현재 토큰의 소스 텍스트.

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -632,14 +632,12 @@ pub const Parser = struct {
         self.scratch.shrinkRetainingCapacity(top);
     }
 
-    /// rest parameter가 마지막이 아니면 에러.
-    /// rest 노드(rest_element는 binding 컨텍스트, spread_element는 cover grammar
-    /// reinterpret 경로) 뒤에 comma가 오면 rest가 마지막이 아닌 것.
+    /// rest parameter가 마지막이 아니면 에러. binding.zig 파싱 경로에서 호출되며
+    /// 항상 rest_element 태그를 본다 (cover grammar 경로는 정규화 후 별도 검증).
     /// 단, ambient context (declare)에서 trailing comma (,...) → ) 는 허용.
     pub fn checkRestParameterLast(self: *Parser, param: NodeIndex) ParseError2!void {
         if (param.isNone() or self.current() != .comma) return;
-        const tag = self.ast.getNode(param).tag;
-        if (tag != .rest_element and tag != .spread_element) return;
+        if (self.ast.getNode(param).tag != .rest_element) return;
         // ambient context에서 trailing comma (rest 뒤 comma + r_paren)는 허용
         if (self.ctx.in_ambient) {
             const next = try self.peekNextKind();
@@ -1234,6 +1232,8 @@ pub const Parser = struct {
                     }
                     try self.checkBindingRestInit(elem.data.unary.operand);
                     _ = try self.coverExpressionToAssignmentTarget(elem.data.unary.operand, false);
+                    // binding 컨텍스트로 reinterpret했으므로 태그도 rest_element로 정규화
+                    self.ast.setTag(elem_idx, .rest_element);
                 } else {
                     _ = try self.coverExpressionToAssignmentTarget(elem_idx, false);
                 }
@@ -1245,6 +1245,7 @@ pub const Parser = struct {
             }
             try self.checkBindingRestInit(node.data.unary.operand);
             _ = try self.coverExpressionToAssignmentTarget(node.data.unary.operand, false);
+            self.ast.setTag(idx, .rest_element);
             try self.scratch.append(self.allocator, idx);
         } else {
             _ = try self.coverExpressionToAssignmentTarget(idx, false);

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -919,7 +919,7 @@ pub const SemanticAnalyzer = struct {
             .assignment_pattern, .assignment_target_with_default => {
                 self.setSymbolIdForPredeclaredBinding(node.data.binary.left);
             },
-            .binding_rest_element, .rest_element, .assignment_target_rest, .spread_element => {
+            .binding_rest_element, .rest_element, .assignment_target_rest => {
                 self.setSymbolIdForPredeclaredBinding(node.data.unary.operand);
             },
             else => {},
@@ -1605,7 +1605,7 @@ pub const SemanticAnalyzer = struct {
                 // default value(right)는 순회하지 않고, 바인딩 이름(left)만 추출
                 try self.predeclareBindingNames(node.data.binary.left, kind);
             },
-            .binding_rest_element, .rest_element, .assignment_target_rest, .spread_element => {
+            .binding_rest_element, .rest_element, .assignment_target_rest => {
                 try self.predeclareBindingNames(node.data.unary.operand, kind);
             },
             else => {},
@@ -1639,7 +1639,7 @@ pub const SemanticAnalyzer = struct {
                 try self.visitBindingPatternExpressions(node.data.binary.left);
                 try self.visitNode(node.data.binary.right);
             },
-            .binding_rest_element, .rest_element, .assignment_target_rest, .spread_element => {
+            .binding_rest_element, .rest_element, .assignment_target_rest => {
                 try self.visitBindingPatternExpressions(node.data.unary.operand);
             },
             else => {},
@@ -2286,7 +2286,7 @@ pub const SemanticAnalyzer = struct {
                 // binary: { left = pattern, right = default }
                 try self.collectAndCheckCatchBindings(node.data.binary.left, names, count);
             },
-            .rest_element, .spread_element => {
+            .rest_element => {
                 try self.collectAndCheckCatchBindings(node.data.unary.operand, names, count);
             },
             else => {},
@@ -2734,10 +2734,7 @@ pub const SemanticAnalyzer = struct {
                 // 기본값 순회 — 식별자 참조를 포함할 수 있음 (e.g. function f(a = imported))
                 try self.visitNode(node.data.binary.right);
             },
-            // parser/binding.zig는 파라미터 위치의 `...x`를 spread_element로 만든다 — binding
-            // 컨텍스트의 rest로 함께 처리하지 않으면 rest 파라미터가 함수 스코프에 등록되지 않아
-            // 함수 내부에서 outer 동명 심볼로 잘못 resolve된다.
-            .binding_rest_element, .rest_element, .assignment_target_rest, .spread_element => {
+            .binding_rest_element, .rest_element, .assignment_target_rest => {
                 // unary: { operand = binding }
                 try self.registerBinding(node.data.unary.operand, kind);
             },

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -451,7 +451,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
                 if (elem.tag == .elision) continue; // 빈 슬롯 스킵
 
-                if (elem.tag == .rest_element or elem.tag == .spread_element or elem.tag == .binding_rest_element) {
+                if (elem.tag == .rest_element or elem.tag == .binding_rest_element) {
                     // ...rest → var rest = _ref.slice(N)
                     const rest_binding = try self.visitNode(elem.data.unary.operand);
                     const rest_init = try buildArraySlice(self, ref_span, idx, span);


### PR DESCRIPTION
## Summary

#1457의 근본 수정. parser가 binding 컨텍스트에서는 항상 `rest_element` 태그만 emit하도록 정리하여 다운스트림 전체가 단일 태그로 일관 처리.

**1. binding 컨텍스트 태그 정정** — \`parser/binding.zig\`의 \`parseBindingPatternInner\`가 함수 파라미터 \`...x\`를 \`spread_element\`로 emit하던 것을 \`rest_element\`로 변경. ESTree 표준(\`RestElement\` ↔ binding, \`SpreadElement\` ↔ expression)과 일관. 동일 파일의 배열/오브젝트 destructuring(binding.zig:345/391)은 이미 \`rest_element\`를 emit 중이라 함수 파라미터만 깨져 있었음.

**2. cover grammar 정규화** — \`coverExpressionToArrowParams\`가 expression을 arrow params로 reinterpret할 때 \`spread_element\` 노드의 태그를 \`rest_element\`로 \`setTag\`. 이제 binding 컨텍스트(=함수 파라미터·destructuring)는 두 진입 경로(직접 binding 파싱 / cover grammar reinterpret) 모두 \`rest_element\`만 emit.

**3. 안전망 정리** — 정규화 후 도달 불가능해진 곳에서 \`spread_element\` 분기 제거:
- \`semantic/analyzer.zig\`의 4개 walker (#1460에서 추가했던 방어 코드)
- \`parser.zig:checkRestParameterLast\` — binding.zig 경로 전용
- \`transformer/es2015_destructuring.zig:emitArrayPatternDeclarators\` — array_pattern 내부

## 보수적으로 유지한 곳

- \`semantic/checker.zig:collectArrowParamNames\` — 코멘트가 "cover 변환 전후 모두 처리"로 명시. 정규화 전 호출 경로가 있어 \`spread_element\` 분기 유지.
- \`parser.zig:collectBoundNames\` — \`checkDuplicateParamsCore\` 외 호출 경로 검증 부담 → 보수적으로 유지.

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] #1457 재현 케이스: \`pipe(filter, map)\` → \`[4,6,8,10]\`
- [x] arrow function rest param via cover grammar: \`(a, ...rest) => ...\` 정상 동작 (rest 사용·중복명·shadowing 케이스)
- [x] 스모크 회귀: remeda / fp-ts / lodash-es 모두 OUTPUT MATCH

## Follow-up (별도 PR 권장)

- 14곳에 중복된 \`(.spread_element, .rest_element, .binding_rest_element, .assignment_target_rest)\` 패턴 → \`ast.zig\`에 \`isRestPatternTag(tag)\` 헬퍼 추가
- \`binding_rest_element\` vs \`rest_element\` 이중 태그 정리 (Flow 전용 vs 일반)

🤖 Generated with [Claude Code](https://claude.com/claude-code)