### PR TITLE
refactor(ast): PropertyFlags struct 신설 + 매직넘버 치환

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2358,7 +2358,7 @@ pub const Codegen = struct {
 
         try self.emitMemberDecorators(deco_start, deco_len);
 
-        if (flags & 0x01 != 0) try self.write("static ");
+        if (flags & ast_mod.PropertyFlags.is_static != 0) try self.write("static ");
         try self.emitNode(key);
         if (!value.isNone()) {
             try self.writeSpace();
@@ -2405,7 +2405,7 @@ pub const Codegen = struct {
 
         try self.emitMemberDecorators(deco_start, deco_len);
 
-        if (flags & 0x01 != 0) try self.write("static ");
+        if (flags & ast_mod.PropertyFlags.is_static != 0) try self.write("static ");
         try self.write("accessor ");
         try self.emitNode(key);
         if (!value.isNone()) {

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1131,6 +1131,17 @@ pub const PropertyExtra = struct {
     pub const deco_len: u32 = 4;
 };
 
+/// property_definition / accessor_property의 flags 비트 (PropertyExtra.flags).
+/// class member parser가 method/property를 같은 함수에서 파싱하므로
+/// `MethodFlags`와 비트 위치를 공유한다. property에서 의미있는 비트만 expose.
+/// (getter/setter/async/generator는 method 전용 — property에선 parser가 기록하지 않음)
+pub const PropertyFlags = struct {
+    pub const is_static: u32 = 0x01;
+    pub const is_abstract: u32 = 0x20;
+    pub const is_declare: u32 = 0x40;
+    pub const flow_variance: u32 = 0x80; // Flow covariant(+)/contravariant(-) — type-only property
+};
+
 /// class_declaration / class_expression extras 레이아웃:
 /// [name, super, body, type_params, impl_start, impl_len, deco_start, deco_len] (#1513).
 pub const ClassExtra = struct {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1481,7 +1481,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const key: NodeIndex = self.readNodeIdx(pe, PropertyExtra.key);
                     const init_val: NodeIndex = self.readNodeIdx(pe, PropertyExtra.init);
                     const flags = self.readU32(pe, PropertyExtra.flags);
-                    const is_static = (flags & 0x01) != 0;
+                    const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
 
                     // private field (#x) → instance: WeakMap, static: descriptor 객체
                     const key_node = self.ast.getNode(key);
@@ -2640,7 +2640,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     // property decorator
                     const pe = member.data.extra;
                     const flags = self.readU32(pe, PropertyExtra.flags);
-                    const is_static = (flags & 0x01) != 0;
+                    const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
                     const deco_start = self.readU32(pe, PropertyExtra.deco_start);
                     const deco_len = self.readU32(pe, PropertyExtra.deco_len);
                     if (deco_len > 0) {

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -230,7 +230,7 @@ pub fn ES2022(comptime Transformer: type) type {
                         if (key_node.tag != .private_identifier) continue;
 
                         const flags = self.readU32(pe, ast_mod.PropertyExtra.flags);
-                        const is_static = (flags & 0x01) != 0;
+                        const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
                         // static private field는 class 이름 기반 brand check 헬퍼를 사용하므로
                         // 익명 class에서는 다운레벨할 수 없다 (클래스 자체 참조가 없음).
                         if (is_static and class_name_text == null) continue;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -4043,7 +4043,7 @@ pub const Transformer = struct {
         const e = node.data.extra;
         const flags = self.readU32(e, 2);
         // declare accessor는 타입 전용이므로 완전히 스트리핑
-        if (self.options.strip_types and (flags & 0x40) != 0) return NodeIndex.none;
+        if (self.options.strip_types and (flags & ast_mod.PropertyFlags.is_declare) != 0) return NodeIndex.none;
         const new_key = try self.visitNode(self.readNodeIdx(e, 0));
         const new_value = try self.visitNode(self.readNodeIdx(e, 1));
         const new_decos = try self.visitExtraList(.{ .start = self.readU32(e, 3), .len = self.readU32(e, 4) });

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -2003,7 +2003,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 const flags = self.readU32(me, ast_mod.PropertyExtra.flags);
                 const deco_start = self.readU32(me, ast_mod.PropertyExtra.deco_start);
                 const deco_len = self.readU32(me, ast_mod.PropertyExtra.deco_len);
-                const is_static = (flags & 0x01) != 0;
+                const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
 
                 // key를 한 번만 방문
                 const key_idx_prop = self.readNodeIdx(me, ast_mod.PropertyExtra.key);
@@ -2087,7 +2087,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 const flags = self.readU32(me, ast_mod.PropertyExtra.flags);
                 const deco_start = self.readU32(me, ast_mod.PropertyExtra.deco_start);
                 const deco_len = self.readU32(me, ast_mod.PropertyExtra.deco_len);
-                const is_static = (flags & 0x01) != 0;
+                const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
 
                 const key_idx = self.readNodeIdx(me, ast_mod.PropertyExtra.key);
                 const new_key = try self.visitNode(key_idx);


### PR DESCRIPTION
## Summary

property_definition / accessor_property의 flags 비트(`static=0x01`, `abstract=0x20`, `declare=0x40`, flow variance=`0x80`)가 parser의 class member 공유 파싱 함수에서 기록되는데, 읽는 쪽에서 날값으로 접근하고 있어 의미가 불분명했다. method 경로와 구분 없이 `flags & 0x01`이 여기저기 뿌려져 있었다.

### 변경

- **`ast.zig`**: `PropertyFlags` struct 신설. MethodFlags와 비트 공간을 공유(parser가 같은 함수에서 파싱)하되, property에서 실제 의미있는 비트만 expose: `is_static`, `is_abstract`, `is_declare`, `flow_variance`.
- **property context의 날값을 상수로 교체** (5 파일):
  - `src/codegen/codegen.zig`: property/accessor emit — static
  - `src/transformer/es2015_class.zig`: member 분류(1484), decorator 분기(2643)
  - `src/transformer/es2022.zig`: private field 다운레벨 — static
  - `src/transformer/transformer/class_decorator.zig`: property / accessor 데코레이터
  - `src/transformer/transformer.zig`: `visitAccessorProperty` — declare 스트리핑

method context의 날값(`transformer.zig:3885, 3917`, `es2015_class.zig:1428-30` 등)은 범위 밖 — **다음 PR**에서 처리.

동작 변경 없음 — 순수 리팩토링.

## Test plan
- [x] `zig build test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)