### PR TITLE
fix(bundler): ESM wrapper 함수 호이스팅 중복 var 선언 제거 (axios@node smoke FAIL)

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -165,20 +165,9 @@ pub fn emitEsmWrappedModule(
                     // body_func_stmts: factory body 최상단에 배치 → forward reference 보존
                     try body_func_stmts.append(allocator, raw_idx);
                 } else {
-                    // strictExecutionOrder=false: function을 __esm factory 밖으로 호이스팅.
-                    // 함수명을 hoisted_var_names에 추가하여 var 선언 생성 (export getter 접근용).
-                    const func_node = if (export_inner) |idx|
-                        esm_ast.nodes.items[@intFromEnum(idx)]
-                    else
-                        stmt_node;
-                    const fn_name_idx: NodeIndex = @enumFromInt(esm_ast.extra_data.items[func_node.data.extra]);
-                    if (!fn_name_idx.isNone()) {
-                        const fn_name_node = esm_ast.nodes.items[@intFromEnum(fn_name_idx)];
-                        if (fn_name_node.tag == .binding_identifier) {
-                            const raw_name = esm_ast.getText(fn_name_node.data.string_ref);
-                            try hoisted_var_names.append(allocator, resolveNodeName(metadata, @intFromEnum(fn_name_idx), raw_name));
-                        }
-                    }
+                    // strictExecutionOrder=false: function 을 __esm factory 밖으로 호이스팅 — `function foo(){}`
+                    // 선언 자체가 모듈 top-level binding 을 생성하므로 별도 `var foo` 를 추가하면 ESM 모드에서
+                    // 중복 선언 에러 (bun / strict 환경). export getter 는 함수명을 직접 참조 가능.
                     try hoisted_stmts.append(allocator, raw_idx);
                 }
             },

--- a/tests/integration/tests/esm-function-hoist.test.ts
+++ b/tests/integration/tests/esm-function-hoist.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "bun:test";
+import { bundleAndRun, createFixture, runZts } from "./helpers";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+/**
+ * ESM wrapper 함수 호이스팅 — `strict_execution_order` 양쪽 경로 검증.
+ *
+ * - false (default, platform=node/browser): 함수는 factory 밖 top-level 에 `function f(){}` 으로 유지.
+ *   함수명은 함수 선언 자체가 binding 을 만들므로 별도 `var f;` 추가 금지 (중복 선언 에러).
+ * - true (platform=react-native, worklet 호환): 함수는 factory 내부에 위치, `f = function(){}` 할당으로
+ *   변환. top-level `var f;` 선언은 export getter 가 참조하기 위해 필요.
+ *
+ * 회귀: axios + supports-color 결합 bundle (@node) 에서 `var hasFlag` + `function hasFlag` 중복 선언으로
+ * bun strict parse 실패 → 함수 호이스팅 경로가 var 을 중복 추가하던 것을 제거.
+ */
+describe("ESM function hoist 양쪽 경로", () => {
+  // 다중 internal function + cross-reference — supports-color / debug 같은 패키지 패턴 모사.
+  const multiFuncFixture = {
+    "index.js": `
+      import { supportsColor } from "pkg";
+      console.log(supportsColor(16));
+    `,
+    "node_modules/pkg/package.json": JSON.stringify({
+      name: "pkg",
+      type: "module",
+      main: "index.js",
+    }),
+    "node_modules/pkg/index.js": `
+      export function hasFlag(f) { return f === "color"; }
+      export function supportsColor(level) { return hasFlag("color") ? level : 0; }
+    `,
+  };
+
+  test("strict=false (default) — 호이스팅된 함수 runtime 정상 (axios 회귀)", async () => {
+    // 중복 var 선언이 있으면 bun strict ESM 파싱 단계에서 실패 → exitCode !== 0.
+    const result = await bundleAndRun(multiFuncFixture, "index.js");
+    try {
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("16");
+    } finally {
+      await result.cleanup();
+    }
+  });
+
+  test("strict=false — 번들 출력에 함수명 중복 선언 없음 (정적 검사)", async () => {
+    const { dir, cleanup } = await createFixture(multiFuncFixture);
+    const outFile = join(dir, "out.js");
+    try {
+      const { exitCode } = await runZts(["--bundle", join(dir, "index.js"), "-o", outFile]);
+      expect(exitCode).toBe(0);
+      const output = readFileSync(outFile, "utf-8");
+      // `function hasFlag` 는 정의된 함수 형태로 한 번만 등장해야 함 — var 와 함께 선언되면 중복.
+      const fnDeclCount = (output.match(/^function hasFlag\b/gm) ?? []).length;
+      expect(fnDeclCount).toBeGreaterThan(0); // 호이스팅된 함수 선언이 존재
+      // top-level `var hasFlag[ ,;]` (리스트 중간 포함) 이 있으면 ESM 모드 중복 선언 에러 발생.
+      const varListContainsFn = /\bvar\s+[^;=]*\bhasFlag\b[^;]*;/.test(output);
+      expect(varListContainsFn).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("strict=true (platform=react-native) — factory 내부 할당 + 외부 var 정상", async () => {
+    const { dir, cleanup } = await createFixture({
+      ...multiFuncFixture,
+      "node_modules/react-native/package.json": JSON.stringify({
+        name: "react-native",
+        main: "index.js",
+      }),
+      "node_modules/react-native/index.js": "export default {};",
+      "node_modules/react-native/Libraries/Image/AssetRegistry.js":
+        "module.exports = { registerAsset: function(a) { return a; }, getAssetByID: function() { return null; } };",
+    });
+    const outFile = join(dir, "out-rn.js");
+    try {
+      const { exitCode } = await runZts([
+        "--bundle",
+        join(dir, "index.js"),
+        "-o",
+        outFile,
+        "--platform=react-native",
+      ]);
+      expect(exitCode).toBe(0);
+      const output = readFileSync(outFile, "utf-8");
+      // RN: factory 내부 할당 스타일 `hasFlag = function(...)` 존재
+      expect(output).toMatch(/hasFlag\s*=\s*function/);
+      // RN: top-level `var ... hasFlag ...` 유지 (export getter 참조용)
+      expect(output).toMatch(/\bvar\s+[^;]*\bhasFlag\b/);
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
CI smoke test 에서 axios \`platform=node\` 가 계속 FAIL 하던 근본 원인 수정 — browser 필드 remap (#1529/#1531) 과 별개의 bundler 호이스팅 버그.

## 문제

\`\`\`
SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'hasFlag'.
\`\`\`

번들 출력 (axios + debug + supports-color):
\`\`\`js
import { createRequire } from "node:module";  // ← ESM 출력 (module 스트릭트 시맨틱)
// ...
var process$1, os, tty, hasFlag, flagForceColor, ...;  // ← 호이스팅 var 리스트 (여기에 hasFlag)
function hasFlag(flag, argv=...) { ... }                // ← 동일 이름 함수 선언 (중복 binding)
\`\`\`

ESM 스코프에서 function 선언은 let-like binding. \`var hasFlag\` + \`function hasFlag\` 는 strict parser (bun / Node) 에서 duplicate binding 으로 SyntaxError.

## 원인

\`src/bundler/emitter/esm_wrap.zig\` 의 **strict_execution_order=false** 분기 (default, platform=node/browser):
- 함수 선언을 factory 밖 top-level 로 hoist (\`hoisted_stmts\`) — 함수 선언 자체가 binding 생성
- **그런데 동시에 함수명도 \`hoisted_var_names\` 에 추가** — \`var X;\` 도 top-level 에 emit
- 둘이 같은 스코프 → 중복 선언

## 수정

strict_execution_order=false 분기에서 \`hoisted_var_names.append()\` 호출 제거. 함수 선언이 binding 을 만들고 export getter 는 함수명 직접 참조 — 별도 \`var\` 불필요.

strict_execution_order=true 경로는 **그대로 유지** — factory 내부에서 \`foo = function(){}\` 할당으로 변환되므로 top-level \`var foo;\` (export getter 참조용) 가 여전히 필요.

## 검증

**strict=false (default)**:
- axios + supports-color 패턴 bundle → \`function function function\` 런타임 정상
- 번들 정적 검사: \`function hasFlag\` 선언 존재 + top-level var 리스트에 hasFlag 없음

**strict=true (platform=react-native)**:
- 번들에 \`hasFlag = function(...)\` factory 할당 + top-level \`var ... hasFlag ...\` 둘 다 존재
- 기존 export getter 동작 완전 유지

## 회귀 가드 (esm-function-hoist.test.ts 3 케이스)

1. strict=false runtime — 다중 function + cross-reference
2. strict=false 정적 검사 — 번들 구조 정규식 검증
3. strict=true RN preset — factory assignment + top-level var 공존

## 전체 suite

3060 pass (+3) / 1 pre-existing flaky. 스냅샷 변경 0.

## Test plan

- [x] axios@node 로컬 bundle runtime 성공
- [x] esm-function-hoist.test.ts 3/3 pass
- [x] full suite 그린
- [x] 기존 RN 통합 테스트 회귀 없음