### PR TITLE
fix(transformer): computed object lowering이 getter/setter를 drop (#1397)

### DIFF
--- a/src/transformer/es2015_computed.zig
+++ b/src/transformer/es2015_computed.zig
@@ -6,6 +6,11 @@
 //! 첫 computed property 이전까지는 일반 object literal에 넣고,
 //! 이후 property는 임시 변수에 대한 assignment로 변환한다.
 //!
+//! getter/setter(method_definition with flags 0x02/0x04)가 computed lowering
+//! 경로에 남으면(비computed getter/setter는 Phase 1 object literal에 그대로
+//! 유지) Phase 2에서 `Object.defineProperty(_a, key, { get/set, enumerable, configurable })`
+//! 호출로 재조립한다.
+//!
 //! 스펙:
 //! - https://tc39.es/ecma262/#sec-object-initialiser (ES2015, computed property names)
 //!
@@ -23,20 +28,22 @@ const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
 
+/// method_definition의 extra[3] flags — parser/object.zig + parser/class.zig와 동일.
+const METHOD_FLAG_GETTER: u32 = 0x02;
+const METHOD_FLAG_SETTER: u32 = 0x04;
+
 pub fn ES2015Computed(comptime Transformer: type) type {
     return struct {
-        /// object_expression에 computed property가 있는지 확인한다.
+        /// object_expression에 computed key를 가진 member가 있는지 확인한다.
+        /// object_property뿐 아니라 method_definition (computed getter/setter/method)도 포함.
         pub fn hasComputedProperty(self: *const Transformer, node: Node) bool {
             const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
             for (members) |raw_idx| {
                 const member = self.ast.getNode(@enumFromInt(raw_idx));
-                if (member.tag == .object_property) {
-                    const key_idx = member.data.binary.left;
-                    if (!key_idx.isNone()) {
-                        const key = self.ast.getNode(key_idx);
-                        if (key.tag == .computed_property_key) return true;
-                    }
-                }
+                const key_idx = memberKeyIdx(self, member);
+                if (key_idx.isNone()) continue;
+                const key = self.ast.getNode(key_idx);
+                if (key.tag == .computed_property_key) return true;
             }
             return false;
         }
@@ -55,22 +62,19 @@ pub fn ES2015Computed(comptime Transformer: type) type {
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
-            // Phase 1: 첫 computed property 이전의 property를 일반 object로 수집
-            // 이 루프는 읽기만 하므로 슬라이스 안전
+            // Phase 1: 첫 computed key 이전의 member를 일반 object로 수집
+            // 이 루프는 읽기만 하므로 슬라이스 안전.
             var first_computed: usize = members_len;
             {
                 const members = self.ast.extra_data.items[members_start .. members_start + members_len];
                 for (members, 0..) |raw_idx, idx| {
                     const member = self.ast.getNode(@enumFromInt(raw_idx));
-                    if (member.tag == .object_property) {
-                        const key_idx = member.data.binary.left;
-                        if (!key_idx.isNone()) {
-                            const key = self.ast.getNode(key_idx);
-                            if (key.tag == .computed_property_key) {
-                                first_computed = idx;
-                                break;
-                            }
-                        }
+                    const key_idx = memberKeyIdx(self, member);
+                    if (key_idx.isNone()) continue;
+                    const key = self.ast.getNode(key_idx);
+                    if (key.tag == .computed_property_key) {
+                        first_computed = idx;
+                        break;
                     }
                 }
             }
@@ -109,17 +113,31 @@ pub fn ES2015Computed(comptime Transformer: type) type {
             const seq_scratch_top = self.scratch.items.len;
             try self.scratch.append(self.allocator, init_assign);
 
-            // Phase 2: computed 이후 property를 assignment로 변환
-            // visitNode가 AST를 변형하므로 인덱스 루프 사용
+            // Phase 2: computed 이후 property/method를 assignment / defineProperty로 변환.
+            // visitNode가 AST를 변형하므로 인덱스 루프 사용.
+            // accessor용 공통 span은 최초 getter/setter 만났을 때 한 번 생성 (addString이 dedup 안 함).
+            var accessor_ctx: ?AccessorSpans = null;
             var i_post: u32 = @intCast(first_computed);
             while (i_post < members_len) : (i_post += 1) {
                 const raw_idx = self.ast.extra_data.items[members_start + i_post];
                 const member = self.ast.getNode(@enumFromInt(raw_idx));
 
-                if (member.tag == .method_definition or member.tag == .spread_element) {
-                    // method_definition은 Object.defineProperty로 변환해야 하나
-                    // ES5 환경에서도 method shorthand 없이 동작하므로 현재는 스킵.
-                    // spread_element는 es2018 변환이 먼저 처리하므로 여기 도달하지 않음.
+                if (member.tag == .spread_element) {
+                    // spread는 es2018 변환이 먼저 처리하므로 여기 도달하지 않음.
+                    continue;
+                }
+
+                if (member.tag == .method_definition) {
+                    const me = member.data.extra;
+                    const flags = self.ast.extra_data.items[me + 3];
+                    const is_getter = (flags & METHOD_FLAG_GETTER) != 0;
+                    const is_setter = (flags & METHOD_FLAG_SETTER) != 0;
+                    // 일반/async/generator 메서드는 es2015_object_methods가 먼저 object_property로 변환한다.
+                    // getter/setter 외의 메서드가 여기 도달하면 pass 순서가 깨진 것.
+                    std.debug.assert(is_getter or is_setter);
+                    if (accessor_ctx == null) accessor_ctx = try makeAccessorSpans(self);
+                    const define_call = try emitDefineAccessor(self, member, is_getter, temp_span, span, accessor_ctx.?);
+                    try self.scratch.append(self.allocator, define_call);
                     continue;
                 }
 
@@ -186,6 +204,140 @@ pub fn ES2015Computed(comptime Transformer: type) type {
                 .data = .{ .list = seq_list },
             });
             return es_helpers.makeParenExpr(self, seq, span);
+        }
+
+        /// member의 key NodeIndex를 반환. object_property는 binary.left, method_definition은 extra[0].
+        /// 해당 없는 tag는 NodeIndex.none.
+        fn memberKeyIdx(self: *const Transformer, member: Node) NodeIndex {
+            return switch (member.tag) {
+                .object_property => member.data.binary.left,
+                .method_definition => @enumFromInt(self.ast.extra_data.items[member.data.extra]),
+                else => NodeIndex.none,
+            };
+        }
+
+        /// emitDefineAccessor / makeTrueProp가 재사용하는 span 캐시.
+        /// addString은 interning을 안 하므로 lowerComputedProperties 한 호출당 한 번만 만든다.
+        const AccessorSpans = struct {
+            object: Span,
+            define_property: Span,
+            enumerable: Span,
+            configurable: Span,
+            truev: Span,
+            get: Span,
+            set: Span,
+        };
+
+        fn makeAccessorSpans(self: *Transformer) Transformer.Error!AccessorSpans {
+            return .{
+                .object = try self.ast.addString("Object"),
+                .define_property = try self.ast.addString("defineProperty"),
+                .enumerable = try self.ast.addString("enumerable"),
+                .configurable = try self.ast.addString("configurable"),
+                .truev = try self.ast.addString("true"),
+                .get = try self.ast.addString("get"),
+                .set = try self.ast.addString("set"),
+            };
+        }
+
+        /// getter/setter method_definition → `Object.defineProperty(_a, key, { get/set: fn, enumerable: true, configurable: true })`.
+        /// 짝 맞추기는 하지 않음 — 인접하지 않아도 각 accessor마다 개별 defineProperty 호출.
+        /// 후속 호출이 이전 descriptor의 get/set 필드를 보존하므로 동작은 정확하다 (ECMAScript ValidateAndApplyPropertyDescriptor).
+        fn emitDefineAccessor(
+            self: *Transformer,
+            member: Node,
+            is_getter: bool,
+            temp_span: Span,
+            span: Span,
+            ctx: AccessorSpans,
+        ) Transformer.Error!NodeIndex {
+            const me = member.data.extra;
+            const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
+
+            const func_expr = try buildAccessorFunction(self, member, span);
+
+            const accessor_kind = try es_helpers.makeIdentifierRefFromSpan(self, if (is_getter) ctx.get else ctx.set);
+            const accessor_prop = try self.ast.addNode(.{
+                .tag = .object_property,
+                .span = span,
+                .data = .{ .binary = .{ .left = accessor_kind, .right = func_expr, .flags = 0 } },
+            });
+            const enum_prop = try makeTrueProp(self, ctx.enumerable, ctx.truev, span);
+            const config_prop = try makeTrueProp(self, ctx.configurable, ctx.truev, span);
+            const desc_list = try self.ast.addNodeList(&.{ accessor_prop, enum_prop, config_prop });
+            const desc_obj = try self.ast.addNode(.{
+                .tag = .object_expression,
+                .span = span,
+                .data = .{ .list = desc_list },
+            });
+
+            const key_arg = try buildAccessorKeyArg(self, key_idx);
+
+            const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
+            const obj_ref = try es_helpers.makeIdentifierRefFromSpan(self, ctx.object);
+            const dp_prop = try es_helpers.makeIdentifierRefFromSpan(self, ctx.define_property);
+            const callee = try es_helpers.makeStaticMember(self, obj_ref, dp_prop, span);
+            return es_helpers.makeCallExpr(self, callee, &.{ temp_ref, key_arg, desc_obj }, span);
+        }
+
+        /// method_definition의 params/body를 방문해 function_expression을 만든다.
+        fn buildAccessorFunction(self: *Transformer, member: Node, span: Span) Transformer.Error!NodeIndex {
+            const me = member.data.extra;
+            const params_list = self.ast.functionParamsList(member);
+            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 2]);
+
+            const new_params = try self.visitExtraList(params_list);
+            const new_body = try self.visitNode(body_idx);
+            const new_params_node = try self.ast.addFormalParameters(new_params, span);
+
+            const none = @intFromEnum(NodeIndex.none);
+            const func_extra = try self.ast.addExtras(&.{
+                none,                   @intFromEnum(new_params_node),
+                @intFromEnum(new_body), 0,
+                none,
+            });
+            return self.ast.addNode(.{
+                .tag = .function_expression,
+                .span = span,
+                .data = .{ .extra = func_extra },
+            });
+        }
+
+        /// Object.defineProperty의 두번째 인자: computed key면 내부 expression,
+        /// non-computed면 "name" string literal.
+        fn buildAccessorKeyArg(self: *Transformer, key_idx: NodeIndex) Transformer.Error!NodeIndex {
+            const key_node = self.ast.getNode(key_idx);
+            if (key_node.tag == .computed_property_key) {
+                return self.visitNode(key_node.data.unary.operand);
+            }
+            // identifier/numeric/string literal → "name" 으로 감싸 string_literal emit
+            const key_text = self.ast.getText(key_node.span);
+            const quoted = try self.allocator.alloc(u8, key_text.len + 2);
+            defer self.allocator.free(quoted);
+            quoted[0] = '"';
+            @memcpy(quoted[1 .. 1 + key_text.len], key_text);
+            quoted[1 + key_text.len] = '"';
+            const quoted_span = try self.ast.addString(quoted);
+            return self.ast.addNode(.{
+                .tag = .string_literal,
+                .span = quoted_span,
+                .data = .{ .string_ref = quoted_span },
+            });
+        }
+
+        /// `{ name: true }` object_property 생성 — span은 모두 pre-cached.
+        fn makeTrueProp(self: *Transformer, name_span: Span, true_span: Span, span: Span) Transformer.Error!NodeIndex {
+            const key = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
+            const val = try self.ast.addNode(.{
+                .tag = .boolean_literal,
+                .span = true_span,
+                .data = .{ .none = 0 },
+            });
+            return self.ast.addNode(.{
+                .tag = .object_property,
+                .span = span,
+                .data = .{ .binary = .{ .left = key, .right = val, .flags = 0 } },
+            });
         }
     };
 }

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1646,17 +1646,20 @@ describe("ES 다운레벨링 런타임 테스트", () => {
     // --- SWC 대비 추가 테스트: Computed Properties ---
 
     test("computed property with getter and setter", async () => {
+      // 회귀 가드(#1397): getter/setter가 drop되지 않고 실제 accessor로 호출되는지 검증.
+      // 이전엔 get/set이 Phase 2에서 skip돼 obj.val=42가 data property로 새로 생성되어 통과했음.
       const result = await bundleAndRun(
         {
           "index.ts": `
             const k = 'val';
+            let hits = 0;
             const obj: any = {
               _v: 0,
-              get [k]() { return this._v; },
-              set [k](v: number) { this._v = v; }
+              get [k]() { hits++; return this._v; },
+              set [k](v: number) { hits++; this._v = v; }
             };
             obj.val = 42;
-            console.log(obj.val);
+            console.log(obj.val, hits);
           `,
         },
         "index.ts",
@@ -1664,7 +1667,68 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       );
       cleanup = result.cleanup;
       expect(result.exitCode).toBe(0);
-      expect(result.runOutput).toBe("42");
+      expect(result.runOutput).toBe("42 2");
+    });
+
+    test("#1397: data-computed key + getter/setter after — accessors preserved", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const k = 'y';
+            let hits = 0;
+            const obj: any = { _v: 0, [k]: 1, get x() { hits++; return this._v; }, set x(v: number) { hits++; this._v = v; } };
+            obj.x = 42;
+            console.log(obj.x, hits, obj.y);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("42 2 1");
+    });
+
+    test("#1397: computed-getter-only triggers lowering", async () => {
+      // getter/setter만 있고 일반 method/data-computed가 없을 때도 computed accessor key 때문에 lowering 필요.
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const k = 'y';
+            let hits = 0;
+            const obj: any = { _v: 5, get [k]() { hits++; return this._v; } };
+            console.log(obj.y, hits);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("5 1");
+    });
+
+    test("#1397: computed-method + non-computed getter (mixed)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const k = 'compMethod';
+            let callOrder: string[] = [];
+            const obj: any = {
+              [k]() { callOrder.push('m'); return 10; },
+              get p() { callOrder.push('g'); return 20; },
+            };
+            const a = obj.compMethod();
+            const b = obj.p;
+            console.log(a, b, callOrder.join(','));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("10 20 m,g");
     });
 
     test("multiple computed properties in one object", async () => {


### PR DESCRIPTION
## Summary

ES2015 computed property 다운레벨링 (\`es2015_computed.zig\`) 의 두 gap 수정:

1. \`hasComputedProperty\` 가 \`method_definition\` (computed getter/setter/method) 의 computed key 를 감지하지 못해 \`{ get [k]() {} }\` 같은 형태에서 lowering 자체가 발동하지 않음 — 출력이 그대로 ES6 syntax 로 남아 진짜 ES5 런타임에선 깨짐.
2. Phase 2 루프가 \`method_definition\` 을 skip — \`{ [k]: 1, get x(), set x(v) {} }\` 에서 getter/setter 가 통째로 drop.

## Root cause
- \`es2015_object_methods\` 가 regular/async/generator 메서드만 object_property 로 변환하고 getter/setter 는 원본 그대로 pass-through. 그래서 computed lowering 경로에서 method_definition 이 남아 있을 수 있음.
- 기존 Phase 2 루프는 \`method_definition or spread_element → continue\` 하나로 스킵.

## Fix
- \`hasComputedProperty\` / \`first_computed\` 탐색에 \`method_definition\` 포함 (공통 \`memberKeyIdx\` 헬퍼).
- Phase 2: getter/setter 는 \`Object.defineProperty(_a, key, { get/set: fn, enumerable: true, configurable: true })\` 호출로 재조립. 짝 매칭 없이 개별 호출 — ECMAScript ValidateAndApplyPropertyDescriptor 가 이전 descriptor 의 get/set 필드를 보존하므로 누적 동작 정확.
- 비 getter/setter 가 Phase 2 에 도달하면 pass 순서 깨진 것 → \`std.debug.assert\`.
- \`addString\` 이 dedup 을 안 하므로 반복 literal (\`Object\`, \`defineProperty\`, \`enumerable\`, \`configurable\`, \`true\`, \`get\`, \`set\`) 을 호출당 한 번만 생성 (\`AccessorSpans\` 캐시).

## Test plan
- [x] 회귀 가드 보강: 기존 \`computed property with getter and setter\` 테스트가 실제로 getter/setter 호출 여부를 검증하지 못했음 (\`obj.val = 42\` 가 그냥 data property 로 쓰여서 통과). 이제 hit counter 로 accessor 호출 횟수 확인.
- [x] 신규 케이스 3 개 추가:
  - \`#1397: data-computed key + getter/setter after — accessors preserved\`
  - \`#1397: computed-getter-only triggers lowering\`
  - \`#1397: computed-method + non-computed getter (mixed)\`
- [x] \`tests/integration/tests/downlevel.test.ts\` 165 tests pass (회귀 0)
- [x] \`zig build test\` pass

## Follow-up (out of scope)
- \`es2015_class.zig:2139\` 의 동일한 quote 패턴이 \`[256]u8\` 고정 버퍼라 긴 키 이름에서 truncation 위험 — 별도 이슈 권장.
- \`es2015_class.zig:buildAccessorFunc\` 과 본 PR 의 \`buildAccessorFunction\` 이 거의 동일 — \`es_helpers.zig\` 로 추출 가능. 별도 리팩터 PR.
- \`method_definition\` extras (\`me+0\` key, \`me+2\` body, \`me+3\` flags) 매직 offset 이 여러 파일에 흩어져 있음 — 상수화 또는 typed accessor 도입 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)