### PR TITLE
perf(graph): add sub-profile scopes for discover parallel/serial split

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -213,6 +213,9 @@ pub const ModuleGraph = struct {
                 const result = channel.recv();
                 inflight -= 1;
 
+                var apply_scope = profile.begin(.graph_discover_apply);
+                defer apply_scope.end();
+
                 const mod_idx = @intFromEnum(result.module_idx);
                 self.applySideEffectsFromPackageJson(&self.modules.items[mod_idx]);
                 self.modules.items[mod_idx].state = .ready;
@@ -679,6 +682,9 @@ pub const ModuleGraph = struct {
     /// 이벤트 큐 스캔 워커: parse + resolve 후 결과를 채널로 전송.
     /// 그래프 변형(addModule 등)은 하지 않으므로 메인 스레드의 sole writer 보장.
     fn scanWorker(self: *ModuleGraph, idx: ModuleIndex, channel: *MpscChannel(ScanResult)) void {
+        var scope = profile.begin(.graph_discover_scan_worker);
+        defer scope.end();
+
         self.parseModule(idx);
 
         const mod_idx = @intFromEnum(idx);

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -55,6 +55,8 @@ pub const Category = enum {
     graph_build,
     graph_worker,
     graph_discover,
+    graph_discover_scan_worker,
+    graph_discover_apply,
     graph_finalize,
 
     // ── Linking / Tree-shaking ──


### PR DESCRIPTION
## Summary
- `graph_discover_scan_worker` (worker thread) / `graph_discover_apply` (event loop) Category 2개 추가
- `scanWorker` 진입부와 `build()` event loop recv 직후에 `profile.begin` scope 삽입
- 이 측정으로 "graph.discover 362ms" 가 **이미 14x 규모로 잘 병렬화** 되어 있음을 데이터로 확인 → 추가 최적화 타깃을 I/O / parse / apply 로 재지정

## 배경
에픽 #1737 의 마지막 서브. #1733 서브패스 profile 이 `graph.discover` 단일 값(362ms date-fns, 386ms effect) 만 노출해 **병렬 worker 누적 시간 vs main loop serial 시간 비중**을 알 수 없었음.

## 실측 결과 (--profile=graph --profile-level=detailed)

### date-fns (305 modules)
\`\`\`
graph.discover              355ms  ← wall
graph.discover.scan.worker 4992ms  (305 calls, 누적)    ← 병렬도 ~14x
graph.discover.apply         40ms  (305 calls, 0.13ms/call)  ← main loop 빠름
parse                        48ms  (305 calls)
resolve                      81ms  (864 calls)
\`\`\`

### effect (601 modules)
\`\`\`
graph.discover              385ms
graph.discover.scan.worker 5214ms  (601 calls, 누적)    ← 병렬도 ~13.5x
graph.discover.apply        273ms  (237 calls, 1.15ms/call)  ← serial, 무시 못 함
parse                       424ms
resolve                     640ms
\`\`\`

## 진단
1. **병렬화 자체는 이미 충분** — worker 누적 대비 wall 비율이 13~14x. CPU 코어를 효과적으로 활용 중
2. **나머지 wall 시간의 구성**:
   - per-worker: disk I/O (readFileAlloc) + parseModule 내부 (scanner + parser + semantic + import_scanner + binding_scanner)
   - main loop: apply 단계 (applyResolveResult 루프 — effect 는 import 많아 273ms serial)
3. **"graph 병렬화" 추가 여지 제한적** — 실제 최적화 타깃은:
   - (a) disk I/O / parse 스루풋 (예: mmap, read 배치)
   - (b) `applyResolveResult` 루프 최적화 (effect 의 1.15ms/call 을 줄이는 방향)

이 PR 은 그 판단 근거를 제공하는 측정 인프라까지만 커버. 실제 최적화는 scope 분리 필요시 follow-up 이슈로.

## 누적 개선 (에픽 #1737 전체)
| 측정                              | 원본    | #1733+1734 | +#1735 | +#1736 |
|----------------------------------|---------|-----------|---------|--------|
| effect wall clock                | 1220ms  | 1190ms    | **930ms** | 동일   |
| metadata.register.ns.rewrites    | 934ms   | 479ms     | 515ms   | 동일   |
| link.populate.namespace.accesses | 410ms   | 410ms     | **141ms** | 동일   |
| graph.discover 분해 가시성       | 없음    | 없음      | 없음    | **확보** |

date-fns 는 graph/IO 병목이라 이 PR 에서는 개선 없이 원인 가시화가 주 성과.

Closes #1736

## Test plan
- [x] `zig build` 통과
- [x] `--profile=graph --profile-level=detailed` 로 `scan.worker`, `apply` 서브 출력 확인
- [x] 기능 회귀 없음 (scope 삽입만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)