### PR TITLE
fix(generator): #1756 __generator(body, genFn) 의 genFn 이름에 symbol_id 전파

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1120,3 +1120,40 @@ test "Bundler: #1751 ESM wrap function decl assignment has trailing semicolon" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "};\"use strict\"") != null or
         std.mem.indexOf(u8, result.output, "}\"use strict\"") == null);
 }
+
+// #1756: generator 다운레벨 시 `__generator(body, genFn)` 의 `genFn` 인자가
+// `makeIdentifierRefFromSpan` 로만 만들어져 symbol_id 미전파 → 번들 mangler
+// rename 이 이 이름에 반영되지 않아 원본 이름으로 emit 되면서 ReferenceError.
+// makeIdentifierRefWithSymbol 로 원본 binding 의 symbol_id 전파해 해결.
+test "Bundler: #1756 generator downlevel + minify genFn rename" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\function* tick(): Generator<string> { yield 'a'; yield 'b'; }
+        \\const g = tick();
+        \\console.log(g.next().value, g.next().value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .platform = .react_native, // ES5 downlevel → __generator 활성
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 원본 이름 `tick` 은 mangle 되어 3자 이하 알파벳으로 rename. `$gn(..., tick)`
+    // 같이 원본 이름이 `$gn` 호출부 두번째 인자로 남아있으면 안됨.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ",tick)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ", tick)") == null);
+    // $gn( 호출부가 존재해야 함 (generator downlevel 확인).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$gn(") != null);
+}

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -97,11 +97,16 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const sm_result = try buildStateMachine(self, body_idx, span);
             if (sm_result.body.isNone()) return .none;
 
-            // generator function 이름이 있으면 프로토타입 체인 설정을 위해 __generator에 전달
-            const genFn_ref: NodeIndex = if (!new_name.isNone()) blk: {
-                const name_node = self.ast.getNode(new_name);
-                break :blk try es_helpers.makeIdentifierRefFromSpan(self, name_node.span);
-            } else .none;
+            // generator function 이름이 있으면 프로토타입 체인 설정을 위해 __generator에 전달.
+            // #1756: makeIdentifierRefFromSpan 만 쓰면 symbol_id 가 전파되지 않아
+            // 번들 모드에서 mangler rename (`function foo → function t`) 이 반영 안 됨.
+            // `__generator(body, foo)` 의 `foo` 가 원본 이름 그대로 emit → ReferenceError.
+            // makeIdentifierRefWithSymbol 로 원본 binding 의 symbol_id 까지 전파해야
+            // codegen 이 `meta.renames.get(sid)` 로 mangled name 을 찾아 emit 함.
+            const genFn_ref: NodeIndex = if (!new_name.isNone())
+                try self.makeIdentifierRefWithSymbol(self.ast.getNode(new_name).data.string_ref, new_name)
+            else
+                .none;
             const gen_call = try buildGeneratorHelperCallWithProto(self, sm_result.body, genFn_ref, span);
 
             // return __generator(...) 문


### PR DESCRIPTION
## Summary

generator 다운레벨 시 `__generator(body, genFn)` 의 두번째 인자 `genFn` identifier 가 **symbol_id 미전파**로 mangler rename 을 놓쳐 원본 이름으로 emit → runtime `ReferenceError`.

## Reproduction

```ts
function* makeIter(): Generator<number> { yield 10; yield 20; }
const it = makeIter();
console.log(it.next().value, it.next().value);
```

```
$ zts --bundle --platform=react-native --rn-platform=ios --minify ...
$ node out.js
ReferenceError: makeIter is not defined
```

출력에서 `function t(){return $gn(function(_state){...}, makeIter);}` 확인 — `function makeIter` 가 `function t` 로 mangle 됐는데 `$gn(..., makeIter)` 의 `makeIter` 는 원본 이름 그대로.

## Root Cause

`src/transformer/es2015_generator.zig`:
```zig
const genFn_ref: NodeIndex = if (!new_name.isNone()) blk: {
    const name_node = self.ast.getNode(new_name);
    break :blk try es_helpers.makeIdentifierRefFromSpan(self, name_node.span);  // ← symbol_id 누락
} else .none;
```

`makeIdentifierRefFromSpan` 은 span 만 복사하고 symbol_id 는 설정 안 함. codegen 의 identifier emit 경로:

```zig
if (self.options.linking_metadata) |meta| {
    const sym_id = self.resolveSymbolId(idx, meta);  // meta.symbol_ids[node_i] 조회
    if (sym_id) |sid| {
        if (meta.renames.get(sid)) |new_name| {
            try self.write(new_name);  // ← rename 적용
            return;
        }
    }
}
try self.writeNodeSpan(node);  // ← fallback: 원본 text emit
```

symbol_id 가 null 이면 rename 을 건너뛰고 원본 text 를 그대로 emit → 버그.

## Fix

`makeIdentifierRefWithSymbol(span, old_idx)` 로 교체. 이 함수는 `propagateSymbolId(old_idx, new_ref)` 를 내부에서 호출해 **원본 binding 노드 (`new_name`) 의 symbol_id 를 새 identifier_reference 에 복사**. codegen 이 rename map 을 찾아 mangled name 을 emit.

```zig
const genFn_ref: NodeIndex = if (!new_name.isNone())
    try self.makeIdentifierRefWithSymbol(self.ast.getNode(new_name).data.string_ref, new_name)
else
    .none;
```

## Regression Test

`basic.zig` 에 fixture 추가: RN + `--minify` + generator 다운레벨. 원본 이름 `tick` 이 `$gn(` 호출 두번째 인자로 남지 않는지 검증. Fix revert 시 테스트 실패 확인 완료.

## Verification

- [x] `zig build test` — 3494/3494 통과 (regression 포함)
- [x] 재현 코드: `node out.js` 가 `10 20` 정상 출력
- [x] Fix revert 시 regression 테스트 실패

## 남은 follow-up (별도 이슈)

Complex generator (outer fn + inner var 가 같은 mangler slot 에 배정) 에서 shadowing:
```js
function e() { ... }  // outer: counter → e
function t() {
  var e, x;           // inner: shadows outer e!
  ...
  e()                 // ← 이게 outer counter 아니라 inner var 를 참조
}
```
mangler 의 liveness-based slot reuse 가 function declaration 이름을 enclosing scope 전체 live 로 간주해야 함. 별도 scope-aware mangler 수정 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)