### PR TITLE
fix(parser): #1656 object literal 의 private method/accessor 전체 variant 에 early error

### DIFF
--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -68,6 +68,7 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
             const method_flags: u16 = if (self.current() == .kw_get) 0x02 else 0x04;
             try self.advance(); // skip get/set
             const key = try self.parsePropertyKey();
+            try checkObjectPropertyKeyNotPrivate(self, key);
             return parseObjectMethodBody(self, start, key, method_flags);
         }
     }
@@ -84,6 +85,7 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
             // async generator: { async *foo() {} }
             if (try self.eat(.star)) method_flags |= 0x10;
             const key = try self.parsePropertyKey();
+            try checkObjectPropertyKeyNotPrivate(self, key);
             return parseObjectMethodBody(self, start, key, method_flags);
         }
     }
@@ -92,16 +94,17 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .star) {
         try self.advance(); // skip '*'
         const key = try self.parsePropertyKey();
+        try checkObjectPropertyKeyNotPrivate(self, key);
         return parseObjectMethodBody(self, start, key, 0x10); // generator
     }
 
     // 키: identifier, string, number, 또는 computed [expr]
     const key = try self.parsePropertyKey();
 
-    // object literal에서 private identifier는 키로 사용 불가
-    if (!key.isNone() and self.ast.getNode(key).tag == .private_identifier) {
-        try self.addErrorCode(self.ast.getNode(key).span, "Private identifier is not allowed as object property key", .private_object_key);
-    }
+    // object literal에서 private identifier는 키로 사용 불가 — shorthand method 포함.
+    // ECMA §sec-method-definitions-static-semantics-early-errors:
+    //   PrivateBoundNames of MethodDefinition must be empty in PropertyDefinition context.
+    try checkObjectPropertyKeyNotPrivate(self, key);
 
     // 메서드 shorthand: { foo() {} } 또는 { foo<T>() {} }
     if (self.current() == .l_paren or self.isAtOpeningAngleBracket()) {
@@ -161,6 +164,23 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
 }
 
 /// 객체 리터럴 메서드의 파라미터와 본문을 파싱한다.
+/// Object literal 의 property key 가 private identifier 인 경우 early SyntaxError 를 보고한다.
+/// ECMA §sec-method-definitions-static-semantics-early-errors / §sec-object-initializer:
+///   PrivateIdentifier 는 class body 안 에서만 허용된다. object literal 에서는
+///   shorthand field · shorthand method · get/set · async · generator · async-generator
+///   어떤 형태로도 허용되지 않는다.
+fn checkObjectPropertyKeyNotPrivate(self: *Parser, key: NodeIndex) ParseError2!void {
+    if (key.isNone()) return;
+    const key_node = self.ast.getNode(key);
+    if (key_node.tag == .private_identifier) {
+        try self.addErrorCode(
+            key_node.span,
+            "Private identifier is not allowed as object property key",
+            .private_object_key,
+        );
+    }
+}
+
 pub fn parseObjectMethodBody(self: *Parser, start: u32, key: NodeIndex, flags: u16) ParseError2!NodeIndex {
     // 메서드 컨텍스트 진입 — 파라미터/본문 모두 이 컨텍스트에서 파싱
     const saved_ctx = self.enterFunctionContext(

--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -164,11 +164,9 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
 }
 
 /// 객체 리터럴 메서드의 파라미터와 본문을 파싱한다.
-/// Object literal 의 property key 가 private identifier 인 경우 early SyntaxError 를 보고한다.
-/// ECMA §sec-method-definitions-static-semantics-early-errors / §sec-object-initializer:
-///   PrivateIdentifier 는 class body 안 에서만 허용된다. object literal 에서는
-///   shorthand field · shorthand method · get/set · async · generator · async-generator
-///   어떤 형태로도 허용되지 않는다.
+/// Object literal 의 property key 가 PrivateIdentifier 면 early SyntaxError.
+/// 모든 MethodDefinition variant (shorthand · get/set · async · generator · async-generator)
+/// 에서 금지 — ECMA §sec-method-definitions-static-semantics-early-errors.
 fn checkObjectPropertyKeyNotPrivate(self: *Parser, key: NodeIndex) ParseError2!void {
     if (key.isNone()) return;
     const key_node = self.ast.getNode(key);

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3109,7 +3109,6 @@ test "Flow: shorthand function type as method return" {
     );
 }
 
-// ============================================================
 // async arrow: 내부 arrow 의 파라미터에서도 'await' 식별자 금지
 // (ECMA §sec-async-arrow-function-definitions)
 // ============================================================
@@ -3125,4 +3124,41 @@ test "Async arrow: nested arrow rest param 'await' is error" {
 test "Async arrow: nested arrow ident 'await' (with preceding statement)" {
     // 이전 statement 가 있어도 파서 상태가 올바르게 유지되어야 한다.
     try expectParseError("var x = 1; async(a = await => {}) => {};", .{ .message_contains = "await" });
+}
+
+// ============================================================
+// Object literal: private identifier 금지 (ECMA §sec-method-definitions-static-semantics-early-errors)
+// 모든 method definition variant 와 shorthand 에서 PrivateIdentifier 는 early SyntaxError.
+// ============================================================
+
+test "Object literal: private shorthand method is error" {
+    try expectParseError("var o = { #m() {} };", .{ .message_contains = "Private identifier" });
+}
+
+test "Object literal: private generator method is error" {
+    try expectParseError("var o = { *#m() {} };", .{ .message_contains = "Private identifier" });
+}
+
+test "Object literal: private async method is error" {
+    try expectParseError("var o = { async #m() {} };", .{ .message_contains = "Private identifier" });
+}
+
+test "Object literal: private async generator method is error" {
+    try expectParseError("var o = { async *#m() {} };", .{ .message_contains = "Private identifier" });
+}
+
+test "Object literal: private getter is error" {
+    try expectParseError("var o = { get #m() {} };", .{ .message_contains = "Private identifier" });
+}
+
+test "Object literal: private setter is error" {
+    try expectParseError("var o = { set #m(x) {} };", .{ .message_contains = "Private identifier" });
+}
+
+test "Object literal inside class field: private generator is error" {
+    try expectParseError("class C { field = { *#m() {} } }", .{ .message_contains = "Private identifier" });
+}
+
+test "Object literal inside class field: private async is error" {
+    try expectParseError("class C { field = { async #m() {} } }", .{ .message_contains = "Private identifier" });
 }


### PR DESCRIPTION
## Summary
- Object literal 의 method definition 에서 PrivateIdentifier 금지 (ECMA §sec-method-definitions-static-semantics-early-errors) 를 **모든 variant** 로 확장. 기존에 누락되었던 generator · async · async-generator · getter · setter 다섯 경우 + class field 안 object literal 동일 상황을 잡는다.
- `src/parser/object.zig` 에 `checkObjectPropertyKeyNotPrivate` helper 추가 (ZTS0615).
- `parser_test.zig` 에 8 개 유닛테스트 추가.

## Impact

test262: **10건 해결** (expressions/object/method-definition/private-name-early-error-*).

## Test plan
- [x] `zig build` 통과
- [x] `zig build test` 전체 통과 (parser 유닛 포함, 새 8 케이스)
- [x] `zig build test262-run` — 86 → 76 fail (본 PR 단독, PR #1655 미머지 기준. 두 PR 병합 시 25건 남을 예정)
- [ ] CI 통과 확인

Closes #1656