### PR TITLE
feat(cli): --tsconfig-path 플래그 + -p 에 파일 경로 지원

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -352,8 +352,13 @@ function parseArgs(argv) {
       opts.keyfile = args[++i];
       continue;
     }
-    if (arg === "-p" || arg === "--project") {
+    if (arg === "-p" || arg === "--project" || arg === "--tsconfig-path") {
+      // `-p`, `--project` (tsc 전통), `--tsconfig-path` (NAPI `tsconfigPath` 와 이름 통일)
       opts.project = args[++i];
+      continue;
+    }
+    if (arg.startsWith("--tsconfig-path=")) {
+      opts.project = arg.slice("--tsconfig-path=".length);
       continue;
     }
     if (arg === "--plugin") {
@@ -431,8 +436,17 @@ function parseArgs(argv) {
 // ─── tsconfig.json 로드 ───
 
 function loadTsConfig(opts) {
-  // --project로 지정하거나 자동 탐색
+  // --project/--tsconfig-path 로 지정하거나 자동 탐색
   let tsconfigPath = opts.project;
+  // 경로가 디렉토리면 내부의 tsconfig.json 을 대상 파일로 보정 (NAPI `loadFromPath` 와 동일 규칙).
+  if (tsconfigPath && existsSync(tsconfigPath)) {
+    try {
+      const { statSync } = require("node:fs");
+      if (statSync(tsconfigPath).isDirectory()) {
+        tsconfigPath = join(tsconfigPath, "tsconfig.json");
+      }
+    } catch {}
+  }
   if (!tsconfigPath) {
     // 엔트리 파일 기준으로 상위 디렉토리 탐색
     const startDir =
@@ -471,6 +485,10 @@ function loadTsConfig(opts) {
     }
     if (co.useDefineForClassFields === false) {
       opts.useDefineForClassFields = false;
+    }
+    // verbatimModuleSyntax (TS 5.0+): 미사용 값 import 보존. CLI 이 설정 안 했으면 tsconfig 반영.
+    if (co.verbatimModuleSyntax === true && opts.verbatimModuleSyntax === undefined) {
+      opts.verbatimModuleSyntax = true;
     }
 
     // jsx: "react" → classic, "react-jsx" → automatic, "react-jsxdev" → automatic-dev
@@ -562,6 +580,7 @@ async function runTranspile(opts) {
     flow: opts.flow,
     experimentalDecorators: opts.experimentalDecorators,
     useDefineForClassFields: opts.useDefineForClassFields,
+    verbatimModuleSyntax: opts.verbatimModuleSyntax,
     asciiOnly: opts.asciiOnly,
     charsetUtf8: opts.charsetUtf8,
     quotes: opts.quotes,
@@ -625,6 +644,7 @@ async function runBundle(opts) {
     charsetUtf8: opts.charsetUtf8,
     useDefineForClassFields: opts.useDefineForClassFields,
     experimentalDecorators: opts.experimentalDecorators,
+    verbatimModuleSyntax: opts.verbatimModuleSyntax,
     banner: opts.banner,
     footer: opts.footer,
     globalName: opts.globalName,

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -978,6 +978,30 @@ describe("CLI: tsconfig", () => {
     rmSync(configDir, { recursive: true, force: true });
   });
 
+  test("--tsconfig-path 는 -p 의 alias (NAPI `tsconfigPath` 와 통일된 이름)", () => {
+    // 공백/=형 모두, 디렉토리/파일 경로 모두 지원.
+    const configDir = mkdtempSync(join(tmpdir(), "zts-cli-tsc-alias-"));
+    writeFileSync(
+      join(configDir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { verbatimModuleSyntax: true } }),
+    );
+    const inputPath = join(configDir, "input.ts");
+    writeFileSync(inputPath, 'import { foo } from "./bar";');
+
+    for (const args of [
+      ["--tsconfig-path", configDir],
+      [`--tsconfig-path=${configDir}`],
+      ["--tsconfig-path", join(configDir, "tsconfig.json")],
+      ["-p", join(configDir, "tsconfig.json")], // -p 도 파일 경로 지원 (loadFromPath 전환)
+    ]) {
+      const { stdout, exitCode } = runCli([inputPath, ...args]);
+      expect(exitCode).toBe(0);
+      // verbatimModuleSyntax 가 적용되면 미사용 import 도 보존
+      expect(stdout).toContain("./bar");
+    }
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
   test("CLI 옵션이 tsconfig보다 우선", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-cli-override-"));
     writeFileSync(

--- a/src/main.zig
+++ b/src/main.zig
@@ -400,11 +400,16 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             opts.sourcemap_debug_ids = true;
         } else if (std.mem.eql(u8, arg, "--sourcemap-function-map")) {
             opts.sourcemap_function_map = true;
-        } else if (std.mem.eql(u8, arg, "--project") or std.mem.eql(u8, arg, "-p")) {
+        } else if (std.mem.eql(u8, arg, "--project") or std.mem.eql(u8, arg, "-p") or
+            std.mem.eql(u8, arg, "--tsconfig-path"))
+        {
+            // `-p`, `--project` (tsc 전통), `--tsconfig-path` (NAPI 의 `tsconfigPath` 와 통일) 모두 지원.
             if (i + 1 < args.len) {
                 i += 1;
                 opts.project_path = args[i];
             }
+        } else if (std.mem.startsWith(u8, arg, "--tsconfig-path=")) {
+            opts.project_path = arg["--tsconfig-path=".len..];
         } else if (std.mem.eql(u8, arg, "--watch-json")) {
             opts.watch = true;
             opts.watch_json = true;
@@ -1196,14 +1201,15 @@ pub fn main() !void {
     }
 
     // tsconfig.json 로드 — 번들/트랜스파일 양쪽에서 사용.
-    // 우선순위: --project 경로 > 입력 파일의 부모 디렉토리 > CWD
+    // 우선순위: --project/--tsconfig-path 경로 > 입력 파일의 부모 디렉토리 > CWD
+    // loadFromPath 는 파일/디렉토리 둘 다 받으므로 `-p ./tsconfig.json` 도 동작.
     const tsconfig_dir_early: []const u8 = if (opts.project_path) |pp|
         pp
     else if (opts.input_file) |inp|
         if (!std.mem.eql(u8, inp, "-")) (std.fs.path.dirname(inp) orelse ".") else "."
     else
         ".";
-    var tsconfig = TsConfig.load(allocator, tsconfig_dir_early) catch TsConfig{};
+    var tsconfig = TsConfig.loadFromPath(allocator, tsconfig_dir_early) catch TsConfig{};
     defer tsconfig.deinit();
 
     // tsconfig 값 적용 — CLI 옵션이 우선, 미지정 옵션만 tsconfig에서 가져옴
@@ -2246,7 +2252,8 @@ fn printUsage(writer: anytype) !void {
         \\  --ascii-only                     Escape non-ASCII to \uXXXX
         \\  --quotes=<style>                 String quote style (double|single|preserve)
         \\  -w, --watch                      Watch for file changes
-        \\  -p, --project <path>             Path to tsconfig.json directory
+        \\  -p, --project <path>             Path to tsconfig.json file or directory
+        \\  --tsconfig-path <path>           Alias of -p/--project (matches NAPI `tsconfigPath`)
         \\  --tokenize                       Print tokens instead of transpiling
         \\  --test262 <dir>                  Run Test262 tests
         \\  -h, --help                       Show this help


### PR DESCRIPTION
## Summary

NAPI 의 \`tsconfigPath\` 와 CLI 플래그 이름을 통일하고, \`-p\`/\`--project\` 의 경로 해석을 NAPI 와 일관되게 맞춤. 관련해 JS CLI 레이어의 누락된 wiring 몇 개 보강.

## 배경

#1545 에서 NAPI 에 \`tsconfigPath\` 옵션을 추가했는데, CLI 는 tsc 전통의 \`-p\` / \`--project\` 만 쓰고 있어 이름이 분산됨. 또한 JS CLI (\`zts.mjs\`) 는 \`-p <dir>\` 을 파일로 읽으려다 silent fail 했고 \`verbatimModuleSyntax\` 플러밍이 일부 누락된 상태였음.

## 변경

1. **\`--tsconfig-path\` 플래그 추가 (Zig CLI + JS CLI)** — \`-p\` / \`--project\` 와 동일 기능, 공백/\`=\` 형식 모두 지원.
2. **\`-p\` 에 파일 경로 지원 (Zig CLI)** — \`TsConfig.load(dir)\` → \`TsConfig.loadFromPath(path)\` 로 교체. 파일/디렉토리 둘 다 처리.
3. **JS CLI \`loadTsConfig\` 에 디렉토리 자동 보정** — 기존엔 \`-p <dir>\` 에서 \`readFileSync(dir)\` 가 silent fail. 이제 stat 해서 디렉토리면 내부 \`tsconfig.json\` 탐색.
4. **\`verbatimModuleSyntax\` 를 JS CLI 전 경로에 연결** — \`loadTsConfig\` 매핑 + \`runTranspile\`/\`runBundle\` 옵션 pass-through.

## 사용 예

\`\`\`bash
zts -p ./tsconfig.json                     # 파일 경로 (NEW)
zts --tsconfig-path=./project-dir          # NAPI 와 동일 이름
zts --project ./project-dir                # 기존 tsc 호환
\`\`\`

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] \`bun test bin/zts.test.ts\` 59/59 (신규 alias/파일경로/디렉토리 회귀 케이스 포함)
- [x] 수동: 네 가지 형태 모두 verbatim 적용 확인

## 관련 PR
- #1545 (NAPI \`tsconfigPath\`) — 이 PR 의 네이밍 통일 대상
- #1546 (머지 규칙 helper 리팩터) — 베이스로 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)