### PR TITLE
fix(transformer): Stage 3 decorator derived class 합성 constructor에 super() 누락

### DIFF
--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -990,6 +990,52 @@ pub fn insertFieldAssignmentsIntoConstructor(
     });
 }
 
+/// block_statement body에서 첫 super() 호출 뒤에 stmt를 삽입한 새 block_statement 반환.
+/// super() 없으면 body 시작에 prepend.
+fn insertAfterSuperCall(self: *Transformer, body_idx: NodeIndex, stmt: NodeIndex) Error!NodeIndex {
+    if (body_idx.isNone()) return body_idx;
+    const body = self.ast.getNode(body_idx);
+    if (body.tag != .block_statement) {
+        return self.prependStatementsToBody(body_idx, &.{stmt});
+    }
+    const old_list = body.data.list;
+    const old_stmts_start = old_list.start;
+    const old_stmts_len = old_list.len;
+
+    var insert_pos: u32 = 0;
+    {
+        const old_stmts = self.ast.extra_data.items[old_stmts_start .. old_stmts_start + old_stmts_len];
+        for (old_stmts, 0..) |raw_idx, idx| {
+            if (self.isSuperCallStatement(@enumFromInt(raw_idx))) {
+                insert_pos = @intCast(idx + 1);
+                break;
+            }
+        }
+    }
+
+    const scratch_top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    var i_pre: u32 = 0;
+    while (i_pre < insert_pos) : (i_pre += 1) {
+        const raw_idx = self.ast.extra_data.items[old_stmts_start + i_pre];
+        try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+    }
+    try self.scratch.append(self.allocator, stmt);
+    var i_post: u32 = insert_pos;
+    while (i_post < old_stmts_len) : (i_post += 1) {
+        const raw_idx = self.ast.extra_data.items[old_stmts_start + i_post];
+        try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+    }
+
+    const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    return self.ast.addNode(.{
+        .tag = .block_statement,
+        .span = body.span,
+        .data = .{ .list = new_list },
+    });
+}
+
 /// super() 호출 expression_statement인지 판별
 pub fn isSuperCallStatement(self: *const Transformer, idx: NodeIndex) bool {
     if (idx.isNone()) return false;
@@ -2385,6 +2431,8 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
             .data = .{ .unary = .{ .operand = run_init, .flags = 0 } },
         });
 
+        const has_super = !super_idx.isNone();
+
         if (has_constructor) {
             // new_members에서 constructor를 key 기반으로 탐색 (static block 삽입에 무관)
             for (new_members.items, 0..) |member_node_idx, mi| {
@@ -2398,9 +2446,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 if (m_key.tag != .identifier_reference and m_key.tag != .binding_identifier) continue;
                 if (!std.mem.eql(u8, self.ast.getText(m_key.data.string_ref), "constructor")) continue;
 
-                // prependStatementsToBody로 기존 body 앞에 삽입
                 const old_body_idx = self.readNodeIdx(m.data.extra, 2);
-                const new_body_ctor = try self.prependStatementsToBody(old_body_idx, &.{run_init_stmt});
+                const new_body_ctor = if (has_super)
+                    try insertAfterSuperCall(self, old_body_idx, run_init_stmt)
+                else
+                    try self.prependStatementsToBody(old_body_idx, &.{run_init_stmt});
                 const empty_decos = try self.ast.addNodeList(&.{});
                 // method_definition: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
                 const new_ctor_method = try self.addExtraNode(.method_definition, m.span, &.{
@@ -2415,8 +2465,59 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 break;
             }
         } else {
-            // 빈 constructor 생성
-            const ctor_body_list = try self.ast.addNodeList(&.{run_init_stmt});
+            // 합성 constructor: derived면 `constructor(...args) { super(...args); __runInitializers(...); }`,
+            // 아니면 `constructor() { __runInitializers(...); }`. super stmt는 scratch에 push, params는 반환.
+            const stmts_scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(stmts_scratch_top);
+
+            const ctor_params_node: NodeIndex = if (has_super) blk: {
+                const args_span = try self.ast.addString("args");
+                const args_id = try self.ast.addNode(.{
+                    .tag = .binding_identifier,
+                    .span = args_span,
+                    .data = .{ .string_ref = args_span },
+                });
+                const rest = try self.ast.addNode(.{
+                    .tag = .rest_element,
+                    .span = zero_span,
+                    .data = .{ .unary = .{ .operand = args_id, .flags = 0 } },
+                });
+                const params_list = try self.ast.addNodeList(&.{rest});
+                const params_node = try self.ast.addFormalParameters(params_list, zero_span);
+
+                const super_expr = try self.ast.addNode(.{
+                    .tag = .super_expression,
+                    .span = zero_span,
+                    .data = .{ .none = 0 },
+                });
+                const args_ref = try self.ast.addNode(.{
+                    .tag = .identifier_reference,
+                    .span = args_span,
+                    .data = .{ .string_ref = args_span },
+                });
+                const spread_args = try self.ast.addNode(.{
+                    .tag = .spread_element,
+                    .span = zero_span,
+                    .data = .{ .unary = .{ .operand = args_ref, .flags = 0 } },
+                });
+                const call_args = try self.ast.addNodeList(&.{spread_args});
+                const super_call = try self.addExtraNode(.call_expression, zero_span, &.{
+                    @intFromEnum(super_expr), call_args.start, call_args.len, 0,
+                });
+                const super_stmt = try self.ast.addNode(.{
+                    .tag = .expression_statement,
+                    .span = zero_span,
+                    .data = .{ .unary = .{ .operand = super_call, .flags = 0 } },
+                });
+                try self.scratch.append(self.allocator, super_stmt);
+                break :blk params_node;
+            } else blk: {
+                const empty_params = try self.ast.addNodeList(&.{});
+                break :blk try self.ast.addFormalParameters(empty_params, zero_span);
+            };
+            try self.scratch.append(self.allocator, run_init_stmt);
+
+            const ctor_body_list = try self.ast.addNodeList(self.scratch.items[stmts_scratch_top..]);
             const ctor_body = try self.ast.addNode(.{
                 .tag = .block_statement,
                 .span = zero_span,
@@ -2428,12 +2529,10 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 .span = ctor_key_span,
                 .data = .{ .string_ref = ctor_key_span },
             });
-            const empty_params = try self.ast.addNodeList(&.{});
-            const empty_params_node = try self.ast.addFormalParameters(empty_params, zero_span);
             const empty_decos = try self.ast.addNodeList(&.{});
             const ctor_method = try self.addExtraNode(.method_definition, zero_span, &.{
                 @intFromEnum(ctor_key),
-                @intFromEnum(empty_params_node),
+                @intFromEnum(ctor_params_node),
                 @intFromEnum(ctor_body),
                 0, // flags (no static/getter/setter)
                 empty_decos.start,

--- a/tests/integration/tests/stage3-decorator.test.ts
+++ b/tests/integration/tests/stage3-decorator.test.ts
@@ -1135,4 +1135,137 @@ describe("Stage 3 Decorators", () => {
     expect(result.runOutput).toContain("stamp:method");
     expect(result.runOutput).toContain("1 2");
   });
+
+  // --- Derived class constructor (super() injection 회귀) ---
+  // 이전: transformStage3Decorators의 합성 constructor가 extends 여부 무시 → super() 누락
+  // → ReferenceError: 'super()' must be called... . 또한 user-written constructor 경로는
+  // prependStatementsToBody가 super() 앞에 __runInitializers를 삽입해 this before super 오류.
+
+  it("derived class: synthesized constructor injects super(...args)", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function deco(arg: string): any {
+          return function(target: any, ctx: any) { return target; };
+        }
+        class Base { baseVal: number; constructor(n: number = 0) { this.baseVal = n; } }
+        class Derived extends Base {
+          @deco("x") accessor x = 10;
+          @deco("foo") foo() { return 1; }
+        }
+        const d: any = new (Derived as any)(5);
+        console.log(d.baseVal, d.x, d.foo());
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("5 10 1");
+  });
+
+  it("derived class: user-written constructor — __runInitializers inserted after super()", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function deco(arg: string): any {
+          return function(target: any, ctx: any) { return target; };
+        }
+        class Base { baseVal: number; constructor(n: number) { this.baseVal = n; } }
+        class Derived extends Base {
+          @deco("x") accessor x = 10;
+          constructor() {
+            super(99);
+            console.log("user ctor");
+          }
+        }
+        const d: any = new Derived();
+        console.log(d.baseVal, d.x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("user ctor");
+    expect(result.runOutput).toContain("99 10");
+  });
+
+  it("derived class: super() after pre-computation in user ctor", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function deco(arg: string): any {
+          return function(target: any, ctx: any) { return target; };
+        }
+        class Base { baseVal: number; constructor(n: number) { this.baseVal = n; } }
+        class Derived extends Base {
+          @deco("x") accessor x = 10;
+          constructor() {
+            const computed = 42;
+            super(computed);
+            console.log("after-super");
+          }
+        }
+        const d: any = new Derived();
+        console.log(d.baseVal, d.x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("42 10");
+  });
+
+  it("derived class: multi-level inheritance (Base → Mid → Derived)", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function deco(arg: string): any {
+          return function(target: any, ctx: any) { return target; };
+        }
+        class Base { v: number; constructor(n: number = 0) { this.v = n; } }
+        class Mid extends Base {
+          @deco("m") mid = "M";
+        }
+        class Leaf extends Mid {
+          @deco("l") accessor x = 10;
+        }
+        const l: any = new (Leaf as any)(7);
+        console.log(l.v, l.mid, l.x);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("7 M 10");
+  });
+
+  it("derived class: extends expression (not simple identifier)", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function deco(arg: string): any {
+          return function(target: any, ctx: any) { return target; };
+        }
+        class Base { val: number; constructor(n: number = 0) { this.val = n; } }
+        function getBase() { return Base; }
+        class E extends getBase() {
+          @deco("z") accessor z = 30;
+        }
+        const e: any = new (E as any)(77);
+        console.log(e.val, e.z);
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("77 30");
+  });
+
+  it("derived class: super.method() in decorated method", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `
+        function deco(arg: string): any {
+          return function(target: any, ctx: any) { return target; };
+        }
+        class Base { greet() { return "base"; } }
+        class J extends Base {
+          @deco("g") greet() { return "derived-" + super.greet(); }
+        }
+        console.log(new J().greet());
+      `,
+    });
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toContain("derived-base");
+  });
 });


### PR DESCRIPTION
## Summary

Stage 3 decorator lowering (\`class_decorator.zig:transformStage3Decorators\`) 가 derived class (extends 있음) 의 합성 constructor 에 \`super()\` 호출을 주입하지 않고, user-written constructor 경로도 \`__runInitializers\` 를 super() **앞**에 삽입해 \`ReferenceError: 'super()' must be called in derived constructor before accessing |this|\`. MobX 6 의 \`class XXX extends Base\` 패턴이나 Lit 의 \`@customElement class C extends LitElement\` 에서 즉시 재현.

최초 발견: #1505 Lit 검증 중.

## 재현 (최소)
\`\`\`ts
class Base { constructor() { console.log("Base ctor"); } }
class Derived extends Base {
  @deco accessor x = 10;
}
new Derived();  // ReferenceError
\`\`\`

## 근본 원인
1. **합성 ctor 경로** (\`has_constructor == false\`): body 가 \`[run_init_stmt]\`, params 가 empty — super() 호출 없음.
2. **user-written ctor 경로**: \`prependStatementsToBody\` 가 user body 맨 앞에 \`__runInitializers(this, ...)\` 삽입. user 가 \`constructor() { super(); ... }\` 로 써도 결과는 \`__runInitializers(this, ...); super(); ...\` — 여전히 super 전 this 접근.

## 수정
- \`has_super = !super_idx.isNone()\` 산출.
- user-ctor 경로: derived 면 신규 \`insertAfterSuperCall\` 로 super() **뒤**에 삽입, 아니면 기존 \`prependStatementsToBody\`.
- 합성 ctor 경로: derived 면 \`constructor(...args) { super(...args); __runInitializers(this, ...); }\`, 아니면 기존 빈 params + run_init.
- 신규 \`insertAfterSuperCall(body_idx, stmt)\`: 기존 \`isSuperCallStatement\` 재사용 + scan/splice.

## Test plan
회귀 가드 6 건 (\`stage3-decorator.test.ts\`):
- [x] \`derived class: synthesized constructor injects super(...args)\`
- [x] \`derived class: user-written constructor — __runInitializers inserted after super()\`
- [x] \`derived class: super() after pre-computation in user ctor\` (computed = 42; super(computed))
- [x] \`derived class: multi-level inheritance (Base → Mid → Derived)\`
- [x] \`derived class: extends expression (not simple identifier)\` (\`class E extends getBase() {}\`)
- [x] \`derived class: super.method() in decorated method\`

\`stage3-decorator.test.ts\` 56 pass (50 + 6 신규). \`zig build test\` 통과. 통합 suite 3015 pass 회귀 0.

## 다른 번들러 비교
Babel / esbuild / oxc 모두 super-aware 로 처리. ZTS 의 Stage 3 emitter 가 derived 경계 인지 누락이 단독 버그.

## Follow-up (out of scope)
\`insertAfterSuperCall\` 과 \`insertFieldAssignmentsIntoConstructor\` 의 scan-splice 패턴이 거의 동일. 합성 \`super(...args)\` + rest param 블록이 비-Stage3 의 \`buildConstructorWithFieldAssignments\` 와 near-verbatim 중복. 공용 helper 로 \`buildSuperSpreadArgsCallStmt\` / \`buildRestArgsParams\` / \`spliceBlockAt\` 추출하면 ~90 LoC dedup. 별도 리팩터 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)