### PR TITLE
fix(transformer): `#x **= n` 에 Math.pow 경유 (#1486)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -828,11 +828,17 @@ pub fn ES2015Class(comptime Transformer: type) type {
             if (compoundAssignBaseOp(node.data.binary.flags)) |bin_op| {
                 const get_call = try buildPrivateFieldGetCall(self, mapping, obj_idx, node.span);
                 const new_rhs = try self.visitNode(node.data.binary.right);
-                const computed = try self.ast.addNode(.{
-                    .tag = .binary_expression,
-                    .span = node.span,
-                    .data = .{ .binary = .{ .left = get_call, .right = new_rhs, .flags = bin_op } },
-                });
+                // `**=` + target<es2016: 내부 `**` 도 Math.pow로 lowering해야 함. 일반 binary
+                // 경로를 거치지 않고 여기서 직접 생성 — 그렇지 않으면 `**` 가 그대로 남아
+                // es2015 타겟에서 syntax error (#1486).
+                const computed = if (bin_op == @intFromEnum(token_mod.Kind.star2) and self.options.unsupported.exponentiation)
+                    try es_helpers.makeMathPowCall(self, get_call, new_rhs, node.span)
+                else
+                    try self.ast.addNode(.{
+                        .tag = .binary_expression,
+                        .span = node.span,
+                        .data = .{ .binary = .{ .left = get_call, .right = new_rhs, .flags = bin_op } },
+                    });
                 return buildPrivateFieldSetWithComputedValue(self, mapping, obj_idx, computed, node.span);
             }
 

--- a/src/transformer/es2016.zig
+++ b/src/transformer/es2016.zig
@@ -18,6 +18,7 @@ const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const es_helpers = @import("es_helpers.zig");
 
 pub fn ES2016(comptime Transformer: type) type {
     return struct {
@@ -25,8 +26,7 @@ pub fn ES2016(comptime Transformer: type) type {
         pub fn lowerExponentiation(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const new_left = try self.visitNode(node.data.binary.left);
             const new_right = try self.visitNode(node.data.binary.right);
-
-            return buildMathPowCall(self, node.span, new_left, new_right);
+            return es_helpers.makeMathPowCall(self, new_left, new_right, node.span);
         }
 
         /// `a **= b` → `a = Math.pow(a, b)`
@@ -37,7 +37,7 @@ pub fn ES2016(comptime Transformer: type) type {
             // Math.pow(a, b) — left를 복사해서 callee의 인자로 사용
             const left_copy = try self.ast.addNode(self.ast.getNode(new_left));
             self.copySymbolId(new_left, left_copy);
-            const pow_call = try buildMathPowCall(self, node.span, left_copy, new_right);
+            const pow_call = try es_helpers.makeMathPowCall(self, left_copy, new_right, node.span);
 
             // a = Math.pow(a, b)
             return self.ast.addNode(.{
@@ -48,49 +48,6 @@ pub fn ES2016(comptime Transformer: type) type {
                     .right = pow_call,
                     .flags = @intFromEnum(token_mod.Kind.eq),
                 } },
-            });
-        }
-
-        /// Math.pow(left, right) 호출 노드를 생성.
-        fn buildMathPowCall(self: *Transformer, span: Span, left: NodeIndex, right: NodeIndex) Transformer.Error!NodeIndex {
-            // "Math" 식별자
-            const math_span = try self.ast.addString("Math");
-            const math_node = try self.ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = math_span,
-                .data = .{ .string_ref = math_span },
-            });
-
-            // "pow" 식별자
-            const pow_span = try self.ast.addString("pow");
-            const pow_node = try self.ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = pow_span,
-                .data = .{ .string_ref = pow_span },
-            });
-
-            // Math.pow (static member expression) — extra = [object, property, flags]
-            const member_extra = try self.ast.addExtras(&.{ @intFromEnum(math_node), @intFromEnum(pow_node), 0 });
-            const callee = try self.ast.addNode(.{
-                .tag = .static_member_expression,
-                .span = span,
-                .data = .{ .extra = member_extra },
-            });
-
-            // 인자 리스트: (left, right)
-            const args = try self.ast.addNodeList(&.{ left, right });
-
-            // call_expression: extra = [callee, args_start, args_len, flags]
-            const call_extra = try self.ast.addExtras(&.{
-                @intFromEnum(callee),
-                args.start,
-                args.len,
-                0,
-            });
-            return self.ast.addNode(.{
-                .tag = .call_expression,
-                .span = span,
-                .data = .{ .extra = call_extra },
             });
         }
     };

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -257,6 +257,23 @@ fn makeNullCompare(self: anytype, base: NodeIndex, span: Span, op: token_mod.Kin
     });
 }
 
+/// `Math.pow(left, right)` 호출 노드 생성 — left/right는 이미 visit된(new-AST) 노드.
+/// `**` lowering(es2016) 및 `**=` private field compound 경로에서 공용.
+pub fn makeMathPowCall(self: anytype, left: NodeIndex, right: NodeIndex, span: Span) !NodeIndex {
+    const math_ref = try makeIdentifierRef(self, "Math");
+    const pow_ref = try makeIdentifierRef(self, "pow");
+    const callee = try makeStaticMember(self, math_ref, pow_ref, span);
+    const args = try self.ast.addNodeList(&.{ left, right });
+    const call_extra = try self.ast.addExtras(&.{
+        @intFromEnum(callee), args.start, args.len, 0,
+    });
+    return self.ast.addNode(.{
+        .tag = .call_expression,
+        .span = span,
+        .data = .{ .extra = call_extra },
+    });
+}
+
 /// binding_identifier 노드 생성 (변수 바인딩용).
 /// span은 이미 addString된 이름 span.
 pub fn makeBindingIdentifier(self: anytype, name_span: Span) !NodeIndex {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -309,6 +309,102 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("42");
     });
 
+    test("private field **= Math.pow 경유 (target=es2015)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              #n = 2;
+              static #s = 3;
+              pow(e: number) { this.#n **= e; }
+              static spow(e: number) { C.#s **= e; }
+              get v() { return this.#n; }
+              static get sv() { return C.#s; }
+            }
+            const c = new C(); c.pow(5); C.spow(4);
+            console.log(c.v + "," + C.sv);
+          `,
+        },
+        "index.ts",
+        ["--target=es2015"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("32,81");
+    });
+
+    test("private field **=  target=es2016(supported) `**` 유지", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              #n = 2;
+              pow(e: number) { this.#n **= e; }
+              get v() { return this.#n; }
+            }
+            const c = new C(); c.pow(8);
+            console.log(c.v);
+          `,
+        },
+        "index.ts",
+        ["--target=es2016"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("256");
+    });
+
+    // TODO: private field compound/update가 expression 자리에서 반환하는 값이
+    // spec(`this.#n++` → 이전 값)과 불일치 — `_n.set(this, ...)` 이 WeakMap을 반환해 섞여 나옴.
+    // 별도 이슈 필요 (set 반환값을 _classPrivateFieldSet 헬퍼로 래핑).
+    test.todo("private field ++ 연쇄 expression 사용 시 반환값 정확성");
+
+    test("private field compound + deep template literal 보간", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Tag {
+              #label = "";
+              push(s: string) { this.#label += \`[\${s.toUpperCase()}]\`; }
+              get v() { return this.#label; }
+            }
+            const t = new Tag();
+            t.push("a"); t.push("b"); t.push("c");
+            console.log(t.v);
+          `,
+        },
+        "index.ts",
+        ["--target=es2015"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("[A][B][C]");
+    });
+
+    test("private field ||=/??= 연쇄 nested class 인스턴스 간 격리", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Row {
+              #label: string | null = null;
+              setFirst(s: string) { this.#label ??= s; }
+              setIfTruthy(s: string) { this.#label ||= s; }
+              get v() { return this.#label; }
+            }
+            const r1 = new Row(); const r2 = new Row();
+            r1.setFirst("a"); r1.setFirst("b"); r1.setIfTruthy("c"); // r1=a
+            r2.setIfTruthy("x"); r2.setFirst("y"); r2.setFirst("z"); // r2=x
+            console.log(r1.v + "," + r2.v);
+          `,
+        },
+        "index.ts",
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("a,x");
+    });
+
     test("private method + private field 상호 호출", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary
- target<es2016 에서 private field `**=` 가 `_x.set(this, _x.get(this) ** e)` 처럼 lowering돼 내부 `**` 이 원문으로 남음. ES5/ES2015 런타임에선 파싱 실패.
- 원인: `lowerPrivateFieldSet` 의 compound 경로가 `self.ast.addNode(.binary_expression, ** )` 를 직접 만들고 `es2016` lowering 기회를 주지 않음.
- 수정: compound 경로에서 `bin_op == star2` 이고 `exponentiation` 미지원이면 `Math.pow(get(), rhs)` 로 바로 생성.
- 부수 정리: `es2016.zig` 내부에만 있던 `buildMathPowCall` 을 `es_helpers.makeMathPowCall` 로 추출해 양쪽에서 공용.

## Before / After (target=es2015, private `**=`)
| | pow 메서드 |
|---|---|
| Before | `_n.set(this, _n.get(this) ** e);` → SyntaxError |
| After  | `_n.set(this, Math.pow(_n.get(this), e));` ✓ |

static도 동일(내부 `**` 가 `Math.pow` 로 대체).

## Test plan
- [x] `#n **= e` target=es2015 (instance + static) → Math.pow 경유, `2^5=32`, `3^4=81`
- [x] `#n **= e` target=es2016 (exponentiation 지원) → `**` 유지, `2^8=256`
- [x] `#n += compound + template literal 보간` target=es2015 회귀 없음
- [x] `#n ??=/||=` nested 인스턴스 간 상태 격리 target=es2019 회귀 없음
- [x] downlevel-edge: 104 pass 0 fail
- [x] 통합 테스트 전체 green (watch-stress flaky 1건 제외)

## Follow-up
- `test.todo("private field ++ 연쇄 expression 사용 시 반환값 정확성")` 로 표시한 한계: `_x.set()` 이 WeakMap 반환이라 postfix/prefix 결과값이 spec과 불일치. 별도 이슈 예정(set을 `_classPrivateFieldSet` 스타일 값-반환 헬퍼로 래핑).
- #1485 (destructuring assignment target + private field) 별도 진행 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)