### PR TITLE
refactor(minify): require scratch allocator as explicit parameter

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -865,9 +865,8 @@ pub fn emitModule(
             .symbol_ids = transformer.symbol_ids.items,
             .scopes = sem.scopes,
             .unresolved_globals = &sem.unresolved_references,
-            .scratch_allocator = arena_alloc,
         } else .empty;
-        minify_mod.minify(&transformer.ast, ctx, root);
+        minify_mod.minify(&transformer.ast, ctx, arena_alloc, root);
     }
 
     // 런타임 헬퍼 사용 추적: transformer가 설정한 플래그를 out parameter로 전달

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -39,9 +39,6 @@ pub const MinifyCtx = struct {
     symbol_ids: []const ?u32,
     scopes: []const scope_mod.Scope,
     unresolved_globals: ?*const purity.GlobalRefSet,
-    /// 임시 버퍼 (skip/live bitset, BFS 큐) 전용 allocator. null 이면 `ast.allocator` fallback.
-    /// watch 모드에서 parse_arena 누적을 피하려면 caller 의 ephemeral arena 를 전달.
-    scratch_allocator: ?std.mem.Allocator = null,
 
     /// semantic 없이 호출할 때 사용. dead store pass 는 skip 된다.
     pub const empty: MinifyCtx = .{
@@ -200,14 +197,11 @@ fn wrapInParen(ast: *Ast, inner_idx: NodeIndex) !NodeIndex {
 /// transformer 가 `visitNode` 에서 매번 새 노드를 만들어 원본을 `ast.nodes` 에 orphan 으로
 /// 남기는데, orphan 의 init 을 제거하면서 `decrementRefsInExpr` 가 살아있는 심볼의
 /// `reference_count` 를 중복 감산해 live 선언까지 잘못 제거되는 문제를 막는다 (#번개 실측).
-pub fn minify(ast: *Ast, ctx: MinifyCtx, root: NodeIndex) void {
-    // 임시 버퍼 (skip/live bitset, BFS 큐) 는 caller 의 scratch arena 가 있으면 그쪽을
-    // 쓰고, 없으면 `ast.allocator` 로 fallback. watch 모드에서 parse_arena 는 모듈 수명
-    // 동안 재활용되므로 매 rebuild 의 임시 할당이 누적될 수 있지만, 호출 빈도가 낮고
-    // bitset/큐 자체가 ~KB 단위라 실측상 눈에 띄지 않는다. caller 가 emit_arena 등을
-    // 넘기고 싶으면 별도 wrapper 로 감싸면 된다.
-    const scratch = ctx.scratch_allocator orelse ast.allocator;
-
+///
+/// `scratch` 는 skip/live bitset 과 BFS 큐 전용 임시 allocator. 호출 종료 시 해제되는
+/// ephemeral arena 를 권장한다 (예: bundler 의 emit_arena). `ast.allocator` (parse_arena)
+/// 를 넘기면 watch 모드 rebuild 마다 버퍼가 모듈 수명 동안 누적되므로 피할 것.
+pub fn minify(ast: *Ast, ctx: MinifyCtx, scratch: std.mem.Allocator, root: NodeIndex) void {
     // for-loop binding 은 fold passes 가 새로 만들지 않아 iter-invariant — 미리 1회만 수집.
     var skip_for_binding: ?std.DynamicBitSet = null;
     defer if (skip_for_binding) |*b| b.deinit();

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -32,7 +32,7 @@ fn expectMinifyOpts(
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast, .empty, root);
+    minify_mod.minify(&transformer.ast, .empty, a, root);
     minify_mod.mergeDecls(&transformer.ast, null);
 
     var cg = Codegen.initWithOptions(a, &transformer.ast, codegen_opts);
@@ -55,7 +55,7 @@ fn expectMergeIdempotent(input: []const u8, expected: []const u8) !void {
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast, .empty, root);
+    minify_mod.minify(&transformer.ast, .empty, a, root);
     minify_mod.mergeDecls(&transformer.ast, null);
     minify_mod.mergeDecls(&transformer.ast, null); // 두 번째 호출 — 결과 동일해야 함
 
@@ -87,7 +87,7 @@ fn expectMergeWithSkip(
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast, .empty, root);
+    minify_mod.minify(&transformer.ast, .empty, a, root);
 
     var skip = try std.DynamicBitSet.initEmpty(a, transformer.ast.nodes.items.len);
     // substring의 시작 위치와 일치하는 variable_declaration을 **전부** 마킹.
@@ -763,7 +763,7 @@ fn expectMinifyDead(body: []const u8, expected: []const u8) !void {
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, root);
+    minify_mod.minify(&transformer.ast, ctx, a, root);
     minify_mod.mergeDecls(&transformer.ast, null);
 
     var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
@@ -886,7 +886,7 @@ test "dead store: await using — 유지" {
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, root);
+    minify_mod.minify(&transformer.ast, ctx, a, root);
     var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
     const result = try cg.generate(root);
     try std.testing.expect(std.mem.indexOf(u8, result, "await using x") != null);
@@ -969,7 +969,7 @@ test "dead store: top-level const 는 tree-shaker 영역 — 유지" {
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, root);
+    minify_mod.minify(&transformer.ast, ctx, a, root);
     var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
     const result = try cg.generate(root);
     try std.testing.expect(std.mem.indexOf(u8, result, "const x = 1") != null);
@@ -1010,7 +1010,7 @@ test "dead store: 제거 시 init 내부 식별자 reference_count 감산" {
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, root);
+    minify_mod.minify(&transformer.ast, ctx, a, root);
 
     // 제거 후: x 가 사라지면서 y 의 reference_count 도 1 → 0
     var y_ref_after: u32 = 0;
@@ -1459,7 +1459,7 @@ test "unused: /*#__PURE__*/ super(x, y) — derived constructor semantic 필수 
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, root);
+    minify_mod.minify(&transformer.ast, ctx, a, root);
     var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
     const result = try cg.generate(root);
     try std.testing.expect(std.mem.indexOf(u8, result, "super(x, y)") != null);

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -349,7 +349,7 @@ pub fn transpileWithCallback(
             .scopes = analyzer.scopes.items,
             .unresolved_globals = null,
         };
-        minify_mod.minify(&transformer.ast, ctx, root);
+        minify_mod.minify(&transformer.ast, ctx, arena_alloc, root);
         minify_mod.mergeDecls(&transformer.ast, null);
     }
 


### PR DESCRIPTION
## 요약

`MinifyCtx.scratch_allocator` 를 optional + `ast.allocator` fallback 구조에서
`minify()` 의 필수 positional parameter 로 승격. 임시 버퍼(skip/live bitset,
BFS 큐)의 수명 소유권을 호출부 시그니처에서 명시하도록 만들어, 이전에 fallback
경로로 조용히 parse_arena 에 누적되던 실수 가능성을 타입 수준에서 제거합니다.

PR #1677 리뷰 후속 정리입니다.

## 변경 이유

PR #1677 에서 temp 버퍼가 `ast.allocator` (= module 의 `parse_arena`) 로 가면
watch 모드에서 매 rebuild 마다 버퍼가 누적되는 문제를 막으려고
`MinifyCtx.scratch_allocator: ?Allocator = null` 을 추가하고 null 이면
`ast.allocator` 로 fallback 하게 했습니다. 동작은 맞았지만:

- fallback 경로가 있는 optional 필드라 호출자가 깜빡하면 **조용히 느린 경로**
  로 떨어지고, 수명 계약이 타입에서 보이지 않음.
- Zig stdlib 관례(할당 함수는 allocator 를 positional 로 명시) 와도 어긋남.

positional 로 바꾸면 "어느 arena 로 버퍼가 들어가는가" 가 모든 호출지점에서
강제로 선언됩니다.

## 변경 내용

- **`src/transformer/minify.zig`**
  - `MinifyCtx.scratch_allocator` 제거.
  - `minify()` 시그니처: `(ast, ctx, root)` → `(ast, ctx, scratch, root)`.
  - doc comment 에 "호출 종료 시 해제되는 ephemeral arena 권장, `ast.allocator`
    넘기지 말 것" 을 명시.
- **`src/bundler/emitter.zig`** — 기존에 이미 `arena_alloc` (emit_arena) 를
  `scratch_allocator` 로 넘기고 있었음. 필드 대신 argument 로 전달하도록 한 줄
  조정.
- **`src/transpile.zig`** — `arena_alloc` 을 동일한 방식으로 전달.
- **`src/transformer/minify_test.zig`** — 모든 테스트 호출부가 기존의 per-test
  arena `a` 를 명시적으로 넘기도록 일괄 수정.

## 동작 변화

없음. 순수 API 정돈. 기존 호출자들은 이미 ephemeral arena 를 넘기고 있어
bitset/큐 할당 경로가 동일합니다.

## 테스트

- [x] `zig build test` — 유닛 테스트 통과
- [x] `cd tests/integration && bun test tests/minify-orphan-dead-store.test.ts tests/es5-class-super-shared-node.test.ts` — #1676 / #1677 회귀 테스트 통과
- [x] `zts --bundle --platform=react-native /.../react-devtools-core/dist/backend.js` — `UPDATE_AGE_ON_GET` 선언 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)