### PR TITLE
fix(tree_shaker): namespace import target "*" 마킹으로 E2E dangling 복구 (#1558)

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -762,8 +762,11 @@ test "TreeShaking: sideEffects:false + namespace import — symbol-based BFS see
     try std.testing.expect(!result.hasErrors());
     // TypeId가 번들에 포함 (namespace import를 통한 참조)
     try std.testing.expect(std.mem.indexOf(u8, result.output, "Symbol.for") != null);
-    // left는 미사용이므로 제거 (tree-shaking 정밀도)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "function left") == null);
+    // NOTE(#1558): 현재 namespace import는 target 모듈 전체를 보존한다 —
+    // processModuleImportsInner가 dead statement의 member access까지 커버하기 위해
+    // "*" sentinel을 마킹하는 보수 동작. 결과적으로 `left` 같은 미사용 export도 남는다.
+    // symbol-level 정밀 tree-shake은 #1558 (2→1 phase 재설계) 완료 후 복원 예정.
+    // try std.testing.expect(std.mem.indexOf(u8, result.output, "function left") == null);
 }
 
 test "TreeShaking: sideEffects:false deep re-export chain — symbol reachability" {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -875,6 +875,18 @@ pub const TreeShaker = struct {
                     }
                 }
             } else if (ib.kind == .namespace) {
+                // namespace import(`import * as x`)는 모든 member가 동적으로 접근 가능.
+                // 정적 분석으로 수집한 namespace_used_properties가 dead statement의
+                // 참조를 포함/누락하는 보수성 문제가 있어 "*" sentinel을 항상 마킹한다(#1558).
+                // "*"는 crossModuleBFS seed 조건(is_bfs_seed)을 충족시켜 target 모듈의
+                // 전체 statement가 reachable이 된다. esbuild/rolldown도 동일 의미론.
+                try self.markAllExportsUsed(@intCast(target_mod));
+                if (!self.included.isSet(target_mod)) {
+                    self.included.set(target_mod);
+                    newly_included = true;
+                }
+                // namespace_used_properties가 있으면 canonical 체인 전파도 유지.
+                // resolveExportChain이 중간 모듈(barrel)을 canonical까지 연결.
                 if (ib.namespace_used_properties) |props| {
                     for (props) |prop_name| {
                         if (self.linker.resolveExportChain(rec.resolved, prop_name, 0)) |c| {
@@ -887,14 +899,7 @@ pub const TreeShaker = struct {
                                 }
                             }
                         }
-                        try self.markExportUsed(@intCast(target_mod), prop_name);
                     }
-                } else {
-                    try self.markAllExportsUsed(@intCast(target_mod));
-                }
-                if (!self.included.isSet(target_mod)) {
-                    self.included.set(target_mod);
-                    newly_included = true;
                 }
             }
         }
@@ -985,6 +990,12 @@ pub const TreeShaker = struct {
                 const rec = m.import_records[ib.import_record_index];
                 if (rec.resolved.isNone()) continue;
 
+                const target_mod = @intFromEnum(rec.resolved);
+                if (target_mod >= self.modules.len) continue;
+
+                // namespace import의 target은 processModuleImportsInner에서 "*"로 마킹되어
+                // 아래 Step 2의 `isExportUsed(i, "*")` 가드로 자동 스킵 — 별도 보호 불필요.
+
                 // reachable_stmts 없는 모듈(entry/opaque)은 보수적으로 live 취급.
                 const is_live = if (mi < self.reachable_stmts.len and self.reachable_stmts[mi] != null)
                     self.isImportLiveInModule(@intCast(mi), ib.local_name)
@@ -992,13 +1003,10 @@ pub const TreeShaker = struct {
                     true;
                 if (!is_live) continue;
 
-                const target_mod = @intFromEnum(rec.resolved);
-                if (target_mod < self.modules.len) {
-                    protected_modules.set(target_mod);
-                    if (self.linker.resolveExportChain(rec.resolved, ib.imported_name, 0)) |c| {
-                        const canon_mod = @intFromEnum(c.module_index);
-                        if (canon_mod < self.modules.len) protected_modules.set(canon_mod);
-                    }
+                protected_modules.set(target_mod);
+                if (self.linker.resolveExportChain(rec.resolved, ib.imported_name, 0)) |c| {
+                    const canon_mod = @intFromEnum(c.module_index);
+                    if (canon_mod < self.modules.len) protected_modules.set(canon_mod);
                 }
             }
         }


### PR DESCRIPTION
## 요약

PR #1555 머지 후 발생한 effect E2E 회귀(`ReferenceError: Order\$6 is not defined`)를 복구합니다. 동시에 **정확도 trade-off 영역**을 투명히 기록 — valibot 같이 entry 자체가 namespace import인 경우 크기 증가(5.9→142 KB). 근본 해결은 #1558 (2→1 phase 재설계).

## 원인

PR #1555가 `crossModuleBFS` seed 조건을 `entry or \"*\" sentinel`로 좁혔습니다. 그런데 `processModuleImportsInner`의 namespace 분기는 `namespace_used_properties`(semantic analyzer 수집)가 있으면 target에 개별 prop만 `markExportUsed`하고 `\"*\"`는 **마킹하지 않음**. 결과적으로 target 모듈이 BFS seed 대상에서 제외됨.

### effect 시나리오

```js
// node_modules/effect/dist/esm/Fiber.js
import * as internal from \"./internal/fiber.js\";
export const Order = internal.Order;
```

1. 1차 fixpoint: `processModuleImportsInner(Fiber.js)` → `namespace_used_properties`에 `\"Order\"` 포함 → `markExportUsed(./internal/fiber.js, \"Order\")`. 하지만 `\"*\"` 없음.
2. crossModuleBFS seed 조건(`entry or \"*\"`)으로 `./internal/fiber.js` seed 제외.
3. Fiber.js의 `export const Order = internal.Order;` statement는 다른 이유(가짜 used)로 live지만, target의 `Order` 선언이 BFS에서 reachable되지 않음 → statement_shaker가 dead 처리.
4. `const Order\$7 = Order\$6;` alias만 남고 `Order\$6` 선언 사라져 dangling.

## 수정

`src/bundler/tree_shaker.zig`의 `processModuleImportsInner`의 namespace 분기를 단순화 — **`namespace_used_properties` 존재 여부와 관계없이 항상 `markAllExportsUsed(target)`**.

```zig
} else if (ib.kind == .namespace) {
    // namespace import는 모든 member가 동적으로 접근 가능.
    // 정적 분석으로 수집한 namespace_used_properties가 dead statement의 참조를
    // 포함/누락하는 보수성 문제 → \"*\" sentinel 항상 마킹(#1558).
    try self.markAllExportsUsed(@intCast(target_mod));
    if (!self.included.isSet(target_mod)) {
        self.included.set(target_mod);
        newly_included = true;
    }
    // canonical 체인 전파는 유지 (barrel re-export를 canonical까지 연결)
    if (ib.namespace_used_properties) |props| {
        for (props) |prop_name| {
            if (self.linker.resolveExportChain(...)) |c| {
                ...
            }
        }
    }
}
```

그리고 `pruneUnreachableExports`의 namespace 특별 보호는 **중복 제거** — target이 `\"*\"`로 마킹되므로 기존 Step 2의 `isExportUsed(i, \"*\")` 가드로 자동 스킵.

## Trade-off

| 시나리오 | main | PR #1555 후 | 이 PR 후 |
|---|---:|---:|---:|
| svelte readable | 71 KB | 18 KB | **27 KB** |
| effect E2E | SUCCESS | **FAIL** | **SUCCESS** (복구) |
| valibot (entry `import * as v`) | 5.9 KB | 5.9 KB | **142 KB** |
| smoke 264 FAIL 수 | 3 (mobx/lru-cache/effect smoke) | 3 (동일) | 3 (동일) |

- **effect 복구는 1순위 달성**.
- svelte readable이 18→27 KB로 일부 손실 — 그래도 main(71KB) 대비 −62%.
- valibot 증가는 entry가 namespace import(`import * as v from 'valibot'`)이기 때문에 \"namespace의 모든 member가 런타임에 접근 가능\" 의미론을 보수적으로 반영한 결과. esbuild/rolldown은 **member access 정밀 수집**(예: entry의 `v.object`, `v.string`, `v.number`, `v.parse`만 추적)으로 5.9 KB 유지. 이 정밀 수집은 #1558 근본 수정의 영역.

## 테스트 변경

`bundler_test/minify_loader.zig`의 \"effect pattern\" 테스트에서 `function left 제거` assertion을 주석 처리 — namespace 보수 동작으로 미사용 member도 유지됨을 명시. #1558 완료 후 복원 예정.

## 단위 테스트

- 기존 3,032건 전원 통과.
- 주석 처리된 assertion은 현재 동작 명시 (사유 기록).

## 관련

- 회귀 복구: PR #1555의 `crossModuleBFS` seed 변경 + namespace 경로 상호작용.
- 근본 개선: **#1558** (tree_shake 2→1 phase 재설계). effect smoke(Node), mobx, lru-cache@es2021 기존 FAIL과 valibot 정밀도 손실까지 자연 해결 기대.

## 구현 상세 (Zig 초보자용)

- `markAllExportsUsed(target)`: target 모듈의 `\"*\"` sentinel + 모든 export를 used_exports에 추가. re-export 체인도 재귀 처리.
- `namespace_used_properties`: semantic analyzer가 AST 전체에서 `ns.prop` 형태 member access를 수집한 목록. `null`이면 \"모든 member가 사용될 수 있음\", non-null이면 \"이 props만 정적으로 확인됨\".
- `\"*\"` sentinel: `markAllExportsUsed`가 `used_exports`에 추가하는 특수 key. crossModuleBFS의 `is_bfs_seed` 조건에서 시드 대상 여부 판별.

## 확인

- [x] `zig build test` 전원 통과
- [x] effect browser 번들 실행 결과 `43` 출력 (Order\$6 정상 정의)
- [x] smoke 264 프로젝트 — 새 FAIL 없음 (기존 3건 유지)
- [x] svelte/effect trade-off 정량 기록