### PR TITLE
feat(minify): #1650 step 2 — unused expression simplify (c/d)

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -873,7 +873,9 @@ fn simplifySequence(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, change
 
     for (indices[0 .. list.len - 1]) |raw| {
         if (raw >= ast.nodes.items.len) return;
-        if (isStmtRemovable(ast, @enumFromInt(raw), ctx)) {
+        // 내부 부분 rewrite 도 동시에 수행 (`a ? b : c` → `a || c` 등).
+        // rewriter 가 내부 제거분은 이미 감산함 — 최종 removable 로 판정되면 호출자가 raw 전체 감산.
+        if (simplifyUnusedInPlace(ast, ctx, @enumFromInt(raw), changed, 0)) {
             removed_buf.append(ast.allocator, raw) catch return;
         } else {
             kept_buf.append(ast.allocator, raw) catch return;
@@ -903,12 +905,13 @@ fn simplifySequence(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, change
     changed.* = true;
 }
 
-/// expression_statement 의 자식 expression 이 side-effect 없이 제거 가능하면
-/// `empty_statement` 로 교체한다. 제거 시 내부 identifier_reference 의
-/// reference_count 를 감산 (dead store PR1 과 동일 방식).
+/// expression_statement 의 자식 expression 을 unused 맥락에서 축약하고, 최종적으로
+/// removable 이면 `empty_statement` 로 교체한다.
+/// `simplifyUnusedInPlace` 가 내부 부분 제거 (`a ? b : c;` → `a || c;` 등) 를 수행.
 fn simplifyUnusedExprStmt(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, changed: *bool) void {
     const operand = node.data.unary.operand;
-    if (!isStmtRemovable(ast, operand, ctx)) return;
+    const removable = simplifyUnusedInPlace(ast, ctx, operand, changed, 0);
+    if (!removable) return;
 
     decrementRefsInExpr(ast, ctx, operand);
     replaceNode(ast, node_idx, .{
@@ -916,6 +919,166 @@ fn simplifyUnusedExprStmt(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, 
         .span = node.span,
         .data = .{ .none = 0 },
     }, changed);
+}
+
+// ================================================================
+// Unused Expression In-Place Simplify (#1650 step 2 — c/d)
+// ================================================================
+//
+// **호출 site contract**: `idx` 의 expression 결과값이 **버려지는 자리** (statement 자리 또는
+// `sequence_expression` 비마지막 원소) 전용. call callee (`(0, f)()` 의 `0`), assignment RHS,
+// return expression 등 결과값이 관측되는 자리에 쓰면 semantic 위반.
+//
+// **Mutation contract**:
+//   - 내부 rewrite 시 제거되는 sub-expression 의 `reference_count` 를 **내부에서 감산**.
+//   - 반환 `true`: 현재 idx 전체가 removable — 호출자는 idx 를 drop 하고 **추가로** idx 전체의
+//     refs 를 감산해야 함 (최종 drop).
+//   - 반환 `false`: 호출자는 idx 를 유지. 감산 금지.
+//
+// **Rewrites** (모두 fixed-point loop 하에서 연쇄):
+//   - `a ? b : c` 에서 b / c 가 removable → `a && b` / `a || c` (logical_expression 으로 변환)
+//   - `a ? b : c` 에서 둘 다 removable → `a` (conditional 을 test 로 교체)
+//   - `a <op> b` (비교) 에서 한쪽 removable → 나머지로 교체
+//   - `a && b` / `a || b` / `a ?? b` 에서 right removable → left 만 남김 (short-circuit 의미상 OK)
+//   - template_literal 전체 (모든 substitution removable) → true 판정만
+
+// depth 제한은 `isStmtRemovableDepth` 와 맞춤 — 두 함수가 상호 재귀.
+const max_unused_simplify_depth: u32 = max_stmt_removable_depth;
+
+fn simplifyUnusedInPlace(ast: *Ast, ctx: MinifyCtx, idx: NodeIndex, changed: *bool, depth: u32) bool {
+    if (depth >= max_unused_simplify_depth) return false;
+    if (idx.isNone()) return true;
+    const ni = @intFromEnum(idx);
+    if (ni >= ast.nodes.items.len) return false;
+    const node = ast.nodes.items[ni];
+
+    // 3개 rewritable tag 만 여기서 mutation. 그 외는 `isStmtRemovableDepth` 판정에 위임 —
+    // literal / identifier / unary / sequence / template / call 등은 판정만 필요.
+    return switch (node.tag) {
+        .binary_expression => rewriteBinaryUnused(ast, ctx, ni, node, changed, depth),
+        .logical_expression => rewriteLogicalUnused(ast, ctx, ni, node, changed, depth),
+        .conditional_expression => rewriteConditionalUnused(ast, ctx, ni, node, changed, depth),
+        .parenthesized_expression => simplifyUnusedInPlace(ast, ctx, node.data.unary.operand, changed, depth + 1),
+        else => isStmtRemovableDepth(ast, idx, ctx, depth),
+    };
+}
+
+/// 비교 연산 (`==`, `===`, `!=`, `!==`, `<`, `>`, `<=`, `>=`, `in`, `instanceof`) 은
+/// 양쪽 operand 가 pure 면 전체 removable. 한쪽만 removable 이면 나머지로 교체.
+/// 비교 외 binary (`+`, `-`, `*`, `|`, ...) 는 양쪽 pure 여야 removable — JS `valueOf`/`toString`
+/// 의 side-effect 는 purity 가 이미 식별. 부분 rewrite 는 안 함 (의미 보존 복잡).
+fn rewriteBinaryUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed: *bool, depth: u32) bool {
+    const op: Kind = @enumFromInt(node.data.binary.flags);
+    const is_comparison = switch (op) {
+        .eq3, .neq2, .eq2, .neq, .l_angle, .r_angle, .lt_eq, .gt_eq, .kw_in, .kw_instanceof => true,
+        else => false,
+    };
+
+    const left_idx = node.data.binary.left;
+    const right_idx = node.data.binary.right;
+    const d = depth + 1;
+
+    if (!is_comparison) {
+        return isStmtRemovableDepth(ast, left_idx, ctx, d) and
+            isStmtRemovableDepth(ast, right_idx, ctx, d);
+    }
+
+    const left_rem = isStmtRemovableDepth(ast, left_idx, ctx, d);
+    const right_rem = isStmtRemovableDepth(ast, right_idx, ctx, d);
+
+    if (left_rem and right_rem) return true;
+
+    if (left_rem) {
+        // `pure == impure` → `impure`
+        const right_ni = @intFromEnum(right_idx);
+        if (right_ni >= ast.nodes.items.len) return false;
+        decrementRefsInExpr(ast, ctx, left_idx);
+        replaceNode(ast, ni, ast.nodes.items[right_ni], changed);
+        return false;
+    }
+    if (right_rem) {
+        // `impure == pure` → `impure`
+        const left_ni = @intFromEnum(left_idx);
+        if (left_ni >= ast.nodes.items.len) return false;
+        decrementRefsInExpr(ast, ctx, right_idx);
+        replaceNode(ast, ni, ast.nodes.items[left_ni], changed);
+        return false;
+    }
+    return false;
+}
+
+/// `&&`, `||`, `??` 는 short-circuit 때문에 left 의 truthy/nullish 판정이 b 의 실행을 제어.
+/// statement 자리에선 결과값은 버려지므로:
+///   - right removable → `left` 만 남김 (b 의 실행 여부 차이는 "pure" 라 관측 불가)
+///   - left removable only → 그대로 유지 (b 의 실행 여부가 바뀜 → 의미 변경)
+///   - 둘 다 removable → 전체 removable
+fn rewriteLogicalUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed: *bool, depth: u32) bool {
+    const left_idx = node.data.binary.left;
+    const right_idx = node.data.binary.right;
+    const d = depth + 1;
+
+    const right_rem = isStmtRemovableDepth(ast, right_idx, ctx, d);
+    if (!right_rem) return false;
+
+    const left_rem = isStmtRemovableDepth(ast, left_idx, ctx, d);
+    if (left_rem) return true;
+
+    // right drop, left 만 남김
+    const left_ni = @intFromEnum(left_idx);
+    if (left_ni >= ast.nodes.items.len) return false;
+    decrementRefsInExpr(ast, ctx, right_idx);
+    replaceNode(ast, ni, ast.nodes.items[left_ni], changed);
+    return false;
+}
+
+/// Conditional `a ? b : c` 를 unused 자리에서 축약:
+///   - b, c 둘 다 removable → `a` 로 교체 (a 자체 removable 여부로 반환)
+///   - b removable → `a || c` (b 는 a truthy 시 실행되므로 drop OK)
+///   - c removable → `a && b`
+///   - 둘 다 impure → 그대로
+fn rewriteConditionalUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed: *bool, depth: u32) bool {
+    const test_idx = node.data.ternary.a;
+    const cons_idx = node.data.ternary.b;
+    const alt_idx = node.data.ternary.c;
+    const d = depth + 1;
+
+    const cons_rem = isStmtRemovableDepth(ast, cons_idx, ctx, d);
+    const alt_rem = isStmtRemovableDepth(ast, alt_idx, ctx, d);
+
+    if (cons_rem and alt_rem) {
+        const test_ni = @intFromEnum(test_idx);
+        if (test_ni >= ast.nodes.items.len) return false;
+        decrementRefsInExpr(ast, ctx, cons_idx);
+        decrementRefsInExpr(ast, ctx, alt_idx);
+        replaceNode(ast, ni, ast.nodes.items[test_ni], changed);
+        return isStmtRemovableDepth(ast, test_idx, ctx, d);
+    }
+
+    if (cons_rem) {
+        // a ? [pure] : c → a || c
+        decrementRefsInExpr(ast, ctx, cons_idx);
+        ast.nodes.items[ni] = .{
+            .tag = .logical_expression,
+            .span = node.span,
+            .data = .{ .binary = .{ .left = test_idx, .right = alt_idx, .flags = @intFromEnum(Kind.pipe2) } },
+        };
+        changed.* = true;
+        return false;
+    }
+
+    if (alt_rem) {
+        // a ? b : [pure] → a && b
+        decrementRefsInExpr(ast, ctx, alt_idx);
+        ast.nodes.items[ni] = .{
+            .tag = .logical_expression,
+            .span = node.span,
+            .data = .{ .binary = .{ .left = test_idx, .right = cons_idx, .flags = @intFromEnum(Kind.amp2) } },
+        };
+        changed.* = true;
+        return false;
+    }
+
+    return false;
 }
 
 /// expression 이 **statement 자리에서 안전히 삭제 가능한지** 판정. `purity.isExprPure`
@@ -1001,6 +1164,21 @@ fn isStmtRemovableDepth(ast: *const Ast, idx: NodeIndex, ctx: MinifyCtx, depth: 
             const list = node.data.list;
             if (list.start + list.len > ast.extra_data.items.len) break :blk false;
             for (ast.extra_data.items[list.start .. list.start + list.len]) |raw| {
+                if (!isStmtRemovableDepth(ast, @enumFromInt(raw), ctx, d)) break :blk false;
+            }
+            break :blk true;
+        },
+
+        .template_literal => blk: {
+            // 단순 문자열 template (data.none = 0) — substitution 없음, removable.
+            if (node.data.none == 0) break :blk true;
+            const list = node.data.list;
+            if (list.start + list.len > ast.extra_data.items.len) break :blk false;
+            for (ast.extra_data.items[list.start .. list.start + list.len]) |raw| {
+                if (raw >= ast.nodes.items.len) break :blk false;
+                const child = ast.nodes.items[raw];
+                // template_element 는 리터럴 문자열 조각 — 항상 removable.
+                if (child.tag == .template_element) continue;
                 if (!isStmtRemovableDepth(ast, @enumFromInt(raw), ctx, d)) break :blk false;
             }
             break :blk true;

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -168,6 +168,24 @@ inline fn replaceNode(ast: *Ast, idx: u32, new_node: Node, changed: *bool) void 
     changed.* = true;
 }
 
+/// `inner_idx` 를 감싸는 새 `parenthesized_expression` 노드를 append 하고 그 NodeIndex 반환.
+/// 실패 시 (OOM) `inner_idx` 를 그대로 반환 — 호출자가 grammar 위반이 발생할 수 있는 자리에
+/// 이 결과를 넣으면 안 됨. 필요 시 호출자가 사전에 realloc 감수.
+fn wrapInParen(ast: *Ast, inner_idx: NodeIndex) !NodeIndex {
+    const inner_ni = @intFromEnum(inner_idx);
+    const span = if (inner_ni < ast.nodes.items.len)
+        ast.nodes.items[inner_ni].span
+    else
+        Span{ .start = 0, .end = 0 };
+    const new_ni: u32 = @intCast(ast.nodes.items.len);
+    try ast.nodes.append(ast.allocator, .{
+        .tag = .parenthesized_expression,
+        .span = span,
+        .data = .{ .unary = .{ .operand = inner_idx, .flags = 0 } },
+    });
+    return @enumFromInt(new_ni);
+}
+
 /// AST minify 패스를 실행한다. ast를 in-place 수정.
 /// `ctx` 에 semantic 정보가 있으면 dead store (unused declaration) 제거도 함께 수행.
 ///
@@ -192,20 +210,26 @@ pub fn minify(ast: *Ast, ctx: MinifyCtx) void {
 
 /// minify 1 iteration. 변경이 있었으면 true 반환 (fixed-point 종료 판정용).
 /// `changed` 는 보수적 true 허용 — 실제 mutation 없이 true 설정해도 최악 1 iter 더 돌고 끝.
+///
+/// **Index-based loop**: rewrite 중 `ast.nodes.append` (e.g. paren 노드 생성) 로
+/// items slice 가 재할당되어도 안전 — 매 iter `ast.nodes.items[i]` 재슬라이스.
+/// 새로 append 된 노드는 `items.len` 증가로 자동 순회됨.
 fn runOnce(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.DynamicBitSet) bool {
     var changed = false;
-    for (ast.nodes.items, 0..) |node, i| {
+    var i: u32 = 0;
+    while (i < ast.nodes.items.len) : (i += 1) {
+        const node = ast.nodes.items[i];
         switch (node.tag) {
-            .binary_expression => foldBinary(ast, @intCast(i), node, &changed),
-            .logical_expression => foldLogical(ast, @intCast(i), node, &changed),
-            .unary_expression => foldUnary(ast, @intCast(i), node, &changed),
-            .conditional_expression => foldConditional(ast, @intCast(i), node, &changed),
-            .if_statement => foldIf(ast, @intCast(i), node, &changed),
-            .while_statement => foldWhile(ast, @intCast(i), node, &changed),
-            .sequence_expression => simplifySequence(ast, ctx, @intCast(i), node, &changed),
+            .binary_expression => foldBinary(ast, i, node, &changed),
+            .logical_expression => foldLogical(ast, i, node, &changed),
+            .unary_expression => foldUnary(ast, i, node, &changed),
+            .conditional_expression => foldConditional(ast, i, node, &changed),
+            .if_statement => foldIf(ast, i, node, &changed),
+            .while_statement => foldWhile(ast, i, node, &changed),
+            .sequence_expression => simplifySequence(ast, ctx, i, node, &changed),
             // PR1.5 (a): unused expression statement 축약 — semantic 정보 있을 때만
             // (symbol_ids 가 없으면 identifier local binding 판정 불가)
-            .expression_statement => if (ctx.hasSemantic()) simplifyUnusedExprStmt(ast, ctx, @intCast(i), node, &changed),
+            .expression_statement => if (ctx.hasSemantic()) simplifyUnusedExprStmt(ast, ctx, i, node, &changed),
             else => {},
         }
     }
@@ -1036,6 +1060,11 @@ fn rewriteLogicalUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed:
 ///   - b removable → `a || c` (b 는 a truthy 시 실행되므로 drop OK)
 ///   - c removable → `a && b`
 ///   - 둘 다 impure → 그대로
+///
+/// **Grammar**: conditional 의 cons/alt 는 `AssignmentExpression` 을 paren 없이 허용
+/// (`a ? b : c = d` → `a ? b : (c = d)` 로 파싱). 그러나 `logical_expression` 의 right 자리는
+/// `LogicalORExpression` 이라 assignment / sequence 직접 불가. rewrite 시 kept operand 가
+/// 이 두 tag 이면 `parenthesized_expression` 노드를 새로 만들어 감싸서 옮긴다.
 fn rewriteConditionalUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed: *bool, depth: u32) bool {
     const test_idx = node.data.ternary.a;
     const cons_idx = node.data.ternary.b;
@@ -1056,11 +1085,12 @@ fn rewriteConditionalUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, chan
 
     if (cons_rem) {
         // a ? [pure] : c → a || c
+        const right_idx = ensureLogicalOperand(ast, alt_idx) catch return false;
         decrementRefsInExpr(ast, ctx, cons_idx);
         ast.nodes.items[ni] = .{
             .tag = .logical_expression,
             .span = node.span,
-            .data = .{ .binary = .{ .left = test_idx, .right = alt_idx, .flags = @intFromEnum(Kind.pipe2) } },
+            .data = .{ .binary = .{ .left = test_idx, .right = right_idx, .flags = @intFromEnum(Kind.pipe2) } },
         };
         changed.* = true;
         return false;
@@ -1068,17 +1098,30 @@ fn rewriteConditionalUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, chan
 
     if (alt_rem) {
         // a ? b : [pure] → a && b
+        const right_idx = ensureLogicalOperand(ast, cons_idx) catch return false;
         decrementRefsInExpr(ast, ctx, alt_idx);
         ast.nodes.items[ni] = .{
             .tag = .logical_expression,
             .span = node.span,
-            .data = .{ .binary = .{ .left = test_idx, .right = cons_idx, .flags = @intFromEnum(Kind.amp2) } },
+            .data = .{ .binary = .{ .left = test_idx, .right = right_idx, .flags = @intFromEnum(Kind.amp2) } },
         };
         changed.* = true;
         return false;
     }
 
     return false;
+}
+
+/// `logical_expression` 의 operand 자리에 paren 없이 올 수 있는 `NodeIndex` 로 변환.
+/// `assignment_expression` / `sequence_expression` 은 JS grammar 상 paren 필수 (LogicalOR
+/// 자리에 직접 못 옴) — `wrapInParen` 으로 감싼다. 그 외는 그대로 반환.
+fn ensureLogicalOperand(ast: *Ast, idx: NodeIndex) !NodeIndex {
+    const ni = @intFromEnum(idx);
+    if (ni >= ast.nodes.items.len) return idx;
+    return switch (ast.nodes.items[ni].tag) {
+        .assignment_expression, .sequence_expression => try wrapInParen(ast, idx),
+        else => idx,
+    };
 }
 
 /// expression 이 **statement 자리에서 안전히 삭제 가능한지** 판정. `purity.isExprPure`

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -1285,3 +1285,29 @@ test "unused: assignment RHS 의 conditional 은 rewrite 안 됨" {
         "function run() {\n\tlet x = foo() ? 1 : 2;\n\tconsole.log(x);\n}\nrun();",
     );
 }
+
+// ---- 안전성: conditional rewrite 시 logical operand 에 paren 자동 삽입 ----
+
+test "unused: conditional kept operand 가 assignment → paren 삽입 rewrite (mobx 회귀)" {
+    // `foo() ? pure : x = bar()` 의 alt 는 AssignmentExpression (paren 없이 허용).
+    // `foo() || (x = bar())` 로 재작성해야 `||` 우측 grammar 만족.
+    // 실제 mobx 번들의 `(_a = annotations) != null ? _a : (annotations = ...)` 회귀 가드.
+    try expectMinifyDead(
+        "let x = 0; foo() ? 1 : x = bar(); console.log(x);",
+        "function run() {\n\tlet x = 0;\n\tfoo() || (x = bar());\n\tconsole.log(x);\n}\nrun();",
+    );
+}
+
+test "unused: conditional alt_rem 의 cons 가 assignment → paren 삽입" {
+    try expectMinifyDead(
+        "let x = 0; foo() ? x = bar() : 1; console.log(x);",
+        "function run() {\n\tlet x = 0;\n\tfoo() && (x = bar());\n\tconsole.log(x);\n}\nrun();",
+    );
+}
+
+test "unused: conditional kept operand 가 sequence → paren 삽입" {
+    try expectMinifyDead(
+        "foo() ? 1 : (bar(), baz());",
+        "function run() {\n\tfoo() || (bar(),baz());\n}\nrun();",
+    );
+}

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -1152,3 +1152,136 @@ test "fixed-point: 사용 중인 chain 은 보존" {
         "function run() {\n\tlet y = 1,x = y;\n\tconsole.log(x);\n}\nrun();",
     );
 }
+
+// ================================================================
+// Unused Expression In-Place Simplify (#1650 step 2 — c/d)
+// ================================================================
+//
+// statement / sequence 비마지막 원소 자리에서 결과값이 버려지므로 short-circuit 의미만
+// 보존되면 내부 부분 제거가 안전. fixed-point loop 로 연쇄됨.
+// 대부분 테스트가 `foo()` / `bar()` 같은 unresolved identifier call (impure) 을 써서
+// dead store 연쇄를 차단하고 rewrite 자체를 검증한다.
+
+// ---- c.1 conditional → logical rewrite ----
+
+test "unused: foo() ? pure : bar() → foo() || bar()" {
+    try expectMinifyDead(
+        "foo() ? 1 : bar();",
+        "function run() {\n\tfoo() || bar();\n}\nrun();",
+    );
+}
+
+test "unused: foo() ? bar() : pure → foo() && bar()" {
+    try expectMinifyDead(
+        "foo() ? bar() : 1;",
+        "function run() {\n\tfoo() && bar();\n}\nrun();",
+    );
+}
+
+test "unused: foo() ? pure : pure → foo()" {
+    // b, c 둘 다 removable — test 로 교체 후 test 는 impure 라 유지
+    try expectMinifyDead(
+        "foo() ? 1 : 2;",
+        "function run() {\n\tfoo();\n}\nrun();",
+    );
+}
+
+test "unused: pure ? pure : pure → empty" {
+    try expectMinifyDead(
+        "1 ? 2 : 3;",
+        "function run() {\n\t;\n}\nrun();",
+    );
+}
+
+test "unused: foo() ? bar() : baz() → 그대로 (둘 다 impure)" {
+    try expectMinifyDead(
+        "foo() ? bar() : baz();",
+        "function run() {\n\tfoo() ? bar() : baz();\n}\nrun();",
+    );
+}
+
+// ---- c.2 logical simplify ----
+
+test "unused: foo() && pure → foo()" {
+    try expectMinifyDead(
+        "foo() && 42;",
+        "function run() {\n\tfoo();\n}\nrun();",
+    );
+}
+
+test "unused: foo() || pure → foo()" {
+    try expectMinifyDead(
+        "foo() || 1;",
+        "function run() {\n\tfoo();\n}\nrun();",
+    );
+}
+
+test "unused: foo() ?? pure → foo()" {
+    try expectMinifyDead(
+        "foo() ?? 42;",
+        "function run() {\n\tfoo();\n}\nrun();",
+    );
+}
+
+test "unused: foo() && bar() → 그대로 (right impure)" {
+    try expectMinifyDead(
+        "foo() && bar();",
+        "function run() {\n\tfoo() && bar();\n}\nrun();",
+    );
+}
+
+// ---- c.3 binary 비교 ----
+
+test "unused: foo() === pure → foo()" {
+    try expectMinifyDead(
+        "foo() === 1;",
+        "function run() {\n\tfoo();\n}\nrun();",
+    );
+}
+
+test "unused: pure < foo() → foo()" {
+    try expectMinifyDead(
+        "1 < foo();",
+        "function run() {\n\tfoo();\n}\nrun();",
+    );
+}
+
+test "unused: foo() == bar() → 그대로 (둘 다 impure)" {
+    try expectMinifyDead(
+        "foo() == bar();",
+        "function run() {\n\tfoo() == bar();\n}\nrun();",
+    );
+}
+
+// ---- d template literal ----
+
+test "unused: `static`; → empty" {
+    try expectMinifyDead(
+        "`hello`;",
+        "function run() {\n\t;\n}\nrun();",
+    );
+}
+
+test "unused: `a ${pure} c` — substitution 모두 pure → empty" {
+    try expectMinifyDead(
+        "`a ${1 + 2} c`;",
+        "function run() {\n\t;\n}\nrun();",
+    );
+}
+
+test "unused: `a ${foo()} b` — substitution impure → 유지" {
+    try expectMinifyDead(
+        "`a ${foo()} b`;",
+        "function run() {\n\t`a ${foo()} b`;\n}\nrun();",
+    );
+}
+
+// ---- 안전성: RHS 자리에선 rewrite 안 됨 ----
+
+test "unused: assignment RHS 의 conditional 은 rewrite 안 됨" {
+    // `x = foo() ? 1 : 2;` 은 결과값이 x 에 할당되므로 건드리면 안 됨 — RHS 는 statement 자리 아님
+    try expectMinifyDead(
+        "let x = foo() ? 1 : 2; console.log(x);",
+        "function run() {\n\tlet x = foo() ? 1 : 2;\n\tconsole.log(x);\n}\nrun();",
+    );
+}


### PR DESCRIPTION
## Summary

#1650 RFC 의 **step 2 (c + d)** 구현. unused 결과값 자리 (`expression_statement`, `sequence_expression` 비마지막 원소) 에서 내부 부분 제거. oxc `remove_unused_expression.rs` 이식.

## 범위

### c.1 conditional → logical rewrite

| 입력 | 출력 | 조건 |
|---|---|---|
| `a ? b : c;` | `a \|\| c;` | `b` removable |
| `a ? b : c;` | `a && b;` | `c` removable |
| `a ? b : c;` | `a;` | `b, c` 모두 removable |
| `1 ? 2 : 3;` | `;` | 모두 removable |

### c.2 logical short-circuit

| 입력 | 출력 | 조건 |
|---|---|---|
| `a && b;` / `a \|\| b;` / `a ?? b;` | `a;` | `b` removable |

`b` 는 a 의 short-circuit 으로 실행 제어되지만 b 가 pure 라 관측 불가 → drop 안전.

### c.3 binary 비교

| 입력 | 출력 | 조건 |
|---|---|---|
| `a == b;` / `a === b;` / `a < b;` / `a in b;` 등 | 나머지 | 한쪽 removable |

### d template literal

| 입력 | 출력 | 조건 |
|---|---|---|
| `` `static`; `` | `;` | substitution 없음 |
| `` `a ${pure} b`; `` | `;` | 모든 substitution removable |
| `` `a ${foo()} b`; `` | 유지 | impure substitution |

부분 제거는 element/expression 배치가 의미 있어 구조 깨짐 — 전체 판정만.

## 설계

### 새 함수 `simplifyUnusedInPlace(ast, ctx, idx, changed, depth) bool`

**Thin dispatcher** — 3개 rewritable tag (binary/logical/conditional) 만 여기서 mutation, 나머지는 기존 `isStmtRemovableDepth` 판정에 위임. ~50 LOC 중복 제거.

**Contract**:
- 반환 `true`: 현재 idx 전체가 removable. 호출자는 idx 를 drop + refs 감산.
- 반환 `false`: 호출자는 idx 유지. 감산 금지.
- 내부 부분 제거 시 제거되는 sub-expression 의 refs 는 **함수 내부에서** 감산.

### 호출 site 제한 (중요)

결과값이 **버려지는 자리** 에서만 호출 안전:
- ✅ `expression_statement` operand
- ✅ `sequence_expression` 비마지막 원소
- ❌ `call_expression` callee (`(0, f)()` 의 `0` 제거는 `this` 바인딩 변경)
- ❌ assignment RHS (값 의미 관측)
- ❌ `return` expression
- ❌ 객체/배열 원소

## 안전성

| 항목 | 대응 |
|---|---|
| `a && b` 에서 `a` removable only | drop 안 함 (short-circuit 의미 변경) |
| assignment RHS | 호출 site 가 statement / sequence 뿐이라 rewrite 안 됨 (테스트로 검증) |
| conditional rewrite 시 references | 제거 operand 의 refs 만 감산 |
| fixed-point 수렴 | `a && b` → `a` → a 가 local identifier 면 다음 iter 에서 empty + dead store 연쇄 |
| template literal 구조 | 부분 제거 금지 — element 배치 유지 |

## 테스트

- [x] `zig build test` — 전 테스트 통과 (+ 신규 15건)
- [x] `bun run test:smoke` 139 pass / 0 fail
- [x] svelte-mount-min 46KB (변화 없음 — svelte 번들에 `a ? pure : side` 패턴 드묾)
- [x] pipeline benchmark 노이즈 범위 (10k lines: 32154→32192 us)

신규 테스트 15건:
- c.1 conditional 5건 (removable 각 조합)
- c.2 logical 4건 (right removable + right impure)
- c.3 binary 3건 (비교)
- d template 3건
- 안전성 1건 (assignment RHS 은 rewrite 안 됨)

## /simplify 반영

리뷰 agent 3개 findings:
- **(1) reuse HIGH**: `simplifyUnusedInPlace` 와 `isStmtRemovableDepth` 의 50 LOC 중복 → thin dispatcher 로 리팩터
- **(2) correctness-adjacent**: sequence arm 재귀 비대칭 → dispatcher 로 자동 해결
- **(3) quality LOW**: WHAT 주석 제거, depth 상수 coupling 명시

## 연관

- #1650 step 1 (fixed-point loop wrapper) 완료 — PR #1651
- **이 PR 로 #1650 전체 RFC 범위 완료**

Closes #1650