### PR TITLE
perf(bundler): #1567 refine — oxc-style strict whitelist + Error Symbol safety

### DIFF
--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -102,16 +102,25 @@ fn isNodePureDepth(ast: *const Ast, node: Node, unresolved_globals: ?*const Glob
     };
 }
 
-/// call/new expression 순수성.
-/// 1) `@__PURE__` 플래그가 있으면 순수
-/// 2) callee가 `new Set()`/`new Map()` 등 빌트인 pure 생성자이고 인자가 모두 순수이면 순수
+/// call/new expression 순수성. (oxc `known_globals.rs` 포팅)
+///
+/// 판정 순서:
+///   1. `@__PURE__` 플래그 → 무조건 pure
+///   2. callee 가 identifier_reference + unresolved global 이어야 함 (사용자 shadow 차단)
+///   3. 이름별 category 판정:
+///      - collection (Set/Map/WeakSet/WeakMap): `new` 전용 (call 은 throw). 인자는
+///        엄격 — 무인자/null/undefined/ArrayExpression 만. 그 외는 iterator protocol
+///        의 Symbol.iterator getter side-effect 를 놓칠 위험 있어 보수적 impure.
+///      - dotcall_only (Symbol): call 전용 (new Symbol() 은 throw).
+///      - unconditional / either (Object/Boolean/Array/Date/String + Error 계열):
+///        new/call 양쪽 safe. 인자는 재귀 pure 검사.
 fn isCallOrNewPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {
     // (1) @__PURE__ 플래그
     if (ast.hasExtra(node.data.extra, 3)) {
         if ((ast.readExtra(node.data.extra, 3) & CallFlags.is_pure) != 0) return true;
     }
 
-    // (2) 빌트인 화이트리스트. unresolved_globals 컨텍스트가 있을 때만 활성.
+    // (2) 빌트인 화이트리스트 — unresolved_globals 컨텍스트 + identifier_reference callee
     const globals = unresolved_globals orelse return false;
     if (!ast.hasExtra(node.data.extra, 2)) return false;
 
@@ -121,18 +130,172 @@ fn isCallOrNewPure(ast: *const Ast, node: Node, unresolved_globals: ?*const Glob
     if (callee.tag != .identifier_reference) return false;
 
     const name = ast.getText(callee.span);
-    if (!isPureBuiltinConstructor(name)) return false;
 
-    // 모듈 스코프에서 선언/import가 없어야 전역 빌트인임이 확정된다.
-    // 로컬 `const Set = ...` 또는 `import { Set }`가 있으면 unresolved에 없으므로 pure 판정 안 됨.
+    // 모듈 스코프에서 선언/import 없는 전역 참조여야 함.
+    // 로컬 `const Set = ...` / `import { Set }` / `class Set {}` 는 shadow → unresolved
+    // 에 없음 → 안전하게 false.
     if (!globals.contains(name)) return false;
 
-    // 인자 순회: 모두 순수여야 함. spread는 iterator 호출 side effect가 있으므로 제외.
+    const kind = categorizeBuiltin(name);
+    const is_new = node.tag == .new_expression;
     const args_start = ast.readExtra(node.data.extra, 1);
     const args_len = ast.readExtra(node.data.extra, 2);
+
+    return switch (kind) {
+        .unknown => false,
+        .collection => blk: {
+            if (!is_new) break :blk false; // `Set()` / `Map()` 등 call 은 TypeError
+            break :blk isPureCollectionArgs(ast, name, args_start, args_len, unresolved_globals, depth);
+        },
+        .dotcall_only => blk: {
+            if (is_new) break :blk false; // `new Symbol()` 은 TypeError
+            break :blk allArgsPure(ast, args_start, args_len, unresolved_globals, depth);
+        },
+        .error_ctor => isPureErrorArgs(ast, args_start, args_len, unresolved_globals, depth),
+        .unconditional, .either => allArgsPure(ast, args_start, args_len, unresolved_globals, depth),
+    };
+}
+
+/// 빌트인 이름별 분류.
+///
+/// - `collection` (new 전용, strict args): `Set` / `Map` / `WeakSet` / `WeakMap`
+///   call 로 쓰면 TypeError.
+/// - `dotcall_only` (call 전용): `Symbol` — `new Symbol()` 은 TypeError.
+/// - `unconditional` (new/call 어느 쪽도 safe, 인자 무관한 내부 연산만): `Object`,
+///   `Boolean` — ToBoolean 은 user code 호출 없음.
+/// - `either` (new/call 모두 safe, 인자는 재귀 pure): `Array`, `Date`, `String`.
+/// - `error_ctor` (new/call 양쪽 OK 이지만 msg 인자가 Symbol 이면 TypeError throw —
+///   ECMA-262 §20.5.1 Error constructor 가 `ToString(msg)` 호출, `ToString(Symbol)` 은
+///   TypeError): `Error` + 하위 타입 (EvalError/RangeError/ReferenceError/SyntaxError/
+///   TypeError/URIError). 인자가 Symbol 이 **아님** 을 정적으로 증명 가능할 때만 pure.
+/// - `unknown`: 위 목록 외.
+///
+/// 제외된 것들:
+/// - `RegExp(pattern, flags)` — invalid pattern SyntaxError 가능
+/// - `BigInt(x)` — invalid value TypeError
+/// - `Number(x)` — Symbol 피연산자에 ToNumber → TypeError
+/// - `Proxy`, `WeakRef`, `Function` — 임의 사용자 코드 실행
+/// - TypedArray (`Int8Array` 등) — iteration side-effect 가능
+const BuiltinKind = enum { unknown, collection, dotcall_only, unconditional, either, error_ctor };
+
+fn categorizeBuiltin(name: []const u8) BuiltinKind {
+    const eql = std.mem.eql;
+    if (eql(u8, name, "Set") or eql(u8, name, "Map") or eql(u8, name, "WeakSet") or eql(u8, name, "WeakMap")) {
+        return .collection;
+    }
+    if (eql(u8, name, "Symbol")) return .dotcall_only;
+    if (eql(u8, name, "Object") or eql(u8, name, "Boolean")) return .unconditional;
+    if (eql(u8, name, "Array") or eql(u8, name, "Date") or eql(u8, name, "String")) return .either;
+    if (eql(u8, name, "Error") or eql(u8, name, "EvalError") or eql(u8, name, "RangeError") or
+        eql(u8, name, "ReferenceError") or eql(u8, name, "SyntaxError") or
+        eql(u8, name, "TypeError") or eql(u8, name, "URIError")) return .error_ctor;
+    return .unknown;
+}
+
+/// Collection constructor (new Set/Map/WeakSet/WeakMap) 의 인자 safety.
+/// ECMAScript 명세상 인자는 단일 iterable — iterator protocol 발동이 Symbol.iterator
+/// getter side-effect 를 트리거할 수 있어, 아래 형태만 pure:
+/// - 무인자
+/// - `null` literal
+/// - 전역 `undefined` identifier
+/// - ArrayExpression — Set/WeakSet 은 원소 각각 재귀 pure, Map/WeakMap 은 각 원소가
+///   추가로 ArrayExpression ([k,v] 쌍) 이어야 + 재귀 pure.
+///
+/// 그 외 (identifier / call / member_expression / object_expression / spread) 는
+/// iterator 가 custom 구현/Proxy/getter 일 수 있어 보수적 impure.
+fn isPureCollectionArgs(
+    ast: *const Ast,
+    name: []const u8,
+    args_start: u32,
+    args_len: u32,
+    unresolved_globals: ?*const GlobalRefSet,
+    depth: u32,
+) bool {
+    if (args_len == 0) return true;
+    if (args_len > 1) return false; // spec: 단일 인자. 초과면 보수적
+    if (args_start >= ast.extra_data.items.len) return false;
+
+    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+
+    return switch (arg.tag) {
+        .null_literal => true,
+        .identifier_reference => blk: {
+            const arg_name = ast.getText(arg.span);
+            if (!std.mem.eql(u8, arg_name, "undefined")) break :blk false;
+            const g = unresolved_globals orelse break :blk false;
+            break :blk g.contains("undefined");
+        },
+        .array_expression => blk: {
+            const is_map = std.mem.eql(u8, name, "Map") or std.mem.eql(u8, name, "WeakMap");
+            const list = arg.data.list;
+            if (list.start + list.len > ast.extra_data.items.len) break :blk false;
+            for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_el| {
+                const el_idx: NodeIndex = @enumFromInt(raw_el);
+                if (el_idx.isNone()) continue; // elision NodeIndex.none
+                if (@intFromEnum(el_idx) >= ast.nodes.items.len) break :blk false;
+                const el = ast.nodes.items[@intFromEnum(el_idx)];
+                if (el.tag == .elision) continue;
+                if (el.tag == .spread_element) break :blk false;
+                // Map/WeakMap: 각 원소가 [k,v] ArrayExpression 이어야
+                if (is_map and el.tag != .array_expression) break :blk false;
+                // 재귀 pure — foo()/identifier 등 side-effect 방지
+                if (!isNodePureDepth(ast, el, unresolved_globals, depth + 1)) break :blk false;
+            }
+            break :blk true;
+        },
+        else => false,
+    };
+}
+
+/// Error 계열 생성자의 msg 인자 safety.
+/// ECMA-262 §20.5.1 Error 는 `ToString(msg)` 호출 — Symbol 이면 TypeError throw.
+/// msg 가 Symbol 이 아님을 정적으로 보장할 수 있는 케이스만 pure.
+/// 기존 `canBeSymbol` 을 재사용 (literal/template_literal/array/object/function/unary/
+/// binary/update 는 non-Symbol 확정, identifier/call/member 는 보수적 Symbol 가능).
+/// - 무인자: 항상 pure
+/// - 단일 msg 인자: non-Symbol 확정 + 재귀 pure
+/// - 2개 이상 인자: 보수적 impure (spec: `options.cause` 는 실사용 드묾 + toString 부수효과 가능)
+/// - `undefined` 전역 identifier 는 Symbol 아닌 게 확정이므로 특수 허용
+fn isPureErrorArgs(
+    ast: *const Ast,
+    args_start: u32,
+    args_len: u32,
+    unresolved_globals: ?*const GlobalRefSet,
+    depth: u32,
+) bool {
+    if (args_len == 0) return true;
+    if (args_len > 1) return false;
+    if (args_start >= ast.extra_data.items.len) return false;
+
+    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+    if (arg.tag == .spread_element) return false;
+
+    // Symbol 가능성 배제: canBeSymbol + 전역 undefined 특수 허용.
+    const undef_ok = arg.tag == .identifier_reference and blk: {
+        const name = ast.getText(arg.span);
+        if (!std.mem.eql(u8, name, "undefined")) break :blk false;
+        const g = unresolved_globals orelse break :blk false;
+        break :blk g.contains("undefined");
+    };
+    if (!undef_ok and canBeSymbol(ast, arg_idx)) return false;
+
+    return isNodePureDepth(ast, arg, unresolved_globals, depth);
+}
+
+/// 인자 전체가 pure + spread 없음 체크. collection 외 category 용.
+fn allArgsPure(
+    ast: *const Ast,
+    args_start: u32,
+    args_len: u32,
+    unresolved_globals: ?*const GlobalRefSet,
+    depth: u32,
+) bool {
     if (args_len == 0) return true;
     if (args_start + args_len > ast.extra_data.items.len) return false;
-
     for (ast.extra_data.items[args_start .. args_start + args_len]) |raw| {
         const arg_idx: NodeIndex = @enumFromInt(raw);
         if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) continue;
@@ -141,23 +304,6 @@ fn isCallOrNewPure(ast: *const Ast, node: Node, unresolved_globals: ?*const Glob
         if (!isNodePureDepth(ast, arg, unresolved_globals, depth)) return false;
     }
     return true;
-}
-
-/// 빌트인 pure 생성자 이름. (esbuild `isPrimitiveConstructor`, rolldown `is_primitive_constructor`)
-///
-/// RegExp는 invalid pattern이 SyntaxError를 throw할 수 있어 제외.
-/// Boolean/Number/String/BigInt는 coercion으로 인자 평가 외 부수효과 없지만
-/// 실사용이 드물어 당장은 생략 (필요 시 추가).
-fn isPureBuiltinConstructor(name: []const u8) bool {
-    const pure_names = [_][]const u8{
-        "Set",    "Map",   "WeakMap", "WeakSet",
-        "Symbol", "Array", "Object",  "Date",
-        "Error",
-    };
-    for (pure_names) |candidate| {
-        if (std.mem.eql(u8, name, candidate)) return true;
-    }
-    return false;
 }
 
 fn isObjectPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -78,13 +78,13 @@ test "pure builtin: new Set() with unresolved globals is pure" {
     try std.testing.expect(purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
 }
 
-test "pure builtin: whitelist covers Map/WeakMap/WeakSet/Symbol/Array/Object/Date/Error" {
+test "pure builtin: whitelist covers Map/WeakMap/WeakSet/Array/Object/Date/Error" {
+    // `new Symbol()` 은 ECMAScript 명세상 TypeError throw → pure 아님 (아래 별도 테스트).
     const alloc = std.testing.allocator;
     const src =
         \\const a = new Map();
         \\const b = new WeakMap();
         \\const c = new WeakSet();
-        \\const d = new Symbol();
         \\const e = new Array(4);
         \\const f = new Object();
         \\const g = new Date();
@@ -94,7 +94,7 @@ test "pure builtin: whitelist covers Map/WeakMap/WeakSet/Symbol/Array/Object/Dat
     defer ctx.deinit();
 
     const globals = &ctx.analyzer.unresolved_references;
-    for (0..8) |i| {
+    for (0..7) |i| {
         const init = initOfDecl(&ctx, i);
         try std.testing.expect(purity.isExprPure(&ctx.ast, init, globals));
     }
@@ -183,4 +183,590 @@ test "pure builtin: spread arg blocks pure classification" {
 
     const init = initOfDecl(&ctx, 0);
     try std.testing.expect(!purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
+// ================================================================
+// Collection constructor — oxc-style strict rule (#1567 Phase A refinement)
+// ================================================================
+//
+// `new Set()/Map()/WeakSet()/WeakMap()` 의 인자는 iterator protocol 발동 가능성
+// 때문에 아래 형태만 pure:
+//   - 무인자 / null / 전역 undefined / ArrayExpression (각 원소 재귀 pure)
+// Map/WeakMap 은 ArrayExpression 의 각 outer 원소가 또 ArrayExpression ([k,v]) 이어야.
+
+fn expectPure(ctx: *const TestCtx, stmt_idx: usize, pure: bool) !void {
+    const init = initOfDecl(ctx, stmt_idx);
+    try std.testing.expectEqual(pure, purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
+test "collection: no args — pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Set();
+        \\const b = new Map();
+        \\const c = new WeakSet();
+        \\const d = new WeakMap();
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+    try expectPure(&ctx, 2, true);
+    try expectPure(&ctx, 3, true);
+}
+
+test "collection: null arg — pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Set(null);
+        \\const b = new Map(null);
+        \\const c = new WeakSet(null);
+        \\const d = new WeakMap(null);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+    try expectPure(&ctx, 2, true);
+    try expectPure(&ctx, 3, true);
+}
+
+test "collection: global undefined arg — pure" {
+    const alloc = std.testing.allocator;
+    // top-level 에서 undefined 는 unresolved global. Set 도 unresolved global.
+    const src = "const a = new Set(undefined);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+}
+
+test "collection: shadowed undefined arg — NOT pure" {
+    const alloc = std.testing.allocator;
+    // undefined 를 local 로 shadow → unresolved 에서 빠짐 → pure 판정 불가.
+    const src =
+        \\const undefined = 1;
+        \\const a = new Set(undefined);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 1, false);
+}
+
+test "collection: empty array arg — pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Set([]);
+        \\const b = new Map([]);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+}
+
+test "collection: array of literals — Set/WeakSet pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Set([1, 2, 3]);
+        \\const b = new Set(["x", true, null]);
+        \\const c = new WeakSet([{}, [], 42]);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+    try expectPure(&ctx, 2, true);
+}
+
+test "collection: Map with pair-of-literals — pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Map([["a", 1]]);
+        \\const b = new Map([["a", 1], ["b", 2]]);
+        \\const c = new WeakMap([[{}, 1]]);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+    try expectPure(&ctx, 2, true);
+}
+
+test "collection: Map with non-array element — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Map([1, 2]);"; // outer array 원소가 ArrayExpression 아님
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "collection: identifier arg — NOT pure (iterator protocol risk)" {
+    const alloc = std.testing.allocator;
+    // 현재 구현의 **이전 permissive 버그** 시나리오. Symbol.iterator getter side-effect
+    // 가능성 때문에 보수적 impure.
+    const src =
+        \\const a = new Set(someIter);
+        \\const b = new Map(m);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+    try expectPure(&ctx, 1, false);
+}
+
+test "collection: call result arg — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Set(getIter());";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "collection: member access arg — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Set(obj.items);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "collection: object literal arg — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Set({});";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "collection: array with spread element — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Set([1, ...xs, 3]);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "collection: array with impure element — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Set([1, fetch()]);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "collection: multiple args — NOT pure (spec: 1 arg)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Set(1, 2);"; // 실제로는 2번째 무시되지만 보수적 skip
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "collection: call form Set() — NOT pure (TypeError throws)" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = Set();
+        \\const b = Map();
+        \\const c = WeakSet();
+        \\const d = WeakMap();
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+    try expectPure(&ctx, 1, false);
+    try expectPure(&ctx, 2, false);
+    try expectPure(&ctx, 3, false);
+}
+
+test "collection: Map with nested impure inner — NOT pure" {
+    const alloc = std.testing.allocator;
+    // [[foo(), 1]] — outer 는 array, inner 도 array — ArrayExpression 조건은 만족.
+    // 하지만 재귀 pure 체크에서 foo() 가 impure → 전체 impure.
+    const src = "const a = new Map([[foo(), 1]]);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "collection: nested literal containers — pure" {
+    const alloc = std.testing.allocator;
+    // Set([[1,2], [3,4]]) — 각 원소는 array literal, 재귀 pure. Set 규칙 상 OK.
+    const src = "const a = new Set([[1, 2], [3, 4]]);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+}
+
+test "collection: elision in array — pure (빈 슬롯 skip)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Set([1, , 3]);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+}
+
+// ================================================================
+// Symbol — dotcall_only
+// ================================================================
+
+test "Symbol: call form — pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = Symbol();
+        \\const b = Symbol("desc");
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+}
+
+test "Symbol: new form — NOT pure (TypeError throws)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Symbol();";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+// ================================================================
+// Error constructors — 하위 타입 모두 커버
+// ================================================================
+
+test "Error: Error + all subtypes pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Error("x");
+        \\const b = new EvalError("x");
+        \\const c = new RangeError("x");
+        \\const d = new ReferenceError("x");
+        \\const e = new SyntaxError("x");
+        \\const f = new TypeError("x");
+        \\const g = new URIError("x");
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    for (0..7) |i| try expectPure(&ctx, i, true);
+}
+
+test "Error: call form also pure (Error() 동등)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = Error(\"x\");";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+}
+
+test "Error: CustomError — NOT pure (whitelist 외)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new CustomError();";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "Error: 인자가 impure — 보존" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Error(getMsg());";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "Error: Symbol() 인자 — NOT pure (ToString(Symbol) throws TypeError)" {
+    // ECMA-262 §20.5.1: Error constructor 가 ToString(msg) 호출. Symbol 이면 TypeError.
+    // Symbol() 자체는 whitelist 상 pure 지만, Error msg 로는 static-proof 불가 → impure.
+    const alloc = std.testing.allocator;
+    const src = "const a = new Error(Symbol());";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "Error: identifier arg — NOT pure (Symbol 여부 불명)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Error(maybeSymbol);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "Error: member access arg — NOT pure (Symbol 여부 불명)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Error(obj.msg);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "Error: call result arg — NOT pure (Symbol 여부 불명)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new TypeError(makeMsg());";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "Error: string literal arg — pure (non-Symbol 보장)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new TypeError(\"fail\");";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+}
+
+test "Error: template literal arg — currently 보존 (isNodePureDepth 미지원)" {
+    // template_literal 은 canBeSymbol 상으로 non-Symbol (항상 string) 이지만
+    // 일반 isNodePureDepth 경로가 template_literal 을 처리하지 않아 보수적 impure.
+    // 별도 PR 에서 isNodePureDepth 에 template_literal 추가 시 pure 가능.
+    const alloc = std.testing.allocator;
+    const src = "const a = new RangeError(`value: ${1}`);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "Error: numeric literal arg — pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new SyntaxError(42);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+}
+
+test "Error: null/undefined arg — pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Error(null);
+        \\const b = new TypeError(undefined);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+}
+
+test "Error: 2+ args — NOT pure (보수적)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Error(\"msg\", { cause: e });";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+// ================================================================
+// Object / Boolean — unconditional (new + call 모두 pure)
+// ================================================================
+
+test "Object/Boolean: new + call 모두 pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Object();
+        \\const b = new Object({ x: 1 });
+        \\const c = new Boolean();
+        \\const d = new Boolean(true);
+        \\const e = Object();
+        \\const f = Object(42);
+        \\const g = Boolean();
+        \\const h = Boolean(0);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    for (0..8) |i| try expectPure(&ctx, i, true);
+}
+
+test "Object/Boolean: impure arg — 보존" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = Object(fetch());
+        \\const b = Boolean(sideEffect());
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+    try expectPure(&ctx, 1, false);
+}
+
+// ================================================================
+// Array / Date / String — either (new + call 모두 pure)
+// ================================================================
+
+test "Array/Date/String: new + call 모두 pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Array();
+        \\const b = new Array(5);
+        \\const c = new Array(1, 2, 3);
+        \\const d = Array();
+        \\const e = Array(5);
+        \\const f = new Date();
+        \\const g = new Date(2024, 0, 1);
+        \\const h = Date();
+        \\const i = new String();
+        \\const j = new String("x");
+        \\const k = String();
+        \\const l = String(42);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    for (0..12) |i| try expectPure(&ctx, i, true);
+}
+
+test "Array/Date/String: impure arg — 보존" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Array(getLen());
+        \\const b = Date(getTime());
+        \\const c = String(compute());
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+    try expectPure(&ctx, 1, false);
+    try expectPure(&ctx, 2, false);
+}
+
+// ================================================================
+// Whitelist 외 — 항상 impure
+// ================================================================
+
+test "excluded: RegExp — NOT pure (invalid pattern SyntaxError)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new RegExp(\"[\");";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "excluded: BigInt — NOT pure (invalid value TypeError)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = BigInt(1.5);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "excluded: Number — NOT pure (Symbol TypeError)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = Number(x);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "excluded: Proxy — NOT pure (handler 임의 코드)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Proxy({}, {});";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "excluded: WeakRef — NOT pure (target mutable)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new WeakRef(obj);";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "excluded: TypedArray — NOT pure (iteration side-effect)" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Int8Array(4);
+        \\const b = new Uint8Array(4);
+        \\const c = new Float32Array(4);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+    try expectPure(&ctx, 1, false);
+    try expectPure(&ctx, 2, false);
+}
+
+test "excluded: Function (eval) — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new Function(\"return 1\");";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+test "excluded: user class — NOT pure (whitelist 외)" {
+    const alloc = std.testing.allocator;
+    const src = "const a = new MyClass();";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, false);
+}
+
+// ================================================================
+// Global binding 검증 (shadow 시나리오 확장)
+// ================================================================
+
+test "shadow: function param named Set — NOT pure" {
+    // 함수 안의 `new Set()` 이지만 param 으로 Set 이 있으면 shadow.
+    // 여기선 위 initOfDecl 헬퍼가 top-level 전용이라, 함수 body 안 구조는
+    // 직접 테스트하기 복잡 — 대신 top-level 재선언으로 equivalent 검증.
+    const alloc = std.testing.allocator;
+    const src =
+        \\function Set() { return {}; }
+        \\const s = new Set();
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 1, false);
+}
+
+test "shadow: import of Set — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\import { Set } from "./my-set";
+        \\const s = new Set();
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 1, false);
+}
+
+test "shadow: class Set {} — NOT pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\class Set { constructor() {} }
+        \\const s = new Set();
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 1, false);
+}
+
+// ================================================================
+// @__PURE__ override
+// ================================================================
+
+test "pure annotation: /*#__PURE__*/ myFunc() 은 whitelist 무관하게 pure" {
+    const alloc = std.testing.allocator;
+    const src = "const a = /*#__PURE__*/ myCustomFn();";
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    try expectPure(&ctx, 0, true);
+}
+
+// ================================================================
+// null unresolved_globals — 기존 동작 유지 (#1567 호환)
+// ================================================================
+
+test "null context: all builtins impure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = new Set();
+        \\const b = new Map();
+        \\const c = new Date();
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+    for (0..3) |i| {
+        const init = initOfDecl(&ctx, i);
+        try std.testing.expect(!purity.isExprPure(&ctx.ast, init, null));
+    }
 }


### PR DESCRIPTION
## Summary
기존 pure 빌트인 생성자 화이트리스트 (#4216393f) 를 oxc \`known_globals.rs\` 기준으로 **엄격화** + Error 하위타입 확장 + call-form 지원. 3개 correctness 버그 수정.

### 발견한 correctness 버그들

1. **\`new Set(weirdIterable)\` 로 Symbol.iterator getter side-effect 놓침** — collection constructor 인자가 identifier/call/member 이면 iterator protocol 이 custom getter/Proxy 호출 가능. 이전 permissive rule 이 \"arg 가 pure identifier 면 OK\" 로 판정해서 dead 제거.
2. **\`new Error(Symbol())\` throws TypeError 인데 pure 판정** — ECMA-262 §20.5.1: Error constructor 가 \`ToString(msg)\` 호출, \`ToString(Symbol)\` → TypeError.
3. **\`new Symbol()\` throws TypeError 인데 pure 판정** — ECMA-262 §20.4.1: Symbol 은 new 로 호출 불가.

### 변경
- \`BuiltinKind\` enum 도입: \`collection\` / \`dotcall_only\` / \`unconditional\` / \`either\` / \`error_ctor\` / \`unknown\`
- Collection (Set/Map/WeakSet/WeakMap) new 전용, oxc 식 strict args (무인자/null/전역 undefined/ArrayExpression 만)
- Error + 6 하위타입 (EvalError/RangeError/ReferenceError/SyntaxError/TypeError/URIError) — 이전엔 Error 만
- Error msg safety: \`canBeSymbol\` 로 non-Symbol 정적 보장
- Call-form 지원: \`Date()\` / \`Boolean(x)\` / \`Object(x)\` / \`String(x)\` 등 new 없는 호출
- Symbol dotcall_only: new Symbol() 차단

### Test plan
- [x] \`zig build test\`: 3410/3411 pass (+50 purity 테스트)
- [x] smoke 136 packages all ✅, average 0.82x 불변
- [x] minify-bench 6 library: pre/post size 동일 (regression 없음)
- [x] Correctness 재현 테스트 (iterator side-effect, Error+Symbol, new Symbol)

### 커버된 테스트 (50건)
**Collection strict rule**: 무인자/null/undefined/literal array/Map 쌍/nested literal/elision/identifier/call/member/object/spread/non-array-element-for-Map/multi-args/call-form-throws

**Error safety**: 7 하위타입 포함/Symbol msg/identifier msg/member msg/call msg/literal msg/template/numeric/null/undefined/2+args

**Object·Boolean·Array·Date·String**: new + call, impure arg 보존

**제외**: RegExp/BigInt/Number/Proxy/WeakRef/TypedArray(3종)/Function/CustomError

**Shadow**: class/function/import/local const

**@__PURE__** override + null context 기존 동작 유지

Refs #1567

🤖 Generated with [Claude Code](https://claude.com/claude-code)