### PR TITLE
refactor(semantic): #1640 compound assign / update 를 {read, write} 로 정확 분류 (PR C)

### DIFF
--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -387,6 +387,12 @@ pub const Kind = enum(u8) {
         return self.inRange(.eq, .question2_eq);
     }
 
+    /// Compound assignment 연산자인지 (+=, -=, ... 단순 = 제외).
+    /// compound 는 LHS 를 읽고 + 연산 + 다시 쓰기 때문에 read+write 참조로 분류된다.
+    pub fn isCompoundAssignment(self: Kind) bool {
+        return self.isAssignment() and self != .eq;
+    }
+
     /// 이 토큰 뒤에 `/`가 나오면 regex로 해석해야 하는지.
     /// false면 division으로 해석.
     ///

--- a/src/lexer/token_test.zig
+++ b/src/lexer/token_test.zig
@@ -89,6 +89,14 @@ test "Kind.isAssignment" {
     try std.testing.expect(!Kind.eq2.isAssignment());
 }
 
+test "Kind.isCompoundAssignment" {
+    try std.testing.expect(!Kind.eq.isCompoundAssignment());
+    try std.testing.expect(Kind.plus_eq.isCompoundAssignment());
+    try std.testing.expect(Kind.question2_eq.isCompoundAssignment());
+    try std.testing.expect(!Kind.plus.isCompoundAssignment());
+    try std.testing.expect(!Kind.eq2.isCompoundAssignment());
+}
+
 test "Kind.slashIsRegex" {
     // 식별자/리터럴 뒤 → division (false)
     try std.testing.expect(!Kind.identifier.slashIsRegex());

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -17,7 +17,8 @@ const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
 const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
-const Span = @import("../lexer/token.zig").Span;
+const token = @import("../lexer/token.zig");
+const Span = token.Span;
 const scope_mod = @import("scope.zig");
 const ScopeId = scope_mod.ScopeId;
 const ScopeKind = scope_mod.ScopeKind;
@@ -793,7 +794,7 @@ pub const SemanticAnalyzer = struct {
     /// tree-shaking에서 reference_count == 0인 심볼은 미사용으로 판단할 수 있다.
     /// 글로벌 스코프까지 올라가도 못 찾으면 외부 참조(미선언 변수)로 무시한다.
     ///
-    fn resolveIdentifier(self: *SemanticAnalyzer, name: []const u8, node_idx: NodeIndex, is_write: bool) void {
+    fn resolveIdentifier(self: *SemanticAnalyzer, name: []const u8, node_idx: NodeIndex, flags: symbol_mod.ReferenceFlags) void {
         var scope_id = self.current_scope;
 
         // 스코프 체인을 따라 올라가며 심볼 검색
@@ -804,7 +805,7 @@ pub const SemanticAnalyzer = struct {
             if (self.scope_maps.items[idx].get(name)) |sym_idx| {
                 // 심볼을 찾음 — reference_count 증가
                 self.symbols.items[sym_idx].reference_count += 1;
-                if (is_write) self.symbols.items[sym_idx].write_count += 1;
+                if (flags.write) self.symbols.items[sym_idx].write_count += 1;
                 // symbol_ids + references 기록. node_idx 는 non-none 으로 강제 (NodeIndex
                 // 타입). nullable 경로를 우회하면 mangler liveness 에 silent 누락이 생기므로
                 // 타입 수준에서 차단한다.
@@ -817,7 +818,7 @@ pub const SemanticAnalyzer = struct {
                     .scope_id = self.current_scope,
                     .symbol_id = @enumFromInt(sym_idx),
                     .stmt_idx = self.current_top_stmt_idx orelse symbol_mod.Reference.NO_STMT,
-                    .flags = .{ .read = !is_write, .write = is_write },
+                    .flags = flags,
                 }) catch {};
 
                 return;
@@ -945,7 +946,7 @@ pub const SemanticAnalyzer = struct {
         switch (node.tag) {
             .identifier_reference, .assignment_target_identifier => {
                 const name = self.ast.getSourceText(node.span);
-                self.resolveIdentifier(name, idx, true);
+                self.resolveIdentifier(name, idx, .{ .write = true });
             },
             .array_assignment_target, .object_assignment_target => {
                 const split = self.ast.nodeListSplitRest(node.data.list);
@@ -982,12 +983,13 @@ pub const SemanticAnalyzer = struct {
 
     /// 호출자는 write 컨텍스트(assignment LHS/update operand)이므로 해결된 심볼의
     /// `write_count`를 증가시킨다. 일반 read 참조에서는 `visitNode` 경유.
-    fn tryResolveNodeAsRef(self: *SemanticAnalyzer, node_idx: NodeIndex) bool {
+    /// flags 는 호출자가 compound(`x += 1`, `x++`)인지 pure write(`x = 1`)인지 구분해 전달.
+    fn tryResolveNodeAsRef(self: *SemanticAnalyzer, node_idx: NodeIndex, flags: symbol_mod.ReferenceFlags) bool {
         if (node_idx.isNone() or @intFromEnum(node_idx) >= self.ast.nodes.items.len) return false;
         const node = self.ast.getNode(node_idx);
         if (node.tag == .identifier_reference or node.tag == .assignment_target_identifier) {
             const name = self.ast.getSourceText(node.span);
-            self.resolveIdentifier(name, node_idx, true);
+            self.resolveIdentifier(name, node_idx, flags);
             return true;
         }
         return false;
@@ -1210,17 +1212,21 @@ pub const SemanticAnalyzer = struct {
             // ---- 식별자 참조 추적 ----
             .identifier_reference, .assignment_target_identifier => {
                 const name = self.ast.getSourceText(node.span);
-                // assignment_target_identifier는 parser가 LHS로 확정한 쓰기 위치.
-                // identifier_reference는 읽기.
-                const is_write = node.tag == .assignment_target_identifier;
-                self.resolveIdentifier(name, idx, is_write);
+                // assignment_target_identifier 는 parser 가 LHS 로 확정한 pure write 위치
+                // (for-in/of LHS 등 assignment_expression 상위 분기를 거치지 않는 target).
+                // compound/update 는 각각의 분기에서 tryResolveNodeAsRef 로 flags 를 직접 지정.
+                const flags: symbol_mod.ReferenceFlags = if (node.tag == .assignment_target_identifier)
+                    .{ .write = true }
+                else
+                    .{ .read = true };
+                self.resolveIdentifier(name, idx, flags);
             },
 
             // JSX tag name이 대문자로 시작하면 컴포넌트 참조 (e.g. <Header />)
             .jsx_identifier => {
                 const name = self.ast.getSourceText(node.span);
                 if (name.len > 0 and std.ascii.isUpper(name[0])) {
-                    self.resolveIdentifier(name, idx, false);
+                    self.resolveIdentifier(name, idx, .{ .read = true });
                 }
             },
             // JSX member expression: <Foo.Bar> → left(Foo)를 재귀 방문하여 symbol 등록
@@ -1231,7 +1237,13 @@ pub const SemanticAnalyzer = struct {
             // ---- 일반 표현식 순회 (private name 참조 등을 위해) ----
             .assignment_expression => {
                 const lhs_idx = node.data.binary.left;
-                if (!self.tryResolveNodeAsRef(lhs_idx)) {
+                // operator 토큰은 binary.flags 에 저장. compound 면 LHS 는 read+write, 아니면 pure write.
+                const op_kind: token.Kind = @enumFromInt(node.data.binary.flags);
+                const lhs_flags: symbol_mod.ReferenceFlags = if (op_kind.isCompoundAssignment())
+                    .{ .read = true, .write = true }
+                else
+                    .{ .write = true };
+                if (!self.tryResolveNodeAsRef(lhs_idx, lhs_flags)) {
                     // LHS가 private_field_expression이면 write usage로 기록
                     if (!lhs_idx.isNone() and @intFromEnum(lhs_idx) < self.ast.nodes.items.len and
                         self.ast.getNode(lhs_idx).tag == .private_field_expression)
@@ -1261,7 +1273,7 @@ pub const SemanticAnalyzer = struct {
                 const extras = self.ast.extra_data.items;
                 if (e < extras.len) {
                     const operand_idx: NodeIndex = @enumFromInt(extras[e]);
-                    if (!self.tryResolveNodeAsRef(operand_idx)) {
+                    if (!self.tryResolveNodeAsRef(operand_idx, .{ .read = true, .write = true })) {
                         // ++this.#x는 read+write — write로 기록하여 method/getter-only 에러 감지
                         if (!operand_idx.isNone() and @intFromEnum(operand_idx) < self.ast.nodes.items.len and
                             self.ast.getNode(operand_idx).tag == .private_field_expression)

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1381,6 +1381,51 @@ test "references: scope_id 가 참조 발생 위치" {
     try std.testing.expect(!std.meta.eql(ref_scope, decl_scope));
 }
 
+test "references: compound assign 은 read+write 동시 기록" {
+    // PR C: `x += 1` → `{read=true, write=true}`. 이전에는 write 만 set.
+    var fx = try RefFixture.init("let x = 1; x += 2;");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("x", &refs);
+
+    // 1 read/write combined (compound) — 초기 선언의 read 는 없음.
+    try std.testing.expectEqual(@as(usize, 1), refs.items.len);
+    try std.testing.expect(refs.items[0].flags.read);
+    try std.testing.expect(refs.items[0].flags.write);
+}
+
+test "references: pure assign 은 write 만" {
+    // `x = 1` (초기 선언 아님) → write 만 set.
+    var fx = try RefFixture.init("let x = 1; x = 2;");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("x", &refs);
+
+    try std.testing.expectEqual(@as(usize, 1), refs.items.len);
+    try std.testing.expect(!refs.items[0].flags.read);
+    try std.testing.expect(refs.items[0].flags.write);
+}
+
+test "references: update expression 은 read+write" {
+    // `x++`, `++x`, `x--`, `--x` 모두 read+write.
+    var fx = try RefFixture.init("let x = 0; x++; ++x;");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("x", &refs);
+
+    try std.testing.expectEqual(@as(usize, 2), refs.items.len);
+    for (refs.items) |r| {
+        try std.testing.expect(r.flags.read);
+        try std.testing.expect(r.flags.write);
+    }
+}
+
 test "references: enable_stmt_info 시 top-level 선언에 declare flag 기록" {
     // PR B: `stmt_declared` 중간 캐시 제거 후, buildFromSemantic 이 references 의 declare flag 로
     // declared_symbols 를 재구성하는지 검증. enable_stmt_info 꺼져 있으면 declare ref 는 생성 안 됨.

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -338,7 +338,7 @@ pub const Reference = struct {
     /// `NO_STMT`. span 기반 역추적은 decorator 등 "stmt span 외부 노드" 에서 누락되므로
     /// analyzer 가 `current_top_stmt_idx` 를 직접 저장한다.
     stmt_idx: u32 = NO_STMT,
-    /// 참조 종류 (bitset). 현재 analyzer 는 read 또는 write 한 플래그만 set 한다.
+    /// 참조 종류 (bitset). read / write / read+write / declare 조합.
     flags: ReferenceFlags = .{},
 
     pub const NO_STMT: u32 = std.math.maxInt(u32);
@@ -347,9 +347,10 @@ pub const Reference = struct {
 /// 참조 종류 플래그 (packed bitset).
 ///
 /// 현재 analyzer 가 생성하는 조합:
-///   - `{ .read = true }`    — `f(x)`, `y = x` 등 값 읽기
-///   - `{ .write = true }`   — `x = 1`, `x += 1`, `x++` (compound/update 도 현재는 write 로만 뭉뚱)
-///   - `{ .declare = true }` — top-level scope 선언 위치. node_index 는 NodeIndex.none
+///   - `{ .read = true }`               — `f(x)`, `y = x` 등 값 읽기
+///   - `{ .write = true }`              — `x = 1` (pure assign)
+///   - `{ .read = true, .write = true }` — `x += 1`, `x++`, `--x` 등 compound/update
+///   - `{ .declare = true }`            — top-level scope 선언 위치. node_index 는 NodeIndex.none
 ///     (선언 span 을 Reference 에 싣지 않음 — buildFromSemantic 은 stmt_idx 로만 bucket 분배)
 pub const ReferenceFlags = packed struct(u8) {
     read: bool = false,


### PR DESCRIPTION
## Summary

#1640 PR C — compound assign (`x += 1`) 과 update (`x++`, `--x`) 참조를 `{read=true, write=true}` 로 정확 분류. 이전에는 `{write=true}` 로 뭉뚱.

## 왜

RFC #1634 + ReferenceFlags bitset (PR A #1641, PR B #1642) 로 플래그 조합이 가능해진 기반 위에서, 실제로 의미를 풍부하게 채우는 단계. 

- `x += 1` 은 LHS 를 **읽고 → 연산 → 다시 씀** — 한 ref 로 read+write 플래그 둘 다 set 이 정확한 표현
- dead store 분석 false positive 방지: `x = 1; x += 1` 에서 첫 할당이 dead 여부는 두 번째 참조의 read 여부로 판정
- oxc `ReferenceFlags` 와 동일 방향

## 변경

| 파일 | 변경 |
|---|---|
| `src/lexer/token.zig` | `Kind.isCompoundAssignment()` 헬퍼 — `isAssignment() and self != .eq` |
| `src/semantic/analyzer.zig` | `resolveIdentifier` / `tryResolveNodeAsRef` 시그니처: `is_write: bool` → `flags: ReferenceFlags`. `assignment_expression` 에서 operator token 해석 후 compound 판단. `update_expression` 은 항상 read+write. 5개 호출자 업데이트 |
| `src/semantic/symbol.zig` | `ReferenceFlags` doc 갱신 — 새로운 `{read, write}` 조합 반영 |
| `src/lexer/token_test.zig` | `isCompoundAssignment` 케이스 테스트 1건 |
| `src/semantic/analyzer_test.zig` | compound / pure assign / update expression 각각 검증 테스트 3건 |

## 플래그 조합 (PR C 시점 최종)

```
{ read=true }              — f(x), y = x
{ write=true }             — x = 1 (pure assign)
{ read=true, write=true }  — x += 1, x++, --x (compound + update)
{ declare=true }           — top-level 선언 (PR B)
```

## 의미 동일성

- `reference_count`: compound/update 는 이전에도 **ref 1개로 기록** — 변동 없음 (array 크기 동일)
- `write_count`: compound/update 는 `flags.write == true` → 여전히 +1 — 변동 없음
- mangler / tree-shaker / bundler 등 기존 consumer 는 `flags.read` / `flags.write` 를 직접 보지 않음 (reference_count, write_count 만 사용) — 정확도는 향상되지만 현재 소비자 관점 동작 동일

## 후속 / 별도 이슈

- dead store 분석: compound 의 read flag 가 제대로 set 됐으므로 `x = 1; x = 2` (첫 할당 dead) vs `x = 1; x += 1` (dead 아님) 구분 가능
- TS type-only 참조 플래그 (`type_ref`): 별도 이슈 (#1640 RFC 본문의 "PR D" 후보)

## Test plan

- [x] `zig build test` — 신규 유닛 테스트 4건 추가 (isCompoundAssignment + compound / pure / update)
- [x] `bun run test:smoke` 139 pass / 0 fail
- [x] semantic pipeline profile 회귀 없음 (1k/5k/10k line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)