### PR TITLE
refactor(bundler): /simplify 후속 — browser field 공용화 + 타입 통합 + 테스트 strictness

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1153,22 +1153,7 @@ pub const ModuleGraph = struct {
         module.state = .parsed;
     }
 
-    /// 모듈 경로에서 node_modules/패키지/ 디렉토리 경로를 추출.
-    /// 스코프 패키지 (@scope/name) 지원.
-    fn findPackageDirPath(module_path: []const u8) ?[]const u8 {
-        const nm = "node_modules" ++ std.fs.path.sep_str;
-        const nm_pos = std.mem.lastIndexOf(u8, module_path, nm) orelse return null;
-        const pkg_start = nm_pos + nm.len;
-        var pkg_end = pkg_start;
-        if (pkg_end < module_path.len and module_path[pkg_end] == '@') {
-            if (std.mem.indexOfPos(u8, module_path, pkg_end, std.fs.path.sep_str)) |sep1| {
-                pkg_end = std.mem.indexOfPos(u8, module_path, sep1 + 1, std.fs.path.sep_str) orelse module_path.len;
-            } else pkg_end = module_path.len;
-        } else {
-            pkg_end = std.mem.indexOfPos(u8, module_path, pkg_start, std.fs.path.sep_str) orelse module_path.len;
-        }
-        return module_path[0..pkg_end];
-    }
+    const findPackageDirPath = resolve_cache_mod.findPackageDirPath;
 
     /// node_modules 패키지의 package.json sideEffects 필드를 module.side_effects에 반영.
     fn applySideEffectsFromPackageJson(self: *ModuleGraph, module: *Module) void {

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -93,17 +93,11 @@ pub const ResolveCache = struct {
         }
     };
 
-    const BrowserOverrideKind = union(enum) {
+    /// browser override 결과 — path-key 와 bare-module-key 양쪽에서 공용.
+    /// remap 의 의미는 caller 문맥 결정: path-key 조회면 pkg-root 상대 경로, bare-module 조회면 replacement specifier.
+    const OverrideKind = union(enum) {
         none,
         disabled,
-        /// package-root 상대 대체 경로 (caller 가 pkg_dir 과 조합하여 재-resolve).
-        remap: []const u8,
-    };
-
-    const BareOverrideKind = union(enum) {
-        none,
-        disabled,
-        /// replacement specifier — caller 가 동일 source_dir 에서 재-resolve.
         remap: []const u8,
     };
 
@@ -410,7 +404,7 @@ pub const ResolveCache = struct {
                     .remap => |rep| {
                         // rep 는 package-root 상대. Resolver.resolve(pkg_root, "./rep") 로
                         // 확장자 / directory index 등 정상 resolve path 재사용. 성공 시 대체 결과 반환.
-                        if (findPackageRoot(result.path)) |pkg_root| {
+                        if (findPackageDirPath(result.path)) |pkg_root| {
                             const spec_buf = std.fmt.allocPrint(self.allocator, "./{s}", .{rep}) catch {
                                 // fallthrough
                                 const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
@@ -450,28 +444,6 @@ pub const ResolveCache = struct {
         return result;
     }
 
-    /// resolved_path 에서 `.../node_modules/<pkg>` 패키지 루트 slice 를 반환 (소유권 없음, resolved_path 의 prefix).
-    /// 파일 경로 / 패키지 루트 dir / trailing slash 포함 dir 세 경우 모두 매칭.
-    fn findPackageRoot(resolved_path: []const u8) ?[]const u8 {
-        const nm = "node_modules" ++ std.fs.path.sep_str;
-        const nm_pos = std.mem.lastIndexOf(u8, resolved_path, nm) orelse return null;
-        const after_nm = resolved_path[nm_pos + nm.len ..];
-
-        var pkg_end: usize = 0;
-        if (after_nm.len > 0 and after_nm[0] == '@') {
-            const first_slash = std.mem.indexOf(u8, after_nm, std.fs.path.sep_str) orelse return null;
-            // scoped pkg: `node_modules/@scope/pkg` 로 끝나는 디렉토리 자체 — 두 번째 slash 가 없으면 end 를 문자열 끝으로.
-            pkg_end = std.mem.indexOfPos(u8, after_nm, first_slash + 1, std.fs.path.sep_str) orelse after_nm.len;
-        } else {
-            // unscoped: 첫 slash 없으면 after_nm 전체가 pkg name (dir 자체).
-            pkg_end = std.mem.indexOf(u8, after_nm, std.fs.path.sep_str) orelse after_nm.len;
-        }
-
-        // trailing slash 를 포함해서 저장된 경로는 after_nm 에 slash 가 있지만 pkg_end 가 0 이 되는 케이스 방어.
-        if (pkg_end == 0) return null;
-        return resolved_path[0 .. nm_pos + nm.len + pkg_end];
-    }
-
     /// 캐시에 엔트리 저장. 기존 키가 있으면 이전 키/값 해제 (Critical #1 수정).
     fn putCache(self: *ResolveCache, cache_key: []const u8, value: CachedResult) !void {
         // 기존 엔트리가 있으면 해제
@@ -490,7 +462,7 @@ pub const ResolveCache = struct {
     /// 해석된 절대 경로가 package.json "browser" 필드에서 override (disabled / remap) 되었는지 판별.
     /// node_modules 내 파일만 대상. 결과는 패키지 디렉토리별로 캐싱 (반복 파싱 방지).
     /// remap 의 value 는 BrowserOverrides 가 소유 — caller 는 외부 저장 금지.
-    fn getBrowserOverride(self: *ResolveCache, resolved_path: []const u8) BrowserOverrideKind {
+    fn getBrowserOverride(self: *ResolveCache, resolved_path: []const u8) OverrideKind {
         // node_modules 내 파일만 대상
         const nm = "node_modules" ++ std.fs.path.sep_str;
         const nm_pos = std.mem.lastIndexOf(u8, resolved_path, nm) orelse return .none;
@@ -551,9 +523,9 @@ pub const ResolveCache = struct {
     /// source_dir 의 패키지 browser 필드에서 specifier (bare module name) 매칭 조회.
     /// `import "fs"` / `import "module-a"` 형태를 resolve 전에 intercept 하기 위한 진입점 (#1530).
     /// browser 필드 remap value 는 BrowserOverrides 소유 — caller 외부 저장 금지.
-    fn getBareModuleOverride(self: *ResolveCache, source_dir: []const u8, specifier: []const u8) BareOverrideKind {
+    fn getBareModuleOverride(self: *ResolveCache, source_dir: []const u8, specifier: []const u8) OverrideKind {
         // source_dir 이 node_modules/<pkg> 내부이면 해당 pkg 의 browser 필드 조회.
-        const pkg_dir_path = findPackageRoot(source_dir) orelse return .none;
+        const pkg_dir_path = findPackageDirPath(source_dir) orelse return .none;
 
         const overrides_opt = self.browser_overrides_cache.get(pkg_dir_path) orelse blk: {
             const built = self.buildBrowserOverrides(pkg_dir_path);
@@ -661,6 +633,25 @@ pub const ResolveCache = struct {
         return std.mem.concat(self.allocator, u8, &.{ source_dir, "\x00", specifier, "\x00", kind_str });
     }
 };
+
+/// 경로에서 `.../node_modules/<pkg>` 또는 `.../node_modules/@scope/<pkg>` 패키지 루트 slice 반환.
+/// 파일 경로 / 패키지 루트 dir / trailing slash 포함 dir 모두 매칭. graph.zig 및 resolve_cache 내에서 공용.
+pub fn findPackageDirPath(path: []const u8) ?[]const u8 {
+    const nm = "node_modules" ++ std.fs.path.sep_str;
+    const nm_pos = std.mem.lastIndexOf(u8, path, nm) orelse return null;
+    const after_nm = path[nm_pos + nm.len ..];
+
+    var pkg_end: usize = 0;
+    if (after_nm.len > 0 and after_nm[0] == '@') {
+        const first_slash = std.mem.indexOf(u8, after_nm, std.fs.path.sep_str) orelse return null;
+        pkg_end = std.mem.indexOfPos(u8, after_nm, first_slash + 1, std.fs.path.sep_str) orelse after_nm.len;
+    } else {
+        pkg_end = std.mem.indexOf(u8, after_nm, std.fs.path.sep_str) orelse after_nm.len;
+    }
+
+    if (pkg_end == 0) return null;
+    return path[0 .. nm_pos + nm.len + pkg_end];
+}
 
 /// specifier가 Node.js 빌트인 모듈인지 판별.
 /// "util", "fs", "node:fs", "util/types" 등을 인식.

--- a/tests/integration/tests/browser-field.test.ts
+++ b/tests/integration/tests/browser-field.test.ts
@@ -72,7 +72,7 @@ describe("package.json browser 필드", () => {
     try {
       expect(result.exitCode).toBe(0);
       // false → 빈 모듈 — namespace import 는 빈 object (혹은 undefined-like).
-      expect(result.runOutput).toMatch(/\{\}|undefined/);
+      expect(result.runOutput).toBe("{}");
     } finally {
       await result.cleanup();
     }
@@ -156,7 +156,7 @@ describe("package.json browser 필드", () => {
     );
     try {
       expect(result.exitCode).toBe(0);
-      expect(result.runOutput).toMatch(/\{\}|undefined/);
+      expect(result.runOutput).toBe("{}");
     } finally {
       await result.cleanup();
     }


### PR DESCRIPTION
최근 3 PR (#1529, #1531, #1532) merge 후 /simplify 3-에이전트 병렬 리뷰 결과 **true positive** 3건 수정.

## 1. `findPackageDirPath` 중복 제거

- \`src/bundler/graph.zig:1158\` 의 \`findPackageDirPath\` (기존)
- \`src/bundler/resolve_cache.zig\` 의 \`findPackageRoot\` (#1529 에서 추가)

두 함수가 **동일 로직** (node_modules/<pkg> slice 추출) — graph 의 것은 파일 경로만 처리하고 resolve_cache 의 것은 dir 자체 + trailing slash 방어 추가. 후자의 robust 한 버전을 resolve_cache 의 module top-level 로 올리고 public (`resolve_cache_mod.findPackageDirPath`) 으로 노출, graph.zig 는 alias 로 교체.

## 2. `BrowserOverrideKind` + `BareOverrideKind` 통합

두 union 이 `{none, disabled, remap: []const u8}` 로 완전 동일 선언이었음. 단일 `OverrideKind` 로 통합, 주석에 caller 별 `.remap` 의미 차이 (path-key → pkg-root 상대, bare-module → replacement specifier) 기록.

## 3. 테스트 assertion strictness

`browser-field.test.ts` 의 disabled 테스트가 \`toMatch(/\{\}|undefined/)\` 로 두 경우 모두 수용. 실제 출력은 정확히 `"{}"` — `toBe("{}")` 로 pin.

## 검토 결과 — skip 항목 (benign / 범위 외)

- cycle 감지 first-iteration self-remap: depth=0 직접 감지 안 하지만 depth=1 에서 즉시 break, 1회 wasted HashMap lookup — benign
- mutex lock/unlock/relock 패턴: thread-safe 하고 로직 명확, 복잡도 정당
- 4 개 StringHashMap 구조: 분리 타입 안전 우세
- findPackageDirPath 반복 호출: 짧은 node_modules 경로는 `lastIndexOf` 부담 없음
- `allocator.dupe + put + free-on-fail` 3회: dedup helper 가치 낮음 (각기 다른 컨텍스트)

## LoC

-23 순 감소 (27 add / 50 del).

## 검증

- `zig build` 성공
- full integration: 3060 pass (기존 그린 유지) / 1 pre-existing flaky
- `browser-field.test.ts` 8/8, `esm-function-hoist.test.ts` 3/3
- 동작 변경 0 (순수 refactor + 테스트 strictness)

## Test plan

- [x] zig build 성공
- [x] 전체 integration 그린
- [x] 스냅샷 변경 0 건
- [x] axios / happy-dom 회귀 지속 pass