### PR TITLE
refactor(ast): MethodFlags 잔여 매직넘버 일소 (parser/semantic/transformer/codegen)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -521,9 +521,9 @@ pub const Codegen = struct {
     /// getter → "get__name", setter → "set__name", constructor → class 이름.
     /// 부모 class 이름이 있으면 "ClassName#method" / "ClassName.method" 형태.
     fn resolveMethodName(self: *Codegen, key: NodeIndex, flags: u32) ![]const u8 {
-        const is_getter = flags & 0x02 != 0;
-        const is_setter = flags & 0x04 != 0;
-        const is_static = flags & 0x01 != 0;
+        const is_getter = flags & ast_mod.MethodFlags.is_getter != 0;
+        const is_setter = flags & ast_mod.MethodFlags.is_setter != 0;
+        const is_static = flags & ast_mod.MethodFlags.is_static != 0;
         const sep: []const u8 = if (is_static) "." else "#";
 
         const raw = self.resolveKeyName(key) orelse "<anonymous>";

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -30,8 +30,8 @@ const ts_class_modifiers: []const []const u8 = &.{ "readonly", "abstract", "over
 fn detectAbstractDeclare(self: *Parser) u16 {
     if (self.current() != .identifier) return 0;
     const text = self.scanner.source[self.scanner.token.span.start..self.scanner.token.span.end];
-    if (std.mem.eql(u8, text, "abstract")) return 0x20;
-    if (std.mem.eql(u8, text, "declare")) return 0x40;
+    if (std.mem.eql(u8, text, "abstract")) return @intCast(ast_mod.MethodFlags.is_abstract);
+    if (std.mem.eql(u8, text, "declare")) return @intCast(ast_mod.MethodFlags.is_declare);
     return 0;
 }
 
@@ -545,7 +545,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
             next != .r_curly and next != .eof and
             !(try self.peekNext()).has_newline_before)
         {
-            flags |= 0x01; // static modifier
+            flags |= @intCast(ast_mod.MethodFlags.is_static);
             try self.advance();
         }
     }
@@ -555,7 +555,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
     // static 키워드 소비 후, 프로퍼티 키 파싱 전에 variance marker를 건너뛴다.
     if (self.is_flow and (self.current() == .plus or self.current() == .minus)) {
         try self.advance(); // skip variance marker
-        flags |= 0x80; // Flow covariant/contravariant → type-only property
+        flags |= @intCast(ast_mod.PropertyFlags.flow_variance);
     }
 
     // static 뒤의 TS modifier도 소비 (static readonly x 등)
@@ -597,9 +597,9 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
     // get/set: 다음 토큰이 줄바꿈 없이 프로퍼티 이름이면 accessor, 아니면 필드 이름
     // 예: class A { get\n*x() {} } → get은 필드 (ASI), *x는 generator
     const accessor_flag: ?u16 = if (self.current() == .kw_get)
-        0x02
+        @intCast(ast_mod.MethodFlags.is_getter)
     else if (self.current() == .kw_set)
-        0x04
+        @intCast(ast_mod.MethodFlags.is_setter)
     else
         null;
     if (accessor_flag) |flag| {
@@ -623,13 +623,13 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .kw_async and try self.peekNextKind() != .l_paren and
         !(try self.peekNext()).has_newline_before)
     {
-        flags |= 0x08; // async flag
+        flags |= @intCast(ast_mod.MethodFlags.is_async);
         try self.advance();
     }
 
     // generator (선택): *method() {}
     if (try self.eat(.star)) {
-        flags |= 0x10; // generator flag
+        flags |= @intCast(ast_mod.MethodFlags.is_generator);
     }
 
     // TS 인덱스 시그니처: [key: string]: any — class body에서만 유효, 타입 스트리핑 대상
@@ -721,13 +721,14 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
                 self.ast.source[mk.span.start + 1 .. mk.span.end - 1]
             else
                 @as([]const u8, "");
-            if ((flags & 0x01) != 0 and std.mem.eql(u8, method_name, "prototype")) {
+            if ((flags & ast_mod.MethodFlags.is_static) != 0 and std.mem.eql(u8, method_name, "prototype")) {
                 try self.addErrorCode(mk.span, "Static class method cannot be named 'prototype'", .static_method_prototype);
             }
             // constructor는 일반 method만 가능 — getter/setter/generator/async 금지
-            if ((flags & 0x01) == 0 and std.mem.eql(u8, method_name, "constructor")) {
-                // flags: 0x02=getter, 0x04=setter, 0x08=async, 0x10=generator
-                if ((flags & 0x1E) != 0) {
+            if ((flags & ast_mod.MethodFlags.is_static) == 0 and std.mem.eql(u8, method_name, "constructor")) {
+                const invalid_mask = ast_mod.MethodFlags.is_getter | ast_mod.MethodFlags.is_setter |
+                    ast_mod.MethodFlags.is_async | ast_mod.MethodFlags.is_generator;
+                if ((flags & invalid_mask) != 0) {
                     try self.addErrorCode(mk.span, "Class constructor cannot be a getter, setter, generator, or async", .class_constructor_invalid);
                 }
             }
@@ -819,7 +820,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
             if (std.mem.eql(u8, key_text, "constructor")) {
                 try self.addErrorCode(key_node.span, "Class field cannot be named 'constructor'", .class_field_constructor);
             }
-            if ((flags & 0x01) != 0 and std.mem.eql(u8, key_text, "prototype")) {
+            if ((flags & ast_mod.PropertyFlags.is_static) != 0 and std.mem.eql(u8, key_text, "prototype")) {
                 try self.addErrorCode(key_node.span, "Static class field cannot be named 'prototype'", .static_field_prototype);
             }
         }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -2075,8 +2075,8 @@ pub const SemanticAnalyzer = struct {
                     const kind: PrivateNameKind = blk: {
                         if (extra_start + 3 < self.ast.extra_data.items.len) {
                             const flags = self.ast.extra_data.items[extra_start + ast_mod.MethodExtra.flags];
-                            if (flags & 0x02 != 0) break :blk .getter;
-                            if (flags & 0x04 != 0) break :blk .setter;
+                            if (flags & ast_mod.MethodFlags.is_getter != 0) break :blk .getter;
+                            if (flags & ast_mod.MethodFlags.is_setter != 0) break :blk .setter;
                         }
                         break :blk .method;
                     };

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -41,10 +41,10 @@ const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
 const es2022 = @import("es2022.zig");
 
-const METHOD_FLAG_STATIC = ast_mod.MethodFlags.is_static;
-const METHOD_FLAG_SETTER = ast_mod.MethodFlags.is_setter;
 const MethodExtra = ast_mod.MethodExtra;
+const MethodFlags = ast_mod.MethodFlags;
 const PropertyExtra = ast_mod.PropertyExtra;
+const PropertyFlags = ast_mod.PropertyFlags;
 
 pub fn ES2015Class(comptime Transformer: type) type {
     return struct {
@@ -1425,10 +1425,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const me = member.data.extra;
                     const key: NodeIndex = self.readNodeIdx(me, MethodExtra.key);
                     const flags = self.readU32(me, MethodExtra.flags);
-                    const is_static = (flags & 0x01) != 0;
-                    const is_abstract = (flags & 0x20) != 0;
-                    const is_declare = (flags & 0x40) != 0;
-                    const kind = (flags >> 1) & 0x03; // 0=method, 1=get, 2=set
+                    const is_static = (flags & ast_mod.MethodFlags.is_static) != 0;
+                    const is_abstract = (flags & ast_mod.MethodFlags.is_abstract) != 0;
+                    const is_declare = (flags & ast_mod.MethodFlags.is_declare) != 0;
+                    const kind = (flags >> 1) & 0x03; // 0=method, 1=get, 2=set (MethodFlags.is_getter/is_setter를 >>1 shift해 0/1/2 값으로)
 
                     // 본문 없는 메서드 스트리핑: abstract, declare, TS 오버로드 시그니처
                     const method_body: NodeIndex = @enumFromInt(self.readU32(me, MethodExtra.body));
@@ -1581,7 +1581,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const key_idx = self.readNodeIdx(pe, PropertyExtra.key);
             const init_idx = self.readNodeIdx(pe, PropertyExtra.init);
             const flags = self.readU32(pe, PropertyExtra.flags);
-            const is_static = (flags & METHOD_FLAG_STATIC) != 0;
+            const is_static = (flags & PropertyFlags.is_static) != 0;
 
             const key_node = self.ast.getNode(key_idx);
             if (key_node.tag == .private_identifier) {
@@ -2609,7 +2609,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 if (member.tag == .method_definition) {
                     const me = member.data.extra;
                     const flags = self.readU32(me, MethodExtra.flags);
-                    const is_static = (flags & 0x01) != 0;
+                    const is_static = (flags & ast_mod.MethodFlags.is_static) != 0;
                     const key: NodeIndex = self.readNodeIdx(me, MethodExtra.key);
                     const params_list_m = self.ast.functionParamsList(member);
 

--- a/src/transformer/es2015_object_methods.zig
+++ b/src/transformer/es2015_object_methods.zig
@@ -35,9 +35,9 @@ pub fn ES2015ObjectMethods(comptime Transformer: type) type {
             for (members) |raw_idx| {
                 const m = self.ast.getNode(@enumFromInt(raw_idx));
                 if (m.tag != .method_definition) continue;
-                const flags = self.ast.extra_data.items[m.data.extra + 3];
-                // getter(0x02) / setter(0x04) 는 ES5 지원 → 변환 제외
-                if ((flags & 0x02) != 0 or (flags & 0x04) != 0) continue;
+                const flags = self.ast.extra_data.items[m.data.extra + ast_mod.MethodExtra.flags];
+                // getter / setter 는 ES5 지원 → 변환 제외
+                if ((flags & ast_mod.MethodFlags.is_getter) != 0 or (flags & ast_mod.MethodFlags.is_setter) != 0) continue;
                 return true;
             }
             return false;
@@ -69,13 +69,13 @@ pub fn ES2015ObjectMethods(comptime Transformer: type) type {
                 }
 
                 const me = m.data.extra;
-                const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
-                const params_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
-                const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 2]);
-                const flags: u32 = self.ast.extra_data.items[me + 3];
+                const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + ast_mod.MethodExtra.key]);
+                const params_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + ast_mod.MethodExtra.params]);
+                const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + ast_mod.MethodExtra.body]);
+                const flags: u32 = self.ast.extra_data.items[me + ast_mod.MethodExtra.flags];
 
                 // getter/setter는 원본 그대로 방문 (ES5 지원)
-                if ((flags & 0x02) != 0 or (flags & 0x04) != 0) {
+                if ((flags & ast_mod.MethodFlags.is_getter) != 0 or (flags & ast_mod.MethodFlags.is_setter) != 0) {
                     const new_m = try self.visitNode(m_idx);
                     if (!new_m.isNone()) try self.scratch.append(self.allocator, new_m);
                     continue;

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -207,9 +207,9 @@ pub fn ES2022(comptime Transformer: type) type {
                     if (lower_methods and member.tag == .method_definition) {
                         const me = member.data.extra;
                         const extras = self.ast.extra_data.items;
-                        const key: NodeIndex = @enumFromInt(extras[me]);
-                        const flags = extras[me + 3];
-                        const is_static = (flags & 0x01) != 0;
+                        const key: NodeIndex = @enumFromInt(extras[me + ast_mod.MethodExtra.key]);
+                        const flags = extras[me + ast_mod.MethodExtra.flags];
+                        const is_static = (flags & ast_mod.MethodFlags.is_static) != 0;
                         if (key.isNone() or is_static) continue;
                         const key_node = self.ast.getNode(key);
                         if (key_node.tag != .private_identifier) continue;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3877,12 +3877,12 @@ pub const Transformer = struct {
 
     // method_definition: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
     // constructor의 parameter property (public x: number) 변환도 처리.
-    // abstract 메서드 (flags bit5=0x20)는 런타임에 존재하면 안 되므로 완전히 제거.
+    // abstract 메서드는 런타임에 존재하면 안 되므로 완전히 제거.
     pub fn visitMethodDefinition(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
-        const flags = self.readU32(e, 3);
+        const flags = self.readU32(e, ast_mod.MethodExtra.flags);
         // abstract 메서드는 타입 전용이므로 완전히 스트리핑
-        if (self.options.strip_types and (flags & 0x20) != 0) return NodeIndex.none;
+        if (self.options.strip_types and (flags & ast_mod.MethodFlags.is_abstract) != 0) return NodeIndex.none;
         // TS method overload signature: body가 없으면 제거
         if (self.readNodeIdx(e, 2).isNone()) return NodeIndex.none;
         const new_key = try self.visitNode(self.readNodeIdx(e, 0));
@@ -3914,7 +3914,7 @@ pub const Transformer = struct {
         const saved_new_target_ctx = self.new_target_ctx;
         if (self.options.unsupported.new_target) {
             const is_ctor = blk: {
-                if ((flags & 0x01) != 0) break :blk false; // static
+                if ((flags & ast_mod.MethodFlags.is_static) != 0) break :blk false;
                 const key_idx = self.readNodeIdx(e, 0);
                 const key_node = self.ast.getNode(key_idx);
                 if (key_node.tag == .identifier_reference) {

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -588,12 +588,13 @@ pub fn classifyPropertyDefinition(
     const member_decorators = ctx.member_decorators;
     const me = member.data.extra;
     const flags = self.readU32(me, ast_mod.PropertyExtra.flags);
-    const is_static = (flags & 0x01) != 0;
-    const is_abstract = (flags & 0x20) != 0;
-    const is_declare = (flags & 0x40) != 0;
+    const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
+    const is_abstract = (flags & ast_mod.PropertyFlags.is_abstract) != 0;
+    const is_declare = (flags & ast_mod.PropertyFlags.is_declare) != 0;
 
-    // abstract(0x20), declare(0x40), Flow variance(0x80)는 타입 전용 → 스트리핑
-    if (self.options.strip_types and (flags & 0xE0) != 0) {
+    // abstract / declare / Flow variance는 타입 전용 → 스트리핑
+    const type_only_mask = ast_mod.PropertyFlags.is_abstract | ast_mod.PropertyFlags.is_declare | ast_mod.PropertyFlags.flow_variance;
+    if (self.options.strip_types and (flags & type_only_mask) != 0) {
         return;
     }
 
@@ -672,7 +673,7 @@ pub fn classifyMethodDefinition(
     const member_decorators = ctx.member_decorators;
     const me = member.data.extra;
     const flags = self.readU32(me, ast_mod.MethodExtra.flags);
-    const is_static = (flags & 0x01) != 0;
+    const is_static = (flags & ast_mod.MethodFlags.is_static) != 0;
     const params_list_m = self.ast.functionParamsList(member);
 
     // constructor 감지
@@ -1914,9 +1915,9 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 const flags = self.readU32(me, ast_mod.MethodExtra.flags);
                 const deco_start = self.readU32(me, ast_mod.MethodExtra.deco_start);
                 const deco_len = self.readU32(me, ast_mod.MethodExtra.deco_len);
-                const is_static = (flags & 0x01) != 0;
-                const is_getter = (flags & 0x02) != 0;
-                const is_setter = (flags & 0x04) != 0;
+                const is_static = (flags & ast_mod.MethodFlags.is_static) != 0;
+                const is_getter = (flags & ast_mod.MethodFlags.is_getter) != 0;
+                const is_setter = (flags & ast_mod.MethodFlags.is_setter) != 0;
 
                 // constructor 감지
                 if (!is_getter and !is_setter and !is_static) {
@@ -2389,8 +2390,10 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
             for (new_members.items, 0..) |member_node_idx, mi| {
                 const m = self.ast.getNode(member_node_idx);
                 if (m.tag != .method_definition) continue;
-                const m_flags = self.readU32(m.data.extra, 3);
-                if ((m_flags & 0x07) != 0) continue; // getter/setter/static이면 skip
+                const m_flags = self.readU32(m.data.extra, ast_mod.MethodExtra.flags);
+                // static/getter/setter 중 하나라도 있으면 skip (plain instance constructor 아님)
+                const non_ctor_mask = ast_mod.MethodFlags.is_static | ast_mod.MethodFlags.is_getter | ast_mod.MethodFlags.is_setter;
+                if ((m_flags & non_ctor_mask) != 0) continue;
                 const m_key_idx = self.readNodeIdx(m.data.extra, 0);
                 if (m_key_idx.isNone()) continue;
                 const m_key = self.ast.getNode(m_key_idx);


### PR DESCRIPTION
## Summary

parser 기록부부터 semantic/transformer/codegen 읽기부까지 `MethodFlags` 비트를 날값(`0x01`/`0x02`/`0x04`/`0x08`/`0x10`/`0x20`/`0x40`)으로 쓰던 **모든 잔여 지점**을 상수로 교체. 이전 PR들(#1570, #1571, #1572, #1573)과 합쳐 method/property flags 비트는 이제 전 계층이 이름 접근으로 통일된다.

### 변경

- **`parser/declaration.zig`**: static/getter/setter/async/generator 플래그 `set`, `detectAbstractDeclare` 반환값, constructor/prototype 이름 검증
- **`semantic/analyzer.zig`**: private method kind 분류 (getter/setter)
- **`transformer/es2015_class.zig`**: 잔여 member 분류·decorator 분기. `METHOD_FLAG_STATIC` alias(property_definition 컨텍스트에 잘못 오용되던 이름)를 제거하고 `MethodFlags` / `PropertyFlags` struct 직접 import로 교체
- **`transformer/es2015_object_methods.zig`**: getter/setter 스킵 + `MethodExtra` offset 사용
- **`transformer/es2022.zig`**: method context static 분기
- **`transformer/transformer.zig`**: `visitMethodDefinition` — abstract 스트리핑, static check
- **`transformer/transformer/class_decorator.zig`**: property/method decorator 경로의 static/getter/setter/abstract/declare 읽기. type-only 마스크(`0xE0`)를 `is_abstract | is_declare | flow_variance` 식으로 풀어 의미 명시
- **`codegen/codegen.zig`**: `resolveMethodName`의 static/getter/setter 분기

동작 변경 없음 — 순수 리팩토링.

## Test plan
- [x] `zig build test` 전체 통과
- [x] integration downlevel + bundle-smoke 694 pass
- [x] grep으로 method/property context에 `flags & 0x0[1-9a-f]` 잔여 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)