### PR TITLE
refactor(semantic): binding walker가 nodeListSplitRest 경유 (#1462 Phase 2a)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -934,20 +934,13 @@ pub const Ast = struct {
         elements: []const u32,
     };
 
-    /// 지원 컨테이너: array_pattern / object_pattern / formal_parameters /
-    /// array_assignment_target / object_assignment_target.
-    /// rest 태그: rest_element / binding_rest_element / assignment_target_rest.
-    pub inline fn containerSplitRest(self: *const Ast, node: Node) ContainerRestSplit {
+    /// binding-pattern 컨테이너(array_pattern / object_pattern / formal_parameters /
+    /// array_assignment_target / object_assignment_target)의 NodeList에서
+    /// 마지막 element가 rest 노드(rest_element / binding_rest_element /
+    /// assignment_target_rest)인지 검사하고 분리해 반환한다.
+    /// 호출자는 보통 switch arm 안에서 컨테이너 태그를 이미 확인했으므로 NodeList만 넘긴다.
+    pub inline fn nodeListSplitRest(self: *const Ast, list: NodeList) ContainerRestSplit {
         const empty: ContainerRestSplit = .{ .rest_operand = null, .elements = &[_]u32{} };
-        const list = switch (node.tag) {
-            .array_pattern,
-            .object_pattern,
-            .formal_parameters,
-            .array_assignment_target,
-            .object_assignment_target,
-            => node.data.list,
-            else => return empty,
-        };
         if (list.len == 0) return empty;
         if (list.start + list.len > self.extra_data.items.len) return empty;
         const all = self.extra_data.items[list.start .. list.start + list.len];

--- a/src/parser/ast_test.zig
+++ b/src/parser/ast_test.zig
@@ -49,7 +49,7 @@ test "Ast node list" {
     try std.testing.expectEqual(@as(u32, 2), list.len);
 }
 
-test "containerSplitRest" {
+test "nodeListSplitRest" {
     var ast = Ast.init(std.testing.allocator, "");
     defer ast.deinit();
 
@@ -64,30 +64,21 @@ test "containerSplitRest" {
 
     // case: [a, b, ...c] — rest가 마지막
     const with_rest = try ast.addNodeList(&.{ a, b, rest });
-    const ap_with = try ast.addNode(.{ .tag = .array_pattern, .span = Span.EMPTY, .data = .{ .list = with_rest } });
-    const split_with = ast.containerSplitRest(ast.getNode(ap_with));
+    const split_with = ast.nodeListSplitRest(with_rest);
     try std.testing.expect(split_with.rest_operand != null);
     try std.testing.expectEqual(@intFromEnum(c), @intFromEnum(split_with.rest_operand.?));
     try std.testing.expectEqual(@as(usize, 2), split_with.elements.len);
 
     // case: [a, b] — rest 없음
     const no_rest = try ast.addNodeList(&.{ a, b });
-    const ap_no = try ast.addNode(.{ .tag = .array_pattern, .span = Span.EMPTY, .data = .{ .list = no_rest } });
-    const split_no = ast.containerSplitRest(ast.getNode(ap_no));
+    const split_no = ast.nodeListSplitRest(no_rest);
     try std.testing.expect(split_no.rest_operand == null);
     try std.testing.expectEqual(@as(usize, 2), split_no.elements.len);
 
-    // case: 빈 패턴
-    const empty_list = try ast.addNodeList(&.{});
-    const ap_empty = try ast.addNode(.{ .tag = .array_pattern, .span = Span.EMPTY, .data = .{ .list = empty_list } });
-    const split_empty = ast.containerSplitRest(ast.getNode(ap_empty));
+    // case: 빈 리스트
+    const split_empty = ast.nodeListSplitRest(.{ .start = 0, .len = 0 });
     try std.testing.expect(split_empty.rest_operand == null);
     try std.testing.expectEqual(@as(usize, 0), split_empty.elements.len);
-
-    // case: 컨테이너가 아닌 노드
-    const split_other = ast.containerSplitRest(ast.getNode(a));
-    try std.testing.expect(split_other.rest_operand == null);
-    try std.testing.expectEqual(@as(usize, 0), split_other.elements.len);
 
     // case: assignment_target_rest (assignment context)
     const at_rest = try ast.addNode(.{
@@ -96,8 +87,7 @@ test "containerSplitRest" {
         .data = .{ .unary = .{ .operand = c, .flags = 0 } },
     });
     const at_list = try ast.addNodeList(&.{ a, at_rest });
-    const aat = try ast.addNode(.{ .tag = .array_assignment_target, .span = Span.EMPTY, .data = .{ .list = at_list } });
-    const split_aat = ast.containerSplitRest(ast.getNode(aat));
+    const split_aat = ast.nodeListSplitRest(at_list);
     try std.testing.expect(split_aat.rest_operand != null);
     try std.testing.expectEqual(@intFromEnum(c), @intFromEnum(split_aat.rest_operand.?));
     try std.testing.expectEqual(@as(usize, 1), split_aat.elements.len);

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -905,12 +905,12 @@ pub const SemanticAnalyzer = struct {
                 self.setSymbolIdForPredeclared(node.span, ni);
             },
             .array_pattern, .array_assignment_target, .object_pattern, .object_assignment_target => {
-                const list = node.data.list;
-                if (list.len == 0) return;
-                if (list.start + list.len > self.ast.extra_data.items.len) return;
-                const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-                for (indices) |raw| {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw| {
                     self.setSymbolIdForPredeclaredBinding(@enumFromInt(raw));
+                }
+                if (split.rest_operand) |op| {
+                    self.setSymbolIdForPredeclaredBinding(op);
                 }
             },
             .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
@@ -918,9 +918,6 @@ pub const SemanticAnalyzer = struct {
             },
             .assignment_pattern, .assignment_target_with_default => {
                 self.setSymbolIdForPredeclaredBinding(node.data.binary.left);
-            },
-            .binding_rest_element, .rest_element, .assignment_target_rest => {
-                self.setSymbolIdForPredeclaredBinding(node.data.unary.operand);
             },
             else => {},
         }
@@ -1590,12 +1587,12 @@ pub const SemanticAnalyzer = struct {
                 try self.declareSymbolWithNode(node.span, kind, node.span, @intFromEnum(idx));
             },
             .array_pattern, .array_assignment_target, .object_pattern, .object_assignment_target => {
-                const list = node.data.list;
-                if (list.len == 0) return;
-                if (list.start + list.len > self.ast.extra_data.items.len) return;
-                const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-                for (indices) |raw_idx| {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
                     try self.predeclareBindingNames(@enumFromInt(raw_idx), kind);
+                }
+                if (split.rest_operand) |op| {
+                    try self.predeclareBindingNames(op, kind);
                 }
             },
             .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
@@ -1604,9 +1601,6 @@ pub const SemanticAnalyzer = struct {
             .assignment_pattern, .assignment_target_with_default => {
                 // default value(right)는 순회하지 않고, 바인딩 이름(left)만 추출
                 try self.predeclareBindingNames(node.data.binary.left, kind);
-            },
-            .binding_rest_element, .rest_element, .assignment_target_rest => {
-                try self.predeclareBindingNames(node.data.unary.operand, kind);
             },
             else => {},
         }
@@ -1623,12 +1617,12 @@ pub const SemanticAnalyzer = struct {
                 // 단순 식별자 — 표현식 없음
             },
             .array_pattern, .array_assignment_target, .object_pattern, .object_assignment_target => {
-                const list = node.data.list;
-                if (list.len == 0) return;
-                if (list.start + list.len > self.ast.extra_data.items.len) return;
-                const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-                for (indices) |raw_idx| {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
                     try self.visitBindingPatternExpressions(@enumFromInt(raw_idx));
+                }
+                if (split.rest_operand) |op| {
+                    try self.visitBindingPatternExpressions(op);
                 }
             },
             .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
@@ -1638,9 +1632,6 @@ pub const SemanticAnalyzer = struct {
                 // default value(right)를 순회
                 try self.visitBindingPatternExpressions(node.data.binary.left);
                 try self.visitNode(node.data.binary.right);
-            },
-            .binding_rest_element, .rest_element, .assignment_target_rest => {
-                try self.visitBindingPatternExpressions(node.data.unary.operand);
             },
             else => {},
         }
@@ -1935,22 +1926,13 @@ pub const SemanticAnalyzer = struct {
             .binding_identifier, .identifier_reference, .assignment_target_identifier => {
                 try self.declareSymbolWithNode(node.span, .parameter, node.span, @intFromEnum(idx));
             },
-            .object_pattern, .object_assignment_target => {
-                const list = node.data.list;
-                if (list.len == 0) return;
-                if (list.start + list.len > self.ast.extra_data.items.len) return;
-                const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-                for (indices) |raw_idx| {
+            .object_pattern, .object_assignment_target, .array_pattern, .array_assignment_target => {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
                     try self.declareBindingPattern(@enumFromInt(raw_idx));
                 }
-            },
-            .array_pattern, .array_assignment_target => {
-                const list = node.data.list;
-                if (list.len == 0) return;
-                if (list.start + list.len > self.ast.extra_data.items.len) return;
-                const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-                for (indices) |raw_idx| {
-                    try self.declareBindingPattern(@enumFromInt(raw_idx));
+                if (split.rest_operand) |op| {
+                    try self.declareBindingPattern(op);
                 }
             },
             .binding_property => {
@@ -2257,19 +2239,17 @@ pub const SemanticAnalyzer = struct {
                 }
             },
             .array_pattern => {
-                // list: binding elements
-                if (node.data.list.len == 0) return;
-                if (node.data.list.start + node.data.list.len > self.ast.extra_data.items.len) return;
-                const indices = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                for (indices) |raw_idx| {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
                     try self.collectAndCheckCatchBindings(@enumFromInt(raw_idx), names, count);
+                }
+                if (split.rest_operand) |op| {
+                    try self.collectAndCheckCatchBindings(op, names, count);
                 }
             },
             .object_pattern => {
-                if (node.data.list.len == 0) return;
-                if (node.data.list.start + node.data.list.len > self.ast.extra_data.items.len) return;
-                const indices = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                for (indices) |raw_idx| {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
                     const prop_idx: NodeIndex = @enumFromInt(raw_idx);
                     if (prop_idx.isNone() or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) continue;
                     const prop = self.ast.getNode(prop_idx);
@@ -2281,13 +2261,13 @@ pub const SemanticAnalyzer = struct {
                         try self.collectAndCheckCatchBindings(prop_idx, names, count);
                     }
                 }
+                if (split.rest_operand) |op| {
+                    try self.collectAndCheckCatchBindings(op, names, count);
+                }
             },
             .assignment_pattern, .assignment_target_with_default => {
                 // binary: { left = pattern, right = default }
                 try self.collectAndCheckCatchBindings(node.data.binary.left, names, count);
-            },
-            .rest_element => {
-                try self.collectAndCheckCatchBindings(node.data.unary.operand, names, count);
             },
             else => {},
         }
@@ -2713,13 +2693,14 @@ pub const SemanticAnalyzer = struct {
             .binding_identifier, .assignment_target_identifier => {
                 try self.declareSymbolWithNode(node.span, kind, node.span, @intFromEnum(idx));
             },
-            .array_pattern, .array_assignment_target => {
-                // list of elements
-                try self.registerBindingList(node.data.list, kind);
-            },
-            .object_pattern, .object_assignment_target => {
-                // list of binding_property
-                try self.registerBindingList(node.data.list, kind);
+            .array_pattern, .array_assignment_target, .object_pattern, .object_assignment_target => {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
+                    try self.registerBinding(@enumFromInt(raw_idx), kind);
+                }
+                if (split.rest_operand) |op| {
+                    try self.registerBinding(op, kind);
+                }
             },
             .binding_property,
             .assignment_target_property_identifier,
@@ -2734,30 +2715,18 @@ pub const SemanticAnalyzer = struct {
                 // 기본값 순회 — 식별자 참조를 포함할 수 있음 (e.g. function f(a = imported))
                 try self.visitNode(node.data.binary.right);
             },
-            .binding_rest_element, .rest_element, .assignment_target_rest => {
-                // unary: { operand = binding }
-                try self.registerBinding(node.data.unary.operand, kind);
-            },
             else => {},
-        }
-    }
-
-    fn registerBindingList(self: *SemanticAnalyzer, list: NodeList, kind: SymbolKind) AllocError!void {
-        if (list.len == 0) return;
-        if (list.start + list.len > self.ast.extra_data.items.len) return;
-        const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-        for (indices) |raw_idx| {
-            try self.registerBinding(@enumFromInt(raw_idx), kind);
         }
     }
 
     /// 함수 파라미터를 현재 스코프에 등록한다.
     fn registerParams(self: *SemanticAnalyzer, params: ast_mod.NodeList) AllocError!void {
-        if (params.len == 0) return;
-        if (params.start + params.len > self.ast.extra_data.items.len) return;
-        const param_indices = self.ast.extra_data.items[params.start .. params.start + params.len];
-        for (param_indices) |raw_idx| {
+        const split = self.ast.nodeListSplitRest(params);
+        for (split.elements) |raw_idx| {
             try self.registerBinding(@enumFromInt(raw_idx), .parameter);
+        }
+        if (split.rest_operand) |op| {
+            try self.registerBinding(op, .parameter);
         }
     }
 


### PR DESCRIPTION
## Summary

#1462 마이그레이션 Phase 2a. \`semantic/analyzer.zig\`의 7개 binding-pattern walker가 ast helper를 거쳐 rest를 처리하도록 변경.

**대상 walker**:
- \`setSymbolIdForPredeclaredBinding\`
- \`predeclareBindingNames\`
- \`visitBindingPatternExpressions\`
- \`declareBindingPattern\` (array/object case 통합)
- \`collectAndCheckCatchBindings\` (array, object 각각, object_property 특수 처리 유지)
- \`registerBinding\` (registerBindingList helper 흡수)
- \`registerParams\` (NodeList 직접 받는 형태)

각 walker의 인라인 list 순회 + 별도 rest 태그 switch arm 패턴을 \`ast.nodeListSplitRest\` 한 곳으로 캡슐화 — **rest dispatch case set이 한 곳에 모임** → 새 walker 추가 시 #1457 같은 누락 위험 0.

## ast.zig 정리

- \`containerSplitRest\` 제거 (호출자가 이미 switch arm에서 컨테이너 태그 검증하므로 redundant)
- \`nodeListSplitRest\`에 \`inline\` 추가 (호출 사이트 작아 inlining 비용 적음, 이전 두 단계 dispatch 제거)
- 코멘트의 caller 참조 제거 (CLAUDE.md \"don't reference callers\" 준수)

## 호환성

- 기존 AST layout 유지: parser는 여전히 \`rest_element\`를 list 마지막에 emit
- 호출자 외부 (transformer/codegen/bundler 등) 미수정
- Phase 3에서 layout 자체 변경 (extra slot에 rest_idx 분리)

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] \`ast_test.zig\` 단위 테스트 추가 (\`nodeListSplitRest\`)
- [x] #1457 회귀 테스트 통과 — registerParams 마이그레이션이 누락되었을 때 회귀를 잡았고, 수정 후 통과
- [x] 스모크 회귀: remeda / fp-ts / lodash-es 모두 OUTPUT MATCH

## Phase Plan (#1462)

- ✅ Phase 1 (#1463): ast helper 추가
- **✅ Phase 2a (이 PR)**: semantic walker 마이그레이션
- Phase 2b: transformer 마이그레이션 (es2015_destructuring/generator/params/block_scoping)
- Phase 2c: codegen 마이그레이션
- Phase 3: parser layout 변경
- Phase 4: ESTree adapter 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)