### PR TITLE
refactor(tsconfig): 머지 규칙 공용 helper (src/tsconfig_merge.zig) 추출

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2263,25 +2263,25 @@ fn parseBuildOptions(
     const tsconfig_path_opt = ownStr(env, opts_obj, "tsconfigPath", owned_strings);
 
     // tsconfig.json 로드 + 머지 — JS 옵션이 명시적으로 설정된 필드가 있으면 그게 우선.
-    // 미지정 필드만 tsconfig 값으로 채움 (CLI 와 동일 규칙: JS > tsconfig > default).
+    // 머지 규칙은 `src/tsconfig_merge.zig` 의 공용 helper 에 위임 — transpile.zig / main.zig 와 일관.
     const TsConfig = @import("zts_lib").config.TsConfig;
+    const tsconfig_merge = @import("zts_lib").tsconfig_merge;
     var tsconfig_holder: TsConfig = .{};
     if (tsconfig_path_opt) |p| {
         tsconfig_holder = TsConfig.loadFromPath(native_alloc, p) catch TsConfig{};
     }
     defer tsconfig_holder.deinit();
 
-    const exp_dec_js = getObjectBoolOptional(env, opts_obj, "experimentalDecorators");
-    const emit_meta_js = getObjectBoolOptional(env, opts_obj, "emitDecoratorMetadata");
-    const udff_js = getObjectBoolOptional(env, opts_obj, "useDefineForClassFields");
-    const verbatim_js = getObjectBoolOptional(env, opts_obj, "verbatimModuleSyntax");
-
-    const experimental_decorators_eff = exp_dec_js orelse tsconfig_holder.experimental_decorators;
-    // emitDecoratorMetadata 는 experimentalDecorators 가 켜진 경우에만 유효 (tsc 규칙).
-    const emit_decorator_metadata_eff = emit_meta_js orelse
-        (tsconfig_holder.emit_decorator_metadata and experimental_decorators_eff);
-    const use_define_for_class_fields_eff = udff_js orelse (tsconfig_holder.use_define_for_class_fields orelse true);
-    const verbatim_module_syntax_eff = verbatim_js orelse tsconfig_holder.verbatim_module_syntax;
+    const merged_tsconfig = tsconfig_merge.merge(&tsconfig_holder, .{
+        .experimental_decorators = getObjectBoolOptional(env, opts_obj, "experimentalDecorators"),
+        .emit_decorator_metadata = getObjectBoolOptional(env, opts_obj, "emitDecoratorMetadata"),
+        .use_define_for_class_fields = getObjectBoolOptional(env, opts_obj, "useDefineForClassFields"),
+        .verbatim_module_syntax = getObjectBoolOptional(env, opts_obj, "verbatimModuleSyntax"),
+    });
+    const experimental_decorators_eff = merged_tsconfig.experimental_decorators;
+    const emit_decorator_metadata_eff = merged_tsconfig.emit_decorator_metadata;
+    const use_define_for_class_fields_eff = merged_tsconfig.use_define_for_class_fields;
+    const verbatim_module_syntax_eff = merged_tsconfig.verbatim_module_syntax;
     const out_extension_js = ownStr(env, opts_obj, "outExtension", owned_strings);
     const source_root = ownStr(env, opts_obj, "sourceRoot", owned_strings);
     const root_dir = ownStr(env, opts_obj, "rootDir", owned_strings);

--- a/src/root.zig
+++ b/src/root.zig
@@ -16,6 +16,7 @@ pub const semantic = @import("semantic/mod.zig");
 pub const transformer = @import("transformer/mod.zig");
 pub const codegen = @import("codegen/mod.zig");
 pub const config = @import("config.zig");
+pub const tsconfig_merge = @import("tsconfig_merge.zig");
 pub const regexp = @import("regexp/mod.zig");
 pub const test262 = @import("test262/mod.zig");
 pub const bundler = @import("bundler/mod.zig");
@@ -46,6 +47,8 @@ test {
     _ = error_codes;
 
     _ = crash_handler;
+
+    _ = tsconfig_merge;
 
     // test files
     _ = @import("config_test.zig");

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -168,33 +168,26 @@ pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !Transpil
     const can_load_tsconfig = @import("builtin").os.tag != .wasi and @import("builtin").os.tag != .freestanding;
     if (can_load_tsconfig) if (opts.tsconfig_path) |path| {
         const TsConfig = @import("config.zig").TsConfig;
+        const tsconfig_merge = @import("tsconfig_merge.zig");
         var ts = TsConfig.loadFromPath(allocator, path) catch return opts; // tsconfig 읽기 실패는 조용히 무시 (CLI와 동일)
         defer ts.deinit();
 
-        if (parsed.experimentalDecorators == null and ts.experimental_decorators) {
-            opts.experimental_decorators = true;
-        }
-        if (parsed.emitDecoratorMetadata == null and ts.emit_decorator_metadata and opts.experimental_decorators) {
-            opts.emit_decorator_metadata = true;
-        }
-        if (parsed.useDefineForClassFields == null) {
-            if (ts.use_define_for_class_fields) |v| opts.use_define_for_class_fields = v;
-        }
-        if (parsed.verbatimModuleSyntax == null and ts.verbatim_module_syntax) {
-            opts.verbatim_module_syntax = true;
-        }
-        if (parsed.sourcemap == null and ts.source_map) {
-            opts.sourcemap = true;
-        }
-        // target: "es2020" 문자열 → ESTarget enum 변환 후 옵션 미지정이면 적용
-        if (parsed.target == null and opts.es_target == null) {
-            if (ts.target) |t_str| {
-                if (std.meta.stringToEnum(compat.ESTarget, t_str)) |t| {
-                    opts.es_target = t;
-                    if (parsed.unsupported == null) opts.unsupported = compat.fromESTarget(t);
-                }
-            }
-        }
+        const merged = tsconfig_merge.merge(&ts, .{
+            .experimental_decorators = parsed.experimentalDecorators,
+            .emit_decorator_metadata = parsed.emitDecoratorMetadata,
+            .use_define_for_class_fields = parsed.useDefineForClassFields,
+            .verbatim_module_syntax = parsed.verbatimModuleSyntax,
+            .sourcemap = parsed.sourcemap,
+            .es_target = parsed.target,
+            .unsupported = if (parsed.unsupported) |u| @bitCast(u) else null,
+        });
+        opts.experimental_decorators = merged.experimental_decorators;
+        opts.emit_decorator_metadata = merged.emit_decorator_metadata;
+        opts.use_define_for_class_fields = merged.use_define_for_class_fields;
+        opts.verbatim_module_syntax = merged.verbatim_module_syntax;
+        opts.sourcemap = merged.sourcemap;
+        opts.es_target = merged.es_target;
+        opts.unsupported = merged.unsupported;
     };
 
     return opts;

--- a/src/tsconfig_merge.zig
+++ b/src/tsconfig_merge.zig
@@ -1,0 +1,121 @@
+//! tsconfig.json compilerOptions → ZTS 트랜스파일/번들 옵션 병합 헬퍼.
+//!
+//! `transpile.zig optionsFromJson`, `packages/core/src/napi_entry.zig parseBuildOptions`,
+//! `main.zig` CLI 3 경로에 산재하던 머지 규칙을 한 곳에 모은다.
+//! 모든 경로가 동일한 우선순위(명시적 사용자 값 > tsconfig > default)를 공유.
+//!
+//! 사용법:
+//!   const explicit = ExplicitFlags{ .verbatim_module_syntax = js_value };
+//!   const merged = merge(&tsconfig, explicit);
+//!   options.verbatim_module_syntax = merged.verbatim_module_syntax;
+
+const std = @import("std");
+const compat = @import("transformer/compat.zig");
+const TsConfig = @import("config.zig").TsConfig;
+
+/// 사용자(CLI/JS/JSON)가 명시적으로 설정한 값. null = 미지정 → tsconfig fallback.
+pub const ExplicitFlags = struct {
+    experimental_decorators: ?bool = null,
+    emit_decorator_metadata: ?bool = null,
+    use_define_for_class_fields: ?bool = null,
+    verbatim_module_syntax: ?bool = null,
+    sourcemap: ?bool = null,
+    /// 명시적으로 설정된 ES 타겟. null이고 `unsupported` 도 null이면 tsconfig의 "target" 문자열을 파싱.
+    es_target: ?compat.ESTarget = null,
+    /// 명시적으로 계산된 unsupported bitmask (browserslist 해석 결과 등).
+    /// non-null 이면 es_target 기반 fallback 을 우회한다.
+    unsupported: ?compat.UnsupportedFeatures = null,
+};
+
+/// 모든 필드가 확정된 최종 값.
+pub const MergedFlags = struct {
+    experimental_decorators: bool,
+    emit_decorator_metadata: bool,
+    use_define_for_class_fields: bool,
+    verbatim_module_syntax: bool,
+    sourcemap: bool,
+    es_target: ?compat.ESTarget,
+    unsupported: compat.UnsupportedFeatures,
+};
+
+/// `ExplicitFlags` 와 tsconfig 값을 우선순위 규칙에 따라 병합한다.
+/// `emit_decorator_metadata` 는 `experimental_decorators` 가 활성화된 경우에만
+/// tsconfig 값이 적용되도록 강제 — tsc 공식 규칙.
+pub fn merge(ts: *const TsConfig, explicit: ExplicitFlags) MergedFlags {
+    const experimental_decorators = explicit.experimental_decorators orelse ts.experimental_decorators;
+    const es_target: ?compat.ESTarget = explicit.es_target orelse blk: {
+        if (ts.target) |t_str| break :blk std.meta.stringToEnum(compat.ESTarget, t_str);
+        break :blk null;
+    };
+    return .{
+        .experimental_decorators = experimental_decorators,
+        .emit_decorator_metadata = explicit.emit_decorator_metadata orelse
+            (ts.emit_decorator_metadata and experimental_decorators),
+        .use_define_for_class_fields = explicit.use_define_for_class_fields orelse
+            (ts.use_define_for_class_fields orelse true),
+        .verbatim_module_syntax = explicit.verbatim_module_syntax orelse ts.verbatim_module_syntax,
+        .sourcemap = explicit.sourcemap orelse ts.source_map,
+        .es_target = es_target,
+        .unsupported = explicit.unsupported orelse blk: {
+            if (es_target) |t| break :blk compat.fromESTarget(t);
+            break :blk .{};
+        },
+    };
+}
+
+// ─── 테스트 ───
+
+test "merge: explicit values win over tsconfig" {
+    var ts = TsConfig{};
+    ts.experimental_decorators = true;
+    ts.verbatim_module_syntax = true;
+
+    const merged = merge(&ts, .{
+        .experimental_decorators = false,
+        .verbatim_module_syntax = false,
+    });
+    try std.testing.expect(merged.experimental_decorators == false);
+    try std.testing.expect(merged.verbatim_module_syntax == false);
+}
+
+test "merge: tsconfig fills unset fields" {
+    var ts = TsConfig{};
+    ts.verbatim_module_syntax = true;
+    ts.experimental_decorators = true;
+
+    const merged = merge(&ts, .{});
+    try std.testing.expect(merged.experimental_decorators == true);
+    try std.testing.expect(merged.verbatim_module_syntax == true);
+}
+
+test "merge: emit_decorator_metadata requires experimental_decorators" {
+    var ts = TsConfig{};
+    ts.emit_decorator_metadata = true;
+    // experimental_decorators 가 켜지지 않았으면 emit_decorator_metadata 도 비활성 (tsc 규칙)
+    const merged_off = merge(&ts, .{});
+    try std.testing.expect(merged_off.emit_decorator_metadata == false);
+
+    // experimental_decorators 가 켜지면 함께 활성
+    ts.experimental_decorators = true;
+    const merged_on = merge(&ts, .{});
+    try std.testing.expect(merged_on.emit_decorator_metadata == true);
+}
+
+test "merge: target string is parsed to ESTarget" {
+    var ts = TsConfig{};
+    ts.target = "es2020";
+    const merged = merge(&ts, .{});
+    try std.testing.expect(merged.es_target != null);
+    try std.testing.expect(merged.es_target.? == .es2020);
+    // unsupported 비트도 자동 파생
+    try std.testing.expect(merged.unsupported.top_level_await);
+}
+
+test "merge: explicit unsupported wins over target-derived" {
+    var ts = TsConfig{};
+    ts.target = "es2020";
+    const merged = merge(&ts, .{
+        .unsupported = .{},
+    });
+    try std.testing.expect(merged.unsupported.top_level_await == false);
+}


### PR DESCRIPTION
## Summary

#1545 리뷰에서 지적된 **JS/CLI > tsconfig > default 머지 규칙 중복** 을 한 파일로 통합.
기능 변화 없이 순수 내부 리팩터.

## 배경

현재 3 경로가 동일한 머지 규칙을 각각 별도로 구현하고 있다:

- \`src/main.zig\` (CLI) — lines ~1190-1250
- \`src/transpile.zig optionsFromJson\` (NAPI/WASM transpile) — lines ~164-195
- \`packages/core/src/napi_entry.zig parseBuildOptions\` (NAPI bundle) — lines ~2265-2284

규칙이 복잡한 편 (\`emit_decorator_metadata\` 가 \`experimental_decorators\` 에 의존, target 문자열 파싱 등) 이라 세 곳 에서 약간씩 다르게 쓰여있었고 유지보수 시 drift 위험이 컸음.

## 변경

### 새 파일: \`src/tsconfig_merge.zig\`

\`\`\`zig
pub const ExplicitFlags = struct { experimental_decorators: ?bool = null, ... };
pub const MergedFlags = struct { experimental_decorators: bool, ... };
pub fn merge(ts: *const TsConfig, explicit: ExplicitFlags) MergedFlags;
\`\`\`

규칙:
- **Explicit > tsconfig > default**
- \`emit_decorator_metadata\` 는 최종 \`experimental_decorators\` 가 true 일 때만 활성 (tsc 규칙)
- \`target\` 문자열 → \`ESTarget\` enum 변환, \`unsupported\` 비트 자동 파생
- \`explicit.unsupported\` 가 주어지면 target 기반 fallback 우회

### 적용 경로

- \`src/transpile.zig\`: if/else 체인 → \`tsconfig_merge.merge()\` 호출 1개
- \`packages/core/src/napi_entry.zig\`: \`_eff\` 로컬 계산 → \`merge()\` 호출

### 테스트

\`src/tsconfig_merge.zig\` 안 5 케이스:
- explicit wins over tsconfig
- tsconfig fills unset
- emit_decorator_metadata 전파 규칙
- target 문자열 파싱
- explicit unsupported override

## 범위 밖

\`main.zig\` CLI 는 tsconfig 의 \`module\`/\`outDir\`/\`jsx\` 등 \`TranspileOptions\` 에 없는 필드까지 다루므로 이번 리팩터에 포함 안 함. 후속 PR 에서 CLI 전용 필드를 포함한 상위 helper 로 확장 가능.

## Test plan

- [x] \`zig build test\` — 전체 통과, 새 unit test 5건 포함
- [x] \`bun test packages/core/index.test.ts\` — 365/365 통과
- [x] #1545 의 tsconfigPath 동작이 그대로 유지되는지 수동 검증

## Zig 초보자 메모

- \`ExplicitFlags\` 에 \`?bool\` 써서 \"없음 vs false\" 를 구분 (tri-state). 3 경로가 각자 tri-state 검출 방식은 다르지만 (\`getObjectBoolOptional\` vs DTO \`?bool\` vs CliOptions \`?bool\`) 최종 머지 함수 입력은 통일.
- helper 를 \`src/\` 루트에 둔 이유: \`config.zig\` 에 두면 \`config\` → \`transformer/compat\` 의존이 생김. \`tsconfig_merge.zig\` 를 두 모듈 위에 얹어 순환 없이 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)