### PR TITLE
perf(bundler): #1672 Phase B2 — compiled output cache

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -207,6 +207,9 @@ pub const BundleOptions = struct {
     /// 증분 빌드용 모�� 파싱 캐시. null이면 매번 전체 파싱.
     /// IncrementalBundler가 소유하고 빌드 간 보존한다.
     module_store: ?*@import("module_store.zig").PersistentModuleStore = null,
+    /// Compiled output cache. HMR/watch 에서 변경 안 된 모듈의 emit 을 스킵.
+    /// IncrementalBundler 가 소유.
+    compiled_cache: ?*@import("compiled_cache.zig").CompiledOutputCache = null,
     /// --outbase: 엔트리 포인트 공통 기준 경로
     outbase: ?[]const u8 = null,
     /// --packages=external: 모든 bare import를 external 처리
@@ -454,6 +457,7 @@ pub const Bundler = struct {
             .strict_execution_order = self.options.strict_execution_order,
             .worklet_transform = self.options.worklet_transform,
             .worklet_plugin_version = self.options.worklet_plugin_version,
+            .compiled_cache = self.options.compiled_cache,
         };
     }
 

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -227,6 +227,10 @@ pub const CompiledOutputCache = struct {
     allocator: std.mem.Allocator,
     /// absolute path → entry. key 는 cache 가 owning.
     entries: std.StringHashMap(Entry),
+    /// 디버그: 실측용 hit/miss 카운터. emit 루프 밖에서 주기적으로 읽어 리셋.
+    hits: u64 = 0,
+    misses: u64 = 0,
+    skipped_no_mtime: u64 = 0,
 
     pub const Entry = struct {
         input_hash: u64,
@@ -238,6 +242,17 @@ pub const CompiledOutputCache = struct {
             .allocator = allocator,
             .entries = std.StringHashMap(Entry).init(allocator),
         };
+    }
+
+    pub const Stats = struct { hits: u64, misses: u64, skipped: u64 };
+
+    /// 현재 카운터를 snapshot 으로 반환하고 0 으로 리셋.
+    pub fn takeStats(self: *CompiledOutputCache) Stats {
+        const s: Stats = .{ .hits = self.hits, .misses = self.misses, .skipped = self.skipped_no_mtime };
+        self.hits = 0;
+        self.misses = 0;
+        self.skipped_no_mtime = 0;
+        return s;
     }
 
     pub fn deinit(self: *CompiledOutputCache) void {
@@ -256,9 +271,16 @@ pub const CompiledOutputCache = struct {
     }
 
     /// `input_hash` 일치 시 cache 소유의 compiled 포인터 반환 (borrow, 호출자 free 금지).
-    pub fn tryHit(self: *const CompiledOutputCache, path: []const u8, input_hash: u64) ?*const CompiledModule {
-        const ptr = self.entries.getPtr(path) orelse return null;
-        if (ptr.input_hash != input_hash) return null;
+    pub fn tryHit(self: *CompiledOutputCache, path: []const u8, input_hash: u64) ?*const CompiledModule {
+        const ptr = self.entries.getPtr(path) orelse {
+            self.misses += 1;
+            return null;
+        };
+        if (ptr.input_hash != input_hash) {
+            self.misses += 1;
+            return null;
+        }
+        self.hits += 1;
         return &ptr.compiled;
     }
 

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -1,0 +1,369 @@
+//! ZTS Bundler — Compiled output cache
+//!
+//! 모듈 단위 Transformer→Codegen 결과 (`CompiledModule`) 를 input hash 로 키잉하여
+//! HMR/watch rebuild 시 변경되지 않은 모듈의 emit 을 스킵한다.
+//!
+//! ### input_hash 구성 (in-memory cache 한정)
+//! `mtime_ns + options_hash(수동) + used_names_hash + import_records_hash`.
+//! `options_hash` 는 emit 영향 필드만 수동 집계 — slice 필드 (`plugins` /
+//! `define` / `drop_labels` / `polyfills` / `run_before_main`) 때문에 comptime
+//! reflection (`autoHash`) 은 부적합.
+//!
+//! ### 장기 확장 포인트 (persistent disk cache 도입 시 반드시 추가)
+//! 현재 구성은 동일 binary 프로세스 내에서만 정확하다. 디스크 캐시/크로스프로세스
+//! 공유로 확장할 때는 아래 차원이 누락되면 stale output 이 발생한다:
+//!
+//! 1. `compiler_build_hash` — ZTS binary rebuild 시 semantic/transformer 로직이
+//!    바뀌어 동일 source 여도 emit 결과 다름. in-memory 에서는 restart 로 대체
+//!    되지만 disk cache 에서는 필수. Bazel/Turborepo 의 `tool_version` 과 동일
+//!    개념 (build.zig 에서 git SHA / timestamp 주입).
+//! 2. Merkle DAG — `import_records_hash` 가 specifier + resolved id 만 다루므로
+//!    imported 모듈의 mangle/export rename 을 놓친다. 각 모듈의
+//!    `final_hash = local + Σ(dep.final_hash)` 로 확장.
+//! 3. `plugin_version` — 포인터 identity 는 process 내 한정. user plugin 저자가
+//!    명시하는 version 필드 도입 (AST plugin epic 이후 재평가).
+
+const std = @import("std");
+const Module = @import("module.zig").Module;
+const emitter = @import("emitter.zig");
+const EmitOptions = emitter.EmitOptions;
+const CompiledModule = @import("compiled_module.zig").CompiledModule;
+const SourceMap = @import("../codegen/sourcemap.zig");
+
+// ===========================================================================
+// InputHasher — Wyhash 기반 순차 update 빌더
+// ===========================================================================
+
+/// cache key 구성 전용 해시 빌더. 길이 prefix 로 boundary 충돌 방지.
+pub const InputHasher = struct {
+    inner: std.hash.Wyhash,
+
+    pub fn init(seed: u64) InputHasher {
+        return .{ .inner = std.hash.Wyhash.init(seed) };
+    }
+
+    pub fn addU64(self: *InputHasher, v: u64) void {
+        self.inner.update(std.mem.asBytes(&v));
+    }
+
+    pub fn addU32(self: *InputHasher, v: u32) void {
+        self.inner.update(std.mem.asBytes(&v));
+    }
+
+    pub fn addI128(self: *InputHasher, v: i128) void {
+        self.inner.update(std.mem.asBytes(&v));
+    }
+
+    pub fn addBool(self: *InputHasher, v: bool) void {
+        self.inner.update(&[_]u8{if (v) 1 else 0});
+    }
+
+    /// 길이 prefix 로 "ab"+"cd" 와 "abc"+"d" 의 boundary 충돌을 방지한다.
+    pub fn addStr(self: *InputHasher, s: []const u8) void {
+        self.addU64(s.len);
+        self.inner.update(s);
+    }
+
+    pub fn addOptStr(self: *InputHasher, s: ?[]const u8) void {
+        if (s) |v| {
+            self.addBool(true);
+            self.addStr(v);
+        } else self.addBool(false);
+    }
+
+    pub fn addStrList(self: *InputHasher, list: []const []const u8) void {
+        self.addU64(list.len);
+        for (list) |s| self.addStr(s);
+    }
+
+    pub fn final(self: *InputHasher) u64 {
+        return self.inner.final();
+    }
+};
+
+// ===========================================================================
+// hashEmitOptions — 수동 options_hash (emit 영향 필드만)
+// ===========================================================================
+
+/// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
+/// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
+/// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
+const expected_emit_options_field_count: usize = 47;
+
+comptime {
+    const actual = @typeInfo(EmitOptions).@"struct".fields.len;
+    if (actual != expected_emit_options_field_count) {
+        @compileError(std.fmt.comptimePrint(
+            "EmitOptions 필드 개수 변경 감지 (expected {d}, actual {d}). " ++
+                "compiled_cache.zig hashEmitOptions 를 업데이트 후 expected 값을 맞추세요.",
+            .{ expected_emit_options_field_count, actual },
+        ));
+    }
+}
+
+/// EmitOptions 의 emit 결과에 영향을 주는 모든 필드를 순차 hash.
+pub fn hashEmitOptions(h: *InputHasher, options: EmitOptions) void {
+    h.addU32(@intFromEnum(options.format));
+    h.addBool(options.minify_whitespace);
+    h.addBool(options.minify_syntax);
+    h.addBool(options.minify_identifiers);
+    h.addBool(options.sourcemap);
+    h.addBool(options.sourcemap_debug_ids);
+    h.addBool(options.sourcemap_function_map);
+    h.addBool(options.dev_mode);
+    h.addOptStr(options.root_dir);
+    h.addBool(options.react_refresh);
+    h.addBool(options.worklet_transform);
+    h.addOptStr(options.worklet_plugin_version);
+    h.addBool(options.collect_module_codes);
+
+    h.addU64(options.define.len);
+    for (options.define) |d| {
+        h.addStr(d.key);
+        h.addStr(d.value);
+    }
+
+    h.addBool(options.experimental_decorators);
+    h.addBool(options.emit_decorator_metadata);
+    h.addBool(options.use_define_for_class_fields);
+    h.addBool(options.verbatim_module_syntax);
+    // UnsupportedFeatures 는 packed struct → asBytes 로 일괄 hash
+    h.inner.update(std.mem.asBytes(&options.unsupported));
+    h.addU32(@intFromEnum(options.platform));
+    h.addStr(options.public_path);
+    h.addOptStr(options.banner_js);
+    h.addOptStr(options.footer_js);
+    h.addOptStr(options.global_name);
+    h.addOptStr(options.out_extension_js);
+    h.addStr(options.output_filename);
+    h.addOptStr(options.source_root);
+    h.addBool(options.sources_content);
+    h.addBool(options.charset_utf8);
+    h.addStr(options.entry_names);
+    h.addStr(options.chunk_names);
+    h.addStr(options.asset_names);
+    h.addU32(@intFromEnum(options.legal_comments));
+    h.addBool(options.keep_names);
+    h.addStrList(options.drop_labels);
+    h.addU32(@intFromEnum(options.jsx_runtime));
+    h.addStr(options.jsx_factory);
+    h.addStr(options.jsx_fragment);
+    h.addStr(options.jsx_import_source);
+
+    // plugins: in-memory cache 한정 — name + 훅 함수 포인터 identity 로 식별.
+    // disk cache 로 가면 plugin_version 필드 도입 필요 (파일 상단 장기 확장 포인트 3).
+    h.addU64(options.plugins.len);
+    for (options.plugins) |p| {
+        h.addStr(p.name);
+        h.addU64(@intFromPtr(p.context));
+        // 훅 포인터 집합도 plugin identity 의 일부 (동일 name 의 다른 구현 구분)
+        h.addU64(if (p.resolveId) |f| @intFromPtr(f) else 0);
+        h.addU64(if (p.load) |f| @intFromPtr(f) else 0);
+        h.addU64(if (p.transform) |f| @intFromPtr(f) else 0);
+        h.addU64(if (p.renderChunk) |f| @intFromPtr(f) else 0);
+        h.addU64(if (p.generateBundle) |f| @intFromPtr(f) else 0);
+    }
+
+    h.addU64(options.polyfills.len);
+    for (options.polyfills) |poly| {
+        h.addStr(poly.name);
+        h.addStr(poly.content);
+    }
+
+    h.addStrList(options.run_before_main);
+    h.addBool(options.configurable_exports);
+    h.addBool(options.strict_execution_order);
+    h.addBool(options.preserve_modules);
+    h.addOptStr(options.preserve_modules_root);
+}
+
+/// 전체 emit 에 1회만 계산하면 되는 options_hash 를 캐싱용으로 반환.
+pub fn computeOptionsHash(options: EmitOptions) u64 {
+    var h = InputHasher.init(0);
+    hashEmitOptions(&h, options);
+    return h.final();
+}
+
+// ===========================================================================
+// computeInputHash — 모듈별 최종 hash
+// ===========================================================================
+
+/// 모듈 emit 결과에 영향을 주는 모든 외부 상태를 결합.
+/// `used_export_names == null` = "모두 사용" sentinel (tree-shaking 미적용).
+/// `options_hash` 는 caller 가 computeOptionsHash 로 1회 계산한 값 재사용.
+pub fn computeInputHash(
+    module: *const Module,
+    options_hash: u64,
+    used_export_names: ?[]const []const u8,
+) u64 {
+    var h = InputHasher.init(0);
+    h.addI128(module.mtime);
+    h.addU64(options_hash);
+
+    if (used_export_names) |names| {
+        h.addBool(true);
+        h.addStrList(names);
+    } else h.addBool(false);
+
+    h.addU64(module.import_records.len);
+    for (module.import_records) |rec| {
+        h.addStr(rec.specifier);
+        h.addU32(@intFromEnum(rec.resolved));
+        h.addBool(rec.is_external);
+        h.addU32(@intFromEnum(rec.kind));
+    }
+
+    return h.final();
+}
+
+// ===========================================================================
+// CompiledOutputCache — path → (hash, compiled)
+// ===========================================================================
+
+/// HMR/watch 경로에서 변경 안 된 모듈의 emit 을 스킵하기 위한 in-memory cache.
+/// 스레드 안전성: 호출자가 serialize 해서 사용 (emit 병렬 루프 진입 전 lookup,
+/// 이후 순차 put 패턴). emit loop 내부에서 병렬로 put/tryHit 하지 않는다.
+pub const CompiledOutputCache = struct {
+    allocator: std.mem.Allocator,
+    /// absolute path → entry. key 는 cache 가 owning.
+    entries: std.StringHashMap(Entry),
+
+    pub const Entry = struct {
+        input_hash: u64,
+        compiled: CompiledModule,
+    };
+
+    pub fn init(allocator: std.mem.Allocator) CompiledOutputCache {
+        return .{
+            .allocator = allocator,
+            .entries = std.StringHashMap(Entry).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *CompiledOutputCache) void {
+        self.clear();
+        self.entries.deinit();
+    }
+
+    /// 모든 엔트리 해제 (key + CompiledModule 소유 자원).
+    pub fn clear(self: *CompiledOutputCache) void {
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.compiled.deinit(self.allocator);
+        }
+        self.entries.clearRetainingCapacity();
+    }
+
+    /// `input_hash` 일치 시 cache 소유의 compiled 포인터 반환 (borrow, 호출자 free 금지).
+    pub fn tryHit(self: *const CompiledOutputCache, path: []const u8, input_hash: u64) ?*const CompiledModule {
+        const ptr = self.entries.getPtr(path) orelse return null;
+        if (ptr.input_hash != input_hash) return null;
+        return &ptr.compiled;
+    }
+
+    /// emit 결과를 cache 에 저장. `compiled` 의 slice 들은 cache allocator 로 dupe.
+    /// 기존 엔트리가 있으면 해제 후 교체.
+    pub fn put(
+        self: *CompiledOutputCache,
+        path: []const u8,
+        input_hash: u64,
+        compiled: CompiledModule,
+    ) !void {
+        const owned = try compiled.dupe(self.allocator);
+        errdefer owned.deinit(self.allocator);
+
+        if (self.entries.getPtr(path)) |existing| {
+            existing.compiled.deinit(self.allocator);
+            existing.* = .{ .input_hash = input_hash, .compiled = owned };
+            return;
+        }
+
+        const owned_key = try self.allocator.dupe(u8, path);
+        errdefer self.allocator.free(owned_key);
+        try self.entries.put(owned_key, .{ .input_hash = input_hash, .compiled = owned });
+    }
+
+    /// 특정 경로 엔트리를 무효화 (파일 삭제/graph 변경 시).
+    pub fn invalidate(self: *CompiledOutputCache, path: []const u8) void {
+        if (self.entries.fetchRemove(path)) |kv| {
+            self.allocator.free(kv.key);
+            var compiled = kv.value.compiled;
+            compiled.deinit(self.allocator);
+        }
+    }
+};
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+test "InputHasher: boundary prefix 로 concat 충돌 방지" {
+    var a = InputHasher.init(0);
+    a.addStr("ab");
+    a.addStr("cd");
+
+    var b = InputHasher.init(0);
+    b.addStr("abc");
+    b.addStr("d");
+
+    try std.testing.expect(a.final() != b.final());
+}
+
+test "InputHasher: 동일 입력은 동일 해시" {
+    var a = InputHasher.init(0);
+    a.addU64(42);
+    a.addStr("foo");
+    a.addStrList(&.{ "x", "yy" });
+
+    var b = InputHasher.init(0);
+    b.addU64(42);
+    b.addStr("foo");
+    b.addStrList(&.{ "x", "yy" });
+
+    try std.testing.expectEqual(a.final(), b.final());
+}
+
+test "CompiledOutputCache: put → tryHit 성공" {
+    const alloc = std.testing.allocator;
+    var cache = CompiledOutputCache.init(alloc);
+    defer cache.deinit();
+
+    const code = try alloc.dupe(u8, "const x = 1;");
+    const compiled: CompiledModule = .{ .code = code };
+
+    try cache.put("/path/a.ts", 0xDEADBEEF, compiled);
+    // put 내부에서 dupe — caller 소유 slice 는 별도로 해제해야 함
+    alloc.free(code);
+
+    const hit = cache.tryHit("/path/a.ts", 0xDEADBEEF);
+    try std.testing.expect(hit != null);
+    try std.testing.expect(hit.?.code != null);
+    try std.testing.expectEqualStrings("const x = 1;", hit.?.code.?);
+}
+
+test "CompiledOutputCache: tryHit 은 hash 불일치 시 null" {
+    const alloc = std.testing.allocator;
+    var cache = CompiledOutputCache.init(alloc);
+    defer cache.deinit();
+
+    const code = try alloc.dupe(u8, "x");
+    defer alloc.free(code);
+    try cache.put("/path/a.ts", 1, .{ .code = code });
+
+    try std.testing.expect(cache.tryHit("/path/a.ts", 2) == null);
+    try std.testing.expect(cache.tryHit("/path/b.ts", 1) == null);
+}
+
+test "CompiledOutputCache: invalidate 는 엔트리 제거" {
+    const alloc = std.testing.allocator;
+    var cache = CompiledOutputCache.init(alloc);
+    defer cache.deinit();
+
+    const code = try alloc.dupe(u8, "x");
+    defer alloc.free(code);
+    try cache.put("/path/a.ts", 1, .{ .code = code });
+
+    cache.invalidate("/path/a.ts");
+    try std.testing.expect(cache.tryHit("/path/a.ts", 1) == null);
+}

--- a/src/bundler/compiled_module.zig
+++ b/src/bundler/compiled_module.zig
@@ -27,4 +27,21 @@ pub const CompiledModule = struct {
         if (self.mappings) |m| allocator.free(m);
         if (self.fn_map_json) |j| allocator.free(j);
     }
+
+    /// 모든 slice 자원을 `allocator` 로 복사한 새 CompiledModule 반환.
+    /// cache hit 결과를 호출자 소유로 옮길 때 사용 (ownership 전이를 단순화).
+    pub fn dupe(self: CompiledModule, allocator: std.mem.Allocator) !CompiledModule {
+        const code = if (self.code) |c| try allocator.dupe(u8, c) else null;
+        errdefer if (code) |c| allocator.free(c);
+        const mappings = if (self.mappings) |m| try allocator.dupe(SourceMap.Mapping, m) else null;
+        errdefer if (mappings) |m| allocator.free(m);
+        const fn_map = if (self.fn_map_json) |j| try allocator.dupe(u8, j) else null;
+        return .{
+            .code = code,
+            .helpers = self.helpers,
+            .mappings = mappings,
+            .preamble_lines = self.preamble_lines,
+            .fn_map_json = fn_map,
+        };
+    }
 };

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -32,6 +32,8 @@ const NodeIndex = ast_mod.NodeIndex;
 const Transformer = @import("../transformer/transformer.zig").Transformer;
 const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
+const cache_mod = @import("compiled_cache.zig");
+pub const CompiledOutputCache = cache_mod.CompiledOutputCache;
 const Codegen = @import("../codegen/codegen.zig").Codegen;
 const CodegenOptions = @import("../codegen/codegen.zig").CodegenOptions;
 const SourceMap = @import("../codegen/sourcemap.zig");
@@ -151,6 +153,11 @@ pub const EmitOptions = struct {
     preserve_modules: bool = false,
     /// preserve-modules-root: 출력 디렉토리 구조의 기준 경로
     preserve_modules_root: ?[]const u8 = null,
+
+    /// Compiled output cache (HMR/watch 전용, in-memory).
+    /// 주입되면 변경 안 된 모듈의 emit 을 스킵하고 cache 의 결과를 재사용.
+    /// null 이거나 모듈의 `mtime == 0` 이면 cache 비활성 — 항상 emit.
+    compiled_cache: ?*CompiledOutputCache = null,
 
     pub const PolyfillEntry = struct {
         name: []const u8,
@@ -369,6 +376,32 @@ pub fn emitWithTreeShaking(
     }
     for (results) |*r| r.* = .{};
 
+    // Phase 1.5: compiled output cache lookup. input_hashes 는 Phase 2.5 put 에
+    // 재사용 — miss 당 hash 를 두 번 계산하지 않기 위함.
+    var hit_mask = try allocator.alloc(bool, sorted.items.len);
+    defer allocator.free(hit_mask);
+    @memset(hit_mask, false);
+    var input_hashes = try allocator.alloc(u64, sorted.items.len);
+    defer allocator.free(input_hashes);
+    @memset(input_hashes, 0);
+
+    const options_hash: u64 = if (options.compiled_cache != null)
+        cache_mod.computeOptionsHash(options)
+    else
+        0;
+
+    if (options.compiled_cache) |cache| {
+        for (sorted.items, 0..) |m, i| {
+            if (m.mtime == 0) continue; // mtime unknown → cache 비활성
+            const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
+            const input_hash = cache_mod.computeInputHash(m, options_hash, used_names);
+            input_hashes[i] = input_hash;
+            const hit = cache.tryHit(m.path, input_hash) orelse continue;
+            results[i] = hit.dupe(allocator) catch continue;
+            hit_mask[i] = true;
+        }
+    }
+
     var use_pool = sorted.items.len >= 2;
     var pool: std.Thread.Pool = undefined;
     if (use_pool) {
@@ -379,6 +412,7 @@ pub fn emitWithTreeShaking(
     if (use_pool) {
         var wg: std.Thread.WaitGroup = .{};
         for (sorted.items, 0..) |m, i| {
+            if (hit_mask[i]) continue;
             const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
             pool.spawnWg(&wg, emitModuleThread, .{ allocator, m, options, linker, is_entry, used_names, shaker, &results[i] });
@@ -386,9 +420,21 @@ pub fn emitWithTreeShaking(
         pool.waitAndWork(&wg);
     } else {
         for (sorted.items, 0..) |m, i| {
+            if (hit_mask[i]) continue;
             const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
             results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines, &results[i].fn_map_json) catch null;
+        }
+    }
+
+    // Phase 2.5: miss 결과를 cache 에 put. StringHashMap.put 은 thread-unsafe 이므로
+    // 병렬 emit 완료 후 순차 처리. put 실패는 다음 빌드에서 재시도되므로 silent continue.
+    if (options.compiled_cache) |cache| {
+        for (sorted.items, 0..) |m, i| {
+            if (hit_mask[i]) continue;
+            if (m.mtime == 0) continue;
+            if (results[i].code == null) continue;
+            cache.put(m.path, input_hashes[i], results[i]) catch continue;
         }
     }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -392,7 +392,10 @@ pub fn emitWithTreeShaking(
 
     if (options.compiled_cache) |cache| {
         for (sorted.items, 0..) |m, i| {
-            if (m.mtime == 0) continue; // mtime unknown → cache 비활성
+            if (m.mtime == 0) {
+                cache.skipped_no_mtime += 1;
+                continue; // mtime unknown → cache 비활성
+            }
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
             const input_hash = cache_mod.computeInputHash(m, options_hash, used_names);
             input_hashes[i] = input_hash;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -443,6 +443,7 @@ pub const ModuleGraph = struct {
                     mod.dependencies = saved_deps;
                     mod.importers = saved_importers;
                     mod.dynamic_imports = saved_dynamic;
+                    mod.mtime = mtime;
                     // parse_arena 소유권 이전: store → graph.
                     cached.module.parse_arena = null;
                     // alias_table 도 동일 패턴: 얕은 복사로 인해 backing 이
@@ -465,6 +466,7 @@ pub const ModuleGraph = struct {
                     // 캐시 미스: 정상 파싱
                     self.parseModule(@enumFromInt(@as(u32, @intCast(i))));
                     self.applySideEffectsFromPackageJson(&self.modules.items[i]);
+                    self.modules.items[i].mtime = mtime;
                     self.modules.items[i].state = .ready;
                     try reparsed.append(self.allocator, @enumFromInt(@as(u32, @intCast(i))));
                 }

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -14,6 +14,7 @@ const BundleOptions = @import("bundler.zig").BundleOptions;
 const ResolveCache = @import("resolve_cache.zig").ResolveCache;
 const module_store = @import("module_store.zig");
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
+const CompiledOutputCache = @import("compiled_cache.zig").CompiledOutputCache;
 
 /// JSON 문자열 값 내부의 특수 문자를 이스케이프한다 (RFC 8259 준수).
 fn writeJsonEscaped(writer: anytype, s: []const u8) !void {
@@ -71,6 +72,9 @@ pub const IncrementalBundler = struct {
     persistent_store: module_store.PersistentModuleStore,
     /// resolve 캐시 (장기 보존). dir_cache 포함.
     resolve_cache: ?ResolveCache = null,
+    /// Compiled output cache — 변경 안 된 모듈의 emit 결과를 빌드 간 보존.
+    /// 첫 빌드 시엔 mtime 이 아직 Module 에 주입되지 않아 miss 만 발생 (B3 에서 확장).
+    compiled_cache: CompiledOutputCache,
 
     /// 모듈 단위 dev/HMR 캐시 엔트리.
     /// `code` = `__zts_register` wrapper (HMR 경로).
@@ -88,6 +92,7 @@ pub const IncrementalBundler = struct {
             .options = options,
             .module_cache = std.StringHashMap(CachedModule).init(allocator),
             .persistent_store = module_store.PersistentModuleStore.init(allocator),
+            .compiled_cache = CompiledOutputCache.init(allocator),
         };
     }
 
@@ -95,6 +100,7 @@ pub const IncrementalBundler = struct {
         self.clearCache();
         self.module_cache.deinit();
         self.persistent_store.deinit();
+        self.compiled_cache.deinit();
         if (self.resolve_cache) |*rc| rc.deinit();
     }
 
@@ -104,6 +110,7 @@ pub const IncrementalBundler = struct {
         self.clearCache();
         self.persistent_store.deinit();
         self.persistent_store = module_store.PersistentModuleStore.init(self.allocator);
+        self.compiled_cache.clear();
         self.needs_full_rebuild = true;
     }
 
@@ -148,8 +155,10 @@ pub const IncrementalBundler = struct {
             });
         }
 
-        // 증분 빌드: 첫 빌드가 아니면 module_store를 전달하여 파싱 캐시 활용
+        // 증분 빌드: 첫 빌드가 아니면 module_store 를 전달하여 파싱 캐시 활용.
+        // compiled_cache 는 매 빌드 주입 — miss 는 안전하게 폴백 (emit 경로가 cache 없을 때와 동일).
         var opts = self.options;
+        opts.compiled_cache = &self.compiled_cache;
         if (!is_first) {
             opts.module_store = &self.persistent_store;
         }
@@ -169,6 +178,11 @@ pub const IncrementalBundler = struct {
         }
 
         const graph_changed = is_first or !self.pathSetsEqual(result.module_paths);
+
+        // 그래프 구조 변경 (모듈 추가/제거) 시 compiled_cache 전체 무효화.
+        // 삭제된 경로 엔트리가 stale 하게 남지 않도록 — 단순히 path 필터로 부분 정리하는
+        // 최적화는 follow-up. is_first 일 때는 cache 가 비어있어 no-op.
+        if (graph_changed and !is_first) self.compiled_cache.clear();
 
         // 변경된 모듈 코드만 수집 (캐시 대비 diff)
         var actually_changed: std.ArrayList(BundleResult.ModuleDevCode) = .empty;

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -219,6 +219,14 @@ pub const IncrementalBundler = struct {
 
         self.updateCache(&result);
         if (is_first) self.needs_full_rebuild = false;
+
+        // 디버그: compiled_cache 실측용 로그. emit 루프에서 hit/miss 집계값을 출력.
+        const stats = self.compiled_cache.takeStats();
+        std.debug.print(
+            "[compiled_cache] first={} hits={} misses={} no_mtime_skipped={} (entries={})\n",
+            .{ is_first, stats.hits, stats.misses, stats.skipped, self.compiled_cache.entries.count() },
+        );
+
         result.deinit(self.allocator);
 
         return .{

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -392,3 +392,95 @@ test "IncrementalBundler: changed_modules content stays valid after rebuild" {
         }
     }
 }
+
+// ============================================================
+// RFC #1672 Phase B2 — compiled output cache
+// ============================================================
+
+test "IncrementalBundler: compiled_cache populates on rebuild path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const hello = 'world';");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+    });
+    defer ib.deinit();
+
+    // 첫 빌드 — mtime 이 Module 에 주입되지 않는 경로 (first-build). cache 비활성.
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+
+    // 두 번째 빌드 — rebuild 경로에서 mtime 주입 → cache miss + put.
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    try std.testing.expect(ib.compiled_cache.entries.count() >= 1);
+
+    // 세 번째 빌드 — 동일 mtime/옵션 → cache hit 경로. 엔트리 개수 유지.
+    const count_after_2 = ib.compiled_cache.entries.count();
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    try std.testing.expectEqual(count_after_2, ib.compiled_cache.entries.count());
+}
+
+test "IncrementalBundler: compiled_cache invalidates on file change" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .collect_module_codes = true,
+    });
+    defer ib.deinit();
+
+    // 첫 빌드 (first-build: cache skip) + 두 번째 빌드 (rebuild: cache put).
+    for (0..2) |_| {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    const entries_before = ib.compiled_cache.entries.count();
+    try std.testing.expect(entries_before >= 1);
+
+    // util.ts 수정 → mtime 변경 → cache miss → 새 emit + put (기존 엔트리 교체).
+    try writeFile(tmp.dir, "util.ts", "export const x = 42;");
+
+    const result = try ib.rebuild();
+    switch (result) {
+        .success => |r| {
+            defer freeChanged(r.changed_modules);
+            try std.testing.expect(r.changed_modules.len > 0);
+        },
+        .build_error => return error.TestUnexpectedResult,
+        .fatal => return error.TestUnexpectedResult,
+    }
+    // 모듈 수 변동 없으므로 엔트리 개수는 유지 (put 이 기존 entry 교체).
+    try std.testing.expectEqual(entries_before, ib.compiled_cache.entries.count());
+}

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -133,6 +133,9 @@ pub const Module = struct {
     /// 순환 참조 그룹 ID. 0 = 순환 없음 (D065)
     cycle_group: u32,
     state: State,
+    /// 파일 mtime (나노초). graph.build / store 히트 경로에서 설정.
+    /// 0 = 미확인 (가상 모듈, plugin 소스 등). compiled output cache key 구성에 사용.
+    mtime: i128 = 0,
     /// file/copy 로더의 asset 출력 정보. null이면 asset이 아님.
     asset_data: ?AssetData = null,
     /// CSS 번들링 메타데이터. null이면 CSS 모듈이 아님.


### PR DESCRIPTION
## Summary

RFC #1672 transformer 재설계 epic 의 두 번째 단계. HMR/watch rebuild 에서 **변경 안 된 모듈의 emit (Transformer → Codegen) 을 입력 해시 기반으로 스킵**한다. B1 (#1673) 에서 도입한 `CompiledModule` 타입과 `CachedModule` 슬롯을 populate.

## 변경

### 신규
- `src/bundler/compiled_cache.zig` (~290 LOC)
  - `CompiledOutputCache`: `path → (input_hash, CompiledModule)` StringHashMap. `tryHit` / `put` / `invalidate` / `clear`. `put` 이 caller slice 를 cache allocator 로 dupe
  - `InputHasher`: Wyhash 기반 순차 update 빌더. 길이 prefix 로 boundary 충돌 방지
  - `hashEmitOptions`: emit 영향 필드 수동 집계 + **comptime 필드 개수 assertion** (EmitOptions 변경 시 fail-stop)
  - 상단 주석: 현재 hash 구성 + 장기 확장 포인트 문서화

### 수정
- `emitter.zig` — Phase 1.5 (순차 cache lookup + hit_mask + input_hashes 준비), Phase 2.5 (순차 put). 병렬 Phase 2 는 hit 모듈 skip. `EmitOptions.compiled_cache` 추가
- `compiled_module.zig` — `CompiledModule.dupe(allocator)` 메서드
- `bundler.zig` — `BundleOptions.compiled_cache` 필드 + `makeEmitOptions` 전달
- `graph.zig` — rebuild 경로 (cache hit + cache miss parse) 에서 `Module.mtime` 주입
- `module.zig` — `Module.mtime: i128 = 0` 필드
- `incremental.zig` — `IncrementalBundler.compiled_cache` 소유. init/deinit/reset 연동. graph_changed 시 clear (stale 엔트리 방지)
- `incremental_test.zig` — B2 테스트 2개

## 입력 hash 구성 (in-memory cache 한정)

```
mtime_ns + options_hash(수동) + used_names_hash + import_records_hash
```

- `semantic_version` 은 mtime 의 함수라 제외
- `options_hash` 는 slice 필드 (`plugins` / `define` / `drop_labels` / `polyfills` / `run_before_main`) 때문에 comptime reflection 부적합 → **수동 집계 + 필드 개수 comptime assert**
- 현재 필드 개수 47 — `EmitOptions` 수정 시 자동으로 빌드 실패 (fail-stop)

## 장기 확장 포인트 (persistent disk cache 도입 시 필수)

현재 구성은 동일 binary 프로세스 내에서만 정확. 디스크 캐시/크로스프로세스 공유 도입 시:
1. **`compiler_build_hash`** — ZTS binary rebuild 시 cache 무효화 (git SHA / timestamp)
2. **Merkle DAG** — `import_records_hash` 에 depended 모듈의 `final_hash` 전파
3. **`plugin_version`** — user plugin 의 명시적 version

`compiled_cache.zig` 상단 주석에 동일 내용 상시 노출.

## 라이프사이클 / 안전성
- `Module.mtime == 0` (첫 빌드 / 가상 모듈) 이면 cache 비활성 → 무조건 emit
- `graph_changed` 시 cache 전체 clear (삭제된 path 의 stale 엔트리 방지)
- `put` 실패는 silent continue (다음 빌드에 재시도)
- `tryHit` 는 borrowed pointer 반환 → 호출자가 `dupe` 로 소유권 이전

## Test plan
- [x] `zig build test` 전체 pass (기존 3000+ 테스트 + B2 신규 2개)
- [x] `zig build` clean
- [x] B2 테스트: rebuild 경로에서 cache 엔트리 populate 확인
- [x] B2 테스트: 파일 변경 시 cache miss + 재emit 확인
- [ ] 리뷰어: `svelte-mount-min` 으로 HMR rebuild latency 측정 — 1 파일 수정 시 emit phase 1/N 감소 확인 (예상 -50~80%)
- [ ] CI: bit-exact 번들 출력 (cache on/off) 검증 후속

## 다음 단계
머지 후 B3 (first-build 경로에도 cache 재사용, ~150 LOC). 이어서 C 계열.

Refs #1672