### PR TITLE
fix(minify): #1647 dead store 가 for-loop binding 을 제거하던 회귀

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -199,9 +199,51 @@ pub fn minify(ast: *Ast, ctx: MinifyCtx) void {
 // 감산해 semantic scalar 와의 정합성을 유지한다 (미래 fixed-point loop 도입 시 필수).
 
 fn removeDeadStores(ast: *Ast, ctx: MinifyCtx) void {
+    // Pre-pass: for-loop 의 binding 위치에 있는 variable_declaration 을 모두 수집.
+    // for (let x = 0; ...), for (const x of it), for await (const x of it) 등에서 `x` 가
+    // body 안에서 참조되지 않아도 binding 자체를 지우면 구문 붕괴 (#1647).
+    // ast.allocator 는 bundle 경로에선 arena (CLAUDE.md Memory ownership) — defer 와 함께
+    // 써도 arena.deinit 시 이중 해제 없음 (DynamicBitSet 은 개별 free 가 no-op 이 되도록
+    // arena 안 bytes 만 사용). 단일 transpile 경로에선 일반 allocator.
+    var skip_for_binding = std.DynamicBitSet.initEmpty(ast.allocator, ast.nodes.items.len) catch return;
+    defer skip_for_binding.deinit();
+    markForLoopBindings(ast, &skip_for_binding);
+
     for (ast.nodes.items, 0..) |node, i| {
         if (node.tag != .variable_declaration) continue;
+        if (skip_for_binding.isSet(i)) continue;
         tryRemoveDeadDecl(ast, ctx, @intCast(i), node);
+    }
+}
+
+/// for-loop (for / for-in / for-of / for-await-of) 의 init/left 자리에 있는
+/// variable_declaration 노드 인덱스를 bitset 에 set. 해당 binding 은 body 에서
+/// 사용되지 않더라도 구문상 필수이므로 dead store 제거 대상이 아니다.
+fn markForLoopBindings(ast: *const Ast, skip: *std.DynamicBitSet) void {
+    for (ast.nodes.items) |node| {
+        switch (node.tag) {
+            .for_statement => {
+                // extra = [init, test, update, body] — init 이 자식 0
+                const ei = node.data.extra;
+                if (ei >= ast.extra_data.items.len) continue;
+                const raw = ast.extra_data.items[ei];
+                if (raw < ast.nodes.items.len and
+                    ast.nodes.items[raw].tag == .variable_declaration)
+                {
+                    skip.set(raw);
+                }
+            },
+            .for_in_statement, .for_of_statement, .for_await_of_statement => {
+                // ternary: a = LHS (variable_declaration 또는 assignment target)
+                const raw = @intFromEnum(node.data.ternary.a);
+                if (raw < ast.nodes.items.len and
+                    ast.nodes.items[raw].tag == .variable_declaration)
+                {
+                    skip.set(raw);
+                }
+            },
+            else => {},
+        }
     }
 }
 

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -919,6 +919,32 @@ test "dead store: eval 포함 스코프 — 유지 (direct eval 이 동적 looku
     );
 }
 
+test "dead store: for (let i=0;...) 의 i — 유지 (for-loop binding, #1647)" {
+    try expectMinifyDead(
+        "for (let i = 0; i < 3; i++) { break; }",
+        "function run() {\n\tfor (let i = 0; i < 3; i++) {\n\t\tbreak;\n\t}\n}\nrun();",
+    );
+}
+
+test "dead store: for-of 의 binding 은 body 미사용이어도 유지 (#1647)" {
+    // for-of binding 을 제거하면 `for (of arr)` 로 구문 붕괴
+    try expectMinifyDead(
+        "for (const x of [1,2,3]) { break; }",
+        "function run() {\n\tfor (const x of [1, 2, 3]) {\n\t\tbreak;\n\t}\n}\nrun();",
+    );
+}
+
+test "dead store: for-in 의 binding 유지 (#1647)" {
+    try expectMinifyDead(
+        "for (const k in {a:1}) { break; }",
+        "function run() {\n\tfor (const k in { a: 1 }) {\n\t\tbreak;\n\t}\n}\nrun();",
+    );
+}
+
+// for-await-of 케이스는 async function 래퍼 안에서만 유효하고 codegen 경로도 다름.
+// 통합 테스트 (`tests/integration/tests/downlevel-edge.test.ts` - "for-await-of break +
+// async iterator return()") 가 회귀를 검증한다.
+
 test "dead store: top-level const 는 tree-shaker 영역 — 유지" {
     // 함수 래핑 없이 직접 top-level 로 — scope_id == 0 가드 검증
     const allocator = std.testing.allocator;


### PR DESCRIPTION
## Summary

#1645 PR1 (dead store) 머지 후 발생한 회귀. **for-loop 계열의 binding 위치**에 있는 `variable_declaration` 도 dead store 제거 대상이 되어 구문이 깨짐.

## 재현

```js
for await (const _v of gen()) { break; }
```

- `_v` 는 body 에서 참조되지 않음 → `reference_count == 0`
- 함수 scope (scope_id != 0)
- init 없음 (pure 간주)
- → dead store 판정 → `variable_declaration` 제거
- → `for await (; of gen())` 로 **구문 붕괴** → SyntaxError

## 수정

`removeDeadStores` 시작 시 pre-pass 로 for-loop 계열 노드의 **binding 위치**에 있는 `variable_declaration` 을 bitset 에 마킹하고, 제거 대상에서 제외:

| AST 노드 | binding 위치 |
|---|---|
| `for_statement` | extra[0] (init) |
| `for_in_statement` | ternary.a (LHS) |
| `for_of_statement` | ternary.a (LHS) |
| `for_await_of_statement` | ternary.a (LHS) |

bitset 은 `ast.allocator` 로 초기화 — bundle 경로에선 arena, transpile 단독에선 일반 allocator. `defer bitset.deinit()` 으로 안전 해제.

## 영향받은 회귀 테스트 (pre-fix fail → post-fix pass)

- **ES 다운레벨링 엣지케이스** > iterator / async cleanup > `for-await-of break + async iterator return()`
- **RN ES5: ExampleApp 번들 테스트** > `bundle (no target): Node 실행 검증`
- **RN 번들: Metro vs ZTS 모듈 수 비교** > `Hermes 구문 검증 (hermesc)`

## 신규 유닛 테스트 (재발 방지)

- `for (let i = 0; ...) { break; }` — `i` 가 body 미참조여도 유지
- `for (const x of [1,2,3]) { break; }` — `x` 유지
- `for (const k in { a: 1 }) { break; }` — `k` 유지
- for-await 케이스는 transformer 경로가 복잡해서 `downlevel-edge.test.ts` 통합 테스트로 커버 (주석에 링크)

## Test plan

- [x] `zig build test` — 유닛 테스트 3 건 추가
- [x] `bun run test:smoke` 139 pass / 0 fail
- [x] 3 개 회귀 테스트 개별 실행 모두 pass 확인

## 왜 PR1 리뷰에서 못 잡았나

PR1 의 안전성 체크리스트 (RFC #1644) 는 eval/with/using/closure/export 등 **11 항목** 을 다뤘는데, for-loop binding 은 누락. AST 관점에서 보면 `variable_declaration` 의 부모가 `for_*_statement` 인 경우의 특수성 — 통상적 "statement context" 와 달리 제거 시 구문 자체가 깨진다. RFC 에 "#12: for-loop / catch binding" 항목 추가 필요 (본 PR 이 for-loop 만 처리, catch binding 은 PR1 에서 이미 `variable_declaration` 이 아니라 별도 tag 로 제외됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)