### PR TITLE
feat(profile): zts bench 서브커맨드 + NAPI benchmark() API (#1672 D2 PR 5)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -56,6 +56,21 @@ interface NativeModule {
   buildSync(options: Record<string, unknown>): NativeBuildResult;
   build(options: Record<string, unknown>): Promise<NativeBuildResult>;
   watch(options: Record<string, unknown>): NativeWatchHandle;
+  benchmark(options: Record<string, unknown>): {
+    phases: Record<
+      string,
+      {
+        samples: number;
+        mean_ms: number;
+        median_ms: number;
+        p95_ms: number;
+        p99_ms: number;
+        min_ms: number;
+        max_ms: number;
+        stddev_ms: number;
+      }
+    >;
+  };
 }
 
 let native: NativeModule | null = null;
@@ -756,6 +771,87 @@ export function buildSync(options: BuildOptions): BuildResult {
  */
 export function close(): void {
   native = null;
+}
+
+// ─── Benchmark API (CLI `zts bench` 의 NAPI 대응) ───
+
+/**
+ * 벤치마크 옵션. `source` 또는 `file` 중 하나는 반드시 지정.
+ */
+export interface BenchmarkOptions {
+  /** Source 코드 문자열 (file 과 둘 중 하나) */
+  source?: string;
+  /** 파일 경로 (source 와 둘 중 하나) */
+  file?: string;
+  /** filename (source 와 함께 사용, 확장자 감지) */
+  filename?: string;
+  /**
+   * 측정할 profile category 목록 (required, non-empty).
+   * 예: `["parse"]`, `["scan", "parse", "transform"]`, `["transform.jsx"]`.
+   * `all` / `none` 은 허용되지 않음 — 구체적 phase 이름만.
+   */
+  phases: string[];
+  /** 반복 횟수 (default 100) */
+  iterations?: number;
+  /** Warmup 반복 (default 10) */
+  warmup?: number;
+}
+
+/**
+ * Phase 하나의 통계 (모든 값 ms 단위).
+ */
+export interface BenchmarkPhaseStats {
+  samples: number;
+  mean_ms: number;
+  median_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  min_ms: number;
+  max_ms: number;
+  stddev_ms: number;
+}
+
+/**
+ * 벤치마크 결과 — `phases` 옵션에 지정된 각 category 별 통계.
+ */
+export interface BenchmarkResult {
+  phases: Record<string, BenchmarkPhaseStats>;
+}
+
+/**
+ * 특정 phase 를 N 회 반복 실행하고 통계 (mean/median/p95/p99/stddev/min/max) 를 반환한다.
+ *
+ * CLI `zts bench --phase=...` 의 NAPI 대응 — 같은 engine 사용.
+ *
+ * @example
+ * ```ts
+ * import { init, benchmark } from "@zts/core";
+ * init();
+ *
+ * const result = benchmark({
+ *   file: "./src/App.tsx",
+ *   phases: ["parse"],
+ *   iterations: 100,
+ * });
+ * console.log(result.phases.parse.mean_ms);  // 42.3
+ * ```
+ */
+export function benchmark(options: BenchmarkOptions): BenchmarkResult {
+  if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
+  if (!options.source && !options.file) {
+    throw new Error("@zts/core.benchmark: 'source' or 'file' is required");
+  }
+  if (!Array.isArray(options.phases) || options.phases.length === 0) {
+    throw new Error("@zts/core.benchmark: 'phases' must be a non-empty string array");
+  }
+  return native.benchmark({
+    source: options.source,
+    file: options.file,
+    filename: options.filename ?? "input.ts",
+    phases: options.phases,
+    iterations: options.iterations ?? 100,
+    warmup: options.warmup ?? 10,
+  });
 }
 
 // ─── Vite/Rollup 플러그인 어댑터 ───

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2561,5 +2561,125 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     _ = c.napi_create_function(env, "watch", "watch".len, napiWatch, null, &watch_fn);
     _ = c.napi_set_named_property(env, exports, "watch", watch_fn);
 
+    var bench_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "benchmark", "benchmark".len, napiBenchmark, null, &bench_fn);
+    _ = c.napi_set_named_property(env, exports, "benchmark", bench_fn);
+
     return exports;
+}
+
+// ─── benchmark 함수 (CLI `zts bench` 의 NAPI 대응) ───
+
+/// benchmark(optionsObj) → { phases: { <name>: { mean_ms, median_ms, p95_ms, p99_ms, min_ms, max_ms, stddev_ms, samples } } }
+///
+/// optionsObj:
+/// - source: string (source code, 또는)
+/// - file: string (파일 경로)
+/// - filename: string (source 와 함께, 확장자 감지용)
+/// - phases: string[] (측정할 category 목록, required)
+/// - iterations: number (default 100)
+/// - warmup: number (default 10)
+fn napiBenchmark(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "failed to get arguments");
+    }
+    if (argc < 1) return throwError(env, "benchmark requires an options object");
+
+    const opts_obj = argv[0];
+
+    // source or file
+    var arena = std.heap.ArenaAllocator.init(native_alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const filename = getObjectString(env, opts_obj, "filename", arena_alloc) orelse
+        arena_alloc.dupe(u8, "input.ts") catch return throwError(env, "OutOfMemory");
+
+    const source_owned: []const u8 = blk: {
+        if (getObjectString(env, opts_obj, "source", arena_alloc)) |s| break :blk s;
+        if (getObjectString(env, opts_obj, "file", arena_alloc)) |path| {
+            const loaded = std.fs.cwd().readFileAlloc(arena_alloc, path, 100 * 1024 * 1024) catch {
+                return throwError(env, "benchmark: cannot read file");
+            };
+            break :blk loaded;
+        }
+        return throwError(env, "benchmark requires 'source' or 'file' option");
+    };
+
+    // phases
+    const phase_names = getObjectStringArray(env, opts_obj, "phases", arena_alloc) orelse
+        return throwError(env, "benchmark requires 'phases' (string array)");
+    if (phase_names.len == 0) return throwError(env, "benchmark: 'phases' must be non-empty");
+
+    const Profile = @import("zts_lib").profile;
+    var phase_cats: std.ArrayList(Profile.Category) = .empty;
+    defer phase_cats.deinit(arena_alloc);
+    for (phase_names) |name| {
+        const cat = Profile.Category.fromString(name) orelse {
+            return throwError(env, "benchmark: unknown phase name");
+        };
+        phase_cats.append(arena_alloc, cat) catch return throwError(env, "OutOfMemory");
+    }
+
+    const iterations = getObjectUint32(env, opts_obj, "iterations", 100);
+    const warmup = getObjectUint32(env, opts_obj, "warmup", 10);
+    if (iterations == 0) return throwError(env, "benchmark: 'iterations' must be >= 1");
+
+    // Benchmark 실행
+    const Bench = @import("zts_lib").bench;
+    const Ctx = struct {
+        source: []const u8,
+        filename: []const u8,
+        fn run(a: std.mem.Allocator, raw_ctx: ?*anyopaque) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(raw_ctx.?));
+            var r = @import("zts_lib").transpile.transpileWithCallback(a, self.source, self.filename, .{}, null) catch return;
+            r.deinit(a);
+        }
+    };
+    var ctx: Ctx = .{ .source = source_owned, .filename = filename };
+    var samples = Bench.runBenchmark(arena_alloc, phase_cats.items, iterations, warmup, Ctx.run, &ctx) catch {
+        return throwError(env, "benchmark: runner failed");
+    };
+    defer samples.deinit(arena_alloc);
+
+    // 결과 객체 구성: { phases: { <name>: PhaseStats-flat } }
+    var js_result: c.napi_value = undefined;
+    if (c.napi_create_object(env, &js_result) != c.napi_ok) return throwError(env, "failed to create result");
+
+    var js_phases: c.napi_value = undefined;
+    _ = c.napi_create_object(env, &js_phases);
+    _ = c.napi_set_named_property(env, js_result, "phases", js_phases);
+
+    for (phase_names, 0..) |name, i| {
+        const stats = Bench.PhaseStats.fromSamples(samples.per_phase[i].items);
+        var js_stats: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_stats);
+        setDoubleProp(env, js_stats, "mean_ms", stats.meanMs());
+        setDoubleProp(env, js_stats, "median_ms", stats.medianMs());
+        setDoubleProp(env, js_stats, "p95_ms", stats.p95Ms());
+        setDoubleProp(env, js_stats, "p99_ms", stats.p99Ms());
+        setDoubleProp(env, js_stats, "min_ms", stats.minMs());
+        setDoubleProp(env, js_stats, "max_ms", stats.maxMs());
+        setDoubleProp(env, js_stats, "stddev_ms", stats.stddevMs());
+
+        var js_samples: c.napi_value = undefined;
+        _ = c.napi_create_uint32(env, @intCast(stats.samples), &js_samples);
+        _ = c.napi_set_named_property(env, js_stats, "samples", js_samples);
+
+        var key_buf: [128]u8 = undefined;
+        if (name.len >= key_buf.len) continue;
+        @memcpy(key_buf[0..name.len], name);
+        key_buf[name.len] = 0;
+        _ = c.napi_set_named_property(env, js_phases, @ptrCast(&key_buf), js_stats);
+    }
+
+    return js_result;
+}
+
+fn setDoubleProp(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, value: f64) void {
+    var v: c.napi_value = undefined;
+    _ = c.napi_create_double(env, value, &v);
+    _ = c.napi_set_named_property(env, obj, key, v);
 }

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -1,0 +1,452 @@
+//! ZTS 벤치마크 인프라.
+//!
+//! 특정 phase 를 N 회 반복 실행하며 `profile` 모듈이 수집한 수치로부터 통계
+//! (mean / median / p95 / p99 / stddev / min / max) 를 계산한다. baseline
+//! save/compare 로 최적화 전후 비교 가능.
+//!
+//! 사용자 진입점:
+//! - CLI: `zts bench --phase=parse ./App.tsx` (PR 5 / main.zig)
+//! - NAPI: `benchmark({ phases: ["parse"], iterations: 100, ... })` (PR 5 / napi_entry.zig)
+//!
+//! ### Flow
+//! ```zig
+//! const bench = @import("bench.zig");
+//! const stats = bench.PhaseStats.fromSamples(allocator, samples_ns);
+//! try bench.writeBaseline(writer, &.{ .{ "parse", stats } });
+//! const baseline = try bench.readBaseline(allocator, json_text);
+//! const cmp = bench.compare(baseline, stats);
+//! ```
+
+const std = @import("std");
+const profile = @import("profile.zig");
+
+/// Phase 하나의 통계. 모든 값은 나노초(ns) 단위 원본 + ms 변환 게터.
+pub const PhaseStats = struct {
+    samples: usize,
+    mean_ns: f64,
+    median_ns: u64,
+    p95_ns: u64,
+    p99_ns: u64,
+    min_ns: u64,
+    max_ns: u64,
+    stddev_ns: f64,
+
+    pub fn meanMs(self: PhaseStats) f64 {
+        return self.mean_ns / 1_000_000.0;
+    }
+    pub fn medianMs(self: PhaseStats) f64 {
+        return @as(f64, @floatFromInt(self.median_ns)) / 1_000_000.0;
+    }
+    pub fn p95Ms(self: PhaseStats) f64 {
+        return @as(f64, @floatFromInt(self.p95_ns)) / 1_000_000.0;
+    }
+    pub fn p99Ms(self: PhaseStats) f64 {
+        return @as(f64, @floatFromInt(self.p99_ns)) / 1_000_000.0;
+    }
+    pub fn minMs(self: PhaseStats) f64 {
+        return @as(f64, @floatFromInt(self.min_ns)) / 1_000_000.0;
+    }
+    pub fn maxMs(self: PhaseStats) f64 {
+        return @as(f64, @floatFromInt(self.max_ns)) / 1_000_000.0;
+    }
+    pub fn stddevMs(self: PhaseStats) f64 {
+        return self.stddev_ns / 1_000_000.0;
+    }
+
+    /// 샘플 배열로부터 통계 계산. `samples` 는 정렬된다 (caller 가 허용).
+    pub fn fromSamples(samples: []u64) PhaseStats {
+        std.debug.assert(samples.len > 0);
+        std.mem.sort(u64, samples, {}, std.sort.asc(u64));
+
+        var sum: u128 = 0;
+        for (samples) |s| sum += s;
+        const mean: f64 = @as(f64, @floatFromInt(sum)) / @as(f64, @floatFromInt(samples.len));
+
+        var sq: f64 = 0.0;
+        for (samples) |s| {
+            const d = @as(f64, @floatFromInt(s)) - mean;
+            sq += d * d;
+        }
+        const stddev: f64 = if (samples.len > 1)
+            @sqrt(sq / @as(f64, @floatFromInt(samples.len - 1)))
+        else
+            0.0;
+
+        return .{
+            .samples = samples.len,
+            .mean_ns = mean,
+            .median_ns = percentile(samples, 50),
+            .p95_ns = percentile(samples, 95),
+            .p99_ns = percentile(samples, 99),
+            .min_ns = samples[0],
+            .max_ns = samples[samples.len - 1],
+            .stddev_ns = stddev,
+        };
+    }
+};
+
+/// p 번째 백분위수 (정렬된 배열 기준). p ∈ [0, 100]. 선형 보간 X — nearest rank.
+fn percentile(sorted: []const u64, p: u32) u64 {
+    std.debug.assert(p <= 100);
+    if (sorted.len == 0) return 0;
+    if (sorted.len == 1) return sorted[0];
+    // Nearest-rank: idx = ceil(p/100 * N) - 1, clamped.
+    const scaled = @as(u64, @intCast(p)) * @as(u64, @intCast(sorted.len));
+    var idx: usize = @intCast((scaled + 99) / 100);
+    if (idx == 0) idx = 1;
+    if (idx > sorted.len) idx = sorted.len;
+    return sorted[idx - 1];
+}
+
+/// Baseline 파일 포맷 — `--save` 가 출력, `--compare` 가 입력.
+pub const Baseline = struct {
+    bench_version: u32 = 1,
+    source_hint: []const u8 = "",
+    iterations: u32 = 0,
+    warmup: u32 = 0,
+    /// phase name → PhaseStats. Allocator 소유.
+    phases: std.StringHashMap(PhaseStats),
+
+    pub fn init(allocator: std.mem.Allocator) Baseline {
+        return .{
+            .phases = std.StringHashMap(PhaseStats).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *Baseline, allocator: std.mem.Allocator) void {
+        var it = self.phases.keyIterator();
+        while (it.next()) |k| allocator.free(k.*);
+        self.phases.deinit();
+    }
+};
+
+/// Baseline 을 JSON 으로 직렬화.
+pub fn writeBaselineJson(writer: anytype, baseline: *const Baseline) !void {
+    try writer.writeAll("{\n");
+    try writer.print("  \"bench_version\": {d},\n", .{baseline.bench_version});
+    try writer.print("  \"source_hint\": \"{s}\",\n", .{baseline.source_hint});
+    try writer.print("  \"iterations\": {d},\n", .{baseline.iterations});
+    try writer.print("  \"warmup\": {d},\n", .{baseline.warmup});
+    try writer.writeAll("  \"phases\": {\n");
+
+    var it = baseline.phases.iterator();
+    var first = true;
+    while (it.next()) |entry| {
+        if (!first) try writer.writeAll(",\n");
+        first = false;
+        const s = entry.value_ptr.*;
+        try writer.print(
+            "    \"{s}\": {{ \"samples\": {d}, \"mean_ms\": {d:.4}, \"median_ms\": {d:.4}, \"p95_ms\": {d:.4}, \"p99_ms\": {d:.4}, \"min_ms\": {d:.4}, \"max_ms\": {d:.4}, \"stddev_ms\": {d:.4} }}",
+            .{
+                entry.key_ptr.*,
+                s.samples,
+                s.meanMs(),
+                s.medianMs(),
+                s.p95Ms(),
+                s.p99Ms(),
+                s.minMs(),
+                s.maxMs(),
+                s.stddevMs(),
+            },
+        );
+    }
+    try writer.writeAll("\n  }\n}\n");
+}
+
+/// Baseline JSON 파일로부터 읽기. ms → ns 역변환.
+pub fn readBaselineJson(allocator: std.mem.Allocator, json_text: []const u8) !Baseline {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_text, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+
+    var bl = Baseline.init(allocator);
+    errdefer bl.deinit(allocator);
+
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return error.InvalidBaselineFormat,
+    };
+
+    if (obj.get("iterations")) |v| switch (v) {
+        .integer => |i| bl.iterations = @intCast(i),
+        else => {},
+    };
+    if (obj.get("warmup")) |v| switch (v) {
+        .integer => |i| bl.warmup = @intCast(i),
+        else => {},
+    };
+
+    if (obj.get("phases")) |phases_val| {
+        const phases = switch (phases_val) {
+            .object => |o| o,
+            else => return error.InvalidBaselineFormat,
+        };
+        var it = phases.iterator();
+        while (it.next()) |entry| {
+            const name = try allocator.dupe(u8, entry.key_ptr.*);
+            errdefer allocator.free(name);
+            const stats_obj = switch (entry.value_ptr.*) {
+                .object => |o| o,
+                else => continue,
+            };
+            const mean_ms = jsonNumber(stats_obj.get("mean_ms")) orelse 0.0;
+            const median_ms = jsonNumber(stats_obj.get("median_ms")) orelse 0.0;
+            const p95_ms = jsonNumber(stats_obj.get("p95_ms")) orelse 0.0;
+            const p99_ms = jsonNumber(stats_obj.get("p99_ms")) orelse 0.0;
+            const min_ms = jsonNumber(stats_obj.get("min_ms")) orelse 0.0;
+            const max_ms = jsonNumber(stats_obj.get("max_ms")) orelse 0.0;
+            const stddev_ms = jsonNumber(stats_obj.get("stddev_ms")) orelse 0.0;
+            const samples = if (stats_obj.get("samples")) |v| switch (v) {
+                .integer => |i| @as(usize, @intCast(i)),
+                else => 0,
+            } else 0;
+            try bl.phases.put(name, .{
+                .samples = samples,
+                .mean_ns = mean_ms * 1_000_000.0,
+                .median_ns = @intFromFloat(median_ms * 1_000_000.0),
+                .p95_ns = @intFromFloat(p95_ms * 1_000_000.0),
+                .p99_ns = @intFromFloat(p99_ms * 1_000_000.0),
+                .min_ns = @intFromFloat(min_ms * 1_000_000.0),
+                .max_ns = @intFromFloat(max_ms * 1_000_000.0),
+                .stddev_ns = stddev_ms * 1_000_000.0,
+            });
+        }
+    }
+
+    return bl;
+}
+
+fn jsonNumber(v: ?std.json.Value) ?f64 {
+    if (v == null) return null;
+    return switch (v.?) {
+        .integer => |i| @floatFromInt(i),
+        .float => |f| f,
+        else => null,
+    };
+}
+
+/// Baseline 비교 결과.
+pub const Comparison = struct {
+    before_mean_ms: f64,
+    after_mean_ms: f64,
+    delta_ms: f64,
+    pct: f64,
+    verdict: Verdict,
+
+    pub const Verdict = enum { improved, regressed, unchanged };
+};
+
+/// 단일 phase 의 before/after 비교. 5% 이내 변화는 unchanged.
+pub fn comparePhase(before: PhaseStats, after: PhaseStats) Comparison {
+    const before_ms = before.meanMs();
+    const after_ms = after.meanMs();
+    const delta = after_ms - before_ms;
+    const pct = if (before_ms == 0) 0.0 else (delta / before_ms) * 100.0;
+    const verdict: Comparison.Verdict = if (@abs(pct) < 5.0)
+        .unchanged
+    else if (delta < 0)
+        .improved
+    else
+        .regressed;
+    return .{
+        .before_mean_ms = before_ms,
+        .after_mean_ms = after_ms,
+        .delta_ms = delta,
+        .pct = pct,
+        .verdict = verdict,
+    };
+}
+
+// ============================================================================
+// Benchmark runner (CLI/NAPI 공용)
+// ============================================================================
+
+/// Iteration 하나를 실행하는 콜백. caller 가 transpile/bundle 등을 호출.
+/// profile 모듈 상태는 bench runner 가 매 iteration 마다 reset + activate.
+pub const RunOnceFn = *const fn (allocator: std.mem.Allocator, ctx: ?*anyopaque) anyerror!void;
+
+/// Phase 별 ns 샘플 배열.
+pub const Samples = struct {
+    /// `phase_cats[i]` 에 대응하는 샘플 목록. Allocator 소유.
+    per_phase: []std.ArrayListUnmanaged(u64),
+
+    pub fn deinit(self: *Samples, allocator: std.mem.Allocator) void {
+        for (self.per_phase) |*arr| arr.deinit(allocator);
+        allocator.free(self.per_phase);
+    }
+};
+
+/// 통합 benchmark 실행 — profile 모듈을 활용해 phase 별 ns 를 수집.
+///
+/// `run_one` 은 실제 작업 (transpile / bundle / 기타) 을 수행하는 콜백.
+/// 에러는 iteration skip 으로 처리 (warmup/측정 모두 continue).
+pub fn runBenchmark(
+    allocator: std.mem.Allocator,
+    phase_cats: []const profile.Category,
+    iterations: u32,
+    warmup: u32,
+    run_one: RunOnceFn,
+    ctx: ?*anyopaque,
+) !Samples {
+    std.debug.assert(iterations > 0);
+
+    // 샘플 버퍼 초기화 (phase 별).
+    const per_phase = try allocator.alloc(std.ArrayListUnmanaged(u64), phase_cats.len);
+    errdefer {
+        for (per_phase) |*arr| arr.deinit(allocator);
+        allocator.free(per_phase);
+    }
+    for (per_phase) |*arr| arr.* = .empty;
+
+    // warmup — 샘플 수집 없이 JIT/cache 워밍.
+    {
+        var w: u32 = 0;
+        while (w < warmup) : (w += 1) {
+            resetAndActivate(phase_cats);
+            run_one(allocator, ctx) catch continue;
+        }
+    }
+
+    // iterations — phase 별 ns 수집.
+    {
+        var i: u32 = 0;
+        while (i < iterations) : (i += 1) {
+            resetAndActivate(phase_cats);
+            run_one(allocator, ctx) catch continue;
+
+            for (phase_cats, 0..) |cat, idx| {
+                const ns = profile.totalNs(cat);
+                try per_phase[idx].append(allocator, ns);
+            }
+        }
+    }
+
+    return .{ .per_phase = per_phase };
+}
+
+fn resetAndActivate(phase_cats: []const profile.Category) void {
+    profile.resetForTest();
+    for (phase_cats) |cat| {
+        const name_slice: [1][]const u8 = .{@tagName(cat)};
+        profile.addCategories(&name_slice);
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+const testing = std.testing;
+
+test "percentile nearest-rank" {
+    var data = [_]u64{ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 };
+    try testing.expectEqual(@as(u64, 50), percentile(&data, 50));
+    try testing.expectEqual(@as(u64, 100), percentile(&data, 100));
+    try testing.expectEqual(@as(u64, 10), percentile(&data, 10));
+    try testing.expectEqual(@as(u64, 100), percentile(&data, 99));
+    try testing.expectEqual(@as(u64, 100), percentile(&data, 95));
+}
+
+test "PhaseStats.fromSamples 단일 샘플" {
+    var data = [_]u64{100};
+    const s = PhaseStats.fromSamples(&data);
+    try testing.expectEqual(@as(u64, 100), s.median_ns);
+    try testing.expectEqual(@as(u64, 100), s.p95_ns);
+    try testing.expectEqual(@as(u64, 100), s.min_ns);
+    try testing.expectEqual(@as(u64, 100), s.max_ns);
+    try testing.expectEqual(@as(f64, 100.0), s.mean_ns);
+    try testing.expectEqual(@as(f64, 0.0), s.stddev_ns);
+}
+
+test "PhaseStats.fromSamples 통계 정확성" {
+    // 샘플: 10, 20, 30, 40, 50 — mean 30, median 30, stddev 이론값 √250
+    var data = [_]u64{ 10, 20, 30, 40, 50 };
+    const s = PhaseStats.fromSamples(&data);
+    try testing.expectApproxEqAbs(@as(f64, 30.0), s.mean_ns, 0.001);
+    try testing.expectEqual(@as(u64, 30), s.median_ns);
+    try testing.expectEqual(@as(u64, 10), s.min_ns);
+    try testing.expectEqual(@as(u64, 50), s.max_ns);
+    try testing.expectApproxEqAbs(@as(f64, @sqrt(250.0)), s.stddev_ns, 0.001);
+}
+
+test "PhaseStats.fromSamples 정렬 독립" {
+    var data = [_]u64{ 50, 10, 40, 20, 30 };
+    const s = PhaseStats.fromSamples(&data);
+    try testing.expectEqual(@as(u64, 10), s.min_ns);
+    try testing.expectEqual(@as(u64, 50), s.max_ns);
+    try testing.expectEqual(@as(u64, 30), s.median_ns);
+}
+
+test "ms 변환 게터" {
+    const s: PhaseStats = .{
+        .samples = 1,
+        .mean_ns = 1_000_000.0,
+        .median_ns = 2_000_000,
+        .p95_ns = 3_000_000,
+        .p99_ns = 3_500_000,
+        .min_ns = 500_000,
+        .max_ns = 5_000_000,
+        .stddev_ns = 100_000.0,
+    };
+    try testing.expectApproxEqAbs(@as(f64, 1.0), s.meanMs(), 0.001);
+    try testing.expectApproxEqAbs(@as(f64, 2.0), s.medianMs(), 0.001);
+    try testing.expectApproxEqAbs(@as(f64, 3.0), s.p95Ms(), 0.001);
+    try testing.expectApproxEqAbs(@as(f64, 0.1), s.stddevMs(), 0.001);
+}
+
+test "Baseline JSON round-trip" {
+    const allocator = testing.allocator;
+    var bl = Baseline.init(allocator);
+    defer bl.deinit(allocator);
+    bl.iterations = 100;
+    bl.warmup = 10;
+    try bl.phases.put(try allocator.dupe(u8, "parse"), .{
+        .samples = 100,
+        .mean_ns = 42_300_000.0,
+        .median_ns = 41_800_000,
+        .p95_ns = 48_200_000,
+        .p99_ns = 52_100_000,
+        .min_ns = 40_100_000,
+        .max_ns = 55_300_000,
+        .stddev_ns = 2_100_000.0,
+    });
+
+    var buf: [2048]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try writeBaselineJson(fbs.writer(), &bl);
+    const json = fbs.getWritten();
+
+    var roundtrip = try readBaselineJson(allocator, json);
+    defer roundtrip.deinit(allocator);
+    try testing.expectEqual(@as(u32, 100), roundtrip.iterations);
+    try testing.expectEqual(@as(u32, 10), roundtrip.warmup);
+    const parse_stats = roundtrip.phases.get("parse") orelse return error.MissingPhase;
+    try testing.expectApproxEqAbs(@as(f64, 42.3), parse_stats.meanMs(), 0.01);
+    try testing.expectApproxEqAbs(@as(f64, 2.1), parse_stats.stddevMs(), 0.01);
+}
+
+test "comparePhase improved / regressed / unchanged verdict" {
+    const before: PhaseStats = .{ .samples = 100, .mean_ns = 42_300_000.0, .median_ns = 0, .p95_ns = 0, .p99_ns = 0, .min_ns = 0, .max_ns = 0, .stddev_ns = 0 };
+
+    // improved: 25% 감소
+    {
+        const after: PhaseStats = .{ .samples = 100, .mean_ns = 31_800_000.0, .median_ns = 0, .p95_ns = 0, .p99_ns = 0, .min_ns = 0, .max_ns = 0, .stddev_ns = 0 };
+        const cmp = comparePhase(before, after);
+        try testing.expect(cmp.verdict == .improved);
+        try testing.expect(cmp.delta_ms < 0);
+        try testing.expect(cmp.pct < -20);
+    }
+    // regressed: 10% 증가
+    {
+        const after: PhaseStats = .{ .samples = 100, .mean_ns = 46_500_000.0, .median_ns = 0, .p95_ns = 0, .p99_ns = 0, .min_ns = 0, .max_ns = 0, .stddev_ns = 0 };
+        const cmp = comparePhase(before, after);
+        try testing.expect(cmp.verdict == .regressed);
+        try testing.expect(cmp.delta_ms > 0);
+        try testing.expect(cmp.pct > 5);
+    }
+    // unchanged: 2% 변화
+    {
+        const after: PhaseStats = .{ .samples = 100, .mean_ns = 43_100_000.0, .median_ns = 0, .p95_ns = 0, .p99_ns = 0, .min_ns = 0, .max_ns = 0, .stddev_ns = 0 };
+        const cmp = comparePhase(before, after);
+        try testing.expect(cmp.verdict == .unchanged);
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1059,6 +1059,266 @@ fn walkAndTranspile(
     if (had_errors) return error.WalkFailed;
 }
 
+/// `zts bench --phase=<CATS> [options] <FILE>` 서브커맨드.
+///
+/// 지정한 phase 를 N 회 반복 실행하며 `profile` 모듈의 수치로부터
+/// 통계 (mean/median/p95/p99/stddev/min/max) 를 출력한다. baseline save/compare
+/// 로 최적화 전후 비교 가능.
+///
+/// CLI spec: docs/design/profile-infrastructure.md § zts bench.
+const BenchArgs = struct {
+    phases_csv: ?[]const u8 = null,
+    iterations: u32 = 100,
+    warmup: u32 = 10,
+    save_path: ?[]const u8 = null,
+    compare_path: ?[]const u8 = null,
+    format: lib.profile.Format = .table,
+    profile_level: lib.profile.Level = .summary,
+    input_file: ?[]const u8 = null,
+};
+
+fn parseBenchArgs(args: []const []const u8) !BenchArgs {
+    var result: BenchArgs = .{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const a = args[i];
+        if (std.mem.startsWith(u8, a, "--phase=")) {
+            result.phases_csv = a["--phase=".len..];
+        } else if (std.mem.startsWith(u8, a, "--iterations=")) {
+            result.iterations = try std.fmt.parseInt(u32, a["--iterations=".len..], 10);
+        } else if (std.mem.startsWith(u8, a, "--warmup=")) {
+            result.warmup = try std.fmt.parseInt(u32, a["--warmup=".len..], 10);
+        } else if (std.mem.startsWith(u8, a, "--save=")) {
+            result.save_path = a["--save=".len..];
+        } else if (std.mem.startsWith(u8, a, "--compare=")) {
+            result.compare_path = a["--compare=".len..];
+        } else if (std.mem.startsWith(u8, a, "--format=")) {
+            const s = a["--format=".len..];
+            result.format = lib.profile.Format.fromString(s) orelse return error.InvalidFormat;
+        } else if (std.mem.startsWith(u8, a, "--profile-level=")) {
+            const s = a["--profile-level=".len..];
+            result.profile_level = lib.profile.Level.fromString(s) orelse return error.InvalidLevel;
+        } else if (std.mem.startsWith(u8, a, "-")) {
+            return error.UnknownFlag;
+        } else if (result.input_file == null) {
+            result.input_file = a;
+        } else {
+            return error.MultipleInputFiles;
+        }
+    }
+    return result;
+}
+
+fn runBench(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    const stderr = std.fs.File.stderr().deprecatedWriter();
+
+    const opts = parseBenchArgs(args) catch |err| {
+        try stderr.print("zts bench: argument error ({s}). See `zts bench --help`.\n", .{@errorName(err)});
+        std.process.exit(1);
+    };
+    const phases_csv = opts.phases_csv orelse {
+        try stderr.writeAll("zts bench: --phase=<CATS> is required (e.g. --phase=parse)\n");
+        std.process.exit(1);
+    };
+    const input_file = opts.input_file orelse {
+        try stderr.writeAll("zts bench: missing input file\n");
+        std.process.exit(1);
+    };
+    if (opts.iterations == 0) {
+        try stderr.writeAll("zts bench: --iterations must be >= 1\n");
+        std.process.exit(1);
+    }
+
+    // Phase 목록 파싱 (profile Category 로 변환 + owned slice 로 보관).
+    var phase_names: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer phase_names.deinit(allocator);
+    var phase_cats: std.ArrayListUnmanaged(lib.profile.Category) = .empty;
+    defer phase_cats.deinit(allocator);
+    {
+        var it = std.mem.splitScalar(u8, phases_csv, ',');
+        while (it.next()) |raw| {
+            const name = std.mem.trim(u8, raw, " \t");
+            if (name.len == 0) continue;
+            if (std.ascii.eqlIgnoreCase(name, "all") or std.ascii.eqlIgnoreCase(name, "none")) {
+                try stderr.print("zts bench: --phase={s} not allowed (must be specific phase names)\n", .{name});
+                std.process.exit(1);
+            }
+            const cat = lib.profile.Category.fromString(name) orelse {
+                try stderr.print("zts bench: unknown phase '{s}'\n", .{name});
+                std.process.exit(1);
+            };
+            try phase_names.append(allocator, name);
+            try phase_cats.append(allocator, cat);
+        }
+    }
+
+    // 소스 읽기 (한 번, iteration 간 동일한 입력 사용).
+    const source = std.fs.cwd().readFileAlloc(allocator, input_file, 100 * 1024 * 1024) catch |err| {
+        try stderr.print("zts bench: cannot read '{s}': {}\n", .{ input_file, err });
+        std.process.exit(1);
+    };
+    defer allocator.free(source);
+
+    // Benchmark 실행 — bench.zig 의 공용 runner (NAPI 와 공유).
+    const Ctx = struct {
+        source: []const u8,
+        filename: []const u8,
+        fn run(a: std.mem.Allocator, raw_ctx: ?*anyopaque) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(raw_ctx.?));
+            var result = lib.transpile.transpileWithCallback(a, self.source, self.filename, .{}, null) catch return;
+            result.deinit(a);
+        }
+    };
+    var ctx: Ctx = .{ .source = source, .filename = input_file };
+    var samples = try lib.bench.runBenchmark(
+        allocator,
+        phase_cats.items,
+        opts.iterations,
+        opts.warmup,
+        Ctx.run,
+        &ctx,
+    );
+    defer samples.deinit(allocator);
+
+    // 통계 계산.
+    var phase_stats: std.ArrayListUnmanaged(lib.bench.PhaseStats) = .empty;
+    defer phase_stats.deinit(allocator);
+    for (samples.per_phase) |*arr| {
+        try phase_stats.append(allocator, lib.bench.PhaseStats.fromSamples(arr.items));
+    }
+
+    // compare — 먼저 비교 출력, save 는 그 다음.
+    if (opts.compare_path) |cmp_path| {
+        const cmp_json = std.fs.cwd().readFileAlloc(allocator, cmp_path, 10 * 1024 * 1024) catch |err| {
+            try stderr.print("zts bench: cannot read baseline '{s}': {}\n", .{ cmp_path, err });
+            std.process.exit(1);
+        };
+        defer allocator.free(cmp_json);
+        var baseline = lib.bench.readBaselineJson(allocator, cmp_json) catch |err| {
+            try stderr.print("zts bench: invalid baseline format: {}\n", .{err});
+            std.process.exit(1);
+        };
+        defer baseline.deinit(allocator);
+        try printBenchCompare(stdout, phase_names.items, phase_stats.items, &baseline);
+    } else {
+        try printBenchSummary(stdout, phase_names.items, phase_stats.items, opts.iterations, opts.warmup, opts.format);
+    }
+
+    // save — 현재 결과를 baseline 으로 저장.
+    if (opts.save_path) |save_path| {
+        var bl = lib.bench.Baseline.init(allocator);
+        defer bl.deinit(allocator);
+        bl.iterations = opts.iterations;
+        bl.warmup = opts.warmup;
+        bl.source_hint = std.fs.path.basename(input_file);
+        for (phase_names.items, phase_stats.items) |name, stats| {
+            const name_dup = try allocator.dupe(u8, name);
+            try bl.phases.put(name_dup, stats);
+        }
+        const file = std.fs.cwd().createFile(save_path, .{}) catch |err| {
+            try stderr.print("zts bench: cannot create '{s}': {}\n", .{ save_path, err });
+            std.process.exit(1);
+        };
+        defer file.close();
+        try lib.bench.writeBaselineJson(file.deprecatedWriter(), &bl);
+        try stderr.print("baseline saved: {s}\n", .{save_path});
+    }
+}
+
+fn printBenchSummary(
+    writer: anytype,
+    phase_names: []const []const u8,
+    stats: []const lib.bench.PhaseStats,
+    iterations: u32,
+    warmup: u32,
+    format: lib.profile.Format,
+) !void {
+    switch (format) {
+        .json => try printBenchJson(writer, phase_names, stats, iterations, warmup),
+        .csv => try printBenchCsv(writer, phase_names, stats),
+        else => try printBenchTable(writer, phase_names, stats, iterations, warmup),
+    }
+}
+
+fn printBenchTable(
+    writer: anytype,
+    phase_names: []const []const u8,
+    stats: []const lib.bench.PhaseStats,
+    iterations: u32,
+    warmup: u32,
+) !void {
+    try writer.writeAll("=== ZTS Benchmark ===\n");
+    try writer.print("iterations: {d} (warmup: {d})\n\n", .{ iterations, warmup });
+    try writer.writeAll("Phase       mean       median     p95        p99        stddev     min        max\n");
+    try writer.writeAll("----------|----------|----------|----------|----------|----------|----------|----------\n");
+    for (phase_names, stats) |name, s| {
+        try writer.print("{s: <10} {d: >6.2}ms  {d: >6.2}ms  {d: >6.2}ms  {d: >6.2}ms  {d: >6.2}ms  {d: >6.2}ms  {d: >6.2}ms\n", .{
+            name, s.meanMs(), s.medianMs(), s.p95Ms(), s.p99Ms(), s.stddevMs(), s.minMs(), s.maxMs(),
+        });
+    }
+}
+
+fn printBenchJson(
+    writer: anytype,
+    phase_names: []const []const u8,
+    stats: []const lib.bench.PhaseStats,
+    iterations: u32,
+    warmup: u32,
+) !void {
+    try writer.writeAll("{\n");
+    try writer.print("  \"bench_version\": 1,\n", .{});
+    try writer.print("  \"iterations\": {d},\n", .{iterations});
+    try writer.print("  \"warmup\": {d},\n", .{warmup});
+    try writer.writeAll("  \"phases\": {\n");
+    for (phase_names, stats, 0..) |name, s, i| {
+        if (i > 0) try writer.writeAll(",\n");
+        try writer.print(
+            "    \"{s}\": {{ \"samples\": {d}, \"mean_ms\": {d:.4}, \"median_ms\": {d:.4}, \"p95_ms\": {d:.4}, \"p99_ms\": {d:.4}, \"min_ms\": {d:.4}, \"max_ms\": {d:.4}, \"stddev_ms\": {d:.4} }}",
+            .{ name, s.samples, s.meanMs(), s.medianMs(), s.p95Ms(), s.p99Ms(), s.minMs(), s.maxMs(), s.stddevMs() },
+        );
+    }
+    try writer.writeAll("\n  }\n}\n");
+}
+
+fn printBenchCsv(
+    writer: anytype,
+    phase_names: []const []const u8,
+    stats: []const lib.bench.PhaseStats,
+) !void {
+    try writer.writeAll("phase,samples,mean_ms,median_ms,p95_ms,p99_ms,min_ms,max_ms,stddev_ms\n");
+    for (phase_names, stats) |name, s| {
+        try writer.print("{s},{d},{d:.4},{d:.4},{d:.4},{d:.4},{d:.4},{d:.4},{d:.4}\n", .{
+            name, s.samples, s.meanMs(), s.medianMs(), s.p95Ms(), s.p99Ms(), s.minMs(), s.maxMs(), s.stddevMs(),
+        });
+    }
+}
+
+fn printBenchCompare(
+    writer: anytype,
+    phase_names: []const []const u8,
+    stats: []const lib.bench.PhaseStats,
+    baseline: *const lib.bench.Baseline,
+) !void {
+    try writer.writeAll("=== ZTS Benchmark (vs baseline) ===\n\n");
+    try writer.writeAll("Phase       before     after      delta     %         verdict\n");
+    try writer.writeAll("----------|----------|----------|---------|---------|----------\n");
+    for (phase_names, stats) |name, after| {
+        const before = baseline.phases.get(name) orelse continue;
+        const cmp = lib.bench.comparePhase(before, after);
+        const verdict_str: []const u8 = switch (cmp.verdict) {
+            .improved => "+ improved",
+            .regressed => "- regressed",
+            .unchanged => "= unchanged",
+        };
+        const sign_delta: []const u8 = if (cmp.delta_ms >= 0) "+" else "";
+        const sign_pct: []const u8 = if (cmp.pct >= 0) "+" else "";
+        try writer.print("{s: <10} {d: >6.2}ms  {d: >6.2}ms  {s}{d: >6.2}ms {s}{d: >6.1}%  {s}\n", .{
+            name, cmp.before_mean_ms, cmp.after_mean_ms, sign_delta, cmp.delta_ms, sign_pct, cmp.pct, verdict_str,
+        });
+    }
+}
+
 pub fn main() !void {
     const stdout = std.fs.File.stdout().deprecatedWriter();
     const stderr = std.fs.File.stderr().deprecatedWriter();
@@ -1078,6 +1338,11 @@ pub fn main() !void {
     // CLI 인자 파싱
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
+
+    // Subcommand dispatch — `zts bench ...` 는 별도 경로.
+    if (args.len >= 2 and std.mem.eql(u8, args[1], "bench")) {
+        return runBench(allocator, args[2..]);
+    }
 
     var opts = try parseCliArguments(args, allocator) orelse return;
     defer opts.deinit(allocator);
@@ -2260,6 +2525,7 @@ fn printUsage(writer: anytype) !void {
         \\  zts --bundle <entry.ts> -o out   Bundle to file
         \\  zts --bundle <entry.ts> --splitting --outdir dist  Code splitting
         \\  zts - < input.ts                 Read from stdin
+        \\  zts bench --phase=<CATS> <file>  Benchmark a specific phase (see below)
         \\
         \\Options:
         \\  -o, --out-file <path>            Output file path
@@ -2334,6 +2600,29 @@ fn printUsage(writer: anytype) !void {
         \\    ZTS_PROFILE_LEVEL=<L>           Same as --profile-level
         \\
         \\  See `docs/design/profile-infrastructure.md` for full reference.
+        \\
+        \\Benchmark subcommand (`zts bench`):
+        \\  Run a specific phase N times and emit statistics (mean/median/p95/p99/stddev).
+        \\  Useful for optimization work: measure before, change, measure after.
+        \\
+        \\  Options:
+        \\    --phase=<CATS>                  Phase categories (comma-separated; required).
+        \\                                      e.g. --phase=parse
+        \\                                           --phase=scan,parse,transform
+        \\                                      `all` / `none` are NOT allowed here (must be specific).
+        \\    --iterations=<N>                Iterations after warmup (default: 100).
+        \\    --warmup=<N>                    Warmup iterations discarded (default: 10).
+        \\    --profile-level=<L>             summary | detailed (default: summary).
+        \\    --format=<F>                    table | json | csv (default: table).
+        \\    --save=<PATH>                   Save result as baseline for future --compare.
+        \\    --compare=<PATH>                Compare against a saved baseline.
+        \\
+        \\  Examples:
+        \\    zts bench --phase=parse ./src/App.tsx
+        \\    zts bench --phase=parse ./src/App.tsx --iterations=50
+        \\    zts bench --phase=parse,transform --format=json ./src/App.tsx
+        \\    zts bench --phase=parse ./src/App.tsx --save=./perf/baseline.json
+        \\    zts bench --phase=parse ./src/App.tsx --compare=./perf/baseline.json
         \\
     , .{});
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,6 +27,7 @@ pub const util = @import("util/mod.zig");
 pub const crash_handler = @import("crash_handler.zig");
 pub const debug_log = @import("debug_log.zig");
 pub const profile = @import("profile.zig");
+pub const bench = @import("bench.zig");
 
 test {
     _ = lexer;

--- a/tests/integration/tests/bench.test.ts
+++ b/tests/integration/tests/bench.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect, afterEach, beforeAll, afterAll } from "bun:test";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createFixture, runZts } from "./helpers";
+import { init, close, benchmark } from "../../../packages/core/index";
+
+// PR 5: zts bench 서브커맨드 + NAPI benchmark() API.
+//
+// CLI 와 NAPI 동일 기능:
+//   - 특정 phase 를 N 회 반복 실행
+//   - mean/median/p95/p99/stddev/min/max 통계
+//   - save/compare (CLI 만, NAPI 는 결과 객체 직접 조작 가능)
+
+describe("zts bench subcommand (CLI)", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  const smallSource = `
+    export const x: number = 1;
+    export function foo(a: string, b: number) { return a + b.toString(); }
+    export class K { constructor(public name: string) {} }
+  `;
+
+  test("--phase=parse 로 bench 실행 + 테이블 출력", async () => {
+    const fixture = await createFixture({ "input.ts": smallSource });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      "bench",
+      "--phase=parse",
+      "--iterations=10",
+      "--warmup=2",
+      join(fixture.dir, "input.ts"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("=== ZTS Benchmark ===");
+    expect(result.stdout).toContain("parse");
+    expect(result.stdout).toContain("ms");
+  });
+
+  test("--format=json 은 유효한 JSON 출력", async () => {
+    const fixture = await createFixture({ "input.ts": smallSource });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      "bench",
+      "--phase=parse",
+      "--iterations=10",
+      "--warmup=2",
+      "--format=json",
+      join(fixture.dir, "input.ts"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.bench_version).toBe(1);
+    expect(json.iterations).toBe(10);
+    expect(json.warmup).toBe(2);
+    expect(json.phases.parse).toBeDefined();
+    expect(json.phases.parse.samples).toBe(10);
+    expect(typeof json.phases.parse.mean_ms).toBe("number");
+    expect(typeof json.phases.parse.median_ms).toBe("number");
+    expect(typeof json.phases.parse.p95_ms).toBe("number");
+    expect(typeof json.phases.parse.p99_ms).toBe("number");
+    expect(typeof json.phases.parse.stddev_ms).toBe("number");
+  });
+
+  test("--format=csv 는 헤더 + 데이터 행", async () => {
+    const fixture = await createFixture({ "input.ts": smallSource });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      "bench",
+      "--phase=parse",
+      "--iterations=5",
+      "--warmup=1",
+      "--format=csv",
+      join(fixture.dir, "input.ts"),
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(
+      "phase,samples,mean_ms,median_ms,p95_ms,p99_ms,min_ms,max_ms,stddev_ms",
+    );
+    expect(result.stdout).toContain("parse,");
+  });
+
+  test("--save --compare 워크플로우", async () => {
+    const fixture = await createFixture({ "input.ts": smallSource });
+    cleanup = fixture.cleanup;
+    const baselinePath = join(tmpdir(), `zts-bench-${Date.now()}.json`);
+
+    // 1. 저장
+    const save = await runZts([
+      "bench",
+      "--phase=parse",
+      "--iterations=5",
+      "--warmup=1",
+      "--save=" + baselinePath,
+      join(fixture.dir, "input.ts"),
+    ]);
+    expect(save.exitCode).toBe(0);
+    expect(existsSync(baselinePath)).toBe(true);
+    const baseline = JSON.parse(readFileSync(baselinePath, "utf-8"));
+    expect(baseline.bench_version).toBe(1);
+    expect(baseline.phases.parse).toBeDefined();
+
+    // 2. 비교
+    const cmp = await runZts([
+      "bench",
+      "--phase=parse",
+      "--iterations=5",
+      "--warmup=1",
+      "--compare=" + baselinePath,
+      join(fixture.dir, "input.ts"),
+    ]);
+    expect(cmp.exitCode).toBe(0);
+    expect(cmp.stdout).toContain("vs baseline");
+    expect(cmp.stdout).toMatch(/improved|regressed|unchanged/);
+
+    unlinkSync(baselinePath);
+  });
+
+  test("여러 phase CSV 입력", async () => {
+    const fixture = await createFixture({ "input.ts": smallSource });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts([
+      "bench",
+      "--phase=parse,transform",
+      "--iterations=5",
+      "--warmup=1",
+      "--format=json",
+      join(fixture.dir, "input.ts"),
+    ]);
+
+    // transform timer 는 PR 7 에서 삽입되므로 수치는 0. 구조 검증만.
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.phases.parse).toBeDefined();
+    expect(json.phases.transform).toBeDefined();
+  });
+
+  test("phase 없으면 exit 1", async () => {
+    const fixture = await createFixture({ "input.ts": smallSource });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts(["bench", join(fixture.dir, "input.ts")]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("--phase=");
+  });
+
+  test("input file 없으면 exit 1", async () => {
+    const result = await runZts(["bench", "--phase=parse"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("missing input file");
+  });
+
+  test("알 수 없는 phase 이름은 exit 1", async () => {
+    const fixture = await createFixture({ "input.ts": smallSource });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts(["bench", "--phase=bogus_phase", join(fixture.dir, "input.ts")]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("unknown phase");
+  });
+
+  test("--phase=all 은 거부 (구체적 phase 이름 필요)", async () => {
+    const fixture = await createFixture({ "input.ts": smallSource });
+    cleanup = fixture.cleanup;
+
+    const result = await runZts(["bench", "--phase=all", join(fixture.dir, "input.ts")]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("not allowed");
+  });
+
+  test("--help 에 zts bench 섹션 포함", async () => {
+    const result = await runZts(["--help"]);
+    expect(result.stdout).toContain("zts bench");
+    expect(result.stdout).toContain("--phase=");
+    expect(result.stdout).toContain("--iterations=");
+    expect(result.stdout).toContain("--save=");
+    expect(result.stdout).toContain("--compare=");
+  });
+});
+
+describe("benchmark() NAPI API", () => {
+  beforeAll(() => init());
+  afterAll(() => close());
+
+  const smallSource = `
+    export const x: number = 1;
+    export function foo(a: string) { return a; }
+  `;
+
+  test("source + phases 로 benchmark 호출", () => {
+    const result = benchmark({
+      source: smallSource,
+      filename: "input.ts",
+      phases: ["parse"],
+      iterations: 10,
+      warmup: 2,
+    });
+    expect(result.phases.parse).toBeDefined();
+    expect(result.phases.parse.samples).toBe(10);
+    expect(typeof result.phases.parse.mean_ms).toBe("number");
+    expect(typeof result.phases.parse.median_ms).toBe("number");
+    expect(typeof result.phases.parse.p95_ms).toBe("number");
+    expect(typeof result.phases.parse.stddev_ms).toBe("number");
+  });
+
+  test("여러 phase 동시 측정", () => {
+    const result = benchmark({
+      source: smallSource,
+      filename: "input.ts",
+      phases: ["parse", "transform"],
+      iterations: 5,
+      warmup: 1,
+    });
+    expect(result.phases.parse).toBeDefined();
+    expect(result.phases.transform).toBeDefined();
+  });
+
+  test("default iterations=100, warmup=10", () => {
+    const result = benchmark({
+      source: smallSource,
+      filename: "input.ts",
+      phases: ["parse"],
+    });
+    expect(result.phases.parse.samples).toBe(100);
+  });
+
+  test("phases 비어있으면 throw", () => {
+    expect(() =>
+      benchmark({
+        source: smallSource,
+        phases: [],
+      }),
+    ).toThrow(/non-empty/);
+  });
+
+  test("source/file 둘 다 없으면 throw", () => {
+    expect(() =>
+      benchmark({
+        phases: ["parse"],
+      } as any),
+    ).toThrow(/source.*file/);
+  });
+
+  test("CLI json 출력 ↔ NAPI result parity", () => {
+    const napi = benchmark({
+      source: smallSource,
+      filename: "input.ts",
+      phases: ["parse"],
+      iterations: 5,
+      warmup: 1,
+    });
+    // NAPI 결과가 CLI JSON 과 동일한 키셋
+    const stats = napi.phases.parse;
+    expect(stats).toHaveProperty("samples");
+    expect(stats).toHaveProperty("mean_ms");
+    expect(stats).toHaveProperty("median_ms");
+    expect(stats).toHaveProperty("p95_ms");
+    expect(stats).toHaveProperty("p99_ms");
+    expect(stats).toHaveProperty("min_ms");
+    expect(stats).toHaveProperty("max_ms");
+    expect(stats).toHaveProperty("stddev_ms");
+  });
+});


### PR DESCRIPTION
## Summary

Profile infrastructure **PR 5** — 특정 phase 를 N 회 반복 실행하며 통계 (mean/median/p95/p99/stddev/min/max) 를 출력/반환. 최적화 전후 비교 (\`--save\` / \`--compare\`) 가능.

CLI ↔ NAPI feature parity — 같은 \`bench.runBenchmark\` engine 사용.

## CLI

\`\`\`
zts bench --phase=parse --iterations=100 ./App.tsx
zts bench --phase=parse,transform --format=json ./App.tsx
zts bench --phase=parse ./App.tsx --save=./baseline.json
zts bench --phase=parse ./App.tsx --compare=./baseline.json
\`\`\`

## NAPI

\`\`\`typescript
import { benchmark } from "@zts/core";

const result = benchmark({
  source: "...",           // 또는 file: "./App.tsx"
  filename: "input.ts",
  phases: ["parse"],
  iterations: 100,
  warmup: 10,
});

result.phases.parse.mean_ms;    // 42.3
result.phases.parse.p95_ms;     // 48.2
result.phases.parse.stddev_ms;  // 2.1
\`\`\`

## 구현

- \`src/bench.zig\`: PhaseStats (mean/median/p95/p99/stddev/min/max), Baseline I/O (JSON), comparePhase (±5% unchanged 기준), runBenchmark (공용 runner)
- \`src/main.zig\`: \`zts bench\` 서브커맨드 + runner + printers (table/json/csv/compare)
- \`packages/core/src/napi_entry.zig\`: napiBenchmark NAPI function
- \`packages/core/index.ts\`: \`benchmark()\` export + TS types

## 테스트 — 23 total pass

- \`src/bench.zig\` 유닛 7/7: percentile / PhaseStats / baseline round-trip / compare verdict
- CLI 통합 10/10: table/json/csv / save/compare / multi-phase / error cases / --help
- NAPI 6/6: source/file options / multi-phase / defaults / errors / CLI↔NAPI parity

## oxc/swc vs ZTS

oxc/swc 는 \`cargo bench\` (criterion.rs) 에만 있어 개발자 전용. ZTS 가 CLI ↔ NAPI 양쪽 노출 — 번들러 분야 **유일한 사용자 레벨 benchmark 도구**.

## Test plan

- [x] \`zig build\` / \`zig build test\` 그린
- [x] bench.zig 7 unit tests pass
- [x] bench CLI+NAPI integration 16 tests pass
- [x] 실측 save/compare 워크플로우 동작
- [ ] CI 통과

## Related

- Design: #1702 § zts bench
- Epic: #1672 D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)