### PR TITLE
perf(bundler): #1672 Phase B3 — first-build compiled_cache reuse

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1441,7 +1441,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     initial_opts.module_store = &persistent_store;
     initial_opts.compiled_cache = &async_data.compiled_cache;
     // rebuild 루프와 동일한 collect_module_codes 로 맞춘다 — options_hash 가 같아야
-    // first-build 의 cache put 이 첫 rebuild 에서 그대로 hit 된다 (#1687 follow-up).
+    // first-build 의 cache put 이 첫 rebuild 에서 그대로 hit 된다.
     initial_opts.collect_module_codes = bundle_opts.dev_mode;
 
     var bundler = Bundler.init(allocator, initial_opts);

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1439,6 +1439,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
 
     var initial_opts = bundle_opts;
     initial_opts.module_store = &persistent_store;
+    initial_opts.compiled_cache = &async_data.compiled_cache;
 
     var bundler = Bundler.init(allocator, initial_opts);
     var result = bundler.bundle() catch |err| {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1440,6 +1440,9 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     var initial_opts = bundle_opts;
     initial_opts.module_store = &persistent_store;
     initial_opts.compiled_cache = &async_data.compiled_cache;
+    // rebuild 루프와 동일한 collect_module_codes 로 맞춘다 — options_hash 가 같아야
+    // first-build 의 cache put 이 첫 rebuild 에서 그대로 hit 된다 (#1687 follow-up).
+    initial_opts.collect_module_codes = bundle_opts.dev_mode;
 
     var bundler = Bundler.init(allocator, initial_opts);
     var result = bundler.bundle() catch |err| {

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -191,10 +191,13 @@ pub fn computeOptionsHash(options: EmitOptions) u64 {
 /// 모듈 emit 결과에 영향을 주는 모든 외부 상태를 결합.
 /// `used_export_names == null` = "모두 사용" sentinel (tree-shaking 미적용).
 /// `options_hash` 는 caller 가 computeOptionsHash 로 1회 계산한 값 재사용.
+/// `modules` 는 `ModuleIndex` → path 조회용. `ModuleIndex` 자체는 빌드 간
+/// 재할당되므로 path 로 hash 해야 initial/rebuild 간 input_hash 가 안정적.
 pub fn computeInputHash(
     module: *const Module,
     options_hash: u64,
     used_export_names: ?[]const []const u8,
+    modules: []const Module,
 ) u64 {
     var h = InputHasher.init(0);
     h.addI128(module.mtime);
@@ -208,9 +211,22 @@ pub fn computeInputHash(
     h.addU64(module.import_records.len);
     for (module.import_records) |rec| {
         h.addStr(rec.specifier);
-        h.addU32(@intFromEnum(rec.resolved));
         h.addBool(rec.is_external);
         h.addU32(@intFromEnum(rec.kind));
+        // resolved 는 `modules[index].path` 로 hash — ModuleIndex 는 빌드 간
+        // 재할당되므로 path 가 안정적. external/unresolved 는 specifier 만.
+        if (rec.is_external or rec.resolved.isNone()) {
+            h.addBool(false);
+        } else {
+            h.addBool(true);
+            const idx = rec.resolved.toU32();
+            if (idx < modules.len) {
+                h.addStr(modules[idx].path);
+            } else {
+                // 방어: 범위 밖이면 stable sentinel 로 hash (극히 이례적).
+                h.addStr("");
+            }
+        }
     }
 
     return h.final();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -397,7 +397,7 @@ pub fn emitWithTreeShaking(
                 continue; // mtime unknown → cache 비활성
             }
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
-            const input_hash = cache_mod.computeInputHash(m, options_hash, used_names);
+            const input_hash = cache_mod.computeInputHash(m, options_hash, used_names, graph.modules.items);
             input_hashes[i] = input_hash;
             const hit = cache.tryHit(m.path, input_hash) orelse continue;
             results[i] = hit.dupe(allocator) catch continue;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -746,6 +746,9 @@ pub const ModuleGraph = struct {
 
         var module = &self.modules.items[mod_idx];
         module.state = .parsing;
+        // compiled_cache key 는 mtime 을 요구한다. first build 경로는 여기서 처음 계산,
+        // rebuild 경로는 cache lookup 시 이미 설정됐으므로 fsStat 재호출 없이 통과.
+        if (module.mtime == 0) module.mtime = getMtime(module.path) catch 0;
 
         // Plugin runner: parseModule 내에서 load + transform 훅에 공용
         const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -443,6 +443,78 @@ test "IncrementalBundler: conflict 가 사라진 cache-hit 모듈의 canonical_n
     }
 }
 
+// ============================================================
+// RFC #1672 Phase B3 — first-build cache reuse
+// ============================================================
+
+test "IncrementalBundler: compiled_cache populates on FIRST build (B3)" {
+    // B3: parseModule 이 Module.mtime 을 주입하게 되어 첫 build 부터 cache put.
+    // 이전 (B2 단독): 첫 build 는 mtime=0 이라 cache 비활성.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+    });
+    defer ib.deinit();
+
+    // 첫 빌드 — 이제 mtime 이 주입되어 cache put 이 작동해야 함.
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    // 2개 모듈 (util + index) 모두 cache 에 저장됐어야.
+    try std.testing.expect(ib.compiled_cache.entries.count() >= 2);
+}
+
+test "IncrementalBundler: first rebuild hits cache from first build (B3)" {
+    // B3 효과 검증: util.ts 는 변경 안 함 → index.ts 수정 후 첫 rebuild 에서 cache hit.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .collect_module_codes = true,
+    });
+    defer ib.deinit();
+
+    // 첫 빌드 (cache populate).
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    _ = ib.compiled_cache.takeStats(); // 카운터 리셋 — 첫 빌드의 miss 는 제외하고 rebuild 만 관측.
+
+    // index.ts 만 수정, util.ts 는 그대로.
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x + 1);");
+
+    const r = try ib.rebuild();
+    switch (r) {
+        .success => |s| freeChanged(s.changed_modules),
+        else => return error.TestUnexpectedResult,
+    }
+    // util.ts 가 변경 안 됐으므로 cache hit 되어야 함.
+    try std.testing.expect(ib.compiled_cache.hits >= 1);
+}
+
 test "BundleResult.reparsed_paths: cache-hit 모듈은 제외, cache-miss 만 포함" {
     // HMR `phantom updates` 필터의 source-of-truth. napi_entry 가 이 리스트로
     // cache-hit 모듈을 HMR payload 에서 제외하므로, 리스트가 정확해야 한다.


### PR DESCRIPTION
## Summary

B2 에서는 \`compiled_cache\` 가 rebuild 경로만 mtime 을 받아 **첫 rebuild 가 전체 miss**. B3 는 first-build 에도 mtime 을 채우고 NAPI watch initial build 에 cache 를 주입해 **첫 rebuild 부터 hit**.

## 변경 (~80 LOC)

### \`src/bundler/graph.zig\`
\`parseModule\` 진입 시 \`module.mtime\` 이 0 이면 (first build) \`getMtime\` 호출해서 설정. rebuild cache-hit 경로는 이미 설정되어 있으므로 fsStat 재호출 없이 통과 (성능 보존).

### \`packages/core/src/napi_entry.zig\`
\`watchWorkerThread\` 의 **initial build** 옵션에도 \`compiled_cache\` 주입. 이전엔 rebuild 루프에만 있어서 첫 build 가 cache 를 채우지 못했음.

### \`src/bundler/incremental_test.zig\`
- \`first build 에서 cache populate\` 테스트
- \`first rebuild hits cache\` 테스트 (util.ts unchanged → cache hit)

## 번개 실측 (ExampleApp, 1172 모듈)

| | B2 only | B3 (이 PR) |
|-|---------|------------|
| 1차 rebuild hits | 0 | **1041 / 1172 (89%)** |
| 1차 rebuild latency | 326ms | **284ms (13% 감소)** |
| 2차 이후 | 1171 hits, 197ms | 동일 |

첫 rebuild 가 이전엔 완전 cold (miss 만) 였는데 이제 89% hit. 남은 131 miss 는 별도 follow-up (initial build 와 worker rebuild 간 state sync 세부 조사).

## Test plan
- [x] \`zig build test\` EXIT=0 (3300+ tests)
- [x] \`zig build napi\` EXIT=0
- [x] 번개 실측: 첫 rebuild 284ms (cold→warm 개선)
- [x] 신규 B3 테스트 2개 pass

## Follow-ups (별도 이슈)
- 1차 rebuild 에 남은 131 miss 조사
- \`graph_changed\` 시 \`compiled_cache.clear()\` (B2 부터 follow-up)

Refs #1672