### PR TITLE
feat(debug): AST lifetime 디버그 인프라 — D1 재개 준비

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -38,6 +38,7 @@ await build({
 | 이름 | 출력 내용 | 추가된 PR |
 |------|-----------|-----------|
 | `compiled_cache` | HMR/watch 의 compiled output cache hit/miss 집계 | RFC #1672 B2 |
+| `ast_mutation` | `Ast.addNode` 추적 (idx, tag, total, transform_boundary) | RFC #1672 D1 prep |
 
 추가 시: `src/debug_log.zig` 의 `Category` enum 에 이름만 추가 → 사용처에서 `debug_log.print(.new_category, ...)` 호출 → 이 표 업데이트.
 
@@ -54,7 +55,21 @@ await build({
 예시:
 ```
 [compiled_cache] first=false hits=3 misses=1 no_mtime_skipped=0 (entries=4)
+[ast_mutation] addNode idx=42 tag=identifier_reference (total=43, boundary=37)
 ```
+
+### `ast_mutation` 활용 (RFC #1672 D1 디버깅)
+
+D1 (Ast mutable + clone 제거) 재개 시 transformer 가 parse_arena 의 AST 에 in-place
+append 하는 흐름을 추적하는 데 사용. `transform_boundary` 는 parser 영역의 경계
+(`Transformer.init` 시점의 `nodes.items.len`) — 이후 추가되는 노드는 transformer 의
+결과. boundary 가 null 이면 아직 transform 전.
+
+함께 제공되는 인프라:
+- `Ast.transform_boundary: ?u32` — 변환 시작 시점 snapshot (필드만 정의, 사용은 D1 에서)
+- `Ast.transformed_root: ?NodeIndex` — transform() 결과 root cache (재진입 방지)
+- `Ast.assertInvariants()` — Debug 빌드 전용 invariant 검증
+- `Module.ast` 의 ownership 주석 — parse_arena 소유 규약 명시
 
 ## 코드 사용법
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -63,7 +63,17 @@ pub const Module = struct {
     dev_id: []const u8 = "",
     /// 소스 코드. parse_arena에서 할당 (Module.arena가 소유).
     source: []const u8,
-    /// 파싱된 AST. parse_arena에서 할당 (Module.arena가 소유).
+    /// 파싱된 AST. nodes/extra_data/string_table 의 backing 은 `parse_arena` 가 소유.
+    ///
+    /// ### Ownership 규약 (D1 디버그 인프라 — RFC #1672)
+    /// - 소유자: `parse_arena`. `Module.deinit` / `graph.deinit` 시 arena 를 해제하면
+    ///   ast 도 함께 free. 별도로 `ast.deinit()` 호출 금지.
+    /// - 변이 경로: 현재는 `cloneForTransformer` 로 별도 allocator 에 복제된 AST 위에서
+    ///   transformer 가 mutation. main 의 `Module.ast` 는 parse 직후 상태 유지.
+    /// - D1 이 in-place 로 전환하면 transformer 가 이 `ast` 에 직접 append. 그때는
+    ///   `transform_boundary` 로 parser 영역을 표시, `assertInvariants` 로 검증.
+    /// - 재진입: code splitting 의 shared module 은 같은 `ast` 에 여러 chunk 경로로
+    ///   접근할 수 있음. D1 완료 후 `transformed_root` cache 로 멱등 보장 예정.
     ast: ?Ast,
     /// import_scanner가 추출한 레코드. graph allocator에서 할당 (소스 텍스트를 참조).
     import_records: []ImportRecord,

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -28,6 +28,10 @@ const std = @import("std");
 /// 로그 카테고리. 추가 시 이 enum 에만 이름 넣으면 됨.
 pub const Category = enum {
     compiled_cache,
+    /// AST mutation 추적 — `Ast.addNode` / `addString` / `addNodeList` 시점 로그.
+    /// RFC #1672 D1 (Ast mutable + clone 제거) 디버깅용. parse_arena 소유권과
+    /// transformer 의 in-place append 상호작용 확인.
+    ast_mutation,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {
@@ -87,7 +91,8 @@ pub fn resetForTest() void {
 
 /// 카테고리 prefix 를 붙여 stderr 로 출력. 비활성이면 no-op.
 /// 호출 예: `print(.compiled_cache, "hits={d}\n", .{count})`
-pub fn print(cat: Category, comptime fmt: []const u8, args: anytype) void {
+/// `cat` 은 comptime — prefix 를 comptime concat 하여 호출 사이트별 zero-cost.
+pub fn print(comptime cat: Category, comptime fmt: []const u8, args: anytype) void {
     if (!enabled(cat)) return;
     std.debug.print("[" ++ @tagName(cat) ++ "] " ++ fmt, args);
 }

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -808,6 +808,16 @@ pub const Ast = struct {
     /// 파싱 중 JSX element/fragment가 발견되었는지 (automatic JSX import 주입용)
     has_jsx: bool = false,
 
+    /// D1 (RFC #1672) 디버그 인프라. Transformer.init 시점의 `nodes.items.len` snapshot.
+    /// null = 미변환. D1 이 in-place mutation 으로 전환되면 이 boundary 이상의 노드가
+    /// transformer append. 현재 main 은 cloneForTransformer 경로 — 필드만 정의, 사용
+    /// 안 됨. debug_log 의 `ast_mutation` 카테고리 + `assertInvariants` 에서 활용.
+    transform_boundary: ?u32 = null,
+
+    /// D1 디버그 인프라. transform() 완료 시 root NodeIndex snapshot.
+    /// code splitting 의 shared module 재진입 시 기존 결과 재사용 용 (D1 에서 연결).
+    transformed_root: ?NodeIndex = null,
+
     /// 메모리 할당자 (Zig 0.15: ArrayList가 더 이상 allocator를 저장하지 않음)
     allocator: std.mem.Allocator,
 
@@ -855,7 +865,35 @@ pub const Ast = struct {
     pub fn addNode(self: *Ast, node: Node) !NodeIndex {
         const index: u32 = @intCast(self.nodes.items.len);
         try self.nodes.append(self.allocator, node);
+        const debug_log = @import("../debug_log.zig");
+        if (debug_log.enabled(.ast_mutation)) {
+            debug_log.print(
+                .ast_mutation,
+                "addNode idx={d} tag={s} (total={d}, boundary={?})\n",
+                .{ index, @tagName(node.tag), self.nodes.items.len, self.transform_boundary },
+            );
+        }
         return @enumFromInt(index);
+    }
+
+    /// Debug-only invariant 검증 (D1 디버깅 인프라).
+    /// `transform_boundary` 가 설정됐다면 boundary 이하의 노드는 parser 가 채운 것,
+    /// 이상의 노드는 transformer 가 append 한 것. 이 영역이 명확한지 확인한다.
+    /// 프로덕션에서는 no-op — Debug 빌드에서만 실행.
+    pub fn assertInvariants(self: *const Ast) void {
+        if (@import("builtin").mode != .Debug) return;
+        if (self.transform_boundary) |boundary| {
+            // boundary 는 nodes.items.len 을 넘지 않아야 — transformer 가 노드를
+            // 제거하지 않고 append 만 한다는 설계 규약.
+            std.debug.assert(boundary <= self.nodes.items.len);
+        }
+        // transformed_root 가 있다면 valid index 여야.
+        if (self.transformed_root) |root| {
+            const idx = @intFromEnum(root);
+            if (!root.isNone()) {
+                std.debug.assert(idx < self.nodes.items.len);
+            }
+        }
     }
 
     /// 인덱스로 노드를 가져온다.


### PR DESCRIPTION
## Summary

RFC #1672 D1 (Ast mutable + clone 제거) 이 첫 시도에서 JSON module emit SIGABRT 등 예상 못 한 AST lifetime 이슈에 막혀 보류됨. **재개 전에 디버그/검증 인프라를 먼저 main 에 안착**시켜 다음 시도가 기존 도구 위에서 진행되도록 하는 것이 목적.

## 변경 (~70 LOC)

### `src/debug_log.zig`
- `ast_mutation` 카테고리 추가
- `print` 를 `comptime cat` 으로 수정 — category prefix 를 comptime concat (새 카테고리 증가 대응)

### `src/parser/ast.zig`
- `Ast.transform_boundary: ?u32 = null` — Transformer.init 시점 `nodes.items.len` snapshot
- `Ast.transformed_root: ?NodeIndex = null` — transform() 결과 cache (재진입 방지)
- `Ast.assertInvariants()` — Debug 빌드 전용 invariant 검증. 프로덕션 no-op
- `Ast.addNode` 에 ast_mutation 로그 hook

### `src/bundler/module.zig`
- `Module.ast` 주석 보강 — parse_arena 소유권 / D1 변이 규약 / 재진입 케이스 (code splitting 의 shared module) 명시

### `docs/DEBUG.md`
- `ast_mutation` 카테고리 표/예시 + D1 디버깅 활용 섹션

## 영향
- **기존 동작 불변** — 필드 default null, main 은 cloneForTransformer 경로 유지
- Hot path: `Ast.addNode` 에 `debug_log.enabled` 단일 bool 체크 추가 (비활성 시 즉시 return)
- 3307+ tests pass, smoke 영향 없음

## D1 재개 활용
```bash
ZTS_DEBUG=ast_mutation zts --bundle entry.ts
# [ast_mutation] addNode idx=42 tag=identifier_reference (total=43, boundary=37)
```
- `transform_boundary` 로 parser/transformer 노드 구간 구분
- `assertInvariants` 로 Debug 빌드에서 규약 위반 조기 감지
- `transformed_root` 는 D1 에서 재진입 방지 sentinel 로 활용 예정

## Test plan
- [x] `zig build test` 3307+ tests green
- [x] `zig build` clean
- [x] `debug_log.print` comptime 시그니처 변경 후 빌드 회귀 없음
- [ ] 리뷰어: D1 branch 에서 이 인프라로 JSON module emit SIGABRT 재현 + 원인 격리 가능한지 확인

Refs #1672