### PR TITLE
refactor(bundler): #1672 Phase B1 — CompiledModule 타입 도입

### DIFF
--- a/src/bundler/compiled_module.zig
+++ b/src/bundler/compiled_module.zig
@@ -1,0 +1,30 @@
+//! ZTS Bundler — Compiled module output
+//!
+//! 모듈 컴파일 결과 (Transformer → Codegen 산출물) 를 표현한다.
+//! emit 병렬 결과 수집 (emitter.zig) 및 HMR/watch compiled output cache 의
+//! 공용 값 타입.
+
+const std = @import("std");
+const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
+const SourceMap = @import("../codegen/sourcemap.zig");
+
+/// 모듈 단위 컴파일 결과. 동일 입력 해시로 재사용 시 cache hit 로 활용된다.
+pub const CompiledModule = struct {
+    /// 생성 코드. null = emit 실패/skip.
+    code: ?[]const u8 = null,
+    /// 이 모듈이 요구하는 런타임 헬퍼 집합.
+    helpers: RuntimeHelpers = .{},
+    /// codegen 이 생성한 매핑 (bundle SourceMap 빌더에 병합).
+    mappings: ?[]const SourceMap.Mapping = null,
+    /// preamble/래퍼 헤더로 codegen 매핑과 어긋나는 줄 수.
+    preamble_lines: u32 = 0,
+    /// per-source function map JSON. null = 비활성/함수 없음.
+    fn_map_json: ?[]const u8 = null,
+
+    /// 모듈 소유 자원 해제 (code/mappings/fn_map_json).
+    pub fn deinit(self: CompiledModule, allocator: std.mem.Allocator) void {
+        if (self.code) |c| allocator.free(c);
+        if (self.mappings) |m| allocator.free(m);
+        if (self.fn_map_json) |j| allocator.free(j);
+    }
+};

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -31,6 +31,7 @@ const Ast = ast_mod.Ast;
 const NodeIndex = ast_mod.NodeIndex;
 const Transformer = @import("../transformer/transformer.zig").Transformer;
 const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
+const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const Codegen = @import("../codegen/codegen.zig").Codegen;
 const CodegenOptions = @import("../codegen/codegen.zig").CodegenOptions;
 const SourceMap = @import("../codegen/sourcemap.zig");
@@ -361,13 +362,9 @@ pub fn emitWithTreeShaking(
     }
 
     // Phase 2: emitModule 병렬 실행 (2개 이상이면 스레드 풀, 아니면 순차)
-    var results = try allocator.alloc(ModuleEmitResult, sorted.items.len);
+    var results = try allocator.alloc(CompiledModule, sorted.items.len);
     defer {
-        for (results) |r| {
-            if (r.code) |c| allocator.free(c);
-            if (r.mappings) |m| allocator.free(m);
-            if (r.fn_map_json) |j| allocator.free(j);
-        }
+        for (results) |r| r.deinit(allocator);
         allocator.free(results);
     }
     for (results) |*r| r.* = .{};
@@ -698,16 +695,6 @@ pub const contentHash = chunks.contentHash;
 pub const applyNamingPattern = chunks.applyNamingPattern;
 const computeAllUsedNames = chunks.computeAllUsedNames;
 
-/// 스레드 풀에서 실행되는 emitModule 래퍼.
-const ModuleEmitResult = struct {
-    code: ?[]const u8 = null,
-    helpers: RuntimeHelpers = .{},
-    mappings: ?[]const SourceMap.Mapping = null,
-    /// preamble(cjs_import_preamble 등)과 래핑 헤더로 인해 codegen 매핑과 어긋나는 줄 수.
-    preamble_lines: u32 = 0,
-    /// function map JSON (`{"names":[...],"mappings":"..."}`). null이면 비활성 또는 함수 없음.
-    fn_map_json: ?[]const u8 = null,
-};
 
 /// JS 예약어이거나 유효한 식별자가 아니면 프로퍼티 키에 따옴표가 필요.
 pub fn needsPropertyQuote(name: []const u8) bool {
@@ -773,7 +760,7 @@ fn emitModuleThread(
     is_entry: bool,
     used_names: ?[]const []const u8,
     shaker: ?*const TreeShaker,
-    result: *ModuleEmitResult,
+    result: *CompiledModule,
 ) void {
     result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.preamble_lines, &result.fn_map_json) catch null;
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -695,7 +695,6 @@ pub const contentHash = chunks.contentHash;
 pub const applyNamingPattern = chunks.applyNamingPattern;
 const computeAllUsedNames = chunks.computeAllUsedNames;
 
-
 /// JS 예약어이거나 유효한 식별자가 아니면 프로퍼티 키에 따옴표가 필요.
 pub fn needsPropertyQuote(name: []const u8) bool {
     if (name.len == 0) return true;

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -13,6 +13,7 @@ const BundleResult = @import("bundler.zig").BundleResult;
 const BundleOptions = @import("bundler.zig").BundleOptions;
 const ResolveCache = @import("resolve_cache.zig").ResolveCache;
 const module_store = @import("module_store.zig");
+const CompiledModule = @import("compiled_module.zig").CompiledModule;
 
 /// JSON 문자열 값 내부의 특수 문자를 이스케이프한다 (RFC 8259 준수).
 fn writeJsonEscaped(writer: anytype, s: []const u8) !void {
@@ -71,9 +72,14 @@ pub const IncrementalBundler = struct {
     /// resolve 캐시 (장기 보존). dir_cache 포함.
     resolve_cache: ?ResolveCache = null,
 
+    /// 모듈 단위 dev/HMR 캐시 엔트리.
+    /// `code` = `__zts_register` wrapper (HMR 경로).
+    /// `compiled` / `input_hash` = compiled output cache 재사용용 (populate 는 별도 PR).
     const CachedModule = struct {
         id: []const u8,
         code: []const u8,
+        compiled: ?CompiledModule = null,
+        input_hash: u64 = 0,
     };
 
     pub fn init(allocator: std.mem.Allocator, options: BundleOptions) IncrementalBundler {
@@ -106,6 +112,7 @@ pub const IncrementalBundler = struct {
         while (it.next()) |entry| {
             self.allocator.free(entry.value_ptr.id);
             self.allocator.free(entry.value_ptr.code);
+            if (entry.value_ptr.compiled) |c| c.deinit(self.allocator);
         }
         self.module_cache.clearRetainingCapacity();
 


### PR DESCRIPTION
## Summary

RFC #1672 (transformer 재설계 epic) 의 첫 단계. emit 파이프라인의 모듈 단위 산출물을 공용 값 타입 `CompiledModule` 로 분리하여 후속 PR 에서 compiled output cache 의 key/value 로 재사용할 수 있도록 한다. **setup 전용 — 기능 변화 없음.**

### 변경
- `src/bundler/compiled_module.zig` 신규
  - `CompiledModule { code, helpers, mappings, preamble_lines, fn_map_json }` + `deinit(allocator)`
- `src/bundler/emitter.zig`
  - 파일 내부 `const ModuleEmitResult` 제거, `CompiledModule` 로 대체
  - 병렬 emit 결과 `defer` 의 수동 `free` 3줄을 `deinit` 호출로 정리
- `src/bundler/incremental.zig`
  - `CachedModule` 에 `compiled: ?CompiledModule = null`, `input_hash: u64 = 0` 슬롯 추가 (populate 는 후속 PR)
  - `clearCache` 에 `compiled.deinit` 추가

### Why
- 현재 `ModuleEmitResult` 가 emitter.zig 내부에만 존재 → cache 경로에서 재사용 불가
- RFC #1672 의 B2 (`compiled_cache.zig`) 에서 이 타입이 cache value 로 사용될 예정
- 의미상 "compile 결과" 이므로 `CompiledModule` 이 더 정확한 이름

### 설계 근거
- `compiled_module.zig` 는 `types.zig` 와 분리된 위치. 이유: `types.zig` 는 현재 parser/transformer/codegen 레이어를 import 하지 않는 기초 타입 위치인데, `CompiledModule` 은 `RuntimeHelpers`/`SourceMap.Mapping` 에 의존하므로 레이어 경계를 유지하기 위해 별도 파일로 분리
- `InputHasher` 같은 hash 빌더는 **이 PR 에 포함하지 않음** — 첫 callsite 구조가 확정되는 B2 에서 함께 도입 (premature abstraction 회피)

## Test plan
- [x] `zig build` clean (no errors/warnings)
- [x] `zig build test` 전체 pass
- [x] 병렬 emit 경로의 free/deinit 의미 동일 (code/mappings/fn_map_json 세 슬라이스 동일 순서로 해제)
- [x] `CachedModule` 신규 필드는 기본값 null/0 → 기존 HMR put 경로 (`.{ .id = id, .code = code }`) 무수정 통과
- [ ] 리뷰어: merge 후 dev server/HMR 스모크로 회귀 없음 확인

Refs #1672