### PR TITLE
refactor(bundler): ModuleIndex.toU32() 헬퍼로 @intFromEnum 패턴 제거 (#1553 항목 2)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -336,7 +336,7 @@ pub fn emitWithTreeShaking(
     // Module.is_entry_point 플래그로 정확히 식별 — 정렬 순서나 exec_index와 무관.
     const entry_idx: ?u32 = blk: {
         for (sorted.items) |m| {
-            if (m.is_entry_point) break :blk @intFromEnum(m.index);
+            if (m.is_entry_point) break :blk m.index.toU32();
         }
         break :blk null;
     };
@@ -372,14 +372,14 @@ pub fn emitWithTreeShaking(
     if (use_pool) {
         var wg: std.Thread.WaitGroup = .{};
         for (sorted.items, 0..) |m, i| {
-            const is_entry = if (entry_idx) |ei| @intFromEnum(m.index) == ei else false;
+            const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
             pool.spawnWg(&wg, emitModuleThread, .{ allocator, m, options, linker, is_entry, used_names, shaker, &results[i] });
         }
         pool.waitAndWork(&wg);
     } else {
         for (sorted.items, 0..) |m, i| {
-            const is_entry = if (entry_idx) |ei| @intFromEnum(m.index) == ei else false;
+            const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
             results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines, &results[i].fn_map_json) catch null;
         }
@@ -434,7 +434,7 @@ pub fn emitWithTreeShaking(
 
         // --run-before-main: 엔트리 모듈 직전에 해당 모듈의 require/init 호출 삽입.
         // __esm 래핑된 엔트리(RN)는 emitEsmWrappedModule에서 body 안에 삽입.
-        const is_entry = if (entry_idx) |ei| @intFromEnum(m.index) == ei else false;
+        const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
         if (is_entry and options.run_before_main.len > 0 and m.wrap_kind != .esm) {
             const before_len = module_output.items.len;
             try appendRunBeforeMainCalls(&module_output, allocator, graph.modules.items, options.run_before_main);
@@ -564,7 +564,7 @@ pub fn emitWithTreeShaking(
     // RN 플랫폼에서는 엔트리도 __esm 래핑되므로 init_xxx() 호출이 필요.
     if (entry_idx) |ei| {
         for (sorted.items) |em| {
-            if (@intFromEnum(em.index) == ei and em.wrap_kind.isWrapped()) {
+            if (em.index.toU32() == ei and em.wrap_kind.isWrapped()) {
                 try appendModuleCall(&output, allocator, em);
                 break;
             }
@@ -876,7 +876,7 @@ pub fn emitModule(
         // ast 기준으로 skip_nodes 구축 (transformer 이후이므로 노드 인덱스가 ast와 일치)
         var md = try l.buildMetadataForAst(
             &transformer.ast,
-            @intFromEnum(module.index),
+            module.index.toU32(),
             is_entry,
             override_syms,
         );
@@ -905,7 +905,7 @@ pub fn emitModule(
                         sem.symbol_ids;
 
                     // 크로스-모듈 BFS 결과: tree-shaker의 reachable_stmts로 skip_nodes 설정
-                    const mod_idx: u32 = @intFromEnum(module.index);
+                    const mod_idx: u32 = module.index.toU32();
                     if (shaker) |s| {
                         if (s.getModuleStmtInfos(mod_idx)) |ts_infos| {
                             // 변환 후 AST의 program statement list에서 span 매칭
@@ -1209,7 +1209,7 @@ fn propagateCrossModulePurity(
     if (sem.scope_maps.len == 0) return;
     if (module.import_bindings.len == 0) return;
     const module_scope = sem.scope_maps[0];
-    const module_index: u32 = @intFromEnum(module.index);
+    const module_index: u32 = module.index.toU32();
 
     // 1단계: no_side_effects인 import binding의 local symbol_id를 수집한다.
     // 비트셋 대신 bool 배열 사용 — 스택 256개, 초과 시 arena fallback.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -893,7 +893,7 @@ pub fn computeAllUsedNames(
 
     // 모든 모듈의 import_bindings + export_bindings(re-export)를 순회하여 역방향 맵 구축
     for (graph.modules.items) |*importer| {
-        const imp_i: u32 = @intFromEnum(importer.index);
+        const imp_i: u32 = importer.index.toU32();
 
         // export_bindings 중 re_export / re_export_all → 타겟 모듈로 역매핑
         for (importer.export_bindings) |ieb| {
@@ -938,7 +938,7 @@ pub fn computeAllUsedNames(
     }
 
     for (sorted, 0..) |m, idx| {
-        const mod_idx: u32 = @intFromEnum(m.index);
+        const mod_idx: u32 = m.index.toU32();
         // ALL_EXPORTS_SENTINEL 마킹이 있고 BFS reachable_stmts가 없으면 모든 export 사용
         if (s.isExportUsed(mod_idx, ALL_EXPORTS_SENTINEL) and s.getModuleStmtInfos(mod_idx) == null) {
             list[idx] = .{ .names = &.{}, .all_used = true };

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -491,7 +491,7 @@ pub fn emitEsmWrappedModule(
                                 break :blk override;
                         }
                         if (linker) |l| {
-                            const mi: u32 = @intFromEnum(module.index);
+                            const mi: u32 = module.index.toU32();
                             if (l.getCanonicalName(mi, local_name)) |renamed|
                                 break :blk renamed;
                         }
@@ -1014,7 +1014,7 @@ fn makeStarGetterValue(
             // 직접 export에 없으면 소스의 re_export_all 체인을 따라간다.
             // resolveExportChain으로 canonical 이름을 찾는다.
             if (l.resolveExportChain(@enumFromInt(src_i), name, 0)) |resolved| {
-                const canonical_mod_i = @intFromEnum(resolved.module_index);
+                const canonical_mod_i = resolved.module_index.toU32();
                 const canonical_mod = &l.modules[canonical_mod_i];
                 // canonical 모듈이 래핑되어 있으면 exports_xxx.name 형태
                 if (canonical_mod.wrap_kind == .esm) {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1183,7 +1183,7 @@ pub const Linker = struct {
     /// SymbolRef를 scope hoisting 후 최종 로컬 이름으로 해결.
     /// resolveExportChain → getExportLocalName → getCanonicalName 3단계를 캡슐화.
     pub fn resolveToLocalName(self: *const Linker, ref: SymbolRef) []const u8 {
-        const cmod: u32 = @intCast(@intFromEnum(ref.module_index));
+        const cmod = ref.module_index.toU32();
         const local = self.getExportLocalName(cmod, ref.export_name) orelse ref.export_name;
         const canonical = self.getCanonicalName(cmod, local) orelse local;
         return self.safeIdentifierName(canonical, cmod);
@@ -1532,7 +1532,7 @@ pub const Linker = struct {
             } else if (eb.kind == .re_export) blk: {
                 if (self.resolveExportChain(module_idx, eb.exported_name, 0)) |canonical| {
                     // canonical이 export * as ns 패턴인지 확인
-                    const cmod_i = @intFromEnum(canonical.module_index);
+                    const cmod_i = canonical.module_index.toU32();
                     if (cmod_i < self.modules.len) {
                         for (self.modules[cmod_i].export_bindings) |ceb| {
                             if (ceb.kind.isReExportAll() and

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -613,7 +613,7 @@ pub fn buildMetadataForAst(
 /// CJS 래핑 모듈과 scope hoisted ESM+CJS 혼합 모듈 모두에서 사용.
 pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHashMapUnmanaged([]const u8) {
     var require_rewrites: std.StringHashMapUnmanaged([]const u8) = .{};
-    const self_idx = @intFromEnum(m.index);
+    const self_idx = m.index.toU32();
     for (m.import_records) |rec| {
         if (rec.resolved.isNone()) {
             // UMD/AMD: external require → factory 매개변수 참조.
@@ -729,7 +729,7 @@ pub fn buildCrossModuleConstValues(
         const rec = m.import_records[ib.import_record_index];
         if (rec.resolved.isNone()) continue;
         const canon = self.resolveExportChain(rec.resolved, ib.imported_name, 0) orelse continue;
-        const canon_mod_idx = @intFromEnum(canon.module_index);
+        const canon_mod_idx = canon.module_index.toU32();
         if (canon_mod_idx >= self.modules.len) continue;
         const target_module = self.modules[canon_mod_idx];
         const target_sem = target_module.semantic orelse continue;

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -608,10 +608,10 @@ pub const TreeShaker = struct {
             if (target_mod < self.modules.len) self.included.set(target_mod);
             return;
         };
-        const canon_mod = @intFromEnum(canonical.module_index);
+        const canon_mod = canonical.module_index.toU32();
         if (canon_mod >= self.modules.len) return;
 
-        try self.markExportUsed(@intCast(canon_mod), canonical.export_name);
+        try self.markExportUsed(canon_mod, canonical.export_name);
         self.included.set(canon_mod);
 
         // namespace barrel re-export: canonical이 namespace import를 가리키면
@@ -834,9 +834,9 @@ pub const TreeShaker = struct {
 
             const canonical = self.linker.resolveExportChain(rec.resolved, ib.imported_name, 0);
             if (canonical) |c| {
-                const canon_idx = @intFromEnum(c.module_index);
+                const canon_idx = c.module_index.toU32();
                 if (canon_idx < self.modules.len) {
-                    try self.markExportUsed(@intCast(canon_idx), c.export_name);
+                    try self.markExportUsed(canon_idx, c.export_name);
                     if (!self.included.isSet(canon_idx)) {
                         self.included.set(canon_idx);
                         newly_included = true;
@@ -857,9 +857,9 @@ pub const TreeShaker = struct {
                 if (ib.namespace_used_properties) |props| {
                     for (props) |prop_name| {
                         if (self.linker.resolveExportChain(rec.resolved, prop_name, 0)) |c| {
-                            const canon_idx = @intFromEnum(c.module_index);
+                            const canon_idx = c.module_index.toU32();
                             if (canon_idx < self.modules.len) {
-                                try self.markExportUsed(@intCast(canon_idx), c.export_name);
+                                try self.markExportUsed(canon_idx, c.export_name);
                                 if (!self.included.isSet(canon_idx)) {
                                     self.included.set(canon_idx);
                                     newly_included = true;
@@ -910,10 +910,10 @@ pub const TreeShaker = struct {
                                     m.exportBindingLocalName(eb),
                                     0,
                                 )) |canonical| {
-                                    const canon_idx = @intFromEnum(canonical.module_index);
+                                    const canon_idx = canonical.module_index.toU32();
                                     if (canon_idx < self.modules.len) {
                                         if (!self.included.isSet(canon_idx)) self.included.set(canon_idx);
-                                        try self.markExportUsed(@intCast(canon_idx), canonical.export_name);
+                                        try self.markExportUsed(canon_idx, canonical.export_name);
                                     }
                                 }
                             }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -39,6 +39,18 @@ pub const ModuleIndex = enum(u32) {
     pub fn isNone(self: ModuleIndex) bool {
         return self == .none;
     }
+
+    /// `modules[m.index.toU32()]` 형태의 인덱스 접근용.
+    /// `@intFromEnum(m.index)`를 호출부마다 반복하지 않도록 한다 (#1553 항목 2).
+    /// `none`에는 호출하지 말 것 — u32::MAX가 반환됨.
+    pub inline fn toU32(self: ModuleIndex) u32 {
+        return @intFromEnum(self);
+    }
+
+    /// usize 인덱서(ArrayList 등)용 편의.
+    pub inline fn toUsize(self: ModuleIndex) usize {
+        return @intCast(@intFromEnum(self));
+    }
 };
 
 // ============================================================


### PR DESCRIPTION
## Summary

#1553 항목 2 — tree_shaker/linker/emitter 등 15+ 곳에서 `@intFromEnum(canonical.module_index)`, `@intFromEnum(m.index)`처럼 `ModuleIndex` enum의 내부 표현을 호출부가 직접 꺼내 쓰고 있었다. 이슈 제안대로 `ModuleIndex`에 `toU32()` / `toUsize()` 메서드를 붙이고 호출부를 `x.module_index.toU32()`로 교체.

SymbolRef가 가진 `module_index`도 동일 패턴이라 모든 SymbolRef 참조도 함께 정리됨.

### 변경

- `src/bundler/types.zig`: `ModuleIndex`에 `toU32`, `toUsize` inline 메서드 추가
- `src/bundler/linker.zig`: `resolveToLocalName` 등 2곳
- `src/bundler/tree_shaker.zig`: canonical mod 인덱스 4곳
- `src/bundler/linker/metadata.zig`: namespace 해석 경로 2곳
- `src/bundler/emitter.zig`: entry 판정·build metadata·prune 5곳
- `src/bundler/emitter/chunks.zig`: importer/m index 2곳
- `src/bundler/emitter/esm_wrap.zig`: canonical mod 2곳

`@intCast`로 감싸던 군더더기도 같이 제거. 동작 변경 없음.

## Test plan
- [x] `zig build test` 전체 통과
- [x] integration downlevel + bundle-smoke 694 pass
- [x] grep으로 `@intFromEnum(...index)` / `@intFromEnum(...module_index)` 잔여 없음 확인

Closes: #1553 항목 2 (항목 1은 #1575, 3~4는 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)