### PR TITLE
perf(bundler): dev_mode 에서 minify pass skip — HMR rebuild -14%

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -918,7 +918,11 @@ pub fn emitModule(
     //
     // Dead store (#1644 PR1): semantic 정보가 있을 때만 unused declaration 제거 활성.
     // tree-shaker 가 top-level export 미사용은 이미 커버하지만, 함수 내부 local 은 여기서 처리.
-    {
+    //
+    // **dev_mode 예외**: HMR rebuild 체감 우선 — minify pass 전체 skip. fold/dead-store/
+    // inline 은 출력 품질 개선이지 correctness 가 아니라 런타임 의미 동일. Metro 가
+    // dev 에서 아무 minify 안 하는 것과 동일한 trade-off.
+    if (!options.dev_mode) {
         const minify_mod = @import("../transformer/minify.zig");
         const ctx: minify_mod.MinifyCtx = if (module.semantic) |sem| .{
             .symbols = sem.symbols.items,
@@ -1077,10 +1081,13 @@ pub fn emitModule(
     // `var A=1; var B=2;`에서 `B`만 미사용으로 마킹된 경우, 먼저 merge했다면 합쳐진
     // statement는 A가 사용되므로 제거 불가 → B의 초기화식이 살아남아 죽은 심볼을 참조.
     // 순서: transform → minify(fold) → tree-shake → downgradeToVar → mergeDecls → codegen.
-    @import("../transformer/minify.zig").mergeDecls(
-        transformer.ast,
-        if (metadata) |*m| @as(?*const std.DynamicBitSet, &m.skip_nodes) else null,
-    );
+    // dev_mode 에선 skip — 병합은 출력 크기 최적화용이라 런타임 의미 불변. HMR 체감 우선.
+    if (!options.dev_mode) {
+        @import("../transformer/minify.zig").mergeDecls(
+            transformer.ast,
+            if (metadata) |*m| @as(?*const std.DynamicBitSet, &m.skip_nodes) else null,
+        );
+    }
 
     // __esm 모듈: AST 수준 var/function 호이스팅 (esbuild/rolldown 방식)
     if (module.wrap_kind == .esm) {


### PR DESCRIPTION
## Summary
번개 ExampleApp (1172 모듈) HMR rebuild 실측: **231ms → 200ms (-14%, warm 평균)**.

\`emitModule\` 이 \`#1552\` 근거로 \`minify_mod.minify()\` + \`mergeDecls()\` 를 항상 실행. 이 두 pass 는:
- **minify()**: const fold / dead store / single-use inline (#1666)
- **mergeDecls()**: 인접 var 병합 (#1588)

**모두 런타임 의미 불변 — 출력 품질 개선용**. dev 빌드 체감 (HMR rebuild) 우선이 합리적 trade-off. Metro / esbuild / rolldown 이 dev 에서 최소 pass 돌리는 것과 같은 방향.

## 변경
- \`src/bundler/emitter.zig\` \`emitModule\`: 두 pass 에 \`if (!options.dev_mode)\` 가드
- production 경로 (dev_mode=false) 불변 — size 영향 없음

## Test plan
- [x] \`zig build test\` 3411/3411 pass
- [x] HMR warm 7 rebuild 안정적 (182-207ms, variance 25ms)
- [x] production 번들 size 불변 — smoke 영향 없음
- [x] breakdown 재측정:
  - detect 51→51ms (debounce 불변)
  - **parse 99→66ms (-33%)** — 주 절감처. minify AST mutation 감소로 compiled_cache 재사용 효율 증가 (가설)
  - semantic 5→5ms
  - emit 68→67ms (거의 동일 — minify pass 자체는 1 모듈 기준 수 ms)
  - delta 1→1ms

## 의외 발견
emit 시간이 거의 안 줄어듦 — minify pass 가 emit bottleneck 이 아님이 확인됨. 실제 절감은 parse 에서 발생.

## 다음 개선 방향 (별도 PR)
- detect 51ms → ~1ms: mtime 전수 scan 대신 incremental watcher event
- parse 나머지 ~66ms: Babel 제거 or 경량화 (큰 epic)
- Metro 80ms parity 를 노리면 위 2개 추가 작업 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)