### PR TITLE
fix(tree_shaker): 가짜 used_exports 정정으로 tree-shake 누수 해결 (#1551)

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1506,3 +1506,116 @@ test "#1291 실제 증상: \"use strict\" + non-simple params 있는 모듈이 g
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_lib = __commonJS") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = foo") != null);
 }
+
+test "TreeShaking: dead statement references don't keep upstream module (#1551)" {
+    // svelte/store readable 누수 재현:
+    //   entry → barrel의 readable만 사용. barrel 내 unused_fn이 runtime를 참조.
+    //   unused_fn은 statement-level DCE로 제거되지만 AST에 참조가 남아
+    //   processModuleImports의 reference_count > 0 판정에 의해 runtime이
+    //   가짜 used로 마킹되는 문제(#1551). pruneUnreachableExports가 정정.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "runtime.ts",
+        \\export const UPSTREAM_MARKER = "RUNTIME_LEAKED";
+        \\export const UPSTREAM_B = "B_LEAKED";
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import { UPSTREAM_MARKER, UPSTREAM_B } from './runtime';
+        \\export function readable(v: number) { return { value: v }; }
+        \\export function unused_fn() {
+        \\  return UPSTREAM_MARKER + UPSTREAM_B;
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { readable } from './barrel';
+        \\console.log(readable(42).value);
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "readable") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "RUNTIME_LEAKED") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "B_LEAKED") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "unused_fn") == null);
+}
+
+test "TreeShaking: dead statement import chain 2 hops removed (#1551)" {
+    // 2-hop 체인: entry → mid. mid는 live export + dead export.
+    // dead 함수 안에서만 runtime 참조 — 체인 전체가 제거되어야 함.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "runtime.ts",
+        \\export const RUNTIME_TWO_HOP_MARKER = "LEAKED_TWO_HOP";
+    );
+    try writeFile(tmp.dir, "mid.ts",
+        \\import { RUNTIME_TWO_HOP_MARKER } from './runtime';
+        \\export function used_mid(n: number) { return n * 2; }
+        \\export function dead_mid() { return RUNTIME_TWO_HOP_MARKER; }
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used_mid } from './mid';
+        \\console.log(used_mid(21));
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "used_mid") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LEAKED_TWO_HOP") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "dead_mid") == null);
+}
+
+test "TreeShaking: live statement preserves upstream module (#1551 anti-regression)" {
+    // 반대 케이스: runtime import가 live 함수에서 참조되면 runtime 모듈은 보존.
+    // 보호 모듈 집합(alias 타겟)이 정상 동작하는지 검증.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "runtime.ts",
+        \\export const RUNTIME_LIVE = "RUNTIME_STILL_NEEDED";
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import { RUNTIME_LIVE } from './runtime';
+        \\export function hello() { return RUNTIME_LIVE; }
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { hello } from './barrel';
+        \\console.log(hello());
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "RUNTIME_STILL_NEEDED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "hello") != null);
+}

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -289,6 +289,11 @@ pub const TreeShaker = struct {
         try self.buildSymToIbMaps();
         try self.crossModuleBFS(module_stmt_infos, reachable_stmts);
 
+        // BFS 결과 기반 used_exports 정정(#1551):
+        // 첫 fixpoint가 AST 전체 reference_count 신호로 마킹한 "가짜 used"를,
+        // statement-level reachability로 제거한다. 이후 아래 included prune이 정상 동작.
+        try self.pruneUnreachableExports();
+
         // 미사용 sideEffects=false 모듈 제거
         for (self.modules, 0..) |m, i| {
             if (!self.included.isSet(i)) continue;
@@ -482,24 +487,31 @@ pub const TreeShaker = struct {
                 }
             }
 
-            // used export 선언 statement 시드 (rolldown include_symbol 동등).
-            // entry: 모든 export. sideEffects:false: fixpoint에서 used인 export만.
-            // sideEffects:true non-entry: BFS가 side-effect statement에서 시작하므로 불필요.
-            if (self.entry_set.isSet(i) or !m.side_effects) {
+            // used export 선언 statement 시드(#1551).
+            // 시드 대상:
+            //   (1) entry: 번들 외부 사용자가 접근 가능 — 모든 export live.
+            //   (2) "*" sentinel이 마킹된 모듈: markAllExportsUsed 호출 대상
+            //       = dynamic import target(#1260), namespace import, export * 전파.
+            //       모듈 전체가 live여야 하므로 모든 export 선언을 시드.
+            // non-entry·'*' 없음: followImport만으로 도달 — 이전 fixpoint의
+            //   processModuleImports(null)가 AST 전체 reference_count로 마킹한
+            //   "가짜 used"로 시드하면, dead statement의 참조가 BFS로 확산되어
+            //   pruneUnreachableExports가 제거하지 못한다(tree-shake 누수).
+            // side_effects=true non-entry는 위쪽 side-effect statement 시드로 커버.
+            const is_bfs_seed = self.entry_set.isSet(i) or self.isExportUsed(@intCast(i), "*");
+            if (is_bfs_seed) {
                 const sem = m.semantic orelse continue;
                 if (sem.scope_maps.len == 0) continue;
-                const mi: u32 = @intCast(i);
                 for (m.export_bindings) |eb| {
                     if (eb.kind.isReExportAll()) continue;
-                    if (!self.entry_set.isSet(i) and !self.isExportUsed(mi, eb.exported_name)) continue;
                     const sym_idx = eb.symbol.semanticIndex() orelse continue;
                     if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
                         try self.enqueue(@intCast(i), stmt_idx, reachable_stmts, &queue);
                     }
                 }
-                if (self.entry_set.isSet(i)) {
-                    try self.seedOpaqueModule(@intCast(i), &queue, module_stmt_infos, reachable_stmts);
-                }
+                // dynamic import target도 re-export 체인 따라 transitive 모듈까지
+                // 전파해야 함(#1260). seedOpaqueModule은 opaque_visited로 중복 방지.
+                try self.seedOpaqueModule(@intCast(i), &queue, module_stmt_infos, reachable_stmts);
             }
         }
 
@@ -920,6 +932,106 @@ pub const TreeShaker = struct {
         // O(1) per-module used export 플래그 갱신
         if (module_index < self.has_direct_used_export.len) {
             self.has_direct_used_export[module_index] = true;
+        }
+    }
+
+    /// used_exports에서 (module, export) 항목을 제거한다.
+    /// 가짜 used 정정(#1551)에서 사용.
+    fn unmarkExportUsed(self: *TreeShaker, module_index: u32, export_name: []const u8) void {
+        var key_buf: [4096]u8 = undefined;
+        const lookup_key = types.makeModuleKeyBuf(&key_buf, module_index, export_name);
+        if (self.used_exports.fetchRemove(lookup_key)) |kv| {
+            self.allocator.free(kv.key);
+        }
+    }
+
+    /// crossModuleBFS 결과 기반으로 **모듈 전체**가 unreachable한 경우만 제거한다(#1551).
+    ///
+    /// **배경**: analyze() 첫 패스의 fixpoint에서 processModuleImports는
+    /// `isImportBindingUsed`의 AST 전체 reference_count > 0 신호에 의존해
+    /// used_exports를 채운다. 그러나 참조가 "이 모듈에서 이후 dead로 판정되는
+    /// statement" 안에 있어도 카운트 > 0이므로 가짜 used가 마킹된다. 결과적으로
+    /// 상류(upstream) 모듈 전체가 included로 유지되어 tree-shake 누수 발생.
+    ///
+    /// 본 함수는 BFS로 결정된 statement-level reachability를 권위 있는 source로
+    /// 삼아, **모듈의 모든 export 선언이 unreachable**인 경우에만 해당 모듈의
+    /// used_exports를 전부 제거한다. 이후 analyze() 말미의 included prune 루프가
+    /// 해당 상류 모듈을 included에서 정상 배제한다.
+    ///
+    /// **부분 export 제거는 수행하지 않음**. linker가 canonical symbol을 참조하는
+    /// alias 선언(`const Local$N = Canonical$M;`)을 emit할 수 있는데, 개별 export만
+    /// 제거하면 canonical이 사라져 dangling reference(ReferenceError)가 된다.
+    /// 모듈 통째 제거는 해당 모듈의 모든 선언과 alias를 함께 드롭하므로 안전하다.
+    ///
+    /// 보호 규칙:
+    ///   - 진입점(entry_set): 외부 사용자 접근 가능 — 제거 금지.
+    ///   - side_effects=true: import 자체가 사이드이펙트 — 원본 유지.
+    ///   - wrapped(CJS/ESM wrap): statement 경계 부재 — prune 불가.
+    ///   - "*" sentinel: dynamic import / namespace import / export * 대상.
+    ///   - **alias 타겟 보호**: 다른 included 모듈의 live import_binding이 이 모듈의
+    ///     export를 참조 중인 경우 해당 모듈 전체 보존.
+    fn pruneUnreachableExports(self: *TreeShaker) !void {
+        if (self.module_stmt_infos.len == 0 or self.reachable_stmts.len == 0) return;
+
+        // Step 1: alias 타겟 보호 모듈 수집.
+        var protected_modules = try std.DynamicBitSet.initEmpty(self.allocator, self.modules.len);
+        defer protected_modules.deinit();
+
+        for (self.modules, 0..) |m, mi| {
+            if (!self.included.isSet(mi)) continue;
+
+            for (m.import_bindings) |ib| {
+                if (ib.import_record_index >= m.import_records.len) continue;
+                const rec = m.import_records[ib.import_record_index];
+                if (rec.resolved.isNone()) continue;
+
+                // reachable_stmts 없는 모듈(entry/opaque)은 보수적으로 live 취급.
+                const is_live = if (mi < self.reachable_stmts.len and self.reachable_stmts[mi] != null)
+                    self.isImportLiveInModule(@intCast(mi), ib.local_name)
+                else
+                    true;
+                if (!is_live) continue;
+
+                const target_mod = @intFromEnum(rec.resolved);
+                if (target_mod < self.modules.len) {
+                    protected_modules.set(target_mod);
+                    if (self.linker.resolveExportChain(rec.resolved, ib.imported_name, 0)) |c| {
+                        const canon_mod = @intFromEnum(c.module_index);
+                        if (canon_mod < self.modules.len) protected_modules.set(canon_mod);
+                    }
+                }
+            }
+        }
+
+        // Step 2: 모듈 단위 dead 판정 + 제거.
+        for (self.modules, 0..) |m, i| {
+            if (self.entry_set.isSet(i)) continue;
+            if (m.side_effects) continue;
+            if (m.wrap_kind.isWrapped()) continue;
+            if (self.isExportUsed(@intCast(i), "*")) continue;
+            if (protected_modules.isSet(i)) continue;
+
+            const infos = self.module_stmt_infos[i] orelse continue;
+            const reachable = self.reachable_stmts[i] orelse continue;
+
+            // 모든 export 선언 statement가 unreachable인가?
+            // re-export-all 또는 symbol 해석 실패 1건이라도 있으면 보수적으로 유지.
+            const all_dead = blk: for (m.export_bindings) |eb| {
+                if (eb.kind.isReExportAll()) break :blk false;
+                const sym_idx = eb.symbol.semanticIndex() orelse break :blk false;
+                const stmt_idx = infos.declaredStmtBySymbol(@intCast(sym_idx)) orelse break :blk false;
+                if (reachable.isSet(stmt_idx)) break :blk false;
+            } else true;
+            if (!all_dead) continue;
+
+            for (m.export_bindings) |eb| {
+                self.unmarkExportUsed(@intCast(i), eb.exported_name);
+            }
+            self.unmarkExportUsed(@intCast(i), "*");
+            // 전부 unmark 되었으므로 has_direct_used_export는 자명히 false.
+            if (i < self.has_direct_used_export.len) {
+                self.has_direct_used_export[i] = false;
+            }
         }
     }
 


### PR DESCRIPTION
## 요약

`svelte/store`의 `readable` 한 개만 import하는 CI smoke 시나리오에서 **71 KB → 18 KB (-74.6%)** 로 tree-shake 누수를 해결합니다. Issue #1551의 모듈-수준 1단계.

## 문제

### 재현 (축소 repro)

```js
// runtime.js
export const active_effect = null;
export const active_reaction = null;
// ... (4개 export)

// barrel.js — readable과 unused_fn을 export, runtime을 import
import { active_effect, active_reaction, ... } from './runtime.js';
export function readable(v) { return { subscribe: () => () => {} }; }
export function unused_fn() { return active_effect + active_reaction + ...; }  // dead 경로

// entry.js
import { readable } from './barrel.js';
console.log(readable(0));
```

**기대**: `runtime.js` 전체 제거.
**실제 (수정 전)**: runtime 4개 선언이 전부 번들에 살아남음 → 259 B (vs esbuild 86 B).

## 원인

`tree_shaker.zig`의 2-phase 구조에서 **1차 fixpoint**의 `processModuleImports(null)`이 `isImportBindingUsed`의 `semantic.symbols[sym_idx].reference_count > 0` 신호로 `used_exports`를 마킹합니다. 이 `reference_count`는 **AST 전체**의 참조 수 — 이후 statement-level DCE로 제거될 dead statement(예: 위 `unused_fn`) 내부의 참조도 포함합니다.

결과:
1. `barrel.js`의 `active_effect` import가 `unused_fn`에서만 쓰이지만 `reference_count = 1` → used.
2. `markExportUsed(runtime, "active_effect")` 호출 → `runtime.js`가 `included`에 들어감.
3. **2차** `crossModuleBFS`가 정확한 statement reachability를 계산하지만, BFS **seed 단계**가 **1차의 가짜 `used_exports`를 그대로 읽어** dead statement의 선언을 reachable로 마킹.
4. 결국 fixpoint 말미의 `hasAnyUsedExport` 체크로 `runtime.js`가 prune되지 못함.

## 수정 내용

두 곳 수정:

### 1. BFS seed 단계의 가짜 used 확산 차단 (`crossModuleBFS`)

**Before**
```zig
if (self.entry_set.isSet(i) or !m.side_effects) {
    for (m.export_bindings) |eb| {
        if (!self.entry_set.isSet(i) and !self.isExportUsed(mi, eb.exported_name)) continue;
        // ...seed
    }
    if (self.entry_set.isSet(i)) {
        try self.seedOpaqueModule(...);
    }
}
```

**After**
```zig
// entry + "*" sentinel(dynamic import / namespace / export * 대상)만 seed.
// non-entry는 followImport만으로 도달 — 가짜 used가 BFS로 확산되는 경로 차단.
const is_bfs_seed = self.entry_set.isSet(i) or self.isExportUsed(@intCast(i), "*");
if (is_bfs_seed) {
    for (m.export_bindings) |eb| {
        // isExportUsed 조건 제거 — entry/"*" 모듈의 모든 export는 무조건 live.
        // ...seed
    }
    // seedOpaqueModule을 "*" 모듈까지 확장 — #1260 dynamic import 체인의
    // transitive 모듈 전파.
    try self.seedOpaqueModule(...);
}
```

핵심 변화:
- non-entry + `side_effects=false` 모듈의 **used_exports 기반 seed 로직 제거**. followImport가 정확한 경로로 도달.
- `seedOpaqueModule` 호출을 `"*"` sentinel 모듈까지 확장 → #1260 dynamic import 타겟의 re-export 체인 보존.

### 2. BFS 결과 기반 `used_exports` 정정 (`pruneUnreachableExports`)

`analyze()` 말미에 새 단계 추가:

- **Step 1 (보호 모듈 수집)**: 모든 included 모듈 순회 → `import_binding`이 `isImportLiveInModule`(= live statement에서 참조)인 경우, 그 타겟 모듈과 `resolveExportChain`의 canonical 모듈을 `protected_modules` bitset에 마킹.
- **Step 2 (모듈 단위 dead 판정)**: 각 비엔트리·`side_effects=false`·non-wrapped·non-`"*"`·non-protected 모듈에 대해, **모든 export의 선언 statement가 unreachable**이면 해당 모듈의 `used_exports` 전체 + `"*"` sentinel 제거.

이후 기존 "미사용 `sideEffects=false` 모듈 제거" 루프가 정상 동작해 `included`에서 unset.

### 왜 모듈 단위 제거인가

linker가 canonical symbol을 참조하는 alias 선언(`const Local$N = Canonical$M;`)을 emit할 수 있습니다. 개별 export만 제거하면 canonical이 사라져 dangling reference로 `ReferenceError` 발생. 모듈 통째 제거는 해당 모듈의 alias도 함께 드롭되므로 안전합니다. 진정한 symbol-level tree-shaking은 linker 정합성 재설계가 필요한 **별도 이슈**(후속 작업 참고).

## 안전 장치

| 규칙 | 이유 |
|---|---|
| `entry_set` 제외 | 외부 사용자 접근 가능 |
| `side_effects=true` 제외 | import 자체가 사이드이펙트 |
| `wrap_kind.isWrapped()` 제외 | statement 경계 부재 (CJS/ESM wrap) |
| `"*"` sentinel 제외 | dynamic import / namespace import / export * 대상 |
| **alias 타겟 보호 모듈** 제외 | linker alias emit 정합성 |

## 측정

### 단일 시나리오

| Bundler | CI smoke (readable 하나) | svelte 풀세트 (19 export) |
|---|---:|---:|
| **ZTS 수정 전** | 71 KB | 92 KB |
| **ZTS 수정 후** | **18 KB (-74.6%)** | **77 KB (-17%)** |
| esbuild | 4.7 KB | 46 KB |
| rolldown | 3.5 KB | 38 KB |
| rspack | 197 KB | 32 KB |

esbuild/rolldown 수준(≈1 KB)까지 내려가지 않는 이유는 이 PR이 **모듈 통째 제거**만 수행하고 symbol-level tree-shake은 하지 않기 때문. 그 격차는 후속 작업:
- #1552 (minify: top-level mangle, `process.env.NODE_ENV` 상수 폴딩)
- 별도 이슈 (linker alias ⇔ reachable 정합성, effect `Order$6` 수정)

### 전수 회귀 (smoke, 264 프로젝트)

| 카테고리 | main | 이 PR |
|---|---|---|
| ZTS FAIL | 3건 (effect, mobx, lru-cache@es2021) | **동일 3건 — 회귀 0** |
| 크기 감소 예시 | — | drizzle 20→13 KB, toolkit 65→42 KB, cheerio 1755→1646 KB, fast-glob 165→160 KB, micromatch 82→76 KB 등 |

기존 FAIL 3건은 이 PR과 무관한 별개 linker/CJS 이슈(effect는 linker alias 정합성, mobx는 이전부터 존재).

### 유닛 테스트

기존 3,029건 전원 통과 + **신규 3건 추가** (모두 통과):

- `TreeShaking: dead statement references don't keep upstream module (#1551)` — 핵심 repro
- `TreeShaking: dead statement import chain 2 hops removed (#1551)` — 2-hop 체인
- `TreeShaking: live statement preserves upstream module (#1551 anti-regression)` — 보호 로직 검증

## 구현 상세 (Zig 초보자용)

- `std.DynamicBitSet`: 가변 크기 bitset. `protected_modules`에 사용.
- `fetchRemove` 후 `allocator.free(kv.key)`: HashMap에서 제거하면서 key 문자열 소유권을 수동 해제.
- `blk: for (...) { ...; break :blk false; } else true`: Zig의 for-else + labeled block — for이 break 없이 끝나면 `else` 값이 반환. "모든 원소가 조건을 만족"을 단일 식으로 표현.
- `@intFromEnum(ModuleIndex)`: enum을 내부 정수로 변환 (기존 패턴; 추상화 개선은 #1553에서).

## 관련

- Part of #1551 — 이 PR이 tree-shake 누수의 모듈-수준 부분을 해결.
- #1553 — `"*"` sentinel 상수화, SymbolRef 추상화, 테스트 헬퍼 (리팩터링 별도 PR).
- #1554 — `resolveExportChain` memo / import-liveness 캐시 (측정 후 hot path 개선).
- 후속 (별도) — linker alias ⇔ reachable 정합성 (effect `Order$6` 수정, symbol-level tree-shake 전환).
- #1552 — minify(top-level identifier mangle, NODE_ENV 상수 폴딩).

## 확인

- [x] `zig build test` 전원 통과 (3,032건)
- [x] 유닛 테스트 3건 신규 추가
- [x] svelte smoke 크기 감소 확인 (71→18 KB)
- [x] main 대비 smoke 전수 회귀 없음
- [x] `/simplify` 리뷰 반영 (`recomputeHasDirectUsedExport` 제거, `all_dead` for-else 평탄화)