### PR TITLE
refactor(codegen, semantic): method/property extras 매직 offset 상수화 (#1513 2/N)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2270,18 +2270,17 @@ pub const Codegen = struct {
         try self.emitNode(node.data.unary.operand);
     }
 
-    // method_definition: extra = [key, params, body, flags, deco_start, deco_len]
     fn emitMethodDef(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         const extras = self.ast.extra_data.items[e .. e + 6];
-        const key: NodeIndex = @enumFromInt(extras[0]);
+        const key: NodeIndex = @enumFromInt(extras[ast_mod.MethodExtra.key]);
         const params_list = self.ast.functionParamsList(node);
         const params_start = params_list.start;
         const params_len = params_list.len;
-        const body: NodeIndex = @enumFromInt(extras[2]);
-        const flags = extras[3];
-        const deco_start = extras[4];
-        const deco_len = extras[5];
+        const body: NodeIndex = @enumFromInt(extras[ast_mod.MethodExtra.body]);
+        const flags = extras[ast_mod.MethodExtra.flags];
+        const deco_start = extras[ast_mod.MethodExtra.deco_start];
+        const deco_len = extras[ast_mod.MethodExtra.deco_len];
 
         // function map: ClassName#method / ClassName.method / get__name / set__name
         if (self.fn_map_builder != null) {
@@ -2311,15 +2310,14 @@ pub const Codegen = struct {
         try self.emitNode(body);
     }
 
-    // property_definition: extra = [key, init_val, flags, deco_start, deco_len]
     fn emitPropertyDef(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         const extras = self.ast.extra_data.items[e .. e + 5];
-        const key: NodeIndex = @enumFromInt(extras[0]);
-        const value: NodeIndex = @enumFromInt(extras[1]);
-        const flags = extras[2];
-        const deco_start = extras[3];
-        const deco_len = extras[4];
+        const key: NodeIndex = @enumFromInt(extras[ast_mod.PropertyExtra.key]);
+        const value: NodeIndex = @enumFromInt(extras[ast_mod.PropertyExtra.init]);
+        const flags = extras[ast_mod.PropertyExtra.flags];
+        const deco_start = extras[ast_mod.PropertyExtra.deco_start];
+        const deco_len = extras[ast_mod.PropertyExtra.deco_len];
 
         try self.emitMemberDecorators(deco_start, deco_len);
 
@@ -2359,15 +2357,14 @@ pub const Codegen = struct {
         }
     }
 
-    // accessor_property: extra = [key, init_val, flags, deco_start, deco_len]
     fn emitAccessorProp(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         const extras = self.ast.extra_data.items[e .. e + 5];
-        const key: NodeIndex = @enumFromInt(extras[0]);
-        const value: NodeIndex = @enumFromInt(extras[1]);
-        const flags = extras[2];
-        const deco_start = extras[3];
-        const deco_len = extras[4];
+        const key: NodeIndex = @enumFromInt(extras[ast_mod.PropertyExtra.key]);
+        const value: NodeIndex = @enumFromInt(extras[ast_mod.PropertyExtra.init]);
+        const flags = extras[ast_mod.PropertyExtra.flags];
+        const deco_start = extras[ast_mod.PropertyExtra.deco_start];
+        const deco_len = extras[ast_mod.PropertyExtra.deco_len];
 
         try self.emitMemberDecorators(deco_start, deco_len);
 

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1120,7 +1120,6 @@ pub const SemanticAnalyzer = struct {
 
             // ---- method_definition/property_definition 내부 순회 ----
             .method_definition => {
-                // extra: [key, params, body, flags, deco_start, deco_len]
                 const extra_start = node.data.extra;
                 const extras = self.ast.extra_data.items;
                 if (extra_start + 2 < extras.len) {
@@ -1131,7 +1130,7 @@ pub const SemanticAnalyzer = struct {
                     // `import * as fiberRefs`의 namespace 객체로 치환됨).
                     // private_identifier key는 collectPrivateNames에서 이미 선언 등록했으므로
                     // 여기서 방문하면 usePrivateName(.read)가 잘못 호출된다.
-                    const key_idx: NodeIndex = @enumFromInt(extras[extra_start]);
+                    const key_idx: NodeIndex = @enumFromInt(extras[extra_start + ast_mod.MethodExtra.key]);
                     const key_node = self.ast.getNode(key_idx);
                     if (key_node.tag == .computed_property_key) {
                         try self.visitNode(key_idx);
@@ -1139,13 +1138,16 @@ pub const SemanticAnalyzer = struct {
 
                     // 멤버 decorator 순회 — 누락 시 import binding이 resolve 안 돼 tree-shake로 drop (#1504 follow-up).
                     if (extra_start + 5 < extras.len) {
-                        try self.visitNodeList(.{ .start = extras[extra_start + 4], .len = extras[extra_start + 5] });
+                        try self.visitNodeList(.{
+                            .start = extras[extra_start + ast_mod.MethodExtra.deco_start],
+                            .len = extras[extra_start + ast_mod.MethodExtra.deco_len],
+                        });
                     }
 
                     // getter/setter 파라미터 개수 검증
                     try checker.checkGetterSetterParams(self.ast, node, &self.errors, self.allocator);
 
-                    const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 2]);
+                    const body_idx: NodeIndex = @enumFromInt(extras[extra_start + ast_mod.MethodExtra.body]);
                     // 함수 본문을 function scope로 감싸서 순회
                     const scope_saved = try self.enterScope(.function, self.is_strict_mode);
                     const params_list = self.ast.functionParamsList(node);
@@ -1157,7 +1159,6 @@ pub const SemanticAnalyzer = struct {
                 }
             },
             .property_definition, .accessor_property => {
-                // extra: [key, init_val, flags, deco_start, deco_len]
                 // key는 computed property([expr])일 때만 순회.
                 // private_identifier key는 collectPrivateNames에서 이미 선언 등록했으므로
                 // 여기서 방문하면 usePrivateName(.read)가 잘못 호출된다.
@@ -1166,12 +1167,12 @@ pub const SemanticAnalyzer = struct {
                 const e = node.data.extra;
                 const extras_p = self.ast.extra_data.items;
                 if (e + 1 < extras_p.len) {
-                    const key_idx: NodeIndex = @enumFromInt(extras_p[e]);
+                    const key_idx: NodeIndex = @enumFromInt(extras_p[e + ast_mod.PropertyExtra.key]);
                     const key_node = self.ast.getNode(key_idx);
                     if (key_node.tag == .computed_property_key) {
                         try self.visitNode(key_idx);
                     }
-                    try self.visitNode(@enumFromInt(extras_p[e + 1]));
+                    try self.visitNode(@enumFromInt(extras_p[e + ast_mod.PropertyExtra.init]));
                 }
                 // 필드/accessor decorator 순회 — 누락 시 import binding tree-shake로 drop.
                 if (e + 4 < extras_p.len) {
@@ -2068,14 +2069,12 @@ pub const SemanticAnalyzer = struct {
             const node = self.ast.getNode(idx);
             switch (node.tag) {
                 .method_definition => {
-                    // extra: [key, params, body, flags]
                     const extra_start = node.data.extra;
                     if (extra_start >= self.ast.extra_data.items.len) continue;
-                    const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[extra_start]);
-                    // flags는 extra_start + 3: 0x02=getter, 0x04=setter
+                    const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[extra_start + ast_mod.MethodExtra.key]);
                     const kind: PrivateNameKind = blk: {
                         if (extra_start + 3 < self.ast.extra_data.items.len) {
-                            const flags = self.ast.extra_data.items[extra_start + 3];
+                            const flags = self.ast.extra_data.items[extra_start + ast_mod.MethodExtra.flags];
                             if (flags & 0x02 != 0) break :blk .getter;
                             if (flags & 0x04 != 0) break :blk .setter;
                         }
@@ -2084,10 +2083,9 @@ pub const SemanticAnalyzer = struct {
                     try self.tryRegisterPrivateKey(key_idx, kind);
                 },
                 .property_definition, .accessor_property => {
-                    // extra: [key, init_val, flags, deco_start, deco_len]
                     const e = node.data.extra;
                     if (e < self.ast.extra_data.items.len) {
-                        try self.tryRegisterPrivateKey(@enumFromInt(self.ast.extra_data.items[e]), .field);
+                        try self.tryRegisterPrivateKey(@enumFromInt(self.ast.extra_data.items[e + ast_mod.PropertyExtra.key]), .field);
                     }
                 },
                 else => {},

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -612,13 +612,12 @@ pub fn buildWeakCollectionDecl(self: anytype, constructor_name: []const u8, var_
 }
 
 /// method_definition → standalone function declaration으로 추출.
-/// method_definition: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
 pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeIndex, span: Span) !NodeIndex {
     const method_node = self.ast.getNode(method_idx);
     const params_list_old = self.ast.functionParamsList(method_node);
     const params_start = params_list_old.start;
     const params_len = params_list_old.len;
-    const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[method_node.data.extra + 2]);
+    const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[method_node.data.extra + ast_mod.MethodExtra.body]);
 
     const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 


### PR DESCRIPTION
Part of #1513 (2/N) — #1534 (1/N) 후속으로 나머지 consumer 3 파일 migrate.

## 파일별 변경

- **\`codegen/codegen.zig\`** — \`emitMethodDef\` / \`emitPropertyDef\` / \`emitAccessorProp\` 의 direct indexing \`extras[0]\` ~ \`extras[5]\` → \`extras[MethodExtra.key]\` / \`extras[PropertyExtra.flags]\` 등
- **\`semantic/analyzer.zig\`** — \`visitNode\` method/property/accessor_property branch + \`collectPrivateNames\` 동일 branch offset 상수화
- **\`transformer/es_helpers.zig\`** — \`buildStandaloneFunc\` 의 body offset 하드코딩 상수화

## 검증

- \`zig build\` 성공
- \`bun test --cwd tests/integration\` → 3060 pass (기존 그린 유지) / 1 pre-existing flaky
- 스냅샷 변경 0 건
- **동작 변경 0** (순수 리팩터)

LoC: -6 net (27 add / 33 del — 중복 layout 주석 제거).

## 남은 follow-up (#1513)

- **\`es2015_params.zig\`** — \`formal_parameter\` extras (다른 schema: [pattern, type_ann, default, flags, deco_start, deco_len]). 새 \`FormalParameterExtra\` struct 추가 필요.
- **class_declaration / class_expression extras** — \`ClassExtra\` 상수는 #1534 에서 이미 추가. 사용처 (\`transformStage3Decorators\` class body 접근 등) migrate 는 \`ce\` 변수가 call_expression 과 ambiguity 있어 신중 PR 분리.

## Test plan

- [x] zig build 성공
- [x] 전체 integration 그린
- [x] 스냅샷 diff 0 건
- [x] 모든 기존 회귀 지속 pass