### PR TITLE
fix(transpile): #1633 단일 파일 --minify-identifiers 에서 export 보존

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -33,6 +33,20 @@
 
 ---
 
+## Phase 6 semantic 확장 — 미구현 / 대체됨
+
+D053에서 "Phase 6(minifier/bundler)에서 추가"로 예정됐던 semantic 확장 항목. 번들러는 별도 자료구조로 우회 구현되어 필수 기능은 충족됐으나, 아래는 남은 갭.
+
+| # | 항목 | 상태 | 대체물 / 영향 |
+|---|------|------|---------------|
+| 61 | `Reference[]` 배열 (read/write/read_write 종류 + 정확한 위치) | ⚪ 미구현 (RFC #1634) | `reference_count`/`write_count` scalar로 대체. dead store 분석·single-use inline 등 고급 최적화 포기 |
+| 62 | `is_reassigned` / `is_read` 개별 플래그 | ⚪ 필드 자체 미추가 | `write_count`/`reference_count` scalar가 같은 정보 제공 (let const promotion, tree-shake 기준) — 실질 대체 완료 |
+| 63 | Dead store 분석 | ⚪ 미구현 | 쓰기 후 미사용 검출 불가. write_count만으로는 판별 안 됨 — per-reference 위치 배열이 선행 필요 |
+
+※ #60 (`is_exported`/`is_default_export` 세팅) 은 #1633 에서 해결됨.
+
+---
+
 ## TS 타입 전용 (d.ts 생성 시 필요)
 
 ZTS는 타입 체크를 하지 않으므로 (스트리핑만) 당장 필요하지 않음.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -284,6 +284,9 @@
 - **결정**: 최소 심볼 (name + scope_id + kind + flags + declaration_span)
 - **이유**: 재선언 검증에 필요한 최소 정보만. references(참조 추적)는 Phase 6(minifier/bundler)에서 추가
 - **SymbolKind**: var/let/const/function/class/parameter/catch_binding/import_binding (8가지). 재선언 규칙이 kind별로 다르므로 세분화
+- **D053a 이행 현황 (Phase 6 완료 후 재정리)**:
+  - **대체 구현**: 계획된 `Reference[]`(종류 + 위치 배열)는 **scalar 카운터로 대체**됨 — `reference_count`(tree-shake 기준), `write_count`(let→const promotion 기준). oxc/rolldown과 동일한 패턴. dead store 분석 같이 per-reference 위치가 필요한 최적화는 포기 (RFC #1634 에서 재도입 논의).
+  - **`is_exported`/`is_default_export` (#1633 완료)**: `analyzer.visitExportNamedDeclaration`/`visitExportDefaultDeclaration` 경로에서 대상 심볼에 세팅. 단일 파일 `--minify-identifiers` 경로의 export mangle 버그를 해소. 번들러는 여전히 `Module.export_bindings` + `linker.collectManglingCandidates` 를 entry-boundary 필터링의 권원으로 사용하며, 플래그는 단일 파일 mangler.shouldSkip 의 근거로 한정.
 
 ### D054: Strict Mode 추적
 - **결정**: 파서에서 추적 ("use strict" directive + module mode)

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -70,6 +70,11 @@ pub const LinkingMetadata = struct {
     /// named import를 namespace 접근 패턴으로 전환할 때 사용.
     /// e.g., ["__ns_0", "__ns_1"] → 호이스팅: var __ns_0, __ns_1;
     dev_ns_vars: ?[]const []const u8 = null,
+    /// true  = scope-hoisted 번들러 → codegen 이 export 키워드를 생략하고 declaration 만 출력.
+    /// false = 단일 파일 transpile — rename map 전달 목적으로만 사용, export 선언 구조 보존.
+    /// 기본값 true 는 현재 모든 생성 지점이 번들러(`buildMetadataForAst` 계열)라는 사실에
+    /// 의존한다. 비-번들러 생성 지점을 추가할 때는 반드시 false 를 명시할 것.
+    is_bundle_context: bool = true,
     allocator: std.mem.Allocator,
 
     pub const NsMemberRewrites = struct {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2882,10 +2882,13 @@ pub const Codegen = struct {
             return self.emitExportNamedCJS(decl, specs_start, specs_len, source);
         }
 
-        // 번들 모드: export 키워드 생략, declaration만 출력
-        if (self.options.linking_metadata != null and !decl.isNone()) {
-            try self.emitNode(decl);
-            return;
+        // 번들 모드: export 키워드 생략, declaration만 출력.
+        // 단일 파일 transpile 은 rename map 전달용으로만 linking_metadata 를 쓰므로 분기 제외.
+        if (self.options.linking_metadata) |lm| {
+            if (lm.is_bundle_context and !decl.isNone()) {
+                try self.emitNode(decl);
+                return;
+            }
         }
 
         try self.write("export ");
@@ -3067,28 +3070,30 @@ pub const Codegen = struct {
             try self.writeByte(';');
             return;
         }
-        // 번들 모드: export default 키워드 생략, 내부 선언만 출력
-        if (self.options.linking_metadata != null) {
-            const inner = node.data.unary.operand;
-            if (!inner.isNone()) {
-                const inner_node = self.ast.getNode(inner);
-                // 이름이 있는 function/class → 그대로 출력
-                const is_named_decl = (inner_node.tag == .function_declaration or inner_node.tag == .class_declaration) and
-                    !(@as(NodeIndex, @enumFromInt(self.ast.extra_data.items[inner_node.data.extra]))).isNone();
-                if (is_named_decl) {
-                    try self.emitNode(inner);
-                } else {
-                    const def_name = self.options.linking_metadata.?.default_export_name;
-                    if (!self.isExportDefaultSelfRef(inner, def_name)) {
-                        // namespace import는 실제 값이 `X_ns` 변수에 저장되므로
-                        // `def_name = X_ns;` 로 할당. 일반 케이스는 inner 표현식 직접 대입.
-                        if (!(try self.tryEmitNsVarAssignment(def_name, inner))) {
-                            try self.emitDefaultVarAssignment(def_name, inner);
+        // 번들 모드: export default 키워드 생략, 내부 선언만 출력.
+        if (self.options.linking_metadata) |lm| {
+            if (lm.is_bundle_context) {
+                const inner = node.data.unary.operand;
+                if (!inner.isNone()) {
+                    const inner_node = self.ast.getNode(inner);
+                    // 이름이 있는 function/class → 그대로 출력
+                    const is_named_decl = (inner_node.tag == .function_declaration or inner_node.tag == .class_declaration) and
+                        !(@as(NodeIndex, @enumFromInt(self.ast.extra_data.items[inner_node.data.extra]))).isNone();
+                    if (is_named_decl) {
+                        try self.emitNode(inner);
+                    } else {
+                        const def_name = lm.default_export_name;
+                        if (!self.isExportDefaultSelfRef(inner, def_name)) {
+                            // namespace import는 실제 값이 `X_ns` 변수에 저장되므로
+                            // `def_name = X_ns;` 로 할당. 일반 케이스는 inner 표현식 직접 대입.
+                            if (!(try self.tryEmitNsVarAssignment(def_name, inner))) {
+                                try self.emitDefaultVarAssignment(def_name, inner);
+                            }
                         }
                     }
                 }
+                return;
             }
-            return;
         }
         try self.write("export default ");
         const inner_idx = node.data.unary.operand;

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -793,8 +793,9 @@ pub const SemanticAnalyzer = struct {
     /// tree-shaking에서 reference_count == 0인 심볼은 미사용으로 판단할 수 있다.
     /// 글로벌 스코프까지 올라가도 못 찾으면 외부 참조(미선언 변수)로 무시한다.
     ///
-    /// Note: 번들러(Phase 6)에서는 Reference 배열도 기록하여 read/write/read_write
-    /// 종류와 정확한 위치를 추적할 예정 (dead store 분석 등).
+    /// Note: 원 계획(D053)의 per-reference 위치 배열은 미구현. `reference_count` +
+    /// `write_count` scalar로 대체되어 tree-shake/let→const promotion에는 충분하나
+    /// dead store / single-use inline 같이 위치 기반 최적화는 현재 불가 (BACKLOG #61).
     fn resolveIdentifier(self: *SemanticAnalyzer, name: []const u8, node_idx: ?u32, is_write: bool) void {
         var scope_id = self.current_scope;
 
@@ -2595,6 +2596,10 @@ pub const SemanticAnalyzer = struct {
                             if (local_node.tag != .string_literal) {
                                 const local_name = self.ast.getText(local_node.span);
                                 try self.checkExportBinding(local_name, local_node.span);
+                                // local 심볼에 is_exported 세팅 — mangler.shouldSkip 이 단일 파일
+                                // transpile 에서 이름을 보존하고, specifier 출력이 원본 이름을
+                                // 그대로 쓰더라도 참조 정합성이 유지된다.
+                                self.markSymbolExported(local_name, false);
                             }
                         }
                     }
@@ -2610,6 +2615,12 @@ pub const SemanticAnalyzer = struct {
         }
 
         try self.visitNode(decl_idx);
+
+        // visitNode 가 심볼을 생성한 뒤에야 플래그 세팅이 가능. 그 이전에는 심볼이 존재하지 않는다.
+        if (!decl_idx.isNone() and @intFromEnum(decl_idx) < self.ast.nodes.items.len) {
+            const decl_node = self.ast.getNode(decl_idx);
+            self.markExportedDeclSymbols(decl_node);
+        }
     }
 
     /// export default 시 "default" 이름을 등록한다.
@@ -2645,7 +2656,7 @@ pub const SemanticAnalyzer = struct {
                     .name = node.span, // export default 문 전체 span
                     .scope_id = module_scope,
                     .kind = .variable_const,
-                    .decl_flags = .{ .block_scoped = true, .is_const = true },
+                    .decl_flags = .{ .block_scoped = true, .is_const = true, .is_exported = true, .is_default_export = true },
                     .declaration_span = node.span,
                     .origin_scope = module_scope,
                 });
@@ -2678,6 +2689,28 @@ pub const SemanticAnalyzer = struct {
 
         // 내부 선언 순회
         try self.visitNode(inner_idx);
+
+        // needs_facade=false 경로: inner 가 named function/class/identifier 이므로 원본 이름이
+        // public default export 로 노출된다. 해당 심볼의 mangle 을 막기 위해 플래그 세팅.
+        if (!needs_facade and !inner_idx.isNone() and @intFromEnum(inner_idx) < self.ast.nodes.items.len) {
+            const inner = self.ast.getNode(inner_idx);
+            switch (inner.tag) {
+                .function_declaration, .class_declaration => {
+                    const e = inner.data.extra;
+                    if (e < self.ast.extra_data.items.len) {
+                        const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                        if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
+                            const name_node = self.ast.getNode(name_idx);
+                            self.markSymbolExported(self.ast.getText(name_node.span), true);
+                        }
+                    }
+                },
+                .identifier_reference => {
+                    self.markSymbolExported(self.ast.getText(inner.span), true);
+                },
+                else => {},
+            }
+        }
     }
 
     /// export * as name — name을 등록한다.
@@ -2748,6 +2781,91 @@ pub const SemanticAnalyzer = struct {
             const name = self.ast.getText(node.span);
             try self.registerExportedName(name, node.span);
         }
+    }
+
+    /// `export` 선언이 만든 심볼들에 `is_exported` 플래그를 세팅한다.
+    /// visitNode 로 심볼 생성이 완료된 후 호출되어야 한다.
+    ///
+    /// Note: `collectExportedDeclNames` 와 동일한 AST 구조 (variable_declaration /
+    /// function_declaration / class_declaration) 를 순회한다. 지원 대상이 바뀌면
+    /// 두 함수를 함께 갱신할 것 — 한쪽만 놓치면 이름은 exported 로 기록되는데
+    /// 심볼 플래그가 안 세팅되거나 반대의 불일치가 발생한다.
+    fn markExportedDeclSymbols(self: *SemanticAnalyzer, node: Node) void {
+        switch (node.tag) {
+            .variable_declaration => {
+                const extra_start = node.data.extra;
+                const extras = self.ast.extra_data.items;
+                if (extra_start + 2 >= extras.len) return;
+                const decl_start = extras[extra_start + 1];
+                const decl_len = extras[extra_start + 2];
+                if (decl_start + decl_len > extras.len) return;
+                for (extras[decl_start .. decl_start + decl_len]) |raw_idx| {
+                    const decl_idx: NodeIndex = @enumFromInt(raw_idx);
+                    if (decl_idx.isNone() or @intFromEnum(decl_idx) >= self.ast.nodes.items.len) continue;
+                    const decl_node = self.ast.getNode(decl_idx);
+                    if (decl_node.tag == .variable_declarator) {
+                        const binding_idx: NodeIndex = @enumFromInt(extras[decl_node.data.extra]);
+                        self.markExportedBinding(binding_idx);
+                    }
+                }
+            },
+            .function_declaration, .class_declaration => {
+                const extras = self.ast.extra_data.items;
+                if (node.data.extra >= extras.len) return;
+                const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);
+                if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
+                    const name_node = self.ast.getNode(name_idx);
+                    const name = self.ast.getText(name_node.span);
+                    self.markSymbolExported(name, false);
+                }
+            },
+            else => {},
+        }
+    }
+
+    /// 바인딩 패턴을 재귀 순회하며 식별자 심볼에 `is_exported` 세팅.
+    /// destructuring export 지원 (`export const { a, b } = obj`). 지원 태그는
+    /// `registerBinding` 의 부분집합 — assignment_target_* 은 export 가 아니므로 제외.
+    fn markExportedBinding(self: *SemanticAnalyzer, idx: NodeIndex) void {
+        if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return;
+        const node = self.ast.getNode(idx);
+        switch (node.tag) {
+            .binding_identifier => {
+                const name = self.ast.getText(node.span);
+                self.markSymbolExported(name, false);
+            },
+            .array_pattern, .object_pattern => {
+                const split = self.ast.nodeListSplitRest(node.data.list);
+                for (split.elements) |raw_idx| {
+                    self.markExportedBinding(@enumFromInt(raw_idx));
+                }
+                if (split.rest_operand) |op| self.markExportedBinding(op);
+            },
+            .binding_property => {
+                // binary: { left = key, right = value (binding) }
+                self.markExportedBinding(node.data.binary.right);
+            },
+            .assignment_pattern => {
+                // binary: { left = binding, right = default_value }
+                self.markExportedBinding(node.data.binary.left);
+            },
+            else => {},
+        }
+    }
+
+    /// module scope 에서 `name` 심볼을 찾아 export 플래그를 세팅한다.
+    /// `is_default` true 이면 `is_default_export` 도 함께 세팅.
+    /// 찾지 못하면 no-op — `export { x } from 'mod'` 처럼 local binding 이 없는 재export,
+    /// 또는 import binding 만 있는 이름이 대상일 수 있다.
+    fn markSymbolExported(self: *SemanticAnalyzer, name: []const u8, is_default: bool) void {
+        const module_scope = self.findVarScope();
+        if (module_scope.isNone()) return;
+        const scope_idx = module_scope.toIndex();
+        if (scope_idx >= self.scope_maps.items.len) return;
+        const sym_idx = self.scope_maps.items[scope_idx].get(name) orelse return;
+        if (sym_idx >= self.symbols.items.len) return;
+        self.symbols.items[sym_idx].decl_flags.is_exported = true;
+        if (is_default) self.symbols.items[sym_idx].decl_flags.is_default_export = true;
     }
 
     /// 내보낸 이름을 등록한다. JS에서 중복이면 에러, TS에서는 허용 (oxc 동일).

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -119,9 +119,11 @@ pub const DeclFlags = packed struct(u16) {
     is_catch_binding: bool = false,
     /// import binding
     is_import: bool = false,
-    /// export된 심볼
+    /// export 된 top-level 심볼. `analyzer.visitExportNamedDeclaration` /
+    /// `visitExportDefaultDeclaration` 에서 세팅. `mangler.shouldSkip` 이 단일 파일 transpile
+    /// 에서 이름 보존 근거로 소비. 번들러는 `Module.export_bindings` 로 entry-boundary 를 별도 관리.
     is_exported: bool = false,
-    /// export default
+    /// `export default` 대상. `is_exported` 와 함께 세팅됨.
     is_default_export: bool = false,
     /// @__NO_SIDE_EFFECTS__ 어노테이션 — 이 함수의 모든 호출이 pure
     no_side_effects: bool = false,

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -362,6 +362,8 @@ pub fn transpileWithCallback(
                 analyzer.symbol_ids.items
             else
                 &.{},
+            // 단일 파일 transpile: codegen 의 scope-hoisted 전용 분기를 타지 않도록 false.
+            .is_bundle_context = false,
             .allocator = arena_alloc,
         };
     }

--- a/tests/integration/tests/export-preserve-minify.test.ts
+++ b/tests/integration/tests/export-preserve-minify.test.ts
@@ -1,0 +1,81 @@
+/// #1633 회귀 가드:
+/// `zts <file> --minify-identifiers` (단일 파일 transpile) 경로에서
+/// export 심볼의 이름과 `export` 키워드가 보존되어야 한다.
+/// 번들러 경로(scope hoisting)와 구분된다 — 번들러는 export 키워드를 생략해도 맞음.
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runZts } from "./helpers";
+
+async function transpileMinify(src: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "zts-1633-"));
+  const file = join(dir, "t.ts");
+  writeFileSync(file, src);
+  try {
+    const { stdout, exitCode, stderr } = await runZts([file, "--minify-identifiers"]);
+    if (exitCode !== 0) throw new Error(`zts failed: ${stderr}`);
+    return stdout;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("#1633: 단일 파일 --minify-identifiers export 보존", () => {
+  test("export function 이름 + 키워드 보존", async () => {
+    const out = await transpileMinify("export function myPublicApi(x) { return x*2; }");
+    expect(out).toContain("export function myPublicApi");
+  });
+
+  test("export const / export let 이름 + 키워드 보존", async () => {
+    const out = await transpileMinify(
+      "export const THRESHOLD = 100; export let mutableExport = 0;",
+    );
+    expect(out).toContain("export const THRESHOLD");
+    expect(out).toContain("export let mutableExport");
+  });
+
+  test("export default function named — 이름 + 키워드 보존", async () => {
+    const out = await transpileMinify("export default function defaultFn(){ return 42; }");
+    expect(out).toContain("export default function defaultFn");
+  });
+
+  test("export class 이름 + 키워드 보존", async () => {
+    const out = await transpileMinify("export class MyExportedClass { method(){ return 'hi'; } }");
+    expect(out).toContain("export class MyExportedClass");
+  });
+
+  test("export { local } — specifier 심볼이 mangle되지 않아 참조 정합", async () => {
+    const out = await transpileMinify("function myLocal(){ return 1; } export { myLocal };");
+    // local 선언도 export specifier도 원본 이름 유지
+    expect(out).toContain("function myLocal");
+    expect(out).toContain("export { myLocal }");
+  });
+
+  test("export { local as publicName } — rename specifier도 정합", async () => {
+    const out = await transpileMinify(
+      "const originalName = 42; export { originalName as publicName };",
+    );
+    expect(out).toContain("const originalName");
+    expect(out).toContain("export { originalName as publicName }");
+  });
+
+  test("exported 심볼만 보존, 내부 심볼은 여전히 mangle", async () => {
+    const out = await transpileMinify(
+      "function helperLocal(){return 1;} export const THRESHOLD = helperLocal();",
+    );
+    // 내부 함수는 짧은 이름으로 mangle
+    expect(out).not.toContain("function helperLocal");
+    // export const 이름은 보존
+    expect(out).toContain("export const THRESHOLD");
+  });
+
+  test("exported function 내부 nested는 여전히 mangle", async () => {
+    const out = await transpileMinify(
+      "export function api() { function internalHelper() { return 42; } return internalHelper(); }",
+    );
+    expect(out).toContain("export function api");
+    expect(out).not.toContain("internalHelper");
+  });
+});


### PR DESCRIPTION
## Summary

- `zts <file> --minify-identifiers` 경로에서 export 심볼의 이름과 `export` 키워드가 깨지던 버그 수정 (#1633). 번들러 경로 영향 없음.
- 두 개의 독립된 원인: (A) `is_exported` 플래그 dead placeholder + (B) codegen 의 번들/단일 파일 분기 부재. 둘 다 수정.
- 재현 케이스 8개 통합 테스트로 회귀 가드.

## 변경 사항

### A. analyzer 에서 `is_exported` / `is_default_export` 플래그 세팅
- `src/semantic/analyzer.zig`: `visitExportNamedDeclaration`, `visitExportDefaultDeclaration` 이후 대상 심볼에 플래그 세팅.
- `export function/const/let/class`, `export default function named`, `export default someVar`, `export { local }`, `export { local as public }`, destructuring export 전부 커버.
- 헬퍼 3개 추가: `markExportedDeclSymbols`, `markExportedBinding`, `markSymbolExported`.
- `src/semantic/symbol.zig`: dead placeholder 였던 플래그의 주석을 실제 사용처로 갱신.

### B. codegen 에 번들/단일파일 분기 구분
- `src/bundler/linker.zig`: `LinkingMetadata` 에 `is_bundle_context: bool = true` 필드 추가.
- `src/codegen/codegen.zig`: `emitExportNamed` / `emitExportDefault` 의 export 키워드 drop 분기가 `is_bundle_context` 를 추가 조건으로 사용.
- `src/transpile.zig`: 단일 파일 경로에서 `is_bundle_context = false` 명시.

### C (스킵됨)
- `emitExportSpecifier` 의 rename map 조회는 **필요 없음**. A 로 local 심볼이 mangle 되지 않으므로 원본 텍스트 출력이 자연스럽게 정합 유지.

### 문서
- `docs/BACKLOG.md`: #60 해결 표시. #61-#63 (Reference 배열, dead store 등) 잔여 항목 유지.
- `docs/DECISIONS.md` D053: 이행 현황 갱신 (RFC #1634 참조).

## Test plan

- [x] `zig build test` 전체 통과
- [x] `cd tests/integration && bun test tests/export-preserve-minify.test.ts` 8/8 pass (신규)
- [x] `bun test tests/mangler-minify.test.ts` 2/2 pass (회귀)
- [x] `bun test tests/bundle-smoke.test.ts` 139/139 pass (번들러 회귀 없음)
- [x] `cd tests/benchmark && bun run smoke.ts --filter=svelte` 5/5 MATCH, 사이즈 baseline 유지
- [x] 6개 재현 케이스 CLI 수동 검증:
  - `export function myPublicApi(x)` → `export function myPublicApi(x)` ✅
  - `export const THRESHOLD = 100; export let x = 0;` → 보존 ✅
  - `export default function defaultFn()` → `export default function defaultFn()` ✅
  - `export class MyExportedClass` → `export class MyExportedClass` ✅
  - `function myLocal; export { myLocal };` → 원본 이름 + specifier 정합 ✅
  - `const originalName; export { originalName as publicName };` → 정합 ✅
- [x] 내부 심볼은 여전히 mangle 확인:
  - `export function api() { function internalHelper(){} return internalHelper(); }` → `internalHelper` → `e` ✅

## 관련

- Closes #1633
- 선행 논의: #1634 RFC (per-reference array 재도입, 본 수정과 독립된 장기 설계)
- BACKLOG: #60 해결, #61-#63 잔여

🤖 Generated with [Claude Code](https://claude.com/claude-code)