### PR TITLE
refactor(profile): /simplify follow-up — 주석 정리 + workaround 헬퍼

### DIFF
--- a/docs/design/profile-infrastructure.md
+++ b/docs/design/profile-infrastructure.md
@@ -18,9 +18,9 @@ ZTS 에는 여러 측정 도구가 독립적으로 존재한다:
 | HMR `phaseDurations` | NAPI watch 이벤트 | `detect / graph / link / shake / emit / delta / total` + sub |
 | `BUNGAE_HMR_PROFILE=1` | 번개 opt-in 로그 | phase breakdown 한 줄 |
 
-### 1.2 파편화의 문제 (2026-04-22 이전, #1 는 해소)
+### 1.2 파편화의 문제
 
-1. ~~**의미 혼재**: `phaseDurations.parse` 가 실제로는 "graph build 전체"~~ (resolve + parse + semantic + finalize). ~~`phaseDurations.sem` 은 "link + shake"~~. 이름이 실체와 다름. — **해소: 기본 phase 는 `graph/link/shake` 로 분리, sub-phase 의 `parse/semantic` 은 진짜 parser/analyzer 의미**.
+1. **의미 혼재 (해소, 2026-04-22)**: 이전엔 `phaseDurations.parse` 가 graph build 전체 (resolve + parse + semantic + finalize), `phaseDurations.sem` 은 link + shake 였다. 기본 phase 를 `graph`/`link`/`shake` 로 분리하고 sub-phase 의 `parse`/`semantic` 은 진짜 parser/analyzer 시간을 의미하도록 rename 완료.
 2. **CLI ↔ NAPI 불일치**: `--timing` 은 single-file 만. NAPI watch 는 HMR 전용 포맷. 공통 출력 형식/옵션 없음.
 3. **Sub-phase 없음**: `emit 67ms` 안의 transform / codegen / metadata 비중 모름.
 4. **벤치마크 부재**: 특정 phase 만 반복 측정하는 도구가 없음. 최적화 전후 비교 수동.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -441,11 +441,11 @@ export interface WatchRebuildEvent {
 
     /** Scanner tokenization */
     scan: number;
-    /** Parser (진짜 parser 시간, 레거시 `parse_ms`=graph 아님) */
+    /** Parser — 실제 parser 시간만 */
     parse: number;
     /** Dependency resolution */
     resolve: number;
-    /** Semantic analyzer (진짜 semantic, 레거시 `semantic_ms`=link+shake 아님) */
+    /** SemanticAnalyzer — 실제 semantic 분석 시간만 */
     semantic: number;
     /** Transformer 전체 */
     transform: number;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1230,6 +1230,10 @@ const WatchReadyEvent = struct {
 /// `link+shake` 를 담았던 레거시 이름이었다. 이름=의미 일치를 위해 기본 phase 에서
 /// `parse_ms`/`semantic_ms` 를 제거하고 `graph_ms`/`link_ms`/`shake_ms` 로 분리.
 /// Sub-phase 의 `parse_ms`/`semantic_ms` 는 이제 진짜 parser/analyzer 시간을 의미.
+///
+/// Sub-phase 필드는 `profile.Category` enum 과 1:1 매핑. Category 에 phase 추가 시
+/// 동기화 위치: (1) 이 struct, (2) `fields[]` 배열 (rebuild 이벤트 변환), (3) phase_durations
+/// 초기화, (4) `packages/core/index.ts` TS 타입, (5) docs/HMR.md / docs/DEBUG.md.
 const PhaseDurations = struct {
     // ── 기본 phase (항상 측정) ──
     detect_ms: f64 = 0,

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -76,8 +76,9 @@ function createWasiImports(memory: () => WebAssembly.Memory) {
         }
         return 0;
       },
-      // clock_id: 0=realtime, 1=monotonic, 2/3=cputime. precision 인자는 무시.
-      // 결과는 u64 ns 로 timestamp_ptr 에 little-endian 기록.
+      // clock_id: 0=realtime(Date.now ms 해상도), 1/2/3=monotonic/cputime(performance.now).
+      // precision 인자는 WASI spec 상 hint 일뿐 무시. 결과는 u64 ns LE 로 timestamp_ptr 기록.
+      // 정확도는 호스트 브라우저의 reduced-precision 정책에 종속 (보통 100μs~1ms 단위).
       clock_time_get(clock_id: number, _precision: bigint, ts_ptr: number): number {
         const mem = new DataView(memory().buffer);
         const ns =

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -267,23 +267,27 @@ pub fn initFromEnv(allocator: std.mem.Allocator) void {
     } else |_| {}
 }
 
+/// totals_ns / counts 를 0 으로 초기화.
+///
+/// Debug + Linux x86_64 에서 `@memset` 이 `mov m64 m64` 로 encode 되어 Zig 0.15.2
+/// 컴파일러 버그(InvalidInstruction) 를 유발 — comptime array literal 대입으로 회피.
+/// Zig upgrade 로 버그 사라지면 이 함수 제거하고 `@memset` 두 줄 복원.
+fn zeroCounters() void {
+    totals_ns = [_]u64{0} ** num_categories;
+    counts = [_]u32{0} ** num_categories;
+}
+
 /// 테스트 / 재초기화용. 전체 상태 초기화 (mask + level + counters 모두).
 pub fn resetForTest() void {
     enabled_mask = 0;
     current_level = .summary;
-    // Debug + x86_64 에서 `@memset` 이 mov m64 m64 로 encode 되어 Zig 0.15.2
-    // 컴파일러 버그(InvalidInstruction) 를 유발 — comptime array literal 대입으로 회피.
-    totals_ns = [_]u64{0} ** num_categories;
-    counts = [_]u32{0} ** num_categories;
+    zeroCounters();
 }
 
 /// counters 만 reset (mask 와 level 은 유지).
 /// HMR rebuild 시작 전에 호출 — 이전 rebuild 의 누적치가 이월되지 않도록.
 pub fn resetCounters() void {
-    // Debug + x86_64 에서 `@memset` 이 mov m64 m64 로 encode 되어 Zig 0.15.2
-    // 컴파일러 버그(InvalidInstruction) 를 유발 — comptime array literal 대입으로 회피.
-    totals_ns = [_]u64{0} ** num_categories;
-    counts = [_]u32{0} ** num_categories;
+    zeroCounters();
 }
 
 /// 하나의 category 를 활성화하고, prefix 로 시작하는 child category 도 모두 활성화.


### PR DESCRIPTION
## 요약

오늘 7 PR 세션 (#1715-1721) 에 대해 `/simplify` 3-agent 리뷰를 돌려 나온 실질 수정 5건. 기능 변경 없음, 주석/구조 정리만.

## 변경 내용

### 1. `src/profile.zig` — `@memset` workaround 헬퍼화
`resetForTest` / `resetCounters` 양쪽에 동일한 2줄 + 주석이 중복이었음. `zeroCounters()` 헬퍼 하나로 통합 → Zig 0.15.2 버그 레퍼런스가 한 곳에만 유지. 추후 Zig upgrade 시 한 줄만 되돌리면 됨.

### 2. `packages/core/src/napi_entry.zig` — `PhaseDurations` 동기화 체크리스트
`profile.Category` enum 에 sub-phase 추가 시 동기화해야 할 5곳 (struct / `fields[]` / 초기화 / TS 타입 / docs) 을 struct 위 주석에 박아둠. Leaky abstraction 이 의도된 것임을 명시.

### 3. `docs/design/profile-infrastructure.md` — strikethrough 정리
`~~이전 설명~~` 형태가 가독성 저하였음. "(해소, 2026-04-22)" 로 깔끔히 재작성. Git history 가 원문 보존.

### 4. `packages/core/index.ts` — JSDoc 잡음 제거
`"레거시 parse_ms=graph 아님"` 같은 이제 존재하지 않는 이름 언급 삭제. `"실제 parser 시간만"` 한 문장으로 간결화.

### 5. `packages/wasm/index.ts` — `clock_time_get` 주석 보강
`Date.now()` ms 해상도 vs `performance.now()`, 브라우저 reduced-precision 종속성 명시.

## Heisenberg 실측 (Agent 3 추정 검증)

Scanner `.scan` 토큰당 Timer overhead 를 Agent 3 가 "20-50% 인플레이션" 으로 추정했으나 `hyperfine` 20회 실측:

| 시나리오 | 평균 |
|----------|-----:|
| baseline (profile 비활성) | **9.9ms** ±0.3 |
| ZTS_PROFILE=scan | 10.5ms ±0.2 (+6%) |
| ZTS_PROFILE=all | 10.5ms ±0.3 (+6%) |

**실제 ~6%** — 파이프라인 전체에 희석되어 acceptable. 구조 변경 (scope 상향) 불필요.

## Skip (문서화)

- **profile 테스트 helper 공통화**: 현재 `.scan` / `.resolve` 2 category 만 반복되어 premature. 다음 category (transform_jsx 등) 추가 시 `src/profile_test_utils.zig` 로 추출 예정.
- **Silent breakage migration 표**: 출시 전이라 외부 consumer 없음. 필요 시 bungae server/index.ts 업데이트 PR 에서 다룸.

## 테스트 Plan

- [x] `zig build test` 통과
- [ ] CI 전 단계 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)