### PR TITLE
fix(bundler): #1751 RN + minify 조합 크래시/문법 4가지 fix

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1039,3 +1039,84 @@ test "Bundler: AMD external dependencies in wrapper" {
     // factory 매개변수 포함
     try std.testing.expect(std.mem.indexOf(u8, output, "function(Lodash)") != null);
 }
+
+// #1751: Flow `component` + --flow + --minify 조합이 mangler OOB 크래시를 유발했다.
+// Parser (flow.zig) 가 `const Name = React.forwardRef(Name_withRef)` 의 binding
+// identifier span 을 `addString(name_text)` 로 재래핑하면서 bit-31 tagged (string_table)
+// span 을 만들었고, 이게 semantic 에서 const 선언의 Symbol.name 으로 전파되어
+// mangler 가 `source[span.start..]` 슬라이싱 시 OOB. root cause 는 원본 name 노드
+// span 을 재사용하도록 fix. 이 테스트는 crash-free + 정상 실행 검증.
+test "Bundler: #1751 Flow component with ref + minify regression" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\// @flow strict-local
+        \\component MyComp(
+        \\  title: string,
+        \\  ref: (x: any) => void,
+        \\) {
+        \\  return title;
+        \\}
+        \\const v = MyComp({title: "hi", ref: () => {}});
+        \\console.log(v);
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+        .flow = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "React.forwardRef") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_withRef") != null);
+}
+
+// #1751: ESM wrap 의 function_declaration → `foo = function(){...}` 변환형에
+// trailing `;` 을 codegen 이 누락하여, 뒤따르는 `"use strict"` directive 와 ASI
+// 구분 실패 → SyntaxError. 변환형은 expression statement 이므로 `;` 필수.
+test "Bundler: #1751 ESM wrap function decl assignment has trailing semicolon" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "mod.js",
+        \\"use strict";
+        \\var warnedKeys = {};
+        \\function warnOnce(key, message) {
+        \\  if (warnedKeys[key]) return;
+        \\  console.warn(message);
+        \\  warnedKeys[key] = true;
+        \\}
+        \\export default warnOnce;
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import w from './mod.js';
+        \\w("x", "hi");
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .platform = .react_native, // ESM wrap + strict_execution_order 강제
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 변환형 `t = function(...){...}` 뒤에 반드시 `;`. `}"use strict"` 붙지 않음.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "};\"use strict\"") != null or
+        std.mem.indexOf(u8, result.output, "}\"use strict\"") == null);
+}

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -161,7 +161,8 @@ pub const CJS_RUNTIME_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=(cb,mod)=>funct
 
 /// __commonJS ES5 호환: arrow → function.
 pub const CJS_RUNTIME_ES5 = "var __commonJS = function(cb, mod) { return function __require() {\n\treturn mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;\n}; };\n";
-pub const CJS_RUNTIME_ES5_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=function(cb,mod){return function " ++ NAMES.REQUIRE_MIN ++ "(){return mod||(0,cb[Object.keys(cb)[0]])((mod={exports:{}}).exports,mod),mod.exports}}";
+// #1751: trailing `;` — 뒤따르는 `var __xxx=...` 와 문법 구분 필수 (minify 연속 emit).
+pub const CJS_RUNTIME_ES5_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=function(cb,mod){return function " ++ NAMES.REQUIRE_MIN ++ "(){return mod||(0,cb[Object.keys(cb)[0]])((mod={exports:{}}).exports,mod),mod.exports}};";
 
 /// __toESM: CJS 모듈을 ESM namespace로 변환 (rolldown 호환).
 /// isNodeMode=true(--platform=node)이면 항상 default: mod를 설정.
@@ -256,7 +257,8 @@ pub const ESM_RUNTIME_MIN = "var " ++ NAMES.ESM_FACTORY_MIN ++ "=(fn,res)=>funct
 
 /// __esm ES5 호환: arrow → function.
 pub const ESM_RUNTIME_ES5 = "var __esm = function(fn, res) { return function __init() {\n\tif (!fn) return res;\n\tvar f = fn; fn = 0;\n\ttry { res = (0, f[Object.keys(f)[0]])(); }\n\tcatch(e) { fn = f; throw e; }\n\treturn res;\n}; };\n";
-pub const ESM_RUNTIME_ES5_MIN = "var " ++ NAMES.ESM_FACTORY_MIN ++ "=function(fn,res){return function __init(){if(!fn)return res;var f=fn;fn=0;try{res=(0,f[Object.keys(f)[0]])()}catch(e){fn=f;throw e}return res}}";
+// #1751: trailing `;` — 뒤따르는 `var __xxx=...` 와 문법 구분 필수.
+pub const ESM_RUNTIME_ES5_MIN = "var " ++ NAMES.ESM_FACTORY_MIN ++ "=function(fn,res){return function __init(){if(!fn)return res;var f=fn;fn=0;try{res=(0,f[Object.keys(f)[0]])()}catch(e){fn=f;throw e}return res}};";
 
 /// __export: ESM namespace 객체에 live getter 등록 (esbuild 호환).
 /// var foo_exports = {}; __export(foo_exports, { greet: () => greet });
@@ -628,7 +630,8 @@ pub const PRIVATE_METHOD_GET_RUNTIME =
     \\};
     \\
 ;
-pub const PRIVATE_METHOD_GET_RUNTIME_MIN = "var " ++ NAMES.PRIVATE_METHOD_GET_MIN ++ "=function(receiver,privateSet,fn){if(!privateSet.has(receiver))throw new TypeError(\"attempted to get private field on non-instance\");return fn}";
+// #1751: trailing `;` — 뒤따르는 `var __xxx=...` 와 문법 구분 필수.
+pub const PRIVATE_METHOD_GET_RUNTIME_MIN = "var " ++ NAMES.PRIVATE_METHOD_GET_MIN ++ "=function(receiver,privateSet,fn){if(!privateSet.has(receiver))throw new TypeError(\"attempted to get private field on non-instance\");return fn};";
 
 // ============================================================
 // Static Private Field (ES2022 downlevel)

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2216,6 +2216,11 @@ pub const Codegen = struct {
         try self.writeByte(')');
         try self.emitNode(body);
 
+        // #1751: assignment 로 변환된 form 은 expression statement 라서 `;` 종결 필요.
+        // 다음 statement 가 directive ("use strict") 처럼 ASI 로 구분 안 되는 경우
+        // 문법 오류 유발. function declaration 원형은 `}` 로 충분하지만 변환형은 아님.
+        if (convert_fn_to_assign) try self.writeByte(';');
+
         // keepNames: function_declaration에서 이름이 rename된 경우 entry 수집
         if (self.options.keep_names and node.tag == .function_declaration and !name.isNone()) {
             self.collectKeepNameEntry(name);

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -317,6 +317,14 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
         // Bundler 합성 심볼(#1338)은 source AST에 식별자 참조가 없고 span이 (0,0).
         // rename은 parser AST의 identifier 노드를 바꾸는 것이라 무의미 — skip.
         if (sym.isSynthetic()) continue;
+        // string_table-backed span (Ast.STRING_TABLE_BIT). parser/transformer 가
+        // `addString` 으로 합성한 identifier 가 semantic 에서 const/let declaration
+        // 으로 재분석될 때 발생 (#1751). 이런 심볼의 이름은 source 에 존재하지 않고
+        // string_table 에만 있으므로 원본 텍스트 비교가 의미 없고 slice 는 OOB.
+        // 현재 mangler 는 `source: []const u8` 만 받아서 string_table 접근 불가 —
+        // 합성 이름은 rename 대상에서 제외한다 (mangle 해도 renames 맵이 span-offset
+        // 기반 codegen 과 맞물리지 않아 효과도 없음).
+        if (sym.name.start & 0x80000000 != 0) continue;
         const orig_name = source[sym.name.start..sym.name.end];
 
         if (std.mem.eql(u8, orig_name, new_name)) continue;

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1189,11 +1189,16 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
             .data = .{ .extra = call_extra },
         });
 
-        const binding_span = try self.ast.addString(name_text);
+        // #1751: 원본 `component Name(...)` 의 name 노드 span 을 재사용.
+        // `addString(name_text)` 로 string_table 에 중복 저장하면 bit-31 tagged span
+        // 이 되어, 이후 semantic 이 이 binding 을 const 선언 심볼로 등록할 때
+        // `Symbol.name` 이 string_table 참조가 된다. mangler 가 `source[span.start..]`
+        // 를 naive slice 하면서 OOB 크래시 (RN + --minify + Flow component 조합).
+        // 이름이 이미 원본 source 에 존재하므로 원본 span 그대로 재사용한다.
         const binding = try self.ast.addNode(.{
             .tag = .binding_identifier,
-            .span = binding_span,
-            .data = .{ .string_ref = binding_span },
+            .span = name_node.span,
+            .data = .{ .string_ref = name_node.span },
         });
         // variable_declarator: extra = [name, type_ann, init]
         const decl_extra = try self.ast.addExtras(&.{


### PR DESCRIPTION
## Summary

PR #1750 (#1621 축약 확장) 를 RN + minify 번들에서 검증하려다 **main 에서도 크래시**하는 4중 pre-existing 버그 연쇄를 발견. 각각 root cause 를 잡고 regression 테스트 추가.

## 버그 1 — mangler OOB (root cause: parser)

**증상**: `zts --bundle --platform=react-native --minify --flow ...` 실행 시
```
index out of bounds: index 2147483693, len 5349
mangler.zig:320: source[sym.name.start..sym.name.end]
```

**원인 체인**:

1. `Ast.STRING_TABLE_BIT = 0x80000000` — Span `start` 의 bit 31 이 1 이면 "source 가 아니라 string_table 에서 읽어라" 라는 tag. `addString()` 이 이 marker 를 박은 span 반환.
2. `parser/flow.zig:1192` 가 Flow `component Foo(...)` 를 `const Foo = React.forwardRef(Foo_withRef)` 로 다운레벨 할 때 `addString(name_text)` 로 binding identifier span 을 **재래핑** — `name_text` 는 이미 원본 source 에 존재하는 이름이라 string_table 재저장은 불필요했지만, 실수로 bit-31 tagged span 생성.
3. 이 binding 이 semantic 에서 `variable_const` 심볼로 등록 → `Symbol.name = bit-31 span`.
4. `mangler.zig:320` 이 `source[sym.name.start..end]` 를 naive slice → `source[0x8000002D..]` = index 2147483693 > len 5349 → OOB crash.

**Fix** (`parser/flow.zig:1192`): `addString(name_text)` 제거, 원본 `name_node.span` 재사용.
**Defense-in-depth** (`codegen/mangler.zig`): bit-31 span 심볼은 mangle 대상에서 skip. 다른 경로에서 유사 synthetic span 이 유입되어도 crash 대신 no-op.

## 버그 2 — CJS/ESM ES5_MIN trailing `;` 누락

3 runtime 상수 (`CJS_RUNTIME_ES5_MIN`, `ESM_RUNTIME_ES5_MIN`, `PRIVATE_METHOD_GET_RUNTIME_MIN`) 가 모두 `function(){...}}` 로 끝남 — 뒤따르는 `var __xxx=...` preamble 과 연속 emit 시 `}}var __xxx` 조합으로 문법 오류. `};` 로 수정.

## 버그 3 — ESM wrap function_decl→assignment trailing `;` 누락

`codegen/codegen.zig:2194` 의 `convert_fn_to_assign` 경로 — `function foo(){}` → `foo = function(){}` 변환시 body 끝난 후 `;` 미추가. 다음 statement 가 `"use strict"` directive 면 `}"use strict"` 가 되어 ASI 실패 → SyntaxError. `if (convert_fn_to_assign) try self.writeByte(';');` 추가.

## 버그 4 — (이 PR 범위 밖, 별도 이슈)

RN 번들 전체를 minify 하면 여전히 `ReactNativeRenderer-dev.js` 의 `"use strict";false&&(function(){...})()` dead-code IIFE 경로에서 43 개 unclosed bracket 이 발생. **pre-existing** (main 은 버그 1 로 bundle 자체 생성 불가해서 드러나지 않았음). tree-shaking/DCE 가 IIFE body 일부만 제거하고 wrapping parens 를 남기는 가설. 별도 조사 이슈로 분리.

## Test plan

- [x] `zig build test` — 3482/3482 통과 (regression 2건 추가: `basic.zig`)
- [x] Flow component + minify 최소 repro 번들 생성 성공
- [x] ESM wrap + `"use strict"` + function_decl 최소 repro `node --check` 통과
- [x] RN 전체 번들: main 은 mangler 크래시로 3.7KB 에서 abort, 이 PR 은 2.1MB 정상 emit (이후 버그 4 로 파싱 실패는 별개)

## 관련

- Opens follow-up 이슈: RN dead-code IIFE tree-shaking 43-unclosed bracket
- #1750 (#1621 축약 확장) 의 실측 검증에 필요 — 두 PR 모두 머지되면 RN 효과 측정 가능해짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)