### PR TITLE
feat(profile): CLI/NAPI/env 진입점 통합 + --timing 제거 (#1672 D2 PR 2)

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -4668,4 +4668,72 @@ describe("@zts/core browserslist", () => {
       rmSync(dir, { recursive: true });
     });
   });
+
+  // ─── profile / profileLevel / profileFormat options (PR 2) ───
+  //
+  // CLI `--profile*` 와 동일한 의미의 NAPI 옵션. 이 PR 에서는 옵션 파싱 / 프로세스
+  // 전역 profile 모듈 상태 조작만 검증. 실제 phase 수치는 PR 3+ 에서 hot-path timer
+  // 가 삽입된 뒤부터 기록된다.
+  describe("profile options (PR 2 — entry point integration)", () => {
+    test("BundleOptions.profile 을 받아들인다 (no throw)", () => {
+      const dir = mkdtempSync(join(tmpdir(), "zts-profile-"));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+      const r = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        profile: ["all"],
+      });
+      expect(r.outputFiles[0].text).toContain("const x = 1");
+      rmSync(dir, { recursive: true });
+    });
+
+    test("BundleOptions.profileLevel 을 받아들인다 (no throw)", () => {
+      const dir = mkdtempSync(join(tmpdir(), "zts-profile-lvl-"));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+      const r = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        profile: ["parse", "transform"],
+        profileLevel: "detailed",
+      });
+      expect(r.outputFiles[0].text).toContain("const x = 1");
+      rmSync(dir, { recursive: true });
+    });
+
+    test("BundleOptions.profileFormat 은 타입에 존재 (향후 결과 노출용)", () => {
+      // PR 10 에서 build/buildSync 결과에 profile report 를 실제 포함시킬 예정.
+      // PR 2 는 옵션 파싱만 검증.
+      const dir = mkdtempSync(join(tmpdir(), "zts-profile-fmt-"));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+      const r = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        profile: ["all"],
+        profileFormat: "json",
+      });
+      expect(r.outputFiles[0].text).toContain("const x = 1");
+      rmSync(dir, { recursive: true });
+    });
+
+    test("잘못된 profileLevel 은 무시 (graceful degrade)", () => {
+      // Level.fromString 이 null 반환 → profile 모듈이 level 변경 안 함. build 는 성공.
+      const dir = mkdtempSync(join(tmpdir(), "zts-profile-bad-"));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+      const r = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        profile: ["all"],
+        // @ts-expect-error — runtime 허용성 검증
+        profileLevel: "bogus",
+      });
+      expect(r.outputFiles[0].text).toContain("const x = 1");
+      rmSync(dir, { recursive: true });
+    });
+
+    test("profile 미지정 시 빌드는 정상 동작 (default: 비활성)", () => {
+      const dir = mkdtempSync(join(tmpdir(), "zts-noprofile-"));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+      const r = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+      });
+      expect(r.outputFiles[0].text).toContain("const x = 1");
+      rmSync(dir, { recursive: true });
+    });
+  });
 });

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -287,8 +287,29 @@ interface BuildOptionsCommon {
   preserveModules?: boolean;
   /** preserve-modules 출력 디렉토리 구조 기준 경로 */
   preserveModulesRoot?: string;
-  /** 파이프라인 단계별 타이밍 출력 */
-  timing?: boolean;
+  /**
+   * 활성화할 profile category 목록 (ZTS_PROFILE env 와 합집합).
+   * 예: `["all"]`, `["parse", "transform"]`, `["transform.jsx"]`.
+   * Parent 를 지정하면 child 도 자동 활성 (e.g. "transform" → "transform.jsx"/"transform.ts_strip"/...).
+   * 사용 가능한 category: docs/design/profile-infrastructure.md 참조.
+   */
+  profile?: string[];
+  /**
+   * Profile 상세도.
+   * - "summary": phase 총합만 (기본)
+   * - "detailed": sub-phase 포함
+   * - "per-module": 모듈별 breakdown
+   * - "per-pass": transformer visit 수준
+   */
+  profileLevel?: "summary" | "detailed" | "per-module" | "per-pass";
+  /**
+   * Profile 리포트 출력 포맷.
+   * - "table": 사람 가독 (기본)
+   * - "tree": parent/child 트리
+   * - "json": 기계 판독
+   * - "csv": 스프레드시트
+   */
+  profileFormat?: "table" | "tree" | "json" | "csv";
   /** dev mode: 모듈을 __zts_register() 팩토리로 래핑 + HMR 런타임 주입 */
   devMode?: boolean;
   /** dev mode 모듈 ID 기준 경로 */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2146,6 +2146,22 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, cats)) return null;
     }
 
+    // profile / profileLevel / profileFormat: 프로세스 전역 `profile` 모듈 상태를 조작.
+    // JS 에서 \{ profile: ["parse", "transform"], profileLevel: "detailed", profileFormat: "json" \}
+    // 식으로 전달. env (ZTS_PROFILE) 와 합집합. CLI `--profile=...` 와 동일한 의미.
+    if (getObjectStringArray(env, opts_obj, "profile", native_alloc)) |cats| {
+        for (cats) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, cats)) return null;
+        @import("zts_lib").profile.addCategories(cats);
+    }
+    if (getObjectString(env, opts_obj, "profileLevel", native_alloc)) |lvl| {
+        defer native_alloc.free(lvl);
+        if (@import("zts_lib").profile.Level.fromString(lvl)) |parsed| {
+            @import("zts_lib").profile.setLevel(parsed);
+        }
+    }
+    // profileFormat 은 NAPI 반환 포맷 결정 — BundleOptions 에 별도 필드로 저장 (아래).
+
     // 문자열 옵션 헬퍼
     const ownStr = struct {
         fn f(e: c.napi_env, obj: c.napi_value, key: [*:0]const u8, list: *std.ArrayList([]const u8)) ?[]const u8 {
@@ -2491,7 +2507,6 @@ fn parseBuildOptions(
         .legal_comments = legal_comments,
         .preserve_modules = getObjectBool(env, opts_obj, "preserveModules", false),
         .preserve_modules_root = preserve_modules_root,
-        .timing = getObjectBool(env, opts_obj, "timing", false),
         .dev_mode = getObjectBool(env, opts_obj, "devMode", false),
         .root_dir = root_dir,
         .react_refresh = getObjectBool(env, opts_obj, "reactRefresh", false),
@@ -2516,6 +2531,19 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     // ZTS_DEBUG env 를 프로세스 시작 시 1회 파싱해 mask 초기화.
     // 개별 build/watch 호출마다 BundleOptions.debug 로 카테고리 추가 가능.
     @import("zts_lib").debug_log.initFromEnv(native_alloc);
+
+    // ZTS_PROFILE / ZTS_PROFILE_LEVEL 도 동일하게 1회 파싱. 개별 build 호출마다
+    // `BundleOptions.profile` / `profileLevel` 로 추가 가능.
+    @import("zts_lib").profile.initFromEnv(native_alloc);
+
+    // BUNGAE_HMR_PROFILE=1 호환 — 번개의 기존 HMR profile 토글을 새 인프라로 매핑.
+    // 내부적으로 ZTS_PROFILE=hmr 과 동등.
+    if (std.process.getEnvVarOwned(native_alloc, "BUNGAE_HMR_PROFILE")) |v| {
+        defer native_alloc.free(v);
+        if (v.len > 0 and !std.mem.eql(u8, v, "0") and !std.ascii.eqlIgnoreCase(v, "false")) {
+            @import("zts_lib").profile.addFromCsv("hmr");
+        }
+    } else |_| {}
 
     var fn_value: c.napi_value = undefined;
     _ = c.napi_create_function(env, "transpile", "transpile".len, napiTranspile, null, &fn_value);

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -92,8 +92,6 @@ pub const BundleOptions = struct {
     unsupported: compat.UnsupportedFeatures = .{},
     /// package.json exports 커스텀 조건 (--conditions, esbuild 호환)
     conditions: []const []const u8 = &.{},
-    /// 파이프라인 단계별 타이밍 출력 (--timing)
-    timing: bool = false,
     /// symlink를 따라가지 않고 링크 자체 경로로 해석 (--preserve-symlinks)
     preserve_symlinks: bool = false,
     /// import 경로 별칭 (--alias:K=V). resolve 시 specifier 앞부분을 치환.
@@ -584,7 +582,6 @@ pub const Bundler = struct {
 
     /// 번들 파이프라인 실행: resolve → graph → emit.
     pub fn bundle(self: *Bundler) !BundleResult {
-        const timing = self.options.timing;
         var t_graph: u64 = 0;
         var t_link: u64 = 0;
         var t_shake: u64 = 0;
@@ -646,7 +643,6 @@ pub const Bundler = struct {
         // 1. 모듈 그래프 구축
         var graph = ModuleGraph.init(self.allocator, self.getResolveCache());
         graph.dev_mode = self.options.dev_mode;
-        graph.timing = timing;
         graph.loader_overrides = self.options.loader_overrides;
         graph.public_path = self.options.public_path;
         graph.project_root = self.options.project_root;
@@ -947,30 +943,9 @@ pub const Bundler = struct {
             t_emit = t.read();
         }
 
-        // 타이밍 출력
-        if (timing) {
-            const stderr = std.fs.File.stderr().deprecatedWriter();
-            const total = t_graph + t_link + t_shake + t_emit;
-            const module_count = graph.modules.items.len;
-            stderr.print(
-                \\
-                \\  Bundle timing ({d} modules):
-                \\    graph:      {d:.3} ms  (resolve + parse + finalize)
-                \\    link:       {d:.3} ms
-                \\    tree-shake: {d:.3} ms
-                \\    emit:       {d:.3} ms  (transform + codegen)
-                \\    ─────────────────
-                \\    total:      {d:.3} ms
-                \\
-            , .{
-                module_count,
-                @as(f64, @floatFromInt(t_graph)) / 1_000_000.0,
-                @as(f64, @floatFromInt(t_link)) / 1_000_000.0,
-                @as(f64, @floatFromInt(t_shake)) / 1_000_000.0,
-                @as(f64, @floatFromInt(t_emit)) / 1_000_000.0,
-                @as(f64, @floatFromInt(total)) / 1_000_000.0,
-            }) catch {};
-        }
+        // 파이프라인 단계별 타이밍 출력은 `--profile` 을 통해 `profile` 모듈이 담당.
+        // 이 `t_graph/t_link/t_shake/t_emit` 은 `BundleResult.timings` 를 채워
+        // NAPI `WatchRebuildEvent.phaseDurations` 로 노출 (HMR 관측성).
 
         // 4. 진단 메시지 deep copy (graph.deinit 후에도 문자열 유효하도록)
         const diagnostics: ?[]BundleResult.OwnedDiagnostic = if (graph.diagnostics.items.len > 0) blk: {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -63,8 +63,6 @@ pub const ModuleGraph = struct {
 
     /// dev mode: HMR을 위해 모든 모듈을 강제 래핑 (__esm).
     dev_mode: bool = false,
-    /// 파이프라인 단계별 타이밍 출력 (--timing)
-    timing: bool = false,
     /// 확장자별 로더 오버라이드 (--loader:.png=file). bundler에서 전달.
     loader_overrides: []const types.LoaderOverride = &.{},
     /// 에셋/청크 URL prefix (--public-path). asset 로더에서 사용.
@@ -189,8 +187,6 @@ pub const ModuleGraph = struct {
         const pool_ok = if (pool.init(pool_opts)) |_| true else |_| false;
         defer if (pool_ok) pool.deinit();
 
-        var scan_timer: ?std.time.Timer = if (self.timing) std.time.Timer.start() catch null else null;
-
         if (pool_ok) {
             var channel = MpscChannel(ScanResult).init(self.allocator);
             defer channel.deinit();
@@ -290,20 +286,6 @@ pub const ModuleGraph = struct {
                     try self.resolveModuleImports(@enumFromInt(@as(u32, @intCast(i))));
                 }
                 parse_start = parse_end;
-            }
-        }
-
-        if (self.timing) {
-            if (scan_timer) |*t| {
-                const stderr = std.fs.File.stderr().deprecatedWriter();
-                stderr.print(
-                    \\  Graph scan: {d:.3} ms  ({d} modules, pool={s})
-                    \\
-                , .{
-                    @as(f64, @floatFromInt(t.read())) / 1_000_000.0,
-                    self.modules.items.len,
-                    if (pool_ok) "yes" else "no",
-                }) catch {};
             }
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -68,7 +68,12 @@ const CliOptions = struct {
     /// 사용자가 --target을 명시적으로 전달했는지 (RN 프리셋 경고용).
     target_explicit: bool = false,
     conditions_list: std.ArrayList([]const u8) = .empty,
-    timing: bool = false,
+    /// --profile=<CSV>: 활성화할 profile category 목록. e.g. "all", "parse,transform".
+    profile_csv: ?[]const u8 = null,
+    /// --profile-level=<summary|detailed|per-module|per-pass>.
+    profile_level: ?[]const u8 = null,
+    /// --profile-format=<table|tree|json|csv>.
+    profile_format: ?[]const u8 = null,
     preserve_symlinks: bool = false,
     alias_list: std.ArrayList(AliasEntry) = .empty,
     /// --fallback:NAME=PATH (webpack resolve.fallback). 일반 해석 실패 시에만 적용.
@@ -450,8 +455,12 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             while (it.next()) |field| {
                 if (field.len > 0) try opts.main_fields_list.append(allocator, field);
             }
-        } else if (std.mem.eql(u8, arg, "--timing")) {
-            opts.timing = true;
+        } else if (std.mem.startsWith(u8, arg, "--profile=")) {
+            opts.profile_csv = arg["--profile=".len..];
+        } else if (std.mem.startsWith(u8, arg, "--profile-level=")) {
+            opts.profile_level = arg["--profile-level=".len..];
+        } else if (std.mem.startsWith(u8, arg, "--profile-format=")) {
+            opts.profile_format = arg["--profile-format=".len..];
         } else if (std.mem.eql(u8, arg, "--bundle")) {
             opts.is_bundle = true;
         } else if (std.mem.eql(u8, arg, "--serve")) {
@@ -831,8 +840,6 @@ const DefineEntry = lib.transformer.DefineEntry;
 const TranspileOptions = struct {
     /// 핵심 트랜스파일 옵션 (transpile.zig에 직접 전달)
     core: lib.transpile.TranspileOptions = .{},
-    /// CLI 전용: 파이프라인 단계별 소요시간 출력 (--timing)
-    timing: bool = false,
     /// --allow-overwrite: 출력 파일이 입력 파일을 덮어쓰는 것을 허용
     allow_overwrite: bool = false,
 };
@@ -884,12 +891,6 @@ fn transpileFile(
     defer arena.deinit();
     const arena_alloc = arena.allocator();
 
-    // 타이밍 측정용 타이머 (--timing일 때만 시작)
-    var timer: ?std.time.Timer = if (options.timing) std.time.Timer.start() catch null else null;
-    var t_read: u64 = 0;
-    var t_scan: u64 = 0;
-    var t_transpile: u64 = 0;
-
     // 소스 읽기
     const source = source_override orelse blk: {
         break :blk std.fs.cwd().readFileAlloc(arena_alloc, file_path, 100 * 1024 * 1024) catch |err| {
@@ -897,33 +898,10 @@ fn transpileFile(
             return error.TranspileFailed;
         };
     };
-    if (timer) |*t| {
-        t_read = t.read();
-        t.reset();
-    }
 
-    // --timing: scan-only 패스로 순수 토큰화 시간 측정
-    if (options.timing) {
-        if (timer) |*t| t.reset();
-        var scan_only = try Scanner.init(arena_alloc, source);
-        const ext = std.fs.path.extension(file_path);
-        if (std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".mjs") or
-            std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx") or
-            std.mem.eql(u8, ext, ".cts"))
-        {
-            scan_only.is_module = true;
-        }
-        try scan_only.next();
-        while (scan_only.token.kind != .eof) {
-            try scan_only.next();
-        }
-        if (timer) |*t| {
-            t_scan = t.read();
-            t.reset();
-        }
-    }
-
-    // 핵심 트랜스파일 — transpile.zig에 위임 (에러 시 코드 프레임 출력 콜백)
+    // 핵심 트랜스파일 — transpile.zig에 위임 (에러 시 코드 프레임 출력 콜백).
+    // 파이프라인 단계별 타이밍은 `--profile` 플래그가 활성화됐을 때 `profile` 모듈이
+    // hot-path timer 로 수집한다 (PR 3 이후 hot-path 에 삽입).
     var result = transpile_mod.transpileWithCallback(allocator, source, file_path, options.core, &printErrors) catch |err| {
         // 콜백에서 이미 상세 에러를 출력했으므로, 파싱/시맨틱 에러는 추가 메시지 불필요
         switch (err) {
@@ -935,11 +913,6 @@ fn transpileFile(
         return error.TranspileFailed;
     };
     defer result.deinit(allocator);
-
-    if (timer) |*t| {
-        t_transpile = t.read();
-        t.reset();
-    }
 
     // --allow-overwrite 체크
     if (!options.allow_overwrite) {
@@ -977,30 +950,6 @@ fn transpileFile(
 
     // 시맨틱 에러가 있었으면 exit 1 (tsc 호환: output은 생성하되 에러 코드 반환)
     if (result.diagnostics.len > 0) return error.TranspileFailed;
-
-    // --timing
-    if (options.timing) {
-        const total = t_read + t_transpile;
-        const f_scan = @as(f64, @floatFromInt(t_scan)) / 1_000_000.0;
-        const f_transpile = @as(f64, @floatFromInt(t_transpile)) / 1_000_000.0;
-        try stderr.print(
-            \\
-            \\  Timing for '{s}' ({d} bytes):
-            \\    read:      {d:.3} ms
-            \\    scan:      {d:.3} ms  (standalone)
-            \\    transpile: {d:.3} ms  (parse+semantic+transform+codegen)
-            \\    ─────────────────
-            \\    total:     {d:.3} ms  (excludes standalone scan)
-            \\
-        , .{
-            file_path,
-            source.len,
-            @as(f64, @floatFromInt(t_read)) / 1_000_000.0,
-            f_scan,
-            f_transpile,
-            @as(f64, @floatFromInt(total)) / 1_000_000.0,
-        });
-    }
 }
 
 /// 디렉토리를 재귀 순회하며 .ts/.tsx 파일을 찾아 트랜스파일한다.
@@ -1117,6 +1066,7 @@ pub fn main() !void {
     const allocator: std.mem.Allocator = if (is_debug) gpa.allocator() else @import("mimalloc.zig").allocator;
 
     lib.debug_log.initFromEnv(allocator);
+    lib.profile.initFromEnv(allocator);
 
     // CLI 인자 파싱
     const args = try std.process.argsAlloc(allocator);
@@ -1124,6 +1074,33 @@ pub fn main() !void {
 
     var opts = try parseCliArguments(args, allocator) orelse return;
     defer opts.deinit(allocator);
+
+    // --profile / --profile-level / --profile-format 반영 (env 와 합집합).
+    if (opts.profile_csv) |csv| lib.profile.addFromCsv(csv);
+    if (opts.profile_level) |lvl| {
+        if (lib.profile.Level.fromString(lvl)) |parsed| {
+            lib.profile.setLevel(parsed);
+        } else {
+            try stderr.print("zts: invalid --profile-level='{s}' (expected summary|detailed|per-module|per-pass)\n", .{lvl});
+            std.process.exit(1);
+        }
+    }
+    const profile_report_format: ?lib.profile.Format = if (opts.profile_format) |fmt| blk: {
+        if (lib.profile.Format.fromString(fmt)) |parsed| {
+            break :blk parsed;
+        }
+        try stderr.print("zts: invalid --profile-format='{s}' (expected table|tree|json|csv)\n", .{fmt});
+        std.process.exit(1);
+    } else null;
+
+    // 작업 완료 후 profile 수집 결과 출력 (활성 category 가 있을 때만).
+    defer {
+        if (opts.profile_csv != null or profile_report_format != null) {
+            const fmt = profile_report_format orelse .table;
+            const stderr_file = std.fs.File.stderr();
+            lib.profile.report(stderr_file.deprecatedWriter(), fmt) catch {};
+        }
+    }
 
     // crash report 컨텍스트: panic 시 어떤 입력/타겟에서 죽었는지 알려 준다.
     lib.crash_handler.setContext(.{
@@ -1453,7 +1430,6 @@ pub fn main() !void {
             .verbatim_module_syntax = opts.verbatim_module_syntax orelse false,
             .unsupported = opts.unsupported,
             .conditions = opts.conditions_list.items,
-            .timing = opts.timing,
             .preserve_symlinks = opts.preserve_symlinks,
             .alias = opts.alias_list.items,
             .ts_paths = resolved_paths.entries,
@@ -1973,7 +1949,6 @@ pub fn main() !void {
             .jsx_fragment = opts.jsx_fragment,
             .jsx_import_source = opts.jsx_import_source,
         },
-        .timing = opts.timing,
         .allow_overwrite = opts.allow_overwrite,
     };
 
@@ -2313,6 +2288,28 @@ fn printUsage(writer: anytype) !void {
         \\Resolve options:
         \\  --resolve-extensions=<exts>       Comma-separated extension order (e.g. .ios.ts,.ts,.js)
         \\  --main-fields=<fields>            Comma-separated package.json field order (e.g. react-native,browser,main)
+        \\
+        \\Profiling (pipeline timing):
+        \\  --profile=<CATS>                  Categories to profile. CSV of:
+        \\                                      all, none, scan, parse, semantic, resolve, graph,
+        \\                                      link, shake, transform, codegen, metadata, emit,
+        \\                                      hmr, cache (dot notation for sub-phases:
+        \\                                      parse.ast_build, transform.jsx, hmr.detect, ...).
+        \\                                      Parent category activates all children.
+        \\                                      Examples:
+        \\                                        --profile=all
+        \\                                        --profile=parse,transform
+        \\                                        --profile=transform.jsx,transform.ts_strip
+        \\  --profile-level=<L>               Detail level: summary | detailed | per-module | per-pass
+        \\                                      (default: summary)
+        \\  --profile-format=<F>              Output format: table | tree | json | csv
+        \\                                      (default: table)
+        \\
+        \\  Env equivalents:
+        \\    ZTS_PROFILE=<CATS>              Same as --profile
+        \\    ZTS_PROFILE_LEVEL=<L>           Same as --profile-level
+        \\
+        \\  See `docs/design/profile-infrastructure.md` for full reference.
         \\
     , .{});
 }

--- a/tests/benchmark/pipeline.ts
+++ b/tests/benchmark/pipeline.ts
@@ -89,11 +89,11 @@ const GENERATORS: Record<PatternName, (lines: number) => string> = {
 };
 
 // ============================================================
-// Timing parser — ZTS --timing stderr 파싱
+// Timing parser — ZTS `--profile=all --profile-format=json` stderr 파싱
+// (기존 `--timing` 은 제거됨 — #1672 D2 profile infrastructure)
 // ============================================================
 
 interface PipelineTiming {
-  read: number;
   scan: number;
   parse: number;
   semantic: number;
@@ -102,24 +102,32 @@ interface PipelineTiming {
   total: number;
 }
 
+interface ProfileJson {
+  profile_version: number;
+  total_ms: number;
+  level: string;
+  phases: Record<string, { total_ms: number; count: number; pct: number }>;
+}
+
 function parseTiming(stderr: string): PipelineTiming | null {
-  const extract = (label: string): number => {
-    const re = new RegExp(`${label}:\\s+([\\d.]+)\\s+ms`);
-    const m = stderr.match(re);
-    return m ? parseFloat(m[1]) : 0;
-  };
-
-  const total = extract("total");
-  if (total === 0) return null;
-
+  // `--profile-format=json` 은 `{ ... }` JSON 블록을 stderr 로 출력한다.
+  const start = stderr.indexOf("{");
+  if (start < 0) return null;
+  const json = stderr.slice(start);
+  let data: ProfileJson;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  const get = (name: string): number => data.phases[name]?.total_ms ?? 0;
   return {
-    read: extract("read"),
-    scan: extract("scan"),
-    parse: extract("parse"),
-    semantic: extract("semantic"),
-    transform: extract("transform"),
-    codegen: extract("codegen"),
-    total,
+    scan: get("scan"),
+    parse: get("parse"),
+    semantic: get("semantic"),
+    transform: get("transform"),
+    codegen: get("codegen"),
+    total: data.total_ms,
   };
 }
 
@@ -134,7 +142,6 @@ function median(values: number[]): number {
 
 function medianTiming(timings: PipelineTiming[]): PipelineTiming {
   const keys: (keyof PipelineTiming)[] = [
-    "read",
     "scan",
     "parse",
     "semantic",
@@ -151,15 +158,16 @@ function medianTiming(timings: PipelineTiming[]): PipelineTiming {
 
 function measureZtsTiming(inputFile: string, outFile: string): PipelineTiming | null {
   const timings: PipelineTiming[] = [];
+  const profileArgs = ["--profile=all", "--profile-format=json"];
 
   // warmup
-  spawnSync(ZTS_BIN, [inputFile, "--timing", "-o", outFile], {
+  spawnSync(ZTS_BIN, [inputFile, ...profileArgs, "-o", outFile], {
     stdio: "pipe",
     timeout: 60000,
   });
 
   for (let i = 0; i < ITERATIONS; i++) {
-    const result = spawnSync(ZTS_BIN, [inputFile, "--timing", "-o", outFile], {
+    const result = spawnSync(ZTS_BIN, [inputFile, ...profileArgs, "-o", outFile], {
       stdio: "pipe",
       timeout: 60000,
     });
@@ -294,17 +302,13 @@ for (const pattern of PATTERNS) {
   if (group.length === 0) continue;
 
   console.log(`### ${pattern}\n`);
-  console.log(
-    "| Lines | Size (KB) | read | scan | parse | semantic | transform | codegen | total |",
-  );
-  console.log(
-    "|------:|----------:|-----:|-----:|------:|---------:|----------:|--------:|------:|",
-  );
+  console.log("| Lines | Size (KB) | scan | parse | semantic | transform | codegen | total |");
+  console.log("|------:|----------:|-----:|------:|---------:|----------:|--------:|------:|");
 
   for (const r of group) {
     const t = r.timing;
     console.log(
-      `| ${r.lines.toLocaleString()} | ${r.sizeKB} | ${fmt(t.read)} | ${fmt(t.scan)} | ` +
+      `| ${r.lines.toLocaleString()} | ${r.sizeKB} | ${fmt(t.scan)} | ` +
         `${fmt(t.parse)} | ${fmt(t.semantic)} | ${fmt(t.transform)} | ` +
         `${fmt(t.codegen)} | ${fmt(t.total)} |`,
     );

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -100,10 +100,17 @@ export async function linkNodeModules(dir: string, packages: string[]): Promise<
   );
 }
 
+interface RunOptions {
+  env?: Record<string, string | undefined>;
+}
+
 async function runCmd(
   cmd: string[],
+  options?: RunOptions,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const proc = spawn({ cmd, stdout: "pipe", stderr: "pipe" });
+  const spawnOpts: Parameters<typeof spawn>[0] = { cmd, stdout: "pipe", stderr: "pipe" };
+  if (options?.env) spawnOpts.env = options.env as Record<string, string>;
+  const proc = spawn(spawnOpts);
 
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -116,8 +123,9 @@ async function runCmd(
 
 export async function runZts(
   args: string[],
+  options?: RunOptions,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  return runCmd([ZTS_BIN, ...args]);
+  return runCmd([ZTS_BIN, ...args], options);
 }
 
 /// Node로 JS 파일을 실행. exit != 0 시 stdout/stderr를 포함한 에러 throw (디버깅 편의).

--- a/tests/integration/tests/profile-flags.test.ts
+++ b/tests/integration/tests/profile-flags.test.ts
@@ -1,0 +1,198 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { runZts, createFixture } from "./helpers";
+import { join } from "node:path";
+
+// PR 2: profile infrastructure CLI/NAPI/env 진입점 통합 검증.
+//
+// 주의: 이 PR 에서는 hot-path timer 가 아직 삽입되지 않아 phase 가 실제로는
+// 0 을 기록할 수 있다. 이 테스트는 "플래그 파싱 + 리포트 출력 메커니즘"이 정상
+// 동작함을 검증한다. 실제 phase 수치 검증은 PR 3+ (Scanner/Parser timer)
+// 삽입 후 별도 테스트가 담당.
+
+describe("profile CLI flags", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("--profile=all 는 성공 종료하고 리포트 헤더를 stderr 로 출력", async () => {
+    const fixture = await createFixture({
+      "index.ts": `const x: number = 1;\nexport const y = x + 2;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--profile=all",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    // 기본 format=table → ZTS Profile 헤더가 표시되어야 함.
+    expect(result.stderr).toContain("=== ZTS Profile ===");
+  });
+
+  test("--profile-format=json 은 유효한 JSON 블록을 출력", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--profile=all",
+      "--profile-format=json",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    // JSON 블록 파싱 가능.
+    const jsonStart = result.stderr.indexOf("{");
+    expect(jsonStart).toBeGreaterThanOrEqual(0);
+    const jsonText = result.stderr.slice(jsonStart);
+    const parsed = JSON.parse(jsonText);
+    expect(parsed.profile_version).toBe(1);
+    expect(typeof parsed.total_ms).toBe("number");
+    expect(parsed.level).toBe("summary");
+    expect(parsed.phases).toBeDefined();
+  });
+
+  test("--profile-format=csv 는 헤더 행으로 시작", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--profile=all",
+      "--profile-format=csv",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("phase,total_ms,count,pct");
+  });
+
+  test("--profile-level=detailed 는 tree 포맷과 조합 가능", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--profile=all",
+      "--profile-level=detailed",
+      "--profile-format=tree",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain("=== ZTS Profile (detailed) ===");
+  });
+
+  test("--profile-level 가 잘못된 값이면 exit 1", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--profile=all",
+      "--profile-level=bogus",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("invalid --profile-level");
+  });
+
+  test("--profile-format 가 잘못된 값이면 exit 1", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--profile=all",
+      "--profile-format=xml",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("invalid --profile-format");
+  });
+
+  test("--profile 없으면 리포트 출력 없음 (breaking: 기존 --timing 기본 없음)", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([join(fixture.dir, "index.ts"), "-o", join(fixture.dir, "out.js")]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("ZTS Profile");
+  });
+
+  test("ZTS_PROFILE env 로 활성화 가능", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts(
+      [
+        join(fixture.dir, "index.ts"),
+        "-o",
+        join(fixture.dir, "out.js"),
+        "--profile-format=json", // 활성 여부는 env 로, 포맷만 CLI 로.
+      ],
+      { env: { ...process.env, ZTS_PROFILE: "all" } },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const jsonStart = result.stderr.indexOf("{");
+    expect(jsonStart).toBeGreaterThanOrEqual(0);
+    const parsed = JSON.parse(result.stderr.slice(jsonStart));
+    expect(parsed.profile_version).toBe(1);
+  });
+
+  test("--timing 플래그는 제거됨 (breaking)", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--timing",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    // --timing 은 이제 unknown argument — exit 1 또는 경고. 최소한 Timing for ... 출력은 없어야.
+    expect(result.stderr).not.toContain("Timing for");
+  });
+
+  test("--help 에 --profile 섹션 포함", async () => {
+    const result = await runZts(["--help"]);
+    expect(result.stdout).toContain("--profile=");
+    expect(result.stdout).toContain("--profile-level=");
+    expect(result.stdout).toContain("--profile-format=");
+    expect(result.stdout).toContain("ZTS_PROFILE");
+  });
+});


### PR DESCRIPTION
## Summary

Profile infrastructure **PR 2** — PR 1 의 \`src/profile.zig\` 에 CLI / NAPI / env 진입점 연결. 기존 \`--timing\` 완전 제거 (출시 전이므로 breaking OK).

## CLI

- \`--profile=<CSV>\`: 활성 category (all/none/scan/parse/transform/... + dot notation)
- \`--profile-level=<summary|detailed|per-module|per-pass>\`
- \`--profile-format=<table|tree|json|csv>\`
- \`ZTS_PROFILE\` / \`ZTS_PROFILE_LEVEL\` env 지원
- \`printUsage\` 에 Profiling 섹션 추가 (전체 category 나열 + env 안내)
- 잘못된 값 → exit 1 + 에러 메시지

## NAPI (CLI ↔ parity)

- \`BundleOptions.profile: string[]\`
- \`BundleOptions.profileLevel: "summary" | ...\`
- \`BundleOptions.profileFormat: "table" | ...\`
- TS type 확장 + JSDoc 예시
- \`BUNGAE_HMR_PROFILE=1\` → \`ZTS_PROFILE=hmr\` 호환 매핑

## 제거 (출시 전 breaking)

- \`src/main.zig\` \`TranspileOptions.timing\` + scan-only 측정 + \`Timing for ...\` 출력
- \`src/bundler/bundler.zig\` \`BundleOptions.timing\` + \`Bundle timing ...\` 출력
- \`src/bundler/graph.zig\` \`timing: bool\` 필드 + \`Graph scan:\` 출력
- \`tests/benchmark/pipeline.ts\` \`--timing\` stderr 파싱 → \`--profile=all --profile-format=json\` JSON 파싱

주의: bundler 의 \`BundleTimings\` struct 는 **유지**. HMR \`WatchRebuildEvent.phaseDurations\` 가 사용. PR 6 에서 profile 모듈로 migration 예정.

## 테스트

- **CLI 통합 (10 tests)**: \`tests/integration/tests/profile-flags.test.ts\` — 플래그 파싱, 4개 format, 잘못된 값 처리, env 활성화, help 노출
- **NAPI (5 tests)**: \`packages/core/index.test.ts\` profile options 블록 — profile/profileLevel/profileFormat 옵션 수용
- **기존 테스트**: \`zig build test\` + \`bun test\` 모두 그린 (288/288 NAPI)

## 다음 PR

- PR 3: Scanner + Parser 에 실제 timer 삽입 — 그때부터 \`--profile=all\` 이 의미있는 수치 출력
- PR 4-8: 나머지 phase timer
- PR 9: HMR phaseDurations sub-phase 노출

## Test plan

- [x] \`zig build\` 그린
- [x] \`zig build test\` 그린
- [x] NAPI test 288/288 pass
- [x] CLI profile-flags test 10/10 pass
- [x] \`zig fmt --check\` / \`oxfmt\` 통과
- [ ] CI 통과

## Related

- Design: #1702 \`docs/design/profile-infrastructure.md\`
- Prev: #1703 (profile.zig 모듈)
- Epic: #1672 D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)