### PR TITLE
perf(graph): cache package.json type field — date-fns 13x → 4x

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -58,6 +58,14 @@ pub const ModuleGraph = struct {
     /// 같은 패키지의 여러 모듈이 동일 package.json을 반복 읽지 않도록.
     side_effects_cache: std.StringHashMap(pkg_json.PackageJson.SideEffects),
 
+    /// 패키지 "type": "module" 필드 캐시. pkg_dir_path → isModule 결과.
+    /// 키는 module_path 의 substring (graph 수명 동안 유효) — dupe 불필요.
+    /// date-fns 같이 한 패키지 안 수백 파일이 반복 lookup 하는 케이스에서
+    /// per-file 4.5ms → cache hit 1회로 감소 (#1742).
+    pkg_type_cache: std.StringHashMapUnmanaged(bool) = .{},
+    /// pkg_type_cache 병렬 접근 보호. scanWorker 가 병렬 호출.
+    pkg_type_cache_mutex: std.Thread.Mutex = .{},
+
     // DFS 상태
     exec_counter: u32 = 0,
     cycle_counter: u32 = 0,
@@ -134,6 +142,7 @@ pub const ModuleGraph = struct {
         var se_it = self.side_effects_cache.valueIterator();
         while (se_it.next()) |se| se.deinit(self.allocator);
         self.side_effects_cache.deinit();
+        self.pkg_type_cache.deinit(self.allocator);
         self.diagnostics.deinit(self.allocator);
         for (self.worker_entries.items) |we| {
             self.allocator.free(we.resolved_path);
@@ -897,6 +906,8 @@ pub const ModuleGraph = struct {
             return;
         }
 
+        var setup_scope = profile.begin(.graph_discover_pm_setup);
+
         // 모듈별 Arena: Scanner/Parser/AST 메모리를 소유 (D061)
         // 플러그인 load 훅에서 이미 설정된 경우 건너뜀
         if (module.parse_arena == null) {
@@ -983,6 +994,7 @@ pub const ModuleGraph = struct {
         }
         // Inline scanning: 파서가 AST를 구축하면서 import/export 레코드를 동시 수집
         parser.enable_scan = true;
+        setup_scope.end();
         _ = parser.parse() catch {
             self.addDiag(.parse_error, .@"error", module.path, Span.EMPTY, .parse, "Parse failed", null);
             module.state = .ready;
@@ -1063,6 +1075,9 @@ pub const ModuleGraph = struct {
                 ) catch null;
             }
         }
+
+        var post_scope = profile.begin(.graph_discover_pm_post);
+        defer post_scope.end();
 
         module.ast = parser.ast;
         module.line_offsets = scanner.line_offsets.items;
@@ -1565,12 +1580,32 @@ pub const ModuleGraph = struct {
 
     /// 모듈 경로에서 가장 가까운 package.json의 "type" 필드가 "module"인지 확인.
     fn isPackageTypeModule(self: *ModuleGraph, module_path: []const u8) bool {
+        var scope = profile.begin(.graph_discover_pm_is_pkg_type);
+        defer scope.end();
+
         const pkg_dir_path = findPackageDirPath(module_path) orelse return false;
-        var pkg_dir = std.fs.cwd().openDir(pkg_dir_path, .{}) catch return false;
-        defer pkg_dir.close();
-        var parsed = pkg_json.parsePackageJson(self.allocator, pkg_dir) catch return false;
-        defer parsed.deinit();
-        return parsed.pkg.isModule();
+
+        // Fast path: 패키지 단위 캐시 조회. date-fns 처럼 한 패키지 안 수백 파일이
+        // 반복 호출하는 케이스에서 fs openDir + readFile + JSON parse 를 1회로.
+        self.pkg_type_cache_mutex.lock();
+        const cache_hit = self.pkg_type_cache.get(pkg_dir_path);
+        self.pkg_type_cache_mutex.unlock();
+        if (cache_hit) |v| return v;
+
+        // Slow path: 실제 package.json 읽기
+        const result = blk: {
+            var pkg_dir = std.fs.cwd().openDir(pkg_dir_path, .{}) catch break :blk false;
+            defer pkg_dir.close();
+            var parsed = pkg_json.parsePackageJson(self.allocator, pkg_dir) catch break :blk false;
+            defer parsed.deinit();
+            break :blk parsed.pkg.isModule();
+        };
+
+        // 캐시 put — race 시 다른 스레드가 먼저 put 해도 같은 결과이므로 덮어써도 안전.
+        self.pkg_type_cache_mutex.lock();
+        defer self.pkg_type_cache_mutex.unlock();
+        self.pkg_type_cache.put(self.allocator, pkg_dir_path, result) catch {};
+        return result;
     }
 
     /// TLA 전이적 전파: TLA 모듈을 static import하는 모듈도 TLA로 표시.

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -57,6 +57,9 @@ pub const Category = enum {
     graph_discover,
     graph_discover_scan_worker,
     graph_discover_apply,
+    graph_discover_pm_setup,
+    graph_discover_pm_post,
+    graph_discover_pm_is_pkg_type,
     graph_finalize,
 
     // ── Linking / Tree-shaking ──


### PR DESCRIPTION
## Summary
- `ModuleGraph` 에 `pkg_type_cache: StringHashMapUnmanaged(bool)` + `Thread.Mutex` 추가
- `isPackageTypeModule` 에 fast path(lock→get→unlock) / slow path(pkg.json 읽기는 lock 밖, put 만 lock 안) 패턴
- `parseModule` 에 `pm_setup` / `pm_post` / `pm_is_pkg_type` profile scope 추가 — 진단 핵심

## 배경 — 진단 경로
#1742 Arena prewarm 가설이 기각된 후 **순차(`--jobs=1`) 모드에서 재프로파일**:

```
scan.worker          1530ms  (305 calls, 5ms/file)
  pm.setup          1435ms  (94% of scan.worker!) ← 범인 발견
  pm.parse            32ms
  pm.semantic          5ms
  pm.post              0.4ms
```

`pm.setup` 을 더 분해한 결과 `pm.is_pkg_type = 1363ms (99% of setup!)`.

### 원인
\`\`\`zig
fn isPackageTypeModule(self: *ModuleGraph, module_path: []const u8) bool {
    const pkg_dir_path = findPackageDirPath(module_path) orelse return false;
    var pkg_dir = std.fs.cwd().openDir(pkg_dir_path, .{}) catch return false;  // fs syscall!
    defer pkg_dir.close();
    var parsed = pkg_json.parsePackageJson(self.allocator, pkg_dir) catch return false;  // fs read + JSON parse
    defer parsed.deinit();
    return parsed.pkg.isModule();
}
\`\`\`

**캐시 없음**. 305 files × 동일 `node_modules/date-fns/package.json` 반복 읽기.

## 해결
`pkg_dir_path` 별 캐시 + Mutex 보호. 키는 `module.path` substring (graph 수명 동안 유효) → dupe 불필요.

## 실측 (local, date-fns 305 files)
| 측정 | Before | After | Δ |
|------|--------|-------|-----|
| `--jobs=1` (sequential) | 1520ms | **150ms** | **10.1x** |
| `--jobs=8` (parallel)   | 390ms  | **120ms** | 3.25x |
| default                 | 400ms  | **130ms** | 3.1x |
| effect default (보너스) | 930ms  | **700ms** | 1.33x |

**esbuild 대비**: date-fns 13x → **4.3x**. multi-package 번들(effect) 에서도 유의미 개선.

출력/기능: 동일 (37113 bytes date-fns, 264707 bytes effect, baseline match).

## Follow-up
리뷰에서 발견된 **`side_effects_cache` thread-safety 결함** (`applySideEffectsFromPackageJson` 도 mutex 없이 scanWorker 경로에서 호출) 은 기존 결함이라 이 PR scope 밖 → 별도 이슈로 분리 예정. `side_effects_cache` 와 `pkg_type_cache` 를 통합(single pkg.json read로 두 필드 다 추출)하는 리팩토링도 follow-up 후보.

Closes #1742

## Test plan
- [x] `zig build` / `zig build test` 통과
- [x] date-fns 스모크: 37113 bytes, esbuild baseline match
- [x] effect 스모크: 264707 bytes, esbuild baseline match
- [x] `--profile=graph --profile-level=detailed` 로 `pm.is_pkg_type` 수치 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)