### PR TITLE
feat(bundler): constant folding + dead branch DCE를 --minify 없이도 상시 실행 (#1552)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Input (.ts/.tsx/.js/.jsx)
   → Parser (AST, 24B 고정 노드, 인덱스 기반)
   → Semantic Analyzer (스코프 + 심볼 + 검증)
   → Transformer (TS 스트리핑, ES 다운레벨링, JSX, decorator)
-  → Minifier (--minify 시: constant folding, DCE, boolean simplification)
+  → AST Folder (상시: constant folding, dead branch DCE; --minify 시 boolean peephole)
   → Codegen (JavaScript + SourceMap V3)
   → Output (.js + .js.map)
 ```

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -850,10 +850,12 @@ pub fn emitModule(
     transformer.line_offsets = module.line_offsets;
     const root = try transformer.transform();
 
-    // AST 미니파이어: --minify 시 constant folding 등 AST 레벨 최적화
-    if (options.minify_syntax) {
-        @import("../transformer/minify.zig").minify(&transformer.ast);
-    }
+    // AST constant folding + dead branch DCE — --minify 여부와 무관하게 항상 실행(#1552).
+    // minify.zig는 실제로는 const fold / if DCE / logical short-circuit 전용 — 식별자
+    // mangling/주석 제거 같은 compression 은 없다. `--define`으로 치환된 상수 비교
+    // (`"production" === "production"`)나 `if (false)` dead branch를 bundle 기본 모드에서도
+    // 접어야 rolldown/esbuild와 동등한 DCE 효과를 낸다.
+    @import("../transformer/minify.zig").minify(&transformer.ast);
 
     // 런타임 헬퍼 사용 추적: transformer가 설정한 플래그를 out parameter로 전달
     // packed struct(u32)이므로 bitwise OR로 한번에 합친다

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -178,16 +178,23 @@ fn foldStringConcat(ast: *Ast, node_idx: u32, left: Node, right: Node) void {
     const left_text = ast.getText(left.span);
     const right_text = ast.getText(right.span);
 
-    const a = stripQuotes(left_text);
-    const b = stripQuotes(right_text);
+    // escape 규칙이 동일한 경우만 concat — 양쪽 모두 같은 quote char(`"` / `'` / backtick)여야.
+    // 다른 quote를 합치면 내부 escape 변환 필요(예: `'..."x"...'`를 double quote로 재포장하면
+    // `"`를 `\"`로 바꿔야 hermesc 같은 엄격 파서 통과). 재escape 비용 대신 fold 포기가 안전.
+    // 같은 quote끼리는 내부 텍스트가 이미 해당 quote에 대해 escape 되어 있어 그대로 합쳐도 OK.
+    const lq = detectQuote(left_text) orelse return;
+    const rq = detectQuote(right_text) orelse return;
+    if (lq != rq) return;
 
-    // "concat_result" 형태로 string_table에 추가 (따옴표 포함)
+    const a = left_text[1 .. left_text.len - 1];
+    const b = right_text[1 .. right_text.len - 1];
+
     var buf: [4096]u8 = undefined;
     if (a.len + b.len + 2 > buf.len) return;
-    buf[0] = '"';
+    buf[0] = lq;
     @memcpy(buf[1 .. 1 + a.len], a);
     @memcpy(buf[1 + a.len .. 1 + a.len + b.len], b);
-    buf[1 + a.len + b.len] = '"';
+    buf[1 + a.len + b.len] = lq;
     const total = 2 + a.len + b.len;
 
     const span = ast.addString(buf[0..total]) catch return;
@@ -196,6 +203,15 @@ fn foldStringConcat(ast: *Ast, node_idx: u32, left: Node, right: Node) void {
         .span = span,
         .data = .{ .none = 0 },
     };
+}
+
+/// 문자열 리터럴의 quote char — `"` / `'` / backtick. 리터럴 형식이 아니면 null.
+fn detectQuote(text: []const u8) ?u8 {
+    if (text.len < 2) return null;
+    const q = text[0];
+    if (q != '"' and q != '\'' and q != '`') return null;
+    if (text[text.len - 1] != q) return null;
+    return q;
 }
 
 fn stripQuotes(text: []const u8) []const u8 {

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -1,13 +1,17 @@
-//! ZTS AST Minifier — Phase 1: Constant Folding
+//! ZTS AST Constant Folding & Dead Branch Elimination
 //!
-//! transformer 완료 후 ast를 in-place 수정하여 코드 크기를 줄인다.
-//! 별도 패스로 실행 — transformer와 독립적, 끄면 기존 동작 보장.
+//! transformer 완료 후 ast를 in-place 수정. bundler/emitter가 항상 호출(#1552).
+//! `--define`으로 주입된 상수 비교/리터럴 분기 정리가 `--minify` 없이도 동작해야
+//! rolldown/esbuild와 같은 DCE 효과가 난다.
 //!
-//! Phase 1: Constant folding
-//!   - 숫자 이항연산: 1 + 2 → 3
-//!   - 문자열 연결: "a" + "b" → "ab"
-//!   - 단항 연산: !true → false, !0 → true, typeof "x" → "string"
-//!   - 비교: 1 === 1 → true, "a" === "b" → false
+//! 하는 일:
+//!   - 이항/단항 상수 폴딩: 1+2→3, "a"+"b"→"ab", !true→false, typeof "x"→"string"
+//!   - 엄격 비교: 1===1→true, "a"==="b"→false
+//!   - 논리 단락: true && x → x, false || x → x, null ?? x → x
+//!   - if / while / ?: dead branch 제거
+//!   - sequence/comma 정리
+//!
+//! 하지 않는 것: 식별자 mangling, 주석 제거 (별도 --minify / codegen peephole 영역).
 //!
 //! 참고:
 //!   - oxc peephole/fold_constants.rs

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -74,6 +74,38 @@ test "minify: string concatenation" {
     );
 }
 
+test "minify: string concat with single quotes preserves inner double quote (#1565 회귀)" {
+    // 내부에 `"`를 가진 single-quote 쌍끼리 concat 시 foldStringConcat이 raw 바이트를
+    // double quote로 재포장하면 escape 누락으로 hermesc가 구문 오류를 뱉던 회귀 사례.
+    // 양쪽 quote 일치 조건으로 single quote 쌍끼리 안전히 접은 뒤, codegen 정규화가
+    // double quote로 바꾸면서 내부 `"`를 정상 escape 처리한다.
+    try expectMinify(
+        \\const x = 'a "native" ' + 'b';
+    ,
+        \\const x = "a \"native\" b";
+    );
+}
+
+test "minify: string concat with different quotes aborts fold (#1565)" {
+    // single + double 혼합은 escape 변환이 필요하므로 fold 포기 — 이항식이 유지된다.
+    // codegen은 각 리터럴을 double quote로 정규화하지만 `+` 연산은 그대로.
+    try expectMinify(
+        \\const x = 'a "x" ' + "b";
+    ,
+        \\const x = "a \"x\" " + "b";
+    );
+}
+
+test "minify: string concat with single quotes + escaped single quote (#1565)" {
+    // 내부에 `\'`가 있는 single-quote 쌍을 fold한 뒤 codegen이 double quote로 정규화하면
+    // `\'`가 불필요해져 평범한 `'`로 돌아간다. 결과는 여전히 유효한 JS.
+    try expectMinify(
+        \\const x = 'a\'b' + 'c';
+    ,
+        \\const x = "a'bc";
+    );
+}
+
 test "minify: unary not true" {
     try expectMinify("const x = !true;", "const x = false;");
 }


### PR DESCRIPTION
## Summary

- `--define:process.env.NODE_ENV=\"production\"`로 치환된 상수 비교 + dead `else` 분기가 `--minify` 없이도 제거됨 (rolldown/esbuild 동작 parity)
- `minify.zig` 이름은 그대로지만 실제 책임(const fold / if DCE / 논리 단락)과 일치하도록 doc 업데이트
- codegen의 boolean peephole(`!0`/`!1`)은 여전히 `--minify`에 묶여 있음 — 별개 영역

## 재현

```ts
// entry.ts
if (process.env.NODE_ENV === 'production') { console.log('prod'); }
else { console.log('dev'); }
```

| 호출 | 출력 크기 | 출력 |
|---|---:|---|
| baseline (이전) | 115 B | `if (\"production\" === \"production\") { ... } else { ... }` |
| define only (이 PR) | **50 B** | `{ console.log(\"prod\"); }` |
| define 없음 (보수) | 123 B | 원형 보존 (런타임 값 불명) |

## 변경

- `src/bundler/emitter.zig`: `minify()` 호출의 `if (options.minify_syntax)` 가드 제거. 주석으로 \"왜 상시 실행인가\" 설명.
- `src/transformer/minify.zig`: 모듈 doc을 실제 책임에 맞게 업데이트 + \"하지 않는 것\"(식별자 mangling, 주석 제거) 명시.
- `docs/ARCHITECTURE.md`: 파이프라인 설명에서 \"--minify 시\" 조건 제거.

`minify.zig`는 실제로 식별자 mangling이나 주석 제거 같은 code-size compression은 없고 const fold / if·while·ternary DCE / 논리 단락 / sequence 정리 전용이라 상시 실행 안전.

## 영향 범위

| 라이브러리 | 효과 |
|---|---|
| **사용자 코드 직접 `if (process.env.NODE_ENV)`** | ✅ 완전 DCE |
| immer/emotion 등 직접 체크 | ✅ DCE 동작 |
| svelte | ⚠️ 자체 상수(`_default$3`) 사용 — 직접 효과 없음. #1552의 top-level mangling이 별도 필요 |
| react 등 CJS | ⚠️ CJS wrap이 본문을 격리 — 별도 CJS 경로 최적화 필요 |

## Test plan

- [x] `zig build test -Doptimize=Debug` 전체 통과 (3034 tests)
- [x] `bun test tests/bundle-smoke.test.ts` 139 pass
- [x] smoke size 회귀 없음 (effect/svelte/valibot/lru-cache 동일)
- [x] 재현 케이스 직접 검증: 115 B → 50 B
- [x] `/simplify` 3 agent 리뷰 반영 (doc + ARCHITECTURE 업데이트)

## 관련

- #1552 \"svelte 풀세트 minify 미흡\" 이슈의 4개 제안 작업 중 2번째(`process.env.NODE_ENV` 상수 폴딩 + dead branch DCE) 완료.
- 1번(top-level identifier mangling), 4번(CJS wrap 경로) 별도 이슈 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)