### PR TITLE
fix(transformer): private field assignment expression 반환값 spec 일치 (#1488)

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -491,10 +491,23 @@ pub const STATIC_PRIVATE_FIELD_RUNTIME =
     \\  __classCheckPrivateStaticFieldDescriptor(descriptor, "set");
     \\  if (descriptor.set) descriptor.set.call(receiver, value);
     \\  else descriptor.value = value;
+    \\  return value;
     \\};
     \\
 ;
-pub const STATIC_PRIVATE_FIELD_RUNTIME_MIN = "var __classCheckPrivateStaticAccess=function(receiver,classConstructor){if(receiver!==classConstructor)throw new TypeError(\"Private static access of wrong provenance\")};var __classCheckPrivateStaticFieldDescriptor=function(descriptor,action){if(descriptor===undefined)throw new TypeError(\"attempted to \"+action+\" private static field before its declaration\")};var __classStaticPrivateFieldSpecGet=function(receiver,classConstructor,descriptor){__classCheckPrivateStaticAccess(receiver,classConstructor);__classCheckPrivateStaticFieldDescriptor(descriptor,\"get\");return descriptor.get?descriptor.get.call(receiver):descriptor.value};var __classStaticPrivateFieldSpecSet=function(receiver,classConstructor,descriptor,value){__classCheckPrivateStaticAccess(receiver,classConstructor);__classCheckPrivateStaticFieldDescriptor(descriptor,\"set\");if(descriptor.set)descriptor.set.call(receiver,value);else descriptor.value=value};";
+pub const STATIC_PRIVATE_FIELD_RUNTIME_MIN = "var __classCheckPrivateStaticAccess=function(receiver,classConstructor){if(receiver!==classConstructor)throw new TypeError(\"Private static access of wrong provenance\")};var __classCheckPrivateStaticFieldDescriptor=function(descriptor,action){if(descriptor===undefined)throw new TypeError(\"attempted to \"+action+\" private static field before its declaration\")};var __classStaticPrivateFieldSpecGet=function(receiver,classConstructor,descriptor){__classCheckPrivateStaticAccess(receiver,classConstructor);__classCheckPrivateStaticFieldDescriptor(descriptor,\"get\");return descriptor.get?descriptor.get.call(receiver):descriptor.value};var __classStaticPrivateFieldSpecSet=function(receiver,classConstructor,descriptor,value){__classCheckPrivateStaticAccess(receiver,classConstructor);__classCheckPrivateStaticFieldDescriptor(descriptor,\"set\");if(descriptor.set)descriptor.set.call(receiver,value);else descriptor.value=value;return value};";
+
+/// __classPrivateFieldSet: instance private field 쓰기 + 값 반환.
+/// `wm.set(obj, value)` 는 WeakMap을 반환하므로 expression 값이 값 자체가 되도록 helper 사용.
+/// 통합 spec: `this.#x = v` expression value === v, `this.#x += 5` === new value.
+pub const PRIVATE_FIELD_SET_RUNTIME =
+    \\var __classPrivateFieldSet = function(wm, obj, value) {
+    \\  wm.set(obj, value);
+    \\  return value;
+    \\};
+    \\
+;
+pub const PRIVATE_FIELD_SET_RUNTIME_MIN = "var __classPrivateFieldSet=function(wm,obj,value){wm.set(obj,value);return value};";
 
 // ============================================================
 // HMR (Dev Server)
@@ -815,6 +828,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
     if (helpers.class_static_private_field) {
         try buf.appendSlice(allocator, if (minify) STATIC_PRIVATE_FIELD_RUNTIME_MIN else STATIC_PRIVATE_FIELD_RUNTIME);
+    }
+    if (helpers.class_private_field_set) {
+        try buf.appendSlice(allocator, if (minify) PRIVATE_FIELD_SET_RUNTIME_MIN else PRIVATE_FIELD_SET_RUNTIME);
     }
     if (helpers.call_super) {
         try buf.appendSlice(allocator, if (minify) CALL_SUPER_RUNTIME_MIN else CALL_SUPER_RUNTIME);

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1542,9 +1542,10 @@ test "ES2015: class private field WeakMap" {
 }
 
 test "ES2015: class private field set" {
+    // #1488: wm.set 은 WeakMap을 반환하므로 expression 값이 value가 되도록 helper 경유.
     var r = try e2eTarget(std.testing.allocator, "class F{#x=0;s(v){this.#x=v;}}", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "_x.set(this,v)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateFieldSet(_x,this,v)") != null);
 }
 
 // --- class static private field ---

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -826,9 +826,11 @@ test "#1275: private method + field 혼합 (RN PerformanceObserver 케이스)" {
     // private method도 변환됨
     try std.testing.expect(std.mem.indexOf(u8, r.output, "var _createObserver=new WeakSet") != null);
     // ctor 안에 field init + method init + 원본 body가 모두 포함
+    // field init은 expression_statement 형태라 내부 값 반환 불필요 → _x.set 그대로 유지.
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_nativeHandle.set(this,null)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodInit(this,_createObserver)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "_callback.set(this,callback)") != null);
+    // this.#callback = callback 은 assignment_expression → expression value 반환 helper 경유 (#1488).
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateFieldSet(_callback,this,callback)") != null);
 }
 
 test "#1275: private method만 있고 원본 constructor 없을 때 새 constructor 1개 생성" {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -794,6 +794,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
         /// private field용 set 호출 생성 — new_value는 이미 완성된(new-AST) 노드여야 함.
         /// obj_idx는 old AST 노드로, 내부에서 visit 수행.
+        /// instance는 `__classPrivateFieldSet` helper, static은 수정된 spec helper 모두 value를 반환 (#1488).
         fn buildPrivateFieldSetWithComputedValue(self: *Transformer, mapping: Transformer.PrivateFieldMapping, obj_idx: NodeIndex, new_value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             if (mapping.is_static) {
                 const helper = try es_helpers.makeIdentifierRef(self, "__classStaticPrivateFieldSpecSet");
@@ -803,11 +804,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 self.runtime_helpers.class_static_private_field = true;
                 return es_helpers.makeCallExpr(self, helper, &.{ new_obj, class_ref, desc_ref, new_value }, span);
             }
+            const helper = try es_helpers.makeIdentifierRef(self, "__classPrivateFieldSet");
             const wm_ref = try es_helpers.makeIdentifierRef(self, mapping.var_name);
-            const set_prop = try es_helpers.makeIdentifierRef(self, "set");
-            const callee = try es_helpers.makeStaticMember(self, wm_ref, set_prop, span);
             const new_obj = try self.visitNode(obj_idx);
-            return es_helpers.makeCallExpr(self, callee, &.{ new_obj, new_value }, span);
+            self.runtime_helpers.class_private_field_set = true;
+            return es_helpers.makeCallExpr(self, helper, &.{ wm_ref, new_obj, new_value }, span);
         }
 
         /// this.#x = v → instance: _x.set(this, v), static: __classStaticPrivateFieldSpecSet(receiver, ClassName, _x, v)
@@ -842,10 +843,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 return buildPrivateFieldSetWithComputedValue(self, mapping, obj_idx, computed, node.span);
             }
 
-            if (mapping.is_static) {
-                return buildStaticPrivateFieldSet(self, mapping, obj_idx, node.data.binary.right, node.span);
-            }
-            return buildWeakMapCall(self, mapping.var_name, "set", obj_idx, &.{node.data.binary.right}, node.span);
+            // plain `=` : right를 visit한 뒤 buildPrivateFieldSetWithComputedValue 경유 —
+            // instance(__classPrivateFieldSet) / static(__classStaticPrivateFieldSpecSet)
+            // 모두 value를 반환해 expression semantic 일치 (#1488).
+            const new_rhs = try self.visitNode(node.data.binary.right);
+            return buildPrivateFieldSetWithComputedValue(self, mapping, obj_idx, new_rhs, node.span);
         }
 
         /// `this.#x ??=/||=/&&= v` lowering.
@@ -889,10 +891,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
         }
 
-        /// this.#x++ / --  →  _x.set(this, _x.get(this) + 1)  / - 1
-        /// static: ClassName.#x++ → __classStaticPrivateFieldSpecSet(ClassName, ClassName, _x, get(...) + 1)
-        /// postfix/prefix 동일한 결과(새 값)로 lowering — expression 사용 시 postfix 원래 값 반환 못함.
-        /// 현재 instance 경로도 같은 한계이며 #1468 범위 밖이라 동일하게 둠.
+        /// prefix  ++this.#x → set(get() + 1)   (expression 값 = 새 값)
+        /// postfix this.#x++  → (_t = get(), set(_t + 1), _t)   (expression 값 = 이전 값)
+        /// op_flags 의 0x100 비트가 postfix 표시 (parser/expression.zig 참고).
         pub fn lowerPrivateFieldUpdate(self: *Transformer, operand: Node, op_flags: u32, span: Span) ?Transformer.Error!NodeIndex {
             const oe = operand.data.extra;
             if (oe + 1 >= self.ast.extra_data.items.len) return null;
@@ -901,8 +902,46 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             const op_kind = op_flags & 0xFF;
             const is_increment = (op_kind == @intFromEnum(token_mod.Kind.plus2));
+            const is_postfix = (op_flags & 0x100) != 0;
             const bin_op: u16 = if (is_increment) @intFromEnum(token_mod.Kind.plus) else @intFromEnum(token_mod.Kind.minus);
 
+            if (is_postfix) {
+                const scratch_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+                const temp_span = try es_helpers.makeTempVarSpan(self);
+                // _t = get()
+                const get_call = try buildPrivateFieldGetCall(self, mapping, obj_idx, span);
+                const tmp_ref_lhs = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
+                const init_assign = try self.ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = tmp_ref_lhs, .right = get_call, .flags = @intFromEnum(token_mod.Kind.eq) } },
+                });
+                try self.scratch.append(self.allocator, init_assign);
+                // set(_t + 1)
+                const tmp_ref_read = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
+                const one = try es_helpers.makeNumericLiteral(self, 1);
+                const computed = try self.ast.addNode(.{
+                    .tag = .binary_expression,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = tmp_ref_read, .right = one, .flags = bin_op } },
+                });
+                const set_call = try buildPrivateFieldSetWithComputedValue(self, mapping, obj_idx, computed, span);
+                try self.scratch.append(self.allocator, set_call);
+                // _t (최종 expression 값)
+                try self.scratch.append(self.allocator, try es_helpers.makeTempVarRef(self, temp_span, temp_span));
+
+                const seq_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+                const seq = try self.ast.addNode(.{
+                    .tag = .sequence_expression,
+                    .span = span,
+                    .data = .{ .list = seq_list },
+                });
+                return es_helpers.makeParenExpr(self, seq, span);
+            }
+
+            // prefix: set(get() + 1) — expression 값이 새 값이라 세팅 결과 그대로 사용
             const get_call = try buildPrivateFieldGetCall(self, mapping, obj_idx, span);
             const one = try es_helpers.makeNumericLiteral(self, 1);
             const computed = try self.ast.addNode(.{

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -173,7 +173,9 @@ pub const RuntimeHelpers = packed struct(u32) {
     es_decorator: bool = false,
     /// __asyncValues: for-await-of → while 루프 변환 (ES2018)
     async_values: bool = false,
-    _padding: u15 = 0,
+    /// __classPrivateFieldSet: instance private field set with return value (#1488).
+    class_private_field_set: bool = false,
+    _padding: u14 = 0,
 };
 
 /// 단일 AST append-only 변환기.

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -354,10 +354,80 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("256");
     });
 
-    // TODO: private field compound/update가 expression 자리에서 반환하는 값이
-    // spec(`this.#n++` → 이전 값)과 불일치 — `_n.set(this, ...)` 이 WeakMap을 반환해 섞여 나옴.
-    // 별도 이슈 필요 (set 반환값을 _classPrivateFieldSet 헬퍼로 래핑).
-    test.todo("private field ++ 연쇄 expression 사용 시 반환값 정확성");
+    test("private field assignment expression 반환값 spec 일치 (#1488)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              #n = 0;
+              static #s = 0;
+              inc() { return this.#n++; }              // spec: 0 (이전 값)
+              pre() { return ++this.#n; }               // spec: 2
+              compound() { return (this.#n += 5); }     // spec: 7
+              plain() { return (this.#n = 100); }       // spec: 100
+              static sinc() { return C.#s++; }          // static postfix
+              static spre() { return ++C.#s; }
+            }
+            const c = new C();
+            const r = [c.inc(), c.pre(), c.compound(), c.plain(), C.sinc(), C.spre()];
+            console.log(r.join(","));
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("0,2,7,100,0,2");
+    });
+
+    test("private field logical assign 반환값 (Babel 호환, #1488)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              #v: number | null = null;
+              init(n: number) { const r = (this.#v ??= n); return r; }
+              orSet(n: number) { return (this.#v ||= n); }
+              andMul(n: number) { return (this.#v &&= (this.#v as number) * n); }
+            }
+            const c = new C();
+            const a = c.init(10);   // null → 10, return 10
+            const b = c.init(99);    // 10 유지, return 10
+            const d = c.orSet(7);    // truthy 유지, return 10
+            const e = c.andMul(3);   // 10 * 3 = 30, return 30
+            console.log(a + "," + b + "," + d + "," + e);
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("10,10,10,30");
+    });
+
+    test("private field postfix++ sequence 안에서 연쇄 사용", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              #n = 0;
+              step() { return this.#n++ + this.#n++ + this.#n; }
+              get v() { return this.#n; }
+            }
+            const c = new C();
+            const s = c.step();       // 0 + 1 + 2 = 3, final v = 2
+            console.log(s + "," + c.v);
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("3,2");
+    });
 
     test("private field compound + deep template literal 보간", async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
## Summary
\`this.#n = v\` / \`+= 5\` / \`++\` 등이 expression 자리에서 WeakMap을 반환해(`Map.prototype.set` 반환값) spec과 전혀 다른 결과를 만드는 버그 수정. Babel / SWC의 \`_classPrivateFieldSet\` 스타일 helper 도입.

## Before → After (target=es2020)

입력:
\`\`\`ts
class C {
  #n = 0;
  inc() { return this.#n++; }
  pre() { return ++this.#n; }
  compound() { return (this.#n += 5); }
  plain() { return (this.#n = 100); }
}
console.log([c.inc(), c.pre(), c.compound(), c.plain()].join(","));
\`\`\`

| | 결과 |
|---|---|
| Before | `[object WeakMap],[object WeakMap],[object WeakMap],[object WeakMap]` |
| After (zts, Babel 일치) | `0,2,7,100` |

## 구현
- `runtime_helpers`:
  - `__classPrivateFieldSet(wm, obj, value)` 추가 — `wm.set(obj, value); return value;`
  - `__classStaticPrivateFieldSpecSet` 에 `return value` 추가
- `transformer`: `class_private_field_set: bool` 플래그 추가
- `es2015_class`:
  - `buildPrivateFieldSetWithComputedValue` 가 instance/static 모두 helper 경유
  - `lowerPrivateFieldSet` 의 plain `=` 경로도 helper 통해 반환
  - `lowerPrivateFieldUpdate` postfix(op_flags의 `0x100` 비트) → `(_t = get(), set(_t + 1), _t)` sequence
  - prefix 는 기존대로 `set(get() + 1)` (expression 값 = 새 값)
- 기존 단위 테스트 2건 assertion 업데이트 (new helper pattern 기대)

## Test plan
- [x] plain/postfix/prefix/compound 각각 spec 값 반환 (instance+static)
- [x] logical ??=/||=/&&= 반환값 일치
- [x] postfix sequence 안 연쇄 (`a++ + a++ + a`)
- [x] `zig build test` 전부 통과 (3014 tests)
- [x] 통합 downlevel-edge 107 pass 0 fail
- [x] 전체 통합 2983 pass (watch-stress flaky 1건 무관)

## 파급 효과
static private field의 set도 이제 값을 반환하므로 `__classStaticPrivateFieldSpecSet` helper 시그니처가 미묘하게 변함(호환성 유지: 반환값은 undefined였다가 value 반환). 기존 함수 시그니처 호환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)