### PR TITLE
feat(codegen): minify_syntax 시 undefined → (void 0) peephole (#1552)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -863,6 +863,25 @@ pub const Codegen = struct {
             .binding_identifier,
             .assignment_target_identifier,
             => {
+                // Peephole: global `undefined` → `(void 0)` (minify_syntax 활성화 시).
+                // 9 bytes → 8 bytes, 1 byte 절감. parens는 member/call/new 등 모든 parent
+                // context에서 안전하게 해석되도록 유지 — `undefined.x`/`undefined()` 같은
+                // 경로를 간단한 치환으로 깨지 않기 위함 (`void 0.x`는 `void (0.x)`로 오파싱).
+                // global binding일 때만 치환 (shadow rebind 드물지만 보호).
+                if (self.options.minify_syntax and node.tag == .identifier_reference) {
+                    const text = self.ast.getText(node.span);
+                    if (std.mem.eql(u8, text, "undefined")) {
+                        const is_global = if (self.options.linking_metadata) |meta|
+                            self.resolveSymbolId(idx, meta) == null
+                        else
+                            true;
+                        if (is_global) {
+                            try self.write("(void 0)");
+                            return;
+                        }
+                    }
+                }
+
                 if (self.options.linking_metadata) |meta| {
                     const sym_id = self.resolveSymbolId(idx, meta);
                     if (sym_id) |sid| {

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -6,6 +6,19 @@ const Codegen = @import("../codegen/codegen.zig").Codegen;
 const minify_mod = @import("minify.zig");
 
 fn expectMinify(input: []const u8, expected: []const u8) !void {
+    return expectMinifyOpts(input, expected, .{});
+}
+
+/// `--minify` 플래그 시 codegen peephole(`true`→`!0`, `undefined`→`(void 0)`)까지 적용된 결과 비교.
+fn expectMinifySyntax(input: []const u8, expected: []const u8) !void {
+    return expectMinifyOpts(input, expected, .{ .minify_syntax = true });
+}
+
+fn expectMinifyOpts(
+    input: []const u8,
+    expected: []const u8,
+    codegen_opts: @import("../codegen/codegen.zig").CodegenOptions,
+) !void {
     const allocator = std.testing.allocator;
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -20,7 +33,7 @@ fn expectMinify(input: []const u8, expected: []const u8) !void {
 
     minify_mod.minify(&transformer.ast);
 
-    var cg = Codegen.init(a, &transformer.ast);
+    var cg = Codegen.initWithOptions(a, &transformer.ast, codegen_opts);
     const result = try cg.generate(root);
     const trimmed = std.mem.trimRight(u8, result, "\n");
     try std.testing.expectEqualStrings(expected, trimmed);
@@ -307,4 +320,40 @@ test "minify: comma operator with 3+ literal items simplified" {
 
 test "minify: comma operator mixed keeps non-literal" {
     try expectMinify("const x = (0, a(), foo);", "const x = (a(),foo);");
+}
+
+// ================================================================
+// Peephole: undefined → (void 0) (minify_syntax only, #1552)
+// ================================================================
+
+test "minify_syntax: undefined → (void 0)" {
+    try expectMinifySyntax("const x = undefined;", "const x = (void 0);");
+}
+
+test "minify_syntax: undefined 비교" {
+    try expectMinifySyntax(
+        "const x = a === undefined;",
+        "const x = a === (void 0);",
+    );
+}
+
+test "minify_syntax: undefined.x 치환 시 parens로 안전 유지" {
+    // `undefined.x`를 bare `void 0.x`로 바꾸면 `void (0.x)`로 오파싱.
+    // `(void 0)` 형태 유지로 member access가 정확히 `(void 0).x`가 된다.
+    try expectMinifySyntax(
+        "const x = undefined.foo;",
+        "const x = (void 0).foo;",
+    );
+}
+
+test "minify_syntax: undefined() call" {
+    try expectMinifySyntax(
+        "try { undefined(); } catch(e) {}",
+        "try {\n\t(void 0)();\n} catch (e) {\n}",
+    );
+}
+
+test "minify_syntax 없음: undefined 보존" {
+    // minify_syntax 꺼져 있으면 바꾸지 않음 — 디버깅 가독성 유지.
+    try expectMinify("const x = undefined;", "const x = undefined;");
 }


### PR DESCRIPTION
## Summary

#1552의 peephole 확장 중 마지막 남은 `undefined` → `(void 0)` 항목 구현. `--minify` 활성화 시 codegen이 global `undefined` 참조를 `(void 0)`으로 치환 (9 → 8 bytes).

## 설계 포인트

- **parens 항상 포함**: bare `void 0`으로 바꾸면 `undefined.x` → `void 0.x` → `void (0.x)` 오파싱. `(void 0).x` 형태로 member/call/new 모든 context 안전.
- **global binding만 치환**: bundle 모드는 `resolveSymbolId`가 null인 경우만. transpile 모드는 보수적으로 global 간주 (esbuild/terser도 동일 관례, local `undefined` rebind는 strict mode에서 금지되며 실사용 극히 드묾).
- **minify_syntax 꺼지면 원형 유지**: 디버깅 가독성 보호.

## 실측

svelte 풀세트 (`--minify --define:NODE_ENV=production`): 70,841 B → **70,799 B** (-42 B, 42곳 치환). 단일 byte 단위 최적화라 효과는 라이브러리별 `undefined` 출현 빈도에 비례.

## 검증

- [x] `zig build test -Doptimize=Debug` 전체 통과 (+5 tests, 총 3049)
- [x] `bun test` integration bundle-smoke + hermes + es5-rn 174 pass
- [x] edge case 직접 실행: `undefined.x`, `undefined()`, `a === undefined` 모두 유효한 JS 출력
- [x] minify_syntax 꺼졌을 때 `undefined` 원형 유지 회귀 가드

## 관련

#1552의 4개 제안 작업 완료 상태:
- [x] Top-level mangling (기존 구현)
- [x] `process.env.NODE_ENV` 상수 폴딩 + DCE (#1565)
- [x] Peephole 확장 (`true`→`!0`/`!1` 기존, `undefined`→`(void 0)` 이번 PR, 상수 접힘/논리 단락 기존)
- [x] IIFE 제거 / ESM 기본 (이미 ESM)

→ 이 PR 머지 시 **#1552 close 가능**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)