### PR TITLE
perf(bundler): namespace 접근 정밀도 분석 infrastructure (#1603 Phase 1a)

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -31,4 +31,5 @@ comptime {
     _ = @import("bundler_test/minify_loader.zig");
     _ = @import("bundler_test/plugin_misc.zig");
     _ = @import("bundler_test/function_map.zig");
+    _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1241,6 +1241,92 @@ pub const Linker = struct {
         return false;
     }
 
+    /// namespace 심볼에 대한 AST 수준의 멤버 접근 정밀도 분석 결과 (#1603 Phase 1).
+    ///
+    /// `kind == .member_only`: 모든 참조가 `ns.prop` 형태 — `members` 집합이 접근된 프로퍼티.
+    /// `kind == .opaque`: 값으로 사용되거나 computed access 등 → `members`는 비어 있고 fallback 필요.
+    pub const NamespaceAccess = struct {
+        kind: Kind,
+        members: std.StringHashMapUnmanaged(void) = .{},
+
+        pub const Kind = enum { member_only, @"opaque" };
+
+        pub fn deinit(self: *NamespaceAccess, allocator: std.mem.Allocator) void {
+            self.members.deinit(allocator);
+        }
+    };
+
+    /// namespace 심볼의 모든 참조를 스캔해 member-only 접근 여부와 접근된 프로퍼티 집합을 수집.
+    /// tree-shaker가 이 정보를 바탕으로 target 모듈의 `export` 중 실제 필요한 것만 live로 표시.
+    ///
+    /// member_only 조건:
+    ///   - 모든 ns 참조가 `static_member_expression` / `private_field_expression`의 object 위치
+    ///   - import specifier / binding_identifier 등 선언 위치는 제외 (참조 아님)
+    ///
+    /// opaque 처리되는 경우:
+    ///   - 값 전달(`f(ns)`), spread(`{...ns}`), 리플렉션(`Object.keys(ns)`)
+    ///   - computed access (`ns[key]`) — key가 동적이라 정밀도 보장 불가
+    ///
+    /// 주의: members의 문자열은 `ast.getText` 결과 (source 버퍼 참조). ast 수명 동안만 유효.
+    pub fn analyzeNamespaceAccess(
+        allocator: std.mem.Allocator,
+        ast: *const Ast,
+        symbol_ids: []const ?u32,
+        ns_sym_id: u32,
+    ) std.mem.Allocator.Error!NamespaceAccess {
+        const node_count = ast.nodes.items.len;
+        var access: NamespaceAccess = .{ .kind = .member_only };
+        errdefer access.deinit(allocator);
+        if (node_count == 0) return access;
+
+        // obj_node_idx → prop_node_idx 매핑. ns 참조가 member-expr의 object인지 O(1)로 확인.
+        // computed_member_expression은 제외 — key가 literal이 아니면 opaque 취급이 안전.
+        var prop_by_obj: std.AutoHashMapUnmanaged(u32, u32) = .{};
+        defer prop_by_obj.deinit(allocator);
+
+        for (ast.nodes.items) |node| {
+            if (node.tag != .static_member_expression and node.tag != .private_field_expression) continue;
+            const e = node.data.extra;
+            if (!ast.hasExtra(e, 2)) continue;
+            const obj_idx = ast.readExtra(e, 0);
+            const prop_idx = ast.readExtra(e, 1);
+            if (obj_idx < node_count and prop_idx < node_count) {
+                try prop_by_obj.put(allocator, obj_idx, prop_idx);
+            }
+        }
+
+        for (symbol_ids, 0..) |maybe_sid, node_i| {
+            const sid = maybe_sid orelse continue;
+            if (sid != ns_sym_id) continue;
+            if (node_i >= node_count) {
+                // 인덱스 범위 밖 참조는 보수적으로 opaque
+                access.members.deinit(allocator);
+                access.members = .{};
+                access.kind = .@"opaque";
+                return access;
+            }
+
+            const tag = ast.nodes.items[node_i].tag;
+            // 선언 위치는 참조 아님 — 건너뜀
+            if (tag == .import_namespace_specifier or tag == .import_default_specifier or
+                tag == .import_specifier or tag == .binding_identifier) continue;
+
+            if (prop_by_obj.get(@intCast(node_i))) |prop_node_idx| {
+                const prop_node = ast.nodes.items[prop_node_idx];
+                const name = ast.getText(prop_node.span);
+                if (name.len > 0) try access.members.put(allocator, name, {});
+            } else {
+                // member-expr object가 아닌 참조 위치 — opaque
+                access.members.deinit(allocator);
+                access.members = .{};
+                access.kind = .@"opaque";
+                return access;
+            }
+        }
+
+        return access;
+    }
+
     /// SymbolRef를 scope hoisting 후 최종 로컬 이름으로 해결.
     /// resolveExportChain → getExportLocalName → getCanonicalName 3단계를 캡슐화.
     pub fn resolveToLocalName(self: *const Linker, ref: SymbolRef) []const u8 {

--- a/src/bundler/namespace_access_test.zig
+++ b/src/bundler/namespace_access_test.zig
@@ -1,0 +1,182 @@
+//! `Linker.analyzeNamespaceAccess` 유닛 테스트 (#1603 Phase 1a).
+//!
+//! `import * as X` 형태 namespace 심볼에 대해 AST 수준 멤버 접근 정밀도 분석을 검증.
+//! - member-only 패턴에서 접근된 prop 집합이 정확히 추출되는지
+//! - 값 전달 / spread / computed access / 재export 등은 opaque로 판정되는지
+
+const std = @import("std");
+const Scanner = @import("../lexer/scanner.zig").Scanner;
+const Parser = @import("../parser/parser.zig").Parser;
+const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
+const Linker = @import("linker.zig").Linker;
+const NamespaceAccess = Linker.NamespaceAccess;
+
+/// 소스를 파싱 + semantic 돌린 뒤, `import * as <ns_name>` 의 심볼 id를 찾아
+/// `analyzeNamespaceAccess` 결과를 반환한다.
+const Harness = struct {
+    scanner: Scanner,
+    parser: Parser,
+    analyzer: SemanticAnalyzer,
+    access: NamespaceAccess,
+
+    fn deinit(self: *Harness, allocator: std.mem.Allocator) void {
+        self.access.deinit(allocator);
+        self.analyzer.deinit();
+        self.parser.deinit();
+        self.scanner.deinit();
+    }
+};
+
+fn runAccess(allocator: std.mem.Allocator, source: []const u8, ns_name: []const u8) !Harness {
+    var scanner = try Scanner.init(allocator, source);
+    errdefer scanner.deinit();
+    var parser = Parser.init(allocator, &scanner);
+    errdefer parser.deinit();
+    _ = try parser.parse();
+
+    var analyzer = SemanticAnalyzer.init(allocator, &parser.ast);
+    errdefer analyzer.deinit();
+    try analyzer.analyze();
+
+    // import_namespace_specifier는 그 자체가 binding 노드 (data = .{ .string_ref = span }).
+    // span text가 ns_name과 일치하는 specifier의 symbol_ids를 찾는다.
+    var ns_sym_id: ?u32 = null;
+    const ast = &parser.ast;
+    for (ast.nodes.items, 0..) |node, i| {
+        if (node.tag != .import_namespace_specifier) continue;
+        const text = ast.getText(node.span);
+        if (!std.mem.eql(u8, text, ns_name)) continue;
+        if (i < analyzer.symbol_ids.items.len) {
+            if (analyzer.symbol_ids.items[i]) |sid| {
+                ns_sym_id = sid;
+                break;
+            }
+        }
+    }
+    // 찾지 못했으면 analyzer의 symbol 테이블에서 이름으로 검색 (fallback)
+    if (ns_sym_id == null) {
+        for (analyzer.symbols.items, 0..) |sym, idx| {
+            if (std.mem.eql(u8, sym.nameText(source), ns_name)) {
+                ns_sym_id = @intCast(idx);
+                break;
+            }
+        }
+    }
+    const sid = ns_sym_id orelse return error.NamespaceSymbolNotFound;
+
+    const access = try Linker.analyzeNamespaceAccess(allocator, ast, analyzer.symbol_ids.items, sid);
+    return .{
+        .scanner = scanner,
+        .parser = parser,
+        .analyzer = analyzer,
+        .access = access,
+    };
+}
+
+fn expectMembers(access: *const NamespaceAccess, expected: []const []const u8) !void {
+    try std.testing.expectEqual(NamespaceAccess.Kind.member_only, access.kind);
+    try std.testing.expectEqual(expected.len, access.members.count());
+    for (expected) |name| {
+        try std.testing.expect(access.members.contains(name));
+    }
+}
+
+test "analyzeNamespaceAccess: 단일 member 접근" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\X.foo();
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try expectMembers(&h.access, &.{"foo"});
+}
+
+test "analyzeNamespaceAccess: 여러 member 접근 + 중복 제거" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\X.foo();
+        \\X.bar;
+        \\X.foo(1, 2);
+        \\const v = X.baz;
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try expectMembers(&h.access, &.{ "foo", "bar", "baz" });
+}
+
+test "analyzeNamespaceAccess: 사용 없으면 빈 member_only" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\const unrelated = 1;
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.member_only, h.access.kind);
+    try std.testing.expectEqual(@as(usize, 0), h.access.members.count());
+}
+
+test "analyzeNamespaceAccess: 값으로 전달 → opaque" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\console.log(X);
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+    try std.testing.expectEqual(@as(usize, 0), h.access.members.count());
+}
+
+test "analyzeNamespaceAccess: spread → opaque" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\const merged = { ...X };
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+}
+
+test "analyzeNamespaceAccess: computed access (X[key]) → opaque" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\const key = 'foo';
+        \\const v = X[key];
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+}
+
+test "analyzeNamespaceAccess: 재-alias 후 사용 → opaque" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\const alias = X;
+        \\alias.foo();
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+}
+
+test "analyzeNamespaceAccess: member 접근 + 값 전달 혼합 → opaque" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\X.foo();
+        \\console.log(X);
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+}
+
+test "analyzeNamespaceAccess: chained member (X.a.b) — 바깥 X.a만 기록" {
+    // `X.a.b()`는 `X.a`로 접근 후 그 결과의 `.b` 호출 — X에 대해선 'a'만 접근.
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\X.a.b();
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try expectMembers(&h.access, &.{"a"});
+}
+
+test "analyzeNamespaceAccess: 표현식 내 member 접근" {
+    var h = try runAccess(std.testing.allocator,
+        \\import * as X from './mod';
+        \\const arr = [X.a, X.b, X.c];
+        \\const result = X.a + X.b;
+    , "X");
+    defer h.deinit(std.testing.allocator);
+    try expectMembers(&h.access, &.{ "a", "b", "c" });
+}


### PR DESCRIPTION
## Summary

- `Linker.analyzeNamespaceAccess()` 추가 — namespace 심볼의 AST 수준 정밀도 분석.
- 모든 `ns.prop` 형태 참조에서 접근된 prop 집합을 수집, 값으로 사용되거나 computed access 등이 섞이면 `.opaque` 반환.
- **이번 PR은 인프라만 추가**. 다음 Phase에서 tree-shaker가 소비 → `export * as Ns` target의 미사용 export 정밀 prune.

## 배경 (#1603 실측)

Effect v3.21.0 번들 대상 namespace import 555개 조사 결과:

| 지표 | 값 |
|---|---:|
| Member-only 접근 | **555 (100%)** |
| Opaque 사용 | 0 |
| Target export 대비 접근률 | **10.7%** (2,561 / 24,007) |
| **잠재 prune** | **89.3%** (21,446개 export) |

접근률 0-9%가 248개 (44.7%)로 가장 많음. 이론적으로 ~80KB 회수 여지.

## 설계

**왜 Tree-shaker 전파(A) 방식인가**:
- 단일 책임: liveness는 tree-shaker가 결정, codegen은 emit만
- 추가적 변경 (기존 `used_exports: StringHashMap(void)` 확장)
- opaque fallback으로 회귀 리스크 0 (결과가 커지거나 작아지기만)
- rolldown 방식 (memory의 oxc/rolldown 참고 원칙)

vs AST rewrite(B) / codegen skip(C) 는 유지보수 난이도/런타임 안전 측면 열세.

## Phase 로드맵

- **[x] Phase 1a (이 PR)**: `analyzeNamespaceAccess` + 단위 테스트
- [ ] Phase 1b: tree-shaker 연동 — 직접 `import * as X` 케이스
- [ ] Phase 2: `export * as X` re-export 전파
- [ ] Phase 3 (선택): 중첩 chain (`Effect.Fiber.await`)
- [ ] 최종: 전 라이브러리 fallback 비율 측정 리포트

## Test plan

- [x] `zig build test` — 신규 단위 10개 + 기존 전부 pass
- [x] 회귀 없음 (함수 추가만 했고 아직 호출 사이트 없음)

Refs #1603

🤖 Generated with [Claude Code](https://claude.com/claude-code)