### PR TITLE
fix(transformer): #1473 regex named group strip 시 String.replace의 $<name> 도 함께 변환

### DIFF
--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -214,6 +214,111 @@ fn rewritePattern(
     }
 }
 
+/// `String.prototype.replace` replacement string 의 `$<name>` 변환을 위한 매핑 항목.
+/// 같은 walk 로 named group 인덱스를 추적해 외부에 노출한다.
+pub const NamedGroupMapping = struct {
+    name: []const u8, // pattern 내부 원본 슬라이스 (수명: pattern 원본)
+    index: u32, // 1-based capture group 인덱스
+};
+
+/// pattern 을 한 번 순회하며 named group 의 (name, capture index) 매핑을 추출.
+/// 비-capture / lookahead / lookbehind 는 capture index 를 차지하지 않는다.
+/// 호출자는 반환 슬라이스를 free 해야 한다.
+pub fn extractNamedGroupMap(allocator: std.mem.Allocator, pattern: []const u8) ![]const NamedGroupMapping {
+    var out: std.ArrayList(NamedGroupMapping) = .empty;
+    errdefer out.deinit(allocator);
+
+    var i: usize = 0;
+    var in_class: bool = false;
+    var group_idx: u32 = 0;
+    while (i < pattern.len) {
+        const c = pattern[i];
+        if (c == '\\') {
+            i += if (i + 1 < pattern.len) 2 else 1;
+            continue;
+        }
+        if (in_class) {
+            if (c == ']') in_class = false;
+            i += 1;
+            continue;
+        }
+        if (c == '[') {
+            in_class = true;
+            i += 1;
+            continue;
+        }
+        if (c != '(') {
+            i += 1;
+            continue;
+        }
+        if (i + 2 < pattern.len and pattern[i + 1] == '?') {
+            const tag = pattern[i + 2];
+            if (tag == ':' or tag == '=' or tag == '!') {
+                i += 1;
+                continue;
+            }
+            if (tag == '<') {
+                if (i + 3 < pattern.len and (pattern[i + 3] == '=' or pattern[i + 3] == '!')) {
+                    i += 1;
+                    continue;
+                }
+                group_idx += 1;
+                if (std.mem.indexOfScalarPos(u8, pattern, i + 3, '>')) |gt| {
+                    try out.append(allocator, .{ .name = pattern[i + 3 .. gt], .index = group_idx });
+                    i = gt + 1;
+                    continue;
+                }
+            }
+        }
+        group_idx += 1;
+        i += 1;
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+/// `String.prototype.replace` replacement 의 `$<name>` 을 `$N` (positional)으로 치환.
+/// 변환된 부분이 하나도 없으면 null (호출자는 원본 그대로 사용).
+/// `$$`, `$&`, `$\``, `$'`, `$N` 은 그대로 보존.
+pub fn rewriteReplacementNamedRefs(
+    allocator: std.mem.Allocator,
+    content: []const u8,
+    mapping: []const NamedGroupMapping,
+) !?[]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var changed = false;
+    var i: usize = 0;
+    while (i < content.len) {
+        if (content[i] == '$' and i + 2 < content.len and content[i + 1] == '<') {
+            if (std.mem.indexOfScalarPos(u8, content, i + 2, '>')) |gt| {
+                const name = content[i + 2 .. gt];
+                var found_idx: ?u32 = null;
+                for (mapping) |m| {
+                    if (std.mem.eql(u8, m.name, name)) {
+                        found_idx = m.index;
+                        break;
+                    }
+                }
+                if (found_idx) |idx| {
+                    var buf: [16]u8 = undefined;
+                    const s = std.fmt.bufPrint(&buf, "${d}", .{idx}) catch unreachable;
+                    try out.appendSlice(allocator, s);
+                    i = gt + 1;
+                    changed = true;
+                    continue;
+                }
+            }
+        }
+        try out.append(allocator, content[i]);
+        i += 1;
+    }
+    if (!changed) {
+        out.deinit(allocator);
+        return null;
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
 /// pattern에 `(?<name>...)` (lookbehind 제외) 가 있는지 스캔.
 fn hasNamedGroup(pattern: []const u8) bool {
     var i: usize = 0;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3446,6 +3446,24 @@ pub const Transformer = struct {
         const args_start = self.readU32(e, 1);
         const args_len = self.readU32(e, 2);
         const flags = self.readU32(e, 3);
+
+        // String.{replace,replaceAll} 의 replacement string 안 `$<name>` → `$N` 변환.
+        // regex_lower 가 named group 을 strip하면 인덱스 매핑이 깨져 replacement 가 매칭 실패하므로,
+        // literal regex + literal string 조합에 한해 replacement 도 함께 변환한다.
+        if (self.options.unsupported.regex_named_groups and args_len == 2) {
+            if (try self.tryRewriteReplaceNamedRefs(callee_idx, args_start)) |rewritten_args| {
+                const new_callee = try self.visitNode(callee_idx);
+                const new_extra = try self.ast.addExtras(&.{
+                    @intFromEnum(new_callee), rewritten_args.start, rewritten_args.len, flags,
+                });
+                return self.ast.addNode(.{
+                    .tag = .call_expression,
+                    .span = node.span,
+                    .data = .{ .extra = new_extra },
+                });
+            }
+        }
+
         const new_callee = try self.visitNode(callee_idx);
 
         // Auto-workletization: callee 이름이 플러그인 목록에 매칭되면
@@ -3464,6 +3482,56 @@ pub const Transformer = struct {
             .span = node.span,
             .data = .{ .extra = new_extra },
         });
+    }
+
+    /// `x.replace(/.../u, "...$<n>...")` 패턴 매칭 + replacement string 변환.
+    /// 매칭 실패 (callee 형태 다름, regex가 dynamic, replacement가 literal 아님 등) 시 null.
+    fn tryRewriteReplaceNamedRefs(self: *Transformer, callee_idx: NodeIndex, args_start: u32) Error!?ast_mod.NodeList {
+        const callee = self.ast.getNode(callee_idx);
+        if (callee.tag != .static_member_expression) return null;
+        const ce = callee.data.extra;
+        if (ce + 1 >= self.ast.extra_data.items.len) return null;
+        const prop_idx = self.readNodeIdx(ce, 1);
+        const prop = self.ast.getNode(prop_idx);
+        if (prop.tag != .identifier_reference) return null;
+        const prop_name = self.ast.getText(prop.span);
+        if (!std.mem.eql(u8, prop_name, "replace") and !std.mem.eql(u8, prop_name, "replaceAll")) return null;
+
+        const arg0_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[args_start]);
+        const arg1_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[args_start + 1]);
+        const arg0 = self.ast.getNode(arg0_idx);
+        const arg1 = self.ast.getNode(arg1_idx);
+        if (arg0.tag != .regexp_literal or arg1.tag != .string_literal) return null;
+
+        const raw = self.ast.getText(arg0.span);
+        if (raw.len < 3 or raw[0] != '/') return null;
+        const last_slash = std.mem.lastIndexOfScalar(u8, raw, '/') orelse return null;
+        if (last_slash == 0) return null;
+        const pattern = raw[1..last_slash];
+
+        const mapping = try regex_lower.extractNamedGroupMap(self.allocator, pattern);
+        defer self.allocator.free(mapping);
+        if (mapping.len == 0) return null;
+
+        const replace_raw = self.ast.getText(arg1.data.string_ref);
+        if (replace_raw.len < 2) return null;
+        const quote = replace_raw[0];
+        if (quote != '"' and quote != '\'') return null;
+        const content = replace_raw[1 .. replace_raw.len - 1];
+
+        const new_content = (try regex_lower.rewriteReplacementNamedRefs(self.allocator, content, mapping)) orelse return null;
+        defer self.allocator.free(new_content);
+
+        const new_raw = try std.fmt.allocPrint(self.allocator, "{c}{s}{c}", .{ quote, new_content, quote });
+        defer self.allocator.free(new_raw);
+        const new_span = try self.ast.addString(new_raw);
+        const new_str_node = try self.ast.addNode(.{
+            .tag = .string_literal,
+            .span = new_span,
+            .data = .{ .string_ref = new_span },
+        });
+        const new_arg0 = try self.visitNode(arg0_idx);
+        return self.ast.addNodeList(&[_]NodeIndex{ new_arg0, new_str_node }) catch return Error.OutOfMemory;
     }
 
     /// new_expression: extra = [callee, args_start, args_len, flags]

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3625,8 +3625,9 @@ pub const Transformer = struct {
             const sym_id = self.getSymbolIdAt(name_idx) orelse continue;
             const owned_pattern = try self.allocator.dupe(u8, raw[1..last_slash]);
             errdefer self.allocator.free(owned_pattern);
-            // 중복 선언 (eg. block-shadow) 시 이전 entry 해제.
-            if (self.regex_var_map.fetchPut(self.allocator, sym_id, owned_pattern) catch null) |old| {
+            // 중복 선언 (eg. block-shadow) 시 이전 entry 해제. OOM 은 상위로 전파 — 조용히 삼키면
+            // 후속 lookup 이 실패해 #1473 변환이 silent 누락되는 regression.
+            if (try self.regex_var_map.fetchPut(self.allocator, sym_id, owned_pattern)) |old| {
                 self.allocator.free(old.value);
             }
         }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -335,8 +335,13 @@ pub const Transformer = struct {
 
     /// TS const enum: 선언 시 멤버 값을 미리 평가하여 보관.
     /// 후속 visitMemberExpression에서 `E.A` 형태 참조를 literal로 인라인.
-    /// 단순 케이스(numeric/string literal + auto-increment)만 지원.
     const_enums: std.ArrayList(ConstEnumDecl) = .empty,
+
+    /// `const re = /.../;` 형태로 선언된 regex literal 추적.
+    /// key=symbol_id, value=pattern 텍스트 (`/`/flags 제외 owned slice).
+    /// `String.replace(re, "$<name>...")` 같은 호출에서 named group 매핑 lookup 에 사용 (#1473).
+    /// const 바인딩만 추적 (let/var 는 재할당 가능).
+    regex_var_map: std.AutoHashMapUnmanaged(u32, []const u8) = .empty,
 
     pub const BlockRenameEntry = struct {
         old_name: []const u8,
@@ -447,6 +452,11 @@ pub const Transformer = struct {
             self.allocator.free(decl.members);
         }
         self.const_enums.deinit(self.allocator);
+        {
+            var it = self.regex_var_map.iterator();
+            while (it.next()) |entry| self.allocator.free(entry.value_ptr.*);
+            self.regex_var_map.deinit(self.allocator);
+        }
     }
 
     /// semantic analyzer의 symbol_ids를 통합 배열로 복사한다.
@@ -2423,6 +2433,12 @@ pub const Transformer = struct {
         }
         const e = node.data.extra;
         const orig_kind = self.ast.variableDeclarationKind(node);
+
+        // `const re = /.../` 추적 — String.replace 의 named group 매핑 lookup 용 (#1473).
+        // const 만 추적: let/var 는 재할당 가능해 추적 결과를 신뢰할 수 없음.
+        if (self.options.unsupported.regex_named_groups and orig_kind == .@"const") {
+            self.collectConstRegexDeclarators(self.readU32(e, 1), self.readU32(e, 2)) catch {};
+        }
         const kind = if (self.options.unsupported.block_scoping)
             es2015_block_scoping.lowerKind(orig_kind)
         else
@@ -3484,8 +3500,12 @@ pub const Transformer = struct {
         });
     }
 
-    /// `x.replace(/.../u, "...$<n>...")` 패턴 매칭 + replacement string 변환.
-    /// 매칭 실패 (callee 형태 다름, regex가 dynamic, replacement가 literal 아님 등) 시 null.
+    /// `x.replace(re, "...$<n>...")` / `x.replace(/.../u, \`...$<n>...\`)` 패턴 매칭 + replacement 변환.
+    /// 매칭 실패 (callee 형태 다름, regex pattern 미상, replacement 가 literal 형태 아님 등) 시 null.
+    ///
+    /// 지원:
+    ///   - args[0]: regex literal `/.../`, 또는 `const re = /.../;` 로 선언된 변수 (symbol_id 기반 추적)
+    ///   - args[1]: string literal, 또는 interpolation 없는 template literal (\`...\`)
     fn tryRewriteReplaceNamedRefs(self: *Transformer, callee_idx: NodeIndex, args_start: u32) Error!?ast_mod.NodeList {
         const callee = self.ast.getNode(callee_idx);
         if (callee.tag != .static_member_expression) return null;
@@ -3499,29 +3519,19 @@ pub const Transformer = struct {
 
         const arg0_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[args_start]);
         const arg1_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[args_start + 1]);
-        const arg0 = self.ast.getNode(arg0_idx);
-        const arg1 = self.ast.getNode(arg1_idx);
-        if (arg0.tag != .regexp_literal or arg1.tag != .string_literal) return null;
 
-        const raw = self.ast.getText(arg0.span);
-        if (raw.len < 3 or raw[0] != '/') return null;
-        const last_slash = std.mem.lastIndexOfScalar(u8, raw, '/') orelse return null;
-        if (last_slash == 0) return null;
-        const pattern = raw[1..last_slash];
-
+        const pattern = (self.resolveRegexPatternForCall(arg0_idx)) orelse return null;
         const mapping = try regex_lower.extractNamedGroupMap(self.allocator, pattern);
         defer self.allocator.free(mapping);
         if (mapping.len == 0) return null;
 
-        const replace_raw = self.ast.getText(arg1.data.string_ref);
-        if (replace_raw.len < 2) return null;
-        const quote = replace_raw[0];
-        if (quote != '"' and quote != '\'') return null;
-        const content = replace_raw[1 .. replace_raw.len - 1];
+        const replacement = (try self.extractReplacementContent(arg1_idx)) orelse return null;
+        defer self.allocator.free(replacement.content);
 
-        const new_content = (try regex_lower.rewriteReplacementNamedRefs(self.allocator, content, mapping)) orelse return null;
+        const new_content = (try regex_lower.rewriteReplacementNamedRefs(self.allocator, replacement.content, mapping)) orelse return null;
         defer self.allocator.free(new_content);
 
+        const quote: u8 = if (replacement.is_template) '"' else replacement.quote;
         const new_raw = try std.fmt.allocPrint(self.allocator, "{c}{s}{c}", .{ quote, new_content, quote });
         defer self.allocator.free(new_raw);
         const new_span = try self.ast.addString(new_raw);
@@ -3532,6 +3542,94 @@ pub const Transformer = struct {
         });
         const new_arg0 = try self.visitNode(arg0_idx);
         return self.ast.addNodeList(&[_]NodeIndex{ new_arg0, new_str_node }) catch return Error.OutOfMemory;
+    }
+
+    /// arg0 가 regex literal 또는 추적된 const regex 변수면 pattern slice 반환.
+    /// 반환 슬라이스의 수명: ast.string_table (literal) 또는 self.regex_var_map (변수) — 둘 다 변환 동안 유효.
+    fn resolveRegexPatternForCall(self: *const Transformer, arg_idx: NodeIndex) ?[]const u8 {
+        if (arg_idx.isNone()) return null;
+        const node = self.ast.getNode(arg_idx);
+        switch (node.tag) {
+            .regexp_literal => {
+                const raw = self.ast.getText(node.span);
+                if (raw.len < 3 or raw[0] != '/') return null;
+                const last_slash = std.mem.lastIndexOfScalar(u8, raw, '/') orelse return null;
+                if (last_slash == 0) return null;
+                return raw[1..last_slash];
+            },
+            .identifier_reference => {
+                const sym = self.getSymbolIdAt(arg_idx) orelse return null;
+                return self.regex_var_map.get(sym);
+            },
+            else => return null,
+        }
+    }
+
+    const ReplacementContent = struct {
+        content: []u8, // owned dup of literal body
+        quote: u8, // string literal 의 따옴표 (template 인 경우 무관)
+        is_template: bool,
+    };
+
+    /// arg1 가 string literal 또는 interpolation 없는 template literal 이면 그 본문 (escape 보존)을 owned 로 반환.
+    fn extractReplacementContent(self: *Transformer, arg_idx: NodeIndex) Error!?ReplacementContent {
+        if (arg_idx.isNone()) return null;
+        const node = self.ast.getNode(arg_idx);
+        switch (node.tag) {
+            .string_literal => {
+                const raw = self.ast.getText(node.data.string_ref);
+                if (raw.len < 2) return null;
+                const q = raw[0];
+                if (q != '"' and q != '\'') return null;
+                const body = raw[1 .. raw.len - 1];
+                const owned = try self.allocator.dupe(u8, body);
+                return .{ .content = owned, .quote = q, .is_template = false };
+            },
+            .template_literal => {
+                // 보간 없는 template literal (`text`): parser 가 data: .none 으로 저장 + span 은 backtick 포함 전체.
+                // 보간 있는 경우(template_head 진입): data: .list 형식 — 우리는 보간 없는 케이스만 지원.
+                if (node.data.none != 0) return null;
+                const raw = self.ast.getText(node.span);
+                if (raw.len < 2 or raw[0] != '`' or raw[raw.len - 1] != '`') return null;
+                const body = raw[1 .. raw.len - 1];
+                // 본문 안에 ${ 가 있으면 보간 있는 케이스 — 안전하게 fallback.
+                if (std.mem.indexOf(u8, body, "${") != null) return null;
+                const owned = try self.allocator.dupe(u8, body);
+                return .{ .content = owned, .quote = '"', .is_template = true };
+            },
+            else => return null,
+        }
+    }
+
+    /// `const re = /.../;` 형태의 declarator 들을 self.regex_var_map 에 등록.
+    /// destructuring/function call init/non-regex init 은 모두 skip.
+    fn collectConstRegexDeclarators(self: *Transformer, list_start: u32, list_len: u32) Error!void {
+        var i: u32 = 0;
+        while (i < list_len) : (i += 1) {
+            const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list_start + i]);
+            const decl = self.ast.getNode(decl_idx);
+            if (decl.tag != .variable_declarator) continue;
+            const de = decl.data.extra;
+            if (de + 2 >= self.ast.extra_data.items.len) continue;
+            const name_idx = self.readNodeIdx(de, 0);
+            const init_idx = self.readNodeIdx(de, 2);
+            if (name_idx.isNone() or init_idx.isNone()) continue;
+            const name_node = self.ast.getNode(name_idx);
+            if (name_node.tag != .binding_identifier) continue;
+            const init_node = self.ast.getNode(init_idx);
+            if (init_node.tag != .regexp_literal) continue;
+            const raw = self.ast.getText(init_node.span);
+            if (raw.len < 3 or raw[0] != '/') continue;
+            const last_slash = std.mem.lastIndexOfScalar(u8, raw, '/') orelse continue;
+            if (last_slash == 0) continue;
+            const sym_id = self.getSymbolIdAt(name_idx) orelse continue;
+            const owned_pattern = try self.allocator.dupe(u8, raw[1..last_slash]);
+            errdefer self.allocator.free(owned_pattern);
+            // 중복 선언 (eg. block-shadow) 시 이전 entry 해제.
+            if (self.regex_var_map.fetchPut(self.allocator, sym_id, owned_pattern) catch null) |old| {
+                self.allocator.free(old.value);
+            }
+        }
     }
 
     /// new_expression: extra = [callee, args_start, args_len, flags]

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1395,8 +1395,7 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("1,2");
     });
 
-    // skip: regex named group strip 시 `String.replace` replacement 의 `$<name>` 미변환 — #1473
-    test.skip("multiple named groups + replace string $<name>", async () => {
+    test("multiple named groups + replace string $<name>", async () => {
       const result = await bundleAndRun(
         {
           "index.ts": `

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1411,6 +1411,71 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("15/01/2020");
     });
 
+    test("const 변수 regex + replace의 $<name> 추적", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const re = /(?<y>\\d{4})-(?<m>\\d{2})-(?<d>\\d{2})/;
+            console.log('2020-01-15'.replace(re, '$<d>/$<m>/$<y>'));
+          `,
+        },
+        "index.ts",
+        ["--target=es2017"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("15/01/2020");
+    });
+
+    test("template literal replacement (보간 없음)의 $<name>", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const r = 'hello'.replace(/(?<word>\\w+)/, \`<\$<word>>\`);
+            console.log(r);
+          `,
+        },
+        "index.ts",
+        ["--target=es2017"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("<hello>");
+    });
+
+    test("const 변수 regex + template literal 조합", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const re = /(?<a>\\w+)-(?<b>\\d+)/;
+            console.log('foo-42'.replace(re, \`[\$<b>:\$<a>]\`));
+          `,
+        },
+        "index.ts",
+        ["--target=es2017"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("[42:foo]");
+    });
+
+    test("let 변수 regex는 추적 안 됨 (재할당 가능)", async () => {
+      // let 은 재할당 가능 → 추적 비활성. ES2018+ 타겟이라 named group 그대로 유지.
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let re = /(?<n>\\d+)/;
+            console.log('a1'.replace(re, '<$<n>>'));
+          `,
+        },
+        "index.ts",
+        ["--target=es2018"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("a<1>");
+    });
+
     test("regex literal escape in character class", async () => {
       const result = await bundleAndRun(
         {
@@ -1448,6 +1513,261 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
         expect(result.runOutput).toBe("4,5");
       });
     }
+  });
+
+  describe("추가 일반 엣지 케이스", () => {
+    test("arrow returning object literal `() => ({})`", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const fn = (x: number) => ({ value: x * 2 });
+            console.log(fn(5).value);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("10");
+    });
+
+    test("logical assignment in deep member access", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const obj: any = { a: { b: { c: null } } };
+            obj.a.b.c ??= compute();
+            function compute() { return 42; }
+            console.log(obj.a.b.c);
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("42");
+    });
+
+    test("try-catch-finally + return: finally가 catch보다 우선", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function fn(): string {
+              try {
+                throw new Error('boom');
+              } catch (e: any) {
+                return 'caught:' + e.message;
+              } finally {
+                return 'finally-wins';
+              }
+            }
+            console.log(fn());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("finally-wins");
+    });
+
+    // skip: ES5 generator state machine의 for loop + break op 시퀀스 빌드 오류 — #1480
+    test.skip("generator + yield in for loop with break", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function* g() {
+              for (let i = 0; i < 10; i++) {
+                if (i === 5) break;
+                yield i;
+              }
+            }
+            const arr = [];
+            for (const v of g()) arr.push(v);
+            console.log(arr.join(','));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("0,1,2,3,4");
+    });
+
+    test("tagged template + 다중 expression", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function tag(strs: TemplateStringsArray, ...vals: any[]): string {
+              let out = '';
+              for (let i = 0; i < strs.length; i++) {
+                out += strs[i];
+                if (i < vals.length) out += '<' + vals[i] + '>';
+              }
+              return out;
+            }
+            const a = 1, b = 2, c = 3;
+            console.log(tag\`x=\${a},y=\${b},z=\${c}\`);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("x=<1>,y=<2>,z=<3>");
+    });
+
+    test("computed class method name + key 표현식", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const k = 'greet';
+            class C {
+              [k + '!']() { return 'hi'; }
+              [\`get_\${k}\`]() { return 'getter'; }
+            }
+            const c: any = new C();
+            console.log(c['greet!'](), c['get_greet']());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("hi getter");
+    });
+
+    test("async arrow + try-catch-finally", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const fn = async () => {
+              try { return await Promise.resolve('a'); }
+              catch (e) { return 'err'; }
+              finally { /* no-op */ }
+            };
+            fn().then(v => console.log(v));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("a");
+    });
+
+    test("destructuring in for-of with rest", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const data: number[][] = [[1, 2, 3], [4, 5, 6]];
+            const out: string[] = [];
+            for (const [first, ...rest] of data) {
+              out.push(first + ':' + rest.join('+'));
+            }
+            console.log(out.join('|'));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1:2+3|4:5+6");
+    });
+
+    test("Symbol.iterator 직접 구현 + spread + for-of", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const obj = {
+              [Symbol.iterator]() {
+                let i = 0;
+                return {
+                  next() { return i < 3 ? { value: i++, done: false } : { value: undefined, done: true }; }
+                };
+              }
+            };
+            const a = [...(obj as any)];
+            const b: number[] = [];
+            for (const v of obj as any) b.push(v);
+            console.log(a.join(','), b.join(','));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("0,1,2 0,1,2");
+    });
+
+    test("async generator + yield* 위임 (ES2018+)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            async function* inner() { yield 1; yield 2; }
+            async function* outer() { yield 0; yield* inner(); yield 3; }
+            (async () => {
+              const arr: number[] = [];
+              for await (const v of outer()) arr.push(v);
+              console.log(arr.join(','));
+            })();
+          `,
+        },
+        "index.ts",
+        ["--target=es2018"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("0,1,2,3");
+    });
+
+    test("nullish coalescing chain with falsy values", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const a = 0;
+            const b = '';
+            const c = false;
+            const d = null;
+            console.log(a ?? 'A', b ?? 'B', c ?? 'C', d ?? 'D');
+          `,
+        },
+        "index.ts",
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("0  false D");
+    });
+
+    // skip: ES5 class expression(mixin) lowering이 corrupted name 출력 — #1481
+    test.skip("class extends 표현식 (computed class)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const mixin = (Base: any) => class extends Base { extra() { return 'mixin'; } };
+            class P { greet() { return 'hi'; } }
+            class C extends mixin(P) {}
+            const c: any = new C();
+            console.log(c.greet(), c.extra());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("hi mixin");
+    });
   });
 
   describe("미해결 (알려진 한계)", () => {


### PR DESCRIPTION
## 요약

regex \`(?<y>\\d{4})\` 가 ES2017 미지원 타겟에서 positional \`(\\d{4})\` 로 strip 되지만, 같은 호출의 \`String.replace\` replacement 의 \`\$<y>\` 는 그대로 남아 매칭 실패 (literal 출력).

## 변경

### \`regex_lower.zig\`
- \`extractNamedGroupMap(allocator, pattern) → []NamedGroupMapping\` — pattern 한 번 순회로 named group의 (name, capture index) 매핑 추출. non-capture/lookahead/lookbehind 는 카운트 제외.
- \`rewriteReplacementNamedRefs(allocator, content, mapping) → ?[]u8\` — replacement string 의 \`\$<name>\` → \`\$N\` 치환. 변환 없으면 null.

### \`transformer.zig::visitCallExpression\`
- \`regex_named_groups\` 미지원 + \`args_len == 2\` → \`tryRewriteReplaceNamedRefs\` 호출.
- callee 가 \`.replace\`/\`.replaceAll\` static_member_expression, args[0] = regex literal, args[1] = string literal, regex 가 named group 보유 → replacement 변환 후 args[1] 교체.
- 위 조건 미충족 시 null → 기존 경로 그대로.

## 한계 (의도된 fallback)

- dynamic regex (\`new RegExp(...)\`) — 컴파일타임에 named group 매핑 알 수 없음
- template literal replacement (\`\\\`\$<n>\\\`\`) — 단순 string literal 만 지원
- 함수 replacement — 의미 없음 (replacer가 사용자 코드)

## 비교 (issue #1473 기준)

| ZTS (이전) | ZTS (이번) | SWC | Babel |
|---|---|---|---|
| ❌ \`\$<d>/\$<m>/\$<y>\` | ✅ \`15/01/2020\` | ✅ \`15/01/2020\` | ✅ \`15/01/2020\` |

## Test plan

- [x] \`zig build\` + \`zig fmt\`
- [x] 직접 케이스 변환 결과: \`/(\\d{4})-(\\d{2})-(\\d{2})/\` + \`"\$3/\$2/\$1"\` (named index 매핑 정확)
- [x] 전체 통합 테스트 2,468 통과 / 0 fail / 10 skip / 2 todo (regression 없음)

closes #1473