### PR TITLE
fix(linker): #1754 analyzeNamespaceAccess opaque 경로 ArrayList leak

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1760,3 +1760,37 @@ test "CJS: ESM-wrapped named import from CJS — namespace rename must survive c
     // binding that the broken destructuring creates.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "Registry$1.getEnforcing(") == null);
 }
+
+// #1754: namespace import 가 member access (ns.prop) 로 먼저 수집된 후
+// bare reference (ns 자체를 값으로) 로 opaque 전환될 때, opaque 경로에서
+// `access.members.deinit` 만 호출하여 이전에 append 된 ArrayList 의 backing
+// buffer 가 leak. GPA debug allocator 가 leak 검출하므로 이 테스트 자체가 regression.
+test "ESM ns-access: opaque path (bare ref after member access) doesn't leak" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "utils.js",
+        \\export function greet() { return 'hi'; }
+        \\export function wave() { return 'wave'; }
+        \\export const tag = 'tag';
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as utils from './utils.js';
+        \\// 먼저 member access 여러 번 (access.members 에 append 됨)
+        \\console.log(utils.greet(), utils.wave(), utils.tag);
+        \\// 이어서 bare reference (opaque 로 전환 → 이전 ArrayList 들 해제되어야)
+        \\const all = utils;
+        \\console.log(Object.keys(all).length);
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 실제 검증은 GPA debug allocator 의 leak 검출에 위임 —
+    // leak 발생 시 `zig build test` 가 테스트 실패 처리.
+}

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1413,7 +1413,9 @@ pub const Linker = struct {
             if (sid != ns_sym_id) continue;
             if (node_i >= node_count) {
                 // 인덱스 범위 밖 참조는 보수적으로 opaque
-                access.members.deinit(allocator);
+                // #1754: `members.deinit` 만 호출하면 value ArrayList 의 backing
+                // buffer 가 leak. 전체 deinit 으로 value 까지 해제 후 초기화.
+                access.deinit(allocator);
                 access.members = .{};
                 access.kind = .@"opaque";
                 return access;
@@ -1461,7 +1463,9 @@ pub const Linker = struct {
                 }
             } else {
                 // member-expr object가 아닌 참조 위치 — opaque
-                access.members.deinit(allocator);
+                // #1754: `members.deinit` 만 호출하면 이전에 append 된 value ArrayList 의
+                // backing buffer 가 leak. 전체 deinit 으로 value 까지 해제 후 초기화.
+                access.deinit(allocator);
                 access.members = .{};
                 access.kind = .@"opaque";
                 return access;


### PR DESCRIPTION
## Summary

`NamespaceAccess.members` 는 `StringHashMapUnmanaged(ArrayListUnmanaged(u32))` 타입. opaque 전환 경로 두 곳 (`linker.zig:1414-1420`, `linker.zig:1462-1468`) 에서 `access.members.deinit(allocator)` 만 호출 — **HashMap backing 만 해제되고 이미 append 된 각 value ArrayList 의 backing buffer 가 leak**.

PR #1750 이후 RN+minify 번들에서 이런 경고 2건 발생 (기능상 크래시는 아니지만 누수):
```
error(gpa): memory address 0x11504a780 leaked:
linker.zig:1459:53: analyzeNamespaceAccessWithIndex
linker.zig:1688:61: populateNamespaceAccesses
```

## Root Cause

```zig
// BEFORE
} else {
    access.members.deinit(allocator);  // ← HashMap 만 해제, value ArrayList 는 leak
    access.members = .{};
    access.kind = .@"opaque";
    return access;
}
```

opaque 전환 이전에 member access 가 여러 번 append 되어 각 key 의 value ArrayList backing 이 할당된 상태에서 발생.

## Fix

```zig
// AFTER
access.deinit(allocator);  // value 순회 후 HashMap 해제 (전체 해제)
access.members = .{};      // caller 의 defer deinit 이 double-free 없이 no-op
access.kind = .@"opaque";
return access;
```

`NamespaceAccess.deinit` 이 이미 value 순회 + HashMap 해제 로직을 가지고 있으므로 재사용. 이후 `members = .{}` 초기화로 caller 의 `defer access.deinit(...)` 이 안전히 no-op.

## Regression Test

`bundler_test/cjs_esm.zig` 에 testcase 추가: member access 후 bare reference 로 opaque 전환되는 fixture.

GPA debug allocator 가 leak 검출하므로 이 테스트 자체가 regression — fix 없이는 실패, 적용 후 pass 확인 완료.

## Verification

- [x] `zig build test` — 3492/3492 통과 (regression test 포함, GPA leak 검출)
- [x] RN+minify 전체 번들: 2건의 leak 메시지 소거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)