### PR TITLE
fix(transformer): destructuring target에 private field 허용 (#1485)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -792,6 +792,46 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return buildWeakMapCall(self, mapping.var_name, "get", obj_idx, &.{}, span);
         }
 
+        /// target이 private_field_expression이면 set 호출 생성(instance/static 자동 분기). 해당 없으면 null.
+        /// destructuring assignment에서 `this.#x` 가 target일 때 `_x.get(this) = v` 같은 잘못된 target을
+        /// 만들지 않도록 set 호출로 직접 변환 (#1485). value는 이미 변환된(new-AST) 노드여야 함.
+        pub fn tryLowerPrivateFieldAssign(self: *Transformer, target_old_idx: NodeIndex, value: NodeIndex, span: Span) Transformer.Error!?NodeIndex {
+            if (target_old_idx.isNone()) return null;
+            const target_node = self.ast.getNode(target_old_idx);
+            if (target_node.tag != .private_field_expression) return null;
+            const te = target_node.data.extra;
+            if (te >= self.ast.extra_data.items.len) return null;
+            const obj_idx = self.readNodeIdx(te, 0);
+            const mapping = findPrivateFieldMapping(self, self.readNodeIdx(te, 1)) orelse return null;
+            return try buildPrivateFieldSetWithComputedValue(self, mapping, obj_idx, value, span);
+        }
+
+        /// destructuring assignment target 트리 안에 private_field_expression이 포함됐는지 검사.
+        /// transformer 디스패처가 강제 destructuring lowering 여부 판정할 때 사용 (#1485).
+        pub fn destructuringTargetHasPrivateField(self: *const Transformer, node_idx: NodeIndex) bool {
+            if (node_idx.isNone()) return false;
+            const node = self.ast.getNode(node_idx);
+            return switch (node.tag) {
+                .private_field_expression => true,
+                .object_assignment_target, .array_assignment_target => blk: {
+                    const start = node.data.list.start;
+                    const len = node.data.list.len;
+                    var i: u32 = 0;
+                    while (i < len) : (i += 1) {
+                        const child_raw = self.ast.extra_data.items[start + i];
+                        const child_idx: NodeIndex = @enumFromInt(child_raw);
+                        if (destructuringTargetHasPrivateField(self, child_idx)) break :blk true;
+                    }
+                    break :blk false;
+                },
+                // assignment_target_property_property: binary {left=key, right=target} — target에만 있음.
+                // assignment_target_with_default: binary {left=target, right=default} — target에만 있음.
+                .assignment_target_property_property => destructuringTargetHasPrivateField(self, node.data.binary.right),
+                .assignment_target_with_default => destructuringTargetHasPrivateField(self, node.data.binary.left),
+                else => false,
+            };
+        }
+
         /// private field용 set 호출 생성 — new_value는 이미 완성된(new-AST) 노드여야 함.
         /// obj_idx는 old AST 노드로, 내부에서 visit 수행.
         /// instance는 `__classPrivateFieldSet` helper, static은 수정된 spec helper 모두 value를 반환 (#1488).

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -26,6 +26,7 @@ const Tag = Node.Tag;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
+const es2015_class = @import("es2015_class.zig");
 
 pub fn ES2015Destructuring(comptime Transformer: type) type {
     return struct {
@@ -224,23 +225,11 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     const right_node = self.ast.getNode(right_idx);
 
                     if (right_node.tag == .assignment_target_with_default) {
-                        const target_node = try self.visitNode(right_node.data.binary.left);
                         const default_val = try self.visitNode(right_node.data.binary.right);
                         const rhs = try buildDefaulted(self, access, default_val, ref_span, key_idx, key_node.tag, span);
-                        const assign = try self.ast.addNode(.{
-                            .tag = .assignment_expression,
-                            .span = span,
-                            .data = .{ .binary = .{ .left = target_node, .right = rhs, .flags = 0 } },
-                        });
-                        try self.scratch.append(self.allocator, assign);
+                        try emitTargetAssignOrRecurse(self, right_node.data.binary.left, rhs, span);
                     } else {
-                        const target_node = try self.visitNode(right_idx);
-                        const assign = try self.ast.addNode(.{
-                            .tag = .assignment_expression,
-                            .span = span,
-                            .data = .{ .binary = .{ .left = target_node, .right = access, .flags = 0 } },
-                        });
-                        try self.scratch.append(self.allocator, assign);
+                        try emitTargetAssignOrRecurse(self, right_idx, access, span);
                     }
                 }
             }
@@ -265,7 +254,6 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
                 if (elem.tag == .assignment_target_with_default) {
                     // [x = 1] → x = _ref[0] === void 0 ? 1 : _ref[0]
-                    const target_node = try self.visitNode(elem.data.binary.left);
                     const default_val = try self.visitNode(elem.data.binary.right);
                     const void_zero = try es_helpers.makeVoidZero(self, span);
                     const eq_check = try self.ast.addNode(.{
@@ -280,23 +268,49 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         .span = span,
                         .data = .{ .ternary = .{ .a = eq_check, .b = default_val, .c = access2 } },
                     });
-                    const assign = try self.ast.addNode(.{
-                        .tag = .assignment_expression,
-                        .span = span,
-                        .data = .{ .binary = .{ .left = target_node, .right = conditional, .flags = 0 } },
-                    });
-                    try self.scratch.append(self.allocator, assign);
+                    try emitTargetAssignOrRecurse(self, elem.data.binary.left, conditional, span);
                 } else {
-                    // target = _ref[idx]
-                    const target_node = try self.visitNode(@enumFromInt(raw_idx));
-                    const assign = try self.ast.addNode(.{
-                        .tag = .assignment_expression,
-                        .span = span,
-                        .data = .{ .binary = .{ .left = target_node, .right = access, .flags = 0 } },
-                    });
-                    try self.scratch.append(self.allocator, assign);
+                    // target = _ref[idx]. nested destructuring, private field, 일반 assignment 분기.
+                    try emitTargetAssignOrRecurse(self, @enumFromInt(raw_idx), access, span);
                 }
             }
+        }
+
+        /// target(old AST)에 value(new AST)를 배정. target 종류에 따라 분기:
+        ///   - private_field_expression → `__classPrivateFieldSet(...)` (#1485).
+        ///   - object/array_assignment_target → 임시 변수 + 재귀 emit (nested destructuring).
+        ///   - 나머지 (identifier, member expr 등) → 일반 `target = value` assignment.
+        /// 생성된 표현식은 self.scratch 에 push된다 (lowerDestructuringAssignment 패턴 유지).
+        fn emitTargetAssignOrRecurse(self: *Transformer, target_old_idx: NodeIndex, value: NodeIndex, span: Span) Transformer.Error!void {
+            if (try es2015_class.ES2015Class(Transformer).tryLowerPrivateFieldAssign(self, target_old_idx, value, span)) |call| {
+                try self.scratch.append(self.allocator, call);
+                return;
+            }
+            const target_node = self.ast.getNode(target_old_idx);
+            if (target_node.tag == .object_assignment_target or target_node.tag == .array_assignment_target) {
+                // nested: _inner = value; 각 element 재귀 emit.
+                const inner_span = try es_helpers.makeTempVarSpan(self);
+                const inner_lhs = try es_helpers.makeTempVarRef(self, inner_span, inner_span);
+                const init = try self.ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = inner_lhs, .right = value, .flags = 0 } },
+                });
+                try self.scratch.append(self.allocator, init);
+                if (target_node.tag == .object_assignment_target) {
+                    try emitObjectAssignments(self, target_node, inner_span, span);
+                } else {
+                    try emitArrayAssignments(self, target_node, inner_span, span);
+                }
+                return;
+            }
+            const visited_target = try self.visitNode(target_old_idx);
+            const assign = try self.ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = visited_target, .right = value, .flags = 0 } },
+            });
+            try self.scratch.append(self.allocator, assign);
         }
 
         /// object_pattern 또는 array_pattern을 개별 declarator로 분해.

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -71,12 +71,28 @@ pub fn tempVarName(idx: u32, buf: *[16]u8) []const u8 {
 }
 
 /// 임시 변수명 생성: _a, _b, _c, ..., _a2, _b2, ...
+/// private field var 이름(`#name` → `_name`)과 충돌하면 다음 이름으로 건너뜀.
+/// 같은 letter 끝자는 해시 충돌 가능하므로 #1485 수정의 일환으로 회피 로직 추가.
 pub fn makeTempVarSpan(self: anytype) !Span {
-    const idx = self.temp_var_counter;
-    self.temp_var_counter += 1;
     var buf: [16]u8 = undefined;
-    const name = tempVarName(idx, &buf);
-    return self.ast.addString(name);
+    while (true) {
+        const idx = self.temp_var_counter;
+        self.temp_var_counter += 1;
+        const name = tempVarName(idx, &buf);
+        if (collidesWithPrivateField(self, name)) continue;
+        return self.ast.addString(name);
+    }
+}
+
+fn collidesWithPrivateField(self: anytype, name: []const u8) bool {
+    for (self.current_private_fields) |pf| {
+        if (std.mem.eql(u8, pf.var_name, name)) return true;
+    }
+    for (self.current_private_methods) |pm| {
+        if (std.mem.eql(u8, pm.weakset_name, name)) return true;
+        if (std.mem.eql(u8, pm.func_name, name)) return true;
+    }
+    return false;
 }
 
 /// 임시 변수 identifier_reference 노드 생성.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -845,13 +845,19 @@ pub const Transformer = struct {
                         return es2021.ES2021(Transformer).lowerLogicalAssignment(self, node, .amp2);
                     }
                 }
-                // ES2015: assignment destructuring → sequence expression
-                if (self.options.unsupported.destructuring) {
+                // ES2015: assignment destructuring → sequence expression.
+                // destructuring 자체가 지원되더라도 target에 private field가 있으면 강제 lowering —
+                // 일반 visit 경로가 `this.#x` 를 `_x.get(this)` 로 만들어 invalid assignment target이 됨 (#1485).
+                {
                     const left_idx = node.data.binary.left;
                     if (!left_idx.isNone()) {
                         const left_node = self.ast.getNode(left_idx);
                         if (left_node.tag == .object_assignment_target or left_node.tag == .array_assignment_target) {
-                            return es2015_destructuring.ES2015Destructuring(Transformer).lowerDestructuringAssignment(self, node);
+                            const has_private = self.current_private_fields.len > 0 and
+                                es2015_class.ES2015Class(Transformer).destructuringTargetHasPrivateField(self, left_idx);
+                            if (self.options.unsupported.destructuring or has_private) {
+                                return es2015_destructuring.ES2015Destructuring(Transformer).lowerDestructuringAssignment(self, node);
+                            }
                         }
                     }
                 }

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -475,6 +475,96 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("a,x");
     });
 
+    test("destructuring assignment target이 private field (#1485)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class M {
+              #a = 0; #b = 0;
+              static #s = 0;
+              setMulti(obj: any) { ({a: this.#a, b: this.#b} = obj); }
+              setWithDefault(obj: any) { ({a: this.#a = 100} = obj); }
+              setArr(arr: any) { [this.#a, this.#b] = arr; }
+              setArrDefault(arr: any) { [this.#a = 1, this.#b = 2] = arr; }
+              setNested(obj: any) { ({x: {y: this.#a}} = obj); }
+              static setStatic(v: any) { ({s: M.#s} = v); }
+              get va() { return this.#a; }
+              get vb() { return this.#b; }
+              static get vs() { return M.#s; }
+            }
+            const m = new M();
+            m.setMulti({a: 1, b: 2});
+            const r1 = [m.va, m.vb];
+            m.setWithDefault({});
+            const r2 = m.va;
+            m.setWithDefault({a: 5});
+            const r3 = m.va;
+            m.setArr([7, 8]);
+            const r4 = [m.va, m.vb];
+            m.setArrDefault([undefined, undefined]);
+            const r5 = [m.va, m.vb];
+            m.setNested({x: {y: 42}});
+            const r6 = m.va;
+            M.setStatic({s: 99});
+            const r7 = M.vs;
+            console.log([...r1, r2, r3, ...r4, ...r5, r6, r7].join(","));
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1,2,100,5,7,8,1,2,42,99");
+    });
+
+    test("destructuring target private field target=es5 (destructuring lowered) (#1485)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              #x = 0;
+              set(v: number) { ({x: this.#x} = {x: v}); }
+              get v() { return this.#x; }
+            }
+            const c = new C();
+            c.set(42);
+            console.log(c.v);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("42");
+    });
+
+    test("temp var가 private field 이름과 충돌하지 않음 (#1485)", async () => {
+      // 기존 `_a` temp 이름 vs `#a` → `_a` private var 충돌 회귀.
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              #a = 0; #b = 0; #c = 0; #d = 0;
+              swap(obj: {a: number; b: number; c: number; d: number}) {
+                ({a: this.#a, b: this.#b, c: this.#c, d: this.#d} = obj);
+              }
+              sum() { return this.#a + this.#b + this.#c + this.#d; }
+            }
+            const c = new C();
+            c.swap({a: 1, b: 2, c: 3, d: 4});
+            console.log(c.sum());
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("10");
+    });
+
     test("private method + private field 상호 호출", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary
\`({x: this.#y} = obj)\` 같은 destructuring assignment target에 private field가 오면 \`_y.get(this) = value\` 형태의 invalid assignment target이 생성돼 parse 에러. visitor가 private field를 RVAL로만 변환하던 것이 원인.

## 구조적 수정 (Babel/SWC 플러그인 순서 동일)
1. \`transformer.zig\`: \`.assignment_expression\` dispatcher — destructuring target에 private field가 있으면 destructuring 자체가 지원되는 타겟(=es2020)이어도 강제 lowering.
2. \`es2015_class.zig\`: 공개 헬퍼 2개 추가
   - \`tryLowerPrivateFieldAssign(target, value, span)\` → private field target이면 \`__classPrivateFieldSet(...)\` 경유.
   - \`destructuringTargetHasPrivateField(node)\` → dispatcher의 강제 lowering 판정용.
3. \`es2015_destructuring.zig\`: \`emitTargetAssignOrRecurse\` 추출 — private field / nested destructuring / 일반 assignment 3분기.
4. \`es_helpers.zig:makeTempVarSpan\`: private field var 이름과 충돌하는 letter 건너뜀 (\`#a\` 필드 있으면 \`_a\` temp 건너뛰고 \`_c\` 부터 사용). 이 충돌로 \`wm.set is not a function\` 런타임 에러 발생하던 부작용 수정.

## Before / After (target=es2020)

\`\`\`ts
setObj(v) { ({x: this.#x} = {x: v}); }
\`\`\`

| | 출력 |
|---|---|
| Before | \`({ x:_x.get(this) } = { x: v });\` → SyntaxError |
| After | \`(_a = {x: v}, __classPrivateFieldSet(_x, this, _a.x), _a);\` ✓ |

## 처리 케이스 (테스트 포함)
- [x] \`{a: this.#a, b: this.#b} = obj\` (multi-field)
- [x] \`{a: this.#a = default} = obj\` (shorthand with default)
- [x] \`[this.#a, this.#b] = arr\` (array)
- [x] \`[this.#a = 1, this.#b = 2] = arr\` (array with default)
- [x] \`{x: {y: this.#a}} = obj\` (nested object)
- [x] \`{s: M.#s} = v\` (static)
- [x] 4-field (\`#a, #b, #c, #d\`) + destructuring — temp var collision 회귀 방지

## Test plan
- [x] 3건 신규 엣지 테스트 통과
- [x] downlevel-edge 110 pass 0 fail
- [x] zig build test 전부 통과
- [x] 통합 테스트 전체 green (watch-stress flaky 무관)

## Follow-up
- destructuring declaration(`var {a} = obj`)에서 private field 타겟은 문법적으로 불가능(`#a`는 반드시 `this.#a` 또는 `ClassName.#x`)이라 별도 처리 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)