### PR TITLE
fix(parser): #1652 directive prologue 를 .directive 노드로 파싱 — #1649 회귀

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -829,7 +829,13 @@ pub const Codegen = struct {
             .catch_clause => try self.emitCatch(node),
             .labeled_statement => try self.emitLabeled(node),
             .with_statement => try self.emitWith(node),
-            .directive => try self.writeNodeSpan(node),
+            .directive => {
+                // span 은 문자열 리터럴 범위 (따옴표 포함). quote_style 정규화를 적용해
+                // `'use server'` → `"use server"` 같은 변환이 일반 string_literal 과 동일하게
+                // 일어나도록 writeStringLiteral 사용. 항상 `;` 를 붙여 ASI 의존을 피한다.
+                try self.writeStringLiteral(node.span);
+                try self.writeByte(';');
+            },
             .hashbang => {
                 if (!self.options.strip_hashbang) try self.writeNodeSpan(node);
             },

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1427,6 +1427,52 @@ pub const Parser = struct {
         return std.mem.eql(u8, inner, "use strict");
     }
 
+    /// 파싱된 statement 가 bare `StringLiteral ;` 형태이면 `.directive` 노드로 재해석.
+    /// oxc 의 post-parse 판정 방식 (crates/oxc_parser/src/js/statement.rs, `parse_directives_and_statements`):
+    /// ASI/peek 예측 없이 실제 파스 결과를 검사하므로 정확하다.
+    ///
+    /// 괄호 방어: `("use strict");` 은 directive 아님. 현재 파서는 괄호를
+    /// `.parenthesized_expression` 로 보존하므로 operand tag 검사만으로 걸러지지만,
+    /// span.start 비교도 함께 둬 paren unwrapping 이 생길 경우에도 견딘다.
+    ///
+    /// 효율: 새 노드를 할당하지 않고 기존 slot 의 tag/data 를 in-place 로 덮어쓴다
+    /// (minify.zig 의 empty_statement 치환과 동일한 관행). 반환값은 directive 면
+    /// 동일한 stmt_idx, 아니면 `.none`.
+    pub fn tryConvertToDirective(self: *Parser, stmt_idx: NodeIndex) NodeIndex {
+        if (stmt_idx.isNone()) return NodeIndex.none;
+        const stmt = self.ast.getNode(stmt_idx);
+        if (stmt.tag != .expression_statement) return NodeIndex.none;
+        const operand = stmt.data.unary.operand;
+        if (operand.isNone()) return NodeIndex.none;
+        const expr = self.ast.getNode(operand);
+        if (expr.tag != .string_literal) return NodeIndex.none;
+        if (stmt.span.start != expr.span.start) return NodeIndex.none;
+        // span 은 문자열 리터럴 범위 (따옴표 포함). worklet 의 getText(span)[1..len-1]
+        // 슬라이싱과 호환. codegen 은 `.directive` 출력 시 span + `;` 를 쓴다.
+        self.ast.nodes.items[@intFromEnum(stmt_idx)] = .{
+            .tag = .directive,
+            .span = expr.span,
+            .data = .{ .none = 0 },
+        };
+        return stmt_idx;
+    }
+
+    /// parseStatement 결과를 stmts 에 추가하면서 directive prologue 상태를 갱신한다.
+    /// prologue 중이고 stmt 이 bare string 이면 `.directive` 로 in-place 전환, 아니면
+    /// prologue 종료. program 파서와 function body 파서에서 공유.
+    pub fn appendStatementTrackingPrologue(
+        self: *Parser,
+        stmts: *std.ArrayList(NodeIndex),
+        stmt: NodeIndex,
+        in_prologue: *bool,
+    ) !void {
+        if (stmt.isNone()) return;
+        if (in_prologue.* and self.tryConvertToDirective(stmt).isNone()) {
+            in_prologue.* = false;
+        }
+        try stmts.append(self.allocator, stmt);
+    }
+
     /// 루프 본문을 파싱한다. in_loop를 save/restore.
     pub fn parseLoopBody(self: *Parser) ParseError2!NodeIndex {
         const saved_in_loop = self.in_loop;
@@ -1677,6 +1723,9 @@ pub const Parser = struct {
 
         while (self.current() != .r_curly and self.current() != .eof) {
             const loop_guard_pos = self.scanner.token.span.start;
+
+            // Pre-parse: "use strict" 및 octal escape 감지는 파싱 결과에 영향을 주므로
+            // parseStatement 호출 전에 수행. directive 노드로의 변환은 post-parse.
             if (in_directive_prologue) {
                 if (self.isUseStrictDirective()) {
                     // non-simple parameters + "use strict" → 에러
@@ -1696,13 +1745,12 @@ pub const Parser = struct {
                         has_prologue_octal = true;
                         prologue_octal_span = self.currentSpan();
                     }
-                } else {
-                    in_directive_prologue = false;
                 }
             }
 
             const stmt = try self.parseStatement();
-            if (!stmt.isNone()) try stmts.append(self.allocator, stmt);
+            try self.appendStatementTrackingPrologue(&stmts, stmt, &in_directive_prologue);
+
             if (try self.ensureLoopProgress(loop_guard_pos)) break;
         }
 

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -52,20 +52,16 @@ pub fn parse(self: *Parser) !NodeIndex {
     while (self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
 
-        if (in_directive_prologue) {
-            if (self.isUseStrictDirective()) {
-                self.is_strict_mode = true;
-                self.strict_from_directive = true;
-            } else if (self.current() != .string_literal) {
-                // directive prologue는 문자열 expression statement가 연속되는 동안 유효
-                in_directive_prologue = false;
-            }
+        // Pre-parse: "use strict" 는 파싱 결과가 strict mode 파싱에 영향을 주므로
+        // parseStatement 호출 전에 미리 감지해 플래그를 세팅한다. directive 노드로의
+        // 실제 변환은 post-parse (tryConvertToDirective) 에서 수행.
+        if (in_directive_prologue and self.isUseStrictDirective()) {
+            self.is_strict_mode = true;
+            self.strict_from_directive = true;
         }
 
         const stmt = try parseStatement(self);
-        if (!stmt.isNone()) {
-            try stmts.append(self.allocator, stmt);
-        }
+        try self.appendStatementTrackingPrologue(&stmts, stmt, &in_directive_prologue);
 
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
@@ -339,6 +335,8 @@ fn parseEmptyStatement(self: *Parser) ParseError2!NodeIndex {
 }
 
 pub fn parseExpressionStatement(self: *Parser) ParseError2!NodeIndex {
+    // span.start = 첫 토큰 위치 불변식 — Parser.tryConvertToDirective 가 괄호 방어에
+    // 이를 이용 (bare string 이면 stmt.span.start == string_literal.span.start).
     const start = self.currentSpan().start;
     self.has_cover_init_name = false;
     const expr = try self.parseExpression();

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -1030,8 +1030,10 @@ test "expr simplify: 리터럴 statement — empty 로 축약" {
     try expectMinifyDead("1;", "function run() {\n\t;\n}\nrun();");
 }
 
-test "expr simplify: string literal statement 축약" {
-    try expectMinifyDead("\"x\";", "function run() {\n\t;\n}\nrun();");
+test "expr simplify: string literal statement 축약 (non-prologue)" {
+    // 선두 `1;` 로 directive prologue 를 종료 — 뒤 `"x";` 는 .directive 가 아닌 일반
+    // expression_statement 로 파싱되어 unused simplify 대상이 된다.
+    try expectMinifyDead("1; \"x\";", "function run() {\n\t;\n\t;\n}\nrun();");
 }
 
 test "expr simplify: pure binary statement 축약" {

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -465,15 +465,9 @@ fn hasFileWorkletDirective(t: *Transformer, list_start: u32, list_len: u32) bool
     var i: u32 = 0;
     while (i < list_len) : (i += 1) {
         const idx: NodeIndex = @enumFromInt(t.ast.extra_data.items[list_start + i]);
-        if (idx.isNone()) continue;
-        const stmt = t.ast.getNode(idx);
-        if (stmt.tag != .expression_statement) return false;
-        const inner_idx = stmt.data.unary.operand;
-        if (inner_idx.isNone()) return false;
-        const inner = t.ast.getNode(inner_idx);
-        if (inner.tag != .string_literal) return false;
-        const text = t.ast.getText(inner.span);
-        if (std.mem.eql(u8, text, "\"worklet\"") or std.mem.eql(u8, text, "'worklet'")) return true;
+        // prologue 종료 감지: directive 가 아닌 첫 문장에서 바로 false.
+        const text = worklet_mod.directiveText(&t.ast, idx) orelse return false;
+        if (std.mem.eql(u8, text, "worklet")) return true;
     }
     return false;
 }

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -39,10 +39,32 @@ pub const ClosureVar = struct {
 // Phase 1: "worklet" 디렉티브 감지 + 제거
 // ================================================================
 
-/// 함수 body의 첫 문장이 지정된 디렉티브인지 확인한다 (범용).
-/// 함수 body에서 지정된 디렉티브를 찾는다.
-/// ES5 변환(rest params 등)이 body 앞에 문장을 삽입할 수 있으므로,
-/// 첫 문장뿐 아니라 앞쪽 몇 문장 내에서 탐색한다.
+/// statement 가 directive prologue 형태면 따옴표 제거된 내부 문자열을 반환.
+/// `.directive` (신 경로, parser post-parse 변환) 와 `.expression_statement` + `.string_literal`
+/// (레거시 경로, 변환 단계에서 재구성되는 경우 대비) 둘 다 지원.
+/// 괄호 / 다른 모양은 null 반환.
+pub fn directiveText(ast: anytype, stmt_idx: NodeIndex) ?[]const u8 {
+    if (stmt_idx.isNone()) return null;
+    const stmt = ast.getNode(stmt_idx);
+    const literal_span = switch (stmt.tag) {
+        .directive => stmt.span,
+        .expression_statement => blk: {
+            const inner_idx = stmt.data.unary.operand;
+            if (inner_idx.isNone()) return null;
+            const inner = ast.getNode(inner_idx);
+            if (inner.tag != .string_literal) return null;
+            break :blk inner.span;
+        },
+        else => return null,
+    };
+    const text = ast.getText(literal_span);
+    if (text.len < 2) return null;
+    return text[1 .. text.len - 1];
+}
+
+/// 함수 body에서 지정된 디렉티브를 찾는다. ES5 변환(rest params 등)이 body 앞에 문장을
+/// 삽입할 수 있으므로 첫 문장뿐 아니라 앞쪽 최대 5문장 내에서 탐색한다 — non-directive
+/// 문장은 건너뛰고 계속 탐색.
 /// 발견 시 해당 문장의 리스트 내 오프셋을 반환, 없으면 null.
 pub fn findDirectiveOffset(self: *Transformer, body_idx: NodeIndex, directive: []const u8) ?u32 {
     if (body_idx.isNone()) return null;
@@ -50,33 +72,12 @@ pub fn findDirectiveOffset(self: *Transformer, body_idx: NodeIndex, directive: [
     if (body.tag != .block_statement and body.tag != .function_body) return null;
 
     const list = body.data.list;
-    // 앞쪽 최대 5문장 내에서 탐색 (rest params, default params 등이 삽입될 수 있음)
     const search_len = @min(list.len, 5);
     var si: u32 = 0;
     while (si < search_len) : (si += 1) {
-        const stmt_raw = self.ast.extra_data.items[list.start + si];
-        const stmt_idx: NodeIndex = @enumFromInt(stmt_raw);
-        if (stmt_idx.isNone()) continue;
-
-        const stmt = self.ast.getNode(stmt_idx);
-
-        if (stmt.tag == .directive) {
-            const text = self.ast.getText(stmt.span);
-            if (text.len >= 2 and std.mem.eql(u8, text[1 .. text.len - 1], directive)) {
-                return si;
-            }
-        } else if (stmt.tag == .expression_statement) {
-            const operand_idx = stmt.data.unary.operand;
-            if (!operand_idx.isNone()) {
-                const operand = self.ast.getNode(operand_idx);
-                if (operand.tag == .string_literal) {
-                    const text = self.ast.getText(operand.data.string_ref);
-                    if (text.len >= 2 and std.mem.eql(u8, text[1 .. text.len - 1], directive)) {
-                        return si;
-                    }
-                }
-            }
-        }
+        const stmt_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + si]);
+        const text = directiveText(&self.ast, stmt_idx) orelse continue;
+        if (std.mem.eql(u8, text, directive)) return si;
     }
     return null;
 }


### PR DESCRIPTION
## Summary

- #1649 (unused expression simplify) 가 `"use client"` / `"use strict"` 등 디렉티브를 unused string literal 로 간주해 제거하던 회귀 (RSC 테스트 17개 실패) 를 AST 층에서 근본 수정
- 파서가 bare `StringLiteral ;` 을 post-parse 로 `.directive` 노드로 in-place 재해석 (oxc 방식) → minifier/semantic/번들러가 tag 만으로 directive 자동 구분
- `.directive` tag / codegen 경로 / worklet findDirectiveOffset 의 이중 경로 지원 등 인프라는 이미 존재, 파서만 실제로 `.directive` 를 생성하지 않던 것이 원인

## 변경

**Parser**
- `Parser.tryConvertToDirective(stmt_idx)` — bare `StringLiteral ;` 을 `.directive` 노드로 in-place 재해석 (새 노드 할당 없이 기존 slot 덮어쓰기 — minify.zig 관행)
- `Parser.appendStatementTrackingPrologue()` helper — top-level (statement.zig) / 함수 body (parser.zig) 의 prologue append 로직 공유
- 괄호 방어: `("use strict");` 는 directive 아님 (tag + span.start 이중 검사)

**Codegen**
- `.directive` 출력: `writeNodeSpan` 대신 `writeStringLiteral` 로 quote 정규화 적용 + `;` (ASI 의존 회피)

**Worklet**
- `directiveText(ast, idx)` helper 신설 — `.directive` + legacy `.expression_statement` + `.string_literal` 둘 다 처리
- `findDirectiveOffset` / `hasFileWorkletDirective` 재사용으로 중복 제거

**Tests**
- `minify_test.zig`: string literal 축약 테스트가 prologue 위치 의존이라 `1; "x";` 로 변경 (non-prologue 위치)

## 대안 검토 (리뷰 커밋 이전 합의)

1. minifier 호출 site 에서 가드 — 패스마다 prologue 문맥 추적, 차기 패스 또 밟음 ❌
2. `isStmtRemovable` 에서 string 제외 — 정상 `"unused";` 최적화 손실 ❌
3. **파서가 `.directive` 생성** — AST 에 의미 인코딩, 모든 패스 자동 정확 (oxc/swc/babel 표준) ✅

## Test plan

- [x] `tests/rsc-directives.test.ts` 53/53 통과 (회귀 17 + simplify 도중 발견한 5 포함)
- [x] `zig build test` 3210/3210 통과
- [x] Test262: 23298/86fail (main 과 동일, 회귀 0)
- [x] Spot-check: top-level / 함수 body 디렉티브 / 괄호 `("use strict")` / hashbang + directive / minify-syntax 정상

## Out of scope

- `stripQuotes` 3곳 중복 (`import_scanner.zig`, `es2015_class.zig`, `minify.zig`) — 별도 refactor 이슈로
- Parser Conformance 86 failures 정리 — 별도 이슈 (한달째 고정, 이 PR 과 무관)
- ROADMAP 의 Test262 "100% 통과" 문구 업데이트

Closes #1652

🤖 Generated with [Claude Code](https://claude.com/claude-code)