### PR TITLE
feat(profile): Scanner `.scan` timer 삽입 (lex 시간 분리 측정)

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -15,6 +15,7 @@ const std = @import("std");
 const token = @import("token.zig");
 const unicode = @import("unicode.zig");
 const regexp_mod = @import("../regexp/mod.zig");
+const profile = @import("../profile.zig");
 
 const Token = token.Token;
 const Kind = token.Kind;
@@ -389,6 +390,9 @@ pub const Scanner = struct {
     /// 다음 토큰을 스캔한다.
     /// 파서가 이 함수를 반복 호출하여 토큰을 소비한다.
     pub fn next(self: *Scanner) !void {
+        var scope = profile.begin(.scan);
+        defer scope.end();
+
         self.token.has_newline_before = false;
         self.token.has_pure_comment_before = false;
         self.token.has_no_side_effects_comment = false;
@@ -615,6 +619,9 @@ pub const Scanner = struct {
     /// 속성 값 문자열은 이스케이프를 처리하지 않는다.
     /// 파서가 `<` 뒤에서 이 함수를 호출한다.
     pub fn nextInsideJSXElement(self: *Scanner) !void {
+        var scope = profile.begin(.scan);
+        defer scope.end();
+
         self.token.has_newline_before = false;
 
         // JSX element 내에서 주석 스킵 (// line comment, /* block comment */)
@@ -686,6 +693,9 @@ pub const Scanner = struct {
     /// JSX 자식 위치에서 다음 토큰을 스캔한다 (태그 사이의 텍스트).
     /// `<` 또는 `{`를 만날 때까지 텍스트를 소비한다.
     pub fn nextJSXChild(self: *Scanner) !void {
+        var scope = profile.begin(.scan);
+        defer scope.end();
+
         self.token.has_newline_before = false;
         self.start = self.current;
 

--- a/src/lexer/scanner_test.zig
+++ b/src/lexer/scanner_test.zig
@@ -3,6 +3,7 @@ const scanner_mod = @import("scanner.zig");
 const Scanner = scanner_mod.Scanner;
 const token_mod = @import("token.zig");
 const Kind = token_mod.Kind;
+const profile = @import("../profile.zig");
 
 test "Scanner: empty source" {
     var scanner = try Scanner.init(std.testing.allocator, "");
@@ -1416,4 +1417,40 @@ test "Scanner: <!-- comment is recorded in comments list" {
     try scanner.next(); // skips <!-- comment, returns x
     try std.testing.expectEqual(@as(usize, 1), scanner.comments.items.len);
     try std.testing.expect(!scanner.comments.items[0].is_multiline);
+}
+
+test "Scanner: profile .scan 활성 시 토큰당 누적" {
+    profile.resetForTest();
+    defer profile.resetForTest();
+    profile.addFromCsv("scan");
+
+    var scanner = try Scanner.init(std.testing.allocator, "const x = 42;");
+    defer scanner.deinit();
+
+    // `Scanner.init` 직후 token.kind 가 불확정 — next() 먼저 한 번 부르고 루프.
+    while (true) {
+        try scanner.next();
+        if (scanner.token.kind == .eof) break;
+    }
+
+    // 정확한 count 보단 "> 0" 만 검증 — 토큰 분리 로직 변화에 brittle 하지 않도록.
+    try std.testing.expect(profile.count(.scan) > 0);
+    try std.testing.expect(profile.totalNs(.scan) > 0);
+}
+
+test "Scanner: profile .scan 비활성 시 누적 없음 (zero-cost)" {
+    profile.resetForTest();
+    defer profile.resetForTest();
+    // addFromCsv 호출 안 함 → .scan 비활성 상태.
+
+    var scanner = try Scanner.init(std.testing.allocator, "a+b");
+    defer scanner.deinit();
+
+    while (true) {
+        try scanner.next();
+        if (scanner.token.kind == .eof) break;
+    }
+
+    try std.testing.expectEqual(@as(u32, 0), profile.count(.scan));
+    try std.testing.expectEqual(@as(u64, 0), profile.totalNs(.scan));
 }


### PR DESCRIPTION
## 요약

- `src/lexer/scanner.zig` 의 3개 진입점 (`next`, `nextInsideJSXElement`, `nextJSXChild`) 시작에 `profile.begin(.scan)` scope 삽입
- `scanner_test.zig` 에 활성/비활성 검증 2개 테스트 추가
- 이제 `zts bench --phase=scan,parse <file>` 또는 `ZTS_PROFILE=scan` 로 lex 와 parse 를 분리 측정 가능

## 배경

Profile 인프라 에픽 (#1672 D2) 에서 `Category.scan` enum 과 NAPI `phaseDurations.scan_ms` 필드는 정의됐지만 **실제 측정 코드는 삽입 안 된 상태** 였음. 2026-04-22 bungae HMR 실측 중 발견:

- `ZTS_PROFILE=all` 로 활성화해도 `scan_ms` 가 항상 0
- `zts bench --phase=scan` 도 0 누적 → 파서 최적화 방향 결정용 breakdown 불가능

## 실측 효과

```
$ zts bench --phase=scan,parse --iterations=300 \
    tests/integration/tests/tsc/expressions.test.ts

Phase    mean     median   p95      stddev
scan     4.49ms   4.53ms   4.57ms   0.15ms
parse    5.69ms   5.73ms   5.81ms   0.18ms
```

expressions.test.ts (20K줄, TSC 테스트 파일) 에서 **parse 5.73ms 중 scan 4.53ms (79%)**. template literal 지배 파일 특성 반영.

## 구현 방식 (A-1)

Scanner 3개 진입점에 동일 2줄 삽입:

```zig
var scope = profile.begin(.scan);
defer scope.end();
```

`parser.zig:1791`, `bundler.zig:647`, `transformer.zig:531` 등 기존 삽입 지점과 동일한 관용구. file-level import (`const profile = @import("../profile.zig");`) 는 3번 호출되므로 일관성 + 간결성 위해 채택.

## 트레이드오프

**활성 측정 시 `std.time.Timer.start()` + `read()` 가 토큰당 ~50-80 ns overhead** — scan 측정값이 대략 **15-25% 과대평가** (Timer 호출이 scan scope 안에 포함). 방향 설정용 breakdown 에는 충분.

**비활성 시 zero-cost**: `profile.begin()` 의 `if (!enabled(cat)) return .{};` 분기 + `defer scope.end()` 의 `if (timer) |*t|` 분기 = 토큰당 2 branch 추가. 정상 실행에선 branch predictor 에 의해 사실상 무비용.

더 정확한 측정이 필요하면 후속 PR 에서 (1) 토큰당 → 함수당 scope 승격 또는 (2) 샘플링 기반 측정 검토.

## 변경 내용

| 파일 | 변경 |
|------|------|
| `src/lexer/scanner.zig` | `+const profile` import + 3곳 scope 삽입 (각 2줄) |
| `src/lexer/scanner_test.zig` | profile import + 유닛 테스트 2개 (활성 누적, 비활성 zero) |

총 `2 files changed, 47 insertions(+)`.

## 테스트 Plan

- [x] 로컬 `zig build test` 통과 (macOS arm64)
- [x] `zts bench --phase=scan,parse` 로 scan 누적 확인 (expressions.test.ts: scan 4.53ms)
- [ ] GitHub Actions 전 단계 통과 (아래 의존성 참고)
- [ ] 기존 Scanner 테스트 회귀 없음 확인

## 의존성

**이 PR 단독으로는 main CI 가 여전히 Zig 0.15.2 `@memset` 버그로 실패** (이 PR 와 무관한 `src/profile.zig` 버그). workaround PR 이 먼저 머지돼야 CI 녹색:

- #1715 — `fix(profile): workaround Zig 0.15.2 x86_64 @memset encoder bug`

#1715 머지 후 이 PR 도 자동으로 rebase 되어 CI 통과 예상.

## 다음 작업 (별개 PR)

- `.resolve` 측정점 삽입 (bundler resolver 단계) — graph_ns 60ms 내부 breakdown 에 필요
- `phaseDurations` 의 레거시 이름 정리 (`parse_ms` = 사실은 `graph_ns`, NAPI 소비자 혼란 원인) — breaking change, deprecation cycle 필요
- 토큰 드레인 루프 헬퍼 추출 (`scanAllToEof`, scanner_test.zig 내 6곳 동일 패턴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)