### PR TITLE
fix(minify): !!x 축약에 boolean 타입 가드 추가 (#1577)

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -83,6 +83,50 @@ fn formatNumber(ast: *Ast, value: f64) ?Span {
     return ast.addString(text) catch null;
 }
 
+/// `(expr)` 래핑을 재귀적으로 벗겨 실제 노드를 반환.
+/// parenthesized_expression는 semantic상 투명이므로 타입 판별/치환 전에 unwrap.
+fn unwrapParens(ast: *const Ast, node: Node) Node {
+    var cur = node;
+    while (cur.tag == .parenthesized_expression) {
+        const inner_ni: u32 = @intFromEnum(cur.data.unary.operand);
+        if (inner_ni >= ast.nodes.items.len) break;
+        cur = ast.nodes.items[inner_ni];
+    }
+    return cur;
+}
+
+/// 노드가 boolean primitive를 반환함이 정적으로 보장되는지 판별.
+/// `!!x → x` / `x === true → x` 류 축약에서 operand 타입 가드로 사용한다.
+/// 증명 못 하면 false — 축약을 거부해 semantic 보존 (#1577).
+///
+/// 참고:
+///   - oxc: peephole/minimize_not_expression.rs — `value_type().is_boolean()`
+///   - esbuild: js_ast_helpers.go — `KnownPrimitiveType() == PrimitiveBoolean`
+///   - swc: compress/optimize/ops.rs — `get_type() == Known(Type::Bool)`
+fn isGuaranteedBoolean(ast: *const Ast, node: Node) bool {
+    const inner = unwrapParens(ast, node);
+    return switch (inner.tag) {
+        .boolean_literal => true,
+        .unary_expression => blk: {
+            const e = inner.data.extra;
+            if (e + 1 >= ast.extra_data.items.len) break :blk false;
+            const op: Kind = @enumFromInt(@as(u8, @truncate(ast.extra_data.items[e + 1])));
+            break :blk switch (op) {
+                .bang, .kw_delete => true,
+                else => false,
+            };
+        },
+        .binary_expression => blk: {
+            const op: Kind = @enumFromInt(inner.data.binary.flags);
+            break :blk switch (op) {
+                .eq3, .neq2, .eq2, .neq, .l_angle, .r_angle, .lt_eq, .gt_eq, .kw_in, .kw_instanceof => true,
+                else => false,
+            };
+        },
+        else => false,
+    };
+}
+
 /// AST minify 패스를 실행한다. ast를 in-place 수정.
 pub fn minify(ast: *Ast) void {
     for (ast.nodes.items, 0..) |node, i| {
@@ -245,9 +289,14 @@ fn simplifyBooleanComparison(
 
     // 양쪽 다 리터럴이면 foldStrictEquality에서 처리 (여기서는 축약하지 않음)
     const other_ni = if (left.tag == .boolean_literal) right_ni else left_ni;
-    const other = ast.nodes.items[other_ni];
-    if (other.tag == .boolean_literal or other.tag == .numeric_literal or
-        other.tag == .string_literal or other.tag == .null_literal) return false;
+    const other_raw = ast.nodes.items[other_ni];
+    if (other_raw.tag == .boolean_literal or other_raw.tag == .numeric_literal or
+        other_raw.tag == .string_literal or other_raw.tag == .null_literal) return false;
+
+    // other가 boolean임이 보장되지 않으면 축약 거부 — `y === true` 와 `y`는 다르다
+    // (y=1일 때 y===true는 false, y는 1). `!!x`와 같은 이유로 #1577에서 가드.
+    const other = unwrapParens(ast, other_raw);
+    if (!isGuaranteedBoolean(ast, other)) return false;
 
     // x === true → x, x === false → !x
     // x !== true → !x, x !== false → x
@@ -310,7 +359,9 @@ fn foldUnary(ast: *Ast, node_idx: u32, node: Node) void {
 
     switch (op) {
         .bang => {
-            // !!x → x (double negation elimination)
+            // !!x → x — inner operand가 이미 boolean일 때만 안전 (#1577).
+            // 예: !!(a === b) → a === b. 그러나 !!variable은 ToBoolean 강제변환이
+            // 사라지므로 유지해야 함 (undefined/null/0 → false 보존).
             if (operand.tag == .unary_expression) {
                 const inner_e = operand.data.extra;
                 if (inner_e + 1 < ast.extra_data.items.len) {
@@ -318,8 +369,11 @@ fn foldUnary(ast: *Ast, node_idx: u32, node: Node) void {
                     if (inner_op == .bang) {
                         const inner_operand_ni = ast.extra_data.items[inner_e];
                         if (inner_operand_ni < ast.nodes.items.len) {
-                            ast.nodes.items[node_idx] = ast.nodes.items[inner_operand_ni];
-                            return;
+                            const unwrapped = unwrapParens(ast, ast.nodes.items[inner_operand_ni]);
+                            if (isGuaranteedBoolean(ast, unwrapped)) {
+                                ast.nodes.items[node_idx] = unwrapped;
+                                return;
+                            }
                         }
                     }
                 }

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -253,45 +253,80 @@ test "minify: if false no else becomes empty" {
 // Phase 3: Boolean Simplification
 // ================================================================
 
-test "minify: double negation elimination" {
-    try expectMinify("const x = !!y;", "const x = y;");
+// `!!x`는 `ToBoolean(x)` 강제변환이므로 operand가 이미 boolean일 때만 축약 안전.
+// 증명 불가한 경우 유지 — oxc/esbuild/swc 모두 같은 가드 (#1577).
+
+test "minify: !! preserved on identifier (non-boolean)" {
+    try expectMinify("const x = !!y;", "const x = !!y;");
 }
 
-test "minify: double negation with expression" {
-    try expectMinify("const x = !!foo();", "const x = foo();");
+test "minify: !! preserved on function call" {
+    // 반환 타입을 정적으로 알 수 없음
+    try expectMinify("const x = !!foo();", "const x = !!foo();");
 }
 
-test "minify: x === true simplifies to x" {
-    try expectMinify("const x = y === true;", "const x = y;");
+test "minify: !! eliminated on strict equality" {
+    // a === b는 항상 boolean
+    try expectMinify("const x = !!(a === b);", "const x = a === b;");
 }
 
-test "minify: x === false simplifies to !x" {
-    try expectMinify("const x = y === false;", "const x = !y;");
+test "minify: !! eliminated on relational" {
+    try expectMinify("const x = !!(a < b);", "const x = a < b;");
 }
 
-test "minify: x !== true simplifies to !x" {
-    try expectMinify("const x = y !== true;", "const x = !y;");
+test "minify: !! eliminated on instanceof" {
+    try expectMinify("const x = !!(a instanceof B);", "const x = a instanceof B;");
 }
 
-test "minify: x !== false simplifies to x" {
-    try expectMinify("const x = y !== false;", "const x = y;");
-}
-
-test "minify: true === x simplifies to x" {
-    try expectMinify("const x = true === y;", "const x = y;");
-}
-
-test "minify: false === x simplifies to !x" {
-    try expectMinify("const x = false === y;", "const x = !y;");
-}
-
-test "minify: literal === literal not simplified here" {
-    // 양쪽 모두 리터럴이면 foldStrictEquality에서 처리
-    try expectMinify("const x = true === true;", "const x = true;");
+test "minify: !! preserved on logical AND" {
+    // `a && b`는 b 값을 반환 — boolean이 아닐 수 있음
+    try expectMinify("const x = !!(a && b);", "const x = !!(a && b);");
 }
 
 test "minify: triple negation reduces to single" {
+    // !!!y → !y : outer 노드의 inner_operand는 `!y`이고 `!y`는 보장 boolean
     try expectMinify("const x = !!!y;", "const x = !y;");
+}
+
+// x === true / x === false 축약도 같은 이유로 가드 (#1577).
+// `y = 1` 일 때 `y === true`는 false, `y`는 1 — 서로 다르다.
+
+test "minify: x === true preserved on non-boolean x" {
+    try expectMinify("const x = y === true;", "const x = y === true;");
+}
+
+test "minify: x === false preserved on non-boolean x" {
+    try expectMinify("const x = y === false;", "const x = y === false;");
+}
+
+test "minify: x !== true preserved on non-boolean x" {
+    try expectMinify("const x = y !== true;", "const x = y !== true;");
+}
+
+test "minify: x !== false preserved on non-boolean x" {
+    try expectMinify("const x = y !== false;", "const x = y !== false;");
+}
+
+test "minify: true === x preserved on non-boolean x" {
+    try expectMinify("const x = true === y;", "const x = true === y;");
+}
+
+test "minify: false === x preserved on non-boolean x" {
+    try expectMinify("const x = false === y;", "const x = false === y;");
+}
+
+test "minify: (a === b) === true simplifies — boolean-typed lhs" {
+    // 좌변이 비교 연산이면 boolean 보장 → 축약 가능
+    try expectMinify("const x = (a === b) === true;", "const x = a === b;");
+}
+
+test "minify: (!y) === true simplifies to !y — unary ! is boolean-typed" {
+    try expectMinify("const x = (!y) === true;", "const x = !y;");
+}
+
+test "minify: literal === literal still folds" {
+    // 양쪽 모두 리터럴이면 foldStrictEquality에서 처리
+    try expectMinify("const x = true === true;", "const x = true;");
 }
 
 // ================================================================


### PR DESCRIPTION
## Summary

- `!!x → x` / `x === true → x` 류 축약이 operand 타입 가드 없이 동작해 non-boolean에서 **ToBoolean 강제변환**이 사라지는 문제 (closes #1577).
- oxc `value_type().is_boolean()` / esbuild `KnownPrimitiveType` / swc `get_type()` 와 동일하게 operand가 **정적으로 boolean임이 증명될 때만** 축약. 증명 불가 시 보존.
- 실제 영향: `react-native-worklets`의 `createShareable(..., !!initSynchronously, ...)` 패턴이 망가져 Reanimated 사용 앱 부팅 크래시.

## 변경 내역

- `src/transformer/minify.zig`
  - `unwrapParens(ast, node)` — `parenthesized_expression` 재귀 unwrap
  - `isGuaranteedBoolean(ast, node)` — `boolean_literal` / `!`·`delete` / `===`·`!==`·`==`·`!=`·`<`·`>`·`<=`·`>=`·`in`·`instanceof` 만 true
  - `foldUnary(.bang)`: inner operand가 `isGuaranteedBoolean` 일 때만 치환 (paren 투명)
  - `simplifyBooleanComparison`: non-literal other가 `isGuaranteedBoolean` 아니면 축약 거부
- `src/transformer/minify_test.zig`
  - 잘못된 축약을 기대하던 기존 8개 테스트를 "유지" 동작으로 뒤집음
  - 가드 통과/거부 케이스 8개 추가 (`!!(a === b)`, `!!(a < b)`, `!!(a instanceof B)`, `!!(a && b)` preserved, `(a === b) === true` 등)

## 왜 minify 플래그로 분리하지 않았는가

Minify는 **semantic-preserving**이 원칙. `--minify` on/off로 프로그램 동작이 바뀌면 최적화가 아니라 버그. 따라서 타입 가정이 증명 안 되면 모든 경로에서 축약하지 않음. 번들러가 `--minify` 없이도 minify 패스를 상시 실행(#1552)하는 정책 자체는 문제 없음 — 다른 패스(리터럴 폴딩, dead code)는 전부 이미 semantic-preserving.

## Test plan

- [x] `zig build test` 전체 통과
- [x] 재현 스크립트 검증:
  - 입력 `function foo(x) { return !!x; } console.log(foo(), typeof foo());`
  - 번들 전: `return x; ... undefined undefined`
  - 번들 후: `return !!x; ... false boolean` ✅
- [x] `(a === b) === true` 같은 가드 통과 케이스는 여전히 축약
- [x] `(!y) === true`, `!!!y` 등 unary 체인 축약 유지
- [ ] RN 번개 ExampleApp에서 Reanimated 부팅 확인 (리뷰어 또는 merge 후 smoke)

## 참고

- oxc: `crates/oxc_minifier/src/peephole/minimize_not_expression.rs`
- esbuild: `internal/js_ast/js_ast_helpers.go` — `KnownPrimitiveType`
- swc: `crates/swc_ecma_minifier/src/compress/optimize/ops.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)