### PR TITLE
fix(transformer): new this.#priv.method() ES5 private field lowering (#1507)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1983,6 +1983,23 @@ pub const Codegen = struct {
         return false;
     }
 
+    /// `new MemberExpression Arguments` 문법상 callee 는 MemberExpression 이어야 함.
+    /// callee 의 member chain 안에 call_expression 이 있으면 `new A(x)` 가 `new (A)(x)` 로
+    /// 잘못 파싱되어 뒤따르는 `()` 가 외부 call 로 붙음 (#1507). 감싸서 Primary 로 승격.
+    fn newCalleeNeedsParens(self: *Codegen, idx: NodeIndex) bool {
+        var cur = idx;
+        while (true) {
+            const n = self.ast.getNode(cur);
+            switch (n.tag) {
+                .call_expression => return true,
+                .static_member_expression, .computed_member_expression, .private_field_expression => {
+                    cur = self.ast.readExtraNode(n.data.extra, 0);
+                },
+                else => return false,
+            }
+        }
+    }
+
     fn emitNew(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         if (!self.ast.hasExtra(e, 3)) return;
@@ -1996,7 +2013,10 @@ pub const Codegen = struct {
         if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
 
         try self.write("new ");
+        const needs_parens = self.newCalleeNeedsParens(callee);
+        if (needs_parens) try self.writeByte('(');
         try self.emitNode(callee);
+        if (needs_parens) try self.writeByte(')');
         try self.writeByte('(');
         try self.emitNodeList(args_start, args_len, self.listSep());
         try self.writeByte(')');

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1161,8 +1161,13 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
                 {
                     const prop_end = if (!prop.isNone()) self.ast.getNode(prop).span.end else self.currentSpan().start;
                     const me = try self.ast.addExtras(&.{ @intFromEnum(expr), @intFromEnum(prop), 0 });
+                    // `new obj.#priv()` — prop 이 private_identifier 면 private_field_expression 태그를
+                    // 써야 transformer 가 `_priv.get(obj)` 로 lowering 함. 일반 `.dot` 경로와 동기화 (#1507).
                     expr = try self.ast.addNode(.{
-                        .tag = .static_member_expression,
+                        .tag = if (!prop.isNone() and self.ast.getNode(prop).tag == .private_identifier)
+                            .private_field_expression
+                        else
+                            .static_member_expression,
                         .span = .{ .start = expr_start, .end = prop_end },
                         .data = .{ .extra = me },
                     });

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1931,6 +1931,88 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("D");
     });
+
+    // #1507: `new this.#priv...()` 에서 parseNewCallee 가 private identifier prop 에
+    // `static_member_expression` 태그를 잘못 붙여 private field lowering 이 미스됨.
+    // parser 수정 — private_identifier 면 `private_field_expression` 으로 분기.
+    test("new this.#priv() 직접 호출 (#1507 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class X {
+              #Ctor: any = class B { v = 5; };
+              make() { return new this.#Ctor(); }
+            }
+            console.log(new X().make().v);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("5");
+    });
+
+    test("new this.#priv.method() dot 체인 (#1507 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class X {
+              #foo: any = { bar: class B { v = 42; } };
+              make() { return new this.#foo.bar(); }
+            }
+            console.log(new X().make().v);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("42");
+    });
+
+    test("new this.#priv[key].Ctor() bracket 체인 (#1507 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class X {
+              #doc: any = { win: { Thing: class T { tag = "ok"; } } };
+              make() { return new this.#doc["win"].Thing(); }
+            }
+            console.log(new X().make().tag);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("ok");
+    });
+
+    test("happy-dom style `throw new this.#ownerDocument[key].TypeError(...)` (#1507 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Dom {
+              #ownerDocument: any = { main: { TypeError: class E { msg: string; constructor(m: string) { this.msg = m; } } } };
+              fail() {
+                try { throw new this.#ownerDocument["main"].TypeError("boom"); }
+                catch (e: any) { return e.msg; }
+              }
+            }
+            console.log(new Dom().fail());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("boom");
+    });
   });
 
   describe("TS-specific", () => {

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -192,7 +192,7 @@ exports[`TSC: expressions asOpEmitParens 1`] = `
 // Should still emit as x.y
 x.y;
 // Emit as new (x())
-new x()();
+new (x())();
 "
 `;
 


### PR DESCRIPTION
Closes #1507

## Summary

`--target=es5` 에서 `new this.#priv(...)` 와 그 체인 형태가 lowering 안 되고 verbatim 출력 → 런타임 실패. 두 레이어 근본 수정.

## Before

```ts
class X {
  #foo: any = { bar: class B {} };
  b() { return new this.#foo.bar(); }
}
```
↓
```js
X.prototype.b = function() {
  return new this.#foo.bar();  // ❌ invalid JS - # syntax in ES5 output
};
```

괄호치면 정상 (`new (this.#foo.bar)()` → `new (_foo.get(this).bar)()`).

## Root Cause 1: Parser Tag 미전파

`parseNewCallee` (`src/parser/expression.zig:1100`) 의 `.dot` 케이스가 prop tag 를 확인하지 않고 **무조건 `static_member_expression`** 생성:

```zig
// ❌ before
expr = try self.ast.addNode(.{
    .tag = .static_member_expression,  // prop 이 private_identifier 여도 static
    ...
});
```

일반 expression `.dot` 경로(line 893-910)는 `private_identifier` 면 `private_field_expression` 으로 분기하는데 new callee 경로만 누락됨. 결과적으로 transformer 가 `this.#foo` 를 private field 로 인식 못 하고 lowering 미스.

## Root Cause 2: `new` + call-chain Parsing Ambiguity

Parser 수정 후 lowering 은 타지만 새 문제 발생:
```js
new _foo.get(this).bar()
```
JS 파싱 규칙상 `new MemberExpression Arguments` — MemberExpression 은 top-level call 을 포함 못 함. 그래서:
```
new _foo.get(this).bar()  파싱  →  (new (_foo.get)(this)).bar()
                                   ↑ new 의 args 로 (this) 소비됨
```
→ `new _foo.get(this)` 가 `(new _foo.get)(this)` 로 잘못 결합 → `TypeError: function is not a constructor`.

`codegen.emitNew` 에 `newCalleeNeedsParens` helper 추가: callee 의 member chain 을 walk 해서 `call_expression` 포함 시 callee 를 `(...)` 로 감쌈:
```js
new (_foo.get(this).bar)()  ✅ 의도대로 new 의 callee 가 전체 chain
```

## After

```js
X.prototype.b = function() {
  return new (_foo.get(this).bar)();  // ✅
};
```

## 변경

1. `src/parser/expression.zig:parseNewCallee` — `.dot` 케이스 조건부 tag 분기 (일반 `.dot` 경로와 대칭)
2. `src/codegen/codegen.zig:emitNew` + `newCalleeNeedsParens` helper 추가
3. `tests/integration/tests/downlevel-edge.test.ts` — 회귀 가드 4 케이스
4. `tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap` — `asOpEmitParens` 1줄 cosmetic 갱신

## 회귀 가드 4 케이스

- `new this.#Ctor()` — 직접 호출
- `new this.#foo.bar()` — dot 체인
- `new this.#doc["win"].Thing()` — bracket 체인
- happy-dom style `throw new this.#ownerDocument[key].TypeError(...)` (이슈에 언급된 실사용 패턴)

모두 `bundleAndRun` + 런타임 결과 검증.

## 스냅샷 변경 (1건)

`tsc/expressions.test.ts > asOpEmitParens`:
```diff
- new x()();
+ new (x())();
```
Pre-existing 케이스에서 parens wrap 이 활성화됨 — 소스 `new (x() as any)` 가 `new (x())` 에 해당 (new callee 에 call 포함), 더 정확한 파싱 보장.

## /simplify 리뷰

클린. parser 수정은 일반 `.dot` 경로와 정확히 대칭, `newCalleeNeedsParens` 는 chain walk (평균 depth 1-3) 로 hot-path 영향 미미, 사용자 parens(parenthesized_expression 노드)와 안전한 double-wrap.

## Follow-up (별도 이슈 권장)

`new (x() as any);` 케이스에서 trailing empty `()` 가 추가됨 (`new (x())();`). 의도는 `new (x())` 인데 args 가 언제나 붙음 — TSC 와 동작 차이. 이번 PR 수정 범위는 아니지만 cosmetic 차이. 필요 시 별도 이슈.

## Test plan

- [x] #1507 회귀 4 케이스 pass
- [x] full suite: 3034 pass (pre-existing flaky `watch-stress` 1건만 fail)
- [x] 스냅샷 diff 1 건 (surgical)
- [x] #1508/#1515/#1516 회귀 지속 pass