### PR TITLE
feat(transformer): #1672 Phase D1a — boundary/root fields 활성화 (clone 경로)

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -66,9 +66,9 @@ append 하는 흐름을 추적하는 데 사용. `transform_boundary` 는 parser
 결과. boundary 가 null 이면 아직 transform 전.
 
 함께 제공되는 인프라:
-- `Ast.transform_boundary: ?u32` — 변환 시작 시점 snapshot (필드만 정의, 사용은 D1 에서)
-- `Ast.transformed_root: ?NodeIndex` — transform() 결과 root cache (재진입 방지)
-- `Ast.assertInvariants()` — Debug 빌드 전용 invariant 검증
+- `Ast.transform_boundary: ?u32` — `Transformer.init` 시점 snapshot. D1a 부터 clone 경로에서 활성 (`cloneForTransformer` 가 생성한 AST 의 `nodes.items.len`).
+- `Ast.transformed_root: ?NodeIndex` — `transform()` 종료 시 root 기록. D1a 부터 활성. 이중 호출 (재진입) 은 `transform()` 진입 시 null 검증으로 탐지.
+- `Ast.assertInvariants()` — Debug 빌드 전용 invariant 검증. boundary 범위 + transformed_root 유효성.
 - `Module.ast` 의 ownership 주석 — parse_arena 소유 규약 명시
 
 ## 코드 사용법

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -809,13 +809,16 @@ pub const Ast = struct {
     has_jsx: bool = false,
 
     /// D1 (RFC #1672) 디버그 인프라. Transformer.init 시점의 `nodes.items.len` snapshot.
-    /// null = 미변환. D1 이 in-place mutation 으로 전환되면 이 boundary 이상의 노드가
-    /// transformer append. 현재 main 은 cloneForTransformer 경로 — 필드만 정의, 사용
-    /// 안 됨. debug_log 의 `ast_mutation` 카테고리 + `assertInvariants` 에서 활용.
+    /// null = 미변환. boundary 이상의 노드는 transformer 가 append 한 것.
+    /// D1a 부터 clone 경로 (Transformer.init → cloneForTransformer) 에서 활성.
+    /// D1b 이후 in-place mutation 경로에서도 동일 의미 유지. debug_log 의
+    /// `ast_mutation` 카테고리 + `assertInvariants` 에서 활용.
     transform_boundary: ?u32 = null,
 
     /// D1 디버그 인프라. transform() 완료 시 root NodeIndex snapshot.
-    /// code splitting 의 shared module 재진입 시 기존 결과 재사용 용 (D1 에서 연결).
+    /// D1a 부터 clone AST 에 기록 — 같은 Transformer 인스턴스의 이중 transform 을
+    /// `assertInvariants` 가 탐지. D1b (in-place) 전환 시 shared module 재진입
+    /// 탐지/차단 용도로 확장 예정.
     transformed_root: ?NodeIndex = null,
 
     /// 메모리 할당자 (Zig 0.15: ArrayList가 더 이상 allocator를 저장하지 않음)

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -453,7 +453,9 @@ pub const Transformer = struct {
         if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
 
         // 파서 AST를 트랜스포머 allocator로 복제 (원본 보존)
-        const cloned_ast = try Ast.cloneForTransformer(source_ast, allocator);
+        var cloned_ast = try Ast.cloneForTransformer(source_ast, allocator);
+        // D1 (RFC #1672): parser/transformer 영역 경계 스냅샷.
+        cloned_ast.transform_boundary = @intCast(cloned_ast.nodes.items.len);
 
         var self: Transformer = .{
             .ast = cloned_ast,
@@ -520,6 +522,12 @@ pub const Transformer = struct {
     /// 반환값: 새 AST에서의 루트 NodeIndex.
     /// 변환된 AST는 self.ast에 저장된다.
     pub fn transform(self: *Transformer) Error!NodeIndex {
+        // D1 (RFC #1672): 재진입 가드 (D1b in-place 전환 시 shared module 이중 transform 을 조기 탐지).
+        self.ast.assertInvariants();
+        if (@import("builtin").mode == .Debug) {
+            std.debug.assert(self.ast.transformed_root == null);
+        }
+
         // define value를 미리 string_table에 저장하여 tryDefineReplace에서 중복 addString 방지
         if (self.options.define.len > 0) {
             self.define_spans = self.allocator.alloc(Span, self.options.define.len) catch return Error.OutOfMemory;
@@ -559,9 +567,11 @@ pub const Transformer = struct {
 
         // React Fast Refresh: 컴포넌트 등록 코드를 프로그램 끝에 추가 ($RefreshReg$만, $RefreshSig$ 제거)
         if (self.options.react_refresh and self.plugins.refresh.registrations.items.len > 0) {
-            return try self.appendRefreshRegistrations(root);
+            root = try self.appendRefreshRegistrations(root);
         }
 
+        self.ast.transformed_root = root;
+        self.ast.assertInvariants();
         return root;
     }
 


### PR DESCRIPTION
## Summary
- `#1690` 가 올려둔 디버그 인프라 (`Ast.transform_boundary`, `Ast.transformed_root`, `Ast.assertInvariants`, `ZTS_DEBUG=ast_mutation`) 를 실제로 **활성화**. 이전엔 필드만 존재하고 세팅되지 않아 로그가 언제나 `boundary=null` 이었음.
- `Transformer.init` 에서 `cloneForTransformer` 직후 `transform_boundary = nodes.items.len` 스냅샷, `Transformer.transform()` 종료 시 `transformed_root = root` 기록.
- `transform()` 진입에 `assertInvariants()` + Debug-only `std.debug.assert(transformed_root == null)` — D1b (in-place 전환) 에서 shared module 이중 transform 을 즉시 탐지하기 위한 사전 배치.
- 순수 metadata 기록 + Debug-only assertion. **Release 경로 영향 0** (assertInvariants 는 첫 줄에서 `if (mode != .Debug) return;`, 명시 assert 도 Debug 가드 안).

## Why D1a (not full D1)
`#1672` D1 의 직전 시도 (`transformer-d1-ast-mutable-no-clone`, 로컬 branch + stash) 는 전체 in-place 전환을 한 PR 로 시도했다가 code splitting 의 shared module 경로에서 SIGABRT. 원인 격리를 위해 D1 을 3단계로 분할:
- **D1a (이 PR)**: 디버그 필드 활성. clone 유지. 가장 안전.
- D1b: single-bundle (`emitWithTreeShaking`) 경로만 in-place 전환. splitting 경로는 계속 clone.
- D1c: splitting 경로 구조 변경 (transform/codegen 분리).

D1a 자체로는 재진입 차단을 구현하지 않는다 — compiled output cache (`#1674`) 가 이미 상위에서 처리. 다만 **필드/invariant 를 활성화**해 D1b 진입 시 `ZTS_DEBUG=ast_mutation` 이 진짜 boundary 를 보여주고, `assertInvariants` 가 meaningful 한 검증을 수행.

## 효과 확인
`ZTS_DEBUG=ast_mutation` 샘플 (`const a: number = 1; console.log(a);`):
```
[ast_mutation] addNode idx=0  tag=binding_identifier    (total=1,  boundary=null)  ← parser 영역
[ast_mutation] addNode idx=11 tag=program               (total=12, boundary=null)
[ast_mutation] addNode idx=12 tag=variable_declarator   (total=13, boundary=12)    ← transformer 영역 (cloned + boundary=12)
[ast_mutation] addNode idx=13 tag=variable_declaration  (total=14, boundary=12)
```
이전엔 전 구간 `boundary=null`.

## Test plan
- [x] `zig build test` — 3307/3307 pass
- [x] smoke (`tests/benchmark/smoke.ts`, 136 패키지) — all ✅
- [x] `ZTS_DEBUG=ast_mutation` 로그가 parser 영역 / transformer 영역을 실제로 구분해서 출력하는지 샘플 실측
- [x] Debug Transformer phase @ 1000줄: 402us → 395us (노이즈 범위)
- [x] Release 경로 zero-overhead — `assertInvariants` 와 명시 assert 모두 `if (mode != .Debug)` 가드

Refs #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)