### PR TITLE
refactor(ast): methodFlagsToFunctionFlags 헬퍼로 매핑 통일

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1100,6 +1100,17 @@ pub const MethodFlags = struct {
     pub const is_declare: u32 = 0x40;
 };
 
+/// method_definition → function_declaration/expression으로 추출할 때
+/// async/generator 비트를 FunctionFlags 위치로 옮긴다.
+/// 두 공간의 비트 위치가 달라 복사할 때마다 같은 매핑이 반복되던 것을 한 곳에 모았다.
+/// (method의 static/getter/setter 비트는 function에 해당 개념 없음 — 폐기)
+pub fn methodFlagsToFunctionFlags(method_flags: u32) u32 {
+    var fn_flags: u32 = 0;
+    if ((method_flags & MethodFlags.is_async) != 0) fn_flags |= FunctionFlags.is_async;
+    if ((method_flags & MethodFlags.is_generator) != 0) fn_flags |= FunctionFlags.is_generator;
+    return fn_flags;
+}
+
 /// method_definition extras 레이아웃: [key, params, body, flags, deco_start, deco_len] (#1513).
 /// 매직 offset 숫자 (`readU32(e, 3)`) 대신 `MethodExtra.flags` 사용.
 pub const MethodExtra = struct {

--- a/src/transformer/es2015_object_methods.zig
+++ b/src/transformer/es2015_object_methods.zig
@@ -81,12 +81,8 @@ pub fn ES2015ObjectMethods(comptime Transformer: type) type {
                     continue;
                 }
 
-                // function_expression 플래그 재매핑
-                // method flags: bit3=async(0x08), bit4=generator(0x10)
-                // function flags: bit0=async(0x01), bit1=generator(0x02)
-                var fn_flags: u32 = 0;
-                if ((flags & 0x08) != 0) fn_flags |= ast_mod.FunctionFlags.is_async;
-                if ((flags & 0x10) != 0) fn_flags |= ast_mod.FunctionFlags.is_generator;
+                // method → function 플래그 재매핑 (비트 위치가 다름).
+                const fn_flags = ast_mod.methodFlagsToFunctionFlags(flags);
 
                 const none = @intFromEnum(NodeIndex.none);
 

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -630,9 +630,7 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const name_span = try self.ast.addString(name);
     const name_node = try makeBindingIdentifier(self, name_span);
 
-    var fn_flags: u32 = 0;
-    if ((method_flags & ast_mod.MethodFlags.is_async) != 0) fn_flags |= ast_mod.FunctionFlags.is_async;
-    if ((method_flags & ast_mod.MethodFlags.is_generator) != 0) fn_flags |= ast_mod.FunctionFlags.is_generator;
+    const fn_flags = ast_mod.methodFlagsToFunctionFlags(method_flags);
 
     const none = @intFromEnum(NodeIndex.none);
     const new_params_node = try self.ast.addFormalParameters(new_params, span);


### PR DESCRIPTION
## Summary

`MethodFlags`(bit3=async, bit4=generator)와 `FunctionFlags`(bit0=async, bit1=generator)의 비트 위치가 달라, method_definition을 function으로 추출하는 곳마다 동일한 2-line 매핑이 반복됐다. 한 곳(`es_helpers.zig`)은 상수 사용, 다른 한 곳(`es2015_object_methods.zig`)은 매직넘버 `0x08`/`0x10`을 써서 같은 연산이라는 점이 눈에 보이지 않았다.

`ast.methodFlagsToFunctionFlags(u32) u32` 헬퍼로 묶고 두 호출부를 한 줄로 교체. #1564 Case 2 (generator private method에서 flags=0 하드코딩) 같은 누락 재발 면역성도 소폭 상승.

- `src/parser/ast.zig`: `methodFlagsToFunctionFlags` 신설
- `src/transformer/es_helpers.zig:buildStandaloneFunc` (#1564 수정분): 헬퍼 호출로 대체
- `src/transformer/es2015_object_methods.zig`: 매직넘버 제거 + 헬퍼 호출

동작 변경 없음 — 순수 리팩토링.

## Test plan
- [x] `zig build test` 전체 통과
- [x] integration downlevel 553 pass
- [x] 동일 출력 확인 (매핑 결과 불변)

🤖 Generated with [Claude Code](https://claude.com/claude-code)