### PR TITLE
perf(bundler): mangling 제외 범위를 public API 경계로 축소

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -869,8 +869,9 @@ test "Minify: CJS import binding preamble uses mangled name" {
     try std.testing.expect(std.mem.indexOf(u8, output, "console.log") != null);
 }
 
-test "Minify: ESM import binding not mangled" {
-    // ESM export 함수의 import binding은 mangler가 덮어쓰면 안 된다.
+test "Minify: ESM import binding resolves correctly after mangling (#1581)" {
+    // 중간 모듈의 export는 mangled되지만 import binding이 올바른 mangled 이름으로
+    // 치환되어 호출이 정상 해소되어야 한다 (scope hoisting 후 같은 심볼 1개).
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "import { greet } from './lib';\nconsole.log(greet('world'));");
@@ -891,8 +892,11 @@ test "Minify: ESM import binding not mangled" {
 
     try std.testing.expect(!result.hasErrors());
     const output = result.output;
-    try std.testing.expect(std.mem.indexOf(u8, output, "greet") != null);
+    // 실행 결과에 영향을 주는 문자열은 보존
     try std.testing.expect(std.mem.indexOf(u8, output, "Hello") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "world") != null);
+    // 원본 이름은 축약됨 (중간 모듈 export는 public API 아님)
+    try std.testing.expect(std.mem.indexOf(u8, output, "greet") == null);
 }
 
 test "Minify: for-loop body var declaration has semicolon" {
@@ -921,11 +925,11 @@ test "Minify: for-loop body var declaration has semicolon" {
 }
 
 test "Minify: template literal expression identifiers renamed (#493)" {
-    // template literal 내 ${identifier} 참조가 mangled name으로 치환되어야 한다.
+    // template literal 내 ${identifier} 참조가 mangled name으로 일관되게 치환되어야 한다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "entry.ts", "import { prefix } from './lib';\nconsole.log(`val=${prefix}!`);");
-    try writeFile(tmp.dir, "lib.ts", "export const prefix = 'hello';");
+    try writeFile(tmp.dir, "entry.ts", "import { long_prefix_name } from './lib';\nconsole.log(`val=${long_prefix_name}!`);");
+    try writeFile(tmp.dir, "lib.ts", "export const long_prefix_name = 'hello';");
 
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
@@ -942,8 +946,10 @@ test "Minify: template literal expression identifiers renamed (#493)" {
 
     try std.testing.expect(!result.hasErrors());
     const output = result.output;
-    // export이므로 prefix 이름 보존, template literal에 올바르게 참조됨
-    try std.testing.expect(std.mem.indexOf(u8, output, "prefix") != null);
+    // 중간 모듈 export는 mangled됨 (#1581)
+    try std.testing.expect(std.mem.indexOf(u8, output, "long_prefix_name") == null);
+    // template literal 구조와 실행 결과 문자열은 보존
+    try std.testing.expect(std.mem.indexOf(u8, output, "val=") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "hello") != null);
 }
 
@@ -1201,6 +1207,103 @@ test "Minify: with statement preserves bindings in enclosing scope (#1258)" {
     const has_decl = std.mem.indexOf(u8, result.output, "greetingOuter=") != null or
         std.mem.indexOf(u8, result.output, "greetingOuter =") != null;
     try std.testing.expect(has_decl);
+}
+
+// ============================================================
+// Mangler: public-API boundary (#1581)
+// ============================================================
+// mangling 보존 대상은 entry 모듈의 export와 external import local binding만이다.
+// 중간 모듈에서 export된 이름도 bundle 내부에서만 소비되므로 자유롭게 축약 가능.
+// esbuild/rolldown 관행과 동일.
+
+test "Minify: non-entry export name is mangled (#1581)" {
+    // 중간 모듈의 긴 export 이름은 bundle 외부로 노출되지 않으므로 축약되어야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { VERY_LONG_INTERNAL_CONSTANT_NAME } from './constants';
+        \\console.log(VERY_LONG_INTERNAL_CONSTANT_NAME);
+    );
+    try writeFile(tmp.dir, "constants.ts",
+        \\export const VERY_LONG_INTERNAL_CONSTANT_NAME = 42;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 긴 이름이 축약되어 출력에 남지 않는다
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "VERY_LONG_INTERNAL_CONSTANT_NAME") == null);
+    // 값 42는 그대로 존재
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "42") != null);
+}
+
+test "Minify: entry export name preserved (#1581)" {
+    // entry 모듈의 export는 public API이므로 보존되어야 한다 (ESM 포맷).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const helper = 42;
+        \\export const PUBLIC_API = helper * 2;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // entry의 public API 이름은 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "PUBLIC_API") != null);
+    // 내부 helper 이름은 축약
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "helper") == null);
+}
+
+test "Minify: external import local binding preserved (#1581)" {
+    // external로 남는 import는 bundle 밖에서 해소되므로 local 이름을 보존해야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { readFileSync } from 'node:fs';
+        \\console.log(readFileSync('/tmp/x'));
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // external import → local 이름 보존 (외부에서 정의된 이름)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "readFileSync") != null);
 }
 
 // ============================================================

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -593,15 +593,23 @@ pub const Linker = struct {
         var name_refs = std.StringHashMap(u32).init(self.allocator);
         defer name_refs.deinit();
 
-        // export/import binding 이름 수집 (mangling 제외 대상)
+        // mangling 제외 대상 수집 (public API 경계) — #1581:
+        //   - entry 모듈의 export: 번들 외부 소비자에게 노출되는 public API
+        //   - external import의 local binding: 번들 밖에서 해소되므로 원본 이름이 정답
+        // 중간 모듈의 export 이름은 scope hoisting 후 bundle 내부에서만 소비되므로
+        // 자유롭게 축약 가능. esbuild/rolldown도 동일한 boundary로 동작.
         var exported = std.StringHashMap(void).init(self.allocator);
         errdefer exported.deinit();
         for (self.modules) |m| {
-            for (m.export_bindings) |eb| {
-                try exported.put(eb.exported_name, {});
-                try exported.put(m.exportBindingLocalName(eb), {});
+            if (m.is_entry_point) {
+                for (m.export_bindings) |eb| {
+                    try exported.put(eb.exported_name, {});
+                    try exported.put(m.exportBindingLocalName(eb), {});
+                }
             }
             for (m.import_bindings) |ib| {
+                if (ib.import_record_index >= m.import_records.len) continue;
+                if (!m.import_records[ib.import_record_index].is_external) continue;
                 try exported.put(m.importBindingLocalName(ib), {});
             }
         }


### PR DESCRIPTION
## 요약

identifier mangler가 "보존"해야 하는 이름의 범위를 재정의.
- **이전**: 모든 모듈의 모든 `export_binding` + 모든 `import_binding` 이름을 보존
- **이후**: entry 모듈의 export + external import의 local binding만 보존

중간 모듈의 export 이름은 scope hoisting 후 bundle 내부에서만 소비되므로 이름을 자유롭게 축약 가능 (esbuild/rolldown 관행과 동일).

Closes #1581

## 실측 (svelte 5.55.1 readable 단일 import, `--minify --platform=browser`)

| Bundler | 크기 | 차이 |
|---|---:|---:|
| **ZTS (before)** | 1,519 B | — |
| **ZTS (after)** | **1,342 B** | **-177 B (-11.6%)** |
| esbuild (default) | 1,204 B | — |
| rolldown | 933 B | — |

축약 확인: `STATE_SYMBOL` → `he`, `LEGACY_PROPS` → `vi`, `LOADING_ATTR_SYMBOL` → `yi`, `PROXY_PATH_SYMBOL` → \`\$t\`, `STALE_REACTION` → `te`, `noop` → `re`. 전부 중간 모듈(`svelte/internal/client/constants.js` 등)의 export로 bundle 외부에서는 참조 불가능한 심볼.

esbuild와의 138 B 차이는 nested scope mangling(top-level 외 식별자 축약) 때문이며 별개 작업.

## 근본 원인

`src/bundler/linker.zig:599-607`의 `exported` set 구성이 모든 모듈을 순회:
```zig
for (self.modules) |m| {
    for (m.export_bindings) |eb| {
        try exported.put(eb.exported_name, {});
        try exported.put(m.exportBindingLocalName(eb), {});
    }
    for (m.import_bindings) |ib| {
        try exported.put(m.importBindingLocalName(ib), {});
    }
}
```

결과적으로 `svelte/internal/client/constants.js` 같은 중간 모듈이 내부용으로 export한 이름까지 mangling 제외 대상이 되어 `STATE_SYMBOL` 등이 원본 그대로 출력. 이는 "public API 경계 = bundle 외부에서 참조 가능한 이름" 정의와 어긋남.

## 변경점

`src/bundler/linker.zig` — `collectManglingCandidates()`의 `exported` set 수집:
- `m.is_entry_point`인 경우에만 `export_bindings`를 보존 대상에 추가
- `import_bindings`는 `import_records[idx].is_external == true`인 경우에만 보존 대상에 추가

## 테스트

### 신규 (`src/bundler/bundler_test/minify_loader.zig`)
- `Minify: non-entry export name is mangled (#1581)` — 중간 모듈의 `VERY_LONG_INTERNAL_CONSTANT_NAME`이 출력에서 사라짐을 검증
- `Minify: entry export name preserved (#1581)` — entry의 `PUBLIC_API`는 보존, 내부 `helper`는 축약
- `Minify: external import local binding preserved (#1581)` — `node:fs`의 `readFileSync` local 이름 보존

### 재작성
- `Minify: ESM import binding not mangled` → `Minify: ESM import binding resolves correctly after mangling (#1581)` — 이름 보존 검증 대신 실행 결과(`"Hello world"`) 보존을 검증
- `Minify: template literal expression identifiers renamed (#493)` — 짧은 `prefix` 대신 `long_prefix_name`으로 변경하여 mangling 발생을 확실히 트리거, template literal 구조와 실행 결과 문자열 보존을 검증

## 안전성

- 같은 이름이 여러 모듈에 존재해도 `all_names` 충돌 체크 (linker.zig:670-684)가 mangled 이름과 원본 이름 충돌을 막음
- entry 보존 규칙이 좁혀졌지만 scope hoisting 후 번들 내부 참조는 전부 canonical_name으로 해소되므로 의미 변화 없음
- external import는 번들 밖에서 정의되므로 원본 이름이 정답

## 관련

- #1581 — 본 PR 대상 이슈
- #1552 — svelte 풀세트 minify 미흡 (본 PR로 상당 부분 해소 예상)
- #1558 — statement-level symbol graph (선행, `reference_count` 확립)
- #1580 — arrow IIFE 래퍼 (#1583에서 해소)

## 후속 작업 (별도 PR)

현재 mangler는 top-level scope(`scope_maps[0]`)만 순회하여 함수 내부/블록 스코프의 local 변수는 축약 대상이 아님. esbuild와의 남은 138 B 차이는 주로 이 영역. `src/codegen/mangler.zig`의 liveness 기반 mangler를 번들 파이프라인에 통합하면 추가 개선 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)