### PR TITLE
feat(profile): emit_output 내부 분해 — emitter.zig 4단계 sub-phase

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -323,6 +323,7 @@ Sub-phase (`ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` 활성 시):
 - 파이프라인: `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
 - Graph 내부: `graphBuild` / `graphWorker` / `graphDiscover` (BFS 스캔) / `graphFinalize` (DFS+승격)
 - Emit 내부 (bundler 수준): `emitPolyfill` / `emitRefresh` / `emitOutput` / `emitMetafile` / `emitCss`
+- emit_output 내부 (emitter 수준): `emitPrelude` / `emitModulePass` / `emitConcat` / `emitSourcemapFinalize`
 - 비활성 상태에선 모두 0. `parse`/`semantic` 은 진짜 parser/analyzer 시간.
 
 ## 4.1 번개 (bungae) HMR 실측

--- a/docs/HMR.md
+++ b/docs/HMR.md
@@ -103,6 +103,7 @@ Sub-phase (profile 활성 시):
 - 파이프라인: `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
 - Graph 내부: `graphBuild` / `graphWorker` / `graphDiscover` (BFS 스캔) / `graphFinalize` (DFS+승격)
 - Emit 내부: `emitPolyfill` / `emitRefresh` / `emitOutput` / `emitMetafile` / `emitCss`
+- emit_output 내부: `emitPrelude` / `emitModulePass` / `emitConcat` / `emitSourcemapFinalize`
 
 ```ts
 watch({

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -477,6 +477,17 @@ export interface WatchRebuildEvent {
     emitMetafile: number;
     /** CSS 엔트리별 번들 + lightningcss 후처리 */
     emitCss: number;
+
+    // emit_output 내부 (emitter.emitWithTreeShaking 분해)
+
+    /** 포맷 prologue + polyfill IIFE + runtime helper 주입 */
+    emitPrelude: number;
+    /** Phase 1/1.5/2/2.5 — used_names + cache lookup + emitModule + cache put */
+    emitModulePass: number;
+    /** Phase 3: module concat + runtime helpers 합산 + renderChunk + epilogue */
+    emitConcat: number;
+    /** 소스맵 V3 JSON 생성 (VLQ encode + sources content + debugId) */
+    emitSourcemapFinalize: number;
   };
   /** 증분 그래프에서 재파싱된 모듈 수. 캐시 미스된 모듈만 카운트. 전체 빌드에서는 미노출. */
   reparsedModules?: number;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1265,6 +1265,12 @@ const PhaseDurations = struct {
     emit_output_ms: f64 = 0,
     emit_metafile_ms: f64 = 0,
     emit_css_ms: f64 = 0,
+
+    // ── emit_output 내부 분해 (emitter.emitWithTreeShaking) ──
+    emit_prelude_ms: f64 = 0,
+    emit_module_pass_ms: f64 = 0,
+    emit_concat_ms: f64 = 0,
+    emit_sourcemap_finalize_ms: f64 = 0,
 };
 
 /// onRebuild 콜백에 전달할 이벤트 데이터
@@ -1435,6 +1441,11 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
                 .{ .name = "emitOutput", .value = pd.emit_output_ms },
                 .{ .name = "emitMetafile", .value = pd.emit_metafile_ms },
                 .{ .name = "emitCss", .value = pd.emit_css_ms },
+                // emit_output 내부 (emitter.emitWithTreeShaking 분해).
+                .{ .name = "emitPrelude", .value = pd.emit_prelude_ms },
+                .{ .name = "emitModulePass", .value = pd.emit_module_pass_ms },
+                .{ .name = "emitConcat", .value = pd.emit_concat_ms },
+                .{ .name = "emitSourcemapFinalize", .value = pd.emit_sourcemap_finalize_ms },
             };
             for (fields) |f| {
                 var js_num: c.napi_value = undefined;
@@ -1915,6 +1926,10 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             .emit_output_ms = nsToMs(profile_mod.totalNs(.emit_output)),
             .emit_metafile_ms = nsToMs(profile_mod.totalNs(.emit_metafile)),
             .emit_css_ms = nsToMs(profile_mod.totalNs(.emit_css)),
+            .emit_prelude_ms = nsToMs(profile_mod.totalNs(.emit_prelude)),
+            .emit_module_pass_ms = nsToMs(profile_mod.totalNs(.emit_module_pass)),
+            .emit_concat_ms = nsToMs(profile_mod.totalNs(.emit_concat)),
+            .emit_sourcemap_finalize_ms = nsToMs(profile_mod.totalNs(.emit_sourcemap_finalize)),
         };
         event.reparsed_modules = rebuild_result.reparsed_modules;
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -14,6 +14,7 @@
 //!   - D058: exec_index 순서 = ESM 실행 순서
 
 const std = @import("std");
+const profile = @import("../profile.zig");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const ModuleType = types.ModuleType;
@@ -278,6 +279,10 @@ pub fn emitWithTreeShaking(
         try ext_param_names.append(allocator, try types.specifierToParamName(allocator, spec));
     }
 
+    // emit_prelude: 포맷 prologue + polyfill 주입 + runtime helper 준비.
+    // emit_module_pass 시작점 (`Phase 1: used_names`) 직전에 end.
+    var prelude_scope = profile.begin(.emit_prelude);
+
     // 포맷별 prologue
     try emitFormatPrologue(&output, allocator, options.format, options.global_name, factory_fn, ext_specifiers.items, ext_param_names.items);
 
@@ -358,6 +363,13 @@ pub fn emitWithTreeShaking(
         }
         break :blk null;
     };
+
+    prelude_scope.end();
+
+    // emit_module_pass: Phase 1 (used_names 사전 계산) + Phase 1.5 (compiled cache
+    // lookup) + Phase 2 (emitModule 병렬/순차) + Phase 2.5 (cache put). transform /
+    // codegen 실제 호출이 이 범위에서 발생.
+    var module_pass_scope = profile.begin(.emit_module_pass);
 
     // Phase 1: used_names 사전 계산 (순차 — 모듈 간 의존)
     const used_names_list = try computeAllUsedNames(allocator, sorted.items, graph, shaker);
@@ -440,6 +452,12 @@ pub fn emitWithTreeShaking(
             cache.put(m.path, input_hashes[i], results[i]) catch continue;
         }
     }
+
+    module_pass_scope.end();
+
+    // emit_concat: Phase 3 순차 합류 — exec_index 순서대로 module concat + runtime
+    // helper 합산 + 소스맵 매핑 누적 + renderChunk 훅 + epilogue.
+    var concat_scope = profile.begin(.emit_concat);
 
     // Phase 3: 순차 합류 — exec_index 순서대로 concat + helpers 합산 + 소스맵 수집
     var module_output: std.ArrayList(u8) = .empty;
@@ -648,6 +666,13 @@ pub fn emitWithTreeShaking(
         SourceMap.generateUuidV4(&debug_id_buf);
         break :blk &debug_id_buf;
     } else null;
+
+    concat_scope.end();
+
+    // emit_sourcemap_finalize: 소스맵 V3 JSON 생성 (mapping VLQ 인코딩 + sources
+    // 내용 첨부 + debugId 삽입) + 번들 끝의 sourceMappingURL 주석 추가.
+    var sm_finalize_scope = profile.begin(.emit_sourcemap_finalize);
+    defer sm_finalize_scope.end();
 
     // 소스맵 JSON 생성
     var sourcemap_json: ?[]const u8 = null;

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -82,6 +82,11 @@ pub const Category = enum {
     emit_output,
     emit_metafile,
     emit_css,
+    // ── emit_output 내부 (emitter.emitWithTreeShaking 분해) ──
+    emit_prelude,
+    emit_module_pass,
+    emit_concat,
+    emit_sourcemap_finalize,
 
     // ── HMR ──
     hmr,


### PR DESCRIPTION
## 요약

`emitOutput=73ms` (bungae App.tsx warm HMR 실측) 내부 70ms 가 미측정 영역이었음. `emitter.emitWithTreeShaking()` 내부를 4단계로 분해해 진짜 병목 식별.

## 신규 Category

| Category | 측정 대상 |
|----------|----------|
| `.emit_prelude` | 포맷 prologue + polyfill IIFE + runtime helper 주입 |
| `.emit_module_pass` | Phase 1/1.5/2/2.5 — used_names + cache lookup + emitModule + cache put. **transform/codegen 실제 호출 포함** |
| `.emit_concat` | Phase 3 — module concat + helpers 합산 + renderChunk + epilogue |
| `.emit_sourcemap_finalize` | 소스맵 V3 JSON 생성 (VLQ + sources + debugId) |

## 삽입 방식

`emitWithTreeShaking` 본체에 4개 scope 순차 체인:
- 앞 scope `end()` → 다음 scope `begin()` (3회)
- 마지막 `sm_finalize_scope` 만 `defer scope.end()` (함수 끝까지)

## 예상 breakdown

```
warm HMR emit=74ms
├─ emitOutput=73ms
│  ├─ emitPrelude=?           ← NEW
│  ├─ emitModulePass=?        ← NEW (transform/codegen 포함)
│  ├─ emitConcat=?            ← NEW (string 조립 + renderChunk)
│  └─ emitSourcemapFinalize=? ← NEW (sourcemap JSON)
├─ emitCss=4.3ms
└─ polyfill/refresh/metafile ≈ 0
```

- emitConcat 크면 → string 조립/renderChunk 가 병목
- emitSourcemapFinalize 크면 → VLQ 인코딩이 비쌈 (sourcemap off 고려)
- emitModulePass 크면 → transform/codegen 본체가 실제 원인 확정

## 변경

- `src/profile.zig` — Category 4 variant
- `src/bundler/emitter.zig` — `profile` import + 4 scope 삽입
- `packages/core/src/napi_entry.zig` — PhaseDurations + JS property + 초기화
- `packages/core/index.ts` — TS 타입
- `docs/HMR.md`, `docs/DEBUG.md` — 리스트

총 `6 files / +58 -0`.

## /simplify

3-agent 종합 리뷰 모두 pass. NAPI 삼중 기재 헬퍼는 known backlog (별도 PR).

## 테스트

- [x] 로컬 `zig build test` 통과
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)