### PR TITLE
fix(bundler): remove compiled_cache debug print noise

### DIFF
--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -220,13 +220,6 @@ pub const IncrementalBundler = struct {
         self.updateCache(&result);
         if (is_first) self.needs_full_rebuild = false;
 
-        // 디버그: compiled_cache 실측용 로그. emit 루프에서 hit/miss 집계값을 출력.
-        const stats = self.compiled_cache.takeStats();
-        std.debug.print(
-            "[compiled_cache] first={} hits={} misses={} no_mtime_skipped={} (entries={})\n",
-            .{ is_first, stats.hits, stats.misses, stats.skipped, self.compiled_cache.entries.count() },
-        );
-
         result.deinit(self.allocator);
 
         return .{


### PR DESCRIPTION
## Summary

B2 (#1674) 실측용으로 추가한 \`std.debug.print\` 가 f6b2e666 로 main 에 들어가 **매 rebuild 마다 stderr 로 noise 출력**. Production 빌드에서 consumer (번개 등) 로 그대로 전파됨.

\`\`\`
[compiled_cache] first=false hits=3 misses=1 no_mtime_skipped=0 (entries=4)
\`\`\`

## 수정

- \`incremental.zig\` \`doBuild\` 에서 \`std.debug.print\` 블록 제거
- \`CompiledOutputCache.hits\` / \`misses\` / \`skipped_no_mtime\` 카운터 필드와 \`takeStats\` API 는 **유지** — 후속 PR 에서 debug log 인프라의 첫 consumer 로 연결 예정

## 후속 계획 (별도 PR)

\`src/log/debug_log.zig\` 신규 — \`ZTS_DEBUG=compiled_cache,hmr,resolve\` env 기반 카테고리 토글 + NAPI option (\`{ debug: ['compiled_cache'] }\`) 노출. 비활성 시 cost 0. \`compiled_cache\` 를 첫 카테고리로 연결.

## Test plan
- [x] \`zig build test\` 전체 pass (3298 tests EXIT=0)
- [ ] 번개 재실행 시 \`[compiled_cache]\` 로그 사라짐 확인