### PR TITLE
feat(semantic): #1634 per-reference 배열 재도입 (PR1/4 — 필드 추가)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -134,6 +134,12 @@ pub const SemanticAnalyzer = struct {
     /// (symbol_index, reference_scope_id) — liveness BitSet 계산에 사용.
     ref_scope_pairs: std.ArrayList(symbol_mod.RefScopePair),
 
+    /// per-reference 배열. resolveIdentifier에서 symbol resolve 성공 시 기록.
+    /// node_index가 없는 경로(predeclared 보충 등)는 건너뛴다 — 즉 `Symbol.reference_count`
+    /// 가 항상 authoritative 하고, 이 배열은 위치 기반 최적화(mangler liveness, dead store
+    /// 분석, single-use inline 등) consumer의 입력.
+    references: std.ArrayList(symbol_mod.Reference),
+
     /// Annex B: if/else/labeled body에서 function declaration을 만나면
     /// var hoisting conflict check를 건너뛴다.
     /// sloppy mode에서 `if (true) function f() {}` 같은 구문이 let/const와 충돌하지 않도록 한다.
@@ -203,6 +209,7 @@ pub const SemanticAnalyzer = struct {
             .unresolved_references = std.StringHashMap(void).init(allocator),
             .symbol_ids = .empty,
             .ref_scope_pairs = .empty,
+            .references = .empty,
             .errors = .empty,
             .allocator = allocator,
         };
@@ -230,6 +237,7 @@ pub const SemanticAnalyzer = struct {
         self.errors.deinit(self.allocator);
         self.symbol_ids.deinit(self.allocator);
         self.ref_scope_pairs.deinit(self.allocator);
+        self.references.deinit(self.allocator);
         // StmtInfo 사전 수집 데이터 해제
         for (self.stmt_declared.items) |*b| b.deinit(self.allocator);
         self.stmt_declared.deinit(self.allocator);
@@ -254,6 +262,10 @@ pub const SemanticAnalyzer = struct {
         try self.symbol_ids.ensureTotalCapacity(self.allocator, self.ast.nodes.items.len);
         self.symbol_ids.items.len = self.ast.nodes.items.len;
         @memset(self.symbol_ids.items, null);
+
+        // references capacity hint: 경험적으로 참조는 노드 수의 ~25% 정도.
+        // 하한을 미리 확보해 growth realloc 횟수를 줄인다 (measured ~11회 → ~2회).
+        try self.references.ensureTotalCapacity(self.allocator, self.ast.nodes.items.len / 4);
 
         const root_idx: NodeIndex = @enumFromInt(@as(u32, @intCast(self.ast.nodes.items.len - 1)));
         try self.visitNode(root_idx);
@@ -793,9 +805,6 @@ pub const SemanticAnalyzer = struct {
     /// tree-shaking에서 reference_count == 0인 심볼은 미사용으로 판단할 수 있다.
     /// 글로벌 스코프까지 올라가도 못 찾으면 외부 참조(미선언 변수)로 무시한다.
     ///
-    /// Note: 원 계획(D053)의 per-reference 위치 배열은 미구현. `reference_count` +
-    /// `write_count` scalar로 대체되어 tree-shake/let→const promotion에는 충분하나
-    /// dead store / single-use inline 같이 위치 기반 최적화는 현재 불가 (BACKLOG #61).
     fn resolveIdentifier(self: *SemanticAnalyzer, name: []const u8, node_idx: ?u32, is_write: bool) void {
         var scope_id = self.current_scope;
 
@@ -818,6 +827,12 @@ pub const SemanticAnalyzer = struct {
                     if (ni < self.symbol_ids.items.len) {
                         self.symbol_ids.items[ni] = @intCast(sym_idx);
                     }
+                    self.references.append(self.allocator, .{
+                        .node_index = @enumFromInt(ni),
+                        .scope_id = self.current_scope,
+                        .symbol_id = @enumFromInt(sym_idx),
+                        .kind = if (is_write) .write else .read,
+                    }) catch {};
                 }
 
                 // StmtInfo 사전 수집: 현재 top-level statement가 참조하는 심볼 기록

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1260,3 +1260,124 @@ test "ClassExpression: name scoped to class body — not visible outside (#1592)
     }
     try std.testing.expect(false);
 }
+
+// ============================================================
+// per-reference 배열 (references) 테스트
+// ============================================================
+
+const RefFixture = struct {
+    scanner: Scanner,
+    parser: Parser,
+    ana: SemanticAnalyzer,
+
+    fn init(source: []const u8) !RefFixture {
+        var scanner = try Scanner.init(std.testing.allocator, source);
+        errdefer scanner.deinit();
+        var parser = Parser.init(std.testing.allocator, &scanner);
+        errdefer parser.deinit();
+        _ = try parser.parse();
+        var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+        errdefer ana.deinit();
+        try ana.analyze();
+        return .{ .scanner = scanner, .parser = parser, .ana = ana };
+    }
+
+    fn deinit(self: *RefFixture) void {
+        self.ana.deinit();
+        self.parser.deinit();
+        self.scanner.deinit();
+    }
+
+    /// 주어진 이름으로 선언된 심볼을 가리키는 references 항목만 필터.
+    fn collectRefs(self: *const RefFixture, target_name: []const u8, out: *std.ArrayList(symbol_mod.Reference)) !void {
+        for (self.ana.references.items) |r| {
+            const sym_idx = @intFromEnum(r.symbol_id);
+            if (sym_idx >= self.ana.symbols.items.len) continue;
+            const name = self.ana.symbols.items[sym_idx].nameText(self.parser.ast.source);
+            if (std.mem.eql(u8, name, target_name)) {
+                try out.append(std.testing.allocator, r);
+            }
+        }
+    }
+};
+
+test "references: read + write 각각 기록" {
+    var fx = try RefFixture.init("let x = 1; x = 2; f(x);");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("x", &refs);
+
+    try std.testing.expectEqual(@as(usize, 2), refs.items.len);
+    var write_seen: usize = 0;
+    var read_seen: usize = 0;
+    for (refs.items) |r| switch (r.kind) {
+        .write => write_seen += 1,
+        .read => read_seen += 1,
+        .read_write => {},
+    };
+    try std.testing.expectEqual(@as(usize, 1), write_seen);
+    try std.testing.expectEqual(@as(usize, 1), read_seen);
+}
+
+test "references: node_index 로 AST 위치 역참조" {
+    var fx = try RefFixture.init("const y = 1; g(y);");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("y", &refs);
+
+    try std.testing.expectEqual(@as(usize, 1), refs.items.len);
+    const node = fx.parser.ast.getNode(refs.items[0].node_index);
+    const text = fx.parser.ast.source[node.span.start..node.span.end];
+    try std.testing.expectEqualStrings("y", text);
+    try std.testing.expectEqual(symbol_mod.ReferenceKind.read, refs.items[0].kind);
+}
+
+test "references: unresolved (전역) 은 기록 안 됨" {
+    var fx = try RefFixture.init("console.log(1);");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("console", &refs);
+
+    try std.testing.expectEqual(@as(usize, 0), refs.items.len);
+}
+
+test "references: reference_count 와 정합" {
+    var fx = try RefFixture.init("const x = 1; f(x); g(x); h(x);");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("x", &refs);
+
+    try std.testing.expectEqual(@as(usize, 3), refs.items.len);
+    for (refs.items) |r| try std.testing.expectEqual(symbol_mod.ReferenceKind.read, r.kind);
+
+    for (fx.ana.symbols.items) |sym| {
+        const name = sym.nameText(fx.parser.ast.source);
+        if (std.mem.eql(u8, name, "x")) {
+            try std.testing.expectEqual(@as(u32, 3), sym.reference_count);
+        }
+    }
+}
+
+test "references: scope_id 가 참조 발생 위치" {
+    // inner block 에서 outer let 참조 — 기록된 scope_id 는 block scope여야 함.
+    var fx = try RefFixture.init("let x = 1; { f(x); }");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("x", &refs);
+
+    try std.testing.expectEqual(@as(usize, 1), refs.items.len);
+    // x 가 선언된 scope 는 program scope (첫 번째). 참조는 block scope 에서 발생.
+    const ref_scope = refs.items[0].scope_id;
+    const decl_scope = fx.ana.symbols.items[@intFromEnum(refs.items[0].symbol_id)].scope_id;
+    try std.testing.expect(!std.meta.eql(ref_scope, decl_scope));
+}

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -335,6 +335,9 @@ pub const RefScopePair = struct {
 /// 참조 하나의 데이터.
 /// 식별자가 어떤 심볼을 참조하는지, read/write인지 기록한다.
 /// 번들러의 tree-shaking과 미니파이어의 dead store 분석에 사용.
+///
+/// Consumer 주의: analyzer 는 OOM 시 append 를 조용히 스킵하므로 배열이 불완전할 수 있다.
+/// "이 배열에 없으면 참조 없음" 으로 판단하지 말 것 — 존재 여부 기준은 `Symbol.reference_count`.
 pub const Reference = struct {
     /// 참조하는 AST 노드의 인덱스
     node_index: NodeIndex,
@@ -351,6 +354,9 @@ pub const Reference = struct {
 /// - read:       `f(x)`, `y = x`에서의 x
 /// - write:      `x = 1`에서의 x
 /// - read_write: `x += 1`, `x++`에서의 x
+///
+/// 현재 analyzer 는 read/write 두 종만 생성 — compound assign/update 의 read_write
+/// 세분화는 미구현(`resolveIdentifier` 가 단일 `is_write: bool` 를 받음).
 pub const ReferenceKind = enum(u2) {
     read,
     write,


### PR DESCRIPTION
## Summary

- #1634 RFC 착수. `SemanticAnalyzer` 에 `references: ArrayList(Reference)` 필드 추가
- `resolveIdentifier` 에서 symbol resolve 성공 시 `{node_index, scope_id, symbol_id, kind}` 기록
- 기존 `reference_count` / `ref_scope_pairs` / `stmt_referenced` 와 **병렬**로 동작하는 pure addition — 소비자는 후속 PR 에서 교체

## 배경

`Reference` struct 는 `src/semantic/symbol.zig:338` 에 정의되어 있으나 2026-03-21 \`/simplify\` 에서 ArrayList 저장만 제거된 상태. 2026-04-20 ROI 재실측 결과 직접 이득은 원 RFC 추정 2-5 KB 의 하단(1.7-3.1 KB) 으로 확인됐으나, `#1632` property mangle 등 다운스트림의 전제 조건이므로 재도입 착수.

## 이 PR 의 범위 (1/4)

- ✅ `references: ArrayList(Reference)` 필드 + init/deinit
- ✅ `resolveIdentifier` append 지점 (기존 코드 유지)
- ✅ `references.ensureTotalCapacity(nodes.len / 4)` capacity hint
- ✅ `Reference` doc: OOM 시 부분성 + `Symbol.reference_count` authoritative 명시
- ✅ `RefFixture` 헬퍼 + 유닛 테스트 5건 (read/write/node_index/unresolved/scope_id)

## 후속 PR

- **PR2**: `ref_scope_pairs` → `references` 투영 (mangler liveness 마이그레이션)
- **PR3**: `StmtInfo` 슬림화 (`sym_to_referencing_stmts` → `references` 투영)
- **PR4**: DECISIONS.md D053 / BACKLOG #61 close

## Test plan

- [x] `zig build` green
- [x] `zig build test` green (기존 + 신규 5건)
- [x] 131 smoke 회귀 없음 (평균 0.82x 유지, svelte-mount-min 46KB)
- [x] Debug Semantic pipeline 변화 없음 (1000 라인 1123→1125μs, 노이즈 범위)

## 메모리/성능 영향

- 추가 메모리: ~16 B/참조 × 참조 수. 5000 라인 ≈ +24 KB/모듈, 200 모듈 번들 ≈ +5 MB peak (RFC 추정치와 일치)
- Semantic pass 시간 영향 < 1% (append 1회/ref, capacity hint 로 realloc 최소화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)