### PR TITLE
docs(semantic): #1634 RFC 완료 반영 (PR4/4)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -39,9 +39,9 @@ D053에서 "Phase 6(minifier/bundler)에서 추가"로 예정됐던 semantic 확
 
 | # | 항목 | 상태 | 대체물 / 영향 |
 |---|------|------|---------------|
-| 61 | `Reference[]` 배열 (read/write/read_write 종류 + 정확한 위치) | ⚪ 미구현 (RFC #1634) | `reference_count`/`write_count` scalar로 대체. dead store 분석·single-use inline 등 고급 최적화 포기 |
+| 61 | `Reference[]` 배열 (read/write 종류 + 정확한 위치) | ✅ RFC #1634 완료 | `references: ArrayList(Reference)` 재도입 (`node_index, scope_id, symbol_id, stmt_idx, kind`). mangler liveness / StmtInfo / 후속 최적화의 공통 입력. `ReferenceFlags` bitset 풍부화 (declare/type 구분) 는 별도 후속 이슈 |
 | 62 | `is_reassigned` / `is_read` 개별 플래그 | ⚪ 필드 자체 미추가 | `write_count`/`reference_count` scalar가 같은 정보 제공 (let const promotion, tree-shake 기준) — 실질 대체 완료 |
-| 63 | Dead store 분석 | ⚪ 미구현 | 쓰기 후 미사용 검출 불가. write_count만으로는 판별 안 됨 — per-reference 위치 배열이 선행 필요 |
+| 63 | Dead store 분석 | ⚪ 미구현 | #61 완료로 선행 조건 해제. per-reference 위치 + kind 로 구현 가능 — 별도 이슈 |
 
 ※ #60 (`is_exported`/`is_default_export` 세팅) 은 #1633 에서 해결됨.
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -285,8 +285,9 @@
 - **이유**: 재선언 검증에 필요한 최소 정보만. references(참조 추적)는 Phase 6(minifier/bundler)에서 추가
 - **SymbolKind**: var/let/const/function/class/parameter/catch_binding/import_binding (8가지). 재선언 규칙이 kind별로 다르므로 세분화
 - **D053a 이행 현황 (Phase 6 완료 후 재정리)**:
-  - **대체 구현**: 계획된 `Reference[]`(종류 + 위치 배열)는 **scalar 카운터로 대체**됨 — `reference_count`(tree-shake 기준), `write_count`(let→const promotion 기준). oxc/rolldown과 동일한 패턴. dead store 분석 같이 per-reference 위치가 필요한 최적화는 포기 (RFC #1634 에서 재도입 논의).
+  - **`references: ArrayList(Reference)` 재도입 (RFC #1634 완료)**: 2026-03-21 `/simplify` 에서 제거됐던 구조를 per-reference 위치 기반 최적화의 전제로 재도입. `Reference { node_index, scope_id, symbol_id, stmt_idx, kind }` — analyzer 가 resolve 성공 시 append. `reference_count`/`write_count` scalar 는 hot path O(1) 캐시로 유지. mangler liveness, `StmtInfo.referenced_symbols`, 후속 dead store/single-use inline 등이 이 배열을 소비.
   - **`is_exported`/`is_default_export` (#1633 완료)**: `analyzer.visitExportNamedDeclaration`/`visitExportDefaultDeclaration` 경로에서 대상 심볼에 세팅. 단일 파일 `--minify-identifiers` 경로의 export mangle 버그를 해소. 번들러는 여전히 `Module.export_bindings` + `linker.collectManglingCandidates` 를 entry-boundary 필터링의 권원으로 사용하며, 플래그는 단일 파일 mangler.shouldSkip 의 근거로 한정.
+  - **후속**: `ReferenceFlags` bitset 으로 풍부화 (declare/type/value 구분) 는 별도 이슈로 관리 — `stmt_declared` 까지 제거해 analyzer 가 "references 하나" 만 보유하는 이상적 구조 도달 경로.
 
 ### D054: Strict Mode 추적
 - **결정**: 파서에서 추적 ("use strict" directive + module mode)


### PR DESCRIPTION
## Summary

#1634 RFC (per-reference array 재도입) 의 마지막 단계. 문서 정리 + RFC close.

## 변경

- **`docs/DECISIONS.md` D053a**: `references` 재도입을 Phase 6 이행 현황에 기록. scalar 캐시 정책(reference_count/write_count 은 hot path 캐시로 유지) 명시. `ReferenceFlags` 풍부화(declare/type 구분)는 별도 후속 이슈로 분리한다는 점 적시.
- **`docs/BACKLOG.md` #61**: ⚪ 미구현 → ✅ 완료. #63 (dead store) 의 선행 조건(per-reference 위치) 이 해제됐음을 반영.

## RFC 시리즈 완료

| PR | 커밋 | 내용 |
|---|---|---|
| #1636 | PR1 | `references: ArrayList(Reference)` 필드 추가 (pure addition) |
| #1637 | PR2 | `ref_scope_pairs` → `references` 투영 (mangler liveness 이전) |
| #1638 | PR3 | `stmt_referenced` 중간 캐시 제거 + `Reference.stmt_idx` 도입 (decorator 등 span-외부 노드 correctness 포함) |
| 본 PR | PR4 | 문서 정리 |

## 후속

- **Reference 풍부화 (신규 이슈)**: `ReferenceFlags { read, write, declare, type, value }` bitset. `stmt_declared` 까지 references 에서 유도 → analyzer 가 "references 하나" 만 보유. TS type-only tree-shake 부산물. 계획은 [#1634 코멘트](https://github.com/ohah/zts/issues/1634#issuecomment-4276635401) 참고.
- **Minifier 백로그**: #1630 (const→var), #1632 (property mangle, per-ref 의존), BACKLOG #63 (dead store, per-ref 의존) 등.

## Test plan

- [x] 문서만 변경 — 빌드/테스트 영향 없음
- [ ] 머지 후 RFC #1634 close

🤖 Generated with [Claude Code](https://claude.com/claude-code)