### PR TITLE
fix(parser, transformer): @decorator export [default] class 보존 (#1538)

### DIFF
--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -476,6 +476,12 @@ fn parseImportSpecifier(self: *Parser) ParseError2!NodeIndex {
 }
 
 pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
+    return parseExportDeclarationWithDecorators(self, .{ .start = 0, .len = 0 });
+}
+
+/// `@dec export [default] class`: decorators를 class_declaration으로 전파한다.
+/// parseDecoratedStatement가 이 경로로 위임하며, 일반 `parseExportDeclaration`은 빈 list로 호출.
+pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.NodeList) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     // @__NO_SIDE_EFFECTS__ 주석이 export 키워드 앞에 있으면 캡처.
     // export function f() {} 형태에서 주석은 export 토큰에 붙지만,
@@ -519,7 +525,7 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
                 }
                 break :blk fn_decl;
             },
-            .kw_class => try self.parseClassDeclaration(),
+            .kw_class => try self.parseClassWithDecorators(.class_declaration, decorators),
             else => blk: {
                 // export default interface Foo {} — TS 전용, 런타임에 제거
                 if (self.current() == .kw_interface) {
@@ -532,7 +538,7 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
                     const peek = try self.peekNext();
                     if (peek.kind == .kw_class and !peek.has_newline_before) {
                         try self.advance(); // skip 'abstract'
-                        break :blk try self.parseClassDeclaration();
+                        break :blk try self.parseClassWithDecorators(.class_declaration, decorators);
                     }
                     // abstract 단독 → 식별자 expression (fallthrough)
                 }
@@ -804,7 +810,11 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
     }
 
     // export var/let/const/function/class
-    const decl = try self.parseStatement();
+    // `@dec export class Foo {}` — decorators는 parseStatement를 거치면 drop되므로 여기서 직접 전달.
+    const decl = if (decorators.len > 0 and self.current() == .kw_class)
+        try self.parseClassWithDecorators(.class_declaration, decorators)
+    else
+        try self.parseStatement();
     // type-only 선언이면 export_named_declaration을 생성하지 않음.
     // 남으면 import_scanner가 has_esm_syntax=true로 잘못 판별하여
     // CJS 모듈이 __esm으로 래핑됨.

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -326,7 +326,7 @@ pub fn parseDecoratedStatement(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .kw_class) {
         return self.parseClassWithDecorators(.class_declaration, decorators);
     } else if (self.current() == .kw_export) {
-        return self.parseExportDeclaration();
+        return @import("module.zig").parseExportDeclarationWithDecorators(self, decorators);
     } else if (self.isContextual("abstract")) {
         return parseTsAbstractClass(self);
     } else if (self.isContextual("declare")) {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1038,8 +1038,10 @@ pub const Transformer = struct {
                 const replacement_idx = try self.dispatchVisitor(.on_class_declaration, idx);
                 const target_node = if (replacement_idx) |r| self.ast.getNode(r) else node;
                 // Stage 3 decorator는 unsupported.class 분기보다 먼저 돌려야 한다 — 반대면 decorator가 silent drop.
-                // Stage 3 출력은 IIFE로 감싼 class_expression을 포함하므로, ES5 target일 땐 재방문해서
-                // 내부 class_expression을 lowerClassExpression로 추가 다운레벨링한다.
+                // 이름 있는 class_declaration은 Stage 3 내부에서 outer_var_decl을 pending_nodes로 hoist하고
+                // `.none`을 반환하므로, export_named/default declaration이 이름을 감지해 `export { X };` 또는
+                // `export default X;` 형태로 분리한다 (#1538). 익명/class_expression은 iife_call을 직접 반환해
+                // 아래 visitNode 재방문이 arrow/let/static block을 ES5로 마저 다운레벨링한다.
                 if (try self.tryTransformStage3(target_node)) |stage3_result| {
                     if (self.options.unsupported.class) return self.visitNode(stage3_result);
                     return stage3_result;
@@ -4124,6 +4126,34 @@ pub const Transformer = struct {
         // export interface/type alias 등 타입 선언만 있으면 빈 export {} 제거
         // export { type Foo } from './a' 같은 re-export는 source가 있으므로 유지
         if (new_decl.isNone() and new_specs.len == 0 and new_source.isNone()) {
+            // `@dec export class Named`: Stage 3 decorator pass가 outer_var_decl을
+            // pending_nodes로 hoist하고 `.none`을 반환한 경우 — 원본 class 이름으로
+            // `export { Named };` specifier를 합성해 export 키워드가 drop되지 않게 한다.
+            const orig_decl_idx = self.readNodeIdx(e, 0);
+            if (!orig_decl_idx.isNone()) {
+                const orig_decl = self.ast.getNode(orig_decl_idx);
+                if (orig_decl.tag == .class_declaration) {
+                    const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[orig_decl.data.extra]);
+                    if (!name_idx.isNone()) {
+                        const name_span = self.ast.getNode(name_idx).data.string_ref;
+                        const local_ref = try self.makeIdentifierRefWithSymbol(name_span, name_idx);
+                        const exported_ref = try self.ast.addNode(.{
+                            .tag = .identifier_reference,
+                            .span = name_span,
+                            .data = .{ .string_ref = name_span },
+                        });
+                        const specifier = try self.ast.addNode(.{
+                            .tag = .export_specifier,
+                            .span = node.span,
+                            .data = .{ .binary = .{ .left = local_ref, .right = exported_ref, .flags = 0 } },
+                        });
+                        const specs = try self.ast.addNodeList(&.{specifier});
+                        return self.addExtraNode(.export_named_declaration, node.span, &.{
+                            @intFromEnum(NodeIndex.none), specs.start, specs.len, @intFromEnum(NodeIndex.none),
+                        });
+                    }
+                }
+            }
             return NodeIndex.none;
         }
         return self.addExtraNode(.export_named_declaration, node.span, &.{

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -2590,12 +2590,17 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         1, outer_decl_list.start, outer_decl_list.len, // 1 = let
     });
 
-    // ES5 target: outer_var_decl을 반환해 호출자(transformer.zig:1044)가 visitNode로 재방문,
-    // arrow/let/class/static block을 추가 다운레벨링하게 한다. pending_nodes로 넘기면
-    // class_declaration 위치에 .none이 박혀 재방문이 일어나지 않는다.
-    if (self.options.unsupported.class) return outer_var_decl;
-
-    try self.pending_nodes.append(self.allocator, outer_var_decl);
+    // pending_nodes로 hoist한 뒤 `.none` 반환 — export 컨텍스트에서
+    // `export default Named;` / `export { Named };`로 분리되는 pattern을 유지한다.
+    // ES5 target은 outer_var_decl 내부의 arrow/let/class/static block을 추가 다운레벨링하기
+    // 위해 pending에 push하기 전에 visitNode로 재방문한다.
+    const to_hoist = if (self.options.unsupported.class)
+        try self.visitNode(outer_var_decl)
+    else
+        outer_var_decl;
+    if (!to_hoist.isNone()) {
+        try self.pending_nodes.append(self.allocator, to_hoist);
+    }
     return .none;
 }
 

--- a/tests/integration/tests/es5-stage3-decorator.test.ts
+++ b/tests/integration/tests/es5-stage3-decorator.test.ts
@@ -161,6 +161,51 @@ console.log(ad.x);
     expect(runInNode(out)).toBe("99\n5");
   });
 
+  // #1538 — @decorator가 붙은 `export [default] class`가 parser에서 drop되던 회귀 방지.
+  test("@decorator export class: decorator 보존 + export 유지 (#1538)", async () => {
+    const out = await transpileES5(`
+function tag(target: any, ctx: any) {
+  ctx.addInitializer(function(this: any) { (this as any).tag = "T"; });
+}
+@tag
+export class Named { hello() { return "named"; } }
+`);
+    expectNoEs6Syntax(out);
+    // export 키워드가 drop되지 않아야 한다 (이전엔 decorator가 silent drop되며 export도 유지되던 것이
+    // decorator 수정 과정에서 회귀로 사라졌었음).
+    expect(out).toMatch(/export\s*\{\s*Named\s*\}/);
+    // decorator가 제대로 처리되어 __esDecorate 호출이 생성되어야 한다.
+    expect(out).toMatch(/__esDecorate/);
+  });
+
+  test("@decorator export default class (named): let + export 분리 (#1538)", async () => {
+    const out = await transpileES5(`
+function tag(target: any, ctx: any) {
+  ctx.addInitializer(function(this: any) { (this as any).tag = "T"; });
+}
+@tag
+export default class C { hello() { return "c"; } }
+`);
+    expectNoEs6Syntax(out);
+    expect(out).toMatch(/export default\s+C\s*;/);
+    expect(out).toMatch(/__esDecorate/);
+  });
+
+  test("@decorator export default class (anonymous): 빈 변수명 없이 IIFE 감싸기 (#1538)", async () => {
+    const out = await transpileES5(`
+function tag(target: any, ctx: any) {
+  ctx.addInitializer(function(this: any) { (this as any).tag = "T"; });
+}
+@tag
+export default class { hello() { return "anon"; } }
+`);
+    expectNoEs6Syntax(out);
+    // 이전 회귀: `var  = (function() {...})()` 처럼 binding 이름이 빈 상태로 생성되던 버그.
+    expect(out).not.toMatch(/var\s+=\s*/);
+    expect(out).toMatch(/export default\s*\(/);
+    expect(out).toMatch(/__esDecorate/);
+  });
+
   // static block 내 this → class name 치환 (Stage 3 decorator와 독립된 일반 버그 수정)
   test("일반 static block: this → class name 치환", async () => {
     const out = await transpileES5(`

--- a/tests/integration/tests/tsc/__snapshots__/es6-decorators.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-decorators.test.ts.snap
@@ -136,22 +136,201 @@ let c = new C();
 `;
 
 exports[`TSC: es6/decorators decoratorOnClass2.es6 1`] = `
-"export class C {
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C = (() => {
+	let _classThis;
+	let _classDecorators = [dec];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var C = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			C = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+	};
+	return C = _classThis;
+})();
+export { C };
 let c = new C();
 "
 `;
 
 exports[`TSC: es6/decorators decoratorOnClass3.es6 1`] = `
-"export default class C {
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C = (() => {
+	let _classThis;
+	let _classDecorators = [dec];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var C = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			C = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+	};
+	return C = _classThis;
+})();
+export default C;
 let c = new C();
 "
 `;
 
 exports[`TSC: es6/decorators decoratorOnClass4.es6 1`] = `
-"export default class {
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+export default (() => {
+	let _classThis;
+	let _classDecorators = [dec];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var _Class = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			_Class = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+	};
+	return _Class = _classThis;
+})();
 "
 `;
 
@@ -226,31 +405,210 @@ let c = new C();
 `;
 
 exports[`TSC: es6/decorators decoratorOnClass6.es6 1`] = `
-"export class C {
-	static x() {
-		return C.y;
-	}
-	static y = 1;
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C = (() => {
+	let _classThis;
+	let _classDecorators = [dec];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var C = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			C = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+		static x() {
+			return C.y;
+		}
+		static y = 1;
+	};
+	return C = _classThis;
+})();
+export { C };
 let c = new C();
 "
 `;
 
 exports[`TSC: es6/decorators decoratorOnClass7.es6 1`] = `
-"export default class C {
-	static x() {
-		return C.y;
-	}
-	static y = 1;
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C = (() => {
+	let _classThis;
+	let _classDecorators = [dec];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var C = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			C = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+		static x() {
+			return C.y;
+		}
+		static y = 1;
+	};
+	return C = _classThis;
+})();
+export default C;
 let c = new C();
 "
 `;
 
 exports[`TSC: es6/decorators decoratorOnClass8.es6 1`] = `
-"export default class {
-	static y = 1;
-}
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+export default (() => {
+	let _classThis;
+	let _classDecorators = [dec];
+	let _classDescriptor;
+	let _classExtraInitializers = [];
+	var _Class = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			__esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, { kind: "class", name: _classThis.name, metadata: _metadata }, null, _classExtraInitializers);
+			_Class = _classThis = _classDescriptor.value;
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+			__runInitializers(_classThis, _classExtraInitializers);
+		}
+		static y = 1;
+	};
+	return _Class = _classThis;
+})();
 "
 `;
 


### PR DESCRIPTION
## Summary

두 가지 연관 버그를 근본 수정:

### 1. Parser — \`@dec export [default] class\`에서 decorator silent drop
\`parseDecoratedStatement\`의 \`.kw_export\` 분기가 수집한 decorators를 \`parseExportDeclaration\`에 전달하지 않아 파서 레벨에서 decorator가 drop되던 버그. 기존에는 \`@tag export default class { ... }\`의 \`@tag\`가 ES2022 출력에서도 흔적 없이 사라졌다.

수정:
- \`parseExportDeclarationWithDecorators\` wrapper 추가, 내부 \`parseClassDeclaration\` 호출을 \`parseClassWithDecorators\`로 교체.
- non-default \`export class\` 경로(parseStatement 위임)도 decorators가 있으면 직접 \`parseClassWithDecorators\` 호출로 바이패스.

### 2. Transformer — \`@dec export class Named\`에서 export 키워드 drop
Stage 3 decorator pass가 \`let Named = IIFE();\`를 \`pending_nodes\`로 hoist하고 \`.none\`을 반환하면, \`visitExportNamedDeclaration\`이 빈 declaration을 보고 export 문 전체를 제거해버리던 버그.

수정:
- \`visitExportNamedDeclaration\`이 pending-hoisted class_declaration을 감지해 원본 이름으로 \`export { Named };\` specifier를 합성.
- \`visitExportDefaultDeclaration\`의 기존 \`export default Named;\` 합성 로직과 대칭.

### 3. ES5 재방문 경로 정리
\`transformStage3Decorators\`가 ES5 target일 때 outer_var_decl을 pending에 push하기 전에 \`visitNode\` 재방문을 먼저 수행하도록 통일. 이로써 \`export default class Named\` / \`export class Named\` 케이스도 ES5에서 \`export default let Named = ...;\` 같은 잘못된 구문 없이 \`export { X };\` / \`export default X;\` 분리 패턴이 적용됨.

## Before / After

입력:
\`\`\`ts
function tag(target, ctx) { ctx.addInitializer(() => { target.tag = \"T\"; }); }
@tag
export default class { hello() { return \"anon\"; } }
\`\`\`

Before (\`--target=es5\`):
\`\`\`js
function tag(...) {...}
var  = (function() {          // ← 빈 변수명 (SyntaxError)
  function _Class() {...}
  return _Class;
})();
export default _Class;
\`\`\`
(ES2022에선 \`@tag\` 자체가 silent drop되어 decorator가 실행되지 않음.)

After:
\`\`\`js
function tag(...) {...}
export default (function() {
  var _classThis;
  var _classDecorators = [tag];
  var _Class = (function() {
    function _Class() { __classCallCheck(this, _Class); }
    _Class.prototype.hello = function() { return \"anon\"; };
    _classThis = _Class;
    __esDecorate(null, _classDescriptor = { value: _classThis }, _classDecorators, ...);
    _Class = _classThis = _classDescriptor.value;
    __runInitializers(_classThis, _classExtraInitializers);
    return _Class;
  })();
  return _Class = _classThis;
})();
\`\`\`

Named export도:
- \`@dec export class C\` → \`... (IIFE wrapper); export { C };\`
- \`@dec export default class C\` → \`let/var C = IIFE(); export default C;\`

## Test plan

- [x] \`tests/integration/tests/es5-stage3-decorator.test.ts\` — #1538 회귀 가드 3개 추가 (named export class, named export default class, anonymous export default class). 13/13 pass.
- [x] \`tests/integration/tests/tsc/es6-decorators.test.ts\` — snapshot 12개 갱신. 이전엔 decorator drop 상태로 저장되어 있었으나, 이제 \`__esDecorate\` 호출 + export 키워드 보존이 정확히 반영됨.
- [x] \`tests/integration/tests/tsc/\` 전체 — 2177 pass / 4 skip / 0 fail
- [x] \`tests/integration/tests/stage3-decorator*.test.ts\` — 147/147 pass
- [x] \`tests/integration/tests/es5-rn.test.ts\` — 30/30 pass
- [x] full integration: 3076 pass (watch 메모리 스트레스 flaky 1개 제외 — 이번 PR 무관)

Closes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)