### PR TITLE
refactor(arch): #1752 runtime helper 이름 테이블 공용 모듈 분리 (역의존 정리)

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -23,137 +23,16 @@ pub fn appendRequireShim(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, 
     try buf.appendSlice(allocator, if (minify) REQUIRE_SHIM_MIN else REQUIRE_SHIM);
 }
 
-// #1618 / #1621: minify 모드에서 runtime helper 이름을 2~3자로 축약하여 수 KB 감축.
-// 이름 충돌 방지: `mangler.isReservedOrGlobal` 이 `PAIRS` 를 소비해 reserved 등록 —
-// base54 가 사용자 심볼에 동일 이름을 배정해 preamble 정의를 덮어쓰는 것을 차단.
-// dev mode 는 `__zts_g.<name>` 글로벌 공유 경로라 축약 대상이 아님.
-// ZTS 는 `importHelpers: true` 를 honor 하지 않고 자체 preamble 만 쓰므로 tslib 이름과
-// 충돌 없음 — 모든 helper 의 rename 은 안전.
-pub const NAMES = struct {
-    // bundler interop
-    pub const CJS_FACTORY_MIN = "$cj"; // __commonJS
-    pub const REQUIRE_MIN = "$r"; // __commonJS body 내부 function __require
-    pub const ESM_FACTORY_MIN = "$e"; // __esm
-    pub const EXPORT_MIN = "$x"; // __export
-    pub const TOESM_MIN = "$tE"; // __toESM
-    pub const TOCOMMONJS_MIN = "$tC"; // __toCommonJS
-    // Object.* alias — __toESM/__export body 에서 참조.
-    pub const CREATE_MIN = "$cr"; // __create
-    pub const GET_PROTO_OF_MIN = "$gP"; // __getProtoOf
-    pub const DEF_PROP_MIN = "$dp"; // __defProp
-    pub const GET_OWN_PROP_NAMES_MIN = "$gN"; // __getOwnPropNames
-    pub const GET_OWN_PROP_DESC_MIN = "$gD"; // __getOwnPropDesc
-    pub const HAS_OWN_MIN = "$hO"; // __hasOwn
-    pub const COPY_PROPS_MIN = "$cp"; // __copyProps
-    // transformer-emitted downlevel (RN/ES5 타겟에서 다수 emit)
-    pub const EXTENDS_MIN = "$eX"; // __extends (ES2015 class)
-    pub const CLASS_CALL_CHECK_MIN = "$cC"; // __classCallCheck
-    pub const CALL_SUPER_MIN = "$cS"; // __callSuper
-    pub const ASYNC_MIN = "$aS"; // __async (async/await → generator)
-    pub const ASYNC_VALUES_MIN = "$aV"; // __asyncValues (for-await-of)
-    pub const GENERATOR_MIN = "$gn"; // __generator
-    pub const REST_MIN = "$rs"; // __rest (object rest destructure)
-    pub const TAGGED_TEMPLATE_MIN = "$tt"; // __taggedTemplateLiteral
-    pub const ARRAY_LIKE_TO_ARRAY_MIN = "$aL"; // __arrayLikeToArray
-    pub const TO_CONSUMABLE_ARRAY_MIN = "$tA"; // __toConsumableArray (array spread)
-    pub const NAME_MIN = "$nm"; // __name (--keep-names)
-    pub const TO_BINARY_MIN = "$tb"; // __toBinary (binary loader asset)
-    // ES2022 private field downlevel
-    pub const PRIVATE_METHOD_INIT_MIN = "$pI"; // __classPrivateMethodInit
-    pub const PRIVATE_METHOD_GET_MIN = "$pG"; // __classPrivateMethodGet
-    pub const PRIVATE_FIELD_SET_MIN = "$pF"; // __classPrivateFieldSet
-    pub const STATIC_PRIVATE_ACCESS_MIN = "$sA"; // __classCheckPrivateStaticAccess
-    pub const STATIC_PRIVATE_DESC_MIN = "$sD"; // __classCheckPrivateStaticFieldDescriptor
-    pub const STATIC_PRIVATE_GET_MIN = "$sG"; // __classStaticPrivateFieldSpecGet
-    pub const STATIC_PRIVATE_SET_MIN = "$sS"; // __classStaticPrivateFieldSpecSet
-    // decorator
-    pub const DECORATE_CLASS_MIN = "$dC"; // __decorateClass
-    pub const DECORATE_PARAM_MIN = "$dK"; // __decorateParam (K = param 식별)
-    pub const DEF_PROP_2_MIN = "$dp2"; // __defProp2 (DECORATOR body, $dp 와 분리)
-    pub const METADATA_MIN = "$mD"; // __metadata
-    pub const ES_DECORATE_MIN = "$eD"; // __esDecorate
-    pub const RUN_INITIALIZERS_MIN = "$rI"; // __runInitializers
-    pub const SET_FUNCTION_NAME_MIN = "$sF"; // __setFunctionName
-    pub const PROP_KEY_MIN = "$pK"; // __propKey
-    // ES2025 explicit resource management
-    pub const USING_MIN = "$us"; // __using
-    pub const CALL_DISPOSE_MIN = "$cD"; // __callDispose
-};
-
-/// 모든 runtime helper 의 `(base_name, short_name)` 단일 소스 테이블.
-/// 새 helper 추가는 여기에 entry 만 추가 — `helperName` 조회, mangler 예약, 테스트
-/// iteration 이 전부 이 테이블을 consume 하므로 세 곳의 drift 를 구조적으로 방지한다.
-pub const PAIRS = [_]struct { base: []const u8, short: []const u8 }{
-    // bundler interop (#1618 + #1621)
-    .{ .base = "__commonJS", .short = NAMES.CJS_FACTORY_MIN },
-    .{ .base = "__require", .short = NAMES.REQUIRE_MIN },
-    .{ .base = "__esm", .short = NAMES.ESM_FACTORY_MIN },
-    .{ .base = "__export", .short = NAMES.EXPORT_MIN },
-    .{ .base = "__toESM", .short = NAMES.TOESM_MIN },
-    .{ .base = "__toCommonJS", .short = NAMES.TOCOMMONJS_MIN },
-    .{ .base = "__create", .short = NAMES.CREATE_MIN },
-    .{ .base = "__getProtoOf", .short = NAMES.GET_PROTO_OF_MIN },
-    .{ .base = "__defProp", .short = NAMES.DEF_PROP_MIN },
-    .{ .base = "__getOwnPropNames", .short = NAMES.GET_OWN_PROP_NAMES_MIN },
-    .{ .base = "__getOwnPropDesc", .short = NAMES.GET_OWN_PROP_DESC_MIN },
-    .{ .base = "__hasOwn", .short = NAMES.HAS_OWN_MIN },
-    .{ .base = "__copyProps", .short = NAMES.COPY_PROPS_MIN },
-    // transformer-emitted downlevel (#1621)
-    .{ .base = "__extends", .short = NAMES.EXTENDS_MIN },
-    .{ .base = "__classCallCheck", .short = NAMES.CLASS_CALL_CHECK_MIN },
-    .{ .base = "__callSuper", .short = NAMES.CALL_SUPER_MIN },
-    .{ .base = "__async", .short = NAMES.ASYNC_MIN },
-    .{ .base = "__asyncValues", .short = NAMES.ASYNC_VALUES_MIN },
-    .{ .base = "__generator", .short = NAMES.GENERATOR_MIN },
-    .{ .base = "__rest", .short = NAMES.REST_MIN },
-    .{ .base = "__taggedTemplateLiteral", .short = NAMES.TAGGED_TEMPLATE_MIN },
-    .{ .base = "__arrayLikeToArray", .short = NAMES.ARRAY_LIKE_TO_ARRAY_MIN },
-    .{ .base = "__toConsumableArray", .short = NAMES.TO_CONSUMABLE_ARRAY_MIN },
-    .{ .base = "__name", .short = NAMES.NAME_MIN },
-    .{ .base = "__toBinary", .short = NAMES.TO_BINARY_MIN },
-    .{ .base = "__classPrivateMethodInit", .short = NAMES.PRIVATE_METHOD_INIT_MIN },
-    .{ .base = "__classPrivateMethodGet", .short = NAMES.PRIVATE_METHOD_GET_MIN },
-    .{ .base = "__classPrivateFieldSet", .short = NAMES.PRIVATE_FIELD_SET_MIN },
-    .{ .base = "__classCheckPrivateStaticAccess", .short = NAMES.STATIC_PRIVATE_ACCESS_MIN },
-    .{ .base = "__classCheckPrivateStaticFieldDescriptor", .short = NAMES.STATIC_PRIVATE_DESC_MIN },
-    .{ .base = "__classStaticPrivateFieldSpecGet", .short = NAMES.STATIC_PRIVATE_GET_MIN },
-    .{ .base = "__classStaticPrivateFieldSpecSet", .short = NAMES.STATIC_PRIVATE_SET_MIN },
-    .{ .base = "__decorateClass", .short = NAMES.DECORATE_CLASS_MIN },
-    .{ .base = "__decorateParam", .short = NAMES.DECORATE_PARAM_MIN },
-    .{ .base = "__defProp2", .short = NAMES.DEF_PROP_2_MIN },
-    .{ .base = "__metadata", .short = NAMES.METADATA_MIN },
-    .{ .base = "__esDecorate", .short = NAMES.ES_DECORATE_MIN },
-    .{ .base = "__runInitializers", .short = NAMES.RUN_INITIALIZERS_MIN },
-    .{ .base = "__setFunctionName", .short = NAMES.SET_FUNCTION_NAME_MIN },
-    .{ .base = "__propKey", .short = NAMES.PROP_KEY_MIN },
-    .{ .base = "__using", .short = NAMES.USING_MIN },
-    .{ .base = "__callDispose", .short = NAMES.CALL_DISPOSE_MIN },
-};
-
-/// PAIRS 로부터 base_name → short_name comptime 해시맵.
-const helper_map: std.StaticStringMap([]const u8) = blk: {
-    var entries: [PAIRS.len]struct { []const u8, []const u8 } = undefined;
-    for (PAIRS, 0..) |p, i| entries[i] = .{ p.base, p.short };
-    break :blk std.StaticStringMap([]const u8).initComptime(entries);
-};
-
-/// PAIRS 의 short name 만 뽑은 comptime 배열. mangler 예약/테스트 iterate 용.
-pub const ALL_SHORT_NAMES: [PAIRS.len][]const u8 = blk: {
-    var names: [PAIRS.len][]const u8 = undefined;
-    for (PAIRS, 0..) |p, i| names[i] = p.short;
-    break :blk names;
-};
-
-/// transformer 가 AST identifier 로 emit 하는 runtime helper 이름을
-/// minify 플래그에 따라 축약/원본으로 선택한다. non-helper identifier (Math, writable 등)
-/// 는 호출하지 않는다 — 이 함수는 `PAIRS` 테이블에 등록된 이름만 처리.
-///
-/// 매핑에 없으면 원본 그대로 반환 → preamble 과 호출부가 어긋나 런타임 에러.
-/// mangler_test "runtime_helpers names are registered" 가 빌드 타임에 drift 를 잡는다.
-pub fn helperName(base_name: []const u8, minify: bool) []const u8 {
-    if (!minify) return base_name;
-    return helper_map.get(base_name) orelse base_name;
-}
+// #1618 / #1621 / #1752: runtime helper 축약 이름 테이블은 `src/runtime_helper_names.zig`
+// 공용 모듈로 이전. transformer (`es_helpers.makeRuntimeHelperRef`) 와 bundler (이 파일의
+// preamble 템플릿 + `mangler.isReservedOrGlobal`) 가 해당 공용 모듈에만 의존하여 레이어
+// 역전이 없다. 기존 `runtime_helpers.NAMES` / `PAIRS` / `helperName` 접근 경로는
+// re-export 로 호환 유지.
+const names_mod = @import("../runtime_helper_names.zig");
+pub const NAMES = names_mod.NAMES;
+pub const PAIRS = names_mod.PAIRS;
+pub const ALL_SHORT_NAMES = names_mod.ALL_SHORT_NAMES;
+pub const helperName = names_mod.helperName;
 
 /// __commonJS 팩토리 함수 (esbuild 호환)
 pub const CJS_RUNTIME = "var __commonJS = (cb, mod) => function __require() {\n\treturn mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;\n};\n";

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -516,9 +516,10 @@ pub fn isReservedOrGlobal(name: []const u8) bool {
     }
     // #1618 / #1621: bundler runtime helper 축약 이름 — base54 가 사용자 심볼에
     //                동일 이름을 배정해 preamble 정의를 덮어쓰는 것을 방지.
-    //                `runtime_helpers.PAIRS` 가 단일 소스 — drift 불가.
-    const rt = @import("../bundler/runtime_helpers.zig");
-    for (rt.ALL_SHORT_NAMES) |s| {
+    //                #1752: `runtime_helper_names.PAIRS` 공용 모듈 — 단일 소스 + mangler
+    //                가 bundler 를 import 하지 않도록 레이어 역전 회피.
+    const names = @import("../runtime_helper_names.zig");
+    for (names.ALL_SHORT_NAMES) |s| {
         if (std.mem.eql(u8, name, s)) return true;
     }
     return false;

--- a/src/codegen/mangler_test.zig
+++ b/src/codegen/mangler_test.zig
@@ -50,7 +50,7 @@ test "isReservedOrGlobal" {
 // #1618 / #1621: runtime helper 축약 이름이 모두 mangler 예약 목록에 등록되어 있는지.
 // `runtime_helpers.PAIRS` 가 단일 소스 — 빌드 타임에 순회해 drift 를 잡는다.
 test "isReservedOrGlobal: all #1621 runtime helper short names registered" {
-    const rt = @import("../bundler/runtime_helpers.zig");
+    const rt = @import("../runtime_helper_names.zig");
     inline for (rt.PAIRS) |p| {
         try std.testing.expect(isReservedOrGlobal(p.short));
     }
@@ -64,7 +64,7 @@ test "isReservedOrGlobal: all #1621 runtime helper short names registered" {
 }
 
 test "nextBase54Name: skips all runtime helper short names" {
-    const rt = @import("../bundler/runtime_helpers.zig");
+    const rt = @import("../runtime_helper_names.zig");
     const nextBase54Name = mangler.nextBase54Name;
     var buf: [8]u8 = undefined;
     var counter: u32 = 0;
@@ -81,7 +81,7 @@ test "nextBase54Name: skips all runtime helper short names" {
 // `helperName` 분배 함수가 각 base_name 에 대해 올바른 축약 이름을 반환하는지.
 // transformer 가 이 함수를 통해 AST identifier 이름을 결정하므로 정의 ↔ 매핑 drift 검증.
 test "helperName: base_name → short mapping for every PAIR" {
-    const rt = @import("../bundler/runtime_helpers.zig");
+    const rt = @import("../runtime_helper_names.zig");
     inline for (rt.PAIRS) |p| {
         try std.testing.expectEqualStrings(p.base, rt.helperName(p.base, false));
         try std.testing.expectEqualStrings(p.short, rt.helperName(p.base, true));

--- a/src/runtime_helper_names.zig
+++ b/src/runtime_helper_names.zig
@@ -1,0 +1,139 @@
+//! Runtime Helper 이름 테이블 — transformer/bundler 공용 abstraction.
+//!
+//! minify 모드에서 `__xxx` → `$xx` 축약 이름 매핑을 단일 소스로 관리한다.
+//! transformer (AST identifier emit) 와 bundler (preamble + mangler reserved)
+//! 양쪽이 **이 모듈에만 의존** — 서로에게 의존하지 않아 레이어 역전 없음.
+//!
+//! - `NAMES`: 각 helper 의 축약 이름 상수 (base_name 참조용).
+//! - `PAIRS`: `(base_name, short)` 매핑 테이블. 단일 소스.
+//! - `helperName(base, minify)`: transformer 가 AST identifier 이름 결정 시 호출.
+//! - `ALL_SHORT_NAMES`: mangler 예약 / 테스트 iterate 용.
+//!
+//! 실제 preamble 문자열 템플릿 (`CJS_RUNTIME_MIN` 등) 은 `bundler/runtime_helpers.zig`
+//! 에 유지된다 — bundler-only concern. 이 모듈은 **이름만** 담당.
+
+const std = @import("std");
+
+pub const NAMES = struct {
+    // bundler interop
+    pub const CJS_FACTORY_MIN = "$cj"; // __commonJS
+    pub const REQUIRE_MIN = "$r"; // __commonJS body 내부 function __require
+    pub const ESM_FACTORY_MIN = "$e"; // __esm
+    pub const EXPORT_MIN = "$x"; // __export
+    pub const TOESM_MIN = "$tE"; // __toESM
+    pub const TOCOMMONJS_MIN = "$tC"; // __toCommonJS
+    // Object.* alias — __toESM/__export body 에서 참조.
+    pub const CREATE_MIN = "$cr"; // __create
+    pub const GET_PROTO_OF_MIN = "$gP"; // __getProtoOf
+    pub const DEF_PROP_MIN = "$dp"; // __defProp
+    pub const GET_OWN_PROP_NAMES_MIN = "$gN"; // __getOwnPropNames
+    pub const GET_OWN_PROP_DESC_MIN = "$gD"; // __getOwnPropDesc
+    pub const HAS_OWN_MIN = "$hO"; // __hasOwn
+    pub const COPY_PROPS_MIN = "$cp"; // __copyProps
+    // transformer-emitted downlevel (RN/ES5 타겟에서 다수 emit)
+    pub const EXTENDS_MIN = "$eX"; // __extends (ES2015 class)
+    pub const CLASS_CALL_CHECK_MIN = "$cC"; // __classCallCheck
+    pub const CALL_SUPER_MIN = "$cS"; // __callSuper
+    pub const ASYNC_MIN = "$aS"; // __async (async/await → generator)
+    pub const ASYNC_VALUES_MIN = "$aV"; // __asyncValues (for-await-of)
+    pub const GENERATOR_MIN = "$gn"; // __generator
+    pub const REST_MIN = "$rs"; // __rest (object rest destructure)
+    pub const TAGGED_TEMPLATE_MIN = "$tt"; // __taggedTemplateLiteral
+    pub const ARRAY_LIKE_TO_ARRAY_MIN = "$aL"; // __arrayLikeToArray
+    pub const TO_CONSUMABLE_ARRAY_MIN = "$tA"; // __toConsumableArray (array spread)
+    pub const NAME_MIN = "$nm"; // __name (--keep-names)
+    pub const TO_BINARY_MIN = "$tb"; // __toBinary (binary loader asset)
+    // ES2022 private field downlevel
+    pub const PRIVATE_METHOD_INIT_MIN = "$pI"; // __classPrivateMethodInit
+    pub const PRIVATE_METHOD_GET_MIN = "$pG"; // __classPrivateMethodGet
+    pub const PRIVATE_FIELD_SET_MIN = "$pF"; // __classPrivateFieldSet
+    pub const STATIC_PRIVATE_ACCESS_MIN = "$sA"; // __classCheckPrivateStaticAccess
+    pub const STATIC_PRIVATE_DESC_MIN = "$sD"; // __classCheckPrivateStaticFieldDescriptor
+    pub const STATIC_PRIVATE_GET_MIN = "$sG"; // __classStaticPrivateFieldSpecGet
+    pub const STATIC_PRIVATE_SET_MIN = "$sS"; // __classStaticPrivateFieldSpecSet
+    // decorator
+    pub const DECORATE_CLASS_MIN = "$dC"; // __decorateClass
+    pub const DECORATE_PARAM_MIN = "$dK"; // __decorateParam
+    pub const DEF_PROP_2_MIN = "$dp2"; // __defProp2 (DECORATOR body, $dp 와 분리)
+    pub const METADATA_MIN = "$mD"; // __metadata
+    pub const ES_DECORATE_MIN = "$eD"; // __esDecorate
+    pub const RUN_INITIALIZERS_MIN = "$rI"; // __runInitializers
+    pub const SET_FUNCTION_NAME_MIN = "$sF"; // __setFunctionName
+    pub const PROP_KEY_MIN = "$pK"; // __propKey
+    // ES2025 explicit resource management
+    pub const USING_MIN = "$us"; // __using
+    pub const CALL_DISPOSE_MIN = "$cD"; // __callDispose
+};
+
+/// 모든 runtime helper 의 `(base_name, short_name)` 단일 소스 테이블.
+/// 새 helper 추가는 여기에 entry 만 추가 — `helperName` 조회, mangler 예약, 테스트
+/// iteration 이 전부 이 테이블을 consume 하므로 세 곳의 drift 를 구조적으로 방지한다.
+pub const PAIRS = [_]struct { base: []const u8, short: []const u8 }{
+    // bundler interop (#1618 + #1621)
+    .{ .base = "__commonJS", .short = NAMES.CJS_FACTORY_MIN },
+    .{ .base = "__require", .short = NAMES.REQUIRE_MIN },
+    .{ .base = "__esm", .short = NAMES.ESM_FACTORY_MIN },
+    .{ .base = "__export", .short = NAMES.EXPORT_MIN },
+    .{ .base = "__toESM", .short = NAMES.TOESM_MIN },
+    .{ .base = "__toCommonJS", .short = NAMES.TOCOMMONJS_MIN },
+    .{ .base = "__create", .short = NAMES.CREATE_MIN },
+    .{ .base = "__getProtoOf", .short = NAMES.GET_PROTO_OF_MIN },
+    .{ .base = "__defProp", .short = NAMES.DEF_PROP_MIN },
+    .{ .base = "__getOwnPropNames", .short = NAMES.GET_OWN_PROP_NAMES_MIN },
+    .{ .base = "__getOwnPropDesc", .short = NAMES.GET_OWN_PROP_DESC_MIN },
+    .{ .base = "__hasOwn", .short = NAMES.HAS_OWN_MIN },
+    .{ .base = "__copyProps", .short = NAMES.COPY_PROPS_MIN },
+    // transformer-emitted downlevel (#1621)
+    .{ .base = "__extends", .short = NAMES.EXTENDS_MIN },
+    .{ .base = "__classCallCheck", .short = NAMES.CLASS_CALL_CHECK_MIN },
+    .{ .base = "__callSuper", .short = NAMES.CALL_SUPER_MIN },
+    .{ .base = "__async", .short = NAMES.ASYNC_MIN },
+    .{ .base = "__asyncValues", .short = NAMES.ASYNC_VALUES_MIN },
+    .{ .base = "__generator", .short = NAMES.GENERATOR_MIN },
+    .{ .base = "__rest", .short = NAMES.REST_MIN },
+    .{ .base = "__taggedTemplateLiteral", .short = NAMES.TAGGED_TEMPLATE_MIN },
+    .{ .base = "__arrayLikeToArray", .short = NAMES.ARRAY_LIKE_TO_ARRAY_MIN },
+    .{ .base = "__toConsumableArray", .short = NAMES.TO_CONSUMABLE_ARRAY_MIN },
+    .{ .base = "__name", .short = NAMES.NAME_MIN },
+    .{ .base = "__toBinary", .short = NAMES.TO_BINARY_MIN },
+    .{ .base = "__classPrivateMethodInit", .short = NAMES.PRIVATE_METHOD_INIT_MIN },
+    .{ .base = "__classPrivateMethodGet", .short = NAMES.PRIVATE_METHOD_GET_MIN },
+    .{ .base = "__classPrivateFieldSet", .short = NAMES.PRIVATE_FIELD_SET_MIN },
+    .{ .base = "__classCheckPrivateStaticAccess", .short = NAMES.STATIC_PRIVATE_ACCESS_MIN },
+    .{ .base = "__classCheckPrivateStaticFieldDescriptor", .short = NAMES.STATIC_PRIVATE_DESC_MIN },
+    .{ .base = "__classStaticPrivateFieldSpecGet", .short = NAMES.STATIC_PRIVATE_GET_MIN },
+    .{ .base = "__classStaticPrivateFieldSpecSet", .short = NAMES.STATIC_PRIVATE_SET_MIN },
+    .{ .base = "__decorateClass", .short = NAMES.DECORATE_CLASS_MIN },
+    .{ .base = "__decorateParam", .short = NAMES.DECORATE_PARAM_MIN },
+    .{ .base = "__defProp2", .short = NAMES.DEF_PROP_2_MIN },
+    .{ .base = "__metadata", .short = NAMES.METADATA_MIN },
+    .{ .base = "__esDecorate", .short = NAMES.ES_DECORATE_MIN },
+    .{ .base = "__runInitializers", .short = NAMES.RUN_INITIALIZERS_MIN },
+    .{ .base = "__setFunctionName", .short = NAMES.SET_FUNCTION_NAME_MIN },
+    .{ .base = "__propKey", .short = NAMES.PROP_KEY_MIN },
+    .{ .base = "__using", .short = NAMES.USING_MIN },
+    .{ .base = "__callDispose", .short = NAMES.CALL_DISPOSE_MIN },
+};
+
+/// PAIRS 로부터 base_name → short_name comptime 해시맵.
+const helper_map: std.StaticStringMap([]const u8) = blk: {
+    var entries: [PAIRS.len]struct { []const u8, []const u8 } = undefined;
+    for (PAIRS, 0..) |p, i| entries[i] = .{ p.base, p.short };
+    break :blk std.StaticStringMap([]const u8).initComptime(entries);
+};
+
+/// PAIRS 의 short name 만 뽑은 comptime 배열. mangler 예약/테스트 iterate 용.
+pub const ALL_SHORT_NAMES: [PAIRS.len][]const u8 = blk: {
+    var names: [PAIRS.len][]const u8 = undefined;
+    for (PAIRS, 0..) |p, i| names[i] = p.short;
+    break :blk names;
+};
+
+/// transformer 가 AST identifier 로 emit 하는 runtime helper 이름을 minify 플래그에
+/// 따라 축약/원본으로 선택한다. non-helper identifier (Math, writable 등) 에는
+/// 호출하지 않는다 — `PAIRS` 에 등록된 이름만 처리. 매핑에 없으면 원본 반환
+/// (mangler_test 가 drift 를 빌드 타임에 잡음).
+pub fn helperName(base_name: []const u8, minify: bool) []const u8 {
+    if (!minify) return base_name;
+    return helper_map.get(base_name) orelse base_name;
+}

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -40,7 +40,8 @@ const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
 const es2022 = @import("es2022.zig");
-const rt = @import("../bundler/runtime_helpers.zig");
+// #1752: 공용 helper 이름 모듈 (transformer → bundler 역의존 회피).
+const rt = @import("../runtime_helper_names.zig");
 
 const MethodExtra = ast_mod.MethodExtra;
 const MethodFlags = ast_mod.MethodFlags;

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -149,16 +149,19 @@ pub fn makeIdentifierRef(self: anytype, name: []const u8) !NodeIndex {
     });
 }
 
-/// #1621: runtime helper (`__extends`, `__classCallCheck` 등) 용 identifier_reference.
-/// `self.options.minify_whitespace` 가 true 면 preamble 과 동일한 축약 이름(`$eX`, `$cC` 등)
-/// 으로 emit. 그렇지 않으면 원본 이름 그대로.
+/// #1621 / #1752: runtime helper (`__extends`, `__classCallCheck` 등) 용
+/// identifier_reference. `self.options.minify_whitespace` 가 true 면 preamble 과
+/// 동일한 축약 이름(`$eX`, `$cC` 등) 으로 emit. 그렇지 않으면 원본 이름 그대로.
 ///
 /// 일반 identifier (`Math`, `writable`, `value` 등) 에는 절대 쓰지 말 것 — 이 함수는
-/// `runtime_helpers.helperName` 화이트리스트에 등록된 이름만 처리한다. 등록되지 않은
-/// 이름을 넘기면 minify 모드에서도 원본 그대로 반환 → 동작은 정상이지만 축약 효과 없음.
+/// `runtime_helper_names.helperName` 화이트리스트에 등록된 이름만 처리한다. 등록되지
+/// 않은 이름을 넘기면 minify 모드에서도 원본 그대로 반환 → 동작은 정상이지만 축약 효과 없음.
+///
+/// transformer → bundler 역의존을 피하기 위해 `bundler/runtime_helpers.zig` 가 아니라
+/// 공용 모듈 `../runtime_helper_names.zig` 를 import 한다.
 pub fn makeRuntimeHelperRef(self: anytype, base_name: []const u8) !NodeIndex {
-    const rt = @import("../bundler/runtime_helpers.zig");
-    const resolved = rt.helperName(base_name, self.options.minify_whitespace);
+    const names = @import("../runtime_helper_names.zig");
+    const resolved = names.helperName(base_name, self.options.minify_whitespace);
     return makeIdentifierRef(self, resolved);
 }
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -18,7 +18,8 @@ const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
 const PrivateMethodMapping = Transformer.PrivateMethodMapping;
 const es_helpers = @import("../es_helpers.zig");
-const rt = @import("../../bundler/runtime_helpers.zig");
+// #1752: 공용 helper 이름 모듈 (transformer → bundler 역의존 회피).
+const rt = @import("../../runtime_helper_names.zig");
 const es2022 = @import("../es2022.zig");
 
 pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {


### PR DESCRIPTION
## Summary

PR #1750 (#1621 축약 확장) 에서 **transformer → bundler 레이어 역전** 이 발생. 이를 정리.

### 역의존이란

ZTS 파이프라인은 단방향 레이어:
```
lexer → parser → semantic → transformer → bundler → emitter
```

각 레이어는 자기보다 앞 단계에만 의존. **bundler 가 transformer 결과를 소비** 하지 반대가 아님.

PR #1750 에서 transformer 가 `bundler/runtime_helpers.zig` 를 import:
```zig
// src/transformer/es_helpers.zig (이전)
const rt = @import("../bundler/runtime_helpers.zig");  // ← 역의존!
```

### 왜 문제

1. **독립 실행 불가**: standalone transpile 이 transformer 만 쓰고 싶어도 bundler 가 딸려옴
2. **개념 레이어 위반**: 축약 이름 매핑은 transformer/bundler 공통 abstraction
3. **순환 위험**: import cycle 유발 가능

### 정석 해결

"이름 테이블" 을 공용 모듈 `src/runtime_helper_names.zig` 로 분리:

```
          ┌───────────────────┐
          │ runtime_helper_   │
          │ names             │
          └────┬──────────────┘
       ┌──────┼──────┐
       ▼      ▼      ▼
 transformer  bundler  codegen
       │      │
       └──→───┘  (기존 정방향 의존 유지)
```

## 변경

| 파일 | 변경 |
|------|------|
| `src/runtime_helper_names.zig` | **NEW** — NAMES / PAIRS / helperName / ALL_SHORT_NAMES |
| `src/bundler/runtime_helpers.zig` | names 를 공용 모듈 re-export (preamble 템플릿은 유지) |
| `src/transformer/es_helpers.zig` | `@import("../runtime_helper_names.zig")` 로 변경 |
| `src/transformer/es2015_class.zig` | 동일 |
| `src/transformer/transformer/class_decorator.zig` | 동일 |
| `src/codegen/mangler.zig` | 동일 |
| `src/codegen/mangler_test.zig` | 동일 |

기능 변화 없음. 유닛 테스트 3482/3482 통과.

## Test plan

- [x] `zig build test` — 3482/3482 통과
- [x] 기존 #1621 축약 기능 변화 없음 (re-export 유지)
- [x] transformer 가 더 이상 `bundler/` 를 import 하지 않음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)