### PR TITLE
fix(transformer): Stage 3 accessor+decorator × ES5 private backing WeakMap lowering (#1537)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1486,10 +1486,13 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     // private field (#x) → instance: WeakMap, static: descriptor 객체
                     const key_node = self.ast.getNode(key);
                     if (key_node.tag == .private_identifier) {
-                        const orig_name = self.ast.getText(key_node.span); // "#x"
+                        // getText는 source_text 또는 string_table(Stage 3 생성 span)을 가리키는데,
+                        // 후자는 후속 addString realloc으로 dangling된다 (#1481 · findPrivateFieldMapping 키).
+                        const orig_name_owned = try self.allocator.dupe(u8, self.ast.getText(key_node.span));
+                        try cm.synthesized_private_names.append(self.allocator, orig_name_owned);
                         const field_info = PrivateFieldInfo{
-                            .name = try es_helpers.makePrivateVarName(self.allocator, orig_name),
-                            .original_name = orig_name,
+                            .name = try es_helpers.makePrivateVarName(self.allocator, orig_name_owned),
+                            .original_name = orig_name_owned,
                             .init = init_val,
                         };
                         if (is_static) {

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1885,10 +1885,6 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     var has_instance_decorators = false;
     var has_static_decorators = false;
 
-    // accessor + decorator의 private backing은 아직 ES5 WeakMap으로 풀리지 않는다 (#1537).
-    // true면 ES5 재방문을 skip해 modern-runtime-only 기존 동작을 유지한다.
-    var has_private_accessor_backing = false;
-
     const body_node = self.ast.getNode(body_idx);
     const body_start = body_node.data.list.start;
     const body_len = body_node.data.list.len;
@@ -2118,9 +2114,6 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .extra_initializers_name = names.extra_name,
                         .deco_var_name = deco_vname,
                     });
-
-                    // private backing field를 생성하므로, ES5 재방문 경로를 건너뛰도록 표시.
-                    has_private_accessor_backing = true;
 
                     // accessor → private backing field + getter + setter
                     const storage_name = try std.fmt.allocPrint(self.allocator, "#_{s}_accessor_storage", .{clean_name});
@@ -2600,8 +2593,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     // ES5 target: outer_var_decl을 반환해 호출자(transformer.zig:1044)가 visitNode로 재방문,
     // arrow/let/class/static block을 추가 다운레벨링하게 한다. pending_nodes로 넘기면
     // class_declaration 위치에 .none이 박혀 재방문이 일어나지 않는다.
-    // private accessor backing(#1537)은 재방문 시 깨지므로 기존 pending_nodes 경로로 fallthrough.
-    if (self.options.unsupported.class and !has_private_accessor_backing) return outer_var_decl;
+    if (self.options.unsupported.class) return outer_var_decl;
 
     try self.pending_nodes.append(self.allocator, outer_var_decl);
     return .none;

--- a/tests/integration/tests/es5-stage3-decorator.test.ts
+++ b/tests/integration/tests/es5-stage3-decorator.test.ts
@@ -138,6 +138,29 @@ console.log(new P().p(), new Q().q());
     expect(runInNode(out)).toBe("1 2");
   });
 
+  // #1537 — Stage 3가 accessor에 붙인 `#_{name}_accessor_storage` private backing이
+  // ES5 lowering에서 WeakMap으로 풀리는지. 핵심 회귀 가드.
+  test("accessor + decorator의 private backing → WeakMap lowering (#1537)", async () => {
+    const out = await transpileES5(`
+function defaultTo(def: any) {
+  return function (_: any, _ctx: any) {
+    return { init(v: any) { return v == null ? def : v; } };
+  };
+}
+class AccDec { @defaultTo(99) accessor x: any = undefined; }
+const ad = new AccDec();
+console.log(ad.x);
+ad.x = 5;
+console.log(ad.x);
+`);
+    expectNoEs6Syntax(out);
+    // private field syntax(#name)가 출력에 남지 않아야 한다 — ES5 parser 실패 방지.
+    expect(out).not.toMatch(/#[A-Za-z_]/);
+    // accessor backing은 WeakMap으로 변환되어야 한다.
+    expect(out).toMatch(/new WeakMap\(\)/);
+    expect(runInNode(out)).toBe("99\n5");
+  });
+
   // static block 내 this → class name 치환 (Stage 3 decorator와 독립된 일반 버그 수정)
   test("일반 static block: this → class name 치환", async () => {
     const out = await transpileES5(`


### PR DESCRIPTION
## Summary

- \`classifyMembers\`의 일반 private field 경로가 \`ast.getText(key_node.span)\` slice를 그대로 \`PrivateFieldInfo.original_name\`에 저장 → 이후 \`addString\` 호출이 string_table을 grow시켜 slice가 dangling → \`findPrivateFieldMapping\`의 \`std.mem.eql\` 비교 실패.
- 증상: Stage 3가 accessor + decorator 조합에서 \`#_{name}_accessor_storage\` private backing을 만들면, ES5 재방문에서 getter/setter body 안의 \`this.#_x_accessor_storage\` 참조가 \`__weakmap.get/set\`으로 치환되지 않고 그대로 남아 ES5 parser 실패.
- 수정: 기존 accessor/computed accessor 경로에서 쓰던 \`synthesized_private_names\` 메커니즘(heap-owned 복사본 보관)을 일반 private field 경로에도 적용. 동류의 소유권 문제 #1481 해결책 재사용.
- 후속 정리: #1539에서 임시 회피로 넣었던 \`has_private_accessor_backing\` flag 제거.

## Before / After

입력:
\`\`\`ts
function defaultTo(def: any) {
  return function (_: any, _ctx: any) {
    return { init(v: any) { return v == null ? def : v; } };
  };
}
class AccDec { @defaultTo(99) accessor x: any = undefined; }
\`\`\`

Before (\`--target=es5\`, #1539 flag fallthrough로 modern-runtime-only):
\`\`\`js
let AccDec = (() => {
  var AccDec = class {
    static { _classThis = this; }
    #_x_accessor_storage = ...;          // ← ES5 parser fail
    get x() { return this.#_x_accessor_storage; }
    ...
  };
})();
\`\`\`

After:
\`\`\`js
var AccDec = (function() {
  var _classThis = void 0; ...
  var AccDec = (function() {
    var __x_accessor_storage = new WeakMap();
    function _Class() {
      __classCallCheck(this, _Class);
      __x_accessor_storage.set(this, (__runInitializers(this, _instanceExtraInitializers), __runInitializers(this, _x_initializers, undefined)));
      __runInitializers(this, _x_extraInitializers);
    }
    Object.defineProperty(_Class.prototype, \"x\", { configurable: true,
      get: function() { return __x_accessor_storage.get(this); },
      set: function(value) { __classPrivateFieldSet(__x_accessor_storage, this, value); }
    });
    _classThis = _Class;
    __esDecorate(_Class, null, _x_decorators, { kind: \"accessor\", ... });
    return _Class;
  })();
  return AccDec = _classThis;
})();
\`\`\`

## Test plan

- [x] \`tests/integration/tests/es5-stage3-decorator.test.ts\` — accessor + decorator × --target=es5 회귀 가드 추가 (WeakMap 생성 + #private syntax 제거 + 런타임 값 검증). 10/10 pass.
- [x] \`tests/integration/tests/stage3-decorator-smoke.test.ts\` — MobX 6 @observable accessor + @computed getter chain --target=es5 통과
- [x] \`tests/integration/tests/stage3-decorator.test.ts\` — 회귀 없음
- [x] \`tests/integration/tests/tsc/\` — 2177/0 fail
- [x] \`tests/integration/tests/es5-rn.test.ts\` — 회귀 없음

Closes #1537

🤖 Generated with [Claude Code](https://claude.com/claude-code)