### PR TITLE
feat(minify): #1644 PR1 — unused declaration 제거 (dead store elimination)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -866,7 +866,19 @@ pub fn emitModule(
     // mangling/주석 제거 같은 compression 은 없다. `--define`으로 치환된 상수 비교
     // (`"production" === "production"`)나 `if (false)` dead branch를 bundle 기본 모드에서도
     // 접어야 rolldown/esbuild와 동등한 DCE 효과를 낸다.
-    @import("../transformer/minify.zig").minify(&transformer.ast);
+    //
+    // Dead store (#1644 PR1): semantic 정보가 있을 때만 unused declaration 제거 활성.
+    // tree-shaker 가 top-level export 미사용은 이미 커버하지만, 함수 내부 local 은 여기서 처리.
+    {
+        const minify_mod = @import("../transformer/minify.zig");
+        const ctx: minify_mod.MinifyCtx = if (module.semantic) |sem| .{
+            .symbols = sem.symbols.items,
+            .symbol_ids = transformer.symbol_ids.items,
+            .scopes = sem.scopes,
+            .unresolved_globals = &sem.unresolved_references,
+        } else .empty;
+        minify_mod.minify(&transformer.ast, ctx);
+    }
 
     // 런타임 헬퍼 사용 추적: transformer가 설정한 플래그를 out parameter로 전달
     // packed struct(u32)이므로 bitwise OR로 한번에 합친다

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -22,8 +22,38 @@ const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const Ast = ast_mod.Ast;
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const Span = @import("../lexer/token.zig").Span;
 const Kind = @import("../lexer/token.zig").Kind;
+const symbol_mod = @import("../semantic/symbol.zig");
+const scope_mod = @import("../semantic/scope.zig");
+const purity = @import("../bundler/purity.zig");
+
+/// Minify pass 컨텍스트. semantic 정보가 있을 때만 dead store 제거가 동작한다.
+/// `symbols` 는 mutable slice — dead declaration 제거 시 init 내부 identifier reference 의
+/// `reference_count` 를 감산하기 위해 필요하다 (stale 방지).
+/// `scopes` 는 eval / with 포함 여부 조회용 (dynamic lookup 보호).
+pub const MinifyCtx = struct {
+    symbols: []symbol_mod.Symbol,
+    symbol_ids: []const ?u32,
+    scopes: []const scope_mod.Scope,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+
+    /// semantic 없이 호출할 때 사용. dead store pass 는 skip 된다.
+    pub const empty: MinifyCtx = .{
+        .symbols = &.{},
+        .symbol_ids = &.{},
+        .scopes = &.{},
+        .unresolved_globals = null,
+    };
+
+    /// semantic 정보 3축 (symbols / symbol_ids / scopes) 이 모두 채워졌는지 확인.
+    /// scopes 누락 시 eval / with 가드가 silent 통과되어 직접 eval 스코프 안의 변수가
+    /// 잘못 제거될 수 있으므로, 세 필드 모두 요구하는 all-or-nothing 계약.
+    inline fn hasSemantic(self: MinifyCtx) bool {
+        return self.symbols.len > 0 and self.symbol_ids.len > 0 and self.scopes.len > 0;
+    }
+};
 
 /// f64 → i32 (ToInt32, ECMAScript 7.1.6)
 fn toI32(val: f64) i32 {
@@ -128,7 +158,8 @@ fn isGuaranteedBoolean(ast: *const Ast, node: Node) bool {
 }
 
 /// AST minify 패스를 실행한다. ast를 in-place 수정.
-pub fn minify(ast: *Ast) void {
+/// `ctx` 에 semantic 정보가 있으면 dead store (unused declaration) 제거도 함께 수행.
+pub fn minify(ast: *Ast, ctx: MinifyCtx) void {
     for (ast.nodes.items, 0..) |node, i| {
         switch (node.tag) {
             .binary_expression => foldBinary(ast, @intCast(i), node),
@@ -140,6 +171,163 @@ pub fn minify(ast: *Ast) void {
             .sequence_expression => simplifySequence(ast, @intCast(i), node),
             else => {},
         }
+    }
+    if (ctx.hasSemantic()) {
+        removeDeadStores(ast, ctx);
+    }
+}
+
+// ================================================================
+// Dead Store Elimination — Unused Declaration (#1644 PR1)
+// ================================================================
+//
+// 제거 조건 (모두 만족):
+//   - `var` / `let` / `const` 의 **단일** `binding_identifier` declarator
+//   - symbol 의 `scope_id != 0` (함수/블록 local 만) — top-level 은 tree-shaker 영역
+//   - `reference_count == 0` and `write_count == 0`
+//   - `is_exported` / `is_default_export` 둘 다 false
+//   - init 이 없거나 `purity.isExprPure` 가 true
+//
+// 제외:
+//   - top-level (module scope) 선언     — tree-shaker 가 커버, 중복 제거는 fixture 회귀
+//   - `using` / `await using`           — `[Symbol.dispose]` 호출이 side-effect
+//   - destructuring / non-identifier    — pattern 은 간접 getter 호출 가능
+//   - declarator 2개 이상               — 부분 제거는 PR 범위 밖 (복잡도)
+//   - init 이 불순                      — "강등" (→ expression_statement) 은 PR1.5
+//
+// 제거 시 init expression 내 모든 identifier_reference 의 `reference_count` 를
+// 감산해 semantic scalar 와의 정합성을 유지한다 (미래 fixed-point loop 도입 시 필수).
+
+fn removeDeadStores(ast: *Ast, ctx: MinifyCtx) void {
+    for (ast.nodes.items, 0..) |node, i| {
+        if (node.tag != .variable_declaration) continue;
+        tryRemoveDeadDecl(ast, ctx, @intCast(i), node);
+    }
+}
+
+fn tryRemoveDeadDecl(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node) void {
+    const kind = ast.variableDeclarationKind(node);
+    // `using` / `await using`: Symbol.dispose 호출 side-effect → 보존
+    if (kind.isUsing()) return;
+
+    const extra = node.data.extra;
+    if (extra + 2 >= ast.extra_data.items.len) return;
+    const list_start = ast.extra_data.items[extra + 1];
+    const list_len = ast.extra_data.items[extra + 2];
+    // 단일 declarator 만 처리 (부분 제거는 PR 범위 밖)
+    if (list_len != 1) return;
+    if (list_start >= ast.extra_data.items.len) return;
+
+    const decl_raw = ast.extra_data.items[list_start];
+    if (decl_raw >= ast.nodes.items.len) return;
+    const decl = ast.nodes.items[decl_raw];
+    if (decl.tag != .variable_declarator) return;
+
+    // variable_declarator: extra = [name, type_ann, init]
+    const de = decl.data.extra;
+    if (de + 2 >= ast.extra_data.items.len) return;
+    const name_raw = ast.extra_data.items[de];
+    const init_raw = ast.extra_data.items[de + 2];
+
+    if (name_raw >= ast.nodes.items.len) return;
+    const name_node = ast.nodes.items[name_raw];
+    // 단일 binding_identifier 만 — destructuring/array/object pattern 제외
+    if (name_node.tag != .binding_identifier) return;
+
+    // symbol_ids[name_node_idx] → symbol index
+    if (name_raw >= ctx.symbol_ids.len) return;
+    const sym_id = ctx.symbol_ids[name_raw] orelse return;
+    if (sym_id >= ctx.symbols.len) return;
+    const sym = ctx.symbols[sym_id];
+
+    // top-level (module scope=0) 는 tree-shaker 영역 — 여기서 지우면 bundle 경로의 entry
+    // top-level 선언이 사라져 fixture 가 깨진다. 함수/블록 local 만 대상.
+    const scope_idx = @intFromEnum(sym.scope_id);
+    if (scope_idx == 0) return;
+
+    // eval / with 스코프 안의 선언은 동적 lookup 대상이 될 수 있다. mangler 와 동일 보호
+    // (Scope.blocksMangling — subtree_has_direct_eval / subtree_has_with).
+    if (scope_idx < ctx.scopes.len and ctx.scopes[scope_idx].blocksMangling()) return;
+
+    // exported binding 보호 — transpile 단독 경로는 tree-shaker 가 없어 직접 지키는 외엔 없다
+    if (sym.decl_flags.is_exported or sym.decl_flags.is_default_export) return;
+
+    // reference 가 있거나 다른 곳에서 쓰이면 dead 아님
+    if (sym.reference_count != 0 or sym.write_count != 0) return;
+
+    // init 이 있으면 purity 검사 — 불순하면 RHS 보존을 위해 (아직) 제거 불가
+    const init_idx: NodeIndex = @enumFromInt(init_raw);
+    if (!init_idx.isNone()) {
+        if (!purity.isExprPure(ast, init_idx, ctx.unresolved_globals)) return;
+        // init 내부의 pure identifier_reference 들의 reference_count 를 감산
+        decrementRefsInExpr(ast, ctx, init_idx);
+    }
+
+    // variable_declaration 전체를 empty_statement 로 교체
+    ast.nodes.items[node_idx] = .{
+        .tag = .empty_statement,
+        .span = node.span,
+        .data = .{ .none = 0 },
+    };
+}
+
+/// expression 안의 모든 `identifier_reference` 노드를 찾아, symbol_ids 로 symbol 을
+/// 역매핑해 `reference_count` 를 1 감산한다. init expression 은 RHS 이므로
+/// assignment_target_identifier 는 등장하지 않아 read 경로만 처리.
+fn decrementRefsInExpr(ast: *const Ast, ctx: MinifyCtx, idx: NodeIndex) void {
+    if (idx.isNone()) return;
+    const ni = @intFromEnum(idx);
+    if (ni >= ast.nodes.items.len) return;
+    const node = ast.nodes.items[ni];
+
+    if (node.tag == .identifier_reference) {
+        if (ni < ctx.symbol_ids.len) {
+            if (ctx.symbol_ids[ni]) |sid| {
+                if (sid < ctx.symbols.len and ctx.symbols[sid].reference_count > 0) {
+                    ctx.symbols[sid].reference_count -= 1;
+                }
+            }
+        }
+        return;
+    }
+
+    switch (Node.Tag.dataKind(node.tag)) {
+        .leaf => {},
+        .unary => decrementRefsInExpr(ast, ctx, node.data.unary.operand),
+        .binary => {
+            decrementRefsInExpr(ast, ctx, node.data.binary.left);
+            decrementRefsInExpr(ast, ctx, node.data.binary.right);
+        },
+        .ternary => {
+            decrementRefsInExpr(ast, ctx, node.data.ternary.a);
+            decrementRefsInExpr(ast, ctx, node.data.ternary.b);
+            decrementRefsInExpr(ast, ctx, node.data.ternary.c);
+        },
+        .list => walkListChildren(ast, ctx, node.data.list),
+        .extra => {
+            for (Node.Tag.extraChildOffsets(node.tag)) |off| {
+                const ei = node.data.extra + off;
+                if (ei >= ast.extra_data.items.len) continue;
+                decrementRefsInExpr(ast, ctx, @enumFromInt(ast.extra_data.items[ei]));
+            }
+            for (Node.Tag.extraListOffsets(node.tag)) |pair| {
+                const start_off = node.data.extra + pair[0];
+                const len_off = node.data.extra + pair[1];
+                if (len_off >= ast.extra_data.items.len) continue;
+                const start = ast.extra_data.items[start_off];
+                const len = ast.extra_data.items[len_off];
+                walkListChildren(ast, ctx, .{ .start = start, .len = len });
+            }
+        },
+    }
+}
+
+fn walkListChildren(ast: *const Ast, ctx: MinifyCtx, list: ast_mod.NodeList) void {
+    if (list.len == 0) return;
+    const end = list.start + list.len;
+    if (end > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[list.start..end]) |raw| {
+        decrementRefsInExpr(ast, ctx, @enumFromInt(raw));
     }
 }
 

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -31,7 +31,7 @@ fn expectMinifyOpts(
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast);
+    minify_mod.minify(&transformer.ast, .empty);
     minify_mod.mergeDecls(&transformer.ast, null);
 
     var cg = Codegen.initWithOptions(a, &transformer.ast, codegen_opts);
@@ -54,7 +54,7 @@ fn expectMergeIdempotent(input: []const u8, expected: []const u8) !void {
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast);
+    minify_mod.minify(&transformer.ast, .empty);
     minify_mod.mergeDecls(&transformer.ast, null);
     minify_mod.mergeDecls(&transformer.ast, null); // 두 번째 호출 — 결과 동일해야 함
 
@@ -86,7 +86,7 @@ fn expectMergeWithSkip(
     var transformer = try Transformer.init(a, &parser.ast, .{});
     _ = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast);
+    minify_mod.minify(&transformer.ast, .empty);
 
     var skip = try std.DynamicBitSet.initEmpty(a, transformer.ast.nodes.items.len);
     // substring의 시작 위치와 일치하는 variable_declaration을 **전부** 마킹.
@@ -724,4 +724,272 @@ test "merge decls: skip_nodes가 kind 차이가 있는 경계에서는 merge 차
         2,
         2,
     );
+}
+
+// ================================================================
+// Dead Store Elimination — Unused Declaration (#1644 PR1)
+// ================================================================
+
+const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
+
+/// Semantic analyzer 를 포함한 minify 파이프라인. dead store pass 가 활성화된다.
+/// 함수 body 안에 코드를 넣어야 top-level 제외 규칙을 피할 수 있다 — 헬퍼가 자동 래핑.
+fn expectMinifyDead(body: []const u8, expected: []const u8) !void {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // 함수 본문으로 감싸서 로컬 스코프 안의 선언으로 만듬 (top-level 제외 규칙 우회).
+    // 외부에서 run 을 호출하므로 run 자체는 reference_count > 0 → 제거 안 됨.
+    const wrapped = try std.fmt.allocPrint(a, "function run(){{{s}}}run();", .{body});
+
+    var scanner = try Scanner.init(a, wrapped);
+    var parser = Parser.init(a, &scanner);
+    _ = try parser.parse();
+
+    var analyzer = SemanticAnalyzer.init(a, &parser.ast);
+    try analyzer.analyze();
+
+    var transformer = try Transformer.init(a, &parser.ast, .{});
+    try transformer.initSymbolIds(analyzer.symbol_ids.items);
+    transformer.symbols = analyzer.symbols.items;
+    const root = try transformer.transform();
+
+    const ctx: minify_mod.MinifyCtx = .{
+        .symbols = analyzer.symbols.items,
+        .symbol_ids = transformer.symbol_ids.items,
+        .scopes = analyzer.scopes.items,
+        .unresolved_globals = null,
+    };
+    minify_mod.minify(&transformer.ast, ctx);
+    minify_mod.mergeDecls(&transformer.ast, null);
+
+    var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
+    const result = try cg.generate(root);
+    const trimmed = std.mem.trimRight(u8, result, "\n");
+    try std.testing.expectEqualStrings(expected, trimmed);
+}
+
+// ---- 제거 가능 (함수 local, unused, pure init) ----
+
+test "dead store: unused let with literal init 제거" {
+    try expectMinifyDead("let x = 1;", "function run() {\n\t;\n}\nrun();");
+}
+
+test "dead store: unused const with literal init 제거" {
+    try expectMinifyDead("const x = 1;", "function run() {\n\t;\n}\nrun();");
+}
+
+test "dead store: unused var with literal init 제거" {
+    try expectMinifyDead("var x = 1;", "function run() {\n\t;\n}\nrun();");
+}
+
+test "dead store: unused let init 없음 — 제거" {
+    try expectMinifyDead("let x;", "function run() {\n\t;\n}\nrun();");
+}
+
+test "dead store: unused let with string literal 제거" {
+    try expectMinifyDead("let x = \"secret\";", "function run() {\n\t;\n}\nrun();");
+}
+
+test "dead store: unused let with member access (pure) 제거 — 연쇄로 o 도 제거" {
+    // obj.prop 은 purity 관점 pure. x 제거 시 o 의 ref_count 가 0 → 같은 pass 안에서
+    // o 가 아직 방문 안 된 상태면 연쇄 제거됨 (oxc fixed-point 효과를 단일 pass 로 부분 달성).
+    try expectMinifyDead(
+        "const o = { a: 1 }; let x = o.a;",
+        "function run() {\n\t;\n\t;\n}\nrun();",
+    );
+}
+
+test "dead store: unused let with pure binary 제거" {
+    try expectMinifyDead("let x = 1 + 2;", "function run() {\n\t;\n}\nrun();");
+}
+
+// ---- 제거 금지 — 사용됨 ----
+
+test "dead store: read 1회 — 유지" {
+    try expectMinifyDead(
+        "let x = 1; console.log(x);",
+        "function run() {\n\tlet x = 1;\n\tconsole.log(x);\n}\nrun();",
+    );
+}
+
+test "dead store: write (reassign) — 유지 (write_count 증가)" {
+    try expectMinifyDead(
+        "let x = 1; x = 2;",
+        "function run() {\n\tlet x = 1;\n\tx = 2;\n}\nrun();",
+    );
+}
+
+test "dead store: compound assign — 유지" {
+    try expectMinifyDead(
+        "let x = 1; x += 2;",
+        "function run() {\n\tlet x = 1;\n\tx += 2;\n}\nrun();",
+    );
+}
+
+test "dead store: update expression — 유지" {
+    try expectMinifyDead(
+        "let x = 0; x++;",
+        "function run() {\n\tlet x = 0;\n\tx++;\n}\nrun();",
+    );
+}
+
+// ---- 제거 금지 — init 불순 ----
+
+test "dead store: unused let with impure call — 유지" {
+    // helper() 는 @__PURE__ 없으면 불순. 강등(→ expression_statement)은 PR1.5 범위
+    try expectMinifyDead(
+        "let x = helper();",
+        "function run() {\n\tlet x = helper();\n}\nrun();",
+    );
+}
+
+test "dead store: unused let with @__PURE__ call — 제거" {
+    try expectMinifyDead(
+        "let x = /*#__PURE__*/ helper();",
+        "function run() {\n\t;\n}\nrun();",
+    );
+}
+
+// ---- 제거 금지 — 안전성 체크리스트 ----
+
+test "dead store: using declaration — 유지 (Symbol.dispose side-effect)" {
+    try expectMinifyDead(
+        "using x = getResource();",
+        "function run() {\n\tusing x = getResource();\n}\nrun();",
+    );
+}
+
+test "dead store: await using — 유지" {
+    // await 은 async function 안에서만 유효해서 이 테스트는 별도 래퍼 필요
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = "async function run(){await using x = getResource();}run();";
+    var scanner = try Scanner.init(a, src);
+    var parser = Parser.init(a, &scanner);
+    _ = try parser.parse();
+    var analyzer = SemanticAnalyzer.init(a, &parser.ast);
+    try analyzer.analyze();
+    var transformer = try Transformer.init(a, &parser.ast, .{});
+    try transformer.initSymbolIds(analyzer.symbol_ids.items);
+    transformer.symbols = analyzer.symbols.items;
+    const root = try transformer.transform();
+    const ctx: minify_mod.MinifyCtx = .{
+        .symbols = analyzer.symbols.items,
+        .symbol_ids = transformer.symbol_ids.items,
+        .scopes = analyzer.scopes.items,
+        .unresolved_globals = null,
+    };
+    minify_mod.minify(&transformer.ast, ctx);
+    var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
+    const result = try cg.generate(root);
+    try std.testing.expect(std.mem.indexOf(u8, result, "await using x") != null);
+}
+
+test "dead store: destructuring binding — 유지 (pattern 은 getter 호출 가능)" {
+    try expectMinifyDead(
+        "const { x } = { x: 1 };",
+        "function run() {\n\tconst { x:x } = { x: 1 };\n}\nrun();",
+    );
+}
+
+test "dead store: array destructuring — 유지" {
+    try expectMinifyDead(
+        "const [x] = [1];",
+        "function run() {\n\tconst [x] = [1];\n}\nrun();",
+    );
+}
+
+test "dead store: declarator 2개 — 유지 (부분 제거는 PR 범위 밖)" {
+    try expectMinifyDead(
+        "let x = 1, y = 2;",
+        "function run() {\n\tlet x = 1,y = 2;\n}\nrun();",
+    );
+}
+
+test "dead store: eval 포함 스코프 — 유지 (direct eval 이 동적 lookup)" {
+    try expectMinifyDead(
+        "const veryLongPasswordVar = \"secret\"; return eval(\"veryLongPasswordVar\");",
+        "function run() {\n\tconst veryLongPasswordVar = \"secret\";\n\treturn eval(\"veryLongPasswordVar\");\n}\nrun();",
+    );
+}
+
+test "dead store: top-level const 는 tree-shaker 영역 — 유지" {
+    // 함수 래핑 없이 직접 top-level 로 — scope_id == 0 가드 검증
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = "const x = 1;";
+    var scanner = try Scanner.init(a, src);
+    var parser = Parser.init(a, &scanner);
+    _ = try parser.parse();
+    var analyzer = SemanticAnalyzer.init(a, &parser.ast);
+    try analyzer.analyze();
+    var transformer = try Transformer.init(a, &parser.ast, .{});
+    try transformer.initSymbolIds(analyzer.symbol_ids.items);
+    transformer.symbols = analyzer.symbols.items;
+    const root = try transformer.transform();
+    const ctx: minify_mod.MinifyCtx = .{
+        .symbols = analyzer.symbols.items,
+        .symbol_ids = transformer.symbol_ids.items,
+        .scopes = analyzer.scopes.items,
+        .unresolved_globals = null,
+    };
+    minify_mod.minify(&transformer.ast, ctx);
+    var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
+    const result = try cg.generate(root);
+    try std.testing.expect(std.mem.indexOf(u8, result, "const x = 1") != null);
+}
+
+// ---- reference_count decrement 검증 ----
+
+test "dead store: 제거 시 init 내부 식별자 reference_count 감산" {
+    // `let y = 1; let x = y;` 에서 x 제거 시 y 의 reference_count 가 1 → 0 이 되어야 함.
+    // (fixed-point loop 가 도입되면 다음 pass 에서 y 도 제거되는 기반.)
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = "function run(){let y = 1; let x = y;}run();";
+    var scanner = try Scanner.init(a, src);
+    var parser = Parser.init(a, &scanner);
+    _ = try parser.parse();
+    var analyzer = SemanticAnalyzer.init(a, &parser.ast);
+    try analyzer.analyze();
+    var transformer = try Transformer.init(a, &parser.ast, .{});
+    try transformer.initSymbolIds(analyzer.symbol_ids.items);
+    transformer.symbols = analyzer.symbols.items;
+    _ = try transformer.transform();
+
+    // 초기: x 는 0 ref, y 는 1 ref (x 의 init 에서 읽힘)
+    var y_ref_before: u32 = 0;
+    for (analyzer.symbols.items) |sym| {
+        const name = sym.nameText(parser.ast.source);
+        if (std.mem.eql(u8, name, "y")) y_ref_before = sym.reference_count;
+    }
+    try std.testing.expectEqual(@as(u32, 1), y_ref_before);
+
+    const ctx: minify_mod.MinifyCtx = .{
+        .symbols = analyzer.symbols.items,
+        .symbol_ids = transformer.symbol_ids.items,
+        .scopes = analyzer.scopes.items,
+        .unresolved_globals = null,
+    };
+    minify_mod.minify(&transformer.ast, ctx);
+
+    // 제거 후: x 가 사라지면서 y 의 reference_count 도 1 → 0
+    var y_ref_after: u32 = 0;
+    for (analyzer.symbols.items) |sym| {
+        const name = sym.nameText(parser.ast.source);
+        if (std.mem.eql(u8, name, "y")) y_ref_after = sym.reference_count;
+    }
+    try std.testing.expectEqual(@as(u32, 0), y_ref_after);
 }

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -342,8 +342,15 @@ pub fn transpileWithCallback(
     const root = transformer.transform() catch return error.TransformError;
 
     if (options.minify_syntax) {
-        @import("transformer/minify.zig").minify(&transformer.ast);
-        @import("transformer/minify.zig").mergeDecls(&transformer.ast, null);
+        const minify_mod = @import("transformer/minify.zig");
+        const ctx: minify_mod.MinifyCtx = .{
+            .symbols = analyzer.symbols.items,
+            .symbol_ids = transformer.symbol_ids.items,
+            .scopes = analyzer.scopes.items,
+            .unresolved_globals = null,
+        };
+        minify_mod.minify(&transformer.ast, ctx);
+        minify_mod.mergeDecls(&transformer.ast, null);
     }
 
     // 5. Mangling 메타데이터 구성. skip_nodes는 arena-owned이라 별도 deinit 불필요


### PR DESCRIPTION
## Summary

issue #1644 (RFC: Dead store 분석) 의 PR1. 함수/블록 local scope 의 **사용되지 않는 `var` / `let` / `const` 선언** 을 제거. oxc `peephole/remove_unused_declaration.rs` 방식.

## 제거 조건 (모두 만족)

- `var` / `let` / `const` 의 **단일** `binding_identifier` declarator
- symbol 의 `scope_id != 0` (함수/블록 local 만 — top-level 은 tree-shaker 영역)
- 포함 scope 가 `blocksMangling()` 아님 (eval / with 없음)
- `reference_count == 0` and `write_count == 0`
- `is_exported` / `is_default_export` 둘 다 false
- init 이 없거나 `purity.isExprPure` 가 true

## 제거 시 처리

- `variable_declaration` 노드를 `empty_statement` 로 in-place 교체
- **init expression 내부의 모든 identifier_reference 의 `reference_count` 를 감산**
  (stale 방지 — 미래 fixed-point loop 도입 시 누적 효과 활성)

실제로 단일 pass 만으로도 연쇄 효과가 부분 발생: `const o = {a:1}; let x = o.a;` → 둘 다 제거됨 (o 가 후순위 노드라 ref_count 감산 반영).

## 제외 (PR 범위 밖)

- **top-level (module scope) 선언** — tree-shaker 영역, 여기서 지우면 bundle entry fixture 회귀
- **`using` / `await using`** — `[Symbol.dispose]` 호출이 side-effect
- **destructuring / non-identifier** — pattern 은 간접 getter 호출 가능
- **declarator 2개 이상** — 부분 제거는 복잡도 이슈로 후속 PR
- **init 이 불순** — "강등" (expression_statement 로) 은 PR1.5 로 분리 (이슈 #1644 본문의 `SimplifyUnusedExpr` 범위)

## 시그니처 변경

```zig
// Before
pub fn minify(ast: *Ast) void

// After
pub fn minify(ast: *Ast, ctx: MinifyCtx) void

pub const MinifyCtx = struct {
    symbols: []symbol_mod.Symbol,
    symbol_ids: []const ?u32,
    scopes: []const scope_mod.Scope,
    unresolved_globals: ?*const purity.GlobalRefSet,
    pub const empty: MinifyCtx = .{ ... };
};
```

- 호출부 2곳 (`src/transpile.zig:344`, `src/bundler/emitter.zig:869`) 동시 업데이트
- 하위호환 shim 없음 — `MinifyCtx.empty` 는 semantic 없이 호출 시 (dead store skip)
- **`hasSemantic()` 은 `symbols` / `symbol_ids` / `scopes` 3축 모두 확인** (scopes 누락 시 eval/with 가드 silent 통과 방지)

## 안전성 체크리스트 커버 현황 (RFC 기준)

| # | 안전성 조건 | PR1 구현 |
|---|---|---|
| 1 | direct eval / with | ✅ `blocksMangling()` 가드 |
| 2 | using / await using | ✅ `kind.isUsing()` 가드 |
| 3 | TDZ | ✅ `reference_count == 0 && write_count == 0` 보수적 |
| 4 | closure capture / arguments | ✅ semantic analyzer 가 `reference_count` 집계 — 함수 경계 포함 |
| 5 | exported binding | ✅ `is_exported` / `is_default_export` 가드 |
| 6 | RHS side-effect | ✅ `purity.isExprPure` — 불순 시 제거 안 함 |
| 7 | getter/setter on assignment target | ✅ init 제거만 (assignment target 은 PR2 범위) |
| 8 | global / unbound | ✅ symbol_ids lookup 실패 시 skip |
| 9 | decorator / class field initializer | ✅ 대상 아님 (variable_declaration 만) |
| 10 | catch param | ✅ 대상 아님 |
| 11 | /*#__PURE__*/ / no_side_effects | ✅ `purity.isExprPure` 가 `@__PURE__` 인식 |

## Test plan

- [x] `zig build test` — dead store 엣지 테스트 20 건 추가
  - 제거 가능: literal / init없음 / member access / pure binary / @__PURE__ call (연쇄 제거 케이스 포함)
  - 제거 금지: read / write / compound / update / impure / using / await using / destructuring / declarator 2개 / eval 스코프 / top-level
  - `reference_count` decrement 직접 검증 (after-state 가 0 확인)
- [x] 통합 139 smoke pass / 0 fail
- [x] 기존 minify_test / emitter_test / bundler_test 회귀 없음

## 후속

- **PR1.5**: `SimplifyUnusedExpr` 포팅 — unused expression statement 의 side-effect-free 부분 축약. oxc `remove_unused_expression.rs`
- **PR2 (별도 이슈)**: swc 식 `drop_unused_assignments` — `x = e;` 자체 제거. closure capture 안전성 data-flow 필요
- **별도 refactor 이슈**: AST walker 공통화 — 본 PR 의 `decrementRefsInExpr` 가 5번째 near-copy. 5곳 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)