### PR TITLE
perf(emitter): emit_concat module_output 버퍼 pre-size

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -511,6 +511,19 @@ pub fn emitWithTreeShaking(
     // merge 시 output.items의 줄 수를 기준 오프셋으로 사용
     var module_line: u32 = 0;
 
+    // module_output pre-size: 합계 capacity 를 한 번 확보해 concat 루프의 모듈별 appendSlice
+    // 가 매번 grow (~log2(N) realloc) 하는 비용을 제거 (Issue #1727 §1).
+    var module_output_estimate: usize = 0;
+    for (sorted.items, 0..) |m, i| {
+        const code = results[i].code orelse continue;
+        module_output_estimate += code.len;
+        if (!options.minify_whitespace) {
+            // `"// --- " + basename + " ---\n"` (12 + basename) + 모듈 말미 개행 1
+            module_output_estimate += std.fs.path.basename(m.path).len + 13;
+        }
+    }
+    try module_output.ensureTotalCapacity(allocator, module_output_estimate);
+
     for (sorted.items, 0..) |m, i| {
         // helpers 합산 (bitwise OR)
         collected_helpers = @bitCast(@as(u32, @bitCast(collected_helpers)) | @as(u32, @bitCast(results[i].helpers)));


### PR DESCRIPTION
## Summary

- `emit_module_pass` 가 끝난 시점에서 각 모듈의 `code.len` 을 모두 알고 있으므로, concat 루프 진입 전에 합계 capacity 를 한 번만 `ensureTotalCapacity` 로 확보
- ArrayList 기본 1.5x grow 로는 수백 모듈 × N MB 번들에서 `~log2(N)` 번 realloc + 누적 memcpy 가 발생 — Issue #1727 §1 의 `emitConcat = 40ms` 병목 중 모듈 합류 부분 타겟
- 용량 추정: `Σ results[i].code.len` + 헤더 주석/개행 (`13B + basename`, minify 시 생략)

## Why

Issue #1727 의 실행 계획 #2 항목 "emitConcat pre-sized buffer" 직접 구현. lazy sourcemap (Phase B) 부수 효과로 이미 `emitConcat = 14.6ms` 까지 내려왔지만, 모듈별 `appendSlice` 의 realloc 자체는 그대로 남아있던 상태.

## Notes

- `extractLeadingDirectives` 는 hoisted_directives 로 옮기며 실제 append 코드를 줄이므로 추정이 upper bound 가 되어 안전
- `appendRunBeforeMainCalls` (entry + `--run-before-main` + non-ESM 한정) 는 추정에 미포함 — `ensureTotalCapacity` 가 hard limit 이 아니라 hint 라 부족하면 자연스럽게 grow. correctness 영향 없는 perf 엣지케이스
- `output` (외곽 ArrayList) 의 단일 `appendSlice(module_output.items)` 는 내부적으로 `ensureUnusedCapacity` 호출 → 1회 realloc 으로 끝남. 별도 pre-size 불필요

## Test plan

- [x] `zig build` 성공
- [x] `zig build test` 통과
- [x] `bun test tests/bundle-smoke.test.ts tests/hmr.test.ts` — 143 pass, 0 fail
- [ ] bungae ExampleApp 에서 `BUNGAE_HMR_PROFILE=1 ZTS_PROFILE=all npm run start:bungae:debug` 로 `emitConcat` 실측 (Issue #1727 의 14.6ms baseline 대비)