### PR TITLE
fix(transformer): ES5 target에서 Stage 3 decorator가 silent drop (#1389)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,7 +47,7 @@
 | 34. 플러그인 훅 확장 | renderChunk/generateBundle NAPI 노출 + vitePlugin 매핑 | ✅ |
 | 35. async 플러그인 | 모든 훅 async/Promise 반환 지원 (MaybePromise) | ✅ |
 | 36. import.meta.glob | Vite 호환 `import.meta.glob()`, eager/import 옵션 | ✅ |
-| 37. Stage 3 decorators | TC39 Stage 3 데코레이터 (method/getter/setter/field/accessor/class, MobX 6 호환, target ≥ ES2015 한정 — ES5 lowering은 #1389) | ✅ |
+| 37. Stage 3 decorators | TC39 Stage 3 데코레이터 (method/getter/setter/field/accessor/class, MobX 6 호환). ES5 타겟 lowering 포함 완료 — 단 `accessor #x` / `accessor [k]` 는 미구현 (실사용 라이브러리 없음, 필요 시 추가) | ✅ |
 | 38. CSS 번들링 | @import 인라이닝, 별도 .css 파일 emit, Lightning CSS minify 연동 | ✅ |
 
 ## 번들러 성능 현황 (2026-04-10 실측)
@@ -196,7 +196,7 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 - **mangleProps** — `XL` | 선행: 없음 | 배치: 단독
 - ~~**import.meta.glob**~~ — ✅ 완료. Vite 호환 `import.meta.glob()` (eager/import 옵션 지원)
 - ~~**Virtual modules**~~ — ✅ 완료. `\0` prefix 기반 virtual module 지원 (플러그인 resolveId/load)
-- ~~**Stage 3 decorators**~~ — ✅ 완료 (target ≥ ES2015). TC39 Stage 3 데코레이터 다운레벨링 (method/getter/setter/field/accessor/class, initializer 체이닝, MobX 6 호환). ES5 타겟 lowering은 #1389 참고.
+- ~~**Stage 3 decorators**~~ — ✅ 완료. TC39 Stage 3 데코레이터 다운레벨링 (method/getter/setter/field/accessor/class, initializer 체이닝, MobX 6 호환). ES5 타겟 포함 (dispatch 수정 #1389). **알려진 제약**: `accessor #x` (private key) / `accessor [k]` (computed key) 는 ES5 direct path에서 미구현 — Babel/esbuild/oxc는 지원하나 프로덕션 라이브러리 (MobX 6, Lit, Angular signals 등) 모두 공개 키 accessor만 사용하므로 실사용 사례 없음. 필요 시 추가 구현.
 - **Module Concatenation 고도화** — `XL` | rspack/rolldown 수준 scope hoisting
 - **innerGraph** — `L` | 변수 할당 분석으로 더 정밀한 DCE
 - **lazyBarrel** — `L` | barrel 파일 re-export 컴파일 생략 (rolldown)

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1446,10 +1446,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             const key_node = self.ast.getNode(key_idx);
             if (key_node.tag == .private_identifier or key_node.tag == .computed_property_key) {
-                std.debug.panic(
-                    "classifyMembers: accessor_property with {s} key: unsupported in ES5 lowering; requires decorator path",
+                // private/computed accessor는 ES5 direct path 미구현 — drop + warn (별도 이슈).
+                std.log.warn(
+                    "ES5 target: accessor_property with {s} key is not yet lowered — member dropped",
                     .{@tagName(key_node.tag)},
                 );
+                return;
             }
 
             const raw_key = self.ast.getText(key_node.span);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1032,7 +1032,13 @@ pub const Transformer = struct {
             .class_declaration => {
                 const replacement_idx = try self.dispatchVisitor(.on_class_declaration, idx);
                 const target_node = if (replacement_idx) |r| self.ast.getNode(r) else node;
-                // 관심사 분리: plugin은 worklet 변환만, transformer는 ES downlevel 일관 처리.
+                // Stage 3 decorator는 unsupported.class 분기보다 먼저 돌려야 한다 — 반대면 decorator가 silent drop.
+                // Stage 3 출력은 IIFE로 감싼 class_expression을 포함하므로, ES5 target일 땐 재방문해서
+                // 내부 class_expression을 lowerClassExpression로 추가 다운레벨링한다.
+                if (try self.tryTransformStage3(target_node)) |stage3_result| {
+                    if (self.options.unsupported.class) return self.visitNode(stage3_result);
+                    return stage3_result;
+                }
                 if (self.options.unsupported.class) {
                     return es2015_class.ES2015Class(Transformer).lowerClassDeclaration(self, target_node);
                 }
@@ -1042,6 +1048,10 @@ pub const Transformer = struct {
             .class_expression => {
                 const replacement_idx = try self.dispatchVisitor(.on_class_expression, idx);
                 const target_node = if (replacement_idx) |r| self.ast.getNode(r) else node;
+                if (try self.tryTransformStage3(target_node)) |stage3_result| {
+                    if (self.options.unsupported.class) return self.visitNode(stage3_result);
+                    return stage3_result;
+                }
                 if (self.options.unsupported.class) {
                     return es2015_class.ES2015Class(Transformer).lowerClassExpression(self, target_node);
                 }
@@ -3464,6 +3474,18 @@ pub const Transformer = struct {
     // Class + Decorator — transformer/class_decorator.zig로 위임
     // ================================================================
     const class_deco = @import("transformer/class_decorator.zig");
+
+    /// Stage 3 decorator lowering이 필요한 class면 실행해 결과 NodeIndex 반환, 아니면 null.
+    /// `unsupported.class` 분기보다 먼저 호출해 ES5 target에서 decorator silent drop을 방지한다.
+    fn tryTransformStage3(self: *Transformer, node: Node) Error!?NodeIndex {
+        if (self.options.experimental_decorators) return null;
+        const e = node.data.extra;
+        const class_deco_len = self.readU32(e, 7);
+        const has_member_decos = self.hasAnyMemberDecorators(e);
+        if (class_deco_len == 0 and !has_member_decos) return null;
+        return try self.transformStage3Decorators(node);
+    }
+
     pub const visitClass = class_deco.visitClass;
     pub const visitClassWithAssignSemantics = class_deco.visitClassWithAssignSemantics;
     pub const buildStaticFieldAssignment = class_deco.buildStaticFieldAssignment;

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -21,17 +21,9 @@ const es_helpers = @import("../es_helpers.zig");
 const es2022 = @import("../es2022.zig");
 
 pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
+    // Stage 3 decorator dispatch는 transformer.zig `.class_declaration`/`.class_expression`의
+    // `tryTransformStage3`가 선처리. 여기 들어온 시점엔 Stage 3 대상이 아니라고 가정.
     const e = node.data.extra;
-
-    // Stage 3 decorator: experimental_decorators=false이고 decorator가 있으면 TC39 변환.
-    // class/member decorator 존재 여부를 먼저 확인한다.
-    if (!self.options.experimental_decorators) {
-        const class_deco_len = self.readU32(e, 7);
-        const has_member_decos = self.hasAnyMemberDecorators(e);
-        if (class_deco_len > 0 or has_member_decos) {
-            return self.transformStage3Decorators(node);
-        }
-    }
 
     // Fast path: useDefineForClassFields=true AND !experimentalDecorators → 기존 동작
     // 멤버별 분류가 불필요하므로 body를 통째로 방문한다.

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -563,6 +563,81 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("100 200");
     });
 
+    test("#1389: Stage 3 member decorator + ES5 target — decorator applied", async () => {
+      // 이전엔 unsupported.class 분기가 visitClass(→Stage3 dispatch)를 bypass해서 decorator drop.
+      // 이제 dispatch가 Stage 3를 먼저 돌리고 결과 IIFE를 재방문해 inner class_expression을 ES5 lower.
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function logged(target: any, ctx: ClassMemberDecoratorContext) {
+              return function (this: any, ...args: any[]) {
+                console.log('wrapped:' + String(ctx.name));
+                return (target as any).apply(this, args);
+              };
+            }
+            class C {
+              @logged tick() { return 42; }
+            }
+            console.log('result:' + new C().tick());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("wrapped:tick\nresult:42");
+    });
+
+    test("#1389: Stage 3 class decorator + ES5 target — class wrapped", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function tag<T extends new (...args: any[]) => any>(ctor: T, ctx: ClassDecoratorContext) {
+              return class extends ctor {
+                tagged = true;
+              };
+            }
+            @tag
+            class C {
+              x = 1;
+            }
+            const c: any = new C();
+            console.log(c.tagged, c.x);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("true 1");
+    });
+
+    test("#1389: Stage 3 decorator + accessor field + ES5 target — both transformed", async () => {
+      // #1389 (decorator dispatch) + #1398 (accessor expansion) 상호작용 확인.
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function logged(target: any, ctx: ClassMemberDecoratorContext) {
+              return function (this: any, ...args: any[]) { return (target as any).apply(this, args); };
+            }
+            class C {
+              accessor counter = 10;
+              @logged tick() { this.counter += 1; return this.counter; }
+            }
+            const c = new C();
+            console.log(c.tick(), c.counter);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("11 11");
+    });
+
     test("nested arrow this capture", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary

ES5 target 에서 Stage 3 decorator 가 조용히 drop 되던 dispatch 버그 수정 + accessor panic 안전성 개선.

## 문제
\`src/transformer/transformer.zig:1032-1050\` \`.class_declaration\` / \`.class_expression\` dispatch 가 \`unsupported.class\` 분기에서 \`lowerClassDeclaration\` 을 즉시 호출해 \`visitClass\` → \`transformStage3Decorators\` 경로를 완전히 bypass. 결과:
\`\`\`ts
@logged class C { @wrap tick() {} }  // --target=es5
\`\`\`
→ decorator wrapping 전부 소실, class 만 함수로 lowering.

## 수정
### Part A — dispatch 재정렬 (#1389 본체)
1. dispatch 에서 \`unsupported.class\` 분기 **이전**에 \`tryTransformStage3\` 호출.
2. Stage 3 가 적용됐고 ES5 target 이면 결과 (IIFE 로 감싼 class_expression) 를 \`self.visitNode\` 로 **재방문** — 내부 class_expression 이 \`lowerClassExpression\` 로 ES5 다운레벨링됨. 재귀 안전 (Stage 3 가 decorator 를 소비해서 내부 class_expression 에는 decorator 없음 → 재체크 false 로 빠져나옴).
3. dispatch 선처리 덕에 \`visitClass\` 내부의 같은 Stage 3 체크는 dead code가 되어 제거 — 단일 진입점 확보.

### Part B — accessor panic 안전성
\`classifyMembers\` 의 \`accessor_property\` 처리가 private/computed key 에서 \`std.debug.panic\` 해서 프로세스 크래시.
Babel/esbuild/oxc 모두 지원하는 유효 TC39 문법 (\`accessor #x\`, \`accessor [k]\`) 인데 크래시는 부적절 — \`std.log.warn + return\` 으로 교체 (drop + 경고). 완전 구현은 follow-up 이슈.

## Test plan
- [x] \`#1389: Stage 3 member decorator + ES5 target — decorator applied\`
- [x] \`#1389: Stage 3 class decorator + ES5 target — class wrapped\`
- [x] \`#1389: Stage 3 decorator + accessor field + ES5 target — both transformed\` (#1389 + #1398 상호작용)
- [x] \`downlevel.test.ts\` 171 pass (회귀 0)
- [x] \`stage3-decorator.test.ts\` 46 pass, \`stage3-decorator-smoke.test.ts\` 3 pass
- [x] \`zig build test\` 통과

## 다른 번들러 비교
조사 결과 (Babel / esbuild / oxc 모두 확인):
- Auto-accessor lowering 은 decorator 변환과 **분리된 transform** (ZTS 의 #1398 + #1389 설계와 동일)
- 출력 구조는 동일: \`private backing field + getter/setter\` (WeakMap 이나 plain property 아님)
- 네이밍만 다름: ZTS \`#_x_acc\` / Babel \`#A\` (minified) / oxc \`#_x_accessor_storage\`
- decorator 경로는 runtime helper (\`__esDecorate\`, \`applyDecs2311\` 등) 로 감쌈 — ZTS 도 동일

## Follow-up
1. **private/computed accessor ES5 완전 구현**: Babel 의 \`#A\` 스타일 backing + private getter/setter pipeline 확장 (현재는 drop + warn).
2. **\`buildSetterMethod\` 추출 + Stage 3 경로 latent bug 정리**: \`class_decorator.zig:2164\` 의 \`.static_member_expression\` + private_identifier 조합은 현재 fragile (Stage 3 출력이 재방문되며 우연히 동작). \`.private_field_expression\` 으로 통일 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)