### PR TITLE
fix(transformer): Stage 3 decorator + --target=es5 재방문 활성화

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -56,6 +56,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const e = node.data.extra;
             const span = node.span;
 
+            // lowerClassExpression과 동일: class body는 독립 this 스코프이므로 arrow_this_depth 리셋.
+            const saved_arrow_depth = self.arrow_this_depth;
+            self.arrow_this_depth = 0;
+            defer self.arrow_this_depth = saved_arrow_depth;
+
             const name_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.name);
             const super_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.super);
             const body_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.body);
@@ -97,7 +102,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             defer self.current_super_class_old_idx = saved_super_old_idx;
 
             // 클래스 바디 멤버 분류
-            var cm = try classifyMembers(self, body_idx, span);
+            var cm = try classifyMembers(self, body_idx, span, name_span);
             defer cm.deinit(self.allocator);
 
             const saved_private_fields = self.current_private_fields;
@@ -276,6 +281,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const e = node.data.extra;
             const span = node.span;
 
+            // Class body는 독립된 this 스코프. 외부 arrow의 arrow_this_depth가 leak되면
+            // field initializer의 `this`가 `_this`로 잘못 치환된다 (Stage 3 decorator 재방문 케이스).
+            const saved_arrow_depth = self.arrow_this_depth;
+            self.arrow_this_depth = 0;
+            defer self.arrow_this_depth = saved_arrow_depth;
+
             const name_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.name);
             const super_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.super);
             const body_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.body);
@@ -316,7 +327,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             defer self.current_super_class_old_idx = saved_super_old_idx;
 
             // 바디 멤버 분류
-            var cm = try classifyMembers(self, body_idx, span);
+            var cm = try classifyMembers(self, body_idx, span, name_span);
             defer cm.deinit(self.allocator);
 
             const saved_private_fields = self.current_private_fields;
@@ -1387,7 +1398,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return total;
         }
 
-        fn classifyMembers(self: *Transformer, body_idx: NodeIndex, span: Span) Transformer.Error!ClassifiedMembers {
+        fn classifyMembers(self: *Transformer, body_idx: NodeIndex, span: Span, class_name_span: Span) Transformer.Error!ClassifiedMembers {
             const body_node = self.ast.getNode(body_idx);
             const members_start = body_node.data.list.start;
             const members_len = body_node.data.list.len;
@@ -1521,6 +1532,18 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     if (!sb_body_idx.isNone()) {
                         const sb_body = self.ast.getNode(sb_body_idx);
                         if (sb_body.tag == .block_statement) {
+                            // Class IIFE body로 flatten할 때 static block의 `this`는 class 자체를
+                            // 가리키던 scope가 사라진다. transformer.zig:1135의 치환 훅을 활성화해
+                            // this → class name identifier로 바꾼다. 중첩 함수 안의 this는
+                            // this_depth > 0이므로 영향받지 않음.
+                            const saved_sb_name = self.static_block_class_name;
+                            const saved_sb_depth = self.this_depth;
+                            self.static_block_class_name = class_name_span;
+                            self.this_depth = 0;
+                            defer {
+                                self.static_block_class_name = saved_sb_name;
+                                self.this_depth = saved_sb_depth;
+                            }
                             const sb_stmts_start = sb_body.data.list.start;
                             const sb_stmts_len = sb_body.data.list.len;
                             var i_loop: u32 = 0;

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1885,6 +1885,10 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     var has_instance_decorators = false;
     var has_static_decorators = false;
 
+    // accessor + decorator의 private backing은 아직 ES5 WeakMap으로 풀리지 않는다 (#1537).
+    // true면 ES5 재방문을 skip해 modern-runtime-only 기존 동작을 유지한다.
+    var has_private_accessor_backing = false;
+
     const body_node = self.ast.getNode(body_idx);
     const body_start = body_node.data.list.start;
     const body_len = body_node.data.list.len;
@@ -2114,6 +2118,9 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .extra_initializers_name = names.extra_name,
                         .deco_var_name = deco_vname,
                     });
+
+                    // private backing field를 생성하므로, ES5 재방문 경로를 건너뛰도록 표시.
+                    has_private_accessor_backing = true;
 
                     // accessor → private backing field + getter + setter
                     const storage_name = try std.fmt.allocPrint(self.allocator, "#_{s}_accessor_storage", .{clean_name});
@@ -2589,6 +2596,12 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     const outer_var_decl = try self.addExtraNode(.variable_declaration, zero_span, &.{
         1, outer_decl_list.start, outer_decl_list.len, // 1 = let
     });
+
+    // ES5 target: outer_var_decl을 반환해 호출자(transformer.zig:1044)가 visitNode로 재방문,
+    // arrow/let/class/static block을 추가 다운레벨링하게 한다. pending_nodes로 넘기면
+    // class_declaration 위치에 .none이 박혀 재방문이 일어나지 않는다.
+    // private accessor backing(#1537)은 재방문 시 깨지므로 기존 pending_nodes 경로로 fallthrough.
+    if (self.options.unsupported.class and !has_private_accessor_backing) return outer_var_decl;
 
     try self.pending_nodes.append(self.allocator, outer_var_decl);
     return .none;

--- a/tests/integration/tests/es5-stage3-decorator.test.ts
+++ b/tests/integration/tests/es5-stage3-decorator.test.ts
@@ -1,0 +1,153 @@
+import { describe, test, expect } from "bun:test";
+import { createFixture, runZts } from "./helpers";
+import { spawnSync } from "node:child_process";
+
+// Stage 3 decorator + --target=es5 다운레벨링 검증.
+// - Stage 3 decorator pass가 `let C = (() => { ... })()` 형태 IIFE를 emit한다.
+// - transformer.zig가 visitNode 재방문으로 arrow/let/class/accessor/static block을 ES5로 추가 lowering.
+// - static block 안의 `this`는 class name identifier로 치환되어야 한다 (class scope 소실).
+async function transpileES5(code: string): Promise<string> {
+  const fixture = await createFixture({ "input.ts": code });
+  try {
+    const result = await runZts([`${fixture.dir}/input.ts`, "--target=es5"]);
+    if (result.exitCode !== 0) throw new Error(`zts failed: ${result.stderr}`);
+    return result.stdout;
+  } finally {
+    await fixture.cleanup();
+  }
+}
+
+function runInNode(code: string): string {
+  const proc = spawnSync("node", ["--input-type=module", "-e", code], { encoding: "utf8" });
+  if (proc.status !== 0) throw new Error(proc.stderr || proc.stdout);
+  return proc.stdout.trim();
+}
+
+// ES5 syntax 금지 패턴: ES5 런타임 파서가 실패하는 구문이 출력에 남으면 회귀.
+function expectNoEs6Syntax(output: string) {
+  // class keyword
+  expect(output).not.toMatch(/\bclass\s+[A-Za-z_$][\w$]*\s*\{/);
+  expect(output).not.toMatch(/\bclass\s*\{/);
+  // static { ... } 블록
+  expect(output).not.toMatch(/^\s*static\s*\{/m);
+  // accessor 키워드
+  expect(output).not.toMatch(/\baccessor\s+[A-Za-z_$]/);
+  // arrow function (expression body/block body 모두)
+  expect(output).not.toMatch(/=>/);
+  // let/const (block_scoping 다운레벨링 완료)
+  expect(output).not.toMatch(/^\s*let\s+[A-Za-z_$]/m);
+}
+
+describe("Stage 3 decorator + --target=es5 다운레벨링", () => {
+  test("method decorator + accessor field (이슈 본문 케이스)", async () => {
+    const out = await transpileES5(`
+function logged(target: any, ctx: any) {
+  return function (this: any, ...args: any[]) { return target.apply(this, args); };
+}
+class C {
+  accessor counter = 0;
+  @logged tick() { this.counter += 1; return this.counter; }
+}
+const c = new C();
+console.log(c.tick(), c.tick());
+`);
+    expectNoEs6Syntax(out);
+    expect(runInNode(out)).toBe("1 2");
+  });
+
+  test("class-level decorator (addInitializer)", async () => {
+    const out = await transpileES5(`
+function addStatic(target: any, ctx: any) {
+  ctx.addInitializer(() => { (target as any).tag = "TAGGED"; });
+}
+@addStatic
+class A { hello() { return "hi"; } }
+console.log(new A().hello(), (A as any).tag);
+`);
+    expectNoEs6Syntax(out);
+    expect(runInNode(out)).toBe("hi TAGGED");
+  });
+
+  test("field decorator (init 변환) — arrow_this_depth leak 회귀 방지", async () => {
+    const out = await transpileES5(`
+function double(_v: any, _ctx: any) { return function (initial: number) { return initial * 2; }; }
+class F { @double value = 10; }
+console.log(new F().value);
+`);
+    expectNoEs6Syntax(out);
+    // field init 안의 this가 _this로 잘못 치환되면 ReferenceError 발생 (과거 회귀).
+    expect(runInNode(out)).toBe("20");
+  });
+
+  test("static method decorator", async () => {
+    const out = await transpileES5(`
+function wrap(target: any, _ctx: any) {
+  return function (this: any, ...args: any[]) { return "W:" + target.apply(this, args); };
+}
+class S { @wrap static greet(name: string) { return "Hi " + name; } }
+console.log(S.greet("bob"));
+`);
+    expectNoEs6Syntax(out);
+    expect(runInNode(out)).toBe("W:Hi bob");
+  });
+
+  test("getter decorator", async () => {
+    const out = await transpileES5(`
+function log(target: any, ctx: any) {
+  if (ctx.kind === "getter") return function (this: any) { return target.call(this) + "!"; };
+  return target;
+}
+class G { _v = 5; @log get v() { return this._v; } set v(n: number) { this._v = n; } }
+const g = new G(); console.log(g.v); g.v = 7; console.log(g.v);
+`);
+    expectNoEs6Syntax(out);
+    expect(runInNode(out)).toBe("5!\n7!");
+  });
+
+  test("extends + class decorator", async () => {
+    const out = await transpileES5(`
+function tag(target: any, ctx: any) { ctx.addInitializer(() => { (target as any).tag = "X"; }); }
+class Base { base() { return "B"; } }
+@tag
+class Child extends Base { child() { return this.base() + "-C"; } }
+console.log(new Child().child(), (Child as any).tag);
+`);
+    expectNoEs6Syntax(out);
+    expect(runInNode(out)).toBe("B-C X");
+  });
+
+  test("chained decorators (적용 순서)", async () => {
+    const out = await transpileES5(`
+function a(t: any, _c: any) { return function (this: any) { return "a(" + t.apply(this, arguments) + ")"; }; }
+function b(t: any, _c: any) { return function (this: any) { return "b(" + t.apply(this, arguments) + ")"; }; }
+class Ch { @a @b go() { return "core"; } }
+console.log(new Ch().go());
+`);
+    expectNoEs6Syntax(out);
+    expect(runInNode(out)).toBe("a(b(core))");
+  });
+
+  test("동일 scope에 여러 decorated class", async () => {
+    const out = await transpileES5(`
+function id(t: any, _c: any) { return t; }
+class P { @id p() { return 1; } }
+class Q { @id q() { return 2; } }
+console.log(new P().p(), new Q().q());
+`);
+    expectNoEs6Syntax(out);
+    expect(runInNode(out)).toBe("1 2");
+  });
+
+  // static block 내 this → class name 치환 (Stage 3 decorator와 독립된 일반 버그 수정)
+  test("일반 static block: this → class name 치환", async () => {
+    const out = await transpileES5(`
+class D {
+  static counter = 0;
+  static { (D as any).x = 42; this.counter = 1; }
+}
+console.log(D.counter, (D as any).x);
+`);
+    expectNoEs6Syntax(out);
+    expect(runInNode(out)).toBe("1 42");
+  });
+});


### PR DESCRIPTION
## Summary

- Stage 3 decorator transformer가 \`outer_var_decl\`을 \`pending_nodes\`에 push하고 \`.none\`을 반환해 \`transformer.zig:1044\`의 \`visitNode(stage3_result)\` 재방문이 never-fire → \`--target=es5\`에서 arrow/let/class/static block이 ES5로 추가 다운레벨링되지 않던 버그 수정.
- 연관 근본 수정 2건:
  - static block의 \`this\` → class name 치환 훅 활성화 (classifyMembers에 class_name_span 전달)
  - lowerClass(Declaration|Expression) 진입부에 arrow_this_depth save+reset (외부 arrow leak 방지 → field initializer \`_this\` 참조 오류 차단)
- accessor + decorator × ES5의 private accessor backing(WeakMap) lowering은 #1537, export default 익명 class + decorator는 #1538로 분리. 이번 PR은 전자를 \`has_private_accessor_backing\` flag로 기존 pending_nodes 경로로 fallthrough시켜 modern-runtime 회귀 방지.

## Before / After

입력:
\`\`\`ts
function logged(target, ctx) { return function (...args) { return target.apply(this, args); }; }
class C {
  accessor counter = 0;
  @logged tick() { this.counter += 1; return this.counter; }
}
\`\`\`

Before (\`--target=es5\`):
\`\`\`js
let C = (() => {
  var C = class {
    static { _classThis = this; }          // ← ES5 parser fail
    static { __esDecorate(...); }
    accessor counter = 0;                   // ← ES5 parser fail
    tick() { ... }
  };
})();
\`\`\`

After:
\`\`\`js
var C = (function() {
  var _classThis = void 0;
  var C = (function() {
    var __counter_acc = new WeakMap();
    function _Class() { __classCallCheck(this, _Class); __counter_acc.set(this, 0); ... }
    _Class.prototype.tick = function() { ... };
    Object.defineProperty(_Class.prototype, "counter", { get: ..., set: ... });
    _classThis = _Class;                    // ← static block this 치환
    __esDecorate(_Class, null, _tick_decorators, ...);
    return _Class;
  })();
  return C = _classThis;
})();
\`\`\`

## Reference

- Babel의 Stage 3 decorator → ES2015 출력(\`2023-11-classes--to-es2015/ctx\`)은 static block을 전혀 쓰지 않고 \`class extends babelHelpers.identity\` 패턴으로 회피. ZTS는 TS 스타일(static block 포함) + 후속 class lowering(this 치환) 조합으로 동일 결과.

## Test plan

- [x] \`tests/integration/tests/es5-stage3-decorator.test.ts\` — 9 new cases (method/field/static/getter/extends/chained/multi-class decorator + 일반 static block this 치환). All pass.
- [x] \`tests/integration/tests/stage3-decorator.test.ts\` — 회귀 없음
- [x] \`tests/integration/tests/stage3-decorator-smoke.test.ts\` — MobX 6 @observable accessor + @action --target=es5 회귀 없음 (has_private_accessor_backing fallthrough 덕분)
- [x] \`tests/integration/tests/tsc/decorator.test.ts\` — 73/73 pass
- [x] \`tests/integration/tests/es5-rn.test.ts\` — 회귀 없음
- [x] full suite: 3072 pass / 4 skip / 2 todo

## Follow-ups

- #1537 — accessor + decorator × ES5: private backing WeakMap lowering
- #1538 — export default 익명 class + decorator: 빈 변수명 emit

🤖 Generated with [Claude Code](https://claude.com/claude-code)