### PR TITLE
feat(profile): graph 내부 분해 — discover / finalize sub-phase

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -321,7 +321,7 @@ HMR rebuild 의 각 phase 는 `WatchRebuildEvent.phaseDurations` 에 노출.
 
 Sub-phase (`ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` 활성 시):
 - 파이프라인: `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
-- Graph 내부: `graphBuild` (모듈 그래프 구축) / `graphWorker` (worker entries)
+- Graph 내부: `graphBuild` / `graphWorker` / `graphDiscover` (BFS 스캔) / `graphFinalize` (DFS+승격)
 - Emit 내부 (bundler 수준): `emitPolyfill` / `emitRefresh` / `emitOutput` / `emitMetafile` / `emitCss`
 - 비활성 상태에선 모두 0. `parse`/`semantic` 은 진짜 parser/analyzer 시간.
 

--- a/docs/HMR.md
+++ b/docs/HMR.md
@@ -101,7 +101,7 @@ HMR rebuild 의 각 phase 소요시간은 `WatchRebuildEvent.phaseDurations` 에
 
 Sub-phase (profile 활성 시):
 - 파이프라인: `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
-- Graph 내부: `graphBuild` / `graphWorker`
+- Graph 내부: `graphBuild` / `graphWorker` / `graphDiscover` (BFS 스캔) / `graphFinalize` (DFS+승격)
 - Emit 내부: `emitPolyfill` / `emitRefresh` / `emitOutput` / `emitMetafile` / `emitCss`
 
 ```ts

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -460,6 +460,10 @@ export interface WatchRebuildEvent {
     graphBuild: number;
     /** `new Worker(new URL(...))` 패턴 entry 별도 빌드 */
     graphWorker: number;
+    /** Phase 1: 이벤트 큐 BFS 스캔 (모듈 발견 + 파싱 + resolve) */
+    graphDiscover: number;
+    /** Phase 2-4: DFS exec_index + ExportsKind 승격 + TLA 전파 */
+    graphFinalize: number;
 
     // Emit sub-phase (bundler.zig 수준 분해)
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1256,6 +1256,8 @@ const PhaseDurations = struct {
     // ── Graph sub-phase (graph 내부 분해) ──
     graph_build_ms: f64 = 0,
     graph_worker_ms: f64 = 0,
+    graph_discover_ms: f64 = 0,
+    graph_finalize_ms: f64 = 0,
 
     // ── Emit sub-phase (emit 내부 분해) ──
     emit_polyfill_ms: f64 = 0,
@@ -1425,6 +1427,8 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
                 // Graph sub-phase.
                 .{ .name = "graphBuild", .value = pd.graph_build_ms },
                 .{ .name = "graphWorker", .value = pd.graph_worker_ms },
+                .{ .name = "graphDiscover", .value = pd.graph_discover_ms },
+                .{ .name = "graphFinalize", .value = pd.graph_finalize_ms },
                 // Emit sub-phase (bundler.zig 수준).
                 .{ .name = "emitPolyfill", .value = pd.emit_polyfill_ms },
                 .{ .name = "emitRefresh", .value = pd.emit_refresh_ms },
@@ -1904,6 +1908,8 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             // Graph / Emit sub-phase — bundler.zig 내부 단계 분해.
             .graph_build_ms = nsToMs(profile_mod.totalNs(.graph_build)),
             .graph_worker_ms = nsToMs(profile_mod.totalNs(.graph_worker)),
+            .graph_discover_ms = nsToMs(profile_mod.totalNs(.graph_discover)),
+            .graph_finalize_ms = nsToMs(profile_mod.totalNs(.graph_finalize)),
             .emit_polyfill_ms = nsToMs(profile_mod.totalNs(.emit_polyfill)),
             .emit_refresh_ms = nsToMs(profile_mod.totalNs(.emit_refresh)),
             .emit_output_ms = nsToMs(profile_mod.totalNs(.emit_output)),

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -34,6 +34,7 @@ const json_to_esm = @import("json_to_esm.zig");
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
+const profile = @import("../profile.zig");
 const semantic_symbol = @import("../semantic/symbol.zig");
 const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
 const stmt_info_mod = @import("stmt_info.zig");
@@ -175,6 +176,7 @@ pub const ModuleGraph = struct {
         // 워커: parseModule + resolve → 채널 send (그래프 변형 없음)
         // 메인: 채널 recv → 결과 적용 + addModule → 즉시 새 워커 스폰
         // 배치 경계 없이 모듈 발견 즉시 파싱 시작 → CPU 유휴 시간 최소화.
+        var discover_scope = profile.begin(.graph_discover);
         for (entry_points) |entry_path| {
             _ = try self.addModule(entry_path);
         }
@@ -303,6 +305,7 @@ pub const ModuleGraph = struct {
                 }
             }
         }
+        discover_scope.end();
 
         try self.finalizeGraph(entry_points);
     }
@@ -310,6 +313,9 @@ pub const ModuleGraph = struct {
     /// Phase 2-4: DFS exec_index + ExportsKind 승격 + TLA 전파.
     /// build()와 buildIncremental() 양쪽에서 호출.
     fn finalizeGraph(self: *ModuleGraph, entry_points: []const []const u8) !void {
+        var scope = profile.begin(.graph_finalize);
+        defer scope.end();
+
         const count = self.modules.items.len;
         if (count == 0) return;
 
@@ -399,6 +405,8 @@ pub const ModuleGraph = struct {
         var reparsed: std.ArrayListUnmanaged(types.ModuleIndex) = .empty;
         var graph_changed = false;
 
+        var discover_scope = profile.begin(.graph_discover);
+
         // 순차 처리 — 증분 빌드는 캐시 히트가 대부분이므로 스레드 풀 오버헤드보다 효율적.
         var parse_start: usize = 0;
         while (parse_start < self.modules.items.len) {
@@ -479,6 +487,8 @@ pub const ModuleGraph = struct {
                 }
             }
         }
+
+        discover_scope.end();
 
         try self.finalizeGraph(entry_points);
 

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -54,6 +54,8 @@ pub const Category = enum {
     graph,
     graph_build,
     graph_worker,
+    graph_discover,
+    graph_finalize,
 
     // ── Linking / Tree-shaking ──
     link,


### PR DESCRIPTION
## 요약

`graphBuild=64.5ms` (bungae App.tsx warm HMR 실측) 내부를 BFS 스캔 vs DFS 승격 2단계로 분해.

## 신규 Category

| Category | 측정 대상 |
|----------|----------|
| `.graph_discover` | Phase 1: 이벤트 큐 BFS 스캔 (모듈 발견 + 파싱 + resolve). 스레드 풀 워커 + 채널 recv 루프 |
| `.graph_finalize` | Phase 2-4: DFS exec_index + ExportsKind 승격 + TLA 전파 |

## 삽입 위치

| 함수 | scope |
|------|-------|
| `graph.zig:build()` | Phase 1 BFS 전체를 `discover_scope` (명시적 begin/end) |
| `graph.zig:buildIncremental()` | 동일 패턴 (증분 버전) |
| `graph.zig:finalizeGraph()` | 함수 진입 `defer scope.end()` |

## 예상 활용

```
warm HMR
└─ graph=65ms
   ├─ graphBuild=64.5ms
   │  ├─ graphDiscover=?   ← NEW: BFS 스캔 비중
   │  └─ graphFinalize=?   ← NEW: DFS+승격 비중
   └─ graphWorker=0
```

- graphDiscover 크면 → module parse / resolve / cache 가 병목
- graphFinalize 크면 → DFS order / exports promotion 이 병목

## /simplify 결과

3-agent 종합 리뷰 모두 pass. 명시 end vs defer 일관성은 bundler.zig 기존 scope 들 (refresh_scope, output_scope 등) 과 동일 규약이라 이 PR 에서 수정 안 함 — 전역 컨벤션 이슈는 별도 PR.

## 테스트

- [x] 로컬 `zig build test` 통과
- [ ] CI
- [ ] 머지 후 bungae 쪽 로그 포맷 sync + 실측

🤖 Generated with [Claude Code](https://claude.com/claude-code)