### PR TITLE
feat(transformer): #1672 Phase D1b-2 — single-bundle in-place mutation

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -30,6 +30,8 @@ const ast_mod = @import("../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const NodeIndex = ast_mod.NodeIndex;
 const Transformer = @import("../transformer/transformer.zig").Transformer;
+const TransformOptions = @import("../transformer/transformer.zig").TransformOptions;
+const AstHandling = @import("../transformer/transformer.zig").AstHandling;
 const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const cache_mod = @import("compiled_cache.zig");
@@ -426,7 +428,7 @@ pub fn emitWithTreeShaking(
             if (hit_mask[i]) continue;
             const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
-            results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines, &results[i].fn_map_json) catch null;
+            results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines, &results[i].fn_map_json, .in_place) catch null;
         }
     }
 
@@ -810,12 +812,17 @@ fn emitModuleThread(
     shaker: ?*const TreeShaker,
     result: *CompiledModule,
 ) void {
-    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.preamble_lines, &result.fn_map_json) catch null;
+    // emitWithTreeShaking 경로 — 모듈당 emitModule 1회 호출이 보장되므로 in-place.
+    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.preamble_lines, &result.fn_map_json, .in_place) catch null;
 }
 
 /// 단일 모듈을 Transformer → Codegen 파이프라인으로 처리.
 /// 모듈별 arena에 AST가 보존되어 있으므로 재파싱 불필요.
 /// emitChunks에서도 사용하므로 pub으로 노출.
+///
+/// `ast_handling` (D1b-2, RFC #1672): `.in_place` 는 module.ast 를 직접 mutate 후
+/// parser 상태로 truncate 복구. `.cloned` 은 기존 clone 경로 (splitting 처럼 같은 module
+/// 을 여러 번 emit 하는 경로 전용).
 pub fn emitModule(
     allocator: std.mem.Allocator,
     module: *const Module,
@@ -828,6 +835,7 @@ pub fn emitModule(
     mappings_out: ?*?[]const SourceMap.Mapping,
     preamble_lines_out: ?*u32,
     fn_map_json_out: ?*?[]const u8,
+    ast_handling: AstHandling,
 ) !?[]const u8 {
     // Disabled 모듈 (platform=browser에서 Node 빌트인): 빈 __commonJS wrapper 출력.
     // esbuild 호환: var require_X = __commonJS({ "(disabled)"(exports, module) {} });
@@ -844,7 +852,7 @@ pub fn emitModule(
         return emitAssetModule(allocator, module, options);
     }
 
-    const ast = &(module.ast orelse return null);
+    if (module.ast == null) return null;
 
     // 변환용 arena (Transformer/Codegen 내부 메모리)
     var emit_arena = std.heap.ArenaAllocator.init(allocator);
@@ -855,7 +863,7 @@ pub fn emitModule(
     // JSX lowering: 번들 모드에서 Transformer가 jsx_element → call_expression 변환.
     // classic: React.createElement() 호출, automatic: _jsx/_jsxs/_jsxDEV 호출.
     // graph.zig의 synthetic import가 automatic 모드 바인딩을 처리.
-    const jsx_active = ast.has_jsx;
+    const jsx_active = module.ast.?.has_jsx;
     const is_user_code = std.mem.indexOf(u8, module.path, "/node_modules/") == null;
     const apply_refresh = options.react_refresh and is_user_code;
     const builtin = @import("../transformer/plugins/builtin.zig");
@@ -868,7 +876,7 @@ pub fn emitModule(
         .worklet = options.worklet_transform and !exclude_worklet,
     }, options.plugins, arena_alloc) catch return error.OutOfMemory;
 
-    var transformer = try Transformer.init(arena_alloc, ast, .{
+    const transform_opts: TransformOptions = .{
         .react_refresh = apply_refresh,
         .plugins = merged_plugins,
         .define = options.define,
@@ -887,7 +895,19 @@ pub fn emitModule(
         .worklet_plugin_version = options.worklet_plugin_version,
         .minify_syntax = options.minify_syntax,
         .keep_names = options.keep_names,
-    });
+    };
+    var transformer = switch (ast_handling) {
+        .in_place => blk: {
+            // parse_arena 로부터 **지금** 새로 allocator 를 캡처 — module.ast.allocator 는
+            // parse 시점 캡처라 graph.modules 가 relocated 되면 stale 가능. initInPlace
+            // 가 ast 에 refresh. scratch 는 emit_arena.
+            const parse_alloc = @constCast(&module.parse_arena.?).allocator();
+            break :blk try Transformer.initInPlace(arena_alloc, @constCast(&module.ast.?), parse_alloc, transform_opts);
+        },
+        .cloned => try Transformer.init(arena_alloc, &module.ast.?, transform_opts),
+    };
+    // borrow 경로에서 deinit 이 ast 를 parser 상태로 truncate — 에러 경로 포함 보장.
+    defer transformer.deinit();
     // symbol_ids 전파: semantic analyzer가 생성한 원본 AST의 symbol_ids를
     // transformer가 ast 기준으로 재매핑. symbols slice도 함께 전달하여
     // reference_count 기반 optimization(#1587 등)이 번들 경로에서도 동작하도록 함.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -249,7 +249,9 @@ pub fn emitChunks(
             const m = &modules[mi];
 
             const is_entry = if (entry_mod_idx) |ei| mi == ei else false;
-            const raw_code = try emitModule(allocator, m, options, linker, is_entry, null, null, null, null, null, null) orelse continue;
+            // splitting 경로는 같은 module 이 여러 chunk 에 걸쳐 emit 될 수 있어
+            // in-place mutation 과 호환 안 됨 — 반드시 clone 경로.
+            const raw_code = try emitModule(allocator, m, options, linker, is_entry, null, null, null, null, null, null, .cloned) orelse continue;
             defer allocator.free(raw_code);
 
             // 동적 import 경로 리라이트: import('./page') → import('./page.js')

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -67,6 +67,13 @@ pub const DefineEntry = struct {
     value: []const u8,
 };
 
+/// emitModule 이 Transformer 를 어떤 방식으로 초기화할지 (RFC #1672 D1b-2).
+/// - `.in_place`: `Transformer.initInPlace` — module.ast 를 직접 mutate, 종료 시 parser
+///   상태로 truncate 복구. single-bundle 경로 (`emitWithTreeShaking`) 전용.
+/// - `.cloned`: `Transformer.init` — ast 를 heap cell 로 clone. splitting 처럼 같은
+///   module 을 여러 번 emit 하는 경로에서 사용.
+pub const AstHandling = enum { in_place, cloned };
+
 /// 정규화 버퍼 크기. `process.env.NODE_ENV`류 식별자 체인은 훨씬 짧지만 여유.
 /// 초과 시 normalizeOptionalChain은 null을 반환해 치환을 스킵한다.
 const DEFINE_KEY_NORM_BUF: usize = 256;
@@ -228,9 +235,13 @@ pub const RuntimeHelpers = packed struct(u32) {
 pub const Transformer = struct {
     /// 통합 AST. 파서 노드(0..parser_node_count-1)는 읽기 전용,
     /// 트랜스포머가 추가한 노드(parser_node_count..)는 append-only.
-    /// `*Ast` — Transformer 가 소유권을 가진다 (clone 경로). D1b-2 의 `initInPlace` 는
-    /// 외부 소유 AST 를 borrow 하는 variant 로 같은 필드를 공유.
+    /// `init` 은 heap cell 을 owns=true 로 만들어 clone, `initInPlace` 는 외부
+    /// AST 를 owns=false 로 borrow.
     ast: *Ast,
+
+    /// AST 소유권 플래그. true → deinit 이 ast.deinit() + destroy.
+    /// false → deinit 이 parser 영역 경계로 truncate 만 수행 (parse_arena 가 소유).
+    owns_ast: bool,
 
     /// 파서 노드 수. transform() 시작 시 루트 인덱스(parser_node_count - 1) 계산에 사용.
     parser_node_count: u32,
@@ -463,6 +474,7 @@ pub const Transformer = struct {
 
         var self: Transformer = .{
             .ast = ast_ptr,
+            .owns_ast = true,
             .parser_node_count = @intCast(source_ast.nodes.items.len),
             .options = opts,
             .allocator = allocator,
@@ -473,9 +485,73 @@ pub const Transformer = struct {
         return self;
     }
 
+    /// Borrow-mode initializer — AST 를 clone 하지 않고 외부 소유 AST 를 직접 변이한다.
+    /// D1b-2 (RFC #1672).
+    ///
+    /// **왜 `ast_allocator` 를 따로 받는가**: `source_ast.allocator` 는 parse 시점에
+    /// 캡처된 `*ArenaAllocator` 주소인데, owning Module 이 `graph.modules` ArrayList 의
+    /// 재할당으로 이동하면 stale pointer 가 된다. 기존 clone 경로는 `source_ast.allocator`
+    /// 를 쓰지 않아서 드러나지 않았지만 in-place 는 그걸로 addNode append 를 하면 즉시
+    /// segfault. 호출자가 지금 이 시점의 Module 위치 기준으로 parse_arena 를 다시
+    /// 캡처해 넘기고, 이 함수가 `source_ast.allocator` 를 그 값으로 refresh 한다.
+    ///
+    /// **재진입**: 이전 transform 잔재가 있으면 parser boundary 로 truncate 하고 시작.
+    /// `deinit` 이 다시 truncate 해서 cross-emit consumer 가 transformer 노드를 보지
+    /// 않게 한다.
+    ///
+    /// - `scratch_allocator`: transformer 자체 scratch/pending_nodes 용 (보통 emit_arena).
+    /// - `ast_allocator`: AST ArrayList 의 mutation 용 (보통 parse_arena — 호출자가 fresh 캡처).
+    pub fn initInPlace(
+        scratch_allocator: std.mem.Allocator,
+        source_ast: *Ast,
+        ast_allocator: std.mem.Allocator,
+        options: TransformOptions,
+    ) Error!Transformer {
+        var opts = options;
+        if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
+
+        // source_ast.allocator 를 fresh 한 값으로 교체 — parse 시 캡처된 값은 Module
+        // relocation 후 stale 일 수 있음.
+        source_ast.allocator = ast_allocator;
+
+        // 재진입: 이전 transform 잔재가 있으면 boundary 이상 노드를 truncate.
+        // extra_data / string_table 은 단조 증가 (parser 스팬이 string_table 뒤쪽을
+        // 참조할 수 있어 truncate 불가). 불변식: transform() 은 extra_data/string_table 의
+        // 기존 엔트리를 덮어쓰지 않고 append 만 한다 — 이 불변식이 깨지면 (예: copy-GC
+        // 최적화 도입 시) 재진입 경로에서 corrupted 출력이 나올 수 있으니 주의.
+        // 현재 orphaned tail 은 새 node 가 가리키지 않아 출력에는 영향 없음.
+        if (source_ast.transform_boundary) |boundary| {
+            source_ast.nodes.shrinkRetainingCapacity(boundary);
+            source_ast.transformed_root = null;
+        }
+        source_ast.transform_boundary = @intCast(source_ast.nodes.items.len);
+
+        var self: Transformer = .{
+            .ast = source_ast,
+            .owns_ast = false,
+            .parser_node_count = @intCast(source_ast.nodes.items.len),
+            .options = opts,
+            .allocator = scratch_allocator,
+            .scratch = .empty,
+            .pending_nodes = .empty,
+        };
+        if (opts.unsupported.arrow) self.runtime_es5_compat = true;
+        return self;
+    }
+
     pub fn deinit(self: *Transformer) void {
-        self.ast.deinit();
-        self.allocator.destroy(self.ast);
+        if (self.owns_ast) {
+            self.ast.deinit();
+            self.allocator.destroy(self.ast);
+        } else if (self.ast.transform_boundary) |boundary| {
+            // borrow-mode: parse_arena 가 소유한 AST 를 parser-only 상태로 복구.
+            // 다음 emit 때 linker/shaker 등 consumer 가 transformer append 영역을 보지
+            // 않도록 함. extra_data/string_table 은 append-only 라 그대로 둠 — 다음
+            // transform 이 계속 append.
+            self.ast.nodes.shrinkRetainingCapacity(boundary);
+            self.ast.transform_boundary = null;
+            self.ast.transformed_root = null;
+        }
         self.deinitExceptAst();
     }
 


### PR DESCRIPTION
## Summary
D1b 본 기능. single-bundle emit 경로 (\`emitWithTreeShaking\`) 에서 per-module AST clone 을 제거하고 \`module.ast\` 를 직접 mutate. splitting (\`emitChunks\`) 은 기존 clone 경로 유지.

### 핵심 추가
- \`Transformer.initInPlace(scratch_alloc, source_ast, ast_alloc, options)\` — borrow-mode. 두 allocator 를 분리:
  - \`scratch\` (emit_arena) — transformer 자체 버퍼
  - \`ast_alloc\` (parse_arena, 호출자가 **지금 시점에 새로 캡처**) — ast ArrayList mutation
- \`Transformer.owns_ast\` 플래그 + \`deinit\` 분기. borrow 경로는 \`shrinkRetainingCapacity(boundary)\` 로 parser 상태 복구
- \`AstHandling\` enum \`{ in_place, cloned }\` — bool 대신 call site 가독성
- \`emitModule\` 에 \`defer transformer.deinit()\` — 에러 경로에서도 truncation 보장

### 왜 \`ast_alloc\` 을 따로 받나 (중요)
\`source_ast.allocator\` 는 parse 시점에 캡처된 \`*ArenaAllocator\` 주소. \`graph.modules\` ArrayList 가 grow 하면 Module struct 가 재할당되어 이동 → \`ast.allocator.ptr\` stale. 기존 clone 경로는 이 allocator 를 안 써서 드러나지 않았음. in-place 는 그걸로 addNode append 하면 즉시 \`0xaaaaaaaaaaaaaaa2\` (Zig undefined poison) segfault. 이전 D1 시도 (로컬 stash) 가 정확히 이 지점에서 죽었음.

## Why D1b-2 (not full D1)
- **D1b-1 (merged #1692)**: \`.ast\` 를 \`*Ast\` 로 전환, 동작 불변
- **D1b-2 (이 PR)**: in-place borrow mode 활성화, single-bundle 경로만. splitting 은 clone
- D1c (별도): splitting 경로 구조 변경 (transform/codegen 분리)

## Test plan
- [x] \`zig build test\` — 3307/3307 pass
- [x] smoke (136 패키지) — all ✅
- [x] **이전 D1 시도의 SIGABRT 재현 → 원인 격리 (stale allocator) → 해결** 확인
  (\`JSON module — ESM format\` 테스트가 \`0xaaaaaaaaaaaaaaa2\` 로 죽었던 경로 해결)
- [x] /simplify 3-agent 리뷰 — bool → enum, 주석 restructure, truncation append-only 불변식 명시 3건 반영
- [ ] 번개 ExampleApp 실측 (RN 번들 경로) — 머지 후 별도 확인

## 메모리 안전성
- borrow 경로에서 transformer-appended 노드는 parse_arena 에 residue 로 남지만 \`shrinkRetainingCapacity\` 로 length 만 줄여 다음 transform 이 capacity 재사용. 모듈별 최대 transform 크기로 bounded.
- \`extra_data\` / \`string_table\` 은 append-only 유지 — parser 스팬이 string_table 뒤쪽도 참조할 수 있어 truncate 불가. 불변식 (transform 이 기존 entry 덮어쓰지 않음) 이 깨지면 corrupted output 위험 — 주석에 명시.

Refs #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)