### PR TITLE
refactor(ast): formal_parameter + class_declaration extras 상수화 (#1513 3/N)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1133,6 +1133,16 @@ pub const ClassExtra = struct {
     pub const deco_len: u32 = 7;
 };
 
+/// formal_parameter extras 레이아웃: [pattern, type_ann, default, flags, deco_start, deco_len] (#1513).
+pub const FormalParameterExtra = struct {
+    pub const pattern: u32 = 0;
+    pub const type_ann: u32 = 1;
+    pub const default: u32 = 2;
+    pub const flags: u32 = 3;
+    pub const deco_start: u32 = 4;
+    pub const deco_len: u32 = 5;
+};
+
 /// call_expression / new_expression의 flags 비트 (D082).
 /// extra: [callee, args_start, args_len, flags]
 pub const CallFlags = struct {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -56,9 +56,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const e = node.data.extra;
             const span = node.span;
 
-            const name_idx: NodeIndex = self.readNodeIdx(e, 0);
-            const super_idx: NodeIndex = self.readNodeIdx(e, 1);
-            const body_idx: NodeIndex = self.readNodeIdx(e, 2);
+            const name_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.name);
+            const super_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.super);
+            const body_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.body);
 
             // 클래스 이름 추출
             const new_name = try self.visitNode(name_idx);
@@ -276,9 +276,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const e = node.data.extra;
             const span = node.span;
 
-            const name_idx: NodeIndex = self.readNodeIdx(e, 0);
-            const super_idx: NodeIndex = self.readNodeIdx(e, 1);
-            const body_idx: NodeIndex = self.readNodeIdx(e, 2);
+            const name_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.name);
+            const super_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.super);
+            const body_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.body);
 
             // 클래스 이름
             const new_name = try self.visitNode(name_idx);
@@ -2558,8 +2558,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const e = node.data.extra;
 
             // class decorator: extra offset 6, 7
-            const old_deco_start = self.readU32(e, 6);
-            const old_deco_len = self.readU32(e, 7);
+            const old_deco_start = self.readU32(e, ast_mod.ClassExtra.deco_start);
+            const old_deco_len = self.readU32(e, ast_mod.ClassExtra.deco_len);
 
             // body 멤버를 순회하여 member decorator + constructor param decorator 수집
             const body_node = self.ast.getNode(body_idx);

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -112,10 +112,9 @@ pub fn ES2015Params(comptime Transformer: type) type {
                 }
 
                 if (param.tag == .formal_parameter) {
-                    // extra = [pattern, type_ann, default, flags, deco_start, deco_len]
                     const pe = param.data.extra;
-                    const pattern_idx: NodeIndex = self.readNodeIdx(pe, 0);
-                    const default_idx: NodeIndex = self.readNodeIdx(pe, 2);
+                    const pattern_idx: NodeIndex = self.readNodeIdx(pe, ast_mod.FormalParameterExtra.pattern);
+                    const default_idx: NodeIndex = self.readNodeIdx(pe, ast_mod.FormalParameterExtra.default);
 
                     if (!default_idx.isNone()) {
                         const pat_node = self.ast.getNode(pattern_idx);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3485,7 +3485,7 @@ pub const Transformer = struct {
     fn tryTransformStage3(self: *Transformer, node: Node) Error!?NodeIndex {
         if (self.options.experimental_decorators) return null;
         const e = node.data.extra;
-        const class_deco_len = self.readU32(e, 7);
+        const class_deco_len = self.readU32(e, ast_mod.ClassExtra.deco_len);
         const has_member_decos = self.hasAnyMemberDecorators(e);
         if (class_deco_len == 0 and !has_member_decos) return null;
         return try self.transformStage3Decorators(node);

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -28,10 +28,10 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
     // Fast path: useDefineForClassFields=true AND !experimentalDecorators → 기존 동작
     // 멤버별 분류가 불필요하므로 body를 통째로 방문한다.
     if (self.options.use_define_for_class_fields and !self.options.experimental_decorators) {
-        const new_name = try self.visitNode(self.readNodeIdx(e, 0));
-        const new_super = try self.visitNode(self.readNodeIdx(e, 1));
+        const new_name = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.name));
+        const new_super = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.super));
 
-        var current_body_idx = self.readNodeIdx(e, 2);
+        var current_body_idx = self.readNodeIdx(e, ast_mod.ClassExtra.body);
 
         // ES2022 다운레벨링: private method (WeakSet + standalone fn) + private field (WeakMap + ctor init).
         // 두 변환은 단일 Pass로 통합 — body 순회 1회 + ctor_init 주입 1회.
@@ -113,7 +113,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
             if (had_static_blocks) {
                 current_body_idx = new_body;
 
-                const new_decos = try self.visitExtraList(.{ .start = self.readU32(e, 6), .len = self.readU32(e, 7) });
+                const new_decos = try self.visitExtraList(.{ .start = self.readU32(e, ast_mod.ClassExtra.deco_start), .len = self.readU32(e, ast_mod.ClassExtra.deco_len) });
                 const none = @intFromEnum(NodeIndex.none);
                 const class_result = try self.addExtraNode(node.tag, node.span, &.{
                     @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(current_body_idx),
@@ -146,7 +146,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
 
         // private method/field 가 있고 static block은 없는 경우
         if (had_private_methods or had_private_fields) {
-            const new_decos = try self.visitExtraList(.{ .start = self.readU32(e, 6), .len = self.readU32(e, 7) });
+            const new_decos = try self.visitExtraList(.{ .start = self.readU32(e, ast_mod.ClassExtra.deco_start), .len = self.readU32(e, ast_mod.ClassExtra.deco_len) });
             const none = @intFromEnum(NodeIndex.none);
             const class_result = try self.addExtraNode(node.tag, node.span, &.{
                 @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(current_body_idx),
@@ -173,7 +173,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         }
 
         const new_body = try self.visitNode(current_body_idx);
-        const new_decos = try self.visitExtraList(.{ .start = self.readU32(e, 6), .len = self.readU32(e, 7) });
+        const new_decos = try self.visitExtraList(.{ .start = self.readU32(e, ast_mod.ClassExtra.deco_start), .len = self.readU32(e, ast_mod.ClassExtra.deco_len) });
         const none = @intFromEnum(NodeIndex.none);
         return self.addExtraNode(node.tag, node.span, &.{
             @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
@@ -252,12 +252,12 @@ fn wrapClassExprInIIFE(
 pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeIndex {
     // TODO(es2021): apply same IIFE wrapping for class_expression with private methods — see wrapClassExprInIIFE in fast path
     const e = node.data.extra;
-    const has_super = !self.readNodeIdx(e, 1).isNone();
-    const new_name = try self.visitNode(self.readNodeIdx(e, 0));
-    const new_super = try self.visitNode(self.readNodeIdx(e, 1));
+    const has_super = !self.readNodeIdx(e, ast_mod.ClassExtra.super).isNone();
+    const new_name = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.name));
+    const new_super = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.super));
 
     // 원본 class_body를 직접 순회
-    const body_idx = self.readNodeIdx(e, 2);
+    const body_idx = self.readNodeIdx(e, ast_mod.ClassExtra.body);
     const body_node = self.ast.getNode(body_idx);
     const body_members_start = body_node.data.list.start;
     const body_members_len = body_node.data.list.len;
@@ -416,8 +416,8 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
 
     // experimentalDecorators — decorator를 class에서 제거하고 __decorateClass 호출 생성
     if (self.options.experimental_decorators) {
-        const old_deco_start = self.readU32(e, 6);
-        const old_deco_len = self.readU32(e, 7);
+        const old_deco_start = self.readU32(e, ast_mod.ClassExtra.deco_start);
+        const old_deco_len = self.readU32(e, ast_mod.ClassExtra.deco_len);
 
         if (old_deco_len > 0 or member_decorators.items.len > 0 or ctor_param_decos.items.len > 0) {
             return try self.transformExperimentalDecorators(
@@ -439,7 +439,7 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
 
     // decorator 리스트 복사 (experimental이 아닌 경우)
     const new_decos = if (!self.options.experimental_decorators)
-        try self.visitExtraList(.{ .start = self.readU32(e, 6), .len = self.readU32(e, 7) })
+        try self.visitExtraList(.{ .start = self.readU32(e, ast_mod.ClassExtra.deco_start), .len = self.readU32(e, ast_mod.ClassExtra.deco_len) })
     else
         NodeList{ .start = 0, .len = 0 };
 
@@ -1846,11 +1846,11 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     self.runtime_helpers.es_decorator = true;
 
     // 클래스 이름, super, body, decorator 추출
-    const name_idx = self.readNodeIdx(e, 0);
-    const super_idx = self.readNodeIdx(e, 1);
-    const body_idx = self.readNodeIdx(e, 2);
-    const class_deco_start = self.readU32(e, 6);
-    const class_deco_len = self.readU32(e, 7);
+    const name_idx = self.readNodeIdx(e, ast_mod.ClassExtra.name);
+    const super_idx = self.readNodeIdx(e, ast_mod.ClassExtra.super);
+    const body_idx = self.readNodeIdx(e, ast_mod.ClassExtra.body);
+    const class_deco_start = self.readU32(e, ast_mod.ClassExtra.deco_start);
+    const class_deco_len = self.readU32(e, ast_mod.ClassExtra.deco_len);
 
     // 클래스 이름 텍스트 (Foo). 익명/default class는 "_Class"를 사용.
     // "default"는 JS 예약어이므로 변수명으로 사용 불가.


### PR DESCRIPTION
Closes #1513

#1534 (1/N) / #1535 (2/N) 에 이은 마지막 배치 — spec 의 남은 두 영역 (formal_parameter + class_declaration extras).

## 변경

### FormalParameterExtra 추가

\`ast.zig\`:
\`\`\`zig
pub const FormalParameterExtra = struct {
    pub const pattern: u32 = 0;
    pub const type_ann: u32 = 1;
    pub const default: u32 = 2;
    pub const flags: u32 = 3;
    pub const deco_start: u32 = 4;
    pub const deco_len: u32 = 5;
};
\`\`\`

\`es2015_params.zig\` 의 2 사이트 (\`readNodeIdx(pe, 0)\` / \`readNodeIdx(pe, 2)\`) 치환.

### ClassExtra 사용처 migrate

**offset 6/7 (\`ClassExtra.deco_start\` / \`deco_len\`)** — class-specific (다른 노드는 8 extras 없음, 안전하게 일괄 치환):
- class_decorator.zig 5 사이트 (\`transformStage3Decorators\`, \`transformExperimentalDecorators\`, class-level decorator collect 경로)
- transformer.zig 1 사이트 (\`hasAnyMemberDecorators\` — 0x80 flag 체크)
- es2015_class.zig 2 사이트 (\`emitDecoratorsForLoweredClass\`)

**offset 0/1/2 (name/super/body)** — class-context 확인 후 치환:
- \`lowerClassDeclaration\` / \`lowerClassExpression\` (es2015_class.zig)
- \`visitClass\` fast path (class_decorator.zig)
- \`transformStage3Decorators\` (class_decorator.zig)
- \`transformExperimentalDecorators\` (class_decorator.zig)

### 의도적 skip

call_expression / new_expression 의 \`ce\` (callee/args_start/args_len/flags) — 다른 schema 로 \`CallFlags\` 와 별개 작업.

## 검증

- \`zig build\` 성공
- \`bun test --cwd tests/integration\` → 3060 pass (기존 그린 유지) / 1 pre-existing flaky
- 스냅샷 변경 0 건
- **동작 변경 0** (순수 리팩터)

LoC: +9 net (39 add / 30 del — layout 주석 중복 제거).

## #1513 완료 정리

| 배치 | PR | 파일 | 사이트 |
|---|---|---|---|
| 1/N | #1534 | ast.zig (+3 struct), es2015_class, es2022, class_decorator | ~55 |
| 2/N | #1535 | codegen, semantic/analyzer, es_helpers | ~15 |
| 3/N | 이 PR | +FormalParameterExtra, class_decl/expr 사이트 | ~11 |

**총 ~80 사이트 매직 offset → 명명 상수**. class extras 주요 소비자 전부 migrate 완료.

## Test plan

- [x] zig build 성공
- [x] 전체 integration 그린
- [x] 스냅샷 diff 0 건
- [x] 모든 기존 회귀 지속 pass