### PR TITLE
feat(bundler): #1760 mangler property measurement harness

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -22,7 +22,9 @@ const emitter = @import("emitter.zig");
 const EmitOptions = emitter.EmitOptions;
 const OutputFile = emitter.OutputFile;
 const chunk_mod = @import("chunk.zig");
-const Linker = @import("linker.zig").Linker;
+const linker_mod = @import("linker.zig");
+const Linker = linker_mod.Linker;
+const MangleReportCollector = linker_mod.MangleReportCollector;
 const TreeShaker = @import("tree_shaker.zig").TreeShaker;
 const module_store = @import("module_store.zig");
 const transpile_mod = @import("../transpile.zig");
@@ -142,6 +144,9 @@ pub const BundleOptions = struct {
     legal_comments: types.LegalComments = .default,
     /// metafile JSON 생성 (--metafile)
     metafile: bool = false,
+    /// `--mangle-report=<path>` — mangler property 측정 JSON 저장 (#1760).
+    /// `minify_identifiers=true` 일 때만 의미 있음 (그 외에는 빈 report).
+    mangle_report_path: ?[]const u8 = null,
     /// 번들 분석 출력 (--analyze). metafile을 내부적으로 강제 활성화.
     analyze: bool = false,
     /// 모든 모듈에 자동 import (--inject:./file.js). 절대 경로 목록.
@@ -645,6 +650,12 @@ pub const Bundler = struct {
             }
         }
 
+        // --mangle-report (#1760) property harness. main linker path 에만 연결.
+        // mangle_report_enabled=false 여도 storage 는 만들어 두지만 deinit/연결 skip.
+        var mangle_collector: MangleReportCollector = .init(self.allocator);
+        const mangle_report_enabled = self.options.mangle_report_path != null;
+        defer if (mangle_report_enabled) mangle_collector.deinit();
+
         // 1. 모듈 그래프 구축
         var graph_scope = profile.begin(.graph);
         var graph = ModuleGraph.init(self.allocator, self.getResolveCache());
@@ -743,6 +754,7 @@ pub const Bundler = struct {
             l.dev_mode = self.options.dev_mode;
             // #1621: preamble/metadata 가 __toESM/__toCommonJS 를 축약 이름으로 emit.
             l.minify_whitespace = self.options.minify_whitespace;
+            if (mangle_report_enabled) l.mangle_report = &mangle_collector;
             try l.link();
             if (!self.options.code_splitting) {
                 try l.computeRenames();
@@ -1111,6 +1123,27 @@ pub const Bundler = struct {
             }
             break :blk merged;
         } else asset_outputs;
+
+        // --mangle-report (#1760): 번들 크기 집계 후 JSON 파일 기록.
+        if (mangle_report_enabled) {
+            var total_bytes: usize = output.len;
+            if (outputs) |outs| {
+                total_bytes = 0;
+                for (outs) |o| total_bytes += o.contents.len;
+            }
+            mangle_collector.bundle_size_bytes = total_bytes;
+
+            if (self.options.mangle_report_path) |path| write_blk: {
+                const file = std.fs.cwd().createFile(path, .{}) catch |err| {
+                    std.log.warn("--mangle-report: cannot create '{s}': {s}", .{ path, @errorName(err) });
+                    break :write_blk;
+                };
+                defer file.close();
+                mangle_collector.writeJson(file.deprecatedWriter()) catch |err| {
+                    std.log.warn("--mangle-report: write failed ({s}): {s}", .{ path, @errorName(err) });
+                };
+            }
+        }
 
         // 증분 빌드: graph.deinit() 전에 모듈을 store로 이전.
         // putModule이 parse_arena 소유권을 store로 가져가므로

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -26,6 +26,7 @@ const bundler_symbol = @import("symbol.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const profile = @import("../profile.zig");
 const rt = @import("runtime_helpers.zig");
+const ManglerStats = @import("../codegen/mangler.zig").ManglerStats;
 
 /// namespace 접근 패턴에서 생성되는 변수 prefix.
 /// metadata.zig, codegen.zig, emitter.zig에서 공유.
@@ -36,6 +37,96 @@ pub const NS_VAR_PREFIX = "__ns_";
 pub inline fn isNamespaceRename(rename: []const u8) bool {
     return std.mem.startsWith(u8, rename, NS_VAR_PREFIX);
 }
+
+/// `--mangle-report` 전용 측정 수집기 (#1760 property harness).
+///
+/// Bundler 가 생성해 `Linker.mangle_report` 에 꽂으면 `computeMangling` 과
+/// `buildMetadataForAst` 내부 nested mangler 가 호출마다 통계를 append.
+/// Unified mangler 마이그레이션 전/후의 수치 비교 baseline.
+///
+/// `buildMetadataForAst` 는 emitter 가 병렬 호출하므로 `recordNested` 는 mutex 보호.
+pub const MangleReportCollector = struct {
+    allocator: std.mem.Allocator,
+    mutex: std.Thread.Mutex = .{},
+
+    top_level: ManglerStats = .{},
+    /// top-level 충돌 방지 pool 크기 (scope_maps 이름 + canonical_strings 합집합).
+    top_level_reserved_pool: usize = 0,
+
+    nested: std.ArrayListUnmanaged(NestedEntry) = .empty,
+    /// Bundle emit 후 채움.
+    bundle_size_bytes: usize = 0,
+
+    pub const NestedEntry = struct {
+        /// linker 생명주기 내 유효 (module.path 차용).
+        module_path: []const u8,
+        stats: ManglerStats,
+    };
+
+    pub fn init(allocator: std.mem.Allocator) MangleReportCollector {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *MangleReportCollector) void {
+        self.nested.deinit(self.allocator);
+    }
+
+    pub fn recordNested(
+        self: *MangleReportCollector,
+        module_path: []const u8,
+        stats: ManglerStats,
+    ) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        try self.nested.append(self.allocator, .{ .module_path = module_path, .stats = stats });
+    }
+
+    pub fn writeJson(self: *const MangleReportCollector, writer: anytype) !void {
+        var totals: ManglerStats = .{
+            .slot_count = self.top_level.slot_count,
+            .slot_name_length_sum = self.top_level.slot_name_length_sum,
+            .renamed_symbol_count = self.top_level.renamed_symbol_count,
+        };
+        try writer.writeAll("{\n  \"top_level\": ");
+        try writeStatsJson(writer, self.top_level);
+        try writer.print(",\n  \"top_level_reserved_pool\": {d},\n  \"nested\": [", .{self.top_level_reserved_pool});
+        for (self.nested.items, 0..) |entry, i| {
+            try writer.writeAll(if (i == 0) "\n    " else ",\n    ");
+            try writer.writeAll("{\"module_path\": ");
+            try writeJsonString(writer, entry.module_path);
+            try writer.writeAll(", \"stats\": ");
+            try writeStatsJson(writer, entry.stats);
+            try writer.writeAll("}");
+            totals.slot_count += entry.stats.slot_count;
+            totals.slot_name_length_sum += entry.stats.slot_name_length_sum;
+            totals.renamed_symbol_count += entry.stats.renamed_symbol_count;
+        }
+        try writer.writeAll(if (self.nested.items.len == 0) "]" else "\n  ]");
+        try writer.print(",\n  \"bundle_size_bytes\": {d},\n  \"totals\": ", .{self.bundle_size_bytes});
+        try writeStatsJson(writer, totals);
+        try writer.writeAll("\n}\n");
+    }
+
+    fn writeStatsJson(writer: anytype, s: ManglerStats) !void {
+        try writer.print(
+            "{{\"slot_count\": {d}, \"slot_name_length_sum\": {d}, \"name_counter_final\": {d}, \"reserved_size\": {d}, \"renamed_symbol_count\": {d}}}",
+            .{ s.slot_count, s.slot_name_length_sum, s.name_counter_final, s.reserved_size, s.renamed_symbol_count },
+        );
+    }
+
+    fn writeJsonString(writer: anytype, s: []const u8) !void {
+        try writer.writeByte('"');
+        for (s) |c| switch (c) {
+            '"' => try writer.writeAll("\\\""),
+            '\\' => try writer.writeAll("\\\\"),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            else => try writer.writeByte(c),
+        };
+        try writer.writeByte('"');
+    }
+};
 
 /// 크로스 모듈 심볼 참조. 어떤 모듈의 어떤 export를 가리키는지.
 /// codegen에 전달하는 per-module 메타데이터.
@@ -230,6 +321,10 @@ pub const Linker = struct {
 
     /// computeMangling 완료 후 true. buildMetadataForAst에서 nested mangling 수행 여부 결정.
     nested_mangling_enabled: bool = false,
+
+    /// --mangle-report 수집기 (#1760). `null` 이면 instrumentation skip.
+    /// Bundler 가 생성 및 소유. Linker 는 참조만 보유.
+    mangle_report: ?*MangleReportCollector = null,
 
     /// 모듈별 중첩 스코프 바인딩 이름 집합 (사전 구축).
     /// computeRenames에서 한 번 구축, hasNestedBinding에서 O(1) 조회.
@@ -801,6 +896,7 @@ pub const Linker = struct {
 
         var name_counter: u32 = 0;
         var name_buf: [8]u8 = undefined;
+        var slot_name_length_sum: usize = 0;
         for (candidates.entries.items) |entry| {
             var new_name = Mangler.nextBase54Name(&name_counter, &name_buf);
             while (all_names.contains(new_name) or
@@ -809,12 +905,24 @@ pub const Linker = struct {
             {
                 new_name = Mangler.nextBase54Name(&name_counter, &name_buf);
             }
+            slot_name_length_sum += new_name.len;
 
             if (!std.mem.eql(u8, entry.name, new_name)) {
                 const duped = try self.allocator.dupe(u8, new_name);
                 try name_map.put(entry.name, duped);
                 try used_names.put(duped, {});
             }
+        }
+
+        if (self.mangle_report) |r| {
+            r.top_level = .{
+                .slot_count = candidates.entries.items.len,
+                .slot_name_length_sum = slot_name_length_sum,
+                .name_counter_final = name_counter,
+                .reserved_size = 0, // top-level 에는 mangler 내부 reserved_names 개념이 없음
+                .renamed_symbol_count = name_map.count(),
+            };
+            r.top_level_reserved_pool = all_names.count();
         }
 
         // 3. 기존 canonical_name이 mangling 대상이면 새 이름으로 교체.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -516,6 +516,11 @@ pub fn buildMetadataForAst(
                 .skip_symbols = skip_syms,
             });
 
+            // #1760 property harness: nested mangler stats 를 collector 로.
+            if (self.mangle_report) |r| {
+                r.recordNested(m.path, nested_result.stats) catch {};
+            }
+
             // nested renames를 기존 renames에 merge (소유권 이전)
             var taken = nested_result.takeRenames();
             defer taken.deinit(); // HashMap 자체만 해제 (값은 owned_nested_renames가 관리)

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -29,6 +29,8 @@ pub const ManglerResult = struct {
     /// symbol_id -> 새 이름. codegen의 linking_metadata.renames에 주입.
     renames: std.AutoHashMap(u32, []const u8),
     allocator: std.mem.Allocator,
+    /// 이 호출의 측정값. `--mangle-report` 경로 외엔 무시됨. #1760 property harness.
+    stats: ManglerStats = .{},
 
     pub fn deinit(self: *ManglerResult) void {
         var it = self.renames.valueIterator();
@@ -43,6 +45,21 @@ pub const ManglerResult = struct {
         self.renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
         return taken;
     }
+};
+
+/// Mangler 호출 1회의 측정값. Unified mangler 로 마이그레이션 전/후의
+/// property 검증 (번들 크기 ± 1%, 이름 길이 총합 등) 에 사용.
+pub const ManglerStats = struct {
+    /// Phase 3 에서 생성된 고유 slot 수 (= 고유 base54 이름 수).
+    slot_count: usize = 0,
+    /// Phase 4 에서 할당된 slot 이름 길이의 합.
+    slot_name_length_sum: usize = 0,
+    /// Phase 4 종료 시점의 base54 name_counter 값 (예약어 스킵 포함 소비).
+    name_counter_final: u32 = 0,
+    /// Phase 3 종료 시점의 reserved_names set 크기.
+    reserved_size: usize = 0,
+    /// Phase 5 후 renames 에 기록된 심볼 수 (원본과 동일하면 skip 되므로 slot_count 와 다를 수 있음).
+    renamed_symbol_count: usize = 0,
 };
 
 /// mangle() 입력 데이터.
@@ -291,6 +308,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
 
     var name_counter: u32 = 0;
     var name_buf: [8]u8 = undefined;
+    var slot_name_length_sum: usize = 0;
     for (sorted_slots) |entry| {
         // 예약어/글로벌 + mangling 제외 심볼의 원본 이름은 건너뜀 (#1609)
         var name = base54(name_counter, &name_buf);
@@ -300,6 +318,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
             name_counter += 1;
         }
         slot_names[entry.slot_id] = try allocator.dupe(u8, name);
+        slot_name_length_sum += name.len;
     }
 
     // ================================================================
@@ -344,7 +363,17 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
         }
     }
 
-    return .{ .renames = renames, .allocator = allocator };
+    return .{
+        .renames = renames,
+        .allocator = allocator,
+        .stats = .{
+            .slot_count = slot_count,
+            .slot_name_length_sum = slot_name_length_sum,
+            .name_counter_final = name_counter,
+            .reserved_size = reserved_names.count(),
+            .renamed_symbol_count = renames.count(),
+        },
+    };
 }
 
 // ============================================================

--- a/src/main.zig
+++ b/src/main.zig
@@ -104,6 +104,8 @@ const CliOptions = struct {
     asset_registry_explicit_off: bool = false,
     loader_list: std.ArrayList(LoaderOverride) = .empty,
     metafile_path: ?[]const u8 = null,
+    /// --mangle-report=<path>: mangler property 측정 JSON 저장 (#1760).
+    mangle_report_path: ?[]const u8 = null,
     analyze: bool = false,
     legal_comments: @import("zts_lib").bundler.types.LegalComments = .default,
     inject_list: std.ArrayList([]const u8) = .empty,
@@ -665,6 +667,8 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             opts.metafile_path = arg["--metafile=".len..];
         } else if (std.mem.eql(u8, arg, "--metafile")) {
             opts.metafile_path = "meta.json";
+        } else if (std.mem.startsWith(u8, arg, "--mangle-report=")) {
+            opts.mangle_report_path = arg["--mangle-report=".len..];
         } else if (std.mem.eql(u8, arg, "--analyze")) {
             opts.analyze = true;
         } else if (std.mem.eql(u8, arg, "--keep-names")) {
@@ -1721,6 +1725,7 @@ pub fn main() !void {
             .asset_registry = opts.asset_registry,
             .loader_overrides = opts.loader_list.items,
             .metafile = opts.metafile_path != null or opts.analyze,
+            .mangle_report_path = opts.mangle_report_path,
             .analyze = opts.analyze,
             .legal_comments = opts.legal_comments,
             .inject = opts.inject_list.items,

--- a/tests/benchmark/_fixtures.ts
+++ b/tests/benchmark/_fixtures.ts
@@ -1,0 +1,48 @@
+/**
+ * 여러 benchmark runner 가 공유하는 fixture 정의.
+ * 각 entry 는 `tests/benchmark/node_modules` 아래 실제 의존성을 참조한다.
+ */
+
+export interface CommonFixture {
+  name: string;
+  entry: string;
+  platform?: "node" | "browser";
+  format?: "esm" | "cjs";
+}
+
+export const COMMON_FIXTURES: CommonFixture[] = [
+  {
+    name: "effect",
+    entry: `import { Effect, pipe } from 'effect';
+const p = pipe(Effect.succeed(42), Effect.map((n: number) => n + 1));
+Effect.runPromise(p).then(r => console.log(r));`,
+  },
+  {
+    name: "lodash-es",
+    entry: `import { groupBy, sortBy, uniq } from 'lodash-es';
+console.log(groupBy, sortBy, uniq);`,
+  },
+  {
+    name: "zod",
+    entry: `import { z } from 'zod';
+const schema = z.string().email();
+console.log(schema.parse('test@test.com'));`,
+  },
+  {
+    name: "rxjs",
+    entry: `import { of, map, filter, toArray } from 'rxjs';
+of(1,2,3,4,5).pipe(filter(x=>x%2===0), map(x=>x*10), toArray()).subscribe(arr=>console.log(JSON.stringify(arr)));`,
+  },
+  {
+    name: "three",
+    entry: `import { Vector3 } from 'three';
+const v = new Vector3(1, 2, 3);
+console.log(v.length().toFixed(2));`,
+  },
+  {
+    name: "react",
+    entry: `import React from 'react';
+const el = React.createElement('div', {id:'t'}, 'hi');
+console.log(el.type, el.props.id);`,
+  },
+];

--- a/tests/benchmark/baselines/mangler-property.json
+++ b/tests/benchmark/baselines/mangler-property.json
@@ -1,0 +1,5132 @@
+{
+  "version": 1,
+  "generated_at": "2026-04-22T18:21:20.991Z",
+  "fixtures": [
+    {
+      "name": "effect",
+      "report": {
+        "top_level": {
+          "slot_count": 10135,
+          "slot_name_length_sum": 27038,
+          "name_counter_final": 10328,
+          "reserved_size": 0,
+          "renamed_symbol_count": 10135
+        },
+        "top_level_reserved_pool": 13047,
+        "nested": [
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/effect.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Equivalence.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 7,
+              "reserved_size": 46,
+              "renamed_symbol_count": 36
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/pair.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 13,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/option.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 34,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/request.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 43,
+              "renamed_symbol_count": 25
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Differ.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 52,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/boundaries.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 27,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/state.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 71,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/registry.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 16,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberMessage.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 16,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/key.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 43,
+              "renamed_symbol_count": 19
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/completedRequestMap.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/supervisor/patch.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 33,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/keyType.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 74,
+              "renamed_symbol_count": 19
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberScope.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 17,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/supervisor.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 42,
+              "renamed_symbol_count": 70
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Scope.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberRefsPatch.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberStatus.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/executionStrategy.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 22,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberStatus.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 39,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_effect.ts",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/logSpan.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Effectable.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Scheduler.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 35,
+              "renamed_symbol_count": 65
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/label.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 17,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberRefs.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRefs/patch.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 24,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/hook.js",
+            "stats": {
+              "slot_count": 18,
+              "slot_name_length_sum": 18,
+              "name_counter_final": 24,
+              "reserved_size": 48,
+              "renamed_symbol_count": 103
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/tracer.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 7,
+              "reserved_size": 25,
+              "renamed_symbol_count": 31
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/config.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 7,
+              "reserved_size": 115,
+              "renamed_symbol_count": 117
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/defaultServices/console.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/LogLevel.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 40,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtime.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 105,
+              "renamed_symbol_count": 84
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/configError.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/logger.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 22,
+              "reserved_size": 106,
+              "renamed_symbol_count": 113
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Micro.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 25,
+              "reserved_size": 461,
+              "renamed_symbol_count": 456
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/random.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 6,
+              "reserved_size": 30,
+              "renamed_symbol_count": 28
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/deferred.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider/pathPatch.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 25,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/clock.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 24,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/singleShotGen.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRefs.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 45,
+              "renamed_symbol_count": 72
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/cause.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configError.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 56,
+              "renamed_symbol_count": 54
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/deferred.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 12,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/RuntimeFlagsPatch.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlags.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 66,
+              "renamed_symbol_count": 42
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlagsPatch.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 39,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/defaultServices.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 69,
+              "renamed_symbol_count": 33
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/MutableHashMap.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 58,
+              "renamed_symbol_count": 63
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/data.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 12,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiber.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 14,
+              "reserved_size": 119,
+              "renamed_symbol_count": 64
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/hashSetPatch.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 39,
+              "renamed_symbol_count": 21
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 43,
+              "renamed_symbol_count": 66
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/contextPatch.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 9,
+              "reserved_size": 45,
+              "renamed_symbol_count": 27
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 14,
+              "reserved_size": 114,
+              "renamed_symbol_count": 216
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/readonlyArrayPatch.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 8,
+              "reserved_size": 42,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/blockedRequests.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 86,
+              "renamed_symbol_count": 76
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberId.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/array.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 9,
+              "renamed_symbol_count": 15
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/stack.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/HashSet.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 55,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/bitwise.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/config.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/MutableRef.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 4,
+              "reserved_size": 49,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core-effect.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 24,
+              "reserved_size": 345,
+              "renamed_symbol_count": 370
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Context.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/HashMap.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 82,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Effect.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 14,
+              "reserved_size": 696,
+              "renamed_symbol_count": 75
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/RegExp.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 5,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberId.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 5,
+              "reserved_size": 76,
+              "renamed_symbol_count": 33
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/cause.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 14,
+              "reserved_size": 178,
+              "renamed_symbol_count": 202
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashSet.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 7,
+              "reserved_size": 82,
+              "renamed_symbol_count": 63
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/array.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/node.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 21,
+              "reserved_size": 53,
+              "renamed_symbol_count": 109
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/version.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/List.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 15,
+              "reserved_size": 137,
+              "renamed_symbol_count": 121
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/either.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 42,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/context.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 89,
+              "renamed_symbol_count": 57
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Tuple.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 30,
+              "renamed_symbol_count": 16
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 7,
+              "reserved_size": 127,
+              "renamed_symbol_count": 120
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 12,
+              "reserved_size": 590,
+              "renamed_symbol_count": 424
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Pipeable.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 9,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/errors.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/effectable.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 37,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Order.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 60,
+              "renamed_symbol_count": 66
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Hash.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 40,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Duration.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 147,
+              "renamed_symbol_count": 159
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/GlobalValue.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Number.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 9,
+              "reserved_size": 63,
+              "renamed_symbol_count": 24
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Equal.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 18,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Chunk.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 12,
+              "reserved_size": 220,
+              "renamed_symbol_count": 120
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Inspectable.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 14,
+              "reserved_size": 45,
+              "renamed_symbol_count": 27
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Utils.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 13,
+              "reserved_size": 68,
+              "renamed_symbol_count": 42
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Either.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 5,
+              "reserved_size": 104,
+              "renamed_symbol_count": 42
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Option.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 4,
+              "reserved_size": 148,
+              "renamed_symbol_count": 65
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Predicate.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 5,
+              "reserved_size": 110,
+              "renamed_symbol_count": 64
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Function.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 15,
+              "reserved_size": 50,
+              "renamed_symbol_count": 32
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRuntime.js",
+            "stats": {
+              "slot_count": 23,
+              "slot_name_length_sum": 23,
+              "name_counter_final": 34,
+              "reserved_size": 333,
+              "renamed_symbol_count": 679
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Array.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 12,
+              "reserved_size": 308,
+              "renamed_symbol_count": 229
+            }
+          }
+        ],
+        "bundle_size_bytes": 141133,
+        "totals": {
+          "slot_count": 10580,
+          "slot_name_length_sum": 27483,
+          "name_counter_final": 0,
+          "reserved_size": 0,
+          "renamed_symbol_count": 15519
+        }
+      },
+      "nested_module_count": 102,
+      "nested_totals": {
+        "slot_count": 445,
+        "slot_name_length_sum": 445,
+        "name_counter_final": 0,
+        "reserved_size": 6941,
+        "renamed_symbol_count": 5384
+      }
+    },
+    {
+      "name": "lodash-es",
+      "report": {
+        "top_level": {
+          "slot_count": 1203,
+          "slot_name_length_sum": 2354,
+          "name_counter_final": 1216,
+          "reserved_size": 0,
+          "renamed_symbol_count": 1203
+        },
+        "top_level_reserved_pool": 1556,
+        "nested": [
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObjectLike.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_root.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArray.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/identity.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseToString.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 16,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_shortOut.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 8,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nativeKeys.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/noop.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayMap.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_coreJsData.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/keys.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObject.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArrayLike.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseKeys.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/constant.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setToArray.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapToArray.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalObjects.js",
+            "stats": {
+              "slot_count": 22,
+              "slot_name_length_sum": 22,
+              "name_counter_final": 22,
+              "reserved_size": 10,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_cacheHas.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseUniq.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 13,
+              "reserved_size": 16,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/uniq.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalByTag.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 11,
+              "reserved_size": 44,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_lodash-es.ts",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/lodash.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createSet.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 10,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createAggregator.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 10,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseForOwn.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayIncludesWith.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareMultiple.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 4,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createBaseEach.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 4,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/groupBy.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMap.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIteratee.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 12,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalArrays.js",
+            "stats": {
+              "slot_count": 17,
+              "slot_name_length_sum": 17,
+              "name_counter_final": 18,
+              "reserved_size": 12,
+              "renamed_symbol_count": 19
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayAggregator.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 2,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseAggregator.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 4,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/property.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 10,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/hasIn.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFor.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMatchesProperty.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 20,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_basePropertyDeep.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseHasIn.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseSortBy.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseOrderBy.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 20,
+              "renamed_symbol_count": 14
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createBaseFor.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 2,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheHas.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isStrictComparable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseProperty.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsMatch.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 14,
+              "reserved_size": 10,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheAdd.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Set.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseEach.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getMatchData.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_SetCache.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqual.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Promise.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/sortBy.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Uint8Array.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMatches.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubArray.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getSymbols.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hasPath.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 14,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_matchesStrictComparable.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_DataView.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackHas.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackClear.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getAllKeys.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arraySome.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGetAllKeys.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 6,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackGet.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayFilter.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 2,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isFlattenable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 10,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGet.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 6,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackSet.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 10,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareAscending.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 4,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/toString.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqualDeep.js",
+            "stats": {
+              "slot_count": 17,
+              "slot_name_length_sum": 17,
+              "name_counter_final": 20,
+              "reserved_size": 30,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Stack.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 14,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheHas.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toKey.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFlatten.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 6,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getTag.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 38,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_castPath.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 10,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/get.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stringToPath.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheGet.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayPush.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheDelete.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheHas.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackDelete.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheSet.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_assocIndexOf.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Hash.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 12,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheClear.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getMapData.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isKeyable.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Map.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_memoizeCapped.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashDelete.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheSet.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashGet.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseUnary.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashHas.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_overArg.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheGet.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubFalse.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nativeCreate.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isTypedArray.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isKey.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseTimes.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 4,
+              "reserved_size": 3,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheClear.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/memoize.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isLength.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArguments.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 12,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashSet.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsArguments.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashClear.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_overRest.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 6,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nodeUtil.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 2,
+              "reserved_size": 13,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheDelete.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/eq.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isPrototype.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIndex.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_ListCache.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 12,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseRest.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_MapCache.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 12,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsNaN.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_defineProperty.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 2,
+              "reserved_size": 5,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isBuffer.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getNative.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFindIndex.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 2,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_strictIndexOf.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_WeakMap.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toSource.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 2,
+              "reserved_size": 7,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseAssignValue.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIndexOf.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setToString.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_objectToString.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isMasked.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Symbol.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getValue.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_freeGlobal.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGetTag.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 14,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIterateeCall.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 10,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayIncludes.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsTypedArray.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 58,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayLikeKeys.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 18,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseSetToString.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isFunction.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 14,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsNative.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 24,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_apply.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isSymbol.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getRawTag.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 13,
+              "renamed_symbol_count": 5
+            }
+          }
+        ],
+        "bundle_size_bytes": 20292,
+        "totals": {
+          "slot_count": 1674,
+          "slot_name_length_sum": 2825,
+          "name_counter_final": 0,
+          "reserved_size": 0,
+          "renamed_symbol_count": 1691
+        }
+      },
+      "nested_module_count": 153,
+      "nested_totals": {
+        "slot_count": 471,
+        "slot_name_length_sum": 471,
+        "name_counter_final": 0,
+        "reserved_size": 973,
+        "renamed_symbol_count": 488
+      }
+    },
+    {
+      "name": "zod",
+      "report": {
+        "top_level": {
+          "slot_count": 139,
+          "slot_name_length_sum": 237,
+          "name_counter_final": 154,
+          "reserved_size": 0,
+          "renamed_symbol_count": 139
+        },
+        "top_level_reserved_pool": 359,
+        "nested": [
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/helpers/errorUtil.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/locales/en.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/errors.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 7,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/ZodError.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 9,
+              "renamed_symbol_count": 25
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/helpers/util.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 6,
+              "reserved_size": 12,
+              "renamed_symbol_count": 30
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 10,
+              "reserved_size": 28,
+              "renamed_symbol_count": 31
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_zod.ts",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/index.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/types.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 15,
+              "name_counter_final": 96,
+              "reserved_size": 273,
+              "renamed_symbol_count": 637
+            }
+          }
+        ],
+        "bundle_size_bytes": 68937,
+        "totals": {
+          "slot_count": 172,
+          "slot_name_length_sum": 275,
+          "name_counter_final": 0,
+          "reserved_size": 0,
+          "renamed_symbol_count": 869
+        }
+      },
+      "nested_module_count": 9,
+      "nested_totals": {
+        "slot_count": 33,
+        "slot_name_length_sum": 38,
+        "name_counter_final": 0,
+        "reserved_size": 339,
+        "renamed_symbol_count": 730
+      }
+    },
+    {
+      "name": "rxjs",
+      "report": {
+        "top_level": {
+          "slot_count": 1080,
+          "slot_name_length_sum": 2129,
+          "name_counter_final": 1122,
+          "reserved_size": 0,
+          "renamed_symbol_count": 1080
+        },
+        "top_level_reserved_pool": 1545,
+        "nested": [
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/arrRemove.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/config.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/noop.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subscription.js",
+            "stats": {
+              "slot_count": 14,
+              "slot_name_length_sum": 14,
+              "name_counter_final": 21,
+              "reserved_size": 26,
+              "renamed_symbol_count": 37
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zipAll.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeoutWith.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_rxjs.ts",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 9,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zipWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throttleTime.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zip.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeWhile.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timestamp.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchAll.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeUntil.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowToggle.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 12,
+              "reserved_size": 22,
+              "renamed_symbol_count": 21
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchScan.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 7,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipWhile.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/withLatestFrom.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 14,
+              "reserved_size": 25,
+              "renamed_symbol_count": 18
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/tap.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 15
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/window.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 12,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throttle.js",
+            "stats": {
+              "slot_count": 17,
+              "slot_name_length_sum": 17,
+              "name_counter_final": 17,
+              "reserved_size": 8,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchMapTo.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowTime.js",
+            "stats": {
+              "slot_count": 12,
+              "slot_name_length_sum": 12,
+              "name_counter_final": 12,
+              "reserved_size": 18,
+              "renamed_symbol_count": 31
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipUntil.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowCount.js",
+            "stats": {
+              "slot_count": 12,
+              "slot_name_length_sum": 12,
+              "name_counter_final": 17,
+              "reserved_size": 15,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeInterval.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 10,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowWhen.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 10,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/index.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 342,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchMap.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/startWith.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sampleTime.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skip.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 5,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/shareReplay.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 6,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipLast.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 8,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sequenceEqual.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 9,
+              "reserved_size": 12,
+              "renamed_symbol_count": 16
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/raceWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 19,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/scan.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retryWhen.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 10,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishLast.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sample.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/repeat.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishReplay.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/share.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 22,
+              "reserved_size": 23,
+              "renamed_symbol_count": 35
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/min.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/repeatWhen.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 11,
+              "reserved_size": 10,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/flatMap.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publish.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/single.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishBehavior.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/max.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/pairwise.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 7,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMapTo.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/onErrorResumeNextWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/multicast.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeScan.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retry.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 11,
+              "reserved_size": 12,
+              "renamed_symbol_count": 18
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/isEmpty.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/pluck.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 7,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/materialize.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/merge.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 21,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeLast.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 10,
+              "reserved_size": 14,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/find.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 8,
+              "reserved_size": 9,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/findIndex.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/last.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 16,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/finalize.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/first.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 16,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/exhaust.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/expand.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/groupBy.js",
+            "stats": {
+              "slot_count": 14,
+              "slot_name_length_sum": 14,
+              "name_counter_final": 14,
+              "reserved_size": 12,
+              "renamed_symbol_count": 29
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/exhaustAll.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throwIfEmpty.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 10,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinctUntilKeyChanged.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinctUntilChanged.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/every.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/exhaustMap.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 13,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/endWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinct.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/dematerialize.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/elementAt.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 14,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/delayWhen.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 14,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/delay.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mapTo.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/count.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 5,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromSubscribable.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/ignoreElements.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineAll.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/take.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatMapTo.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/defaultIfEmpty.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatMap.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatest.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 25,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounceTime.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/reduce.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/joinAllInternals.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounce.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 10,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/connect.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 12,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/toArray.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferWhen.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/buffer.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 11,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concat.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 9,
+              "reserved_size": 21,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/types.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/using.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/catchError.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 8,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferToggle.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 10,
+              "reserved_size": 20,
+              "renamed_symbol_count": 16
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/scanInternals.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 11,
+              "reserved_size": 5,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/auditTime.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestAll.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/audit.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/zip.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 12,
+              "reserved_size": 25,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/partition.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/range.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 5,
+              "reserved_size": 7,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/filter.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferCount.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 20,
+              "reserved_size": 14,
+              "renamed_symbol_count": 25
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/interval.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/pairs.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/never.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/iif.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferTime.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 14,
+              "reserved_size": 22,
+              "renamed_symbol_count": 30
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/merge.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 12,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/not.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/argsOrArgArray.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatAll.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/race.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 14,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/defer.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeAll.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/forkJoin.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 16,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/timer.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/generate.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 14,
+              "reserved_size": 20,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/concat.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/onErrorResumeNext.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 12,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/connectable.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 10,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/map.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/createObject.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 3,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isDate.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindNodeCallback.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromEventPattern.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 9,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMap.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 15,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/SequenceError.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindCallback.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindCallbackInternals.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 16,
+              "reserved_size": 25,
+              "renamed_symbol_count": 25
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/argsArgArrayOrObject.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 12,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/firstValueFrom.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ArgumentOutOfRangeError.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/NotFoundError.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/mapOneOrManyArgs.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 19,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/lastValueFrom.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 4,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeout.js",
+            "stats": {
+              "slot_count": 12,
+              "slot_name_length_sum": 12,
+              "name_counter_final": 12,
+              "reserved_size": 18,
+              "renamed_symbol_count": 24
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isObservable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/combineLatest.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 10,
+              "reserved_size": 25,
+              "renamed_symbol_count": 24
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/EmptyError.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/of.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromEvent.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 13,
+              "reserved_size": 36,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleObservable.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeInternals.js",
+            "stats": {
+              "slot_count": 15,
+              "slot_name_length_sum": 15,
+              "name_counter_final": 15,
+              "reserved_size": 8,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Notification.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 14,
+              "renamed_symbol_count": 33
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/from.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/observeOn.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleReadableStreamLike.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/schedulePromise.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/throwUnobservableError.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isIterable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleAsyncIterable.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/subscribeOn.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isAsyncIterable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleIterable.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/symbol/iterator.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isArrayLike.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduled.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 28,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isPromise.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/queue.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/executeSchedule.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 2,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isScheduler.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/animationFrame.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameScheduler.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 9,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/args.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/asap.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleArray.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 5,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/throwError.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isReadableStreamLike.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 16,
+              "reserved_size": 25,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isInteropObservable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameAction.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 15
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/empty.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/QueueScheduler.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 9,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Scheduler.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/QueueAction.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 9,
+              "renamed_symbol_count": 14
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/async.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/VirtualTimeScheduler.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 16,
+              "renamed_symbol_count": 30
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/innerFrom.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 23,
+              "reserved_size": 60,
+              "renamed_symbol_count": 56
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsapScheduler.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 9,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsapAction.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 15
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/Immediate.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/immediateProvider.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ObjectUnsubscribedError.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsyncAction.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 14,
+              "renamed_symbol_count": 29
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/performanceTimestampProvider.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/intervalProvider.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 11,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/AsyncSubject.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 9,
+              "renamed_symbol_count": 18
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/dateTimestampProvider.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/Action.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 9,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsyncScheduler.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 9,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/identity.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/dom/animationFrames.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/ReplaySubject.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 9,
+              "reserved_size": 12,
+              "renamed_symbol_count": 29
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/symbol/observable.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isFunction.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/refCount.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/reportUnhandledError.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Observable.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 23,
+              "renamed_symbol_count": 37
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/ConnectableObservable.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 17,
+              "renamed_symbol_count": 14
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/pipe.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/NotificationFactories.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subject.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 10,
+              "reserved_size": 25,
+              "renamed_symbol_count": 53
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 11,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/animationFrameProvider.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 13,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/errorContext.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/timeoutProvider.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 11,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subscriber.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 37,
+              "renamed_symbol_count": 38
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/lift.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/UnsubscriptionError.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 3,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/BehaviorSubject.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 9,
+              "renamed_symbol_count": 13
+            }
+          }
+        ],
+        "bundle_size_bytes": 211407,
+        "totals": {
+          "slot_count": 2033,
+          "slot_name_length_sum": 3082,
+          "name_counter_final": 0,
+          "reserved_size": 0,
+          "renamed_symbol_count": 2876
+        }
+      },
+      "nested_module_count": 224,
+      "nested_totals": {
+        "slot_count": 953,
+        "slot_name_length_sum": 953,
+        "name_counter_final": 0,
+        "reserved_size": 2438,
+        "renamed_symbol_count": 1796
+      }
+    },
+    {
+      "name": "three",
+      "report": {
+        "top_level": {
+          "slot_count": 1080,
+          "slot_name_length_sum": 2136,
+          "name_counter_final": 1184,
+          "reserved_size": 0,
+          "renamed_symbol_count": 1080
+        },
+        "top_level_reserved_pool": 3433,
+        "nested": [
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_three.ts",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/three@0.170.0/node_modules/three/build/three.module.js",
+            "stats": {
+              "slot_count": 100,
+              "slot_name_length_sum": 200,
+              "name_counter_final": 1220,
+              "reserved_size": 2190,
+              "renamed_symbol_count": 7121
+            }
+          }
+        ],
+        "bundle_size_bytes": 213672,
+        "totals": {
+          "slot_count": 1180,
+          "slot_name_length_sum": 2336,
+          "name_counter_final": 0,
+          "reserved_size": 0,
+          "renamed_symbol_count": 8201
+        }
+      },
+      "nested_module_count": 2,
+      "nested_totals": {
+        "slot_count": 100,
+        "slot_name_length_sum": 200,
+        "name_counter_final": 0,
+        "reserved_size": 2190,
+        "renamed_symbol_count": 7121
+      }
+    },
+    {
+      "name": "react",
+      "report": {
+        "top_level": {
+          "slot_count": 38,
+          "slot_name_length_sum": 38,
+          "name_counter_final": 43,
+          "reserved_size": 0,
+          "renamed_symbol_count": 38
+        },
+        "top_level_reserved_pool": 193,
+        "nested": [
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/react@19.2.4/node_modules/react/index.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_react.ts",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/react@19.2.4/node_modules/react/cjs/react.production.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 48,
+              "reserved_size": 77,
+              "renamed_symbol_count": 111
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/react@19.2.4/node_modules/react/cjs/react.development.js",
+            "stats": {
+              "slot_count": 72,
+              "slot_name_length_sum": 95,
+              "name_counter_final": 77,
+              "reserved_size": 5,
+              "renamed_symbol_count": 265
+            }
+          }
+        ],
+        "bundle_size_bytes": 9741,
+        "totals": {
+          "slot_count": 118,
+          "slot_name_length_sum": 141,
+          "name_counter_final": 0,
+          "reserved_size": 0,
+          "renamed_symbol_count": 414
+        }
+      },
+      "nested_module_count": 4,
+      "nested_totals": {
+        "slot_count": 80,
+        "slot_name_length_sum": 103,
+        "name_counter_final": 0,
+        "reserved_size": 82,
+        "renamed_symbol_count": 376
+      }
+    }
+  ]
+}

--- a/tests/benchmark/mangler-property.ts
+++ b/tests/benchmark/mangler-property.ts
@@ -141,9 +141,8 @@ type Check = { ok: boolean; label: string; detail: string };
 function checkFixture(baseline: FixtureResult, current: FixtureResult): Check[] {
   const checks: Check[] = [];
   const size_delta = current.report.bundle_size_bytes - baseline.report.bundle_size_bytes;
-  const size_ratio = baseline.report.bundle_size_bytes === 0
-    ? 0
-    : size_delta / baseline.report.bundle_size_bytes;
+  const size_ratio =
+    baseline.report.bundle_size_bytes === 0 ? 0 : size_delta / baseline.report.bundle_size_bytes;
   checks.push({
     ok: Math.abs(size_ratio) <= BUNDLE_SIZE_TOLERANCE,
     label: `bundle_size(${baseline.name})`,

--- a/tests/benchmark/mangler-property.ts
+++ b/tests/benchmark/mangler-property.ts
@@ -1,0 +1,229 @@
+#!/usr/bin/env bun
+/**
+ * Mangler property harness — Issue #1760 baseline runner.
+ *
+ * 각 fixture 에 대해 `zts --bundle --minify --mangle-report=<path>` 를 돌려
+ * ManglerReport JSON 을 수집하고 baseline 과 비교한다.
+ *
+ * Unified mangler 마이그레이션(#1760) 전/후의 property 동치성 검증용.
+ * 개별 이름은 Phase A→B counter 공유로 달라질 수 있으므로 집계값으로만 비교:
+ *   - bundle_size_bytes: ±1%
+ *   - totals.slot_name_length_sum: ±1%
+ *   - top_level_reserved_pool: ±2 개 (exact diff 는 의미 없음)
+ *
+ * 실행:
+ *   bun run tests/benchmark/mangler-property.ts          # baseline 과 비교
+ *   bun run tests/benchmark/mangler-property.ts --write  # baseline 갱신
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { COMMON_FIXTURES, type CommonFixture } from "./_fixtures";
+
+const ROOT = resolve(__dirname, "../..");
+const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
+const BASELINE_PATH = join(__dirname, "baselines", "mangler-property.json");
+
+const BUNDLE_SIZE_TOLERANCE = 0.01; // ±1%
+const NAME_LENGTH_TOLERANCE = 0.01; // ±1%
+const RESERVED_POOL_ABS = 2;
+
+interface ManglerStats {
+  slot_count: number;
+  slot_name_length_sum: number;
+  name_counter_final: number;
+  reserved_size: number;
+  renamed_symbol_count: number;
+}
+
+interface NestedEntry {
+  module_path: string;
+  stats: ManglerStats;
+}
+
+interface ManglerReport {
+  top_level: ManglerStats;
+  top_level_reserved_pool: number;
+  nested: NestedEntry[];
+  bundle_size_bytes: number;
+  totals: ManglerStats;
+}
+
+interface FixtureResult {
+  name: string;
+  report: ManglerReport;
+  nested_module_count: number;
+  nested_totals: ManglerStats;
+}
+
+interface Baseline {
+  version: number;
+  generated_at: string;
+  fixtures: FixtureResult[];
+}
+
+type Fixture = CommonFixture;
+const fixtures: Fixture[] = COMMON_FIXTURES;
+
+function emptyStats(): ManglerStats {
+  return {
+    slot_count: 0,
+    slot_name_length_sum: 0,
+    name_counter_final: 0,
+    reserved_size: 0,
+    renamed_symbol_count: 0,
+  };
+}
+
+function sumNested(report: ManglerReport): ManglerStats {
+  const totals = emptyStats();
+  for (const e of report.nested) {
+    totals.slot_count += e.stats.slot_count;
+    totals.slot_name_length_sum += e.stats.slot_name_length_sum;
+    totals.renamed_symbol_count += e.stats.renamed_symbol_count;
+    totals.reserved_size += e.stats.reserved_size;
+  }
+  return totals;
+}
+
+function runFixture(f: Fixture): FixtureResult {
+  const dir = mkdtempSync(join(tmpdir(), `zts-mangle-${f.name}-`));
+  const entryFile = join(__dirname, `_mangle_entry_${f.name}.ts`);
+  writeFileSync(entryFile, f.entry);
+  try {
+    const outFile = join(dir, "zts.js");
+    const reportFile = join(dir, "report.json");
+    const args = [
+      "--bundle",
+      entryFile,
+      "-o",
+      outFile,
+      "--minify",
+      `--platform=${f.platform ?? "node"}`,
+      `--mangle-report=${reportFile}`,
+    ];
+    const r = spawnSync(ZTS_BIN, args, { encoding: "utf8", timeout: 180_000 });
+    if (r.status !== 0) {
+      throw new Error(`zts failed (${r.status}): ${r.stderr}`);
+    }
+    const report: ManglerReport = JSON.parse(readFileSync(reportFile, "utf8"));
+    return {
+      name: f.name,
+      report,
+      nested_module_count: report.nested.length,
+      nested_totals: sumNested(report),
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    try {
+      rmSync(entryFile);
+    } catch {}
+  }
+}
+
+function formatStats(s: ManglerStats): string {
+  return `slots=${s.slot_count} nameLen=${s.slot_name_length_sum} rename=${s.renamed_symbol_count}`;
+}
+
+function printFixture(r: FixtureResult): void {
+  const top = r.report.top_level;
+  const nest = r.nested_totals;
+  console.log(`\n## ${r.name}`);
+  console.log(`  bundle_size: ${r.report.bundle_size_bytes} B`);
+  console.log(`  top_level:   ${formatStats(top)} (pool=${r.report.top_level_reserved_pool})`);
+  console.log(`  nested(${r.nested_module_count} mod): ${formatStats(nest)}`);
+}
+
+type Check = { ok: boolean; label: string; detail: string };
+
+function checkFixture(baseline: FixtureResult, current: FixtureResult): Check[] {
+  const checks: Check[] = [];
+  const size_delta = current.report.bundle_size_bytes - baseline.report.bundle_size_bytes;
+  const size_ratio = baseline.report.bundle_size_bytes === 0
+    ? 0
+    : size_delta / baseline.report.bundle_size_bytes;
+  checks.push({
+    ok: Math.abs(size_ratio) <= BUNDLE_SIZE_TOLERANCE,
+    label: `bundle_size(${baseline.name})`,
+    detail: `${baseline.report.bundle_size_bytes} -> ${current.report.bundle_size_bytes} (${(size_ratio * 100).toFixed(2)}%)`,
+  });
+
+  const b_nl = baseline.report.totals.slot_name_length_sum;
+  const c_nl = current.report.totals.slot_name_length_sum;
+  const nl_ratio = b_nl === 0 ? 0 : (c_nl - b_nl) / b_nl;
+  checks.push({
+    ok: Math.abs(nl_ratio) <= NAME_LENGTH_TOLERANCE,
+    label: `name_length_sum(${baseline.name})`,
+    detail: `${b_nl} -> ${c_nl} (${(nl_ratio * 100).toFixed(2)}%)`,
+  });
+
+  const b_pool = baseline.report.top_level_reserved_pool;
+  const c_pool = current.report.top_level_reserved_pool;
+  checks.push({
+    ok: Math.abs(c_pool - b_pool) <= RESERVED_POOL_ABS,
+    label: `reserved_pool(${baseline.name})`,
+    detail: `${b_pool} -> ${c_pool} (Δ${c_pool - b_pool})`,
+  });
+
+  return checks;
+}
+
+function main(): void {
+  const writeBaseline = process.argv.includes("--write");
+
+  const results: FixtureResult[] = [];
+  for (const f of fixtures) {
+    try {
+      const r = runFixture(f);
+      results.push(r);
+      printFixture(r);
+    } catch (e) {
+      console.error(`\n## ${f.name}: FAIL — ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  if (writeBaseline) {
+    mkdirSync(join(__dirname, "baselines"), { recursive: true });
+    const bl: Baseline = {
+      version: 1,
+      generated_at: new Date().toISOString(),
+      fixtures: results,
+    };
+    writeFileSync(BASELINE_PATH, JSON.stringify(bl, null, 2) + "\n");
+    console.log(`\nBaseline written: ${BASELINE_PATH}`);
+    return;
+  }
+
+  let baseline: Baseline;
+  try {
+    baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+  } catch {
+    console.log(`\n(no baseline at ${BASELINE_PATH} — run with --write to create)`);
+    return;
+  }
+
+  const baselineByName = new Map(baseline.fixtures.map((f) => [f.name, f]));
+  let failed = 0;
+  console.log("\n# Baseline comparison\n");
+  for (const cur of results) {
+    const base = baselineByName.get(cur.name);
+    if (!base) {
+      console.log(`- ${cur.name}: no baseline entry (add with --write)`);
+      continue;
+    }
+    for (const c of checkFixture(base, cur)) {
+      const mark = c.ok ? "✓" : "✗";
+      console.log(`- ${mark} ${c.label}: ${c.detail}`);
+      if (!c.ok) failed += 1;
+    }
+  }
+  if (failed > 0) {
+    console.error(`\n${failed} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll property checks within tolerance.");
+}
+
+main();

--- a/tests/benchmark/minify-bench.ts
+++ b/tests/benchmark/minify-bench.ts
@@ -13,6 +13,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync, existsSync, statSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { COMMON_FIXTURES, type CommonFixture } from "./_fixtures";
 
 const ROOT = resolve(__dirname, "../..");
 const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
@@ -25,49 +26,8 @@ const ROLLDOWN_BIN = existsSync(join(__dirname, "node_modules/.bin/rolldown"))
 
 const EXEC_TIMEOUT_MS = 180_000;
 
-interface Fixture {
-  name: string;
-  entry: string;
-  platform?: "node" | "browser";
-  format?: "esm" | "cjs";
-}
-
-const fixtures: Fixture[] = [
-  {
-    name: "effect",
-    entry: `import { Effect, pipe } from 'effect';
-const p = pipe(Effect.succeed(42), Effect.map((n: number) => n + 1));
-Effect.runPromise(p).then(r => console.log(r));`,
-  },
-  {
-    name: "lodash-es",
-    entry: `import { groupBy, sortBy, uniq } from 'lodash-es';
-console.log(groupBy, sortBy, uniq);`,
-  },
-  {
-    name: "zod",
-    entry: `import { z } from 'zod';
-const schema = z.string().email();
-console.log(schema.parse('test@test.com'));`,
-  },
-  {
-    name: "rxjs",
-    entry: `import { of, map, filter, toArray } from 'rxjs';
-of(1,2,3,4,5).pipe(filter(x=>x%2===0), map(x=>x*10), toArray()).subscribe(arr=>console.log(JSON.stringify(arr)));`,
-  },
-  {
-    name: "three",
-    entry: `import { Vector3 } from 'three';
-const v = new Vector3(1, 2, 3);
-console.log(v.length().toFixed(2));`,
-  },
-  {
-    name: "react",
-    entry: `import React from 'react';
-const el = React.createElement('div', {id:'t'}, 'hi');
-console.log(el.type, el.props.id);`,
-  },
-];
+type Fixture = CommonFixture;
+const fixtures: Fixture[] = COMMON_FIXTURES;
 
 interface LengthHistogram {
   len1: number;


### PR DESCRIPTION
## Summary

- `--mangle-report=<path>` CLI 플래그 추가: top-level / nested mangler 호출당 통계 (slot 수, 이름 길이 합, reserved pool, 번들 크기) 를 JSON 덤프.
- `ManglerStats` 를 `ManglerResult` 에 붙여 nested 결과 회수. `MangleReportCollector` (linker.zig) — mutex 로 per-module append 보호, `computeMangling` / `metadata.buildMetadataForAst` 양쪽에서 기록.
- TS runner `tests/benchmark/mangler-property.ts` + `tests/benchmark/baselines/mangler-property.json` — rxjs/effect/three/lodash/zod/react fixture 에 대해 현 two-phase 기준값 고정 (번들 크기 ±1%, 이름 길이 총합 ±1%, reserved_pool ±2 tolerance).
- `/simplify` cross-file 정리: `tests/benchmark/_fixtures.ts` 신규 — `minify-bench.ts` / `mangler-property.ts` 중복 fixtures 배열 제거. `linker.zig` 에 `const ManglerStats = ...` alias 로 5회 인라인 import 제거.

#1760 unified mangler 마이그레이션의 property 검증 baseline. **개별 이름은 Phase A→B counter 공유로 달라질 수 있어 exact diff 불가** — 집계값 tolerance 로만 비교 (이슈 본문의 마이그레이션 step 2 와 동기화).

## Test plan

- [x] `zig build test` 통과 (#1757 shadow regression test 포함)
- [x] `bun run tests/benchmark/mangler-property.ts` → 18 check 모두 0.00% diff (determinism 확인)
- [x] `--mangle-report=<path>` smoke: 작은 TS 파일로 JSON 출력 검증
- [x] `/simplify` 실행: ManglerStats alias, 공유 fixtures 모듈 적용 후 baseline 재확인

Refs #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)