### PR TITLE
refactor(ast): method/property extras 매직 offset 상수화 (#1513 1/N)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1100,6 +1100,39 @@ pub const MethodFlags = struct {
     pub const is_declare: u32 = 0x40;
 };
 
+/// method_definition extras 레이아웃: [key, params, body, flags, deco_start, deco_len] (#1513).
+/// 매직 offset 숫자 (`readU32(e, 3)`) 대신 `MethodExtra.flags` 사용.
+pub const MethodExtra = struct {
+    pub const key: u32 = 0;
+    pub const params: u32 = 1;
+    pub const body: u32 = 2;
+    pub const flags: u32 = 3;
+    pub const deco_start: u32 = 4;
+    pub const deco_len: u32 = 5;
+};
+
+/// property_definition / accessor_property extras 레이아웃: [key, init, flags, deco_start, deco_len] (#1513).
+pub const PropertyExtra = struct {
+    pub const key: u32 = 0;
+    pub const init: u32 = 1;
+    pub const flags: u32 = 2;
+    pub const deco_start: u32 = 3;
+    pub const deco_len: u32 = 4;
+};
+
+/// class_declaration / class_expression extras 레이아웃:
+/// [name, super, body, type_params, impl_start, impl_len, deco_start, deco_len] (#1513).
+pub const ClassExtra = struct {
+    pub const name: u32 = 0;
+    pub const super: u32 = 1;
+    pub const body: u32 = 2;
+    pub const type_params: u32 = 3;
+    pub const impl_start: u32 = 4;
+    pub const impl_len: u32 = 5;
+    pub const deco_start: u32 = 6;
+    pub const deco_len: u32 = 7;
+};
+
 /// call_expression / new_expression의 flags 비트 (D082).
 /// extra: [callee, args_start, args_len, flags]
 pub const CallFlags = struct {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -43,6 +43,8 @@ const es2022 = @import("es2022.zig");
 
 const METHOD_FLAG_STATIC = ast_mod.MethodFlags.is_static;
 const METHOD_FLAG_SETTER = ast_mod.MethodFlags.is_setter;
+const MethodExtra = ast_mod.MethodExtra;
+const PropertyExtra = ast_mod.PropertyExtra;
 
 pub fn ES2015Class(comptime Transformer: type) type {
     return struct {
@@ -1225,7 +1227,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const params_list_old = self.ast.functionParamsList(member);
             const params_start = params_list_old.start;
             const params_len = params_list_old.len;
-            const body_idx: NodeIndex = self.readNodeIdx(me, 2);
+            const body_idx: NodeIndex = self.readNodeIdx(me, MethodExtra.body);
 
             const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 
@@ -1410,15 +1412,15 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
                 if (member.tag == .method_definition) {
                     const me = member.data.extra;
-                    const key: NodeIndex = self.readNodeIdx(me, 0);
-                    const flags = self.readU32(me, 3);
+                    const key: NodeIndex = self.readNodeIdx(me, MethodExtra.key);
+                    const flags = self.readU32(me, MethodExtra.flags);
                     const is_static = (flags & 0x01) != 0;
                     const is_abstract = (flags & 0x20) != 0;
                     const is_declare = (flags & 0x40) != 0;
                     const kind = (flags >> 1) & 0x03; // 0=method, 1=get, 2=set
 
                     // 본문 없는 메서드 스트리핑: abstract, declare, TS 오버로드 시그니처
-                    const method_body: NodeIndex = @enumFromInt(self.readU32(me, 2));
+                    const method_body: NodeIndex = @enumFromInt(self.readU32(me, MethodExtra.body));
                     if (is_abstract or is_declare or method_body.isNone()) continue;
 
                     if (!is_static and es_helpers.isConstructorKey(self, key)) {
@@ -1465,9 +1467,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     }
                 } else if (member.tag == .property_definition) {
                     const pe = member.data.extra;
-                    const key: NodeIndex = self.readNodeIdx(pe, 0);
-                    const init_val: NodeIndex = self.readNodeIdx(pe, 1);
-                    const flags = self.readU32(pe, 2);
+                    const key: NodeIndex = self.readNodeIdx(pe, PropertyExtra.key);
+                    const init_val: NodeIndex = self.readNodeIdx(pe, PropertyExtra.init);
+                    const flags = self.readU32(pe, PropertyExtra.flags);
                     const is_static = (flags & 0x01) != 0;
 
                     // private field (#x) → instance: WeakMap, static: descriptor 객체
@@ -1550,9 +1552,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             span: Span,
         ) Transformer.Error!void {
             const pe = member.data.extra;
-            const key_idx = self.readNodeIdx(pe, 0);
-            const init_idx = self.readNodeIdx(pe, 1);
-            const flags = self.readU32(pe, 2);
+            const key_idx = self.readNodeIdx(pe, PropertyExtra.key);
+            const init_idx = self.readNodeIdx(pe, PropertyExtra.init);
+            const flags = self.readU32(pe, PropertyExtra.flags);
             const is_static = (flags & METHOD_FLAG_STATIC) != 0;
 
             const key_node = self.ast.getNode(key_idx);
@@ -1885,13 +1887,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
         /// constructor인지 확인 (key가 "constructor" identifier)
         /// constructor method_definition에서 function_declaration 생성.
-        /// method_definition: extra = [key, params_start, params_len, body, flags, ...]
         fn buildFunctionFromConstructor(self: *Transformer, ctor_idx: NodeIndex, name: NodeIndex, instance_fields: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const ctor = self.ast.getNode(ctor_idx);
             const me = ctor.data.extra;
 
             const params_list_old = self.ast.functionParamsList(ctor);
-            const body_idx: NodeIndex = self.readNodeIdx(me, 2);
+            const body_idx: NodeIndex = self.readNodeIdx(me, MethodExtra.body);
 
             // super_call_this_alias save/restore (lowerSuperCall이 설정)
             const saved_super_alias = self.super_call_this_alias;
@@ -2469,7 +2470,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const member = self.ast.getNode(info.member_idx);
                 const me = member.data.extra;
                 // mutation 이전 읽기 — 캐시 불필요, readNodeIdx 사용.
-                const key_idx = self.readNodeIdx(me, 0);
+                const key_idx = self.readNodeIdx(me, MethodExtra.key);
 
                 const func_expr = try buildAccessorFunc(self, info.member_idx, span);
                 const accessor_key = try es_helpers.makeIdentifierRef(self, if (info.is_getter) "get" else "set");
@@ -2581,9 +2582,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const member = self.ast.getNode(@enumFromInt(raw_idx));
                 if (member.tag == .method_definition) {
                     const me = member.data.extra;
-                    const flags = self.readU32(me, 3);
+                    const flags = self.readU32(me, MethodExtra.flags);
                     const is_static = (flags & 0x01) != 0;
-                    const key: NodeIndex = self.readNodeIdx(me, 0);
+                    const key: NodeIndex = self.readNodeIdx(me, MethodExtra.key);
                     const params_list_m = self.ast.functionParamsList(member);
 
                     if (!is_static and es_helpers.isConstructorKey(self, key)) {
@@ -2593,8 +2594,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     }
 
                     // method decorator + param decorator
-                    const deco_start = self.readU32(me, 4);
-                    const deco_len = self.readU32(me, 5);
+                    const deco_start = self.readU32(me, MethodExtra.deco_start);
+                    const deco_len = self.readU32(me, MethodExtra.deco_len);
                     if (deco_len > 0 or params_list_m.len > 0) {
                         const new_key = try self.visitNode(key);
                         const empty: NodeList = .{ .start = 0, .len = 0 };
@@ -2611,13 +2612,13 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     }
                 } else if (member.tag == .property_definition) {
                     // property decorator
-                    const me = member.data.extra;
-                    const flags = self.readU32(me, 2);
+                    const pe = member.data.extra;
+                    const flags = self.readU32(pe, PropertyExtra.flags);
                     const is_static = (flags & 0x01) != 0;
-                    const deco_start = self.readU32(me, 3);
-                    const deco_len = self.readU32(me, 4);
+                    const deco_start = self.readU32(pe, PropertyExtra.deco_start);
+                    const deco_len = self.readU32(pe, PropertyExtra.deco_len);
                     if (deco_len > 0) {
-                        const key_idx: NodeIndex = self.readNodeIdx(me, 0);
+                        const key_idx: NodeIndex = self.readNodeIdx(pe, PropertyExtra.key);
                         const new_key = try self.visitNode(key_idx);
                         const empty: NodeList = .{ .start = 0, .len = 0 };
                         try self.collectMemberDecorators(

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -224,18 +224,18 @@ pub fn ES2022(comptime Transformer: type) type {
                         });
                     } else if (lower_fields and member.tag == .property_definition) {
                         const pe = member.data.extra;
-                        const key: NodeIndex = self.readNodeIdx(pe, 0);
+                        const key: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
                         if (key.isNone()) continue;
                         const key_node = self.ast.getNode(key);
                         if (key_node.tag != .private_identifier) continue;
 
-                        const flags = self.readU32(pe, 2);
+                        const flags = self.readU32(pe, ast_mod.PropertyExtra.flags);
                         const is_static = (flags & 0x01) != 0;
                         // static private field는 class 이름 기반 brand check 헬퍼를 사용하므로
                         // 익명 class에서는 다운레벨할 수 없다 (클래스 자체 참조가 없음).
                         if (is_static and class_name_text == null) continue;
 
-                        const init_val: NodeIndex = self.readNodeIdx(pe, 1);
+                        const init_val: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.init);
                         const orig_name = self.ast.getText(key_node.span);
                         const var_name = try es_helpers.makePrivateVarName(self.allocator, orig_name);
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -587,7 +587,7 @@ pub fn classifyPropertyDefinition(
     const field_assignments = ctx.field_assignments;
     const member_decorators = ctx.member_decorators;
     const me = member.data.extra;
-    const flags = self.readU32(me, 2);
+    const flags = self.readU32(me, ast_mod.PropertyExtra.flags);
     const is_static = (flags & 0x01) != 0;
     const is_abstract = (flags & 0x20) != 0;
     const is_declare = (flags & 0x40) != 0;
@@ -599,10 +599,10 @@ pub fn classifyPropertyDefinition(
 
     // decorator 수집 (experimental decorators — 경로와 무관하게 한 번만)
     if (self.options.experimental_decorators) {
-        const deco_start = self.readU32(me, 3);
-        const deco_len = self.readU32(me, 4);
+        const deco_start = self.readU32(me, ast_mod.PropertyExtra.deco_start);
+        const deco_len = self.readU32(me, ast_mod.PropertyExtra.deco_len);
         if (deco_len > 0) {
-            const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+            const new_key = try self.visitNode(self.readNodeIdx(me, ast_mod.PropertyExtra.key));
             const empty: ast_mod.NodeList = .{ .start = 0, .len = 0 };
             try self.collectMemberDecorators(member_decorators, deco_start, deco_len, empty, new_key, is_static, 2, empty);
         }
@@ -610,8 +610,8 @@ pub fn classifyPropertyDefinition(
 
     // useDefineForClassFields=false: non-static instance field를 constructor로 이동
     if (!self.options.use_define_for_class_fields and !is_static and !is_abstract and !is_declare) {
-        const key_idx = self.readNodeIdx(me, 0);
-        const init_idx = self.readNodeIdx(me, 1);
+        const key_idx = self.readNodeIdx(me, ast_mod.PropertyExtra.key);
+        const init_idx = self.readNodeIdx(me, ast_mod.PropertyExtra.init);
         if (!init_idx.isNone()) {
             const new_key = try self.visitNode(key_idx);
             // super class가 있으면 field value의 this → _this 치환
@@ -633,8 +633,8 @@ pub fn classifyPropertyDefinition(
 
     // useDefineForClassFields=false + static field
     if (!self.options.use_define_for_class_fields and is_static) {
-        const key_idx = self.readNodeIdx(me, 0);
-        const init_idx = self.readNodeIdx(me, 1);
+        const key_idx = self.readNodeIdx(me, ast_mod.PropertyExtra.key);
+        const init_idx = self.readNodeIdx(me, ast_mod.PropertyExtra.init);
         if (init_idx.isNone()) return; // 초기값 없음 → 타입 선언만, 제거
         // 초기값 있음 → class 밖 할당문으로 이동 (Foo.z = 2)
         if (ctx.static_field_assignments) |sfa| {
@@ -671,13 +671,13 @@ pub fn classifyMethodDefinition(
     const class_members = ctx.class_members;
     const member_decorators = ctx.member_decorators;
     const me = member.data.extra;
-    const flags = self.readU32(me, 3);
+    const flags = self.readU32(me, ast_mod.MethodExtra.flags);
     const is_static = (flags & 0x01) != 0;
     const params_list_m = self.ast.functionParamsList(member);
 
     // constructor 감지
     const is_ctor = if (!is_static) blk: {
-        const key_idx = self.readNodeIdx(me, 0);
+        const key_idx = self.readNodeIdx(me, ast_mod.MethodExtra.key);
         const key_node = self.ast.getNode(key_idx);
         if (key_node.tag == .identifier_reference) {
             const name = self.ast.getText(key_node.span);
@@ -705,10 +705,10 @@ pub fn classifyMethodDefinition(
 
     // 일반 메서드: member decorator + parameter decorator 수집 (single-pass)
     if (self.options.experimental_decorators) {
-        const deco_start = self.readU32(me, 4);
-        const deco_len = self.readU32(me, 5);
+        const deco_start = self.readU32(me, ast_mod.MethodExtra.deco_start);
+        const deco_len = self.readU32(me, ast_mod.MethodExtra.deco_len);
         if (deco_len > 0 or params_list_m.len > 0) {
-            const new_key = try self.visitNode(self.readNodeIdx(me, 0));
+            const new_key = try self.visitNode(self.readNodeIdx(me, ast_mod.MethodExtra.key));
             try self.collectMemberDecorators(
                 member_decorators,
                 deco_start,
@@ -1765,12 +1765,10 @@ pub fn hasAnyMemberDecorators(self: *Transformer, class_extra: u32) bool {
         const me = member.data.extra;
 
         if (member.tag == .property_definition or member.tag == .accessor_property) {
-            // extra = [key, init_val, flags, deco_start, deco_len]
-            const deco_len = self.readU32(me, 4);
+            const deco_len = self.readU32(me, ast_mod.PropertyExtra.deco_len);
             if (deco_len > 0) return true;
         } else if (member.tag == .method_definition) {
-            // extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
-            const deco_len = self.readU32(me, 5);
+            const deco_len = self.readU32(me, ast_mod.MethodExtra.deco_len);
             if (deco_len > 0) return true;
         }
     }
@@ -1913,17 +1911,16 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
             const me = member.data.extra;
 
             if (member.tag == .method_definition) {
-                // extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
-                const flags = self.readU32(me, 3);
-                const deco_start = self.readU32(me, 4);
-                const deco_len = self.readU32(me, 5);
+                const flags = self.readU32(me, ast_mod.MethodExtra.flags);
+                const deco_start = self.readU32(me, ast_mod.MethodExtra.deco_start);
+                const deco_len = self.readU32(me, ast_mod.MethodExtra.deco_len);
                 const is_static = (flags & 0x01) != 0;
                 const is_getter = (flags & 0x02) != 0;
                 const is_setter = (flags & 0x04) != 0;
 
                 // constructor 감지
                 if (!is_getter and !is_setter and !is_static) {
-                    const key_idx = self.readNodeIdx(me, 0);
+                    const key_idx = self.readNodeIdx(me, ast_mod.MethodExtra.key);
                     if (!key_idx.isNone()) {
                         const key_node = self.ast.getNode(key_idx);
                         if (key_node.tag == .identifier_reference or key_node.tag == .binding_identifier) {
@@ -1936,7 +1933,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 }
 
                 // key를 한 번만 방문 (decorator info + stripped method 공용)
-                const key_idx = self.readNodeIdx(me, 0);
+                const key_idx = self.readNodeIdx(me, ast_mod.MethodExtra.key);
                 const new_key = try self.visitNode(key_idx);
                 // private identifier 감지
                 const is_private = blk: {
@@ -1963,7 +1960,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     var m_params: ast_mod.NodeList = .{ .start = 0, .len = 0 };
                     if (is_private_method) {
                         desc_name = try std.fmt.allocPrint(self.allocator, "_private_{s}_descriptor", .{var_n});
-                        m_body = try self.visitNode(self.readNodeIdx(me, 2));
+                        m_body = try self.visitNode(self.readNodeIdx(me, ast_mod.MethodExtra.body));
                         m_params = self.ast.functionParamsList(member);
                     }
 
@@ -1990,11 +1987,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     try new_members.append(self.allocator, getter);
                 } else {
                     // public method 또는 non-decorated → 그대로 추가
-                    const new_body = try self.visitNode(self.readNodeIdx(me, 2));
+                    const new_body = try self.visitNode(self.readNodeIdx(me, ast_mod.MethodExtra.body));
                     const empty_list = try self.ast.addNodeList(&.{});
                     const new_method = try self.addExtraNode(.method_definition, member.span, &.{
                         @intFromEnum(new_key),
-                        self.readU32(me, 1),
+                        self.readU32(me, ast_mod.MethodExtra.params),
                         @intFromEnum(new_body),
                         flags,
                         empty_list.start,
@@ -2003,14 +2000,13 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     try new_members.append(self.allocator, new_method);
                 }
             } else if (member.tag == .property_definition) {
-                // extra = [key, init_val, flags, deco_start, deco_len]
-                const flags = self.readU32(me, 2);
-                const deco_start = self.readU32(me, 3);
-                const deco_len = self.readU32(me, 4);
+                const flags = self.readU32(me, ast_mod.PropertyExtra.flags);
+                const deco_start = self.readU32(me, ast_mod.PropertyExtra.deco_start);
+                const deco_len = self.readU32(me, ast_mod.PropertyExtra.deco_len);
                 const is_static = (flags & 0x01) != 0;
 
                 // key를 한 번만 방문
-                const key_idx_prop = self.readNodeIdx(me, 0);
+                const key_idx_prop = self.readNodeIdx(me, ast_mod.PropertyExtra.key);
                 const new_key = try self.visitNode(key_idx_prop);
                 const is_private_field = self.ast.getNode(key_idx_prop).tag == .private_identifier;
 
@@ -2039,7 +2035,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 }
 
                 // property를 decorator 없이 추가 (decorated면 초기값을 __runInitializers로 래핑)
-                const raw_init = try self.visitNode(self.readNodeIdx(me, 1));
+                const raw_init = try self.visitNode(self.readNodeIdx(me, ast_mod.PropertyExtra.init));
                 const new_init = if (field_init_name) |init_name| blk: {
                     // TypeScript 패턴: (runInit(this, _prevExtra), runInit(this, _x_initializers, val))
                     // 첫 field: _prevExtra = _instanceExtraInitializers
@@ -2088,15 +2084,14 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 });
                 try new_members.append(self.allocator, new_prop);
             } else if (member.tag == .accessor_property) {
-                // extra = [key, init_val, flags, deco_start, deco_len]
-                const flags = self.readU32(me, 2);
-                const deco_start = self.readU32(me, 3);
-                const deco_len = self.readU32(me, 4);
+                const flags = self.readU32(me, ast_mod.PropertyExtra.flags);
+                const deco_start = self.readU32(me, ast_mod.PropertyExtra.deco_start);
+                const deco_len = self.readU32(me, ast_mod.PropertyExtra.deco_len);
                 const is_static = (flags & 0x01) != 0;
 
-                const key_idx = self.readNodeIdx(me, 0);
+                const key_idx = self.readNodeIdx(me, ast_mod.PropertyExtra.key);
                 const new_key = try self.visitNode(key_idx);
-                const new_init = try self.visitNode(self.readNodeIdx(me, 1));
+                const new_init = try self.visitNode(self.readNodeIdx(me, ast_mod.PropertyExtra.init));
 
                 if (deco_len > 0) {
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);


### PR DESCRIPTION
Part of #1513 (첫 번째 배치 — method_definition / property_definition / accessor_property).

## 변경

**`src/parser/ast.zig`** 에 3 개 상수 struct 추가:

\`\`\`zig
pub const MethodExtra = struct {
    pub const key: u32 = 0;
    pub const params: u32 = 1;
    pub const body: u32 = 2;
    pub const flags: u32 = 3;
    pub const deco_start: u32 = 4;
    pub const deco_len: u32 = 5;
};

pub const PropertyExtra = struct {
    pub const key: u32 = 0;
    pub const init: u32 = 1;
    pub const flags: u32 = 2;
    pub const deco_start: u32 = 3;
    pub const deco_len: u32 = 4;
};

pub const ClassExtra = struct { /* ... 미사용, follow-up 용 */ };
\`\`\`

**migrate 파일 3 개**:
- \`es2015_class.zig\` — ~22 사이트 (classifyMembers method/property branch, buildAccessorFunc, buildFunctionFromConstructor, emitAccessors, emitDecoratorsForLoweredClass)
- \`es2022.zig\` — 3 사이트 (property_definition private field 분류)
- \`class_decorator.zig\` — ~30 사이트 (classifyPropertyDefinition, classifyMethodDefinition, hasAnyMemberDecorators, transformStage3Decorators 3-way branch)

## Before / After

\`\`\`zig
// Before
const flags = self.readU32(me, 3);
const key = self.readNodeIdx(me, 0);
const body_idx = self.readNodeIdx(me, 2);

// After
const flags = self.readU32(me, MethodExtra.flags);
const key = self.readNodeIdx(me, MethodExtra.key);
const body_idx = self.readNodeIdx(me, MethodExtra.body);
\`\`\`

## Scope 외 (follow-up PR 로)

- **es2015_params.zig** (formal_parameter extras — 다른 schema, 별도 struct 필요)
- **class_declaration / class_expression extras** — \`ce\` 변수가 call_expression 과 네이밍 ambiguity 존재. ClassExtra 상수는 추가해뒀으나 사용처 migrate 는 다음 PR.
- **codegen.zig / semantic** 의 읽기 전용 경로

## 검증

- \`zig build\` 성공
- \`bun test --cwd tests/integration\` → 3060 pass (기존 그린 유지) / 1 pre-existing flaky
- 스냅샷 변경 0 건
- **동작 변경 0** (순수 리팩터)

LoC: +29 (92 add / 63 del — 주석 layout 중복 제거분 포함).

## Test plan

- [x] zig build 성공
- [x] 전체 integration 그린
- [x] 스냅샷 diff 0 건
- [x] 모든 기존 회귀 지속 pass