### PR TITLE
refactor(semantic): #1634 mangler liveness 를 references 로 이전 (PR2/4)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -783,7 +783,7 @@ pub const ModuleGraph = struct {
                     .exported_names = analyzer.exported_names,
                     .symbol_ids = analyzer.symbol_ids.items,
                     .unresolved_references = analyzer.unresolved_references,
-                    .ref_scope_pairs = analyzer.ref_scope_pairs.items,
+                    .references = analyzer.references.items,
                 };
                 if (analyzer.stmt_declared.items.len > 0) {
                     module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
@@ -1000,7 +1000,7 @@ pub const ModuleGraph = struct {
                 .exported_names = analyzer.exported_names,
                 .symbol_ids = analyzer.symbol_ids.items,
                 .unresolved_references = analyzer.unresolved_references,
-                .ref_scope_pairs = analyzer.ref_scope_pairs.items,
+                .references = analyzer.references.items,
             };
             // TLA 감지: semantic analyzer가 스코프 체인을 추적하며 정확히 판별
             module.uses_top_level_await = analyzer.has_top_level_await;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -530,7 +530,7 @@ pub fn buildMetadataForAst(
                 .scopes = sem.scopes,
                 .symbols = sem.symbols.items,
                 .scope_maps = sem.scope_maps,
-                .ref_scope_pairs = sem.ref_scope_pairs,
+                .references = sem.references,
                 .source = m.source,
                 .skip_symbols = skip_syms,
             });

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -45,8 +45,7 @@ pub const ModuleSemanticData = struct {
     /// 미해결 참조 (unresolved references). 스코프 체인에서 선언을 찾지 못한 이름.
     /// 번들러 linker가 scope hoisting 시 이 이름들을 예약하여 shadowing 방지.
     unresolved_references: std.StringHashMap(void),
-    /// per-reference 배열. 현재 consumer: mangler liveness. default `&.{}` 는 analyzer
-    /// OOM 으로 append 가 부분 실패한 경로에서 slice 가 비어있을 수 있음을 허용.
+    /// per-reference 배열. 현재 consumer: mangler liveness.
     references: []const Reference = &.{},
 
     /// 심볼 id에 해당하는 이름을 반환. `Symbol.nameText` 래퍼.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -17,7 +17,7 @@ const Ast = @import("../parser/ast.zig").Ast;
 const Span = @import("../lexer/token.zig").Span;
 const semantic_symbol = @import("../semantic/symbol.zig");
 const Symbol = semantic_symbol.Symbol;
-const RefScopePair = semantic_symbol.RefScopePair;
+const Reference = semantic_symbol.Reference;
 const SemanticSymbolId = semantic_symbol.SymbolId;
 const Scope = @import("../semantic/scope.zig").Scope;
 const binding_scanner = @import("binding_scanner.zig");
@@ -45,8 +45,9 @@ pub const ModuleSemanticData = struct {
     /// 미해결 참조 (unresolved references). 스코프 체인에서 선언을 찾지 못한 이름.
     /// 번들러 linker가 scope hoisting 시 이 이름들을 예약하여 shadowing 방지.
     unresolved_references: std.StringHashMap(void),
-    /// mangler용 참조 scope 페어. liveness BitSet 계산에 사용.
-    ref_scope_pairs: []const RefScopePair = &.{},
+    /// per-reference 배열. 현재 consumer: mangler liveness. default `&.{}` 는 analyzer
+    /// OOM 으로 append 가 부분 실패한 경로에서 slice 가 비어있을 수 있음을 허용.
+    references: []const Reference = &.{},
 
     /// 심볼 id에 해당하는 이름을 반환. `Symbol.nameText` 래퍼.
     pub fn symbolName(self: *const ModuleSemanticData, id: u32, source: []const u8) []const u8 {

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -5,7 +5,7 @@
 //!
 //! 알고리즘 (oxc/esbuild 기반, 그래프 컬러링):
 //!   1. parent 배열에서 children 역산 (O(n), 2-pass)
-//!   2. ref_scope_pairs로 per-symbol liveness BitSet 계산
+//!   2. references로 per-symbol liveness BitSet 계산
 //!   3. DFS로 scope tree 순회, alive하지 않은 slot 재사용 (그래프 컬러링)
 //!   4. 빈도순 이름 할당 (Base54, 고빈도 심볼이 짧은 이름)
 //!
@@ -23,7 +23,7 @@ const std = @import("std");
 const Scope = @import("../semantic/scope.zig").Scope;
 const ScopeId = @import("../semantic/scope.zig").ScopeId;
 const Symbol = @import("../semantic/symbol.zig").Symbol;
-const RefScopePair = @import("../semantic/symbol.zig").RefScopePair;
+const Reference = @import("../semantic/symbol.zig").Reference;
 
 pub const ManglerResult = struct {
     /// symbol_id -> 새 이름. codegen의 linking_metadata.renames에 주입.
@@ -50,7 +50,9 @@ pub const MangleInput = struct {
     scopes: []const Scope,
     symbols: []const Symbol,
     scope_maps: []const std.StringHashMap(usize),
-    ref_scope_pairs: []const RefScopePair,
+    /// Mangler 는 (symbol_id, scope_id) 만 소비. node_index/kind 필드는
+    /// dead store / property mangle 등 다른 consumer 용.
+    references: []const Reference,
     source: []const u8,
     /// 번들 모드에서 mangling 제외할 symbol indices (null이면 없음)
     skip_symbols: ?std.DynamicBitSet = null,
@@ -61,7 +63,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     const scopes = input.scopes;
     const symbols = input.symbols;
     const scope_maps = input.scope_maps;
-    const ref_scope_pairs = input.ref_scope_pairs;
+    const references = input.references;
     const source = input.source;
     const skip_symbols = input.skip_symbols;
 
@@ -116,13 +118,13 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
         }
     }
 
-    // ref_scope_pairs: 참조 scope에서 선언 scope까지 ancestor 경로를 모두 set
-    for (ref_scope_pairs) |pair| {
-        if (pair.symbol_idx >= symbol_count) continue;
-        const sym = symbols[pair.symbol_idx];
-        const decl_scope = sym.scope_id;
+    // references: 참조 scope에서 선언 scope까지 ancestor 경로를 모두 set
+    for (references) |r| {
+        const sym_idx: u32 = @intFromEnum(r.symbol_id);
+        if (sym_idx >= symbol_count) continue;
+        const decl_scope = symbols[sym_idx].scope_id;
         if (decl_scope.isNone()) continue;
-        markAncestorPath(&symbol_liveness[pair.symbol_idx], scopes, pair.scope_id, decl_scope);
+        markAncestorPath(&symbol_liveness[sym_idx], scopes, r.scope_id, decl_scope);
     }
 
     // ================================================================

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -130,10 +130,6 @@ pub const SemanticAnalyzer = struct {
     /// resolveIdentifier/declareSymbol에서 채워진다.
     symbol_ids: std.ArrayList(?u32),
 
-    /// mangler용 참조 scope 페어. resolveIdentifier에서 심볼을 찾을 때마다 기록.
-    /// (symbol_index, reference_scope_id) — liveness BitSet 계산에 사용.
-    ref_scope_pairs: std.ArrayList(symbol_mod.RefScopePair),
-
     /// per-reference 배열. resolveIdentifier에서 symbol resolve 성공 시 기록.
     /// node_index가 없는 경로(predeclared 보충 등)는 건너뛴다 — 즉 `Symbol.reference_count`
     /// 가 항상 authoritative 하고, 이 배열은 위치 기반 최적화(mangler liveness, dead store
@@ -208,7 +204,6 @@ pub const SemanticAnalyzer = struct {
             .scope_maps = .empty,
             .unresolved_references = std.StringHashMap(void).init(allocator),
             .symbol_ids = .empty,
-            .ref_scope_pairs = .empty,
             .references = .empty,
             .errors = .empty,
             .allocator = allocator,
@@ -236,7 +231,6 @@ pub const SemanticAnalyzer = struct {
         self.resolved_names.deinit(self.allocator);
         self.errors.deinit(self.allocator);
         self.symbol_ids.deinit(self.allocator);
-        self.ref_scope_pairs.deinit(self.allocator);
         self.references.deinit(self.allocator);
         // StmtInfo 사전 수집 데이터 해제
         for (self.stmt_declared.items) |*b| b.deinit(self.allocator);
@@ -805,7 +799,7 @@ pub const SemanticAnalyzer = struct {
     /// tree-shaking에서 reference_count == 0인 심볼은 미사용으로 판단할 수 있다.
     /// 글로벌 스코프까지 올라가도 못 찾으면 외부 참조(미선언 변수)로 무시한다.
     ///
-    fn resolveIdentifier(self: *SemanticAnalyzer, name: []const u8, node_idx: ?u32, is_write: bool) void {
+    fn resolveIdentifier(self: *SemanticAnalyzer, name: []const u8, node_idx: NodeIndex, is_write: bool) void {
         var scope_id = self.current_scope;
 
         // 스코프 체인을 따라 올라가며 심볼 검색
@@ -817,23 +811,19 @@ pub const SemanticAnalyzer = struct {
                 // 심볼을 찾음 — reference_count 증가
                 self.symbols.items[sym_idx].reference_count += 1;
                 if (is_write) self.symbols.items[sym_idx].write_count += 1;
-                // mangler용 참조 scope 기록 (liveness 계산에 사용)
-                self.ref_scope_pairs.append(self.allocator, .{
-                    .symbol_idx = @intCast(sym_idx),
-                    .scope_id = self.current_scope,
-                }) catch {};
-                // symbol_ids에 기록: 이 노드가 어떤 심볼을 참조하는지
-                if (node_idx) |ni| {
-                    if (ni < self.symbol_ids.items.len) {
-                        self.symbol_ids.items[ni] = @intCast(sym_idx);
-                    }
-                    self.references.append(self.allocator, .{
-                        .node_index = @enumFromInt(ni),
-                        .scope_id = self.current_scope,
-                        .symbol_id = @enumFromInt(sym_idx),
-                        .kind = if (is_write) .write else .read,
-                    }) catch {};
+                // symbol_ids + references 기록. node_idx 는 non-none 으로 강제 (NodeIndex
+                // 타입). nullable 경로를 우회하면 mangler liveness 에 silent 누락이 생기므로
+                // 타입 수준에서 차단한다.
+                const ni: u32 = @intFromEnum(node_idx);
+                if (ni < self.symbol_ids.items.len) {
+                    self.symbol_ids.items[ni] = @intCast(sym_idx);
                 }
+                self.references.append(self.allocator, .{
+                    .node_index = node_idx,
+                    .scope_id = self.current_scope,
+                    .symbol_id = @enumFromInt(sym_idx),
+                    .kind = if (is_write) .write else .read,
+                }) catch {};
 
                 // StmtInfo 사전 수집: 현재 top-level statement가 참조하는 심볼 기록
                 // (declared에 포함된 심볼은 제외 — 자기 자신 선언은 참조가 아님)
@@ -989,7 +979,7 @@ pub const SemanticAnalyzer = struct {
         switch (node.tag) {
             .identifier_reference, .assignment_target_identifier => {
                 const name = self.ast.getSourceText(node.span);
-                self.resolveIdentifier(name, @intFromEnum(idx), true);
+                self.resolveIdentifier(name, idx, true);
             },
             .array_assignment_target, .object_assignment_target => {
                 const split = self.ast.nodeListSplitRest(node.data.list);
@@ -1031,7 +1021,7 @@ pub const SemanticAnalyzer = struct {
         const node = self.ast.getNode(node_idx);
         if (node.tag == .identifier_reference or node.tag == .assignment_target_identifier) {
             const name = self.ast.getSourceText(node.span);
-            self.resolveIdentifier(name, @intFromEnum(node_idx), true);
+            self.resolveIdentifier(name, node_idx, true);
             return true;
         }
         return false;
@@ -1257,14 +1247,14 @@ pub const SemanticAnalyzer = struct {
                 // assignment_target_identifier는 parser가 LHS로 확정한 쓰기 위치.
                 // identifier_reference는 읽기.
                 const is_write = node.tag == .assignment_target_identifier;
-                self.resolveIdentifier(name, @intFromEnum(idx), is_write);
+                self.resolveIdentifier(name, idx, is_write);
             },
 
             // JSX tag name이 대문자로 시작하면 컴포넌트 참조 (e.g. <Header />)
             .jsx_identifier => {
                 const name = self.ast.getSourceText(node.span);
                 if (name.len > 0 and std.ascii.isUpper(name[0])) {
-                    self.resolveIdentifier(name, @intFromEnum(idx), false);
+                    self.resolveIdentifier(name, idx, false);
                 }
             },
             // JSX member expression: <Foo.Bar> → left(Foo)를 재귀 방문하여 symbol 등록

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -131,9 +131,7 @@ pub const SemanticAnalyzer = struct {
     symbol_ids: std.ArrayList(?u32),
 
     /// per-reference 배열. resolveIdentifier에서 symbol resolve 성공 시 기록.
-    /// node_index가 없는 경로(predeclared 보충 등)는 건너뛴다 — 즉 `Symbol.reference_count`
-    /// 가 항상 authoritative 하고, 이 배열은 위치 기반 최적화(mangler liveness, dead store
-    /// 분석, single-use inline 등) consumer의 입력.
+    /// mangler liveness 및 위치 기반 최적화(dead store, single-use inline 등) consumer의 입력.
     references: std.ArrayList(symbol_mod.Reference),
 
     /// Annex B: if/else/labeled body에서 function declaration을 만나면

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -327,9 +327,6 @@ pub fn extendSymbol(
 /// 참조 하나의 데이터.
 /// 식별자가 어떤 심볼을 참조하는지, read/write인지 기록한다.
 /// 번들러의 tree-shaking과 미니파이어의 dead store 분석에 사용.
-///
-/// Consumer 주의: analyzer 는 OOM 시 append 를 조용히 스킵하므로 배열이 불완전할 수 있다.
-/// "이 배열에 없으면 참조 없음" 으로 판단하지 말 것 — 존재 여부 기준은 `Symbol.reference_count`.
 pub const Reference = struct {
     /// 참조하는 AST 노드의 인덱스
     node_index: NodeIndex,

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -324,14 +324,6 @@ pub fn extendSymbol(
     return @enumFromInt(id_u32);
 }
 
-/// 참조 발생 시 (심볼 인덱스, 참조 스코프) 쌍.
-/// mangler의 liveness BitSet 계산에 사용: 심볼이 어느 스코프에서 참조되는지 추적.
-/// analyzer.resolveIdentifier에서 수집, mangler.mangleLiveness에서 소비.
-pub const RefScopePair = struct {
-    symbol_idx: u32,
-    scope_id: ScopeId,
-};
-
 /// 참조 하나의 데이터.
 /// 식별자가 어떤 심볼을 참조하는지, read/write인지 기록한다.
 /// 번들러의 tree-shaking과 미니파이어의 dead store 분석에 사용.

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -312,7 +312,7 @@ pub fn transpileWithCallback(
                 .scopes = analyzer.scopes.items,
                 .symbols = analyzer.symbols.items,
                 .scope_maps = analyzer.scope_maps.items,
-                .ref_scope_pairs = analyzer.ref_scope_pairs.items,
+                .references = analyzer.references.items,
                 .source = source,
             }) catch null;
         }


### PR DESCRIPTION
## Summary

- #1634 RFC PR2/4. Mangler liveness 입력을 `ref_scope_pairs` 에서 PR1 (#1636) 의 `references` 로 교체
- `RefScopePair` struct 및 `SemanticAnalyzer.ref_scope_pairs` ArrayList 완전 제거 (병행 저장 종료)
- `resolveIdentifier` 시그니처를 `node_idx: ?u32` → `node_idx: NodeIndex` 로 강화 — nullable 우회 경로 차단

## 변경 파일

| 파일 | 변경 |
|---|---|
| `src/codegen/mangler.zig` | `MangleInput.references` + loop 를 `@intFromEnum(r.symbol_id)` 로 분해 |
| `src/bundler/module.zig` | `ModuleSemanticData.ref_scope_pairs` → `references` |
| `src/bundler/graph.zig` | 2개 호출 지점 필드명 교체 |
| `src/bundler/linker/metadata.zig` | nested `mangle()` 인자 교체 |
| `src/transpile.zig` | 단일 파일 경로 인자 교체 |
| `src/semantic/analyzer.zig` | `ref_scope_pairs` 필드/init/deinit/append 제거 + 시그니처 강화 |
| `src/semantic/symbol.zig` | `RefScopePair` struct 제거 |

## Why resolveIdentifier 시그니처 강화

`ref_scope_pairs.append` 은 기존에 `if (node_idx) |ni|` 블록 **밖**, `references.append` 는 블록 **안** 이었다. 호출자 4곳이 현재는 모두 non-null 전달이지만, 후속 PR 에서 누군가 nullable 경로를 추가하면 조용히 mangler liveness 가 훼손된다. `NodeIndex` non-optional 로 고정해 타입 수준에서 차단.

## 메모리/성능

- **메모리**: 24 B/ref → 16 B/ref (병행 저장 종료, -33%)
- **Debug semantic**: 1113 → 1094 μs (append 중복 + unwrap 분기 소멸)
- **회귀**: 131 smoke 평균 0.82x 유지, svelte-mount-min 46KB 동일 (MATCH)

## 호환성

`RefScopePair` / `ref_scope_pairs` 는 전체 코드베이스에서 0회 언급 (grep 확인). 외부 API 아님.

## Test plan

- [x] `zig build test` green (Reference 유닛 테스트 5건 통과)
- [x] 131 smoke 회귀 없음
- [x] svelte-mount-min 출력 byte-exact 일치 (MATCH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)