### PR TITLE
feat(emitter): HMR per-module code 에 `//# sourceURL=<mod_id>` 주석 (#1727 follow-up)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -570,6 +570,18 @@ pub fn emitWithTreeShaking(
         // IIFE로 래핑 + 런타임 헬퍼 로컬 alias로 eval() 스코프에서 접근 가능.
         if (options.dev_mode and options.collect_module_codes) {
             const mod_id = makeModuleId(m.path, options.root_dir);
+
+            // sourcemap 활성 시 `//# sourceURL=<mod_id>` 주석을 eval 코드 끝에 덧붙여
+            // DevTools 가 익명 eval 스크립트(VM:1) 대신 모듈 경로로 표시하게 한다.
+            // `sourceMappingURL` 은 dev server 가 라우트 컨벤션에 맞춰 별도 부착 —
+            // ZTS 는 서버 URL 구조를 모르므로 여기서는 `sourceURL` 만 담당.
+            // IIFE 끝 뒤에 위치하므로 `HMR_PREAMBLE_LINES` 오프셋에는 영향 없음.
+            var source_url_buf: []const u8 = "";
+            defer if (source_url_buf.len > 0) allocator.free(source_url_buf);
+            if (options.sourcemap.enable) {
+                source_url_buf = try std.fmt.allocPrint(allocator, "//# sourceURL={s}\n", .{mod_id});
+            }
+
             const hmr_code = try std.mem.concat(allocator, u8, &.{
                 "(function(){\n",
                 "var __esm=__zts_g.__esm,__export=__zts_g.__export,__commonJS=__zts_g.__commonJS,",
@@ -581,6 +593,7 @@ pub fn emitWithTreeShaking(
                 "__zts_reload=__zts_g.__zts_reload;\n",
                 code,
                 "\n})();\n",
+                source_url_buf,
             });
 
             // 모듈별 standalone sourcemap (Issue #1248): HMR 클라이언트가 전체 번들

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -1573,3 +1573,212 @@ test "emitter: SourceMapOptions 기본값 — 모든 sourcemap 기능 비활성"
     try std.testing.expect(std.mem.indexOf(u8, res.output, "sourceMappingURL") == null);
     try std.testing.expect(std.mem.indexOf(u8, res.output, "debugId") == null);
 }
+
+// HMR per-module `//# sourceURL=<mod_id>` 주석 (DevTools VM:1 방지). sourceMappingURL 은
+// dev server 가 별도 부착 — 여기서는 sourceURL 만 검증.
+
+test "emitter: dev_mode + sourcemap 활성 시 per-module code 끝에 sourceURL 주석" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 1;\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    for (result.graph.modules.items) |*m| {
+        m.dev_id = try std.testing.allocator.dupe(u8, m.path);
+    }
+    defer for (result.graph.modules.items) |*m| {
+        if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
+        m.dev_id = "";
+    };
+
+    const res = try emit(std.testing.allocator, &result.graph, .{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        .collect_module_codes = true,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    const codes = res.module_codes orelse return error.TestUnexpectedResult;
+    try std.testing.expect(codes.len > 0);
+    for (codes) |c| {
+        // eval 코드 끝에 `//# sourceURL=<mod_id>` 주석. IIFE `})();\n` 이후에 위치.
+        const needle = try std.fmt.allocPrint(std.testing.allocator, "//# sourceURL={s}\n", .{c.id});
+        defer std.testing.allocator.free(needle);
+        try std.testing.expect(std.mem.endsWith(u8, c.code, needle));
+    }
+}
+
+test "emitter: dev_mode + sourcemap 비활성 시 sourceURL 주석 없음" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 1;\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    for (result.graph.modules.items) |*m| {
+        m.dev_id = try std.testing.allocator.dupe(u8, m.path);
+    }
+    defer for (result.graph.modules.items) |*m| {
+        if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
+        m.dev_id = "";
+    };
+
+    const res = try emit(std.testing.allocator, &result.graph, .{
+        .dev_mode = true,
+        .collect_module_codes = true,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    const codes = res.module_codes orelse return error.TestUnexpectedResult;
+    for (codes) |c| {
+        try std.testing.expect(std.mem.indexOf(u8, c.code, "//# sourceURL=") == null);
+    }
+}
+
+test "emitter: multi-module 각각에 고유 sourceURL 포함" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "export const A = 1;\n");
+    try writeFile(tmp.dir, "b.ts", "export const B = 2;\n");
+    try writeFile(tmp.dir, "entry.ts", "import { A } from './a';\nimport { B } from './b';\nconsole.log(A, B);\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "entry.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    for (result.graph.modules.items) |*m| {
+        m.dev_id = try std.testing.allocator.dupe(u8, m.path);
+    }
+    defer for (result.graph.modules.items) |*m| {
+        if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
+        m.dev_id = "";
+    };
+
+    const res = try emit(std.testing.allocator, &result.graph, .{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        .collect_module_codes = true,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    const codes = res.module_codes orelse return error.TestUnexpectedResult;
+    try std.testing.expect(codes.len >= 3);
+
+    // 각 모듈의 sourceURL 이 해당 모듈 path 로 끝나야 한다 (absolute path 포함).
+    var seen_a = false;
+    var seen_b = false;
+    var seen_entry = false;
+    for (codes) |c| {
+        const needle = try std.fmt.allocPrint(std.testing.allocator, "//# sourceURL={s}\n", .{c.id});
+        defer std.testing.allocator.free(needle);
+        try std.testing.expect(std.mem.endsWith(u8, c.code, needle));
+        if (std.mem.endsWith(u8, c.id, "a.ts")) seen_a = true;
+        if (std.mem.endsWith(u8, c.id, "b.ts")) seen_b = true;
+        if (std.mem.endsWith(u8, c.id, "entry.ts")) seen_entry = true;
+    }
+    try std.testing.expect(seen_a);
+    try std.testing.expect(seen_b);
+    try std.testing.expect(seen_entry);
+}
+
+test "emitter: root_dir 설정 시 sourceURL 이 상대경로" {
+    // dev server / DevTools 가 보기 좋은 경로로 표시하려고 root_dir 을 자주 설정함.
+    // sourceURL 값이 절대경로가 아니라 root 기준 상대 — makeModuleId 동작과 일치해야.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 1;\n");
+
+    const tmp_abs = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(tmp_abs);
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    for (result.graph.modules.items) |*m| {
+        m.dev_id = try std.testing.allocator.dupe(u8, m.path);
+    }
+    defer for (result.graph.modules.items) |*m| {
+        if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
+        m.dev_id = "";
+    };
+
+    const res = try emit(std.testing.allocator, &result.graph, .{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        .collect_module_codes = true,
+        .root_dir = tmp_abs,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    const codes = res.module_codes orelse return error.TestUnexpectedResult;
+    for (codes) |c| {
+        // root_dir prefix 가 제거된 상대경로여야 한다.
+        try std.testing.expect(!std.mem.startsWith(u8, c.id, tmp_abs));
+        try std.testing.expect(std.mem.endsWith(u8, c.id, "index.ts"));
+        const needle = try std.fmt.allocPrint(std.testing.allocator, "//# sourceURL={s}\n", .{c.id});
+        defer std.testing.allocator.free(needle);
+        try std.testing.expect(std.mem.endsWith(u8, c.code, needle));
+    }
+}
+
+test "emitter: collect_module_codes=false — per-module code 자체 미수집 (sourceURL 도 없음)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 1;\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const res = try emit(std.testing.allocator, &result.graph, .{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        // collect_module_codes 의도적으로 false.
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    try std.testing.expect(res.module_codes == null);
+    // 번들 output 의 sourceMappingURL 은 eager 경로대로 유지 — sourceURL (per-module)
+    // 은 module code 가 수집되지 않았으므로 어디에도 없어야.
+    try std.testing.expect(std.mem.indexOf(u8, res.output, "//# sourceURL=") == null);
+}
+
+test "emitter: sourceURL 은 IIFE 뒤에 위치 — HMR_PREAMBLE_LINES 오프셋 불변" {
+    // per-module sourcemap 의 preamble offset 은 hmr_code 앞부분 2줄에 의존.
+    // sourceURL 주석이 IIFE 뒤에 와야 mapping offset 이 변하지 않는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 1;\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    for (result.graph.modules.items) |*m| {
+        m.dev_id = try std.testing.allocator.dupe(u8, m.path);
+    }
+    defer for (result.graph.modules.items) |*m| {
+        if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
+        m.dev_id = "";
+    };
+
+    const res = try emit(std.testing.allocator, &result.graph, .{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        .collect_module_codes = true,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    const codes = res.module_codes orelse return error.TestUnexpectedResult;
+    for (codes) |c| {
+        const iife_end = std.mem.indexOf(u8, c.code, "\n})();\n") orelse return error.TestUnexpectedResult;
+        const source_url_idx = std.mem.indexOf(u8, c.code, "//# sourceURL=") orelse return error.TestUnexpectedResult;
+        try std.testing.expect(source_url_idx > iife_end);
+    }
+}


### PR DESCRIPTION
## Summary

Issue #1727 Phase B follow-up. DevTools 가 HMR eval 된 per-module code 를 `VM:1` 같은 익명 스크립트로 표시하던 문제 해결. `sourcemap.enable + dev_mode + collect_module_codes` 조합에서 IIFE 끝 뒤에 `//# sourceURL=<mod_id>` 주석을 덧붙여 DevTools 가 모듈 경로로 스크립트를 식별.

## 관심사 분리

| 주석 | 담당 | 이유 |
|---|---|---|
| `//# sourceURL=<mod_id>` | **ZTS** (이 PR) | 모듈 id 는 `makeModuleId` 가 생성 — dev server URL 구조와 무관 |
| `//# sourceMappingURL=/__zts_hmr_map/:id` | **bungae** dev server | 라우트 경로/쿼리는 dev server 의 결정 — ZTS 가 알 수 없음 |

## 변경

### `src/bundler/emitter.zig:569-600`

```zig
if (options.sourcemap.enable) {
    source_url_buf = try std.fmt.allocPrint(allocator, "//# sourceURL={s}\n", .{mod_id});
}
const hmr_code = try std.mem.concat(allocator, u8, &.{
    "(function(){\n",
    // preamble (var aliases)
    ...
    code,
    "\n})();\n",
    source_url_buf,  // IIFE 뒤 — HMR_PREAMBLE_LINES 오프셋 불변
});
```

- IIFE 시작 + var alias 두 줄은 `HMR_PREAMBLE_LINES = 2` 상수로 고정돼 per-module sourcemap offset 계산에 사용됨. sourceURL 주석은 IIFE 끝 뒤에 위치해 offset 에 영향 없음.

## 테스트 (6 개 추가)

- `dev_mode + sourcemap 활성` → IIFE 끝에 `//# sourceURL=<mod_id>` 포함
- `dev_mode + sourcemap 비활성` → 주석 없음
- `multi-module` → 각 모듈이 고유 sourceURL (a.ts / b.ts / entry.ts)
- `root_dir 설정` → sourceURL 이 root 기준 상대경로 (makeModuleId 동작 검증)
- `collect_module_codes = false` → `module_codes` 자체 null, 번들 output 에도 sourceURL 없음
- `sourceURL 위치` → IIFE 뒤 (`})();\n` 이후) — preamble offset 불변

## 후속

- bungae PR (follow-up) 에서 `sourceURL` 부착 로직 제거, `sourceMappingURL` 만 유지로 정리.

## Test plan

- [x] `zig build` 통과
- [x] `zig build test` 전체 통과 (6 개 신규 테스트 포함)

Refs #1727