### PR TITLE
perf(bundler): #1626 dead-scope gating for namespace member access

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -38,8 +38,7 @@ pub const ImportBinding = struct {
     namespace_used_properties: ?[]const []const u8 = null,
     /// `namespace_used_properties[i]`가 접근된 top-level statement 인덱스 목록.
     /// `module.prebuilt_stmt_info.stmts` 인덱스 기준. 길이는 `namespace_used_properties`와 같다.
-    /// null = stmt-level 정보 없음 (fallback: 전체 seed). linker.populateNamespaceAccesses가 채움.
-    /// #1626 dead-scope gating: BFS dispatch stmt가 이 목록에 없으면 해당 property seed 생략.
+    /// null = 정보 없음 (fallback: 전체 seed). BFS가 dead-scope access를 걸러내는 근거.
     namespace_used_property_stmts: ?[]const []const u32 = null,
     /// #1328 Phase 2: source 모듈의 export 심볼 참조. invalid = 미해결.
     /// Phase 3에서 linker가 cross-module resolve로 채움. 기존 문자열 로직은

--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -36,6 +36,11 @@ pub const ImportBinding = struct {
     /// namespace import에서 실제 접근된 프로퍼티 목록 (v.object → "object")
     /// null = 전체 사용 (동적 접근, namespace 탈출 등 fallback)
     namespace_used_properties: ?[]const []const u8 = null,
+    /// `namespace_used_properties[i]`가 접근된 top-level statement 인덱스 목록.
+    /// `module.prebuilt_stmt_info.stmts` 인덱스 기준. 길이는 `namespace_used_properties`와 같다.
+    /// null = stmt-level 정보 없음 (fallback: 전체 seed). linker.populateNamespaceAccesses가 채움.
+    /// #1626 dead-scope gating: BFS dispatch stmt가 이 목록에 없으면 해당 property seed 생략.
+    namespace_used_property_stmts: ?[]const []const u32 = null,
     /// #1328 Phase 2: source 모듈의 export 심볼 참조. invalid = 미해결.
     /// Phase 3에서 linker가 cross-module resolve로 채움. 기존 문자열 로직은
     /// 병존 (Phase 4에서 제거).

--- a/src/bundler/bundler_test/virtual_ns_treeshake.zig
+++ b/src/bundler/bundler_test/virtual_ns_treeshake.zig
@@ -139,9 +139,9 @@ test "virtual ns (#1603): opaque 사용 시 fallback — 전체 유지" {
 // 해당 export 보존. svelte 번들 기준 약 16-20개 에러 함수 불필요 보존.
 // ============================================================
 
-test "virtual ns (#1626 repro): dead function body 내 namespace access는 target을 보존하면 안 됨" {
-    // 현재는 실패해서는 안 되는 regression 테스트 — 버그 동작을 기록하고,
-    // fix PR에서 expected 값을 뒤집어 올바른 동작을 문서화한다.
+test "virtual ns (#1626): dead function body 내 namespace access는 target을 보존하면 안 됨" {
+    // #1626 fix: linker.analyzeNamespaceAccess가 각 member access의 owning stmt를 기록하고,
+    // tree_shaker.followImport가 dispatch_stmt 기준으로 per-prop seed를 gating한다.
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "errors.ts",
@@ -166,10 +166,8 @@ test "virtual ns (#1626 repro): dead function body 내 namespace access는 targe
     try testing.expect(std.mem.indexOf(u8, code, "live-err-marker") != null);
 
     // dead 경로: `unused_lifecycle`가 entry에서 도달 불가 → body의 `e.dead_err` 접근도 dead.
-    // TODO(#1626): 아래 두 assertion은 현재 버그 동작을 기록.
-    //   fix 후에는 `!= null` → `== null`로 뒤집어야 한다.
-    try testing.expect(std.mem.indexOf(u8, code, "unused_lifecycle") == null); // 함수 자체는 이미 제거되는 듯
-    try testing.expect(std.mem.indexOf(u8, code, "dead-err-marker") != null); // 현재: 남아있음 (버그)
+    try testing.expect(std.mem.indexOf(u8, code, "unused_lifecycle") == null);
+    try testing.expect(std.mem.indexOf(u8, code, "dead-err-marker") == null);
 }
 
 test "virtual ns (#1603): 여러 소비자가 모두 precise하면 union만 유지" {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1254,8 +1254,6 @@ pub const Linker = struct {
         kind: Kind,
         /// property → 해당 `ns.prop` 접근이 발생한 top-level stmt 인덱스 목록.
         /// stmt_spans가 전달된 경우에만 채워지며, 없으면 빈 리스트.
-        /// ArrayListUnmanaged는 allocator 없이 생성되어 deinit도 해당 allocator 필요.
-        /// #1626 dead-scope gating 기반 자료.
         members: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(u32)) = .{},
 
         pub const Kind = enum { member_only, @"opaque" };
@@ -1537,6 +1535,13 @@ pub const Linker = struct {
 
             if (sem.scope_maps.len == 0) continue;
 
+            // 모든 namespace import에 공통으로 쓰일 stmt span 배열을 importer당 1회 구축.
+            const stmt_spans_opt: ?[]const Span = if (importer.prebuilt_stmt_info) |*infos| spans_blk: {
+                const spans_buf = arena.alloc(Span, infos.stmts.len) catch break :spans_blk null;
+                for (infos.stmts, 0..) |s, si| spans_buf[si] = s.span;
+                break :spans_blk spans_buf;
+            } else null;
+
             for (importer.import_bindings) |*ib| {
                 const is_namespace = ib.kind == .namespace;
                 const is_named_candidate = ib.kind == .named and ib.namespace_used_properties == null;
@@ -1563,14 +1568,6 @@ pub const Linker = struct {
 
                 // 소비자 모듈에서 local symbol id 조회. top-level import이므로 scope_maps[0].
                 const sym_idx = sem.scope_maps[0].get(ib.local_name) orelse continue;
-
-                // prebuilt stmt_info의 stmt spans — dead-scope gating용. 없으면 null로 fallback.
-                const stmt_spans_opt: ?[]const Span = if (importer.prebuilt_stmt_info) |*infos| spans_blk: {
-                    // infos.stmts[i].span 배열을 임시 슬라이스로 만들기 위해 arena에 할당.
-                    const spans_buf = arena.alloc(Span, infos.stmts.len) catch break :spans_blk null;
-                    for (infos.stmts, 0..) |s, si| spans_buf[si] = s.span;
-                    break :spans_blk spans_buf;
-                } else null;
 
                 // 분석은 linker.allocator에서 임시로 (내부 HashMap 용), 결과 슬라이스만 arena.
                 var access = analyzeNamespaceAccess(

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -23,6 +23,7 @@ const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Ast = @import("../parser/ast.zig").Ast;
 const semantic_symbol = @import("../semantic/symbol.zig");
 const bundler_symbol = @import("symbol.zig");
+const stmt_info_mod = @import("stmt_info.zig");
 
 /// namespace 접근 패턴에서 생성되는 변수 prefix.
 /// metadata.zig, codegen.zig, emitter.zig에서 공유.
@@ -1251,11 +1252,17 @@ pub const Linker = struct {
     /// `kind == .opaque`: 값으로 사용되거나 computed access 등 → `members`는 비어 있고 fallback 필요.
     pub const NamespaceAccess = struct {
         kind: Kind,
-        members: std.StringHashMapUnmanaged(void) = .{},
+        /// property → 해당 `ns.prop` 접근이 발생한 top-level stmt 인덱스 목록.
+        /// stmt_spans가 전달된 경우에만 채워지며, 없으면 빈 리스트.
+        /// ArrayListUnmanaged는 allocator 없이 생성되어 deinit도 해당 allocator 필요.
+        /// #1626 dead-scope gating 기반 자료.
+        members: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(u32)) = .{},
 
         pub const Kind = enum { member_only, @"opaque" };
 
         pub fn deinit(self: *NamespaceAccess, allocator: std.mem.Allocator) void {
+            var it = self.members.valueIterator();
+            while (it.next()) |list| list.deinit(allocator);
             self.members.deinit(allocator);
         }
     };
@@ -1277,6 +1284,9 @@ pub const Linker = struct {
         ast: *const Ast,
         symbol_ids: []const ?u32,
         ns_sym_id: u32,
+        /// top-level statement의 source span. 전달하면 각 access의 owning stmt 인덱스를
+        /// `members[prop]`에 기록 (#1626 dead-scope gating). null이면 기록하지 않는다.
+        stmt_spans: ?[]const Span,
     ) std.mem.Allocator.Error!NamespaceAccess {
         const node_count = ast.nodes.items.len;
         var access: NamespaceAccess = .{ .kind = .member_only };
@@ -1346,7 +1356,27 @@ pub const Linker = struct {
             if (prop_by_obj.get(@intCast(node_i))) |prop_node_idx| {
                 const prop_node = ast.nodes.items[prop_node_idx];
                 const name = ast.getText(prop_node.span);
-                if (name.len > 0) try access.members.put(allocator, name, {});
+                if (name.len == 0) continue;
+
+                const gop = try access.members.getOrPut(allocator, name);
+                if (!gop.found_existing) gop.value_ptr.* = .empty;
+
+                if (stmt_spans) |spans| {
+                    // owning statement 인덱스 기록. 함수 body 내부 access도 그 함수의
+                    // 선언 statement span 안에 있으므로 binary search로 귀속 가능.
+                    if (stmt_info_mod.findStmtForPos(spans, node.span.start)) |stmt_idx| {
+                        // 중복 방지: 같은 stmt에서 같은 prop이 여러 번 accessed될 수 있다.
+                        const list = gop.value_ptr;
+                        var exists = false;
+                        for (list.items) |existing| {
+                            if (existing == stmt_idx) {
+                                exists = true;
+                                break;
+                            }
+                        }
+                        if (!exists) try list.append(allocator, stmt_idx);
+                    }
+                }
             } else {
                 // member-expr object가 아닌 참조 위치 — opaque
                 access.members.deinit(allocator);
@@ -1534,19 +1564,31 @@ pub const Linker = struct {
                 // 소비자 모듈에서 local symbol id 조회. top-level import이므로 scope_maps[0].
                 const sym_idx = sem.scope_maps[0].get(ib.local_name) orelse continue;
 
+                // prebuilt stmt_info의 stmt spans — dead-scope gating용. 없으면 null로 fallback.
+                const stmt_spans_opt: ?[]const Span = if (importer.prebuilt_stmt_info) |*infos| spans_blk: {
+                    // infos.stmts[i].span 배열을 임시 슬라이스로 만들기 위해 arena에 할당.
+                    const spans_buf = arena.alloc(Span, infos.stmts.len) catch break :spans_blk null;
+                    for (infos.stmts, 0..) |s, si| spans_buf[si] = s.span;
+                    break :spans_blk spans_buf;
+                } else null;
+
                 // 분석은 linker.allocator에서 임시로 (내부 HashMap 용), 결과 슬라이스만 arena.
                 var access = analyzeNamespaceAccess(
                     self.allocator,
                     ast,
                     sem.symbol_ids,
                     @intCast(sym_idx),
+                    stmt_spans_opt,
                 ) catch continue;
                 defer access.deinit(self.allocator);
 
                 if (access.kind == .@"opaque") {
                     // `.namespace`는 text-based 결과를 신뢰하지 않음 — null로 덮어써 fallback.
                     // `.named` virtual ns는 null 유지(기존 동작).
-                    if (is_namespace) ib.namespace_used_properties = null;
+                    if (is_namespace) {
+                        ib.namespace_used_properties = null;
+                        ib.namespace_used_property_stmts = null;
+                    }
                     continue;
                 }
 
@@ -1555,12 +1597,24 @@ pub const Linker = struct {
                 // 슬라이스 자체도 arena로 할당해 deinit 시 자동 해제.
                 const count = access.members.count();
                 const props = arena.alloc([]const u8, count) catch continue;
+                const prop_stmts: ?[][]const u32 = if (stmt_spans_opt != null)
+                    (arena.alloc([]const u32, count) catch null)
+                else
+                    null;
+
                 var i: usize = 0;
-                var kit = access.members.keyIterator();
-                while (kit.next()) |key| : (i += 1) {
-                    props[i] = key.*;
+                var it = access.members.iterator();
+                while (it.next()) |entry| : (i += 1) {
+                    props[i] = entry.key_ptr.*;
+                    if (prop_stmts) |ps| {
+                        const src = entry.value_ptr.items;
+                        const dst = arena.alloc(u32, src.len) catch continue;
+                        @memcpy(dst, src);
+                        ps[i] = dst;
+                    }
                 }
                 ib.namespace_used_properties = props;
+                ib.namespace_used_property_stmts = if (prop_stmts) |ps| ps else null;
             }
         }
     }

--- a/src/bundler/namespace_access_test.zig
+++ b/src/bundler/namespace_access_test.zig
@@ -64,7 +64,7 @@ fn runAccess(allocator: std.mem.Allocator, source: []const u8, ns_name: []const 
     }
     const sid = ns_sym_id orelse return error.NamespaceSymbolNotFound;
 
-    const access = try Linker.analyzeNamespaceAccess(allocator, ast, analyzer.symbol_ids.items, sid);
+    const access = try Linker.analyzeNamespaceAccess(allocator, ast, analyzer.symbol_ids.items, sid, null);
     return .{
         .scanner = scanner,
         .parser = parser,

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -567,10 +567,9 @@ pub const TreeShaker = struct {
         self: *TreeShaker,
         mod_idx: u32,
         ib_idx: u32,
-        /// #1626: 이 import 참조가 발생한 dispatch stmt 인덱스.
-        /// namespace 바인딩에서 per-prop stmt 정보가 있으면 이 stmt에 귀속된 prop만 seed.
-        /// `maxInt(u32)` sentinel = gating 적용 안 함 (기존 전체 seed 동작).
-        dispatch_stmt: u32,
+        /// 이 import 참조가 발생한 dispatch stmt 인덱스. null이면 gating 적용 안 함
+        /// (기존 전체 seed 동작 유지 — dynamic seed 경로 등에서 사용).
+        dispatch_stmt: ?u32,
         queue: *std.ArrayListUnmanaged(BfsItem),
         module_stmt_infos: []?StmtInfos,
         reachable_stmts: []?std.DynamicBitSet,
@@ -587,20 +586,13 @@ pub const TreeShaker = struct {
 
         if (ib.kind == .namespace) {
             if (ib.namespace_used_properties) |props| {
-                // per-prop stmt 정보가 있으면 dispatch_stmt에 귀속된 prop만 seed (#1626).
-                const prop_stmts_opt = ib.namespace_used_property_stmts;
                 for (props, 0..) |prop_name, pi| {
-                    if (prop_stmts_opt) |prop_stmts| {
-                        if (dispatch_stmt != std.math.maxInt(u32) and pi < prop_stmts.len) {
-                            var in_dispatch = false;
-                            for (prop_stmts[pi]) |s| {
-                                if (s == dispatch_stmt) {
-                                    in_dispatch = true;
-                                    break;
-                                }
-                            }
-                            if (!in_dispatch) continue;
-                        }
+                    // per-prop stmt 정보와 dispatch_stmt가 모두 있을 때만 gating 적용.
+                    // 어느 한쪽이라도 없으면 기존 전체 seed로 fallback.
+                    if (dispatch_stmt) |ds| gate: {
+                        const prop_stmts = ib.namespace_used_property_stmts orelse break :gate;
+                        if (pi >= prop_stmts.len) break :gate;
+                        if (!containsU32(prop_stmts[pi], ds)) continue;
                     }
                     try self.seedExport(target, prop_name, queue, module_stmt_infos, reachable_stmts);
                 }
@@ -1029,3 +1021,8 @@ pub const TreeShaker = struct {
         return false;
     }
 };
+
+fn containsU32(slice: []const u32, target: u32) bool {
+    for (slice) |v| if (v == target) return true;
+    return false;
+}

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -501,7 +501,7 @@ pub const TreeShaker = struct {
                     if (self.sym_to_ib[item.mod]) |sym_map| {
                         if (ref_sym < sym_map.len) {
                             if (sym_map[ref_sym]) |ib_idx| {
-                                try self.followImport(item.mod, ib_idx, &queue, module_stmt_infos, reachable_stmts);
+                                try self.followImport(item.mod, ib_idx, item.stmt, &queue, module_stmt_infos, reachable_stmts);
                             }
                         }
                     }
@@ -567,6 +567,10 @@ pub const TreeShaker = struct {
         self: *TreeShaker,
         mod_idx: u32,
         ib_idx: u32,
+        /// #1626: 이 import 참조가 발생한 dispatch stmt 인덱스.
+        /// namespace 바인딩에서 per-prop stmt 정보가 있으면 이 stmt에 귀속된 prop만 seed.
+        /// `maxInt(u32)` sentinel = gating 적용 안 함 (기존 전체 seed 동작).
+        dispatch_stmt: u32,
         queue: *std.ArrayListUnmanaged(BfsItem),
         module_stmt_infos: []?StmtInfos,
         reachable_stmts: []?std.DynamicBitSet,
@@ -583,7 +587,21 @@ pub const TreeShaker = struct {
 
         if (ib.kind == .namespace) {
             if (ib.namespace_used_properties) |props| {
-                for (props) |prop_name| {
+                // per-prop stmt 정보가 있으면 dispatch_stmt에 귀속된 prop만 seed (#1626).
+                const prop_stmts_opt = ib.namespace_used_property_stmts;
+                for (props, 0..) |prop_name, pi| {
+                    if (prop_stmts_opt) |prop_stmts| {
+                        if (dispatch_stmt != std.math.maxInt(u32) and pi < prop_stmts.len) {
+                            var in_dispatch = false;
+                            for (prop_stmts[pi]) |s| {
+                                if (s == dispatch_stmt) {
+                                    in_dispatch = true;
+                                    break;
+                                }
+                            }
+                            if (!in_dispatch) continue;
+                        }
+                    }
                     try self.seedExport(target, prop_name, queue, module_stmt_infos, reachable_stmts);
                 }
             } else {


### PR DESCRIPTION
Closes #1626.

## Summary

`import * as e from './m'` + `e.foo()` 접근이 **unreachable function body 안**에 있을 때 `foo` export를 live로 잘못 마킹하는 false-positive를 제거.

## Before / After

esbuild Part-level reachability의 효과와 동등하게: 죽은 Part(= top-level statement) 안의 symbol use는 기록되지 않음 → target export도 live 되지 않음.

## 구현

1. `linker.analyzeNamespaceAccess`에 `stmt_spans: ?[]const Span` 인자 추가. 각 `ns.prop` member access 노드의 `span.start`로 `stmt_info.findStmtForPos` 이진 검색 → **각 property별 owning top-level stmt 인덱스**를 `NamespaceAccess.members[prop]`에 기록.
2. `ImportBinding`에 `namespace_used_property_stmts: ?[]const []const u32` 추가 (parallel array of `namespace_used_properties`).
3. `linker.populateNamespaceAccesses`가 importer의 `prebuilt_stmt_info`에서 stmt span을 추출해 analyze에 전달 + 결과를 arena에 복사.
4. `tree_shaker.followImport`에 `dispatch_stmt: u32` 인자 추가. namespace 브랜치에서 per-prop stmt 정보가 있으면 **dispatch된 stmt에 귀속된 property만 seedExport** (dead stmt 안의 access는 자동 배제).
5. BFS dequeue에서 `item.stmt`를 dispatch로 전달.

`maxInt(u32)` sentinel과 null stmt 정보는 기존 전체 seed 동작을 유지 (호환성).

## Fixpoint 안정성

Reachability는 monotonic (set-only) — 새 stmt가 reachable해지면 거기서 발생한 namespace access도 추가로 seed됨 → 더 많은 target export live → 추가 reachable stmt. Oscillation 없음.

## 실측 (svelte 5.55, `import { mount }` 엔트리, --minify --define:NODE_ENV=production)

| 상태 | Size | Δ |
|---|---:|---:|
| main (#1567 머지 후) | 49,262 B | — |
| **이 PR** | **47,000 B** | **-2,262 B (-4.6%)** |
| esbuild | 37,823 B | — |

누적 (#1567 전 대비): 50,223 → 47,000 B, **-3,223 B (-6.4%)**.
esbuild 대비 갭: 12,400 → 9,177 B.

`svelte.dev/e/` 에러 URL 개수: 51 → 1 (#1567의 원인이던 svelte errors.js의 미사용 export 대거 제거).

## Runtime 검증

```
$ node --input-type=module -e "$(cat zts-bundle.js)"
function
```

## 테스트

- `src/bundler/bundler_test/virtual_ns_treeshake.zig::virtual ns (#1626)`: #1627에서 기록한 버그 동작 assertion을 올바른 동작(`== null`)으로 전환
- 기존 전체 테스트 통과 (`zig build test`)

## 한계 / Follow-up

- 함수가 아닌 **다른 scope**(예: `if (false) { e.foo(); }` dead branch) 안의 access는 여전히 owning top-level statement span에 포함되므로 seed된다. esbuild는 constant folding 전/후 Part를 재평가하지만, ZTS는 아직 그 수준의 dead-branch 분석 없음. 별도 이슈로 추적 가능.
- `namespace_used_property_stmts`는 `prebuilt_stmt_info`가 있는 모듈에서만 채워짐. analyzer가 stmt_info를 제공하지 않은 모듈은 fallback으로 전체 seed.

## Test plan

- [x] `zig build test` 전체 통과
- [x] svelte 번들 before/after 실측 (-2,262 B)
- [x] Runtime smoke: `node bundle.js` → `function`
- [x] `/simplify` 리뷰

## Related

- #1567 (머지됨) — pure 빌트인 생성자 화이트리스트 (-961 B)
- #1627 (머지됨) — #1626 재현 테스트
- #1603 — namespace access analysis (scope-aware)
- #1616 — scope-aware namespace tree-shaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)