### PR TITLE
feat(profile): Linker metadata timer 삽입 (#1672 D2 PR 8)

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -64,6 +64,9 @@ pub fn buildMetadataForAst(
     is_entry: bool,
     override_symbol_ids: ?[]const ?u32,
 ) !LinkingMetadata {
+    var scope = @import("../../profile.zig").begin(.metadata);
+    defer scope.end();
+
     if (module_index >= self.modules.len) {
         return .{
             .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, 0),


### PR DESCRIPTION
## Summary

Profile infrastructure **PR 8** — \`buildMetadataForAst\` 에 \`.metadata\` scope 추가.

Linker 와 TreeShaker 는 \`bundler.zig\` 의 \`.link\` / \`.shake\` scope 로 이미 상위 구간 측정됨 (#1709) — 중복 방지를 위해 PR 은 \`.metadata\` 만 추가.

## Test plan

- [x] \`zig build\` / \`zig build test\` 그린
- [x] \`--profile=metadata\` 수치 기록 확인
- [ ] CI 통과

## Related

- Design: #1702
- Prev: #1706, #1708, #1709, #1710
- Epic: #1672 D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)