### PR TITLE
refactor(profile)!: phaseDurations 레거시 이름 정리 (BREAKING)

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -315,19 +315,19 @@ result.phases.parse.stddev_ms;  // 2.1
 
 HMR rebuild 의 각 phase 는 `WatchRebuildEvent.phaseDurations` 에 노출.
 
-기본 phase (항상 측정):
-- `detect` / `parse` / `semantic` / `emit` / `delta` / `total`
-- 주의: `parse` 는 실제로 graph build 전체, `semantic` 은 link+shake 의미 (레거시 호환 이름).
+기본 phase (항상 측정, BundleTimings 기반):
+- `detect` / `graph` / `link` / `shake` / `emit` / `delta` / `total`
+- 필드 이름과 실제 값이 일치. 2026-04-22 이전의 `parse`/`semantic` 레거시 이름은 제거됨.
 
-Sub-phase (`ZTS_PROFILE=hmr` / `BUNGAE_HMR_PROFILE=1` 활성 시):
-- `scan` / `resolve` / `graph` / `link` / `shake` / `transform` / `codegen` / `metadata`
-- 비활성 상태에선 모두 0.
+Sub-phase (`ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` 활성 시):
+- `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
+- 비활성 상태에선 모두 0. `parse`/`semantic` 은 진짜 parser/analyzer 시간.
 
 ## 4.1 번개 (bungae) HMR 실측
 
 ```bash
 BUNGAE_HMR_PROFILE=1 bun run start:bungae
-# Rebuilt [ios] (1 files, 175ms) [detect=27 parse=65 sem=5 emit=67 delta=1]
+# Rebuilt [ios] (1 files, 175ms) [detect=27 graph=65 link=3 shake=2 emit=67 delta=1]
 ```
 
 번개는 `phaseDurations.*` 필드를 읽어 log formatting. ZTS 는 필드만 제공 — UI 는 번개 쪽 책임.
@@ -342,8 +342,8 @@ watch({
   profile: ["hmr"],  // sub-phase 수집 활성
   onRebuild: (event) => {
     const pd = event.phaseDurations!;
-    console.log("graph=%d link=%d shake=%d transform=%d codegen=%d",
-      pd.graph, pd.link, pd.shake, pd.transform, pd.codegen);
+    console.log("parse=%d semantic=%d transform=%d codegen=%d resolve=%d",
+      pd.parse, pd.semantic, pd.transform, pd.codegen, pd.resolve);
   },
 });
 ```

--- a/docs/HMR.md
+++ b/docs/HMR.md
@@ -97,10 +97,10 @@ HMR rebuild 의 각 phase 소요시간은 `WatchRebuildEvent.phaseDurations` 에
 자세한 내용: [`docs/DEBUG.md`](./DEBUG.md) § 4 HMR Profile.
 
 기본 측정 항목 (항상):
-- `detect` / `parse` / `semantic` / `emit` / `delta` / `total`
+- `detect` / `graph` / `link` / `shake` / `emit` / `delta` / `total`
 
 Sub-phase (profile 활성 시):
-- `scan` / `resolve` / `graph` / `link` / `shake` / `transform` / `codegen` / `metadata`
+- `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
 
 ```ts
 watch({

--- a/docs/design/profile-infrastructure.md
+++ b/docs/design/profile-infrastructure.md
@@ -15,12 +15,12 @@ ZTS 에는 여러 측정 도구가 독립적으로 존재한다:
 | `src/debug_log.zig` | 카테고리 토글 로그 (`compiled_cache`, `ast_mutation`) | 이벤트 로그 (타이밍 아님) |
 | `--timing` CLI | single-file transpile | `scan / parse / semantic / transform / codegen` 5단계 |
 | `BundleTimings` struct | bundle 모드 내부 | `graph_ns / link_ns / shake_ns / emit_ns` 4 field |
-| HMR `phaseDurations` | NAPI watch 이벤트 | `detect / parse / sem / emit / delta / total` |
+| HMR `phaseDurations` | NAPI watch 이벤트 | `detect / graph / link / shake / emit / delta / total` + sub |
 | `BUNGAE_HMR_PROFILE=1` | 번개 opt-in 로그 | phase breakdown 한 줄 |
 
-### 1.2 파편화의 문제
+### 1.2 파편화의 문제 (2026-04-22 이전, #1 는 해소)
 
-1. **의미 혼재**: `phaseDurations.parse` 가 실제로는 "graph build 전체" (resolve + parse + semantic + finalize). `phaseDurations.sem` 은 "link + shake". 이름이 실체와 다름.
+1. ~~**의미 혼재**: `phaseDurations.parse` 가 실제로는 "graph build 전체"~~ (resolve + parse + semantic + finalize). ~~`phaseDurations.sem` 은 "link + shake"~~. 이름이 실체와 다름. — **해소: 기본 phase 는 `graph/link/shake` 로 분리, sub-phase 의 `parse/semantic` 은 진짜 parser/analyzer 의미**.
 2. **CLI ↔ NAPI 불일치**: `--timing` 은 single-file 만. NAPI watch 는 HMR 전용 포맷. 공통 출력 형식/옵션 없음.
 3. **Sub-phase 없음**: `emit 67ms` 안의 transform / codegen / metadata 비중 모름.
 4. **벤치마크 부재**: 특정 phase 만 반복 측정하는 도구가 없음. 최적화 전후 비교 수동.

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -3853,8 +3853,9 @@ describe("Issue #1223 HMR perf 재현", () => {
 
     expect(event.phaseDurations).toBeDefined();
     expect(typeof event.phaseDurations.detect).toBe("number");
-    expect(typeof event.phaseDurations.parse).toBe("number");
-    expect(typeof event.phaseDurations.semantic).toBe("number");
+    expect(typeof event.phaseDurations.graph).toBe("number");
+    expect(typeof event.phaseDurations.link).toBe("number");
+    expect(typeof event.phaseDurations.shake).toBe("number");
     expect(typeof event.phaseDurations.emit).toBe("number");
     expect(typeof event.phaseDurations.delta).toBe("number");
     expect(typeof event.phaseDurations.total).toBe("number");

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -412,37 +412,41 @@ export interface WatchRebuildEvent {
    *
    * **기본 phase** (항상 측정):
    * - `detect` / `parse` / `semantic` / `emit` / `delta` / `total`
-   * - 주의: `parse` 는 실제로 graph build 전체 (resolve+parse+semantic+finalize) 이고,
-   *   `semantic` 은 link+shake 를 의미. 정확한 분해는 아래 sub-phase 참조.
+   * 필드 이름과 실제 값이 정확히 일치. 2026-04-22 이전의 `parse` / `semantic` 은
+   * 사실 각각 `graph` / `link+shake` 를 담았던 레거시 이름이었으며 제거됨.
    *
-   * **Sub-phase** (`ZTS_PROFILE=hmr` / `BUNGAE_HMR_PROFILE=1` / `profile: ["hmr"]` 활성 시):
-   * - `scan` / `resolve` / `graph` / `link` / `shake` / `transform` / `codegen` / `metadata`
-   * - 비활성 상태에선 모두 0.
+   * **Sub-phase** (`ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` / `profile: ["<cat>"]` 활성 시):
+   * - `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
+   * - 비활성 상태에선 모두 0. `parse` 는 이제 진짜 parser 시간, `semantic` 은 진짜 SemanticAnalyzer.
    */
   phaseDurations?: {
+    // 기본 phase (항상 측정)
+
     /** 변경 감지 (mtime 스캔) */
     detect: number;
-    /** 파싱 (레거시: graph build 전체) */
-    parse: number;
-    /** 의미 분석 (레거시: link + shake) */
-    semantic: number;
-    /** 코드 생성 (transform + codegen + metadata 상위) */
+    /** Module graph build — resolve + parse + semantic + finalize */
+    graph: number;
+    /** Scope hoisting + linker */
+    link: number;
+    /** Tree shaking */
+    shake: number;
+    /** 코드 생성 (transform + codegen + emit) */
     emit: number;
     /** HMR delta 추출 */
     delta: number;
     /** 총 리빌드 시간 (detect → delta 합산) */
     total: number;
 
-    /** Scanner tokenization (profile 활성 시에만) */
+    // Sub-phase (profile 활성 시에만)
+
+    /** Scanner tokenization */
     scan: number;
+    /** Parser (진짜 parser 시간, 레거시 `parse_ms`=graph 아님) */
+    parse: number;
     /** Dependency resolution */
     resolve: number;
-    /** Module graph build (resolve + parse + semantic) */
-    graph: number;
-    /** Scope hoisting + linker */
-    link: number;
-    /** Tree shaking */
-    shake: number;
+    /** Semantic analyzer (진짜 semantic, 레거시 `semantic_ms`=link+shake 아님) */
+    semantic: number;
     /** Transformer 전체 */
     transform: number;
     /** Codegen 전체 */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1219,26 +1219,32 @@ const WatchReadyEvent = struct {
 
 /// HMR rebuild phase 별 소요시간 (밀리초). Issue #1223 관측성.
 ///
-/// 기본 phase 들 (`detect_ms`/`parse_ms`/`semantic_ms`/`emit_ms`/`delta_ms`/`total_ms`) 은
-/// profile 비활성 상태에서도 항상 측정됨 (bundler `BundleTimings` 기반 — 가벼움).
+/// 기본 phase (`detect_ms`/`graph_ms`/`link_ms`/`shake_ms`/`emit_ms`/`delta_ms`/`total_ms`)
+/// 는 profile 비활성 상태에서도 항상 측정 (bundler `BundleTimings` 기반 — 가벼움).
 ///
-/// Sub-phase (`scan_ms`/`resolve_ms`/`graph_ms`/`link_ms`/`shake_ms`/`transform_ms`/
-/// `codegen_ms`/`metadata_ms`) 는 `ZTS_PROFILE=hmr` / `BUNGAE_HMR_PROFILE=1` /
-/// `BundleOptions.profile` 활성 상태에서만 의미있는 값. 비활성 시 모두 0.
+/// Sub-phase (`scan_ms`/`parse_ms`/`resolve_ms`/`semantic_ms`/`transform_ms`/`codegen_ms`/
+/// `metadata_ms`) 는 `ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` / `BundleOptions.profile`
+/// 활성 상태에서만 의미있는 값. 비활성 시 모두 0.
+///
+/// 이름 매핑 이력: 2026-04-22 이전의 `parse_ms` / `semantic_ms` 는 실제로는 `graph_ns` /
+/// `link+shake` 를 담았던 레거시 이름이었다. 이름=의미 일치를 위해 기본 phase 에서
+/// `parse_ms`/`semantic_ms` 를 제거하고 `graph_ms`/`link_ms`/`shake_ms` 로 분리.
+/// Sub-phase 의 `parse_ms`/`semantic_ms` 는 이제 진짜 parser/analyzer 시간을 의미.
 const PhaseDurations = struct {
+    // ── 기본 phase (항상 측정) ──
     detect_ms: f64 = 0,
-    parse_ms: f64 = 0,
-    semantic_ms: f64 = 0,
+    graph_ms: f64 = 0,
+    link_ms: f64 = 0,
+    shake_ms: f64 = 0,
     emit_ms: f64 = 0,
     delta_ms: f64 = 0,
     total_ms: f64 = 0,
 
-    // ── Sub-phase (ZTS_PROFILE=hmr 활성 시에만 값 기록) ──
+    // ── Sub-phase (ZTS_PROFILE=<cat> 활성 시에만 값 기록) ──
     scan_ms: f64 = 0,
+    parse_ms: f64 = 0,
     resolve_ms: f64 = 0,
-    graph_ms: f64 = 0,
-    link_ms: f64 = 0,
-    shake_ms: f64 = 0,
+    semantic_ms: f64 = 0,
     transform_ms: f64 = 0,
     codegen_ms: f64 = 0,
     metadata_ms: f64 = 0,
@@ -1385,18 +1391,19 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
             var js_pd: c.napi_value = undefined;
             _ = c.napi_create_object(env, &js_pd);
             const fields = [_]struct { name: [:0]const u8, value: f64 }{
+                // 기본 phase (항상 측정).
                 .{ .name = "detect", .value = pd.detect_ms },
-                .{ .name = "parse", .value = pd.parse_ms },
-                .{ .name = "semantic", .value = pd.semantic_ms },
-                .{ .name = "emit", .value = pd.emit_ms },
-                .{ .name = "delta", .value = pd.delta_ms },
-                .{ .name = "total", .value = pd.total_ms },
-                // Sub-phase (ZTS_PROFILE=hmr 활성 시 의미있는 값, 아니면 0).
-                .{ .name = "scan", .value = pd.scan_ms },
-                .{ .name = "resolve", .value = pd.resolve_ms },
                 .{ .name = "graph", .value = pd.graph_ms },
                 .{ .name = "link", .value = pd.link_ms },
                 .{ .name = "shake", .value = pd.shake_ms },
+                .{ .name = "emit", .value = pd.emit_ms },
+                .{ .name = "delta", .value = pd.delta_ms },
+                .{ .name = "total", .value = pd.total_ms },
+                // Sub-phase (ZTS_PROFILE=<cat> 활성 시 의미있는 값, 아니면 0).
+                .{ .name = "scan", .value = pd.scan_ms },
+                .{ .name = "parse", .value = pd.parse_ms },
+                .{ .name = "resolve", .value = pd.resolve_ms },
+                .{ .name = "semantic", .value = pd.semantic_ms },
                 .{ .name = "transform", .value = pd.transform_ms },
                 .{ .name = "codegen", .value = pd.codegen_ms },
                 .{ .name = "metadata", .value = pd.metadata_ms },
@@ -1851,22 +1858,21 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         const nsToMs = bundler_mod.BundleResult.nsToMs;
         event.phase_durations = .{
             // 기본 phase — BundleTimings 기반 (profile 비활성에서도 항상 측정).
-            // 주의: `parse_ms` / `semantic_ms` 는 레거시 이름 — 실제로는 각각
-            // graph build 전체 / link+shake 를 의미. 정확한 sub-phase 분해는
-            // ZTS_PROFILE=hmr 활성 시 sub 필드 참조.
+            // 필드 이름과 실제 값이 정확히 일치.
             .detect_ms = nsToMs(detect_ns),
-            .parse_ms = nsToMs(rebuild_result.timings.graph_ns),
-            .semantic_ms = nsToMs(rebuild_result.timings.link_ns + rebuild_result.timings.shake_ns),
+            .graph_ms = nsToMs(rebuild_result.timings.graph_ns),
+            .link_ms = nsToMs(rebuild_result.timings.link_ns),
+            .shake_ms = nsToMs(rebuild_result.timings.shake_ns),
             .emit_ms = nsToMs(rebuild_result.timings.emit_ns),
             .delta_ms = nsToMs(delta_ns),
             .total_ms = nsToMs(total_ns),
 
             // Sub-phase — profile 활성 시에만 의미있는 값. 비활성이면 0.
+            // graph/link/shake 는 기본 phase 와 동일 의미라 중복 노출 안 함.
             .scan_ms = nsToMs(profile_mod.totalNs(.scan)),
+            .parse_ms = nsToMs(profile_mod.totalNs(.parse)),
             .resolve_ms = nsToMs(profile_mod.totalNs(.resolve)),
-            .graph_ms = nsToMs(profile_mod.totalNs(.graph)),
-            .link_ms = nsToMs(profile_mod.totalNs(.link)),
-            .shake_ms = nsToMs(profile_mod.totalNs(.shake)),
+            .semantic_ms = nsToMs(profile_mod.totalNs(.semantic)),
             .transform_ms = nsToMs(profile_mod.totalNs(.transform)),
             .codegen_ms = nsToMs(profile_mod.totalNs(.codegen)),
             .metadata_ms = nsToMs(profile_mod.totalNs(.metadata)),


### PR DESCRIPTION
## 요약 (BREAKING)

`WatchRebuildEvent.phaseDurations` 의 필드 이름과 실제 값이 일치하도록 재정리. 출시 전이라 deprecation cycle 없이 바로 rename.

## 배경

이전 구조 (napi_entry.zig 주석 인용):

> 주의: \`parse_ms\` / \`semantic_ms\` 는 레거시 이름 — 실제로는 각각 graph build 전체 / link+shake 를 의미.

bungae HMR 실측 중 \`parse=60ms\` 를 파서 시간으로 오해해 Scanner 최적화 방향을 잡았다가 실은 \`graph_ns\` (resolve+parse+semantic 묶음) 임을 발견. 이름 매핑이 함정이었음.

## 변경

### 기본 phase (항상 측정, BundleTimings 기반)

| 이전 | 신규 | 의미 |
|------|------|------|
| `detect` | `detect` | 파일 워처 debounce |
| `parse` (사실 graph_ns) | **`graph`** | resolve + parse + semantic + finalize |
| `semantic` (사실 link+shake) | **`link` + `shake`** | linker / tree-shake 분리 |
| `emit` | `emit` | transform + codegen + emit |
| `delta` | `delta` | HMR payload |
| `total` | `total` | 합산 |

### Sub-phase (profile 활성 시)

| 이전 | 신규 |
|------|------|
| scan / resolve / graph / link / shake / transform / codegen / metadata | scan / **parse** / resolve / **semantic** / transform / codegen / metadata |

- `graph`/`link`/`shake` 는 기본 phase 와 중복이라 sub 에서 제거
- `parse`/`semantic` 은 이제 sub-phase 로 이동, **진짜** parser/SemanticAnalyzer 시간

### 변경 파일

- `packages/core/src/napi_entry.zig` — `PhaseDurations` struct + JS property 매핑 + 채우기 로직
- `packages/core/index.ts` — TS 타입 + jsdoc
- `packages/core/index.test.ts` — phase3 테스트 검증 필드 교체 (`parse`/`semantic` → `graph`/`link`/`shake`)
- `docs/HMR.md`, `docs/DEBUG.md`, `docs/design/profile-infrastructure.md` — 이름 갱신

## BREAKING

출시 전이라 사용자 승인으로 deprecation cycle 생략. 외부 소비자 (예: bungae `packages/bungae/src/bundler/zts-bundler/server/index.ts`) 는 **별도로** 업데이트 필요:

```ts
// bungae server/index.ts (별도 PR)
const breakdown = ` [detect=${pd.detect}ms graph=${pd.graph}ms link=${pd.link}ms shake=${pd.shake}ms emit=${pd.emit}ms delta=${pd.delta}ms]`;
```

## 테스트 Plan

- [x] 로컬 `zig build test` 통과
- [x] 로컬 `zig build napi` 통과
- [ ] `packages/core/index.test.ts` 전체 CI 통과

## 관련

- 이번 세션에서 발견 경위: `project_hmr_cache_strategy.md` / `project_profile_epic_complete.md` (memory)
- 선행 PR: #1716 (scan timer), #1717 (WASM fix), #1718 (resolve timer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)