### PR TITLE
perf(bundler): arrow IIFE 래퍼로 전환 (ES2015+)

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -162,7 +162,7 @@ test "Bundler: IIFE format" {
     const result = try b.bundle();
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expect(std.mem.startsWith(u8, result.output, "(function() {\n"));
+    try std.testing.expect(std.mem.startsWith(u8, result.output, "(() => {\n"));
     try std.testing.expect(std.mem.endsWith(u8, result.output, "})();\n"));
 }
 

--- a/src/bundler/bundler_test/compat.zig
+++ b/src/bundler/bundler_test/compat.zig
@@ -256,7 +256,7 @@ test "esbuild: ESM to IIFE with scope hoisting" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.startsWith(u8, result.output, "(function() {\n"));
+    try std.testing.expect(std.mem.startsWith(u8, result.output, "(() => {\n"));
     try std.testing.expect(std.mem.endsWith(u8, result.output, "})();\n"));
     try std.testing.expect(std.mem.indexOf(u8, result.output, "function add") != null);
     // import 문 제거됨

--- a/src/bundler/bundler_test/patterns.zig
+++ b/src/bundler/bundler_test/patterns.zig
@@ -352,7 +352,7 @@ test "Format: all three formats produce valid output for same input" {
     const r3 = try b3.bundle();
     defer r3.deinit(std.testing.allocator);
     try std.testing.expect(!r3.hasErrors());
-    try std.testing.expect(std.mem.startsWith(u8, r3.output, "(function() {\n"));
+    try std.testing.expect(std.mem.startsWith(u8, r3.output, "(() => {\n"));
     try std.testing.expect(std.mem.indexOf(u8, r3.output, "n * n") != null);
 }
 

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -490,7 +490,7 @@ test "Worker: new Worker(new URL) produces separate IIFE bundle" {
         if (std.mem.startsWith(u8, a.path, "worker-")) {
             found_worker = true;
             try std.testing.expect(std.mem.indexOf(u8, a.contents, "self.onmessage") != null);
-            try std.testing.expect(std.mem.startsWith(u8, a.contents, "(function() {"));
+            try std.testing.expect(std.mem.startsWith(u8, a.contents, "(() => {"));
         }
     }
     try std.testing.expect(found_worker);

--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -329,7 +329,7 @@ test "Format: IIFE scope_hoist entry exports" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.startsWith(u8, result.output, "(function() {\n"));
+    try std.testing.expect(std.mem.startsWith(u8, result.output, "(() => {\n"));
     try std.testing.expect(std.mem.indexOf(u8, result.output, "value * 2") != null);
 }
 
@@ -597,8 +597,8 @@ test "IIFE globalName: export → return 변환 (linker integration)" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // IIFE prologue: var MyLib = (function() {
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var MyLib = (function()") != null);
+    // IIFE prologue: var MyLib = (() => {
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var MyLib = (() =>") != null);
     // 엔트리 export가 return으로 변환됨
     try std.testing.expect(std.mem.indexOf(u8, result.output, "return {") != null);
     // export 키워드가 남아있으면 안 됨

--- a/src/bundler/bundler_test/typescript_format.zig
+++ b/src/bundler/bundler_test/typescript_format.zig
@@ -451,7 +451,7 @@ test "Format: IIFE with multiple modules" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.startsWith(u8, result.output, "(function() {\n"));
+    try std.testing.expect(std.mem.startsWith(u8, result.output, "(() => {\n"));
     try std.testing.expect(std.mem.endsWith(u8, result.output, "})();\n"));
     try std.testing.expect(std.mem.indexOf(u8, result.output, "function greet") != null);
 }
@@ -477,7 +477,7 @@ test "Format: minified IIFE" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.startsWith(u8, result.output, "(function() {\n"));
+    try std.testing.expect(std.mem.startsWith(u8, result.output, "(() => {\n"));
     // 모듈 경계 주석 없음
     try std.testing.expect(std.mem.indexOf(u8, result.output, "// ---") == null);
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -232,7 +232,14 @@ pub fn emitWithTreeShaking(
         }
         break :blk false;
     };
-    const factory_fn = if (has_tla) "(async function() {\n" else "(function() {\n";
+    // IIFE 래퍼는 내부에 `this`/`arguments`/`new.target`을 노출하지 않으므로
+    // arrow 전환이 시맨틱을 바꾸지 않는다. ES5 타겟처럼 arrow 미지원 환경에서만
+    // 기존 `function` 형태를 유지 (#1580, esbuild 관행과 동일).
+    const use_arrow = !options.unsupported.arrow;
+    const factory_fn = if (has_tla)
+        (if (use_arrow) "(async () => {\n" else "(async function() {\n")
+    else
+        (if (use_arrow) "(() => {\n" else "(function() {\n");
 
     // UMD/AMD: external specifier 수집 (dependency array + factory params 생성용)
     var ext_specifiers: std.ArrayList([]const u8) = .empty;

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -89,6 +89,28 @@ test "emitter: IIFE format" {
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
+    try std.testing.expect(std.mem.startsWith(u8, output, "(() => {\n"));
+    try std.testing.expect(std.mem.endsWith(u8, output, "})();\n"));
+}
+
+test "emitter: IIFE format — ES5 target uses `function` wrapper" {
+    // arrow 미지원 타겟(ES5)에서는 기존 `(function() { ... })()` 형태를 유지해야 한다.
+    const compat = @import("../transformer/compat.zig");
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "var x = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+        .format = .iife,
+        .unsupported = compat.fromESTarget(.es5),
+    }, null);
+    defer emit_result.deinit(std.testing.allocator);
+    const output = emit_result.output;
+
     try std.testing.expect(std.mem.startsWith(u8, output, "(function() {\n"));
     try std.testing.expect(std.mem.endsWith(u8, output, "})();\n"));
 }
@@ -885,7 +907,7 @@ test "banner/footer — IIFE format" {
     const output = emit_result.output;
 
     // banner → IIFE prologue → code → IIFE epilogue → footer
-    try std.testing.expect(std.mem.startsWith(u8, output, "// license header\n(function() {\n"));
+    try std.testing.expect(std.mem.startsWith(u8, output, "// license header\n(() => {\n"));
     try std.testing.expect(std.mem.endsWith(u8, output, "})();\n// end\n"));
 }
 
@@ -929,8 +951,8 @@ test "globalName — IIFE wrapping" {
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
-    // prologue: "var MyLib = (function() {\n"
-    try std.testing.expect(std.mem.startsWith(u8, output, "var MyLib = (function() {\n"));
+    // prologue: "var MyLib = (() => {\n"
+    try std.testing.expect(std.mem.startsWith(u8, output, "var MyLib = (() => {\n"));
     // epilogue: "})();\n"
     try std.testing.expect(std.mem.endsWith(u8, output, "})();\n"));
 }
@@ -954,7 +976,7 @@ test "globalName — dotted name warning" {
     // 경고 주석이 포함되어야 함
     try std.testing.expect(std.mem.indexOf(u8, output, "[ZTS WARNING] Dotted globalName") != null);
     // dotted name이면 일반 IIFE로 폴백
-    try std.testing.expect(std.mem.indexOf(u8, output, "(function() {\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "(() => {\n") != null);
 }
 
 test "globalName — ignored for non-IIFE" {
@@ -996,7 +1018,7 @@ test "globalName — with banner/footer" {
     const output = emit_result.output;
 
     // banner → globalName prologue → code → epilogue → footer
-    try std.testing.expect(std.mem.startsWith(u8, output, "/* license */\nvar MyLib = (function() {\n"));
+    try std.testing.expect(std.mem.startsWith(u8, output, "/* license */\nvar MyLib = (() => {\n"));
     try std.testing.expect(std.mem.endsWith(u8, output, "})();\n/* end */\n"));
 }
 


### PR DESCRIPTION
## 요약

- `--format=iife` (또는 browser 기본값)에서 번들 래퍼를 `(function(){...})()` → `(() => {...})()`로 전환 (ES2015+)
- `options.unsupported.arrow`가 true인 ES5 타겟에서는 기존 `function` 형태 유지
- svelte readable 단일 import 기준 `1,524 B → 1,519 B` (-5 B)

Closes #1580

## 동기

`#1551` 조사 과정에서 esbuild 기본 출력이 `(()=>{...})()` arrow IIFE로 래핑되는 것을 확인했고, ZTS는 동일 입력에 대해 더 긴 `function` IIFE를 사용 중이었음. 래퍼 내부는 bundler가 생성한 번들 본문이므로 top-level `this`/`arguments`/`new.target` 시맨틱 차이가 의미를 바꾸지 않음 → arrow 전환이 안전함.

## 변경점

`src/bundler/emitter.zig`:
- factory_fn 결정 시 `options.unsupported.arrow` 기준 분기 (sync/async × arrow/function 4-way)

테스트:
- 기존 IIFE snapshot 테스트 8개를 arrow prologue 기대값으로 갱신
- ES5 타겟에서 `function` 래퍼가 유지됨을 검증하는 회귀 테스트 신규 추가 (`emitter: IIFE format — ES5 target uses \`function\` wrapper`)

## 안전성

- IIFE 내부는 ESM 모듈 본문과 동일한 top-level 시맨틱 (`this=undefined`, no `arguments`, no `new.target`)이므로 arrow 전환이 의미 변화를 일으키지 않음
- ES5 타겟(`--target=es5`)에서는 arrow 미지원이므로 기존 form 유지 (`compat.UnsupportedFeatures.arrow` 플래그 활용)
- UMD/AMD factory 함수는 외부에서 인자를 받는 별도 경로 (본 변경 범위 밖)

## 실측 (svelte 5.55.1 readable entry, `--minify --platform=browser`)

| Bundler | 크기 |
|---|---:|
| ZTS (before) | 1,524 B |
| **ZTS (after)** | **1,519 B** |
| esbuild (default) | 1,204 B |

래퍼 차이 5 B 외 남은 갭은 identifier mangler 품질(#1581)이 원인으로, 별도 PR에서 다룸.

## 관련

- #1580 — 본 PR 대상 이슈
- #1581 — identifier mangler 품질 (후속, 주 효과)
- #1551 — 원인 분석에서 분리된 선행 이슈 (close 됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)