### PR TITLE
fix(codegen): ES5 accessor/private method lowering 멤버 주석 위치 이상 (#1516)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -136,7 +136,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             for (cm.private_methods.items) |pm| {
                 try self.scratch.append(self.allocator, try es_helpers.buildWeakCollectionDecl(self, "WeakSet", pm.weakset_name, span));
-                try self.scratch.append(self.allocator, try es_helpers.buildStandaloneFunc(self, pm.func_name, pm.member_idx, span));
+                try self.scratch.append(self.allocator, try es_helpers.buildStandaloneFunc(self, pm.func_name, pm.member_idx, pm.member_span));
             }
 
             try appendPrivateFieldInits(self, &cm, span);
@@ -426,7 +426,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             for (cm.private_methods.items) |pm| {
                 try self.scratch.append(self.allocator, try es_helpers.buildWeakCollectionDecl(self, "WeakSet", pm.weakset_name, span));
-                try self.scratch.append(self.allocator, try es_helpers.buildStandaloneFunc(self, pm.func_name, pm.member_idx, span));
+                try self.scratch.append(self.allocator, try es_helpers.buildStandaloneFunc(self, pm.func_name, pm.member_idx, pm.member_span));
             }
 
             try self.scratch.append(self.allocator, func_node);
@@ -1192,6 +1192,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             member_idx: NodeIndex,
             is_static: bool,
             is_getter: bool,
+            // `Object.defineProperty(...)` statement 및 get/set prop 의 span 으로 사용 —
+            // leading comment 가 `function()` 뒤나 파라미터 안이 아니라 accessor 앞에서 flush 되도록 (#1516).
+            member_span: Span,
         };
 
         const PrivateFieldInfo = struct {
@@ -1336,6 +1339,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                                 .original_name = orig_name,
                                 .weakset_name = names.ws_name,
                                 .func_name = names.fn_name,
+                                .member_span = member.span,
                             });
                             continue;
                         }
@@ -1346,6 +1350,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                             .member_idx = @enumFromInt(raw_idx),
                             .is_static = is_static,
                             .is_getter = kind == 1,
+                            .member_span = member.span,
                         });
                     } else {
                         try cm.methods.append(self.allocator, .{
@@ -1479,6 +1484,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .member_idx = getter_idx,
                 .is_static = is_static,
                 .is_getter = true,
+                // 동일 accessor_property 에서 파생된 getter/setter 는 같은 원본 span 공유 —
+                // 둘이 paired 로 emit 되어 첫 번째(getter) 의 member_span 에서 한 번만 comment flush.
+                .member_span = member.span,
             });
 
             const setter_idx = try buildAccessorSetter(self, key_node.span, storage_span, is_static, span);
@@ -1486,6 +1494,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .member_idx = setter_idx,
                 .is_static = is_static,
                 .is_getter = false,
+                .member_span = member.span,
             });
         }
 
@@ -2246,7 +2255,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const accessor_key = try es_helpers.makeIdentifierRef(self, if (info.is_getter) "get" else "set");
                 const prop1 = try self.ast.addNode(.{
                     .tag = .object_property,
-                    .span = span,
+                    .span = info.member_span,
                     .data = .{ .binary = .{ .left = accessor_key, .right = func_expr, .flags = 0 } },
                 });
 
@@ -2266,7 +2275,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         const pair_key = try es_helpers.makeIdentifierRef(self, if (next.is_getter) "get" else "set");
                         paired_prop = try self.ast.addNode(.{
                             .tag = .object_property,
-                            .span = span,
+                            .span = next.member_span,
                             .data = .{ .binary = .{ .left = pair_key, .right = pair_func, .flags = 0 } },
                         });
                         break;
@@ -2328,7 +2337,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const call = try es_helpers.makeCallExpr(self, dp_callee, &.{ target, key_str, desc_obj }, span);
                 const stmt = try self.ast.addNode(.{
                     .tag = .expression_statement,
-                    .span = span,
+                    .span = info.member_span,
                     .data = .{ .unary = .{ .operand = call, .flags = 0 } },
                 });
                 try self.pending_nodes.append(self.allocator, stmt);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -394,6 +394,9 @@ pub const Transformer = struct {
         weakset_name: []const u8, // "_method" (WeakSet 변수명)
         func_name: []const u8, // "_method_fn" (추출 함수명)
         member_idx: NodeIndex = NodeIndex.none, // method_definition 노드 (ES2015 경로에서 사용)
+        // standalone function_declaration 의 span 으로 사용 — leading comment 가
+        // `function _fn()` 뒤가 아니라 함수 앞에서 flush 되도록 (#1516).
+        member_span: Span = .{ .start = 0, .end = 0 },
     };
 
     // RefreshRegistration / RefreshSignature 타입 정의는 plugin_state.zig로 이사.

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1845,6 +1845,92 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("10");
     });
+
+    // #1516: accessor(getter/setter) 와 private method 에도 유사 패턴 —
+    // 주석이 `function()` 뒤 / 파라미터 안 / 함수 body 앞 등 내부에 끼는 cosmetic 이슈.
+    // AccessorInfo.member_span / PrivateMethodMapping.member_span 전파로 올바른 위치 flush.
+    test("getter/setter 앞 주석 (#1516 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class A {
+              _v = 0;
+              // getter 앞 주석
+              get v() { return this._v; }
+              // setter 앞 주석
+              set v(x: number) { this._v = x * 2; }
+            }
+            const a = new A(); a.v = 5;
+            console.log(a.v);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("10");
+    });
+
+    test("getter only + JSDoc 주석 (#1516 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              /**
+               * JSDoc for getter
+               */
+              get value() { return 42; }
+            }
+            console.log(new B().value);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("42");
+    });
+
+    test("private method 앞 주석 (#1516 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              // private method 주석
+              #bar() { return 7; }
+              call() { return this.#bar(); }
+            }
+            console.log(new C().call());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("7");
+    });
+
+    test("static getter + 주석 (#1516 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class D {
+              // static getter 주석
+              static get tag() { return "D"; }
+            }
+            console.log(D.tag);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("D");
+    });
   });
 
   describe("TS-specific", () => {


### PR DESCRIPTION
Closes #1516

## Summary

#1508 / #1515 에서 method 의 `MethodInfo.member_span` 패턴으로 ES5 class lowering leading comment 위치를 고친 것과 **대칭적으로** accessor(getter/setter) 와 private method 에 동일 패턴 적용.

## Before / After

### Accessor (paired getter/setter)

**Before** — 주석이 `function()` 뒤 / 파라미터 안에 낌 (valid JS 지만 기형):
```js
Object.defineProperty(X.prototype, "foo", {
  configurable: true,
  get: function()// getter 앞 주석
  { return 1; },
  set: function(// setter 앞 주석
  v) {}
});
```

**After** — 각 accessor 앞에 올바르게 위치:
```js
// getter 앞 주석
Object.defineProperty(X.prototype, "foo", {
  configurable: true,
  get: function() { return 1; },
  // setter 앞 주석
  set: function(v) {}
});
```

### Private method

**Before**:
```js
function _bar_fn()// private method 앞 주석
{ return 2; }
```

**After**:
```js
// private method 앞 주석
function _bar_fn() { return 2; }
```

## 변경

1. **`AccessorInfo` + `PrivateMethodMapping`** 에 `member_span: Span` 필드 추가
2. **`classifyMembers`** 에서 `.member_span = member.span` 저장
3. **`classifyAccessorProperty`** (stage 3 `accessor x = init;` synthesis) 의 getter/setter 둘 다 `accessor_property.span` 공유 — paired emit 시 첫 번째에서 한 번만 flush
4. **`emitAccessors`** 3군데에 `span` (class span) → `info.member_span`:
   - `expression_statement.span` (statement boundary)
   - `prop1.span` (get 또는 set property)
   - `paired_prop.span` (짝 accessor property — setter 주석 별도 flush 지점)
5. **`buildStandaloneFunc` 호출** 2군데에서 `span` → `pm.member_span` (instance/static IIFE 경로)

## Paired accessor 처리 설계

하나의 `Object.defineProperty({ get, set })` statement 안에서 getter/setter 각각의 leading comment 가 올바른 위치에 flush 되도록:
- **statement.span = first(getter).member_span** → getter 주석을 statement 앞에서 flush
- **paired_prop.span = second(setter).member_span** → setter 주석을 `set: function...` 앞에서 flush

결과적으로 descriptor object 안에서 자연스러운 위치로 들어감.

## 회귀 가드 (`downlevel-edge.test.ts` 4 케이스)

- paired getter/setter (comment 각각)
- getter-only + JSDoc
- private method (`#bar`)
- static getter

모두 `bundleAndRun` + runtime 결과 검증 — cosmetic 뿐 아니라 기능 회귀까지 동시에 가드.

## /simplify 리뷰

클린 (MethodInfo 와 정확히 대칭, default span 설정은 `current_private_methods` 가 ES2022 decorator 경로에서도 재사용되어 정당, paired emit 중복 flush 없음 검증).

## 스냅샷 변경: 없음

1615 건 그대로 통과 — accessor/private method 관련 snapshot 이 주석 포함된 케이스를 담고 있지 않아서 surgical change 로 종결.

## Test plan

- [x] accessor 최소 재현 → valid JS + 올바른 comment 위치
- [x] private method 최소 재현 → 동일
- [x] #1516 회귀 4 케이스 pass
- [x] full suite: 3030 pass (pre-existing flaky `watch-stress` 1건만 fail)
- [x] 스냅샷 diff 0 건
- [x] #1508/#1515 회귀 5 케이스 지속 pass