### PR TITLE
fix(wasm): add `clock_time_get` WASI stub (LinkError 해소)

### DIFF
--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -76,6 +76,17 @@ function createWasiImports(memory: () => WebAssembly.Memory) {
         }
         return 0;
       },
+      // clock_id: 0=realtime, 1=monotonic, 2/3=cputime. precision 인자는 무시.
+      // 결과는 u64 ns 로 timestamp_ptr 에 little-endian 기록.
+      clock_time_get(clock_id: number, _precision: bigint, ts_ptr: number): number {
+        const mem = new DataView(memory().buffer);
+        const ns =
+          clock_id === 0
+            ? BigInt(Date.now()) * 1_000_000n
+            : BigInt(Math.floor(performance.now() * 1_000_000));
+        mem.setBigUint64(ts_ptr, ns, true);
+        return 0;
+      },
     },
   };
 }


### PR DESCRIPTION
## 요약

- `packages/wasm/index.ts` 의 `createWasiImports` 에 **`clock_time_get` stub 추가**
- WASM 모듈이 import 하는 7개 WASI 함수 중 이 하나가 JS 래퍼에서 빠져 있어 `LinkError: import function wasi_snapshot_preview1:clock_time_get must be callable` 발생
- 결과: `packages/wasm` 테스트 `0 pass / 1 fail` → **`29 pass / 0 fail`**

## 배경

최근 Zig 표준 라이브러리가 `std.time.Timer` / `std.time.nanoTimestamp` 를 더 많은 모듈 (profile, bundler, dev_server 등)에서 쓰면서 WASM 빌드에 `clock_time_get` import 가 link 됨. `src/root.zig` 가 `server`/`bundler`/`profile` 을 re-export 하고 ReleaseSmall DCE 도 pub symbol 은 유지하기 때문.

브라우저/Bun 런타임이 자동으로 WASI import 를 제공하진 않으므로 JS 래퍼 쪽에서 shim 제공이 필요.

## 구현

```ts
// clock_id: 0=realtime, 1=monotonic, 2/3=cputime. precision 인자는 무시.
// 결과는 u64 ns 로 timestamp_ptr 에 little-endian 기록.
clock_time_get(clock_id: number, _precision: bigint, ts_ptr: number): number {
  const mem = new DataView(memory().buffer);
  const ns =
    clock_id === 0
      ? BigInt(Date.now()) * 1_000_000n
      : BigInt(Math.floor(performance.now() * 1_000_000));
  mem.setBigUint64(ts_ptr, ns, true);
  return 0;
}
```

- `realtime` (clock_id=0): `Date.now()` — Unix epoch ms → ns
- `monotonic` / `cputime` (clock_id=1,2,3): `performance.now()` — 프로세스 시작 기준 ms → ns

`precision` 인자는 WASI spec 상 hint 일뿐 무시 가능. `timestamp_ptr` 에 u64 little-endian 으로 기록.

## 대안 검토

1. **Zig 쪽에서 `Timer` 호출을 `comptime builtin.target.os.tag == .wasi` 가드로 감싸기** — 시도했으나 Timer 뿐 아니라 nanoTimestamp 등 여러 API 가 호출되어 각 지점에 가드 추가 필요. JS shim 한 줄이 훨씬 본질적 해결.
2. **`src/root.zig` 에서 WASM 타겟일 때 bundler/server re-export 제외** — 변경 범위 크고 라이브러리 API 영향. JS shim 이 간단.

## 테스트 Plan

- [x] 로컬 `zig build wasm && bun test` → 29 pass
- [ ] GitHub Actions `WASM Build & Test` 통과 확인

## 참조

- Import 전체 목록 (`WebAssembly.Module.imports(mod)`): `clock_time_get`, `random_get`, `fd_filestat_get`, `fd_seek`, `fd_write`, `fd_read`, `fd_pwrite` — 이 중 `clock_time_get` 만 stub 에 누락되어 있었음
- WASI spec: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-clock_time_get

🤖 Generated with [Claude Code](https://claude.com/claude-code)