### PR TITLE
fix(codegen): #1564 for-init 중복 세미콜론 + generator private method 다운레벨

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1236,13 +1236,16 @@ pub const Codegen = struct {
         const e = node.data.extra;
         const extras = self.ast.extra_data.items[e .. e + 4];
         if (self.options.minify_whitespace) try self.write("for(") else try self.write("for (");
+        // in_for_init을 save/restore로 관리: init 안에 중첩된 for/for-in/for-of가 있으면
+        // 내부 for가 끝날 때 plain assignment로 되돌리지 않도록 해야 한다. (#1564 Case 1)
+        const saved_for_init = self.in_for_init;
         self.in_for_init = true;
         try self.emitNode(@enumFromInt(extras[0]));
         if (self.options.minify_whitespace) try self.writeByte(';') else try self.write("; ");
+        self.in_for_init = saved_for_init;
         try self.emitNode(@enumFromInt(extras[1]));
         if (self.options.minify_whitespace) try self.writeByte(';') else try self.write("; ");
         try self.emitNode(@enumFromInt(extras[2]));
-        self.in_for_init = false;
         try self.writeByte(')');
         try self.emitNode(@enumFromInt(extras[3]));
     }
@@ -1257,11 +1260,13 @@ pub const Codegen = struct {
             try self.writeIndent();
         }
         if (self.options.minify_whitespace) try self.write("for await(") else try self.write("for await (");
+        const saved_for_init = self.in_for_init;
+        const saved_skip_var_init = self.skip_var_init;
         self.in_for_init = true;
         self.skip_var_init = try self.shouldSkipVarInit(t.a);
         try self.emitNode(t.a);
-        self.in_for_init = false;
-        self.skip_var_init = false;
+        self.in_for_init = saved_for_init;
+        self.skip_var_init = saved_skip_var_init;
         try self.write(" of ");
         try self.emitNode(t.b);
         try self.writeByte(')');
@@ -1281,11 +1286,13 @@ pub const Codegen = struct {
         }
 
         if (self.options.minify_whitespace) try self.write("for(") else try self.write("for (");
+        const saved_for_init = self.in_for_init;
+        const saved_skip_var_init = self.skip_var_init;
         self.in_for_init = true;
         self.skip_var_init = try self.shouldSkipVarInit(t.a);
         try self.emitNode(t.a);
-        self.in_for_init = false;
-        self.skip_var_init = false;
+        self.in_for_init = saved_for_init;
+        self.skip_var_init = saved_skip_var_init;
         try self.writeByte(' ');
         try self.write(keyword);
         try self.writeByte(' ');

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -167,6 +167,26 @@ test "Codegen: string enum re-export" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "export") != null);
 }
 
+// #1564 Case 1 회귀 가드: for init 안에 중첩된 for/for-in이 끝나면서
+// in_for_init 플래그를 false로 덮어쓰면, 바깥 for의 VariableDeclaration이
+// 자체적으로 세미콜론을 찍어 `;;`이 중복 출력되는 문제. save/restore로 해결.
+test "Codegen #1564: nested for-in inside outer for-init preserves in_for_init" {
+    var r = try e2e(std.testing.allocator,
+        \\for (var r, e = (function(n) { var m = {}; for (var k in n) m[k] = n[k]; return m; })({}), u = 0; !r; ) { r = true; }
+    );
+    defer r.deinit();
+    // `;;` (for init 뒤에 세미콜론 2개) 가 절대 출력되지 않아야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ";;") == null);
+}
+
+test "Codegen #1564: nested classic-for inside outer for-init preserves in_for_init" {
+    var r = try e2e(std.testing.allocator,
+        \\for (var a = (function() { for (var i = 0; i < 1; i++) {} return 0; })(), b = 1; a < 2; ) { a++; }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ";;") == null);
+}
+
 // ============================================================
 // Peephole (#1552 P3): minify_syntax — boolean 축약
 // ============================================================

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -187,6 +187,34 @@ test "Codegen #1564: nested classic-for inside outer for-init preserves in_for_i
     try std.testing.expect(std.mem.indexOf(u8, r.output, ";;") == null);
 }
 
+test "Codegen #1564: triple-nested for-in inside IIFE in outer for-init" {
+    // 3중 중첩: outer for init → IIFE body → 인접한 두 for-in
+    // 내부 for-in이 각각 종료할 때마다 in_for_init을 덮어쓰지 않아야 한다.
+    var r = try e2e(std.testing.allocator,
+        \\for (var r, e = (function(n) { var a = []; for (var x in n) for (var y in n[x]) a.push(x+y); return a; })({p:{q:1}}), u = 0; u < e.length; u++) { }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ";;") == null);
+}
+
+test "Codegen #1564: for-of inside outer for-init preserves in_for_init" {
+    // for-in뿐 아니라 for-of도 같은 플래그를 사용하므로 동일 경로 회귀 확인.
+    var r = try e2e(std.testing.allocator,
+        \\for (var r = 0, arr = (function() { var out = []; for (var v of [1,2,3]) out.push(v); return out; })(), n = arr.length; r < n; r++) { }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ";;") == null);
+}
+
+test "Codegen #1564: let/const mixed with nested for-in" {
+    // `let`, `const` kind도 VariableDeclaration emit 경로를 공유하므로 동일 가드.
+    var r = try e2e(std.testing.allocator,
+        \\for (let r = 0, e = (function(n) { const m = {}; for (const k in n) m[k] = n[k]; return m; })({a:1}), keys = Object.keys(e); r < keys.length; r++) { }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ";;") == null);
+}
+
 // ============================================================
 // Peephole (#1552 P3): minify_syntax — boolean 축약
 // ============================================================

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -248,6 +248,35 @@ test "private method: es2022 target preserves original" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "WeakSet") == null);
 }
 
+// #1564 Case 2 회귀 가드: generator private method (`*#name`) 를 다운레벨링할 때,
+// method_definition의 is_generator flag를 function_declaration으로 복사해야 한다.
+// 과거 `buildStandaloneFunc`가 flags=0으로 하드코딩해서 `function* _fn` 대신
+// 일반 `function _fn`이 생성 → `yield`가 일반 함수에 노출되어 SyntaxError 발생.
+test "private generator method: es2021 → function* _name_fn preserves generator (#1564)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  *#walk() { yield 1; yield 2; }
+        \\  run() { return this.#walk(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // standalone function이 generator(`function*`) kind로 생성되어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function* _walk_fn()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "yield") != null);
+}
+
+test "private async method: es2021 → async function preserves async (#1564)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  async #fetch() { return 1; }
+        \\  run() { return this.#fetch(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // async 플래그도 standalone function으로 전이되어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "async function _fetch_fn()") != null);
+}
+
 // ============================================================
 // JSX text normalization
 // ============================================================

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -277,6 +277,52 @@ test "private async method: es2021 → async function preserves async (#1564)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "async function _fetch_fn()") != null);
 }
 
+test "private async generator method: async *#name → async function* (#1564)" {
+    // async + generator 플래그가 동시에 전이되어야 한다.
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  async *#walk() { yield 1; yield await Promise.resolve(2); }
+        \\  run() { return this.#walk(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "async function* _walk_fn()") != null);
+}
+
+test "private generator method: yield* delegation preserved (#1564)" {
+    // generator 내부에서 다른 private generator를 yield*로 위임하는 경우.
+    // 두 standalone function 모두 `function*` kind로 생성되어야 yield*가 유효.
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Box {
+        \\  *#inner() { yield 1; }
+        \\  *#outer() { yield* this.#inner(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function* _inner_fn()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function* _outer_fn()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "yield*") != null);
+}
+
+test "private methods mixed kinds: generator + async + plain (#1564)" {
+    // 한 클래스에 kind가 다른 private 메서드가 섞여 있어도 각각 올바른 kind로 hoist.
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Registry {
+        \\  *#ids() { yield "a"; }
+        \\  async #name(id: string) { return "n-" + id; }
+        \\  #plain() { return 42; }
+        \\  run() { return [this.#ids(), this.#name("x"), this.#plain()]; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function* _ids_fn()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "async function _name_fn(") != null);
+    // plain은 async/generator 키워드가 붙지 않아야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _plain_fn()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "async function _plain_fn") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function* _plain_fn") == null);
+}
+
 // ============================================================
 // JSX text normalization
 // ============================================================

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -612,12 +612,16 @@ pub fn buildWeakCollectionDecl(self: anytype, constructor_name: []const u8, var_
 }
 
 /// method_definition → standalone function declaration으로 추출.
+/// private generator method (`*#name`) / async method 를 `_name_fn` 으로 꺼낼 때
+/// method flags(is_async, is_generator)를 function flags로 옮겨 호이스팅한다.
+/// 이 매핑이 없으면 `function* _fn` 을 잃어 `yield` 가 일반 함수에 노출돼 SyntaxError (#1564).
 pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeIndex, span: Span) !NodeIndex {
     const method_node = self.ast.getNode(method_idx);
     const params_list_old = self.ast.functionParamsList(method_node);
     const params_start = params_list_old.start;
     const params_len = params_list_old.len;
-    const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[method_node.data.extra + ast_mod.MethodExtra.body]);
+    const body_idx: NodeIndex = @enumFromInt(self.readU32(method_node.data.extra, ast_mod.MethodExtra.body));
+    const method_flags = self.readU32(method_node.data.extra, ast_mod.MethodExtra.flags);
 
     const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 
@@ -626,13 +630,17 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const name_span = try self.ast.addString(name);
     const name_node = try makeBindingIdentifier(self, name_span);
 
+    var fn_flags: u32 = 0;
+    if ((method_flags & ast_mod.MethodFlags.is_async) != 0) fn_flags |= ast_mod.FunctionFlags.is_async;
+    if ((method_flags & ast_mod.MethodFlags.is_generator) != 0) fn_flags |= ast_mod.FunctionFlags.is_generator;
+
     const none = @intFromEnum(NodeIndex.none);
     const new_params_node = try self.ast.addFormalParameters(new_params, span);
     const func_extra = try self.ast.addExtras(&.{
         @intFromEnum(name_node),
         @intFromEnum(new_params_node),
         @intFromEnum(new_body),
-        0,
+        fn_flags,
         none,
     });
     return self.ast.addNode(.{


### PR DESCRIPTION
Closes #1564

## Summary

mobx/lru-cache@es2021 smoke에서 실행 실패하던 두 가지 독립 codegen 버그를 수정.

### Case 1 — `for (...; cond; )` init 뒤에 `;;` 중복
`for (var a, b = IIFE{... for (k in n) ...}, c; cond;) { ... }` 처럼 **init 안에 중첩된 for 문**이 있으면, 내부 for가 종료하며 Codegen의 `in_for_init` 플래그를 `false`로 덮어쓴다. 그 이후 바깥 for init의 남은 declarator를 emit할 때 `emitVariableDeclaration`이 `!in_for_init` 가드를 실패로 판정해 **세미콜론을 자체 출력**한 뒤, `emitFor`가 init→cond 구분자로 `;`을 또 한 번 찍어 `;;`이 된다.

`emitFor` / `emitForAwaitOf` / `emitForInOf`에서 `in_for_init`·`skip_var_init`을 save/restore로 전환해 중첩 상황에서도 바깥 상태가 보존되도록 수정.

### Case 2 — generator/async private method 다운레벨 시 `function*` 키워드 유실
`class { *#walk() { yield ... } }` 를 `--target=es2021`로 낮추면 `buildStandaloneFunc`가 method를 `_walk_fn`으로 꺼내면서 `flags=0`을 하드코딩해 **generator 정보가 사라진다**. 결과적으로 `yield`가 일반 function 안에 놓여 `SyntaxError` 발생. async도 같은 경로라 동일 증상.

`MethodFlags.is_async` / `MethodFlags.is_generator` 비트를 `FunctionFlags`로 매핑하도록 수정. 매핑 규칙은 기존 `src/transformer/es2015_object_methods.zig:85-89`와 동일.

## Verification

로컬 재현으로 확인:
- mobx 번들 실행: 이전 `SyntaxError: Unexpected token ';'` → 수정 후 `42` 정상 출력
- lru-cache@es2021 번들 실행: 이전 `SyntaxError: Unexpected identifier 'e'` → 수정 후 `1` 정상 출력
- `zig build test` · `bun test downlevel` (553 pass) · `bun test bundle-smoke` (139 pass) 모두 통과
- bundle size 변동 없음 (mobx 231566B, lru-cache 34057B)

## Test plan
- [x] `zig build test` 전체 통과
- [x] mobx smoke: 번들 + node 실행 → `42`
- [x] lru-cache@es2021 smoke: 번들 + node 실행 → `1`
- [x] downlevel 통합 테스트 553 pass
- [x] bundle-smoke 139 pass
- [x] 회귀 가드 4건 추가 (`;;` 없음, `function* _walk_fn`, `async function _fetch_fn`, classic-for 중첩)

🤖 Generated with [Claude Code](https://claude.com/claude-code)