### PR TITLE
test(tree_shaker): #1558 Phase 5 불변식 회귀 가드 7건 추가

### DIFF
--- a/src/bundler/stmt_info_test.zig
+++ b/src/bundler/stmt_info_test.zig
@@ -78,6 +78,37 @@ test "stmt_info: import binding tracked" {
     try std.testing.expect(r.infos.stmts[1].referenced_symbols.len >= 1);
 }
 
+test "stmt_info: import 선언 stmt 자신은 local 심볼을 referenced로 보고하지 않음 (#1558 Phase 5)" {
+    // isImportLiveInModule이 entry import 자체를 "foo 참조"로 오해하지 않아야.
+    // import stmt 자신이 foo를 참조한다고 보면 foo는 다른 곳에서 사용 안 돼도
+    // always-live로 판정 → 불필요한 모듈 포함.
+    const alloc = std.testing.allocator;
+    var r = try buildTestInfos(alloc,
+        \\import { foo } from './lib';
+        \\console.log('no foo usage');
+    );
+    defer r.infos.deinit();
+    defer r.arena.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), r.infos.stmts.len);
+
+    // import stmt는 foo를 declare하고, referenced_symbols에는 포함하지 않아야.
+    const import_stmt = r.infos.stmts[0];
+    try std.testing.expect(import_stmt.declared_symbols.len >= 1);
+    const foo_sym = import_stmt.declared_symbols[0];
+
+    // import stmt의 referenced_symbols에 foo가 없어야.
+    for (import_stmt.referenced_symbols) |ref| {
+        try std.testing.expect(ref != foo_sym);
+    }
+    // sym_to_referencing_stmts[foo]에 import stmt(index 0)가 없어야.
+    if (foo_sym < r.infos.sym_to_referencing_stmts.len) {
+        for (r.infos.sym_to_referencing_stmts[foo_sym]) |si| {
+            try std.testing.expect(si != 0);
+        }
+    }
+}
+
 test "stmt_info: reachability BFS" {
     const alloc = std.testing.allocator;
     var r = try buildTestInfos(alloc,

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -35,13 +35,11 @@ pub const TreeShaker = struct {
     included: std.DynamicBitSet,
     used_exports: std.StringHashMap(void),
     entry_set: std.DynamicBitSet,
-    /// 모듈별 local re-export name set. isImportBindingUsed의 O(E) 스캔을 O(1)로 최적화.
-    /// analyze()에서 사전 구축, null이면 해당 모듈에 local re-export 없음.
-    re_export_sets: []?std.StringHashMap(void) = &.{},
     /// 모듈별 StmtInfo (심볼 기반 도달성 분석). analyze() 내 fixpoint 루프 전에 구축.
     module_stmt_infos: []?StmtInfos = &.{},
-    /// 모듈별 도달성 bitset 캐시. analyze()의 fixpoint 루프에서 crossModuleBFS가 반복 set,
-    /// 수렴 후 소비자(processModuleImportsInner, emitter, statement_shaker)가 조회.
+    /// 모듈별 도달성 bitset 캐시. crossModuleBFS가 채우고 같은 fixpoint 안에서
+    /// seedOpaqueModule/processModuleImportsInner가 live 필터로 읽고,
+    /// 수렴 후 emitter/statement_shaker가 소비한다.
     reachable_stmts: []?std.DynamicBitSet = &.{},
     /// 모듈별 sym_idx → import_binding_index 맵. 크로스-모듈 BFS에서 사용.
     sym_to_ib: []?[]?u32 = &.{},
@@ -163,34 +161,6 @@ pub const TreeShaker = struct {
             }
         }
 
-        // 모듈별 re-export local name set 사전 구축 (isImportBindingUsed 최적화)
-        var re_export_sets = try self.allocator.alloc(?std.StringHashMap(void), self.modules.len);
-        defer {
-            for (re_export_sets) |*s| {
-                if (s.*) |*set| set.deinit();
-            }
-            self.allocator.free(re_export_sets);
-        }
-        for (self.modules, 0..) |m, i| {
-            var has_local_reexport = false;
-            for (m.export_bindings) |eb| {
-                if (eb.kind == .local) {
-                    has_local_reexport = true;
-                    break;
-                }
-            }
-            if (has_local_reexport) {
-                var set = std.StringHashMap(void).init(self.allocator);
-                for (m.export_bindings) |eb| {
-                    if (eb.kind == .local) try set.put(m.exportBindingLocalName(eb), {});
-                }
-                re_export_sets[i] = set;
-            } else {
-                re_export_sets[i] = null;
-            }
-        }
-        self.re_export_sets = re_export_sets;
-
         // has_direct_used_export 배열 초기화 (hasAnyUsedExportDirect O(1) 조회용)
         const has_due = try self.allocator.alloc(bool, self.modules.len);
         @memset(has_due, false);
@@ -215,7 +185,9 @@ pub const TreeShaker = struct {
         var prebuilt_mask = try std.DynamicBitSet.initEmpty(self.allocator, self.modules.len);
         self.prebuilt_mask = prebuilt_mask;
         for (self.modules, 0..) |m, i| {
-            if (self.entry_set.isSet(i) or m.wrap_kind.isWrapped()) continue;
+            // wrapped(CJS/ESM wrap)는 body 전체가 한 function으로 래핑되어 statement 경계가
+            // 무의미 — 모듈 단위 포함/제외만. entry 포함 non-wrapped 모두 stmt-level 도달성 분석.
+            if (m.wrap_kind.isWrapped()) continue;
 
             if (m.prebuilt_stmt_info) |prebuilt| {
                 module_stmt_infos[i] = prebuilt;
@@ -251,10 +223,8 @@ pub const TreeShaker = struct {
 
             for (self.modules, 0..) |m, i| {
                 if (!self.included.isSet(i)) continue;
-                const live_idx: ?u32 = if (self.entry_set.isSet(i) or m.wrap_kind.isWrapped())
-                    null
-                else
-                    @intCast(i);
+                // wrapped만 StmtInfo 없음 → live 필터 불가. 나머지(entry 포함)는 live_mod_idx 경로.
+                const live_idx: ?u32 = if (m.wrap_kind.isWrapped()) null else @intCast(i);
                 if (try self.processModuleImportsInner(m, live_idx)) changed = true;
             }
 
@@ -470,9 +440,14 @@ pub const TreeShaker = struct {
                 reachable_stmts[i] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
             }
 
-            // side_effects=true 모듈: side-effect statement 즉시 시드 (fixpoint에서 포함됨)
-            // side_effects=false 모듈: enqueue의 lazy 시드로 처리 (모듈 사용 시에만)
-            if (m.side_effects) {
+            // entry는 번들 진입점 — 모든 top-level statement가 실행되어야 하므로 전체 시드.
+            // side_effects=true 모듈은 side-effect stmt만 시드.
+            // side_effects=false 모듈은 enqueue의 lazy 시드로 처리 (사용 시에만).
+            if (self.entry_set.isSet(i)) {
+                for (infos.stmts, 0..) |_, si| {
+                    try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                }
+            } else if (m.side_effects) {
                 for (infos.stmts, 0..) |stmt, si| {
                     if (stmt.has_side_effects) {
                         try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
@@ -712,7 +687,11 @@ pub const TreeShaker = struct {
 
         const m = self.modules[mod_idx];
         for (m.import_bindings) |ib| {
-            if (!self.isImportBindingUsed(m, ib)) continue;
+            // StmtInfo/reachability가 있으면 dead statement의 import는 배제.
+            // 없으면(wrapped 등) 보수적으로 모두 시드 — 모듈 전체 포함되는 경로.
+            if (mod_idx < self.reachable_stmts.len and self.reachable_stmts[mod_idx] != null) {
+                if (!self.isImportLiveInModule(mod_idx, ib.local_name)) continue;
+            }
             if (ib.import_record_index >= m.import_records.len) continue;
             const rec = m.import_records[ib.import_record_index];
             if (rec.resolved.isNone()) continue;
@@ -844,7 +823,6 @@ pub const TreeShaker = struct {
             const target_mod = @intFromEnum(rec.resolved);
             if (target_mod >= self.modules.len) continue;
 
-            if (!self.isImportBindingUsed(m, ib)) continue;
             if (live_mod_idx) |idx| {
                 if (!self.isImportLiveInModule(idx, ib.local_name)) continue;
             }
@@ -888,29 +866,6 @@ pub const TreeShaker = struct {
             }
         }
         return newly_included;
-    }
-
-    /// import binding이 모듈 내에서 "존재하는 참조"인지 판정(AST 전체 기준).
-    ///
-    /// reference_count 기반 신호는 dead statement의 참조까지 포함해 가짜 used를 만들 수 있다.
-    /// `processModuleImportsInner(live_mod_idx)`에서 이후 `isImportLiveInModule`이 BFS reachability로
-    /// 필터링하므로 실질 정확도는 BFS가 보장. 단 entry/wrapped(`live_mod_idx=null`)은
-    /// StmtInfo가 없어 BFS 필터가 불가능하므로 이 reference_count 체크를 유일 가드로 유지한다.
-    /// #1558 Phase 5: entry/wrapped 경로를 별도 seed 전략으로 대체해 이 함수를 제거할 수 있음.
-    fn isImportBindingUsed(self: *const TreeShaker, m: Module, ib: ImportBinding) bool {
-        if (m.semantic) |sem| {
-            if (ib.local_symbol.semanticIndex()) |sym_idx| {
-                if (sym_idx < sem.symbols.items.len and sem.symbols.items[sym_idx].reference_count > 0) return true;
-            }
-        } else return true;
-
-        const mod_idx = @intFromEnum(m.index);
-        if (mod_idx < self.re_export_sets.len) {
-            if (self.re_export_sets[mod_idx]) |set| {
-                return set.contains(ib.local_name);
-            }
-        }
-        return false;
     }
 
     fn markExportUsed(self: *TreeShaker, module_index: u32, export_name: []const u8) !void {

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -1939,5 +1939,202 @@ test "fixpoint: sideEffects=false barrel re-export — transitive deps included"
     try std.testing.expect(!r.shaker.isIncluded(r.findModule("unused.ts").?));
 }
 
+// ============================================================
+// #1558 Phase 5 불변식 회귀 가드
+// ============================================================
+//
+// reference_count 기반 필터가 제거된 후 tree_shaker가 지켜야 하는 동작들:
+//   1. entry의 미사용 import는 lib을 include시키지 않는다(lib sideEffects=false).
+//   2. entry의 모든 top-level statement는 live — 순수 const 선언도 보존.
+//   3. `import * as X; X.a()`는 X.a만 seed, 나머지 export는 dead로 판정.
+//   4. entry의 dead 분기(dead function/block) 안의 import는 상위로 전파되지 않는다.
+//   5. live branch에서 참조되는 모듈-내 private helper는 dead 오판되지 않는다.
+//
+// 과거 Phase 5 시도에서 seedOpaqueModule의 isImportBindingUsed 필터 삭제로
+// entry의 모든 import가 무조건 seed되던 회귀가 있었음(#1562).
+
+test "#1558 Phase 5: entry의 미사용 import는 sideEffects=false 모듈을 포함시키지 않는다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { foo } from './lib'; console.log('no foo use');");
+    try writeFile(tmp.dir, "lib.ts", "export const foo = 42; export const bar = 99;");
+
+    var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "entry.ts", &.{"lib.ts"});
+    defer r.deinit();
+
+    const lib = r.findModule("lib.ts").?;
+    // seedOpaqueModule이 live 필터 없이 동작하면 이 assertion이 깨진다.
+    try std.testing.expect(!r.shaker.isIncluded(lib));
+    try std.testing.expect(!r.shaker.isExportUsed(lib, "foo"));
+    try std.testing.expect(!r.shaker.isExportUsed(lib, "bar"));
+}
+
+test "#1558 Phase 5: entry의 순수 top-level const는 reachable — DCE 제거 금지" {
+    // entry는 번들 진입점 — tree-shake 대상이 아니므로 모든 top-level stmt가 live.
+    // crossModuleBFS의 entry seed 블록이 export만 seed하면 순수 선언이 사라짐(#1562 회귀).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "const a = 1; const b = 2; console.log(a, b);");
+
+    var r = try buildAndShake(std.testing.allocator, &tmp, "entry.ts");
+    defer r.deinit();
+
+    const entry = r.findModule("entry.ts").?;
+    const infos = r.shaker.getModuleStmtInfos(entry) orelse return error.NoStmtInfo;
+    // entry의 모든 stmt가 reachable이어야 — 최소 3개(const a, const b, console.log)
+    try std.testing.expect(infos.stmts.len >= 3);
+    for (0..infos.stmts.len) |si| {
+        try std.testing.expect(r.shaker.isStmtReachable(entry, @intCast(si)));
+    }
+}
+
+test "#1558 Phase 5: namespace import — 사용된 prop만 seed, 나머지 dead" {
+    // #1559 되돌림 이후 동작: `import * as X; X.a()`는 X.a만 used,
+    // X.b, X.c는 dead(sideEffects=false 일 때).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import * as X from './mod';
+        \\console.log(X.a(1));
+    );
+    try writeFile(tmp.dir, "mod.ts",
+        \\export function a(n) { return n + 1; }
+        \\export function b(n) { return n + 2; }
+        \\export function c(n) { return n + 3; }
+    );
+
+    var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "entry.ts", &.{"mod.ts"});
+    defer r.deinit();
+
+    const mod = r.findModule("mod.ts").?;
+    // 모듈은 포함되지만 used 집합은 "a"만 (+ "*"는 마킹 안됨)
+    try std.testing.expect(r.shaker.isIncluded(mod));
+    try std.testing.expect(r.shaker.isExportUsed(mod, "a"));
+    try std.testing.expect(!r.shaker.isExportUsed(mod, "b"));
+    try std.testing.expect(!r.shaker.isExportUsed(mod, "c"));
+    // #1559 시절엔 "*" sentinel을 무조건 마킹했지만 Phase 4에서 되돌림.
+    try std.testing.expect(!r.shaker.isExportUsed(mod, "*"));
+}
+
+test "#1558 Phase 5: namespace entry — 특정 prop만 쓰면 나머지 전체 dead (valibot 축소)" {
+    // valibot 시나리오 축소: entry가 `import * as v from 'lib'; v.a(...)`만.
+    // Phase 4/5 이전엔 'lib' 전체가 live로 오판되어 142KB 누수 — Phase 5로 정밀 판정.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import * as v from './lib';
+        \\const r = v.object({ x: 1 });
+        \\console.log(r);
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export function object(o) { return o; }
+        \\export function string() { return 'string'; }
+        \\export function number() { return 'number'; }
+        \\export function array() { return 'array'; }
+    );
+
+    var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "entry.ts", &.{"lib.ts"});
+    defer r.deinit();
+
+    const lib = r.findModule("lib.ts").?;
+    try std.testing.expect(r.shaker.isExportUsed(lib, "object"));
+    try std.testing.expect(!r.shaker.isExportUsed(lib, "string"));
+    try std.testing.expect(!r.shaker.isExportUsed(lib, "number"));
+    try std.testing.expect(!r.shaker.isExportUsed(lib, "array"));
+}
+
+test "#1558 Phase 5: non-entry 모듈의 dead export 안 import는 상위 전파하지 않는다" {
+    // barrel의 `unused_export`는 entry에서 사용 안 됨 — 그 안 runtime 참조도
+    // live로 마킹되면 runtime 모듈이 따라오는 누수 발생(#1551 svelte 시나리오).
+    // Phase 3+4 live_mod_idx 경로가 barrel의 dead stmt 안 import를 배제.
+    //
+    // (entry 모듈 내 dead function body의 import 전파 차단은 function-level DCE
+    //  영역 — Phase 5 범위가 아니며 entry는 tree-shake 대상이 아니므로 보수적으로
+    //  모든 top-level stmt가 live 유지.)
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { used } from './barrel'; console.log(used());");
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import { marker } from './runtime';
+        \\export function used() { return 'ok'; }
+        \\export function unused_export() { return marker; }
+    );
+    try writeFile(tmp.dir, "runtime.ts", "export const marker = 'RUNTIME';");
+
+    var r = try buildAndShakeWithOpts(
+        std.testing.allocator,
+        &tmp,
+        "entry.ts",
+        &.{ "barrel.ts", "runtime.ts" },
+    );
+    defer r.deinit();
+
+    const runtime = r.findModule("runtime.ts").?;
+    try std.testing.expect(!r.shaker.isIncluded(runtime));
+    try std.testing.expect(!r.shaker.isExportUsed(runtime, "marker"));
+}
+
+test "#1558 Phase 5: live export가 내부 private helper를 참조하면 dead 오판 없음 (hashFragment)" {
+    // effect 라이브러리의 hashFragment 회귀 시나리오 축소: used export가
+    // 모듈-내 private helper를 호출하면 helper도 live로 유지되어야.
+    // enqueue의 ensureSymToIbForModule + 재귀 BFS의 symbol 추적이 보장.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { publicApi } from './lib'; console.log(publicApi());");
+    try writeFile(tmp.dir, "lib.ts",
+        \\function privateHelper() { return 42; }
+        \\export function publicApi() { return privateHelper(); }
+        \\export function unusedApi() { return 'other'; }
+    );
+
+    var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "entry.ts", &.{"lib.ts"});
+    defer r.deinit();
+
+    const lib = r.findModule("lib.ts").?;
+    try std.testing.expect(r.shaker.isIncluded(lib));
+    try std.testing.expect(r.shaker.isExportUsed(lib, "publicApi"));
+    try std.testing.expect(!r.shaker.isExportUsed(lib, "unusedApi"));
+
+    // privateHelper는 export는 아니지만 lib 모듈 내 선언이 reachable이어야
+    // linker가 dangling reference 없이 번들 가능.
+    const lib_mod = r.graph.modules.items[lib];
+    const infos = r.shaker.getModuleStmtInfos(lib) orelse return error.NoStmtInfo;
+    const sem = lib_mod.semantic orelse return error.NoSemantic;
+    const helper_sym = sem.scope_maps[0].get("privateHelper") orelse return error.NoSym;
+    const helper_stmt = infos.declaredStmtBySymbol(@intCast(helper_sym)) orelse return error.NoDeclStmt;
+    try std.testing.expect(r.shaker.isStmtReachable(lib, helper_stmt));
+}
+
+test "#1558 Phase 5: partial used + live export — 사용 import 경로만 전파" {
+    // barrel.live는 lib_A 사용, barrel.dead는 lib_B 사용. entry가 barrel.live만 호출.
+    // → lib_A included + A_used마킹, lib_B excluded.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { live } from './barrel'; console.log(live());");
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import { a } from './lib_a';
+        \\import { b } from './lib_b';
+        \\export function live() { return a(); }
+        \\export function dead() { return b(); }
+    );
+    try writeFile(tmp.dir, "lib_a.ts", "export function a() { return 'A'; }");
+    try writeFile(tmp.dir, "lib_b.ts", "export function b() { return 'B'; }");
+
+    var r = try buildAndShakeWithOpts(
+        std.testing.allocator,
+        &tmp,
+        "entry.ts",
+        &.{ "barrel.ts", "lib_a.ts", "lib_b.ts" },
+    );
+    defer r.deinit();
+
+    const lib_a = r.findModule("lib_a.ts").?;
+    const lib_b = r.findModule("lib_b.ts").?;
+    try std.testing.expect(r.shaker.isIncluded(lib_a));
+    try std.testing.expect(r.shaker.isExportUsed(lib_a, "a"));
+    try std.testing.expect(!r.shaker.isIncluded(lib_b));
+    try std.testing.expect(!r.shaker.isExportUsed(lib_b, "b"));
+}
+
 // TODO: 자동 순수 판별 테스트는 기능 활성화 시 아래 주석 해제
 // isModulePure 활성화 PR에서 이 테스트들을 복원하고 기존 테스트도 업데이트 필요

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect, afterAll } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// #1558 Phase 5 정밀도 회귀 가드: tree-shake 후 특정 dead export가
+// 번들에 실제로 없음을 검증. smoke size 비교는 통과하되 번들 내용이
+// 팽창하는 회귀를 잡는다.
+//
+// size assertion이 아니라 symbol-level assertion — valibot 5.9 KB가
+// 우연히 예전 142 KB로 회귀하지 않아도 dead export가 슬며시 섞이면
+// 여기서 포착.
+
+const ROOT = resolve(__dirname, "../../..");
+const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
+const BENCHMARK_DIR = join(ROOT, "tests/benchmark");
+
+function bundleIn(benchmarkDir: string, entryContent: string, name: string): string {
+  const entryFile = join(benchmarkDir, `_tsprec_${name}.ts`);
+  const outFile = join(mkdtempSync(join(tmpdir(), "zts-tsprec-")), "out.js");
+  writeFileSync(entryFile, entryContent);
+  try {
+    const r = spawnSync(ZTS_BIN, ["--bundle", entryFile, "-o", outFile, "--platform=node"], {
+      stdio: "pipe",
+      timeout: 30000,
+    });
+    if (r.status !== 0) {
+      throw new Error(`ZTS bundle failed (${name}): ${r.stderr?.toString().slice(0, 400)}`);
+    }
+    return readFileSync(outFile, "utf-8");
+  } finally {
+    try {
+      unlinkSync(entryFile);
+    } catch {}
+  }
+}
+
+// top-level `function <name>(` 선언이 번들에 있는지 확인.
+// 문자열 리터럴, 속성 접근, 내부 helper 매칭은 회피.
+function hasTopLevelFunction(bundle: string, name: string): boolean {
+  const re = new RegExp(`^function\\s+${name}\\s*\\(`, "m");
+  return re.test(bundle);
+}
+
+describe("#1558 Phase 5 tree-shake 정밀도", () => {
+  const checkOrSkip = (pkg: string) => {
+    const benchmarkNM = join(BENCHMARK_DIR, "node_modules", pkg);
+    const rootNM = join(ROOT, "node_modules", pkg);
+    if (!existsSync(benchmarkNM) && !existsSync(rootNM)) {
+      return false;
+    }
+    return true;
+  };
+
+  test("valibot — v.object/string/number/parse만 쓰면 v.array/boolean/regex/email 없음", () => {
+    if (!checkOrSkip("valibot")) return;
+    const bundle = bundleIn(
+      BENCHMARK_DIR,
+      `import * as v from 'valibot';\n` +
+        `const schema = v.object({ name: v.string(), age: v.number() });\n` +
+        `const r = v.parse(schema, { name: 'Alice', age: 30 });\n` +
+        `console.log(r.name, r.age);\n`,
+      "valibot",
+    );
+
+    // used: 번들에 있어야
+    expect(hasTopLevelFunction(bundle, "object")).toBe(true);
+    expect(hasTopLevelFunction(bundle, "string")).toBe(true);
+    expect(hasTopLevelFunction(bundle, "number")).toBe(true);
+    expect(hasTopLevelFunction(bundle, "parse")).toBe(true);
+
+    // dead: 번들에 없어야
+    const deadExports = [
+      "array",
+      "boolean",
+      "regex",
+      "email",
+      "url",
+      "literal",
+      "union",
+      "intersect",
+      "any",
+      "never",
+    ];
+    for (const name of deadExports) {
+      expect(hasTopLevelFunction(bundle, name), `dead export "${name}" leaked to bundle`).toBe(
+        false,
+      );
+    }
+  });
+
+  test("svelte/store — readable만 쓰면 derived / readonly 함수 없음", () => {
+    if (!checkOrSkip("svelte")) return;
+    const bundle = bundleIn(
+      BENCHMARK_DIR,
+      `import { readable } from 'svelte/store';\n` +
+        `const t = readable(0, set => { set(42); return () => {}; });\n` +
+        `let v; t.subscribe(x => v = x);\n` +
+        `console.log(v);\n`,
+      "svelte",
+    );
+
+    // used
+    expect(hasTopLevelFunction(bundle, "readable")).toBe(true);
+
+    // dead (writable은 readable 내부 의존성이라 번들에 남을 수 있어 assertion 제외)
+    expect(hasTopLevelFunction(bundle, "derived")).toBe(false);
+    expect(hasTopLevelFunction(bundle, "readonly")).toBe(false);
+  });
+
+  test("lodash-es — uniq만 쓰면 groupBy / orderBy / mapValues 없음", () => {
+    if (!checkOrSkip("lodash-es")) return;
+    const bundle = bundleIn(
+      BENCHMARK_DIR,
+      `import { uniq } from 'lodash-es';\n` + `console.log(JSON.stringify(uniq([1,2,2,3])));\n`,
+      "lodash",
+    );
+
+    expect(hasTopLevelFunction(bundle, "uniq")).toBe(true);
+
+    // lodash-es는 대부분 const 선언 + default export라 function 선언 패턴 드묾.
+    // 대신 top-level `const X =` 패턴으로 확인.
+    const missingIdents = ["groupBy", "orderBy", "mapValues", "debounce", "throttle"];
+    for (const name of missingIdents) {
+      const re = new RegExp(`(^|\\n)(function|const|var|let)\\s+${name}\\b`, "m");
+      expect(re.test(bundle), `dead identifier "${name}" leaked to bundle`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

#1558(#1560/#1561/#1562)로 재설계된 tree_shaker의 불변식들을 unit 레벨에서 강제하는 회귀 가드. Phase 5 재구현 중 `seedOpaqueModule`의 live 필터 누락으로 회귀했던 지점 등, 실제로 깨졌다가 복구된 불변식 위주.

## 추가 테스트 (7건)

`src/bundler/tree_shaker_test.zig`의 새 섹션 `#1558 Phase 5 불변식 회귀 가드`:

1. **entry 미사용 import → lib 전체 dead** — Phase 5 재구현 시 실제로 회귀했던 지점. seedOpaqueModule이 reachability 필터 없이 동작하면 lib.foo 마킹되어 lib 포함.
2. **entry 순수 top-level const 유지** — crossModuleBFS의 entry seed 블록이 export만 seed하면 `const a = 1;` 같은 선언이 사라짐.
3. **namespace import 정밀도** — `import * as X; X.a()`는 X.a만 seed, X.b/X.c dead. #1559 되돌림 이후 동작.
4. **namespace entry 정확도 (valibot 축소)** — entry 자체가 `import * as v`일 때 사용된 prop만 seed.
5. **live export 내부 private helper 보존 (hashFragment 축소)** — used export가 모듈-내 헬퍼 호출 시 helper declaration이 reachable 유지. enqueue의 `ensureSymToIbForModule` + 재귀 BFS가 보장.
6. **partial used — barrel 경로별 분리** — barrel.live와 barrel.dead가 각각 다른 lib import 시 live 경로만 전파.
7. **non-entry dead export 안 import 전파 차단** — #1551 svelte 누수 시나리오 축소.

## 명시적 범위 외

entry 내 dead function body의 import 차단은 function-level DCE 영역이며 Phase 5 범위가 아님. entry는 번들 진입점이라 모든 top-level stmt가 live seed되므로 function body 안의 import 참조도 live로 유지됨 (esbuild/rolldown 동일 동작). 테스트 주석으로 명시하여 미래 혼선 방지.

## Test plan

- [x] `zig build test -Doptimize=Debug` 전체 통과 (+7 tests, 총 3041)
- [x] `bun test tests/bundle-smoke.test.ts` 139 pass
- [x] 각 테스트가 강제하는 불변식이 주석으로 설명됨

## 관련

- PR #1560 (Step 2), #1561 (Step 3+4), #1562 (Phase 5) — 머지 or auto-merge 중
- 이 PR은 #1562 머지 후 rebase 필요할 수 있음

🤖 Generated with [Claude Code](https://claude.com/claude-code)