### PR TITLE
refactor(semantic): #1669 scope-wide declare ref + per-scope stmt index

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -311,6 +311,10 @@ pub fn buildFromSemantic(
         const sym_u32: u32 = @intFromEnum(r.symbol_id);
         if (sym_u32 >= symbols.len) continue;
         if (r.flags.declare) {
+            // #1669: analyzer 가 모든 scope 선언에 declare ref 를 남기므로 top-level (scope_id==0)
+            // 만 bucket 분배. 함수/블록 내부 declare ref 는 `scope_stmt_idx` 와 함께 references
+            // 배열에 남아 optimizer pass (single-use inline 등) 가 직접 소비.
+            if (@intFromEnum(r.scope_id) != 0) continue;
             try declared_buckets[r.stmt_idx].append(allocator, sym_u32);
         } else {
             try referenced_buckets[r.stmt_idx].append(allocator, sym_u32);

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -150,9 +150,16 @@ pub const SemanticAnalyzer = struct {
 
     /// StmtInfo 사전 수집 활성화 여부. 번들러 모드에서만 true.
     enable_stmt_info: bool = false,
-    /// 현재 순회 중인 top-level statement 인덱스. visitProgram 2nd pass에서 설정.
+    /// 현재 순회 중인 top-level statement 인덱스. visitProgram 2nd pass 에서만 설정되고
+    /// 함수/블록 진입 후에도 유지 — 내부 참조를 enclosing top-level stmt 로 귀속시키는 용도.
+    /// tree-shaker `stmt_info` 의 referenced_symbols 분배에 사용된다.
     current_top_stmt_idx: ?u32 = null,
-    /// top-level statement 개수 (초기화 완료 후 유효)
+    /// #1669: 현재 순회 중인 statement 인덱스 — per-scope 기준 (0부터).
+    /// program / function body / block 각각 자체 카운터를 가지며 `visitStmtList` 가
+    /// save → per-stmt set → restore 로 관리. `NO_STMT` = stmt list 순회 밖.
+    /// single-use inline 등 scope 내부 adjacency 판단 용.
+    current_stmt_idx: u32 = symbol_mod.Reference.NO_STMT,
+    /// top-level statement 개수 (초기화 완료 후 유효). bundler stmt_info bucket 크기.
     stmt_info_count: u32 = 0,
 
     const PrivateRef = struct {
@@ -588,22 +595,26 @@ pub const SemanticAnalyzer = struct {
             try self.scope_maps.items[target_scope.toIndex()].put(name_text, sym_index);
         }
 
-        // StmtInfo 사전 수집: top-level scope(scope_id==0)의 선언을 references 에 declare 플래그로 기록.
-        if (@intFromEnum(target_scope) == 0) {
-            self.recordTopLevelDeclareRef(@intCast(sym_index));
-        }
+        // StmtInfo 사전 수집: 선언 위치를 references 에 declare 플래그로 기록. #1669 부터 모든 scope.
+        // top-level (scope_id==0) 은 bundler stmt_info bucket 분배, 함수/블록 내부는
+        // per-scope stmt index 로 optimizer pass (single-use inline 등) 가 소비.
+        self.recordDeclareRef(@intCast(sym_index), target_scope);
     }
 
-    /// top-level 선언을 `references` 배열에 `flags.declare` 로 기록. enable_stmt_info + current
-    /// top-level stmt 가 있을 때만. buildFromSemantic 에서 stmt_idx 로 bucket 분배.
-    fn recordTopLevelDeclareRef(self: *SemanticAnalyzer, sym_index: u32) void {
+    /// 선언을 `references` 배열에 `flags.declare` 로 기록. #1669.
+    /// 현재 `enable_stmt_info` + 유효 stmt_idx 가 있을 때만 기록.
+    /// `scope_id` 는 선언 대상 scope — top-level 판별은 buildFromSemantic 에서 수행.
+    /// `stmt_idx` (enclosing top-level) 는 bundler bucket 분배용, `scope_stmt_idx` 는 per-scope
+    /// adjacency 검사용 — 둘 다 저장한다.
+    fn recordDeclareRef(self: *SemanticAnalyzer, sym_index: u32, scope_id: ScopeId) void {
         if (!self.enable_stmt_info) return;
-        const stmt_idx = self.current_top_stmt_idx orelse return;
+        if (self.current_stmt_idx == symbol_mod.Reference.NO_STMT) return;
         self.references.append(self.allocator, .{
             .node_index = .none,
-            .scope_id = @enumFromInt(0),
+            .scope_id = scope_id,
             .symbol_id = @enumFromInt(sym_index),
-            .stmt_idx = stmt_idx,
+            .stmt_idx = self.current_top_stmt_idx orelse symbol_mod.Reference.NO_STMT,
+            .scope_stmt_idx = self.current_stmt_idx,
             .flags = .{ .declare = true },
         }) catch {};
     }
@@ -787,8 +798,23 @@ pub const SemanticAnalyzer = struct {
                     .scope_id = self.current_scope,
                     .symbol_id = @enumFromInt(sym_idx),
                     .stmt_idx = self.current_top_stmt_idx orelse symbol_mod.Reference.NO_STMT,
+                    .scope_stmt_idx = self.current_stmt_idx,
                     .flags = flags,
                 }) catch {};
+
+                // #1666 infra: read-only 참조면 single_read_node 관리.
+                // 첫 read → node_idx 저장, 두 번째 read → `.none` 으로 invalidate.
+                // write 가 섞인 compound / assign 은 여기서 건너뛰며, write_count 로 별도 검사.
+                if (flags.read and !flags.write) {
+                    const sym_ptr = &self.symbols.items[sym_idx];
+                    if (sym_ptr.reference_count == 1) {
+                        sym_ptr.single_read_node = node_idx;
+                    } else {
+                        sym_ptr.single_read_node = .none;
+                    }
+                } else if (flags.write) {
+                    self.symbols.items[sym_idx].single_read_node = .none;
+                }
 
                 return;
             }
@@ -821,6 +847,25 @@ pub const SemanticAnalyzer = struct {
         self.symbols.items[sym_idx].decl_flags.no_side_effects = true;
     }
 
+    /// AST node_idx → symbol index 역조회. `declareSymbol` 이 채워둔 `symbol_ids` 를 사용하므로
+    /// var 호이스팅으로 current_scope 에 없는 심볼도 찾을 수 있다 (binding span 이 아닌 노드 기반).
+    /// 경계 / `.none` / empty 매핑을 모두 null 로 통일.
+    fn symbolIndexOfNode(self: *const SemanticAnalyzer, node_idx: NodeIndex) ?usize {
+        if (node_idx.isNone()) return null;
+        const ni: u32 = @intFromEnum(node_idx);
+        if (ni >= self.symbol_ids.items.len) return null;
+        const sym_idx = self.symbol_ids.items[ni] orelse return null;
+        if (sym_idx >= self.symbols.items.len) return null;
+        return sym_idx;
+    }
+
+    /// #1669: binding_identifier node 의 symbol 에 `decl_init` 을 설정.
+    fn setSymbolDeclInit(self: *SemanticAnalyzer, binding_idx: NodeIndex, init_idx: NodeIndex) void {
+        if (init_idx.isNone()) return;
+        const sym_idx = self.symbolIndexOfNode(binding_idx) orelse return;
+        self.symbols.items[sym_idx].decl_init = init_idx;
+    }
+
     /// predeclared 심볼에 대해 symbol_ids[node_idx]를 설정한다.
     /// predeclare 1st pass에서 declareSymbol(node_idx=null)로 등록된 심볼은
     /// symbol_ids에 매핑이 없으므로, 2nd pass에서 skip 시 여기서 보충한다.
@@ -830,9 +875,9 @@ pub const SemanticAnalyzer = struct {
             self.symbol_ids.items[node_idx] = @intCast(sym_idx);
         }
         // StmtInfo 사전 수집: predeclared 심볼도 declared 로 기록.
-        // declareSymbolWithNode 가 skip 되므로 여기서 보충한다.
-        if (sym_idx < self.symbols.items.len and @intFromEnum(self.symbols.items[sym_idx].scope_id) == 0) {
-            self.recordTopLevelDeclareRef(@intCast(sym_idx));
+        // declareSymbolWithNode 가 skip 되므로 여기서 보충한다. #1669: 모든 scope.
+        if (sym_idx < self.symbols.items.len) {
+            self.recordDeclareRef(@intCast(sym_idx), self.symbols.items[sym_idx].scope_id);
         }
     }
 
@@ -1489,6 +1534,22 @@ pub const SemanticAnalyzer = struct {
         }
     }
 
+    /// stmt list 를 per-stmt `current_stmt_idx` 로 순회한다. #1669 per-scope stmt counter.
+    /// program / function body / block 각각 진입 시 save, 종료 시 restore 하여 중첩 scope 간
+    /// stmt_idx 오염을 방지. `enable_stmt_info == false` 이면 그냥 `visitNodeList` 위임.
+    fn visitStmtList(self: *SemanticAnalyzer, list: NodeList) AllocError!void {
+        if (!self.enable_stmt_info) return self.visitNodeList(list);
+        if (list.len == 0) return;
+        if (list.start + list.len > self.ast.extra_data.items.len) return;
+        const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
+        const saved = self.current_stmt_idx;
+        for (indices, 0..) |raw_idx, i| {
+            self.current_stmt_idx = @intCast(i);
+            try self.visitNode(@enumFromInt(raw_idx));
+        }
+        self.current_stmt_idx = saved;
+    }
+
     // ================================================================
     // Visitor 구현 — 스코프 생성 노드
     // ================================================================
@@ -1515,21 +1576,24 @@ pub const SemanticAnalyzer = struct {
             }
         }
 
-        // 2nd pass: top-level statement를 순회하면서 current_top_stmt_idx 추적.
-        // enable_stmt_info일 때만 인덱스를 설정하여 declareSymbol에서 수집.
+        // 2nd pass: top-level statement를 순회하면서 stmt_idx 추적.
+        // `current_top_stmt_idx` 는 enclosing top-level (tree-shaker 의 참조-stmt 귀속용),
+        // `current_stmt_idx` 는 per-scope (#1669 single-use inline adjacency 용) — 둘 다 세팅.
         {
             const list = node.data.list;
             if (list.len > 0 and list.start + list.len <= self.ast.extra_data.items.len) {
                 const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
+                const saved_scope_idx = self.current_stmt_idx;
                 for (indices, 0..) |raw_idx, i| {
                     if (self.enable_stmt_info) {
                         self.current_top_stmt_idx = @intCast(i);
+                        self.current_stmt_idx = @intCast(i);
                     }
-                    const idx: NodeIndex = @enumFromInt(raw_idx);
-                    try self.visitNode(idx);
+                    try self.visitNode(@enumFromInt(raw_idx));
                 }
                 if (self.enable_stmt_info) {
                     self.current_top_stmt_idx = null;
+                    self.current_stmt_idx = saved_scope_idx;
                 }
             }
         }
@@ -1769,7 +1833,7 @@ pub const SemanticAnalyzer = struct {
 
     fn visitBlockStatement(self: *SemanticAnalyzer, node: Node) AllocError!void {
         const saved = try self.enterScope(.block, self.is_strict_mode);
-        try self.visitNodeList(node.data.list);
+        try self.visitStmtList(node.data.list);
         self.exitScope(saved);
     }
 
@@ -2476,6 +2540,17 @@ pub const SemanticAnalyzer = struct {
                 // init 표현식도 순회 (내부에 함수 표현식 등이 있을 수 있음)
                 try self.visitNode(init_idx);
 
+                // #1669: 단순 binding_identifier 에 init 이 있으면 symbol.decl_init 기록.
+                // single-use inline / const-value inline 의 빠른 lookup 용. destructuring 은 대상 외.
+                if (!binding_idx.isNone() and !init_idx.isNone() and
+                    @intFromEnum(binding_idx) < self.ast.nodes.items.len)
+                {
+                    const bnode = self.ast.getNode(binding_idx);
+                    if (bnode.tag == .binding_identifier) {
+                        self.setSymbolDeclInit(binding_idx, init_idx);
+                    }
+                }
+
                 if (!init_idx.isNone() and @intFromEnum(init_idx) < self.ast.nodes.items.len) {
                     const init_node = self.ast.getNode(init_idx);
                     // @__NO_SIDE_EFFECTS__ 전파
@@ -2668,10 +2743,8 @@ pub const SemanticAnalyzer = struct {
                 }
                 // scope_maps[0]에 "_default" 등록 — emitter/StmtInfo가 찾을 수 있도록
                 try self.scope_maps.items[module_scope.toIndex()].put("_default", sym_index);
-                // StmtInfo 사전 수집: facade 심볼을 declared 로 기록
-                if (@intFromEnum(module_scope) == 0) {
-                    self.recordTopLevelDeclareRef(@intCast(sym_index));
-                }
+                // StmtInfo 사전 수집: facade 심볼을 declared 로 기록 (#1669: scope 무관).
+                self.recordDeclareRef(@intCast(sym_index), module_scope);
                 // export default <literal> → facade 심볼에 const_value 설정
                 if (!inner_idx.isNone() and @intFromEnum(inner_idx) < self.ast.nodes.items.len) {
                     const cv = self.extractConstValue(self.ast.getNode(inner_idx));
@@ -2954,7 +3027,7 @@ pub const SemanticAnalyzer = struct {
             // ECMAScript var는 함수 진입 시 hoisting되므로 사용 위치가 선언보다 앞이어도 유효.
             // predeclared_scope는 설정하지 않음 — isVarPredeclared가 var 전용으로 처리.
             try self.predeclareVarDecls(body_node.data.list);
-            try self.visitNodeList(body_node.data.list);
+            try self.visitStmtList(body_node.data.list);
         } else {
             try self.visitNode(body_idx);
         }

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1457,6 +1457,145 @@ test "references: enable_stmt_info 시 top-level 선언에 declare flag 기록" 
 }
 
 // ============================================================
+// #1669: scope-wide declare ref + per-scope stmt index + Symbol 확장
+// ============================================================
+
+test "#1669: 함수 body 내부 선언도 declare ref 로 기록" {
+    // 이전에는 top-level (scope_id==0) 선언만 `flags.declare` 로 기록됐으나, #1669 이후
+    // 모든 scope 의 선언을 기록한다. bundler stmt_info 는 scope_id==0 만 bucket 에 분배.
+    const source = "function f() { const y = 2; return y; }";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    ana.enable_stmt_info = true;
+    try ana.analyze();
+
+    var y_declare_count: usize = 0;
+    var y_declare_scope: u32 = 0;
+    for (ana.references.items) |r| {
+        if (!r.flags.declare) continue;
+        const sym = ana.symbols.items[@intFromEnum(r.symbol_id)];
+        if (std.mem.eql(u8, sym.nameText(parser.ast.source), "y")) {
+            y_declare_count += 1;
+            y_declare_scope = @intFromEnum(r.scope_id);
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 1), y_declare_count);
+    try std.testing.expect(y_declare_scope != 0); // 함수 scope (top-level 아님)
+}
+
+test "#1669: per-scope stmt_idx 는 함수 body 내부에서 0 부터 재시작" {
+    // `current_stmt_idx` 가 scope 별로 0..N 을 할당하는지 검증. 함수 body 내부의 선언은
+    // scope_stmt_idx 가 함수 body 기준 0-based. top-level stmt_idx (`stmt_idx`) 는 별도 유지.
+    const source = "const a = 1;\nfunction f() {\n  const b = 2;\n  const c = 3;\n}\n";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    ana.enable_stmt_info = true;
+    try ana.analyze();
+
+    var b_scope_idx: u32 = std.math.maxInt(u32);
+    var c_scope_idx: u32 = std.math.maxInt(u32);
+    for (ana.references.items) |r| {
+        if (!r.flags.declare) continue;
+        const sym = ana.symbols.items[@intFromEnum(r.symbol_id)];
+        const name = sym.nameText(parser.ast.source);
+        if (std.mem.eql(u8, name, "b")) b_scope_idx = r.scope_stmt_idx;
+        if (std.mem.eql(u8, name, "c")) c_scope_idx = r.scope_stmt_idx;
+    }
+    try std.testing.expectEqual(@as(u32, 0), b_scope_idx);
+    try std.testing.expectEqual(@as(u32, 1), c_scope_idx);
+}
+
+test "#1669: Symbol.decl_init 이 variable_declarator 의 init 을 가리킴" {
+    const source = "const x = 42; const y = x + 1;";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    var x_init: @TypeOf(@as(@import("../parser/ast.zig").NodeIndex, .none)) = .none;
+    for (ana.symbols.items) |sym| {
+        if (std.mem.eql(u8, sym.nameText(parser.ast.source), "x")) {
+            x_init = sym.decl_init;
+        }
+    }
+    try std.testing.expect(!x_init.isNone());
+    // decl_init 노드가 실제로 literal `42` 인지 확인
+    const init_node = parser.ast.getNode(x_init);
+    try std.testing.expect(init_node.tag == .numeric_literal);
+}
+
+test "#1669: Symbol.single_read_node — 단일 read 만 있을 때 설정" {
+    const source = "const x = 1; f(x);";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    var found = false;
+    for (ana.symbols.items) |sym| {
+        if (std.mem.eql(u8, sym.nameText(parser.ast.source), "x")) {
+            try std.testing.expect(!sym.single_read_node.isNone());
+            found = true;
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "#1669: Symbol.single_read_node — read 가 두 번이면 invalidate" {
+    const source = "const x = 1; f(x); g(x);";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    for (ana.symbols.items) |sym| {
+        if (std.mem.eql(u8, sym.nameText(parser.ast.source), "x")) {
+            try std.testing.expect(sym.single_read_node.isNone());
+        }
+    }
+}
+
+test "#1669: Symbol.single_read_node — write 가 섞이면 invalidate" {
+    const source = "let x = 1; x = 2; f(x);";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    for (ana.symbols.items) |sym| {
+        if (std.mem.eql(u8, sym.nameText(parser.ast.source), "x")) {
+            try std.testing.expect(sym.single_read_node.isNone());
+        }
+    }
+}
+
+// ============================================================
 // #1660: block / switch / module / nested-block 에서 var 와 lexical 이름 충돌
 // (ECMA §sec-block-static-semantics-early-errors / §sec-switch-statement-static-semantics-early-errors
 //  / §sec-module-semantics-static-semantics-early-errors)

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -258,6 +258,15 @@ pub const Symbol = struct {
     /// 크로스-모듈 인라인 대상. oxc/rolldown과 동일한 접근.
     write_count: u32 = 0,
 
+    /// 단일 read 로 확신 가능한 유일 read 의 node_index. 두 번째 read 가 발생하면 `.none` 으로
+    /// invalidate. single-use inline (#1666) 이 AST re-walk 없이 read 위치를 찾는 용도.
+    /// write 발생은 `write_count` 로 별도 판단 — 이 필드는 read-only 추적.
+    single_read_node: NodeIndex = .none,
+
+    /// `variable_declarator` 의 init expression NodeIndex. 단순 binding_identifier 선언에만 설정.
+    /// destructuring / 초기값 없는 선언은 `.none`. single-use inline 과 const-value inline 공통.
+    decl_init: NodeIndex = .none,
+
     /// 컴파일 타임 상수 값 (번들러 크로스-모듈 인라인용).
     /// const/let 선언의 초기화 값이 리터럴이면 설정 (단 let은 `write_count == 0`일 때만 인라인).
     const_value: ConstValue = .{},
@@ -334,10 +343,15 @@ pub const Reference = struct {
     scope_id: ScopeId,
     /// 참조 대상 심볼의 인덱스
     symbol_id: SymbolId,
-    /// 이 참조가 속한 top-level statement 인덱스. top-level 이 아니거나 enable_stmt_info=false 이면
-    /// `NO_STMT`. span 기반 역추적은 decorator 등 "stmt span 외부 노드" 에서 누락되므로
-    /// analyzer 가 `current_top_stmt_idx` 를 직접 저장한다.
+    /// 이 참조가 속한 **enclosing top-level** statement 인덱스. top-level 외에서 일어난 참조라도
+    /// 이 값은 해당 참조를 포함하는 top-level stmt (함수 선언 등)의 idx 로 세팅되어 tree-shaker
+    /// 가 "top-level stmt 가 어떤 심볼을 참조하는가" 를 추적할 수 있게 한다. top-level 이 아니거나
+    /// enable_stmt_info=false 이면 `NO_STMT`.
     stmt_idx: u32 = NO_STMT,
+    /// #1669: 이 참조가 속한 **enclosing scope** statement 인덱스 (per-scope 0-base).
+    /// program / function body / block 각각 자체 카운터. single-use inline 이 선언-read adjacency
+    /// 를 같은 scope 내에서 판단할 때 사용. top-level 에서는 `stmt_idx` 와 동일.
+    scope_stmt_idx: u32 = NO_STMT,
     /// 참조 종류 (bitset). read / write / read+write / declare 조합.
     flags: ReferenceFlags = .{},
 
@@ -350,8 +364,8 @@ pub const Reference = struct {
 ///   - `{ .read = true }`               — `f(x)`, `y = x` 등 값 읽기
 ///   - `{ .write = true }`              — `x = 1` (pure assign)
 ///   - `{ .read = true, .write = true }` — `x += 1`, `x++`, `--x` 등 compound/update
-///   - `{ .declare = true }`            — top-level scope 선언 위치. node_index 는 NodeIndex.none
-///     (선언 span 을 Reference 에 싣지 않음 — buildFromSemantic 은 stmt_idx 로만 bucket 분배)
+///   - `{ .declare = true }`            — 선언 위치 (#1669 부터 모든 scope). node_index 는 NodeIndex.none
+///     (선언 span 을 Reference 에 싣지 않음 — buildFromSemantic 은 scope_id==0 + stmt_idx 로 bucket 분배)
 pub const ReferenceFlags = packed struct(u8) {
     read: bool = false,
     write: bool = false,


### PR DESCRIPTION
## Summary

#1666 single-use inline (Phase 2) 의 blocker. 메이저 번들러 (esbuild / oxc / swc / rolldown) 모두 semantic-level 공식 데이터를 optimizer pass 가 **AST re-walk 없이** 소비하는 구조를 ZTS 에 맞춰 구축.

## 변경 내용

### Symbol (`src/semantic/symbol.zig`)
- `single_read_node: NodeIndex` — 단일 read 의 node_index. 두 번째 read 가 생기면 `.none` 으로 invalidate. `reference_count` 증가 직후 판정.
- `decl_init: NodeIndex` — `variable_declarator` 의 init expression. 단순 `binding_identifier` 선언에만 설정 (destructuring / init 없음은 `.none`).

### Reference (`src/semantic/symbol.zig`)
- `scope_stmt_idx: u32 = NO_STMT` — 이 참조의 enclosing **scope** stmt index (per-scope 0-base). 기존 `stmt_idx` 는 enclosing **top-level** stmt 로 의미 유지 — tree-shaker referenced_symbols 분배 호환성.

### Analyzer (`src/semantic/analyzer.zig`)
- `current_stmt_idx: u32 = NO_STMT` 필드 추가, `current_top_stmt_idx: ?u32` 는 유지 (서로 다른 역할).
- `visitStmtList` 헬퍼: program / function body / block 각각 진입 시 save → per-stmt set → restore.
- `recordTopLevelDeclareRef` → `recordDeclareRef` 일반화 — 모든 scope 에서 호출. 두 stmt_idx 모두 저장.
- `visitBlockStatement`, `visitFunctionBodyInner` 가 `visitStmtList` 사용.
- `symbolIndexOfNode` 헬퍼로 node_idx → symbol 역조회 중복 제거.
- `resolveIdentifier` 에서 read 참조 시 `single_read_node` 관리 (첫 read → 저장, 이후 → invalidate, write 섞이면 invalidate).
- `visitVariableDeclaration` 에서 simple binding_identifier 에 대해 `setSymbolDeclInit` 호출.

### Bundler stmt_info (`src/bundler/stmt_info.zig`)
- declare ref 가 모든 scope 에서 생성되므로 `scope_id != 0` 이면 bucket 분배 skip (top-level 만 bundler 가 소비).

## 참고 구현

| 번들러 | 저장 위치 | 특징 |
|---|---|---|
| esbuild | `p.symbols[ref].UseCountEstimate` | 재귀 `substituteSingleUseSymbolInExpr` |
| oxc | `ctx.scoping()` + `ctx.state.symbol_values` | `initialized_constant` (literal only) |
| swc | 별도 `swc_ecma_usage_analyzer` crate | `usage_count == 1` 검사 |
| rolldown | oxc 위임 | — |

모두 optimizer pass 가 AST re-walk 없이 semantic data 를 읽기만. ZTS 도 동일 접근.

## Test plan

- [x] `zig build test` 전체 통과 (기존 회귀 없음, 새 테스트 6개 추가)
- [x] analyzer 단위 테스트:
  - 함수 body 내부 선언도 declare ref 로 기록되는가 (scope_id != 0)
  - per-scope stmt_idx 가 함수 진입 시 0 부터 재시작하는가
  - `decl_init` 이 variable_declarator init 을 가리키는가
  - `single_read_node` 단일/다중 read / write 혼합 시 동작
- [ ] 후속 #1666 Phase 2 에서 svelte-mount-min reference 개수 delta / 빌드 시간 실측

## 비목표 (후속 이슈)

- single-use inline 자체 구현 — #1666 Phase 2
- const-value inline 확장 — #1666 Phase 2 일부
- mangler / tree-shaker 가 새 필드 (`single_read_node`, `decl_init`) 소비 — 별도

Closes #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)