### PR TITLE
feat(log): category-toggleable debug log infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Zig 0.15.2 · C NAPI v8 (vendor/node-api-headers/) · Node.js 24+ / Bun 1.3+ · 
 - [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) — 파이프라인 아키텍처
 - [docs/ROADMAP.md](./docs/ROADMAP.md) — Phase 현황, 성능, 미지원, 기술부채
 - [docs/TESTING.md](./docs/TESTING.md) — Test262, 유닛/통합/스모크 테스트
-- [docs/BUNDLER.md](./docs/BUNDLER.md), [docs/PLUGINS.md](./docs/PLUGINS.md), [docs/HMR.md](./docs/HMR.md), [docs/DECISIONS.md](./docs/DECISIONS.md), [docs/FLOW.md](./docs/FLOW.md)
+- [docs/BUNDLER.md](./docs/BUNDLER.md), [docs/PLUGINS.md](./docs/PLUGINS.md), [docs/HMR.md](./docs/HMR.md), [docs/DECISIONS.md](./docs/DECISIONS.md), [docs/FLOW.md](./docs/FLOW.md), [docs/DEBUG.md](./docs/DEBUG.md)
 - [docs/BACKLOG.md](./docs/BACKLOG.md), [docs/AST_PLUGINS.md](./docs/AST_PLUGINS.md) (미해결 버그는 GitHub Issues)
 - CLI 옵션 전체: `zts --help` / JS API 구현: `packages/core/index.ts`
 

--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -1,0 +1,91 @@
+# Debug Logging
+
+런타임에 진단 로그를 카테고리별로 켜고 끄는 경량 인프라. ZTS 바이너리와 `@zts/core` NAPI 양쪽에서 동일 구조로 동작한다.
+
+- 구현: `src/debug_log.zig`
+- 활성 카테고리 enum: `src/debug_log.zig` 의 `Category`
+- 동작: 프로세스 전역 비트마스크. 비활성 카테고리의 로그 호출은 단일 `bool` 분기 이후 바로 리턴 — hot path 에서도 부담 없음.
+
+## 활성화
+
+### 환경 변수
+```bash
+ZTS_DEBUG=compiled_cache zts --bundle entry.ts
+ZTS_DEBUG=compiled_cache,hmr bun run bungae:start
+```
+
+쉼표 구분. 공백과 대소문자 무시. 알 수 없는 이름은 조용히 무시된다.
+
+### NAPI 옵션
+```ts
+import { build } from "@zts/core";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  debug: ["compiled_cache"],
+});
+```
+
+`ZTS_DEBUG` env 와 **합집합** — 한쪽만 설정해도 충분하고, 둘 다 설정하면 양쪽 카테고리 모두 활성.
+
+### CLI 플래그
+별도 플래그 없음. env 로 전달하는 게 충분하다고 판단 (개별 실행/watch/NAPI 에서 일관된 UX).
+
+## 카테고리
+
+현재 정의된 카테고리:
+
+| 이름 | 출력 내용 | 추가된 PR |
+|------|-----------|-----------|
+| `compiled_cache` | HMR/watch 의 compiled output cache hit/miss 집계 | RFC #1672 B2 |
+
+추가 시: `src/debug_log.zig` 의 `Category` enum 에 이름만 추가 → 사용처에서 `debug_log.print(.new_category, ...)` 호출 → 이 표 업데이트.
+
+## 출력 형식
+
+```
+[<category>] key1=value1 key2=value2 ...
+```
+
+- prefix: `[<category>]` — 카테고리 구분 + grep 친화
+- 본문: 자유 형식 (사용처가 `std.fmt` 포맷 문자열 직접 제공). 권장은 `key=value` 공백 구분
+- 목적지: `stderr` — stdout 이 bundle output 일 수 있으므로
+
+예시:
+```
+[compiled_cache] first=false hits=3 misses=1 no_mtime_skipped=0 (entries=4)
+```
+
+## 코드 사용법
+
+```zig
+const debug_log = @import("debug_log.zig");  // 또는 @import("zts_lib").debug_log
+
+// 단순 로그
+debug_log.print(.compiled_cache, "hits={d} misses={d}\n", .{ hits, misses });
+
+// 비싼 format 계산은 enabled 체크 후에
+if (debug_log.enabled(.compiled_cache)) {
+    const summary = try buildSummary(allocator);
+    defer allocator.free(summary);
+    debug_log.print(.compiled_cache, "{s}\n", .{summary});
+}
+```
+
+## 초기화 시점
+
+- **CLI (`src/main.zig`)**: `pub fn main()` 진입 직후 `debug_log.initFromEnv(allocator)` 호출
+- **NAPI (`packages/core/src/napi_entry.zig`)**: `napi_register_module_v1` 에서 1회 호출
+- **BundleOptions**: `Bundler.init` / `Bundler.initWithResolveCache` 가 `opts.debug` 리스트를 `addCategories` 로 merge
+
+모든 진입점이 `addFromCsv` / `addCategories` 로 **합집합**을 갱신하므로 중복 호출 안전.
+
+## 스레드 안전성
+
+`enabled_mask` 는 단일 `u64`. `initFromEnv` / `addCategories` 는 프로세스 시작 직후 또는 `Bundler.init` 시점에만 호출된다고 가정하며, 로그 호출 시점에는 **read-only** 로 사용된다. 일반적인 ZTS 호출 흐름에서는 mask 변경과 `enabled` 조회가 교차하지 않아 별도 동기화는 두지 않는다.
+
+## 장기 확장
+
+- 카테고리 세부 레벨 (info/debug/trace) 필요하면 `Category` 를 `{category, level}` 쌍으로 확장
+- 구조화 출력 (JSON) 이 필요하면 별도 포매터 분기 — env `ZTS_DEBUG_FORMAT=json` 등
+- 와일드카드 (`ZTS_DEBUG=*` 혹은 `ZTS_DEBUG=bundler:*`) 는 현재 미지원. 카테고리 수가 많아지기 전에는 쉼표 구분이 충분

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2124,6 +2124,13 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, exts)) return null;
     }
 
+    // debug: 활성화할 디버그 로그 카테고리 목록 (ZTS_DEBUG env 와 합집합).
+    const debug_categories = getObjectStringArray(env, opts_obj, "debug", native_alloc);
+    if (debug_categories) |cats| {
+        for (cats) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, cats)) return null;
+    }
+
     // 문자열 옵션 헬퍼
     const ownStr = struct {
         fn f(e: c.napi_env, obj: c.napi_value, key: [*:0]const u8, list: *std.ArrayList([]const u8)) ?[]const u8 {
@@ -2400,6 +2407,7 @@ fn parseBuildOptions(
         .format = format,
         .platform = platform,
         .external = external orelse &.{},
+        .debug = debug_categories orelse &.{},
         .define = define_entries,
         .alias = alias_entries,
         .ts_paths = ts_path_entries,
@@ -2490,6 +2498,10 @@ fn parseBuildOptions(
 // ─── 모듈 등록 ───
 
 export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi_value {
+    // ZTS_DEBUG env 를 프로세스 시작 시 1회 파싱해 mask 초기화.
+    // 개별 build/watch 호출마다 BundleOptions.debug 로 카테고리 추가 가능.
+    @import("zts_lib").debug_log.initFromEnv(native_alloc);
+
     var fn_value: c.napi_value = undefined;
     _ = c.napi_create_function(env, "transpile", "transpile".len, napiTranspile, null, &fn_value);
     _ = c.napi_set_named_property(env, exports, "transpile", fn_value);

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -27,6 +27,10 @@ pub const panic = @import("zts_lib").crash_handler.panic;
 /// WASM에서는 wasm_allocator 사용 (memory.grow 기반)
 const wasm_alloc = std.heap.wasm_allocator;
 
+// WASM transpile-only 진입점. 번들러/HMR 경로가 없어 debug_log 초기화 생략.
+// 향후 WASM 에서 bundler 기능을 export 하게 되면 `debug_log.initFromEnv` 추가 필요.
+// (docs/DEBUG.md 참조)
+
 /// 마지막 에러 메시지를 저장하는 전역 버퍼
 var last_error_buf: ?[]const u8 = null;
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -210,6 +210,9 @@ pub const BundleOptions = struct {
     /// Compiled output cache. HMR/watch 에서 변경 안 된 모듈의 emit 을 스킵.
     /// IncrementalBundler 가 소유.
     compiled_cache: ?*@import("compiled_cache.zig").CompiledOutputCache = null,
+    /// 활성화할 디버그 로그 카테고리 (ZTS_DEBUG env 와 합집합).
+    /// 예: `&.{"compiled_cache", "hmr"}`. 카테고리 enum 은 `src/debug_log.zig` 참조.
+    debug: []const []const u8 = &.{},
     /// --outbase: 엔트리 포인트 공통 기준 경로
     outbase: ?[]const u8 = null,
     /// --packages=external: 모든 bare import를 external 처리
@@ -370,6 +373,7 @@ pub const Bundler = struct {
     pub fn init(allocator: std.mem.Allocator, options: BundleOptions) Bundler {
         var opts = options;
         applyPlatformPreset(&opts);
+        @import("../debug_log.zig").addCategories(opts.debug);
         return .{
             .allocator = allocator,
             .options = opts,
@@ -395,6 +399,7 @@ pub const Bundler = struct {
     pub fn initWithResolveCache(allocator: std.mem.Allocator, options: BundleOptions, rc: *ResolveCache) Bundler {
         var opts = options;
         applyPlatformPreset(&opts);
+        @import("../debug_log.zig").addCategories(opts.debug);
         return .{
             .allocator = allocator,
             .options = opts,

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -15,6 +15,7 @@ const ResolveCache = @import("resolve_cache.zig").ResolveCache;
 const module_store = @import("module_store.zig");
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const CompiledOutputCache = @import("compiled_cache.zig").CompiledOutputCache;
+const debug_log = @import("../debug_log.zig");
 
 /// JSON 문자열 값 내부의 특수 문자를 이스케이프한다 (RFC 8259 준수).
 fn writeJsonEscaped(writer: anytype, s: []const u8) !void {
@@ -220,12 +221,14 @@ pub const IncrementalBundler = struct {
         self.updateCache(&result);
         if (is_first) self.needs_full_rebuild = false;
 
-        // 디버그: compiled_cache 실측용 로그. emit 루프에서 hit/miss 집계값을 출력.
-        const stats = self.compiled_cache.takeStats();
-        std.debug.print(
-            "[compiled_cache] first={} hits={} misses={} no_mtime_skipped={} (entries={})\n",
-            .{ is_first, stats.hits, stats.misses, stats.skipped, self.compiled_cache.entries.count() },
-        );
+        if (debug_log.enabled(.compiled_cache)) {
+            const stats = self.compiled_cache.takeStats();
+            debug_log.print(
+                .compiled_cache,
+                "first={} hits={d} misses={d} no_mtime_skipped={d} (entries={d})\n",
+                .{ is_first, stats.hits, stats.misses, stats.skipped, self.compiled_cache.entries.count() },
+            );
+        }
 
         result.deinit(self.allocator);
 

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -1,0 +1,128 @@
+//! ZTS 디버그 로그 인프라.
+//!
+//! 카테고리별 토글 가능한 진단 로그. `ZTS_DEBUG` env 또는 NAPI option
+//! (`BundleOptions.debug`) 으로 활성화. 비활성 카테고리는 `enabled()` 의 분기
+//! 한 번만 통과하므로 hot path 영향 최소.
+//!
+//! ### 사용법
+//! ```zig
+//! const debug_log = @import("debug_log.zig");
+//!
+//! debug_log.print(.compiled_cache, "hits={d} misses={d}\n", .{ hits, misses });
+//! // 또는 format 계산이 비싸면:
+//! if (debug_log.enabled(.compiled_cache)) {
+//!     const expensive = try computeSummary();
+//!     defer allocator.free(expensive);
+//!     debug_log.print(.compiled_cache, "{s}\n", .{expensive});
+//! }
+//! ```
+//!
+//! ### 카테고리 추가
+//! `Category` enum 에 이름 추가 → 끝. wildcard 는 지원하지 않음 (쉼표 구분 명시만).
+//!
+//! ### env 형식
+//! `ZTS_DEBUG=compiled_cache,hmr` — 쉼표 구분. 공백/대소문자 무시.
+
+const std = @import("std");
+
+/// 로그 카테고리. 추가 시 이 enum 에만 이름 넣으면 됨.
+pub const Category = enum {
+    compiled_cache,
+
+    /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
+    pub fn fromString(s: []const u8) ?Category {
+        const trimmed = std.mem.trim(u8, s, " \t");
+        if (trimmed.len == 0) return null;
+        inline for (@typeInfo(Category).@"enum".fields) |f| {
+            if (std.ascii.eqlIgnoreCase(trimmed, f.name)) {
+                return @field(Category, f.name);
+            }
+        }
+        return null;
+    }
+};
+
+/// 활성 카테고리 bitmask. enum 값을 비트 인덱스로 사용.
+/// 프로세스 전역 — 초기화 후에는 read-only 로 다뤄 thread-safe.
+var enabled_mask: u64 = 0;
+
+/// 활성 여부 조회. hot path 에서 호출 가능 (single u64 AND).
+pub fn enabled(cat: Category) bool {
+    const bit = @as(u64, 1) << @intFromEnum(cat);
+    return (enabled_mask & bit) != 0;
+}
+
+/// 쉼표 구분 카테고리 이름 목록을 mask 에 합집합으로 추가. 기존 활성은 유지.
+/// env / NAPI / CLI 어느 진입점에서 호출해도 동일 동작.
+pub fn addFromCsv(csv: []const u8) void {
+    var it = std.mem.splitScalar(u8, csv, ',');
+    while (it.next()) |name| {
+        if (Category.fromString(name)) |c| {
+            enabled_mask |= @as(u64, 1) << @intFromEnum(c);
+        }
+    }
+}
+
+/// 문자열 리스트를 mask 에 합집합으로 추가 (NAPI option 용).
+pub fn addCategories(names: []const []const u8) void {
+    for (names) |name| {
+        if (Category.fromString(name)) |c| {
+            enabled_mask |= @as(u64, 1) << @intFromEnum(c);
+        }
+    }
+}
+
+/// 프로세스 시작 시 1회 호출. `ZTS_DEBUG` env 를 읽어 mask 초기화.
+/// CLI main / NAPI entry 양쪽에서 호출 — 중복 호출 해도 idempotent.
+pub fn initFromEnv(allocator: std.mem.Allocator) void {
+    const value = std.process.getEnvVarOwned(allocator, "ZTS_DEBUG") catch return;
+    defer allocator.free(value);
+    addFromCsv(value);
+}
+
+/// 테스트/재설정용. 전체 비활성.
+pub fn resetForTest() void {
+    enabled_mask = 0;
+}
+
+/// 카테고리 prefix 를 붙여 stderr 로 출력. 비활성이면 no-op.
+/// 호출 예: `print(.compiled_cache, "hits={d}\n", .{count})`
+pub fn print(cat: Category, comptime fmt: []const u8, args: anytype) void {
+    if (!enabled(cat)) return;
+    std.debug.print("[" ++ @tagName(cat) ++ "] " ++ fmt, args);
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+test "Category.fromString 매칭" {
+    try std.testing.expect(Category.fromString("compiled_cache") == .compiled_cache);
+    try std.testing.expect(Category.fromString("COMPILED_CACHE") == .compiled_cache);
+    try std.testing.expect(Category.fromString("  compiled_cache  ") == .compiled_cache);
+    try std.testing.expect(Category.fromString("nonexistent") == null);
+    try std.testing.expect(Category.fromString("") == null);
+}
+
+test "addFromCsv: 여러 카테고리 + 알 수 없는 이름은 무시" {
+    resetForTest();
+    defer resetForTest();
+
+    addFromCsv("compiled_cache, unknown ,compiled_cache");
+    try std.testing.expect(enabled(.compiled_cache));
+}
+
+test "addFromCsv: 공백만 있는 항목은 무시" {
+    resetForTest();
+    defer resetForTest();
+
+    addFromCsv(" , ,");
+    try std.testing.expect(!enabled(.compiled_cache));
+}
+
+test "enabled: 기본값은 false" {
+    resetForTest();
+    defer resetForTest();
+
+    try std.testing.expect(!enabled(.compiled_cache));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1116,6 +1116,8 @@ pub fn main() !void {
     };
     const allocator: std.mem.Allocator = if (is_debug) gpa.allocator() else @import("mimalloc.zig").allocator;
 
+    lib.debug_log.initFromEnv(allocator);
+
     // CLI 인자 파싱
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);

--- a/src/root.zig
+++ b/src/root.zig
@@ -25,6 +25,7 @@ pub const transpile = @import("transpile.zig");
 pub const string_escape = @import("string_escape.zig");
 pub const util = @import("util/mod.zig");
 pub const crash_handler = @import("crash_handler.zig");
+pub const debug_log = @import("debug_log.zig");
 
 test {
     _ = lexer;


### PR DESCRIPTION
## Summary

ZTS_DEBUG env 또는 NAPI \`BundleOptions.debug\` 로 카테고리별 진단 로그 토글하는 경량 인프라. 첫 사용처는 \`compiled_cache\` (RFC #1672 B2). 비활성 카테고리는 단일 \`u64\` AND 분기 후 즉시 리턴 → hot path 영향 없음.

**배경**: B2 실측용 \`std.debug.print\` 가 f6b2e666 로 main 에 그대로 남아 production 에서 noise. #1684 가 print 만 제거하는 hotfix였는데, 이 PR 이 더 근본적으로 **print 제거 + 영구 진단 인프라**로 격상.

## 활성화

```bash
# env (쉼표 구분, 공백/대소문자 무시)
ZTS_DEBUG=compiled_cache bun run bungae:start

# NAPI
build({ entryPoints: [...], debug: ['compiled_cache'] })
```

둘 다 **합집합**. 알 수 없는 이름은 silent ignore.

## 출력 형식

```
[<category>] key=value ...
```

예:
```
[compiled_cache] first=false hits=3 misses=1 no_mtime_skipped=0 (entries=4)
```

## 변경

### 신규
- \`src/debug_log.zig\` (~100 LOC): \`Category\` enum, \`enabled_mask: u64\` 전역, \`enabled\` / \`print\` / \`addFromCsv\` / \`addCategories\` / \`initFromEnv\` / \`resetForTest\` + 4 unit tests
- \`docs/DEBUG.md\` — 사용법/카테고리/형식/확장 방향

### 수정
- \`src/root.zig\` — \`pub const debug_log\` re-export
- \`src/main.zig\` — CLI 진입 시 1회 \`initFromEnv\`
- \`packages/core/src/napi_entry.zig\` — NAPI register 1회 init + \`parseBuildOptions\` 에 \`debug: string[]\` 파싱
- \`src/bundler/bundler.zig\` — \`BundleOptions.debug: []const []const u8\` 필드, \`Bundler.init\` 에서 \`addCategories\` 호출
- \`src/bundler/incremental.zig\` — \`std.debug.print\` 제거, \`debug_log.print(.compiled_cache, ...)\` 로 교체
- \`packages/wasm/src/wasm_entry.zig\` — transpile-only 라 initFromEnv 생략 (주석 명시)
- \`CLAUDE.md\` — DEBUG.md 링크 추가

## Supersedes

#1684 (debug print noise hotfix) — 이 PR 이 동일 문제를 더 근본적으로 해결. 머지 후 #1684 close.

## Test plan
- [x] \`zig build test\` 3298 tests EXIT=0
- [x] \`zig build napi\` EXIT=0
- [ ] 리뷰어: 번개에서 \`ZTS_DEBUG=compiled_cache bun run bungae:start\` → HMR 파일 수정 시 \`[compiled_cache] hits=... misses=...\` stderr 출력 확인

## 후속

- RFC #1672 B2 실측 (이 PR 머지 후)
- 추가 카테고리 (\`hmr\`, \`resolve\`, \`parse\`, ...) 는 실제 필요 시 \`Category\` enum 에 이름만 추가 + docs/DEBUG.md 표 업데이트