### PR TITLE
refactor: MethodFlags 중앙화 + 긴 key name truncation 방지 + Stage3 accessor private_field_expression 통일

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1088,6 +1088,18 @@ pub const FunctionFlags = struct {
     pub const no_side_effects: u32 = 0x04; // @__NO_SIDE_EFFECTS__
 };
 
+/// method_definition의 flags 비트 (extra[3] u16).
+/// parser/object.zig + parser/class.zig에서 동일하게 기록하고 semantic/transformer가 읽음.
+pub const MethodFlags = struct {
+    pub const is_static: u32 = 0x01;
+    pub const is_getter: u32 = 0x02;
+    pub const is_setter: u32 = 0x04;
+    pub const is_async: u32 = 0x08;
+    pub const is_generator: u32 = 0x10;
+    pub const is_abstract: u32 = 0x20;
+    pub const is_declare: u32 = 0x40;
+};
+
 /// call_expression / new_expression의 flags 비트 (D082).
 /// extra: [callee, args_start, args_len, flags]
 pub const CallFlags = struct {

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -26,15 +26,12 @@ const ErrorCode = @import("../error_codes.zig").Code;
 
 const AllocError = std.mem.Allocator.Error;
 
-// ====================================================================
-// method_definition flags 상수 (parser.zig와 동일)
-// extra_data[extra_start + 4]에 저장됨
-// ====================================================================
-const METHOD_FLAG_STATIC = 0x01;
-const METHOD_FLAG_GETTER = 0x02;
-const METHOD_FLAG_SETTER = 0x04;
-const METHOD_FLAG_ASYNC = 0x08;
-const METHOD_FLAG_GENERATOR = 0x10;
+// method_definition flags — ast.MethodFlags 재export (가독성 위해 짧은 이름 유지).
+const METHOD_FLAG_STATIC = ast_mod.MethodFlags.is_static;
+const METHOD_FLAG_GETTER = ast_mod.MethodFlags.is_getter;
+const METHOD_FLAG_SETTER = ast_mod.MethodFlags.is_setter;
+const METHOD_FLAG_ASYNC = ast_mod.MethodFlags.is_async;
+const METHOD_FLAG_GENERATOR = ast_mod.MethodFlags.is_generator;
 
 // ====================================================================
 // 1. 중복 생성자 검증

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -40,10 +40,8 @@ const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
 
-/// method_definition의 extra[3] flags — parser/class.zig와 동일.
-/// 다른 파일(es2015_computed, checker 등)에 같은 정의가 산재함 — #1398 cleanup 대상.
-const METHOD_FLAG_STATIC: u32 = 0x01;
-const METHOD_FLAG_SETTER: u32 = 0x04;
+const METHOD_FLAG_STATIC = ast_mod.MethodFlags.is_static;
+const METHOD_FLAG_SETTER = ast_mod.MethodFlags.is_setter;
 
 pub fn ES2015Class(comptime Transformer: type) type {
     return struct {
@@ -2304,14 +2302,15 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 else
                     try buildFreshPrototypeRef(self, class_name_span, span);
 
-                // key string literal
+                // key string literal — heap-alloc으로 긴 키 이름 truncation 회피.
                 const old_key_node = self.ast.getNode(key_idx);
                 const key_text = self.ast.getText(old_key_node.span);
-                var quoted_buf: [256]u8 = undefined;
-                quoted_buf[0] = '"';
-                @memcpy(quoted_buf[1 .. 1 + key_text.len], key_text);
-                quoted_buf[1 + key_text.len] = '"';
-                const key_str_span = try self.ast.addString(quoted_buf[0 .. key_text.len + 2]);
+                const quoted = try self.allocator.alloc(u8, key_text.len + 2);
+                defer self.allocator.free(quoted);
+                quoted[0] = '"';
+                @memcpy(quoted[1 .. 1 + key_text.len], key_text);
+                quoted[1 + key_text.len] = '"';
+                const key_str_span = try self.ast.addString(quoted);
                 const key_str = try self.ast.addNode(.{
                     .tag = .string_literal,
                     .span = key_str_span,

--- a/src/transformer/es2015_computed.zig
+++ b/src/transformer/es2015_computed.zig
@@ -28,9 +28,8 @@ const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
 
-/// method_definition의 extra[3] flags — parser/object.zig + parser/class.zig와 동일.
-const METHOD_FLAG_GETTER: u32 = 0x02;
-const METHOD_FLAG_SETTER: u32 = 0x04;
+const METHOD_FLAG_GETTER = ast_mod.MethodFlags.is_getter;
+const METHOD_FLAG_SETTER = ast_mod.MethodFlags.is_setter;
 
 pub fn ES2015Computed(comptime Transformer: type) type {
     return struct {

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -26,12 +26,11 @@ const PluginError = plugin_mod.PluginError;
 const AutoWorkletCallee = plugin_mod.AutoWorkletCallee;
 const Transformer = @import("../transformer.zig").Transformer;
 
-// method_definition flags (parser/object.zig와 동일 인코딩).
-const METHOD_FLAG_STATIC = 0x01;
-const METHOD_FLAG_GETTER = 0x02;
-const METHOD_FLAG_SETTER = 0x04;
-const METHOD_FLAG_ASYNC = 0x08;
-const METHOD_FLAG_GENERATOR = 0x10;
+const METHOD_FLAG_STATIC = ast_mod.MethodFlags.is_static;
+const METHOD_FLAG_GETTER = ast_mod.MethodFlags.is_getter;
+const METHOD_FLAG_SETTER = ast_mod.MethodFlags.is_setter;
+const METHOD_FLAG_ASYNC = ast_mod.MethodFlags.is_async;
+const METHOD_FLAG_GENERATOR = ast_mod.MethodFlags.is_generator;
 
 pub fn plugin() Plugin {
     return .{

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -990,6 +990,26 @@ pub fn insertFieldAssignmentsIntoConstructor(
     });
 }
 
+/// `this.#storage_name` private field access 노드 생성. private_field_expression 태그 사용.
+/// 일반 static_member_expression + private_identifier child 조합은 transformer 의 private field
+/// WeakMap dispatch 를 못 타므로 이 helper 로 통일.
+fn makeThisPrivateField(self: *Transformer, storage_span: Span) Error!NodeIndex {
+    const zero_span = Span{ .start = 0, .end = 0 };
+    const this_node = try self.ast.addNode(.{
+        .tag = .this_expression,
+        .span = zero_span,
+        .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+    });
+    const storage_ref = try self.ast.addNode(.{
+        .tag = .private_identifier,
+        .span = storage_span,
+        .data = .{ .string_ref = storage_span },
+    });
+    return self.addExtraNode(.private_field_expression, zero_span, &.{
+        @intFromEnum(this_node), @intFromEnum(storage_ref), 0,
+    });
+}
+
 /// block_statement body에서 첫 super() 호출 뒤에 stmt를 삽입한 새 block_statement 반환.
 /// super() 없으면 body 시작에 prepend.
 fn insertAfterSuperCall(self: *Transformer, body_idx: NodeIndex, stmt: NodeIndex) Error!NodeIndex {
@@ -2154,18 +2174,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     try new_members.append(self.allocator, backing_field);
 
                     // get x() { return this.#_x_accessor_storage; }
+                    // .private_field_expression 태그 필수 — .static_member_expression 으로 만들면
+                    // transformer.zig:899 private field WeakMap dispatch 를 못 탐 (Stage 3 출력 재방문 경로에서만
+                    // 우연히 동작하던 것을 안정화).
                     {
-                        const this_node = try self.ast.addNode(.{
-                            .tag = .this_expression,
-                            .span = zero_span,
-                            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
-                        });
-                        const storage_ref = try self.ast.addNode(.{
-                            .tag = .private_identifier,
-                            .span = storage_span,
-                            .data = .{ .string_ref = storage_span },
-                        });
-                        const return_expr = try es_helpers.makeStaticMember(self, this_node, storage_ref, zero_span);
+                        const return_expr = try makeThisPrivateField(self, storage_span);
                         const getter_key = try self.ast.addNode(.{
                             .tag = .identifier_reference,
                             .span = self.ast.getNode(new_key).data.string_ref,
@@ -2189,19 +2202,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                             .data = .{ .string_ref = val_param_span },
                         });
                         const setter_params = try self.ast.addNodeList(&.{val_param});
-                        const this_node = try self.ast.addNode(.{
-                            .tag = .this_expression,
-                            .span = zero_span,
-                            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
-                        });
-                        const storage_ref = try self.ast.addNode(.{
-                            .tag = .private_identifier,
-                            .span = storage_span,
-                            .data = .{ .string_ref = storage_span },
-                        });
-                        const this_storage = try self.addExtraNode(.static_member_expression, zero_span, &.{
-                            @intFromEnum(this_node), @intFromEnum(storage_ref), 0,
-                        });
+                        const this_storage = try makeThisPrivateField(self, storage_span);
                         const val_ref = try self.ast.addNode(.{
                             .tag = .identifier_reference,
                             .span = val_param_span,


### PR DESCRIPTION
## Summary
최근 5 PR (#1397/#1398/#1389/#1505/#1506) description 에 'follow-up' 으로 기록해둔 항목 중 간단히 고칠 수 있는 3건 정리.

## 변경

### 1. \`MethodFlags\` 중앙화
\`src/parser/ast.zig\` 의 \`FunctionFlags\` 옆에 \`MethodFlags\` struct 추가:
\`\`\`zig
pub const MethodFlags = struct {
    pub const is_static: u32 = 0x01;
    pub const is_getter: u32 = 0x02;
    pub const is_setter: u32 = 0x04;
    pub const is_async: u32 = 0x08;
    pub const is_generator: u32 = 0x10;
    pub const is_abstract: u32 = 0x20;
    pub const is_declare: u32 = 0x40;
};
\`\`\`

기존 \`0x01 / 0x02 / 0x04\` 매직 넘버 중복 정의 4 파일 (\`es2015_class\`, \`es2015_computed\`, \`semantic/checker\`, \`worklet_plugin\`) 을 \`ast.MethodFlags.is_*\` 재export 로 교체. parser 실제 쓰기(\`parser/object.zig:210\`, \`parser/class.zig:787\`) 와 값 일관성이 단일 진입점에서 보증됨.

### 2. \`es2015_class.zig:2309\` 긴 key name truncation 방지
getter/setter key 를 \`"name"\` 문자열 리터럴로 감쌀 때 고정 256-byte 스택 버퍼(\`quoted_buf: [256]u8\`) 사용 → 257+ 길이 key 이름에서 silently truncation 위험. \`allocator.alloc + defer free\` heap 할당으로 교체.

### 3. Stage 3 accessor 확장 \`this.#storage\` 태그 통일
\`class_decorator.zig\` 의 Stage 3 \`accessor\` 필드 확장(getter/setter 합성) 이 \`this.#_x_accessor_storage\` 를 \`.static_member_expression\` + private_identifier child 조합으로 emit 했음. 현재는 Stage 3 출력 재방문 경로에서 **우연히** 정상 동작 (상위 dispatch 가 re-tag) 하지만 fragile.

신규 helper \`makeThisPrivateField(storage_span)\` 로 \`.private_field_expression\` 태그 직접 emit. getter (\`return this.#_x\`) / setter (\`this.#_x = v\`) 양쪽 통일.

## Test plan
- [x] \`zig build test\` 통과
- [x] \`downlevel.test.ts\` 171 pass / \`stage3-decorator.test.ts\` 56 pass / \`stage3-decorator-smoke.test.ts\` 5 pass
- [x] 동작 변화 없음 — 순수 리팩터 + fragile 경로 안정화

## 제외 (별도 이슈)
- **#1510** — scan-splice / \`buildSuperSpreadArgsCallStmt\` / \`buildSetterMethod\` / Object.defineProperty descriptor 공용 helper 추출 (~200 LoC dedup)
- **#1511** — private/computed accessor ES5 완전 구현 (Babel parity)
- **#1512** — \`ast.addString\` dedup (interning)
- **#1513** — method_definition / class 등 extras 매직 offset 상수화 (~20 파일 영향)

## 새로 발견한 독립 버그 (이슈화됨)
- **#1507** — \`new this.#priv.method()\` 에서 ES5 private field lowering 누락
- **#1508** — 클래스 멤버 주석이 \`X.prototype.\` 과 메서드명 사이에 잘못 삽입 **⚠️ 심각**

🤖 Generated with [Claude Code](https://claude.com/claude-code)