### PR TITLE
test(integration): TLA IIFE 기대값을 arrow 래퍼로 갱신 (#1580 후속)

### DIFF
--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1973,7 +1973,10 @@ describe("JSX classic 모드 번들러 rename", () => {
     expect(code).toContain('async "esm.js"()');
   });
 
-  test("TLA: scope-hoisted IIFE에서 async function으로 감싼다 (#779)", async () => {
+  test("TLA: scope-hoisted IIFE에서 async 래퍼로 감싼다 (#779)", async () => {
+    // #1580 이후 기본 IIFE는 arrow 형태: `(async () => {...})()`.
+    // ES5 타겟에서는 `(async function() {...})()` 유지. 공통 불변식은
+    // "async 키워드"가 래퍼 앞에 있고 sync IIFE가 아니라는 것.
     const { dir, cleanup: cl } = await createFixture({
       "dep.ts": "export const val = await Promise.resolve(42);",
       "index.ts": 'import { val } from "./dep.ts"; console.log(val);',
@@ -1982,8 +1985,9 @@ describe("JSX classic 모드 번들러 rename", () => {
     const outFile = join(dir, "out.js");
     await runZts(["--bundle", join(dir, "index.ts"), "-o", outFile, "--platform=browser"]);
     const code = readFileSync(outFile, "utf-8");
-    expect(code).toContain("(async function()");
+    expect(code).toContain("(async ");
     expect(code).not.toContain("(function()");
+    expect(code).not.toContain("(() =>");
   });
 
   test("TLA: __esm 전이 전파 — import하는 모듈도 async 래핑 (#779)", async () => {


### PR DESCRIPTION
## 요약

#1580(arrow IIFE 치환) 머지 후 main의 Integration Tests job이 실패. TLA 테스트가 `(async function()`을 strict-match하여 회귀. 내 arrow 전환으로 실제 출력은 `(async () => {...})()`이 되었는데 테스트 업데이트가 누락됨.

## 변경점

`tests/integration/tests/bundle-smoke.test.ts`의 `TLA: scope-hoisted IIFE...` 테스트 (#779):
- 제목: "async function으로 감싼다" → "async 래퍼로 감싼다"
- strict `(async function()` 매칭 → 불변식 기반 검증:
  - `(async ` 포함 (async 키워드 존재)
  - `(function()` 미포함 (sync IIFE 아님)
  - `(() =>` 미포함 (non-async arrow 아님 — TLA는 반드시 async)
- 주석에 #1580 이후 동작과 ES5 타겟 예외 설명

## 로컬 검증

```
$ cd tests/integration && bun test tests/bundle-smoke.test.ts -t "scope-hoisted IIFE에서 async"
 1 pass
 0 fail
```

다른 두 TLA 테스트(`__esm 래핑 시 async 키워드`, `__esm 전이 전파`)는 `async "..."():`(IIFE가 아니라 __esm 함수) 형태를 검증하므로 영향 없음.

## 관련

- #1580 — arrow IIFE 전환 (본 수정의 원인)
- #779 — TLA 원래 이슈

🤖 Generated with [Claude Code](https://claude.com/claude-code)