### PR TITLE
feat(profile): Parser .parse phase timer — 첫 hot-path 측정 (#1672 D2 PR 3)

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -9,6 +9,7 @@
 //! - references/oxc/crates/oxc_parser/src/
 
 const std = @import("std");
+const profile = @import("../profile.zig");
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const token_mod = @import("../lexer/token.zig");
 const Kind = token_mod.Kind;
@@ -1787,6 +1788,8 @@ pub const Parser = struct {
     const statement = @import("statement.zig");
 
     pub fn parse(self: *Parser) !NodeIndex {
+        var scope = profile.begin(.parse);
+        defer scope.end();
         return statement.parse(self);
     }
 

--- a/tests/integration/tests/profile-flags.test.ts
+++ b/tests/integration/tests/profile-flags.test.ts
@@ -195,4 +195,36 @@ describe("profile CLI flags", () => {
     expect(result.stdout).toContain("--profile-format=");
     expect(result.stdout).toContain("ZTS_PROFILE");
   });
+
+  // ─── Phase 실제 수치 기록 검증 (PR 3+ 에서 hot-path timer 가 삽입됨) ───
+
+  test("--profile=parse 는 parse phase 에 실제 수치 기록", async () => {
+    const fixture = await createFixture({
+      "index.ts": `
+        export const x: number = 1;
+        export function foo(a: string, b: number) {
+          return a + b.toString();
+        }
+        export class K {
+          constructor(public name: string) {}
+          greet() { return "Hi " + this.name; }
+        }
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--profile=parse",
+      "--profile-format=json",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stderr.slice(result.stderr.indexOf("{")));
+    expect(parsed.phases.parse).toBeDefined();
+    expect(parsed.phases.parse.total_ms).toBeGreaterThan(0);
+    expect(parsed.phases.parse.count).toBeGreaterThanOrEqual(1);
+  });
 });


### PR DESCRIPTION
## Summary

Profile infrastructure **PR 3** — 첫 실제 hot-path timer 삽입. \`Parser.parse()\` 전체에 \`.parse\` scope.

이전 PR #1705 는 base (#1704) 머지 시 자동 close 되어 본 PR 로 대체 (base=main).

## 실측

\`\`\`
$ zts input.ts --profile=parse --profile-format=json
{
  "profile_version": 1,
  "total_ms": 0.412,
  "level": "summary",
  "phases": {
    "parse": { "total_ms": 0.412, "count": 1, "pct": 100.00 }
  }
}
\`\`\`

## Scanner 는 별도 timer 없음 이유

Scanner 가 **lazy tokenization** (\`next()\` 호출마다 토큰 생성). Scanner 비용은 \`.parse\` 에 자연스럽게 포함. eager-tokenize 모드 추가는 별도 PR 주제.

## 테스트

- CLI 통합 +1 (실제 수치 검증)
- 11/11 pass

## Test plan

- [x] \`zig build\` 그린
- [x] \`zig build test\` 그린
- [x] CLI profile-flags 11/11 pass
- [x] 실측 output 검증
- [ ] CI 통과

## Related

- Design: #1702
- Prev merged: #1704
- Epic: #1672 D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)