### PR TITLE
chore(gitignore): `packages/wasm/dist/` 빌드 산출물 제외

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ documents/dist/
 
 # JS build output
 packages/core/dist/
+packages/wasm/dist/
 
 # Build artifacts
 *.o


### PR DESCRIPTION
## Summary

- `packages/wasm/dist/`를 `.gitignore`에 추가.
- `packages/core/dist/`와 동일하게 로컬 빌드 산출물이라 추적 불필요.

## Test plan

- [x] `git check-ignore packages/wasm/dist/` → 무시 확인
- [x] 기존 tracked 파일 없음 (`git log -- packages/wasm/dist/` 비어있음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)