### PR TITLE
perf(hmr): detect debounce 25ms + emit dev-mode skip — HMR -25ms

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -25,9 +25,12 @@ const TrackedFileSet = zts_lib.server.TrackedFileSet;
 /// Issue #1223 Phase 1: 워처 튜닝 상수.
 /// - watch_poll_timeout_ms: stop_flag 체크 주기 (이벤트 워처에서도 주기적으로 깨어나기 위함).
 /// - watch_debounce_ms: 첫 이벤트 이후 정적(idle) 구간 — 연속 저장 병합 윈도우.
+///   debounce loop 첫 iteration 이 kqueue/inotify 에서 최소 이 시간만큼 블로킹되므로
+///   HMR detect 페이즈에 그대로 더해진다. 25ms 는 VS Code / vim 의 atomic save
+///   (rename + write) 사이 간격(5-15ms)을 여전히 흡수하면서 detect 비용을 절반으로.
 /// - watch_debounce_max_ms: 디바운스 최대 대기 시간 — 지속 변경되는 파일에 의한 기아 방지.
 const watch_poll_timeout_ms: u32 = 200;
-const watch_debounce_ms: u32 = 50;
+const watch_debounce_ms: u32 = 25;
 const watch_debounce_max_ms: u64 = 500;
 
 /// 파일 내용 해시 상한 (#1233). RN 등 대형 프로젝트의 vendor 번들/asset catalog/locale

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -952,85 +952,91 @@ pub fn emitModule(
         }
         // statement-level tree-shaking: StmtInfo 기반 도달성 분석으로 미사용 statement 제거.
         // rolldown 방식: 심볼 인덱스로 추적하여 linker rename 후에도 정확한 판정.
-        if (used_export_names) |names| {
-            if (!is_entry and !module.wrap_kind.isWrapped()) {
-                stmt_shake: {
-                    const sem = module.semantic orelse {
-                        statement_shaker.markUnusedStatements(
-                            arena_alloc,
-                            transformer.ast,
-                            root,
-                            names,
-                            &md.skip_nodes,
-                            null,
-                        ) catch {};
-                        break :stmt_shake;
-                    };
-                    const sym_ids: []const ?u32 = if (transformer.symbol_ids.items.len > 0)
-                        transformer.symbol_ids.items
-                    else
-                        sem.symbol_ids;
+        //
+        // **dev_mode 예외**: HMR rebuild 체감 우선. 미사용 statement 를 skip_nodes 로
+        // 마킹하는 것은 출력 크기 최적화지 correctness 가 아니다 — 포함해도 런타임 의미 동일.
+        // dev 번들은 크기 허용, speed 우선 (Metro/esbuild 관습).
+        if (!options.dev_mode) {
+            if (used_export_names) |names| {
+                if (!is_entry and !module.wrap_kind.isWrapped()) {
+                    stmt_shake: {
+                        const sem = module.semantic orelse {
+                            statement_shaker.markUnusedStatements(
+                                arena_alloc,
+                                transformer.ast,
+                                root,
+                                names,
+                                &md.skip_nodes,
+                                null,
+                            ) catch {};
+                            break :stmt_shake;
+                        };
+                        const sym_ids: []const ?u32 = if (transformer.symbol_ids.items.len > 0)
+                            transformer.symbol_ids.items
+                        else
+                            sem.symbol_ids;
 
-                    // 크로스-모듈 BFS 결과: tree-shaker의 reachable_stmts로 skip_nodes 설정
-                    const mod_idx: u32 = module.index.toU32();
-                    if (shaker) |s| {
-                        if (s.getModuleStmtInfos(mod_idx)) |ts_infos| {
-                            // 변환 후 AST의 program statement list에서 span 매칭
-                            const new_root = transformer.ast.nodes.items[transformer.ast.nodes.items.len - 1];
-                            if (new_root.tag == .program and new_root.data.list.len > 0) {
-                                const new_list = new_root.data.list;
-                                if (new_list.start + new_list.len <= transformer.ast.extra_data.items.len) {
-                                    const new_stmt_indices = transformer.ast.extra_data.items[new_list.start .. new_list.start + new_list.len];
-                                    for (ts_infos.stmts, 0..) |ts_stmt, si| {
-                                        if (s.isStmtReachable(mod_idx, @intCast(si))) continue;
-                                        // 변환 후 top-level statement만 스캔 (O(stmts) not O(nodes))
-                                        for (new_stmt_indices) |raw_ni| {
-                                            const ni = @as(usize, raw_ni);
-                                            if (ni >= transformer.ast.nodes.items.len) continue;
-                                            const new_node = transformer.ast.nodes.items[ni];
-                                            if (new_node.span.start == ts_stmt.span.start and
-                                                new_node.span.end == ts_stmt.span.end and
-                                                ni < md.skip_nodes.capacity())
-                                            {
-                                                md.skip_nodes.set(ni);
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        // tree-shaker 없으면 기존 방식 (모듈 내부 computeReachable)
-                        if (stmt_info_mod.build(arena_alloc, transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references)) |maybe_infos| {
-                            if (maybe_infos) |infos| {
-                                var used_sym_buf: std.ArrayListUnmanaged(u32) = .empty;
-                                defer used_sym_buf.deinit(arena_alloc);
-                                if (sem.scope_maps.len > 0) {
-                                    for (names) |name| {
-                                        if (sem.scope_maps[0].get(name)) |sym_idx| {
-                                            used_sym_buf.append(arena_alloc, @intCast(sym_idx)) catch continue;
-                                        } else {
-                                            for (module.export_bindings) |eb| {
-                                                if (std.mem.eql(u8, eb.exported_name, name)) {
-                                                    if (eb.symbol.semanticIndex()) |sym_idx| {
-                                                        used_sym_buf.append(arena_alloc, sym_idx) catch {};
-                                                    }
+                        // 크로스-모듈 BFS 결과: tree-shaker의 reachable_stmts로 skip_nodes 설정
+                        const mod_idx: u32 = module.index.toU32();
+                        if (shaker) |s| {
+                            if (s.getModuleStmtInfos(mod_idx)) |ts_infos| {
+                                // 변환 후 AST의 program statement list에서 span 매칭
+                                const new_root = transformer.ast.nodes.items[transformer.ast.nodes.items.len - 1];
+                                if (new_root.tag == .program and new_root.data.list.len > 0) {
+                                    const new_list = new_root.data.list;
+                                    if (new_list.start + new_list.len <= transformer.ast.extra_data.items.len) {
+                                        const new_stmt_indices = transformer.ast.extra_data.items[new_list.start .. new_list.start + new_list.len];
+                                        for (ts_infos.stmts, 0..) |ts_stmt, si| {
+                                            if (s.isStmtReachable(mod_idx, @intCast(si))) continue;
+                                            // 변환 후 top-level statement만 스캔 (O(stmts) not O(nodes))
+                                            for (new_stmt_indices) |raw_ni| {
+                                                const ni = @as(usize, raw_ni);
+                                                if (ni >= transformer.ast.nodes.items.len) continue;
+                                                const new_node = transformer.ast.nodes.items[ni];
+                                                if (new_node.span.start == ts_stmt.span.start and
+                                                    new_node.span.end == ts_stmt.span.end and
+                                                    ni < md.skip_nodes.capacity())
+                                                {
+                                                    md.skip_nodes.set(ni);
                                                     break;
                                                 }
                                             }
                                         }
                                     }
                                 }
-                                if (infos.computeReachable(arena_alloc, used_sym_buf.items)) |reachable| {
-                                    for (infos.stmts, 0..) |stmt, si| {
-                                        if (!reachable.isSet(si) and stmt.node_idx < md.skip_nodes.capacity()) {
-                                            md.skip_nodes.set(stmt.node_idx);
+                            }
+                        } else {
+                            // tree-shaker 없으면 기존 방식 (모듈 내부 computeReachable)
+                            if (stmt_info_mod.build(arena_alloc, transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references)) |maybe_infos| {
+                                if (maybe_infos) |infos| {
+                                    var used_sym_buf: std.ArrayListUnmanaged(u32) = .empty;
+                                    defer used_sym_buf.deinit(arena_alloc);
+                                    if (sem.scope_maps.len > 0) {
+                                        for (names) |name| {
+                                            if (sem.scope_maps[0].get(name)) |sym_idx| {
+                                                used_sym_buf.append(arena_alloc, @intCast(sym_idx)) catch continue;
+                                            } else {
+                                                for (module.export_bindings) |eb| {
+                                                    if (std.mem.eql(u8, eb.exported_name, name)) {
+                                                        if (eb.symbol.semanticIndex()) |sym_idx| {
+                                                            used_sym_buf.append(arena_alloc, sym_idx) catch {};
+                                                        }
+                                                        break;
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
-                                } else |_| {}
-                            }
-                        } else |_| {}
+                                    if (infos.computeReachable(arena_alloc, used_sym_buf.items)) |reachable| {
+                                        for (infos.stmts, 0..) |stmt, si| {
+                                            if (!reachable.isSet(si) and stmt.node_idx < md.skip_nodes.capacity()) {
+                                                md.skip_nodes.set(stmt.node_idx);
+                                            }
+                                        }
+                                    } else |_| {}
+                                }
+                            } else |_| {}
+                        }
                     }
                 }
             }
@@ -1042,9 +1048,15 @@ pub fn emitModule(
     // Cross-module @__NO_SIDE_EFFECTS__ 전파:
     // import한 함수가 원본 모듈에서 no_side_effects로 선언되었으면
     // 현재 모듈의 해당 호출에 is_pure 플래그를 자동 설정한다.
+    //
+    // **dev_mode 예외**: is_pure 플래그는 minify 의 DCE 만이 읽는다. dev_mode 에선
+    // minify pass 전체가 skip 되므로 전파 결과가 소비되지 않는다. HMR rebuild 체감
+    // 우선 — scope map 스캔 + 2단계 AST 순회 비용 제거.
     if (linker) |l| {
-        const sym_ids = if (metadata) |md| md.symbol_ids else &.{};
-        propagateCrossModulePurity(l, module, transformer.ast, sym_ids, arena_alloc);
+        if (!options.dev_mode) {
+            const sym_ids = if (metadata) |md| md.symbol_ids else &.{};
+            propagateCrossModulePurity(l, module, transformer.ast, sym_ids, arena_alloc);
+        }
     }
 
     // Identifier mangling은 단일 파일 트랜스파일(main.zig)에서만 적용.


### PR DESCRIPTION
## Summary

번개 ExampleApp (1172 모듈) HMR rebuild 실측 기반 개선 3가지.

## 변경

### 1. detect — `watch_debounce_ms` 50 → 25ms (`packages/core/src/napi_entry.zig`)

debounce loop 첫 iteration 이 kqueue/inotify 에서 최소 이 시간만큼 블로킹되므로 HMR detect 페이즈에 그대로 더해진다. 25ms 는 VS Code/vim 의 atomic save (rename + write) 사이 간격 (5-15ms) 을 여전히 흡수하면서 detect 비용을 절반으로.

### 2. emit — `dev_mode` 에서 `propagateCrossModulePurity` skip (`emitter.zig`)

`is_pure` 플래그는 minify 의 DCE 만 소비. `dev_mode` 는 minify pass 전체 skip (선행 PR) 이라 전파 결과가 unused. scope map 스캔 + 2단계 AST 순회 비용 제거.

### 3. emit — `dev_mode` 에서 statement-level tree-shake skip (`emitter.zig`)

미사용 statement 를 `skip_nodes` 로 마킹하는 것은 출력 크기 최적화지 correctness 가 아니다 — 포함해도 런타임 의미 동일. dev 번들은 크기 허용, speed 우선 (Metro/esbuild 관습).

## 실측 (번개 ExampleApp, Release 빌드, 10회 warm rebuild)

| Phase | Before | After | Δ |
|-------|--------|-------|---|
| detect | 51ms | **27ms** | -24ms |
| parse | 66ms | 65ms | 0 |
| sem | 5ms | 5ms | 0 |
| emit | 67ms | 66ms | -1ms |
| **Total** | **~200ms** | **~175ms** | **-25ms** |

- detect 개선 -24ms 적중 (debounce 단축)
- emit 개선은 1 모듈 HMR 에선 skip 된 pass 들이 진입 안 해 1ms 수준. 대규모 refactor 로 여러 모듈 cache miss 시 효과 커짐.
- correctness / 메모리 영향 0.

## Base

- **Base: `revert/d1-inplace-mutation-and-guard` (#1700)**. 해당 PR 머지 후 자동으로 main 으로 rebase.

## Test plan

- [x] `zig build test` 그린
- [x] 번개 ExampleApp HMR 10회 연속 성공 (Release, panic 0)
- [x] Before/After 실측 완료
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)