### PR TITLE
refactor(bundler): #1672 Phase D1c — splitting 경로도 in-place + AstHandling enum 정리

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -31,7 +31,6 @@ const Ast = ast_mod.Ast;
 const NodeIndex = ast_mod.NodeIndex;
 const Transformer = @import("../transformer/transformer.zig").Transformer;
 const TransformOptions = @import("../transformer/transformer.zig").TransformOptions;
-const AstHandling = @import("../transformer/transformer.zig").AstHandling;
 const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const cache_mod = @import("compiled_cache.zig");
@@ -428,7 +427,7 @@ pub fn emitWithTreeShaking(
             if (hit_mask[i]) continue;
             const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
-            results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines, &results[i].fn_map_json, .in_place) catch null;
+            results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines, &results[i].fn_map_json) catch null;
         }
     }
 
@@ -812,17 +811,15 @@ fn emitModuleThread(
     shaker: ?*const TreeShaker,
     result: *CompiledModule,
 ) void {
-    // emitWithTreeShaking 경로 — 모듈당 emitModule 1회 호출이 보장되므로 in-place.
-    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.preamble_lines, &result.fn_map_json, .in_place) catch null;
+    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.preamble_lines, &result.fn_map_json) catch null;
 }
 
 /// 단일 모듈을 Transformer → Codegen 파이프라인으로 처리.
 /// 모듈별 arena에 AST가 보존되어 있으므로 재파싱 불필요.
 /// emitChunks에서도 사용하므로 pub으로 노출.
 ///
-/// `ast_handling` (D1b-2, RFC #1672): `.in_place` 는 module.ast 를 직접 mutate 후
-/// parser 상태로 truncate 복구. `.cloned` 은 기존 clone 경로 (splitting 처럼 같은 module
-/// 을 여러 번 emit 하는 경로 전용).
+/// D1 (RFC #1672) 이후 모든 bundle emit 경로는 `Transformer.initInPlace` 를 사용 —
+/// module.ast 를 직접 mutate 후 deinit 에서 parser 상태로 truncate 복구한다.
 pub fn emitModule(
     allocator: std.mem.Allocator,
     module: *const Module,
@@ -835,7 +832,6 @@ pub fn emitModule(
     mappings_out: ?*?[]const SourceMap.Mapping,
     preamble_lines_out: ?*u32,
     fn_map_json_out: ?*?[]const u8,
-    ast_handling: AstHandling,
 ) !?[]const u8 {
     // Disabled 모듈 (platform=browser에서 Node 빌트인): 빈 __commonJS wrapper 출력.
     // esbuild 호환: var require_X = __commonJS({ "(disabled)"(exports, module) {} });
@@ -896,17 +892,12 @@ pub fn emitModule(
         .minify_syntax = options.minify_syntax,
         .keep_names = options.keep_names,
     };
-    var transformer = switch (ast_handling) {
-        .in_place => blk: {
-            // parse_arena 로부터 **지금** 새로 allocator 를 캡처 — module.ast.allocator 는
-            // parse 시점 캡처라 graph.modules 가 relocated 되면 stale 가능. initInPlace
-            // 가 ast 에 refresh. scratch 는 emit_arena.
-            const parse_alloc = @constCast(&module.parse_arena.?).allocator();
-            break :blk try Transformer.initInPlace(arena_alloc, @constCast(&module.ast.?), parse_alloc, transform_opts);
-        },
-        .cloned => try Transformer.init(arena_alloc, &module.ast.?, transform_opts),
-    };
-    // borrow 경로에서 deinit 이 ast 를 parser 상태로 truncate — 에러 경로 포함 보장.
+    // parse_arena 로부터 **지금** 새로 allocator 를 캡처 — module.ast.allocator 는
+    // parse 시점 캡처라 graph.modules 가 relocated 되면 stale 가능. initInPlace
+    // 가 ast 에 refresh. scratch 는 emit_arena.
+    const parse_alloc = @constCast(&module.parse_arena.?).allocator();
+    var transformer = try Transformer.initInPlace(arena_alloc, @constCast(&module.ast.?), parse_alloc, transform_opts);
+    // deinit 이 ast 를 parser 상태로 truncate — 에러 경로 포함 보장.
     defer transformer.deinit();
     // symbol_ids 전파: semantic analyzer가 생성한 원본 AST의 symbol_ids를
     // transformer가 ast 기준으로 재매핑. symbols slice도 함께 전달하여

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -249,9 +249,7 @@ pub fn emitChunks(
             const m = &modules[mi];
 
             const is_entry = if (entry_mod_idx) |ei| mi == ei else false;
-            // splitting 경로는 같은 module 이 여러 chunk 에 걸쳐 emit 될 수 있어
-            // in-place mutation 과 호환 안 됨 — 반드시 clone 경로.
-            const raw_code = try emitModule(allocator, m, options, linker, is_entry, null, null, null, null, null, null, .cloned) orelse continue;
+            const raw_code = try emitModule(allocator, m, options, linker, is_entry, null, null, null, null, null, null) orelse continue;
             defer allocator.free(raw_code);
 
             // 동적 import 경로 리라이트: import('./page') → import('./page.js')

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -67,13 +67,6 @@ pub const DefineEntry = struct {
     value: []const u8,
 };
 
-/// emitModule 이 Transformer 를 어떤 방식으로 초기화할지 (RFC #1672 D1b-2).
-/// - `.in_place`: `Transformer.initInPlace` — module.ast 를 직접 mutate, 종료 시 parser
-///   상태로 truncate 복구. single-bundle 경로 (`emitWithTreeShaking`) 전용.
-/// - `.cloned`: `Transformer.init` — ast 를 heap cell 로 clone. splitting 처럼 같은
-///   module 을 여러 번 emit 하는 경로에서 사용.
-pub const AstHandling = enum { in_place, cloned };
-
 /// 정규화 버퍼 크기. `process.env.NODE_ENV`류 식별자 체인은 훨씬 짧지만 여유.
 /// 초과 시 normalizeOptionalChain은 null을 반환해 치환을 스킵한다.
 const DEFINE_KEY_NORM_BUF: usize = 256;


### PR DESCRIPTION
## Summary
D1b-2 이후 single-bundle 만 in-place 였던 걸 splitting 도 in-place 로 통일. \`chunk_graph.module_to_chunk\` 가 모듈당 정확히 하나의 chunk 만 매핑한다는 것을 코드 검증으로 확인 → 같은 module 이 emitChunks 한 번에 두 번 emit 되지 않는다. 따라서 clone 경로 (\`.cloned\`) 는 emitter 쪽에서 더 이상 필요하지 않고, 관련 dead code 를 정리.

### 변경
- \`emitChunks\` \`.cloned\` → in-place 전환
- \`emitModule\` 에서 \`ast_handling: AstHandling\` 파라미터 제거, 내부 switch 없이 initInPlace 단일 경로
- \`AstHandling\` enum 제거 (transformer.zig)
- net -18 LOC

### 유지 (의도)
- \`Transformer.init\` (clone 경로) 는 유지 — \`transpile.zig\` 단일 파일 CLI 경로 + 20+ unit test 파일이 사용

## 왜 이전 D1 시도는 splitting 에서 SIGABRT 났나 (결과론)
이전 시도의 "shared module" SIGABRT 는 같은 module 을 두 번 emit 해서가 아니라 \`source_ast.allocator\` 가 graph.modules ArrayList 재할당 때문에 stale 이 된 stale allocator 문제. D1b-2 의 \`ast_allocator\` refresh 로 이미 해결됨 — D1c 는 그 위에서 남은 dead code 를 정리하는 후속 작업.

## Test plan
- [x] \`zig build test\` — 3307/3307 pass (\`emitChunks: two entries with shared module — 3 OutputFiles\` 등 splitting 테스트 포함)
- [x] smoke (136 패키지) — all ✅
- [x] /simplify 리뷰 — dead code 정리 확인 + Transformer.init 유지 타당성 확인

Closes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)