### PR TITLE
refactor(tree_shaker): "*" sentinel → ALL_EXPORTS_SENTINEL 상수화 (#1553 항목 1)

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -22,7 +22,9 @@ const CodegenOptions = @import("../../codegen/codegen.zig").CodegenOptions;
 const SourceMap = @import("../../codegen/sourcemap.zig");
 const Linker = @import("../linker.zig").Linker;
 const LinkingMetadata = @import("../linker.zig").LinkingMetadata;
-const TreeShaker = @import("../tree_shaker.zig").TreeShaker;
+const tree_shaker_mod = @import("../tree_shaker.zig");
+const TreeShaker = tree_shaker_mod.TreeShaker;
+const ALL_EXPORTS_SENTINEL = tree_shaker_mod.ALL_EXPORTS_SENTINEL;
 const statement_shaker = @import("../statement_shaker.zig");
 const ExportBinding = @import("../binding_scanner.zig").ExportBinding;
 const parent = @import("../emitter.zig");
@@ -937,8 +939,8 @@ pub fn computeAllUsedNames(
 
     for (sorted, 0..) |m, idx| {
         const mod_idx: u32 = @intFromEnum(m.index);
-        // "*" 마킹이 있고 BFS reachable_stmts가 없으면 모든 export 사용
-        if (s.isExportUsed(mod_idx, "*") and s.getModuleStmtInfos(mod_idx) == null) {
+        // ALL_EXPORTS_SENTINEL 마킹이 있고 BFS reachable_stmts가 없으면 모든 export 사용
+        if (s.isExportUsed(mod_idx, ALL_EXPORTS_SENTINEL) and s.getModuleStmtInfos(mod_idx) == null) {
             list[idx] = .{ .names = &.{}, .all_used = true };
             continue;
         }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -28,6 +28,11 @@ const purity = @import("purity.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const StmtInfos = stmt_info_mod.ModuleStmtInfos;
 
+/// `used_exports`의 all-exports-used sentinel. 모듈의 전체 export가 사용됨을 표시.
+/// 일반 export 이름과 겹치지 않도록 의도적으로 JS 식별자 아닌 `"*"` 선택.
+/// (export_bindings의 `exported_name == "*"`는 wildcard re-export로 의미가 다름 — 같은 문자열, 다른 공간)
+pub const ALL_EXPORTS_SENTINEL: []const u8 = "*";
+
 pub const TreeShaker = struct {
     allocator: std.mem.Allocator,
     modules: []const Module,
@@ -457,9 +462,9 @@ pub const TreeShaker = struct {
 
             // used export 선언 statement 시드. 시드 대상:
             //   (1) entry: 번들 외부 사용자가 접근 가능 — 모든 export live.
-            //   (2) "*" sentinel 모듈: dynamic import target(#1260) 또는 export * 전파 대상.
-            // non-entry·'*' 없음: followImport만으로 도달해야 가짜 used 확산을 막는다.
-            const is_bfs_seed = self.entry_set.isSet(i) or self.isExportUsed(@intCast(i), "*");
+            //   (2) ALL_EXPORTS_SENTINEL 마킹된 모듈: dynamic import target(#1260) 또는 export * 전파 대상.
+            // non-entry·sentinel 없음: followImport만으로 도달해야 가짜 used 확산을 막는다.
+            const is_bfs_seed = self.entry_set.isSet(i) or self.isExportUsed(@intCast(i), ALL_EXPORTS_SENTINEL);
             if (is_bfs_seed) {
                 const sem = m.semantic orelse continue;
                 if (sem.scope_maps.len == 0) continue;
@@ -885,11 +890,11 @@ pub const TreeShaker = struct {
     fn markAllExportsUsed(self: *TreeShaker, module_index: u32) !void {
         if (module_index >= self.modules.len) return;
         // 순환 export * 방지: 이미 처리한 모듈은 skip
-        if (self.isExportUsed(module_index, "*")) return;
-        try self.markExportUsed(module_index, "*"); // sentinel
+        if (self.isExportUsed(module_index, ALL_EXPORTS_SENTINEL)) return;
+        try self.markExportUsed(module_index, ALL_EXPORTS_SENTINEL);
         const m = self.modules[module_index];
         for (m.export_bindings) |eb| {
-            // re-export 소스 include는 "*" skip 전에 처리
+            // re-export 소스 include는 sentinel skip 전에 처리
             if (eb.kind.isReExportAll() or eb.kind == .re_export) {
                 if (eb.import_record_index) |rec_idx| {
                     if (rec_idx < m.import_records.len) {

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
-const TreeShaker = @import("tree_shaker.zig").TreeShaker;
+const tree_shaker_mod = @import("tree_shaker.zig");
+const TreeShaker = tree_shaker_mod.TreeShaker;
+const ALL_EXPORTS_SENTINEL = tree_shaker_mod.ALL_EXPORTS_SENTINEL;
 const Linker = @import("linker.zig").Linker;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
 const resolve_cache_mod = @import("resolve_cache.zig");
@@ -2007,13 +2009,13 @@ test "#1558 Phase 5: namespace import — 사용된 prop만 seed, 나머지 dead
     defer r.deinit();
 
     const mod = r.findModule("mod.ts").?;
-    // 모듈은 포함되지만 used 집합은 "a"만 (+ "*"는 마킹 안됨)
+    // 모듈은 포함되지만 used 집합은 "a"만 (ALL_EXPORTS_SENTINEL은 마킹 안됨)
     try std.testing.expect(r.shaker.isIncluded(mod));
     try std.testing.expect(r.shaker.isExportUsed(mod, "a"));
     try std.testing.expect(!r.shaker.isExportUsed(mod, "b"));
     try std.testing.expect(!r.shaker.isExportUsed(mod, "c"));
-    // #1559 시절엔 "*" sentinel을 무조건 마킹했지만 Phase 4에서 되돌림.
-    try std.testing.expect(!r.shaker.isExportUsed(mod, "*"));
+    // #1559 시절엔 sentinel을 무조건 마킹했지만 Phase 4에서 되돌림.
+    try std.testing.expect(!r.shaker.isExportUsed(mod, ALL_EXPORTS_SENTINEL));
 }
 
 test "#1558 Phase 5: namespace entry — 특정 prop만 쓰면 나머지 전체 dead (valibot 축소)" {


### PR DESCRIPTION
## Summary

#1553 항목 1 — tree_shaker의 `used_exports` 맵에서 "모듈의 전체 export가 사용됨"을 표시하는 sentinel 문자열 `"*"`가 여러 곳에 리터럴로 하드코딩돼 있었다. `tree_shaker.zig` 상단에 `ALL_EXPORTS_SENTINEL` 상수로 추출해 호출부가 의미 이름으로 접근하도록 교체.

### 변경

- `src/bundler/tree_shaker.zig`: 상수 신설 + BFS seed 판정·`markAllExportsUsed`의 3곳
- `src/bundler/emitter/chunks.zig`: `includedMembers` 판정
- `src/bundler/tree_shaker_test.zig`: #1559 회귀 테스트

### 주의

`export_bindings[i].exported_name == "*"` (wildcard re-export의 AST 표현)는 **다른 의미 공간**이라 이번 변경 대상이 아님. 같은 문자열 값을 쓰지만 tree-shake sentinel과는 별개 — 상수 주석에 명시.

동작 변경 없음 — 순수 리팩토링.

## Test plan
- [x] `zig build test` 전체 통과
- [x] 관련 integration test 통과

Closes: #1553 항목 1 (나머지 항목 2~4는 후속 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)