### PR TITLE
feat(codegen): minify_syntax로 boolean 리터럴 !0/!1 축약 (#1552)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1004,6 +1004,8 @@ pub fn emitModule(
     // Codegen: AST → JS 문자열
     var cg = Codegen.initWithOptions(arena_alloc, &transformer.ast, .{
         .minify_whitespace = options.minify_whitespace,
+        // Peephole boolean 축약 등 codegen-레벨 출력 최적화(#1552).
+        .minify_syntax = options.minify_syntax,
         // scope-hoisted 모듈은 항상 ESM codegen 사용 (bare declarations).
         // __commonJS 래핑 모듈만 CJS codegen (module.exports = ...).
         // 래핑 모듈(CJS/ESM)은 CJS codegen: import→require 변환

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -319,6 +319,7 @@ pub fn emitEsmWrappedModule(
     if (hoisted_stmts.items.len > 0) {
         var hoist_cg = Codegen.initWithOptions(arena_alloc, esm_ast, .{
             .minify_whitespace = options.minify_whitespace,
+            .minify_syntax = options.minify_syntax,
             .module_format = .cjs,
             .skip_cjs_exports = true,
             .use_var_for_imports = true,
@@ -512,6 +513,7 @@ pub fn emitEsmWrappedModule(
     var func_preamble_lines: u32 = 0;
     var body_cg = Codegen.initWithOptions(arena_alloc, esm_ast, .{
         .minify_whitespace = options.minify_whitespace,
+        .minify_syntax = options.minify_syntax,
         .module_format = .cjs,
         .skip_cjs_exports = true,
         .use_var_for_imports = true,
@@ -534,6 +536,7 @@ pub fn emitEsmWrappedModule(
     if (body_func_stmts.items.len > 0) {
         var func_cg = Codegen.initWithOptions(arena_alloc, esm_ast, .{
             .minify_whitespace = options.minify_whitespace,
+            .minify_syntax = options.minify_syntax,
             .module_format = .cjs,
             .skip_cjs_exports = true,
             .use_var_for_imports = true,

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -79,6 +79,9 @@ pub const CodegenOptions = struct {
     newline: []const u8 = "\n",
     /// 공백/줄바꿈/들여쓰기 최소화
     minify_whitespace: bool = false,
+    /// Peephole 출력 최적화 — boolean literal을 `!0`/`!1`로 축약(#1552).
+    /// `minify_whitespace`와 독립적으로 켤 수 있음(transformer의 AST fold와 별개).
+    minify_syntax: bool = false,
     /// 소스맵 생성 활성화
     sourcemap: bool = false,
     /// non-ASCII 문자를 \uXXXX로 이스케이프 (D031)
@@ -835,7 +838,17 @@ pub const Codegen = struct {
             },
 
             // Literals
-            .boolean_literal,
+            .boolean_literal => {
+                // Peephole: true → !0, false → !1 (minify_syntax 활성화 시).
+                // #1552: 각 리터럴당 2-3 byte 절감. 출현 빈도 높아 총 크기 영향 있음.
+                // span의 첫 byte는 `t` 또는 `f`로 고정(렉서 불변식) — 한 byte 검사로 판별.
+                if (self.options.minify_syntax) {
+                    const text = self.ast.getText(node.span);
+                    try self.write(if (text.len > 0 and text[0] == 't') "!0" else "!1");
+                } else {
+                    try self.writeNodeSpan(node);
+                }
+            },
             .null_literal,
             .numeric_literal,
             .bigint_literal,

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -166,3 +166,45 @@ test "Codegen: string enum re-export" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"DELETE\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "export") != null);
 }
+
+// ============================================================
+// Peephole (#1552 P3): minify_syntax — boolean 축약
+// ============================================================
+
+test "Codegen minify_syntax: true → !0, false → !1" {
+    var r = try e2eWithOptions(
+        std.testing.allocator,
+        "const a = true; const b = false; if (a) console.log(b);",
+        .{ .minify_syntax = true },
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "!0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "!1") != null);
+    // 식별자 true/false 자체가 출력에 없어야
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "= true") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "= false") == null);
+}
+
+test "Codegen minify_syntax off: boolean 리터럴 유지 (anti-regression)" {
+    var r = try e2eWithOptions(
+        std.testing.allocator,
+        "const a = true;",
+        .{},
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "!0") == null);
+}
+
+test "Codegen: 원본 소스의 !0/!1은 minify_syntax와 무관하게 유지" {
+    // 안티 회귀: 소스가 이미 `!0`(unary_expression)이면 boolean_literal 분기를
+    // 타지 않으므로 변형이 없어야 한다.
+    var r = try e2eWithOptions(
+        std.testing.allocator,
+        "const x = !0; const y = !1;",
+        .{ .minify_syntax = true },
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "!0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "!1") != null);
+}

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -369,6 +369,7 @@ pub fn transpileWithCallback(
     var cg = Codegen.initWithOptions(arena_alloc, &transformer.ast, .{
         .module_format = options.module_format,
         .minify_whitespace = options.minify_whitespace,
+        .minify_syntax = options.minify_syntax,
         .sourcemap = options.sourcemap,
         .ascii_only = if (options.charset_utf8) false else options.ascii_only,
         .quote_style = options.quote_style,


### PR DESCRIPTION
## 요약

`true`/`false` 리터럴을 codegen 출력 시점에 `!0`/`!1`로 축약하는 peephole 최적화(esbuild/rolldown 표준). Issue #1552의 P3 범위 — 소규모 독립 PR.

리터럴당 2-3 byte 절감으로 작지만 출현 빈도가 높아 번들 전반에 누적 효과.

## 수정

### 1. Codegen 옵션

`src/codegen/codegen.zig`

```zig
/// Peephole 출력 최적화 — boolean literal을 `!0`/`!1`로 축약(#1552).
/// `minify_whitespace`와 독립적으로 켤 수 있음(transformer의 AST fold와 별개).
minify_syntax: bool = false,
```

### 2. boolean_literal 축약

```zig
.boolean_literal => {
    // span의 첫 byte는 `t` 또는 `f`로 고정(렉서 불변식) — 한 byte 검사로 판별.
    if (self.options.minify_syntax) {
        const text = self.ast.getText(node.span);
        try self.write(if (text.len > 0 and text[0] == 't') "!0" else "!1");
    } else {
        try self.writeNodeSpan(node);
    }
},
```

### 3. `minify_syntax` 전파

- `src/bundler/emitter.zig` — scope-hoisted 모듈 codegen.
- `src/bundler/emitter/esm_wrap.zig` — 3곳 (hoist/body/func).
- `src/transpile.zig` — standalone transpile 경로.

## 측정

### 단위 테스트 3건

| 케이스 | 기대 |
|---|---|
| on: `true`/`false` 입력 | `!0`/`!1` 출력 |
| off (기본): `true` 입력 | `true` 유지 (anti-regression) |
| on: 원본 `!0`/`!1` 입력 | `!0`/`!1` 보존 (unary_expression은 분기 안 탐) |

### 실 라이브러리

| | 이전 | 이후 | 절감 |
|---|---:|---:|---:|
| svelte 풀세트(19 export) | 77,242 B | 76,822 B | **−420 B** |
| svelte CI smoke(readable 하나) | 14,979 B | 14,958 B | −21 B |

smoke 264 프로젝트 회귀 0건 (기존 FAIL 3건 동일: effect/mobx/lru-cache@es2021).

## `/simplify` 반영

- `std.mem.eql(u8, text, "true")` → 첫 byte 비교로 단순화. 렉서 불변식에 의존해 안전.
- anti-regression: 원본 `!0`/`!1` 보존 테스트 추가.

## 구현 상세 (Zig 초보자용)

- `Codegen.Options.minify_syntax` — 구조체 필드, 기본 off.
- `text[0] == 't'` — `ast.getText(node.span)` slice에 직접 indexing, `text.len > 0` 가드 선행.
- 연산자 우선순위: `!0`/`!1`은 unary expression이라 `return`/`=`/template `${}` 어디에서도 괄호 없이 안전(`===`보다 우선순위 높음).

## 관련

- Part of #1552 — peephole 축약 한 건.
- 후속 (큰 효과 기대): P2 top-level identifier mangle (별도 시리즈).
- 후속 (작은 효과): `undefined` → `void 0` (scope shadowing 분석 필요로 별도).

## 확인

- [x] `zig build test` 전원 통과
- [x] 단위 테스트 3건 추가 (on/off/anti-regression)
- [x] smoke 264개 회귀 0건
- [x] svelte 풀세트 −420 B 확인