### PR TITLE
refactor(transformer): #1672 Phase D1b-1 — Transformer.ast 를 *Ast 포인터로 전환

### DIFF
--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -1691,7 +1691,7 @@ test "Profile: pipeline stage timing (dev only, not for CI)" {
             xform_ns += std.time.nanoTimestamp() - t0;
 
             t0 = std.time.nanoTimestamp();
-            var cg = Codegen.init(a, &transformer.ast);
+            var cg = Codegen.init(a, transformer.ast);
             _ = try cg.generate(root);
             cg_ns += std.time.nanoTimestamp() - t0;
         }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -915,7 +915,7 @@ pub fn emitModule(
             .scopes = sem.scopes,
             .unresolved_globals = &sem.unresolved_references,
         } else .empty;
-        minify_mod.minify(&transformer.ast, ctx, arena_alloc, root);
+        minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
     }
 
     // 런타임 헬퍼 사용 추적: transformer가 설정한 플래그를 out parameter로 전달
@@ -936,7 +936,7 @@ pub fn emitModule(
             null;
         // ast 기준으로 skip_nodes 구축 (transformer 이후이므로 노드 인덱스가 ast와 일치)
         var md = try l.buildMetadataForAst(
-            &transformer.ast,
+            transformer.ast,
             module.index.toU32(),
             is_entry,
             override_syms,
@@ -953,7 +953,7 @@ pub fn emitModule(
                     const sem = module.semantic orelse {
                         statement_shaker.markUnusedStatements(
                             arena_alloc,
-                            &transformer.ast,
+                            transformer.ast,
                             root,
                             names,
                             &md.skip_nodes,
@@ -997,7 +997,7 @@ pub fn emitModule(
                         }
                     } else {
                         // tree-shaker 없으면 기존 방식 (모듈 내부 computeReachable)
-                        if (stmt_info_mod.build(arena_alloc, &transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references)) |maybe_infos| {
+                        if (stmt_info_mod.build(arena_alloc, transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references)) |maybe_infos| {
                             if (maybe_infos) |infos| {
                                 var used_sym_buf: std.ArrayListUnmanaged(u32) = .empty;
                                 defer used_sym_buf.deinit(arena_alloc);
@@ -1039,7 +1039,7 @@ pub fn emitModule(
     // 현재 모듈의 해당 호출에 is_pure 플래그를 자동 설정한다.
     if (linker) |l| {
         const sym_ids = if (metadata) |md| md.symbol_ids else &.{};
-        propagateCrossModulePurity(l, module, &transformer.ast, sym_ids, arena_alloc);
+        propagateCrossModulePurity(l, module, transformer.ast, sym_ids, arena_alloc);
     }
 
     // Identifier mangling은 단일 파일 트랜스파일(main.zig)에서만 적용.
@@ -1051,14 +1051,14 @@ pub fn emitModule(
     // block-scope 의미 변경 위험 없음. dev 빌드에선 원본 kind 유지 (DX) — esbuild/rolldown
     // 동일 관습. mergeDecls 직전에 호출해 var 끼리 연쇄 merge 극대화.
     if (linker != null and options.minify_syntax) {
-        @import("../transformer/minify.zig").downgradeToVar(&transformer.ast);
+        @import("../transformer/minify.zig").downgradeToVar(transformer.ast);
     }
 
     // Private field name mangle (#1632 Phase 1) — `#commit_callbacks` 같은 긴 이름을
     // class 별 독립 범위로 `#a`, `#b`, ... 단축. JS 언어 규약상 private name 은 선언된
     // class body 바깥에서 참조 불가 → per-class 안전. minify_identifiers 플래그와 묶음.
     if (options.minify_identifiers) {
-        @import("../codegen/private_mangler.zig").manglePrivateFields(&transformer.ast);
+        @import("../codegen/private_mangler.zig").manglePrivateFields(transformer.ast);
     }
 
     // 인접 선언 merge (#1588) — tree-shake 직후에 실행해 skip_nodes 결정과 충돌 방지.
@@ -1066,7 +1066,7 @@ pub fn emitModule(
     // statement는 A가 사용되므로 제거 불가 → B의 초기화식이 살아남아 죽은 심볼을 참조.
     // 순서: transform → minify(fold) → tree-shake → downgradeToVar → mergeDecls → codegen.
     @import("../transformer/minify.zig").mergeDecls(
-        &transformer.ast,
+        transformer.ast,
         if (metadata) |*m| @as(?*const std.DynamicBitSet, &m.skip_nodes) else null,
     );
 
@@ -1075,7 +1075,7 @@ pub fn emitModule(
         const esm_result = try emitEsmWrappedModule(
             allocator,
             arena_alloc,
-            &transformer.ast,
+            transformer.ast,
             root,
             module,
             if (metadata) |*m| @as(?*const LinkingMetadata, m) else null,
@@ -1090,7 +1090,7 @@ pub fn emitModule(
     }
 
     // Codegen: AST → JS 문자열
-    var cg = Codegen.initWithOptions(arena_alloc, &transformer.ast, .{
+    var cg = Codegen.initWithOptions(arena_alloc, transformer.ast, .{
         .minify_whitespace = options.minify_whitespace,
         // Peephole boolean 축약 등 codegen-레벨 출력 최적화(#1552).
         .minify_syntax = options.minify_syntax,

--- a/src/codegen/codegen_test/function_map.zig
+++ b/src/codegen/codegen_test/function_map.zig
@@ -25,7 +25,7 @@ fn e2eFunctionMap(backing_allocator: std.mem.Allocator, source: []const u8) !str
     var t = try h.Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
 
-    var cg = Codegen.initWithOptions(allocator, &t.ast, .{
+    var cg = Codegen.initWithOptions(allocator, t.ast, .{
         .sourcemap = true,
         .sourcemap_function_map = true,
     });
@@ -116,7 +116,7 @@ test "function_map: sourcemap_function_map=false — no x_facebook_sources" {
     _ = try parser.parse();
     var t = try h.Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
-    var cg = Codegen.initWithOptions(allocator, &t.ast, .{ .sourcemap = true });
+    var cg = Codegen.initWithOptions(allocator, t.ast, .{ .sourcemap = true });
     cg.line_offsets = scanner.line_offsets.items;
     try cg.addSourceFile("input.ts");
     _ = try cg.generate(root);

--- a/src/codegen/codegen_test/helpers.zig
+++ b/src/codegen/codegen_test/helpers.zig
@@ -76,7 +76,7 @@ pub fn e2eSourceMap(backing_allocator: std.mem.Allocator, source: []const u8) !S
     var t = try Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
 
-    var cg = Codegen.initWithOptions(allocator, &t.ast, .{ .sourcemap = true });
+    var cg = Codegen.initWithOptions(allocator, t.ast, .{ .sourcemap = true });
     cg.line_offsets = scanner.line_offsets.items;
     try cg.addSourceFile("input.ts");
     const output = try cg.generate(root);
@@ -135,7 +135,7 @@ pub fn e2eFull(backing_allocator: std.mem.Allocator, source: []const u8, t_optio
     t.line_offsets = scanner.line_offsets.items;
     const root = try t.transform();
 
-    var cg = Codegen.initWithOptions(allocator, &t.ast, cg_options);
+    var cg = Codegen.initWithOptions(allocator, t.ast, cg_options);
     const raw_output = try cg.generate(root);
 
     // JSX import prepend (transformer가 JSX lowering 수행한 경우)
@@ -198,7 +198,7 @@ pub fn e2eFlowImpl(backing_allocator: std.mem.Allocator, source: []const u8, is_
     var t = try Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
 
-    var cg = Codegen.initWithOptions(allocator, &t.ast, .{ .minify_whitespace = true });
+    var cg = Codegen.initWithOptions(allocator, t.ast, .{ .minify_whitespace = true });
     const output = try cg.generate(root);
 
     return .{ .output = output, .arena = arena };

--- a/src/codegen/codegen_test/skip_nodes_blank.zig
+++ b/src/codegen/codegen_test/skip_nodes_blank.zig
@@ -50,7 +50,7 @@ fn codegenWithSkippedStatements(
         .allocator = a,
     };
 
-    var cg = Codegen.initWithOptions(a, &t.ast, .{ .linking_metadata = &md });
+    var cg = Codegen.initWithOptions(a, t.ast, .{ .linking_metadata = &md });
     const out = try cg.generate(root);
     return backing.dupe(u8, out);
 }

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -857,7 +857,8 @@ pub const Ast = struct {
             .has_jsx = source_ast.has_jsx,
             .allocator = allocator,
         };
-        // 파서 데이터를 새 allocator로 복사
+        // 세 appendSlice 중 하나라도 실패하면 이미 할당된 ArrayList 버퍼를 정리해야 한다.
+        errdefer cloned.deinit();
         try cloned.nodes.appendSlice(allocator, source_ast.nodes.items);
         try cloned.extra_data.appendSlice(allocator, source_ast.extra_data.items);
         try cloned.string_table.appendSlice(allocator, source_ast.string_table.items);

--- a/src/test_arena.zig
+++ b/src/test_arena.zig
@@ -30,7 +30,7 @@ fn runPipeline(allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
     var transformer = try Transformer.init(allocator, &parser.ast, .{});
     const root = try transformer.transform();
 
-    var cg = Codegen.initWithOptions(allocator, &transformer.ast, .{ .minify_whitespace = true });
+    var cg = Codegen.initWithOptions(allocator, transformer.ast, .{ .minify_whitespace = true });
     return try cg.generate(root);
 }
 

--- a/src/test_fixtures.zig
+++ b/src/test_fixtures.zig
@@ -47,7 +47,7 @@ fn runFixture(backing_allocator: std.mem.Allocator, source: []const u8, cg_optio
     var t = try Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
 
-    var cg = Codegen.initWithOptions(allocator, &t.ast, cg_options);
+    var cg = Codegen.initWithOptions(allocator, t.ast, cg_options);
     const output = try cg.generate(root);
 
     return .{ .output = output, .arena = arena };

--- a/src/test_regression.zig
+++ b/src/test_regression.zig
@@ -43,7 +43,7 @@ fn e2e(backing_allocator: std.mem.Allocator, source: []const u8) !TestResult {
     var t = try Transformer.init(allocator, &parser.ast, .{});
     const root = try t.transform();
 
-    var cg = Codegen.initWithOptions(allocator, &t.ast, .{ .minify = true });
+    var cg = Codegen.initWithOptions(allocator, t.ast, .{ .minify = true });
     const output = try cg.generate(root);
 
     return .{ .output = output, .arena = arena };

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -175,7 +175,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
         /// transformer 신규 노드 영역을 걸러낸다 (extra 자식에만 한정).
         fn collectChildIndices(self: *Transformer, node: Node, buf: *std.ArrayList(NodeIndex)) !void {
             const kind = node.tag.dataKind();
-            var it = ast_walk.children(&self.ast, node);
+            var it = ast_walk.children(self.ast, node);
             while (it.next()) |child| {
                 if (kind == .extra) {
                     const raw = @intFromEnum(child);

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -96,7 +96,7 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
         const child_node = self.ast.getNode(child);
         if (isModuleDeclaration(child_node.tag)) continue;
-        if (hasTopLevelAwait(&self.ast, child)) {
+        if (hasTopLevelAwait(self.ast, child)) {
             has_tla = true;
             break;
         }

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -32,10 +32,10 @@ fn expectMinifyOpts(
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast, .empty, a, root);
-    minify_mod.mergeDecls(&transformer.ast, null);
+    minify_mod.minify(transformer.ast, .empty, a, root);
+    minify_mod.mergeDecls(transformer.ast, null);
 
-    var cg = Codegen.initWithOptions(a, &transformer.ast, codegen_opts);
+    var cg = Codegen.initWithOptions(a, transformer.ast, codegen_opts);
     const result = try cg.generate(root);
     const trimmed = std.mem.trimRight(u8, result, "\n");
     try std.testing.expectEqualStrings(expected, trimmed);
@@ -55,11 +55,11 @@ fn expectMergeIdempotent(input: []const u8, expected: []const u8) !void {
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast, .empty, a, root);
-    minify_mod.mergeDecls(&transformer.ast, null);
-    minify_mod.mergeDecls(&transformer.ast, null); // 두 번째 호출 — 결과 동일해야 함
+    minify_mod.minify(transformer.ast, .empty, a, root);
+    minify_mod.mergeDecls(transformer.ast, null);
+    minify_mod.mergeDecls(transformer.ast, null); // 두 번째 호출 — 결과 동일해야 함
 
-    var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
+    var cg = Codegen.initWithOptions(a, transformer.ast, .{});
     const result = try cg.generate(root);
     const trimmed = std.mem.trimRight(u8, result, "\n");
     try std.testing.expectEqualStrings(expected, trimmed);
@@ -87,7 +87,7 @@ fn expectMergeWithSkip(
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(&transformer.ast, .empty, a, root);
+    minify_mod.minify(transformer.ast, .empty, a, root);
 
     var skip = try std.DynamicBitSet.initEmpty(a, transformer.ast.nodes.items.len);
     // substring의 시작 위치와 일치하는 variable_declaration을 **전부** 마킹.
@@ -102,7 +102,7 @@ fn expectMergeWithSkip(
         }
     }
 
-    minify_mod.mergeDecls(&transformer.ast, &skip);
+    minify_mod.mergeDecls(transformer.ast, &skip);
 
     // program 노드 찾기 (codegen이 쓰는 마지막 .program)
     var prog_idx: ?u32 = null;
@@ -763,10 +763,10 @@ fn expectMinifyDead(body: []const u8, expected: []const u8) !void {
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, a, root);
-    minify_mod.mergeDecls(&transformer.ast, null);
+    minify_mod.minify(transformer.ast, ctx, a, root);
+    minify_mod.mergeDecls(transformer.ast, null);
 
-    var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
+    var cg = Codegen.initWithOptions(a, transformer.ast, .{});
     const result = try cg.generate(root);
     const trimmed = std.mem.trimRight(u8, result, "\n");
     try std.testing.expectEqualStrings(expected, trimmed);
@@ -886,8 +886,8 @@ test "dead store: await using — 유지" {
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, a, root);
-    var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
+    minify_mod.minify(transformer.ast, ctx, a, root);
+    var cg = Codegen.initWithOptions(a, transformer.ast, .{});
     const result = try cg.generate(root);
     try std.testing.expect(std.mem.indexOf(u8, result, "await using x") != null);
 }
@@ -969,8 +969,8 @@ test "dead store: top-level const 는 tree-shaker 영역 — 유지" {
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, a, root);
-    var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
+    minify_mod.minify(transformer.ast, ctx, a, root);
+    var cg = Codegen.initWithOptions(a, transformer.ast, .{});
     const result = try cg.generate(root);
     try std.testing.expect(std.mem.indexOf(u8, result, "const x = 1") != null);
 }
@@ -1013,7 +1013,7 @@ test "dead store: cascading — y dead 여부는 x 제거의 감산으로 결정
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, a, root);
+    minify_mod.minify(transformer.ast, ctx, a, root);
 
     // minify 는 sem.reference_count 를 뮤테이션하지 않아야 한다 (rebuild 누적 감산 방지).
     var y_ref_after: u32 = 0;
@@ -1024,7 +1024,7 @@ test "dead store: cascading — y dead 여부는 x 제거의 감산으로 결정
     try std.testing.expectEqual(@as(u32, 1), y_ref_after);
 
     // 최종 AST: x 와 y 둘 다 empty_statement 여야 함 (cascading dead-store 동작).
-    var codegen = Codegen.init(a, &transformer.ast);
+    var codegen = Codegen.init(a, transformer.ast);
     defer codegen.deinit();
     const output = try codegen.generate(root);
     try std.testing.expect(std.mem.indexOf(u8, output, "let x") == null);
@@ -1469,8 +1469,8 @@ test "unused: /*#__PURE__*/ super(x, y) — derived constructor semantic 필수 
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
     };
-    minify_mod.minify(&transformer.ast, ctx, a, root);
-    var cg = Codegen.initWithOptions(a, &transformer.ast, .{});
+    minify_mod.minify(transformer.ast, ctx, a, root);
+    var cg = Codegen.initWithOptions(a, transformer.ast, .{});
     const result = try cg.generate(root);
     try std.testing.expect(std.mem.indexOf(u8, result, "super(x, y)") != null);
 }

--- a/src/transformer/plugins/worklet_plugin.zig
+++ b/src/transformer/plugins/worklet_plugin.zig
@@ -466,7 +466,7 @@ fn hasFileWorkletDirective(t: *Transformer, list_start: u32, list_len: u32) bool
     while (i < list_len) : (i += 1) {
         const idx: NodeIndex = @enumFromInt(t.ast.extra_data.items[list_start + i]);
         // prologue 종료 감지: directive 가 아닌 첫 문장에서 바로 false.
-        const text = worklet_mod.directiveText(&t.ast, idx) orelse return false;
+        const text = worklet_mod.directiveText(t.ast, idx) orelse return false;
         if (std.mem.eql(u8, text, "worklet")) return true;
     }
     return false;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -228,7 +228,9 @@ pub const RuntimeHelpers = packed struct(u32) {
 pub const Transformer = struct {
     /// 통합 AST. 파서 노드(0..parser_node_count-1)는 읽기 전용,
     /// 트랜스포머가 추가한 노드(parser_node_count..)는 append-only.
-    ast: Ast,
+    /// `*Ast` — Transformer 가 소유권을 가진다 (clone 경로). D1b-2 의 `initInPlace` 는
+    /// 외부 소유 AST 를 borrow 하는 variant 로 같은 필드를 공유.
+    ast: *Ast,
 
     /// 파서 노드 수. transform() 시작 시 루트 인덱스(parser_node_count - 1) 계산에 사용.
     parser_node_count: u32,
@@ -452,13 +454,15 @@ pub const Transformer = struct {
         var opts = options;
         if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
 
-        // 파서 AST를 트랜스포머 allocator로 복제 (원본 보존)
-        var cloned_ast = try Ast.cloneForTransformer(source_ast, allocator);
+        // 파서 AST를 트랜스포머 allocator 의 heap cell 로 복제 (원본 보존).
+        const ast_ptr = try allocator.create(Ast);
+        errdefer allocator.destroy(ast_ptr);
+        ast_ptr.* = try Ast.cloneForTransformer(source_ast, allocator);
         // D1 (RFC #1672): parser/transformer 영역 경계 스냅샷.
-        cloned_ast.transform_boundary = @intCast(cloned_ast.nodes.items.len);
+        ast_ptr.transform_boundary = @intCast(ast_ptr.nodes.items.len);
 
         var self: Transformer = .{
-            .ast = cloned_ast,
+            .ast = ast_ptr,
             .parser_node_count = @intCast(source_ast.nodes.items.len),
             .options = opts,
             .allocator = allocator,
@@ -471,11 +475,13 @@ pub const Transformer = struct {
 
     pub fn deinit(self: *Transformer) void {
         self.ast.deinit();
+        self.allocator.destroy(self.ast);
         self.deinitExceptAst();
     }
 
     /// AST를 제외한 모든 리소스를 해제한다.
-    /// 테스트에서 AST를 별도로 관리할 때 사용.
+    /// 테스트에서 AST를 별도로 관리할 때 사용. `.ast` 는 `*Ast` 이므로 호출자가
+    /// `ast.deinit()` + `allocator.destroy(ast)` 둘 다 책임.
     pub fn deinitExceptAst(self: *Transformer) void {
         self.scratch.deinit(self.allocator);
         self.pending_nodes.deinit(self.allocator);

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -76,7 +76,7 @@ pub fn findDirectiveOffset(self: *Transformer, body_idx: NodeIndex, directive: [
     var si: u32 = 0;
     while (si < search_len) : (si += 1) {
         const stmt_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + si]);
-        const text = directiveText(&self.ast, stmt_idx) orelse continue;
+        const text = directiveText(self.ast, stmt_idx) orelse continue;
         if (std.mem.eql(u8, text, directive)) return si;
     }
     return null;
@@ -341,7 +341,7 @@ fn collectAllIdentifiers(self: *Transformer, idx: NodeIndex, locals: *std.String
         else => {},
     }
     // generic 재귀 순회 — 공통 ChildIterator 사용
-    var it = ast_walk.children(&self.ast, node);
+    var it = ast_walk.children(self.ast, node);
     while (it.next()) |child| {
         if (child.isNone()) continue;
         try collectAllIdentifiers(self, child, locals, depth + 1);
@@ -394,7 +394,7 @@ fn collectNewExpressionCallees(
         }
     }
     // 자식 재귀 — 공통 ChildIterator 로 generic 순회
-    var it = ast_walk.children(&self.ast, node);
+    var it = ast_walk.children(self.ast, node);
     while (it.next()) |child| {
         if (child.isNone()) continue;
         try collectNewExpressionCallees(self, child, new_classes, depth + 1);
@@ -549,7 +549,7 @@ fn walkBodyForClosureAnalysis(
     }
 
     // --- Generic 순회: 공통 ChildIterator ---
-    var it = ast_walk.children(&self.ast, node);
+    var it = ast_walk.children(self.ast, node);
     while (it.next()) |child| {
         if (child.isNone()) continue;
         try walkBodyForClosureAnalysis(self, child, locals, refs, depth + 1);
@@ -965,7 +965,7 @@ pub fn generateInitCode(
 
     // Codegen으로 code string 생성 (minified, TS 타입 스트리핑 완료된 AST 사용)
     const codegen_mod = @import("../../codegen/codegen.zig");
-    var codegen = codegen_mod.Codegen.initWithOptions(self.allocator, &self.ast, .{
+    var codegen = codegen_mod.Codegen.initWithOptions(self.allocator, self.ast, .{
         .minify_whitespace = true,
     });
     const code = codegen.generate(program) catch return error.OutOfMemory;

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -174,8 +174,9 @@ test "Transformer: strip ts_as_expression" {
 // ============================================================
 
 /// 통합 테스트 결과. deinit()으로 모든 리소스를 한 번에 해제.
+/// `ast` 는 transformer 에서 소유권 이전받은 heap-allocated `*Ast`.
 const TestResult = struct {
-    ast: Ast,
+    ast: *Ast,
     root: NodeIndex,
     scanner: *Scanner,
     parser: *Parser,
@@ -183,6 +184,7 @@ const TestResult = struct {
 
     pub fn deinit(self: *TestResult) void {
         self.ast.deinit();
+        self.allocator.destroy(self.ast);
         self.parser.deinit();
         self.allocator.destroy(self.parser);
         self.scanner.deinit();
@@ -740,7 +742,7 @@ pub fn transformWorklet(allocator: std.mem.Allocator, source: []const u8) !TestR
 /// 반환값은 r.allocator로 할당된 복제본 — r.deinit() 후에도 안전하지만 별도 free 필요.
 /// 테스트에서는 allocator가 GPA이므로 검사됨.
 pub fn generateCode(r: *TestResult) ![]const u8 {
-    var codegen = Codegen.init(r.allocator, &r.ast);
+    var codegen = Codegen.init(r.allocator, r.ast);
     const code = try codegen.generate(r.root);
     // 코드를 복제 후 codegen 해제 (buf 누수 방지)
     const duped = try r.allocator.dupe(u8, code);

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -349,8 +349,8 @@ pub fn transpileWithCallback(
             .scopes = analyzer.scopes.items,
             .unresolved_globals = null,
         };
-        minify_mod.minify(&transformer.ast, ctx, arena_alloc, root);
-        minify_mod.mergeDecls(&transformer.ast, null);
+        minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
+        minify_mod.mergeDecls(transformer.ast, null);
     }
 
     // 5. Mangling 메타데이터 구성. skip_nodes는 arena-owned이라 별도 deinit 불필요
@@ -376,7 +376,7 @@ pub fn transpileWithCallback(
     }
 
     // 6. 코드 생성
-    var cg = Codegen.initWithOptions(arena_alloc, &transformer.ast, .{
+    var cg = Codegen.initWithOptions(arena_alloc, transformer.ast, .{
         .module_format = options.module_format,
         .minify_whitespace = options.minify_whitespace,
         .minify_syntax = options.minify_syntax,


### PR DESCRIPTION
## Summary
D1b (single-bundle in-place mutation) 의 토대. `Transformer.ast: Ast` (owned value) → `*Ast` (heap-allocated pointer). **동작 불변** — init 은 여전히 항상 clone, 호출자 API 관점에선 \`&X.ast\` → \`X.ast\` 기계적 전환뿐.

- \`src/transformer/transformer.zig\`:
  - \`Transformer.ast\` 필드 타입 변경
  - \`init\` 에 \`allocator.create(Ast)\` + errdefer destroy
  - \`deinit\` 에 \`allocator.destroy(self.ast)\` 추가
- \`src/parser/ast.zig\` \`cloneForTransformer\`: 세 appendSlice 중간 실패 시 이미 할당된 ArrayList leak 을 막는 \`errdefer cloned.deinit()\` 추가 (pre-existing bug 동시 수정)
- consumer 15 파일 (emitter, transpile, tests, worklet): \`&X.ast\` → \`X.ast\`
- \`TestResult.ast: Ast\` → \`*Ast\`, deinit 이 destroy 추가

## Why D1b 를 둘로 쪼갰나
이전 D1 시도 (로컬 stash) 는 포인터화 + clone 제거 + in-place 전환을 한 PR 로 시도 → code splitting shared module SIGABRT. 이번엔 둘로 분리:
- **D1b-1 (이 PR)**: 포인터화만, 동작 불변
- **D1b-2 (다음 PR)**: \`initInPlace\` 추가 + \`emitWithTreeShaking\` 경로 연결

## Test plan
- [x] \`zig build test\` — 3307/3307 pass
- [x] smoke (136 패키지) — all ✅
- [x] Debug Transformer phase @ 1000줄: 395us (main 대비 noise range)
- [x] emitter 는 arena allocator → \`allocator.create(Ast)\` 는 O(1) bump, 1000 모듈 누적 오버헤드 <1us
- [x] /simplify 3-agent 리뷰 — partial-failure leak (critical, cloneForTransformer) 및 doc comment over-explain 2건 반영

Refs #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)