### PR TITLE
fix(wasm): 빈 출력에서 RangeError (`Start offset -1`) 방지

### DIFF
--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -77,6 +77,18 @@ describe("@zts/wasm", () => {
     expect(() => transpile("")).toThrow();
   });
 
+  test("빈 출력도 정상 반환 — TS 타입 전용 파일", () => {
+    // `type Foo`/`declare`만 있으면 스트리핑 후 출력이 0바이트.
+    // Zig 빈 slice의 `.ptr`이 sentinel이라 u64 packing + BigInt sign-extension 탓에
+    // JS에서 outPtr=-1로 나타나 RangeError가 발생하던 회귀 방지.
+    expect(transpile("type Foo = string;").code).toBe("");
+    expect(transpile("declare const x: number;").code).toBe("");
+    expect(transpile('import { foo } from "./bar";', { filename: "a.ts" }).code).toBe("");
+    // whitespace/comment-only 도 내용상 코드가 없음 → 빈 출력.
+    expect(transpile("   \n\t").code).toBe("");
+    expect(transpile("/* just a block comment */").code).toContain("/* just a block comment */");
+  });
+
   test("파싱 에러", () => {
     // miette 스타일 렌더: "× <message> [ZTS코드]"
     expect(() => transpile("const = ;")).toThrow(/\[ZTS\d{4}\]/);

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -181,7 +181,12 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
     const errLen = wasm.get_error_len();
     const errMsg = errLen === 0 ? "" : readString(wasm.get_error_ptr(), errLen);
 
+    // outPtr=0 은 두 가지 의미를 갖는다:
+    //   1. 빈 출력 성공 (type-only 파일, 빈 입력 등) — outLen=0, errLen=0
+    //   2. 에러 (파싱/시맨틱 실패) — errLen>0
+    // 빈 출력은 errors 없이 code=""로 반환하고, 에러 경로에서만 throw한다.
     if (outPtr === 0) {
+      if (outLen === 0 && errLen === 0) return { code: "" };
       throw new Error(`zts-wasm: ${errMsg || "unknown error"}`);
     }
 

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -173,7 +173,12 @@ export fn transpile(
         break :blk result.code;
     };
 
-    const ptr: u32 = @intFromPtr(output.ptr);
+    // Zig slice의 `.ptr`은 len==0일 때 undefined로 허용되며, wasm_allocator는 이 경우 sentinel
+    // 포인터(예: 0xFFFFFFFF)를 리턴한다. 그대로 packed u64에 실어 JS로 넘기면
+    // i64 ↔ BigInt sign-extension을 거쳐 outPtr=-1이 되고 `new Uint8Array(buffer, -1, 0)`가
+    // RangeError를 던진다. 빈 출력은 성공 경로에서도 합법(예: type-only 파일)이므로
+    // ptr을 0으로 표준화하여 JS가 `{code:""}`로 해석하게 한다.
+    const ptr: u32 = if (output.len == 0) 0 else @intFromPtr(output.ptr);
     const len: u32 = @intCast(output.len);
     return (@as(u64, ptr) << 32) | @as(u64, len);
 }


### PR DESCRIPTION
## Summary

WASM 경로에서 transpile 결과가 빈 문자열일 때 JS 쪽에서 `RangeError: Start offset -1 is outside the bounds of the buffer` 가 터지던 버그 수정.

## 재현

```js
import { init, transpile } from "@zts/wasm";
await init(wasmBytes);
transpile('import { foo } from "./bar";'); // ← RangeError
transpile('type Foo = string;');            // ← RangeError
transpile('declare const x: number;');      // ← RangeError
```

## 원인

`packages/wasm/src/wasm_entry.zig` 의 `transpile()` 은 `(ptr << 32) | len` 형태의 u64 로 결과를 반환한다. `result.code.len == 0` 인 경우:

1. Zig 빈 slice 의 `.ptr` 은 `undefined` 값이 허용되며 `wasm_allocator` 는 실질적으로 `0xFFFFFFFF` 같은 sentinel 을 리턴
2. u64 의 상위 32비트가 `0xFFFFFFFF` 로 차서 값이 2^63 을 넘음
3. WebAssembly i64 ↔ JS BigInt 는 부호 있는 해석 (spec) → packed 가 음수 BigInt
4. `Number(packed >> 32n)` 결과 `outPtr = -1`
5. `new Uint8Array(memory.buffer, -1, 0)` → RangeError

빈 출력은 **성공 경로에서도 정상** 입니다. TS 타입 전용 파일, `declare` 만 있는 파일, 입력이 whitespace 뿐인 경우 등.

## 수정

### `packages/wasm/src/wasm_entry.zig`
```zig
const ptr: u32 = if (output.len == 0) 0 else @intFromPtr(output.ptr);
```
빈 출력은 ptr=0 으로 표준화.

### `packages/wasm/index.ts`
```ts
if (outPtr === 0) {
  if (outLen === 0 && errLen === 0) return { code: "" };
  throw new Error(...);
}
```
`outPtr=0` 의 두 가지 의미를 `errLen` 으로 구분 — 빈 출력 성공 vs 에러.

### `packages/wasm/index.test.ts`
회귀 방지 테스트 추가 (type-only / declare-only / import-only / whitespace / comment-only).

## Test plan

- [x] `bun test` — @zts/wasm 29/29 통과
- [x] `zig build test` — 전체 통과
- [x] 수동 재현: 본문의 세 케이스 모두 `RangeError` 없이 `{ code: "" }` 또는 정상 출력

## Known limitation (별건)

`import { foo } from "./bar";` 가 `.ts` 모드에서 빈 출력을 내는 건 별도 이슈 — import 구문은 transpile 에서 보존돼야 정상. 이 PR 은 **WASM boundary 방어 수정** 만 처리하고, 근본 원인(transpile 파이프라인 어디선가 import drop) 은 후속 PR 에서.

## Zig 초보자 메모

- Zig 의 빈 slice `&[_]u8{}` 는 `.ptr` 이 `undefined` 인 게 합법 (런타임에서도 OK). 다만 `@intFromPtr` 로 꺼내 외부 (WASM host) 로 넘기면 관찰 가능한 가비지가 됨
- WASM 의 `i64` 반환값은 JS 에서 BigInt 로 오는데, **부호 있는 해석** 이라서 u64 최상위 비트가 켜지면 음수가 됨 (Zig 은 u64 로 생각하지만 wire type 은 i64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)