### PR TITLE
test(stage3): MobX 6 --target=es5 회귀 가드 추가 (#1389 follow-up)

### DIFF
--- a/tests/integration/tests/stage3-decorator-smoke.test.ts
+++ b/tests/integration/tests/stage3-decorator-smoke.test.ts
@@ -20,7 +20,7 @@ const hasMobx = await (async () => {
   }
 })();
 
-async function mobxSmoke(code: string) {
+async function mobxSmoke(code: string, extraArgs: string[] = []) {
   const { dir, cleanup } = await createFixture({ "index.ts": code });
 
   await mkdir(join(dir, "node_modules"), { recursive: true });
@@ -29,7 +29,7 @@ async function mobxSmoke(code: string) {
   } catch {}
 
   const outFile = join(dir, "out.js");
-  const bundle = await runZts(["--bundle", join(dir, "index.ts"), "-o", outFile]);
+  const bundle = await runZts(["--bundle", join(dir, "index.ts"), "-o", outFile, ...extraArgs]);
   if (bundle.exitCode !== 0) {
     await cleanup();
     throw new Error("bundle failed: " + bundle.stderr);
@@ -112,5 +112,55 @@ describe.skipIf(!hasMobx)("Stage 3 Decorator Smoke — MobX 6", () => {
     cleanup = r.cleanup;
     expect(r.exitCode).toBe(0);
     expect(r.output).toContain("pending,done,pending");
+  });
+
+  // --- #1389 회귀 가드: --target=es5 에서도 MobX 6 decorator + accessor 동작 ---
+
+  it("#1389: @observable accessor + @action — --target=es5", async () => {
+    const r = await mobxSmoke(
+      `
+      import { makeObservable, observable, action, autorun } from "mobx";
+      class Counter {
+        @observable accessor count = 0;
+        @action increment() { this.count++; }
+        constructor() { makeObservable(this); }
+      }
+      const c = new Counter();
+      const log: number[] = [];
+      autorun(() => { log.push(c.count); });
+      c.increment();
+      c.increment();
+      c.increment();
+      console.log(log.join(","));
+    `,
+      ["--target=es5"],
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("0,1,2,3");
+  });
+
+  it("#1389: @computed getter chain — --target=es5", async () => {
+    const r = await mobxSmoke(
+      `
+      import { makeObservable, observable, computed, action } from "mobx";
+      class Store {
+        @observable accessor firstName = "John";
+        @observable accessor lastName = "Doe";
+        @computed get fullName() { return this.firstName + " " + this.lastName; }
+        @action setName(f: string, l: string) { this.firstName = f; this.lastName = l; }
+        constructor() { makeObservable(this); }
+      }
+      const s = new Store();
+      console.log(s.fullName);
+      s.setName("Jane", "Smith");
+      console.log(s.fullName);
+    `,
+      ["--target=es5"],
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.output).toContain("John Doe");
+    expect(r.output).toContain("Jane Smith");
   });
 });


### PR DESCRIPTION
## Summary

#1389 (ES5 target에서 Stage 3 decorator silent drop 버그 수정) 이 실제 라이브러리에서도 동작하는지 보장하기 위한 회귀 가드 2건 추가.

## 검증 범위

\`tests/integration/tests/stage3-decorator-smoke.test.ts\` 에 MobX 6 + \`--target=es5\` 조합 테스트 2개 추가:

1. **\`@observable accessor + @action\` — ES5**: Counter 클래스로 reactive chain + autorun 관측
   - \`@observable accessor count = 0\` + \`@action increment()\` + \`autorun\`
   - 기대: \`"0,1,2,3"\` (초기값 + 3회 증가 모두 관측)
2. **\`@computed getter chain\` — ES5**: Store 클래스로 firstName/lastName + fullName 파생
   - \`@observable accessor\` 2개 + \`@computed get fullName\` + \`@action setName\`
   - 기대: \`"John Doe"\` / \`"Jane Smith"\` (이름 변경 후 derive 재평가)

## 왜 이 가드가 필요한가

- #1389 fix 이전: \`unsupported.class\` 분기가 \`visitClass\` 를 bypass 해서 \`@observable\` / \`@action\` / \`@computed\` 등 decorator 가 ES5 출력에서 통째로 사라짐 → \`makeObservable(this)\` 호출이 반응성 실패.
- 기존 MobX smoke 테스트는 default target 으로만 돌아서 ES5 분기 회귀 감지 불가.

## Test plan
- [x] 전체 5개 smoke pass (기존 3 + 신규 2)
- [x] MobX node_modules symlink 자동 처리 (CI 미설치 시 \`describe.skipIf\` 로 skip)
- [x] Bun 런타임 실행 결과 stdout 정확 매치

## 왜 별도 PR

#1389 본 PR 은 이미 머지됨. 추가 회귀 가드는 런타임 라이브러리 (MobX) 의존성이 있어 스모크 카테고리로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)