### PR TITLE
feat(define): optional chaining + globalThis root 자동 매칭 + auto-define 확장 (#1552)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -793,10 +793,13 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
         opts.bundle_format = .iife;
     }
 
-    // --bundle + --platform=browser/react-native이면 자동 define (esbuild 호환).
-    // 트랜스파일 모드에서는 적용하지 않음 (esbuild와 동일).
-    // 사용자가 이미 동일 키를 --define: 로 지정한 경우 덮어쓰지 않음.
-    if (opts.is_bundle and opts.platform.isBrowserLike()) {
+    // 자동 define:
+    //   - `--bundle` + browser/react-native: esbuild 호환 — DOM/Metro 환경은 build-time 결정.
+    //   - `--bundle` + `--minify-syntax`: Vite 호환 — 프로덕션 배포 의도 신호로 간주(#1552).
+    // 트랜스파일 모드에서는 적용하지 않음. 사용자가 --define: 으로 명시 지정한 키는 덮어쓰지 않음.
+    // Node 서버 번들에서 runtime NODE_ENV를 원하면 `--minify-syntax` 없이 `--bundle`만 쓰거나
+    // `--define:process.env.NODE_ENV=process.env.NODE_ENV`로 identity 지정.
+    if (opts.is_bundle and (opts.platform.isBrowserLike() or opts.minify_syntax)) {
         var has_node_env = false;
         var has_dev = false;
         for (opts.define_list.items) |d| {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -67,6 +67,33 @@ pub const DefineEntry = struct {
     value: []const u8,
 };
 
+/// 정규화 버퍼 크기. `process.env.NODE_ENV`류 식별자 체인은 훨씬 짧지만 여유.
+/// 초과 시 normalizeOptionalChain은 null을 반환해 치환을 스킵한다.
+const DEFINE_KEY_NORM_BUF: usize = 256;
+
+/// 번들 맥락에서 의미 없는 global root 접두어.
+/// `globalThis.X`, `window.X`, `self.X` → X로 간주해 define 키와 매칭.
+const GLOBAL_ROOT_PREFIXES = [_][]const u8{ "globalThis.", "window.", "self." };
+
+/// optional chaining 토큰 `?.`를 `.`로 치환한 정규화 문자열을 buf에 쓴다.
+/// 정규화된 길이가 buf 용량을 초과하면 null (극히 드문 경로 — 치환 포기).
+fn normalizeOptionalChain(text: []const u8, buf: []u8) ?[]const u8 {
+    const needed = std.mem.replacementSize(u8, text, "?.", ".");
+    if (needed > buf.len) return null;
+    _ = std.mem.replace(u8, text, "?.", ".", buf);
+    return buf[0..needed];
+}
+
+/// define 키 매칭 — 엄격 일치 또는 GLOBAL_ROOT_PREFIXES 제거 후 일치.
+/// 예: `globalThis.process.env.NODE_ENV`를 키 `process.env.NODE_ENV`로 매치.
+fn matchDefineKey(text: []const u8, key: []const u8) bool {
+    if (std.mem.eql(u8, text, key)) return true;
+    for (GLOBAL_ROOT_PREFIXES) |pfx| {
+        if (std.mem.startsWith(u8, text, pfx) and std.mem.eql(u8, text[pfx.len..], key)) return true;
+    }
+    return false;
+}
+
 /// Transformer 설정.
 pub const TransformOptions = struct {
     /// TS 타입 스트리핑 활성화 (기본: true)
@@ -2039,32 +2066,46 @@ pub const Transformer = struct {
     }
 
     /// 노드가 define 치환 대상이면 새 string_literal 노드를 반환.
-    /// 대상: identifier_reference 또는 static_member_expression 체인.
+    /// 대상: identifier_reference / static_member_expression / chain_expression.
+    ///
+    /// 매칭 규칙(#1552):
+    ///   - optional chaining(`?.`)이 포함된 식은 `.`로 정규화 후 매칭.
+    ///     방어적 접근 패턴(`globalThis.process?.env?.NODE_ENV`)까지 커버.
+    ///   - `globalThis.` / `window.` / `self.` 접두어는 번들 맥락에서 의미 없는
+    ///     global root이므로 벗기고 define key와 비교.
     fn tryDefineReplace(self: *Transformer, node: Node) ?Error!NodeIndex {
-        // 노드의 소스 텍스트를 define key와 비교
-        const text = self.getNodeText(node) orelse return null;
+        const raw_text = self.getNodeText(node) orelse return null;
+
+        // parser는 `a?.b`를 chain_expression 없이 static_member_expression + optional
+        // flag로 표현하므로, `?` 존재 여부로만 정규화 필요를 판별.
+        var norm_buf: [DEFINE_KEY_NORM_BUF]u8 = undefined;
+        const text = if (std.mem.indexOfScalar(u8, raw_text, '?') != null)
+            normalizeOptionalChain(raw_text, &norm_buf) orelse return null
+        else
+            raw_text;
 
         for (self.options.define, 0..) |entry, i| {
-            if (std.mem.eql(u8, text, entry.key)) {
-                const value_span = self.define_spans[i];
-                // 값이 따옴표로 시작하면 string_literal, 아니면 identifier_reference.
-                // "production" → string_literal, false/true/숫자 → identifier_reference.
-                const is_string = entry.value.len >= 2 and (entry.value[0] == '"' or entry.value[0] == '\'');
-                return self.ast.addNode(.{
-                    .tag = if (is_string) .string_literal else .identifier_reference,
-                    .span = value_span,
-                    .data = .{ .string_ref = value_span },
-                });
-            }
+            if (!matchDefineKey(text, entry.key)) continue;
+            const value_span = self.define_spans[i];
+            // 값이 따옴표로 시작하면 string_literal, 아니면 identifier_reference.
+            // "production" → string_literal, false/true/숫자 → identifier_reference.
+            const is_string = entry.value.len >= 2 and (entry.value[0] == '"' or entry.value[0] == '\'');
+            return self.ast.addNode(.{
+                .tag = if (is_string) .string_literal else .identifier_reference,
+                .span = value_span,
+                .data = .{ .string_ref = value_span },
+            });
         }
         return null;
     }
 
-    /// 노드의 소스 텍스트를 반환. identifier_reference와 static_member_expression만 지원.
+    /// 노드의 소스 텍스트를 반환. define 치환 대상 노드만 지원.
     fn getNodeText(self: *const Transformer, node: Node) ?[]const u8 {
         return switch (node.tag) {
-            .identifier_reference => self.ast.getText(node.span),
-            .static_member_expression => self.ast.getText(node.span),
+            .identifier_reference,
+            .static_member_expression,
+            .chain_expression,
+            => self.ast.getText(node.span),
             else => null,
         };
     }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1210,3 +1210,67 @@ test "verbatimModuleSyntax=true: 미사용 default import 보존" {
     try std.testing.expect(std.mem.indexOf(u8, result.code, "import") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.code, "foo") != null);
 }
+
+// ============================================================
+// --define 치환 (#1552)
+// ============================================================
+
+test "define: optional chaining + global root prefix 매칭" {
+    const Case = struct {
+        name: []const u8,
+        src: []const u8,
+        must_contain: []const []const u8,
+        must_not_contain: []const []const u8,
+    };
+    const defines = [_]transformer_mod.DefineEntry{
+        .{ .key = "process.env.NODE_ENV", .value = "\"production\"" },
+    };
+    const cases = [_]Case{
+        .{
+            .name = "simple chain",
+            .src = "const x = process.env.NODE_ENV;",
+            .must_contain = &.{"\"production\""},
+            .must_not_contain = &.{"process.env"},
+        },
+        .{
+            .name = "optional chaining (?.)",
+            .src = "const x = process?.env?.NODE_ENV;",
+            .must_contain = &.{"\"production\""},
+            .must_not_contain = &.{"?."},
+        },
+        .{
+            .name = "globalThis + optional chaining",
+            .src = "const x = globalThis.process?.env?.NODE_ENV;",
+            .must_contain = &.{"\"production\""},
+            .must_not_contain = &.{"globalThis"},
+        },
+        .{
+            // anti-regression: 이름이 비슷하지만 다른 식은 치환하지 않아야.
+            .name = "unrelated identifiers preserved",
+            .src = "const a = process.env.PORT; const b = other.env.NODE_ENV;",
+            .must_contain = &.{ "process.env.PORT", "other.env.NODE_ENV" },
+            .must_not_contain = &.{"\"production\""},
+        },
+    };
+    for (cases) |c| {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            c.src,
+            "input.ts",
+            .{ .define = &defines },
+        );
+        defer result.deinit(std.testing.allocator);
+        for (c.must_contain) |needle| {
+            std.testing.expect(std.mem.indexOf(u8, result.code, needle) != null) catch |e| {
+                std.debug.print("case '{s}': expected substring '{s}' in {s}\n", .{ c.name, needle, result.code });
+                return e;
+            };
+        }
+        for (c.must_not_contain) |forbidden| {
+            std.testing.expect(std.mem.indexOf(u8, result.code, forbidden) == null) catch |e| {
+                std.debug.print("case '{s}': forbidden substring '{s}' found in {s}\n", .{ c.name, forbidden, result.code });
+                return e;
+            };
+        }
+    }
+}


### PR DESCRIPTION
## 요약

`--define` 치환에서 누락됐던 두 패턴을 지원하도록 확장합니다.

1. **Optional chaining** — `process?.env?.NODE_ENV`, `globalThis.process?.env?.NODE_ENV` 같은 방어적 접근 패턴.
2. **Global root 접두어 자동 제거** — `globalThis.` / `window.` / `self.` 접두어는 define key와 매칭 시 무시.

추가로 auto-define 범위를 `--bundle + --minify-syntax` 조합까지 확장해 Node 타겟 프로덕션 번들에서도 `process.env.NODE_ENV`가 자동으로 `"production"`으로 접힙니다 (Vite 호환).

Issue #1552의 P1 범위.

## 문제

### 패턴 누락

svelte/store의 진입(`src/index-client.js`)처럼 여러 라이브러리가 DEV 분기 진입 전에 **방어적으로** global과 runtime 접근을 optional chaining으로 감쌉니다.

```js
// svelte/src/internal/flags/index.js 유사 패턴
const at = globalThis.process?.env?.NODE_ENV;
const dev = at && !at.toLowerCase().startsWith("prod");
```

- 기존 `tryDefineReplace`는 `identifier_reference` / `static_member_expression`의 **엄격 일치**만 지원.
- `?.` 토큰이 텍스트에 포함되어 `process.env.NODE_ENV` 키와 매칭 실패.
- 결과: `at`가 build-time 상수가 되지 못하고, DEV 분기도 그대로 남음.

### Auto-define 플랫폼 제한

`--bundle --platform=browser|react-native`에서만 auto-define이 동작. Node 타겟 앱 번들(예: SSR, lambda, CLI)에서는 매번 `--define:process.env.NODE_ENV=...` 필요 — esbuild와 달리 Vite 스타일의 "번들+최적화=프로덕션 신호" 관습이 없음.

## 수정

### 1. `tryDefineReplace` — optional chaining 정규화

`src/transformer/transformer.zig`

```zig
const DEFINE_KEY_NORM_BUF: usize = 256;

// parser는 `a?.b`를 chain_expression 없이 static_member_expression + optional
// flag로 표현하므로, `?` 존재 여부로만 정규화 필요를 판별.
var norm_buf: [DEFINE_KEY_NORM_BUF]u8 = undefined;
const text = if (std.mem.indexOfScalar(u8, raw_text, '?') != null)
    normalizeOptionalChain(raw_text, &norm_buf) orelse return null
else
    raw_text;
```

`normalizeOptionalChain`: `std.mem.replace`로 `?.` → `.` 치환. buf 초과 시 null 반환해 치환 스킵(극히 드문 경로).

### 2. `matchDefineKey` — global root 접두어 자동 제거

```zig
const GLOBAL_ROOT_PREFIXES = [_][]const u8{ "globalThis.", "window.", "self." };

fn matchDefineKey(text: []const u8, key: []const u8) bool {
    if (std.mem.eql(u8, text, key)) return true;
    for (GLOBAL_ROOT_PREFIXES) |pfx| {
        if (std.mem.startsWith(u8, text, pfx) and std.mem.eql(u8, text[pfx.len..], key)) return true;
    }
    return false;
}
```

엄격 일치 우선 → 실패 시 prefix 제거 후 재시도. 사용자가 정확히 `globalThis.process.env.NODE_ENV`를 key로 지정하면 그것도 매치.

### 3. Auto-define 조건 확장

`src/main.zig`

```zig
// 자동 define:
//   - `--bundle` + browser/react-native: esbuild 호환.
//   - `--bundle` + `--minify-syntax`: Vite 호환 — 프로덕션 배포 의도 신호.
if (opts.is_bundle and (opts.platform.isBrowserLike() or opts.minify_syntax)) {
```

Node 서버 번들에서 runtime NODE_ENV를 원하면 `--minify-syntax` 없이 돌리거나 identity override (`--define:process.env.NODE_ENV=process.env.NODE_ENV`).

## 측정

### 기능 검증 (단위 테스트)

`parseAndTransform` 수준에서 4개 패턴 모두 `"production"` 치환 확인:

| 패턴 | 결과 |
|---|---|
| `process.env.NODE_ENV` | → `"production"` (기존) |
| `process?.env?.NODE_ENV` | → `"production"` (신규) |
| `globalThis.process?.env?.NODE_ENV` | → `"production"` (신규) |
| `process.env.PORT` / `other.env.NODE_ENV` | 그대로 유지 (anti-regression) |

### smoke (264 프로젝트) — 회귀 없음

| 카테고리 | main | 이 PR |
|---|---|---|
| ZTS FAIL | 3건 (effect, mobx, lru-cache@es2021) | **동일 3건 — 회귀 0** |
| svelte | 18 KB | 18 KB (동일) |

**svelte 크기 감소가 미미한 이유**: svelte는 `at && !at.toLowerCase().startsWith("prod")`처럼 DEV 체크를 **runtime 메서드 호출**로 합성. 상수 폴딩은 리터럴 기반이라 `"production".toLowerCase()` 같은 메서드 콜을 접지 못함 — esbuild/rolldown도 동일 제약으로 DEV 에러 헬퍼가 완전히 제거되지 않음(각각 35/33개 DEV URL 잔존).

**실제 이득 예상**:
- `if (process.env.NODE_ENV !== "production") { ... }` 같은 **간단한 분기**를 쓰는 라이브러리 (react, preact, redux 류)에서 build-time DCE 작동.
- 이 PR의 smoke는 entry가 짧아 각 라이브러리의 DEV 분기를 타지 않아 ms/byte 단위로는 안 보이지만, 실 애플리케이션에서 번들마다 수 KB 감소 가능.

## `/simplify` 리뷰 반영

- `DEFINE_KEY_NORM_BUF` / `GLOBAL_ROOT_PREFIXES` 상수화
- 미사용 `parseAndTransformOpts` 헬퍼 제거
- 4개 테스트를 table-driven 1개로 통합
- 주석에서 "svelte 류" 하드코딩 제거 → "방어적 optional chaining 패턴"으로 중립화
- auto-define 주석 정확도 (esbuild vs Vite 구분)

## 관련

- Part of #1552 — 모듈-수준 대신 define/constant-folding 측면.
- 후속(별도): top-level identifier mangle(#1552 P2), peephole 확장(#1552 P3).

## 확인

- [x] `zig build test` 전원 통과
- [x] 단위 테스트 신규 1건 (table-driven 4 케이스)
- [x] smoke 264개 회귀 없음