### PR TITLE
feat(profile): ResolveCache `.resolve` timer 삽입

### DIFF
--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -19,6 +19,7 @@ const ResolveError = resolver_mod.ResolveError;
 const types = @import("types.zig");
 const ImportKind = types.ImportKind;
 const pkg_json = @import("package_json.zig");
+const profile = @import("../profile.zig");
 
 /// 타겟 플랫폼. codegen.Platform을 번들러 전체에서 공유.
 pub const Platform = @import("../codegen/codegen.zig").Platform;
@@ -285,6 +286,9 @@ pub const ResolveCache = struct {
         specifier: []const u8,
         kind: ImportKind,
     ) ResolveError!?ResolveResult {
+        var scope = profile.begin(.resolve);
+        defer scope.end();
+
         if (self.isExternal(specifier)) return null;
 
         // 스택 버퍼로 캐시 키 생성 (alloc/free 제거)

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -3,6 +3,7 @@ const resolve_cache = @import("resolve_cache.zig");
 const ResolveCache = resolve_cache.ResolveCache;
 const matchGlob = resolve_cache.matchGlob;
 const isNodeBuiltin = resolve_cache.isNodeBuiltin;
+const profile = @import("../profile.zig");
 
 // ============================================================
 // Tests
@@ -131,4 +132,32 @@ test "resolve: not found cached" {
     // 두 번째 호출도 ModuleNotFound (캐시에서)
     const r2 = cache.resolve(dir_path, "./nonexistent", .static_import);
     try std.testing.expectError(error.ModuleNotFound, r2);
+}
+
+test "resolve: profile .resolve 활성 시 누적" {
+    profile.resetForTest();
+    defer profile.resetForTest();
+    profile.addFromCsv("resolve");
+
+    var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
+    defer cache.deinit();
+
+    // external 경로로 호출 — filesystem 접근 없이 resolveInner 진입 확인.
+    _ = try cache.resolve("/some/dir", "react", .static_import);
+
+    try std.testing.expect(profile.count(.resolve) > 0);
+    try std.testing.expect(profile.totalNs(.resolve) > 0);
+}
+
+test "resolve: profile .resolve 비활성 시 누적 없음" {
+    profile.resetForTest();
+    defer profile.resetForTest();
+
+    var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
+    defer cache.deinit();
+
+    _ = try cache.resolve("/some/dir", "react", .static_import);
+
+    try std.testing.expectEqual(@as(u32, 0), profile.count(.resolve));
+    try std.testing.expectEqual(@as(u64, 0), profile.totalNs(.resolve));
 }


### PR DESCRIPTION
## 요약

- `src/bundler/resolve_cache.zig` 의 `resolveInner` 시작에 `profile.begin(.resolve)` 추가
- `resolve()` + `resolveThreadSafe()` 공통 경로라 모든 kind (static_import / dynamic_import / require / ...) 커버
- `resolve_cache_test.zig` 에 활성/비활성 검증 2개 테스트 추가

## 배경

HMR 실측에서 `phaseDurations.parse_ms` 가 실제론 `BundleTimings.graph_ns` (레거시 이름) 이고, 그 안에 **parse + resolve + semantic 이 섞여** 있음. breakdown 가 없으면 어디가 진짜 병목인지 특정 불가 — `.resolve` 를 분리해서 graph 재구성 중 경로 해석 비중을 측정 가능하게.

## 삽입 위치 선택

| 후보 | 선택 여부 | 이유 |
|------|:-:|------|
| `resolver.zig` 저수준 | ❌ | cache hit 시 해석 로직 안 탐 — 누락 |
| `resolve_cache.zig:resolveInner` | ✅ | public `resolve`/`resolveThreadSafe` 양쪽 공통 경로. cache hit 포함 전체 시간 |
| `graph.zig:1294` 호출 지점 | ❌ | plugin `resolveId` hook 커버 못 함 |

## 테스트

```zig
test "resolve: profile .resolve 활성 시 누적" {
    profile.resetForTest();
    defer profile.resetForTest();
    profile.addFromCsv("resolve");
    // ... resolve() 호출
    try std.testing.expect(profile.count(.resolve) > 0);
}
```

활성/비활성 대칭 2 테스트. external 패턴으로 호출해 filesystem 의존 없이 검증.

## 다음 활용

`ZTS_PROFILE=all` + bungae HMR profile 로 다음 분해 가능 (현재 sub-phase 전달 0 버그 수정 필요):
```
graph(60ms) = resolve(X ms) + parse(Y ms) + semantic(Z ms) + 나머지
```

## 테스트 Plan

- [x] 로컬 `zig build test` 통과 (29 파일 / 3441 tests)
- [ ] CI 전 단계 통과
- [x] 기존 resolve_cache 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)