### PR TITLE
docs(claude): bungae submodule sync 체크리스트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,16 @@ Zig 0.15.2 · C NAPI v8 (vendor/node-api-headers/) · Node.js 24+ / Bun 1.3+ · 
 5. `gh pr create` 시 `--label`, `--assignee` 항상 지정
 6. Zig 초보자에게 설명 포함
 
+## 외부 Consumer 동기화
+- **bungae monorepo** (`/Users/yoonhb/Documents/workspace/bungae/`) 가 ZTS 를 git submodule 로 참조. `.gitmodules` 에 branch 추적 없어서 ZTS 머지 후 수동 sync 필요:
+  ```bash
+  cd /Users/yoonhb/Documents/workspace/bungae && git submodule update --remote zts
+  cd zts && zig build napi && cp zig-out/lib/zts.node packages/core/zts.node
+  cd packages/core && bun build index.ts --outdir dist --format esm --target bun
+  ```
+- 번개에서 HMR 실측 전에는 반드시 submodule update 먼저 — drift 상태면 최신 profile 측정점/NAPI 변경이 반영 안 됨
+- 근본 해결(bungae 측): `.gitmodules` 에 `branch = main` + postinstall 에 `git submodule update --remote` 추가 (별도 bungae PR 필요)
+
 ## Memory ownership
 - **Arena 안 리소스는 개별 deinit 금지**. `arena_alloc`으로 만든 `DynamicBitSet`/`ArrayList` 등은 `arena.deinit()`이 일괄 해제. 개별 `defer X.deinit()`을 함께 걸면 `arena.deinit()` 이후에 실행되어 해제된 메모리 접근 → segfault (#1287).
 - 성공 경로에서 `arena.deinit()`을 명시 호출하지 말 것. `defer arena.deinit()` 하나로 충분.


### PR DESCRIPTION
## 요약

bungae monorepo 가 ZTS 를 git submodule 로 참조하는데 `.gitmodules` 에 branch 추적 설정이 없어서 ZTS 머지 후 수동 submodule update 가 필요. 이 세션에서 실측 중 drift 때문에 sub-phase 가 0 으로 나와 혼란이 생겼기에 CLAUDE.md 에 체크리스트로 박아둠.

## 배경

오늘 세션 실측 기록 (`memory/project_hmr_cache_strategy.md`) 에도 있음:

> `/Users/yoonhb/Documents/workspace/bungae/zts/` — **bungae monorepo 안의 별도 사본**. postinstall 이 여기서 빌드. 실측 중 drift 8시간 확인.

조사 결과 이 사본은 git submodule (`bungae/.git/modules/zts`) 이고 `.gitmodules` 는 다음 형태:

```
[submodule "zts"]
	path = zts
	url = https://github.com/ohah/zts.git
```

`branch` 키가 없어서 `git submodule update --remote` 로 업데이트하지 않으면 pin 된 commit 에 머묾.

## 추가 내용 (CLAUDE.md)

```md
## 외부 Consumer 동기화
- **bungae monorepo** (`/Users/yoonhb/Documents/workspace/bungae/`) 가 ZTS 를 git submodule 로 참조. `.gitmodules` 에 branch 추적 없어서 ZTS 머지 후 수동 sync 필요:
  ```bash
  cd .../bungae && git submodule update --remote zts
  cd zts && zig build napi && cp zig-out/lib/zts.node packages/core/zts.node
  cd packages/core && bun build index.ts --outdir dist --format esm --target bun
  ```
- 번개에서 HMR 실측 전에는 반드시 submodule update 먼저 — drift 상태면 최신 profile 측정점/NAPI 변경이 반영 안 됨
- 근본 해결(bungae 측): `.gitmodules` 에 `branch = main` + postinstall 에 `git submodule update --remote` 추가
```

## 근본 해결은 별도 작업

bungae repo 측에서 `.gitmodules` 에 `branch = main` 추가하고 postinstall 을 개선하는 것이 장기적으로 올바른 방식. 본 PR 범위는 ZTS 쪽 문서만.

## 테스트 Plan

- [x] CLAUDE.md 렌더링 확인 (GitHub preview)
- [ ] CI (docs-only 는 lint 만 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)