### PR TITLE
fix(bundler): `_default` 합성 심볼 중복 등록 제거

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -666,6 +666,22 @@ pub fn populateSyntheticSymbols(
             std.mem.eql(u8, eb.exported_name, "default") and
             (std.mem.eql(u8, eb.local_name, "_default") or std.mem.eql(u8, eb.local_name, "default")))
         {
+            // #1598: semantic analyzer의 visitExportDefaultDeclaration이 `_default` facade
+            // 심볼을 이미 scope_maps[0]에 등록했다면 그걸 재사용 — extend하면 동일 이름이
+            // 중복 등록되어 collectModuleNames가 `_default$1` 충돌 회피 이름을 생성한다.
+            if (module_scope) |scope| {
+                if (scope.get("_default")) |existing_idx| {
+                    if (existing_idx < sem_symbols.items.len) {
+                        // 기존 심볼에 default_export synthetic_kind 마킹.
+                        // synthetic_name은 mangler(#1585) lookup key로 쓰이므로 함께 설정.
+                        sem_symbols.items[existing_idx].synthetic_kind = .default_export;
+                        sem_symbols.items[existing_idx].synthetic_name = "_default";
+                        const sym_id: semantic_symbol.SymbolId = @enumFromInt(@as(u32, @intCast(existing_idx)));
+                        eb.symbol = .{ .semantic = .{ .module = module_index, .symbol = sym_id } };
+                        continue;
+                    }
+                }
+            }
             const sem_id = try semantic_symbol.extendSymbol(
                 arena,
                 sem_symbols,

--- a/src/bundler/bundler_test/default_deconflict.zig
+++ b/src/bundler/bundler_test/default_deconflict.zig
@@ -828,3 +828,112 @@ test "Deconflict: rest parameter shadows renamed function (#1457)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, length_ref) == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, map_ref) == null);
 }
+
+// ============================================================
+// `_default` 중복 심볼 방지 (#1598)
+// ============================================================
+// semantic analyzer의 visitExportDefaultDeclaration이 `_default` facade 심볼을
+// scope_maps[0]에 등록함. 그 뒤 populateSyntheticSymbols가 별도로 extend하면
+// 동일 이름이 중복 등록되어 collectModuleNames 충돌 처리가 `_default$1` 접미사를
+// 붙인다. populateSyntheticSymbols는 기존 심볼을 재사용해야 한다.
+
+test "Default: single inline default export has no `_default$N` suffix (#1598)" {
+    // minify_identifiers 없이 번들하면 canonical_name이 `_default`가 되어야 하며
+    // `_default$1` 같은 충돌 회피 이름이 생기면 안 된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import helper from './helper';
+        \\console.log(helper.x);
+    );
+    try writeFile(tmp.dir, "helper.ts",
+        \\export default { x: 42 };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // `_default$` 접미사가 있으면 중복 등록 버그 재발
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_default$") == null);
+    // `_default` 이름 자체는 존재해야 함 (정의 + 참조)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_default") != null);
+    // 값 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "42") != null);
+}
+
+test "Default: multiple module inline default exports collide cleanly (#1598)" {
+    // 두 모듈 각자 `export default` — $1, $2 정상 접미사. 이전엔 단일 모듈에도
+    // $1이 붙는 버그가 있었지만, 이 테스트는 "정상 충돌 경로"가 여전히 동작함을 가드.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import a from './a';
+        \\import b from './b';
+        \\console.log(a.x + b.y);
+    );
+    try writeFile(tmp.dir, "a.ts",
+        \\export default { x: 10 };
+    );
+    try writeFile(tmp.dir, "b.ts",
+        \\export default { y: 20 };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var bun = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer bun.deinit();
+    const result = try bun.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 실행 결과 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "10") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "20") != null);
+}
+
+test "Default: named `export default function` has no `_default` (#1598)" {
+    // inner가 named function — `_default` facade는 생성되지 않아야 한다
+    // (binding_scanner의 hasSyntheticDefault 조건에 해당 안 됨).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import greet from './lib';
+        \\console.log(greet('world'));
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export default function hello(name) { return 'Hello ' + name; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // named function의 default export는 `_default`라는 이름을 만들지 않아야 함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_default") == null);
+    // 실행 결과 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Hello") != null);
+}

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -351,6 +351,16 @@ pub const Linker = struct {
             const sym_name = scope_entry.key_ptr.*;
             if (std.mem.eql(u8, sym_name, "default")) continue;
 
+            // `_default` 합성 심볼은 scope_maps에도 등록되지만 owner 등록은 export_bindings
+            // 경로(line 394-)에서 전담한다. 여기서도 등록하면 같은 모듈의 같은 이름이
+            // 이중 owner가 되어 collectModuleNames 충돌 처리가 `_default$1` 접미사를
+            // 생성한다 (#1598).
+            const sym_idx_for_kind = scope_entry.value_ptr.*;
+            if (sym_idx_for_kind < sem.symbols.items.len) {
+                const sk = sem.symbols.items[sym_idx_for_kind].synthetic_kind;
+                if (sk == .default_export) continue;
+            }
+
             // import binding은 일반적으로 인라인되어 변수가 생성되지 않으므로 충돌 대상 아님.
             // 단, CJS 모듈을 import하면 preamble에서 `var X = require_xxx().X`로 변수가 생성되므로
             // 충돌 대상에 포함해야 한다.


### PR DESCRIPTION
## 요약

단일 모듈 `export default <expr>` 번들에서 충돌이 없는데도 출력에 `_default\$1` 접미사가 붙던 버그를 수정. 두 경로의 이중 등록이 원인. 근본(생성 시점)과 증상(owner 등록 시점) 양쪽에서 방지.

Closes #1598

## 재현

```ts
// entry.ts
import helper from './helper';
console.log(helper.x);

// helper.ts
export default { x: 42 };
```

```bash
zts --bundle entry.ts --minify-whitespace --minify-syntax -o out.js
```

- **Before**: `var _default\$1={x:42};console.log(_default\$1.x);` (63 B)
- **After**: `var _default={x:42};console.log(_default.x);` (59 B)

## 근본 원인

1. `src/semantic/analyzer.zig` `visitExportDefaultDeclaration` (line 2577-2606) — inline expression인 경우 `_default` facade 심볼을 생성하고 `scope_maps[0]`에 등록
2. `src/bundler/binding_scanner.zig` `populateSyntheticSymbols` (line 665-) — `hasSyntheticDefault` 조건에서 **다시** `extendSymbol`로 새 심볼 생성
3. `src/bundler/linker.zig` `collectModuleNames` — scope_maps 순회에서 `_default` owner 등록 + `export_bindings` 순회에서 또 등록 → 이중 owner
4. `calculateRenames`가 중복 owner를 충돌로 처리하여 `_default\$1` 접미사 생성

## 변경점

### `src/bundler/binding_scanner.zig`
`populateSyntheticSymbols`의 synthetic default 경로:
- `scope_maps[0].get("_default")` lookup. match면 기존 심볼에 `synthetic_kind = .default_export` + `synthetic_name = "_default"` 마킹하고 `continue` (extend 우회)
- miss이면 기존 `extendSymbol` 경로 유지 (named function default 등)

### `src/bundler/linker.zig`
`collectModuleNames` scope_maps 순회:
- 심볼의 `synthetic_kind == .default_export`면 owner 등록 skip
- owner 등록은 `export_bindings` 순회(line 394-)가 전담

## 왜 이중 방어인가

- **binding_scanner 수정 = 근본**: 중복 심볼 자체를 생성하지 않음 (symbol table cleanliness)
- **linker 수정 = 증상 완화**: 만에 하나 binding_scanner fast-path가 skip되는 edge case에서도 owner 단계에서 차단

추후 semantic의 facade 심볼 생성 자체를 없애는 리팩터링이 가능해질 때까지 두 경로 모두 유지.

## 테스트 (신규 3개)

`src/bundler/bundler_test/default_deconflict.zig`:

- `single inline default export has no \`_default\$N\` suffix` — 본 수정의 핵심 회귀 가드
- `multiple module inline default exports collide cleanly` — 정상 충돌 경로(두 모듈 default) 유지 확인
- `named \`export default function\` has no \`_default\`` — named function default는 facade 생성 안 됨

## 영향

- svelte 번들은 크기 변화 없음 — 이미 mangler(#1585)가 `_default\$N`을 `n` 등으로 축약
- 실질 이득:
  - `--no-minify-identifiers` 개발 번들 가독성
  - symbol table의 논리적 정확성 (같은 synthetic 이름이 두 심볼에 매핑되는 상태 제거)
  - 다른 분석/optimization(예: tree-shake, const inline)이 올바른 심볼에 작용

## 관련

- #1598 — 본 PR 대상
- #1585 — mangler에서 `_default\$N` 축약 (증상 무마의 선행 작업)
- #1338 — synthetic symbol 등록 구조

🤖 Generated with [Claude Code](https://claude.com/claude-code)