### PR TITLE
fix(core): lightningcss optional dep 을 `any` 로 선언 — tsc 빌드 회복

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -691,7 +691,11 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
 function postProcessCssOutputs(result: BuildResult, options: BuildOptions): void {
   if (!options.minify) return;
 
-  let lcss: typeof import("lightningcss");
+  // lightningcss 는 optionalDependencies — 런타임에만 로드하므로 타입을 any 로.
+  // `typeof import("lightningcss")` 를 쓰면 tsc strict 모드에서 모듈 resolution 이
+  // 실패해 소비자측 `tsc --emitDeclarationOnly` 가 깨짐. 이 함수 내부만 영향.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let lcss: any;
   try {
     lcss = require("lightningcss");
   } catch {


### PR DESCRIPTION
## 요약

`@zts/core/index.ts:694` 의 `let lcss: typeof import("lightningcss")` 가 tsc strict 모드에서 lightningcss 모듈을 resolve 하려다 실패 — optional dep 이라 소비자 환경에 설치 안 돼 있으면 `bun run build:dts` (`tsc --emitDeclarationOnly`) 실패. → `.d.ts` 생성 누락 → 소비자 TS 프로젝트에서 `@zts/core` implicit any.

## 재현

번개(bungae) monorepo 빌드 중 발견:

```
$ bun run build
$ bun x tsc --emitDeclarationOnly
index.ts(694,27): error TS2307: Cannot find module 'lightningcss' or its corresponding type declarations.
```

소비자 측 typecheck:
```
server/index.ts(17,34): error TS7016: Could not find a declaration file for module '@zts/core'.
```

## 수정

```diff
+ // lightningcss 는 optionalDependencies — 런타임에만 로드하므로 타입을 any 로.
+ // `typeof import("lightningcss")` 를 쓰면 tsc strict 모드에서 모듈 resolution 이
+ // 실패해 소비자측 `tsc --emitDeclarationOnly` 가 깨짐. 이 함수 내부만 영향.
+ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+ let lcss: any;
- let lcss: typeof import("lightningcss");
```

함수 local 타입이라 영향 최소. 런타임 동작 동등 (require 는 그대로).

## 대안 검토

- **lightningcss 를 direct dep 으로 승격**: 무거운 native binary (~15MB WASM + 여러 플랫폼별 .node). optional 유지가 정책.
- **ambient module stub 파일**: 별도 `.d.ts` 추가 필요, 오히려 복잡.
- **tsconfig 에 `typeRoots` skip**: 전역 영향, 다른 타입 놓침.

## 테스트 Plan

- [x] `bun run build` (napi + js + dts) 통과 확인
- [ ] CI 통과
- [ ] 머지 후 소비자 (bungae) 에서 `@zts/core` implicit any 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)