### PR TITLE
fix(transformer): ES5 target 의 private getter/setter lowering (#1523)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -39,6 +39,7 @@ const Tag = Node.Tag;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
+const es2022 = @import("es2022.zig");
 
 const METHOD_FLAG_STATIC = ast_mod.MethodFlags.is_static;
 const METHOD_FLAG_SETTER = ast_mod.MethodFlags.is_setter;
@@ -134,15 +135,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 try self.scratch.append(self.allocator, try es_helpers.buildStaticPrivateFieldDescriptor(self, pf.name, pf.init, span));
                 self.runtime_helpers.class_static_private_field = true;
             }
-            for (cm.private_methods.items) |pm| {
-                try self.scratch.append(self.allocator, try es_helpers.buildWeakCollectionDecl(self, "WeakSet", pm.weakset_name, span));
-                try self.scratch.append(self.allocator, try es_helpers.buildStandaloneFunc(self, pm.func_name, pm.member_idx, pm.member_span));
-            }
+            try emitPrivateMethodArtifacts(self, cm.private_methods.items, &cm.instance_fields, span);
 
             try appendPrivateFieldInits(self, &cm, span);
-            for (cm.private_methods.items) |pm| {
-                try cm.instance_fields.append(self.allocator, try es_helpers.buildPrivateMethodInit(self, pm.weakset_name, span));
-            }
 
             // IIFE 내부 function (fresh identifier — linker 무관)
             var func_node = if (cm.constructor_idx) |ctor_idx|
@@ -424,10 +419,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 try self.scratch.append(self.allocator, try es_helpers.buildStaticPrivateFieldDescriptor(self, pf.name, pf.init, span));
                 self.runtime_helpers.class_static_private_field = true;
             }
-            for (cm.private_methods.items) |pm| {
-                try self.scratch.append(self.allocator, try es_helpers.buildWeakCollectionDecl(self, "WeakSet", pm.weakset_name, span));
-                try self.scratch.append(self.allocator, try es_helpers.buildStandaloneFunc(self, pm.func_name, pm.member_idx, pm.member_span));
-            }
+            try emitPrivateMethodArtifacts(self, cm.private_methods.items, null, span);
 
             try self.scratch.append(self.allocator, func_node);
 
@@ -800,6 +792,41 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return buildWeakMapCall(self, mapping.var_name, "get", obj_idx, &.{}, span);
         }
 
+        /// this.#x = rhs (setter) → __classPrivateMethodGet(obj, _x, _x_set).call(obj, rhs) (#1523).
+        fn lowerPrivateSetterCall(self: *Transformer, setter_mapping: Transformer.PrivateMethodMapping, obj_idx: NodeIndex, rhs_old: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            self.runtime_helpers.class_private_method_get = true;
+            const new_obj = try self.visitNode(obj_idx);
+            const new_rhs = try self.visitNode(rhs_old);
+            const helper_ref = try es_helpers.makeIdentifierRef(self, "__classPrivateMethodGet");
+            const ws_ref = try es_helpers.makeIdentifierRef(self, setter_mapping.weakset_name);
+            const fn_ref = try es_helpers.makeIdentifierRef(self, setter_mapping.func_name);
+            const get_call = try es_helpers.makeCallExpr(self, helper_ref, &.{ new_obj, ws_ref, fn_ref }, span);
+            const call_prop = try es_helpers.makeIdentifierRef(self, "call");
+            const callee = try es_helpers.makeStaticMember(self, get_call, call_prop, span);
+            return es_helpers.makeCallExpr(self, callee, &.{ new_obj, new_rhs }, span);
+        }
+
+        /// private_methods 리스트를 순회하며 WeakSet 선언 + standalone function 을 scratch 에 append.
+        /// 같은 name 의 getter/setter 는 WeakSet 을 공유하므로 weakset_name 기준 첫 등장에만 선언.
+        /// private_field_init 도 동일한 dedup 으로 instance_fields 에 append (#1523).
+        fn emitPrivateMethodArtifacts(self: *Transformer, pms: []const Transformer.PrivateMethodMapping, fields_out: ?*std.ArrayList(NodeIndex), span: Span) Transformer.Error!void {
+            for (pms, 0..) |pm, i| {
+                const first_occurrence = blk: {
+                    for (pms[0..i]) |prev| {
+                        if (std.mem.eql(u8, prev.weakset_name, pm.weakset_name)) break :blk false;
+                    }
+                    break :blk true;
+                };
+                if (first_occurrence) {
+                    try self.scratch.append(self.allocator, try es_helpers.buildWeakCollectionDecl(self, "WeakSet", pm.weakset_name, span));
+                    if (fields_out) |fo| {
+                        try fo.append(self.allocator, try es_helpers.buildPrivateMethodInit(self, pm.weakset_name, span));
+                    }
+                }
+                try self.scratch.append(self.allocator, try es_helpers.buildStandaloneFunc(self, pm.func_name, pm.member_idx, pm.member_span));
+            }
+        }
+
         /// target이 private_field_expression이면 set 호출 생성(instance/static 자동 분기). 해당 없으면 null.
         /// destructuring assignment에서 `this.#x` 가 target일 때 `_x.get(this) = v` 같은 잘못된 target을
         /// 만들지 않도록 set 호출로 직접 변환 (#1485). value는 이미 변환된(new-AST) 노드여야 함.
@@ -886,7 +913,22 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const le = left_node.data.extra;
             if (le >= self.ast.extra_data.items.len) return null;
             const obj_idx: NodeIndex = self.readNodeIdx(le, 0);
-            const mapping = findPrivateFieldMapping(self, self.readNodeIdx(le, 1)) orelse return null;
+            const prop_idx = self.readNodeIdx(le, 1);
+
+            // private setter 인터셉트 — simple `=` 만 처리 (compound 는 getter+setter 합성 필요, 미지원).
+            // this.#x = v → __classPrivateMethodGet(this, _x, _x_set).call(this, v) (#1523).
+            const op_kind_pre: token_mod.Kind = @enumFromInt(node.data.binary.flags);
+            if (op_kind_pre == .eq and !prop_idx.isNone()) {
+                const prop_node_pre = self.ast.getNode(prop_idx);
+                if (prop_node_pre.tag == .private_identifier) {
+                    const orig_name = self.ast.getText(prop_node_pre.span);
+                    if (es2022.ES2022(Transformer).findPrivateMethodMappingOfKind(self, orig_name, 2)) |setter_mapping| {
+                        return lowerPrivateSetterCall(self, setter_mapping, obj_idx, node.data.binary.right, node.span);
+                    }
+                }
+            }
+
+            const mapping = findPrivateFieldMapping(self, prop_idx) orelse return null;
 
             const op_kind: token_mod.Kind = @enumFromInt(node.data.binary.flags);
             if (op_kind == .question2_eq or op_kind == .pipe2_eq or op_kind == .amp2_eq) {
@@ -1326,13 +1368,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         continue;
                     }
 
-                    // private method (#method) → WeakSet + standalone function 분류
+                    // private method (#method) / private getter/setter → WeakSet + standalone function 분류.
+                    // getter/setter 의 경우 kind 로 func_name suffix 구분 (_get / _set), WeakSet 은
+                    // emit 시 name 기준 dedupe 되므로 같은 name 의 get/set 쌍이 하나의 WeakSet 공유 (#1523).
                     if (!key.isNone()) {
                         const key_node = self.ast.getNode(key);
                         if (key_node.tag == .private_identifier) {
                             const orig_name = self.ast.getText(key_node.span); // "#bar"
 
-                            const names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name);
+                            const pm_kind: u8 = if (kind == 1) 1 else if (kind == 2) 2 else 0;
+                            const names = try es_helpers.makePrivateMethodNamesWithKind(self.allocator, orig_name, pm_kind);
 
                             try cm.private_methods.append(self.allocator, .{
                                 .member_idx = @enumFromInt(raw_idx),
@@ -1340,6 +1385,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                                 .weakset_name = names.ws_name,
                                 .func_name = names.fn_name,
                                 .member_span = member.span,
+                                .kind = pm_kind,
                             });
                             continue;
                         }

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -449,8 +449,9 @@ pub fn ES2022(comptime Transformer: type) type {
 
             const orig_name = self.ast.getText(prop_node.span);
 
-            // current_private_methods에서 매핑 찾기
-            const mapping = findPrivateMethodMapping(self, orig_name) orelse return null;
+            // this.#m() 호출 — 오직 kind=0 (메서드) 만 매칭. getter/setter 는 this.#x() 형태가
+            // 아니라 this.#x / this.#x = v 패턴이므로 lowerPrivateMethodGet / lowerPrivateFieldSet 에서 처리 (#1523).
+            const mapping = findPrivateMethodMappingOfKind(self, orig_name, 0) orelse return null;
 
             const args_start = self.readU32(ce, 1);
             const args_len = self.readU32(ce, 2);
@@ -479,8 +480,9 @@ pub fn ES2022(comptime Transformer: type) type {
             return es_helpers.makeCallExpr(self, callee_member, self.scratch.items[scratch_top..], node.span);
         }
 
-        /// private method 단독 참조 변환:
-        ///   this.#method → __classPrivateMethodGet(this, _set, _fn).bind(this)
+        /// private method/getter 참조 변환:
+        ///   this.#method → __classPrivateMethodGet(this, _set, _fn).bind(this)   (kind=0, 메서드)
+        ///   this.#x      → __classPrivateMethodGet(this, _x, _x_get).call(this)  (kind=1, getter)
         pub fn lowerPrivateMethodGet(self: *Transformer, node: Node) ?Transformer.Error!NodeIndex {
             const pfe = node.data.extra;
             if (pfe + 1 >= self.ast.extra_data.items.len) return null;
@@ -492,13 +494,18 @@ pub fn ES2022(comptime Transformer: type) type {
             if (prop_node.tag != .private_identifier) return null;
 
             const orig_name = self.ast.getText(prop_node.span);
-            const mapping = findPrivateMethodMapping(self, orig_name) orelse return null;
+            // getter 우선 — 같은 name 의 setter 와 method 는 공존 불가하므로 분기 안전.
+            const mapping = findPrivateMethodMappingOfKind(self, orig_name, 1) orelse
+                findPrivateMethodMappingOfKind(self, orig_name, 0) orelse
+                return null;
 
             const new_obj = try self.visitNode(obj_idx);
             const get_call = try buildMethodGetCall(self, new_obj, mapping, node.span);
 
-            const bind_prop = try es_helpers.makeIdentifierRef(self, "bind");
-            const callee = try es_helpers.makeStaticMember(self, get_call, bind_prop, node.span);
+            // getter → `.call(this)` 즉시 호출 (값 반환). 메서드 → `.bind(this)` 바운드 참조.
+            const access_prop_name: []const u8 = if (mapping.kind == 1) "call" else "bind";
+            const access_prop = try es_helpers.makeIdentifierRef(self, access_prop_name);
+            const callee = try es_helpers.makeStaticMember(self, get_call, access_prop, node.span);
             return es_helpers.makeCallExpr(self, callee, &.{new_obj}, node.span);
         }
 
@@ -515,6 +522,14 @@ pub fn ES2022(comptime Transformer: type) type {
         fn findPrivateMethodMapping(self: *const Transformer, orig_name: []const u8) ?Transformer.PrivateMethodMapping {
             for (self.current_private_methods) |m| {
                 if (std.mem.eql(u8, m.original_name, orig_name)) return m;
+            }
+            return null;
+        }
+
+        /// 같은 name 에 method/getter/setter 가 공존할 경우 kind 필터링 매핑 검색 (#1523).
+        pub fn findPrivateMethodMappingOfKind(self: *const Transformer, orig_name: []const u8, kind: u8) ?Transformer.PrivateMethodMapping {
+            for (self.current_private_methods) |m| {
+                if (m.kind == kind and std.mem.eql(u8, m.original_name, orig_name)) return m;
             }
             return null;
         }

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -576,12 +576,23 @@ pub fn makePrivateVarName(allocator: std.mem.Allocator, orig_name: []const u8) !
 
 /// "#bar" → { ws_name="_bar", fn_name="_bar_fn" }
 pub fn makePrivateMethodNames(allocator: std.mem.Allocator, orig_name: []const u8) !PrivateMethodNames {
+    return makePrivateMethodNamesWithKind(allocator, orig_name, 0);
+}
+
+/// kind 별 suffix: 0=method → "_fn", 1=getter → "_get", 2=setter → "_set" (#1523).
+/// "#x" + kind=1 → { ws_name="_x", fn_name="_x_get" }
+pub fn makePrivateMethodNamesWithKind(allocator: std.mem.Allocator, orig_name: []const u8, kind: u8) !PrivateMethodNames {
     const ws_name = try makePrivateVarName(allocator, orig_name);
     const bare = orig_name[1..];
-    const fn_name = try allocator.alloc(u8, 1 + bare.len + 3);
+    const suffix: []const u8 = switch (kind) {
+        1 => "_get",
+        2 => "_set",
+        else => "_fn",
+    };
+    const fn_name = try allocator.alloc(u8, 1 + bare.len + suffix.len);
     fn_name[0] = '_';
     @memcpy(fn_name[1 .. 1 + bare.len], bare);
-    @memcpy(fn_name[1 + bare.len ..], "_fn");
+    @memcpy(fn_name[1 + bare.len ..], suffix);
     return .{ .ws_name = ws_name, .fn_name = fn_name };
 }
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -391,12 +391,14 @@ pub const Transformer = struct {
 
     pub const PrivateMethodMapping = struct {
         original_name: []const u8, // "#method" (원본 소스 텍스트)
-        weakset_name: []const u8, // "_method" (WeakSet 변수명)
-        func_name: []const u8, // "_method_fn" (추출 함수명)
+        weakset_name: []const u8, // "_method" (WeakSet 변수명 — 같은 name 의 getter/setter 공유)
+        func_name: []const u8, // kind 에 따라 "_method_fn" / "_method_get" / "_method_set"
         member_idx: NodeIndex = NodeIndex.none, // method_definition 노드 (ES2015 경로에서 사용)
         // standalone function_declaration 의 span 으로 사용 — leading comment 가
         // `function _fn()` 뒤가 아니라 함수 앞에서 flush 되도록 (#1516).
         member_span: Span = .{ .start = 0, .end = 0 },
+        /// 0 = method, 1 = getter, 2 = setter (#1523).
+        kind: u8 = 0,
     };
 
     // RefreshRegistration / RefreshSignature 타입 정의는 plugin_state.zig로 이사.

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1913,6 +1913,72 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("7");
     });
 
+    // #1523: ES5 target 에서 get #x() / set #x(v) (private getter/setter) 가 private method 경로로
+    // 라우팅되어 중복 WeakSet + `.bind(this) = v` invalid JS 생성. PrivateMethodMapping.kind 추가로
+    // get/set 구분 + WeakSet dedupe + call/bind 분기.
+    test("private getter + setter 쌍 runtime (#1523 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class X {
+              #store = 10;
+              get #x() { return this.#store; }
+              set #x(v: number) { this.#store = v * 2; }
+              run() { this.#x = 5; return this.#x; }
+            }
+            console.log(new X().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("10");
+    });
+
+    test("private getter only (#1523 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Y {
+              #v = 42;
+              get #only() { return this.#v; }
+              read() { return this.#only; }
+            }
+            console.log(new Y().read());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("42");
+    });
+
+    test("private method + private get/set 공존 (#1523 회귀)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Z {
+              #state = 1;
+              get #x() { return this.#state; }
+              set #x(v: number) { this.#state = v; }
+              #bump() { this.#x = this.#x + 10; }
+              run() { this.#bump(); this.#bump(); return this.#x; }
+            }
+            console.log(new Z().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("21");
+    });
+
     // #1524: class computed getter/setter 의 key expression 이 평가되지 않고 `"[k]"` 리터럴로 emit
     // 되던 버그. emitAccessors 가 computed_property_key 감지 후 inner 를 visit 하도록 수정.
     test("computed getter/setter key expression 평가 (#1524 회귀)", async () => {


### PR DESCRIPTION
Closes #1523

## Summary

\`get #x()\` / \`set #x(v)\` (private getter/setter) 가 private method 경로로 라우팅되어 **중복 WeakSet 선언 + invalid JS** (\`__classPrivateMethodGet(...).bind(this) = 3\` — 함수 반환값에 대입) 를 생성하던 silent 런타임 파손 수정.

## Before

\`\`\`js
var _x = new WeakSet();            // ← getter 용
function _x_fn() { ... }
var _x = new WeakSet();            // ← setter 용 — 같은 이름 재선언
function _x_fn(v) { ... }          // ← 동일
// bump:
__classPrivateMethodGet(this, _x, _x_fn).bind(this) = 3;   // ← 함수 반환값에 대입 (invalid)
return __classPrivateMethodGet(this, _x, _x_fn).bind(this); // ← value 가 아니라 bound fn 반환
\`\`\`

## After

\`\`\`js
var _x = new WeakSet();            // 단일
function _x_get() { ... }          // getter
function _x_set(v) { ... }         // setter
// bump:
__classPrivateMethodGet(this, _x, _x_set).call(this, 3);   // setter 호출
return __classPrivateMethodGet(this, _x, _x_get).call(this); // getter 호출
\`\`\`

## 구현

1. \`PrivateMethodMapping.kind: u8\` 추가 — 0=method, 1=getter, 2=setter
2. \`makePrivateMethodNamesWithKind\` — kind 별 suffix (\`_fn\`/\`_get\`/\`_set\`)
3. \`emitPrivateMethodArtifacts\` helper — weakset_name 기준 dedupe (같은 name 의 get/set 쌍 단일 WeakSet + 단일 \`__classPrivateMethodInit\` 공유)
4. \`lowerPrivateMethodCall\` — kind=0 (method) 만 매칭
5. \`lowerPrivateMethodGet\` — kind=1 (getter) 은 \`.call(this)\` 로 즉시 호출, kind=0 (메서드 참조) 은 \`.bind(this)\` 유지
6. \`lowerPrivateFieldSet\` — simple \`=\` + LHS 가 kind=2 setter 매칭 시 \`lowerPrivateSetterCall\` 경유

## 제한사항

- **Compound assignment** (\`this.#x += v\`) 미지원 — getter + setter 합성이 필요. 별도 follow-up.
- **Static private getter/setter** 미검증 — 이 PR 은 instance 경로만.

## 회귀 가드 3 케이스

- private get+set 쌍 runtime (10)
- private getter only runtime (42)
- private method + get/set 공존 runtime (21)

## 선행 fix

- #1524 (computed getter/setter, merged #1525) 와 함께 #1511 (accessor synthesis) 의 선행 의존

## Test plan

- [x] #1523 runtime 3 케이스 pass
- [x] full suite: 3036 pass (pre-existing flaky 1건만 fail)
- [x] 스냅샷 변경 0 건
- [x] 기존 회귀 지속 pass