### PR TITLE
refactor(transformer): Object.defineProperty descriptor 공용 helper 추출 (#1510 item4)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2271,26 +2271,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 else
                     try buildFreshPrototypeRef(self, class_name_span, span);
 
-                // key string literal — heap-alloc으로 긴 키 이름 truncation 회피.
-                const old_key_node = self.ast.getNode(key_idx);
-                const key_text = self.ast.getText(old_key_node.span);
-                const quoted = try self.allocator.alloc(u8, key_text.len + 2);
-                defer self.allocator.free(quoted);
-                quoted[0] = '"';
-                @memcpy(quoted[1 .. 1 + key_text.len], key_text);
-                quoted[1 + key_text.len] = '"';
-                const key_str_span = try self.ast.addString(quoted);
-                const key_str = try self.ast.addNode(.{
-                    .tag = .string_literal,
-                    .span = key_str_span,
-                    .data = .{ .string_ref = key_str_span },
-                });
-
-                // Object.defineProperty(target, "key", descriptor)
-                const obj_ref = try es_helpers.makeIdentifierRefFromSpan(self, obj_str_span);
-                const dp_prop = try es_helpers.makeIdentifierRefFromSpan(self, dp_str_span);
-                const dp_callee = try es_helpers.makeStaticMember(self, obj_ref, dp_prop, span);
-                const call = try es_helpers.makeCallExpr(self, dp_callee, &.{ target, key_str, desc_obj }, span);
+                const key_str = try es_helpers.buildQuotedKeyLiteral(self, self.ast.getNode(key_idx).span);
+                const call = try es_helpers.buildObjectDefinePropertyCall(self, obj_str_span, dp_str_span, target, key_str, desc_obj, span);
                 const stmt = try self.ast.addNode(.{
                     .tag = .expression_statement,
                     .span = info.member_span,

--- a/src/transformer/es2015_computed.zig
+++ b/src/transformer/es2015_computed.zig
@@ -273,10 +273,7 @@ pub fn ES2015Computed(comptime Transformer: type) type {
             const key_arg = try buildAccessorKeyArg(self, key_idx);
 
             const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
-            const obj_ref = try es_helpers.makeIdentifierRefFromSpan(self, ctx.object);
-            const dp_prop = try es_helpers.makeIdentifierRefFromSpan(self, ctx.define_property);
-            const callee = try es_helpers.makeStaticMember(self, obj_ref, dp_prop, span);
-            return es_helpers.makeCallExpr(self, callee, &.{ temp_ref, key_arg, desc_obj }, span);
+            return es_helpers.buildObjectDefinePropertyCall(self, ctx.object, ctx.define_property, temp_ref, key_arg, desc_obj, span);
         }
 
         /// method_definition의 params/body를 방문해 function_expression을 만든다.
@@ -309,19 +306,7 @@ pub fn ES2015Computed(comptime Transformer: type) type {
             if (key_node.tag == .computed_property_key) {
                 return self.visitNode(key_node.data.unary.operand);
             }
-            // identifier/numeric/string literal → "name" 으로 감싸 string_literal emit
-            const key_text = self.ast.getText(key_node.span);
-            const quoted = try self.allocator.alloc(u8, key_text.len + 2);
-            defer self.allocator.free(quoted);
-            quoted[0] = '"';
-            @memcpy(quoted[1 .. 1 + key_text.len], key_text);
-            quoted[1 + key_text.len] = '"';
-            const quoted_span = try self.ast.addString(quoted);
-            return self.ast.addNode(.{
-                .tag = .string_literal,
-                .span = quoted_span,
-                .data = .{ .string_ref = quoted_span },
-            });
+            return es_helpers.buildQuotedKeyLiteral(self, key_node.span);
         }
 
         /// `{ name: true }` object_property 생성 — span은 모두 pre-cached.

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -235,6 +235,40 @@ pub fn makeNumericLiteral(self: anytype, value: u32) !NodeIndex {
     });
 }
 
+/// 식별자/numeric/string literal key node 의 span 을 `"name"` 형태 string_literal 로 감쌈.
+/// heap alloc 경유로 긴 key name truncation 회피. (#1510 item4)
+pub fn buildQuotedKeyLiteral(self: anytype, key_span: Span) !NodeIndex {
+    const key_text = self.ast.getText(key_span);
+    const quoted = try self.allocator.alloc(u8, key_text.len + 2);
+    defer self.allocator.free(quoted);
+    quoted[0] = '"';
+    @memcpy(quoted[1 .. 1 + key_text.len], key_text);
+    quoted[1 + key_text.len] = '"';
+    const quoted_span = try self.ast.addString(quoted);
+    return self.ast.addNode(.{
+        .tag = .string_literal,
+        .span = quoted_span,
+        .data = .{ .string_ref = quoted_span },
+    });
+}
+
+/// `Object.defineProperty(target, key_arg, descriptor)` call_expression 생성.
+/// obj_span / dp_span 은 caller 가 pre-cache — hot loop 에서 addString 반복 방지.
+pub fn buildObjectDefinePropertyCall(
+    self: anytype,
+    obj_span: Span,
+    dp_span: Span,
+    target: NodeIndex,
+    key_arg: NodeIndex,
+    descriptor: NodeIndex,
+    span: Span,
+) !NodeIndex {
+    const obj_ref = try makeIdentifierRefFromSpan(self, obj_span);
+    const dp_prop = try makeIdentifierRefFromSpan(self, dp_span);
+    const callee = try makeStaticMember(self, obj_ref, dp_prop, span);
+    return makeCallExpr(self, callee, &.{ target, key_arg, descriptor }, span);
+}
+
 /// 문자열 리터럴 노드를 새 AST에 생성. text는 따옴표 포함 (예: "\"hello\"").
 pub fn buildStringNode(self: anytype, text: []const u8, _: Span) !NodeIndex {
     const str_span = try self.ast.addString(text);


### PR DESCRIPTION
Part of #1510 (item 4 / 5) — **final item**

## Summary

`es2015_class.emitAccessors` 와 `es2015_computed.emitDefineAccessor` 에 반복된 두 패턴을 `es_helpers` 로 통합. **순수 리팩터 — 동작 변경 0**.

## Helper 2개 추가

```zig
pub fn buildQuotedKeyLiteral(self, key_span: Span) !NodeIndex
// 식별자 key 를 `"name"` string_literal 로 감싸기 (heap alloc → truncation 회피)

pub fn buildObjectDefinePropertyCall(self, obj_span, dp_span, target, key_arg, descriptor, span) !NodeIndex
// Object.defineProperty(target, key, desc) call_expression. obj/dp span 은 caller 가 pre-cache 로 제공 (hot loop 에서 addString 반복 방지).
```

## Scope

**의도적으로 포함하지 않은 것**: descriptor 객체 빌드 + 페어링 로직.

이유: class vs computed accessor 의 시맨틱 차이:
- class (`emitAccessors`): `{configurable, get, set}` 순서 + 페어링 (get+set 하나의 defineProperty 호출)
- computed (`emitDefineAccessor`): `{get|set, enumerable, configurable}` 순서 + 개별 호출 (페어링 없음)

완전 공용화하면 conditional flag + branching 복잡도가 dedup 이득보다 커짐 — issue 본문도 "완전 공용화는 어렵지만 descriptor 빌드 부분은 추출 가능" 로 인정.

## LoC

±0 (38 add / 37 del). Helper overhead 로 line count 는 상쇄되지만 **dedup 은 달성** — 두 패턴의 single source of truth.

## 검증

- `zig build` 성공
- `bun test --cwd tests/integration` 3034 pass / 1 pre-existing flaky (`watch-stress`)
- 스냅샷 변경 0 건

## #1510 전체 완료 정리

| item | 내용 | PR | LoC 변화 |
|---|---|---|---|
| 1 | splice helpers (findSuperCallInsertPos, spliceBlockStmtsAt) | #1519 | -23 |
| 2 | super(...args) constructor shell 빌더 | #1520 | -22 |
| 3 | buildSetterMethod + "value" param Babel parity | #1521 | -34 |
| 4 | defineProperty helpers (이 PR) | 이 PR | ±0 |
| 5 | private_field_expression 통일 | e2655c21 | — |

**총 -79 LoC**, 5개 중 4개 PR 분리. 모두 동작 변경 0 (item3 의 param name `v→value` 는 런타임 영향 없는 cosmetic).

## Test plan

- [x] zig build 성공
- [x] 전체 integration 그린
- [x] 스냅샷 diff 0 건
- [x] #1508/#1515/#1516/#1507 회귀 지속 pass