### PR TITLE
perf(graph): watcher-driven mtime cache (Issue #1727 §3)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1842,6 +1842,10 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         incremental_opts.collect_module_codes = bundle_opts.dev_mode;
         incremental_opts.module_store = &persistent_store;
         incremental_opts.compiled_cache = &async_data.compiled_cache;
+        // Watcher-driven mtime cache (Issue #1727 §3): changed 집합을 graph 에 넘겨
+        // 나머지 모듈 stat 을 skip 한다. detect 단계에서 이미 content hash 필터링까지
+        // 통과한 `touched` 를 그대로 재사용 — StringHashMap 포인터라 복사 없음.
+        incremental_opts.changed_files = &touched;
         // Lazy sourcemap (Issue #1727 Phase B): initial build 와 동일 경로 유지. cache 키
         // 일치 필수 — initial 에서 lazy=true 로 put 된 엔트리가 rebuild 에서 hit 해야 함.
         if (bundle_opts.dev_mode and bundle_opts.sourcemap.enable) incremental_opts.sourcemap.lazy = true;

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -197,6 +197,11 @@ pub const BundleOptions = struct {
     /// 증분 빌드용 모�� 파싱 캐시. null이면 매번 전체 파싱.
     /// IncrementalBundler가 소유하고 빌드 간 보존한다.
     module_store: ?*@import("module_store.zig").PersistentModuleStore = null,
+    /// Watcher 가 이번 rebuild 동안 변경됐다고 보고한 절대경로 set (Issue #1727 §3).
+    /// 주입되면 `graph.buildIncremental` 이 set 에 없는 모듈의 mtime stat syscall 을 skip
+    /// — cached mtime 을 신뢰. 수백 모듈 규모에서 graphDiscover 주 병목이었음.
+    /// null 이면 initial build / CLI / 변경 정보 없음 → 전체 stat (기존 동작).
+    changed_files: ?*const std.StringHashMap(void) = null,
     /// Compiled output cache. HMR/watch 에서 변경 안 된 모듈의 emit 을 스킵.
     /// IncrementalBundler 가 소유.
     compiled_cache: ?*@import("compiled_cache.zig").CompiledOutputCache = null,
@@ -673,7 +678,7 @@ pub const Bundler = struct {
             var gb_scope = profile.begin(.graph_build);
             defer gb_scope.end();
             if (self.options.module_store) |store| {
-                const inc_result = try graph.buildIncremental(self.options.entry_points, store);
+                const inc_result = try graph.buildIncremental(self.options.entry_points, store, self.options.changed_files);
                 reparsed_count = inc_result.reparsed_indices.len;
                 if (inc_result.reparsed_indices.len > 0) {
                     const list = try self.allocator.alloc([]const u8, inc_result.reparsed_indices.len);
@@ -1107,7 +1112,10 @@ pub const Bundler = struct {
         if (self.options.module_store) |store| {
             for (graph.modules.items) |*m| {
                 if (m.parse_arena == null) continue; // disabled 등 arena 없는 모듈 스킵
-                const mtime = ModuleGraph.getMtime(m.path) catch 0;
+                // mtime 은 buildIncremental / build 가 이미 module.mtime 에 기록. 여기서 재-stat
+                // 하면 watcher-driven mtime cache 효과가 half-revert 됨 (Issue #1727 §3).
+                // 0 이면 초기 경로에서 실패했던 모듈 — fallback 으로 한 번 더 stat.
+                const mtime = if (m.mtime != 0) m.mtime else (ModuleGraph.getMtime(m.path) catch 0);
                 store.putModule(m.path, m, mtime);
             }
         }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -381,6 +381,11 @@ pub const ModuleGraph = struct {
         self: *ModuleGraph,
         entry_points: []const []const u8,
         store: *module_store.PersistentModuleStore,
+        /// Watcher 가 이번 rebuild 동안 변경됐다고 보고한 절대경로 set.
+        /// null → 현재 변경 정보 없음 (initial build / CLI 모드). 전체 모듈 stat.
+        /// non-null → set 에 없는 path 는 mtime stat 을 skip 하고 store 의 cached mtime 을 그대로 신뢰.
+        /// 새로 그래프에 추가된 모듈 (`store.modules.contains(path) == false`) 은 강제로 stat (Issue #1727 §3).
+        changed_files: ?*const std.StringHashMap(void),
     ) !IncrementalBuildResult {
         // entry_dir 계산: entry point들의 공통 부모 디렉토리 ([dir] 패턴용)
         if (self.entry_dir.len == 0 and entry_points.len > 0) {
@@ -416,7 +421,21 @@ pub const ModuleGraph = struct {
                 if (mod.state == .ready) continue; // disabled 모듈 등
 
                 const mod_path = mod.path;
-                const mtime = getMtime(mod_path) catch 0;
+
+                // Watcher-driven mtime skip (Issue #1727 §3): watcher 가 이 파일을 건드리지
+                // 않았다고 보고했고 cache 에도 있으면 stat syscall 을 생략하고 cached mtime 을
+                // 그대로 쓴다. 수백 모듈 × ~100us stat 이 주 병목이었음. changed_files 가 null
+                // 이거나 cache miss 인 경로는 기존처럼 stat.
+                const mtime: i128 = blk: {
+                    if (changed_files) |cf| {
+                        if (!cf.contains(mod_path)) {
+                            if (store.modules.get(mod_path)) |cached_entry| {
+                                break :blk cached_entry.mtime;
+                            }
+                        }
+                    }
+                    break :blk getMtime(mod_path) catch 0;
+                };
 
                 // 캐시 조회
                 if (store.getIfFresh(mod_path, mtime)) |cached| {

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -6,6 +6,7 @@ const Module = @import("module.zig").Module;
 const types = @import("types.zig");
 const import_scanner = @import("import_scanner.zig");
 const resolve_cache_mod = @import("resolve_cache.zig");
+const module_store_mod = @import("module_store.zig");
 const writeFile = @import("test_helpers.zig").writeFile;
 
 fn createFile(dir: std.fs.Dir, path: []const u8) !void {
@@ -583,4 +584,150 @@ test "matchSideEffectsPatterns: no patterns = no side effects" {
         "/app/node_modules/pkg",
         patterns,
     ));
+}
+
+// Issue #1727 §3 — buildIncremental 의 watcher-driven mtime cache.
+// changed_files 가 전달되면 set 에 없는 모듈의 stat 을 skip 하고 store 의 cached mtime 을 신뢰.
+// `reparsed_indices.len` 으로 cache hit/miss 를 관찰 — disk content 가 바뀌었어도 stat 을
+// 건너뛰면 cache 가 신선한 것으로 판정되어 reparse 가 발생하지 않는다.
+
+/// Build 1 (full) — store 채우기.
+fn populateStoreForChangedFilesTest(
+    cache: *resolve_cache_mod.ResolveCache,
+    store: *module_store_mod.PersistentModuleStore,
+    entry: []const u8,
+) !void {
+    var graph = ModuleGraph.init(std.testing.allocator, cache);
+    defer graph.deinit();
+    try graph.build(&.{entry});
+    for (graph.modules.items) |*m| {
+        if (m.parse_arena == null) continue;
+        store.putModule(m.path, m, m.mtime);
+    }
+}
+
+test "buildIncremental: changed_files=empty → stat skip → cache hit even after disk change" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "export const V = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "entry.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var store = module_store_mod.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+
+    try populateStoreForChangedFilesTest(&cache, &store, entry);
+
+    // mtime resolution(ns) 차이 보장. macOS APFS 는 ns 까지 추적하지만 같은 syscall window
+    // 안에서 두 번 쓰면 동일 mtime 이 될 수 있어 명시적 sleep.
+    std.Thread.sleep(20 * std.time.ns_per_ms);
+    try writeFile(tmp.dir, "entry.ts", "export const V = 2;");
+
+    var empty: std.StringHashMap(void) = .init(std.testing.allocator);
+    defer empty.deinit();
+
+    var graph2 = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph2.deinit();
+    const r = try graph2.buildIncremental(&.{entry}, &store, &empty);
+    defer std.testing.allocator.free(r.reparsed_indices);
+
+    // changed_files 가 비어 있어 entry.ts 의 stat 을 skip → 디스크가 바뀌었어도 cache hit.
+    try std.testing.expectEqual(@as(usize, 0), r.reparsed_indices.len);
+}
+
+test "buildIncremental: changed_files contains entry → stat → cache miss after disk change" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "export const V = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "entry.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var store = module_store_mod.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+
+    try populateStoreForChangedFilesTest(&cache, &store, entry);
+
+    std.Thread.sleep(20 * std.time.ns_per_ms);
+    try writeFile(tmp.dir, "entry.ts", "export const V = 2;");
+
+    var changed: std.StringHashMap(void) = .init(std.testing.allocator);
+    defer changed.deinit();
+    try changed.put(entry, {});
+
+    var graph2 = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph2.deinit();
+    const r = try graph2.buildIncremental(&.{entry}, &store, &changed);
+    defer std.testing.allocator.free(r.reparsed_indices);
+
+    // entry 가 changed set 에 있으므로 stat 정상 수행 → 새 mtime 으로 cache miss → reparse 1건.
+    try std.testing.expectEqual(@as(usize, 1), r.reparsed_indices.len);
+}
+
+test "buildIncremental: changed_files=null → 기존 동작 (전체 stat) — 변경된 파일 reparse" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "export const V = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "entry.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var store = module_store_mod.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+
+    try populateStoreForChangedFilesTest(&cache, &store, entry);
+
+    std.Thread.sleep(20 * std.time.ns_per_ms);
+    try writeFile(tmp.dir, "entry.ts", "export const V = 2;");
+
+    var graph2 = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph2.deinit();
+    const r = try graph2.buildIncremental(&.{entry}, &store, null);
+    defer std.testing.allocator.free(r.reparsed_indices);
+
+    // null fallback — 모든 모듈 stat. 디스크 변경된 entry 는 mtime mismatch → cache miss.
+    try std.testing.expectEqual(@as(usize, 1), r.reparsed_indices.len);
+}
+
+test "buildIncremental: changed_files=empty + cache miss (new module) → 강제 stat 후 정상 파싱" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "export const V = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "entry.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    // store 비어있음 — entry 가 cache 에 없는 신규 모듈.
+    var store = module_store_mod.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+
+    var empty: std.StringHashMap(void) = .init(std.testing.allocator);
+    defer empty.deinit();
+
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+    const r = try graph.buildIncremental(&.{entry}, &store, &empty);
+    defer std.testing.allocator.free(r.reparsed_indices);
+
+    // changed_files 에 없지만 store 에도 없으므로 skip 조건 불성립 → stat → 신규 파싱.
+    try std.testing.expectEqual(@as(usize, 1), r.reparsed_indices.len);
+    try std.testing.expectEqual(@as(usize, 1), graph.modules.items.len);
+    try std.testing.expectEqual(Module.State.ready, graph.modules.items[0].state);
 }


### PR DESCRIPTION
## Summary

- `graph.buildIncremental` 이 매 rebuild 마다 모든 모듈 (~700) 에 대해 `getMtime` (stat syscall) 을 호출하던 병목 제거
- Watcher 가 이미 변경된 파일을 식별하므로 그 set 을 `BundleOptions.changed_files` 로 주입해 미변경 모듈의 stat 을 skip — store 의 cached mtime 을 신뢰
- 보조로 `bundler.zig` post-bundle putModule 루프도 `m.mtime` 재사용 (buildIncremental 이 이미 기록)

Issue #1727 §3 의 #4 "FS watcher mtime cache" 항목 구현.

## 변경

- `src/bundler/graph.zig`: `buildIncremental` 에 `changed_files: ?*const std.StringHashMap(void)` 파라미터 추가. 루프에서 `cf.contains(path) == false` + store cache hit 시 stat 생략
- `src/bundler/bundler.zig`: `BundleOptions.changed_files` 필드 + `buildIncremental` 로 전달. `:1110` putModule 은 `m.mtime != 0 ? m.mtime : getMtime()` 로 재사용
- `packages/core/src/napi_entry.zig`: detect 단계의 `touched` StringHashMap 을 rebuild options 에 포인터로 전달 (복사 없음)

## A/B 실측 (번개 ExampleApp App.tsx warm HMR, 각 2 라운드 × 9 샘플)

| 라운드 | BASELINE `graph` | WITH mtime `graph` | Δ |
|---|---:|---:|---:|
| R1 (fs 캐시 반-cold) | 95.0ms | **65.9ms** | **-29.1ms (-30.6%)** 🎯 |
| R2 (fs 완전 warm) | 66.8ms | 71.0ms | +4.2ms (노이즈) |
| 18-sample mean | 80.9ms | **68.5ms** | **-12.4ms (-15%)** |
| 18-sample median | 73.7ms | **68.4ms** | **-5.3ms (-7%)** |

효과가 round 간 편차 큰 이유: OS FS 캐시 warmth 에 stat 비용이 크게 좌우됨. 완전히 warm 한 상태에선 stat 자체가 ~5μs 라 700 모듈 × 5μs = 3.5ms 수준에 그침. 반대로 캐시가 반쯤 날아간 현실 시나리오 (IDE 분석/빌드 툴이 디스크 때릴 때) 에선 -29ms 까지 절감.

## Notes

- Initial build / CLI 모드에선 `changed_files = null` → 기존 동작 그대로 (전체 stat) — 회귀 없음
- 새로 그래프에 추가된 모듈 (import 새로 생긴 케이스) 은 `store.modules.contains(path) == false` 라 skip 조건 불성립 → 정상 stat 경로로 내려감
- `mtime=0` (1970 epoch) 파일은 `bundler.zig:1115` fallback 분기에서 재-stat. correctness 영향 없이 해당 모듈만 최적화 손실
- Path normalization 은 graph/tracked 모두 `allocator.dupe(u8, abs_path)` 로 동일 소스 — mismatch 없음

## Test plan

- [x] `zig build`
- [x] `zig build test`
- [x] `bun test tests/hmr.test.ts tests/bundle-smoke.test.ts` — 143 pass
- [x] 번개 ExampleApp HMR 20+ 사이클 A/B (위 표)