### PR TITLE
fix(transformer): ES5 class computed getter/setter key expression 평가 (#1524)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2271,7 +2271,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 else
                     try buildFreshPrototypeRef(self, class_name_span, span);
 
-                const key_str = try es_helpers.buildQuotedKeyLiteral(self, self.ast.getNode(key_idx).span);
+                const key_str = try es_helpers.buildDefinePropertyKeyArg(self, key_idx);
                 const call = try es_helpers.buildObjectDefinePropertyCall(self, obj_str_span, dp_str_span, target, key_str, desc_obj, span);
                 const stmt = try self.ast.addNode(.{
                     .tag = .expression_statement,

--- a/src/transformer/es2015_computed.zig
+++ b/src/transformer/es2015_computed.zig
@@ -270,7 +270,7 @@ pub fn ES2015Computed(comptime Transformer: type) type {
                 .data = .{ .list = desc_list },
             });
 
-            const key_arg = try buildAccessorKeyArg(self, key_idx);
+            const key_arg = try es_helpers.buildDefinePropertyKeyArg(self, key_idx);
 
             const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
             return es_helpers.buildObjectDefinePropertyCall(self, ctx.object, ctx.define_property, temp_ref, key_arg, desc_obj, span);
@@ -297,16 +297,6 @@ pub fn ES2015Computed(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .extra = func_extra },
             });
-        }
-
-        /// Object.defineProperty의 두번째 인자: computed key면 내부 expression,
-        /// non-computed면 "name" string literal.
-        fn buildAccessorKeyArg(self: *Transformer, key_idx: NodeIndex) Transformer.Error!NodeIndex {
-            const key_node = self.ast.getNode(key_idx);
-            if (key_node.tag == .computed_property_key) {
-                return self.visitNode(key_node.data.unary.operand);
-            }
-            return es_helpers.buildQuotedKeyLiteral(self, key_node.span);
         }
 
         /// `{ name: true }` object_property 생성 — span은 모두 pre-cached.

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -235,6 +235,17 @@ pub fn makeNumericLiteral(self: anytype, value: u32) !NodeIndex {
     });
 }
 
+/// Object.defineProperty 두번째 인자 (key) 생성: computed_property_key 면 inner 를 visit,
+/// 아니면 식별자/literal span 을 `"name"` 으로 감싼 string_literal. class accessor + object
+/// literal computed accessor 양쪽에서 공용 (#1524).
+pub fn buildDefinePropertyKeyArg(self: anytype, key_idx: NodeIndex) !NodeIndex {
+    const key_node = self.ast.getNode(key_idx);
+    if (key_node.tag == .computed_property_key) {
+        return self.visitNode(key_node.data.unary.operand);
+    }
+    return buildQuotedKeyLiteral(self, key_node.span);
+}
+
 /// 식별자/numeric/string literal key node 의 span 을 `"name"` 형태 string_literal 로 감쌈.
 /// heap alloc 경유로 긴 key name truncation 회피. (#1510 item4)
 pub fn buildQuotedKeyLiteral(self: anytype, key_span: Span) !NodeIndex {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1913,6 +1913,50 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("7");
     });
 
+    // #1524: class computed getter/setter 의 key expression 이 평가되지 않고 `"[k]"` 리터럴로 emit
+    // 되던 버그. emitAccessors 가 computed_property_key 감지 후 inner 를 visit 하도록 수정.
+    test("computed getter/setter key expression 평가 (#1524 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const k = "dyn";
+            class X {
+              _v = 0;
+              get [k]() { return this._v; }
+              set [k](val: number) { this._v = val + 100; }
+            }
+            const x = new X() as any;
+            x[k] = 5;
+            console.log(x[k]);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("105");
+    });
+
+    test("computed getter only — static (#1524 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const key = "tag";
+            class Y {
+              static get [key]() { return "Y-tag"; }
+            }
+            console.log((Y as any)[key]);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("Y-tag");
+    });
+
     test("static getter + 주석 (#1516 회귀)", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #1524

## Summary

\`emitAccessors\` 가 key node 의 \`computed_property_key\` 태그를 감지하지 않고 전체 span 을 \`"[k]"\` quoted 리터럴로 emit 해서 Object.defineProperty 가 엉뚱한 키에 바인딩되던 silent 파손.

## Before / After

```ts
const k = "dyn";
class X {
  _v = 0;
  get [k]() { return this._v; }
  set [k](val: number) { this._v = val + 100; }
}
```

**Before** — key 가 리터럴 \`"[k]"\` (괄호 포함):
```js
Object.defineProperty(X.prototype, "[k]", { get, set });  // ❌ k 값이 아니라 문자 "[k]"
```

**After** — key expression 이 올바르게 평가됨:
```js
Object.defineProperty(X.prototype, k, { get, set });  // ✅ k 의 값 "dyn" 에 바인딩
```

## Root cause

\`src/transformer/es2015_class.zig:emitAccessors\` 가 key 를 항상 \`buildQuotedKeyLiteral\` 로 감싸 string literal 생성. computed_property_key 감지 없음.

\`es2015_computed.zig\` 의 \`buildAccessorKeyArg\` 는 이미 올바른 로직 (computed 면 inner visit, 아니면 quote) 을 갖고 있어 **로직 분기 중복**.

## Fix

\`es_helpers.buildDefinePropertyKeyArg(self, key_idx)\` 로 공용 helper 이관 (computed 감지 + quote 분기). 두 사이트 모두 이 helper 사용.

## LoC

\`es_helpers\` +10, \`es2015_class\` ±0 (1줄 교체), \`es2015_computed\` -13 (기존 helper 삭제 후 공용 helper 호출로 대체).

## 회귀 가드 2 케이스

- instance computed get+set (value+100 assertion, runtime 105)
- static computed getter (\`Y-tag\` literal result)

## 선행 이슈

- #1511 (accessor keyword synthesis) 가 computed accessor 경로에서 이 fix 의존
- #1510 item4 (descriptor helpers) 의 자연스러운 확장

## Follow-up

- #1523 (private getter/setter ES5 lowering 파손) — 남은 선행 버그
- #1511 (accessor synthesis) — #1523 fix 후 착수

## Test plan

- [x] #1524 runtime 2 케이스 pass
- [x] full suite: 3034 pass (pre-existing flaky \`watch-stress\` 만 fail)
- [x] 스냅샷 diff 0 건
- [x] 기존 모든 회귀 지속 pass