### PR TITLE
fix(bundler): TLA non-ESM 경고 중복 emit 제거 + ZTS0002 코드 부여

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1224,7 +1224,7 @@ test "TLA: not detected inside async function" {
     defer result.deinit(std.testing.allocator);
 
     // async 함수 내부 await는 TLA가 아님 → 경고 없음
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS WARNING]") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS0002]") == null);
 }
 
 test "TLA: propagated to importer" {
@@ -1249,7 +1249,7 @@ test "TLA: propagated to importer" {
     defer result.deinit(std.testing.allocator);
 
     // TLA 전파 → CJS에서 경고 주석 포함
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS WARNING]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS0002]") != null);
 }
 
 test "TLA: not propagated via dynamic import" {
@@ -1273,7 +1273,7 @@ test "TLA: not propagated via dynamic import" {
     defer result.deinit(std.testing.allocator);
 
     // 동적 import는 TLA 전파 안 함 → 경고 없음
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS WARNING]") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS0002]") == null);
 }
 
 test "TLA: warning for CJS output" {
@@ -1294,7 +1294,9 @@ test "TLA: warning for CJS output" {
     const result = try b.bundle();
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS WARNING] Top-level await requires ESM output format.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS0002] Top-level await requires ESM output format.") != null);
+    // 중복 경고 방지: 정확히 한 번만 emit되어야 함 (이전엔 iife/umd/amd prologue가 추가로 emit했음)
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, result.output, "[ZTS0002]"));
 }
 
 test "TLA: no warning for ESM output" {
@@ -1316,7 +1318,7 @@ test "TLA: no warning for ESM output" {
     defer result.deinit(std.testing.allocator);
 
     // ESM → 경고 없음
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS WARNING]") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS0002]") == null);
 }
 
 test "TLA: for-await-of detected" {
@@ -1341,7 +1343,7 @@ test "TLA: for-await-of detected" {
     const result = try b.bundle();
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS WARNING]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "[ZTS0002]") != null);
 }
 
 test "TLA: await inside object literal at top level" {
@@ -1363,7 +1365,7 @@ test "TLA: await inside object literal at top level" {
 
     try std.testing.expect(!result.hasErrors());
     // object literal 내부 await도 TLA로 감지 → CJS 경고
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "ZTS WARNING") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ZTS0002") != null);
 }
 
 test "TLA: await inside array literal at top level" {
@@ -1383,7 +1385,7 @@ test "TLA: await inside array literal at top level" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "ZTS WARNING") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ZTS0002") != null);
 }
 
 test "TLA: await inside ternary expression at top level" {
@@ -1403,7 +1405,7 @@ test "TLA: await inside ternary expression at top level" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "ZTS WARNING") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ZTS0002") != null);
 }
 
 test "TLA: for_await_of_statement detected via AST tag" {
@@ -1426,7 +1428,7 @@ test "TLA: for_await_of_statement detected via AST tag" {
 
     try std.testing.expect(!result.hasErrors());
     // for await 감지 → CJS 경고
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "ZTS WARNING") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ZTS0002") != null);
     // codegen이 for await of를 올바르게 출력
     try std.testing.expect(std.mem.indexOf(u8, result.output, "for await") != null);
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -34,6 +34,10 @@ const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
 const Codegen = @import("../codegen/codegen.zig").Codegen;
 const CodegenOptions = @import("../codegen/codegen.zig").CodegenOptions;
 const SourceMap = @import("../codegen/sourcemap.zig");
+const error_codes = @import("../error_codes.zig");
+
+/// ZTS0002 TLA+non-ESM 경고 주석. comptime 고정 — 코드/메시지가 error_codes와 항상 일치.
+const tla_warning_comment = "/* [" ++ error_codes.Code.tla_requires_esm_format.format() ++ "] " ++ error_codes.Code.tla_requires_esm_format.message() ++ ". */\n";
 const Linker = @import("linker.zig").Linker;
 const LinkingMetadata = @import("linker.zig").LinkingMetadata;
 const TreeShaker = @import("tree_shaker.zig").TreeShaker;
@@ -255,7 +259,7 @@ pub fn emitWithTreeShaking(
     }
 
     // 포맷별 prologue
-    try emitFormatPrologue(&output, allocator, options.format, options.global_name, factory_fn, has_tla, ext_specifiers.items, ext_param_names.items);
+    try emitFormatPrologue(&output, allocator, options.format, options.global_name, factory_fn, ext_specifiers.items, ext_param_names.items);
 
     // 폴리필 주입 (--polyfill): IIFE로 감싸서 즉시 실행.
     // Metro/롤다운과 동일하게 모듈 그래프 밖에서 런타임 헬퍼보다 먼저 실행.
@@ -307,13 +311,13 @@ pub fn emitWithTreeShaking(
     try emitBundleRuntimeHelpers(&output, allocator, sorted.items, options);
 
     // TLA 검증: 비-ESM 출력에서 TLA 사용 시 경고 주석 삽입.
-    // Top-Level Await는 ESM 전용 기능이므로 CJS/IIFE 포맷에서는 동작하지 않는다.
+    // Top-Level Await는 ESM 전용 기능이므로 CJS/IIFE/UMD/AMD 포맷에서는 동작하지 않는다.
     // DFS로 exec_index가 부여된 모듈만 확인한다 — 동적 import로만 도달하는 모듈은
     // exec_index가 maxInt(u32)이며, 비동기 로딩이므로 경고 불필요.
     if (options.format != .esm) {
         for (sorted.items) |m| {
             if (m.uses_top_level_await and m.exec_index != std.math.maxInt(u32)) {
-                try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
+                try output.appendSlice(allocator, tla_warning_comment);
                 break;
             }
         }
@@ -1496,15 +1500,11 @@ fn emitFormatPrologue(
     format: types.Format,
     global_name: ?[]const u8,
     factory_fn: []const u8,
-    has_tla: bool,
     external_specifiers: []const []const u8,
     ext_param_names: []const []const u8,
 ) !void {
     switch (format) {
         .iife => {
-            if (has_tla) {
-                try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
-            }
             if (global_name) |gn| {
                 if (std.mem.indexOfScalar(u8, gn, '.') != null) {
                     try output.appendSlice(allocator, "/* [ZTS WARNING] Dotted globalName (\"");
@@ -1522,9 +1522,6 @@ fn emitFormatPrologue(
             }
         },
         .umd => {
-            if (has_tla) {
-                try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
-            }
             try output.appendSlice(allocator, "(function(root, factory) {\n");
             try output.appendSlice(allocator, "  if (typeof define === \"function\" && define.amd) define([");
             try writeDepArray(output, allocator, external_specifiers);
@@ -1546,9 +1543,6 @@ fn emitFormatPrologue(
             try output.appendSlice(allocator, ") {\n");
         },
         .amd => {
-            if (has_tla) {
-                try output.appendSlice(allocator, "/* [ZTS WARNING] Top-level await requires ESM output format. */\n");
-            }
             try output.appendSlice(allocator, "define([");
             try writeDepArray(output, allocator, external_specifiers);
             try output.appendSlice(allocator, "], function(");

--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -28,6 +28,9 @@ pub const Code = enum(u16) {
     // 0001-0099: 타겟/호환성
     // ═══════════════════════════════════════════════════════
     top_level_await_target = 1,
+    /// Top-level await는 ESM 포맷 전용 — CJS/IIFE/UMD/AMD 에서는 런타임 동작 불가.
+    /// bundler emitter 에서 non-ESM 포맷 + TLA 조합 감지 시 경고로 emit.
+    tla_requires_esm_format = 2,
 
     // ═══════════════════════════════════════════════════════
     // 0100-0199: 번들러 — import/export/resolve
@@ -243,6 +246,7 @@ pub const Code = enum(u16) {
             .switch_duplicate_default => "A 'switch' can have at most one 'default' case — remove the duplicate.",
             // 타겟
             .top_level_await_target => "Set --target=es2022 or later, or wrap the code in an 'async' function.",
+            .tla_requires_esm_format => "Use --format=esm, or wrap the top-level await in an async IIFE.",
             // 번들러
             .unresolved_import => "Check the import path spelling and confirm the file exists.",
             .missing_export => "Verify the exported name. Use 'export * from' or named re-exports if needed.",
@@ -268,6 +272,7 @@ pub const Code = enum(u16) {
         return switch (self) {
             // 타겟
             .top_level_await_target => "Top-level await is not available in the configured target environment",
+            .tla_requires_esm_format => "Top-level await requires ESM output format",
             // 번들러
             .unresolved_import => "Could not resolve import",
             .missing_export => "Export not found in module",


### PR DESCRIPTION
## Summary

- 번들러 TLA(Top-Level Await) 경고가 `--format=iife/umd/amd` 에서 **2번 emit** 되던 문제를 1번으로 통합
- raw `[ZTS WARNING]` 주석을 구조화된 `[ZTS0002]` 코드로 교체하고 `error_codes.zig` 레지스트리에 `tla_requires_esm_format` 정식 등록
- 경고 문자열은 `error_codes.Code.format()` + `.message()` 조합을 comptime const 로 빌드 → 코드 번호/메시지가 항상 단일 출처에서 파생

## 배경

`src/bundler/emitter.zig` 에 TLA 경고 emit 이 4곳에 산재:
- 본체 직전 1회 (format-agnostic, `options.format != .esm` 분기)
- `emitFormatPrologue` 안 iife/umd/amd 각각 1회씩 (3곳 추가)

→ iife/umd/amd 포맷 출력에 똑같은 경고가 2번 찍히던 상태.

## 변경

### `src/error_codes.zig`
```diff
+ tla_requires_esm_format = 2,
```
+ `message()` / `help()` 엔트리 추가

### `src/bundler/emitter.zig`
- `emitFormatPrologue()` 시그니처에서 `has_tla` 매개변수 제거
- iife/umd/amd 분기 안의 TLA 경고 emit 3곳 삭제
- 본체 직전의 단일 emit 경로만 유지
- `tla_warning_comment` comptime const 로 문자열 고정

### `src/bundler/bundler_test/cjs_esm.zig`
- 기존 테스트 9건의 매칭 문자열을 `ZTS WARNING` → `ZTS0002` 로 갱신
- **dedup 회귀 방지 테스트 추가**: `std.mem.count(...)` 로 정확히 1번 emit 검증

## Test plan

- [x] `zig build test` — 3015/3015 통과
- [x] 수동 검증: `zts --bundle --format={esm,cjs,iife,umd,amd}` 모두에서 경고 1번씩만 emit
  ```
  === --format=esm  === count=0
  === --format=cjs  === count=1
  === --format=iife === count=1
  === --format=umd  === count=1
  === --format=amd  === count=1
  ```
- [x] `/simplify` 리뷰 반영 (stringly-typed 제거, comptime concat 적용)

## Zig 초보자 메모

- `comptime std.fmt.comptimePrint(...)` 으로 에러 코드 문자열을 빌드 시점에 고정 → 런타임 오버헤드 0
- `const tla_warning_comment = "..." ++ X.format() ++ ...` 처럼 `++` 연산자는 **양쪽이 모두 comptime 이어야** 해서, 함수 호출 결과를 comptime 으로 평가하려면 top-level `const` 에 할당해 컴파일러에 강제
- enum variant 의 `format()` 메서드는 `inline else` 와 `comptime std.fmt.comptimePrint` 조합이라 자동으로 comptime 평가됨 (`src/error_codes.zig:210-215`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)