### PR TITLE
refactor(semantic): #1640 stmt_declared 중간 캐시 제거 — references.declare flag 로 통합 (PR B)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -785,12 +785,11 @@ pub const ModuleGraph = struct {
                     .unresolved_references = analyzer.unresolved_references,
                     .references = analyzer.references.items,
                 };
-                if (analyzer.stmt_declared.items.len > 0) {
+                if (analyzer.stmt_info_count > 0) {
                     module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
                         arena_alloc,
                         &(module.ast.?),
                         analyzer.symbols.items,
-                        analyzer.stmt_declared.items,
                         analyzer.references.items,
                         if (module.semantic) |*s| &s.unresolved_references else null,
                     ) catch null;
@@ -1007,12 +1006,11 @@ pub const ModuleGraph = struct {
 
             // Semantic Analyzer에서 사전 수집한 stmt↔symbol 매핑으로 StmtInfo 구축.
             // tree_shaker가 AST를 다시 순회하지 않아도 된다 (Phase 2 최적화).
-            if (analyzer.stmt_declared.items.len > 0) {
+            if (analyzer.stmt_info_count > 0) {
                 module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
                     arena_alloc,
                     &parser.ast,
                     analyzer.symbols.items,
-                    analyzer.stmt_declared.items,
                     analyzer.references.items,
                     if (module.semantic) |*s| &s.unresolved_references else null,
                 ) catch null;

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -204,14 +204,38 @@ fn buildReverseIndex(allocator: std.mem.Allocator, stmts: []const StmtInfo, sym_
     };
 }
 
-/// Semantic Analyzer에서 사전 수집한 데이터로 ModuleStmtInfos를 구축한다.
-/// - declared: analyzer 의 `stmt_declared` 에서 그대로 복사 (top-level 선언)
-/// - referenced: `references` 배열을 순회해 stmt 단위로 재구성 (`findStmtForPos` 로 역추적)
+/// bucket 을 in-place sort + dedupe 하고, `exclude_sorted` (정렬된 제외 심볼 목록) 와
+/// two-pointer merge 로 교집합을 제거한 slice 를 반환. 결과가 비면 null.
+/// buildFromSemantic Pass 3a/3b 공통 경로. declared 이미 정렬돼 있어 O(N+M).
+fn finalizeBucket(
+    allocator: std.mem.Allocator,
+    bucket: *std.ArrayListUnmanaged(u32),
+    exclude_sorted: []const u32,
+) !?[]const u32 {
+    if (bucket.items.len == 0) return null;
+    std.mem.sort(u32, bucket.items, {}, std.sort.asc(u32));
+
+    var out_len: usize = 0;
+    var last: ?u32 = null;
+    var j: usize = 0;
+    for (bucket.items) |sym| {
+        if (last != null and last.? == sym) continue;
+        last = sym;
+        while (j < exclude_sorted.len and exclude_sorted[j] < sym) : (j += 1) {}
+        if (j < exclude_sorted.len and exclude_sorted[j] == sym) continue;
+        bucket.items[out_len] = sym;
+        out_len += 1;
+    }
+    if (out_len == 0) return null;
+    return try allocator.dupe(u32, bucket.items[0..out_len]);
+}
+
+/// Semantic Analyzer 의 `references` 배열로부터 ModuleStmtInfos 를 구축한다.
+/// declare/read/write 플래그로 stmt 단위 선언·참조 bucket 을 분배 (analyzer 는 중간 캐시를 유지하지 않음).
 pub fn buildFromSemantic(
     allocator: std.mem.Allocator,
     ast: *const Ast,
     symbols: []const Symbol,
-    stmt_declared: []const std.ArrayListUnmanaged(u32),
     references: []const Reference,
     unresolved_globals: ?*const purity.GlobalRefSet,
 ) !?ModuleStmtInfos {
@@ -226,7 +250,6 @@ pub fn buildFromSemantic(
     const stmt_raw_indices = ast.extra_data.items[list.start .. list.start + list.len];
 
     const stmt_count = stmt_raw_indices.len;
-    if (stmt_count != stmt_declared.len) return null;
 
     var stmts = try allocator.alloc(StmtInfo, stmt_count);
     errdefer {
@@ -241,22 +264,17 @@ pub fn buildFromSemantic(
     errdefer allocator.free(sym_to_stmt);
     for (sym_to_stmt) |*s| s.* = null;
 
-    // Pass 1: declared + span + side-effect 결정. referenced 는 빈 상태로 초기화.
+    // Pass 1: span + side-effect 결정. declared/referenced 는 빈 상태로 초기화.
     for (stmt_raw_indices, 0..) |raw_idx, stmt_i| {
         const idx: NodeIndex = @enumFromInt(raw_idx);
         const ni = @intFromEnum(idx);
-
-        const declared = if (stmt_declared[stmt_i].items.len > 0)
-            try allocator.dupe(u32, stmt_declared[stmt_i].items)
-        else
-            &[_]u32{};
 
         if (ni >= ast.nodes.items.len) {
             stmts[stmt_i] = .{
                 .node_idx = @intCast(ni),
                 .span = .{ .start = 0, .end = 0 },
                 .has_side_effects = true,
-                .declared_symbols = declared,
+                .declared_symbols = &[_]u32{},
                 .referenced_symbols = &[_]u32{},
             };
         } else {
@@ -266,55 +284,56 @@ pub fn buildFromSemantic(
                 .node_idx = @intCast(ni),
                 .span = node.span,
                 .has_side_effects = side_effects,
-                .declared_symbols = declared,
+                .declared_symbols = &[_]u32{},
                 .referenced_symbols = &[_]u32{},
             };
         }
-
-        for (declared) |sym_idx| {
-            if (sym_idx < sym_to_stmt.len) {
-                sym_to_stmt[sym_idx] = @intCast(stmt_i);
-            }
-        }
     }
 
-    // Pass 2: references → per-stmt bucket 분배. analyzer 가 이미 `stmt_idx` 를 기록했으므로
-    // span 기반 역추적은 불필요 (decorator 등 stmt span 외부 노드 누락을 방지).
-    var buckets = try allocator.alloc(std.ArrayListUnmanaged(u32), stmt_count);
+    // Pass 2: references → declared/referenced per-stmt bucket 분배.
+    var declared_buckets = try allocator.alloc(std.ArrayListUnmanaged(u32), stmt_count);
     defer {
-        for (buckets) |*b| b.deinit(allocator);
-        allocator.free(buckets);
+        for (declared_buckets) |*b| b.deinit(allocator);
+        allocator.free(declared_buckets);
     }
-    for (buckets) |*b| b.* = .empty;
+    for (declared_buckets) |*b| b.* = .empty;
+
+    var referenced_buckets = try allocator.alloc(std.ArrayListUnmanaged(u32), stmt_count);
+    defer {
+        for (referenced_buckets) |*b| b.deinit(allocator);
+        allocator.free(referenced_buckets);
+    }
+    for (referenced_buckets) |*b| b.* = .empty;
 
     for (references) |r| {
         if (r.stmt_idx == Reference.NO_STMT) continue;
         if (r.stmt_idx >= stmt_count) continue;
         const sym_u32: u32 = @intFromEnum(r.symbol_id);
         if (sym_u32 >= symbols.len) continue;
-        try buckets[r.stmt_idx].append(allocator, sym_u32);
+        if (r.flags.declare) {
+            try declared_buckets[r.stmt_idx].append(allocator, sym_u32);
+        } else {
+            try referenced_buckets[r.stmt_idx].append(allocator, sym_u32);
+        }
     }
 
-    // Pass 3: bucket 을 sort + dedupe + (같은 stmt 의 declared 제외) → stmts[i].referenced_symbols.
+    // Pass 3a: declared bucket → sort + dedupe → stmts[i].declared_symbols + sym_to_stmt 역매핑.
     for (0..stmt_count) |stmt_i| {
-        const bucket = &buckets[stmt_i];
-        if (bucket.items.len == 0) continue;
-
-        std.mem.sort(u32, bucket.items, {}, std.sort.asc(u32));
-
-        const declared = stmts[stmt_i].declared_symbols;
-        var out_len: usize = 0;
-        var last: ?u32 = null;
-        for (bucket.items) |sym| {
-            if (last != null and last.? == sym) continue;
-            last = sym;
-            if (declared.len != 0 and std.mem.indexOfScalar(u32, declared, sym) != null) continue;
-            bucket.items[out_len] = sym;
-            out_len += 1;
+        const bucket = &declared_buckets[stmt_i];
+        const declared_slice = (try finalizeBucket(allocator, bucket, &[_]u32{})) orelse continue;
+        stmts[stmt_i].declared_symbols = declared_slice;
+        for (declared_slice) |sym_idx| {
+            if (sym_idx < sym_to_stmt.len) {
+                sym_to_stmt[sym_idx] = @intCast(stmt_i);
+            }
         }
-        if (out_len == 0) continue;
+    }
 
-        stmts[stmt_i].referenced_symbols = try allocator.dupe(u32, bucket.items[0..out_len]);
+    // Pass 3b: referenced bucket → sort + dedupe + (같은 stmt 의 declared 제외) → stmts[i].referenced_symbols.
+    for (0..stmt_count) |stmt_i| {
+        const bucket = &referenced_buckets[stmt_i];
+        const slice = (try finalizeBucket(allocator, bucket, stmts[stmt_i].declared_symbols)) orelse continue;
+        stmts[stmt_i].referenced_symbols = slice;
     }
 
     // 역인덱스 구축 (buildReverseIndex 재사용)

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -153,9 +153,6 @@ pub const SemanticAnalyzer = struct {
     current_top_stmt_idx: ?u32 = null,
     /// top-level statement 개수 (초기화 완료 후 유효)
     stmt_info_count: u32 = 0,
-    /// Per-statement 선언 심볼 (top-level scope에 선언된 것만).
-    /// 참조 심볼은 `references` 에서 `buildFromSemantic` 이 재구성 — analyzer 는 미리 그룹핑하지 않는다.
-    stmt_declared: std.ArrayListUnmanaged(std.ArrayListUnmanaged(u32)) = .empty,
 
     const PrivateUsage = enum { read, write };
 
@@ -227,9 +224,6 @@ pub const SemanticAnalyzer = struct {
         self.errors.deinit(self.allocator);
         self.symbol_ids.deinit(self.allocator);
         self.references.deinit(self.allocator);
-        // StmtInfo 사전 수집 데이터 해제
-        for (self.stmt_declared.items) |*b| b.deinit(self.allocator);
-        self.stmt_declared.deinit(self.allocator);
         for (self.class_private_declared.items) |*map| map.deinit();
         self.class_private_declared.deinit(self.allocator);
         for (self.class_private_refs.items) |*list| list.deinit(self.allocator);
@@ -625,16 +619,24 @@ pub const SemanticAnalyzer = struct {
             try self.scope_maps.items[target_scope.toIndex()].put(name_text, sym_index);
         }
 
-        // StmtInfo 사전 수집: top-level scope(scope_id==0)의 선언을 현재 statement에 기록
-        if (self.enable_stmt_info and self.current_top_stmt_idx != null and @intFromEnum(target_scope) == 0) {
-            const si = self.current_top_stmt_idx.?;
-            if (si < self.stmt_declared.items.len) {
-                const sym_u32: u32 = @intCast(sym_index);
-                if (std.mem.indexOfScalar(u32, self.stmt_declared.items[si].items, sym_u32) == null) {
-                    try self.stmt_declared.items[si].append(self.allocator, sym_u32);
-                }
-            }
+        // StmtInfo 사전 수집: top-level scope(scope_id==0)의 선언을 references 에 declare 플래그로 기록.
+        if (@intFromEnum(target_scope) == 0) {
+            self.recordTopLevelDeclareRef(@intCast(sym_index));
         }
+    }
+
+    /// top-level 선언을 `references` 배열에 `flags.declare` 로 기록. enable_stmt_info + current
+    /// top-level stmt 가 있을 때만. buildFromSemantic 에서 stmt_idx 로 bucket 분배.
+    fn recordTopLevelDeclareRef(self: *SemanticAnalyzer, sym_index: u32) void {
+        if (!self.enable_stmt_info) return;
+        const stmt_idx = self.current_top_stmt_idx orelse return;
+        self.references.append(self.allocator, .{
+            .node_index = .none,
+            .scope_id = @enumFromInt(0),
+            .symbol_id = @enumFromInt(sym_index),
+            .stmt_idx = stmt_idx,
+            .flags = .{ .declare = true },
+        }) catch {};
     }
 
     /// 가장 가까운 var scope(function/global/module)를 찾는다.
@@ -857,18 +859,10 @@ pub const SemanticAnalyzer = struct {
         if (node_idx < self.symbol_ids.items.len) {
             self.symbol_ids.items[node_idx] = @intCast(sym_idx);
         }
-        // StmtInfo 사전 수집: predeclared 심볼도 declared로 기록.
-        // declareSymbolWithNode가 skip되므로 여기서 보충한다.
-        if (self.enable_stmt_info and self.current_top_stmt_idx != null) {
-            if (sym_idx < self.symbols.items.len and @intFromEnum(self.symbols.items[sym_idx].scope_id) == 0) {
-                const si = self.current_top_stmt_idx.?;
-                if (si < self.stmt_declared.items.len) {
-                    const sym_u32: u32 = @intCast(sym_idx);
-                    if (std.mem.indexOfScalar(u32, self.stmt_declared.items[si].items, sym_u32) == null) {
-                        self.stmt_declared.items[si].append(self.allocator, sym_u32) catch {};
-                    }
-                }
-            }
+        // StmtInfo 사전 수집: predeclared 심볼도 declared 로 기록.
+        // declareSymbolWithNode 가 skip 되므로 여기서 보충한다.
+        if (sym_idx < self.symbols.items.len and @intFromEnum(self.symbols.items[sym_idx].scope_id) == 0) {
+            self.recordTopLevelDeclareRef(@intCast(sym_idx));
         }
     }
 
@@ -1483,17 +1477,12 @@ pub const SemanticAnalyzer = struct {
         try self.predeclareTopLevelBindings(node.data.list);
         self.predeclared_scope = self.current_scope;
 
-        // StmtInfo 사전 수집: per-statement declared 버퍼만 초기화.
-        // referenced 는 `references` 배열에서 buildFromSemantic 이 재구성한다.
+        // StmtInfo 사전 수집: statement 개수만 기록. declared/referenced 둘 다 references 배열에서
+        // buildFromSemantic 이 재구성한다.
         if (self.enable_stmt_info) {
             const list = node.data.list;
             if (list.len > 0 and list.start + list.len <= self.ast.extra_data.items.len) {
-                const count = list.len;
-                self.stmt_info_count = count;
-                try self.stmt_declared.ensureTotalCapacity(self.allocator, count);
-                for (0..count) |_| {
-                    try self.stmt_declared.append(self.allocator, .empty);
-                }
+                self.stmt_info_count = list.len;
             }
         }
 
@@ -2638,15 +2627,9 @@ pub const SemanticAnalyzer = struct {
                 }
                 // scope_maps[0]에 "_default" 등록 — emitter/StmtInfo가 찾을 수 있도록
                 try self.scope_maps.items[module_scope.toIndex()].put("_default", sym_index);
-                // StmtInfo 사전 수집: facade 심볼을 declared로 기록
-                if (self.enable_stmt_info and self.current_top_stmt_idx != null and @intFromEnum(module_scope) == 0) {
-                    const si = self.current_top_stmt_idx.?;
-                    if (si < self.stmt_declared.items.len) {
-                        const sym_u32: u32 = @intCast(sym_index);
-                        if (std.mem.indexOfScalar(u32, self.stmt_declared.items[si].items, sym_u32) == null) {
-                            self.stmt_declared.items[si].append(self.allocator, sym_u32) catch {};
-                        }
-                    }
+                // StmtInfo 사전 수집: facade 심볼을 declared 로 기록
+                if (@intFromEnum(module_scope) == 0) {
+                    self.recordTopLevelDeclareRef(@intCast(sym_index));
                 }
                 // export default <literal> → facade 심볼에 const_value 설정
                 if (!inner_idx.isNone() and @intFromEnum(inner_idx) < self.ast.nodes.items.len) {

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1380,3 +1380,29 @@ test "references: scope_id 가 참조 발생 위치" {
     const decl_scope = fx.ana.symbols.items[@intFromEnum(refs.items[0].symbol_id)].scope_id;
     try std.testing.expect(!std.meta.eql(ref_scope, decl_scope));
 }
+
+test "references: enable_stmt_info 시 top-level 선언에 declare flag 기록" {
+    // PR B: `stmt_declared` 중간 캐시 제거 후, buildFromSemantic 이 references 의 declare flag 로
+    // declared_symbols 를 재구성하는지 검증. enable_stmt_info 꺼져 있으면 declare ref 는 생성 안 됨.
+    const source = "let x = 1; f(x);";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    ana.enable_stmt_info = true;
+    try ana.analyze();
+
+    var declare_count: usize = 0;
+    var read_count: usize = 0;
+    for (ana.references.items) |r| {
+        const sym = ana.symbols.items[@intFromEnum(r.symbol_id)];
+        if (!std.mem.eql(u8, sym.nameText(parser.ast.source), "x")) continue;
+        if (r.flags.declare) declare_count += 1;
+        if (r.flags.read) read_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), declare_count);
+    try std.testing.expectEqual(@as(usize, 1), read_count);
+}

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -347,10 +347,13 @@ pub const Reference = struct {
 /// 참조 종류 플래그 (packed bitset).
 ///
 /// 현재 analyzer 가 생성하는 조합:
-///   - `{ .read = true }`  — `f(x)`, `y = x` 등 값 읽기
-///   - `{ .write = true }` — `x = 1`, `x += 1`, `x++` (compound/update 도 현재는 write 로만 뭉뚱)
+///   - `{ .read = true }`    — `f(x)`, `y = x` 등 값 읽기
+///   - `{ .write = true }`   — `x = 1`, `x += 1`, `x++` (compound/update 도 현재는 write 로만 뭉뚱)
+///   - `{ .declare = true }` — top-level scope 선언 위치. node_index 는 NodeIndex.none
+///     (선언 span 을 Reference 에 싣지 않음 — buildFromSemantic 은 stmt_idx 로만 bucket 분배)
 pub const ReferenceFlags = packed struct(u8) {
     read: bool = false,
     write: bool = false,
-    _reserved: u6 = 0,
+    declare: bool = false,
+    _reserved: u5 = 0,
 };


### PR DESCRIPTION
## Summary

#1640 PR B — `analyzer.stmt_declared` 중간 캐시를 완전 제거하고, top-level 선언을 `references` 배열에 `flags.declare=true` 로 기록한다. analyzer 는 이제 **"references 하나"** 만 유지 (RFC #1634 의 목표 구조).

## 배경

PR A (#1641) 가 `ReferenceKind` enum → `ReferenceFlags` bitset 으로 구조를 바꿨다. bitset 이어야 했던 이유 중 하나: **선언 위치도 reference** 로 표현해야 중간 캐시(`stmt_declared`)를 references 에서 유도할 수 있기 때문. 이 PR 이 그 유도를 실행.

## 이전 구조

```zig
// analyzer 는 references 와 stmt_declared 두 벌을 유지
references: ArrayListUnmanaged(Reference)                  // 참조만
stmt_declared: ArrayListUnmanaged(ArrayListUnmanaged(u32)) // per-stmt 선언
```

- `declareSymbol` 에서 `stmt_declared[current_stmt].append(sym)` + `indexOfScalar` 로 dedupe
- `buildFromSemantic` 은 `stmt_declared` 를 복사 + references 를 bucket 분배

## 변경 구조

```zig
// analyzer 는 references 하나만 유지
references: ArrayListUnmanaged(Reference)  // 선언/참조 모두
```

- `declareSymbol` 에서 `references.append({flags.declare = true, stmt_idx})`
- `buildFromSemantic` 은 references 를 declare/read-write 플래그로 두 bucket 에 분배

## 파일별 변경

| 파일 | 변경 |
|---|---|
| `src/semantic/symbol.zig` | `ReferenceFlags.declare: bool` 추가 (_reserved u6 → u5) |
| `src/semantic/analyzer.zig` | `stmt_declared` 필드/deinit/초기화 제거, `recordTopLevelDeclareRef` 헬퍼로 3개 호출 지점 통합 (declareSymbol / registerPredeclaredSymbol / handleExportDefault) |
| `src/bundler/stmt_info.zig` | `buildFromSemantic` 시그니처에서 `stmt_declared` 인자 제거. Pass 2 에서 declare/referenced 두 bucket 에 분배. Pass 3a/3b 의 sort+dedupe 공통 로직을 `finalizeBucket` 헬퍼로 통합 — declared 제외는 정렬 상태를 활용한 **two-pointer merge** 로 O(N+M) (이전 `indexOfScalar` O(N·M) 대비 개선) |
| `src/bundler/graph.zig` | 2 곳의 호출부 갱신: `stmt_declared` 인자 제거, 조건 `stmt_info_count > 0` |
| `src/semantic/analyzer_test.zig` | `enable_stmt_info=true` 시 declare flag 기록 유닛 테스트 1건 추가 |

## 의미 동일성

- analyzer 가 declare reference 를 생성하는 조건이 기존 `stmt_declared` append 조건과 1:1 일치 (top-level scope + current_top_stmt_idx present + enable_stmt_info)
- `buildFromSemantic` 의 최종 `stmts[i].declared_symbols` 는 이전 경로와 동일한 심볼 집합을 정렬된 slice 로 산출
- mangler 등 `references` 다른 소비자는 `r.flags.read` / `r.flags.write` 만 사용 — declare flag 가 있는 reference 는 자연스럽게 스킵됨

## 성능 / 메모리

- references.len: top-level 선언 수만큼 증가 (모듈당 대개 수십~수백 entries, +24B/entry)
- 대신 `stmt_declared` 가 보유하던 per-stmt ArrayList 배열 전체 제거 (free)
- hot path: declareSymbol 의 `indexOfScalar` 중복 체크 제거로 미세 개선. references.append 1회로 단순화
- buildFromSemantic: Pass 3 의 `indexOfScalar` → two-pointer merge 로 이론적 개선
- 131 smoke 회귀 없음 (139 pass)

## Test plan

- [x] `zig build test` 통과 — declare flag 기록 유닛 테스트 1건 추가
- [x] `bun run test:smoke` 139 pass / 0 fail
- [x] semantic pipeline profile 변동 없음 (1k/5k/10k line 모두 회귀 없음)

## 후속 (PR C)

- compound assign `x += 1` / update `x++` 을 `{read=true, write=true}` 로 정확 분류 (현재는 `{write=true}` 로 뭉뚱)
- 별도 이슈 후보: TS type-only 참조 플래그 (`type_ref`) → `import type { Foo }` tree-shake

🤖 Generated with [Claude Code](https://claude.com/claude-code)