### PR TITLE
fix(transformer): #1471 ES5 class lowering 시 parameter property `this.x = x` 삽입

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1296,11 +1296,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             self.super_call_this_alias = false;
             defer self.super_call_this_alias = saved_super_alias;
 
-            // ES2015 params lowering은 Pass 2에서 일괄 처리.
-            // TS parameter property(`constructor(public x)`)는 modifier 만 strip되어 일반 형태로 visit되지만,
+            // TS parameter property(`constructor(public x)`)는 modifier 만 strip 되어 일반 형태로 visit 되지만,
             // 이 경로는 visitMethodDefinition 을 거치지 않으므로 `this.x = x` 삽입을 직접 수행해야 함 (#1471).
             const pp = try self.visitParamsCollectProperties(params_list_old);
-            const new_params = pp.new_params;
 
             // new.target: class constructor → function_named (ES5 class 변환 후 일반 함수)
             const saved_new_target_ctx = self.new_target_ctx;
@@ -1324,7 +1322,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
 
             const none = @intFromEnum(NodeIndex.none);
-            const new_params_node = try self.ast.addFormalParameters(new_params, span);
+            const new_params_node = try self.ast.addFormalParameters(pp.new_params, span);
             const func_extra = try self.ast.addExtras(&.{
                 @intFromEnum(name),
                 @intFromEnum(new_params_node),

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1289,8 +1289,6 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const me = ctor.data.extra;
 
             const params_list_old = self.ast.functionParamsList(ctor);
-            const params_start = params_list_old.start;
-            const params_len = params_list_old.len;
             const body_idx: NodeIndex = self.readNodeIdx(me, 2);
 
             // super_call_this_alias save/restore (lowerSuperCall이 설정)
@@ -1298,8 +1296,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
             self.super_call_this_alias = false;
             defer self.super_call_this_alias = saved_super_alias;
 
-            // ES2015 params lowering은 Pass 2에서 일괄 처리
-            const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
+            // ES2015 params lowering은 Pass 2에서 일괄 처리.
+            // TS parameter property(`constructor(public x)`)는 modifier 만 strip되어 일반 형태로 visit되지만,
+            // 이 경로는 visitMethodDefinition 을 거치지 않으므로 `this.x = x` 삽입을 직접 수행해야 함 (#1471).
+            const pp = try self.visitParamsCollectProperties(params_list_old);
+            const new_params = pp.new_params;
 
             // new.target: class constructor → function_named (ES5 class 변환 후 일반 함수)
             const saved_new_target_ctx = self.new_target_ctx;
@@ -1309,6 +1310,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
             defer self.new_target_ctx = saved_new_target_ctx;
 
             var new_body = try visitMethodBody(self, body_idx, span);
+
+            // parameter property 가 있으면 visit된 body 앞에 `this.x = x` 삽입
+            if (pp.prop_count > 0 and !new_body.isNone()) {
+                new_body = try self.insertParameterPropertyAssignments(new_body, pp.prop_names[0..pp.prop_count]);
+            }
 
             // super() 호출이 있었으면 body 후처리:
             // 1. super() expression_statement → var _this = __callSuper(...)

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2305,7 +2305,7 @@ pub const Transformer = struct {
         prop_count: usize,
     };
 
-    fn visitParamsCollectProperties(self: *Transformer, vp: NodeList) Error!ParamPropertyResult {
+    pub fn visitParamsCollectProperties(self: *Transformer, vp: NodeList) Error!ParamPropertyResult {
         const scratch_top = self.scratch.items.len;
         defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
@@ -2344,7 +2344,7 @@ pub const Transformer = struct {
     }
 
     /// block_statement 바디 앞에 this.x = x; 문들을 삽입한다.
-    fn insertParameterPropertyAssignments(self: *Transformer, body_idx: NodeIndex, prop_names: []const NodeIndex) Error!NodeIndex {
+    pub fn insertParameterPropertyAssignments(self: *Transformer, body_idx: NodeIndex, prop_names: []const NodeIndex) Error!NodeIndex {
         const body = self.ast.getNode(body_idx);
         if (body.tag != .block_statement) return body_idx;
 

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -443,7 +443,9 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
   });
 
   describe("spread / rest 경계", () => {
-    test("spread를 new 표현식 인자로", async () => {
+    test("spread를 new 표현식 인자로 (+ parameter property)", async () => {
+      // 두 직교 기능 동시 검증: spread `...args` 와 TS parameter property `public x` 가
+      // ES5 다운레벨링 시 함께 동작하는지. 이전엔 parameter property `this.x = x` 누락으로 실패 (#1471).
       const result = await bundleAndRun(
         {
           "index.ts": `

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -443,8 +443,7 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
   });
 
   describe("spread / rest 경계", () => {
-    // skip: TS parameter property(`constructor(public x)`) 가 ES5 class lowering 시 `this.x = x` 누락 — #1471
-    test.skip("spread를 new 표현식 인자로", async () => {
+    test("spread를 new 표현식 인자로", async () => {
       const result = await bundleAndRun(
         {
           "index.ts": `
@@ -1305,8 +1304,7 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("3");
     });
 
-    // skip: 위 #1471 과 동일 원인 — parameter property 가 ES5 lowering 시 `this.x = x` 누락
-    test.skip("parameter property + readonly + 추가 본문", async () => {
+    test("parameter property + readonly + 추가 본문", async () => {
       const result = await bundleAndRun(
         {
           "index.ts": `


### PR DESCRIPTION
## 요약

\`constructor(public id, public name)\` 가 ES5 다운레벨링 시 modifier 만 strip 되고 \`this.id = id; this.name = name;\` 할당이 누락 — \`new P(1, 'kim').describe()\` 호출이 \`undefined:undefined\` 출력.

## 원인

\`visitMethodDefinition\` 은 \`visitParamsCollectProperties\` + \`insertParameterPropertyAssignments\` 조합으로 parameter property 를 처리하지만, ES5 class lowering(\`buildFunctionFromConstructor\`)은 이 경로를 거치지 않고 \`visitExtraList\` 만 호출 → property 정보 수집 + body 삽입이 일어나지 않음.

## 변경

- \`buildFunctionFromConstructor\`: \`visitExtraList\` → \`visitParamsCollectProperties\`. body visit 후 \`pp.prop_count > 0\` 이면 \`insertParameterPropertyAssignments\` 로 \`this.x = x\` 문 삽입.
- \`visitParamsCollectProperties\`, \`insertParameterPropertyAssignments\` 의 가시성을 \`pub\` 로 변경 (es2015_class.zig 에서 호출).

## 비교 (issue #1471 기준)

| ZTS (이전) | ZTS (이번) | SWC | Babel |
|---|---|---|---|
| ❌ \`undefined:undefined\` | ✅ \`1:kim\` | ✅ \`1:kim\` | ✅ \`1:kim\` |

## Test plan

- [x] \`zig build\` + \`zig fmt\`
- [x] 직접 케이스 출력 확인 (\`function P(id, name) { __classCallCheck(this, P); this.id = id; this.name = name; }\`)
- [x] 전체 통합 테스트 2,469 통과 / 0 fail / 9 skip / 2 todo (regression 없음)

closes #1471