### PR TITLE
refactor(ast): MethodFlags 매직넘버 일소 (parser/transformer/codegen)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2332,15 +2332,14 @@ pub const Codegen = struct {
 
         try self.emitMemberDecorators(deco_start, deco_len);
 
-        // flags: bit0=static, bit1=getter, bit2=setter, bit3=async, bit4=generator(*)
-        if (flags & 0x01 != 0) try self.write("static ");
-        if (flags & 0x08 != 0) try self.write("async ");
-        if (flags & 0x02 != 0) {
+        if (flags & ast_mod.MethodFlags.is_static != 0) try self.write("static ");
+        if (flags & ast_mod.MethodFlags.is_async != 0) try self.write("async ");
+        if (flags & ast_mod.MethodFlags.is_getter != 0) {
             try self.write("get ");
-        } else if (flags & 0x04 != 0) {
+        } else if (flags & ast_mod.MethodFlags.is_setter != 0) {
             try self.write("set ");
         }
-        if (flags & 0x10 != 0) try self.writeByte('*');
+        if (flags & ast_mod.MethodFlags.is_generator != 0) try self.writeByte('*');
 
         try self.emitNode(key);
         try self.writeByte('(');

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -688,8 +688,8 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.in_class_field = false;
         // 메서드의 파라미터에서 async/generator 컨텍스트 설정
         // 非async/非generator 메서드에서는 await/yield를 식별자로 사용 가능
-        self.ctx.in_async = (flags & 0x08) != 0;
-        self.ctx.in_generator = (flags & 0x10) != 0;
+        self.ctx.in_async = (flags & ast_mod.MethodFlags.is_async) != 0;
+        self.ctx.in_generator = (flags & ast_mod.MethodFlags.is_generator) != 0;
         // class 메서드의 파라미터에서 super.prop 허용 (ECMAScript 15.7.5)
         self.allow_super_property = true;
         try self.expect(.l_paren);
@@ -744,12 +744,15 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         // 메서드도 함수이므로 컨텍스트 설정
         var body = NodeIndex.none;
         if (self.current() == .l_curly) {
-            // 메서드의 async/generator 플래그는 함수와 비트 위치가 다름 (0x08/0x10)
-            const saved_ctx = self.enterFunctionContext((flags & 0x08) != 0, (flags & 0x10) != 0);
+            // MethodFlags와 FunctionFlags는 비트 위치가 다르다 (MethodFlags는 static/getter/setter 비트가 선점).
+            const saved_ctx = self.enterFunctionContext(
+                (flags & ast_mod.MethodFlags.is_async) != 0,
+                (flags & ast_mod.MethodFlags.is_generator) != 0,
+            );
             // class 메서드는 super.prop 허용 (ECMAScript 12.3.7)
             self.allow_super_property = true;
             // constructor에서는 super() 호출도 허용
-            if (!key.isNone() and (flags & 0x01) == 0) { // non-static
+            if (!key.isNone() and (flags & ast_mod.MethodFlags.is_static) == 0) {
                 const mk = self.ast.getNode(key);
                 const kt = if (mk.tag == .identifier_reference)
                     self.ast.source[mk.span.start..mk.span.end]

--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -161,11 +161,12 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
 }
 
 /// 객체 리터럴 메서드의 파라미터와 본문을 파싱한다.
-/// flags: 0x02=getter, 0x04=setter, 0x08=async, 0x10=generator
 pub fn parseObjectMethodBody(self: *Parser, start: u32, key: NodeIndex, flags: u16) ParseError2!NodeIndex {
     // 메서드 컨텍스트 진입 — 파라미터/본문 모두 이 컨텍스트에서 파싱
-    // flags: 0x02=getter, 0x04=setter, 0x08=async, 0x10=generator
-    const saved_ctx = self.enterFunctionContext((flags & 0x08) != 0, (flags & 0x10) != 0);
+    const saved_ctx = self.enterFunctionContext(
+        (flags & ast_mod.MethodFlags.is_async) != 0,
+        (flags & ast_mod.MethodFlags.is_generator) != 0,
+    );
     // ECMAScript 12.3.7: 객체 리터럴 메서드에서도 super.prop 허용
     self.allow_super_property = true;
 

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2372,8 +2372,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const params_list_unwrap = self.ast.functionParamsList(member);
             const new_params = try self.visitExtraList(params_list_unwrap);
 
-            const is_async = flags & 0x08 != 0;
-            const is_generator = flags & 0x10 != 0;
+            const is_async = flags & ast_mod.MethodFlags.is_async != 0;
+            const is_generator = flags & ast_mod.MethodFlags.is_generator != 0;
 
             // async method + generator 다운레벨링: class lowering이 먼저 실행되어
             // method_definition → function_expression으로 변환되므로,


### PR DESCRIPTION
## Summary

method_definition의 flags 비트(`static=0x01`, `getter=0x02`, `setter=0x04`, `async=0x08`, `generator=0x10`)를 **날값으로 쓰던 5곳**을 `ast_mod.MethodFlags.*` 상수로 통일.

- `src/parser/object.zig:parseObjectMethodBody`
- `src/parser/declaration.zig`: 메서드 params/body 컨텍스트 설정(2곳) + constructor non-static 체크
- `src/transformer/es2015_class.zig`: class lowering의 async/generator 분기
- `src/codegen/codegen.zig`: class method keyword emit (`static`/`async`/`get`/`set`/`*`)

#1564 Case 2가 "flags 비트를 0으로 하드코딩"이었던 만큼, 비트를 눈으로 다루는 패턴이 같은 류의 누락 버그 온상이었다는 맥락에서 정리. Parser/Transformer/Codegen 전 계층이 이제 상수 이름으로 플래그를 읽는다.

동작 변경 없음 — 순수 리팩토링.

## Test plan
- [x] `zig build test` 전체 통과
- [x] integration downlevel + bundle-smoke 694 pass
- [x] grep으로 `flags & 0x0[1-9a-f]`/`0x10`이 메서드 관련 경로에 남지 않음 확인 (nonmember flag들은 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)