### PR TITLE
fix(semantic): cross-module decorator import가 tree-shake로 drop

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1103,6 +1103,10 @@ pub const SemanticAnalyzer = struct {
             // 직접 호출할 수 없으므로, body만 함수 스코프로 방문한다.
             .flow_component_wrapper => try self.visitFlowComponentWrapper(node),
 
+            // `@expr` — decorator의 expression을 방문해 identifier_reference resolve.
+            // 누락 시 import binding이 resolve 안 돼 tree-shake에서 drop됨.
+            .decorator => try self.visitNode(node.data.unary.operand),
+
             // ---- private name 참조 ----
             .private_field_expression, .static_member_expression => {
                 try self.visitPrivateFieldExpr(node.data.extra, .read);
@@ -1116,7 +1120,7 @@ pub const SemanticAnalyzer = struct {
 
             // ---- method_definition/property_definition 내부 순회 ----
             .method_definition => {
-                // extra: [key, params, body, flags]
+                // extra: [key, params, body, flags, deco_start, deco_len]
                 const extra_start = node.data.extra;
                 const extras = self.ast.extra_data.items;
                 if (extra_start + 2 < extras.len) {
@@ -1131,6 +1135,11 @@ pub const SemanticAnalyzer = struct {
                     const key_node = self.ast.getNode(key_idx);
                     if (key_node.tag == .computed_property_key) {
                         try self.visitNode(key_idx);
+                    }
+
+                    // 멤버 decorator 순회 — 누락 시 import binding이 resolve 안 돼 tree-shake로 drop (#1504 follow-up).
+                    if (extra_start + 5 < extras.len) {
+                        try self.visitNodeList(.{ .start = extras[extra_start + 4], .len = extras[extra_start + 5] });
                     }
 
                     // getter/setter 파라미터 개수 검증
@@ -1155,13 +1164,18 @@ pub const SemanticAnalyzer = struct {
                 // non-computed key는 단순 이름이므로 순회하면 namespace import가
                 // 잘못 resolve되는 버그가 발생한다.
                 const e = node.data.extra;
-                if (e + 1 < self.ast.extra_data.items.len) {
-                    const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                const extras_p = self.ast.extra_data.items;
+                if (e + 1 < extras_p.len) {
+                    const key_idx: NodeIndex = @enumFromInt(extras_p[e]);
                     const key_node = self.ast.getNode(key_idx);
                     if (key_node.tag == .computed_property_key) {
                         try self.visitNode(key_idx);
                     }
-                    try self.visitNode(@enumFromInt(self.ast.extra_data.items[e + 1]));
+                    try self.visitNode(@enumFromInt(extras_p[e + 1]));
+                }
+                // 필드/accessor decorator 순회 — 누락 시 import binding tree-shake로 drop.
+                if (e + 4 < extras_p.len) {
+                    try self.visitNodeList(.{ .start = extras_p[e + 3], .len = extras_p[e + 4] });
                 }
             },
             .static_block => {
@@ -1962,11 +1976,17 @@ pub const SemanticAnalyzer = struct {
     }
 
     fn visitClassDeclaration(self: *SemanticAnalyzer, node: Node) AllocError!void {
-        // extra: [name, super_class, body, ...]
+        // extra: [name, super_class, body, type_params, impl_start, impl_len, deco_start, deco_len]
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
         if (extra_start + 2 >= extras.len) return;
         const name_idx: NodeIndex = @enumFromInt(extras[extra_start]);
+
+        // 클래스 decorator 순회 — outer scope에서 평가되므로 class scope push 전에.
+        // 누락 시 import binding이 resolve 안 돼 tree-shake로 drop.
+        if (extra_start + 7 < extras.len) {
+            try self.visitNodeList(.{ .start = extras[extra_start + 6], .len = extras[extra_start + 7] });
+        }
 
         // 클래스 이름을 현재 스코프(외부)에 등록
         // predeclared_scope에서는 이미 1st pass에서 등록했으므로 건너뛴다.
@@ -1988,6 +2008,10 @@ pub const SemanticAnalyzer = struct {
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
         if (extra_start + 2 >= extras.len) return;
+
+        if (extra_start + 7 < extras.len) {
+            try self.visitNodeList(.{ .start = extras[extra_start + 6], .len = extras[extra_start + 7] });
+        }
 
         const heritage_idx: NodeIndex = @enumFromInt(extras[extra_start + 1]);
         try self.visitClassWithHeritage(heritage_idx, @enumFromInt(extras[extra_start + 2]));

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -1033,4 +1033,106 @@ describe("Stage 3 Decorators", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toContain("42");
   });
+
+  // --- Cross-module decorator imports (tree-shaking 회귀) ---
+  // 이전: analyzer가 method/property/class의 decorator extras + `.decorator` 노드 inner expression을
+  // 순회 안 해서 import된 decorator identifier가 symbol resolve 안 됨 → linker가 해당 모듈 dead 판정
+  // → bundle에서 drop → 런타임에 "not defined". Lit/Babel ecosystem 공통 재현.
+
+  it("cross-module: class decorator imported from another file", async () => {
+    const result = await bundleAndRun({
+      "deco.ts": `
+        export function tag(ctor: any, ctx: any) {
+          console.log('tag:' + ctx.name);
+          return ctor;
+        }
+      `,
+      "index.ts": `
+        import { tag } from "./deco";
+        @tag
+        class C { x = 1; }
+        console.log('x:', new C().x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("tag:C");
+    expect(result.runOutput).toContain("x: 1");
+  });
+
+  it("cross-module: method decorator imported from another file", async () => {
+    const result = await bundleAndRun({
+      "deco.ts": `
+        export function log(arg: string): any {
+          return function(target: any, ctx: any) {
+            console.log('wrap:' + arg);
+            return function(this: any, ...args: any[]) { return target.apply(this, args); };
+          };
+        }
+      `,
+      "index.ts": `
+        import { log } from "./deco";
+        class C {
+          @log("m") tick() { return 42; }
+        }
+        console.log('result:' + new C().tick());
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("wrap:m");
+    expect(result.runOutput).toContain("result:42");
+  });
+
+  it("cross-module: accessor decorator imported from another file", async () => {
+    const result = await bundleAndRun({
+      "deco.ts": `
+        export function trace(arg: string): any {
+          return function(target: any, ctx: any) {
+            console.log('traced:' + arg);
+          };
+        }
+      `,
+      "index.ts": `
+        import { trace } from "./deco";
+        class C {
+          @trace("a") accessor value = 10;
+        }
+        console.log('v:' + new C().value);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("traced:a");
+    expect(result.runOutput).toContain("v:10");
+  });
+
+  it("cross-module: decorator through barrel re-export (export * chain)", async () => {
+    // Lit / @lit-labs 스타일: `export * from "@lit/reactive-element/..."`
+    const result = await bundleAndRun({
+      "deco.ts": `
+        export function stamp(arg: string): any {
+          return function(target: any, ctx: any) {
+            console.log('stamp:' + arg);
+            return target;
+          };
+        }
+      `,
+      "barrel.ts": `export * from "./deco";`,
+      "index.ts": `
+        import { stamp } from "./barrel";
+        class C {
+          @stamp("field") x = 1;
+          @stamp("method") foo() { return 2; }
+        }
+        const c = new C();
+        console.log(c.x, c.foo());
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("stamp:field");
+    expect(result.runOutput).toContain("stamp:method");
+    expect(result.runOutput).toContain("1 2");
+  });
 });


### PR DESCRIPTION
## Summary

\`import { deco } from "./other"\` 의 decorator 가 번들 출력에서 drop 되어 런타임 \`ReferenceError: deco is not defined\`. Lit 의 \`@property() accessor x\` 처럼 \`export *\` barrel re-export 체인은 물론 **직접 import 도 영향**. \`--target=es5\` 무관.

최초 발견 경위: #1504 에서 Lit 런타임 검증 중 확인.

## 재현 (최소)
\`\`\`ts
// deco.ts
export function myDeco(arg: string): any { return function(t, c) { return t; }; }

// index.ts
import { myDeco } from "./deco";
class C { @myDeco("x") tick() {} }
\`\`\`
번들 출력: \`myDeco("x")\` 사용되지만 \`deco.ts\` 모듈 자체가 **번들에 포함 안 됨** → ReferenceError.

## 근본 원인 (연쇄 3단)
1. **\`src/semantic/analyzer.zig\` visitNode dispatch 에 \`.decorator\` 케이스 누락** — \`else => {}\` 로 빠져서 decorator 의 inner expression (\`call_expression\` → \`identifier_reference\`) 미방문 → \`deco\` 참조에 symbol_id 할당 안 됨.
2. **class / method / property visitor 가 decorator NodeList 미순회** — extras 내 \`deco_start\` / \`deco_len\` 슬롯이 있지만 visitor 는 \`[name, super, body]\` / \`[key, params, body]\` / \`[key, init]\` 만 방문.
3. **Tree-shake 연쇄 실패** — symbol_id 없으니 \`stmt_info.zig\` 의 is_ref 체크 통과 못 해서 \`referenced_symbols\` 에 기록 안 됨 → linker 가 export 모듈을 dead 판정 → bundle drop.

## Fix (스펙)
\`\`\`zig
// analyzer.zig
.decorator => try self.visitNode(node.data.unary.operand),

// visitClassDeclaration / visitClassExpression (extras[+6] = deco_start, extras[+7] = deco_len)
if (extra_start + 7 < extras.len) {
    try self.visitNodeList(.{ .start = extras[extra_start + 6], .len = extras[extra_start + 7] });
}

// .method_definition (extras[+4], extras[+5])
if (extra_start + 5 < extras.len) {
    try self.visitNodeList(.{ .start = extras[extra_start + 4], .len = extras[extra_start + 5] });
}

// .property_definition / .accessor_property (extras[+3], extras[+4])
if (e + 4 < extras_p.len) {
    try self.visitNodeList(.{ .start = extras_p[e + 3], .len = extras_p[e + 4] });
}
\`\`\`

클래스 decorator 순회는 outer scope 에서 평가되므로 class scope push **이전**에.

## Test plan
신규 회귀 가드 4건 (\`stage3-decorator.test.ts\`):
- [x] cross-module: class decorator imported from another file
- [x] cross-module: method decorator imported from another file
- [x] cross-module: accessor decorator imported from another file
- [x] cross-module: decorator through barrel re-export (\`export *\` chain) — Lit 패턴

\`stage3-decorator.test.ts\` 50 pass (46 + 4 신규). \`zig build test\` 통과. 통합 suite 회귀 0.

## 다른 번들러 비교
Babel / esbuild / oxc 모두 정상 처리. ZTS 의 visitor omission 이 단독 버그.

## Follow-up (별도 PR)
\`class Derived extends Base { @deco ... }\` Stage 3 lowering 시 합성 constructor 가 \`super()\` 호출 안 해서 derived class 에서 ReferenceError — 별개 Stage 3 emit 버그. #1504 Lit 검증 중 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)