### PR TITLE
fix(bundler): #1609 mangler가 shouldSkip된 이름을 slot에 재할당하지 않도록

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -148,6 +148,14 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     var binding_buf: std.ArrayListUnmanaged(SymBinding) = .empty;
     defer binding_buf.deinit(allocator);
 
+    // mangling에서 제외된 심볼의 원본 이름은 그대로 출력에 남거나(shouldSkip,
+    // blocksMangling) 번들러가 별도로 canonicalize하므로(skip_symbols), base54가
+    // 해당 이름을 다른 slot에 재할당하면 동일 스코프 중복 선언(#1609: 9-param
+    // pipe의 1글자 param) 또는 shadowing 오염으로 이어진다. 이들 이름을 Phase 4
+    // 이름 할당에서 reserved로 취급한다.
+    var reserved_names = std.StringHashMap(void).init(allocator);
+    defer reserved_names.deinit();
+
     // DFS로 scope tree 순회
     var dfs_stack: std.ArrayListUnmanaged(u32) = .empty;
     defer dfs_stack.deinit(allocator);
@@ -167,15 +175,24 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
                 const sym = symbols[sym_idx];
                 const name = entry.key_ptr.*;
 
-                // skip 판정
-                if (shouldSkip(sym, name)) continue;
+                // skip 판정 — 아래 세 경로는 원본 이름이 출력에 살아남으므로 reserved
+                if (shouldSkip(sym, name)) {
+                    try reserved_names.put(name, {});
+                    continue;
+                }
                 // direct eval / with 스코프의 바인딩은 mangling 차단 (#1258)
                 if (!sym.scope_id.isNone()) {
                     const s_idx = sym.scope_id.toIndex();
-                    if (s_idx < scopes.len and scopes[s_idx].blocksMangling()) continue;
+                    if (s_idx < scopes.len and scopes[s_idx].blocksMangling()) {
+                        try reserved_names.put(name, {});
+                        continue;
+                    }
                 }
                 if (skip_symbols) |ss| {
-                    if (sym_idx < ss.capacity() and ss.isSet(sym_idx)) continue;
+                    if (sym_idx < ss.capacity() and ss.isSet(sym_idx)) {
+                        try reserved_names.put(name, {});
+                        continue;
+                    }
                 }
 
                 try binding_buf.append(allocator, .{ .sym_idx = sym_idx, .name = name });
@@ -271,10 +288,10 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     var name_counter: u32 = 0;
     var name_buf: [8]u8 = undefined;
     for (sorted_slots) |entry| {
-        // 예약어 충돌 건너뜀
+        // 예약어/글로벌 + mangling 제외 심볼의 원본 이름은 건너뜀 (#1609)
         var name = base54(name_counter, &name_buf);
         name_counter += 1;
-        while (isReservedOrGlobal(name)) {
+        while (isReservedOrGlobal(name) or reserved_names.contains(name)) {
             name = base54(name_counter, &name_buf);
             name_counter += 1;
         }

--- a/tests/integration/tests/mangler-minify.test.ts
+++ b/tests/integration/tests/mangler-minify.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { bundleAndRun } from "./helpers";
+
+describe("mangler --minify 회귀", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  // #1609: shouldSkip(name.len<=1) 파라미터의 원본 이름이 reserved 처리되지 않아
+  // base54 카운터가 같은 이름을 다른 param에 재할당 → "Duplicate parameter name" SyntaxError.
+  // Effect의 pipe(a, ab, ..., hi) 9-param 시그니처가 전형적인 재현 케이스.
+  test("9-param 함수에서 1글자 param과 slot base54 이름이 충돌하지 않는다 (#1609)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          function pipe(a: any, ab: any, bc: any, cd: any, de: any, ef: any, fg: any, gh: any, hi: any): any {
+            switch (arguments.length) {
+              case 1: return a;
+              case 2: return ab(a);
+              case 3: return bc(ab(a));
+              case 4: return cd(bc(ab(a)));
+              case 5: return de(cd(bc(ab(a))));
+              case 6: return ef(de(cd(bc(ab(a)))));
+              case 7: return fg(ef(de(cd(bc(ab(a))))));
+              case 8: return gh(fg(ef(de(cd(bc(ab(a)))))));
+              case 9: return hi(gh(fg(ef(de(cd(bc(ab(a))))))));
+            }
+          }
+          console.log(pipe(1, (x: number) => x + 1, (x: number) => x * 2));
+        `,
+      },
+      "index.ts",
+      ["--minify", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.runStderr).not.toContain("SyntaxError");
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("4");
+  });
+});

--- a/tests/integration/tests/mangler-minify.test.ts
+++ b/tests/integration/tests/mangler-minify.test.ts
@@ -43,4 +43,75 @@ describe("mangler --minify 회귀", () => {
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("4");
   });
+
+  // outer(module) 스코프의 1글자 const를 nested 함수가 참조하는데, base54 결과가
+  // 동일 이름을 함수 param에 할당하면 outer 참조가 shadowing되어 잘못된 값을 반환.
+  test("outer 1글자 const가 nested 함수 param에 shadowing되지 않는다 (#1609)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          const i = 100;
+          function compute(aa: number, ab: number, ac: number, ad: number, ae: number, af: number, ag: number, ah: number): number {
+            return i + aa + ab + ac + ad + ae + af + ag + ah;
+          }
+          console.log(compute(1, 2, 3, 4, 5, 6, 7, 8));
+        `,
+      },
+      "index.ts",
+      ["--minify", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.runStderr).not.toContain("SyntaxError");
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("136"); // 100 + (1+2+...+8)
+  });
+
+  // for-loop의 `i`/`j` counter와 sibling 파라미터가 같은 함수에 공존할 때
+  // base54가 `i`/`j`를 param에 재할당하면 loop counter 참조가 오염됨.
+  test("loop counter i/j가 sibling param과 충돌하지 않는다 (#1609)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          function sum(aa: number[], ab: number[], ac: number[], ad: number[], ae: number[], af: number[], ag: number[]): number {
+            let total = 0;
+            for (let i = 0; i < aa.length; i++) total += aa[i];
+            for (let j = 0; j < ab.length; j++) total += ab[j];
+            return total + ac.length + ad.length + ae.length + af.length + ag.length;
+          }
+          console.log(sum([1, 2], [3], [4], [], [], [], []));
+        `,
+      },
+      "index.ts",
+      ["--minify", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.runStderr).not.toContain("SyntaxError");
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("7"); // (1+2) + 3 + 1 (ac.length) + 0*4
+  });
+
+  // base54 앞자리 0~4가 모두 1글자 local(e,t,n,r,i)로 reserved인 극단 케이스.
+  // 카운터가 5칸 밀려도 이후 이름(c,l,u,d,f,p,m,h,g)이 정상 할당되는지 검증.
+  test("base54 앞자리 5개(e,t,n,r,i)가 전부 reserved여도 번들 성공 (#1609)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          function run(aa: number, ab: number, ac: number, ad: number, ae: number, af: number, ag: number, ah: number, ai: number): number {
+            let e = aa, t = ab, n = ac, r = ad, i = ae;
+            return e + t + n + r + i + af + ag + ah + ai;
+          }
+          console.log(run(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        `,
+      },
+      "index.ts",
+      ["--minify", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.runStderr).not.toContain("SyntaxError");
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("45"); // 1+2+...+9
+  });
 });


### PR DESCRIPTION
Closes #1609

## 배경

`--minify` 모드에서 Effect처럼 9+ 파라미터를 받는 pipe-style 함수를 번들하면 JS 엔진이 거부하는 출력이 나왔다.

```
SyntaxError: Duplicate parameter name not allowed in this context
// function A(a,e,t,n,r,i,a,o,s) { ... }  ← a가 index 0, 6에 중복
```

## 원인

`src/codegen/mangler.zig` Phase 3에서 `shouldSkip(sym, name)`이 `name.len <= 1` 파라미터(`a`)를 mangling 대상에서 빼버리면, 그 1글자 이름은 출력에 그대로 살아남는다. 그런데 같은 함수 안 나머지 파라미터에 Phase 4 base54 할당이 frequency desc로 돌면서 slot 5 → `a` (base54 카운터 5가 `a`) 를 할당 → 같은 스코프에서 `a`가 두 번 선언된다.

같은 구조적 위험이 `blocksMangling()`(#1258, `with`/direct-eval 스코프) 바인딩과 `skip_symbols`(번들러 top-level 스킵) 에서도 존재 — 이들 모두 원본 이름이 유지되거나 별도 canonicalize되므로 nested mangler가 재할당하면 shadowing 오염이 가능하다.

## 수정

Phase 3 DFS 순회에서 `shouldSkip` / `blocksMangling` / `skip_symbols` 세 경로를 타는 심볼의 **원본 이름**을 `reserved_names` (StringHashMap(void))에 수집. Phase 4 base54 카운터가 해당 이름을 생성하면 `isReservedOrGlobal`과 동일하게 다음 카운터로 스킵한다.

## 검증

**재현 스니펫** (9-param `pipe`):

```bash
./zig-out/bin/zts --bundle /tmp/entry.ts --minify -o /tmp/out.js --platform=node
node /tmp/out.js
```

- Before: `function e(a,e,t,n,r,i,a,o,s){...}` → SyntaxError
- After:  `function e(a,e,t,n,i,o,s,c,l){...}` → 정상 실행 (카운터가 5를 건너뛰고 6부터 재개)

**회귀 테스트**: `tests/integration/tests/mangler-minify.test.ts` 추가 — 9-param 함수 + `--minify` + Node 실행 전 과정을 검증.

**전체 스윗**: `zig build test` 통과. `tests/integration/` bundle-smoke / tree-shake-precision / es5-rn / flow-rn / hermes-runtime / asset-registry / runtime-helpers / downlevel 통과.

## Test plan

- [x] `/tmp` 재현 스니펫으로 Node 실행 성공
- [x] `zig build test` (파이프라인 유닛)
- [x] `bun test tests/mangler-minify.test.ts` (신규 회귀)
- [x] `bun test tests/bundle-smoke.test.ts tests/tree-shake-precision.test.ts`
- [x] `bun test tests/es5-rn.test.ts tests/hermes-runtime.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)