### PR TITLE
perf(bundler): #1567 pure 빌트인 생성자 화이트리스트

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -907,6 +907,7 @@ pub fn emitModule(
                             root,
                             names,
                             &md.skip_nodes,
+                            null,
                         ) catch {};
                         break :stmt_shake;
                     };
@@ -946,7 +947,7 @@ pub fn emitModule(
                         }
                     } else {
                         // tree-shaker 없으면 기존 방식 (모듈 내부 computeReachable)
-                        if (stmt_info_mod.build(arena_alloc, &transformer.ast, sem.symbols.items, sym_ids)) |maybe_infos| {
+                        if (stmt_info_mod.build(arena_alloc, &transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references)) |maybe_infos| {
                             if (maybe_infos) |infos| {
                                 var used_sym_buf: std.ArrayListUnmanaged(u32) = .empty;
                                 defer used_sym_buf.deinit(arena_alloc);

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -792,6 +792,7 @@ pub const ModuleGraph = struct {
                         analyzer.symbols.items,
                         analyzer.stmt_declared.items,
                         analyzer.stmt_referenced.items,
+                        if (module.semantic) |*s| &s.unresolved_references else null,
                     ) catch null;
                 }
             } else |_| {}
@@ -1013,6 +1014,7 @@ pub const ModuleGraph = struct {
                     analyzer.symbols.items,
                     analyzer.stmt_declared.items,
                     analyzer.stmt_referenced.items,
+                    if (module.semantic) |*s| &s.unresolved_references else null,
                 ) catch null;
             }
         }

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -110,6 +110,7 @@ test {
     _ = @import("resolver_test.zig");
     _ = @import("package_json_test.zig");
     _ = @import("binding_scanner_test.zig");
+    _ = @import("purity_test.zig");
     _ = @import("import_scanner_test.zig");
     _ = @import("stmt_info_test.zig");
     _ = @import("resolve_cache_test.zig");

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -9,6 +9,9 @@
 //!   - 삼항/이항/논리/단항 → 재귀 검사 (delete 제외)
 //!   - 멤버 접근 → 순수 (getter side effect는 실전에서 극히 드물어 무시, esbuild 동일)
 //!   - @__PURE__ call/new → 순수
+//!   - 빌트인 pure 생성자 (Set/Map/WeakMap/WeakSet 등): callee가 unresolved
+//!     global이고 인자가 모두 pure이면 순수 (esbuild isPrimitiveConstructor,
+//!     rolldown is_primitive_constructor 동일). `unresolved_globals` 전달 시 활성화.
 //!   - 나머지 → 보수적으로 불순
 
 const std = @import("std");
@@ -21,23 +24,30 @@ const Token = @import("../lexer/token.zig");
 /// 재귀 깊이 제한. 초과 시 보수적으로 불순 처리.
 const max_depth: u32 = 128;
 
+/// 모듈별 unresolved 참조 집합 (semantic analyzer 산출).
+/// 이 집합에 속한 이름은 이 모듈 스코프에서 선언/import가 없는 전역 참조.
+/// `new Set()`의 `Set`이 이 집합에 있으면 shadowing 없이 전역 빌트인임이 확정된다.
+pub const GlobalRefSet = std.StringHashMap(void);
+
 /// NodeIndex를 받아 순수성을 판정한다.
-pub fn isExprPure(ast: *const Ast, idx: NodeIndex) bool {
-    return isExprPureDepth(ast, idx, 0);
+/// `unresolved_globals`가 주어지면 빌트인 pure 생성자(`new Set()` 등)도 순수로 인식한다.
+/// null이면 기존 보수적 동작 (`@__PURE__` 플래그가 있을 때만 call/new 순수).
+pub fn isExprPure(ast: *const Ast, idx: NodeIndex, unresolved_globals: ?*const GlobalRefSet) bool {
+    return isExprPureDepth(ast, idx, unresolved_globals, 0);
 }
 
-fn isExprPureDepth(ast: *const Ast, idx: NodeIndex, depth: u32) bool {
+fn isExprPureDepth(ast: *const Ast, idx: NodeIndex, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {
     if (depth >= max_depth) return false;
     if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return true;
-    return isNodePureDepth(ast, ast.nodes.items[@intFromEnum(idx)], depth);
+    return isNodePureDepth(ast, ast.nodes.items[@intFromEnum(idx)], unresolved_globals, depth);
 }
 
 /// Node를 받아 순수성을 판정한다.
-pub fn isNodePure(ast: *const Ast, node: Node) bool {
-    return isNodePureDepth(ast, node, 0);
+pub fn isNodePure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet) bool {
+    return isNodePureDepth(ast, node, unresolved_globals, 0);
 }
 
-fn isNodePureDepth(ast: *const Ast, node: Node, depth: u32) bool {
+fn isNodePureDepth(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {
     if (depth >= max_depth) return false;
     const d = depth + 1;
     return switch (node.tag) {
@@ -58,26 +68,23 @@ fn isNodePureDepth(ast: *const Ast, node: Node, depth: u32) bool {
         // class expression — extends/static 초기화에 side effect 가능
         .class_expression => false,
 
-        .object_expression => isObjectPure(ast, node, d),
-        .array_expression => isArrayPure(ast, node, d),
+        .object_expression => isObjectPure(ast, node, unresolved_globals, d),
+        .array_expression => isArrayPure(ast, node, unresolved_globals, d),
 
-        .call_expression, .new_expression => {
-            if (ast.hasExtra(node.data.extra, 3)) {
-                return (ast.readExtra(node.data.extra, 3) & CallFlags.is_pure) != 0;
-            }
-            return false;
-        },
+        .call_expression, .new_expression => isCallOrNewPure(ast, node, unresolved_globals, d),
 
-        .parenthesized_expression => isExprPureDepth(ast, node.data.unary.operand, d),
+        .parenthesized_expression => isExprPureDepth(ast, node.data.unary.operand, unresolved_globals, d),
 
         .conditional_expression => {
             const t = node.data.ternary;
-            return isExprPureDepth(ast, t.a, d) and isExprPureDepth(ast, t.b, d) and isExprPureDepth(ast, t.c, d);
+            return isExprPureDepth(ast, t.a, unresolved_globals, d) and
+                isExprPureDepth(ast, t.b, unresolved_globals, d) and
+                isExprPureDepth(ast, t.c, unresolved_globals, d);
         },
 
         .binary_expression, .logical_expression => {
-            return isExprPureDepth(ast, node.data.binary.left, d) and
-                isExprPureDepth(ast, node.data.binary.right, d);
+            return isExprPureDepth(ast, node.data.binary.left, unresolved_globals, d) and
+                isExprPureDepth(ast, node.data.binary.right, unresolved_globals, d);
         },
 
         .unary_expression => {
@@ -85,7 +92,7 @@ fn isNodePureDepth(ast: *const Ast, node: Node, depth: u32) bool {
             if (!ast.hasExtra(e, 1)) return false;
             const op_kind: u8 = @truncate(ast.readExtra(e, 1) & 0xFF);
             if (op_kind == @intFromEnum(Token.Kind.kw_delete)) return false;
-            return isExprPureDepth(ast, @enumFromInt(ast.readExtra(e, 0)), d);
+            return isExprPureDepth(ast, @enumFromInt(ast.readExtra(e, 0)), unresolved_globals, d);
         },
 
         // 멤버 접근 — getter side effect는 무시 (esbuild 동일)
@@ -95,7 +102,65 @@ fn isNodePureDepth(ast: *const Ast, node: Node, depth: u32) bool {
     };
 }
 
-fn isObjectPure(ast: *const Ast, node: Node, depth: u32) bool {
+/// call/new expression 순수성.
+/// 1) `@__PURE__` 플래그가 있으면 순수
+/// 2) callee가 `new Set()`/`new Map()` 등 빌트인 pure 생성자이고 인자가 모두 순수이면 순수
+fn isCallOrNewPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {
+    // (1) @__PURE__ 플래그
+    if (ast.hasExtra(node.data.extra, 3)) {
+        if ((ast.readExtra(node.data.extra, 3) & CallFlags.is_pure) != 0) return true;
+    }
+
+    // (2) 빌트인 화이트리스트. unresolved_globals 컨텍스트가 있을 때만 활성.
+    const globals = unresolved_globals orelse return false;
+    if (!ast.hasExtra(node.data.extra, 2)) return false;
+
+    const callee_idx: NodeIndex = @enumFromInt(ast.readExtra(node.data.extra, 0));
+    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return false;
+    const callee = ast.nodes.items[@intFromEnum(callee_idx)];
+    if (callee.tag != .identifier_reference) return false;
+
+    const name = ast.getText(callee.span);
+    if (!isPureBuiltinConstructor(name)) return false;
+
+    // 모듈 스코프에서 선언/import가 없어야 전역 빌트인임이 확정된다.
+    // 로컬 `const Set = ...` 또는 `import { Set }`가 있으면 unresolved에 없으므로 pure 판정 안 됨.
+    if (!globals.contains(name)) return false;
+
+    // 인자 순회: 모두 순수여야 함. spread는 iterator 호출 side effect가 있으므로 제외.
+    const args_start = ast.readExtra(node.data.extra, 1);
+    const args_len = ast.readExtra(node.data.extra, 2);
+    if (args_len == 0) return true;
+    if (args_start + args_len > ast.extra_data.items.len) return false;
+
+    for (ast.extra_data.items[args_start .. args_start + args_len]) |raw| {
+        const arg_idx: NodeIndex = @enumFromInt(raw);
+        if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) continue;
+        const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+        if (arg.tag == .spread_element) return false;
+        if (!isNodePureDepth(ast, arg, unresolved_globals, depth)) return false;
+    }
+    return true;
+}
+
+/// 빌트인 pure 생성자 이름. (esbuild `isPrimitiveConstructor`, rolldown `is_primitive_constructor`)
+///
+/// RegExp는 invalid pattern이 SyntaxError를 throw할 수 있어 제외.
+/// Boolean/Number/String/BigInt는 coercion으로 인자 평가 외 부수효과 없지만
+/// 실사용이 드물어 당장은 생략 (필요 시 추가).
+fn isPureBuiltinConstructor(name: []const u8) bool {
+    const pure_names = [_][]const u8{
+        "Set",    "Map",   "WeakMap", "WeakSet",
+        "Symbol", "Array", "Object",  "Date",
+        "Error",
+    };
+    for (pure_names) |candidate| {
+        if (std.mem.eql(u8, name, candidate)) return true;
+    }
+    return false;
+}
+
+fn isObjectPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {
     const list = node.data.list;
     if (list.len == 0) return true;
     if (list.start + list.len > ast.extra_data.items.len) return false;
@@ -109,12 +174,12 @@ fn isObjectPure(ast: *const Ast, node: Node, depth: u32) bool {
         if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
             if (ast.nodes.items[@intFromEnum(key_idx)].tag == .computed_property_key) return false;
         }
-        if (!isExprPureDepth(ast, prop.data.binary.right, depth)) return false;
+        if (!isExprPureDepth(ast, prop.data.binary.right, unresolved_globals, depth)) return false;
     }
     return true;
 }
 
-fn isArrayPure(ast: *const Ast, node: Node, depth: u32) bool {
+fn isArrayPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {
     const list = node.data.list;
     if (list.len == 0) return true;
     if (list.start + list.len > ast.extra_data.items.len) return false;
@@ -124,14 +189,14 @@ fn isArrayPure(ast: *const Ast, node: Node, depth: u32) bool {
         if (elem_idx.isNone() or @intFromEnum(elem_idx) >= ast.nodes.items.len) continue;
         const elem = ast.nodes.items[@intFromEnum(elem_idx)];
         if (elem.tag == .spread_element) return false;
-        if (!isNodePureDepth(ast, elem, depth)) return false;
+        if (!isNodePureDepth(ast, elem, unresolved_globals, depth)) return false;
     }
     return true;
 }
 
 /// variable declaration의 순수성 판정.
 /// 모든 declarator의 초기값이 순수이면 순수.
-pub fn isVarDeclPure(ast: *const Ast, node: Node) bool {
+pub fn isVarDeclPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet) bool {
     const e = node.data.extra;
     if (e + 2 >= ast.extra_data.items.len) return false;
     const list_start = ast.extra_data.items[e + 1];
@@ -148,24 +213,24 @@ pub fn isVarDeclPure(ast: *const Ast, node: Node) bool {
         if (de + 2 >= ast.extra_data.items.len) return false;
         const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[de + 2]);
         if (init_idx.isNone()) continue;
-        if (!isExprPure(ast, init_idx)) return false;
+        if (!isExprPureDepth(ast, init_idx, unresolved_globals, 0)) return false;
     }
     return true;
 }
 
 /// top-level statement가 side effects를 가지는지 판정.
 /// tree_shaker, statement_shaker, stmt_info에서 공유.
-pub fn stmtHasSideEffects(ast: *const Ast, node: Node) bool {
+pub fn stmtHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet) bool {
     return switch (node.tag) {
         .function_declaration => false,
-        .class_declaration => classHasSideEffects(ast, node),
-        .variable_declaration => !isVarDeclPure(ast, node),
+        .class_declaration => classHasSideEffects(ast, node, unresolved_globals),
+        .variable_declaration => !isVarDeclPure(ast, node, unresolved_globals),
         .export_named_declaration => {
             const e = node.data.extra;
             if (e + 3 < ast.extra_data.items.len) {
                 const decl_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
                 if (!decl_idx.isNone() and @intFromEnum(decl_idx) < ast.nodes.items.len) {
-                    return stmtHasSideEffects(ast, ast.nodes.items[@intFromEnum(decl_idx)]);
+                    return stmtHasSideEffects(ast, ast.nodes.items[@intFromEnum(decl_idx)], unresolved_globals);
                 }
                 return false;
             }
@@ -177,8 +242,8 @@ pub fn stmtHasSideEffects(ast: *const Ast, node: Node) bool {
             const inner = ast.nodes.items[@intFromEnum(inner_idx)];
             return switch (inner.tag) {
                 .function_declaration => false,
-                .class_declaration => classHasSideEffects(ast, inner),
-                else => !isNodePure(ast, inner),
+                .class_declaration => classHasSideEffects(ast, inner, unresolved_globals),
+                else => !isNodePureDepth(ast, inner, unresolved_globals, 0),
             };
         },
         .import_declaration, .empty_statement => false,
@@ -190,13 +255,13 @@ pub fn stmtHasSideEffects(ast: *const Ast, node: Node) bool {
 /// class declaration/expression의 side effect 판정.
 /// esbuild ClassCanBeRemovedIfUnused 동일: extends + body 멤버 전체 검사.
 /// 미사용 class는 순수하면 제거 가능 — 실제 사용 시 referenced_symbols로 포함됨.
-pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
+pub fn classHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet) bool {
     const e = node.data.extra;
     if (e + 7 >= ast.extra_data.items.len) return true;
 
     // extends 절이 불순이면 side-effect
     const super_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
-    if (!isExprPure(ast, super_idx)) return true;
+    if (!isExprPureDepth(ast, super_idx, unresolved_globals, 0)) return true;
 
     // decorator가 있으면 side-effect
     const deco_len = ast.extra_data.items[e + 7];
@@ -223,11 +288,11 @@ pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
             .property_definition, .accessor_property => {
                 const me = member.data.extra;
                 if (me + 4 >= ast.extra_data.items.len) return true;
-                if (computedKeyHasSideEffects(ast, me)) return true;
+                if (computedKeyHasSideEffects(ast, me, unresolved_globals)) return true;
                 // static field의 불순 초기화: static flag (bit 0)
                 if ((ast.extra_data.items[me + 2] & 1) != 0) {
                     const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[me + 1]);
-                    if (!isExprPure(ast, init_idx)) return true;
+                    if (!isExprPureDepth(ast, init_idx, unresolved_globals, 0)) return true;
                 }
                 if (ast.extra_data.items[me + 4] > 0) return true; // decorator
             },
@@ -235,7 +300,7 @@ pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
                 // method_definition: [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
                 const me = member.data.extra;
                 if (me + 5 >= ast.extra_data.items.len) return true;
-                if (computedKeyHasSideEffects(ast, me)) return true;
+                if (computedKeyHasSideEffects(ast, me, unresolved_globals)) return true;
                 if (ast.extra_data.items[me + 5] > 0) return true; // decorator
             },
             else => {},
@@ -245,13 +310,13 @@ pub fn classHasSideEffects(ast: *const Ast, node: Node) bool {
 }
 
 /// class member의 computed key가 불순인지 검사. extra_data[extra_offset]에서 key NodeIndex를 읽는다.
-fn computedKeyHasSideEffects(ast: *const Ast, extra_offset: u32) bool {
+fn computedKeyHasSideEffects(ast: *const Ast, extra_offset: u32, unresolved_globals: ?*const GlobalRefSet) bool {
     if (extra_offset >= ast.extra_data.items.len) return true;
     const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_offset]);
     if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return false;
     const key_node = ast.nodes.items[@intFromEnum(key_idx)];
     if (key_node.tag == .computed_property_key) {
-        return !isExprPure(ast, key_node.data.unary.operand);
+        return !isExprPureDepth(ast, key_node.data.unary.operand, unresolved_globals, 0);
     }
     return false;
 }

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -1,0 +1,186 @@
+//! purity.zig 유닛 테스트.
+//!
+//! 핵심 검증:
+//!   - 빌트인 pure 생성자 화이트리스트(`new Set()` 등)는 unresolved_globals 컨텍스트에서
+//!     순수로 판정되어야 한다.
+//!   - 로컬 바인딩으로 shadowed된 이름(`const Set = ...; new Set()`)은 unresolved에
+//!     등록되지 않으므로 불순으로 남아야 한다.
+//!   - null 컨텍스트에서는 기존 동작(모든 call/new 불순)이 유지되어야 한다 (#1567).
+
+const std = @import("std");
+const purity = @import("purity.zig");
+const Ast = @import("../parser/ast.zig").Ast;
+const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const Scanner = @import("../lexer/scanner.zig").Scanner;
+const Parser = @import("../parser/parser.zig").Parser;
+const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
+
+const TestCtx = struct {
+    arena: std.heap.ArenaAllocator,
+    ast: Ast,
+    root: NodeIndex,
+    analyzer: SemanticAnalyzer,
+
+    fn deinit(self: *TestCtx) void {
+        self.arena.deinit();
+    }
+};
+
+fn setup(allocator: std.mem.Allocator, source: []const u8) !TestCtx {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    var scanner = try Scanner.init(a, source);
+    scanner.is_module = true;
+    var parser = Parser.init(a, &scanner);
+    parser.is_module = true;
+    const root = try parser.parse();
+
+    var analyzer = SemanticAnalyzer.init(a, &parser.ast);
+    analyzer.is_module = true;
+    try analyzer.analyze();
+
+    return .{
+        .arena = arena,
+        .ast = parser.ast,
+        .root = root,
+        .analyzer = analyzer,
+    };
+}
+
+/// program의 `stmt_idx`번째 top-level statement가 불러지는 variable_declaration일 때
+/// 그 첫 declarator의 initializer NodeIndex를 반환한다.
+fn initOfDecl(ctx: *const TestCtx, stmt_idx: usize) NodeIndex {
+    const root_ni = @intFromEnum(ctx.root);
+    const root_node = ctx.ast.nodes.items[root_ni];
+    const stmts = root_node.data.list;
+    const raw_stmt: u32 = ctx.ast.extra_data.items[stmts.start + stmt_idx];
+    const stmt = ctx.ast.nodes.items[raw_stmt];
+    // variable_declaration: [kind(0), list_start(1), list_len(2)]
+    const de = stmt.data.extra;
+    const list_start = ctx.ast.extra_data.items[de + 1];
+    const raw_decl: u32 = ctx.ast.extra_data.items[list_start];
+    const decl = ctx.ast.nodes.items[raw_decl];
+    // variable_declarator extra: [pattern(0), type_ann(1), init(2)]
+    return @enumFromInt(ctx.ast.extra_data.items[decl.data.extra + 2]);
+}
+
+test "pure builtin: new Set() with unresolved globals is pure" {
+    const alloc = std.testing.allocator;
+    var ctx = try setup(alloc, "const s = new Set();");
+    defer ctx.deinit();
+
+    const init = initOfDecl(&ctx, 0);
+    // context 없음 → 기존 동작 유지: call/new는 @__PURE__ 없으면 불순.
+    try std.testing.expect(!purity.isExprPure(&ctx.ast, init, null));
+    // 컨텍스트 전달 시 순수로 승격.
+    try std.testing.expect(purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
+test "pure builtin: whitelist covers Map/WeakMap/WeakSet/Symbol/Array/Object/Date/Error" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Map();
+        \\const b = new WeakMap();
+        \\const c = new WeakSet();
+        \\const d = new Symbol();
+        \\const e = new Array(4);
+        \\const f = new Object();
+        \\const g = new Date();
+        \\const h = new Error("x");
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    const globals = &ctx.analyzer.unresolved_references;
+    for (0..8) |i| {
+        const init = initOfDecl(&ctx, i);
+        try std.testing.expect(purity.isExprPure(&ctx.ast, init, globals));
+    }
+}
+
+test "pure builtin: RegExp is NOT whitelisted (invalid pattern throws)" {
+    const alloc = std.testing.allocator;
+    var ctx = try setup(alloc, "const r = new RegExp(\"x\");");
+    defer ctx.deinit();
+
+    const init = initOfDecl(&ctx, 0);
+    try std.testing.expect(!purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
+test "pure builtin: shadowed Set is impure" {
+    const alloc = std.testing.allocator;
+    // 로컬 `Set` 선언이 있으면 unresolved_references에 `Set`이 없으므로
+    // 화이트리스트 판정이 실패해야 한다.
+    const src =
+        \\const Set = globalThis.X;
+        \\const s = new Set();
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    const init = initOfDecl(&ctx, 1);
+    try std.testing.expect(!purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
+test "pure builtin: impure arg makes the whole call impure" {
+    const alloc = std.testing.allocator;
+    const src = "const s = new Set([sideEffect()]);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    const init = initOfDecl(&ctx, 0);
+    try std.testing.expect(!purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
+test "pure builtin: pure array arg keeps call pure" {
+    const alloc = std.testing.allocator;
+    const src = "const s = new Set([1, 2, 3]);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    const init = initOfDecl(&ctx, 0);
+    try std.testing.expect(purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
+test "pure builtin: stmt-level classification for `const s = new Set();`" {
+    const alloc = std.testing.allocator;
+    var ctx = try setup(alloc, "const s = new Set();");
+    defer ctx.deinit();
+
+    const root_ni = @intFromEnum(ctx.root);
+    const root_node = ctx.ast.nodes.items[root_ni];
+    const stmts = root_node.data.list;
+    const raw_stmt: u32 = ctx.ast.extra_data.items[stmts.start];
+    const stmt_node = ctx.ast.nodes.items[raw_stmt];
+
+    // null 컨텍스트에서는 side-effectful로 남아야 기존 동작 유지
+    try std.testing.expect(purity.stmtHasSideEffects(&ctx.ast, stmt_node, null));
+    // 컨텍스트 전달 시 순수 statement로 판정
+    try std.testing.expect(!purity.stmtHasSideEffects(&ctx.ast, stmt_node, &ctx.analyzer.unresolved_references));
+}
+
+test "pure builtin: call without `new` also pure (Symbol(), Array(3))" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = Symbol();
+        \\const b = Array(3);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    const g = &ctx.analyzer.unresolved_references;
+    try std.testing.expect(purity.isExprPure(&ctx.ast, initOfDecl(&ctx, 0), g));
+    try std.testing.expect(purity.isExprPure(&ctx.ast, initOfDecl(&ctx, 1), g));
+}
+
+test "pure builtin: spread arg blocks pure classification" {
+    const alloc = std.testing.allocator;
+    const src = "const s = new Set(...xs);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    const init = initOfDecl(&ctx, 0);
+    try std.testing.expect(!purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}

--- a/src/bundler/statement_shaker.zig
+++ b/src/bundler/statement_shaker.zig
@@ -32,6 +32,7 @@ pub fn markUnusedStatements(
     root: NodeIndex,
     used_export_names: []const []const u8,
     skip_nodes: *std.DynamicBitSet,
+    unresolved_globals: ?*const purity.GlobalRefSet,
 ) !void {
     const root_ni = @intFromEnum(root);
     if (root_ni >= ast.nodes.items.len) return;
@@ -68,7 +69,7 @@ pub fn markUnusedStatements(
 
         // 선언 이름 추출 + side effects 판정
         try extractDeclaredNames(ast, node, @intCast(i), &name_to_stmt, allocator);
-        stmts[i].has_side_effects = hasSideEffects(ast, node);
+        stmts[i].has_side_effects = hasSideEffects(ast, node, unresolved_globals);
         if (!stmts[i].has_side_effects) removable_count += 1;
     }
 
@@ -333,10 +334,10 @@ fn extractArrayPatternNames(
 
 /// statement가 side effects를 가지는지 보수적으로 판정한다.
 /// import/export 문은 linker skip_nodes와 충돌 방지를 위해 항상 side-effectful로 처리.
-fn hasSideEffects(ast: *const Ast, node: Node) bool {
+fn hasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*const purity.GlobalRefSet) bool {
     // import는 linker가 skip_nodes로 관리하므로 side-effectful 유지
     if (node.tag == .import_declaration) return true;
-    return purity.stmtHasSideEffects(ast, node);
+    return purity.stmtHasSideEffects(ast, node, unresolved_globals);
 }
 
 /// 모든 AST 노드를 순회하면서 identifier_reference를 찾고,

--- a/src/bundler/statement_shaker_test.zig
+++ b/src/bundler/statement_shaker_test.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const statement_shaker = @import("statement_shaker.zig");
+const purity = @import("purity.zig");
 const markUnusedStatements = statement_shaker.markUnusedStatements;
 const Ast = @import("../parser/ast.zig").Ast;
 const Node = @import("../parser/ast.zig").Node;
@@ -7,6 +8,10 @@ const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Span = @import("../lexer/token.zig").Span;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
+
+/// 유닛 테스트는 semantic analyzer 컨텍스트 없이 shaker 동작만 검증한다.
+/// 빌트인 pure 생성자 판정은 purity_test.zig가 담당.
+const no_globals: ?*const purity.GlobalRefSet = null;
 
 fn parseAndGetRoot(allocator: std.mem.Allocator, source: []const u8) !struct {
     ast: Ast,
@@ -43,7 +48,7 @@ test "statement shaker: unused function removed" {
     defer skip_nodes.deinit();
 
     const used_names: [1][]const u8 = .{"used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &used_names, &skip_nodes);
+    try markUnusedStatements(alloc, &r.ast, r.root, &used_names, &skip_nodes, no_globals);
 
     // "unused" 함수의 statement node가 skip_nodes에 포함되어야 함
     // "used"와 "helper"는 포함되지 않아야 함
@@ -67,7 +72,7 @@ test "statement shaker: transitive dependency preserved" {
     defer skip_nodes.deinit();
 
     const used_names: [1][]const u8 = .{"a"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &used_names, &skip_nodes);
+    try markUnusedStatements(alloc, &r.ast, r.root, &used_names, &skip_nodes, no_globals);
 
     // a → b → c는 보존, d만 제거
     var skipped: u32 = 0;
@@ -89,7 +94,7 @@ test "statement shaker: side-effectful statement always included" {
     defer skip_nodes.deinit();
 
     const used_names: [1][]const u8 = .{"used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &used_names, &skip_nodes);
+    try markUnusedStatements(alloc, &r.ast, r.root, &used_names, &skip_nodes, no_globals);
 
     // console.log는 side effect → 항상 포함
     // unused만 제거
@@ -109,7 +114,7 @@ test "statement shaker: empty used_exports skips nothing with side effects" {
     var skip_nodes = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip_nodes.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip_nodes);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip_nodes, no_globals);
 
     // side-effectful statement → 스킵 안 됨
     var skipped: u32 = 0;
@@ -134,7 +139,7 @@ test "statement shaker: let without initializer is side-effect-free" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // "let store"는 side-effect-free지만 "used"가 참조 → 보존
     // "unused"만 제거
@@ -158,7 +163,7 @@ test "statement shaker: const with literal initializer is side-effect-free" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // REGEX: 미참조 → 제거, unused: 미참조 → 제거
     var skipped: u32 = 0;
@@ -181,7 +186,7 @@ test "statement shaker: assignment_target_identifier tracked (++x pattern)" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"make"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // make → ++ID → ID 보존. unused만 제거.
     var skipped: u32 = 0;
@@ -203,7 +208,7 @@ test "statement shaker: export default function removed when unused" {
     defer skip.deinit();
 
     // used_exports 비어있음 → export default + unused 모두 제거
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     var skipped: u32 = 0;
     var it = skip.iterator(.{});
@@ -224,7 +229,7 @@ test "statement shaker: export default preserved when used" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"default"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // export default config → 보존, unused만 제거
     var skipped: u32 = 0;
@@ -247,7 +252,7 @@ test "statement shaker: export specifier-only is side-effect-free" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"object"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // export { ... } → side-effect-free (linker가 skip_nodes로 처리)
     // unused → 미참조 → 제거
@@ -270,7 +275,7 @@ test "statement shaker: class extends identifier is removable" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // class extends identifier → 순수 → Derived + unused 모두 제거
     var skipped: u32 = 0;
@@ -291,7 +296,7 @@ test "statement shaker: class without extends is removable" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"Used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // Unused class (no extends) → 미사용 → 제거
     var skipped: u32 = 0;
@@ -312,7 +317,7 @@ test "statement shaker: var with call initializer is side-effectful" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // var x = init() → side-effectful → 보존
     // unused만 제거
@@ -335,7 +340,7 @@ test "statement shaker: export function declaration" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // export function unused → 미사용 → 제거
     var skipped: u32 = 0;
@@ -356,7 +361,7 @@ test "statement shaker: no removable statements → early return" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     var skipped: u32 = 0;
     var it = skip.iterator(.{});
@@ -376,7 +381,7 @@ test "statement shaker: identifier_reference initializer is side-effect-free" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // const x = globalVal → side-effect-free (identifier) → x 미사용 → 제거
     // unused도 미사용 → 제거
@@ -403,7 +408,7 @@ test "statement shaker: tslib pattern — export default object removes unused" 
 
     // __awaiter만 사용 → __extends, __rest, export default 제거
     const names: [1][]const u8 = .{"__awaiter"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     var skipped: u32 = 0;
     var it = skip.iterator(.{});
@@ -425,7 +430,7 @@ test "statement shaker: conditional init is side-effect-free" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // __createBinding: ternary(member, fn, fn) → side-effect-free → 미사용 → 제거
     var skipped: u32 = 0;
@@ -447,7 +452,7 @@ test "statement shaker: typeof binary is side-effect-free" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // typeof ... === "function" ? ... : ... → side-effect-free → 미사용 → 제거
     var skipped: u32 = 0;
@@ -468,7 +473,7 @@ test "statement shaker: export default class extends identifier is removable" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // export default class extends Base → 순수 식별자 → 미사용 시 제거 가능
     // 둘 다 제거
@@ -490,7 +495,7 @@ test "statement shaker: class extends call expression is side-effectful" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // extends getBase() → 불순 → X 보존, unused만 제거
     var skipped: u32 = 0;
@@ -511,7 +516,7 @@ test "statement shaker: class extends member expression is removable" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // extends ns.Base → 순수 member expression → X + unused 모두 제거
     var skipped: u32 = 0;
@@ -536,7 +541,7 @@ test "statement shaker: class inheritance chain — unused children removable" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"Child"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // Child → used, Base → Child의 의존. Unused, GrandChild → 미사용 → 제거
     var skipped: u32 = 0;
@@ -559,7 +564,7 @@ test "statement shaker: used class with extends preserves parent" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"Used"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // Parent → Used의 의존으로 보존, Used → used, Unused → 미사용 → 제거
     var skipped: u32 = 0;
@@ -582,7 +587,7 @@ test "statement shaker: side-effect on class symbol preserved" {
     defer skip.deinit();
 
     const names: [1][]const u8 = .{"Base"};
-    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
 
     // Base → used, Base.DEFAULT_UP → side-effect → 보존, Unused → 미사용 → 제거
     var skipped: u32 = 0;
@@ -602,7 +607,7 @@ test "statement shaker: class with static block is side-effectful" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // static block → side-effect → X 보존, unused만 제거
     var skipped: u32 = 0;
@@ -623,7 +628,7 @@ test "statement shaker: class with computed key call is side-effectful" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // computed key fn() → side-effect → X와 key 보존, unused만 제거
     var skipped: u32 = 0;
@@ -643,7 +648,7 @@ test "statement shaker: class with impure static field is side-effectful" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // static foo = init() → side-effect → X 보존, unused만 제거
     var skipped: u32 = 0;
@@ -663,7 +668,7 @@ test "statement shaker: class with pure static field is removable" {
     var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
     defer skip.deinit();
 
-    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip);
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
 
     // static foo = 42 → 순수 리터럴 → X + unused 모두 제거
     var skipped: u32 = 0;

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -211,6 +211,7 @@ pub fn buildFromSemantic(
     symbols: []const Symbol,
     stmt_declared: []const std.ArrayListUnmanaged(u32),
     stmt_referenced: []const std.ArrayListUnmanaged(u32),
+    unresolved_globals: ?*const purity.GlobalRefSet,
 ) !?ModuleStmtInfos {
     // program 노드 (마지막 노드)에서 top-level statement 인덱스 추출
     if (ast.nodes.items.len == 0) return null;
@@ -262,7 +263,7 @@ pub fn buildFromSemantic(
             };
         } else {
             const node = ast.nodes.items[ni];
-            const side_effects = if (node.tag == .import_declaration) false else purity.stmtHasSideEffects(ast, node);
+            const side_effects = if (node.tag == .import_declaration) false else purity.stmtHasSideEffects(ast, node, unresolved_globals);
             stmts[stmt_i] = .{
                 .node_idx = @intCast(ni),
                 .span = node.span,
@@ -298,6 +299,7 @@ pub fn build(
     ast: *const Ast,
     symbols: []const Symbol,
     symbol_ids: []const ?u32,
+    unresolved_globals: ?*const purity.GlobalRefSet,
 ) !?ModuleStmtInfos {
     // program 노드 (마지막 노드)
     if (ast.nodes.items.len == 0) return null;
@@ -344,7 +346,7 @@ pub fn build(
         }
         const node = ast.nodes.items[ni];
         stmt_spans[stmt_i] = node.span;
-        const side_effects = if (node.tag == .import_declaration) false else purity.stmtHasSideEffects(ast, node);
+        const side_effects = if (node.tag == .import_declaration) false else purity.stmtHasSideEffects(ast, node, unresolved_globals);
         stmts[stmt_i] = .{
             .node_idx = @intCast(ni),
             .span = node.span,

--- a/src/bundler/stmt_info_test.zig
+++ b/src/bundler/stmt_info_test.zig
@@ -33,6 +33,7 @@ fn buildTestInfos(allocator: std.mem.Allocator, source: []const u8) !struct {
         &parser.ast,
         analyzer.symbols.items,
         analyzer.symbol_ids.items,
+        &analyzer.unresolved_references,
     )) orelse return error.NullResult;
 
     return .{ .infos = infos, .arena = arena };

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -135,7 +135,8 @@ pub const TreeShaker = struct {
             if (m.side_effects_user_defined) continue;
             if (self.entry_set.isSet(i)) continue;
             if (m.ast) |ast| {
-                if (isModulePure(&ast)) {
+                const unresolved = if (m.semantic) |*s| &s.unresolved_references else null;
+                if (isModulePure(&ast, unresolved)) {
                     const mutable_modules: [*]Module = @constCast(self.modules.ptr);
                     mutable_modules[i].side_effects = false;
                 }
@@ -207,6 +208,7 @@ pub const TreeShaker = struct {
                 ast,
                 sem.symbols.items,
                 sem.symbol_ids,
+                &sem.unresolved_references,
             ) catch null;
         }
 
@@ -315,7 +317,7 @@ pub const TreeShaker = struct {
     /// 모듈의 top-level 문장이 모두 순수한지 판별.
     /// 순수: import/export 선언, 함수/클래스 선언, 변수 선언(초기값이 순수), @__PURE__ call.
     /// 불순: 일반 call expression, assignment to global, etc.
-    fn isModulePure(ast: *const Ast) bool {
+    fn isModulePure(ast: *const Ast, unresolved_globals: ?*const purity.GlobalRefSet) bool {
         if (ast.nodes.items.len == 0) return false;
         // program 노드는 파서가 마지막에 추가 — 마지막 노드
         const root = ast.nodes.items[ast.nodes.items.len - 1];
@@ -329,12 +331,12 @@ pub const TreeShaker = struct {
             const idx: NodeIndex = @enumFromInt(raw);
             if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) continue;
             const stmt = ast.nodes.items[@intFromEnum(idx)];
-            if (!isStatementPure(ast, stmt)) return false;
+            if (!isStatementPure(ast, stmt, unresolved_globals)) return false;
         }
         return true;
     }
 
-    fn isStatementPure(ast: *const Ast, stmt: Node) bool {
+    fn isStatementPure(ast: *const Ast, stmt: Node, unresolved_globals: ?*const purity.GlobalRefSet) bool {
         return switch (stmt.tag) {
             .import_declaration,
             .export_all_declaration,
@@ -346,7 +348,7 @@ pub const TreeShaker = struct {
                 if (decl_idx.isNone()) return true;
                 if (@intFromEnum(decl_idx) >= ast.nodes.items.len) return true;
                 const decl = ast.nodes.items[@intFromEnum(decl_idx)];
-                return isStatementPure(ast, decl);
+                return isStatementPure(ast, decl, unresolved_globals);
             },
 
             .export_default_declaration => {
@@ -355,13 +357,13 @@ pub const TreeShaker = struct {
                 const inner = ast.nodes.items[@intFromEnum(inner_idx)];
                 return switch (inner.tag) {
                     .function_declaration => true,
-                    .class_declaration => !purity.classHasSideEffects(ast, inner),
-                    else => purity.isExprPure(ast, inner_idx),
+                    .class_declaration => !purity.classHasSideEffects(ast, inner, unresolved_globals),
+                    else => purity.isExprPure(ast, inner_idx, unresolved_globals),
                 };
             },
 
             .function_declaration => true,
-            .class_declaration => !purity.classHasSideEffects(ast, stmt),
+            .class_declaration => !purity.classHasSideEffects(ast, stmt, unresolved_globals),
 
             .ts_interface_declaration,
             .ts_type_alias_declaration,
@@ -371,8 +373,8 @@ pub const TreeShaker = struct {
             .ts_module_declaration,
             => false,
 
-            .variable_declaration => purity.isVarDeclPure(ast, stmt),
-            .expression_statement => purity.isExprPure(ast, stmt.data.unary.operand),
+            .variable_declaration => purity.isVarDeclPure(ast, stmt, unresolved_globals),
+            .expression_statement => purity.isExprPure(ast, stmt.data.unary.operand, unresolved_globals),
 
             .empty_statement => true,
 


### PR DESCRIPTION
## Summary

- `src/bundler/purity.zig`에 pure 빌트인 생성자 화이트리스트 추가: `Set`, `Map`, `WeakMap`, `WeakSet`, `Symbol`, `Array`, `Object`, `Date`, `Error`.
- callee가 모듈의 `unresolved_references`에 속한 전역일 때만 pure로 판정 → 로컬 `const Set = ...` / `import { Set }` shadowing은 안전하게 걸러짐.
- RegExp는 invalid pattern이 SyntaxError를 throw할 수 있어 제외.

## 접근

기존 `purity.stmtHasSideEffects` / `isExprPure` / `isVarDeclPure` / `classHasSideEffects` 시그니처에 `?*const purity.GlobalRefSet` 매개변수 추가. null이면 기존 보수적 동작 유지 (`@__PURE__`만 pure). 포인터가 있으면 해당 모듈의 `semantic.unresolved_references`를 사용해 빌트인 여부 확정.

호출부 3곳 (tree_shaker / statement_shaker / stmt_info)이 각 모듈의 `ModuleSemanticData.unresolved_references`를 자동 전달. emitter의 fallback 경로만 `null`을 명시.

## 실측 (svelte 5.55, `import { mount } from 'svelte'`, `--minify --define:NODE_ENV=production`)

| 번들러 | Size | vs ZTS |
|---|---:|---:|
| **ZTS (before)** | **50,223 B** | — |
| **ZTS (after)** | **49,262 B** | **-961 B (-1.9%)** |
| esbuild | 37,823 B | -11,439 B |
| rolldown | 27,538 B | -22,538 B |

issue #1567에서 추정한 12 KB 갭 중 1 KB 해소. 나머지는 reachability 누락 함수와 다른 P2/P3 작업에서 점진 개선.

## 테스트

- `src/bundler/purity_test.zig` 신규: 9개 케이스 — 화이트리스트 전체, RegExp 제외, shadowing 차단, impure arg, spread 거부, call-without-new, stmt-level 분류, null 컨텍스트 하위호환.
- 기존 전체 테스트 통과 (`zig build test`).

## Test plan

- [x] `zig build test` 전체 통과
- [x] svelte 번들 before/after 측정 (50,223 → 49,262 B)
- [x] `/simplify` 리뷰 반영 (공개 API `WithGlobals` suffix 제거, 테스트 `no_globals` 상수)
- [ ] reviewer: `new Set(...)`이 tree-shake된 후 런타임 동작 변화 없는지 spot-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)