### PR TITLE
fix(semantic): ClassExpression name을 class body scope에 lexical binding 등록

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -2002,7 +2002,9 @@ pub const SemanticAnalyzer = struct {
         }
 
         const heritage_idx: NodeIndex = @enumFromInt(extras[extra_start + 1]);
-        try self.visitClassWithHeritage(heritage_idx, @enumFromInt(extras[extra_start + 2]));
+        // ClassDeclaration의 name은 이미 outer scope에 등록됐으므로 body scope에 별도 등록 불필요.
+        // body 내부 self-reference는 scope chain을 타고 outer scope의 심볼로 해소된다.
+        try self.visitClassWithHeritage(heritage_idx, @enumFromInt(extras[extra_start + 2]), NodeIndex.none);
     }
 
     fn visitClassExpression(self: *SemanticAnalyzer, node: Node) AllocError!void {
@@ -2014,8 +2016,9 @@ pub const SemanticAnalyzer = struct {
             try self.visitNodeList(.{ .start = extras[extra_start + 6], .len = extras[extra_start + 7] });
         }
 
+        const name_idx: NodeIndex = @enumFromInt(extras[extra_start]);
         const heritage_idx: NodeIndex = @enumFromInt(extras[extra_start + 1]);
-        try self.visitClassWithHeritage(heritage_idx, @enumFromInt(extras[extra_start + 2]));
+        try self.visitClassWithHeritage(heritage_idx, @enumFromInt(extras[extra_start + 2]), name_idx);
     }
 
     /// class를 순회한다. heritage expression과 body를 올바른 private name 환경에서 처리.
@@ -2027,7 +2030,14 @@ pub const SemanticAnalyzer = struct {
     ///
     /// 즉, heritage expression에서는 이 클래스의 private name에 접근할 수 없고,
     /// 오직 외부(부모) 클래스의 private name만 보인다.
-    fn visitClassWithHeritage(self: *SemanticAnalyzer, heritage_idx: NodeIndex, body_idx: NodeIndex) AllocError!void {
+    fn visitClassWithHeritage(
+        self: *SemanticAnalyzer,
+        heritage_idx: NodeIndex,
+        body_idx: NodeIndex,
+        /// ClassExpression name의 node index. ClassDeclaration 또는 익명 expression은 `.none`.
+        /// body scope 진입 후 등록되어 body 내부 self-reference로만 보인다 (#1592, ES 15.7.14).
+        class_expr_name_idx: NodeIndex,
+    ) AllocError!void {
         // Step 1: heritage expression 순회 — 이 클래스의 class scope PUSH 전에!
         // heritage는 outerPrivateEnvironment에서 평가되므로 이 클래스의 #name에 접근 불가.
         // class scope를 push하기 전에 heritage를 순회하면, heritage에서의 #name 참조가
@@ -2040,6 +2050,14 @@ pub const SemanticAnalyzer = struct {
         // class body는 항상 strict mode (ECMAScript 10.2.1)
         const saved = try self.enterScope(.class_body, true);
         try self.pushClassScope();
+
+        // ClassExpression name을 class body scope에 lexical binding으로 등록 (#1592).
+        // heritage 평가 이후, body 순회 이전에 등록되어 body 내부 self-reference는
+        // 이 심볼로 resolve되고, body scope 종료 후 외부 참조는 다른 심볼(또는 unresolved).
+        if (!class_expr_name_idx.isNone()) {
+            const name_node = self.ast.getNode(class_expr_name_idx);
+            try self.declareSymbolWithNode(name_node.span, .class_decl, name_node.span, @intFromEnum(class_expr_name_idx));
+        }
 
         if (!body_idx.isNone() and @intFromEnum(body_idx) < self.ast.nodes.items.len) {
             const body_node = self.ast.getNode(body_idx);

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1141,3 +1141,122 @@ test "TLA: for-await-of at top-level no error when target >= es2022" {
 
     try std.testing.expectEqual(@as(usize, 0), r.analyzer.errors.items.len);
 }
+
+// ============================================================
+// ClassExpression name binding (#1592)
+// ============================================================
+// ECMAScript 15.7.14: ClassExpression의 name은 class body scope에
+// lexical binding되어 body 내부에서 self-reference로 보이고,
+// 외부 scope에서는 보이지 않는다.
+
+test "ClassExpression: name registered as class_decl in class body scope (#1592)" {
+    var scanner = try Scanner.init(std.testing.allocator, "const c = class Foo {};");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expect(ana.errors.items.len == 0);
+    // `c` + `Foo` = 2 심볼이 있어야 함 (Foo가 심볼로 등록됐음을 검증)
+    var found_foo = false;
+    for (ana.symbols.items) |sym| {
+        if (sym.kind == .class_decl) {
+            const name = sym.nameText(parser.ast.source);
+            if (std.mem.eql(u8, name, "Foo")) found_foo = true;
+        }
+    }
+    try std.testing.expect(found_foo);
+}
+
+test "ClassExpression: self-reference in body increments reference_count (#1592)" {
+    var scanner = try Scanner.init(std.testing.allocator,
+        \\const c = class Foo {
+        \\  m() { return Foo; }
+        \\};
+    );
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expect(ana.errors.items.len == 0);
+    var foo_ref_count: u32 = 0;
+    var foo_found = false;
+    for (ana.symbols.items) |sym| {
+        if (sym.kind == .class_decl) {
+            const name = sym.nameText(parser.ast.source);
+            if (std.mem.eql(u8, name, "Foo")) {
+                foo_found = true;
+                foo_ref_count = sym.reference_count;
+            }
+        }
+    }
+    try std.testing.expect(foo_found);
+    // body 내부 `Foo` 참조 정확히 1회 — body scope 바깥은 이 심볼에 해소되지 않아야 함
+    try std.testing.expectEqual(@as(u32, 1), foo_ref_count);
+}
+
+test "ClassExpression: name without self-reference has reference_count 0 (#1592)" {
+    var scanner = try Scanner.init(std.testing.allocator, "const c = class Foo { m() { return 1; } };");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expect(ana.errors.items.len == 0);
+    for (ana.symbols.items) |sym| {
+        if (sym.kind == .class_decl) {
+            const name = sym.nameText(parser.ast.source);
+            if (std.mem.eql(u8, name, "Foo")) {
+                try std.testing.expectEqual(@as(u32, 0), sym.reference_count);
+                return;
+            }
+        }
+    }
+    try std.testing.expect(false); // Foo 심볼이 있어야 함
+}
+
+test "ClassExpression: name scoped to class body — not visible outside (#1592)" {
+    // class body 바깥의 `Foo`는 ClassExpression name을 참조할 수 없다 (별개 scope).
+    // 번들 시 body scope를 벗어난 참조는 별개 심볼이거나 unresolved.
+    var scanner = try Scanner.init(std.testing.allocator,
+        \\const c = class Foo { m() { return Foo; } };
+        \\const outer = Foo;
+    );
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    // body 내부 Foo: reference_count >= 1, body 외부 Foo: 별개 심볼(unresolved) 이거나
+    // 같은 Foo에 바인딩되지 않아야 함.
+    // 검증: class_decl Foo의 ref_count는 body 내부 참조(1회)만 반영.
+    for (ana.symbols.items) |sym| {
+        if (sym.kind == .class_decl) {
+            const name = sym.nameText(parser.ast.source);
+            if (std.mem.eql(u8, name, "Foo")) {
+                // outer Foo 참조가 이 심볼로 resolve되면 ref_count == 2가 됨.
+                // 정확한 lexical binding이면 ref_count == 1.
+                try std.testing.expectEqual(@as(u32, 1), sym.reference_count);
+                return;
+            }
+        }
+    }
+    try std.testing.expect(false);
+}


### PR DESCRIPTION
## 요약

`visitClassExpression`이 name을 심볼 테이블에 등록하지 않아 body 내부 self-reference가 semantic에서 해소되지 않고 `reference_count`도 추적되지 않던 문제를 해결. ECMAScript 15.7.14 ClassDefinitionEvaluation 사양 준수.

Closes #1592

## 근본 원인

`src/semantic/analyzer.zig:2008-2019` `visitClassExpression`에는 ClassDeclaration (라인 1994-2002)이 수행하는 `declareSymbolWithNode` 호출 블록이 **누락**. name이 심볼로 생성되지 않으므로:

- `class Foo { m() { return Foo; } }`에서 body 내부 `Foo` 참조가 미해결 identifier로 처리
- 우연히 codegen이 AST span을 그대로 출력해 런타임은 동작하지만 분석 관점에선 버그
- `reference_count` 0 → mangler의 nested scope 통합 시 self-reference가 깨질 위험

## 변경점

`src/semantic/analyzer.zig`:

1. `visitClassWithHeritage` 시그니처에 `class_expr_name_idx: NodeIndex` 파라미터 추가
2. ClassDeclaration 호출부: `NodeIndex.none` 전달 (name은 이미 outer scope에 등록됨 → scope chain으로 body 내부 self-ref 해소)
3. ClassExpression 호출부: `name_idx` 전달
4. `enterScope(.class_body)` + `pushClassScope()` **이후** (heritage 평가는 이전 scope에서 완료), body 순회 **이전**에 name을 `.class_decl` kind로 등록

이 순서는 ES 15.7.14 step 8(클래스 body scope에 name binding) 순서와 일치. heritage는 outerPrivateEnvironment에서 평가되므로 기존 구조가 그대로 맞음.

## 테스트 (신규 4개)

`src/semantic/analyzer_test.zig`:

- `name registered as class_decl in class body scope` — name 심볼이 `.class_decl` kind로 존재함을 검증
- `self-reference in body increments reference_count` — `class Foo { m() { return Foo; } }`에서 `Foo` 심볼의 reference_count 정확히 1
- `name without self-reference has reference_count 0` — body에 self-ref 없으면 0
- `name scoped to class body — not visible outside` — body 바깥의 `Foo` 참조가 이 심볼에 resolve되지 않음 (정확히 1로 검증)

## 영향

- 참조 분석 정확성 향상
- body scope 격리 검증: 외부 참조가 class expression name과 bind되지 않음
- **#1587 (class anonymous화) 선행 작업** — reference_count == 0 기반 name 제거 판단이 정확해짐
- ClassDeclaration 경로는 `.none` 전달로 동작 불변 (회귀 없음)

## 관련

- #1592 — 본 PR 대상
- #1587 — 본 수정을 선행 조건으로 함 (follow-up PR에서 transformer 최적화)
- ECMAScript 15.7.14 ClassDefinitionEvaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)