### PR TITLE
feat(profile): graph / emit 내부 sub-phase 7개 삽입

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -320,7 +320,9 @@ HMR rebuild 의 각 phase 는 `WatchRebuildEvent.phaseDurations` 에 노출.
 - 필드 이름과 실제 값이 일치. 2026-04-22 이전의 `parse`/`semantic` 레거시 이름은 제거됨.
 
 Sub-phase (`ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` 활성 시):
-- `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
+- 파이프라인: `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
+- Graph 내부: `graphBuild` (모듈 그래프 구축) / `graphWorker` (worker entries)
+- Emit 내부 (bundler 수준): `emitPolyfill` / `emitRefresh` / `emitOutput` / `emitMetafile` / `emitCss`
 - 비활성 상태에선 모두 0. `parse`/`semantic` 은 진짜 parser/analyzer 시간.
 
 ## 4.1 번개 (bungae) HMR 실측

--- a/docs/HMR.md
+++ b/docs/HMR.md
@@ -100,7 +100,9 @@ HMR rebuild 의 각 phase 소요시간은 `WatchRebuildEvent.phaseDurations` 에
 - `detect` / `graph` / `link` / `shake` / `emit` / `delta` / `total`
 
 Sub-phase (profile 활성 시):
-- `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
+- 파이프라인: `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
+- Graph 내부: `graphBuild` / `graphWorker`
+- Emit 내부: `emitPolyfill` / `emitRefresh` / `emitOutput` / `emitMetafile` / `emitCss`
 
 ```ts
 watch({

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -453,6 +453,26 @@ export interface WatchRebuildEvent {
     codegen: number;
     /** Linker metadata build */
     metadata: number;
+
+    // Graph sub-phase (graph 내부 분해)
+
+    /** `graph.build()` / `graph.buildIncremental()` — 모듈 그래프 구축 본체 */
+    graphBuild: number;
+    /** `new Worker(new URL(...))` 패턴 entry 별도 빌드 */
+    graphWorker: number;
+
+    // Emit sub-phase (bundler.zig 수준 분해)
+
+    /** `--polyfill` 파일 내용 로딩 + Flow 트랜스파일 */
+    emitPolyfill: number;
+    /** React Refresh 런타임 preamble/epilogue 조립 (dev + 브라우저) */
+    emitRefresh: number;
+    /** `emitter.emitWithTreeShaking` / `emitChunks` — 번들 출력 생성 본체 */
+    emitOutput: number;
+    /** `--metafile` / `--analyze` JSON 생성 */
+    emitMetafile: number;
+    /** CSS 엔트리별 번들 + lightningcss 후처리 */
+    emitCss: number;
   };
   /** 증분 그래프에서 재파싱된 모듈 수. 캐시 미스된 모듈만 카운트. 전체 빌드에서는 미노출. */
   reparsedModules?: number;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1252,6 +1252,17 @@ const PhaseDurations = struct {
     transform_ms: f64 = 0,
     codegen_ms: f64 = 0,
     metadata_ms: f64 = 0,
+
+    // ── Graph sub-phase (graph 내부 분해) ──
+    graph_build_ms: f64 = 0,
+    graph_worker_ms: f64 = 0,
+
+    // ── Emit sub-phase (emit 내부 분해) ──
+    emit_polyfill_ms: f64 = 0,
+    emit_refresh_ms: f64 = 0,
+    emit_output_ms: f64 = 0,
+    emit_metafile_ms: f64 = 0,
+    emit_css_ms: f64 = 0,
 };
 
 /// onRebuild 콜백에 전달할 이벤트 데이터
@@ -1411,6 +1422,15 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
                 .{ .name = "transform", .value = pd.transform_ms },
                 .{ .name = "codegen", .value = pd.codegen_ms },
                 .{ .name = "metadata", .value = pd.metadata_ms },
+                // Graph sub-phase.
+                .{ .name = "graphBuild", .value = pd.graph_build_ms },
+                .{ .name = "graphWorker", .value = pd.graph_worker_ms },
+                // Emit sub-phase (bundler.zig 수준).
+                .{ .name = "emitPolyfill", .value = pd.emit_polyfill_ms },
+                .{ .name = "emitRefresh", .value = pd.emit_refresh_ms },
+                .{ .name = "emitOutput", .value = pd.emit_output_ms },
+                .{ .name = "emitMetafile", .value = pd.emit_metafile_ms },
+                .{ .name = "emitCss", .value = pd.emit_css_ms },
             };
             for (fields) |f| {
                 var js_num: c.napi_value = undefined;
@@ -1880,6 +1900,15 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             .transform_ms = nsToMs(profile_mod.totalNs(.transform)),
             .codegen_ms = nsToMs(profile_mod.totalNs(.codegen)),
             .metadata_ms = nsToMs(profile_mod.totalNs(.metadata)),
+
+            // Graph / Emit sub-phase — bundler.zig 내부 단계 분해.
+            .graph_build_ms = nsToMs(profile_mod.totalNs(.graph_build)),
+            .graph_worker_ms = nsToMs(profile_mod.totalNs(.graph_worker)),
+            .emit_polyfill_ms = nsToMs(profile_mod.totalNs(.emit_polyfill)),
+            .emit_refresh_ms = nsToMs(profile_mod.totalNs(.emit_refresh)),
+            .emit_output_ms = nsToMs(profile_mod.totalNs(.emit_output)),
+            .emit_metafile_ms = nsToMs(profile_mod.totalNs(.emit_metafile)),
+            .emit_css_ms = nsToMs(profile_mod.totalNs(.emit_css)),
         };
         event.reparsed_modules = rebuild_result.reparsed_modules;
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -674,21 +674,25 @@ pub const Bundler = struct {
         //   rebuild 간 emit 이 달라져도 HMR update 에서 제외.
         var reparsed_count: ?usize = null;
         var reparsed_paths_out: ?[]const []const u8 = null;
-        if (self.options.module_store) |store| {
-            const inc_result = try graph.buildIncremental(self.options.entry_points, store);
-            reparsed_count = inc_result.reparsed_indices.len;
-            if (inc_result.reparsed_indices.len > 0) {
-                const list = try self.allocator.alloc([]const u8, inc_result.reparsed_indices.len);
-                for (inc_result.reparsed_indices, 0..) |mod_idx, i| {
-                    const mi = @intFromEnum(mod_idx);
-                    const src = if (mi < graph.modules.items.len) graph.modules.items[mi].path else "";
-                    list[i] = try self.allocator.dupe(u8, src);
+        {
+            var gb_scope = profile.begin(.graph_build);
+            defer gb_scope.end();
+            if (self.options.module_store) |store| {
+                const inc_result = try graph.buildIncremental(self.options.entry_points, store);
+                reparsed_count = inc_result.reparsed_indices.len;
+                if (inc_result.reparsed_indices.len > 0) {
+                    const list = try self.allocator.alloc([]const u8, inc_result.reparsed_indices.len);
+                    for (inc_result.reparsed_indices, 0..) |mod_idx, i| {
+                        const mi = @intFromEnum(mod_idx);
+                        const src = if (mi < graph.modules.items.len) graph.modules.items[mi].path else "";
+                        list[i] = try self.allocator.dupe(u8, src);
+                    }
+                    reparsed_paths_out = list;
                 }
-                reparsed_paths_out = list;
+                self.allocator.free(inc_result.reparsed_indices);
+            } else {
+                try graph.build(self.options.entry_points);
             }
-            self.allocator.free(inc_result.reparsed_indices);
-        } else {
-            try graph.build(self.options.entry_points);
         }
 
         // Worker 별도 빌드: new Worker(new URL(...)) 패턴에서 수집된 worker 경로를 독립 IIFE로 빌드
@@ -701,18 +705,22 @@ pub const Bundler = struct {
         var worker_output_files: std.ArrayList(OutputFile) = .empty;
         defer worker_output_files.deinit(self.allocator);
 
-        for (graph.worker_entries.items) |we| {
-            // 같은 worker 파일이 여러 곳에서 참조되면 한 번만 빌드
-            if (worker_output_map.contains(we.resolved_path)) continue;
+        {
+            var gw_scope = profile.begin(.graph_worker);
+            defer gw_scope.end();
+            for (graph.worker_entries.items) |we| {
+                // 같은 worker 파일이 여러 곳에서 참조되면 한 번만 빌드
+                if (worker_output_map.contains(we.resolved_path)) continue;
 
-            const worker_result = self.buildWorker(we.resolved_path) catch {
-                continue;
-            };
-            try worker_output_map.put(we.resolved_path, worker_result.filename);
-            try worker_output_files.append(self.allocator, .{
-                .path = try self.allocator.dupe(u8, worker_result.filename),
-                .contents = worker_result.contents,
-            });
+                const worker_result = self.buildWorker(we.resolved_path) catch {
+                    continue;
+                };
+                try worker_output_map.put(we.resolved_path, worker_result.filename);
+                try worker_output_files.append(self.allocator, .{
+                    .path = try self.allocator.dupe(u8, worker_result.filename),
+                    .contents = worker_result.contents,
+                });
+            }
         }
 
         if (timer) |*t| {
@@ -785,6 +793,7 @@ pub const Bundler = struct {
             }
             polyfill_entries.deinit(self.allocator);
         }
+        var polyfill_scope = profile.begin(.emit_polyfill);
         for (self.options.polyfills) |poly_path| {
             const raw = std.fs.cwd().readFileAlloc(self.allocator, poly_path, 10 * 1024 * 1024) catch |err| {
                 std.log.err("zts: cannot read polyfill file '{s}': {}", .{ poly_path, err });
@@ -809,8 +818,10 @@ pub const Bundler = struct {
                 .path = try self.allocator.dupe(u8, poly_path),
             });
         }
+        polyfill_scope.end();
 
         // 2.8. React Refresh 런타임 주입 (dev mode, 브라우저만)
+        var refresh_scope = profile.begin(.emit_refresh);
         // RN: HMR 런타임의 __zts_resolveRefresh()가 모듈 컨텍스트에서 lazy하게
         //      require("react-refresh/runtime")을 호출하여 __ReactRefresh 글로벌에 캐싱.
         //      polyfill 불필요 (polyfill 시점에는 모듈 시스템 미초기화).
@@ -857,7 +868,10 @@ pub const Bundler = struct {
             });
         }
 
+        refresh_scope.end();
+
         // 3. 번들 출력 생성
+        var output_scope = profile.begin(.emit_output);
         var output: []const u8 = "";
         var outputs: ?[]OutputFile = null;
 
@@ -955,6 +969,8 @@ pub const Bundler = struct {
             t_emit = t.read();
         }
 
+        output_scope.end();
+
         // 파이프라인 단계별 타이밍 출력은 `--profile` 을 통해 `profile` 모듈이 담당.
         // 이 `t_graph/t_link/t_shake/t_emit` 은 `BundleResult.timings` 를 채워
         // NAPI `WatchRebuildEvent.phaseDurations` 로 노출 (HMR 관측성).
@@ -1033,10 +1049,12 @@ pub const Bundler = struct {
         const module_dev_codes = module_dev_codes_from_emit;
 
         // 7. Metafile JSON 생성 (--metafile / --analyze)
+        var metafile_scope = profile.begin(.emit_metafile);
         const metafile_json: ?[]const u8 = if (self.options.metafile or self.options.analyze)
             try generateMetafileJson(self.allocator, &graph, output, outputs)
         else
             null;
+        metafile_scope.end();
 
         // 8. Plugin: generateBundle 훅 — 번들 완료 후 모든 플러그인에 알림
         if (self.options.plugins.len > 0) {
@@ -1049,6 +1067,8 @@ pub const Bundler = struct {
         }
 
         // 5.6. CSS 번들 수집 (엔트리별 CSS 모듈 연결)
+        var css_scope = profile.begin(.emit_css);
+        defer css_scope.end();
         var css_output_files: std.ArrayList(OutputFile) = .empty;
         defer css_output_files.deinit(self.allocator);
         {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -52,6 +52,8 @@ pub const Category = enum {
     semantic,
     resolve,
     graph,
+    graph_build,
+    graph_worker,
 
     // ── Linking / Tree-shaking ──
     link,
@@ -73,6 +75,11 @@ pub const Category = enum {
 
     // ── Top-level emit ──
     emit,
+    emit_polyfill,
+    emit_refresh,
+    emit_output,
+    emit_metafile,
+    emit_css,
 
     // ── HMR ──
     hmr,


### PR DESCRIPTION
## 요약

`WatchRebuildEvent.phaseDurations` 의 graph / emit 기본 phase **내부** 를 sub-phase 7개로 분해. HMR 174ms 의 기존 측정 범위 밖 ~130ms 를 breakdown 가능.

## 신규 Category 7개

### Graph 내부 (2)
| Category | 측정 대상 |
|----------|----------|
| `.graph_build` | `graph.build()` / `graph.buildIncremental()` 본체 |
| `.graph_worker` | `new Worker(new URL(...))` entry 별도 빌드 loop |

### Emit 내부 (bundler.zig 수준, 5)
| Category | 측정 대상 |
|----------|----------|
| `.emit_polyfill` | `--polyfill` 파일 로딩 + Flow strip |
| `.emit_refresh` | React Refresh 런타임 preamble 조립 |
| `.emit_output` | `emitter.emitWithTreeShaking` / `emitChunks` 본체 — **대부분의 시간** |
| `.emit_metafile` | `--metafile` / `--analyze` JSON 생성 |
| `.emit_css` | CSS 엔트리별 번들 + lightningcss 후처리 |

## 예상 breakdown (warm HMR)

```
174ms
├─ detect=26
├─ graph=61
│  ├─ graphBuild=X        ← NEW
│  ├─ graphWorker=Y       ← NEW
│  └─ parse/resolve/semantic (이미 측정)
├─ link=5 shake=0
├─ emit=72
│  ├─ emitPolyfill        ← NEW
│  ├─ emitRefresh         ← NEW
│  ├─ emitOutput          ← NEW (대부분 — 후속 PR 에서 emitter 내부 추가 분해)
│  ├─ emitMetafile        ← NEW
│  └─ emitCss             ← NEW
└─ delta=0.8
```

## JS 속성 이름 (camelCase)

기존 (`detect/graph/link/shake/emit/delta/total/scan/parse/resolve/semantic/transform/codegen/metadata`) 는 단일 단어라 camelCase 와 일치. 새 sub-phase 는 두 단어 조합이라 camelCase (`graphBuild/emitPolyfill/...`) — JS/TS convention 에 맞춤.

## 변경 파일

- `src/profile.zig` — Category enum 7 variant
- `src/bundler/bundler.zig` — 7 scope 삽입
- `packages/core/src/napi_entry.zig` — PhaseDurations struct + JS property + 초기화
- `packages/core/index.ts` — TS 타입 동기화
- `docs/HMR.md`, `docs/DEBUG.md` — sub-phase 리스트

총 `6 files / +107 -27`.

## `/simplify` 리뷰 반영

3-agent 리뷰 결과:
- ✅ **Fix**: `graph_worker` scope 를 block + `defer` 패턴으로 통일 (다른 `defer`-based scope 와 일관성)
- ✅ **Fix**: `emit_prelude` / `emit_concat` / `emit_sourcemap_finalize` placeholder 3개 제거 — scope 미삽입 상태로 노출하면 "0ms = 빠르다" 오독 유발. 후속 PR 에서 실제 scope 삽입과 함께 추가.
- **Skip** (이 PR 범위 초과): NAPI 삼중 기재(struct/fields/초기화)를 `inline for (Category)` 로 단일화 — 별도 refactor PR.
- **Skip**: `emit_output` 함수 추출 — `emitBundleOutput()` 로 뽑는 건 별도 refactor.

## 후속 PR

`emit_output` 안 (emitter.zig `emitWithTreeShaking` 100+ 줄) 을 더 분해해서 `emit_prelude` / `emit_concat` / `emit_sourcemap_finalize` 삽입 예정. 이번 PR 은 "bundler 수준" 까지만.

## 테스트 Plan

- [x] 로컬 `zig build test` 통과
- [ ] CI 통과
- [ ] 머지 후 bungae 쪽 sync + 실측 (후속 bungae PR 에서 breakdown 로그 포맷 확장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)