### PR TITLE
refactor(semantic): #1640 ReferenceKind enum 을 ReferenceFlags bitset 으로 교체 (PR A)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -815,7 +815,7 @@ pub const SemanticAnalyzer = struct {
                     .scope_id = self.current_scope,
                     .symbol_id = @enumFromInt(sym_idx),
                     .stmt_idx = self.current_top_stmt_idx orelse symbol_mod.Reference.NO_STMT,
-                    .kind = if (is_write) .write else .read,
+                    .flags = .{ .read = !is_write, .write = is_write },
                 }) catch {};
 
                 return;

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1312,11 +1312,10 @@ test "references: read + write 각각 기록" {
     try std.testing.expectEqual(@as(usize, 2), refs.items.len);
     var write_seen: usize = 0;
     var read_seen: usize = 0;
-    for (refs.items) |r| switch (r.kind) {
-        .write => write_seen += 1,
-        .read => read_seen += 1,
-        .read_write => {},
-    };
+    for (refs.items) |r| {
+        if (r.flags.write) write_seen += 1;
+        if (r.flags.read) read_seen += 1;
+    }
     try std.testing.expectEqual(@as(usize, 1), write_seen);
     try std.testing.expectEqual(@as(usize, 1), read_seen);
 }
@@ -1333,7 +1332,7 @@ test "references: node_index 로 AST 위치 역참조" {
     const node = fx.parser.ast.getNode(refs.items[0].node_index);
     const text = fx.parser.ast.source[node.span.start..node.span.end];
     try std.testing.expectEqualStrings("y", text);
-    try std.testing.expectEqual(symbol_mod.ReferenceKind.read, refs.items[0].kind);
+    try std.testing.expect(refs.items[0].flags.read and !refs.items[0].flags.write);
 }
 
 test "references: unresolved (전역) 은 기록 안 됨" {
@@ -1356,7 +1355,7 @@ test "references: reference_count 와 정합" {
     try fx.collectRefs("x", &refs);
 
     try std.testing.expectEqual(@as(usize, 3), refs.items.len);
-    for (refs.items) |r| try std.testing.expectEqual(symbol_mod.ReferenceKind.read, r.kind);
+    for (refs.items) |r| try std.testing.expect(r.flags.read and !r.flags.write);
 
     for (fx.ana.symbols.items) |sym| {
         const name = sym.nameText(fx.parser.ast.source);

--- a/src/semantic/mod.zig
+++ b/src/semantic/mod.zig
@@ -30,7 +30,7 @@ pub const SymbolId = symbol.SymbolId;
 pub const SymbolKind = symbol.SymbolKind;
 pub const SymbolFlags = symbol.DeclFlags;
 pub const Reference = symbol.Reference;
-pub const ReferenceKind = symbol.ReferenceKind;
+pub const ReferenceFlags = symbol.ReferenceFlags;
 
 test {
     _ = analyzer;

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -7,7 +7,7 @@
 //!
 //! Reference(참조 추적)는 tree-shaking/번들러에서 활용:
 //!   - reference_count == 0 → 미사용 심볼 (tree-shaking 대상)
-//!   - ReferenceKind로 read/write 구분 (dead store 분석용)
+//!   - ReferenceFlags(packed bitset)로 read/write 구분 (dead store 분석용)
 
 const std = @import("std");
 const ScopeId = @import("scope.zig").ScopeId;
@@ -338,22 +338,19 @@ pub const Reference = struct {
     /// `NO_STMT`. span 기반 역추적은 decorator 등 "stmt span 외부 노드" 에서 누락되므로
     /// analyzer 가 `current_top_stmt_idx` 를 직접 저장한다.
     stmt_idx: u32 = NO_STMT,
-    /// 참조 종류 (read/write/read_write)
-    kind: ReferenceKind,
+    /// 참조 종류 (bitset). 현재 analyzer 는 read 또는 write 한 플래그만 set 한다.
+    flags: ReferenceFlags = .{},
 
     pub const NO_STMT: u32 = std.math.maxInt(u32);
 };
 
-/// 참조 종류. 식별자가 읽기/쓰기/둘 다인지 구분.
+/// 참조 종류 플래그 (packed bitset).
 ///
-/// - read:       `f(x)`, `y = x`에서의 x
-/// - write:      `x = 1`에서의 x
-/// - read_write: `x += 1`, `x++`에서의 x
-///
-/// 현재 analyzer 는 read/write 두 종만 생성 — compound assign/update 의 read_write
-/// 세분화는 미구현(`resolveIdentifier` 가 단일 `is_write: bool` 를 받음).
-pub const ReferenceKind = enum(u2) {
-    read,
-    write,
-    read_write,
+/// 현재 analyzer 가 생성하는 조합:
+///   - `{ .read = true }`  — `f(x)`, `y = x` 등 값 읽기
+///   - `{ .write = true }` — `x = 1`, `x += 1`, `x++` (compound/update 도 현재는 write 로만 뭉뚱)
+pub const ReferenceFlags = packed struct(u8) {
+    read: bool = false,
+    write: bool = false,
+    _reserved: u6 = 0,
 };


### PR DESCRIPTION
## Summary

#1640 (Reference 풍부화) 의 1단계 — enum → packed bitset 구조 교체.

- \`ReferenceKind { read, write, read_write }\` enum 제거
- \`ReferenceFlags packed struct(u8) { read: bool, write: bool, _reserved: u6 }\` 추가
- 의미 1:1 보존 (analyzer 는 여전히 read 또는 write 한 플래그만 set)

## 왜 bitset 인가

후속 확장 여지 확보:
- compound assign \`x += 1\` → \`{read=true, write=true}\` 동시 set 으로 정확 분류
- \`declare\` 플래그 추가로 \`stmt_declared\` 제거 가능
- \`type_ref\` 플래그로 TS type-only import tree-shake

enum 으로는 조합 다양성이 제한적. oxc 의 \`ReferenceFlags\` 와 동일 방향.

## 구조

```zig
pub const ReferenceFlags = packed struct(u8) {
    read: bool = false,
    write: bool = false,
    _reserved: u6 = 0,  // declare / type_ref / value_ref 등 후속 확장 여지
};
```

## 변경 파일

| 파일 | 변경 |
|---|---|
| \`src/semantic/symbol.zig\` | \`ReferenceKind\` 삭제, \`ReferenceFlags\` 추가 |
| \`src/semantic/analyzer.zig\` | resolveIdentifier 의 flags 할당 |
| \`src/semantic/mod.zig\` | public re-export 교체 |
| \`src/semantic/analyzer_test.zig\` | flags bit 체크로 업데이트 (3곳) |

## 성능 / 메모리

- \`Reference\` struct 크기 20B 유지 (u2 enum → u8 packed 둘 다 1B + padding 동일)
- hot path (\`resolveIdentifier\` append) 중립 — const propagation 동일
- 131 smoke 평균 0.82x 유지, svelte-mount-min 46KB byte-exact

## Test plan

- [x] \`zig build test\` green (기존 references 테스트 3건 포함)
- [x] 131 smoke 회귀 없음

## 후속

- **PR B**: \`declare\` 플래그 추가 + \`stmt_declared\` 제거 → analyzer 가 "references 하나" 보유
- **PR C**: compound/update 참조의 \`{read, write}\` 정확 분류
- 별도 이슈: TS type-only tree-shake (\`type_ref\` 플래그)

🤖 Generated with [Claude Code](https://claude.com/claude-code)