### PR TITLE
feat(tsconfig): paths를 TS 공식 스펙에 맞게 재설계 (wildcard anywhere + 다중 후보)

### DIFF
--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -1255,6 +1255,50 @@ describe("CLI: tsconfig", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("tsconfig paths: 중간 wildcard (@pkg/*/types)", () => {
+    // TS 공식 스펙: `*` 가 key 중간에 있으면 해당 위치의 세그먼트가 capture 되어 target 에 대입.
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-mid-wild-"));
+    mkdirSync(join(dir, "packages/foo/src"), { recursive: true });
+    mkdirSync(join(dir, "packages/bar/src"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: { paths: { "@pkg/*/types": ["./packages/*/src/types.ts"] } },
+      }),
+    );
+    writeFileSync(join(dir, "packages/foo/src/types.ts"), "export const T = 'FOO_TYPES';");
+    writeFileSync(join(dir, "packages/bar/src/types.ts"), "export const T = 'BAR_TYPES';");
+    writeFileSync(
+      join(dir, "entry.ts"),
+      'import { T as F } from "@pkg/foo/types";\nimport { T as B } from "@pkg/bar/types";\nconsole.log(F, B);',
+    );
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("FOO_TYPES");
+    expect(stdout).toContain("BAR_TYPES");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("tsconfig paths: 다중 후보 순차 fallback (첫 번째 실패 시 두 번째)", () => {
+    // TS 공식 스펙: value 배열은 순서대로 시도. 첫 후보가 파일로 존재 안 하면 다음 후보로.
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-paths-multi-cand-"));
+    mkdirSync(join(dir, "vendor"), { recursive: true });
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: { "@lib": ["./does-not-exist.ts", "./vendor/lib.ts"] },
+        },
+      }),
+    );
+    writeFileSync(join(dir, "vendor/lib.ts"), "export const L = 'FALLBACK_OK';");
+    writeFileSync(join(dir, "entry.ts"), 'import { L } from "@lib";\nconsole.log(L);');
+    const { stdout, exitCode } = runCli(["--bundle", "-p", dir, join(dir, "entry.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("FALLBACK_OK");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("tsconfig paths: .js extension 매핑 — '@util' → './src/util.ts'", () => {
     // tsconfig 값이 ./src/util.ts 인데 source 가 ./src/util.js 로 import 해도
     // resolver 의 TS extension mapping 이 동작해야 함 (pre-existing 기능, 회귀 방지).

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2281,24 +2281,26 @@ fn parseBuildOptions(
     const use_define_for_class_fields_eff = merged_tsconfig.use_define_for_class_fields;
     const verbatim_module_syntax_eff = merged_tsconfig.verbatim_module_syntax;
 
-    // tsconfig paths → alias_list 뒤에 append (JS --alias 가 이미 들어있어서 그게 우선).
+    const alias_entries: []const bundler_mod.types.AliasEntry = alias_list.toOwnedSlice(native_alloc) catch return null;
+
+    // tsconfig paths → resolver 의 ts_paths 로 전달 (alias 와 독립 경로).
+    // TS 스펙대로 wildcard anywhere + 다중 후보 순차 시도를 resolver 가 담당.
+    var ts_path_entries: []const @import("zts_lib").config.TsConfig.PathEntry = &.{};
     if (tsconfig_path_opt != null and tsconfig_holder.paths.len > 0) {
         const lib_config = @import("zts_lib").config;
         const dir_for_join = lib_config.tsconfigDirFromPath(tsconfig_path_opt.?);
-        if (lib_config.normalizePathsToAliases(native_alloc, dir_for_join, &tsconfig_holder)) |norm| {
-            // owned_strings (절대경로 조인 결과) 는 alias 가 shallow-copy 되는 동안 살아있어야 함 →
-            // opts 전체 수명을 따라가도록 tracker 에 등록.
-            if (norm.owned_strings.len > 0) {
-                for (norm.owned_strings) |s| if (!trackStr(owned_strings, s)) return null;
-                if (!trackArr(owned_string_arrays, norm.owned_strings)) return null;
+        if (lib_config.resolveTsPaths(native_alloc, dir_for_join, &tsconfig_holder)) |resolved| {
+            // target.prefix 로 join 된 절대 경로들을 tracker 에 등록 — opts 수명 동안 살아있도록.
+            if (resolved.owned_strings.len > 0) {
+                for (resolved.owned_strings) |s| if (!trackStr(owned_strings, s)) return null;
+                if (!trackArr(owned_string_arrays, resolved.owned_strings)) return null;
             }
-            for (norm.entries) |e| {
-                alias_list.append(native_alloc, .{ .from = e.from, .to = e.to }) catch return null;
-            }
-            native_alloc.free(norm.entries); // PathEntry 슬라이스 자체만 해제 (문자열은 이전됨).
+            ts_path_entries = resolved.entries;
+            // entries 슬라이스와 각 entry.targets 슬라이스도 tracker 에 등록할 수 없으므로
+            // 직접 추적. (TsConfig.PathEntry slice 들은 native_alloc 소유이며 NAPI cleanup 에서 해제되지 않음)
+            // 메모리 leak 방지를 위해 process lifetime 동안 유지 — NAPI 진입점은 single-shot 이라 허용.
         } else |_| {}
     }
-    const alias_entries: []const bundler_mod.types.AliasEntry = alias_list.toOwnedSlice(native_alloc) catch return null;
 
     const out_extension_js = ownStr(env, opts_obj, "outExtension", owned_strings);
     const source_root = ownStr(env, opts_obj, "sourceRoot", owned_strings);
@@ -2370,6 +2372,7 @@ fn parseBuildOptions(
         .external = external orelse &.{},
         .define = define_entries,
         .alias = alias_entries,
+        .ts_paths = ts_path_entries,
         .fallback = fallback_entries,
         .block_list = blk: {
             const user = block_list orelse &.{};

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -98,6 +98,9 @@ pub const BundleOptions = struct {
     preserve_symlinks: bool = false,
     /// import 경로 별칭 (--alias:K=V). resolve 시 specifier 앞부분을 치환.
     alias: []const types.AliasEntry = &.{},
+    /// tsconfig `paths` (절대 경로로 정규화된 형태). `*` wildcard + 다중 후보 순차 시도.
+    /// alias 보다 먼저 매칭되며, resolver 가 파일 존재 확인까지 수행.
+    ts_paths: []const @import("../config.zig").TsConfig.PathEntry = &.{},
     /// Fallback (webpack resolve.fallback / Metro extraNodeModules). 해석 실패 시에만 적용.
     fallback: []const types.FallbackEntry = &.{},
     /// Metro resolver.blockList 호환 — 매칭되는 절대 경로는 해석 차단.
@@ -365,6 +368,7 @@ pub const Bundler = struct {
                 .custom_conditions = options.conditions,
                 .preserve_symlinks = options.preserve_symlinks,
                 .alias = options.alias,
+                .ts_paths = options.ts_paths,
                 .fallback = options.fallback,
                 .block_list = options.block_list,
                 .resolve_extensions = options.resolve_extensions,

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -171,6 +171,8 @@ pub const ResolveCache = struct {
         custom_conditions: []const []const u8 = &.{},
         preserve_symlinks: bool = false,
         alias: []const resolver_mod.AliasEntry = &.{},
+        /// tsconfig `paths` (절대 경로로 정규화됨). alias 보다 먼저 매칭, 다중 후보 순차 시도.
+        ts_paths: []const @import("../config.zig").TsConfig.PathEntry = &.{},
         /// webpack resolve.fallback / Metro extraNodeModules 호환.
         fallback: []const resolver_mod.FallbackEntry = &.{},
         /// Metro resolver.blockList 호환 — 해석 차단 패턴.
@@ -195,6 +197,7 @@ pub const ResolveCache = struct {
         var r = Resolver.init(allocator);
         r.preserve_symlinks = preserve_symlinks;
         r.alias = alias;
+        r.ts_paths = options.ts_paths;
         r.fallback = options.fallback;
         r.block_list = options.block_list;
         r.custom_extensions = options.resolve_extensions;

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -61,6 +61,20 @@ const index_files: []const []const u8 = &.{ "index.ts", "index.tsx", "index.js",
 pub const AliasEntry = types.AliasEntry;
 pub const FallbackEntry = types.FallbackEntry;
 
+/// tsconfig paths entry 의 key 패턴이 specifier 와 매칭되는지 검사.
+/// 매칭되면 wildcard capture (key 가 wildcard 면 `*` 위치의 중간 문자열, 아니면 빈 문자열) 반환.
+/// 매칭 안 되면 null.
+fn matchTsPathEntry(entry: @import("../config.zig").TsConfig.PathEntry, specifier: []const u8) ?[]const u8 {
+    if (!entry.has_wildcard) {
+        if (std.mem.eql(u8, specifier, entry.key_prefix)) return ""; // exact 매칭 — capture 없음
+        return null;
+    }
+    if (specifier.len < entry.key_prefix.len + entry.key_suffix.len) return null;
+    if (!std.mem.startsWith(u8, specifier, entry.key_prefix)) return null;
+    if (!std.mem.endsWith(u8, specifier, entry.key_suffix)) return null;
+    return specifier[entry.key_prefix.len .. specifier.len - entry.key_suffix.len];
+}
+
 /// 디렉토리 엔트리 캐시 (esbuild 방식).
 /// 디렉토리를 처음 접근할 때 readdir()로 파일 목록을 통째로 읽어 캐시.
 /// 이후 같은 디렉토리의 파일 존재 확인은 syscall 없이 메모리 조회.
@@ -195,6 +209,10 @@ pub const Resolver = struct {
     /// 정확 매칭: "react" → "preact/compat"
     /// 접두사 매칭: "react/hooks" → "preact/compat/hooks"
     alias: []const AliasEntry = &.{},
+    /// tsconfig `paths` — alias 와 달리 `*` wildcard 가 위치 자유, 다중 후보 순차 시도.
+    /// resolver 가 패턴 매칭 + 파일 존재 확인을 수행해 첫 resolvable 후보를 반환.
+    /// 절대 경로로 정규화된 상태를 기대 (`config.resolveTsPaths` 참고).
+    ts_paths: []const @import("../config.zig").TsConfig.PathEntry = &.{},
     /// Fallback 엔트리 (webpack `resolve.fallback` / Metro `extraNodeModules` 호환).
     /// alias와 달리 일반 해석이 **실패했을 때만** 적용. 정확 매칭만 지원 (webpack과 동일).
     /// `to == null`이면 빈 모듈(disabled result)로 대체.
@@ -262,6 +280,38 @@ pub const Resolver = struct {
         return null;
     }
 
+    /// tsconfig `paths` 패턴 매칭 + 순차 candidate resolve.
+    /// TS 스펙에 따라:
+    /// 1. 각 paths entry 에 대해 key 패턴 매칭 (exact 또는 prefix + suffix with captured middle)
+    /// 2. 매칭된 entry 의 targets 를 순서대로 시도 — 파일 존재 확인까지 포함
+    /// 3. 첫 resolvable target 의 ResolveResult 반환
+    /// 모든 entry 매칭/resolve 실패 시 null → caller 가 일반 resolve 경로로 fall-through.
+    fn tryTsPaths(self: *Resolver, specifier: []const u8) ResolveError!?ResolveResult {
+        for (self.ts_paths) |entry| {
+            const captured = matchTsPathEntry(entry, specifier) orelse continue;
+            for (entry.targets) |t| {
+                // target.prefix 는 tsconfig_dir 기준 절대 경로로 join 만 되어 있음.
+                // capture 와 concat 후 `path.resolve` 로 한꺼번에 normalize (`./././` 등 정리).
+                const raw = try std.mem.concat(self.allocator, u8, &.{ t.prefix, captured, t.suffix });
+                defer self.allocator.free(raw);
+                const candidate = try std.fs.path.resolve(self.allocator, &.{raw});
+                defer self.allocator.free(candidate);
+                if (try self.tryResolveAbsolutePath(candidate)) |r| return r;
+            }
+        }
+        return null;
+    }
+
+    /// 절대 경로 1 개에 대해 파일 존재 → 확장자 → TS 매핑 → index 순으로 resolve 시도.
+    /// `resolveInner` 의 pass #1–#4 와 동일 로직을 독립 함수로 추출한 것.
+    fn tryResolveAbsolutePath(self: *Resolver, abs_path: []const u8) ResolveError!?ResolveResult {
+        if (self.fileExists(abs_path)) return (try self.makeResult(abs_path));
+        if (try self.tryExtensions(abs_path)) |r| return r;
+        if (try self.tryTsExtensionMapping(abs_path)) |r| return r;
+        if (try self.tryDirectoryIndex(abs_path)) |r| return r;
+        return null;
+    }
+
     pub fn resolve(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
         const result = try self.resolveInner(source_dir, specifier);
         if (self.block_list.len > 0 and !result.disabled) {
@@ -277,13 +327,20 @@ pub const Resolver = struct {
     }
 
     fn resolveInner(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
-        // alias 치환 (resolve 맨 처음에 적용, esbuild 동작과 동일)
+        // 사용자 `--alias` 를 먼저 적용 — CLI 옵션이 tsconfig 보다 우선이라는 원칙.
+        // alias 가 치환하면 치환된 specifier 로 계속 (tsconfig paths 는 원본 specifier 로 매칭될 수 없음).
         const effective_specifier = if (self.alias.len > 0)
             (applyAlias(self.allocator, self.alias, specifier) catch return error.OutOfMemory) orelse specifier
         else
             specifier;
         defer if (self.alias.len > 0 and effective_specifier.ptr != specifier.ptr)
             self.allocator.free(effective_specifier);
+
+        // tsconfig paths — alias 미적용 specifier 에 대해서만 의미 있음. alias 가 이미 치환했다면
+        // 일반 경로로 continue. (alias 는 보통 절대/상대 경로 리턴이라 ts_paths 와 겹치지 않음)
+        if (self.ts_paths.len > 0 and effective_specifier.ptr == specifier.ptr) {
+            if (try self.tryTsPaths(specifier)) |r| return r;
+        }
 
         // #specifier → package.json "imports" 필드 (Node.js subpath imports)
         if (effective_specifier.len > 0 and effective_specifier[0] == '#') {

--- a/src/config.zig
+++ b/src/config.zig
@@ -54,9 +54,11 @@ pub const TsConfig = struct {
     /// null 이면 tsconfig 디렉토리 자체가 기본.
     base_url: ?[]const u8 = null,
 
-    /// "paths": `{ "@/*": ["./src/*"], "@utils": ["./utils/index.ts"] }` 형태의 매핑.
-    /// 값 배열의 첫 항목만 사용 (TS 공식: 여러 후보는 순차 시도. ZTS 는 v1 에서 단일).
-    /// wildcard `*` 는 prefix 매칭으로 변환되어 resolver 에 전달됨.
+    /// "paths": `{ "@/*": ["./src/*", "./vendor/*"], "@utils": ["./utils/index.ts"] }` 매핑.
+    /// TS 공식 스펙:
+    /// - key 는 한 개의 `*` 를 위치 자유롭게 가질 수 있다 (prefix/middle/suffix 모두).
+    /// - value 배열의 각 후보는 key 와 동일한 `*` 유무를 가져야 함 (비대칭은 ts(5063) 에러).
+    /// - 다중 후보는 선언 순서대로 시도하여 첫 resolvable 파일을 사용.
     paths: []const PathEntry = &.{},
 
     /// allocator로 할당된 문자열들을 해제하기 위한 참조.
@@ -65,10 +67,19 @@ pub const TsConfig = struct {
     /// 할당된 문자열 목록. deinit() 시 모두 free된다.
     _allocated_strings: ?std.ArrayList([]const u8) = null,
 
-    /// "paths" 1 개 항목: key → 후보 경로 (첫 번째만 사용).
+    /// `paths` 1 항목. key 는 `*` 기준으로 prefix/suffix 로 분리, targets 는 후보 목록.
+    /// `has_wildcard = false` 이면 exact-match (key_prefix = 전체 key, key_suffix 빈 문자열).
     pub const PathEntry = struct {
-        from: []const u8,
-        to: []const u8,
+        key_prefix: []const u8,
+        key_suffix: []const u8,
+        has_wildcard: bool,
+        targets: []const Target,
+
+        /// value 배열의 한 항목. key 가 wildcard 면 target 도 대응하는 `*` 에서 분리됨.
+        pub const Target = struct {
+            prefix: []const u8,
+            suffix: []const u8,
+        };
     };
 
     /// TsConfig가 소유한 동적 메모리를 해제한다.
@@ -81,8 +92,9 @@ pub const TsConfig = struct {
                 }
                 list.deinit(allocator);
             }
-            // paths 슬라이스 자체는 allocator.alloc 으로 잡은 별도 메모리 (내부 문자열은
-            // _allocated_strings 가 소유).
+            // paths 슬라이스 + 각 entry.targets 슬라이스는 allocator 에 별도 할당. 내부 문자열은
+            // _allocated_strings 가 소유하므로 여기서는 컨테이너만 해제.
+            for (self.paths) |p| if (p.targets.len > 0) allocator.free(p.targets);
             if (self.paths.len > 0) allocator.free(self.paths);
         }
         self.paths = &.{};
@@ -310,19 +322,94 @@ pub const TsConfig = struct {
         if (target.paths.len == 0 and base.paths.len > 0) {
             const duped = try allocator.alloc(TsConfig.PathEntry, base.paths.len);
             for (base.paths, 0..) |e, i| {
-                const from_d = try dupeAndTrack(allocator, e.from, &target._allocated_strings.?);
-                const to_d = try dupeAndTrack(allocator, e.to, &target._allocated_strings.?);
-                duped[i] = .{ .from = from_d, .to = to_d };
+                const kp = try dupeAndTrack(allocator, e.key_prefix, &target._allocated_strings.?);
+                const ks = try dupeAndTrack(allocator, e.key_suffix, &target._allocated_strings.?);
+                const targets = try allocator.alloc(TsConfig.PathEntry.Target, e.targets.len);
+                for (e.targets, 0..) |t, j| {
+                    const tp = try dupeAndTrack(allocator, t.prefix, &target._allocated_strings.?);
+                    const ts = try dupeAndTrack(allocator, t.suffix, &target._allocated_strings.?);
+                    targets[j] = .{ .prefix = tp, .suffix = ts };
+                }
+                duped[i] = .{ .key_prefix = kp, .key_suffix = ks, .has_wildcard = e.has_wildcard, .targets = targets };
             }
             target.paths = duped;
         }
     }
 };
 
-/// TS `paths` 의 wildcard 접미사. 패턴 양쪽이 이 접미사로 끝나야 prefix alias 로 변환된다.
-const PATHS_WILDCARD_SUFFIX = "/*";
 /// tsconfig 파일 경로 판별 접미사 (디렉토리 인지 파일인지 구분).
 pub const TSCONFIG_FILE_EXT = ".json";
+
+/// Resolver 에 주입할 수 있도록 target prefix 를 절대 경로로 만든 형태.
+/// `tsconfig_dir` + `base_url` + target.prefix 를 `std.fs.path.resolve` 로 조인.
+/// entry 구조는 `TsConfig.PathEntry` 와 동일 — 해석(matching) 코드는 양쪽에 재사용 가능.
+pub const ResolvedPaths = struct {
+    entries: []const TsConfig.PathEntry,
+    owned_strings: [][]const u8,
+
+    pub fn deinit(self: *ResolvedPaths, allocator: std.mem.Allocator) void {
+        for (self.entries) |e| if (e.targets.len > 0) allocator.free(e.targets);
+        allocator.free(self.entries);
+        for (self.owned_strings) |s| allocator.free(s);
+        allocator.free(self.owned_strings);
+    }
+};
+
+/// tsconfig 의 paths 를 resolver 용 절대 경로 형태로 정규화한다.
+/// - target.prefix 는 `<tsconfig_dir>/<baseUrl>/<prefix>` 를 `std.fs.path.resolve` 로 정리
+/// - target.suffix 는 suffix 그대로 유지 (wildcard capture 뒤에 concat 되므로 절대화하지 않음)
+/// - entry 의 key_prefix/suffix/has_wildcard 는 그대로 복사
+pub fn resolveTsPaths(
+    allocator: std.mem.Allocator,
+    tsconfig_dir: []const u8,
+    tsconfig: *const TsConfig,
+) error{OutOfMemory}!ResolvedPaths {
+    var out_entries: std.ArrayList(TsConfig.PathEntry) = .empty;
+    errdefer out_entries.deinit(allocator);
+    var owned: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (owned.items) |s| allocator.free(s);
+        owned.deinit(allocator);
+    }
+
+    for (tsconfig.paths) |p| {
+        var targets: std.ArrayList(TsConfig.PathEntry.Target) = .empty;
+        errdefer targets.deinit(allocator);
+
+        for (p.targets) |t| {
+            // `path.resolve` 를 여기서 쓰면 target.prefix 끝의 `/` 가 날아가 capture 와
+            // 붙을 때 경로 세그먼트 경계가 사라진다 (`"/foo/src/" + "greet"` → `"/foo/srcgreet"`).
+            // → `path.join` 으로 절대화만 하고, 최종 candidate 는 resolver 가 합치며 normalize.
+            const abs_prefix = if (tsconfig.base_url) |b|
+                try std.fs.path.join(allocator, &.{ tsconfig_dir, b, t.prefix })
+            else
+                try std.fs.path.join(allocator, &.{ tsconfig_dir, t.prefix });
+            try owned.append(allocator, abs_prefix);
+            // t.suffix 도 dupe — TsConfig 원본 subspan 을 참조하면 TsConfig.deinit 후 dangle.
+            const suffix_owned = try allocator.dupe(u8, t.suffix);
+            try owned.append(allocator, suffix_owned);
+            try targets.append(allocator, .{ .prefix = abs_prefix, .suffix = suffix_owned });
+        }
+
+        // key_prefix/suffix 도 TsConfig 의 문자열이므로 독립 수명으로 dupe.
+        const kp_owned = try allocator.dupe(u8, p.key_prefix);
+        try owned.append(allocator, kp_owned);
+        const ks_owned = try allocator.dupe(u8, p.key_suffix);
+        try owned.append(allocator, ks_owned);
+
+        try out_entries.append(allocator, .{
+            .key_prefix = kp_owned,
+            .key_suffix = ks_owned,
+            .has_wildcard = p.has_wildcard,
+            .targets = try targets.toOwnedSlice(allocator),
+        });
+    }
+
+    return .{
+        .entries = try out_entries.toOwnedSlice(allocator),
+        .owned_strings = try owned.toOwnedSlice(allocator),
+    };
+}
 
 /// 경로가 `.json` 파일이면 상위 디렉토리를, 아니면 경로 자체를 반환한다.
 /// CLI/NAPI 가 `-p`/`tsconfigPath` 로 파일과 디렉토리 둘 다 받을 때 공용으로 사용.
@@ -332,74 +419,11 @@ pub fn tsconfigDirFromPath(path: []const u8) []const u8 {
     return path;
 }
 
-/// tsconfig `paths` 항목의 wildcard 를 prefix alias 로 정규화한다.
-/// - `"@/*": "./src/*"` → `{from="@", to="./src"}` (prefix 매칭)
-/// - `"@utils": "./utils"` → `{from="@utils", to="./utils"}` (정확 매칭)
-/// - 한쪽만 wildcard 이거나 중간 wildcard 는 v1 에서 skip.
-///
-/// baseUrl 이 주어지면 상대경로 value 를 `<baseUrl>/<value>` 로 join 하며
-/// `std.fs.path.resolve` 로 `./././` 같은 불필요 세그먼트를 정규화한다.
-/// 반환된 슬라이스는 `allocator` 에 새로 할당됨 — caller 가 해제.
-pub const NormalizedPaths = struct {
-    entries: []const TsConfig.PathEntry,
-    owned_strings: [][]const u8,
-
-    pub fn deinit(self: *NormalizedPaths, allocator: std.mem.Allocator) void {
-        for (self.owned_strings) |s| allocator.free(s);
-        allocator.free(self.owned_strings);
-        allocator.free(self.entries);
-    }
-};
-
-pub fn normalizePathsToAliases(
-    allocator: std.mem.Allocator,
-    tsconfig_dir: []const u8,
-    tsconfig: *const TsConfig,
-) error{OutOfMemory}!NormalizedPaths {
-    var out: std.ArrayList(TsConfig.PathEntry) = .empty;
-    errdefer out.deinit(allocator);
-    var owned: std.ArrayList([]const u8) = .empty;
-    errdefer {
-        for (owned.items) |s| allocator.free(s);
-        owned.deinit(allocator);
-    }
-
-    for (tsconfig.paths) |p| {
-        var from_src = p.from;
-        var to_src = p.to;
-        const from_wild = std.mem.endsWith(u8, from_src, PATHS_WILDCARD_SUFFIX);
-        const to_wild = std.mem.endsWith(u8, to_src, PATHS_WILDCARD_SUFFIX);
-        // TS 규칙: wildcard 는 key/value 양쪽에 대칭으로 있어야 함 — 한쪽만 있으면 의미 불명확해 v1 은 skip.
-        if (from_wild != to_wild) continue;
-        if (from_wild) {
-            from_src = from_src[0 .. from_src.len - PATHS_WILDCARD_SUFFIX.len];
-            to_src = to_src[0 .. to_src.len - PATHS_WILDCARD_SUFFIX.len];
-        }
-
-        // from 문자열은 원본 TsConfig 의 subspan 이라 TsConfig 가 먼저 deinit 되면 dangle 된다.
-        // owned_strings 로 복사해 alias 수명을 독립시킴.
-        const from_owned = try allocator.dupe(u8, from_src);
-        try owned.append(allocator, from_owned);
-
-        // baseUrl 적용 + 절대 경로로 normalize. `std.fs.path.resolve` 가 `./././` 같은
-        // 불필요 세그먼트를 정리하고 상대/절대 모두 일관된 절대 경로로 만든다.
-        const joined = if (tsconfig.base_url) |b|
-            try std.fs.path.resolve(allocator, &.{ tsconfig_dir, b, to_src })
-        else
-            try std.fs.path.resolve(allocator, &.{ tsconfig_dir, to_src });
-        try owned.append(allocator, joined);
-
-        try out.append(allocator, .{ .from = from_owned, .to = joined });
-    }
-
-    return .{
-        .entries = try out.toOwnedSlice(allocator),
-        .owned_strings = try owned.toOwnedSlice(allocator),
-    };
-}
-
 /// `compilerOptions.paths` JSON 객체 → `[]TsConfig.PathEntry`.
-/// 값 배열의 첫 항목만 사용한다 (TS 공식은 여러 후보 순차 시도이나 ZTS v1 은 단일).
+/// TS 스펙:
+/// - key 는 `*` 한 개를 아무 위치에나 가질 수 있다. 둘 이상의 `*` 는 skip (ts(5073)).
+/// - value 는 배열. 각 후보는 key 와 동일한 wildcard 유무를 가져야 함. 비대칭 후보는 skip.
+/// - 후보 배열의 선언 순서가 resolver 의 시도 순서.
 fn parsePathsObject(
     obj: std.json.ObjectMap,
     allocator: std.mem.Allocator,
@@ -413,15 +437,53 @@ fn parsePathsObject(
         const key = entry.key_ptr.*;
         const val = entry.value_ptr.*;
         if (val != .array or val.array.items.len == 0) continue;
-        const first = val.array.items[0];
-        if (first != .string) continue;
 
-        const key_d = try dupeAndTrack(allocator, key, allocated_strings);
-        const val_d = try dupeAndTrack(allocator, first.string, allocated_strings);
-        try list.append(allocator, .{ .from = key_d, .to = val_d });
+        const parsed_key = splitWildcard(key) orelse continue; // `*` 2 개 이상이면 null → skip
+        const key_prefix_d = try dupeAndTrack(allocator, parsed_key.prefix, allocated_strings);
+        const key_suffix_d = try dupeAndTrack(allocator, parsed_key.suffix, allocated_strings);
+
+        var targets: std.ArrayList(TsConfig.PathEntry.Target) = .empty;
+        errdefer targets.deinit(allocator);
+        for (val.array.items) |v| {
+            if (v != .string) continue;
+            const parsed_t = splitWildcard(v.string) orelse continue;
+            // key 와 wildcard 유무가 다르면 ts(5063) 에 해당 — 해당 후보만 skip.
+            if (parsed_t.has_wildcard != parsed_key.has_wildcard) continue;
+            const tp = try dupeAndTrack(allocator, parsed_t.prefix, allocated_strings);
+            const ts = try dupeAndTrack(allocator, parsed_t.suffix, allocated_strings);
+            try targets.append(allocator, .{ .prefix = tp, .suffix = ts });
+        }
+        if (targets.items.len == 0) {
+            targets.deinit(allocator);
+            continue;
+        }
+
+        try list.append(allocator, .{
+            .key_prefix = key_prefix_d,
+            .key_suffix = key_suffix_d,
+            .has_wildcard = parsed_key.has_wildcard,
+            .targets = try targets.toOwnedSlice(allocator),
+        });
     }
 
     return list.toOwnedSlice(allocator);
+}
+
+/// 패턴을 첫 `*` 기준으로 prefix/suffix 로 나눈다. `*` 이 없으면 prefix = 전체, suffix = "".
+/// `*` 이 둘 이상이면 null (ts(5073): "Pattern '...' can have at most one '*' character.").
+fn splitWildcard(pattern: []const u8) ?struct {
+    prefix: []const u8,
+    suffix: []const u8,
+    has_wildcard: bool,
+} {
+    const first_star = std.mem.indexOfScalar(u8, pattern, '*') orelse
+        return .{ .prefix = pattern, .suffix = "", .has_wildcard = false };
+    if (std.mem.indexOfScalarPos(u8, pattern, first_star + 1, '*') != null) return null;
+    return .{
+        .prefix = pattern[0..first_star],
+        .suffix = pattern[first_star + 1 ..],
+        .has_wildcard = true,
+    };
 }
 
 /// 문자열을 dupe 하고 `allocated_strings` 에 등록해 나중에 일괄 해제되게 한다.

--- a/src/main.zig
+++ b/src/main.zig
@@ -1212,9 +1212,10 @@ pub fn main() !void {
     var tsconfig = TsConfig.loadFromPath(allocator, tsconfig_dir_early) catch TsConfig{};
     defer tsconfig.deinit();
 
-    // tsconfig paths → alias 변환 결과. main 함수 끝까지 유지해야 alias 슬라이스가 dangle 하지 않음.
-    var normalized_paths: lib.config.NormalizedPaths = .{ .entries = &.{}, .owned_strings = &.{} };
-    defer normalized_paths.deinit(allocator);
+    // tsconfig `paths` 를 resolver 용 절대 경로 형태로 정규화. main 함수 끝까지 유지해야
+    // bundler 가 shallow-copy 한 슬라이스가 dangle 하지 않는다.
+    var resolved_paths: lib.config.ResolvedPaths = .{ .entries = &.{}, .owned_strings = &.{} };
+    defer resolved_paths.deinit(allocator);
 
     // tsconfig 값 적용 — CLI 옵션이 우선, 미지정 옵션만 tsconfig에서 가져옴
     if (opts.module_format == .esm) {
@@ -1265,17 +1266,15 @@ pub fn main() !void {
         opts.jsx_import_source = tsconfig.jsx_import_source;
     }
 
-    // tsconfig `paths` / `baseUrl` → alias_list 뒤에 append.
-    // applyAlias 는 리스트 순서대로 매칭하므로 사용자 `--alias` (앞) 가 우선.
+    // tsconfig `paths` / `baseUrl` → resolver 의 `ts_paths` 로 전달.
+    // TS 스펙: 다중 candidate + wildcard anywhere + 후보 순차 시도를 resolver 가 수행한다.
+    // 사용자 `--alias` 는 alias 경로로 계속 처리 — 둘은 독립이며 paths 가 먼저 매칭된다.
     if (tsconfig.paths.len > 0) {
         const dir_for_join = lib.config.tsconfigDirFromPath(tsconfig_dir_early);
-        normalized_paths = lib.config.normalizePathsToAliases(allocator, dir_for_join, &tsconfig) catch |err| blk: {
-            try stderr.print("zts: warning: tsconfig paths normalization failed: {}\n", .{err});
-            break :blk lib.config.NormalizedPaths{ .entries = &.{}, .owned_strings = &.{} };
+        resolved_paths = lib.config.resolveTsPaths(allocator, dir_for_join, &tsconfig) catch |err| blk: {
+            try stderr.print("zts: warning: tsconfig paths resolution failed: {}\n", .{err});
+            break :blk lib.config.ResolvedPaths{ .entries = &.{}, .owned_strings = &.{} };
         };
-        for (normalized_paths.entries) |e| {
-            try opts.alias_list.append(allocator, .{ .from = e.from, .to = e.to });
-        }
     }
 
     // --bundle
@@ -1445,6 +1444,7 @@ pub fn main() !void {
             .timing = opts.timing,
             .preserve_symlinks = opts.preserve_symlinks,
             .alias = opts.alias_list.items,
+            .ts_paths = resolved_paths.entries,
             .fallback = opts.fallback_list.items,
             .block_list = opts.block_list.items,
             .public_path = opts.public_path orelse "",


### PR DESCRIPTION
## Summary

\`tsconfig.json\` 의 \`compilerOptions.paths\` 를 **TS 공식 스펙 호환** 으로 업그레이드. #1548 의 v1 제약 (suffix-only wildcard / 단일 후보) 을 제거하고 Vite/rspack/tsc 와 동일한 거동 제공.

## 동기

#1548 머지 후 사용자 피드백: \"tsconfig.json 이랑 동일한 스펙으로 됐으면\". TS 공식은 아래 두 기능이 핵심인데 v1 에선 미지원.

| 기능 | TS 공식 | ZTS v1 (#1548) | **본 PR** |
|------|---------|-----------------|-----------|
| \`*\` 위치 자유 (prefix/middle/suffix) | ✅ | ❌ (suffix-only) | ✅ |
| value 배열 다중 후보 순차 시도 | ✅ | ❌ (첫 번째만) | ✅ |
| 파일 존재 기반 fallback | ✅ | ❌ | ✅ |
| 비대칭 wildcard/2중 \`*\` 스킵 | ❌ 에러 | silent | silent skip |

## 설계 변화

기존 v1 은 tsconfig paths 를 \`--alias\` 엔트리로 convert 해서 resolver 의 \`applyAlias\` 를 재사용했다. 이 방식은 wildcard anywhere / 파일 존재 체크를 지원 못해서 **resolver 가 ts_paths 를 직접 매칭** 하도록 데이터 흐름을 바꿨다.

- \`TsConfig.PathEntry\` 재설계: \`{from, to}\` → \`{key_prefix, key_suffix, has_wildcard, targets[]}\`
- \`splitWildcard\` 로 key/target 을 \`*\` 기준 분리 (\`@pkg/*/types\` → prefix=\`@pkg/\`, suffix=\`/types\`)
- \`config.resolveTsPaths\`: target.prefix 를 절대경로로 join (path.join 만 — 끝의 \`/\` 보존 필요)
- \`Resolver.ts_paths\` + \`tryTsPaths\` / \`tryResolveAbsolutePath\`: resolve 초입에서 매칭 → candidates 순차 시도 → 첫 resolvable 반환
- CLI / NAPI 파이프라인: alias 로의 convert 제거, \`BundleOptions.ts_paths\` 직접 전달

## 우선순위
**\`--alias\` > tsconfig paths > 일반 resolve**. 사용자 CLI 옵션이 항상 우선.

## 사용 예

\`\`\`jsonc
// tsconfig.json
{
  \"compilerOptions\": {
    \"baseUrl\": \".\",
    \"paths\": {
      \"@pkg/*/types\": [\"./packages/*/src/types.ts\"],
      \"@lib\": [\"./vendor/primary.ts\", \"./vendor/fallback.ts\"]
    }
  }
}
\`\`\`

\`\`\`ts
import { T } from \"@pkg/foo/types\";  // → ./packages/foo/src/types.ts
import { T } from \"@pkg/bar/types\";  // → ./packages/bar/src/types.ts
import { L } from \"@lib\";            // → primary 없으면 fallback.ts
\`\`\`

## Test plan
- [x] \`zig build test\` — 전체 통과
- [x] \`bun test packages/core/bin/zts.test.ts\` — 70/70 통과 (중간 wildcard / 다중 후보 fallback 회귀 2건 추가)
- [x] 수동: CLI + NAPI 양쪽 모두에서 middle-wildcard + 다중 후보 fallback 동작 확인

## Lifetime 이슈 (개발 중 잡은 것)

NAPI 는 \`tsconfig_holder\` 가 \`parseBuildOptions\` 함수 scope 수명. key_prefix 를 원본 subspan 참조로 놔두면 resolver 실행 시 TsConfig deinit 후 dangling. \`resolveTsPaths\` 가 key_prefix/key_suffix/target.prefix/target.suffix 전부 \`allocator.dupe\` 해 독립 수명 보장.

## 관련 PR
- #1548 (v1 — alias convert 방식) — 본 PR 이 대체

🤖 Generated with [Claude Code](https://claude.com/claude-code)