### PR TITLE
fix(parser): #1658 async arrow 중첩 arrow 파라미터 'await' 검사 누락 수정

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1108,8 +1108,7 @@ pub const Parser = struct {
                 try self.checkAsyncArrowParamsForAwait(node.data.binary.left);
                 try self.checkAsyncArrowParamsForAwait(node.data.binary.right);
             },
-            // 중첩 arrow 의 파라미터에도 await 사용 금지 (body 는 별개 scope 라 검사 제외).
-            // arrow_function_expression 의 data 는 extra 레이아웃: {params, body, flags}.
+            // 중첩 arrow: params (extra[0]) 만 검사 — body 는 별개 scope 라 무관.
             .arrow_function_expression => {
                 const params_idx = self.ast.readExtraNode(node.data.extra, 0);
                 try self.checkAsyncArrowParamsForAwait(params_idx);

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1075,7 +1075,12 @@ pub const Parser = struct {
                     try self.addErrorCode(node.span, "'await' is not allowed in async arrow function parameters", .await_in_async_arrow_params);
                 }
             },
-            .parenthesized_expression, .spread_element, .assignment_target_rest => {
+            .parenthesized_expression,
+            .spread_element,
+            .assignment_target_rest,
+            .rest_element,
+            .binding_rest_element,
+            => {
                 try self.checkAsyncArrowParamsForAwait(node.data.unary.operand);
             },
             .sequence_expression,
@@ -1083,6 +1088,7 @@ pub const Parser = struct {
             .object_expression,
             .array_assignment_target,
             .object_assignment_target,
+            .formal_parameters,
             => {
                 const list = node.data.list;
                 var i: u32 = 0;
@@ -1102,9 +1108,11 @@ pub const Parser = struct {
                 try self.checkAsyncArrowParamsForAwait(node.data.binary.left);
                 try self.checkAsyncArrowParamsForAwait(node.data.binary.right);
             },
-            // 중첩 arrow의 파라미터에도 await 사용 금지
+            // 중첩 arrow 의 파라미터에도 await 사용 금지 (body 는 별개 scope 라 검사 제외).
+            // arrow_function_expression 의 data 는 extra 레이아웃: {params, body, flags}.
             .arrow_function_expression => {
-                try self.checkAsyncArrowParamsForAwait(node.data.binary.left);
+                const params_idx = self.ast.readExtraNode(node.data.extra, 0);
+                try self.checkAsyncArrowParamsForAwait(params_idx);
             },
             else => {},
         }

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3108,3 +3108,21 @@ test "Flow: shorthand function type as method return" {
         \\}
     );
 }
+
+// ============================================================
+// async arrow: 내부 arrow 의 파라미터에서도 'await' 식별자 금지
+// (ECMA §sec-async-arrow-function-definitions)
+// ============================================================
+
+test "Async arrow: nested arrow ident param 'await' is error" {
+    try expectParseError("async(a = await => {}) => {};", .{ .message_contains = "await" });
+}
+
+test "Async arrow: nested arrow rest param 'await' is error" {
+    try expectParseError("async(a = (...await) => {}) => {};", .{ .message_contains = "await" });
+}
+
+test "Async arrow: nested arrow ident 'await' (with preceding statement)" {
+    // 이전 statement 가 있어도 파서 상태가 올바르게 유지되어야 한다.
+    try expectParseError("var x = 1; async(a = await => {}) => {};", .{ .message_contains = "await" });
+}


### PR DESCRIPTION
## Summary
- `checkAsyncArrowParamsForAwait` 가 nested arrow 의 params 트리로 내려가지 못하던 두 가지 구멍 수정:
  - `arrow_function_expression` 노드는 `data.extra` 레이아웃인데 `data.binary.left` 를 읽어 무관한 노드로 분기하고 있었음 → `readExtraNode(extra, 0)` 로 교체.
  - `formal_parameters`, `rest_element`, `binding_rest_element` tag 가 switch 에서 빠져 있어 정규화된 params 트리 내부로 재귀 안 됨 → 추가.
- `parser_test.zig` 에 유닛 3건 (ident / rest / preceding-statement).

## Impact

test262: **2건 해결** — `expressions/async-arrow-function/await-as-param-*-nested-arrow-parameter-position.js`.

## Test plan
- [x] `zig build` 통과
- [x] `zig build test` 전체 통과
- [x] `zig build test262-run` — 86 → 84 fail (본 PR 단독 기준, 다른 PR 들과 병합 시 누적 감소)
- [ ] CI 통과 확인

Closes #1658