### PR TITLE
fix(transformer): derived class constructor에서 private field init을 super() 이후에 삽입 (#1495)

### DIFF
--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -132,7 +132,7 @@ pub fn ES2022(comptime Transformer: type) type {
         // ================================================================
 
         /// method_definition의 body 앞에 문들을 삽입하여 새 method_definition 반환.
-        fn injectIntoMethod(self: *Transformer, method_node_idx: NodeIndex, stmts: []const NodeIndex) Transformer.Error!NodeIndex {
+        fn injectIntoMethod(self: *Transformer, method_node_idx: NodeIndex, stmts: []const NodeIndex, has_super: bool) Transformer.Error!NodeIndex {
             const node = self.ast.getNode(method_node_idx);
             const extras = self.ast.extra_data.items;
             const me = node.data.extra;
@@ -145,7 +145,12 @@ pub fn ES2022(comptime Transformer: type) type {
             const saved_deco_len = extras[me + 5];
             const body_idx: NodeIndex = @enumFromInt(extras[me + 2]);
 
-            const new_body = try self.prependStatementsToBody(body_idx, stmts);
+            // derived class면 private field/method init 이 반드시 super() 뒤에 와야 함 (#1495).
+            // this 참조(WeakMap.set 의 첫 인자) 가 super() 호출 전에는 ReferenceError.
+            const new_body = if (has_super)
+                try self.insertStatementsAfterSuper(body_idx, stmts)
+            else
+                try self.prependStatementsToBody(body_idx, stmts);
 
             const new_me = try self.ast.addExtras(&.{
                 saved_key,              saved_params,
@@ -333,7 +338,7 @@ pub fn ES2022(comptime Transformer: type) type {
             // ctor 주입: 기존 constructor에 prepend, 없으면 새로 생성.
             if (ctor_init_stmts.items.len > 0) {
                 if (ctor_pos) |pos| {
-                    body_nodes.items[pos] = try injectIntoMethod(self, body_nodes.items[pos], ctor_init_stmts.items);
+                    body_nodes.items[pos] = try injectIntoMethod(self, body_nodes.items[pos], ctor_init_stmts.items, has_super);
                 } else {
                     const ctor = try buildNewConstructor(self, ctor_init_stmts.items, has_super, span);
                     try body_nodes.insert(self.allocator, 0, ctor);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2877,6 +2877,54 @@ pub const Transformer = struct {
     }
 
     /// block_statement / program / function_body 앞에 문들을 삽입한다.
+    /// body의 첫 super() 호출 이후 위치에 stmts 삽입 — derived class constructor 전용 (#1495).
+    /// super_call이 없으면 body 앞에 prepend (fallback). body가 block이 아니면 block으로 감싼 뒤 처리.
+    pub fn insertStatementsAfterSuper(self: *Transformer, body_idx: NodeIndex, stmts: []const NodeIndex) Error!NodeIndex {
+        const body = self.ast.getNode(body_idx);
+        if (body.tag != .block_statement and body.tag != .function_body) {
+            return self.prependStatementsToBody(body_idx, stmts);
+        }
+        const old_list = body.data.list;
+        const old_stmts_start = old_list.start;
+        const old_stmts_len = old_list.len;
+        const old_stmts = self.ast.extra_data.items[old_stmts_start .. old_stmts_start + old_stmts_len];
+
+        // super() 호출이 들어있는 expression_statement 찾기.
+        var super_idx: ?u32 = null;
+        for (old_stmts, 0..) |raw_idx, i| {
+            const stmt = self.ast.getNode(@enumFromInt(raw_idx));
+            if (stmt.tag != .expression_statement) continue;
+            const operand = stmt.data.unary.operand;
+            if (operand.isNone()) continue;
+            const call = self.ast.getNode(operand);
+            if (call.tag != .call_expression) continue;
+            const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[call.data.extra]);
+            const callee = self.ast.getNode(callee_idx);
+            if (callee.tag == .super_expression) {
+                super_idx = @intCast(i);
+                break;
+            }
+        }
+
+        if (super_idx == null) return self.prependStatementsToBody(body_idx, stmts);
+
+        const scratch_top = self.scratch.items.len;
+        defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+        // [0..super_idx] + super() + stmts + [super_idx+1..]
+        const cut: u32 = super_idx.? + 1;
+        for (old_stmts[0..cut]) |raw_idx| try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+        for (stmts) |stmt| try self.scratch.append(self.allocator, stmt);
+        for (old_stmts[cut..]) |raw_idx| try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+
+        const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+        return self.ast.addNode(.{
+            .tag = body.tag,
+            .span = body.span,
+            .data = .{ .list = new_list },
+        });
+    }
+
     pub fn prependStatementsToBody(self: *Transformer, body_idx: NodeIndex, stmts: []const NodeIndex) Error!NodeIndex {
         const body = self.ast.getNode(body_idx);
         if (body.tag != .block_statement and body.tag != .program and body.tag != .function_body) {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -586,6 +586,58 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("9");
     });
 
+    test("derived class constructor — private field init이 super() 이후 (#1495)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base {
+              baseVal: number;
+              constructor(v: number) { this.baseVal = v; }
+            }
+            class Derived extends Base {
+              #priv = 100;
+              #priv2 = 200;
+              constructor() {
+                super(10);
+                this.logInit();
+              }
+              logInit() { console.log(this.baseVal + "+" + this.#priv + "+" + this.#priv2); }
+            }
+            new Derived();
+          `,
+        },
+        "index.ts",
+        ["--target=es2015"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("10+100+200");
+    });
+
+    test("derived class — constructor body 앞에 사용자 statement + super() (#1495)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class P { constructor(public x: number) {} }
+            class D extends P {
+              #y = 42;
+              constructor() {
+                const a = 5;
+                super(a);
+                console.log(this.x, this.#y);
+              }
+            }
+            new D();
+          `,
+        },
+        "index.ts",
+        ["--target=es2015"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("5 42");
+    });
+
     test("private method + private field 상호 호출", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary
\`extends\` 를 가진 class 의 명시적 constructor에서 private field 초기화가 \`super()\` 앞에 prepend되어 \`ReferenceError: 'super()' must be called in derived constructor before accessing |this|\` 발생. #1491 작업 중 probe로 발견.

## 근본 원인
\`injectIntoMethod\` 가 body 맨 앞에 무조건 prepend. Derived class의 first statement는 반드시 \`super(...)\`.

## Before / After (target=es2015)

\`\`\`ts
class P { val = 5; }
class Q extends P {
  #priv = 100;
  constructor() { super(); console.log(this.val + this.#priv); }
}
\`\`\`

| | 출력 constructor |
|---|---|
| Before | `{ _priv.set(this, 100); super(); ... }` → ReferenceError |
| After | `{ super(); _priv.set(this, 100); ... }` ✓ |

## 구현
- \`transformer.insertStatementsAfterSuper\`: body 첫 super_call 뒤 위치에 삽입. super_call 미발견 시 \`prependStatementsToBody\` 로 fallback.
- \`es2022.injectIntoMethod\`: \`has_super\` 인자 받아 분기. 호출부(\`lowerPrivateMembers\`)에서 기존 \`has_super\` 변수 전달.

## Test plan
- [x] \`super(arg)\` 후 private field 여러 개 + 이후 methods 호출 (target=es2015)
- [x] constructor body에 사용자 local 선언 + super() (삽입 위치 정확성)
- [x] downlevel-edge 113 pass 0 fail
- [x] 기존 class 상속 경로(필드 초기화 순서, arrow bind 등) regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)