### PR TITLE
refactor(ast): rest dispatch helper 추가 (#1462 Phase 1)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -924,6 +924,47 @@ pub const Ast = struct {
         return self.extra_data.items[list.start .. list.start + list.len];
     }
 
+    /// binding-pattern 컨테이너의 elements와 rest를 분리해 반환한다.
+    /// 모든 walker가 이 helper 한 곳을 거치면 rest 태그 case set이 캡슐화되어
+    /// 새 walker 추가 시 누락 위험이 사라진다.
+    pub const ContainerRestSplit = struct {
+        /// rest의 inner binding. rest가 없거나 컨테이너 노드가 아니면 null.
+        rest_operand: ?NodeIndex,
+        /// rest를 제외한 일반 element들의 raw 인덱스 슬라이스.
+        elements: []const u32,
+    };
+
+    /// 지원 컨테이너: array_pattern / object_pattern / formal_parameters /
+    /// array_assignment_target / object_assignment_target.
+    /// rest 태그: rest_element / binding_rest_element / assignment_target_rest.
+    pub inline fn containerSplitRest(self: *const Ast, node: Node) ContainerRestSplit {
+        const empty: ContainerRestSplit = .{ .rest_operand = null, .elements = &[_]u32{} };
+        const list = switch (node.tag) {
+            .array_pattern,
+            .object_pattern,
+            .formal_parameters,
+            .array_assignment_target,
+            .object_assignment_target,
+            => node.data.list,
+            else => return empty,
+        };
+        if (list.len == 0) return empty;
+        if (list.start + list.len > self.extra_data.items.len) return empty;
+        const all = self.extra_data.items[list.start .. list.start + list.len];
+        const last_idx: NodeIndex = @enumFromInt(all[all.len - 1]);
+        if (last_idx.isNone() or @intFromEnum(last_idx) >= self.nodes.items.len) {
+            return .{ .rest_operand = null, .elements = all };
+        }
+        const last_node = self.getNode(last_idx);
+        return switch (last_node.tag) {
+            .rest_element, .binding_rest_element, .assignment_target_rest => .{
+                .rest_operand = last_node.data.unary.operand,
+                .elements = all[0 .. all.len - 1],
+            },
+            else => .{ .rest_operand = null, .elements = all },
+        };
+    }
+
     /// extra_data에 값을 추가하고 시작 인덱스를 반환한다.
     pub fn addExtra(self: *Ast, value: u32) !u32 {
         const index: u32 = @intCast(self.extra_data.items.len);

--- a/src/parser/ast_test.zig
+++ b/src/parser/ast_test.zig
@@ -49,6 +49,60 @@ test "Ast node list" {
     try std.testing.expectEqual(@as(u32, 2), list.len);
 }
 
+test "containerSplitRest" {
+    var ast = Ast.init(std.testing.allocator, "");
+    defer ast.deinit();
+
+    const a = try ast.addNode(.{ .tag = .binding_identifier, .span = Span.EMPTY, .data = .{ .none = 0 } });
+    const b = try ast.addNode(.{ .tag = .binding_identifier, .span = Span.EMPTY, .data = .{ .none = 0 } });
+    const c = try ast.addNode(.{ .tag = .binding_identifier, .span = Span.EMPTY, .data = .{ .none = 0 } });
+    const rest = try ast.addNode(.{
+        .tag = .rest_element,
+        .span = Span.EMPTY,
+        .data = .{ .unary = .{ .operand = c, .flags = 0 } },
+    });
+
+    // case: [a, b, ...c] — rest가 마지막
+    const with_rest = try ast.addNodeList(&.{ a, b, rest });
+    const ap_with = try ast.addNode(.{ .tag = .array_pattern, .span = Span.EMPTY, .data = .{ .list = with_rest } });
+    const split_with = ast.containerSplitRest(ast.getNode(ap_with));
+    try std.testing.expect(split_with.rest_operand != null);
+    try std.testing.expectEqual(@intFromEnum(c), @intFromEnum(split_with.rest_operand.?));
+    try std.testing.expectEqual(@as(usize, 2), split_with.elements.len);
+
+    // case: [a, b] — rest 없음
+    const no_rest = try ast.addNodeList(&.{ a, b });
+    const ap_no = try ast.addNode(.{ .tag = .array_pattern, .span = Span.EMPTY, .data = .{ .list = no_rest } });
+    const split_no = ast.containerSplitRest(ast.getNode(ap_no));
+    try std.testing.expect(split_no.rest_operand == null);
+    try std.testing.expectEqual(@as(usize, 2), split_no.elements.len);
+
+    // case: 빈 패턴
+    const empty_list = try ast.addNodeList(&.{});
+    const ap_empty = try ast.addNode(.{ .tag = .array_pattern, .span = Span.EMPTY, .data = .{ .list = empty_list } });
+    const split_empty = ast.containerSplitRest(ast.getNode(ap_empty));
+    try std.testing.expect(split_empty.rest_operand == null);
+    try std.testing.expectEqual(@as(usize, 0), split_empty.elements.len);
+
+    // case: 컨테이너가 아닌 노드
+    const split_other = ast.containerSplitRest(ast.getNode(a));
+    try std.testing.expect(split_other.rest_operand == null);
+    try std.testing.expectEqual(@as(usize, 0), split_other.elements.len);
+
+    // case: assignment_target_rest (assignment context)
+    const at_rest = try ast.addNode(.{
+        .tag = .assignment_target_rest,
+        .span = Span.EMPTY,
+        .data = .{ .unary = .{ .operand = c, .flags = 0 } },
+    });
+    const at_list = try ast.addNodeList(&.{ a, at_rest });
+    const aat = try ast.addNode(.{ .tag = .array_assignment_target, .span = Span.EMPTY, .data = .{ .list = at_list } });
+    const split_aat = ast.containerSplitRest(ast.getNode(aat));
+    try std.testing.expect(split_aat.rest_operand != null);
+    try std.testing.expectEqual(@intFromEnum(c), @intFromEnum(split_aat.rest_operand.?));
+    try std.testing.expectEqual(@as(usize, 1), split_aat.elements.len);
+}
+
 test "Ast string_table: addString + getText" {
     var ast = Ast.init(std.testing.allocator, "hello world");
     defer ast.deinit();


### PR DESCRIPTION
## Summary

#1462 마이그레이션의 Phase 1. \`ast.zig\`에 \`containerSplitRest(node)\` 헬퍼 추가.

\`\`\`zig
pub const ContainerRestSplit = struct {
    rest_operand: ?NodeIndex,
    elements: []const u32,
};

pub inline fn containerSplitRest(self: *const Ast, node: Node) ContainerRestSplit { ... }
\`\`\`

지원 컨테이너: \`array_pattern\` / \`object_pattern\` / \`formal_parameters\` / \`array_assignment_target\` / \`object_assignment_target\`. rest 태그(\`rest_element\` / \`binding_rest_element\` / \`assignment_target_rest\`) case set을 한 곳에 캡슐화.

## 효과

- 모든 binding-pattern walker가 이 helper를 거치면 rest dispatch 누락 위험 사라짐 (#1457 같은 silent 버그 구조적 차단의 인프라)
- 호환성 100% — 현재 layout 유지(rest_element를 list 마지막에 emit), helper가 마지막을 검사해 분리 반환
- 다운스트림 미수정 — Phase 2에서 walker별 점진 마이그레이션

## Phase Plan (#1462)

- **Phase 1 (이 PR)**: ast.zig helper 추가 + 단위 테스트
- Phase 2: walker가 helper 경유로 점진 마이그레이션 (semantic / transformer / codegen, 각 별도 PR)
- Phase 3: parser layout 변경 — \`extra_data\` slot에 rest_idx 분리, rest_element variant 제거
- Phase 4: ESTree adapter 정리 + WASM API 노출 형식 확정

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] 단위 테스트 추가 (\`containerSplitRest\`): rest 마지막 / rest 없음 / 빈 컨테이너 / 비-컨테이너 노드 / assignment_target_rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)