### PR TITLE
fix(docs): TypeDoc이 packages/core의 Node.js 모듈 타입을 찾도록 설정

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,9 @@
       "bin": {
         "zts": "./bin/zts.mjs",
       },
+      "devDependencies": {
+        "@types/node": "^25.5.2",
+      },
       "optionalDependencies": {
         "browserslist": "^4.24.0",
         "lightningcss": "^1.28.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,9 @@
     "postinstall": "[ -f ../../zig-out/lib/zts.node ] && cp ../../zig-out/lib/zts.node . || true",
     "test": "bun test"
   },
+  "devDependencies": {
+    "@types/node": "^25.5.2"
+  },
   "optionalDependencies": {
     "browserslist": "^4.24.0",
     "lightningcss": "^1.28.0"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
     "declaration": true,
     "declarationDir": "dist",
     "outDir": "dist",


### PR DESCRIPTION
## Summary

Deploy Docs 워크플로우가 typedoc-plugin-markdown으로 \`packages/core/index.ts\`를 처리할 때 Node.js 타입(\`module\`, \`fs\`, \`path\`, \`url\`, \`Buffer\`, \`require\`)을 찾지 못해 실패.

\`\`\`
[ERROR] [starlight-typedoc-plugin] ../packages/core/index.ts:16:31 - error TS2307:
  Cannot find module 'module' or its corresponding type declarations.
\`\`\`

## Root cause

\`@types/node\`가 root \`node_modules\`에 hoisting되어 있지만 \`packages/core\`가 명시 의존이 없어 CI 환경에서 typedoc resolver가 못 찾음. 또한 \`packages/core/tsconfig.json\`에 \`types\` / \`lib\` 명시 없음.

## Fix

- \`packages/core/package.json\`: \`@types/node\` devDependency 명시 추가 (workspace hoisting 의존 해소)
- \`packages/core/tsconfig.json\`: \`lib: ["ES2022"]\`, \`types: ["node"]\` 명시

## Test plan

- [x] \`bun install\` + \`cd documents && bun run build\` 로컬 성공 (338 페이지 생성, link validation OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)