### PR TITLE
fix(linker): exclude CJS-in-ESM named imports from name-collision owners

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1691,3 +1691,72 @@ test "CJS: Flow export type alias + module.exports stays CJS (regression)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__commonJS") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports") != null);
 }
+
+// Regression (mirrors react-native-gesture-handler's NativeRNGestureHandlerModule.ts):
+// ESM-wrapped module does `import { Registry, Handle } from './lib.cjs'`, and a colliding
+// top-level declaration elsewhere in the bundle forces the linker to hand `Registry` a
+// canonical `$N` rename. The canonical-rename pass used to overwrite the CJS-in-ESM
+// namespace rename (`__ns_N.Registry`), causing codegen to emit shorthand destructuring
+// `({Registry,Handle}=require_lib())` into globals, leaving the module-local `Registry$N`
+// undefined — `Registry$N.getEnforcing(...)` then throws at runtime.
+//
+// `early.ts` wins the name race (lowest exec_index) so spec.ts's imported bindings are
+// the losers and get `$N` suffixes — the exact shape the original RN bundle hit.
+test "CJS: ESM-wrapped named import from CJS — namespace rename must survive canonical rename (regression)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import Early from './early';
+        \\import Spec from './spec';
+        \\import Other from './other';
+        \\console.log(Early, Spec, Other);
+    );
+    try writeFile(tmp.dir, "early.ts",
+        \\const Registry = { kind: 'early-registry' };
+        \\const Handle = { tag: 'early-handle' };
+        \\export default { Registry: Registry, Handle: Handle };
+    );
+    try writeFile(tmp.dir, "spec.ts",
+        \\import { Registry, Handle } from './lib.cjs';
+        \\const _handle: Handle = { id: 0 };
+        \\export default Registry.getEnforcing('Foo');
+    );
+    try writeFile(tmp.dir, "other.ts",
+        \\const Registry = { kind: 'other-registry' };
+        \\const Handle = { tag: 'other-handle' };
+        \\export default { Registry: Registry, Handle: Handle };
+    );
+    try writeFile(tmp.dir, "lib.cjs",
+        \\exports.Registry = { getEnforcing: function(n) { return { name: n }; } };
+        \\exports.Handle = {};
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    // BUG MARKER: body must not contain destructuring assignment that writes to
+    //   GLOBAL `Registry`/`Handle` while the module-local vars are `Registry$N`/`Handle$N`.
+    //   `({Registry,Handle}=require_lib())` leaves `Registry$1` undefined and
+    //   `Registry$1.getEnforcing(...)` throws at runtime.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "({Registry,Handle}=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "({Registry, Handle}=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "({Registry}=") == null);
+
+    // CORRECT SHAPE: namespace var preamble + ns-access reference (rolldown style).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".Registry.getEnforcing(") != null);
+
+    // spec.ts's references must go through the __ns_ var, NOT the ghost `Registry$N`
+    // binding that the broken destructuring creates.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Registry$1.getEnforcing(") == null);
+}

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -29,6 +29,12 @@ const stmt_info_mod = @import("stmt_info.zig");
 /// metadata.zig, codegen.zig, emitter.zig에서 공유.
 pub const NS_VAR_PREFIX = "__ns_";
 
+/// `__ns_N.prop` 형태의 namespace-access rename 인지 판정.
+/// CJS-in-ESM-wrapped named import가 이 rename을 가진다 (metadata.zig 참조).
+pub inline fn isNamespaceRename(rename: []const u8) bool {
+    return std.mem.startsWith(u8, rename, NS_VAR_PREFIX);
+}
+
 /// 크로스 모듈 심볼 참조. 어떤 모듈의 어떤 export를 가리키는지.
 /// codegen에 전달하는 per-module 메타데이터.
 /// AST를 수정하지 않고 codegen이 출력 시 참조.
@@ -385,6 +391,10 @@ pub const Linker = struct {
                         if (target_idx >= self.modules.len) break :blk m.wrap_kind == .esm;
                         const target_wrap = self.modules[target_idx].wrap_kind;
                         if (m.wrap_kind == .esm) {
+                            // CJS-in-ESM-wrapped named import는 __ns_N.prop rename으로 처리되어
+                            // top-level var가 emit되지 않음 (metadata.zig:262-281 + emitter.zig:1565).
+                            // → 이름 충돌 owner에서 제외해야 canonical rename이 __ns_ rename을 덮지 않는다.
+                            if (target_wrap == .cjs and ib.kind == .named and !ib.isSynthetic()) break :blk false;
                             // __esm: scope-hoisted 타겟의 import는 skip되어 var 미생성
                             break :blk target_wrap != .none;
                         } else {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2736,7 +2736,7 @@ pub const Codegen = struct {
                 if (!local_idx.isNone()) {
                     if (self.resolveSymbolId(local_idx, meta)) |sid| {
                         if (meta.renames.get(sid)) |rename| {
-                            if (!std.mem.startsWith(u8, rename, linker_mod.NS_VAR_PREFIX)) {
+                            if (!linker_mod.isNamespaceRename(rename)) {
                                 all_ns_renamed = false;
                                 break;
                             }

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1160,10 +1160,13 @@ describe("_default 합성 변수 충돌 방지", () => {
 
     const bundle = await runZts(["--bundle", join(fixture.dir, "index.ts"), "--flow"]);
     expect(bundle.exitCode).toBe(0);
-    // use가 rename되어야 함 (use$1 또는 use$2)
-    // rename이 안 되면 bare 'use'가 CJS wrapper 내부의 'use'를 참조하여 ReferenceError
-    expect(bundle.stdout).not.toMatch(/\buse\("ctx"\)/);
-    expect(bundle.stdout).toMatch(/use\$\d+\("ctx"\)/);
+    // comp.js body의 use 참조는 안전한 경로로 가야 함:
+    //   - canonical rename `use$N("ctx")`, 또는
+    //   - namespace-access `__ns_N_N.use("ctx")` (CJS-in-ESM-wrapped named import 패턴)
+    // bare `use("ctx")` (앞에 `.` 이나 word 문자가 없는)는 CJS wrapper 내부 `use` 함수 선언을
+    // shadow 참조하여 ReferenceError를 일으킬 수 있으므로 금지.
+    expect(bundle.stdout).not.toMatch(/(?<![.\w$])use\("ctx"\)/);
+    expect(bundle.stdout).toMatch(/(use\$\d+\("ctx"\)|__ns_\d+_\d+\.use\("ctx"\))/);
   });
 
   test("import Default, { named } from 동시 사용 시 default와 named 모두 정상 바인딩", async () => {


### PR DESCRIPTION
## Summary

- ESM-wrapped 모듈이 CJS에서 named import한 심볼이 번들 내 다른 top-level 선언과 이름 충돌하면 **runtime TypeError** 발생.
- 실사례: react-native-gesture-handler의 `NativeRNGestureHandlerModule.ts` — `TurboModuleRegistry.getEnforcing of undefined` 크래시.
- **근본 원인**: `Linker.collectModuleNames`가 CJS-in-ESM-wrapped named import를 이름 충돌 owner로 등록. 그런데 이 심볼은 `__ns_N.prop` rename으로 처리되어 실제로는 top-level var가 emit되지 않으므로 애초에 collision 후보가 아님. 잘못된 등록이 canonical rename → `__ns_` rename overwrite → codegen의 `all_ns_renamed` 가드 실패 → body에 shorthand destructuring emit으로 이어짐.
- **수정**: `collectModuleNames`에서 non-synthetic named import이고 target이 CJS인 경우 owner 등록에서 제외. `getCanonicalName`이 null 반환 → canonical rename 자체가 생성되지 않음 → `__ns_` rename이 유일한 rename 소스.
- 부산물: `isNamespaceRename()` 헬퍼를 `linker.zig`에 추가 — `codegen.zig:emitImportCJS`의 `all_ns_renamed` 체크와 idiom 공유.

## 버그 shape (fix 적용 전)

```js
// --- NativeRNGestureHandlerModule.ts ---
var TurboModuleRegistry$50, TurboModule$1, _default$151, __ns_701_0, __ns_701_1;
var init_... = __esm({ "..."() {
    __ns_701_0 = __toESM(require_react_native_index());              // preamble OK
    ({TurboModuleRegistry,TurboModule}=require_react_native_index()); // BUG: 글로벌에 할당
    _default$151 = TurboModuleRegistry$50.getEnforcing("RNGestureHandlerModule");
    //             ^^^^^^^^^^^^^^^^^^^^^^^ 미할당 → undefined.getEnforcing → crash
}}, void 0, ...);
```

## 수정 후

```js
var init_spec = __esm({ "..."() {
    __ns_2_0 = __toESM(require_lib());
    _default$1 = __ns_2_0.Registry.getEnforcing("Foo");   // ns 경로로 정상 참조
}});
```

## 아키텍처 메모

초기 접근은 `buildMetadataForAst`의 canonical-rename 루프에 "이미 `__ns_` rename이 걸린 심볼은 skip" guard를 추가하는 것이었으나, 이는 증상 치료에 가까움 (같은 함수 내 두 단계가 서로 간섭). 근본 원인은 `collectModuleNames`의 collision owner 판정이 **실제로 top-level var를 emit하지 않는 심볼도 owner로 등록**한다는 것. 판정 자체를 수정하여 canonical rename이 아예 생성되지 않도록 함.

## Test plan

- [x] 회귀 테스트 추가: `bundler_test/cjs_esm.zig` — `CJS: ESM-wrapped named import from CJS — namespace rename must survive canonical rename (regression)`
  - body에 `({Registry,Handle}=require_lib())` destructuring이 없어야 함
  - preamble에 `__toESM(require_lib())` 존재
  - 참조가 `__ns_N.Registry.getEnforcing(`를 통과
  - ghost `Registry$1.getEnforcing(` 참조 없음
- [x] `zig build test` 전체 통과 (회귀 없음)
- [ ] bungae dev server에서 ExampleApp 구동 — gesture-handler 크래시 미재현 (수동 smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
