### PR TITLE
perf(napi): wire compiled_cache into NAPI watch worker

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1186,6 +1186,9 @@ const WatchAsyncData = struct {
     watch_include: []const []const u8 = &.{},
     /// watch_roots 스캔 시 제외할 파일 glob (루트 기준 상대).
     watch_exclude: []const []const u8 = &.{},
+    /// Compiled output cache (B2). 워커 스레드에서 매 rebuild 마다 주입.
+    /// watch worker 수명 내내 유지되어 변경 안 된 모듈의 emit 을 스킵.
+    compiled_cache: bundler_mod.CompiledOutputCache,
 
     fn deinit(self: *WatchAsyncData) void {
         // 소유된 문자열 해제
@@ -1198,6 +1201,7 @@ const WatchAsyncData = struct {
         for (self.napi_plugins.items) |np| np.deinit();
         self.napi_plugins.deinit(native_alloc);
         self.zig_plugins.deinit(native_alloc);
+        self.compiled_cache.deinit();
         native_alloc.destroy(self);
     }
 };
@@ -1636,10 +1640,11 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
 
         if (changed_files.items.len == 0) continue;
 
-        // 재번들 — 증분 빌드: persistent_store + persistent_resolve_cache 재사용
+        // 재번들 — 증분 빌드: persistent_store + compiled_cache 재사용
         var incremental_opts = bundle_opts;
         incremental_opts.collect_module_codes = bundle_opts.dev_mode;
         incremental_opts.module_store = &persistent_store;
+        incremental_opts.compiled_cache = &async_data.compiled_cache;
         var rebundler = Bundler.initWithResolveCache(allocator, incremental_opts, &persistent_resolve_cache);
         defer rebundler.deinit();
 
@@ -1657,6 +1662,16 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             continue;
         };
         defer rebuild_result.deinit(allocator);
+
+        // compiled_cache 디버그 통계 — `ZTS_DEBUG=compiled_cache` 활성 시만 출력.
+        if (zts_lib.debug_log.enabled(.compiled_cache)) {
+            const stats = async_data.compiled_cache.takeStats();
+            zts_lib.debug_log.print(
+                .compiled_cache,
+                "hits={d} misses={d} no_mtime_skipped={d} (entries={d})\n",
+                .{ stats.hits, stats.misses, stats.skipped, async_data.compiled_cache.entries.count() },
+            );
+        }
 
         // 출력 파일 쓰기 + 바이트 수 계산
         var output_bytes: usize = 0;
@@ -1906,6 +1921,7 @@ fn napiWatch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_va
         .ready_tsfn = undefined,
         .rebuild_tsfn = undefined,
         .stop_flag = std.atomic.Value(bool).init(false),
+        .compiled_cache = bundler_mod.CompiledOutputCache.init(native_alloc),
     };
 
     // watchFolders/watchInclude/watchExclude 파싱 (parseBuildOptions 바깥에서 수집)

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1186,7 +1186,7 @@ const WatchAsyncData = struct {
     watch_include: []const []const u8 = &.{},
     /// watch_roots 스캔 시 제외할 파일 glob (루트 기준 상대).
     watch_exclude: []const []const u8 = &.{},
-    /// Compiled output cache (B2). 워커 스레드에서 매 rebuild 마다 주입.
+    /// 워커 스레드에서 매 rebuild 마다 주입되는 compiled output cache.
     /// watch worker 수명 내내 유지되어 변경 안 된 모듈의 emit 을 스킵.
     compiled_cache: bundler_mod.CompiledOutputCache,
 
@@ -1640,7 +1640,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
 
         if (changed_files.items.len == 0) continue;
 
-        // 재번들 — 증분 빌드: persistent_store + compiled_cache 재사용
+        // 재번들 — 증분 빌드: persistent_store + persistent_resolve_cache + compiled_cache 재사용
         var incremental_opts = bundle_opts;
         incremental_opts.collect_module_codes = bundle_opts.dev_mode;
         incremental_opts.module_store = &persistent_store;
@@ -1663,15 +1663,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         };
         defer rebuild_result.deinit(allocator);
 
-        // compiled_cache 디버그 통계 — `ZTS_DEBUG=compiled_cache` 활성 시만 출력.
-        if (zts_lib.debug_log.enabled(.compiled_cache)) {
-            const stats = async_data.compiled_cache.takeStats();
-            zts_lib.debug_log.print(
-                .compiled_cache,
-                "hits={d} misses={d} no_mtime_skipped={d} (entries={d})\n",
-                .{ stats.hits, stats.misses, stats.skipped, async_data.compiled_cache.entries.count() },
-            );
-        }
+        async_data.compiled_cache.logStats("");
 
         // 출력 파일 쓰기 + 바이트 수 계산
         var output_bytes: usize = 0;

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -306,6 +306,20 @@ pub const CompiledOutputCache = struct {
         try self.entries.put(owned_key, .{ .input_hash = input_hash, .compiled = owned });
     }
 
+    /// 디버그 로그에 hit/miss stats 출력 + 카운터 리셋. `ZTS_DEBUG=compiled_cache`
+    /// 비활성 시 takeStats 호출도 스킵 — counter 부작용 없음.
+    /// `prefix` 는 caller 가 추가할 선행 키 (예: "first=true "). 빈 문자열이면 prefix 없음.
+    pub fn logStats(self: *CompiledOutputCache, prefix: []const u8) void {
+        const debug_log = @import("../debug_log.zig");
+        if (!debug_log.enabled(.compiled_cache)) return;
+        const stats = self.takeStats();
+        debug_log.print(
+            .compiled_cache,
+            "{s}hits={d} misses={d} no_mtime_skipped={d} (entries={d})\n",
+            .{ prefix, stats.hits, stats.misses, stats.skipped, self.entries.count() },
+        );
+    }
+
     /// 특정 경로 엔트리를 무효화 (파일 삭제/graph 변경 시).
     pub fn invalidate(self: *CompiledOutputCache, path: []const u8) void {
         if (self.entries.fetchRemove(path)) |kv| {

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -15,7 +15,6 @@ const ResolveCache = @import("resolve_cache.zig").ResolveCache;
 const module_store = @import("module_store.zig");
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const CompiledOutputCache = @import("compiled_cache.zig").CompiledOutputCache;
-const debug_log = @import("../debug_log.zig");
 
 /// JSON 문자열 값 내부의 특수 문자를 이스케이프한다 (RFC 8259 준수).
 fn writeJsonEscaped(writer: anytype, s: []const u8) !void {
@@ -221,14 +220,7 @@ pub const IncrementalBundler = struct {
         self.updateCache(&result);
         if (is_first) self.needs_full_rebuild = false;
 
-        if (debug_log.enabled(.compiled_cache)) {
-            const stats = self.compiled_cache.takeStats();
-            debug_log.print(
-                .compiled_cache,
-                "first={} hits={d} misses={d} no_mtime_skipped={d} (entries={d})\n",
-                .{ is_first, stats.hits, stats.misses, stats.skipped, self.compiled_cache.entries.count() },
-            );
-        }
+        self.compiled_cache.logStats(if (is_first) "first=true " else "first=false ");
 
         result.deinit(self.allocator);
 

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -77,6 +77,8 @@ pub const SymbolKind = symbol.SymbolKind;
 pub const AliasTable = symbol.AliasTable;
 pub const incremental = @import("incremental.zig");
 pub const IncrementalBundler = incremental.IncrementalBundler;
+pub const compiled_cache = @import("compiled_cache.zig");
+pub const CompiledOutputCache = compiled_cache.CompiledOutputCache;
 
 test {
     _ = types;


### PR DESCRIPTION
## Summary

B2 (#1674) compiled_cache 가 IncrementalBundler 에만 주입되어 있어서 NAPI consumer (번개, Vite 플러그인 등) 는 emit cache 수혜를 못 받고 있었음. 이 PR 이 NAPI watch 경로에도 cache 를 주입해서 해결.

## Why

\`napiWatch\` 는 \`Bundler.initWithResolveCache\` 를 **매 rebuild 마다 새로 호출**하는 독립 경로라 \`IncrementalBundler\` 를 우회. B2 의 성능 개선이 실제 주요 consumer 에서 미동작 상태였음.

## 변경 (~20 LOC)

- \`src/bundler/mod.zig\`: \`CompiledOutputCache\` re-export
- \`packages/core/src/napi_entry.zig\`:
  - \`WatchAsyncData.compiled_cache: CompiledOutputCache\` 소유 필드
  - \`napiWatch\` init / deinit / rebuild 루프에서 연동
  - \`ZTS_DEBUG=compiled_cache\` 활성 시 stats 출력

## 번개 실측 (ExampleApp, 1172 모듈)

\`\`\`bash
ZTS_DEBUG=compiled_cache bun run bungae:start
# App.tsx 를 5번 수정
\`\`\`

| rebuild | hits | misses | hit rate | latency |
|---------|------|--------|----------|---------|
| 1차 (first put) | 0 | 1172 | 0% | 326ms |
| 2차 | **1171** | 1 | **99.9%** | 208ms |
| 3~6차 | 1171 | 1 | 99.9% | 184-199ms |

**HMR rebuild latency: 326ms → ~197ms (40% 감소)**. 1172 모듈 중 1171 개 emit 스킵.

남은 ~197ms 는 detect/parse/link phase — C2 (copyNodeDirect identity) 이후 parse/AST 재사용으로 추가 단축 가능.

## 유닛 테스트 (NAPI watch 직접 호출)

\`\`\`
[compiled_cache] hits=0 misses=2 entries=2   # 1st put
[compiled_cache] hits=1 misses=1 entries=2   # util.ts hit
[compiled_cache] hits=1 misses=1 entries=2   # util.ts hit
\`\`\`

2 모듈 (util + entry) 중 entry 만 수정 → util cache hit 확인.

## Test plan

- [x] \`zig build test\` 3298 tests EXIT=0
- [x] \`zig build napi\` EXIT=0
- [x] 번개 ExampleApp 실측: 99.9% hit rate, 40% latency 감소 (위 표)
- [x] 2-모듈 unit scenario (tmpdir): 50% hit (1/2)

## Follow-ups (별도 이슈)

- \`graph_changed\` 시 \`compiled_cache.clear()\` — 현재는 stale entry 메모리 누수 (정확성은 \`input_hash\` 비교로 안전하지만 dev server 장기 실행 시 누적)
- NAPI watch 경로 전용 통합 테스트 추가

Refs #1672 (RFC transformer 재설계 epic)