### PR TITLE
perf(transformer): 미참조 class expression name 익명화

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -1584,6 +1584,155 @@ test "Minify: default export has no synthetic variable — no regression (#1585)
 }
 
 // ============================================================
+// Minify syntax: anonymize class expression name (#1587)
+// ============================================================
+// ClassExpression의 name이 body 내부에서 참조되지 않으면 익명 class로 축약.
+// #1592로 semantic이 class body scope에 name을 등록하므로 reference_count
+// 기반 판단이 정확. ClassDeclaration은 외부 scope 심볼이라 영향 없음.
+
+test "Minify: unreferenced class expression name is anonymized (#1587)" {
+    // svelte-style `class StaleReactionError extends Error` 패턴.
+    // body 내부에 StaleReactionError 참조가 없으므로 익명화 가능.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const e = new (class StaleReactionError extends Error {
+        \\  name = "StaleReactionError";
+        \\})();
+        \\console.log(e);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // class 키워드 뒤에 식별자 StaleReactionError가 남으면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class StaleReactionError") == null);
+    // 단 "name = \"StaleReactionError\"" property string literal은 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"StaleReactionError\"") != null);
+}
+
+test "Minify: class expression with self-reference keeps its name (#1587)" {
+    // body 내부에서 self-reference가 있으면 이름 제거 금지 (self-ref 깨짐).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const c = class SelfRef {
+        \\  static make() { return new SelfRef(); }
+        \\};
+        \\console.log(c.make());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // self-ref 있으므로 SelfRef 이름은 유지되어야 함 — 식별자 보존 검증
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SelfRef") != null);
+}
+
+test "Minify: class declaration name never anonymized (#1587)" {
+    // ClassDeclaration은 외부 scope 심볼이므로 anonymize 대상 아님.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\class Box {}
+        \\const x = new Box();
+        \\console.log(x);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // ClassDeclaration은 외부 scope에 이름이 있어야 `new X()` 호출 성립.
+    // mangled로 이름이 바뀌더라도 `class` 뒤 공백+식별자+body 구조는 유지되어야 하고,
+    // 완전 익명(`class {` / `class{`)이 되어서는 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class {") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class{") == null);
+}
+
+test "Minify: anonymization disabled without minify_syntax (#1587)" {
+    // minify_syntax 비활성 시 원본 이름 유지.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const c = class UnusedName extends Error {};
+        \\console.log(c);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 원본 이름 유지
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UnusedName") != null);
+}
+
+test "Minify: keep_names disables anonymization (#1587)" {
+    // keep_names=true일 때는 이름 유지 (debug용 이름 보존 옵션).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const c = class KeepMe extends Error {};
+        \\console.log(c);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+        .keep_names = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // keep_names → 이름 유지
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "KeepMe") != null);
+}
+
+// ============================================================
 // Asset Loader Tests
 // ============================================================
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -847,11 +847,15 @@ pub fn emitModule(
         .jsx_import_source = options.jsx_import_source,
         .jsx_filename = module.path,
         .worklet_plugin_version = options.worklet_plugin_version,
+        .minify_syntax = options.minify_syntax,
+        .keep_names = options.keep_names,
     });
     // symbol_ids 전파: semantic analyzer가 생성한 원본 AST의 symbol_ids를
-    // transformer가 ast 기준으로 재매핑
+    // transformer가 ast 기준으로 재매핑. symbols slice도 함께 전달하여
+    // reference_count 기반 optimization(#1587 등)이 번들 경로에서도 동작하도록 함.
     if (module.semantic) |sem| {
         transformer.initSymbolIds(sem.symbol_ids) catch return error.OutOfMemory;
+        transformer.symbols = sem.symbols.items;
     }
     // jsxDEV source info 계산용 line offsets
     transformer.line_offsets = module.line_offsets;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -163,6 +163,14 @@ pub const TransformOptions = struct {
     /// true일 때 worklet body의 `new X()` 감지 시 `X__classFactory`를 closure에 자동 주입하지 않음.
     disable_worklet_classes: bool = false,
 
+    /// `--minify-syntax` 활성화 — AST 레벨 의미 보존 축약을 허용 (#1587 등).
+    /// 예: 미참조 class expression name 익명화, 잉여 parens 제거(codegen).
+    minify_syntax: bool = false,
+
+    /// `--keep-names` 활성화 — 함수/클래스 이름을 `.name` 프로퍼티로 보존해야 하므로
+    /// minify_syntax 기반 이름 제거 최적화를 비활성화.
+    keep_names: bool = false,
+
     pub const compat = @import("compat.zig");
 };
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -28,7 +28,15 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
     // Fast path: useDefineForClassFields=true AND !experimentalDecorators → 기존 동작
     // 멤버별 분류가 불필요하므로 body를 통째로 방문한다.
     if (self.options.use_define_for_class_fields and !self.options.experimental_decorators) {
-        const new_name = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.name));
+        const raw_name_idx = self.readNodeIdx(e, ast_mod.ClassExtra.name);
+        // #1587: class_expression의 name이 body 내부에서 참조되지 않으면 익명화.
+        // #1592로 ClassExpression name이 body scope 심볼로 등록되어
+        // reference_count == 0이 정확한 "미참조" 시그널. ClassDeclaration은 외부
+        // scope 심볼이라 body 내부 ref만 count되지 않으므로 대상에서 제외.
+        const new_name = if (shouldDropClassExprName(self, node.tag, raw_name_idx))
+            ast_mod.NodeIndex.none
+        else
+            try self.visitNode(raw_name_idx);
         const new_super = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.super));
 
         var current_body_idx = self.readNodeIdx(e, ast_mod.ClassExtra.body);
@@ -251,6 +259,9 @@ fn wrapClassExprInIIFE(
 /// experimental decorator를 __decorateClass 호출로 변환한다.
 pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeIndex {
     // TODO(es2021): apply same IIFE wrapping for class_expression with private methods — see wrapClassExprInIIFE in fast path
+    // NOTE(#1587): class expression anonymization은 fast path에서만 적용한다. 이 경로는
+    //   experimental decorator / useDefineForClassFields=false 등으로 body를 멤버 단위로
+    //   분류하므로 reference_count 기반 판단을 재평가해야 한다. 후속 작업.
     const e = node.data.extra;
     const has_super = !self.readNodeIdx(e, ast_mod.ClassExtra.super).isNone();
     const new_name = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.name));
@@ -3524,4 +3535,21 @@ fn buildPiggybackedInitCall(self: *Transformer, prev_extra_name: []const u8, ini
     } else {
         return prev_call;
     }
+}
+
+/// #1587: class_expression의 name이 body 내부 self-reference 없이 선언된 경우 true.
+/// - `minify_syntax` + `!keep_names` + class_expression + name 존재 + reference_count == 0 필요.
+/// - #1592로 ClassExpression name이 class body scope 심볼로 등록되므로 body 내부 참조만
+///   reference_count에 누적됨. ClassDeclaration name은 외부 scope에 등록되어 내부 사용이
+///   여전히 count되므로 본 predicate는 항상 false를 반환.
+fn shouldDropClassExprName(self: *Transformer, tag: Tag, name_idx: NodeIndex) bool {
+    if (!self.options.minify_syntax) return false;
+    if (self.options.keep_names) return false;
+    if (tag != .class_expression) return false;
+    if (name_idx.isNone()) return false;
+    const node_i = @intFromEnum(name_idx);
+    if (node_i >= self.symbol_ids.items.len) return false;
+    const sym_id = self.symbol_ids.items[node_i] orelse return false;
+    if (sym_id >= self.symbols.len) return false;
+    return self.symbols[sym_id].reference_count == 0;
 }


### PR DESCRIPTION
## 요약

ClassExpression의 name이 body 내부에서 참조되지 않으면 AST 레벨에서 `NodeIndex.none`으로 교체하여 codegen이 이름 없이 emit. svelte-style `new (class StaleReactionError extends Error{...})()` 패턴이 `new class extends Error{...}()`로 축약.

Closes #1587

## 실측 (svelte 5.55.1 readable)

| Bundler | 크기 |
|---|---:|
| ZTS (before) | 1,332 B |
| **ZTS (after)** | **1,313 B** |
| esbuild | 1,204 B |

-19 B.

## 근본 해결

**선행 작업 (#1593 머지)**: semantic analyzer가 `visitClassExpression`에서 name을 class body scope 심볼로 등록하지 않던 버그 수정. ClassExpression name이 lexical binding으로 등록되어 body 내부 self-reference에만 `reference_count`가 누적됨 (ES 15.7.14).

이 PR: 그 `reference_count == 0` 시그널을 기반으로 transformer가 AST 레벨에서 name을 제거. codegen은 기존 `name.isNone()` 분기로 자연스럽게 이름 없이 emit.

## 변경점

### `src/transformer/transformer.zig`
- `TransformOptions`에 `minify_syntax`, `keep_names` 필드 추가

### `src/bundler/emitter.zig`
- Transformer 초기화 시 두 옵션 전달
- `transformer.symbols = sem.symbols.items` 대입 — 번들 경로에서 reference_count 조회 가능하도록

### `src/transformer/transformer/class_decorator.zig`
- fast path(`use_define_for_class_fields AND !experimental_decorators`)의 visitClass에 `shouldDropClassExprName` 조건부 적용
- helper 함수: tag / minify_syntax / keep_names / name_idx / symbol_id / reference_count 체크
- non-fast path는 body 멤버별 분류 때문에 재평가 필요 — NOTE 주석으로 명시 (후속 작업)

## 테스트 (신규 5개)

`src/bundler/bundler_test/minify_loader.zig`:

- `unreferenced class expression name is anonymized` — svelte 패턴
- `class expression with self-reference keeps its name` — self-ref 보존 회귀 가드
- `class declaration name never anonymized` — ClassDeclaration은 외부 scope 심볼이라 영향 없음
- `anonymization disabled without minify_syntax` — flag off 시 원본 유지
- `keep_names disables anonymization` — debug 이름 보존 옵션 존중

## 안전성

- fast path만 적용 → 기존 decorator / legacy field 변환 경로는 영향 없음
- self-reference 있는 class expression은 reference_count >= 1 → 이름 제거되지 않음 (의미 보존)
- ClassDeclaration name은 외부 scope 심볼이라 body 내부 참조만 count되지 않음 → 자동 제외
- keep_names 옵션 존중

## 관련

- #1587 — 본 PR 대상
- #1592 / #1593 — semantic ClassExpression name binding (선행, 머지됨)
- #1586 — new 잉여 parens (svelte 패턴 한 쪽에서 이미 축약)
- #1585, #1581, #1580 — 누적 svelte minify 개선 (1,524 → 1,313 B, -13.8%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)