### PR TITLE
feat(tsconfig): verbatimModuleSyntax 지원 (TS 5.0+)

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -64,6 +64,8 @@ export interface TranspileOptions {
   emitDecoratorMetadata?: boolean;
   /** class field → constructor this.x = v 변환 (기본: true) */
   useDefineForClassFields?: boolean;
+  /** verbatimModuleSyntax (TS 5.0+): true면 미사용 값 import를 elide하지 않음 */
+  verbatimModuleSyntax?: boolean;
   /** 모듈 포맷 */
   format?: "esm" | "cjs";
   /** 문자열 따옴표 스타일 */
@@ -174,6 +176,7 @@ export function buildOptionsJson(
   if (opts.experimentalDecorators) payload.experimentalDecorators = true;
   if (opts.emitDecoratorMetadata) payload.emitDecoratorMetadata = true;
   if (opts.useDefineForClassFields === false) payload.useDefineForClassFields = false;
+  if (opts.verbatimModuleSyntax) payload.verbatimModuleSyntax = true;
   if (opts.format) payload.format = opts.format;
   if (opts.quotes) payload.quotes = opts.quotes;
   if (opts.platform === "react-native") payload.platform = "react_native";

--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -77,6 +77,18 @@ describe("@zts/wasm", () => {
     expect(() => transpile("")).toThrow();
   });
 
+  test("빈 출력도 정상 반환 — TS 타입 전용 파일", () => {
+    // `type Foo`/`declare`만 있으면 스트리핑 후 출력이 0바이트.
+    // Zig 빈 slice의 `.ptr`이 sentinel이라 u64 packing + BigInt sign-extension 탓에
+    // JS에서 outPtr=-1로 나타나 RangeError가 발생하던 회귀 방지.
+    expect(transpile("type Foo = string;").code).toBe("");
+    expect(transpile("declare const x: number;").code).toBe("");
+    expect(transpile('import { foo } from "./bar";', { filename: "a.ts" }).code).toBe("");
+    // whitespace/comment-only 도 내용상 코드가 없음 → 빈 출력.
+    expect(transpile("   \n\t").code).toBe("");
+    expect(transpile("/* just a block comment */").code).toContain("/* just a block comment */");
+  });
+
   test("파싱 에러", () => {
     // miette 스타일 렌더: "× <message> [ZTS코드]"
     expect(() => transpile("const = ;")).toThrow(/\[ZTS\d{4}\]/);

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -181,7 +181,12 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
     const errLen = wasm.get_error_len();
     const errMsg = errLen === 0 ? "" : readString(wasm.get_error_ptr(), errLen);
 
+    // outPtr=0 은 두 가지 의미를 갖는다:
+    //   1. 빈 출력 성공 (type-only 파일, 빈 입력 등) — outLen=0, errLen=0
+    //   2. 에러 (파싱/시맨틱 실패) — errLen>0
+    // 빈 출력은 errors 없이 code=""로 반환하고, 에러 경로에서만 throw한다.
     if (outPtr === 0) {
+      if (outLen === 0 && errLen === 0) return { code: "" };
       throw new Error(`zts-wasm: ${errMsg || "unknown error"}`);
     }
 

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -173,7 +173,12 @@ export fn transpile(
         break :blk result.code;
     };
 
-    const ptr: u32 = @intFromPtr(output.ptr);
+    // Zig slice의 `.ptr`은 len==0일 때 undefined로 허용되며, wasm_allocator는 이 경우 sentinel
+    // 포인터(예: 0xFFFFFFFF)를 리턴한다. 그대로 packed u64에 실어 JS로 넘기면
+    // i64 ↔ BigInt sign-extension을 거쳐 outPtr=-1이 되고 `new Uint8Array(buffer, -1, 0)`가
+    // RangeError를 던진다. 빈 출력은 성공 경로에서도 합법(예: type-only 파일)이므로
+    // ptr을 0으로 표준화하여 JS가 `{code:""}`로 해석하게 한다.
+    const ptr: u32 = if (output.len == 0) 0 else @intFromPtr(output.ptr);
     const len: u32 = @intCast(output.len);
     return (@as(u64, ptr) << 32) | @as(u64, len);
 }

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -86,6 +86,8 @@ pub const BundleOptions = struct {
     emit_decorator_metadata: bool = false,
     /// useDefineForClassFields=false (tsconfig)
     use_define_for_class_fields: bool = true,
+    /// verbatimModuleSyntax=true (tsconfig/CLI): unused value import를 elide하지 않음.
+    verbatim_module_syntax: bool = false,
     /// Unsupported features bitmask (ES/엔진 타겟에서 변환됨)
     unsupported: compat.UnsupportedFeatures = .{},
     /// package.json exports 커스텀 조건 (--conditions, esbuild 호환)
@@ -408,6 +410,7 @@ pub const Bundler = struct {
             .experimental_decorators = self.options.experimental_decorators,
             .emit_decorator_metadata = self.options.emit_decorator_metadata,
             .use_define_for_class_fields = self.options.use_define_for_class_fields,
+            .verbatim_module_syntax = self.options.verbatim_module_syntax,
             .unsupported = self.options.unsupported,
             .public_path = self.options.public_path,
             .banner_js = self.options.banner_js,
@@ -744,6 +747,8 @@ pub const Bundler = struct {
                 const result = transpile_mod.transpile(self.allocator, raw, poly_path, .{
                     .flow = true,
                     .jsx_in_js = self.options.jsx_in_js,
+                    // 폴리필도 verbatim 규칙을 따라야 함 — 그래야 번들 본체와 동일한 import 처리 정책.
+                    .verbatim_module_syntax = self.options.verbatim_module_syntax,
                 }) catch {
                     break :blk raw; // 트랜스파일 실패 시 원본 사용
                 };

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -83,6 +83,8 @@ pub const EmitOptions = struct {
     emit_decorator_metadata: bool = false,
     /// useDefineForClassFields=false
     use_define_for_class_fields: bool = true,
+    /// verbatimModuleSyntax=true: unused value import 를 elide 하지 않음.
+    verbatim_module_syntax: bool = false,
     /// Unsupported features bitmask (ES/엔진 타겟에서 변환됨)
     unsupported: @import("../transformer/transformer.zig").TransformOptions.compat.UnsupportedFeatures = .{},
     /// 타겟 플랫폼. import.meta polyfill 방식을 결정한다.
@@ -828,6 +830,7 @@ pub fn emitModule(
         .experimental_decorators = options.experimental_decorators,
         .emit_decorator_metadata = options.emit_decorator_metadata,
         .use_define_for_class_fields = options.use_define_for_class_fields,
+        .verbatim_module_syntax = options.verbatim_module_syntax,
         .unsupported = options.unsupported,
         .drop_labels = options.drop_labels,
         .jsx_transform = jsx_active,

--- a/src/config.zig
+++ b/src/config.zig
@@ -46,6 +46,9 @@ pub const TsConfig = struct {
     /// null = 설정 안 됨 (기본값은 target에 따라 결정: ES2022+ → true, 이전 → false).
     /// ZTS에서는 명시적으로 false로 설정한 경우에만 assign semantics 적용.
     use_define_for_class_fields: ?bool = null,
+    /// "verbatimModuleSyntax" (TS 5.0+): true면 값 import를 elide하지 않는다.
+    /// esbuild/vite/swc(isolatedModules) 의 표준 동작과 동일.
+    verbatim_module_syntax: bool = false,
 
     /// allocator로 할당된 문자열들을 해제하기 위한 참조.
     /// load()에서 내부적으로 사용하며, deinit() 시 해제된다.
@@ -199,6 +202,9 @@ pub const TsConfig = struct {
                 if (co.get("useDefineForClassFields")) |v| {
                     if (v == .bool) config.use_define_for_class_fields = v.bool;
                 }
+                if (co.get("verbatimModuleSyntax")) |v| {
+                    if (v == .bool) config.verbatim_module_syntax = v.bool;
+                }
             }
         }
 
@@ -251,6 +257,7 @@ pub const TsConfig = struct {
         if (base.strict) target.strict = true;
         if (base.experimental_decorators) target.experimental_decorators = true;
         if (base.emit_decorator_metadata) target.emit_decorator_metadata = true;
+        if (base.verbatim_module_syntax) target.verbatim_module_syntax = true;
         // optional bool: target이 null이면 base에서 상속
         if (target.use_define_for_class_fields == null) {
             target.use_define_for_class_fields = base.use_define_for_class_fields;

--- a/src/config_test.zig
+++ b/src/config_test.zig
@@ -90,6 +90,7 @@ test "TsConfig.load - missing file returns defaults" {
     try std.testing.expect(config.strict == false);
     try std.testing.expect(config.experimental_decorators == false);
     try std.testing.expect(config.emit_decorator_metadata == false);
+    try std.testing.expect(config.verbatim_module_syntax == false);
 }
 
 test "TsConfig.load - parse compilerOptions" {
@@ -114,7 +115,8 @@ test "TsConfig.load - parse compilerOptions" {
         \\    "declaration": true,
         \\    "strict": true,
         \\    "experimentalDecorators": true,
-        \\    "emitDecoratorMetadata": true
+        \\    "emitDecoratorMetadata": true,
+        \\    "verbatimModuleSyntax": true
         \\  }
         \\}
     ;
@@ -138,6 +140,7 @@ test "TsConfig.load - parse compilerOptions" {
     try std.testing.expect(config.strict == true);
     try std.testing.expect(config.experimental_decorators == true);
     try std.testing.expect(config.emit_decorator_metadata == true);
+    try std.testing.expect(config.verbatim_module_syntax == true);
 }
 
 test "TsConfig.load - JSONC with comments" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -60,6 +60,8 @@ const CliOptions = struct {
     use_define_for_class_fields: ?bool = null,
     experimental_decorators: ?bool = null,
     emit_decorator_metadata: bool = false,
+    /// --verbatim-module-syntax: null이면 tsconfig 값 사용, 명시적으로 설정되면 override.
+    verbatim_module_syntax: ?bool = null,
     unsupported: lib.transformer.TransformOptions.compat.UnsupportedFeatures = .{},
     /// --target에서 파싱한 ES 타겟. top-level await 등 타겟 제한 검증에 사용.
     es_target: ?lib.transformer.TransformOptions.compat.ESTarget = null,
@@ -287,6 +289,7 @@ fn applyZtsConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
     if (parsed.experimental_decorators) opts.experimental_decorators = true;
     if (parsed.emit_decorator_metadata) opts.emit_decorator_metadata = true;
     if (parsed.use_define_for_class_fields == false) opts.use_define_for_class_fields = false;
+    if (parsed.verbatim_module_syntax) opts.verbatim_module_syntax = true;
     opts.module_format = parsed.module_format;
     opts.quote_style = parsed.quote_style;
     opts.platform = parsed.platform;
@@ -549,6 +552,10 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             opts.use_define_for_class_fields = false;
         } else if (std.mem.eql(u8, arg, "--use-define-for-class-fields=true")) {
             opts.use_define_for_class_fields = true;
+        } else if (std.mem.eql(u8, arg, "--verbatim-module-syntax")) {
+            opts.verbatim_module_syntax = true;
+        } else if (std.mem.eql(u8, arg, "--verbatim-module-syntax=false")) {
+            opts.verbatim_module_syntax = false;
         } else if (std.mem.startsWith(u8, arg, "--target=")) {
             const val = arg["--target=".len..];
             const compat = lib.transformer.TransformOptions.compat;
@@ -1222,6 +1229,10 @@ pub fn main() !void {
     if (tsconfig.emit_decorator_metadata and (opts.experimental_decorators orelse false)) {
         opts.emit_decorator_metadata = true;
     }
+    // verbatimModuleSyntax: CLI가 명시적 override하지 않았으면 tsconfig 값 사용.
+    if (opts.verbatim_module_syntax == null and tsconfig.verbatim_module_syntax) {
+        opts.verbatim_module_syntax = true;
+    }
     // JSX: CLI/플랫폼 프리셋이 미지정이면 tsconfig에서 가져옴
     if (opts.jsx_runtime == null) {
         if (tsconfig.jsx) |jsx_mode| {
@@ -1405,6 +1416,7 @@ pub fn main() !void {
             .experimental_decorators = opts.experimental_decorators orelse false,
             .emit_decorator_metadata = opts.emit_decorator_metadata,
             .use_define_for_class_fields = opts.use_define_for_class_fields orelse true,
+            .verbatim_module_syntax = opts.verbatim_module_syntax orelse false,
             .unsupported = opts.unsupported,
             .conditions = opts.conditions_list.items,
             .timing = opts.timing,
@@ -1913,6 +1925,7 @@ pub fn main() !void {
             .use_define_for_class_fields = opts.use_define_for_class_fields orelse true,
             .experimental_decorators = opts.experimental_decorators orelse false,
             .emit_decorator_metadata = opts.emit_decorator_metadata,
+            .verbatim_module_syntax = opts.verbatim_module_syntax orelse false,
             .unsupported = opts.unsupported,
             .es_target = opts.es_target,
             .source_root = opts.source_root orelse "",
@@ -2256,6 +2269,7 @@ fn printUsage(writer: anytype) !void {
         \\TypeScript options:
         \\  --experimental-decorators         Legacy decorator (__decorateClass)
         \\  --use-define-for-class-fields=false  Move fields to constructor (assign semantics)
+        \\  --verbatim-module-syntax          Preserve unused value imports (TS 5.0+)
         \\
         \\Flow options:
         \\  --flow                            Enable Flow type stripping (auto-detected via @flow pragma)

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -92,6 +92,10 @@ pub const TransformOptions = struct {
     /// emitDecoratorMetadata: __metadata("design:paramtypes", [...]) 호출 주입.
     /// NestJS, Angular, TypeORM 등 reflect-metadata 기반 DI에 필요.
     emit_decorator_metadata: bool = false,
+    /// verbatimModuleSyntax (TS 5.0+): true면 값 import를 elide하지 않는다.
+    /// `import type`만 제거되고 `import { foo } from "./bar"`는 foo가 미사용이라도 보존.
+    /// esbuild/vite/swc(isolatedModules) 표준 동작. 기본 false (tsc 기본과 동일).
+    verbatim_module_syntax: bool = false,
     /// Unsupported features bitmask. feature별로 다운레벨링 여부를 결정.
     /// ESTarget(es2020) 또는 엔진 버전(chrome80,safari14)에서 변환됨.
     unsupported: compat.UnsupportedFeatures = .{},
@@ -4064,7 +4068,10 @@ pub const Transformer = struct {
 
         // Unused import 제거: 모든 specifier의 reference_count가 0이면 import 전체를 제거.
         // side-effect import는 specifier가 없으므로 제거 불가.
-        if (self.symbols.len > 0 and self.symbol_ids.items.len > 0 and x.specs_len > 0) {
+        // verbatimModuleSyntax=true면 elision 생략 — 값 import는 그대로 보존.
+        if (!self.options.verbatim_module_syntax and
+            self.symbols.len > 0 and self.symbol_ids.items.len > 0 and x.specs_len > 0)
+        {
             if (self.areAllSpecifiersUnused(x.specs_start, x.specs_len)) return .none;
         }
 

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1122,3 +1122,91 @@ test "TLA: ES5 downlevel produces __async + __generator wrap, no bare yield" {
     // bare yield 는 없어야 함.
     try std.testing.expect(std.mem.indexOf(u8, code, "yield ") == null);
 }
+
+// ============================================================
+// verbatimModuleSyntax 테스트 (TS 5.0+)
+// ============================================================
+//
+// 주의: elision 은 semantic analyzer 가 populated symbols 를 만든 뒤에만 발동한다.
+// 단위 헬퍼(parseAsModuleAndTransform)는 semantic 을 건너뛰므로 여기서는 transpile 모듈을
+// 경유해 end-to-end 로 검증한다.
+
+const transpile_mod = @import("../transpile.zig");
+
+test "verbatimModuleSyntax=false (default): unused value import is elided" {
+    var result = try transpile_mod.transpile(
+        std.testing.allocator,
+        \\import { foo } from "./bar";
+    ,
+        "input.ts",
+        .{},
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "import") == null);
+}
+
+test "verbatimModuleSyntax=true: unused value import is preserved" {
+    var result = try transpile_mod.transpile(
+        std.testing.allocator,
+        \\import { foo } from "./bar";
+    ,
+        "input.ts",
+        .{ .verbatim_module_syntax = true },
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "import") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "\"./bar\"") != null);
+}
+
+test "verbatimModuleSyntax=true: type-only named specifier 는 여전히 제거" {
+    var result = try transpile_mod.transpile(
+        std.testing.allocator,
+        \\import { type T, foo } from "./bar";
+        \\const x = foo;
+    ,
+        "input.ts",
+        .{ .verbatim_module_syntax = true },
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "foo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "type T") == null);
+}
+
+test "verbatimModuleSyntax=true: `import type` 전체 선언은 여전히 drop" {
+    // `import type` 은 parse 단계에서 NodeIndex.none 으로 elide 되므로 flag 와 무관.
+    var result = try transpile_mod.transpile(
+        std.testing.allocator,
+        \\import type { T } from "./bar";
+    ,
+        "input.ts",
+        .{ .verbatim_module_syntax = true },
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "import") == null);
+}
+
+test "side-effect import 는 verbatim 과 무관하게 항상 보존" {
+    // `import "./bar"` 은 binding 이 없어 elision 대상이 아님.
+    var result = try transpile_mod.transpile(
+        std.testing.allocator,
+        \\import "./bar";
+    ,
+        "input.ts",
+        .{},
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "\"./bar\"") != null);
+}
+
+test "verbatimModuleSyntax=true: 미사용 default import 보존" {
+    var result = try transpile_mod.transpile(
+        std.testing.allocator,
+        \\import foo from "./bar";
+    ,
+        "input.ts",
+        .{ .verbatim_module_syntax = true },
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "import") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "foo") != null);
+}

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -34,6 +34,7 @@ pub const TranspileOptions = struct {
     use_define_for_class_fields: bool = true,
     experimental_decorators: bool = false,
     emit_decorator_metadata: bool = false,
+    verbatim_module_syntax: bool = false,
     drop_console: bool = false,
     drop_debugger: bool = false,
 
@@ -89,6 +90,7 @@ pub const TranspileOptionsDto = struct {
     experimentalDecorators: ?bool = null,
     emitDecoratorMetadata: ?bool = null,
     useDefineForClassFields: ?bool = null,
+    verbatimModuleSyntax: ?bool = null,
     format: ?@import("codegen/codegen.zig").ModuleFormat = null,
     quotes: ?@import("codegen/codegen.zig").QuoteStyle = null,
     platform: ?@import("codegen/codegen.zig").Platform = null,
@@ -137,6 +139,7 @@ pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !Transpil
     if (parsed.experimentalDecorators) |v| opts.experimental_decorators = v;
     if (parsed.emitDecoratorMetadata) |v| opts.emit_decorator_metadata = v;
     if (parsed.useDefineForClassFields) |v| opts.use_define_for_class_fields = v;
+    if (parsed.verbatimModuleSyntax) |v| opts.verbatim_module_syntax = v;
     if (parsed.format) |v| opts.module_format = v;
     if (parsed.quotes) |v| opts.quote_style = v;
     if (parsed.platform) |v| opts.platform = v;
@@ -287,6 +290,7 @@ pub fn transpileWithCallback(
         .use_define_for_class_fields = options.use_define_for_class_fields,
         .experimental_decorators = options.experimental_decorators,
         .emit_decorator_metadata = options.emit_decorator_metadata,
+        .verbatim_module_syntax = options.verbatim_module_syntax,
         .unsupported = options.unsupported,
         // JSX lowering: JSX가 있는 모듈에서만 활성화
         .jsx_transform = parser.ast.has_jsx,


### PR DESCRIPTION
## Summary

- TS 5.0+ `verbatimModuleSyntax` 옵션을 tsconfig → CLI → TranspileOptions → Transformer 까지 end-to-end 지원
- 기본값은 `false` (기존 tsc 호환 elision 유지), 명시적 활성화 시 **값 import 전부 보존** (esbuild/vite/swc 호환)

## 배경

`.ts` 파일에 `import { foo } from "./bar";` 만 있고 foo 가 참조 안 되면 현재 transpile 출력이 빈 문자열. 이는 tsc 의 기본 import elision 동작과 일치하나, **side-effect 가능성** 때문에 esbuild/vite/swc(isolatedModules) 는 반대로 보존을 기본값으로 삼음. TS 5.0 의 `verbatimModuleSyntax` 플래그가 이 선택을 공식화했고, 이번 PR 에서 ZTS 가 지원.

## 사용법

\`\`\`jsonc
// tsconfig.json
{ "compilerOptions": { "verbatimModuleSyntax": true } }
\`\`\`
\`\`\`bash
$ zts --verbatim-module-syntax input.ts
\`\`\`
\`\`\`ts
// @zts/core / @zts/wasm
transpile(src, { verbatimModuleSyntax: true })
\`\`\`

## 동작 비교

| 입력 | 기본 (\`.ts\`) | \`--verbatim-module-syntax\` |
|------|--------------|----------------------------|
| \`import { foo } from \"./bar\";\` | elide (tsc) | preserve (esbuild) |
| \`import \"./bar\";\` | preserve | preserve |
| \`import type { T } from \"./bar\";\` | drop | drop |
| \`import { type T, foo }\` + foo 사용 | 두 경우 모두 \`import { foo }\` (type 만 제거) | 동일 |

## Test plan

- [x] \`zig build test\` — 전체 3021/3021 통과
- [x] 신규 unit 테스트 6 건 (transformer_test.zig + config_test.zig)
- [x] 수동 검증:
  - \`zts input.ts\` → 기본 elide
  - \`zts --verbatim-module-syntax input.ts\` → 보존
  - \`zts -p <dir with verbatim tsconfig> input.ts\` → 보존

## 변경 파일

### 설정 경로 (데이터 레이어)
- \`src/config.zig\` + \`src/config_test.zig\` — TsConfig 필드 추가 + parse + extends merge
- \`src/transpile.zig\` — TranspileOptions / DTO / optionsFromJson
- \`packages/shared/index.ts\` — TS 타입 + payload 매핑 (Zig DTO 스키마 drift 테스트 통과)

### 실제 동작 지점
- \`src/transformer/transformer.zig\` — \`visitImportDeclaration\` 에서 flag 에 따라 elision 분기
- \`src/bundler/bundler.zig\` + \`src/bundler/emitter.zig\` — bundler 경로 플러밍 (+ 폴리필 Flow transpile 에도 전달)
- \`src/main.zig\` — \`--verbatim-module-syntax\` CLI + tsconfig 머지

## 관련 PR
- #1543 (WASM RangeError — 이번 기능으로 노출되었던 간접 증상의 원인 수정)

## Zig 초보자 메모

- 옵션 struct 에 필드 추가 시 **모든 생성 지점**을 같이 수정해야 한다. 리뷰에서 폴리필 경로(\`bundler.zig:747\`) 하나 놓친 걸 잡음 — IDE 도움 없이 grep 으로 꼼꼼히.
- Zig \`TranspileOptionsDto\` ↔ TS \`@zts/shared TranspileOptions\` 는 \`transpile_options_dto_test.zig\` 의 스키마 drift 테스트로 동기화가 강제됨. 한쪽만 바꾸면 테스트 실패.

🤖 Generated with [Claude Code](https://claude.com/claude-code)