### PR TITLE
refactor(transformer): binding walker가 nodeListSplitRest 경유 (#1462 Phase 2b)

### DIFF
--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -89,28 +89,26 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
                     try names.append(self.allocator, text);
                 },
                 .array_pattern => {
-                    const list = node.data.list;
-                    const stmts = self.ast.extra_data.items[list.start .. list.start + list.len];
-                    for (stmts) |raw| {
+                    const split = self.ast.nodeListSplitRest(node.data.list);
+                    for (split.elements) |raw| {
                         try collectBindingNames(self, @enumFromInt(raw), names);
+                    }
+                    if (split.rest_operand) |op| {
+                        try collectBindingNames(self, op, names);
                     }
                 },
                 .object_pattern => {
-                    const list = node.data.list;
-                    const stmts = self.ast.extra_data.items[list.start .. list.start + list.len];
-                    for (stmts) |raw| {
+                    const split = self.ast.nodeListSplitRest(node.data.list);
+                    for (split.elements) |raw| {
                         const prop = self.ast.getNode(@enumFromInt(raw));
                         // binding_property: binary = { left: key, right: value, flags }
-                        // rest_element: unary = { operand, flags }
                         if (prop.tag == .binding_property) {
                             try collectBindingNames(self, prop.data.binary.right, names);
-                        } else if (prop.tag == .rest_element) {
-                            try collectBindingNames(self, prop.data.unary.operand, names);
                         }
                     }
-                },
-                .rest_element => {
-                    try collectBindingNames(self, node.data.unary.operand, names);
+                    if (split.rest_operand) |op| {
+                        try collectBindingNames(self, op, names);
+                    }
                 },
                 .assignment_pattern => {
                     // assignment_pattern은 binary: left = binding, right = default value

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -71,17 +71,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         }
 
         fn objectPatternHasRest(self: *const Transformer, pattern: Node) bool {
-            const list = pattern.data.list;
-            if (list.len == 0) return false;
-            if (list.start + list.len > self.ast.extra_data.items.len) return false;
-            const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-            for (indices) |raw_idx| {
-                const prop_idx: NodeIndex = @enumFromInt(raw_idx);
-                if (prop_idx.isNone()) continue;
-                const prop = self.ast.getNode(prop_idx);
-                if (prop.tag == .rest_element) return true;
-            }
-            return false;
+            return self.ast.nodeListSplitRest(pattern.data.list).rest_operand != null;
         }
 
         /// destructuring이 있는 variable_declaration을 분해한다.
@@ -188,14 +178,15 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         /// object_assignment_target의 각 property를 assignment로 변환.
         fn emitObjectAssignments(self: *Transformer, target: Node, ref_span: Span, span: Span) Transformer.Error!void {
             const oa_start = target.data.list.start;
-            const oa_len = target.data.list.len;
+            // assignment 컨텍스트의 rest는 declaration 컨텍스트의 __rest 같은 런타임 헬퍼가
+            // 없어 현재 미지원 — split으로 elements만 처리하고 rest는 무시.
+            const split = self.ast.nodeListSplitRest(target.data.list);
+            const non_rest_len: u32 = @intCast(split.elements.len);
             // visitNode가 AST를 변형하므로 인덱스 루프 사용
             var i_loop: u32 = 0;
-            while (i_loop < oa_len) : (i_loop += 1) {
+            while (i_loop < non_rest_len) : (i_loop += 1) {
                 const raw_idx = self.ast.extra_data.items[oa_start + i_loop];
                 const prop = self.ast.getNode(@enumFromInt(raw_idx));
-
-                if (prop.tag == .assignment_target_rest) continue; // rest 미지원
 
                 const key_idx = prop.data.binary.left;
                 if (key_idx.isNone()) continue;
@@ -258,14 +249,16 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         /// array_assignment_target의 각 element를 assignment로 변환.
         fn emitArrayAssignments(self: *Transformer, target: Node, ref_span: Span, span: Span) Transformer.Error!void {
             const aa_start = target.data.list.start;
-            const aa_len = target.data.list.len;
+            // assignment 컨텍스트의 rest는 declaration 컨텍스트의 __rest 같은 런타임 헬퍼가
+            // 없어 현재 미지원 — split으로 elements만 처리하고 rest는 무시.
+            const split = self.ast.nodeListSplitRest(target.data.list);
+            const non_rest_len: u32 = @intCast(split.elements.len);
             // visitNode가 AST를 변형하므로 인덱스 루프 사용
             var idx: u32 = 0;
-            while (idx < aa_len) : (idx += 1) {
+            while (idx < non_rest_len) : (idx += 1) {
                 const raw_idx = self.ast.extra_data.items[aa_start + idx];
                 const elem = self.ast.getNode(@enumFromInt(raw_idx));
                 if (elem.tag == .elision) continue;
-                if (elem.tag == .assignment_target_rest) continue;
 
                 // _ref[idx]
                 const access = try makeArrayAccess(self, ref_span, idx, span);
@@ -321,23 +314,16 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         /// { a, ...rest } → var a = _ref.a, rest = __rest(_ref, ["a"])
         fn emitObjectPatternDeclarators(self: *Transformer, pattern: Node, ref_span: Span, span: Span) Transformer.Error!void {
             const opd_start = pattern.data.list.start;
-            const opd_len = pattern.data.list.len;
+            const split = self.ast.nodeListSplitRest(pattern.data.list);
 
             // 1단계: rest가 아닌 property key 이름을 수집 (__rest의 exclude 배열용)
-            // 이 루프는 읽기만 하므로 슬라이스 안전
+            // 이 루프는 visitNode를 호출하지 않으므로 슬라이스 안전
             var exclude_keys: [64][]const u8 = undefined;
             var exclude_count: usize = 0;
-            var rest_binding_idx: ?NodeIndex = null;
 
             {
-                const members = self.ast.extra_data.items[opd_start .. opd_start + opd_len];
-                for (members) |raw_idx| {
+                for (split.elements) |raw_idx| {
                     const prop = self.ast.getNode(@enumFromInt(raw_idx));
-                    if (prop.tag == .rest_element or prop.tag == .binding_rest_element) {
-                        // rest element의 operand가 바인딩 이름
-                        rest_binding_idx = prop.data.unary.operand;
-                        continue;
-                    }
                     if (prop.tag != .binding_property) continue;
                     // key 이름 수집
                     const key_idx_inner = prop.data.binary.left;
@@ -363,21 +349,12 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             }
 
             // 2단계: 각 property를 declarator로 변환
-            // visitNode가 AST를 변형하므로 인덱스 루프 사용
+            // visitNode가 AST를 변형하므로 인덱스 루프 사용 (split.elements 슬라이스는 stale 가능)
+            const non_rest_len: u32 = @intCast(split.elements.len);
             var i_loop: u32 = 0;
-            while (i_loop < opd_len) : (i_loop += 1) {
+            while (i_loop < non_rest_len) : (i_loop += 1) {
                 const raw_idx = self.ast.extra_data.items[opd_start + i_loop];
                 const prop = self.ast.getNode(@enumFromInt(raw_idx));
-
-                if (prop.tag == .rest_element or prop.tag == .binding_rest_element) {
-                    // rest: var rest = __rest(_ref, ["a", "b"])
-                    if (rest_binding_idx) |rest_idx| {
-                        const rest_decl = try buildRestDeclarator(self, rest_idx, ref_span, exclude_keys[0..exclude_count], span);
-                        try self.scratch.append(self.allocator, rest_decl);
-                        self.runtime_helpers.rest = true;
-                    }
-                    continue;
-                }
 
                 if (prop.tag != .binding_property) continue;
 
@@ -435,30 +412,29 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     }
                 }
             }
+
+            // rest: var rest = __rest(_ref, ["a", "b"])
+            if (split.rest_operand) |rest_inner| {
+                const rest_decl = try buildRestDeclarator(self, rest_inner, ref_span, exclude_keys[0..exclude_count], span);
+                try self.scratch.append(self.allocator, rest_decl);
+                self.runtime_helpers.rest = true;
+            }
         }
 
         /// array_pattern의 각 요소를 declarator로 변환.
         /// [x, y] → var x = _ref[0], y = _ref[1]
         fn emitArrayPatternDeclarators(self: *Transformer, pattern: Node, ref_span: Span, span: Span) Transformer.Error!void {
             const apd_start = pattern.data.list.start;
-            const apd_len = pattern.data.list.len;
+            const split = self.ast.nodeListSplitRest(pattern.data.list);
+            const non_rest_len: u32 = @intCast(split.elements.len);
 
             // visitNode가 AST를 변형하므로 인덱스 루프 사용
             var idx: u32 = 0;
-            while (idx < apd_len) : (idx += 1) {
+            while (idx < non_rest_len) : (idx += 1) {
                 const raw_idx = self.ast.extra_data.items[apd_start + idx];
                 const elem = self.ast.getNode(@enumFromInt(raw_idx));
 
                 if (elem.tag == .elision) continue; // 빈 슬롯 스킵
-
-                if (elem.tag == .rest_element or elem.tag == .binding_rest_element) {
-                    // ...rest → var rest = _ref.slice(N)
-                    const rest_binding = try self.visitNode(elem.data.unary.operand);
-                    const rest_init = try buildArraySlice(self, ref_span, idx, span);
-                    const rest_decl = try es_helpers.makeDeclarator(self, rest_binding, rest_init, span);
-                    try self.scratch.append(self.allocator, rest_decl);
-                    continue;
-                }
 
                 // _ref[idx]
                 const elem_access = try makeArrayAccess(self, ref_span, idx, span);
@@ -494,6 +470,14 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     const decl = try es_helpers.makeDeclarator(self, binding, elem_access, span);
                     try self.scratch.append(self.allocator, decl);
                 }
+            }
+
+            // ...rest → var rest = _ref.slice(N)
+            if (split.rest_operand) |rest_inner| {
+                const rest_binding = try self.visitNode(rest_inner);
+                const rest_init = try buildArraySlice(self, ref_span, non_rest_len, span);
+                const rest_decl = try es_helpers.makeDeclarator(self, rest_binding, rest_init, span);
+                try self.scratch.append(self.allocator, rest_decl);
             }
         }
 

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1186,39 +1186,46 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 },
                 .object_pattern => {
                     const props_start = node.data.list.start;
-                    const props_len = node.data.list.len;
+                    const split = self.ast.nodeListSplitRest(node.data.list);
+                    const non_rest_len: u32 = @intCast(split.elements.len);
                     // visitNode가 extra_data를 재할당할 수 있으므로 인덱스 루프 사용
                     var p_loop: u32 = 0;
-                    while (p_loop < props_len) : (p_loop += 1) {
+                    while (p_loop < non_rest_len) : (p_loop += 1) {
                         const raw_idx = self.ast.extra_data.items[props_start + p_loop];
                         const prop = self.ast.getNode(@enumFromInt(raw_idx));
                         if (prop.tag == .binding_property) {
                             // {key: value} → value 쪽에서 identifier 추출
                             try collectBindingIdentifiers(self, prop.data.binary.right, hoisted);
-                        } else if (prop.tag == .rest_element or prop.tag == .binding_rest_element) {
-                            try collectBindingIdentifiers(self, prop.data.unary.operand, hoisted);
                         } else if (prop.tag == .assignment_pattern) {
                             // {x = default} → x
                             try collectBindingIdentifiers(self, prop.data.binary.left, hoisted);
                         }
                     }
+                    if (split.rest_operand) |op| {
+                        try collectBindingIdentifiers(self, op, hoisted);
+                    }
                 },
                 .array_pattern => {
                     const elems_start = node.data.list.start;
-                    const elems_len = node.data.list.len;
+                    const split = self.ast.nodeListSplitRest(node.data.list);
+                    const non_rest_len: u32 = @intCast(split.elements.len);
                     // visitNode가 extra_data를 재할당할 수 있으므로 인덱스 루프 사용
                     var e_loop: u32 = 0;
-                    while (e_loop < elems_len) : (e_loop += 1) {
+                    while (e_loop < non_rest_len) : (e_loop += 1) {
                         const raw_idx = self.ast.extra_data.items[elems_start + e_loop];
                         const elem_idx: NodeIndex = @enumFromInt(raw_idx);
                         if (elem_idx.isNone()) continue; // array hole
                         try collectBindingIdentifiers(self, elem_idx, hoisted);
+                    }
+                    if (split.rest_operand) |op| {
+                        try collectBindingIdentifiers(self, op, hoisted);
                     }
                 },
                 .assignment_pattern => {
                     // [x = default] → x
                     try collectBindingIdentifiers(self, node.data.binary.left, hoisted);
                 },
+                // 외부 첫 호출이 직접 rest 노드일 수 있는 경로 안전망 (함수 파라미터 등).
                 .rest_element, .binding_rest_element => {
                     try collectBindingIdentifiers(self, node.data.unary.operand, hoisted);
                 },


### PR DESCRIPTION
## Summary

#1462 마이그레이션 Phase 2b. 3개 transformer 모듈을 \`ast.nodeListSplitRest\`로 마이그레이션.

**대상**:
- \`es2015_destructuring.zig\`: \`objectPatternHasRest\`, \`emitObjectAssignments\`, \`emitArrayAssignments\`, \`emitObjectPatternDeclarators\`, \`emitArrayPatternDeclarators\` (5곳)
- \`es2015_block_scoping.zig\`: \`collectBindingNames\` (1곳, outer rest arm 제거 — 호출 사이트가 직접 rest 노드를 받지 않음)
- \`es2015_generator.zig\`: \`collectBindingIdentifiers\` (1곳, outer rest arm 보존 — \`else=>unreachable\` 때문에 외부 첫 호출이 직접 rest 노드일 수 있는 경로 안전망)

각 walker의 인라인 list 순회 + 별도 rest 분기 패턴이 \`ast.nodeListSplitRest\` 한 곳으로 캡슐화 — 새 walker 추가 시 #1457 같은 누락 위험 0.

## 주요 변경

- 1단계+2단계 구조의 \`emitObjectPatternDeclarators\`: \`split\`을 한 번 호출해 두 단계 공유. \`rest_binding_idx\` 변수 제거. rest 처리를 함수 끝 별도 분기로 이동.
- \`array_pattern\`/\`object_pattern\` 분리되어 있던 케이스 합침 (동일 처리)
- \`assignment_target_rest\`는 declaration의 \`__rest\`에 해당하는 런타임 헬퍼 부재로 미지원 — 코멘트에 WHY 명시

## 호환성

- AST layout 미변경 (rest_element는 list 마지막에 emit)
- 회귀 테스트 + 스모크 회귀 모두 통과 (remeda / fp-ts / lodash-es / rxjs OUTPUT MATCH)

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] 스모크 회귀: remeda / fp-ts / lodash-es / rxjs 모두 OUTPUT MATCH

## Phase Plan (#1462)

- ✅ Phase 1 (#1463): ast helper 추가
- ✅ Phase 2a (#1464): semantic walker 마이그레이션
- **✅ Phase 2b (이 PR)**: transformer walker 마이그레이션
- Phase 2c: codegen 마이그레이션 (es2015_destructuring 외 잔여 + codegen.zig)
- Phase 3: parser layout 변경 (extra slot에 rest_idx 분리, rest_element variant 제거)
- Phase 4: ESTree adapter 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)