### PR TITLE
fix(mangler): #1757 nested mangler 가 top-level canonical_name 을 reserved 로 인식

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1157,3 +1157,80 @@ test "Bundler: #1756 generator downlevel + minify genFn rename" {
     // $gn( 호출부가 존재해야 함 (generator downlevel 확인).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "$gn(") != null);
 }
+
+// #1757: mangler slot-reuse shadowing — outer function declaration 이름과
+// inner var/let 이 같은 mangler slot 에 배정되어 shadow. RN + generator + async
+// + for-of 조합에서 `TypeError: e is not a function` 으로 표면화.
+test "Bundler: #1757 mangler outer fn / inner var shadowing" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\function* counter(): Generator<number> { yield 1; yield 2; yield 3; }
+        \\async function main() {
+        \\  let sum = 0;
+        \\  for (const x of counter()) sum += x;
+        \\  return sum;
+        \\}
+        \\main().then(v => console.log(v));
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .platform = .react_native,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const out = result.output;
+
+    // outer `function counter` 의 mangled 이름을 찾아, 같은 이름이 inner 의
+    // `var` 선언 리스트에 포함되지 않는지 검증.
+    // counter 는 main 에서 호출되는데 main body 는 `function t(){var <inner>;...}` 꼴.
+    // `var e,...}` 형태로 시작하는 inner 선언이 outer 이름을 재사용하면 shadowing.
+    //
+    // 직접 구조 검증: counter → fn name, 그 name 이 다른 `function` 의 body 안
+    // `var` 로 재선언되면 안 됨.
+    // 검사: mangled counter 함수 선언 `function X(){return $gn(` 를 찾고 그 X 이름이
+    // 다른 위치의 `var X,` / `var X;` 패턴에 나타나지 않는지.
+    const gn_fn_prefix = "(){return $gn(";
+    const pos_gn_fn = std.mem.indexOf(u8, out, gn_fn_prefix) orelse return error.CounterFnNotFound;
+    // `function counter` 의 mangled 이름 역산 — prefix 바로 앞의 identifier.
+    const name_end = pos_gn_fn;
+    var name_start = name_end;
+    while (name_start > 0) : (name_start -= 1) {
+        const c = out[name_start - 1];
+        if (!(std.ascii.isAlphanumeric(c) or c == '_' or c == '$')) break;
+    }
+    const counter_name = out[name_start..name_end];
+    try std.testing.expect(counter_name.len > 0);
+
+    // counter_name 이 `var <name>,` 또는 `var <name>;` 형태로 재등장하는지.
+    // 재등장 시 shadowing (mangler 버그). 여러 `var` 선언문 중 하나라도 해당.
+    var search_from: usize = 0;
+    while (std.mem.indexOfPos(u8, out, search_from, "var ")) |idx| : (search_from = idx + 1) {
+        const after = out[idx + 4 ..];
+        // identifier 추출
+        var end: usize = 0;
+        while (end < after.len) : (end += 1) {
+            const c = after[end];
+            if (!(std.ascii.isAlphanumeric(c) or c == '_' or c == '$')) break;
+        }
+        const decl_name = after[0..end];
+        if (std.mem.eql(u8, decl_name, counter_name)) {
+            // counter_name 이 var 선언으로 재등장 — shadowing!
+            // allowed 예외: 바로 그 function 자체의 scope 에서 이름 재선언은 문법상 없음
+            // (function_declaration 은 var 가 아님). 이 경우는 bug.
+            std.debug.print("SHADOW DETECTED: counter_name='{s}' re-declared as var at offset {d}\n", .{ counter_name, idx });
+            return error.ShadowingDetected;
+        }
+    }
+}

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -192,7 +192,17 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
                 }
                 if (skip_symbols) |ss| {
                     if (sym_idx < ss.capacity() and ss.isSet(sym_idx)) {
-                        try reserved_names.put(name, {});
+                        // #1757: top-level mangler 가 이미 rename 한 심볼의 최종 이름
+                        // (canonical_name) 을 reserved 로 등록. nested mangler 는
+                        // 별도 base54 counter 를 써서 독립 이름 생성하므로, 동일한
+                        // 축약 이름을 선택해 shadow 하는 것을 차단.
+                        // 원본 이름도 함께 reserved — 호출부 식별자 resolve 경로 중
+                        // 혹 renames 가 적용되지 않고 원본으로 emit 되는 노드 보호.
+                        const reserved_name = if (sym.canonical_name.len > 0) sym.canonical_name else name;
+                        try reserved_names.put(reserved_name, {});
+                        if (sym.canonical_name.len > 0 and !std.mem.eql(u8, name, reserved_name)) {
+                            try reserved_names.put(name, {});
+                        }
                         continue;
                     }
                 }


### PR DESCRIPTION
## Summary

Outer `function counter` 와 inner `let sum` 이 같은 mangler slot 이름 `e` 로 배정되어 shadowing → `TypeError: e is not a function`. RN + `--minify` + generator + async + for-of 조합에서 재현.

## 실제 원인 (debug 확증)

Issue #1757 본문의 "transformer-synthetic reference 누락" 가설은 **틀림**. liveness 는 정확:
- `counter` decl=scope 0, refs in scope 2 → liveness `{0, 2, 3}`
- `sum` decl=scope 2, refs in scope 2/3 → liveness `{2, 3}`
- Intersection `{2, 3}` 존재 — 단일 mangler 라면 다른 slot 배정.

실제 원인: **두 mangler 간 정보 격리**.

1. `linker.computeMangling` (top-level) — `counter → e` 배정, `Symbol.canonical_name` 저장.
2. `metadata.buildMetadataForAst` 의 **nested mangler** — 별도 base54 counter 로 실행. top-level 이 쓴 `e` 를 모름.
3. nested 가 scope_maps[0] 심볼을 `skip_symbols` 로 받지만, 그 **rename 결과** (`canonical_name`) 는 `reserved_names` 에 등록 안 됨.
4. nested 가 `sum` 에 `e` 배정 → 같은 이름 → shadow.

## Fix

`mangler.zig` 의 `skip_symbols` 처리에서 `Symbol.canonical_name` (top-level 의 최종 rename) 을 `reserved_names` 에 등록:

```zig
if (skip_symbols) |ss| {
    if (sym_idx < ss.capacity() and ss.isSet(sym_idx)) {
        // top-level mangler 가 rename 한 최종 이름 + 원본 이름 모두 reserved
        const reserved_name = if (sym.canonical_name.len > 0) sym.canonical_name else name;
        try reserved_names.put(reserved_name, {});
        if (sym.canonical_name.len > 0 and !std.mem.eql(u8, name, reserved_name)) {
            try reserved_names.put(name, {});
        }
        continue;
    }
}
```

두 mangler 가 분리 동작하는 현 아키텍처 내 **최소-정확** 수정. 궁극 근본 (single unified mangler) 은 별개 refactor.

## Regression Test

`basic.zig #1757`: generator + async + for-of fixture. outer fn 의 mangled 이름이 inner `var` 로 재선언되지 않는지 구조 검사. Fix revert 시 `error.ShadowingDetected`.

## Verification

- [x] `zig build test` — 3495/3495 통과 (regression 포함)
- [x] `counter + main() → sum` 재현: `6` 출력 (이전 `TypeError: e is not a function`)
- [x] 간단 generator (#1756) 유지 통과

Closes #1757

🤖 Generated with [Claude Code](https://claude.com/claude-code)