### PR TITLE
feat(tsconfig): paths/baseUrl + CLI --alias 병합 지원

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -581,6 +581,7 @@ async function runTranspile(opts) {
     experimentalDecorators: opts.experimentalDecorators,
     useDefineForClassFields: opts.useDefineForClassFields,
     verbatimModuleSyntax: opts.verbatimModuleSyntax,
+    tsconfigPath: opts.project,
     asciiOnly: opts.asciiOnly,
     charsetUtf8: opts.charsetUtf8,
     quotes: opts.quotes,
@@ -627,6 +628,8 @@ async function runBundle(opts) {
     format: opts.format,
     platform: opts.platform,
     external: opts.external,
+    // `--alias:K=V` 플래그 (webpack/rollup 스타일) — JS 옵션이 tsconfig paths 보다 우선 적용됨.
+    alias: Object.keys(opts.alias).length > 0 ? opts.alias : undefined,
     minify: opts.minify,
     minifyWhitespace: opts.minifyWhitespace,
     minifyIdentifiers: opts.minifyIdentifiers,
@@ -645,6 +648,8 @@ async function runBundle(opts) {
     useDefineForClassFields: opts.useDefineForClassFields,
     experimentalDecorators: opts.experimentalDecorators,
     verbatimModuleSyntax: opts.verbatimModuleSyntax,
+    // NAPI 가 tsconfig paths / baseUrl 을 alias 로 변환해 resolver 에 주입하도록 전달.
+    tsconfigPath: opts.project,
     banner: opts.banner,
     footer: opts.footer,
     globalName: opts.globalName,

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -1162,4 +1162,113 @@ describe("CLI: tsconfig", () => {
 
     rmSync(dir, { recursive: true, force: true });
   });
+
+  test("tsconfig paths: 깊은 서브경로 prefix 매칭 (@/a/b/c)", () => {
+    // "@/*" alias 가 중첩 디렉토리까지 정상 전파되는지 — applyAlias 의 prefix 로직 검증.
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-deep-"));
+    mkdirSync(join(dir, "src", "a", "b"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } } }),
+    );
+    writeFileSync(join(dir, "src", "a", "b", "c.ts"), "export const V = 'DEEP_OK';");
+    writeFileSync(join(dir, "entry.ts"), 'import { V } from "@/a/b/c";\nconsole.log(V);');
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("DEEP_OK");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("tsconfig paths: baseUrl 없으면 tsconfig 디렉토리가 기본 base", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-nobase-"));
+    mkdirSync(join(dir, "lib"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { paths: { "#lib": ["./lib/index.ts"] } } }),
+    );
+    writeFileSync(join(dir, "lib", "index.ts"), "export const L = 'NOBASE_OK';");
+    writeFileSync(join(dir, "entry.ts"), 'import { L } from "#lib";\nconsole.log(L);');
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("NOBASE_OK");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("tsconfig paths: 배열 여러 후보 중 첫 번째만 사용 (v1 제약)", () => {
+    // TS 공식은 순차 시도이나 ZTS v1 은 단일 — 첫 번째가 없어도 fallback 안 함을 문서화.
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-multi-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@m": ["./src/a.ts", "./src/b.ts"] } },
+      }),
+    );
+    writeFileSync(join(dir, "src", "a.ts"), "export const M = 'FIRST';");
+    writeFileSync(join(dir, "src", "b.ts"), "export const M = 'SECOND';");
+    writeFileSync(join(dir, "entry.ts"), 'import { M } from "@m";\nconsole.log(M);');
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("FIRST");
+    expect(stdout).not.toContain("SECOND");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("tsconfig paths: 빈 paths 객체는 무시 (no crash)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-empty-"));
+    writeFileSync(join(dir, "tsconfig.json"), JSON.stringify({ compilerOptions: { paths: {} } }));
+    writeFileSync(join(dir, "entry.ts"), "console.log('OK');");
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("tsconfig paths: extends 체인에서 paths 상속", () => {
+    // base tsconfig 의 paths 를 child 가 상속받는지 — mergeFrom 경로 검증.
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-extends-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.base.json"),
+      JSON.stringify({ compilerOptions: { paths: { "@base": ["./src/base.ts"] } } }),
+    );
+    writeFileSync(join(dir, "tsconfig.json"), JSON.stringify({ extends: "./tsconfig.base.json" }));
+    writeFileSync(join(dir, "src", "base.ts"), "export const B = 'EXTENDED';");
+    writeFileSync(join(dir, "entry.ts"), 'import { B } from "@base";\nconsole.log(B);');
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("EXTENDED");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("tsconfig paths: 존재하지 않는 tsconfig 경로 → silent fallback (no crash)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-missing-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('OK');");
+    const { stdout, exitCode } = runCli([
+      "--bundle",
+      "-p",
+      "/nonexistent/path/tsconfig.json",
+      join(dir, "entry.ts"),
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("tsconfig paths: .js extension 매핑 — '@util' → './src/util.ts'", () => {
+    // tsconfig 값이 ./src/util.ts 인데 source 가 ./src/util.js 로 import 해도
+    // resolver 의 TS extension mapping 이 동작해야 함 (pre-existing 기능, 회귀 방지).
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-ext-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { paths: { "@util": ["./src/util"] } } }),
+    );
+    writeFileSync(join(dir, "src", "util.ts"), "export const U = 'EXT_OK';");
+    writeFileSync(join(dir, "entry.ts"), 'import { U } from "@util";\nconsole.log(U);');
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("EXT_OK");
+    rmSync(dir, { recursive: true, force: true });
+  });
 });

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -1090,4 +1090,76 @@ describe("CLI: tsconfig", () => {
     expect(stdout).toContain("__decorate");
     rmSync(dir, { recursive: true, force: true });
   });
+
+  test("tsconfig paths: wildcard + exact alias 가 bundler 에서 해석됨", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-tsc-paths-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "@/*": ["./src/*"],
+            "@utils": ["./src/utils.ts"],
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(dir, "src", "utils.ts"),
+      "export function hello(name: string): string { return `Hello, ${name}!`; }",
+    );
+    writeFileSync(join(dir, "src", "greet.ts"), "export function greet(): string { return 'hi'; }");
+    writeFileSync(
+      join(dir, "entry.ts"),
+      'import { hello } from "@utils";\nimport { greet } from "@/greet";\nconsole.log(hello("world"), greet());',
+    );
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    // 두 파일이 모두 번들에 들어와야 함 (paths 가 해석되지 않으면 resolve 실패로 번들 실패).
+    expect(stdout).toContain("Hello, ${name}!");
+    expect(stdout).toContain(`return "hi"`);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--alias 가 tsconfig paths 를 덮어씀", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-alias-priority-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    mkdirSync(join(dir, "alt"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@utils": ["./src/utils.ts"] } },
+      }),
+    );
+    writeFileSync(
+      join(dir, "src", "utils.ts"),
+      "export function hello(): string { return 'FROM_TSCONFIG'; }",
+    );
+    writeFileSync(
+      join(dir, "alt", "utils.ts"),
+      "export function hello(): string { return 'FROM_ALIAS_CLI'; }",
+    );
+    writeFileSync(join(dir, "entry.ts"), 'import { hello } from "@utils";\nconsole.log(hello());');
+
+    // --alias 없으면 tsconfig 값 적용
+    const withoutAlias = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(withoutAlias.exitCode).toBe(0);
+    expect(withoutAlias.stdout).toContain("FROM_TSCONFIG");
+
+    // --alias 가 붙으면 그 값이 tsconfig 를 덮어씀 (CLI > tsconfig)
+    const withAlias = runCli([
+      "--bundle",
+      "-p",
+      dir,
+      `--alias:@utils=${join(dir, "alt", "utils.ts")}`,
+      join(dir, "entry.ts"),
+    ]);
+    expect(withAlias.exitCode).toBe(0);
+    expect(withAlias.stdout).toContain("FROM_ALIAS_CLI");
+    expect(withAlias.stdout).not.toContain("FROM_TSCONFIG");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
 });

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2180,18 +2180,16 @@ fn parseBuildOptions(
         define_entries = defs;
     }
 
-    // alias: { "from": "to" } → []AliasEntry
+    // alias: { "from": "to" } → []AliasEntry (tsconfig paths 는 tsconfig 로드 후 아래에서 append).
     const alias_pairs = getObjectKeyValuePairs(env, opts_obj, "alias", native_alloc);
-    var alias_entries: []const bundler_mod.types.AliasEntry = &.{};
+    var alias_list: std.ArrayList(bundler_mod.types.AliasEntry) = .empty;
     if (alias_pairs) |pairs| {
-        const als = native_alloc.alloc(bundler_mod.types.AliasEntry, pairs.len) catch return null;
-        for (pairs, 0..) |pair, idx| {
+        defer native_alloc.free(pairs);
+        for (pairs) |pair| {
             if (!trackStr(owned_strings, pair[0])) return null;
             if (!trackStr(owned_strings, pair[1])) return null;
-            als[idx] = .{ .from = pair[0], .to = pair[1] };
+            alias_list.append(native_alloc, .{ .from = pair[0], .to = pair[1] }) catch return null;
         }
-        native_alloc.free(pairs);
-        alias_entries = als;
     }
 
     // fallback: { "crypto": "crypto-browserify", "fs": false } → []FallbackEntry
@@ -2282,6 +2280,29 @@ fn parseBuildOptions(
     const emit_decorator_metadata_eff = merged_tsconfig.emit_decorator_metadata;
     const use_define_for_class_fields_eff = merged_tsconfig.use_define_for_class_fields;
     const verbatim_module_syntax_eff = merged_tsconfig.verbatim_module_syntax;
+
+    // tsconfig paths → alias_list 뒤에 append (JS --alias 가 이미 들어있어서 그게 우선).
+    if (tsconfig_path_opt != null and tsconfig_holder.paths.len > 0) {
+        const tsconfig_file = tsconfig_path_opt.?;
+        const dir_for_join: []const u8 = if (std.mem.endsWith(u8, tsconfig_file, ".json"))
+            std.fs.path.dirname(tsconfig_file) orelse "."
+        else
+            tsconfig_file;
+        if (@import("zts_lib").config.normalizePathsToAliases(native_alloc, dir_for_join, tsconfig_holder.paths, tsconfig_holder.base_url)) |norm| {
+            // owned_strings (절대경로 조인 결과) 는 alias 가 shallow-copy 되는 동안 살아있어야 함 →
+            // opts 전체 수명을 따라가도록 tracker 에 등록.
+            if (norm.owned_strings.len > 0) {
+                for (norm.owned_strings) |s| if (!trackStr(owned_strings, s)) return null;
+                if (!trackArr(owned_string_arrays, norm.owned_strings)) return null;
+            }
+            for (norm.entries) |e| {
+                alias_list.append(native_alloc, .{ .from = e.from, .to = e.to }) catch return null;
+            }
+            native_alloc.free(norm.entries); // PathEntry 슬라이스 자체만 해제 (문자열은 이전됨).
+        } else |_| {}
+    }
+    const alias_entries: []const bundler_mod.types.AliasEntry = alias_list.toOwnedSlice(native_alloc) catch return null;
+
     const out_extension_js = ownStr(env, opts_obj, "outExtension", owned_strings);
     const source_root = ownStr(env, opts_obj, "sourceRoot", owned_strings);
     const root_dir = ownStr(env, opts_obj, "rootDir", owned_strings);

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2283,12 +2283,9 @@ fn parseBuildOptions(
 
     // tsconfig paths → alias_list 뒤에 append (JS --alias 가 이미 들어있어서 그게 우선).
     if (tsconfig_path_opt != null and tsconfig_holder.paths.len > 0) {
-        const tsconfig_file = tsconfig_path_opt.?;
-        const dir_for_join: []const u8 = if (std.mem.endsWith(u8, tsconfig_file, ".json"))
-            std.fs.path.dirname(tsconfig_file) orelse "."
-        else
-            tsconfig_file;
-        if (@import("zts_lib").config.normalizePathsToAliases(native_alloc, dir_for_join, tsconfig_holder.paths, tsconfig_holder.base_url)) |norm| {
+        const lib_config = @import("zts_lib").config;
+        const dir_for_join = lib_config.tsconfigDirFromPath(tsconfig_path_opt.?);
+        if (lib_config.normalizePathsToAliases(native_alloc, dir_for_join, &tsconfig_holder)) |norm| {
             // owned_strings (절대경로 조인 결과) 는 alias 가 shallow-copy 되는 동안 살아있어야 함 →
             // opts 전체 수명을 따라가도록 tracker 에 등록.
             if (norm.owned_strings.len > 0) {

--- a/src/config.zig
+++ b/src/config.zig
@@ -310,10 +310,8 @@ pub const TsConfig = struct {
         if (target.paths.len == 0 and base.paths.len > 0) {
             const duped = try allocator.alloc(TsConfig.PathEntry, base.paths.len);
             for (base.paths, 0..) |e, i| {
-                const from_d = try allocator.dupe(u8, e.from);
-                try target._allocated_strings.?.append(allocator, from_d);
-                const to_d = try allocator.dupe(u8, e.to);
-                try target._allocated_strings.?.append(allocator, to_d);
+                const from_d = try dupeAndTrack(allocator, e.from, &target._allocated_strings.?);
+                const to_d = try dupeAndTrack(allocator, e.to, &target._allocated_strings.?);
                 duped[i] = .{ .from = from_d, .to = to_d };
             }
             target.paths = duped;
@@ -321,12 +319,26 @@ pub const TsConfig = struct {
     }
 };
 
+/// TS `paths` 의 wildcard 접미사. 패턴 양쪽이 이 접미사로 끝나야 prefix alias 로 변환된다.
+const PATHS_WILDCARD_SUFFIX = "/*";
+/// tsconfig 파일 경로 판별 접미사 (디렉토리 인지 파일인지 구분).
+pub const TSCONFIG_FILE_EXT = ".json";
+
+/// 경로가 `.json` 파일이면 상위 디렉토리를, 아니면 경로 자체를 반환한다.
+/// CLI/NAPI 가 `-p`/`tsconfigPath` 로 파일과 디렉토리 둘 다 받을 때 공용으로 사용.
+pub fn tsconfigDirFromPath(path: []const u8) []const u8 {
+    if (std.mem.endsWith(u8, path, TSCONFIG_FILE_EXT))
+        return std.fs.path.dirname(path) orelse ".";
+    return path;
+}
+
 /// tsconfig `paths` 항목의 wildcard 를 prefix alias 로 정규화한다.
 /// - `"@/*": "./src/*"` → `{from="@", to="./src"}` (prefix 매칭)
 /// - `"@utils": "./utils"` → `{from="@utils", to="./utils"}` (정확 매칭)
 /// - 한쪽만 wildcard 이거나 중간 wildcard 는 v1 에서 skip.
 ///
-/// baseUrl 이 주어지면 상대경로 value 를 `<baseUrl>/<value>` 로 join 한다.
+/// baseUrl 이 주어지면 상대경로 value 를 `<baseUrl>/<value>` 로 join 하며
+/// `std.fs.path.resolve` 로 `./././` 같은 불필요 세그먼트를 정규화한다.
 /// 반환된 슬라이스는 `allocator` 에 새로 할당됨 — caller 가 해제.
 pub const NormalizedPaths = struct {
     entries: []const TsConfig.PathEntry,
@@ -342,8 +354,7 @@ pub const NormalizedPaths = struct {
 pub fn normalizePathsToAliases(
     allocator: std.mem.Allocator,
     tsconfig_dir: []const u8,
-    raw_paths: []const TsConfig.PathEntry,
-    base_url: ?[]const u8,
+    tsconfig: *const TsConfig,
 ) error{OutOfMemory}!NormalizedPaths {
     var out: std.ArrayList(TsConfig.PathEntry) = .empty;
     errdefer out.deinit(allocator);
@@ -353,15 +364,16 @@ pub fn normalizePathsToAliases(
         owned.deinit(allocator);
     }
 
-    for (raw_paths) |p| {
+    for (tsconfig.paths) |p| {
         var from_src = p.from;
         var to_src = p.to;
-        const from_wild = std.mem.endsWith(u8, from_src, "/*");
-        const to_wild = std.mem.endsWith(u8, to_src, "/*");
-        if (from_wild != to_wild) continue; // 불일치 wildcard 는 스킵
+        const from_wild = std.mem.endsWith(u8, from_src, PATHS_WILDCARD_SUFFIX);
+        const to_wild = std.mem.endsWith(u8, to_src, PATHS_WILDCARD_SUFFIX);
+        // TS 규칙: wildcard 는 key/value 양쪽에 대칭으로 있어야 함 — 한쪽만 있으면 의미 불명확해 v1 은 skip.
+        if (from_wild != to_wild) continue;
         if (from_wild) {
-            from_src = from_src[0 .. from_src.len - 2];
-            to_src = to_src[0 .. to_src.len - 2];
+            from_src = from_src[0 .. from_src.len - PATHS_WILDCARD_SUFFIX.len];
+            to_src = to_src[0 .. to_src.len - PATHS_WILDCARD_SUFFIX.len];
         }
 
         // from 문자열은 원본 TsConfig 의 subspan 이라 TsConfig 가 먼저 deinit 되면 dangle 된다.
@@ -369,24 +381,15 @@ pub fn normalizePathsToAliases(
         const from_owned = try allocator.dupe(u8, from_src);
         try owned.append(allocator, from_owned);
 
-        // baseUrl 적용: to 가 상대경로면 <tsconfig_dir>/<baseUrl>/<to>.
-        const resolved_to: []const u8 = if (std.fs.path.isAbsolute(to_src)) blk_abs: {
-            // 절대 경로도 TsConfig subspan 이므로 복사.
-            const abs_owned = try allocator.dupe(u8, to_src);
-            try owned.append(allocator, abs_owned);
-            break :blk_abs abs_owned;
-        } else blk: {
-            const base_dir = if (base_url) |b|
-                try std.fs.path.join(allocator, &.{ tsconfig_dir, b })
-            else
-                try allocator.dupe(u8, tsconfig_dir);
-            defer allocator.free(base_dir);
-            const joined = try std.fs.path.join(allocator, &.{ base_dir, to_src });
-            try owned.append(allocator, joined);
-            break :blk joined;
-        };
+        // baseUrl 적용 + 절대 경로로 normalize. `std.fs.path.resolve` 가 `./././` 같은
+        // 불필요 세그먼트를 정리하고 상대/절대 모두 일관된 절대 경로로 만든다.
+        const joined = if (tsconfig.base_url) |b|
+            try std.fs.path.resolve(allocator, &.{ tsconfig_dir, b, to_src })
+        else
+            try std.fs.path.resolve(allocator, &.{ tsconfig_dir, to_src });
+        try owned.append(allocator, joined);
 
-        try out.append(allocator, .{ .from = from_owned, .to = resolved_to });
+        try out.append(allocator, .{ .from = from_owned, .to = joined });
     }
 
     return .{
@@ -413,14 +416,23 @@ fn parsePathsObject(
         const first = val.array.items[0];
         if (first != .string) continue;
 
-        const key_d = try allocator.dupe(u8, key);
-        try allocated_strings.append(allocator, key_d);
-        const val_d = try allocator.dupe(u8, first.string);
-        try allocated_strings.append(allocator, val_d);
+        const key_d = try dupeAndTrack(allocator, key, allocated_strings);
+        const val_d = try dupeAndTrack(allocator, first.string, allocated_strings);
         try list.append(allocator, .{ .from = key_d, .to = val_d });
     }
 
     return list.toOwnedSlice(allocator);
+}
+
+/// 문자열을 dupe 하고 `allocated_strings` 에 등록해 나중에 일괄 해제되게 한다.
+fn dupeAndTrack(
+    allocator: std.mem.Allocator,
+    s: []const u8,
+    allocated_strings: *std.ArrayList([]const u8),
+) ![]const u8 {
+    const duped = try allocator.dupe(u8, s);
+    try allocated_strings.append(allocator, duped);
+    return duped;
 }
 
 /// JSON 객체에서 문자열 값을 복사(dupe)하여 반환한다.
@@ -434,9 +446,7 @@ fn dupeJsonString(
 ) !?[]const u8 {
     const v = co.get(key) orelse return null;
     if (v != .string) return null;
-    const duped = try allocator.dupe(u8, v.string);
-    try allocated_strings.append(allocator, duped);
-    return duped;
+    return try dupeAndTrack(allocator, v.string, allocated_strings);
 }
 
 /// optional 문자열 merge: target이 null이고 base에 값이 있으면 복사.

--- a/src/config.zig
+++ b/src/config.zig
@@ -50,11 +50,26 @@ pub const TsConfig = struct {
     /// esbuild/vite/swc(isolatedModules) 의 표준 동작과 동일.
     verbatim_module_syntax: bool = false,
 
+    /// "baseUrl": paths 해석의 기준 경로 (tsconfig.json 위치 기준 상대).
+    /// null 이면 tsconfig 디렉토리 자체가 기본.
+    base_url: ?[]const u8 = null,
+
+    /// "paths": `{ "@/*": ["./src/*"], "@utils": ["./utils/index.ts"] }` 형태의 매핑.
+    /// 값 배열의 첫 항목만 사용 (TS 공식: 여러 후보는 순차 시도. ZTS 는 v1 에서 단일).
+    /// wildcard `*` 는 prefix 매칭으로 변환되어 resolver 에 전달됨.
+    paths: []const PathEntry = &.{},
+
     /// allocator로 할당된 문자열들을 해제하기 위한 참조.
     /// load()에서 내부적으로 사용하며, deinit() 시 해제된다.
     _allocator: ?std.mem.Allocator = null,
     /// 할당된 문자열 목록. deinit() 시 모두 free된다.
     _allocated_strings: ?std.ArrayList([]const u8) = null,
+
+    /// "paths" 1 개 항목: key → 후보 경로 (첫 번째만 사용).
+    pub const PathEntry = struct {
+        from: []const u8,
+        to: []const u8,
+    };
 
     /// TsConfig가 소유한 동적 메모리를 해제한다.
     /// load()로 생성한 TsConfig는 반드시 deinit()을 호출해야 한다.
@@ -66,7 +81,11 @@ pub const TsConfig = struct {
                 }
                 list.deinit(allocator);
             }
+            // paths 슬라이스 자체는 allocator.alloc 으로 잡은 별도 메모리 (내부 문자열은
+            // _allocated_strings 가 소유).
+            if (self.paths.len > 0) allocator.free(self.paths);
         }
+        self.paths = &.{};
         self._allocated_strings = null;
         self._allocator = null;
     }
@@ -194,6 +213,15 @@ pub const TsConfig = struct {
                 if (try dupeJsonString(co, "jsxImportSource", allocator, &config._allocated_strings.?)) |v| config.jsx_import_source = v;
                 if (try dupeJsonString(co, "outDir", allocator, &config._allocated_strings.?)) |v| config.out_dir = v;
                 if (try dupeJsonString(co, "rootDir", allocator, &config._allocated_strings.?)) |v| config.root_dir = v;
+                if (try dupeJsonString(co, "baseUrl", allocator, &config._allocated_strings.?)) |v| config.base_url = v;
+
+                // paths: {"@/*": ["./src/*"], ...} → []PathEntry
+                if (co.get("paths")) |v| {
+                    if (v == .object) {
+                        const entries = try parsePathsObject(v.object, allocator, &config._allocated_strings.?);
+                        config.paths = entries;
+                    }
+                }
 
                 // bool 옵션 추출
                 if (co.get("sourceMap")) |v| {
@@ -274,8 +302,126 @@ pub const TsConfig = struct {
         if (target.use_define_for_class_fields == null) {
             target.use_define_for_class_fields = base.use_define_for_class_fields;
         }
+
+        // baseUrl / paths: target 에 없을 때만 base 값 승계. 동시 설정 시 target 전체가 이김.
+        if (target.base_url == null) {
+            target.base_url = try mergeOptionalString(null, base.base_url, allocator, &target._allocated_strings.?);
+        }
+        if (target.paths.len == 0 and base.paths.len > 0) {
+            const duped = try allocator.alloc(TsConfig.PathEntry, base.paths.len);
+            for (base.paths, 0..) |e, i| {
+                const from_d = try allocator.dupe(u8, e.from);
+                try target._allocated_strings.?.append(allocator, from_d);
+                const to_d = try allocator.dupe(u8, e.to);
+                try target._allocated_strings.?.append(allocator, to_d);
+                duped[i] = .{ .from = from_d, .to = to_d };
+            }
+            target.paths = duped;
+        }
     }
 };
+
+/// tsconfig `paths` 항목의 wildcard 를 prefix alias 로 정규화한다.
+/// - `"@/*": "./src/*"` → `{from="@", to="./src"}` (prefix 매칭)
+/// - `"@utils": "./utils"` → `{from="@utils", to="./utils"}` (정확 매칭)
+/// - 한쪽만 wildcard 이거나 중간 wildcard 는 v1 에서 skip.
+///
+/// baseUrl 이 주어지면 상대경로 value 를 `<baseUrl>/<value>` 로 join 한다.
+/// 반환된 슬라이스는 `allocator` 에 새로 할당됨 — caller 가 해제.
+pub const NormalizedPaths = struct {
+    entries: []const TsConfig.PathEntry,
+    owned_strings: [][]const u8,
+
+    pub fn deinit(self: *NormalizedPaths, allocator: std.mem.Allocator) void {
+        for (self.owned_strings) |s| allocator.free(s);
+        allocator.free(self.owned_strings);
+        allocator.free(self.entries);
+    }
+};
+
+pub fn normalizePathsToAliases(
+    allocator: std.mem.Allocator,
+    tsconfig_dir: []const u8,
+    raw_paths: []const TsConfig.PathEntry,
+    base_url: ?[]const u8,
+) error{OutOfMemory}!NormalizedPaths {
+    var out: std.ArrayList(TsConfig.PathEntry) = .empty;
+    errdefer out.deinit(allocator);
+    var owned: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (owned.items) |s| allocator.free(s);
+        owned.deinit(allocator);
+    }
+
+    for (raw_paths) |p| {
+        var from_src = p.from;
+        var to_src = p.to;
+        const from_wild = std.mem.endsWith(u8, from_src, "/*");
+        const to_wild = std.mem.endsWith(u8, to_src, "/*");
+        if (from_wild != to_wild) continue; // 불일치 wildcard 는 스킵
+        if (from_wild) {
+            from_src = from_src[0 .. from_src.len - 2];
+            to_src = to_src[0 .. to_src.len - 2];
+        }
+
+        // from 문자열은 원본 TsConfig 의 subspan 이라 TsConfig 가 먼저 deinit 되면 dangle 된다.
+        // owned_strings 로 복사해 alias 수명을 독립시킴.
+        const from_owned = try allocator.dupe(u8, from_src);
+        try owned.append(allocator, from_owned);
+
+        // baseUrl 적용: to 가 상대경로면 <tsconfig_dir>/<baseUrl>/<to>.
+        const resolved_to: []const u8 = if (std.fs.path.isAbsolute(to_src)) blk_abs: {
+            // 절대 경로도 TsConfig subspan 이므로 복사.
+            const abs_owned = try allocator.dupe(u8, to_src);
+            try owned.append(allocator, abs_owned);
+            break :blk_abs abs_owned;
+        } else blk: {
+            const base_dir = if (base_url) |b|
+                try std.fs.path.join(allocator, &.{ tsconfig_dir, b })
+            else
+                try allocator.dupe(u8, tsconfig_dir);
+            defer allocator.free(base_dir);
+            const joined = try std.fs.path.join(allocator, &.{ base_dir, to_src });
+            try owned.append(allocator, joined);
+            break :blk joined;
+        };
+
+        try out.append(allocator, .{ .from = from_owned, .to = resolved_to });
+    }
+
+    return .{
+        .entries = try out.toOwnedSlice(allocator),
+        .owned_strings = try owned.toOwnedSlice(allocator),
+    };
+}
+
+/// `compilerOptions.paths` JSON 객체 → `[]TsConfig.PathEntry`.
+/// 값 배열의 첫 항목만 사용한다 (TS 공식은 여러 후보 순차 시도이나 ZTS v1 은 단일).
+fn parsePathsObject(
+    obj: std.json.ObjectMap,
+    allocator: std.mem.Allocator,
+    allocated_strings: *std.ArrayList([]const u8),
+) ![]const TsConfig.PathEntry {
+    var list: std.ArrayList(TsConfig.PathEntry) = .empty;
+    errdefer list.deinit(allocator);
+
+    var it = obj.iterator();
+    while (it.next()) |entry| {
+        const key = entry.key_ptr.*;
+        const val = entry.value_ptr.*;
+        if (val != .array or val.array.items.len == 0) continue;
+        const first = val.array.items[0];
+        if (first != .string) continue;
+
+        const key_d = try allocator.dupe(u8, key);
+        try allocated_strings.append(allocator, key_d);
+        const val_d = try allocator.dupe(u8, first.string);
+        try allocated_strings.append(allocator, val_d);
+        try list.append(allocator, .{ .from = key_d, .to = val_d });
+    }
+
+    return list.toOwnedSlice(allocator);
+}
 
 /// JSON 객체에서 문자열 값을 복사(dupe)하여 반환한다.
 /// 키가 없거나 값이 문자열이 아니면 null을 반환한다.

--- a/src/main.zig
+++ b/src/main.zig
@@ -1267,19 +1267,9 @@ pub fn main() !void {
 
     // tsconfig `paths` / `baseUrl` → alias_list 뒤에 append.
     // applyAlias 는 리스트 순서대로 매칭하므로 사용자 `--alias` (앞) 가 우선.
-    // baseUrl 은 tsconfig.json 파일 위치 기준 상대 → 절대경로 조인.
     if (tsconfig.paths.len > 0) {
-        const tsconfig_dir = tsconfig_dir_early;
-        const dir_for_join: []const u8 = if (std.mem.endsWith(u8, tsconfig_dir, ".json"))
-            std.fs.path.dirname(tsconfig_dir) orelse "."
-        else
-            tsconfig_dir;
-        normalized_paths = lib.config.normalizePathsToAliases(
-            allocator,
-            dir_for_join,
-            tsconfig.paths,
-            tsconfig.base_url,
-        ) catch |err| blk: {
+        const dir_for_join = lib.config.tsconfigDirFromPath(tsconfig_dir_early);
+        normalized_paths = lib.config.normalizePathsToAliases(allocator, dir_for_join, &tsconfig) catch |err| blk: {
             try stderr.print("zts: warning: tsconfig paths normalization failed: {}\n", .{err});
             break :blk lib.config.NormalizedPaths{ .entries = &.{}, .owned_strings = &.{} };
         };

--- a/src/main.zig
+++ b/src/main.zig
@@ -1212,6 +1212,10 @@ pub fn main() !void {
     var tsconfig = TsConfig.loadFromPath(allocator, tsconfig_dir_early) catch TsConfig{};
     defer tsconfig.deinit();
 
+    // tsconfig paths → alias 변환 결과. main 함수 끝까지 유지해야 alias 슬라이스가 dangle 하지 않음.
+    var normalized_paths: lib.config.NormalizedPaths = .{ .entries = &.{}, .owned_strings = &.{} };
+    defer normalized_paths.deinit(allocator);
+
     // tsconfig 값 적용 — CLI 옵션이 우선, 미지정 옵션만 tsconfig에서 가져옴
     if (opts.module_format == .esm) {
         if (tsconfig.module) |mod| {
@@ -1259,6 +1263,29 @@ pub fn main() !void {
     }
     if (std.mem.eql(u8, opts.jsx_import_source, "react")) {
         opts.jsx_import_source = tsconfig.jsx_import_source;
+    }
+
+    // tsconfig `paths` / `baseUrl` → alias_list 뒤에 append.
+    // applyAlias 는 리스트 순서대로 매칭하므로 사용자 `--alias` (앞) 가 우선.
+    // baseUrl 은 tsconfig.json 파일 위치 기준 상대 → 절대경로 조인.
+    if (tsconfig.paths.len > 0) {
+        const tsconfig_dir = tsconfig_dir_early;
+        const dir_for_join: []const u8 = if (std.mem.endsWith(u8, tsconfig_dir, ".json"))
+            std.fs.path.dirname(tsconfig_dir) orelse "."
+        else
+            tsconfig_dir;
+        normalized_paths = lib.config.normalizePathsToAliases(
+            allocator,
+            dir_for_join,
+            tsconfig.paths,
+            tsconfig.base_url,
+        ) catch |err| blk: {
+            try stderr.print("zts: warning: tsconfig paths normalization failed: {}\n", .{err});
+            break :blk lib.config.NormalizedPaths{ .entries = &.{}, .owned_strings = &.{} };
+        };
+        for (normalized_paths.entries) |e| {
+            try opts.alias_list.append(allocator, .{ .from = e.from, .to = e.to });
+        }
     }
 
     // --bundle


### PR DESCRIPTION
## Summary

tsconfig.json 의 \`compilerOptions.paths\` / \`baseUrl\` 을 읽어 resolver alias 로 자동 주입. CLI \`--alias:K=V\` 와 충돌 시 CLI 가 우선 (esbuild/vite 와 동일한 정책).

## 동기

Vite/rspack 등 현대 번들러는 tsconfig 의 \`paths\` 를 자동 반영해 \`@/foo\` 같은 import 패턴을 resolve 한다. ZTS 는 기존에 \`--alias:K=V\` 만 있었고 tsconfig \`paths\` 는 읽지 않아 외부에서 수동 변환해야 했다.

## 사용 예

\`\`\`jsonc
// tsconfig.json
{ "compilerOptions": { "baseUrl": ".", "paths": { "@/*": ["./src/*"], "@utils": ["./src/utils.ts"] } } }
\`\`\`

\`\`\`ts
import { greet } from "@/greet";       // → ./src/greet
import { hello } from "@utils";         // → ./src/utils.ts
\`\`\`

\`\`\`bash
zts --bundle -p ./tsconfig.json ./entry.ts              # tsconfig paths 적용
zts --bundle -p . --alias:@utils=./patched.ts ./entry.ts # CLI 가 tsconfig 덮어씀
\`\`\`

## 변경

### \`src/config.zig\`
- \`TsConfig.base_url\` + \`TsConfig.paths\`
- \`parsePathsObject\` (JSON → PathEntry[])
- \`normalizePathsToAliases\`: wildcard \`/*\` 정규화 + baseUrl 상대→절대 조인 + **TsConfig 수명 독립을 위해 from/to 모두 dup**
- \`NormalizedPaths.deinit\` 헬퍼
- extends merge 에 paths/baseUrl 승계

### \`src/main.zig\` (Zig CLI) + \`packages/core/src/napi_entry.zig\` (NAPI bundle)
- tsconfig paths 를 \`opts.alias_list\` 뒤에 append → \`applyAlias\` 순서 매칭 덕에 사용자 \`--alias\` 가 자연스럽게 우선.
- NAPI 경로는 \`owned_strings\` 를 tracker 에 등록해 opts 수명과 맞춤.

### \`packages/core/bin/zts.mjs\` (JS CLI)
- **사전 버그 수정**: \`opts.alias\` 가 parse 만 되고 buildSync 에 전달 안 되던 누락 wiring 보강.
- \`tsconfigPath: opts.project\` 를 build/transpile 에 전달.

### 회귀 테스트
- \`packages/core/bin/zts.test.ts\` 에 2 케이스 추가 (wildcard+exact 해석 / CLI override 우선).

## Lifetime 주의사항 (PR 중 잡은 버그)

개발 중 \`TsConfig._allocated_strings\` 가 먼저 deinit 되면 \`normalizePathsToAliases\` 가 반환한 alias 의 \`from\` 필드가 subspan 이라 dangling 되는 문제를 발견 — resolver 에서 \`from='L�l<�'\` 같이 깨진 키가 관찰됐음. 수정: helper 가 **from 도 모두 dup** 해 \`owned_strings\` 로 반환, alias 사용 끝까지 유지되는 수명 보장.

## Wildcard 규칙 (v1)
- \`\"@/*\": \"./src/*\"\` → strip → prefix alias \`@\` → 절대경로
- \`\"@utils\": \"./utils.ts\"\` → exact alias
- 한쪽만 wildcard / 중간 wildcard / 여러 후보(배열 뒤 항목) 는 v1 에서 skip

## Test plan
- [x] \`zig build test\` 전체 통과 (신규 unit 테스트 포함)
- [x] \`bun test packages/core/bin/zts.test.ts\` — 61/61 통과 (paths 해석 + override 회귀)
- [x] 수동: Zig CLI + NAPI 양쪽 모두 \`@/*\`, \`@utils\` resolve 확인 + \`--alias\` override 확인

## 후속 PR 후보
- Wildcard 다중 \`*\` (예: \`./lib/*/index.ts\`)
- 같은 키에 여러 후보 (배열 순차 시도)
- tsconfig 자동 발견 (cwd 상위 탐색) — esbuild 스타일

🤖 Generated with [Claude Code](https://claude.com/claude-code)