### PR TITLE
feat(profile): --stop-after=<phase> 파이프라인 조기 종료 (#1672 D2 PR 4)

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -92,6 +92,17 @@ export interface TranspileOptions {
    * 예: `[{ key: "process.env.NODE_ENV", value: "\"production\"" }]`
    */
   define?: Array<{ key: string; value: string }>;
+  /**
+   * 파이프라인 조기 종료 지점 — debug/profile 용. 지정 시 해당 phase 이후 단계는 skip 하고
+   * 빈 output 을 반환. `profile` 과 조합해 특정 phase 비용을 격리 측정할 때 유용.
+   *
+   * - "scan": Scanner 토큰 drain 만
+   * - "parse": Parser AST 생성 후
+   * - "semantic": Semantic analyzer 후
+   * - "transform": Transformer 후
+   * - "codegen": 전체 실행 (기본 동작과 동일)
+   */
+  stopAfter?: "scan" | "parse" | "semantic" | "transform" | "codegen";
 }
 
 export interface TranspileResult {
@@ -200,6 +211,7 @@ export function buildOptionsJson(
   if (opts.sourcesContent === false) payload.sourcesContent = false;
   if (opts.sourceRoot) payload.sourceRoot = opts.sourceRoot;
   if (opts.define && opts.define.length > 0) payload.define = opts.define;
+  if (opts.stopAfter) payload.stopAfter = opts.stopAfter;
   return JSON.stringify(payload);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -74,6 +74,11 @@ const CliOptions = struct {
     profile_level: ?[]const u8 = null,
     /// --profile-format=<table|tree|json|csv>.
     profile_format: ?[]const u8 = null,
+    /// --stop-after=<scan|parse|semantic|transform|codegen>. debug/profile 용.
+    /// 지정된 phase 이후 파이프라인 skip → empty output.
+    stop_after_str: ?[]const u8 = null,
+    /// 파싱된 stop_after — main() 에서 파싱 후 transpile/bundle 옵션에 전달.
+    core_stop_after: ?lib.transpile.StopAfter = null,
     preserve_symlinks: bool = false,
     alias_list: std.ArrayList(AliasEntry) = .empty,
     /// --fallback:NAME=PATH (webpack resolve.fallback). 일반 해석 실패 시에만 적용.
@@ -461,6 +466,8 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             opts.profile_level = arg["--profile-level=".len..];
         } else if (std.mem.startsWith(u8, arg, "--profile-format=")) {
             opts.profile_format = arg["--profile-format=".len..];
+        } else if (std.mem.startsWith(u8, arg, "--stop-after=")) {
+            opts.stop_after_str = arg["--stop-after=".len..];
         } else if (std.mem.eql(u8, arg, "--bundle")) {
             opts.is_bundle = true;
         } else if (std.mem.eql(u8, arg, "--serve")) {
@@ -1092,6 +1099,16 @@ pub fn main() !void {
         try stderr.print("zts: invalid --profile-format='{s}' (expected table|tree|json|csv)\n", .{fmt});
         std.process.exit(1);
     } else null;
+
+    // --stop-after=<phase> 파싱 → TranspileOptions.stop_after 로 전달.
+    if (opts.stop_after_str) |s| {
+        if (lib.transpile.StopAfter.fromString(s)) |parsed| {
+            opts.core_stop_after = parsed;
+        } else {
+            try stderr.print("zts: invalid --stop-after='{s}' (expected scan|parse|semantic|transform|codegen)\n", .{s});
+            std.process.exit(1);
+        }
+    }
 
     // 작업 완료 후 profile 수집 결과 출력 (활성 category 가 있을 때만).
     defer {
@@ -1948,6 +1965,7 @@ pub fn main() !void {
             .jsx_factory = opts.jsx_factory,
             .jsx_fragment = opts.jsx_fragment,
             .jsx_import_source = opts.jsx_import_source,
+            .stop_after = opts.core_stop_after,
         },
         .allow_overwrite = opts.allow_overwrite,
     };
@@ -2304,6 +2322,12 @@ fn printUsage(writer: anytype) !void {
         \\                                      (default: summary)
         \\  --profile-format=<F>              Output format: table | tree | json | csv
         \\                                      (default: table)
+        \\  --stop-after=<P>                  Stop pipeline after the given phase (debug / profile):
+        \\                                      scan | parse | semantic | transform | codegen
+        \\                                      Output is empty; useful for isolating phase cost with --profile.
+        \\                                      Examples:
+        \\                                        zts input.ts --stop-after=parse --profile=parse
+        \\                                        zts input.ts --stop-after=semantic --profile=all
         \\
         \\  Env equivalents:
         \\    ZTS_PROFILE=<CATS>              Same as --profile

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -9,6 +9,7 @@
 //! - references/oxc/crates/oxc_parser/src/
 
 const std = @import("std");
+const profile = @import("../profile.zig");
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const token_mod = @import("../lexer/token.zig");
 const Kind = token_mod.Kind;
@@ -1787,6 +1788,8 @@ pub const Parser = struct {
     const statement = @import("statement.zig");
 
     pub fn parse(self: *Parser) !NodeIndex {
+        var scope = profile.begin(.parse);
+        defer scope.end();
         return statement.parse(self);
     }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -23,10 +23,37 @@ const rt = @import("bundler/runtime_helpers.zig");
 const Diagnostic = @import("diagnostic.zig").Diagnostic;
 const OwnedDiagnostic = @import("diagnostic.zig").OwnedDiagnostic;
 
+/// 파이프라인 조기 종료 지점. `--stop-after=<phase>` / `stopAfter` 옵션과 매핑.
+///
+/// 주로 debug/profile 용 — 특정 phase 까지만 실행하고 빈 output 반환. 예를 들어
+/// `stop_after = .parse` 이면 AST 는 생성되지만 semantic/transform/codegen 은 skip.
+/// `--profile` 과 결합해 phase 별 비용을 격리 측정할 수 있다.
+pub const StopAfter = enum {
+    scan,
+    parse,
+    semantic,
+    transform,
+    codegen,
+
+    pub fn fromString(s: []const u8) ?StopAfter {
+        const trimmed = std.mem.trim(u8, s, " \t");
+        if (std.ascii.eqlIgnoreCase(trimmed, "scan")) return .scan;
+        if (std.ascii.eqlIgnoreCase(trimmed, "parse")) return .parse;
+        if (std.ascii.eqlIgnoreCase(trimmed, "semantic")) return .semantic;
+        if (std.ascii.eqlIgnoreCase(trimmed, "transform")) return .transform;
+        if (std.ascii.eqlIgnoreCase(trimmed, "codegen")) return .codegen;
+        return null;
+    }
+};
+
 pub const TranspileOptions = struct {
     // --- 파싱 ---
     flow: bool = false,
     jsx_in_js: bool = false,
+
+    /// 파이프라인 조기 종료 지점. null(기본)이면 codegen 까지 실행.
+    /// 지정 시 해당 phase 이후 단계는 skip — debug/profile 용.
+    stop_after: ?StopAfter = null,
 
     // --- 변환 ---
     define: []const DefineEntry = &.{},
@@ -106,6 +133,8 @@ pub const TranspileOptionsDto = struct {
     sourcesContent: ?bool = null,
     sourceRoot: ?[]const u8 = null,
     define: ?[]const DefineEntry = null,
+    /// `--stop-after=<phase>` 동등. JSON 값은 `scan`/`parse`/`semantic`/`transform`/`codegen`.
+    stopAfter: ?StopAfter = null,
 };
 
 /// JSON payload를 파싱해 `TranspileOptions`로 변환한다.
@@ -160,6 +189,7 @@ pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !Transpil
         opts.source_root = s;
     };
     if (parsed.define) |d| opts.define = d;
+    if (parsed.stopAfter) |v| opts.stop_after = v;
 
     // tsconfig.json 로드 + merge — JSON에 명시적으로 설정된 값이 tsconfig 값을 덮어쓴다.
     // `parsed.<field> == null` 인 필드만 tsconfig 값으로 채움. 이로써 JSON > tsconfig > default 우선순위 유지.
@@ -261,6 +291,17 @@ pub fn transpileWithCallback(
 
     // 1. 파싱
     var scanner = Scanner.init(arena_alloc, source) catch return error.OutOfMemory;
+
+    // --stop-after=scan: 파서 호출 없이 토큰 drain 만 수행 (profile/debug 용).
+    // Scanner 가 lazy 이므로 next() 로 EOF 까지 소비해야 실제 tokenization 비용이 발생.
+    if (options.stop_after == .scan) {
+        scanner.next() catch return error.ParseError;
+        while (scanner.token.kind != .eof) {
+            scanner.next() catch return error.ParseError;
+        }
+        return .{ .code = try allocator.dupe(u8, "") };
+    }
+
     var parser = Parser.init(arena_alloc, &scanner);
     parser.configureFromExtension(std.fs.path.extension(file_path));
 
@@ -286,6 +327,10 @@ pub fn transpileWithCallback(
         return error.ParseError;
     }
 
+    if (options.stop_after == .parse) {
+        return .{ .code = try allocator.dupe(u8, "") };
+    }
+
     // 2. Semantic analysis
     // tsc 호환: 시맨틱 에러가 있어도 codegen을 진행한다.
     // 에러는 콜백으로 stderr에 출력하되, 변환 결과도 함께 반환한다.
@@ -300,6 +345,10 @@ pub fn transpileWithCallback(
     if (analyzer.errors.items.len > 0) {
         if (on_error) |cb| cb(source, file_path, &scanner, analyzer.errors.items);
         // tsc처럼 에러와 함께 output도 생성 — 중단하지 않음
+    }
+
+    if (options.stop_after == .semantic) {
+        return .{ .code = try allocator.dupe(u8, "") };
     }
 
     // 3. Identifier mangling (--minify-identifiers)
@@ -340,6 +389,10 @@ pub fn transpileWithCallback(
     transformer.symbols = analyzer.symbols.items;
     transformer.line_offsets = scanner.line_offsets.items;
     const root = transformer.transform() catch return error.TransformError;
+
+    if (options.stop_after == .transform) {
+        return .{ .code = try allocator.dupe(u8, "") };
+    }
 
     if (options.minify_syntax) {
         const minify_mod = @import("transformer/minify.zig");

--- a/tests/integration/tests/profile-flags.test.ts
+++ b/tests/integration/tests/profile-flags.test.ts
@@ -195,4 +195,36 @@ describe("profile CLI flags", () => {
     expect(result.stdout).toContain("--profile-format=");
     expect(result.stdout).toContain("ZTS_PROFILE");
   });
+
+  // ─── Phase 실제 수치 기록 검증 (PR 3+ 에서 hot-path timer 가 삽입됨) ───
+
+  test("--profile=parse 는 parse phase 에 실제 수치 기록", async () => {
+    const fixture = await createFixture({
+      "index.ts": `
+        export const x: number = 1;
+        export function foo(a: string, b: number) {
+          return a + b.toString();
+        }
+        export class K {
+          constructor(public name: string) {}
+          greet() { return "Hi " + this.name; }
+        }
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--profile=parse",
+      "--profile-format=json",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stderr.slice(result.stderr.indexOf("{")));
+    expect(parsed.phases.parse).toBeDefined();
+    expect(parsed.phases.parse.total_ms).toBeGreaterThan(0);
+    expect(parsed.phases.parse.count).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/tests/integration/tests/stop-after.test.ts
+++ b/tests/integration/tests/stop-after.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect, afterEach, beforeAll, afterAll } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createFixture, runZts } from "./helpers";
+import { init, close } from "../../../packages/core/index";
+
+// PR 4: --stop-after=<phase> — 파이프라인 조기 종료. debug/profile 용.
+// 지정한 phase 이후 단계를 skip 하고 빈 output 반환.
+// 실측 격리 (특정 phase 비용만 측정) 에 유용 — `--profile` 과 조합.
+
+describe("--stop-after", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  async function runAndGetOutput(stopAfter: string, extraArgs: string[] = []) {
+    const fixture = await createFixture({
+      "index.ts": `
+        export const x: number = 1;
+        export function foo(a: string): number {
+          return x + a.length;
+        }
+        export class K { constructor(public name: string) {} }
+      `,
+    });
+    cleanup = fixture.cleanup;
+    const outFile = join(fixture.dir, "out.js");
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      `--stop-after=${stopAfter}`,
+      "-o",
+      outFile,
+      ...extraArgs,
+    ]);
+
+    const output = result.exitCode === 0 ? readFileSync(outFile, "utf-8") : "";
+    return { result, output };
+  }
+
+  test("--stop-after=scan 은 성공 종료 + 빈 output", async () => {
+    const { result, output } = await runAndGetOutput("scan");
+    expect(result.exitCode).toBe(0);
+    expect(output).toBe("");
+  });
+
+  test("--stop-after=parse 은 성공 종료 + 빈 output", async () => {
+    const { result, output } = await runAndGetOutput("parse");
+    expect(result.exitCode).toBe(0);
+    expect(output).toBe("");
+  });
+
+  test("--stop-after=semantic 은 성공 종료 + 빈 output", async () => {
+    const { result, output } = await runAndGetOutput("semantic");
+    expect(result.exitCode).toBe(0);
+    expect(output).toBe("");
+  });
+
+  test("--stop-after=transform 은 성공 종료 + 빈 output", async () => {
+    const { result, output } = await runAndGetOutput("transform");
+    expect(result.exitCode).toBe(0);
+    expect(output).toBe("");
+  });
+
+  test("--stop-after=codegen 은 정상 transpile (full 파이프라인 실행)", async () => {
+    const { result, output } = await runAndGetOutput("codegen");
+    expect(result.exitCode).toBe(0);
+    // codegen 까지 실행 → 실제 JS 출력됨
+    expect(output.length).toBeGreaterThan(0);
+    expect(output).toContain("x = 1");
+  });
+
+  test("--stop-after 없으면 full 파이프라인 (기본 동작)", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x: number = 1;`,
+    });
+    cleanup = fixture.cleanup;
+    const outFile = join(fixture.dir, "out.js");
+
+    const result = await runZts([join(fixture.dir, "index.ts"), "-o", outFile]);
+    expect(result.exitCode).toBe(0);
+    const output = readFileSync(outFile, "utf-8");
+    expect(output).toContain("x = 1");
+  });
+
+  test("잘못된 --stop-after 값은 exit 1", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--stop-after=bogus",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("invalid --stop-after");
+  });
+
+  test("--stop-after=parse --profile=parse 조합: 격리 측정", async () => {
+    const fixture = await createFixture({
+      "index.ts": `export const x: number = 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      join(fixture.dir, "index.ts"),
+      "--stop-after=parse",
+      "--profile=parse",
+      "--profile-format=json",
+      "-o",
+      join(fixture.dir, "out.js"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stderr.slice(result.stderr.indexOf("{")));
+    // parse phase 는 기록되었고
+    expect(json.phases.parse).toBeDefined();
+    expect(json.phases.parse.total_ms).toBeGreaterThan(0);
+    // 이후 phase 는 없어야 (transform/codegen 등은 기록 없음)
+    expect(json.phases.transform).toBeUndefined();
+    expect(json.phases.codegen).toBeUndefined();
+  });
+
+  test("--help 에 --stop-after 섹션 포함", async () => {
+    const result = await runZts(["--help"]);
+    expect(result.stdout).toContain("--stop-after=");
+    expect(result.stdout).toContain("scan | parse | semantic | transform | codegen");
+  });
+});
+
+describe("NAPI stopAfter option", () => {
+  beforeAll(() => init());
+  afterAll(() => close());
+
+  test("transpile({ stopAfter: 'parse' }) 성공 + 빈 code", async () => {
+    const { transpile } = await import("../../../packages/core/index");
+    const result = transpile("export const x: number = 1;", {
+      filename: "input.ts",
+      stopAfter: "parse",
+    });
+    expect(result.code).toBe("");
+  });
+
+  test("transpile({ stopAfter: 'codegen' }) 는 full 파이프라인 (기본 동작)", async () => {
+    const { transpile } = await import("../../../packages/core/index");
+    const result = transpile("export const x: number = 1;", {
+      filename: "input.ts",
+      stopAfter: "codegen",
+    });
+    expect(result.code).toContain("x = 1");
+  });
+
+  test("transpile({}) 은 stopAfter 기본 null → full 파이프라인", async () => {
+    const { transpile } = await import("../../../packages/core/index");
+    const result = transpile("export const x: number = 1;", { filename: "input.ts" });
+    expect(result.code).toContain("x = 1");
+  });
+});


### PR DESCRIPTION
## Summary

Profile infrastructure **PR 4** — phase 격리 실행. 지정한 phase 이후 파이프라인 skip, 빈 output 반환. \`--profile\` 과 조합해 특정 phase 비용을 고립 측정.

## CLI

\`\`\`
zts input.ts --stop-after=parse
zts input.ts --stop-after=parse --profile=parse    # 격리 측정
zts input.ts --stop-after=transform --profile=transform
\`\`\`

phase: \`scan | parse | semantic | transform | codegen\`

## NAPI (CLI ↔ parity)

\`\`\`typescript
transpile(source, {
  filename: "input.ts",
  stopAfter: "parse",
});
\`\`\`

## 실측

\`\`\`
$ zts input.ts --stop-after=parse --profile=parse --profile-format=json
{
  "profile_version": 1,
  "total_ms": 0.351,
  "level": "summary",
  "phases": {
    "parse": { "total_ms": 0.351, "count": 1, "pct": 100.00 }
  }
}
$ cat out.js  # empty
\`\`\`

## 테스트 — 12/12 pass

- 각 phase 성공 + 빈 output
- \`stop-after=codegen\` 은 full 파이프라인
- 잘못된 값 → exit 1
- phase 격리 (parse 만 기록, transform/codegen 미기록)
- NAPI transpile({ stopAfter }) 검증

## Test plan

- [x] \`zig build\` 그린
- [x] \`zig build test\` 그린
- [x] stop-after integration 12/12 pass
- [x] 실측 output 검증
- [ ] CI 통과

## Related

- Design: #1702
- Prev: #1704, #1706
- Epic: #1672 D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)