### PR TITLE
refactor(codegen,checker): 잔여 binding walker 마이그레이션 (#1462 Phase 2c)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3546,31 +3546,28 @@ pub const Codegen = struct {
                 try self.writeByte(';');
             },
             .array_pattern => {
-                // list의 각 요소를 재귀 처리
-                const elements = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                for (elements) |raw_idx| {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
                     try self.emitNamespaceBindingExport(ns_name, @enumFromInt(raw_idx));
+                }
+                if (split.rest_operand) |op| {
+                    try self.emitNamespaceBindingExport(ns_name, op);
                 }
             },
             .object_pattern => {
-                const props = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                for (props) |raw_idx| {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
                     const prop = self.ast.getNode(@enumFromInt(raw_idx));
                     // property_property: binary.right = value (binding pattern)
-                    // rest_element: unary.operand
-                    if (prop.tag == .rest_element or prop.tag == .assignment_target_rest) {
-                        try self.emitNamespaceBindingExport(ns_name, prop.data.unary.operand);
-                    } else {
-                        try self.emitNamespaceBindingExport(ns_name, prop.data.binary.right);
-                    }
+                    try self.emitNamespaceBindingExport(ns_name, prop.data.binary.right);
+                }
+                if (split.rest_operand) |op| {
+                    try self.emitNamespaceBindingExport(ns_name, op);
                 }
             },
             .assignment_target_with_default => {
                 // { x = defaultVal } → x
                 try self.emitNamespaceBindingExport(ns_name, node.data.binary.left);
-            },
-            .rest_element, .assignment_target_rest => {
-                try self.emitNamespaceBindingExport(ns_name, node.data.unary.operand);
             },
             else => {},
         }

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -380,12 +380,12 @@ fn collectBindingNames(
             try recordSeenName(ast.getText(node.span), node.span, seen, errors, allocator);
         },
         .array_pattern, .object_pattern => {
-            // list of elements/properties
-            if (node.data.list.len == 0) return;
-            if (node.data.list.start + node.data.list.len > ast.extra_data.items.len) return;
-            const indices = ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-            for (indices) |raw_idx| {
+            const split = ast.nodeListSplitRest(node.data.list);
+            for (split.elements) |raw_idx| {
                 try collectBindingNames(ast, @enumFromInt(raw_idx), seen, errors, allocator);
+            }
+            if (split.rest_operand) |op| {
+                try collectBindingNames(ast, op, seen, errors, allocator);
             }
         },
         .binding_property => {
@@ -395,10 +395,6 @@ fn collectBindingNames(
         .assignment_pattern => {
             // binary: { left = binding, right = default_value }
             try collectBindingNames(ast, node.data.binary.left, seen, errors, allocator);
-        },
-        .binding_rest_element, .rest_element => {
-            // unary: { operand = binding }
-            try collectBindingNames(ast, node.data.unary.operand, seen, errors, allocator);
         },
         else => {},
     }


### PR DESCRIPTION
## Summary

#1462 마이그레이션 Phase 2c. Phase 2a/2b 이후 잔여 binding-pattern walker 정리.

**대상**:
- \`semantic/checker.zig:collectBindingNames\` (1곳)
- \`codegen/codegen.zig:emitNamespaceBindingExport\` (1곳)

각각 array/object_pattern 케이스를 \`ast.nodeListSplitRest\`로 마이그레이션, outer rest 태그 arm 제거.

## 마이그레이션 안 한 곳 (의도적)

- \`codegen.emitNode\` dispatch arm (\`.rest_element, .binding_rest_element, .assignment_target_rest\` → \`emitRest\`): 단일 노드를 \`...\` prefix로 출력하는 책임. visitor pattern의 일부.
- \`codegen.emitArray\` / \`emitObject\`: \`array_pattern\` + \`array_expression\` (또는 \`object_pattern\` + \`object_expression\`) 공유 함수. expression context의 \`spread_element\`도 처리해야 하므로 \`nodeListSplitRest\`(binding rest만 검사) 부적절. 단순 list 순회 + emitNode dispatch가 자연스러움.
- \`semantic/checker.zig:collectArrowParamNames\`: cover grammar reinterpret 전 호출 경로가 있어 \`spread_element\` arm 안전망 유지.

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] 스모크 회귀: remeda / fp-ts / lodash-es 모두 OUTPUT MATCH

## Phase Plan (#1462)

- ✅ Phase 1 (#1463): ast helper 추가
- ✅ Phase 2a (#1464): semantic walker 마이그레이션
- ✅ Phase 2b (#1465): transformer walker 마이그레이션
- **✅ Phase 2c (이 PR)**: codegen/checker 잔여 walker
- Phase 3: parser layout 변경 (extra slot에 rest_idx 분리, rest_element variant 제거)
- Phase 4: ESTree adapter 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)