### PR TITLE
feat(profile): Transformer/Codegen timer 삽입 (#1672 D2 PR 7)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -237,6 +237,9 @@ pub const Codegen = struct {
 
     /// AST를 JS 문자열로 출력한다.
     pub fn generate(self: *Codegen, root: NodeIndex) ![]const u8 {
+        var scope = @import("../profile.zig").begin(.codegen);
+        defer scope.end();
+
         // 출력 크기는 보통 소스 크기와 비슷 → 사전 할당
         try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len);
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -528,6 +528,9 @@ pub const Transformer = struct {
     /// 반환값: 새 AST에서의 루트 NodeIndex.
     /// 변환된 AST는 self.ast에 저장된다.
     pub fn transform(self: *Transformer) Error!NodeIndex {
+        var scope = @import("../profile.zig").begin(.transform);
+        defer scope.end();
+
         // D1 (RFC #1672): 재진입 가드 (D1b in-place 전환 시 shared module 이중 transform 을 조기 탐지).
         self.ast.assertInvariants();
         if (@import("builtin").mode == .Debug) {


### PR DESCRIPTION
## Summary

Profile infrastructure **PR 7** — \`transform\` / \`codegen\` category 실측.

## 추가

- \`src/transformer/transformer.zig\` \`transform()\` 에 \`.transform\` scope
- \`src/codegen/codegen.zig\` \`generate()\` 에 \`.codegen\` scope

## 실측

\`\`\`
$ zts input.ts --profile=all --profile-format=json
{
  "profile_version": 1,
  "total_ms": 1.196,
  "phases": {
    "parse":     { "total_ms": 0.767, "pct": 64.17 },
    "transform": { "total_ms": 0.339, "pct": 28.37 },
    "codegen":   { "total_ms": 0.089, "pct":  7.46 }
  }
}
\`\`\`

Sub-phase (transform.ts_strip/jsx/pass2, codegen.walk/sourcemap) 는 후속 PR 에서 pass 단위로 삽입.

## Test plan

- [x] \`zig build\` / \`zig build test\` 그린
- [x] 실측 output 검증
- [ ] CI 통과

## Related

- Design: #1702
- Prev: #1706, #1708, #1709
- Epic: #1672 D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)