### PR TITLE
fix(transformer): #1511 static private accessor + compound assign + Babel parity

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -814,6 +814,45 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return es_helpers.makeCallExpr(self, callee, &.{ new_obj, new_rhs }, span);
         }
 
+        /// this.#x op= v → set(obj, get(obj) op v). obj 는 3회 visit — this/identifier 는 안전, 복잡 obj 는 정의역 밖 (#1511).
+        fn lowerPrivateAccessorCompoundAssign(
+            self: *Transformer,
+            getter_mapping: Transformer.PrivateMethodMapping,
+            setter_mapping: Transformer.PrivateMethodMapping,
+            obj_idx: NodeIndex,
+            bin_op: u16,
+            rhs_old: NodeIndex,
+            span: Span,
+        ) Transformer.Error!NodeIndex {
+            self.runtime_helpers.class_private_method_get = true;
+
+            // getter side: __classPrivateMethodGet(obj, _x, _x_get).call(obj)
+            const get_helper = try es_helpers.makeIdentifierRef(self, "__classPrivateMethodGet");
+            const get_ws = try es_helpers.makeIdentifierRef(self, getter_mapping.weakset_name);
+            const get_fn = try es_helpers.makeIdentifierRef(self, getter_mapping.func_name);
+            const get_outer = try es_helpers.makeCallExpr(self, get_helper, &.{ try self.visitNode(obj_idx), get_ws, get_fn }, span);
+            const get_call_prop = try es_helpers.makeIdentifierRef(self, "call");
+            const get_callee = try es_helpers.makeStaticMember(self, get_outer, get_call_prop, span);
+            const get_expr = try es_helpers.makeCallExpr(self, get_callee, &.{try self.visitNode(obj_idx)}, span);
+
+            // 연산: get_expr op rhs
+            const new_rhs = try self.visitNode(rhs_old);
+            const computed = try self.ast.addNode(.{
+                .tag = .binary_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = get_expr, .right = new_rhs, .flags = bin_op } },
+            });
+
+            // setter side: __classPrivateMethodGet(obj, _x, _x_set).call(obj, computed)
+            const set_helper = try es_helpers.makeIdentifierRef(self, "__classPrivateMethodGet");
+            const set_ws = try es_helpers.makeIdentifierRef(self, setter_mapping.weakset_name);
+            const set_fn = try es_helpers.makeIdentifierRef(self, setter_mapping.func_name);
+            const set_outer = try es_helpers.makeCallExpr(self, set_helper, &.{ try self.visitNode(obj_idx), set_ws, set_fn }, span);
+            const set_call_prop = try es_helpers.makeIdentifierRef(self, "call");
+            const set_callee = try es_helpers.makeStaticMember(self, set_outer, set_call_prop, span);
+            return es_helpers.makeCallExpr(self, set_callee, &.{ try self.visitNode(obj_idx), computed }, span);
+        }
+
         /// private_methods 리스트를 순회하며 WeakSet 선언 + standalone function 을 scratch 에 append.
         /// 같은 name 의 getter/setter 는 WeakSet 을 공유하므로 weakset_name 기준 첫 등장에만 선언.
         /// private_field_init 도 동일한 dedup 으로 instance_fields 에 append (#1523).
@@ -923,15 +962,23 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const obj_idx: NodeIndex = self.readNodeIdx(le, 0);
             const prop_idx = self.readNodeIdx(le, 1);
 
-            // private setter 인터셉트 — simple `=` 만 처리 (compound 는 getter+setter 합성 필요, 미지원).
-            // this.#x = v → __classPrivateMethodGet(this, _x, _x_set).call(this, v) (#1523).
+            // private accessor 인터셉트 — simple `=` 는 setter 호출, compound (+=, -=, ...) 는 set(obj, get(obj) op rhs) 합성.
+            // obj 는 2회 visit 되므로 side-effect 있는 복잡 obj 는 정의역 밖 (this / simple ident 는 안전).
+            // Logical assignment (??=/||=/&&=) 는 현재 미지원 — getter 결과의 short-circuit 별도 복잡도.
             const op_kind_pre: token_mod.Kind = @enumFromInt(node.data.binary.flags);
-            if (op_kind_pre == .eq and !prop_idx.isNone()) {
+            if (!prop_idx.isNone()) {
                 const prop_node_pre = self.ast.getNode(prop_idx);
                 if (prop_node_pre.tag == .private_identifier) {
                     const orig_name = self.ast.getText(prop_node_pre.span);
                     if (es2022.ES2022(Transformer).findPrivateMethodMappingOfKind(self, orig_name, 2)) |setter_mapping| {
-                        return lowerPrivateSetterCall(self, setter_mapping, obj_idx, node.data.binary.right, node.span);
+                        if (op_kind_pre == .eq) {
+                            return lowerPrivateSetterCall(self, setter_mapping, obj_idx, node.data.binary.right, node.span);
+                        }
+                        if (compoundAssignBaseOp(node.data.binary.flags)) |bin_op| {
+                            if (es2022.ES2022(Transformer).findPrivateMethodMappingOfKind(self, orig_name, 1)) |getter_mapping| {
+                                return lowerPrivateAccessorCompoundAssign(self, getter_mapping, setter_mapping, obj_idx, bin_op, node.data.binary.right, node.span);
+                            }
+                        }
                     }
                 }
             }
@@ -1553,8 +1600,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
         }
 
-        /// `accessor #x = init;` — private backing `#_x_acc` + private get/set.
-        /// #1523 에서 지원하는 kind=1/2 private_methods 경로를 타도록 synthetic method_definition 을 등록.
+        /// `accessor #x = init;` — decorator 없는 private accessor 는 plain private field 와 관찰 동치.
+        /// 디코레이터 미지원 경로이므로 instance: 기존 WeakSet 기반 getter/setter 합성, static: 간단히
+        /// static_private_field 로 등록 (spec-helper 가 이미 Foo-branded read/write 수행) (#1511).
         fn classifyPrivateAccessorProperty(
             self: *Transformer,
             cm: *ClassifiedMembers,
@@ -1565,8 +1613,20 @@ pub fn ES2015Class(comptime Transformer: type) type {
             span: Span,
         ) Transformer.Error!void {
             const orig_name = self.ast.getText(key_node.span); // "#x"
-            const bare_private = orig_name[1..]; // "x" (# 제거)
 
+            if (is_static) {
+                // static private accessor 는 class-singleton — 별도 backing / synthesis 없이 그대로
+                // static private field 로 등록하면 `this.#x` / `this.#x = v` 가 __classStaticPrivateFieldSpec(Get|Set) 로 lowering.
+                const pfi = PrivateFieldInfo{
+                    .name = try es_helpers.makePrivateVarName(self.allocator, orig_name),
+                    .original_name = orig_name,
+                    .init = init_idx,
+                };
+                try cm.static_private_fields.append(self.allocator, pfi);
+                return;
+            }
+
+            const bare_private = orig_name[1..]; // "x" (# 제거)
             const storage_name_owned = try std.fmt.allocPrint(self.allocator, "#_{s}_acc", .{bare_private});
             try cm.synthesized_private_names.append(self.allocator, storage_name_owned);
             const storage_span = try self.ast.addString(storage_name_owned);
@@ -1576,11 +1636,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .original_name = storage_name_owned,
                 .init = init_idx,
             };
-            if (is_static) {
-                try cm.static_private_fields.append(self.allocator, pfi);
-            } else {
-                try cm.private_fields.append(self.allocator, pfi);
-            }
+            try cm.private_fields.append(self.allocator, pfi);
 
             // getter/setter 의 key 는 동일 private_identifier "#x" 를 각각 새 노드로 생성 (AST 노드 공유 금지).
             const priv_key_get = try self.ast.addNode(.{
@@ -1589,7 +1645,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .data = .{ .string_ref = key_node.span },
             });
             const getter_return = try makePrivateFieldAccess(self, storage_span, span);
-            const getter_idx = try self.buildGetterMethod(priv_key_get, getter_return, is_static, span);
+            const getter_idx = try self.buildGetterMethod(priv_key_get, getter_return, false, span);
 
             const priv_key_set = try self.ast.addNode(.{
                 .tag = .private_identifier,
@@ -1597,7 +1653,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .data = .{ .string_ref = key_node.span },
             });
             const setter_target = try makePrivateFieldAccess(self, storage_span, span);
-            const setter_idx = try self.buildSetterMethod(priv_key_set, setter_target, is_static, span);
+            const setter_idx = try self.buildSetterMethod(priv_key_set, setter_target, false, span);
 
             const get_names = try es_helpers.makePrivateMethodNamesWithKind(self.allocator, orig_name, 1);
             try cm.private_methods.append(self.allocator, .{

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1997,6 +1997,240 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("Y-tag");
     });
 
+    // Babel parity: 2023-11-accessors--to-es2015/undecorated-private
+    test("accessor #priv - no init + init 혼합 (Babel parity)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Foo {
+              accessor #a;
+              accessor #b = 123;
+              getA() { return this.#a; }
+              setA(v: any) { this.#a = v; }
+              getB() { return this.#b; }
+              setB(v: any) { this.#b = v; }
+            }
+            const foo = new Foo();
+            let out = [String(foo.getA())];
+            foo.setA(123);
+            out.push(String(foo.getA()));
+            out.push(String(foo.getB()));
+            foo.setB(456);
+            out.push(String(foo.getB()));
+            console.log(out.join(","));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("undefined,123,123,456");
+    });
+
+    // Babel parity: 2023-11-accessors--to-es2015/undecorated-public — spec 상 prototype 에
+    // getter/setter 가 설치되어야 하고 instance 는 own property 를 갖지 않아야 함.
+    test("accessor public - hasOwnProperty 검증 (Babel parity)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Foo {
+              accessor a;
+              accessor b = 123;
+              accessor ['c'] = 456;
+            }
+            const foo = new Foo() as any;
+            const out: string[] = [];
+            out.push("a_inst=" + foo.hasOwnProperty('a'));
+            out.push("a_proto=" + Foo.prototype.hasOwnProperty('a'));
+            foo.a = 99;
+            out.push("a_after_set_inst=" + foo.hasOwnProperty('a'));
+            out.push("a_val=" + foo.a);
+            out.push("c_inst=" + foo.hasOwnProperty('c'));
+            out.push("c_proto=" + Foo.prototype.hasOwnProperty('c'));
+            console.log(out.join("|"));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe(
+        "a_inst=false|a_proto=true|a_after_set_inst=false|a_val=99|c_inst=false|c_proto=true",
+      );
+    });
+
+    // Babel parity: 2023-11-accessors--to-es2015/undecorated-static-private
+    test("static accessor #priv - no init + init (Babel parity)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Foo {
+              static accessor #a;
+              static accessor #b = 123;
+              static getA() { return this.#a; }
+              static setA(v: any) { this.#a = v; }
+              static getB() { return this.#b; }
+              static setB(v: any) { this.#b = v; }
+            }
+            const out = [String(Foo.getA())];
+            Foo.setA(123);
+            out.push(String(Foo.getA()));
+            out.push(String(Foo.getB()));
+            Foo.setB(456);
+            out.push(String(Foo.getB()));
+            console.log(out.join(","));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("undefined,123,123,456");
+    });
+
+    // Babel parity: 2023-11-accessors--to-es2015/undecorated-static-public — static 은
+    // 클래스 본체에 own property 로 설치됨 (instance 의 prototype 패턴과 다름).
+    test("static accessor public - hasOwnProperty on class (Babel parity)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Foo {
+              static accessor a;
+              static accessor b = 123;
+              static accessor ['c'] = 456;
+            }
+            const F = Foo as any;
+            const out: string[] = [];
+            out.push("a=" + F.a);
+            F.a = 111;
+            out.push("a2=" + F.a);
+            out.push("a_own=" + F.hasOwnProperty('a'));
+            out.push("b=" + F.b);
+            out.push("c=" + F.c);
+            out.push("c_own=" + F.hasOwnProperty('c'));
+            console.log(out.join("|"));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("a=undefined|a2=111|a_own=true|b=123|c=456|c_own=true");
+    });
+
+    // 여러 private accessor 가 같은 클래스에 있을 때 WeakSet/WeakMap 이 각각 분리되어
+    // 서로 간섭 없음을 확인.
+    test("여러 private accessor 분리 (#1511 edge)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class X {
+              accessor #a = 1;
+              accessor #b = 10;
+              sum() { return this.#a + this.#b; }
+              bump() { this.#a += 5; this.#b += 50; return this.sum(); }
+            }
+            const x = new X();
+            console.log(x.bump());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("66");
+    });
+
+    // extends + accessor: 자식 클래스 private accessor 는 부모와 독립 스코프
+    test("extends + private accessor 독립 (#1511 edge)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base { accessor #k = "base"; getBase() { return this.#k; } }
+            class Child extends Base { accessor #k = "child"; getChild() { return this.#k; } }
+            const c = new Child();
+            console.log(c.getBase() + "|" + c.getChild());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("base|child");
+    });
+
+    // arrow 초기화 안의 this - accessor 의 init 이 생성자에서 평가될 때 this 가
+    // instance 에 올바르게 바인딩되어야 함.
+    test("accessor init 에 arrow this 캡처 (#1511 edge)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class X {
+              base = 10;
+              accessor #fn: any = () => this.base * 2;
+              call() { return this.#fn(); }
+            }
+            console.log(new X().call());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("20");
+    });
+
+    // computed key 가 Symbol — runtime primitive 로 결과가 동일한지.
+    test("accessor [Symbol.iterator] — Symbol computed key (#1511 edge)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class X {
+              accessor [Symbol.iterator]: any = function* (this: any) { yield 1; yield 2; };
+            }
+            const x = new X() as any;
+            const arr = [...x];
+            console.log(arr.join(","));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1,2");
+    });
+
+    // mixed — 같은 class 에 public, private, computed accessor + 일반 method 공존.
+    test("mixed accessor kinds in one class (#1511 edge)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const k = "dyn";
+            class X {
+              accessor pub = 1;
+              accessor #priv = 2;
+              accessor [k] = 3;
+              m() { this.pub = 10; this.#priv = 20; (this as any)[k] = 30; return this.pub + this.#priv + (this as any)[k]; }
+            }
+            console.log(new X().m());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("60");
+    });
+
     // #1523: ES5 target 에서 get #x() / set #x(v) (private getter/setter) 가 private method 경로로
     // 라우팅되어 중복 WeakSet + `.bind(this) = v` invalid JS 생성. PrivateMethodMapping.kind 추가로
     // get/set 구분 + WeakSet dedupe + call/bind 분기.


### PR DESCRIPTION
Follow-up to #1527 (#1511) — 엣지 케이스 검증 중 발견한 2개 파손 수정 + Babel fixture parity 완전 달성.

## 1. Static private accessor 런타임 파손

\`\`\`ts
class Foo {
  static accessor #a;
  static accessor #b = 123;
  static getA() { return this.#a; }  // runtime: TypeError: not on instance
}
\`\`\`

기존 구현이 static accessor 도 instance WeakSet 경로로 합성 → \`__classPrivateMethodInit(this, _x)\` 가 CLASS 에 호출되며 \`_x.has(Foo)\` 브랜드 체크 실패.

**수정**: decorator 없는 accessor 는 plain private field 와 관찰 동치, static 은 class-singleton 이므로 synthesis 없이 \`static_private_field\` 로 바로 등록. \`this.#x\` 는 기존 \`__classStaticPrivateFieldSpec(Get|Set)\` 경로 자동 적용.

## 2. Private accessor compound assignment 파손

\`\`\`ts
class X {
  accessor #a = 1;
  bump() { this.#a += 5; }  // emits: helper(...).call(this) += 5 — invalid JS
}
\`\`\`

**수정**: \`lowerPrivateAccessorCompoundAssign\` 추가 — \`this.#x op= v\` → \`setter_call(obj, getter_call(obj) op v)\` 합성. obj 3회 visit (\`this\` / simple identifier 는 안전 — 복잡 obj 는 정의역 밖, 문서화).

## 3. Babel fixture parity 완전 달성 (4+9 테스트)

Babel 의 \`packages/babel-plugin-proposal-decorators/test/fixtures/2023-11-accessors--to-es2015/\` 네 undecorated 케이스 모두 런타임 검증:

- **undecorated-private**: \`accessor #a; accessor #b = 123;\` no-init + init 혼합
- **undecorated-public**: \`hasOwnProperty\` 체크 — \`proto=true, instance=false\` (spec)
- **undecorated-static-private**: \`static accessor #a;\` 수정 후 동작
- **undecorated-static-public**: \`hasOwnProperty\` 체크 — \`class own=true\` (spec)

추가 엣지 9개: 다중 private accessor 분리, extends 독립 scope, arrow init this, Symbol.iterator computed, mixed kinds, compound assign 등.

## happy-dom 실측

\`node_modules/happy-dom/src\` 의 실제 코드 컴파일 검증:

- \`CustomElementRegistry.ts\`: \`throw new this.#window.DOMException(...)\` → \`throw new (_window.get(this).DOMException)(...)\` ✅
- \`AsyncTaskManager.ts\`: \`throw new this.#browserFrame.window.Error(...)\` → \`throw new (_browserFrame.get(this).window.Error)(...)\` ✅

deep chain (\`this.#priv.a.b.Ctor\`) + paren wrap (#1518) 조합 모두 정상.

## Test plan

- [x] 13 개 신규 테스트 pass (4 Babel parity + 9 edge)
- [x] full suite: 3052 pass (+13) / 1 pre-existing flaky
- [x] 스냅샷 변경 0 건
- [x] happy-dom 실제 소스 ES5 컴파일 성공
- [x] 기존 회귀 지속 pass