### PR TITLE
fix(profile): workaround Zig 0.15.2 x86_64 @memset encoder bug

### DIFF
--- a/src/profile.zig
+++ b/src/profile.zig
@@ -271,15 +271,19 @@ pub fn initFromEnv(allocator: std.mem.Allocator) void {
 pub fn resetForTest() void {
     enabled_mask = 0;
     current_level = .summary;
-    @memset(&totals_ns, 0);
-    @memset(&counts, 0);
+    // Debug + x86_64 에서 `@memset` 이 mov m64 m64 로 encode 되어 Zig 0.15.2
+    // 컴파일러 버그(InvalidInstruction) 를 유발 — comptime array literal 대입으로 회피.
+    totals_ns = [_]u64{0} ** num_categories;
+    counts = [_]u32{0} ** num_categories;
 }
 
 /// counters 만 reset (mask 와 level 은 유지).
 /// HMR rebuild 시작 전에 호출 — 이전 rebuild 의 누적치가 이월되지 않도록.
 pub fn resetCounters() void {
-    @memset(&totals_ns, 0);
-    @memset(&counts, 0);
+    // Debug + x86_64 에서 `@memset` 이 mov m64 m64 로 encode 되어 Zig 0.15.2
+    // 컴파일러 버그(InvalidInstruction) 를 유발 — comptime array literal 대입으로 회피.
+    totals_ns = [_]u64{0} ** num_categories;
+    counts = [_]u32{0} ** num_categories;
 }
 
 /// 하나의 category 를 활성화하고, prefix 로 시작하는 child category 도 모두 활성화.


### PR DESCRIPTION
## 요약

- Linux x86_64 Debug 빌드에서 Zig 0.15.2 컴파일러가 `@memset(&totals_ns, 0)` 을 `mov m64 m64` 로 encode 시도하여 \`error: emit MIR failed: InvalidInstruction (Zig compiler bug)\` 발생
- \`resetForTest()\` / \`resetCounters()\` 의 \`@memset\` 을 comptime array literal 대입 (\`[_]u64{0} ** num_categories\`) 으로 교체하여 회피
- 의미 동등. macOS arm64 에는 원래 문제 없음

## 배경

최근 CI 실패 ([run 24754276086](https://github.com/ohah/zts/actions/runs/24754276086/job/72424031785)):

\`\`\`
src/profile.zig:271:5: error: emit MIR failed: InvalidInstruction (Zig compiler bug)
pub fn resetForTest() void {
error: error(x86_64_encoder): no encoding found for: none mov m64 m64 none none
\`\`\`

Zig 0.15.2 x86_64 backend 가 `mem-to-mem` 형태의 `@memset` 을 아직 처리 못 하는 컴파일러 버그. `resetForTest` 가 먼저 encode 되어 실패 표시되지만, 동일 패턴인 `resetCounters` 도 같은 버그 유발 가능하여 둘 다 수정.

## 변경 내용

\`\`\`diff
 pub fn resetForTest() void {
     enabled_mask = 0;
     current_level = .summary;
-    @memset(&totals_ns, 0);
-    @memset(&counts, 0);
+    // Debug + x86_64 에서 `@memset` 이 mov m64 m64 로 encode 되어 Zig 0.15.2
+    // 컴파일러 버그(InvalidInstruction) 를 유발 — comptime array literal 대입으로 회피.
+    totals_ns = [_]u64{0} ** num_categories;
+    counts = [_]u32{0} ** num_categories;
 }
\`\`\`

`resetCounters()` 도 동일 패턴 적용.

## 테스트 Plan

- [x] macOS arm64 로컬 \`zig build test\` 통과 확인
- [ ] GitHub Actions Test262 Runner Unit Tests 재통과
- [ ] 기존 \`profile.zig\` 유닛 테스트 (\`resetForTest 초기화\`, \`addFromCsv: none 키워드 초기화\`) 통과 유지

## 영향 범위

- Runtime semantics: 동일 (두 표현 모두 대상 배열 전체를 0 으로 초기화)
- 성능: comptime literal 대입이 최적화 빌드에서는 동일/더 나음 (컴파일러가 `@memset` 대신 직접 vector store 선택 가능)
- Debug 빌드: workaround 의 본래 목적 — `mov m64 m64` 경로 회피

🤖 Generated with [Claude Code](https://claude.com/claude-code)