### PR TITLE
refactor(test): `drainTokensToEof` 헬퍼 추출 (scanner_test 6곳 통합)

### DIFF
--- a/src/lexer/scanner_test.zig
+++ b/src/lexer/scanner_test.zig
@@ -5,6 +5,15 @@ const token_mod = @import("token.zig");
 const Kind = token_mod.Kind;
 const profile = @import("../profile.zig");
 
+/// 스캐너를 eof 까지 소진. line offsets / pragma / profile 등 전체 스캔이
+/// 있어야 관측 가능한 상태를 쌓는 테스트에서 사용.
+fn drainTokensToEof(scanner: *Scanner) !void {
+    while (true) {
+        try scanner.next();
+        if (scanner.token.kind == .eof) break;
+    }
+}
+
 test "Scanner: empty source" {
     var scanner = try Scanner.init(std.testing.allocator, "");
     defer scanner.deinit();
@@ -117,10 +126,7 @@ test "Scanner: line offset table" {
     defer scanner.deinit();
 
     // 전체를 스캔하여 line offset 테이블 구축
-    while (scanner.token.kind != .eof or scanner.start == 0) {
-        try scanner.next();
-        if (scanner.token.kind == .eof) break;
-    }
+    try drainTokensToEof(&scanner);
 
     // line 0 → offset 0, line 1 → offset 2, line 2 → offset 4
     try std.testing.expectEqual(@as(u32, 0), scanner.line_offsets.items[0]);
@@ -143,10 +149,7 @@ test "Scanner: line offsets with TypeScript type declaration" {
     var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
 
-    while (scanner.token.kind != .eof or scanner.start == 0) {
-        try scanner.next();
-        if (scanner.token.kind == .eof) break;
-    }
+    try drainTokensToEof(&scanner);
 
     // 줄 수: 8줄 (7 newlines + 마지막 줄)
     // line 0: import React from "react";
@@ -173,10 +176,7 @@ test "Scanner: getLineColumn" {
     defer scanner.deinit();
 
     // 전체 스캔
-    while (true) {
-        try scanner.next();
-        if (scanner.token.kind == .eof) break;
-    }
+    try drainTokensToEof(&scanner);
 
     // 'a' = offset 0 → line 0, col 0
     const lc0 = scanner.getLineColumn(0);
@@ -1200,10 +1200,7 @@ test "Scanner: multiple pragmas in one file" {
     defer scanner.deinit();
 
     // 전체 스캔
-    while (true) {
-        try scanner.next();
-        if (scanner.token.kind == .eof) break;
-    }
+    try drainTokensToEof(&scanner);
 
     try std.testing.expectEqualStrings("h", scanner.jsx_pragma.?);
     try std.testing.expectEqualStrings("Fragment", scanner.jsx_frag_pragma.?);
@@ -1427,11 +1424,7 @@ test "Scanner: profile .scan 활성 시 토큰당 누적" {
     var scanner = try Scanner.init(std.testing.allocator, "const x = 42;");
     defer scanner.deinit();
 
-    // `Scanner.init` 직후 token.kind 가 불확정 — next() 먼저 한 번 부르고 루프.
-    while (true) {
-        try scanner.next();
-        if (scanner.token.kind == .eof) break;
-    }
+    try drainTokensToEof(&scanner);
 
     // 정확한 count 보단 "> 0" 만 검증 — 토큰 분리 로직 변화에 brittle 하지 않도록.
     try std.testing.expect(profile.count(.scan) > 0);
@@ -1446,10 +1439,7 @@ test "Scanner: profile .scan 비활성 시 누적 없음 (zero-cost)" {
     var scanner = try Scanner.init(std.testing.allocator, "a+b");
     defer scanner.deinit();
 
-    while (true) {
-        try scanner.next();
-        if (scanner.token.kind == .eof) break;
-    }
+    try drainTokensToEof(&scanner);
 
     try std.testing.expectEqual(@as(u32, 0), profile.count(.scan));
     try std.testing.expectEqual(@as(u64, 0), profile.totalNs(.scan));


### PR DESCRIPTION
## 요약

`scanner_test.zig` 에 "eof 까지 토큰 드레인" 반복 루프가 6곳 중복 → `drainTokensToEof` 헬퍼 하나로 통합.

## 중복 내역

| # | 위치 | 테스트 |
|---|------|------|
| 1 | L120 | `Scanner: line offset table` |
| 2 | L146 | `Scanner: line offsets with TypeScript type declaration` |
| 3 | L176 | `Scanner: getLineColumn` |
| 4 | L1203 | `Scanner: @jsx pragma` |
| 5 | L1431 | `Scanner: profile .scan 활성 시 토큰당 누적` (#1716) |
| 6 | L1449 | `Scanner: profile .scan 비활성 시 누적 없음` (#1716) |

두 가지 변종 패턴:

```zig
// 변종 A (L120, L146)
while (scanner.token.kind != .eof or scanner.start == 0) {
    try scanner.next();
    if (scanner.token.kind == .eof) break;
}

// 변종 B (L176, L1203, L1431, L1449)
while (true) {
    try scanner.next();
    if (scanner.token.kind == .eof) break;
}
```

**실행 의미는 동등** (A 도 첫 이터레이션은 `start==0` 조건으로 무조건 실행). 헬퍼 추출 시 변종 B 로 통일.

## 헬퍼

```zig
/// 스캐너를 eof 까지 소진. line offsets / pragma / profile 등 전체 스캔이
/// 있어야 관측 가능한 상태를 쌓는 테스트에서 사용.
fn drainTokensToEof(scanner: *Scanner) !void {
    while (true) {
        try scanner.next();
        if (scanner.token.kind == .eof) break;
    }
}
```

## 효과

- `1 file changed, 15 insertions(+), 25 deletions(-)` — net -10 lines
- 호출부 각 4줄 → 1줄, 향후 scanner 테스트 추가 시 패턴 재사용

## 테스트 Plan

- [x] 로컬 `zig build test` 통과 (회귀 없음)
- [ ] CI 전 단계 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)