### PR TITLE
perf(codegen): #1608 bundle-wide mangler 도입 (Option C, flag-gated)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -66,6 +66,10 @@ pub const BundleOptions = struct {
     /// 켜져 있을 때만 동작하며 실제 mangling 결과는 변경하지 않는다. slot 수/
     /// name length 히스토그램만 stderr에 JSON으로 출력한다.
     mangle_preview: bool = false,
+    /// #1608 Option C: `Linker.computeMangling` + per-module nested mangle을 번들 전역
+    /// 단일 slot coloring으로 대체. `minify_identifiers`가 켜져 있을 때만 동작.
+    /// 플래그로 게이팅 — 기본 off, PR 검증 후 default on 예정.
+    bundle_wide_mangler: bool = false,
     /// 스코프 호이스팅 활성화 (import/export 제거 + 변수 리네임). false면 기존 동작.
     scope_hoist: bool = true,
     /// tree-shaking 활성화 (미사용 export/모듈 제거). scope_hoist가 true일 때만 동작.
@@ -704,7 +708,11 @@ pub const Bundler = struct {
             if (!self.options.code_splitting) {
                 try l.computeRenames();
                 if (self.options.minify_identifiers) {
-                    try l.computeMangling();
+                    if (self.options.bundle_wide_mangler) {
+                        try l.computeBundleWideMangling();
+                    } else {
+                        try l.computeMangling();
+                    }
                     if (self.options.mangle_preview) {
                         const preview = @import("../codegen/bundle_mangler_preview.zig");
                         const stats = try preview.previewBundleWide(self.allocator, graph.modules.items);

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -211,6 +211,12 @@ pub const Linker = struct {
     /// computeMangling 완료 후 true. buildMetadataForAst에서 nested mangling 수행 여부 결정.
     nested_mangling_enabled: bool = false,
 
+    /// #1608: bundle-wide mangler 결과. non-null이면 `computeBundleWideMangling` 완료 상태로,
+    /// `buildMetadataForAst`가 per-module `Mangler.mangle`을 건너뛰고 `renames_per_module[i]`를
+    /// merge한다. top-level은 `assignSymbolCanonical`이 설정한 canonical_name 경로를 그대로 쓴다.
+    /// deinit에서 해제.
+    bundle_wide_result: ?@import("../codegen/bundle_mangler.zig").BundleManglerResult = null,
+
     /// 모듈별 중첩 스코프 바인딩 이름 집합 (사전 구축).
     /// computeRenames에서 한 번 구축, hasNestedBinding에서 O(1) 조회.
     nested_name_sets: []std.StringHashMapUnmanaged(void) = &.{},
@@ -277,6 +283,7 @@ pub const Linker = struct {
         self.canonical_strings.deinit(self.allocator);
         self.canonical_symbols.deinit(self.allocator);
         self.canonical_names_used.deinit();
+        if (self.bundle_wide_result) |*r| r.deinit();
         self.reserved_globals.deinit();
         for (self.nested_name_sets) |*set| {
             set.deinit(self.allocator);
@@ -805,6 +812,43 @@ pub const Linker = struct {
         }
 
         self.nested_mangling_enabled = true;
+    }
+
+    /// #1608 Option C: 번들 전역 단일 slot coloring으로 top-level + nested를 한 번에 mangle.
+    /// `computeMangling()`과 per-module `Mangler.mangle` 호출을 동시에 대체.
+    /// `computeRenames()` 이후, `buildMetadataForAst` 이전에 호출해야 한다.
+    pub fn computeBundleWideMangling(self: *Linker) !void {
+        const bundle_mangler = @import("../codegen/bundle_mangler.zig");
+
+        var result = try bundle_mangler.mangleBundleWide(self.allocator, .{
+            .modules = self.modules,
+            .global_identifiers = self.global_identifiers,
+        });
+        errdefer result.deinit();
+
+        // top-level 심볼(scope_maps[0])의 mangled 이름은 canonical_name 경로에도 주입해야
+        // cross-module import가 올바른 이름을 참조한다. nested 심볼은 metadata.zig의 merge
+        // 단계에서 LinkingMetadata.renames로 소비되므로 canonical_name 설정 불필요.
+        // `computeRenames`가 충돌 해결로 이미 canonical_name을 설정한 심볼도 mangled 이름으로
+        // 덮어써야 한다 — `assignSymbolCanonical`이 이전 등록을 정리해 준다.
+        for (self.modules, 0..) |m, mi| {
+            const sem = m.semantic orelse continue;
+            if (sem.scope_maps.len == 0) continue;
+            const module_scope = sem.scope_maps[0];
+            const module_renames = result.renames_per_module[mi];
+            var sit = module_scope.iterator();
+            while (sit.next()) |entry| {
+                const sym_idx: u32 = @intCast(entry.value_ptr.*);
+                if (module_renames.get(sym_idx)) |mangled| {
+                    if (sym_idx >= sem.symbols.items.len) continue;
+                    const sym_ptr = &sem.symbols.items[sym_idx];
+                    const dup = try self.allocator.dupe(u8, mangled);
+                    try self.assignSymbolCanonical(sym_ptr, dup);
+                }
+            }
+        }
+
+        self.bundle_wide_result = result;
     }
 
     /// 다른 모듈의 리네임 대상으로 이미 할당된 이름인지 O(1) 확인.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -511,8 +511,26 @@ pub fn buildMetadataForAst(
         }
 
         // nested scope mangling (liveness 기반)
-        // top-level은 computeMangling에서 처리됨 → nested만 수행
-        if (self.nested_mangling_enabled and sem.symbols.items.len > 0) {
+        // #1608: bundle-wide 모드면 computeBundleWideMangling이 사전에 모든 심볼의 rename을
+        // 계산해 두었으므로 여기서는 cached 결과를 merge만 한다 (per-module Mangler.mangle skip).
+        if (self.bundle_wide_result) |*bw_const| {
+            // `self`가 *const Linker이지만 bundle_wide_result는 per-module index별로 한 번씩
+            // takeModuleRenames로 소비되도록 설계된 ownership transfer 슬롯이라 mutation 허용.
+            // buildMetadataForAst는 module_index별로 직렬 호출되므로 race 없음.
+            const bw: *@import("../../codegen/bundle_mangler.zig").BundleManglerResult = @constCast(bw_const);
+            var taken = bw.takeModuleRenames(module_index);
+            defer taken.deinit();
+            var nit = taken.iterator();
+            while (nit.next()) |n_entry| {
+                if (!renames.contains(n_entry.key_ptr.*)) {
+                    try renames.put(n_entry.key_ptr.*, n_entry.value_ptr.*);
+                    try owned_nested_renames.append(self.allocator, n_entry.value_ptr.*);
+                } else {
+                    self.allocator.free(n_entry.value_ptr.*);
+                }
+            }
+        } else if (self.nested_mangling_enabled and sem.symbols.items.len > 0) {
+            // Legacy 경로: top-level은 computeMangling에서 처리됨 → nested만 수행
             const Mangler = @import("../../codegen/mangler.zig");
 
             // top-level scope + export/import 심볼은 skip

--- a/src/codegen/bundle_mangler.zig
+++ b/src/codegen/bundle_mangler.zig
@@ -1,0 +1,435 @@
+//! ZTS Bundle-wide Mangler — #1608 Option C
+//!
+//! 모든 모듈의 scope/symbol/ref_scope_pair를 하나의 scope forest로 concat하여
+//! oxc 스타일 slot coloring + Base54 이름 할당을 수행하는 단일 entry point.
+//!
+//! 기존 `Linker.computeMangling`(top-level cross-module)과 `buildMetadataForAst`의
+//! per-module nested mangling을 한 번에 대체한다. 번들 전역에서 slot을 재사용하여
+//! 3-char mangled name을 대부분 2-char로 줄이는 것이 목표.
+//!
+//! 호출 규약:
+//!   - `computeRenames()` 이후, `buildMetadataForAst` **이전**에 호출.
+//!   - 출력인 per-module renames 맵은 `buildMetadataForAst`가 `LinkingMetadata.renames`
+//!     로 merge한다. 기존 per-module nested mangle 호출은 플래그가 켜지면 skip.
+//!
+//! 알고리즘은 `mangler.zig`의 Phase 1~5와 동일하며, 다음 확장:
+//!   - 번들 전역 scope forest (virtual root + 모듈별 scope tree 연결)
+//!   - symbol/scope ID offset 재매핑
+//!   - per-module source lookup을 위한 `bundle_owner` 테이블
+
+const std = @import("std");
+const Module = @import("../bundler/module.zig").Module;
+const Scope = @import("../semantic/scope.zig").Scope;
+const ScopeId = @import("../semantic/scope.zig").ScopeId;
+const Symbol = @import("../semantic/symbol.zig").Symbol;
+const RefScopePair = @import("../semantic/symbol.zig").RefScopePair;
+const Mangler = @import("mangler.zig");
+
+pub const BundleMangleInput = struct {
+    modules: []const Module,
+    /// 전역 reserved 이름 (e.g. `globalThis`, user-defined via CLI). mangled 이름이
+    /// 이 집합과 겹치지 않도록 base54 할당 시 skip.
+    global_identifiers: []const []const u8 = &.{},
+};
+
+pub const BundleManglerResult = struct {
+    /// renames_per_module[i] = module i의 HashMap(sym_idx → new_name).
+    /// codegen의 LinkingMetadata.renames merge용. 값 문자열의 소유권은 이 결과가 보유.
+    renames_per_module: []std.AutoHashMap(u32, []const u8),
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *BundleManglerResult) void {
+        for (self.renames_per_module) |*m| {
+            var vit = m.valueIterator();
+            while (vit.next()) |v| self.allocator.free(v.*);
+            m.deinit();
+        }
+        self.allocator.free(self.renames_per_module);
+    }
+
+    /// 모듈 i의 renames 맵 소유권을 호출자로 이전 (move). 반환 후 slot은 빈 HashMap으로
+    /// 교체되어 이후 `BundleManglerResult.deinit`은 double-free 없이 안전하게 호출 가능.
+    /// 호출자는 반환된 HashMap의 value 문자열을 별도 ownership 경로(e.g. LinkingMetadata.
+    /// owned_rename_values)에 등록하고 본인이 deinit 호출 책임을 진다.
+    ///
+    /// 병렬 호출 금지 — module_idx 인덱스별로 직렬로만 소비할 것.
+    pub fn takeModuleRenames(self: *BundleManglerResult, module_idx: usize) std.AutoHashMap(u32, []const u8) {
+        const taken = self.renames_per_module[module_idx];
+        self.renames_per_module[module_idx] = std.AutoHashMap(u32, []const u8).init(self.allocator);
+        return taken;
+    }
+};
+
+const SymOwner = struct {
+    module_idx: u32,
+    /// 모듈 내 원본 sym_idx
+    local_idx: u32,
+};
+
+pub fn mangleBundleWide(allocator: std.mem.Allocator, input: BundleMangleInput) !BundleManglerResult {
+    const modules = input.modules;
+    const module_count: u32 = @intCast(modules.len);
+
+    // ================================================================
+    // Phase 0: 크기 산출
+    // ================================================================
+    // 각 모듈의 scope[0](module scope)는 scope-hoisting 후 번들 top-level이 된다.
+    // 따라서 virtual_root(bundle idx 0)를 모든 모듈의 scope[0]에 해당하는 "통합 bundle
+    // 모듈 스코프"로 재사용한다 — 모듈별 scope[0]을 별도 bundle scope로 복사하지 않음.
+    // 이렇게 해야 서로 다른 모듈의 top-level 심볼이 같은 scope 내로 들어와 liveness가
+    // 올바르게 겹쳐 slot coloring이 conflict를 정확히 회피한다.
+    var total_scopes: u32 = 1; // virtual root
+    var total_symbols: u32 = 0;
+    var total_pairs: u32 = 0;
+    for (modules) |m| {
+        const sem = m.semantic orelse continue;
+        if (sem.scopes.len == 0) continue;
+        total_scopes += @intCast(sem.scopes.len - 1); // scope[0] 제외 (virtual root로 흡수)
+        total_symbols += @intCast(sem.symbols.items.len);
+        total_pairs += @intCast(sem.ref_scope_pairs.len);
+    }
+
+    // 빈 결과 초기화 (modules 없음 / 심볼 없음)
+    var renames_arr = try allocator.alloc(std.AutoHashMap(u32, []const u8), module_count);
+    for (renames_arr) |*m| m.* = std.AutoHashMap(u32, []const u8).init(allocator);
+    errdefer {
+        for (renames_arr) |*m| {
+            var vit = m.valueIterator();
+            while (vit.next()) |v| allocator.free(v.*);
+            m.deinit();
+        }
+        allocator.free(renames_arr);
+    }
+
+    if (total_symbols == 0) {
+        return .{ .renames_per_module = renames_arr, .allocator = allocator };
+    }
+
+    // ================================================================
+    // Phase 1: concat — scopes / symbols / ref_scope_pairs / owner map
+    // ================================================================
+    const bundle_scopes = try allocator.alloc(Scope, total_scopes);
+    defer allocator.free(bundle_scopes);
+    const bundle_symbols = try allocator.alloc(Symbol, total_symbols);
+    defer allocator.free(bundle_symbols);
+    const bundle_pairs = try allocator.alloc(RefScopePair, total_pairs);
+    defer allocator.free(bundle_pairs);
+    const bundle_owner = try allocator.alloc(SymOwner, total_symbols);
+    defer allocator.free(bundle_owner);
+
+    bundle_scopes[0] = .{
+        .parent = ScopeId.none,
+        .kind = .global,
+        .is_strict = false,
+    };
+
+    // 각 모듈의 local scope_id를 bundle scope_id로 remap.
+    // local_id == 0 → 0 (virtual root), else → module_base + local_id - 1
+    var scope_off: u32 = 1;
+    var symbol_off: u32 = 0;
+    var pair_idx: u32 = 0;
+    // 재사용할 virtual_root의 blocksMangling 속성: 어느 모듈이라도 top-level에 direct eval이
+    // 있으면 전체 top-level 차단이 옳다. OR 축적.
+    for (modules, 0..) |m, mi| {
+        const sem = m.semantic orelse continue;
+        if (sem.scopes.len == 0) continue;
+        const module_base = scope_off; // scope[1..]이 들어갈 시작 인덱스
+        const y_off = symbol_off;
+
+        // 모듈 scope[0]의 eval/with 속성은 virtual root로 전파 (top-level 전체 차단 유지).
+        if (sem.scopes[0].subtree_has_direct_eval) bundle_scopes[0].subtree_has_direct_eval = true;
+        if (sem.scopes[0].subtree_has_with) bundle_scopes[0].subtree_has_with = true;
+
+        // scope[1..]: parent을 remap해서 복사
+        for (sem.scopes[1..], 1..) |s, si| {
+            var copied = s;
+            if (!s.parent.isNone()) {
+                const p = s.parent.toIndex();
+                copied.parent = @enumFromInt(if (p == 0) 0 else (module_base + p - 1));
+            }
+            bundle_scopes[module_base + @as(u32, @intCast(si)) - 1] = copied;
+        }
+
+        for (sem.symbols.items, 0..) |sym, yi| {
+            var copied = sym;
+            if (!sym.scope_id.isNone()) {
+                const sid = sym.scope_id.toIndex();
+                copied.scope_id = @enumFromInt(if (sid == 0) 0 else (module_base + sid - 1));
+            }
+            if (!sym.origin_scope.isNone()) {
+                const oid = sym.origin_scope.toIndex();
+                copied.origin_scope = @enumFromInt(if (oid == 0) 0 else (module_base + oid - 1));
+            }
+            bundle_symbols[y_off + @as(u32, @intCast(yi))] = copied;
+            bundle_owner[y_off + @as(u32, @intCast(yi))] = .{
+                .module_idx = @intCast(mi),
+                .local_idx = @intCast(yi),
+            };
+        }
+
+        for (sem.ref_scope_pairs) |pair| {
+            const rid = pair.scope_id.toIndex();
+            bundle_pairs[pair_idx] = .{
+                .symbol_idx = pair.symbol_idx + y_off,
+                .scope_id = @enumFromInt(if (rid == 0) 0 else (module_base + rid - 1)),
+            };
+            pair_idx += 1;
+        }
+
+        scope_off += @intCast(sem.scopes.len - 1);
+        symbol_off += @intCast(sem.symbols.items.len);
+    }
+
+    // ================================================================
+    // Phase 2: children list (Mangler.buildChildrenList 재사용)
+    // ================================================================
+    const children = try Mangler.buildChildrenList(allocator, bundle_scopes);
+    defer allocator.free(children.offsets);
+    defer allocator.free(children.list);
+
+    // ================================================================
+    // Phase 3: per-symbol liveness BitSet
+    // ================================================================
+    const MaskInt = std.DynamicBitSetUnmanaged.MaskInt;
+    const masks_per_symbol = (total_scopes + @bitSizeOf(MaskInt) - 1) / @bitSizeOf(MaskInt);
+    const all_masks = try allocator.alloc(MaskInt, @as(usize, total_symbols) * masks_per_symbol);
+    defer allocator.free(all_masks);
+    @memset(all_masks, 0);
+
+    var symbol_liveness = try allocator.alloc(std.DynamicBitSet, total_symbols);
+    defer allocator.free(symbol_liveness);
+    for (symbol_liveness, 0..) |*bs, i| {
+        const start = i * masks_per_symbol;
+        bs.* = .{
+            .unmanaged = .{
+                .masks = @ptrCast(all_masks[start..].ptr),
+                .bit_length = total_scopes,
+            },
+            .allocator = allocator,
+        };
+    }
+
+    for (bundle_symbols, 0..) |sym, i| {
+        if (!sym.scope_id.isNone() and sym.scope_id.toIndex() < total_scopes) {
+            symbol_liveness[i].set(sym.scope_id.toIndex());
+        }
+    }
+
+    for (bundle_pairs) |pair| {
+        if (pair.symbol_idx >= total_symbols) continue;
+        const sym = bundle_symbols[pair.symbol_idx];
+        if (sym.scope_id.isNone()) continue;
+        Mangler.markAncestorPath(&symbol_liveness[pair.symbol_idx], bundle_scopes, pair.scope_id, sym.scope_id);
+    }
+
+    // ================================================================
+    // Phase 4a: bindings per scope (scope → symbol indices)
+    // ================================================================
+    const binding_counts = try allocator.alloc(u32, total_scopes);
+    defer allocator.free(binding_counts);
+    @memset(binding_counts, 0);
+    for (bundle_symbols) |sym| {
+        if (sym.scope_id.isNone()) continue;
+        const s_idx = sym.scope_id.toIndex();
+        if (s_idx >= total_scopes) continue;
+        binding_counts[s_idx] += 1;
+    }
+    const binding_offsets = try allocator.alloc(u32, total_scopes + 1);
+    defer allocator.free(binding_offsets);
+    binding_offsets[0] = 0;
+    for (0..total_scopes) |i| binding_offsets[i + 1] = binding_offsets[i] + binding_counts[i];
+    const total_bindings = binding_offsets[total_scopes];
+    const bindings = try allocator.alloc(u32, total_bindings);
+    defer allocator.free(bindings);
+    @memset(binding_counts, 0);
+    for (bundle_symbols, 0..) |sym, yi| {
+        if (sym.scope_id.isNone()) continue;
+        const s_idx = sym.scope_id.toIndex();
+        if (s_idx >= total_scopes) continue;
+        bindings[binding_offsets[s_idx] + binding_counts[s_idx]] = @intCast(yi);
+        binding_counts[s_idx] += 1;
+    }
+
+    // ================================================================
+    // Phase 4b: DFS + slot coloring
+    // ================================================================
+    // Slot 구조: liveness BitSet + 합산 reference_count (Base54 빈도 정렬용)
+    const Slot = struct {
+        liveness: std.DynamicBitSet,
+        total_refs: u32,
+    };
+
+    var slots: std.ArrayListUnmanaged(Slot) = .empty;
+    defer {
+        for (slots.items) |*s| s.liveness.deinit();
+        slots.deinit(allocator);
+    }
+
+    const symbol_to_slot = try allocator.alloc(?u32, total_symbols);
+    defer allocator.free(symbol_to_slot);
+    @memset(symbol_to_slot, null);
+
+    // skip된 심볼의 원본 이름은 출력에 살아남으므로 mangled 이름으로 재할당되지 않도록
+    // reserved_names에 예약 (mangler.zig의 #1609 수정과 동일 정책).
+    var reserved_names = std.StringHashMap(void).init(allocator);
+    defer reserved_names.deinit();
+
+    // global_identifiers도 전역 예약
+    for (input.global_identifiers) |gid| {
+        try reserved_names.put(gid, {});
+    }
+
+    var dfs_stack: std.ArrayListUnmanaged(u32) = .empty;
+    defer dfs_stack.deinit(allocator);
+    try dfs_stack.append(allocator, 0);
+
+    while (dfs_stack.items.len > 0) {
+        const scope_idx = dfs_stack.pop().?;
+        if (scope_idx < total_scopes and bundle_scopes[scope_idx].blocksMangling()) {
+            // eval/with이 있는 subtree는 전체 mangling 차단 — bindings 이름을 reserved에 넣고
+            // children DFS 건너뜀.
+            const bstart = binding_offsets[scope_idx];
+            const bend = binding_offsets[scope_idx + 1];
+            for (bindings[bstart..bend]) |sym_idx| {
+                const sym = bundle_symbols[sym_idx];
+                if (sym.isSynthetic()) continue;
+                const name = originalName(modules, bundle_owner[sym_idx], sym);
+                if (name.len > 0) try reserved_names.put(name, {});
+            }
+            continue;
+        }
+
+        const bstart = binding_offsets[scope_idx];
+        const bend = binding_offsets[scope_idx + 1];
+
+        // 결정론적 순서: bundle symbol_idx 오름차순 (삽입 순서 = yi 증가 → 이미 정렬됨)
+        for (bindings[bstart..bend]) |sym_idx| {
+            if (symbol_to_slot[sym_idx] != null) continue; // var hoisting 등 이미 할당
+            const sym = bundle_symbols[sym_idx];
+            if (sym.isSynthetic()) continue;
+
+            const owner = bundle_owner[sym_idx];
+            const name = originalName(modules, owner, sym);
+            if (shouldSkipBundle(sym, name, modules[owner.module_idx].is_entry_point)) {
+                if (name.len > 0) try reserved_names.put(name, {});
+                continue;
+            }
+
+            var reused_slot: ?u32 = null;
+            for (slots.items, 0..) |*slot, slot_i| {
+                if (!Mangler.bitsetIntersects(slot.liveness, symbol_liveness[sym_idx])) {
+                    reused_slot = @intCast(slot_i);
+                    break;
+                }
+            }
+
+            if (reused_slot) |slot_id| {
+                symbol_to_slot[sym_idx] = slot_id;
+                slots.items[slot_id].liveness.setUnion(symbol_liveness[sym_idx]);
+                slots.items[slot_id].total_refs += sym.reference_count;
+            } else {
+                const new_slot_id: u32 = @intCast(slots.items.len);
+                var new_live = try std.DynamicBitSet.initEmpty(allocator, total_scopes);
+                new_live.setUnion(symbol_liveness[sym_idx]);
+                try slots.append(allocator, .{
+                    .liveness = new_live,
+                    .total_refs = sym.reference_count,
+                });
+                symbol_to_slot[sym_idx] = new_slot_id;
+            }
+        }
+
+        // children DFS (역순 push → 작은 인덱스부터 처리)
+        const start = children.offsets[scope_idx];
+        const end = if (scope_idx + 1 < children.offsets.len) children.offsets[scope_idx + 1] else @as(u32, @intCast(children.list.len));
+        var ci = end;
+        while (ci > start) {
+            ci -= 1;
+            try dfs_stack.append(allocator, children.list[ci]);
+        }
+    }
+
+    // ================================================================
+    // Phase 5a: slot을 빈도순 정렬 → Base54 이름 할당
+    // ================================================================
+    const slot_count = slots.items.len;
+    if (slot_count == 0) {
+        return .{ .renames_per_module = renames_arr, .allocator = allocator };
+    }
+
+    const SlotSort = struct { slot_id: u32, total_refs: u32 };
+    const sorted = try allocator.alloc(SlotSort, slot_count);
+    defer allocator.free(sorted);
+    for (sorted, 0..) |*e, i| e.* = .{ .slot_id = @intCast(i), .total_refs = slots.items[i].total_refs };
+    std.mem.sortUnstable(SlotSort, sorted, {}, struct {
+        fn cmp(_: void, a: SlotSort, b: SlotSort) bool {
+            if (a.total_refs != b.total_refs) return a.total_refs > b.total_refs;
+            return a.slot_id < b.slot_id;
+        }
+    }.cmp);
+
+    // slot_id → base54 이름. 예약어/글로벌/reserved_names 자동 skip.
+    var slot_names = try allocator.alloc([]const u8, slot_count);
+    defer {
+        for (slot_names) |n| allocator.free(n);
+        allocator.free(slot_names);
+    }
+
+    var name_counter: u32 = 0;
+    var name_buf: [8]u8 = undefined;
+    for (sorted) |e| {
+        var name = Mangler.base54(name_counter, &name_buf);
+        name_counter += 1;
+        while (Mangler.isReservedOrGlobal(name) or reserved_names.contains(name)) {
+            name = Mangler.base54(name_counter, &name_buf);
+            name_counter += 1;
+        }
+        slot_names[e.slot_id] = try allocator.dupe(u8, name);
+    }
+
+    // ================================================================
+    // Phase 5b: renames 맵 (per-module)
+    // ================================================================
+    for (symbol_to_slot, 0..) |maybe_slot, bundle_sym_i| {
+        const slot_id = maybe_slot orelse continue;
+        const new_name = slot_names[slot_id];
+        const sym = bundle_symbols[bundle_sym_i];
+        if (sym.isSynthetic()) continue;
+
+        const owner = bundle_owner[bundle_sym_i];
+        const orig_name = originalName(modules, owner, sym);
+        if (std.mem.eql(u8, orig_name, new_name)) continue;
+
+        // 여러 bundle 심볼이 같은 slot을 공유하므로 per-module entry마다 dupe.
+        const dup = try allocator.dupe(u8, new_name);
+        try renames_arr[owner.module_idx].put(owner.local_idx, dup);
+    }
+
+    return .{ .renames_per_module = renames_arr, .allocator = allocator };
+}
+
+// ============================================================
+// 내부 헬퍼
+// ============================================================
+
+fn originalName(modules: []const Module, owner: SymOwner, sym: Symbol) []const u8 {
+    if (owner.module_idx >= modules.len) return "";
+    const m = modules[owner.module_idx];
+    // name.start/end가 source 경계를 벗어난 합성 심볼 방어. nameText는 synthetic_name을
+    // 먼저 반환하므로 이 검사는 합성이 아닌 out-of-range 케이스만 대상.
+    if (sym.synthetic_name.len == 0 and (sym.name.start >= m.source.len or sym.name.end > m.source.len)) return "";
+    return sym.nameText(m.source);
+}
+
+/// Bundle-wide skip 정책:
+///   - `is_import`: 외부 패키지 참조 (이름 보존 필수)
+///   - `is_exported || is_default_export` + entry 모듈: 외부 공개 API
+///   - `"arguments"`: JS 예약 의미
+///   - `len<=1`: 이미 최단
+fn shouldSkipBundle(sym: Symbol, name: []const u8, is_entry_module: bool) bool {
+    if (sym.decl_flags.is_import) return true;
+    if (is_entry_module and (sym.decl_flags.is_exported or sym.decl_flags.is_default_export)) return true;
+    if (std.mem.eql(u8, name, "arguments")) return true;
+    if (name.len <= 1) return true;
+    return false;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -31,6 +31,9 @@ const CliOptions = struct {
     /// #1608 dry-run: bundle-wide slot coloring 시뮬레이션. 실제 mangling 결과는
     /// 변경하지 않고, slot 수/name length 히스토그램을 stderr에 JSON으로 출력.
     mangle_preview: bool = false,
+    /// #1608 Option C: Linker.computeMangling + per-module nested mangle을 번들 전역
+    /// 단일 slot coloring으로 대체. `--minify`와 함께 사용. 기본 off (검증 후 default on).
+    bundle_wide_mangler: bool = false,
     module_format: lib.codegen.codegen.ModuleFormat = .esm,
     drop_console: bool = false,
     drop_debugger: bool = false,
@@ -361,6 +364,8 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             opts.minify_syntax = true;
         } else if (std.mem.eql(u8, arg, "--mangle-preview")) {
             opts.mangle_preview = true;
+        } else if (std.mem.eql(u8, arg, "--bundle-wide-mangler")) {
+            opts.bundle_wide_mangler = true;
         } else if (std.mem.eql(u8, arg, "--format=cjs")) {
             opts.module_format = .cjs;
             opts.bundle_format = .cjs;
@@ -1449,6 +1454,7 @@ pub fn main() !void {
             .minify_identifiers = opts.minify_identifiers,
             .minify_syntax = opts.minify_syntax,
             .mangle_preview = opts.mangle_preview,
+            .bundle_wide_mangler = opts.bundle_wide_mangler,
             .code_splitting = opts.splitting,
             .define = opts.define_list.items,
             .experimental_decorators = opts.experimental_decorators orelse false,
@@ -2307,6 +2313,8 @@ fn printUsage(writer: anytype) !void {
         \\  --rn-platform=ios|android        RN sub-platform (.ios.*/.android.* extensions)
         \\  --mangle-preview                 #1608: bundle-wide slot coloring dry-run to stderr
         \\                                   (stats JSON only, actual output unchanged)
+        \\  --bundle-wide-mangler            #1608 Option C: replace per-module mangling with
+        \\                                   single bundle-wide slot coloring (experimental)
         \\
         \\TypeScript options:
         \\  --experimental-decorators         Legacy decorator (__decorateClass)

--- a/tests/integration/tests/mangler-bundle-wide.test.ts
+++ b/tests/integration/tests/mangler-bundle-wide.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { bundleAndRun, createFixture, runZts } from "./helpers";
+
+// #1608 Option C: bundle-wide slot coloring으로 top-level + nested를 한 번에 mangle.
+// `--bundle-wide-mangler` 플래그 기반 — 기본 off, 검증 후 default on 예정.
+describe("mangler --bundle-wide-mangler (#1608)", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("cross-module 같은 이름 변수가 rename 충돌 없이 분리된다", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          import { foo } from "./a";
+          import { bar } from "./b";
+          console.log(foo() + bar());
+        `,
+        "a.ts": `
+          const value = 10;
+          export function foo() { return value; }
+        `,
+        "b.ts": `
+          const value = 20;
+          export function bar() { return value; }
+        `,
+      },
+      "index.ts",
+      ["--minify", "--bundle-wide-mangler", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.runStderr).not.toContain("SyntaxError");
+    expect(result.runStderr).not.toContain("ReferenceError");
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("30");
+  });
+
+  test("nested 함수의 로컬 변수가 outer 호출과 shadowing되지 않는다", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          import { compute } from "./lib";
+          console.log(compute(3, 4));
+        `,
+        "lib.ts": `
+          function square(n: number): number {
+            const tmp = n * n;
+            return tmp;
+          }
+          export function compute(a: number, b: number): number {
+            const sumSq = square(a) + square(b);
+            return sumSq;
+          }
+        `,
+      },
+      "index.ts",
+      ["--minify", "--bundle-wide-mangler", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("25");
+  });
+
+  test("9-param 함수 + 1글자 param이 충돌하지 않는다 (#1609 bundle-wide 버전)", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          function pipe(a: any, ab: any, bc: any, cd: any, de: any, ef: any, fg: any, gh: any, hi: any): any {
+            switch (arguments.length) {
+              case 1: return a;
+              case 2: return ab(a);
+              case 3: return bc(ab(a));
+              case 4: return cd(bc(ab(a)));
+              case 5: return de(cd(bc(ab(a))));
+              case 6: return ef(de(cd(bc(ab(a)))));
+              case 7: return fg(ef(de(cd(bc(ab(a))))));
+              case 8: return gh(fg(ef(de(cd(bc(ab(a)))))));
+              case 9: return hi(gh(fg(ef(de(cd(bc(ab(a))))))));
+            }
+          }
+          console.log(pipe(1, (x: number) => x + 1, (x: number) => x * 2));
+        `,
+      },
+      "index.ts",
+      ["--minify", "--bundle-wide-mangler", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.runStderr).not.toContain("SyntaxError");
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("4");
+  });
+
+  test("엔트리 모듈의 named export는 mangling에서 보존된다", async () => {
+    // 엔트리의 top-level 심볼 `myApi`가 exported이므로 bundle-wide mangler가 skip해야 한다.
+    // 번들 출력 파일 내용을 읽어 original 이름이 남아 있는지 직접 확인.
+    const fixture = await createFixture({
+      "index.ts": `
+        export const myApi = 42;
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outFile = join(fixture.dir, "out.js");
+    const r = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+      "--minify",
+      "--bundle-wide-mangler",
+      "--platform=node",
+      "--format=esm",
+    ]);
+    expect(r.exitCode).toBe(0);
+
+    const src = readFileSync(outFile, "utf8");
+    // minify된 출력에 `export ... myApi` 또는 `var myApi = ...` 형태로 원본 이름이
+    // 살아 있어야 함 (단순 toContain은 string 내부 문자열과도 매칭되므로 선언 패턴까지 검증).
+    expect(src).toMatch(/export\s*\{[^}]*\bmyApi\b|\bmyApi\s*=/);
+  });
+
+  test("중첩 scope 간 liveness가 올바르게 유지된다", async () => {
+    // 외부 변수 outerVal이 내부 함수에서 참조되므로 inner 함수의 로컬과 충돌 불가.
+    // bundle-wide liveness가 ancestor path를 올바르게 마킹해야 한다.
+    const result = await bundleAndRun(
+      {
+        "index.ts": `
+          const outerVal = 100;
+          function outer() {
+            function inner() {
+              const localVal = 5;
+              return outerVal + localVal;
+            }
+            return inner();
+          }
+          console.log(outer());
+        `,
+      },
+      "index.ts",
+      ["--minify", "--bundle-wide-mangler", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("105");
+  });
+});


### PR DESCRIPTION
## Summary
- #1608 Option C 구현: `Linker.computeMangling` + per-module `Mangler.mangle`을 번들 전역 단일 slot coloring으로 대체
- **플래그 게이팅**: `--bundle-wide-mangler` (기본 off). 검증 후 default on 전환 계획
- 모든 모듈의 scope tree를 virtual root 아래 합쳐 top-level + nested를 하나의 pool에서 coloring

## 핵심 설계 포인트

**virtual root 전략**: 각 모듈의 scope[0]을 virtual root로 접어 흡수. cross-module top-level 심볼이 동일 scope 내에서 liveness를 공유하게 함 (없으면 서로 다른 모듈 top-level이 같은 mangled 이름을 할당받는 correctness 버그 — 구현 중 실제로 재현함).

**canonical_name 경로 호환**: top-level 심볼은 `assignSymbolCanonical`로 주입하여 cross-module import lookup이 기존처럼 작동. nested 심볼만 `LinkingMetadata.renames`로 merge.

**skip 정책** (`shouldSkipBundle`):
- `is_import`: 외부 패키지 참조 보존
- `is_entry_module && (is_exported || is_default_export)`: 엔트리 모듈의 외부 공개 API 보존
- `"arguments"` / `name.len <= 1`: JS 예약 의미 / 이미 최단

## 실측 결과 (Effect 번들)

| | baseline (per-module) | bundle-wide | 변화 |
|---|---|---|---|
| Bundle size | 284,115 bytes | 283,762 bytes | **-0.12%** |
| 1-char distinct | 41 | 45 | +4 |
| 2-char distinct | 1071 | 1239 | +168 |
| **3-char distinct** | **2326** | **2126** | **-200** |
| Total distinct | 4720 | 4692 | -28 |
| RSS | 175 MB | 295 MB | **+69%** |
| Build time | 1.22 s | 2.12 s | **+74%** |

## 한계와 Follow-up

**크기 감소가 preview 예측(0 3-char)보다 작은 이유**:
1. `shouldSkipBundle`이 preview보다 엄격: entry exports/arguments/len≤1 추가 skip
2. Phase 5의 `orig_name == new_name` 스킵 — 변경 불필요한 rename 제거
3. distinct identifier 중 60%가 property/string/builtin — mangling 범위 밖

**메모리 오버헤드**: `all_masks` Cartesian 배열 (`total_symbols × masks_per_symbol × 8B ≈ 85MB`). PR 3에서 sparse liveness 도입으로 대폭 감축 예정.

**크기 최적화는 PR 3에서**: skip 정책 완화, Base54 빈도 순서 튜닝, sparse liveness 등. 본 PR은 **인프라 + correctness 확보**가 주 목적.

## 구현 요약

**신규**:
- `src/codegen/bundle_mangler.zig` (~400줄) — `mangleBundleWide` 엔트리 포인트, 5 phases
- `tests/integration/tests/mangler-bundle-wide.test.ts` (~160줄) — 5 integration tests

**수정**:
- `src/bundler/linker.zig` — `bundle_wide_result` 필드 + `computeBundleWideMangling` 메서드
- `src/bundler/linker/metadata.zig` — bundle-wide 분기 추가 (cached renames merge)
- `src/bundler/bundler.zig`, `src/main.zig` — 플래그 추가

## Test plan
- [x] `zig build` 통과
- [x] `zig build test` 전체 유닛 테스트 회귀 없음
- [x] 신규 `mangler-bundle-wide.test.ts` 5건 통과:
  - cross-module 같은 이름 변수 분리
  - nested 함수 outer 호출 shadowing 방지
  - 9-param 함수 + 1글자 param 충돌 없음 (#1609 bundle-wide 버전)
  - 엔트리 모듈 named export 보존 (regex로 export 선언 패턴 검증)
  - 중첩 scope liveness 유지
- [x] 기존 `mangler-minify.test.ts` / `mangler-preview.test.ts` 회귀 없음 (기본 off)
- [x] `/simplify` 리뷰 반영: redundant state 통합(`bundle_wide_mangling_done` 제거), entry export 테스트 강화 (regex), `originalName` 간소화 (`Symbol.nameText` 재사용), `takeModuleRenames` ownership 주석 강화

## Follow-up (별도 PR)
- **PR 2.5** (예정): 검증 기간 후 `bundle_wide_mangler` default on 전환
- **PR 3**: Base54 빈도 순서 튜닝, skip 정책 완화, sparse liveness
- **Refactor**: `bundle_mangler.zig` / `bundle_mangler_preview.zig` / `mangler.zig`의 Phase 중복 통합

## 관련
- #1608 — Option C 본 구현
- #1611 (merged) — minify 벤치 인프라
- #1612 (merged) — bundle-wide scope forest dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)