### PR TITLE
refactor(ast): UnaryFlags.postfix 매직넘버 0x100 제거

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1490,7 +1490,7 @@ pub const Codegen = struct {
         if (e + 1 >= extras.len) return;
         const operand: NodeIndex = @enumFromInt(extras[e]);
         const flags = extras[e + 1];
-        const is_postfix = (flags & 0x100) != 0;
+        const is_postfix = (flags & ast_mod.UnaryFlags.postfix) != 0;
         const op: Kind = @enumFromInt(@as(u8, @truncate(flags)));
         if (!is_postfix) try self.write(op.symbol());
         try self.emitNode(operand);

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -793,7 +793,7 @@ fn parsePostfixExpression(self: *Parser) ParseError2!NodeIndex {
         const kind = self.current();
         try self.advance();
         {
-            const ue = try self.ast.addExtras(&.{ @intFromEnum(expr), @as(u32, @intFromEnum(kind)) | 0x100 }); // 0x100 = postfix
+            const ue = try self.ast.addExtras(&.{ @intFromEnum(expr), @as(u32, @intFromEnum(kind)) | ast_mod.UnaryFlags.postfix });
             expr = try self.ast.addNode(.{
                 .tag = .update_expression,
                 .span = .{ .start = expr_start, .end = self.currentSpan().start },

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1079,7 +1079,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             const op_kind = op_flags & 0xFF;
             const is_increment = (op_kind == @intFromEnum(token_mod.Kind.plus2));
-            const is_postfix = (op_flags & 0x100) != 0;
+            const is_postfix = (op_flags & ast_mod.UnaryFlags.postfix) != 0;
             const bin_op: u16 = if (is_increment) @intFromEnum(token_mod.Kind.plus) else @intFromEnum(token_mod.Kind.minus);
 
             if (is_postfix) {


### PR DESCRIPTION
## Summary

update_expression의 `postfix` 비트(`0x100`)를 날값으로 쓰던 3곳을 `ast_mod.UnaryFlags.postfix` 상수로 통일. op kind(하위 8비트)와 postfix 비트를 같은 u32에 packed해서 저장하는 구조라 `| 0x100` / `& 0x100`이 parser/transformer/codegen에 흩어져 있었다.

- `src/parser/expression.zig`: postfix 플래그 생성
- `src/codegen/codegen.zig`: update_expression emit
- `src/transformer/es2015_class.zig`: private field update 다운레벨

상수는 이미 `ast.zig:1162-1164`에 정의돼 있던 것 — 사용처만 누락.

동작 변경 없음 — 순수 리팩토링.

## Test plan
- [x] `zig build test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)