### PR TITLE
perf(codegen): minify_syntax 시 `new (expr)()`의 잉여 parens 제거

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -1408,6 +1408,150 @@ test "Minify: entry `export default` preserves external `default` keyword (#1585
     try std.testing.expect(std.mem.indexOf(u8, result.output, "42") != null);
 }
 
+// ============================================================
+// Minify syntax: redundant parens around `new` callee (#1586)
+// ============================================================
+// `new (expr)()`에서 expr이 MemberExpression 자리에 적합하면 parens 불필요.
+// ClassExpression, Identifier, MemberExpression 모두 parens 없이 사용 가능.
+// 단 callee에 CallExpression이 섞여 있으면 기존 newCalleeNeedsParens 로직이
+// 여전히 parens를 유지함.
+
+test "Minify: new (ClassExpression)() drops redundant parens (#1586)" {
+    // svelte-style `new (class X extends Error {...})()` 패턴.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const x = new (class Foo extends Error {
+        \\  name = "Foo";
+        \\})();
+        \\console.log(x);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // parens 제거 후: `new class Foo extends Error{...}()`
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new class") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new (class") == null);
+}
+
+test "Minify: new (Identifier)() drops redundant parens (#1586)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\class Box {}
+        \\const x = new (Box)();
+        \\console.log(x);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new (") == null);
+}
+
+test "Minify: new (MemberExpression)() drops redundant parens (#1586)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const ns = { Box: class { x = 1; } };
+        \\const x = new (ns.Box)();
+        \\console.log(x.x);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // MemberExpression callee에서 parens 완전 제거 — 출력에 `new (` 미존재로 검증
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new (") == null);
+    // MemberExpression 구조는 보존 (`.Box` 접근이 남아있어야 함)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".Box") != null);
+}
+
+test "Minify: new (CallExpression)() keeps parens — safety (#1586)" {
+    // `new (factory())()` 형태는 factory의 반환값을 constructor로 호출.
+    // parens를 벗기면 `new factory()()`로 오파싱되어 의미가 변경됨.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\function factory() { return class { x = 1; }; }
+        \\const x = new (factory())();
+        \\console.log(x.x);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // CallExpression callee는 parens 유지 (newCalleeNeedsParens true)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new (") != null);
+}
+
+test "Minify: redundant parens removal preserved without minify_syntax (#1586)" {
+    // minify_syntax 비활성화 시 원본 parens 유지 (관찰 불변성).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const x = new (class Foo extends Error {})();
+        \\console.log(x);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // parens 유지
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new (class") != null);
+}
+
 test "Minify: default export has no synthetic variable — no regression (#1585)" {
     // default export가 없는 번들은 `_default` 심볼을 만들지 않으므로
     // 본 PR 변경으로 부작용 없이 그대로 통과해야 한다.

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2042,7 +2042,7 @@ pub const Codegen = struct {
     fn emitNew(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         if (!self.ast.hasExtra(e, 3)) return;
-        const callee = self.ast.readExtraNode(e, 0);
+        var callee = self.ast.readExtraNode(e, 0);
         const args_start = self.ast.readExtra(e, 1);
         const args_len = self.ast.readExtra(e, 2);
         const flags = self.ast.readExtra(e, 3);
@@ -2052,6 +2052,18 @@ pub const Codegen = struct {
         if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
 
         try self.write("new ");
+        // 원본의 잉여 parens 제거 (#1586): callee가 `(inner)` 형태이고 inner를
+        // 직접 새 callee로 써도 `new MemberExpression` 문법이 깨지지 않으면 벗긴다.
+        // newCalleeNeedsParens가 이미 call-chain 안전성을 판정하므로 재사용.
+        if (self.options.minify_syntax) {
+            while (true) {
+                const cn = self.ast.getNode(callee);
+                if (cn.tag != .parenthesized_expression) break;
+                const inner = cn.data.unary.operand;
+                if (self.newCalleeNeedsParens(inner)) break;
+                callee = inner;
+            }
+        }
         const needs_parens = self.newCalleeNeedsParens(callee);
         if (needs_parens) try self.writeByte('(');
         try self.emitNode(callee);


### PR DESCRIPTION
## 요약

`minify_syntax` 활성화 시 `new (expr)()` 형태에서 callee가 `parenthesized_expression`이고 내부 operand가 `new MemberExpression Arguments` 문법에 그대로 들어가도 안전하면 parens를 벗긴다.

Closes #1586

## 실측 (svelte 5.55.1 readable)

| Bundler | 크기 |
|---|---:|
| ZTS (before) | 1,334 B |
| **ZTS (after)** | **1,332 B** |

svelte의 `new (class StaleReactionError extends Error{...})()` 같은 패턴이 `new class StaleReactionError extends Error{...}()`로 축약됨 (2 B).

## 변경점

`src/codegen/codegen.zig` `emitNew`:
- callee가 `.parenthesized_expression`이면 inner operand를 새 callee로 취하고, 기존 `newCalleeNeedsParens`로 재판정
- 중첩 parens(`((expr))`)도 while 루프로 반복 unwrap
- `minify_syntax` 비활성화 시 원본 보존

## 안전성

- `newCalleeNeedsParens`가 이미 call-chain 안전성(`new a()()` 오파싱 방지, #1507)을 판정하므로 재사용 가능
- `new (factory())()` 같은 CallExpression callee는 `needs_parens = true`로 판정되어 parens 유지 — 의미 변화 없음
- spec: `new MemberExpression Arguments?` 문법에서 `ClassExpression`, `Identifier`, `MemberExpression` 모두 MemberExpression 자리에 직접 들어갈 수 있음

## 테스트 (신규 5개)

`src/bundler/bundler_test/minify_loader.zig`:
- `new (ClassExpression)() drops redundant parens` — svelte-style 패턴
- `new (Identifier)() drops redundant parens`
- `new (MemberExpression)() drops redundant parens` — `new (ns.Box)()` → `new ns.Box()`
- `new (CallExpression)() keeps parens — safety` — `new (factory())()` 유지 회귀 가드
- `redundant parens removal preserved without minify_syntax` — flag off 시 원본 유지

## 관련

- #1586 — 본 PR 대상
- #1507 — `new`의 call-chain parens 판정 선행
- #1585 / #1581 / #1580 — svelte minify gap 관련 선행 작업들

🤖 Generated with [Claude Code](https://claude.com/claude-code)