### PR TITLE
fix(codegen): ES5 class lowering 멤버 주석이 X.prototype.메서드 사이에 삽입 (#1508)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -758,6 +758,8 @@ pub const Codegen = struct {
             // 주석은 lexer가 직접 수집한 원문 span — 합성 노드 아님 (#1407 safe).
             try self.write(self.ast.source[comment.start..comment.end]);
             try self.writeNewline();
+            // writeNewline 이 indent 를 먹으므로 후속 content 위해 복원 (#1508).
+            try self.writeIndent();
             self.next_comment_idx += 1;
         }
     }

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1178,6 +1178,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
         const MethodInfo = struct {
             member_idx: NodeIndex,
             is_static: bool,
+            // prototype assignment statement 의 span 으로 사용 — leading comment 가
+            // `X.prototype.foo` 토큰 사이가 아니라 statement 앞에서 flush 되도록 (#1508).
+            member_span: Span,
         };
 
         const FieldInfo = struct {
@@ -1348,6 +1351,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         try cm.methods.append(self.allocator, .{
                             .member_idx = @enumFromInt(raw_idx),
                             .is_static = is_static,
+                            .member_span = member.span,
                         });
                     }
                 } else if (member.tag == .property_definition) {
@@ -2214,7 +2218,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
             return self.ast.addNode(.{
                 .tag = .expression_statement,
-                .span = span,
+                .span = info.member_span,
                 .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
             });
         }

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1734,6 +1734,117 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("3");
     });
+
+    // #1508: class 멤버 직전 leading comment 가 `X.prototype.foo` 토큰 사이에
+    // 끼면 syntax error. 원본 member span 을 expression_statement 에 전파해서
+    // codegen 이 statement 앞에서 comment 를 flush 하는지 회귀 가드.
+    test("member 직전 line comment (#1508 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class X {
+              // leading comment
+              foo() { return 1; }
+            }
+            console.log(new X().foo());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1");
+    });
+
+    test("여러 member 사이 line/JSDoc comment 혼합 (#1508 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Y {
+              // c1
+              a() { return 1; }
+              /**
+               * JSDoc
+               * @returns number
+               */
+              b() { return 2; }
+              // c3
+              static s() { return 3; }
+            }
+            const y = new Y();
+            console.log(y.a() + y.b() + Y.s());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("6");
+    });
+
+    test("class extends 의 member 앞 comment (#1508 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base { b() { return 10; } }
+            class Z extends Base {
+              // override comment
+              b() { return super.b() + 1; }
+            }
+            console.log(new Z().b());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("11");
+    });
+
+    test("class expression member 앞 comment (#1508 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const C = class Named {
+              // expression member
+              run() { return 7; }
+            };
+            console.log(new C().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("7");
+    });
+
+    test("연속 line comment + 마지막 member (#1508 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class W {
+              first() { return 1; }
+              // c1
+              // c2
+              // c3
+              last() { return 9; }
+            }
+            const w = new W();
+            console.log(w.first() + w.last());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("10");
+    });
   });
 
   describe("TS-specific", () => {

--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -114,13 +114,13 @@ class D extends A {
 // error -- inherits abstract methods
 class E extends A {
 	// error -- doesn't implement bar
-foo() {
+	foo() {
 		return this.t;
 	}
 }
 class F extends A {
 	// error -- doesn't implement foo
-bar(t) {
+	bar(t) {
 	}
 }
 class G extends A {
@@ -233,7 +233,7 @@ class D extends B {
 // okay
 class E extends B {
 	// okay -- implements abstract method
-bar() {
+	bar() {
 		return 1;
 	}
 }
@@ -376,7 +376,7 @@ class C extends B {
 		return super.foo() || super.foo;
 	}
 	// 2 errors, foo is abstract
-norf() {
+	norf() {
 		return super.bar();
 	}
 }
@@ -463,7 +463,7 @@ var C = "";
 // error
 var M;((M) => {class D {
 	// error
-bar;
+	bar;
 }var D = 1;})(M || (M = {}));
 // error
 "
@@ -733,7 +733,7 @@ exports[`TSC: classes classExtendsShadowedConstructorFunction 1`] = `
 }
 var M;((M) => {var C = 1;class D extends C {
 	// error, C must evaluate to constructor function
-bar;
+	bar;
 }})(M || (M = {}));
 "
 `;
@@ -770,11 +770,11 @@ exports[`TSC: classes constructorFunctionTypeIsAssignableToBaseType 1`] = `
 }
 class Derived extends Base {
 	// ok
-static foo;
+	static foo;
 }
 class Derived2 extends Base {
 	// ok, use assignability here
-static foo;
+	static foo;
 }
 "
 `;
@@ -788,7 +788,7 @@ class Base {
 }
 class Derived extends Base {
 	// ok
-static foo;
+	static foo;
 	constructor(x) {
 		super(x);
 	}
@@ -796,7 +796,7 @@ static foo;
 class Derived2 extends Base {
 	static foo;
 	// ok, not enforcing assignability relation on this
-constructor(x) {
+	constructor(x) {
 		super(x);
 		return 1;
 	}
@@ -830,15 +830,15 @@ exports[`TSC: classes classImplementsMergedClassInterface 1`] = `
 // error -- missing x
 class C3 {
 	// error -- missing y
-x;
+	x;
 }
 class C4 {
 	// error -- missing x
-y;
+	y;
 }
 class C5 {
 	// okay
-x;
+	x;
 	y;
 }
 "
@@ -1113,7 +1113,7 @@ class A {
 }
 function B1() {
 	// class expression can use T
-return class extends A {
+	return class extends A {
 	};
 }
 class B2 {
@@ -1339,7 +1339,7 @@ class B {
 	constructor(a) {
 		const x = friendA.getX(a);
 		// ok
-friendA.setX(a, x + 1);
+		friendA.setX(a, x + 1);
 	}
 }
 // ok
@@ -1407,7 +1407,7 @@ class C {
 exports[`TSC: classes classStaticBlock21 1`] = `
 "class C {
 	/* jsdocs */
-static {
+	static {
         // something
     }
 
@@ -1612,7 +1612,7 @@ exports[`TSC: classes classStaticBlockUseBeforeDef3 1`] = `
 
     
 	// should not error
-static doSomething() {
+	static doSomething() {
 		console.log("gotcha!");
 	}
 }
@@ -1640,7 +1640,7 @@ class CFA {
 
     
 	// should be "BAR"
-static t = 1;
+	static t = 1;
 	static doSomething() {
 	}
 	static {
@@ -1910,14 +1910,14 @@ class DerivedB extends BaseB {
 		new BaseB(8);
 	}
 	// ok
-static staticBaseInstance() {
+	static staticBaseInstance() {
 		new BaseB(9);
 	}
 }
 // ok
 class DerivedC extends BaseC {
 	// error
-constructor(x) {
+	constructor(x) {
 		this.x = x;
 		super(x);
 	}
@@ -1928,7 +1928,7 @@ constructor(x) {
 		new BaseC(10);
 	}
 	// error
-static staticBaseInstance() {
+	static staticBaseInstance() {
 		new BaseC(11);
 	}
 }
@@ -1997,7 +1997,7 @@ exports[`TSC: classes classConstructorAccessibility4 1`] = `
 			}
 		}
 		// OK
-class C extends A {
+		class C extends A {
 		}
 	}
 }
@@ -2012,7 +2012,7 @@ class D {
 			}
 		}
 		// OK
-class F extends D {
+		class F extends D {
 		}
 	}
 }
@@ -2043,13 +2043,13 @@ class Unrelated {
 exports[`TSC: classes classConstructorOverloadsAccessibility 1`] = `
 "class A {
 	// error
-// error
-constructor() {
+	// error
+	constructor() {
 	}
 }
 class B {
 	// error
-constructor() {
+	constructor() {
 	}
 }
 class C {
@@ -2152,7 +2152,7 @@ exports[`TSC: classes classWithTwoConstructorDefinitions 1`] = `
 	constructor() {
 	}
 	// error
-constructor(x) {
+	constructor(x) {
 	}
 }
 // error
@@ -2160,7 +2160,7 @@ class D {
 	constructor(x) {
 	}
 	// error
-constructor(x,y) {
+	constructor(x,y) {
 	}
 }
 // error
@@ -2214,20 +2214,20 @@ exports[`TSC: classes constructorImplementationWithDefaultValues2 1`] = `
 	constructor(x=1) {
 		this.x=1 = x=1;
 		// error
-var y = x;
+		var y = x;
 	}
 }
 class D {
 	constructor(x=1,y=x) {
 		this.y=x = y=x;
 		// error
-var z = x;
+		var z = x;
 	}
 }
 class E {
 	constructor(x=new Date()) {
 		// error
-var y = x;
+		var y = x;
 	}
 }
 "
@@ -2237,13 +2237,13 @@ exports[`TSC: classes constructorOverloadsWithDefaultValues 1`] = `
 "class C {
 	foo;
 	// error
-constructor() {
+	constructor() {
 	}
 }
 class D {
 	foo;
 	// error
-constructor() {
+	constructor() {
 	}
 }
 "
@@ -2351,13 +2351,13 @@ class B extends A {
 	constructor(x) {
 		super(x);
 		// Fails, x is readonly
-this.x = 1;
+		this.x = 1;
 	}
 }
 class C extends A {
 	// This is the usual behavior of readonly properties:
-// if one is redeclared in a base class, then it can be assigned to.
-constructor(x) {
+	// if one is redeclared in a base class, then it can be assigned to.
+	constructor(x) {
 		this.x = x;
 		super(x);
 		this.x = 1;
@@ -3098,13 +3098,13 @@ class DerivedComments extends Object {
 	x;
 	constructor() {
 		// c1
-console.log();
+		console.log();
 		// c2
-// c3
-super();
+		// c3
+		super();
 		// c4
-// c5
-this.x = null;
+		// c5
+		this.x = null;
 	}
 }
 // c6
@@ -3113,15 +3113,15 @@ class DerivedCommentsInvalidThis extends Object {
 	x;
 	constructor() {
 		// c0
-this;
+		this;
 		// c1
-console.log();
+		console.log();
 		// c2
-// c3
-super();
+		// c3
+		super();
 		// c4
-// c5
-this.x = null;
+		// c5
+		this.x = null;
 	}
 }
 // c6
@@ -3170,22 +3170,22 @@ exports[`TSC: classes emitStatementsBeforeSuperCall 1`] = `
 }
 class Sub extends Base {
 	// @ts-ignore
-constructor(p) {
+	constructor(p) {
 		this.p = p;
 		console.log("hi");
 		// should emit before super
-super();
+		super();
 	}
 	field = 0;
 }
 class Test extends Base {
 	prop;
 	// @ts-ignore
-constructor(p) {
+	constructor(p) {
 		this.p = p;
 		1;
 		// should emit before super
-super();
+		super();
 		this.prop = 1;
 	}
 }
@@ -3197,7 +3197,7 @@ exports[`TSC: classes emitStatementsBeforeSuperCallWithDefineFields 1`] = `
 }
 class Sub extends Base {
 	// @ts-ignore
-constructor(p) {
+	constructor(p) {
 		this.p = p;
 		console.log("hi");
 		super();
@@ -3207,7 +3207,7 @@ constructor(p) {
 class Test extends Base {
 	prop;
 	// @ts-ignore
-constructor(p) {
+	constructor(p) {
 		this.p = p;
 		1;
 		super();
@@ -3486,7 +3486,7 @@ exports[`TSC: classes privateProtectedMembersAreNotAccessibleDestructuring 1`] =
 	m() {
 		let { priv:a, prot:b } = this;
 		// ok
-let { priv:priv, prot:prot } = new K();
+		let { priv:priv, prot:prot } = new K();
 	}
 }
 // ok
@@ -3494,7 +3494,7 @@ class C extends K {
 	m2() {
 		let { priv:a } = this;
 		// error
-let { prot:b } = this;
+		let { prot:b } = this;
 	}
 }
 // ok
@@ -3519,7 +3519,7 @@ exports[`TSC: classes privateStaticMemberAccessibility 1`] = `
 class Derived extends Base {
 	static bar = Base.foo;
 	// error
-bing = () => Base.foo;
+	bing = () => Base.foo;
 }
 // error
 "
@@ -3699,7 +3699,7 @@ class C extends B {
 				var c4 = c.bar;
 				var c5 = c.z;
 				// error
-var sc1 = C.x;
+				var sc1 = C.x;
 				var sc2 = C.y;
 				var sc3 = C.foo;
 				var sc4 = C.bar;
@@ -3726,13 +3726,13 @@ exports[`TSC: classes protectedClassPropertyAccessibleWithinNestedSubclass1 1`] 
 				var d4 = undefined;
 				b.x;
 				// OK, accessed within their declaring class
-d1.x;
+				d1.x;
 				// OK, accessed within their declaring class
-d2.x;
+				d2.x;
 				// OK, accessed within their declaring class
-d3.x;
+				d3.x;
 				// Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-d4.x;
+				d4.x;
 			}
 		}
 	}
@@ -3749,13 +3749,13 @@ class Derived1 extends Base {
 				var d4 = undefined;
 				b.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d1.x;
+				d1.x;
 				// OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
-d2.x;
+				d2.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d3.x;
+				d3.x;
 				// Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-d4.x;
+				d4.x;
 			}
 		}
 	}
@@ -3772,13 +3772,13 @@ class Derived2 extends Base {
 				var d4 = undefined;
 				b.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d1.x;
+				d1.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d2.x;
+				d2.x;
 				// OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
-d3.x;
+				d3.x;
 				// Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-d4.x;
+				d4.x;
 			}
 		}
 	}
@@ -3796,13 +3796,13 @@ class Derived3 extends Derived1 {
 				var d4 = undefined;
 				b.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d1.x;
+				d1.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d2.x;
+				d2.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d3.x;
+				d3.x;
 				// OK, accessed within their declaring class
-d4.x;
+				d4.x;
 			}
 		}
 	}
@@ -3819,13 +3819,13 @@ class Derived4 extends Derived2 {
 				var d4 = undefined;
 				b.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d1.x;
+				d1.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d2.x;
+				d2.x;
 				// Error, isn't accessed through an instance of the enclosing class
-d3.x;
+				d3.x;
 				// Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-d4.x;
+				d4.x;
 			}
 		}
 	}
@@ -3895,13 +3895,13 @@ exports[`TSC: classes protectedClassPropertyAccessibleWithinSubclass2 1`] = `
 		var d4 = undefined;
 		b.x;
 		// OK, accessed within their declaring class
-d1.x;
+		d1.x;
 		// OK, accessed within their declaring class
-d2.x;
+		d2.x;
 		// OK, accessed within their declaring class
-d3.x;
+		d3.x;
 		// Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-d4.x;
+		d4.x;
 	}
 }
 // OK, accessed within their declaring class
@@ -3914,13 +3914,13 @@ class Derived1 extends Base {
 		var d4 = undefined;
 		b.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d1.x;
+		d1.x;
 		// OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
-d2.x;
+		d2.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d3.x;
+		d3.x;
 		// Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-d4.x;
+		d4.x;
 	}
 }
 // Error, isn't accessed through an instance of the enclosing class
@@ -3933,13 +3933,13 @@ class Derived2 extends Base {
 		var d4 = undefined;
 		b.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d1.x;
+		d1.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d2.x;
+		d2.x;
 		// OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
-d3.x;
+		d3.x;
 		// Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-d4.x;
+		d4.x;
 	}
 }
 // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class or one of its subclasses
@@ -3953,13 +3953,13 @@ class Derived3 extends Derived1 {
 		var d4 = undefined;
 		b.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d1.x;
+		d1.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d2.x;
+		d2.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d3.x;
+		d3.x;
 		// OK, accessed within their declaring class
-d4.x;
+		d4.x;
 	}
 }
 // Error, isn't accessed through an instance of the enclosing class
@@ -3972,13 +3972,13 @@ class Derived4 extends Derived2 {
 		var d4 = undefined;
 		b.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d1.x;
+		d1.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d2.x;
+		d2.x;
 		// Error, isn't accessed through an instance of the enclosing class
-d3.x;
+		d3.x;
 		// Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-d4.x;
+		d4.x;
 	}
 }
 // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
@@ -4012,7 +4012,7 @@ class Derived extends Base {
 	method1() {
 		this.x;
 		// OK, accessed within a subclass of the declaring class
-super.x;
+		super.x;
 	}
 }
 // Error, x is not public
@@ -4034,36 +4034,36 @@ class B extends A {
 		var t3 = this.y;
 		var t4 = this.z;
 		// error
-var s1 = super.x;
+		var s1 = super.x;
 		// error
-var s2 = super.f();
+		var s2 = super.f();
 		var s3 = super.y;
 		// error
-var s4 = super.z;
+		var s4 = super.z;
 		// error
-var a = undefined;
+		var a = undefined;
 		var a1 = a.x;
 		// error
-var a2 = a.f();
+		var a2 = a.f();
 		// error
-var a3 = a.y;
+		var a3 = a.y;
 		// error
-var a4 = a.z;
+		var a4 = a.z;
 		// error
-var b = undefined;
+		var b = undefined;
 		var b1 = b.x;
 		var b2 = b.f();
 		var b3 = b.y;
 		var b4 = b.z;
 		// error
-var c = undefined;
+		var c = undefined;
 		var c1 = c.x;
 		// error
-var c2 = c.f();
+		var c2 = c.f();
 		// error
-var c3 = c.y;
+		var c3 = c.y;
 		// error
-var c4 = c.z;
+		var c4 = c.z;
 	}
 }
 // error
@@ -4079,11 +4079,11 @@ exports[`TSC: classes protectedStaticClassPropertyAccessibleWithinSubclass 1`] =
 	static staticMethod() {
 		Base.x;
 		// OK, accessed within their declaring class
-Derived1.x;
+		Derived1.x;
 		// OK, accessed within their declaring class
-Derived2.x;
+		Derived2.x;
 		// OK, accessed within their declaring class
-Derived3.x;
+		Derived3.x;
 	}
 }
 // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
@@ -4091,11 +4091,11 @@ class Derived1 extends Base {
 	static staticMethod1() {
 		Base.x;
 		// OK, accessed within a class derived from their declaring class
-Derived1.x;
+		Derived1.x;
 		// OK, accessed within a class derived from their declaring class
-Derived2.x;
+		Derived2.x;
 		// OK, accessed within a class derived from their declaring class
-Derived3.x;
+		Derived3.x;
 	}
 }
 // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
@@ -4103,11 +4103,11 @@ class Derived2 extends Base {
 	static staticMethod2() {
 		Base.x;
 		// OK, accessed within a class derived from their declaring class
-Derived1.x;
+		Derived1.x;
 		// OK, accessed within a class derived from their declaring class
-Derived2.x;
+		Derived2.x;
 		// OK, accessed within a class derived from their declaring class
-Derived3.x;
+		Derived3.x;
 	}
 }
 // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
@@ -4116,11 +4116,11 @@ class Derived3 extends Derived1 {
 	static staticMethod3() {
 		Base.x;
 		// OK, accessed within a class derived from their declaring class
-Derived1.x;
+		Derived1.x;
 		// OK, accessed within a class derived from their declaring class
-Derived2.x;
+		Derived2.x;
 		// OK, accessed within a class derived from their declaring class
-Derived3.x;
+		Derived3.x;
 	}
 }
 // OK, accessed within their declaring class
@@ -4147,7 +4147,7 @@ class Derived1 extends Base {
 	static staticMethod1() {
 		this.x;
 		// OK, accessed within a class derived from their declaring class
-super.x;
+		super.x;
 	}
 }
 // Error, x is not public
@@ -4156,7 +4156,7 @@ class Derived2 extends Derived1 {
 	static staticMethod3() {
 		this.x;
 		// OK, accessed within a class derived from their declaring class
-super.x;
+		super.x;
 	}
 }
 // Error, x is not public
@@ -4201,11 +4201,11 @@ exports[`TSC: classes genericSetterInClassTypeJsDoc 1`] = `
 class Box {
 	#value;
 	/** @param {T} initialValue */
-constructor(initialValue) {
+	constructor(initialValue) {
 		this.#value = initialValue;
 	}
 	/** @type {T} */
-get value() {
+	get value() {
 		return this.#value;
 	}
 	set value(value) {
@@ -5226,7 +5226,7 @@ class E extends D {
 		return "";
 	}
 	// error
-foo() {
+	foo() {
 		return "";
 	}
 }
@@ -5267,7 +5267,7 @@ exports[`TSC: classes thisAndSuperInStaticMembers1 1`] = `
 	static z17 = super.a++;
 	static z18 = super.a\`\`;
 	// these should be unaffected
-x = 1;
+	x = 1;
 	y = this.x;
 	z = super.f();
 }
@@ -5303,7 +5303,7 @@ exports[`TSC: classes thisAndSuperInStaticMembers2 1`] = `
 	static z17 = super.a++;
 	static z18 = super.a\`\`;
 	// these should be unaffected
-x = 1;
+	x = 1;
 	y = this.x;
 	z = super.f();
 }
@@ -5321,7 +5321,7 @@ exports[`TSC: classes thisAndSuperInStaticMembers3 1`] = `
 	static z3 = super.f();
 	static z4 = super["f"]();
 	// these should be unaffected
-x = 1;
+	x = 1;
 	y = this.x;
 	z = super.f();
 }
@@ -5339,7 +5339,7 @@ exports[`TSC: classes thisAndSuperInStaticMembers4 1`] = `
 	static z3 = super.f();
 	static z4 = super["f"]();
 	// these should be unaffected
-x = 1;
+	x = 1;
 	y = this.x;
 	z = super.f();
 }
@@ -5448,7 +5448,7 @@ exports[`TSC: classes typeOfThisInStaticMembers 1`] = `
 	static foo;
 	static bar() {
 		// type of this is the constructor function type
-var t = this;
+		var t = this;
 		return this;
 	}
 }
@@ -5464,7 +5464,7 @@ class C2 {
 	static foo;
 	static bar() {
 		// type of this is the constructor function type
-var t = this;
+		var t = this;
 		return this;
 	}
 }
@@ -5850,7 +5850,7 @@ exports[`TSC: classes privateNameAccessors 1`] = `
 		this.#prop = "";
 		this.#roProp = "";
 		// Error
-console.log(this.#prop);
+		console.log(this.#prop);
 		console.log(this.#roProp);
 	}
 }
@@ -5950,11 +5950,11 @@ exports[`TSC: classes privateNameAndAny 1`] = `
 	method(thing) {
 		thing.#foo;
 		// OK
-thing.#m();
+		thing.#m();
 		thing.#baz;
 		thing.#bar;
 		// Error
-thing.#foo();
+		thing.#foo();
 	}
 	methodU(thing) {
 		thing.#foo;
@@ -5980,10 +5980,10 @@ exports[`TSC: classes privateNameAndIndexSignature 1`] = `
 	#foo = 3;
 	["#bar"] = this["#bar"];
 	// Error (private identifiers should not prevent circularity checking for computeds)
-constructor(message) {
+	constructor(message) {
 		this.#f = 3;
 		// Error (index signatures do not implicitly declare private names)
-this["#foo"] = 3;
+		this["#foo"] = 3;
 	}
 }
 // Okay (type has index signature and "#foo" does not collide with private identifier #foo)
@@ -6035,7 +6035,7 @@ class C {
 	constructor() {
 		exports.#bar = 6;
 		// Error
-this.#foo = 3;
+		this.#foo = 3;
 	}
 }
 // Error (undeclared)
@@ -6210,7 +6210,7 @@ class C {
 		const c = new C();
 		c.#x;
 		// OK
-const d = new C();
+		const d = new C();
 		d.#x;
 	}
 }
@@ -6221,49 +6221,49 @@ const d = new C();
 exports[`TSC: classes privateNameDuplicateField 1`] = `
 "function Field() {
 	// Error
-class A_Field_Field {
+	class A_Field_Field {
 		#foo = "foo";
 		#foo = "foo";
 	}
 	// Error
-class A_Field_Method {
+	class A_Field_Method {
 		#foo = "foo";
 		#foo() {
 		}
 	}
 	// Error
-class A_Field_Getter {
+	class A_Field_Getter {
 		#foo = "foo";
 		get #foo() {
 			return "";
 		}
 	}
 	// Error
-class A_Field_Setter {
+	class A_Field_Setter {
 		#foo = "foo";
 		set #foo(value) {
 		}
 	}
 	// Error
-class A_Field_StaticField {
+	class A_Field_StaticField {
 		#foo = "foo";
 		static #foo = "foo";
 	}
 	// Error
-class A_Field_StaticMethod {
+	class A_Field_StaticMethod {
 		#foo = "foo";
 		static #foo() {
 		}
 	}
 	// Error
-class A_Field_StaticGetter {
+	class A_Field_StaticGetter {
 		#foo = "foo";
 		static get #foo() {
 			return "";
 		}
 	}
 	// Error
-class A_Field_StaticSetter {
+	class A_Field_StaticSetter {
 		#foo = "foo";
 		static set #foo(value) {
 		}
@@ -6271,20 +6271,20 @@ class A_Field_StaticSetter {
 }
 function Method() {
 	// Error
-class A_Method_Field {
+	class A_Method_Field {
 		#foo() {
 		}
 		#foo = "foo";
 	}
 	// Error
-class A_Method_Method {
+	class A_Method_Method {
 		#foo() {
 		}
 		#foo() {
 		}
 	}
 	// Error
-class A_Method_Getter {
+	class A_Method_Getter {
 		#foo() {
 		}
 		get #foo() {
@@ -6292,27 +6292,27 @@ class A_Method_Getter {
 		}
 	}
 	// Error
-class A_Method_Setter {
+	class A_Method_Setter {
 		#foo() {
 		}
 		set #foo(value) {
 		}
 	}
 	// Error
-class A_Method_StaticField {
+	class A_Method_StaticField {
 		#foo() {
 		}
 		static #foo = "foo";
 	}
 	// Error
-class A_Method_StaticMethod {
+	class A_Method_StaticMethod {
 		#foo() {
 		}
 		static #foo() {
 		}
 	}
 	// Error
-class A_Method_StaticGetter {
+	class A_Method_StaticGetter {
 		#foo() {
 		}
 		static get #foo() {
@@ -6320,7 +6320,7 @@ class A_Method_StaticGetter {
 		}
 	}
 	// Error
-class A_Method_StaticSetter {
+	class A_Method_StaticSetter {
 		#foo() {
 		}
 		static set #foo(value) {
@@ -6329,14 +6329,14 @@ class A_Method_StaticSetter {
 }
 function Getter() {
 	// Error
-class A_Getter_Field {
+	class A_Getter_Field {
 		get #foo() {
 			return "";
 		}
 		#foo = "foo";
 	}
 	// Error
-class A_Getter_Method {
+	class A_Getter_Method {
 		get #foo() {
 			return "";
 		}
@@ -6344,7 +6344,7 @@ class A_Getter_Method {
 		}
 	}
 	// Error
-class A_Getter_Getter {
+	class A_Getter_Getter {
 		get #foo() {
 			return "";
 		}
@@ -6353,7 +6353,7 @@ class A_Getter_Getter {
 		}
 	}
 	//OK
-class A_Getter_Setter {
+	class A_Getter_Setter {
 		get #foo() {
 			return "";
 		}
@@ -6361,7 +6361,7 @@ class A_Getter_Setter {
 		}
 	}
 	// Error
-class A_Getter_StaticField {
+	class A_Getter_StaticField {
 		get #foo() {
 			return "";
 		}
@@ -6369,7 +6369,7 @@ class A_Getter_StaticField {
 		}
 	}
 	// Error
-class A_Getter_StaticMethod {
+	class A_Getter_StaticMethod {
 		get #foo() {
 			return "";
 		}
@@ -6377,7 +6377,7 @@ class A_Getter_StaticMethod {
 		}
 	}
 	// Error
-class A_Getter_StaticGetter {
+	class A_Getter_StaticGetter {
 		get #foo() {
 			return "";
 		}
@@ -6386,7 +6386,7 @@ class A_Getter_StaticGetter {
 		}
 	}
 	// Error
-class A_Getter_StaticSetter {
+	class A_Getter_StaticSetter {
 		get #foo() {
 			return "";
 		}
@@ -6396,20 +6396,20 @@ class A_Getter_StaticSetter {
 }
 function Setter() {
 	// Error
-class A_Setter_Field {
+	class A_Setter_Field {
 		set #foo(value) {
 		}
 		#foo = "foo";
 	}
 	// Error
-class A_Setter_Method {
+	class A_Setter_Method {
 		set #foo(value) {
 		}
 		#foo() {
 		}
 	}
 	// OK
-class A_Setter_Getter {
+	class A_Setter_Getter {
 		set #foo(value) {
 		}
 		get #foo() {
@@ -6417,27 +6417,27 @@ class A_Setter_Getter {
 		}
 	}
 	// Error
-class A_Setter_Setter {
+	class A_Setter_Setter {
 		set #foo(value) {
 		}
 		set #foo(value) {
 		}
 	}
 	// Error
-class A_Setter_StaticField {
+	class A_Setter_StaticField {
 		set #foo(value) {
 		}
 		static #foo = "foo";
 	}
 	// Error
-class A_Setter_StaticMethod {
+	class A_Setter_StaticMethod {
 		set #foo(value) {
 		}
 		static #foo() {
 		}
 	}
 	// Error
-class A_Setter_StaticGetter {
+	class A_Setter_StaticGetter {
 		set #foo(value) {
 		}
 		static get #foo() {
@@ -6445,7 +6445,7 @@ class A_Setter_StaticGetter {
 		}
 	}
 	// Error
-class A_Setter_StaticSetter {
+	class A_Setter_StaticSetter {
 		set #foo(value) {
 		}
 		static set #foo(value) {
@@ -6454,49 +6454,49 @@ class A_Setter_StaticSetter {
 }
 function StaticField() {
 	// Error
-class A_StaticField_Field {
+	class A_StaticField_Field {
 		static #foo = "foo";
 		#foo = "foo";
 	}
 	// Error
-class A_StaticField_Method {
+	class A_StaticField_Method {
 		static #foo = "foo";
 		#foo() {
 		}
 	}
 	// Error
-class A_StaticField_Getter {
+	class A_StaticField_Getter {
 		static #foo = "foo";
 		get #foo() {
 			return "";
 		}
 	}
 	// Error
-class A_StaticField_Setter {
+	class A_StaticField_Setter {
 		static #foo = "foo";
 		set #foo(value) {
 		}
 	}
 	// Error
-class A_StaticField_StaticField {
+	class A_StaticField_StaticField {
 		static #foo = "foo";
 		static #foo = "foo";
 	}
 	// Error
-class A_StaticField_StaticMethod {
+	class A_StaticField_StaticMethod {
 		static #foo = "foo";
 		static #foo() {
 		}
 	}
 	// Error
-class A_StaticField_StaticGetter {
+	class A_StaticField_StaticGetter {
 		static #foo = "foo";
 		static get #foo() {
 			return "";
 		}
 	}
 	// Error
-class A_StaticField_StaticSetter {
+	class A_StaticField_StaticSetter {
 		static #foo = "foo";
 		static set #foo(value) {
 		}
@@ -6504,20 +6504,20 @@ class A_StaticField_StaticSetter {
 }
 function StaticMethod() {
 	// Error
-class A_StaticMethod_Field {
+	class A_StaticMethod_Field {
 		static #foo() {
 		}
 		#foo = "foo";
 	}
 	// Error
-class A_StaticMethod_Method {
+	class A_StaticMethod_Method {
 		static #foo() {
 		}
 		#foo() {
 		}
 	}
 	// Error
-class A_StaticMethod_Getter {
+	class A_StaticMethod_Getter {
 		static #foo() {
 		}
 		get #foo() {
@@ -6525,27 +6525,27 @@ class A_StaticMethod_Getter {
 		}
 	}
 	// Error
-class A_StaticMethod_Setter {
+	class A_StaticMethod_Setter {
 		static #foo() {
 		}
 		set #foo(value) {
 		}
 	}
 	// Error
-class A_StaticMethod_StaticField {
+	class A_StaticMethod_StaticField {
 		static #foo() {
 		}
 		static #foo = "foo";
 	}
 	// Error
-class A_StaticMethod_StaticMethod {
+	class A_StaticMethod_StaticMethod {
 		static #foo() {
 		}
 		static #foo() {
 		}
 	}
 	// Error
-class A_StaticMethod_StaticGetter {
+	class A_StaticMethod_StaticGetter {
 		static #foo() {
 		}
 		static get #foo() {
@@ -6553,7 +6553,7 @@ class A_StaticMethod_StaticGetter {
 		}
 	}
 	// Error
-class A_StaticMethod_StaticSetter {
+	class A_StaticMethod_StaticSetter {
 		static #foo() {
 		}
 		static set #foo(value) {
@@ -6562,14 +6562,14 @@ class A_StaticMethod_StaticSetter {
 }
 function StaticGetter() {
 	// Error
-class A_StaticGetter_Field {
+	class A_StaticGetter_Field {
 		static get #foo() {
 			return "";
 		}
 		#foo = "foo";
 	}
 	// Error
-class A_StaticGetter_Method {
+	class A_StaticGetter_Method {
 		static get #foo() {
 			return "";
 		}
@@ -6577,7 +6577,7 @@ class A_StaticGetter_Method {
 		}
 	}
 	// Error
-class A_StaticGetter_Getter {
+	class A_StaticGetter_Getter {
 		static get #foo() {
 			return "";
 		}
@@ -6586,7 +6586,7 @@ class A_StaticGetter_Getter {
 		}
 	}
 	// Error
-class A_StaticGetter_Setter {
+	class A_StaticGetter_Setter {
 		static get #foo() {
 			return "";
 		}
@@ -6594,7 +6594,7 @@ class A_StaticGetter_Setter {
 		}
 	}
 	// Error
-class A_StaticGetter_StaticField {
+	class A_StaticGetter_StaticField {
 		static get #foo() {
 			return "";
 		}
@@ -6602,7 +6602,7 @@ class A_StaticGetter_StaticField {
 		}
 	}
 	// Error
-class A_StaticGetter_StaticMethod {
+	class A_StaticGetter_StaticMethod {
 		static get #foo() {
 			return "";
 		}
@@ -6610,7 +6610,7 @@ class A_StaticGetter_StaticMethod {
 		}
 	}
 	// Error
-class A_StaticGetter_StaticGetter {
+	class A_StaticGetter_StaticGetter {
 		static get #foo() {
 			return "";
 		}
@@ -6619,7 +6619,7 @@ class A_StaticGetter_StaticGetter {
 		}
 	}
 	// OK
-class A_StaticGetter_StaticSetter {
+	class A_StaticGetter_StaticSetter {
 		static get #foo() {
 			return "";
 		}
@@ -6629,20 +6629,20 @@ class A_StaticGetter_StaticSetter {
 }
 function StaticSetter() {
 	// Error
-class A_StaticSetter_Field {
+	class A_StaticSetter_Field {
 		static set #foo(value) {
 		}
 		#foo = "foo";
 	}
 	// Error
-class A_StaticSetter_Method {
+	class A_StaticSetter_Method {
 		static set #foo(value) {
 		}
 		#foo() {
 		}
 	}
 	// Error
-class A_StaticSetter_Getter {
+	class A_StaticSetter_Getter {
 		static set #foo(value) {
 		}
 		get #foo() {
@@ -6650,27 +6650,27 @@ class A_StaticSetter_Getter {
 		}
 	}
 	// Error
-class A_StaticSetter_Setter {
+	class A_StaticSetter_Setter {
 		static set #foo(value) {
 		}
 		set #foo(value) {
 		}
 	}
 	// Error
-class A_StaticSetter_StaticField {
+	class A_StaticSetter_StaticField {
 		static set #foo(value) {
 		}
 		static #foo = "foo";
 	}
 	// Error
-class A_StaticSetter_StaticMethod {
+	class A_StaticSetter_StaticMethod {
 		static set #foo(value) {
 		}
 		static #foo() {
 		}
 	}
 	// OK
-class A_StaticSetter_StaticGetter {
+	class A_StaticSetter_StaticGetter {
 		static set #foo(value) {
 		}
 		static get #foo() {
@@ -6678,7 +6678,7 @@ class A_StaticSetter_StaticGetter {
 		}
 	}
 	// Error
-class A_StaticSetter_StaticSetter {
+	class A_StaticSetter_StaticSetter {
 		static set #foo(value) {
 		}
 		static set #foo(value) {
@@ -6991,7 +6991,7 @@ exports[`TSC: classes privateNameImplicitDeclaration 1`] = `
 "class C {
 	constructor() {
 		/** @type {string} */
-this.#x;
+		this.#x;
 	}
 }
 "
@@ -7001,11 +7001,11 @@ exports[`TSC: classes privateNameInInExpressionUnused 1`] = `
 "class Foo {
 	#unused;
 	// expect unused error
-#brand;
+	#brand;
 	// expect no error
-isFoo(v) {
+	isFoo(v) {
 		// This should count as using/reading '#brand'
-return #brand in v;
+		return #brand in v;
 	}
 }
 "
@@ -7091,7 +7091,7 @@ exports[`TSC: classes privateNameMethod 1`] = `
 		this.#method("");
 		this.#method(1);
 		// Error
-this.#method();
+		this.#method();
 	}
 }
 // Error 
@@ -7134,16 +7134,16 @@ exports[`TSC: classes privateNameMethodAssignment 1`] = `
 		this.#method = () => {
 		};
 		// Error, not writable 
-a.#method = () => {
+		a.#method = () => {
 		};
 		// Error, not writable 
-b.#method = () => {
+		b.#method = () => {
 		};
 		//Error, not writable 
-({ x:this.#method } = { x: () => {
+		({ x:this.#method } = { x: () => {
 		} });
 		//Error, not writable 
-let x = this.#method;
+		let x = this.#method;
 		b.#method++;
 	}
 }
@@ -7188,12 +7188,12 @@ exports[`TSC: classes privateNameMethodCallExpression 1`] = `
 		this.#method2(0, ...arr, 3);
 		const b = new this.#method2(0, ...arr, 3);
 		//Error 
-const str = this.#method2\`head\${1}middle\${2}tail\`;
+		const str = this.#method2\`head\${1}middle\${2}tail\`;
 		this.getInstance().#method2\`test\${1}and\${2}\`;
 		this.getInstance().#method2(0, ...arr, 3);
 		const b2 = new (this.getInstance().#method2)(0, ...arr, 3);
 		//Error 
-const str2 = this.getInstance().#method2\`head\${1}middle\${2}tail\`;
+		const str2 = this.getInstance().#method2\`head\${1}middle\${2}tail\`;
 	}
 	getInstance() {
 		return new AA();
@@ -7340,7 +7340,7 @@ exports[`TSC: classes privateNameNestedMethodAccess 1`] = `
 				new C().#foo;
 				new C().#bar;
 				// Error
-new C().#baz;
+				new C().#baz;
 				new D().#bar;
 			}
 			n(x) {
@@ -7433,9 +7433,9 @@ let A = (() => {
 			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
 			_foo_decorators = [dec];
 			_bar_decorators = [// Error
-dec];
+			dec];
 			__esDecorate(this, _private_bar_descriptor = { value: __setFunctionName(function()// Error
-{
+			{
 			}, "#bar") }, _bar_decorators, { kind: "method", name: "#bar", static: false, private: true, access: { has: (obj) => #bar in obj, get: (obj) => obj.#bar }, metadata: _metadata }, null, _instanceExtraInitializers);
 			__esDecorate(null, null, _foo_decorators, { kind: "field", name: "#foo", static: false, private: true, access: { has: (obj) => #foo in obj, get: (obj) => obj.#foo, set: function(obj,value) {
 				obj.#foo = value;
@@ -7582,7 +7582,7 @@ exports[`TSC: classes privateNamesAndStaticFields 1`] = `
 		A.#foo = 3;
 		B.#foo;
 		// Error
-B.#bar;
+		B.#bar;
 	}
 }
 // Error
@@ -7669,14 +7669,14 @@ exports[`TSC: classes privateNamesConstructorChain-1 1`] = `
 	accessChildProps() {
 		new Child().#foo;
 		// OK (\`#foo\` was added when \`Parent\`'s constructor was called on \`child\`)
-Child.#bar;
+		Child.#bar;
 	}
 }
 // Error: not found
 class Child extends Parent {
 	#foo = "foo";
 	// OK (Child's #foo does not conflict, as \`Parent\`'s \`#foo\` is not accessible)
-#bar = "bar";
+	#bar = "bar";
 }
 // OK
 "
@@ -7689,14 +7689,14 @@ exports[`TSC: classes privateNamesConstructorChain-2 1`] = `
 	accessChildProps() {
 		new Child().#foo;
 		// OK (\`#foo\` was added when \`Parent\`'s constructor was called on \`child\`)
-Child.#bar;
+		Child.#bar;
 	}
 }
 // Error: not found
 class Child extends Parent {
 	#foo = "foo";
 	// OK (Child's #foo does not conflict, as \`Parent\`'s \`#foo\` is not accessible)
-#bar = "bar";
+	#bar = "bar";
 }
 // OK
 new Parent().accessChildProps();
@@ -7735,65 +7735,65 @@ exports[`TSC: classes privateNamesIncompatibleModifiersJs 1`] = `
 	/**
      * @public
      */
-#a = 1;
+	#a = 1;
 	/**
      * @private
      */
-#b = 1;
+	#b = 1;
 	/**
      * @protected
      */
-#c = 1;
+	#c = 1;
 	/**
      * @public
      */
-#aMethod() {
+	#aMethod() {
 		return 1;
 	}
 	/**
      * @private
      */
-#bMethod() {
+	#bMethod() {
 		return 1;
 	}
 	/**
      * @protected
      */
-#cMethod() {
+	#cMethod() {
 		return 1;
 	}
 	/**
      * @public
      */
-get #aProp() {
+	get #aProp() {
 		return 1;
 	}
 	/**
      * @public
      */
-set #aProp(value) {
+	set #aProp(value) {
 	}
 	/**
      * @private
      */
-get #bProp() {
+	get #bProp() {
 		return 1;
 	}
 	/**
      * @private
      */
-set #bProp(value) {
+	set #bProp(value) {
 	}
 	/**
     * @protected
     */
-get #cProp() {
+	get #cProp() {
 		return 1;
 	}
 	/**
      * @protected
      */
-set #cProp(value) {
+	set #cProp(value) {
 	}
 }
 "
@@ -7815,35 +7815,35 @@ exports[`TSC: classes privateNamesInGenericClasses 1`] = `
 		return x.#foo;
 	}
 	// OK
-bar2(x) {
+	bar2(x) {
 		return x.#method();
 	}
 	// OK
-bar3(x) {
+	bar3(x) {
 		return x.#prop;
 	}
 	// OK
-baz(x) {
+	baz(x) {
 		return x.#foo;
 	}
 	// OK
-baz2(x) {
+	baz2(x) {
 		return x.#method;
 	}
 	// OK
-baz3(x) {
+	baz3(x) {
 		return x.#prop;
 	}
 	// OK
-quux(x) {
+	quux(x) {
 		return x.#foo;
 	}
 	// OK
-quux2(x) {
+	quux2(x) {
 		return x.#method;
 	}
 	// OK
-quux3(x) {
+	quux3(x) {
 		return x.#prop;
 	}
 }
@@ -7872,16 +7872,16 @@ exports[`TSC: classes privateNamesInNestedClasses-1 1`] = `
 				a.#foo;
 			}
 			// OK, no compile-time error, don't know what \`a\` is
-baz(a) {
+			baz(a) {
 				a.#foo;
 			}
 			// compile-time error, shadowed
-quux(b) {
+			quux(b) {
 				b.#foo;
 			}
 		}
 		// OK
-const a = new A();
+		const a = new A();
 		new B().bar(a);
 		new B().baz(a);
 		const b = new B();
@@ -7939,7 +7939,7 @@ exports[`TSC: classes privateNameStaticAccessors 1`] = `
 		A1.#prop = "";
 		A1.#roProp = "";
 		// Error
-console.log(A1.#prop);
+		console.log(A1.#prop);
 		console.log(A1.#roProp);
 	}
 }
@@ -8051,7 +8051,7 @@ exports[`TSC: classes privateNameStaticFieldAccess 1`] = `
 	constructor() {
 		console.log(A.#myField);
 		//Ok
-console.log(this.#myField);
+		console.log(this.#myField);
 	}
 }
 //Error
@@ -8151,7 +8151,7 @@ exports[`TSC: classes privateNameStaticFieldDerivedClasses 1`] = `
 	static method(x) {
 		Derived.#derivedProp;
 		// error
-Base.#prop = 10;
+		Base.#prop = 10;
 	}
 }
 class Derived extends Base {
@@ -8257,7 +8257,7 @@ exports[`TSC: classes privateNameStaticMethod 1`] = `
 		A1.#method("");
 		A1.#method(1);
 		// Error
-A1.#method();
+		A1.#method();
 	}
 }
 // Error 
@@ -8272,16 +8272,16 @@ exports[`TSC: classes privateNameStaticMethodAssignment 1`] = `
 		A3.#method = () => {
 		};
 		// Error, not writable 
-a.#method = () => {
+		a.#method = () => {
 		};
 		// Error, not writable 
-b.#method = () => {
+		b.#method = () => {
 		};
 		//Error, not writable 
-({ x:A3.#method } = { x: () => {
+		({ x:A3.#method } = { x: () => {
 		} });
 		//Error, not writable 
-let x = A3.#method;
+		let x = A3.#method;
 		b.#method++;
 	}
 }
@@ -8306,12 +8306,12 @@ exports[`TSC: classes privateNameStaticMethodCallExpression 1`] = `
 		AA.#method2(0, ...arr, 3);
 		const b = new AA.#method2(0, ...arr, 3);
 		//Error 
-const str = AA.#method2\`head\${1}middle\${2}tail\`;
+		const str = AA.#method2\`head\${1}middle\${2}tail\`;
 		AA.getClass().#method2\`test\${1}and\${2}\`;
 		AA.getClass().#method2(0, ...arr, 3);
 		const b2 = new (AA.getClass().#method2)(0, ...arr, 3);
 		//Error 
-const str2 = AA.getClass().#method2\`head\${1}middle\${2}tail\`;
+		const str2 = AA.getClass().#method2\`head\${1}middle\${2}tail\`;
 	}
 	static getClass() {
 		return AA;
@@ -8444,26 +8444,26 @@ exports[`TSC: classes privateNamesUseBeforeDef 1`] = `
 "class A {
 	#foo = this.#bar;
 	// Error
-#bar = 3;
+	#bar = 3;
 }
 class A2 {
 	#foo = this.#bar();
 	// No Error
-#bar() {
+	#bar() {
 		return 3;
 	}
 }
 class A3 {
 	#foo = this.#bar;
 	// No Error
-get #bar() {
+	get #bar() {
 		return 3;
 	}
 }
 class B {
 	#foo = this.#bar;
 	// Error
-#bar = this.#foo;
+	#bar = this.#foo;
 }
 "
 `;
@@ -8519,26 +8519,26 @@ exports[`TSC: classes privateNameWhenNotUseDefineForClassFieldsInEsNext 1`] = `
 	#prop = 0;
 	static dd = new TestWithStatics().#prop;
 	// OK
-static ["X_ z_ zz"] = class Inner {
+	static ["X_ z_ zz"] = class Inner {
 		#foo = 10;
 		m() {
 			new TestWithStatics().#prop;
 		}
 		// OK
-static C = class InnerInner {
+		static C = class InnerInner {
 			m() {
 				new TestWithStatics().#prop;
 				// OK
-new Inner().#foo;
+				new Inner().#foo;
 			}
 		};
 		// OK
-static M() {
+		static M() {
 			return class {
 				m() {
 					new TestWithStatics().#prop;
 					// OK
-new Inner().#foo;
+					new Inner().#foo;
 				}
 			};
 		}
@@ -8549,26 +8549,26 @@ class TestNonStatics {
 	#prop = 0;
 	dd = new TestNonStatics().#prop;
 	// OK
-["X_ z_ zz"] = class Inner {
+	["X_ z_ zz"] = class Inner {
 		#foo = 10;
 		m() {
 			new TestNonStatics().#prop;
 		}
 		// Ok
-C = class InnerInner {
+		C = class InnerInner {
 			m() {
 				new TestNonStatics().#prop;
 				// Ok
-new Inner().#foo;
+				new Inner().#foo;
 			}
 		};
 		// Ok
-static M() {
+		static M() {
 			return class {
 				m() {
 					new TestNonStatics().#prop;
 					// OK
-new Inner().#foo;
+					new Inner().#foo;
 				}
 			};
 		}
@@ -8587,11 +8587,11 @@ exports[`TSC: classes privateStaticNameShadowing 1`] = `
 	static #m() {
 		const X = {};
 		// shadow the class
-const _a = {};
+		const _a = {};
 		// shadow the first generated var
-X.#m();
+		X.#m();
 		// Should check with X as the receiver with _b as the class constructor 
-return 1;
+		return 1;
 	}
 }
 "
@@ -8611,23 +8611,23 @@ exports[`TSC: classes privateWriteOnlyAccessorRead 1`] = `
 		const foo = { bar: 1 };
 		console.log(this.#value);
 		// error
-this.#value = { foo };
+		this.#value = { foo };
 		// ok
-this.#value = { foo };
+		this.#value = { foo };
 		// ok
-this.#value.foo = foo;
+		this.#value.foo = foo;
 		// error
-({ o:this.#value } = { o: { foo } });
+		({ o:this.#value } = { o: { foo } });
 		//ok
-({ ...this.#value } = { foo });
+		({ ...this.#value } = { foo });
 		//ok
-({ foo:this.#value.foo } = { foo });
+		({ foo:this.#value.foo } = { foo });
 		//error
-({ foo:{ ...this.#value.foo } } = { foo });
+		({ foo:{ ...this.#value.foo } } = { foo });
 		//error
-let r = { o: this.#value };
+		let r = { o: this.#value };
 		//error
-[this.#valueOne, ...this.#valueRest] = [1, 2, 3];
+		[this.#valueOne, ...this.#valueRest] = [1, 2, 3];
 		let arr = [this.#valueOne, ...this.#valueRest];
 		this.#valueCompound += 3;
 	}
@@ -8651,9 +8651,9 @@ exports[`TSC: classes typeFromPrivatePropertyAssignment 1`] = `
 exports[`TSC: classes typeFromPrivatePropertyAssignmentJs 1`] = `
 "class C {
 	/** @type {{ foo?: string } | undefined } */
-#a;
+	#a;
 	/** @type {{ foo?: string } | undefined } */
-#b;
+	#b;
 	m() {
 		const a = this.#a || {};
 		this.#b = this.#b || {};
@@ -8666,7 +8666,7 @@ exports[`TSC: classes optionalMethodDeclarations 1`] = `
 "// https://github.com/microsoft/TypeScript/issues/34952#issuecomment-552025027
 class C {
 	// ? should be removed in emit
-method() {
+	method() {
 	}
 }
 "
@@ -8675,7 +8675,7 @@ method() {
 exports[`TSC: classes mixinAbstractClasses.2 1`] = `
 "function Mixin(baseClass) {
 	// error expected: A mixin class that extends from a type variable containing an abstract construct signature must also be declared 'abstract'.
-class MixinClass extends baseClass {
+	class MixinClass extends baseClass {
 		mixinMethod() {
 		}
 	}
@@ -8726,8 +8726,8 @@ exports[`TSC: classes mixinAbstractClassesReturnTypeInference 1`] = `
 }
 function Mixin2(baseClass) {
 	// must be \`abstract\` because we cannot know *all* of the possible abstract members that need to be
-// implemented for this to be concrete.
-class MixinClass extends baseClass {
+	// implemented for this to be concrete.
+	class MixinClass extends baseClass {
 		mixinMethod() {
 		}
 		static staticMixinMethod() {
@@ -8824,13 +8824,13 @@ class C5 extends Mix(Protected, Public) {
 	f(c4,c5,c6) {
 		c4.p;
 		// Error, not in class deriving from Protected2
-c5.p;
+		c5.p;
 		c6.p;
 	}
 	static g() {
 		C4.s;
 		// Error, not in class deriving from Protected2
-C5.s;
+		C5.s;
 		C6.s;
 	}
 }
@@ -8838,13 +8838,13 @@ class C6 extends Mix(Public, Public2) {
 	f(c4,c5,c6) {
 		c4.p;
 		// Error, not in class deriving from Protected2
-c5.p;
+		c5.p;
 		c6.p;
 	}
 	static g() {
 		C4.s;
 		// Error, not in class deriving from Protected2
-C5.s;
+		C5.s;
 		C6.s;
 	}
 }
@@ -8863,19 +8863,19 @@ class ProtectedGeneric2 {
 function f7(x) {
 	x.privateMethod();
 	// Error, private constituent makes method inaccessible
-x.protectedMethod();
+	x.protectedMethod();
 }
 // Error, protected when all constituents are protected
 function f8(x) {
 	x.privateMethod();
 	// Error, private constituent makes method inaccessible
-x.protectedMethod();
+	x.protectedMethod();
 }
 // Error, protected when all constituents are protected
 function f9(x) {
 	x.privateMethod();
 	// Error, private constituent makes method inaccessible
-x.protectedMethod();
+	x.protectedMethod();
 }
 // Error, protected when all constituents are protected
 "
@@ -9283,7 +9283,7 @@ class D extends C {
 		return this._secret;
 	}
 	// error
-set p(value) {
+	set p(value) {
 		this._secret = value;
 	}
 }
@@ -9314,7 +9314,7 @@ class Derived extends Base {
 		return 2;
 	}
 	// should be an error
-set x(value) {
+	set x(value) {
 		console.log(\`x was set to \${value}\`);
 	}
 }
@@ -9332,7 +9332,7 @@ exports[`TSC: classes accessorsOverrideProperty3 1`] = `
 		return this._sound;
 	}
 	// error here
-set sound(val) {
+	set sound(val) {
 		this._sound = val;
 	}
 }
@@ -9384,7 +9384,7 @@ class D extends C {
 		return this._secret;
 	}
 	// error
-set p(value) {
+	set p(value) {
 		this._secret = value;
 	}
 }
@@ -9449,7 +9449,7 @@ function ApiItemContainerMixin(baseClass) {
 // Subclass inheriting from mixin
 export class ApiEnum extends ApiItemContainerMixin(ApiItem) {
 	// This worked prior to TypeScript 4.0:
-get members() {
+	get members() {
 		return [];
 	}
 }
@@ -9460,30 +9460,30 @@ exports[`TSC: classes assignParameterPropertyToPropertyDeclarationES2022 1`] = `
 "class C {
 	qux = this.bar;
 	// should error
-bar = this.foo;
+	bar = this.foo;
 	// should error
-quiz = this.bar;
+	quiz = this.bar;
 	// ok
-quench = this.m1();
+	quench = this.m1();
 	// ok
-quanch = this.m3();
+	quanch = this.m3();
 	// should error
-m1() {
+	m1() {
 		this.foo;
 	}
 	// ok
-m3 = function() {
+	m3 = function() {
 	};
 	constructor(foo) {
 		this.foo = foo;
 	}
 	quim = this.baz;
 	// should error
-baz = this.foo;
+	baz = this.foo;
 	// should error
-quid = this.baz;
+	quid = this.baz;
 	// ok
-m2() {
+	m2() {
 		this.foo;
 	}
 }
@@ -9495,7 +9495,7 @@ class D extends C {
 class E {
 	bar = () => this.foo1 + this.foo2;
 	// both ok
-foo1 = "";
+	foo1 = "";
 	constructor(foo2) {
 		this.foo2 = foo2;
 	}
@@ -9530,30 +9530,30 @@ exports[`TSC: classes assignParameterPropertyToPropertyDeclarationESNext 1`] = `
 "class C {
 	qux = this.bar;
 	// should error
-bar = this.foo;
+	bar = this.foo;
 	// should error
-quiz = this.bar;
+	quiz = this.bar;
 	// ok
-quench = this.m1();
+	quench = this.m1();
 	// ok
-quanch = this.m3();
+	quanch = this.m3();
 	// should error
-m1() {
+	m1() {
 		this.foo;
 	}
 	// ok
-m3 = function() {
+	m3 = function() {
 	};
 	constructor(foo) {
 		this.foo = foo;
 	}
 	quim = this.baz;
 	// should error
-baz = this.foo;
+	baz = this.foo;
 	// should error
-quid = this.baz;
+	quid = this.baz;
 	// ok
-m2() {
+	m2() {
 		this.foo;
 	}
 }
@@ -9565,7 +9565,7 @@ class D extends C {
 class E {
 	bar = () => this.foo1 + this.foo2;
 	// both ok
-foo1 = "";
+	foo1 = "";
 	constructor(foo2) {
 		this.foo2 = foo2;
 	}
@@ -9852,7 +9852,7 @@ var x = 1;
 class C {
 	b = x;
 	// error, evaluated in scope of constructor, cannot reference x
-constructor(x) {
+	constructor(x) {
 		x = 2;
 	}
 }
@@ -9861,7 +9861,7 @@ var y = 1;
 class D {
 	b = y;
 	// error, evaluated in scope of constructor, cannot reference y
-constructor(x) {
+	constructor(x) {
 		var y = "";
 	}
 }
@@ -9882,21 +9882,21 @@ var x = 1;
 class C {
 	b = x;
 	// ok
-constructor(x) {
+	constructor(x) {
 	}
 }
 var y = 1;
 class D {
 	b = y;
 	// ok
-constructor(x) {
+	constructor(x) {
 		var y = "";
 	}
 }
 class E {
 	b = z;
 	// not ok
-constructor(z) {
+	constructor(z) {
 	}
 }
 "
@@ -9987,7 +9987,7 @@ class J {
 class K extends J {
 	q;
 	// ok, extends a property from an interface
-r;
+	r;
 }
 // error, from class
 // #35327
@@ -10029,26 +10029,26 @@ exports[`TSC: classes initializerReferencingConstructorLocals 1`] = `
 class C {
 	a = z;
 	// error
-b;
+	b;
 	// error
-c = this.z;
+	c = this.z;
 	// error
-d;
+	d;
 	// error
-constructor(x) {
+	constructor(x) {
 		z = 1;
 	}
 }
 class D {
 	a = z;
 	// error
-b;
+	b;
 	// error
-c = this.z;
+	c = this.z;
 	// error
-d;
+	d;
 	// error
-constructor(x) {
+	constructor(x) {
 		z = 1;
 	}
 }
@@ -10060,35 +10060,35 @@ exports[`TSC: classes initializerReferencingConstructorParameters 1`] = `
 class C {
 	a = x;
 	// error
-b;
+	b;
 	// error
-constructor(x) {
+	constructor(x) {
 	}
 }
 class D {
 	a = x;
 	// error
-b;
+	b;
 	// error
-constructor(x) {
+	constructor(x) {
 		this.x = x;
 	}
 }
 class E {
 	a = this.x;
 	// ok
-b;
+	b;
 	// ok
-constructor(x) {
+	constructor(x) {
 		this.x = x;
 	}
 }
 class F {
 	a = this.x;
 	// ok
-b = x;
+	b = x;
 	// error
-constructor(x) {
+	constructor(x) {
 		this.x = x;
 	}
 }
@@ -10211,12 +10211,12 @@ exports[`TSC: classes typeOfThisInAccessor 1`] = `
 	get x() {
 		var r = this;
 		// C
-return 1;
+		return 1;
 	}
 	static get y() {
 		var r2 = this;
 		// typeof C
-return 1;
+		return 1;
 	}
 }
 class D {
@@ -10224,18 +10224,18 @@ class D {
 	get x() {
 		var r = this;
 		// D<T>
-return 1;
+		return 1;
 	}
 	static get y() {
 		var r2 = this;
 		// typeof D
-return 1;
+		return 1;
 	}
 }
 var x = { get a() {
 	var r3 = this;
 	// any
-return 1;
+	return 1;
 } };
 "
 `;
@@ -10253,9 +10253,9 @@ class Derived extends Base {
 	bar() {
 		var r = super.foo({ a: 1 });
 		// { a: number }
-var r2 = super.foo({ a: 1, b: 2 });
+		var r2 = super.foo({ a: 1, b: 2 });
 		// { a: number }
-var r3 = this.foo({ a: 1, b: 2 });
+		var r3 = this.foo({ a: 1, b: 2 });
 	}
 }
 // { a: number; b: number; }
@@ -10272,11 +10272,11 @@ exports[`TSC: classes instanceMemberAssignsToClassPrototype 1`] = `
 		C.prototype.bar = () => {
 		};
 		// error
-C.prototype.bar = (x) => x;
+		C.prototype.bar = (x) => x;
 		// ok
-C.prototype.bar = (x) => 1;
+		C.prototype.bar = (x) => 1;
 		// ok
-return 1;
+		return 1;
 	}
 }
 "
@@ -10357,43 +10357,43 @@ class D {
 exports[`TSC: classes memberFunctionsWithPublicPrivateOverloads 1`] = `
 "class C {
 	// error
-foo(x,y) {
+	foo(x,y) {
 	}
 	// error
-bar(x,y) {
+	bar(x,y) {
 	}
 	// error
-static foo(x,y) {
+	static foo(x,y) {
 	}
 	// error
-// error
-baz(x,y) {
+	// error
+	baz(x,y) {
 	}
 	// error
-static bar(x,y) {
+	static bar(x,y) {
 	}
 	// error
-static baz(x,y) {
+	static baz(x,y) {
 	}
 }
 class D {
 	// error
-foo(x,y) {
+	foo(x,y) {
 	}
 	// error
-bar(x,y) {
+	bar(x,y) {
 	}
 	// error
-baz(x,y) {
+	baz(x,y) {
 	}
 	// error
-static foo(x,y) {
+	static foo(x,y) {
 	}
 	// error
-static bar(x,y) {
+	static bar(x,y) {
 	}
 	// error
-static baz(x,y) {
+	static baz(x,y) {
 	}
 }
 var r = c.foo(1);
@@ -10432,11 +10432,11 @@ exports[`TSC: classes staticMemberAssignsToConstructorFunctionMembers 1`] = `
 		C.bar = () => {
 		};
 		// error
-C.bar = (x) => x;
+		C.bar = (x) => x;
 		// ok
-C.bar = (x) => 1;
+		C.bar = (x) => 1;
 		// ok
-return 1;
+		return 1;
 	}
 }
 "
@@ -10490,7 +10490,7 @@ exports[`TSC: classes optionalProperty 1`] = `
 exports[`TSC: classes overrideInterfaceProperty 1`] = `
 "class Sizz extends Mup {
 	// ok, because Mup is an interface
-get size() {
+	get size() {
 		return 0;
 	}
 }
@@ -10505,7 +10505,7 @@ exports[`TSC: classes propertyAndAccessorWithSameName 1`] = `
 	x;
 	get x() {
 		// error
-return 1;
+		return 1;
 	}
 }
 class D {
@@ -10518,7 +10518,7 @@ class E {
 	x;
 	get x() {
 		// error
-return 1;
+		return 1;
 	}
 	set x(v) {
 	}
@@ -10531,7 +10531,7 @@ exports[`TSC: classes propertyAndFunctionWithSameName 1`] = `
 	x;
 	x() {
 		// error
-return 1;
+		return 1;
 	}
 }
 class D {
@@ -10598,7 +10598,7 @@ exports[`TSC: classes propertyOverridesAccessors3 1`] = `
 		this._sound = val;
 	}
 	/* some important code here, perhaps tracking known sounds, etc */
-makeSound() {
+	makeSound() {
 		console.log(this._sound);
 	}
 }
@@ -10685,7 +10685,7 @@ exports[`TSC: classes redefinedPararameterProperty 1`] = `
 class Derived extends Base {
 	b = this.a;
 	/*undefined*/
-constructor(a) {
+	constructor(a) {
 		this.a = a;
 		super();
 	}
@@ -10709,9 +10709,9 @@ exports[`TSC: classes staticAutoAccessors 1`] = `
 "// https://github.com/microsoft/TypeScript/issues/53752
 class A {
 	// uses class reference
-static accessor x = 1;
+	static accessor x = 1;
 	// uses 'this'
-accessor y = 2;
+	accessor y = 2;
 }
 "
 `;
@@ -10775,10 +10775,10 @@ let A = (() => {
 		static {
 			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
 			_x_decorators = [// uses class reference
-((t, c) => {
+			((t, c) => {
 			})];
 			_y_decorators = [// uses 'this'
-((t, c) => {
+			((t, c) => {
 			})];
 			__esDecorate(this, null, _x_decorators, { kind: "accessor", name: "x", static: true, private: false, access: { has: (obj) => "x" in obj, get: (obj) => obj.x, set: function(obj,value) {
 				obj.x = value;
@@ -10840,16 +10840,16 @@ exports[`TSC: classes strictPropertyInitialization 1`] = `
 class C1 {
 	a;
 	// Error
-b;
+	b;
 	c;
 	// Error
-d;
+	d;
 	#f;
 	//Error
-#g;
+	#g;
 	#h;
 	//Error
-#i;
+	#i;
 }
 // No strict initialization checks in ambient contexts
 // No strict initialization checks for static members
@@ -10881,7 +10881,7 @@ class C5 {
 class C6 {
 	a;
 	// Error
-#b;
+	#b;
 	constructor(cond) {
 		if (cond) {
 			return;
@@ -10907,7 +10907,7 @@ class C7 {
 class C8 {
 	a;
 	// Error
-"b";
+	"b";
 	0;
 }
 // No strict initialization checks for abstract members
@@ -10923,11 +10923,11 @@ class C10 {
 	constructor() {
 		let x = this.a;
 		// Error
-this.a = this.b;
+		this.a = this.b;
 		// Error
-this.b = this.#d;
+		this.b = this.#d;
 		//Error
-this.b = x;
+		this.b = x;
 		this.#d = x;
 		let y = this.c;
 	}

--- a/tests/integration/tests/tsc/__snapshots__/es6-Symbols.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-Symbols.test.ts.snap
@@ -350,7 +350,7 @@ exports[`TSC: es6/Symbols symbolProperty46 1`] = `
 		return "";
 	}
 	// Should take a string
-set [Symbol.hasInstance](x) {
+	set [Symbol.hasInstance](x) {
 	}
 }
 (new C())[Symbol.hasInstance] = 0;
@@ -364,7 +364,7 @@ exports[`TSC: es6/Symbols symbolProperty47 1`] = `
 		return "";
 	}
 	// Should take a string
-set [Symbol.hasInstance](x) {
+	set [Symbol.hasInstance](x) {
 	}
 }
 (new C())[Symbol.hasInstance] = 0;

--- a/tests/integration/tests/tsc/__snapshots__/es6-arrowFunction.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-arrowFunction.test.ts.snap
@@ -283,14 +283,14 @@ function f() {
 	function g() {
 		var _arguments = 10;
 		// No capture in 'g', so no conflict.
-function h() {
+		function h() {
 			var capture = () => arguments;
 			// Should trigger an '_arguments' capture into function 'h'
-foo(_arguments);
+			foo(_arguments);
 		}
 	}
 	// Error as this does not resolve to the user defined '_arguments'
-function foo(x) {
+	function foo(x) {
 		return 100;
 	}
 }
@@ -303,14 +303,14 @@ function f() {
 	function g() {
 		var _arguments = 10;
 		// No capture in 'g', so no conflict.
-function h() {
+		function h() {
 			var capture = () => arguments;
 			// Should trigger an '_arguments' capture into function 'h'
-foo(_arguments);
+			foo(_arguments);
 		}
 	}
 	// Error as this does not resolve to the user defined '_arguments'
-function foo(x) {
+	function foo(x) {
 		return 100;
 	}
 }

--- a/tests/integration/tests/tsc/__snapshots__/es6-classDeclaration.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-classDeclaration.test.ts.snap
@@ -369,9 +369,9 @@ class D extends Base {
 		};
 		x();
 		// no error; we only check super is called before this when the container is a constructor
-this._t;
+		this._t;
 		// error
-super(undefined);
+		super(undefined);
 	}
 }
 "

--- a/tests/integration/tests/tsc/__snapshots__/es6-computedProperties.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-computedProperties.test.ts.snap
@@ -600,7 +600,7 @@ exports[`TSC: es6/computedProperties computedPropertyNames29_ES5 1`] = `
 			} };
 		};
 		// needs capture
-return 0;
+		return 0;
 	}
 }
 "
@@ -614,7 +614,7 @@ exports[`TSC: es6/computedProperties computedPropertyNames29_ES6 1`] = `
 			} };
 		};
 		// needs capture
-return 0;
+		return 0;
 	}
 }
 "
@@ -628,9 +628,9 @@ class C extends Base {
 		super();
 		() => {
 			var obj = { // Ideally, we would capture this. But the reference is
-// illegal, and not capturing this is consistent with
-//treatment of other similar violations.
-[(super(),"prop")]() {
+			// illegal, and not capturing this is consistent with
+			//treatment of other similar violations.
+			[(super(),"prop")]() {
 			} };
 		};
 	}
@@ -646,9 +646,9 @@ class C extends Base {
 		super();
 		() => {
 			var obj = { // Ideally, we would capture this. But the reference is
-// illegal, and not capturing this is consistent with
-//treatment of other similar violations.
-[(super(),"prop")]() {
+			// illegal, and not capturing this is consistent with
+			//treatment of other similar violations.
+			[(super(),"prop")]() {
 			} };
 		};
 	}
@@ -669,7 +669,7 @@ class C extends Base {
 			} };
 		};
 		// needs capture
-return 0;
+		return 0;
 	}
 }
 "
@@ -688,7 +688,7 @@ class C extends Base {
 			} };
 		};
 		// needs capture
-return 0;
+		return 0;
 	}
 }
 "
@@ -788,7 +788,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-get ["get1"]() {
+	get ["get1"]() {
 		return new Foo();
 	}
 	set ["set1"](p) {
@@ -807,7 +807,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-get ["get1"]() {
+	get ["get1"]() {
 		return new Foo();
 	}
 	set ["set1"](p) {
@@ -826,7 +826,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-get ["get1"]() {
+	get ["get1"]() {
 		return new Foo();
 	}
 	set ["set1"](p) {
@@ -845,7 +845,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-get ["get1"]() {
+	get ["get1"]() {
 		return new Foo();
 	}
 	set ["set1"](p) {
@@ -864,7 +864,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-get [1 << 6]() {
+	get [1 << 6]() {
 		return new Foo();
 	}
 	set [1 << 6](p) {
@@ -883,7 +883,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-get [1 << 6]() {
+	get [1 << 6]() {
 		return new Foo();
 	}
 	set [1 << 6](p) {
@@ -902,7 +902,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-get [1 << 6]() {
+	get [1 << 6]() {
 		return new Foo();
 	}
 	set [1 << 6](p) {
@@ -921,7 +921,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-get [1 << 6]() {
+	get [1 << 6]() {
 		return new Foo();
 	}
 	set [1 << 6](p) {
@@ -956,7 +956,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-[""]() {
+	[""]() {
 		return new Foo();
 	}
 	[""]() {
@@ -976,7 +976,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-[""]() {
+	[""]() {
 		return new Foo();
 	}
 	[""]() {
@@ -996,7 +996,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-static [""]() {
+	static [""]() {
 		return new Foo();
 	}
 }
@@ -1013,7 +1013,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-static [""]() {
+	static [""]() {
 		return new Foo();
 	}
 }
@@ -1030,7 +1030,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-[""];
+	[""];
 }
 "
 `;
@@ -1045,7 +1045,7 @@ class Foo2 {
 }
 class C {
 	// Computed properties
-[""];
+	[""];
 }
 "
 `;
@@ -1062,7 +1062,7 @@ class C {
 }
 class D extends C {
 	// Computed properties
-get ["get1"]() {
+	get ["get1"]() {
 		return new Foo();
 	}
 	set ["set1"](p) {
@@ -1083,7 +1083,7 @@ class C {
 }
 class D extends C {
 	// Computed properties
-get ["get1"]() {
+	get ["get1"]() {
 		return new Foo();
 	}
 	set ["set1"](p) {
@@ -1147,7 +1147,7 @@ class C {
 }
 class D extends C {
 	// No error when the indexer is in a class more derived than the computed property
-set ["set1"](p) {
+	set ["set1"](p) {
 	}
 }
 "
@@ -1168,7 +1168,7 @@ class C {
 }
 class D extends C {
 	// No error when the indexer is in a class more derived than the computed property
-set ["set1"](p) {
+	set ["set1"](p) {
 	}
 }
 "
@@ -1229,7 +1229,7 @@ exports[`TSC: es6/computedProperties computedPropertyNames49_ES5 1`] = `
 	return 10;
 }, set [1 + 1]() {
 	// just throw
-throw 10;
+	throw 10;
 }, get foo() {
 	if (1 == 1) {
 		return 10;
@@ -1249,7 +1249,7 @@ exports[`TSC: es6/computedProperties computedPropertyNames49_ES6 1`] = `
 	return 10;
 }, set [1 + 1]() {
 	// just throw
-throw 10;
+	throw 10;
 }, get foo() {
 	if (1 == 1) {
 		return 10;
@@ -1281,7 +1281,7 @@ exports[`TSC: es6/computedProperties computedPropertyNames50_ES5 1`] = `
 	throw 10;
 }, set [1 + 1]() {
 	// just throw
-throw 10;
+	throw 10;
 }, get [1 + 1]() {
 	return 10;
 }, get foo() {
@@ -1301,7 +1301,7 @@ exports[`TSC: es6/computedProperties computedPropertyNames50_ES6 1`] = `
 	throw 10;
 }, set [1 + 1]() {
 	// just throw
-throw 10;
+	throw 10;
 }, get [1 + 1]() {
 	return 10;
 }, get foo() {

--- a/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
@@ -35,18 +35,18 @@ function f1() {
 function f2() {
 	var {} = { x: 5, y: "hello" };
 	// Ok, empty binding pattern means nothing
-var { x:x } = { x: 5, y: "hello" };
+	var { x:x } = { x: 5, y: "hello" };
 	// Error, no y in target
-var { y:y } = { x: 5, y: "hello" };
+	var { y:y } = { x: 5, y: "hello" };
 	// Error, no x in target
-var { x:x, y:y } = { x: 5, y: "hello" };
+	var { x:x, y:y } = { x: 5, y: "hello" };
 	var x;
 	var y;
 	var { x:a } = { x: 5, y: "hello" };
 	// Error, no y in target
-var { y:b } = { x: 5, y: "hello" };
+	var { y:b } = { x: 5, y: "hello" };
 	// Error, no x in target
-var { x:a, y:b } = { x: 5, y: "hello" };
+	var { x:a, y:b } = { x: 5, y: "hello" };
 	var a;
 	var b;
 }
@@ -70,26 +70,26 @@ function f6() {
 function f7() {
 	var [x=0, y=1] = [1, "hello"];
 	// Error, initializer for y must be string
-var x;
+	var x;
 	var y;
 }
 function f8() {
 	var [a, b, c] = [];
 	// Error, [] is an empty tuple
-var [d, e, f] = [1];
+	var [d, e, f] = [1];
 }
 // Error, [1] is a tuple
 function f9() {
 	var [a, b] = {};
 	// Error, not array type
-var [c, d] = { 0: 10, 1: 20 };
+	var [c, d] = { 0: 10, 1: 20 };
 	// Error, not array type
-var [e, f] = [10, 20];
+	var [e, f] = [10, 20];
 }
 function f10() {
 	var { a:a, b:b } = {};
 	// Error
-var { a:a, b:b } = [];
+	var { a:a, b:b } = [];
 }
 // Error
 function f11() {
@@ -145,7 +145,7 @@ function f18() {
 	[aa[0], b] = [a, b];
 	[a, b] = [b, a];
 	// Error
-[a=1, b="abc"] = [2, "def"];
+	[a=1, b="abc"] = [2, "def"];
 }
 function f19() {
 	var a,b;
@@ -485,23 +485,23 @@ exports[`TSC: es6/destructuring destructuringControlFlow 1`] = `
 		obj = {};
 		let a1 = obj["a"];
 		// string | undefined
-let a2 = obj.a;
+		let a2 = obj.a;
 	}
 }
 // string | undefined
 function f2(obj) {
 	let a0 = obj[0];
 	// number | null
-let a1 = obj[1];
+	let a1 = obj[1];
 	// string | null
-let [b0, b1] = obj;
+	let [b0, b1] = obj;
 	([a0, a1] = obj);
 	if (obj[0] && obj[1]) {
 		let c0 = obj[0];
 		// number
-let c1 = obj[1];
+		let c1 = obj[1];
 		// string
-let [d0, d1] = obj;
+		let [d0, d1] = obj;
 		([c0, c1] = obj);
 	}
 }
@@ -509,16 +509,16 @@ function f3(obj) {
 	if (obj.a && obj.b) {
 		let { a:a, b:b } = obj;
 		// number, string
-({ a, b } = obj);
+		({ a, b } = obj);
 	}
 }
 function f4() {
 	let x;
 	({ x } = 0);
 	// Error
-({ ["x"]:x } = 0);
+	({ ["x"]:x } = 0);
 	// Error
-({ ["x" + ""]:x } = 0);
+	({ ["x" + ""]:x } = 0);
 }
 // Errpr
 // Repro from #31770

--- a/tests/integration/tests/tsc/__snapshots__/es6-for-ofStatements.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-for-ofStatements.test.ts.snap
@@ -294,7 +294,7 @@ exports[`TSC: es6/for-ofStatements for-of31 1`] = `
 class MyStringIterator {
 	next() {
 		return { // no done property
-value: "" };
+		value: "" };
 	}
 	[Symbol.iterator]() {
 		return this;

--- a/tests/integration/tests/tsc/__snapshots__/es6-functionDeclarations.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-functionDeclarations.test.ts.snap
@@ -15,7 +15,7 @@ exports[`TSC: es6/functionDeclarations FunctionDeclaration11_es6 1`] = `
 exports[`TSC: es6/functionDeclarations FunctionDeclaration13_es6 1`] = `
 "function* foo() {
 	// Legal to use 'yield' in a type context.
-var v;
+	var v;
 }
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/es6-restParameters.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-restParameters.test.ts.snap
@@ -111,7 +111,7 @@ exports[`TSC: es6/restParameters readonlyRestParameters 1`] = `
 function f1(...args) {
 	f0(...args);
 	// Error
-f1("abc", "def");
+	f1("abc", "def");
 	f1("abc", ...args);
 	f1(...args);
 }
@@ -123,7 +123,7 @@ function f2(...args) {
 	f2("abc", "def");
 	f2("abc", ...args);
 	// Error
-f2(...args);
+	f2(...args);
 }
 function f4(...args) {
 	args[0] = "abc";

--- a/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
@@ -1287,7 +1287,7 @@ exports[`TSC: es6/templates templateStringInYieldKeyword 1`] = `
 "// @strict: false
 function* gen() {
 	// Once this is supported, the inner expression does not need to be parenthesized.
-var x = yield \`abc\${ x }def\`;
+	var x = yield \`abc\${ x }def\`;
 }
 "
 `;
@@ -1744,7 +1744,7 @@ exports[`TSC: es6/templates templateStringWithEmbeddedYieldKeywordES6 1`] = `
 "// @strict: false
 function* gen() {
 	// Once this is supported, yield *must* be parenthesized.
-var x = \`abc\${ yield 10 }def\`;
+	var x = \`abc\${ yield 10 }def\`;
 }
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/es6-yieldExpressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-yieldExpressions.test.ts.snap
@@ -756,7 +756,7 @@ export function strategy(stratName,gen) {
 export const Nothing = strategy("Nothing", function*(state) {
 	yield 1;
 	// number isn't a \`State\`, so this should error.
-return state;
+	return state;
 });
 // \`return\`/\`TReturn\` isn't supported by \`strategy\`, so this should error.
 export const Nothing1 = strategy("Nothing", function*(state) {

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -733,27 +733,27 @@ function foo(t,u) {
 	let g;
 	let f;
 	// type parameter as left operand
-var r1 = t + a;
+	var r1 = t + a;
 	// ok, one operand is any
-var r2 = t + b;
+	var r2 = t + b;
 	var r3 = t + c;
 	var r4 = t + d;
 	// ok, one operand is string
-var r5 = t + e;
+	var r5 = t + e;
 	var r6 = t + g;
 	var r7 = t + f;
 	// type parameter as right operand
-var r8 = a + t;
+	var r8 = a + t;
 	// ok, one operand is any
-var r9 = b + t;
+	var r9 = b + t;
 	var r10 = c + t;
 	var r11 = d + t;
 	// ok, one operand is string
-var r12 = e + t;
+	var r12 = e + t;
 	var r13 = g + t;
 	var r14 = f + t;
 	// other cases
-var r15 = t + null;
+	var r15 = t + null;
 	var r16 = t + undefined;
 	var r17 = t + t;
 	var r18 = t + u;
@@ -3576,7 +3576,7 @@ function foo(t,u) {
 	var r7 = t === u;
 	var r8 = t !== u;
 	// operator <
-var r1a1 = t < a;
+	var r1a1 = t < a;
 	var r1a2 = t < b;
 	var r1a3 = t < c;
 	var r1a4 = t < d;
@@ -3591,7 +3591,7 @@ var r1a1 = t < a;
 	var r1b6 = f < t;
 	var r1b7 = g < t;
 	// operator >
-var r2a1 = t < a;
+	var r2a1 = t < a;
 	var r2a2 = t < b;
 	var r2a3 = t < c;
 	var r2a4 = t < d;
@@ -3606,7 +3606,7 @@ var r2a1 = t < a;
 	var r2b6 = f < t;
 	var r2b7 = g < t;
 	// operator <=
-var r3a1 = t < a;
+	var r3a1 = t < a;
 	var r3a2 = t < b;
 	var r3a3 = t < c;
 	var r3a4 = t < d;
@@ -3621,7 +3621,7 @@ var r3a1 = t < a;
 	var r3b6 = f < t;
 	var r3b7 = g < t;
 	// operator >=
-var r4a1 = t < a;
+	var r4a1 = t < a;
 	var r4a2 = t < b;
 	var r4a3 = t < c;
 	var r4a4 = t < d;
@@ -3636,7 +3636,7 @@ var r4a1 = t < a;
 	var r4b6 = f < t;
 	var r4b7 = g < t;
 	// operator ==
-var r5a1 = t < a;
+	var r5a1 = t < a;
 	var r5a2 = t < b;
 	var r5a3 = t < c;
 	var r5a4 = t < d;
@@ -3651,7 +3651,7 @@ var r5a1 = t < a;
 	var r5b6 = f < t;
 	var r5b7 = g < t;
 	// operator !=
-var r6a1 = t < a;
+	var r6a1 = t < a;
 	var r6a2 = t < b;
 	var r6a3 = t < c;
 	var r6a4 = t < d;
@@ -3666,7 +3666,7 @@ var r6a1 = t < a;
 	var r6b6 = f < t;
 	var r6b7 = g < t;
 	// operator ===
-var r7a1 = t < a;
+	var r7a1 = t < a;
 	var r7a2 = t < b;
 	var r7a3 = t < c;
 	var r7a4 = t < d;
@@ -3681,7 +3681,7 @@ var r7a1 = t < a;
 	var r7b6 = f < t;
 	var r7b7 = g < t;
 	// operator !==
-var r8a1 = t < a;
+	var r8a1 = t < a;
 	var r8a2 = t < b;
 	var r8a3 = t < c;
 	var r8a4 = t < d;
@@ -5180,7 +5180,7 @@ function foo(/* extends T*/
 /* extends U*/
 t,u,v) {
 	// errors
-var ra1 = t < u;
+	var ra1 = t < u;
 	var ra2 = t > u;
 	var ra3 = t <= u;
 	var ra4 = t >= u;
@@ -5213,7 +5213,7 @@ var ra1 = t < u;
 	var rd7 = v === t;
 	var rd8 = v !== t;
 	// ok
-var re1 = t < a;
+	var re1 = t < a;
 	var re2 = t > a;
 	var re3 = t <= a;
 	var re4 = t >= a;
@@ -5852,7 +5852,7 @@ function fn2(/* extends T*/
 t,u,v) {
 	var r1 = t || u;
 	//var r2: T = t || u;
-var r3 = u || u;
+	var r3 = u || u;
 	var r4 = u || u;
 	var r5 = u || v;
 	var r6 = u || v;
@@ -6643,7 +6643,7 @@ class C {
 		return "string";
 	}
 	// Error; get contextual type by set accessor parameter type annotation
-set Y(y) {
+	set Y(y) {
 	}
 	get Y() {
 		return true;
@@ -6714,7 +6714,7 @@ class A {
 }
 class B extends A {
 	// Ensure 'value' is of type 'number (and not '{}') by using its 'toExponential()' method.
-constructor() {
+	constructor() {
 		super((value) => String(value.toExponential()));
 	}
 }
@@ -6730,7 +6730,7 @@ class A {
 }
 class C extends A {
 	// Ensure 'value' is not of type 'any' by invoking it with type arguments.
-constructor() {
+	constructor() {
 		super((value) => String(value()));
 	}
 }
@@ -6748,13 +6748,13 @@ class CBase {
 class C extends CBase {
 	constructor() {
 		// Should be okay.
-// 'p' should have type 'string'.
-super({ method(p) {
+		// 'p' should have type 'string'.
+		super({ method(p) {
 			p.length;
 		} });
 		// Should be okay.
-// 'p' should have type 'string'.
-super.foo({ method(p) {
+		// 'p' should have type 'string'.
+		super.foo({ method(p) {
 			p.length;
 		} });
 	}
@@ -8131,13 +8131,13 @@ exports[`TSC: expressions contextuallyTypedFunctionExpressionsAndReturnAnnotatio
 foo((y) => {
 	var z = y.charAt(0);
 	// Should be string
-return null;
+	return null;
 });
 foo((y) => {
 	return (y2) => {
 		var z = y2.toFixed();
 		// Should be string
-return 0;
+		return 0;
 	};
 });
 "
@@ -8950,9 +8950,9 @@ exports[`TSC: expressions privateIdentifierChain.1 1`] = `
 	constructor() {
 		this?.#b;
 		// Error
-this?.a.#b;
+		this?.a.#b;
 		// Error
-this?.getA().#b;
+		this?.getA().#b;
 	}
 }
 // Error
@@ -9115,11 +9115,11 @@ function g2(headerNames) {
 function foo(options) {
 	let x1 = (options || {}).a;
 	// Object type not widened
-let x2 = (options || {})["a"];
+	let x2 = (options || {})["a"];
 	// Object type not widened
-(options || {}).a = 1;
+	(options || {}).a = 1;
 	// Object type widened, error
-(options || {})["a"] = 1;
+	(options || {})["a"] = 1;
 }
 // Object type widened, error
 "
@@ -9135,11 +9135,11 @@ function v() {
 }
 class Derived extends Base {
 	//super call in class constructor of derived type
-constructor(q) {
+	constructor(q) {
 		this.q = q;
 		super("");
 		//type of super call expression is void
-var p = super("");
+		var p = super("");
 		var p = v();
 	}
 }
@@ -9306,7 +9306,7 @@ exports[`TSC: expressions thisInInvalidContexts 1`] = `
 class ClassWithNoInitializer extends BaseErrClass {
 	t;
 	//'this' in optional super call
-constructor() {
+	constructor() {
 		super(this);
 	}
 }
@@ -9314,7 +9314,7 @@ constructor() {
 class ClassWithInitializer extends BaseErrClass {
 	t = 4;
 	//'this' in required super call
-constructor() {
+	constructor() {
 		super(this);
 	}
 }
@@ -9346,7 +9346,7 @@ exports[`TSC: expressions thisInInvalidContextsExternalModule 1`] = `
 class ClassWithNoInitializer extends BaseErrClass {
 	t;
 	//'this' in optional super call
-constructor() {
+	constructor() {
 		super(this);
 	}
 }
@@ -9354,7 +9354,7 @@ constructor() {
 class ClassWithInitializer extends BaseErrClass {
 	t = 4;
 	//'this' in required super call
-constructor() {
+	constructor() {
 		super(this);
 	}
 }
@@ -9384,7 +9384,7 @@ exports[`TSC: expressions thisInObjectLiterals 1`] = `
 	t;
 	fn() {
 		//type of 'this' in an object literal is the containing scope's this
-var t = { x: this, y: this.t };
+		var t = { x: this, y: this.t };
 		var t;
 	}
 }
@@ -9402,19 +9402,19 @@ exports[`TSC: expressions typeOfThisGeneral 1`] = `
 	static staticCanary;
 	constructor() {
 		//type of 'this' in constructor body is the class instance type
-var p = this.canary;
+		var p = this.canary;
 		var p;
 		this.canary = 3;
 	}
 	//type of 'this' in member function param list is the class instance type
-memberFunc(t=this) {
+	memberFunc(t=this) {
 		var t;
 		//type of 'this' in member function body is the class instance type
-var p = this;
+		var p = this;
 		var p;
 	}
 	//type of 'this' in member accessor(get and set) body is the class instance type
-get prop() {
+	get prop() {
 		var p = this;
 		var p;
 		return this;
@@ -9427,23 +9427,23 @@ get prop() {
 	}
 	someFunc = () => {
 		//type of 'this' in member variable initializer is the class instance type
-var t = this;
+		var t = this;
 		var t;
 	};
 	//type of 'this' in static function param list is constructor function type
-static staticFn(t=this) {
+	static staticFn(t=this) {
 		var t;
 		var t = MyTestClass;
 		t.staticCanary;
 		//type of 'this' in static function body is constructor function type
-var p = this;
+		var p = this;
 		var p;
 		var p = MyTestClass;
 		p.staticCanary;
 	}
 	static get staticProp() {
 		//type of 'this' in static accessor body is constructor function type
-var p = this;
+		var p = this;
 		var p;
 		var p = MyTestClass;
 		p.staticCanary;
@@ -9451,7 +9451,7 @@ var p = this;
 	}
 	static set staticProp(v) {
 		//type of 'this' in static accessor body is constructor function type
-var p = this;
+		var p = this;
 		var p;
 		var p = MyTestClass;
 		p.staticCanary;
@@ -9462,19 +9462,19 @@ class MyGenericTestClass {
 	static staticCanary;
 	constructor() {
 		//type of 'this' in constructor body is the class instance type
-var p = this.canary;
+		var p = this.canary;
 		var p;
 		this.canary = 3;
 	}
 	//type of 'this' in member function param list is the class instance type
-memberFunc(t=this) {
+	memberFunc(t=this) {
 		var t;
 		//type of 'this' in member function body is the class instance type
-var p = this;
+		var p = this;
 		var p;
 	}
 	//type of 'this' in member accessor(get and set) body is the class instance type
-get prop() {
+	get prop() {
 		var p = this;
 		var p;
 		return this;
@@ -9487,23 +9487,23 @@ get prop() {
 	}
 	someFunc = () => {
 		//type of 'this' in member variable initializer is the class instance type
-var t = this;
+		var t = this;
 		var t;
 	};
 	//type of 'this' in static function param list is constructor function type
-static staticFn(t=this) {
+	static staticFn(t=this) {
 		var t;
 		var t = MyGenericTestClass;
 		t.staticCanary;
 		//type of 'this' in static function body is constructor function type
-var p = this;
+		var p = this;
 		var p;
 		var p = MyGenericTestClass;
 		p.staticCanary;
 	}
 	static get staticProp() {
 		//type of 'this' in static accessor body is constructor function type
-var p = this;
+		var p = this;
 		var p;
 		var p = MyGenericTestClass;
 		p.staticCanary;
@@ -9511,7 +9511,7 @@ var p = this;
 	}
 	static set staticProp(v) {
 		//type of 'this' in static accessor body is constructor function type
-var p = this;
+		var p = this;
 		var p;
 		var p = MyGenericTestClass;
 		p.staticCanary;
@@ -9522,7 +9522,7 @@ function fn(s=this) {
 	var s;
 	s.spaaaaaaace = 4;
 	//type of 'this' in a function declaration body is Any
-var t;
+	var t;
 	var t = this;
 	this.spaaaaace = 4;
 }
@@ -9531,7 +9531,7 @@ var q1 = function(s=this) {
 	var s;
 	s.spaaaaaaace = 4;
 	//type of 'this' in a function expression body is Any
-var t;
+	var t;
 	var t = this;
 	this.spaaaaace = 4;
 };
@@ -9540,7 +9540,7 @@ var q2 = (s = this) => {
 	var s;
 	s.spaaaaaaace = 4;
 	//type of 'this' in a fat arrow expression body is typeof globalThis
-var t;
+	var t;
 	var t = this;
 	this.spaaaaace = 4;
 };
@@ -9555,7 +9555,7 @@ exports[`TSC: expressions typeOfThisInConstructorParamList 1`] = `
 "//type of 'this' in constructor param list is the class instance type (error)
 class ErrClass {
 	// Should be an error
-constructor(f=this) {
+	constructor(f=this) {
 	}
 }
 "
@@ -9988,9 +9988,9 @@ function hasWings(x) {
 // Function to identify a given beast by detecting its features
 function identifyBeast(beast) {
 	// All beasts with legs
-if (hasLegs(beast)) {
+	if (hasLegs(beast)) {
 		// All winged beasts with legs
-if (hasWings(beast)) {
+		if (hasWings(beast)) {
 			if (beast.legs === 4) {
 				log(\`pegasus - 4 legs, wings\`);
 			} else if (beast.legs === 2) {
@@ -9999,11 +9999,11 @@ if (hasWings(beast)) {
 				log(\`unknown - \${beast.legs} legs, wings\`);
 			}
 		} else // All non-winged beasts with legs
-{
+		{
 			log(\`manbearpig - \${beast.legs} legs, no wings\`);
 		}
 	} else // All beasts without legs    
-{
+	{
 		if (hasWings(beast)) {
 			log(\`quetzalcoatl - no legs, wings\`);
 		} else {
@@ -10015,7 +10015,7 @@ function beastFoo(beast) {
 	if (hasWings(beast) && hasLegs(beast)) {
 		beast;
 	} else // Winged & Legged
-{
+	{
 		beast;
 	}
 	if (hasLegs(beast) && hasWings(beast)) {
@@ -10115,12 +10115,12 @@ if (typeof strOrNumOrBoolOrC !== "string" && typeof strOrNumOrBoolOrC !== "numbe
 if (typeof strOrNumOrBoolOrC !== "string" && typeof strOrNumOrBoolOrC !== "number" && typeof strOrNumOrBool === "boolean") {
 	cOrBool = strOrNumOrBoolOrC;
 	// C | boolean
-bool = strOrNumOrBool;
+	bool = strOrNumOrBool;
 } else // boolean
 {
 	var r1 = strOrNumOrBoolOrC;
 	// string | number | boolean | C
-var r2 = strOrNumOrBool;
+	var r2 = strOrNumOrBool;
 }
 // (typeguard1) && simpleExpr
 if (typeof strOrNumOrBool !== "string" && numOrBool !== strOrNumOrBool) {
@@ -10170,11 +10170,11 @@ if (typeof strOrNumOrBoolOrC === "string" || typeof strOrNumOrBoolOrC === "numbe
 if (typeof strOrNumOrBoolOrC === "string" || typeof strOrNumOrBoolOrC === "number" || typeof strOrNumOrBool !== "boolean") {
 	var r1 = strOrNumOrBoolOrC;
 	// string | number | boolean | C
-var r2 = strOrNumOrBool;
+	var r2 = strOrNumOrBool;
 } else {
 	cOrBool = strOrNumOrBoolOrC;
 	// C | boolean
-bool = strOrNumOrBool;
+	bool = strOrNumOrBool;
 }
 // boolean
 // (typeguard1) || simpleExpr
@@ -10623,7 +10623,7 @@ function f10(x) {
 	if (typeof x === "function") {
 		x;
 	} else // () => string
-{
+	{
 		x;
 	}
 }
@@ -10632,7 +10632,7 @@ function f11(x) {
 	if (typeof x === "function") {
 		x;
 	} else // () => string
-{
+	{
 		x;
 	}
 }
@@ -10641,7 +10641,7 @@ function f12(x) {
 	if (typeof x === "function") {
 		x;
 	} else // never
-{
+	{
 		x;
 	}
 }
@@ -10872,7 +10872,7 @@ if (typeof boolOrC === "Object") {
 // boolean
 if (typeof strOrC === "Object") {
 	// comparison is OK with cast
-c = strOrC;
+	c = strOrC;
 } else // error: but no narrowing to C
 {
 	var r5 = strOrC;
@@ -11164,7 +11164,7 @@ function foo(x) {
 		f();
 		return x.length;
 	} else // string
-{
+	{
 		return x++;
 	}
 }
@@ -11173,7 +11173,7 @@ function foo2(x) {
 	if (typeof x === "string") {
 		return x.length;
 	} else // string
-{
+	{
 		var f = function() {
 			return x * x;
 		};
@@ -11185,7 +11185,7 @@ function foo3(x) {
 	if (typeof x === "string") {
 		return x.length;
 	} else // string
-{
+	{
 		var f = () => x * x;
 	}
 	x = "hello";
@@ -11203,98 +11203,98 @@ var strOrNum;
 var var1;
 class ClassWithAccessors {
 	// Inside public accessor getter
-get p1() {
+	get p1() {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-return strOrNum;
+		return strOrNum;
 	}
 	// Inside public accessor setter
-set p1(param) {
+	set p1(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// parameter of function declaration
-num = typeof param === "string" && param.length;
+		// parameter of function declaration
+		num = typeof param === "string" && param.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 	}
 	// string
-// Inside private accessor getter
-get pp1() {
+	// Inside private accessor getter
+	get pp1() {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-return strOrNum;
+		return strOrNum;
 	}
 	// Inside private accessor setter
-set pp1(param) {
+	set pp1(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// parameter of function declaration
-num = typeof param === "string" && param.length;
+		// parameter of function declaration
+		num = typeof param === "string" && param.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 	}
 	// string
-// Inside static accessor getter
-static get s1() {
+	// Inside static accessor getter
+	static get s1() {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-return strOrNum;
+		return strOrNum;
 	}
 	// Inside static accessor setter
-static set s1(param) {
+	static set s1(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// parameter of function declaration
-num = typeof param === "string" && param.length;
+		// parameter of function declaration
+		num = typeof param === "string" && param.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 	}
 	// string
-// Inside private static accessor getter
-static get ss1() {
+	// Inside private static accessor getter
+	static get ss1() {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-return strOrNum;
+		return strOrNum;
 	}
 	// Inside private static accessor setter
-static set ss1(param) {
+	static set ss1(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// parameter of function declaration
-num = typeof param === "string" && param.length;
+		// parameter of function declaration
+		num = typeof param === "string" && param.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 	}
 }
@@ -11311,66 +11311,66 @@ var var1;
 class C1 {
 	constructor(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-// parameters in function declaration
-num = typeof param === "string" && param.length;
+		// parameters in function declaration
+		num = typeof param === "string" && param.length;
 	}
 	// string
-// Inside function declaration
-p1(param) {
+	// Inside function declaration
+	p1(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-// parameters in function declaration
-num = typeof param === "string" && param.length;
+		// parameters in function declaration
+		num = typeof param === "string" && param.length;
 	}
 	// string
-// Inside function declaration
-p2(param) {
+	// Inside function declaration
+	p2(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-// parameters in function declaration
-num = typeof param === "string" && param.length;
+		// parameters in function declaration
+		num = typeof param === "string" && param.length;
 	}
 	// string
-// Inside function declaration
-static s1(param) {
+	// Inside function declaration
+	static s1(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-// parameters in function declaration
-num = typeof param === "string" && param.length;
+		// parameters in function declaration
+		num = typeof param === "string" && param.length;
 	}
 	// string
-// Inside function declaration
-static s2(param) {
+	// Inside function declaration
+	static s2(param) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables in function declaration
-var var2;
+		// variables in function declaration
+		var var2;
 		num = typeof var2 === "string" && var2.length;
 		// string
-// parameters in function declaration
-num = typeof param === "string" && param.length;
+		// parameters in function declaration
+		num = typeof param === "string" && param.length;
 	}
 }
 // string
@@ -11386,84 +11386,84 @@ exports[`TSC: expressions typeGuardsInConditionalExpression 1`] = `
 // provided the false expression contains no assignments to the variable or parameter.
 function foo(x) {
 	return typeof x === "string" ? x.length : // string
-x++;
+	x++;
 }
 // number
 function foo2(x) {
 	return typeof x === "string" ? ((x = "hello") && x) : // string
-x;
+	x;
 }
 // number
 function foo3(x) {
 	return typeof x === "string" ? ((x = 10) && x) : // number
-x;
+	x;
 }
 // number
 function foo4(x) {
 	return typeof x === "string" ? x : // string
-// string
-((x = 10) && x);
+	// string
+	((x = 10) && x);
 }
 // number
 function foo5(x) {
 	return typeof x === "string" ? x : // string
-// string
-((x = "hello") && x);
+	// string
+	((x = "hello") && x);
 }
 // string
 function foo6(x) {
 	// Modify in both branches
-return typeof x === "string" ? ((x = 10) && x) : // number
-((x = "hello") && x);
+	return typeof x === "string" ? ((x = 10) && x) : // number
+	((x = "hello") && x);
 }
 // string
 function foo7(x) {
 	return typeof x === "string" ? x === "hello" : // boolean
-typeof x === "boolean" ? x : // boolean
-// boolean
-x == 10;
+	typeof x === "boolean" ? x : // boolean
+	// boolean
+	x == 10;
 }
 // boolean
 function foo8(x) {
 	var b;
 	return typeof x === "string" ? x === "hello" : ((b = x) && //  number | boolean
-(typeof x === "boolean" ? x : // boolean
-// boolean
-x == 10));
+	(typeof x === "boolean" ? x : // boolean
+	// boolean
+	x == 10));
 }
 // boolean
 function foo9(x) {
 	var y = 10;
 	// usage of x or assignment to separate variable shouldn't cause narrowing of type to stop
-return typeof x === "string" ? ((y = x.length) && x === "hello") : // boolean
-x === 10;
+	return typeof x === "string" ? ((y = x.length) && x === "hello") : // boolean
+	x === 10;
 }
 // boolean
 function foo10(x) {
 	// Mixing typeguards
-var b;
+	var b;
 	return typeof x === "string" ? x : // string
-// string
-((b = x) && // x is number | boolean
-typeof x === "number" && x.toString());
+	// string
+	((b = x) && // x is number | boolean
+	typeof x === "number" && x.toString());
 }
 // x is number
 function foo11(x) {
 	// Mixing typeguards
-var b;
+	var b;
 	return typeof x === "string" ? x : // string
-// string
-((b = x) && // x is number | boolean
-typeof x === "number" && (x = 10) && // assignment to x
-x);
+	// string
+	((b = x) && // x is number | boolean
+	typeof x === "number" && (x = 10) && // assignment to x
+	x);
 }
 // x is number
 function foo12(x) {
 	// Mixing typeguards
-var b;
+	var b;
 	return typeof x === "string" ? ((x = 10) && x.toString().length) : // number
-((b = x) && // x is number | boolean
-typeof x === "number" && x);
+	((b = x) && // x is number | boolean
+	typeof x === "number" && x);
 }
 // x is number
 "
@@ -11476,7 +11476,7 @@ function a(x) {
 	do {
 		x;
 		// boolean | string
-x = undefined;
+		x = undefined;
 	} while (typeof x === "string");
 	x;
 }
@@ -11486,7 +11486,7 @@ function b(x) {
 	do {
 		x;
 		// boolean | string
-if (cond)continue;
+		if (cond)continue;
 		x = undefined;
 	} while (typeof x === "string");
 	x;
@@ -11497,7 +11497,7 @@ function c(x) {
 	do {
 		x;
 		// string
-if (cond)break;
+		if (cond)break;
 		x = undefined;
 	} while (typeof x === "string");
 	x;
@@ -11524,7 +11524,7 @@ var strOrNum;
 export var var2;
 if (typeof var2 === "string") {
 	// export makes the var property and not variable
-strOrNum = var2;
+	strOrNum = var2;
 } else // string | number
 {
 	strOrNum = var2;
@@ -11540,14 +11540,14 @@ function a(x) {
 		x;
 	}
 	// string
-x;
+	x;
 }
 // number
 function b(x) {
 	for (x = undefined; typeof x !== "number"; x = undefined) {
 		x;
 		// string
-if (cond)continue;
+		if (cond)continue;
 	}
 	x;
 }
@@ -11556,7 +11556,7 @@ function c(x) {
 	for (x = undefined; typeof x !== "number"; x = undefined) {
 		x;
 		// string
-if (cond)break;
+		if (cond)break;
 	}
 	x;
 }
@@ -11573,14 +11573,14 @@ var var1;
 // Inside function declaration
 function f(param) {
 	// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+	num = typeof var1 === "string" && var1.length;
 	// string
-// variables in function declaration
-var var2;
+	// variables in function declaration
+	var var2;
 	num = typeof var2 === "string" && var2.length;
 	// string
-// parameters in function declaration
-num = typeof param === "string" && param.length;
+	// parameters in function declaration
+	num = typeof param === "string" && param.length;
 }
 // string
 // local function declaration
@@ -11588,67 +11588,67 @@ function f1(param) {
 	var var2;
 	function f2(param1) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables from outer function declaration
-num = typeof var2 === "string" && var2.length;
+		// variables from outer function declaration
+		num = typeof var2 === "string" && var2.length;
 		// string
-// parameters in outer declaration
-num = typeof param === "string" && param.length;
+		// parameters in outer declaration
+		num = typeof param === "string" && param.length;
 		// string
-// local
-var var3;
+		// local
+		var var3;
 		num = typeof var3 === "string" && var3.length;
 		// string
-num = typeof param1 === "string" && param1.length;
+		num = typeof param1 === "string" && param1.length;
 	}
 }
 // string
 // Function expression
 function f2(param) {
 	// variables in function declaration
-var var2;
+	var var2;
 	// variables in function expressions
-var r = function(param1) {
+	var r = function(param1) {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables from outer function declaration
-num = typeof var2 === "string" && var2.length;
+		// variables from outer function declaration
+		num = typeof var2 === "string" && var2.length;
 		// string
-// parameters in outer declaration
-num = typeof param === "string" && param.length;
+		// parameters in outer declaration
+		num = typeof param === "string" && param.length;
 		// string
-// local
-var var3;
+		// local
+		var var3;
 		num = typeof var3 === "string" && var3.length;
 		// string
-num = typeof param1 === "string" && param1.length;
+		num = typeof param1 === "string" && param1.length;
 	}(// string
-param);
+	param);
 }
 // Arrow expression
 function f3(param) {
 	// variables in function declaration
-var var2;
+	var var2;
 	// variables in function expressions
-var r = ((param1) => {
+	var r = ((param1) => {
 		// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+		num = typeof var1 === "string" && var1.length;
 		// string
-// variables from outer function declaration
-num = typeof var2 === "string" && var2.length;
+		// variables from outer function declaration
+		num = typeof var2 === "string" && var2.length;
 		// string
-// parameters in outer declaration
-num = typeof param === "string" && param.length;
+		// parameters in outer declaration
+		num = typeof param === "string" && param.length;
 		// string
-// local
-var var3;
+		// local
+		var var3;
 		num = typeof var3 === "string" && var3.length;
 		// string
-num = typeof param1 === "string" && param1.length;
+		num = typeof param1 === "string" && param1.length;
 	})(// string
-param);
+	param);
 }
 // Return type of function
 // Inside function declaration
@@ -11668,8 +11668,8 @@ function foo(x) {
 	return typeof x === "string" ? x : function f() {
 		var b = x;
 		// number | boolean
-return typeof x === "boolean" ? x.toString() : // boolean
-x.toString();
+		return typeof x === "boolean" ? x.toString() : // boolean
+		x.toString();
 	}();
 }
 // number
@@ -11677,18 +11677,18 @@ function foo2(x) {
 	return typeof x === "string" ? x : function f(a) {
 		var b = x;
 		// new scope - number | boolean
-return typeof x === "boolean" ? x.toString() : // boolean
-x.toString();
+		return typeof x === "boolean" ? x.toString() : // boolean
+		x.toString();
 	}(// number
-x);
+	x);
 }
 // x here is narrowed to number | boolean
 function foo3(x) {
 	return typeof x === "string" ? x : (() => {
 		var b = x;
 		// new scope - number | boolean
-return typeof x === "boolean" ? x.toString() : // boolean
-x.toString();
+		return typeof x === "boolean" ? x.toString() : // boolean
+		x.toString();
 	})();
 }
 // number
@@ -11696,10 +11696,10 @@ function foo4(x) {
 	return typeof x === "string" ? x : ((a) => {
 		var b = x;
 		// new scope - number | boolean
-return typeof x === "boolean" ? x.toString() : // boolean
-x.toString();
+		return typeof x === "boolean" ? x.toString() : // boolean
+		x.toString();
 	})(// number
-x);
+	x);
 }
 // x here is narrowed to number | boolean
 // Type guards do not affect nested function declarations
@@ -11707,7 +11707,7 @@ function foo5(x) {
 	if (typeof x === "string") {
 		var y = x;
 		// string;
-function foo() {
+		function foo() {
 			var z = x;
 		}
 	}
@@ -11720,7 +11720,7 @@ var y;if (typeof x === "string") {
 // string;
 {
 	y = typeof x === "boolean" ? x.toString() : // boolean
-x.toString();
+	x.toString();
 }})(m2 = m.m2 || (m.m2 = {}));})(m || (m = {}));
 // number
 var m1;((m1) => {var x;let m2;((m2) => {let m3;((m3) => {var b = x;// new scope - number | boolean | string
@@ -11730,7 +11730,7 @@ var y;if (typeof x === "string") {
 // string;
 {
 	y = typeof x === "boolean" ? x.toString() : // boolean
-x.toString();
+	x.toString();
 }})(m3 = m2.m3 || (m2.m3 = {}));})(m2 = m1.m2 || (m1.m2 = {}));})(m1 || (m1 = {}));
 // number
 "
@@ -11761,7 +11761,7 @@ function foo(x) {
 	if (typeof x === "string") {
 		return x.length;
 	} else // string
-{
+	{
 		return x++;
 	}
 }
@@ -11771,7 +11771,7 @@ function foo2(x) {
 		x = 10;
 		return x;
 	} else // number
-{
+	{
 		return x;
 	}
 }
@@ -11781,7 +11781,7 @@ function foo3(x) {
 		x = "Hello";
 		return x;
 	} else // string
-{
+	{
 		return x;
 	}
 }
@@ -11790,7 +11790,7 @@ function foo4(x) {
 	if (typeof x === "string") {
 		return x;
 	} else // string
-{
+	{
 		x = 10;
 		return x;
 	}
@@ -11800,7 +11800,7 @@ function foo5(x) {
 	if (typeof x === "string") {
 		return x;
 	} else // string
-{
+	{
 		x = "hello";
 		return x;
 	}
@@ -11811,7 +11811,7 @@ function foo6(x) {
 		x = 10;
 		return x;
 	} else // number
-{
+	{
 		x = "hello";
 		return x;
 	}
@@ -11821,10 +11821,10 @@ function foo7(x) {
 	if (typeof x === "string") {
 		return x === "hello";
 	} else // string
-if (typeof x === "boolean") {
+	if (typeof x === "boolean") {
 		return x;
 	} else // boolean
-{
+	{
 		return x == 10;
 	}
 }
@@ -11833,13 +11833,13 @@ function foo8(x) {
 	if (typeof x === "string") {
 		return x === "hello";
 	} else // string
-{
+	{
 		var b = x;
 		//  number | boolean
-if (typeof x === "boolean") {
+		if (typeof x === "boolean") {
 			return x;
 		} else // boolean
-{
+		{
 			return x == 10;
 		}
 	}
@@ -11849,63 +11849,63 @@ function foo9(x) {
 	var y = 10;
 	if (typeof x === "string") {
 		// usage of x or assignment to separate variable shouldn't cause narrowing of type to stop
-y = x.length;
+		y = x.length;
 		return x === "hello";
 	} else // string
-{
+	{
 		return x == 10;
 	}
 }
 // number
 function foo10(x) {
 	// Mixing typeguard narrowing in if statement with conditional expression typeguard
-if (typeof x === "string") {
+	if (typeof x === "string") {
 		return x === "hello";
 	} else // string
-{
+	{
 		var y;
 		var b = x;
 		// number | boolean
-return typeof x === "number" ? x === 10 : // number
-x;
+		return typeof x === "number" ? x === 10 : // number
+		x;
 	}
 }
 // x should be boolean
 function foo11(x) {
 	// Mixing typeguard narrowing in if statement with conditional expression typeguard
-// Assigning value to x deep inside another guard stops narrowing of type too
-if (typeof x === "string") {
+	// Assigning value to x deep inside another guard stops narrowing of type too
+	if (typeof x === "string") {
 		return x;
 	} else // string | number | boolean - x changed in else branch
-{
+	{
 		var y;
 		var b = x;
 		// number | boolean | string - because below we are changing value of x in if statement
-return typeof x === "number" ? (// change value of x
-// change value of x
-// change value of x
-x = 10 && x.toString()) : // number | boolean | string
-(// do not change value
-// do not change value
-// do not change value
-// do not change value
-// do not change value
-y = x && x.toString());
+		return typeof x === "number" ? (// change value of x
+		// change value of x
+		// change value of x
+		x = 10 && x.toString()) : // number | boolean | string
+		(// do not change value
+		// do not change value
+		// do not change value
+		// do not change value
+		// do not change value
+		y = x && x.toString());
 	}
 }
 // number | boolean | string
 function foo12(x) {
 	// Mixing typeguard narrowing in if statement with conditional expression typeguard
-// Assigning value to x in outer guard shouldn't stop narrowing in the inner expression
-if (typeof x === "string") {
+	// Assigning value to x in outer guard shouldn't stop narrowing in the inner expression
+	if (typeof x === "string") {
 		return x.toString();
 	} else // string | number | boolean - x changed in else branch
-{
+	{
 		x = 10;
 		var b = x;
 		// number | boolean | string
-return typeof x === "number" ? x.toString() : // number
-x.toString();
+		return typeof x === "number" ? x.toString() : // number
+		x.toString();
 	}
 }
 // boolean | string
@@ -11989,15 +11989,15 @@ class C1 {
 	pp1;
 	pp2;
 	// Inside public accessor getter
-get pp3() {
+	get pp3() {
 		return strOrNum;
 	}
 	method() {
 		strOrNum = typeof this.pp1 === "string" && this.pp1;
 		// string | number
-strOrNum = typeof this.pp2 === "string" && this.pp2;
+		strOrNum = typeof this.pp2 === "string" && this.pp2;
 		// string | number
-strOrNum = typeof this.pp3 === "string" && this.pp3;
+		strOrNum = typeof this.pp3 === "string" && this.pp3;
 	}
 }
 // string | number
@@ -12021,46 +12021,46 @@ function foo(x) {
 // string
 function foo2(x) {
 	// modify x in right hand operand
-return typeof x === "string" && ((x = 10) && x);
+	return typeof x === "string" && ((x = 10) && x);
 }
 // string | number
 function foo3(x) {
 	// modify x in right hand operand with string type itself
-return typeof x === "string" && ((x = "hello") && x);
+	return typeof x === "string" && ((x = "hello") && x);
 }
 // string | number
 function foo4(x) {
 	return typeof x !== "string" && // string | number | boolean
-typeof x !== "number" && // number | boolean
-x;
+	typeof x !== "number" && // number | boolean
+	x;
 }
 // boolean
 function foo5(x) {
 	// usage of x or assignment to separate variable shouldn't cause narrowing of type to stop
-var b;
+	var b;
 	return typeof x !== "string" && // string | number | boolean
-((b = x) && (typeof x !== "number" && // number | boolean
-x));
+	((b = x) && (typeof x !== "number" && // number | boolean
+	x));
 }
 // boolean
 function foo6(x) {
 	// Mixing typeguard narrowing in if statement with conditional expression typeguard
-return typeof x !== "string" && // string | number | boolean
-(typeof x !== "number" ? // number | boolean
-x : // boolean
-// boolean
-x === 10);
+	return typeof x !== "string" && // string | number | boolean
+	(typeof x !== "number" ? // number | boolean
+	x : // boolean
+	// boolean
+	x === 10);
 }
 // number 
 function foo7(x) {
 	var y;
 	var z;
 	// Mixing typeguard narrowing
-return typeof x !== "string" && ((z = x) && // number | boolean
-(typeof x === "number" ? // change value of x
-((x = 10) && x.toString()) : // x is number
-// do not change value
-((y = x) && x.toString())));
+	return typeof x !== "string" && ((z = x) && // number | boolean
+	(typeof x === "number" ? // change value of x
+	((x = 10) && x.toString()) : // x is number
+	// do not change value
+	((y = x) && x.toString())));
 }
 // x is boolean
 "
@@ -12076,46 +12076,46 @@ function foo(x) {
 // string
 function foo2(x) {
 	// modify x in right hand operand
-return typeof x !== "string" || ((x = 10) || x);
+	return typeof x !== "string" || ((x = 10) || x);
 }
 // string | number
 function foo3(x) {
 	// modify x in right hand operand with string type itself
-return typeof x !== "string" || ((x = "hello") || x);
+	return typeof x !== "string" || ((x = "hello") || x);
 }
 // string | number
 function foo4(x) {
 	return typeof x === "string" || // string | number | boolean
-typeof x === "number" || // number | boolean
-x;
+	typeof x === "number" || // number | boolean
+	x;
 }
 // boolean
 function foo5(x) {
 	// usage of x or assignment to separate variable shouldn't cause narrowing of type to stop
-var b;
+	var b;
 	return typeof x === "string" || // string | number | boolean
-((b = x) || (typeof x === "number" || // number | boolean
-x));
+	((b = x) || (typeof x === "number" || // number | boolean
+	x));
 }
 // boolean
 function foo6(x) {
 	// Mixing typeguard
-return typeof x === "string" || // string | number | boolean
-(typeof x !== "number" ? // number | boolean
-x : // boolean
-// boolean
-x === 10);
+	return typeof x === "string" || // string | number | boolean
+	(typeof x !== "number" ? // number | boolean
+	x : // boolean
+	// boolean
+	x === 10);
 }
 // number 
 function foo7(x) {
 	var y;
 	var z;
 	// Mixing typeguard narrowing
-return typeof x === "string" || ((z = x) || // number | boolean
-(typeof x === "number" ? // change value of x
-((x = 10) && x.toString()) : // number | boolean | string
-// do not change value
-((y = x) && x.toString())));
+	return typeof x === "string" || ((z = x) || // number | boolean
+	(typeof x === "number" ? // change value of x
+	((x = 10) && x.toString()) : // number | boolean | string
+	// do not change value
+	((y = x) && x.toString())));
 }
 // number | boolean | string
 "
@@ -12127,7 +12127,7 @@ function a(x) {
 	while (typeof x === "string") {
 		x;
 		// string
-x = undefined;
+		x = undefined;
 	}
 	x;
 }
@@ -12137,7 +12137,7 @@ function b(x) {
 		if (cond)continue;
 		x;
 		// string
-x = undefined;
+		x = undefined;
 	}
 	x;
 }
@@ -12147,7 +12147,7 @@ function c(x) {
 		if (cond)break;
 		x;
 		// string
-x = undefined;
+		x = undefined;
 	}
 	x;
 }
@@ -12165,35 +12165,35 @@ var var1;
 var obj1 = { // Inside method
 method(param) {
 	// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+	num = typeof var1 === "string" && var1.length;
 	// string
-// variables in function declaration
-var var2;
+	// variables in function declaration
+	var var2;
 	num = typeof var2 === "string" && var2.length;
 	// string
-// parameters in function declaration
-num = typeof param === "string" && param.length;
+	// parameters in function declaration
+	num = typeof param === "string" && param.length;
 	// string
-return strOrNum;
+	return strOrNum;
 }, get prop() {
 	// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+	num = typeof var1 === "string" && var1.length;
 	// string
-// variables in function declaration
-var var2;
+	// variables in function declaration
+	var var2;
 	num = typeof var2 === "string" && var2.length;
 	// string
-return strOrNum;
+	return strOrNum;
 }, set prop(param) {
 	// global vars in function declaration
-num = typeof var1 === "string" && var1.length;
+	num = typeof var1 === "string" && var1.length;
 	// string
-// variables in function declaration
-var var2;
+	// variables in function declaration
+	var var2;
 	num = typeof var2 === "string" && var2.length;
 	// string
-// parameters in function declaration
-num = typeof param === "string" && param.length;
+	// parameters in function declaration
+	num = typeof param === "string" && param.length;
 } };
 // string
 // return expression of the method
@@ -12288,25 +12288,25 @@ function foo() {
 		v;
 	}
 	// Validator & Partial<OnChanges> & C
-// Validator & Partial<OnChanges> & C
-// Validator & Partial<OnChanges> & C
-v;
+	// Validator & Partial<OnChanges> & C
+	// Validator & Partial<OnChanges> & C
+	v;
 	// Validator & Partial<OnChanges> via subtype reduction
-// In 4.1, we introduced a change which _fixed_ a bug with CFA
-// correctly setting this to be the right object. With 4.2,
-// we reverted that fix in #42231 which brought behavior back to
-// before 4.1.
-// Validator & Partial<OnChanges> via subtype reduction
-// In 4.1, we introduced a change which _fixed_ a bug with CFA
-// correctly setting this to be the right object. With 4.2,
-// we reverted that fix in #42231 which brought behavior back to
-// before 4.1.
-// Validator & Partial<OnChanges> via subtype reduction
-// In 4.1, we introduced a change which _fixed_ a bug with CFA
-// correctly setting this to be the right object. With 4.2,
-// we reverted that fix in #42231 which brought behavior back to
-// before 4.1.
-if (v.onChanges) {
+	// In 4.1, we introduced a change which _fixed_ a bug with CFA
+	// correctly setting this to be the right object. With 4.2,
+	// we reverted that fix in #42231 which brought behavior back to
+	// before 4.1.
+	// Validator & Partial<OnChanges> via subtype reduction
+	// In 4.1, we introduced a change which _fixed_ a bug with CFA
+	// correctly setting this to be the right object. With 4.2,
+	// we reverted that fix in #42231 which brought behavior back to
+	// before 4.1.
+	// Validator & Partial<OnChanges> via subtype reduction
+	// In 4.1, we introduced a change which _fixed_ a bug with CFA
+	// correctly setting this to be the right object. With 4.2,
+	// we reverted that fix in #42231 which brought behavior back to
+	// before 4.1.
+	if (v.onChanges) {
 		v.onChanges({});
 	}
 }
@@ -12316,7 +12316,7 @@ if (v.onChanges) {
 exports[`TSC: expressions typeGuardsWithInstanceOfByConstructorSignature 1`] = `
 "if (obj1 instanceof A) {
 	// narrowed to A.
-obj1.foo;
+	obj1.foo;
 	obj1.bar;
 }
 if (obj2 instanceof A) {
@@ -12326,7 +12326,7 @@ if (obj2 instanceof A) {
 // a construct signature with generics
 if (obj3 instanceof B) {
 	// narrowed to B<number>.
-obj3.foo = 1;
+	obj3.foo = 1;
 	obj3.foo = "str";
 	obj3.bar = "str";
 }
@@ -12338,7 +12338,7 @@ if (obj4 instanceof B) {
 // has multiple construct signature
 if (obj5 instanceof C) {
 	// narrowed to C1.
-obj5.foo;
+	obj5.foo;
 	obj5.c;
 	obj5.bar1;
 	obj5.bar2;
@@ -12351,7 +12351,7 @@ if (obj6 instanceof C) {
 // with object type literal
 if (obj7 instanceof D) {
 	// narrowed to D.
-obj7.foo;
+	obj7.foo;
 	obj7.bar;
 }
 if (obj8 instanceof D) {
@@ -12361,7 +12361,7 @@ if (obj8 instanceof D) {
 // a construct signature that returns a union type
 if (obj9 instanceof E) {
 	// narrowed to E1
-obj9.foo;
+	obj9.foo;
 	obj9.bar1;
 	obj9.bar2;
 }
@@ -12373,7 +12373,7 @@ if (obj10 instanceof E) {
 // a construct signature that returns any
 if (obj11 instanceof F) {
 	// can't type narrowing, construct signature returns any.
-obj11.foo;
+	obj11.foo;
 	obj11.bar;
 }
 if (obj12 instanceof F) {
@@ -12385,7 +12385,7 @@ if (obj12 instanceof F) {
 // low priority
 if (obj13 instanceof G) {
 	// narrowed to G1. G1 is return type of prototype property.
-obj13.foo1;
+	obj13.foo1;
 	obj13.foo2;
 }
 if (obj14 instanceof G) {
@@ -12397,7 +12397,7 @@ if (obj14 instanceof G) {
 // low priority
 if (obj15 instanceof H) {
 	// narrowed to H.
-obj15.foo;
+	obj15.foo;
 	obj15.bar;
 }
 if (obj16 instanceof H) {
@@ -12406,12 +12406,12 @@ if (obj16 instanceof H) {
 }
 if (obj17 instanceof Object) {
 	// can't narrow type from 'any' to 'Object'
-obj17.foo1;
+	obj17.foo1;
 	obj17.foo2;
 }
 if (obj18 instanceof Function) {
 	// can't narrow type from 'any' to 'Function'
-obj18.foo1;
+	obj18.foo1;
 	obj18.foo2;
 }
 "
@@ -14281,29 +14281,29 @@ function fn2(x,y) {
 	x = 3;
 	(x) = 3;
 	// OK
-x = "";
+	x = "";
 	// Error
-(x) = "";
+	(x) = "";
 	// Error
-(y).t = 3;
+	(y).t = 3;
 	// OK
-(y.t) = 3;
+	(y.t) = 3;
 	// OK
-(y).t = "";
+	(y).t = "";
 	// Error
-(y.t) = "";
+	(y.t) = "";
 	// Error
-y["t"] = 3;
+	y["t"] = 3;
 	// OK
-(y)["t"] = 3;
+	(y)["t"] = 3;
 	// OK
-(y["t"]) = 3;
+	(y["t"]) = 3;
 	// OK
-y["t"] = "";
+	y["t"] = "";
 	// Error
-(y)["t"] = "";
+	(y)["t"] = "";
 	// Error
-(y["t"]) = "";
+	(y["t"]) = "";
 }
 // Error
 var E = /* @__PURE__ */ ((E) => {E[E["A"]=0]="A";return E;})(E || {});

--- a/tests/integration/tests/tsc/__snapshots__/generators.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/generators.test.ts.snap
@@ -33,33 +33,33 @@ for (_ of g2);
 // ok
 async function asyncfn() {
 	// for-await-of over iterable
-for await (_ of g1);
+	for await (_ of g1);
 	// error
-for await (_ of g2);
+	for await (_ of g2);
 	// ok
-// for-await-of over asynciterable
-for await (_ of g4);
+	// for-await-of over asynciterable
+	for await (_ of g4);
 	// error
-for await (_ of g5);
+	for await (_ of g5);
 }
 // ok
 function* f1() {
 	// yield* over iterable
-yield* g1;
+	yield* g1;
 	// error
-yield* g3;
+	yield* g3;
 }
 // ok
 async function* f2() {
 	// yield* over iterable
-yield* g1;
+	yield* g1;
 	// error
-yield* g3;
+	yield* g3;
 	// ok
-// yield* over asynciterable
-yield* g4;
+	// yield* over asynciterable
+	yield* g4;
 	// error
-yield* g6;
+	yield* g6;
 }
 // ok
 async function f3() {
@@ -78,11 +78,11 @@ exports[`TSC: generators generatorExplicitReturnType 1`] = `
 "function* g1() {
 	yield;
 	// error
-yield "a";
+	yield "a";
 	// error
-const x = yield 1;
+	const x = yield 1;
 	// error
-return 10;
+	return 10;
 }
 // error
 function* g2() {
@@ -92,7 +92,7 @@ function* g2() {
 function* g3() {
 	const x = yield* generator;
 	// error
-return true;
+	return true;
 }
 function* g4() {
 	const x = yield* generator;
@@ -116,17 +116,17 @@ function* g3() {
 function* g4() {
 	yield;
 	// ok, result is unused
-yield,noop();
+	yield,noop();
 	// ok, result is unused
-noop(),yield,noop();
+	noop(),yield,noop();
 	// ok, result is unused
-(yield);
+	(yield);
 	// ok, result is unused
-(yield,noop()),noop();
+	(yield,noop()),noop();
 	// ok, result is unused
-for (yield; false; yield);
+	for (yield; false; yield);
 	// ok, results are unused
-void (yield);
+	void (yield);
 }
 // ok, results are unused
 function* g5() {
@@ -229,120 +229,120 @@ exports[`TSC: generators generatorReturnTypeInference 1`] = `
 // 'yield' iteration type inference
 function* g001() {
 	// Generator<undefined, void, unknown>
-yield;
+	yield;
 }
 function* g002() {
 	// Generator<number, void, unknown>
-yield 1;
+	yield 1;
 }
 function* g003() {
 	// Generator<never, void, undefined>
-yield* [];
+	yield* [];
 }
 function* g004() {
 	// Generator<number, void, undefined>
-yield* iterableIterator;
+	yield* iterableIterator;
 }
 function* g005() {
 	// Generator<number, void, boolean>
-const x = yield* generator;
+	const x = yield* generator;
 }
 function* g006() {
 	// Generator<1 | 2, void, unknown>
-yield 1;
+	yield 1;
 	yield 2;
 }
 function* g007() {
 	// Generator<never, void, unknown>
-yield never;
+	yield never;
 }
 // 'return' iteration type inference
 function* g102() {
 	// Generator<never, number, unknown>
-return 1;
+	return 1;
 }
 function* g103() {
 	// Generator<never, 1 | 2, unknown>
-if (Math.random())return 1;
+	if (Math.random())return 1;
 	return 2;
 }
 function* g104() {
 	// Generator<never, never, unknown>
-return never;
+	return never;
 }
 // 'next' iteration type inference
 function* g201() {
 	// Generator<number, void, string>
-let a = yield 1;
+	let a = yield 1;
 }
 function* g202() {
 	// Generator<1 | 2, void, never>
-let a = yield 1;
+	let a = yield 1;
 	let b = yield 2;
 }
 function* g203() {
 	// Generator<number, void, string>
-const x = f1(yield 1);
+	const x = f1(yield 1);
 }
 function* g204() {
 	// Generator<number, void, any>
-const x = f2(yield 1);
+	const x = f2(yield 1);
 }
 // mixed iteration types inference
 function* g301() {
 	// Generator<undefined, void, unknown>
-yield;
+	yield;
 	return;
 }
 function* g302() {
 	// Generator<number, void, unknown>
-yield 1;
+	yield 1;
 	return;
 }
 function* g303() {
 	// Generator<undefined, string, unknown>
-yield;
+	yield;
 	return "a";
 }
 function* g304() {
 	// Generator<number, string, unknown>
-yield 1;
+	yield 1;
 	return "a";
 }
 function* g305() {
 	// Generator<1 | 2, "a" | "b", unknown>
-if (Math.random())yield 1;
+	if (Math.random())yield 1;
 	yield 2;
 	if (Math.random())return "a";
 	return "b";
 }
 function* g306() {
 	// Generator<number, boolean, "hi">
-const a = yield 1;
+	const a = yield 1;
 	return true;
 }
 function* g307() {
 	// Generator<number, T, T>
-const a = yield 0;
+	const a = yield 0;
 	return a;
 }
 function* g308(x) {
 	// Generator<T, T, T>
-const a = yield x;
+	const a = yield x;
 	return a;
 }
 function* g309(x,y) {
 	// Generator<T, U, V>
-const a = yield x;
+	const a = yield x;
 	return y;
 }
 function* g310() {
 	// Generator<undefined, void, [(1 | undefined)?, (2 | undefined)?]>
-const [a=1, b=2] = yield;
+	const [a=1, b=2] = yield;
 }
 function* g311() {
 	// Generator<undefined, void, string>
-yield* (function*() {
+	yield* (function*() {
 		const y = yield;
 	})();
 }
@@ -356,122 +356,122 @@ exports[`TSC: generators generatorReturnTypeInferenceNonStrict 1`] = `
 // 'yield' iteration type inference
 function* g001() {
 	// Generator<any (implicit), void, unknown>
-yield;
+	yield;
 }
 function* g002() {
 	// Generator<number, void, unknown>
-yield 1;
+	yield 1;
 }
 function* g003() {
 	// Generator<any (implicit), void, unknown>
-// NOTE: In strict mode, \`[]\` produces the type \`never[]\`.
-//       In non-strict mode, \`[]\` produces the type \`undefined[]\` which is implicitly any.
-yield* [];
+	// NOTE: In strict mode, \`[]\` produces the type \`never[]\`.
+	//       In non-strict mode, \`[]\` produces the type \`undefined[]\` which is implicitly any.
+	yield* [];
 }
 function* g004() {
 	// Generator<number, void, undefined>
-yield* iterableIterator;
+	yield* iterableIterator;
 }
 function* g005() {
 	// Generator<number, void, boolean>
-const x = yield* generator;
+	const x = yield* generator;
 }
 function* g006() {
 	// Generator<1 | 2, void, unknown>
-yield 1;
+	yield 1;
 	yield 2;
 }
 function* g007() {
 	// Generator<never, void, unknown>
-yield never;
+	yield never;
 }
 // 'return' iteration type inference
 function* g102() {
 	// Generator<never, number, unknown>
-return 1;
+	return 1;
 }
 function* g103() {
 	// Generator<never, 1 | 2, unknown>
-if (Math.random())return 1;
+	if (Math.random())return 1;
 	return 2;
 }
 function* g104() {
 	// Generator<never, never, unknown>
-return never;
+	return never;
 }
 // 'next' iteration type inference
 function* g201() {
 	// Generator<number, void, string>
-let a = yield 1;
+	let a = yield 1;
 }
 function* g202() {
 	// Generator<1 | 2, void, never>
-let a = yield 1;
+	let a = yield 1;
 	let b = yield 2;
 }
 function* g203() {
 	// Generator<number, void, string>
-const x = f1(yield 1);
+	const x = f1(yield 1);
 }
 function* g204() {
 	// Generator<number, void, any>
-const x = f2(yield 1);
+	const x = f2(yield 1);
 }
 // mixed iteration types inference
 function* g301() {
 	// Generator<any (implicit), void, unknown>
-yield;
+	yield;
 	return;
 }
 function* g302() {
 	// Generator<number, void, unknown>
-yield 1;
+	yield 1;
 	return;
 }
 function* g303() {
 	// Generator<any (implicit), string, unknown>
-yield;
+	yield;
 	return "a";
 }
 function* g304() {
 	// Generator<number, string, unknown>
-yield 1;
+	yield 1;
 	return "a";
 }
 function* g305() {
 	// Generator<1 | 2, "a" | "b", unknown>
-if (Math.random())yield 1;
+	if (Math.random())yield 1;
 	yield 2;
 	if (Math.random())return "a";
 	return "b";
 }
 function* g306() {
 	// Generator<number, boolean, "hi">
-const a = yield 1;
+	const a = yield 1;
 	return true;
 }
 function* g307() {
 	// Generator<number, T, T>
-const a = yield 0;
+	const a = yield 0;
 	return a;
 }
 function* g308(x) {
 	// Generator<T, T, T>
-const a = yield x;
+	const a = yield x;
 	return a;
 }
 function* g309(x,y) {
 	// Generator<T, U, V>
-const a = yield x;
+	const a = yield x;
 	return y;
 }
 function* g310() {
 	// Generator<any (implicit), void, [(1 | undefined)?, (2 | undefined)?]>
-const [a=1, b=2] = yield;
+	const [a=1, b=2] = yield;
 }
 function* g311() {
 	// Generator<any (implicit), void, string>
-yield* (function*() {
+	yield* (function*() {
 		const y = yield;
 	})();
 }
@@ -518,63 +518,63 @@ function* mergeStringLists(...strings) {
 exports[`TSC: generators yieldStatementNoAsiAfterTransform 1`] = `
 "function* t1() {
 	yield // comment
-// comment
-// comment
-a;
+	// comment
+	// comment
+	a;
 }
 function* t2() {
 	yield // comment
-// comment
-// comment
-a + 1;
+	// comment
+	// comment
+	a + 1;
 }
 function* t3() {
 	yield // comment
-// comment
-// comment
-a ? 0 : 1;
+	// comment
+	// comment
+	a ? 0 : 1;
 }
 function* t4() {
 	yield // comment
-// comment
-// comment
-a.b;
+	// comment
+	// comment
+	a.b;
 }
 function* t5() {
 	yield // comment
-// comment
-// comment
-a[a];
+	// comment
+	// comment
+	a[a];
 }
 function* t6() {
 	yield // comment
-// comment
-// comment
-a();
+	// comment
+	// comment
+	a();
 }
 function* t7() {
 	yield // comment
-// comment
-// comment
-a\`\`;
+	// comment
+	// comment
+	a\`\`;
 }
 function* t8() {
 	yield // comment
-// comment
-// comment
-a;
+	// comment
+	// comment
+	a;
 }
 function* t9() {
 	yield // comment
-// comment
-// comment
-a;
+	// comment
+	// comment
+	a;
 }
 function* t10() {
 	yield // comment
-// comment
-// comment
-a;
+	// comment
+	// comment
+	a;
 }
 "
 `;


### PR DESCRIPTION
Closes #1508

## Summary

`--target=es5` 로 class 를 function+prototype 으로 lowering 할 때 클래스 멤버 앞 주석이 `X.prototype.` 과 메서드명 사이에 emit 되어 **syntax error** 를 일으키던 버그를 두 레이어에서 근본 수정.

### Before
```js
X.prototype.// 이 주석이 문제
foo = function() { return 1; };   // invalid JS
```

### After
```js
// 이 주석이 문제
X.prototype.foo = function() { return 1; };
```

## 원인 및 수정

**Layer 1 — transformer (`src/transformer/es2015_class.zig`)**
`buildMethodAssignment` 가 expression_statement 에 **class 의 span** 을 사용하고 있었음. 그 결과 codegen 이 statement 진입 시점엔 leading comment 가 flush 되지 않고, 하위 property 식별자의 원본 span 시점에야 comment 가 emit → `X.prototype.` 과 method name 사이에 삽입됨.

→ `MethodInfo` 에 `member_span: Span` 추가, expression_statement 생성 시 원본 member span 을 사용.

**Layer 2 — codegen (`src/codegen/codegen.zig`)**
`emitComments` 가 주석 뒤 `writeNewline()` 만 호출하고 indent 를 복원하지 않아, 주석 뒤 첫 줄이 들여쓰기를 잃는 pre-existing cosmetic 결함이 있었음 (스냅샷 1615건에 화석화되어 있던 현상). layer 1 수정 후 증상이 정확히 드러나서 함께 수정.

→ `emitComments` 가 각 주석 flush 후 `writeIndent()` 로 현재 indent level 복원.

## 스냅샷 변경 (1615건)

전수 샘플 검토 — **모두 indent 복원만 반영**, 의미 변경 0건. 예:
```diff
 class E extends A {
 	// error -- doesn't implement bar
-foo() {
+	foo() {
 		return this.t;
 	}
 }
```

## 회귀 가드 (`downlevel-edge.test.ts` 5 케이스 추가)

- member 직전 line comment (최소 재현)
- JSDoc + 여러 member + static 혼합
- class extends 의 override member
- class expression member
- 연속 line comment + 마지막 member

모두 `bundleAndRun` + 런타임 결과 검증 → syntax error 시 즉시 실패.

## 제외: RN fixture drift

`tests/integration/tests/fixtures/rn-example-app/` 의 3개 파일에 diff 가 나타났으나 main 체크아웃 후 동일 테스트 실행으로 **pre-existing drift** 임을 확인 (이 PR 수정과 무관). 이번 PR 에는 포함하지 않음.

## Follow-up 권장 (별도 이슈)

Accessor/private method 에도 약한 유사 케이스:
```js
Object.defineProperty(X.prototype, "foo", { get: function()// comment
{ return 1; } });
```
→ syntax 는 유효하지만 주석 위치가 `function()` 뒤나 파라미터 안에 끼는 cosmetic 문제. `AccessorInfo` 에도 동일 패턴(`member_span`) 적용하면 해결 가능.

## Test plan

- [x] repro 최소 케이스 → valid JS 생성
- [x] 회귀 가드 5개 pass
- [x] `bun test --cwd tests/integration` 3026 pass (pre-existing flaky `watch-stress` 1건만 fail — main 에서도 동일)
- [x] 스냅샷 diff 전수 샘플 육안 검증 — indent only
- [x] Zig 유닛 테스트 (`zig build test`) pass