### PR TITLE
refactor(tree_shaker): reference_count 신호 완전 제거 (#1558 Phase 5)

### DIFF
--- a/src/bundler/stmt_info_test.zig
+++ b/src/bundler/stmt_info_test.zig
@@ -78,6 +78,37 @@ test "stmt_info: import binding tracked" {
     try std.testing.expect(r.infos.stmts[1].referenced_symbols.len >= 1);
 }
 
+test "stmt_info: import 선언 stmt 자신은 local 심볼을 referenced로 보고하지 않음 (#1558 Phase 5)" {
+    // isImportLiveInModule이 entry import 자체를 "foo 참조"로 오해하지 않아야.
+    // import stmt 자신이 foo를 참조한다고 보면 foo는 다른 곳에서 사용 안 돼도
+    // always-live로 판정 → 불필요한 모듈 포함.
+    const alloc = std.testing.allocator;
+    var r = try buildTestInfos(alloc,
+        \\import { foo } from './lib';
+        \\console.log('no foo usage');
+    );
+    defer r.infos.deinit();
+    defer r.arena.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), r.infos.stmts.len);
+
+    // import stmt는 foo를 declare하고, referenced_symbols에는 포함하지 않아야.
+    const import_stmt = r.infos.stmts[0];
+    try std.testing.expect(import_stmt.declared_symbols.len >= 1);
+    const foo_sym = import_stmt.declared_symbols[0];
+
+    // import stmt의 referenced_symbols에 foo가 없어야.
+    for (import_stmt.referenced_symbols) |ref| {
+        try std.testing.expect(ref != foo_sym);
+    }
+    // sym_to_referencing_stmts[foo]에 import stmt(index 0)가 없어야.
+    if (foo_sym < r.infos.sym_to_referencing_stmts.len) {
+        for (r.infos.sym_to_referencing_stmts[foo_sym]) |si| {
+            try std.testing.expect(si != 0);
+        }
+    }
+}
+
 test "stmt_info: reachability BFS" {
     const alloc = std.testing.allocator;
     var r = try buildTestInfos(alloc,

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -35,13 +35,11 @@ pub const TreeShaker = struct {
     included: std.DynamicBitSet,
     used_exports: std.StringHashMap(void),
     entry_set: std.DynamicBitSet,
-    /// 모듈별 local re-export name set. isImportBindingUsed의 O(E) 스캔을 O(1)로 최적화.
-    /// analyze()에서 사전 구축, null이면 해당 모듈에 local re-export 없음.
-    re_export_sets: []?std.StringHashMap(void) = &.{},
     /// 모듈별 StmtInfo (심볼 기반 도달성 분석). analyze() 내 fixpoint 루프 전에 구축.
     module_stmt_infos: []?StmtInfos = &.{},
-    /// 모듈별 도달성 bitset 캐시. analyze()의 fixpoint 루프에서 crossModuleBFS가 반복 set,
-    /// 수렴 후 소비자(processModuleImportsInner, emitter, statement_shaker)가 조회.
+    /// 모듈별 도달성 bitset 캐시. crossModuleBFS가 채우고 같은 fixpoint 안에서
+    /// seedOpaqueModule/processModuleImportsInner가 live 필터로 읽고,
+    /// 수렴 후 emitter/statement_shaker가 소비한다.
     reachable_stmts: []?std.DynamicBitSet = &.{},
     /// 모듈별 sym_idx → import_binding_index 맵. 크로스-모듈 BFS에서 사용.
     sym_to_ib: []?[]?u32 = &.{},
@@ -163,34 +161,6 @@ pub const TreeShaker = struct {
             }
         }
 
-        // 모듈별 re-export local name set 사전 구축 (isImportBindingUsed 최적화)
-        var re_export_sets = try self.allocator.alloc(?std.StringHashMap(void), self.modules.len);
-        defer {
-            for (re_export_sets) |*s| {
-                if (s.*) |*set| set.deinit();
-            }
-            self.allocator.free(re_export_sets);
-        }
-        for (self.modules, 0..) |m, i| {
-            var has_local_reexport = false;
-            for (m.export_bindings) |eb| {
-                if (eb.kind == .local) {
-                    has_local_reexport = true;
-                    break;
-                }
-            }
-            if (has_local_reexport) {
-                var set = std.StringHashMap(void).init(self.allocator);
-                for (m.export_bindings) |eb| {
-                    if (eb.kind == .local) try set.put(m.exportBindingLocalName(eb), {});
-                }
-                re_export_sets[i] = set;
-            } else {
-                re_export_sets[i] = null;
-            }
-        }
-        self.re_export_sets = re_export_sets;
-
         // has_direct_used_export 배열 초기화 (hasAnyUsedExportDirect O(1) 조회용)
         const has_due = try self.allocator.alloc(bool, self.modules.len);
         @memset(has_due, false);
@@ -215,7 +185,9 @@ pub const TreeShaker = struct {
         var prebuilt_mask = try std.DynamicBitSet.initEmpty(self.allocator, self.modules.len);
         self.prebuilt_mask = prebuilt_mask;
         for (self.modules, 0..) |m, i| {
-            if (self.entry_set.isSet(i) or m.wrap_kind.isWrapped()) continue;
+            // wrapped(CJS/ESM wrap)는 body 전체가 한 function으로 래핑되어 statement 경계가
+            // 무의미 — 모듈 단위 포함/제외만. entry 포함 non-wrapped 모두 stmt-level 도달성 분석.
+            if (m.wrap_kind.isWrapped()) continue;
 
             if (m.prebuilt_stmt_info) |prebuilt| {
                 module_stmt_infos[i] = prebuilt;
@@ -251,10 +223,8 @@ pub const TreeShaker = struct {
 
             for (self.modules, 0..) |m, i| {
                 if (!self.included.isSet(i)) continue;
-                const live_idx: ?u32 = if (self.entry_set.isSet(i) or m.wrap_kind.isWrapped())
-                    null
-                else
-                    @intCast(i);
+                // wrapped만 StmtInfo 없음 → live 필터 불가. 나머지(entry 포함)는 live_mod_idx 경로.
+                const live_idx: ?u32 = if (m.wrap_kind.isWrapped()) null else @intCast(i);
                 if (try self.processModuleImportsInner(m, live_idx)) changed = true;
             }
 
@@ -470,9 +440,14 @@ pub const TreeShaker = struct {
                 reachable_stmts[i] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
             }
 
-            // side_effects=true 모듈: side-effect statement 즉시 시드 (fixpoint에서 포함됨)
-            // side_effects=false 모듈: enqueue의 lazy 시드로 처리 (모듈 사용 시에만)
-            if (m.side_effects) {
+            // entry는 번들 진입점 — 모든 top-level statement가 실행되어야 하므로 전체 시드.
+            // side_effects=true 모듈은 side-effect stmt만 시드.
+            // side_effects=false 모듈은 enqueue의 lazy 시드로 처리 (사용 시에만).
+            if (self.entry_set.isSet(i)) {
+                for (infos.stmts, 0..) |_, si| {
+                    try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                }
+            } else if (m.side_effects) {
                 for (infos.stmts, 0..) |stmt, si| {
                     if (stmt.has_side_effects) {
                         try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
@@ -712,7 +687,11 @@ pub const TreeShaker = struct {
 
         const m = self.modules[mod_idx];
         for (m.import_bindings) |ib| {
-            if (!self.isImportBindingUsed(m, ib)) continue;
+            // StmtInfo/reachability가 있으면 dead statement의 import는 배제.
+            // 없으면(wrapped 등) 보수적으로 모두 시드 — 모듈 전체 포함되는 경로.
+            if (mod_idx < self.reachable_stmts.len and self.reachable_stmts[mod_idx] != null) {
+                if (!self.isImportLiveInModule(mod_idx, ib.local_name)) continue;
+            }
             if (ib.import_record_index >= m.import_records.len) continue;
             const rec = m.import_records[ib.import_record_index];
             if (rec.resolved.isNone()) continue;
@@ -844,7 +823,6 @@ pub const TreeShaker = struct {
             const target_mod = @intFromEnum(rec.resolved);
             if (target_mod >= self.modules.len) continue;
 
-            if (!self.isImportBindingUsed(m, ib)) continue;
             if (live_mod_idx) |idx| {
                 if (!self.isImportLiveInModule(idx, ib.local_name)) continue;
             }
@@ -888,29 +866,6 @@ pub const TreeShaker = struct {
             }
         }
         return newly_included;
-    }
-
-    /// import binding이 모듈 내에서 "존재하는 참조"인지 판정(AST 전체 기준).
-    ///
-    /// reference_count 기반 신호는 dead statement의 참조까지 포함해 가짜 used를 만들 수 있다.
-    /// `processModuleImportsInner(live_mod_idx)`에서 이후 `isImportLiveInModule`이 BFS reachability로
-    /// 필터링하므로 실질 정확도는 BFS가 보장. 단 entry/wrapped(`live_mod_idx=null`)은
-    /// StmtInfo가 없어 BFS 필터가 불가능하므로 이 reference_count 체크를 유일 가드로 유지한다.
-    /// #1558 Phase 5: entry/wrapped 경로를 별도 seed 전략으로 대체해 이 함수를 제거할 수 있음.
-    fn isImportBindingUsed(self: *const TreeShaker, m: Module, ib: ImportBinding) bool {
-        if (m.semantic) |sem| {
-            if (ib.local_symbol.semanticIndex()) |sym_idx| {
-                if (sym_idx < sem.symbols.items.len and sem.symbols.items[sym_idx].reference_count > 0) return true;
-            }
-        } else return true;
-
-        const mod_idx = @intFromEnum(m.index);
-        if (mod_idx < self.re_export_sets.len) {
-            if (self.re_export_sets[mod_idx]) |set| {
-                return set.contains(ib.local_name);
-            }
-        }
-        return false;
     }
 
     fn markExportUsed(self: *TreeShaker, module_index: u32, export_name: []const u8) !void {


### PR DESCRIPTION
## Summary

- **reference_count 신호 완전 제거** — tree_shaker가 rolldown/esbuild/rspack과 동일한 **statement-level symbol graph** 단일 소스로 동작.
- entry 모듈도 StmtInfo 구축 + live_mod_idx 경로 적용. `isImportBindingUsed`/`re_export_sets` 완전 삭제.
- 미사용 import에 대한 정확한 dead 판정: `import { foo } from './lib';` 가 foo를 안 쓰면 lib 전체 제거.

## 배경

이전 세션에서 Phase 5 첫 시도 시 effect-like 시나리오에서 미사용 `lib.foo`가 번들에 살아남는 회귀 발견. 원인은 `seedOpaqueModule`의 `isImportBindingUsed` 필터를 그냥 지워서 entry의 모든 import가 무조건 seed되던 것. 이번 PR은 해당 필터를 **reachability 기반 `isImportLiveInModule`**로 교체해 같은 자리에서 정확한 live 판정을 수행.

## 변경 상세

- **entry도 StmtInfo 구축**: `entry_set.isSet` 가드 제거. 이제 wrapped(CJS/ESM wrap)만 StmtInfo 없음.
- **crossModuleBFS 시드**: entry는 모든 top-level statement를 live seed(번들 진입점은 tree-shake 대상 아님), side-effects 모듈은 side-effect stmt만, 그 외는 enqueue lazy 시드 유지.
- **processModuleImportsInner live_idx**: wrapped만 null, entry 포함 non-wrapped는 모두 `@intCast(i)`.
- **seedOpaqueModule 필터 교체**: `isImportBindingUsed` → reachability 체크 + `isImportLiveInModule`. reachability 없는 모듈(wrapped 등)은 기존처럼 보수적으로 전체 seed.
- **`isImportBindingUsed` + `re_export_sets` 삭제**. local re-export는 BFS가 export declaration stmt의 referenced_symbols를 따라 자동 처리.
- **stmt_info_test 회귀 가드 추가**: import 선언 stmt 자신이 local 심볼을 `referenced_symbols`로 보고하지 않음을 검증 — 향후 stmt_info 변경으로 isImportLiveInModule이 false positive 내면 즉시 포착.

`Symbol.reference_count` 필드 자체는 linker mangler의 이름 빈도 정렬(`linker.zig:609, 627`)에서 여전히 사용되므로 유지. tree_shaker만 단절.

## 검증

- [x] `zig build test -Doptimize=Debug` — 3034 tests 통과 (새 회귀 가드 포함)
- [x] `bun test tests/bundle-smoke.test.ts` — 139 pass
- [x] smoke: Step 3+4(#1561)와 동일 결과 — **회귀 없음**
  - effect 636 KB, svelte 2.9 KB, valibot 5.9 KB, lru-cache 21 KB
  - mobx / lru-cache@es2021 FAIL은 tree-shaker 무관한 codegen 이슈
- [x] 재현 케이스 직접 검증: `import { foo } from './lib';` 미사용 시 **lib 전체 번들 제외 (107 B → 71 B)**
- [x] `/simplify` 3 agent 병렬 리뷰 반영 (reachable_stmts 필드 주석 업데이트)

## 관련

- PR #1560 (Step 2) — 머지됨
- PR #1561 (Step 3+4) — 머지됨
- 본 PR 머지로 #1558 전체 완료 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)