### PR TITLE
feat(bundler): #1760 unified mangler shadow collection (Step 2)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -759,6 +759,12 @@ pub const Bundler = struct {
             if (!self.options.code_splitting) {
                 try l.computeRenames();
                 if (self.options.minify_identifiers) {
+                    // #1760 Step 2 shadow: computeMangling 전에 unified 도 돌려 수치 수집.
+                    if (mangle_report_enabled) {
+                        runUnifiedShadow(self.allocator, &l, &mangle_collector) catch |err| {
+                            std.log.warn("mangle-report: unified shadow failed: {s}", .{@errorName(err)});
+                        };
+                    }
                     try l.computeMangling();
                 }
             }
@@ -1180,6 +1186,39 @@ pub const Bundler = struct {
         };
     }
 };
+
+/// #1760 Step 2 shadow — `mangleAll()` 을 같은 번들에 돌려 `collector.unified`
+/// 에 요약을 기록. 실제 번들 출력에는 영향 없음.
+fn runUnifiedShadow(
+    allocator: std.mem.Allocator,
+    linker: *Linker,
+    collector: *MangleReportCollector,
+) !void {
+    const um = @import("../codegen/unified_mangler.zig");
+    const ManglerStats = @import("../codegen/mangler.zig").ManglerStats;
+
+    var collected = try linker.collectUnifiedInput();
+    defer collected.deinit();
+
+    var res = try um.mangleAll(allocator, .{
+        .modules = collected.modules,
+        .top_level_candidates = collected.top_level_candidates,
+    });
+    defer res.deinit();
+
+    var phase_b_totals: ManglerStats = .{};
+    for (res.phase_b_modules) |s| {
+        phase_b_totals.slot_count += s.slot_count;
+        phase_b_totals.slot_name_length_sum += s.slot_name_length_sum;
+        phase_b_totals.renamed_symbol_count += s.renamed_symbol_count;
+    }
+    collector.unified = .{
+        .phase_a = res.phase_a,
+        .phase_b_totals = phase_b_totals,
+        .total_renames = res.renames.count(),
+        .module_count = res.phase_b_modules.len,
+    };
+}
 
 /// metafile JSON을 생성한다 (esbuild 호환 형식).
 /// inputs: 각 모듈의 경로, 바이트 수, import 목록

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -38,6 +38,26 @@ pub inline fn isNamespaceRename(rename: []const u8) bool {
     return std.mem.startsWith(u8, rename, NS_VAR_PREFIX);
 }
 
+/// `Linker.collectUnifiedInput` 반환 컨테이너. unified_mangler.mangleAll 에
+/// 그대로 넘길 수 있는 형태.
+///
+/// 수명 주의: `bitsets[i]` 는 `modules[i].module_scope_symbols` 의 backing
+/// store. caller 는 `modules` 를 계속 사용하는 동안 `bitsets` 를 먼저
+/// 해제해서는 안 된다. `deinit()` 이 올바른 순서로 처리.
+pub const UnifiedCollect = struct {
+    top_level_candidates: []@import("../codegen/unified_mangler.zig").TopLevelCandidate,
+    modules: []@import("../codegen/unified_mangler.zig").ModuleMangleInput,
+    bitsets: []std.DynamicBitSet,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *UnifiedCollect) void {
+        self.allocator.free(self.top_level_candidates);
+        self.allocator.free(self.modules);
+        for (self.bitsets) |*b| b.deinit();
+        self.allocator.free(self.bitsets);
+    }
+};
+
 /// `--mangle-report` 전용 측정 수집기 (#1760 property harness).
 ///
 /// Bundler 가 생성해 `Linker.mangle_report` 에 꽂으면 `computeMangling` 과
@@ -57,10 +77,24 @@ pub const MangleReportCollector = struct {
     /// Bundle emit 후 채움.
     bundle_size_bytes: usize = 0,
 
+    /// #1760 Step 2 shadow mode — `mangleAll()` 을 같은 번들에 대해 한 번 더
+    /// 돌려 수집한 수치. 실제 번들 출력에는 영향 없음, 비교 용도.
+    unified: ?UnifiedSummary = null,
+
     pub const NestedEntry = struct {
         /// linker 생명주기 내 유효 (module.path 차용).
         module_path: []const u8,
         stats: ManglerStats,
+    };
+
+    pub const UnifiedSummary = struct {
+        phase_a: ManglerStats,
+        /// 모든 모듈 Phase B stats 의 합 (slot/length/renamed).
+        phase_b_totals: ManglerStats,
+        /// 전체 renames 개수 (Phase A + Phase B 합).
+        total_renames: usize,
+        /// 모듈 수 (phase_b_modules 길이).
+        module_count: usize,
     };
 
     pub fn init(allocator: std.mem.Allocator) MangleReportCollector {
@@ -104,6 +138,15 @@ pub const MangleReportCollector = struct {
         try writer.writeAll(if (self.nested.items.len == 0) "]" else "\n  ]");
         try writer.print(",\n  \"bundle_size_bytes\": {d},\n  \"totals\": ", .{self.bundle_size_bytes});
         try writeStatsJson(writer, totals);
+
+        if (self.unified) |u| {
+            try writer.writeAll(",\n  \"unified\": {\n    \"phase_a\": ");
+            try writeStatsJson(writer, u.phase_a);
+            try writer.writeAll(",\n    \"phase_b_totals\": ");
+            try writeStatsJson(writer, u.phase_b_totals);
+            try writer.print(",\n    \"total_renames\": {d},\n    \"module_count\": {d}\n  }}", .{ u.total_renames, u.module_count });
+        }
+
         try writer.writeAll("\n}\n");
     }
 
@@ -849,6 +892,130 @@ pub const Linker = struct {
         }.cmp);
 
         return .{ .exported = exported, .entries = entries, .synthetic_defaults = synthetic_defaults };
+    }
+
+    /// #1760 shadow mode: unified_mangler.mangleAll() 을 호출하기 위한 입력 수집.
+    /// `collectManglingCandidates` 와 같은 필터 (exported/imported/1-char/default)
+    /// 를 적용하지만 이름별 집계 대신 `(module_index, symbol_id)` 단위 후보를
+    /// 개별 생성한다. 결과는 caller 가 `deinit` 해야 함.
+    ///
+    /// Step 3 (unified 경로로 전환) 시 이 필터 체인과 `collectManglingCandidates`
+    /// 가 통합되며, 이 함수가 기본 경로로 남고 구 함수는 제거 예정.
+    pub fn collectUnifiedInput(self: *const Linker) !UnifiedCollect {
+        const um = @import("../codegen/unified_mangler.zig");
+
+        const modules = try self.allocator.alloc(um.ModuleMangleInput, self.modules.len);
+        errdefer self.allocator.free(modules);
+
+        const bitsets = try self.allocator.alloc(std.DynamicBitSet, self.modules.len);
+        var created: usize = 0;
+        errdefer {
+            for (bitsets[0..created]) |*b| b.deinit();
+            self.allocator.free(bitsets);
+        }
+
+        var candidates: std.ArrayListUnmanaged(um.TopLevelCandidate) = .empty;
+        errdefer candidates.deinit(self.allocator);
+
+        var exported = std.StringHashMap(void).init(self.allocator);
+        defer exported.deinit();
+        for (self.modules) |m| {
+            if (m.is_entry_point) {
+                for (m.export_bindings) |eb| {
+                    try exported.put(eb.exported_name, {});
+                    try exported.put(m.exportBindingLocalName(eb), {});
+                }
+            }
+            for (m.import_bindings) |ib| {
+                if (ib.import_record_index >= m.import_records.len) continue;
+                if (!m.import_records[ib.import_record_index].is_external) continue;
+                try exported.put(m.importBindingLocalName(ib), {});
+            }
+        }
+
+        for (self.modules, 0..) |m, mi| {
+            const sem_opt = m.semantic;
+            const sym_count = if (sem_opt) |s| s.symbols.items.len else 0;
+            bitsets[created] = try std.DynamicBitSet.initEmpty(self.allocator, sym_count);
+            created += 1;
+
+            if (sem_opt) |sem| {
+                const blocks = sem.scopes.len > 0 and sem.scopes[0].blocksMangling();
+                if (sem.scope_maps.len > 0) {
+                    var sit = sem.scope_maps[0].iterator();
+                    while (sit.next()) |entry| {
+                        const sym_name = entry.key_ptr.*;
+                        const sym_idx_usize = entry.value_ptr.*;
+                        if (sym_idx_usize >= sym_count) continue;
+                        const sym_idx: u32 = @intCast(sym_idx_usize);
+
+                        // Phase B 는 module scope 심볼 skip (Phase A 담당).
+                        bitsets[mi].set(sym_idx_usize);
+
+                        if (blocks) continue;
+                        if (exported.contains(sym_name)) continue;
+                        if (sym_name.len <= 1) continue;
+                        if (std.mem.eql(u8, sym_name, "default")) continue;
+                        if (std.mem.eql(u8, sym_name, "arguments")) continue;
+
+                        const sym = &sem.symbols.items[sym_idx];
+                        if (sym.kind == .import_binding) continue;
+
+                        const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym_name;
+                        if (key.len <= 1) continue;
+                        if (exported.contains(key)) continue;
+
+                        try candidates.append(self.allocator, .{
+                            .module_index = @intCast(mi),
+                            .symbol_id = sym_idx,
+                            .name = key,
+                            .ref_count = sym.reference_count,
+                        });
+                    }
+                }
+
+                if (!blocks) {
+                    for (sem.symbols.items, 0..) |*sym, si| {
+                        const sk = sym.synthetic_kind orelse continue;
+                        if (sk != .default_export) continue;
+                        const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym.synthetic_name;
+                        if (key.len <= 1) continue;
+                        if (exported.contains(key)) continue;
+                        try candidates.append(self.allocator, .{
+                            .module_index = @intCast(mi),
+                            .symbol_id = @intCast(si),
+                            .name = key,
+                            .ref_count = sym.reference_count,
+                        });
+                    }
+                }
+
+                modules[mi] = .{
+                    .scopes = sem.scopes,
+                    .symbols = sem.symbols.items,
+                    .scope_maps = sem.scope_maps,
+                    .references = sem.references,
+                    .source = m.source,
+                    .module_scope_symbols = bitsets[mi],
+                };
+            } else {
+                modules[mi] = .{
+                    .scopes = &.{},
+                    .symbols = &.{},
+                    .scope_maps = &.{},
+                    .references = &.{},
+                    .source = m.source,
+                    .module_scope_symbols = bitsets[mi],
+                };
+            }
+        }
+
+        return .{
+            .top_level_candidates = try candidates.toOwnedSlice(self.allocator),
+            .modules = modules,
+            .bitsets = bitsets,
+            .allocator = self.allocator,
+        };
     }
 
     /// minify 활성화 시, scope hoisting 후 모든 top-level 이름을 짧은 이름으로 교체.

--- a/tests/benchmark/baselines/mangler-property.json
+++ b/tests/benchmark/baselines/mangler-property.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-04-22T18:21:20.991Z",
+  "generated_at": "2026-04-22T20:17:11.219Z",
   "fixtures": [
     {
       "name": "effect",
@@ -15,23 +15,23 @@
         "top_level_reserved_pool": 13047,
         "nested": [
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/effect.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/version.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Equivalence.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Function.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 7,
-              "reserved_size": 46,
-              "renamed_symbol_count": 36
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 15,
+              "reserved_size": 50,
+              "renamed_symbol_count": 32
             }
           },
           {
@@ -45,103 +45,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/option.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 34,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/request.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/supervisor.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 43,
-              "renamed_symbol_count": 25
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Differ.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 52,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/boundaries.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 27,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/state.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 71,
-              "renamed_symbol_count": 23
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/registry.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 16,
-              "renamed_symbol_count": 20
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberMessage.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 16,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/key.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 43,
-              "renamed_symbol_count": 19
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/completedRequestMap.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/supervisor/patch.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 33,
-              "renamed_symbol_count": 22
+              "reserved_size": 42,
+              "renamed_symbol_count": 70
             }
           },
           {
@@ -155,27 +65,97 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberScope.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Scope.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 17,
-              "renamed_symbol_count": 8
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/supervisor.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/key.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 42,
-              "renamed_symbol_count": 70
+              "reserved_size": 43,
+              "renamed_symbol_count": 19
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Scope.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Differ.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 52,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/registry.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 16,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/state.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 71,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/request.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 43,
+              "renamed_symbol_count": 25
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberMessage.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 16,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/supervisor/patch.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 33,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/boundaries.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 27,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/completedRequestMap.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -195,13 +175,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberStatus.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberStatus.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 39,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberScope.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 17,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/hook.js",
+            "stats": {
+              "slot_count": 18,
+              "slot_name_length_sum": 18,
+              "name_counter_final": 24,
+              "reserved_size": 48,
+              "renamed_symbol_count": 103
             }
           },
           {
@@ -215,23 +215,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberStatus.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 39,
-              "renamed_symbol_count": 12
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_effect.ts",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberStatus.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/label.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 17,
+              "renamed_symbol_count": 5
             }
           },
           {
@@ -245,33 +245,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Effectable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_effect.ts",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Scheduler.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 35,
-              "renamed_symbol_count": 65
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/label.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 17,
-              "renamed_symbol_count": 5
             }
           },
           {
@@ -295,33 +275,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/hook.js",
-            "stats": {
-              "slot_count": 18,
-              "slot_name_length_sum": 18,
-              "name_counter_final": 24,
-              "reserved_size": 48,
-              "renamed_symbol_count": 103
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/tracer.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 7,
-              "reserved_size": 25,
-              "renamed_symbol_count": 31
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/config.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Effectable.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Scheduler.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 35,
+              "renamed_symbol_count": 65
             }
           },
           {
@@ -335,13 +305,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/defaultServices/console.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/tracer.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 20
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 7,
+              "reserved_size": 25,
+              "renamed_symbol_count": 31
             }
           },
           {
@@ -355,17 +325,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtime.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/defaultServices/console.js",
             "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 105,
-              "renamed_symbol_count": 84
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 20
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/configError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/config.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -385,27 +355,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Micro.js",
-            "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 25,
-              "reserved_size": 461,
-              "renamed_symbol_count": 456
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/random.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 6,
-              "reserved_size": 30,
-              "renamed_symbol_count": 28
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/deferred.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/configError.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -415,13 +365,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider/pathPatch.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRefs.js",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 25,
-              "renamed_symbol_count": 13
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 45,
+              "renamed_symbol_count": 72
             }
           },
           {
@@ -445,13 +395,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRefs.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/deferred.js",
             "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 45,
-              "renamed_symbol_count": 72
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -465,13 +415,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider/pathPatch.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 56,
-              "renamed_symbol_count": 54
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 25,
+              "renamed_symbol_count": 13
             }
           },
           {
@@ -485,33 +435,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/RuntimeFlagsPatch.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/MutableHashMap.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 58,
+              "renamed_symbol_count": 63
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlags.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtime.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 66,
-              "renamed_symbol_count": 42
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 105,
+              "renamed_symbol_count": 84
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlagsPatch.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/random.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 39,
-              "renamed_symbol_count": 22
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 6,
+              "reserved_size": 30,
+              "renamed_symbol_count": 28
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configError.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 56,
+              "renamed_symbol_count": 54
             }
           },
           {
@@ -525,13 +485,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/MutableHashMap.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiber.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 58,
-              "renamed_symbol_count": 63
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 14,
+              "reserved_size": 119,
+              "renamed_symbol_count": 64
             }
           },
           {
@@ -545,13 +505,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiber.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlagsPatch.js",
             "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 14,
-              "reserved_size": 119,
-              "renamed_symbol_count": 64
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 39,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/RuntimeFlagsPatch.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -575,23 +545,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/contextPatch.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberId.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 9,
-              "reserved_size": 45,
-              "renamed_symbol_count": 27
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlags.js",
             "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 14,
-              "reserved_size": 114,
-              "renamed_symbol_count": 216
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 66,
+              "renamed_symbol_count": 42
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Micro.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 25,
+              "reserved_size": 461,
+              "renamed_symbol_count": 456
             }
           },
           {
@@ -605,43 +585,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/blockedRequests.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/MutableRef.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 8,
-              "reserved_size": 86,
-              "renamed_symbol_count": 76
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 4,
+              "reserved_size": 49,
+              "renamed_symbol_count": 23
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberId.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/cause.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/array.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 9,
-              "renamed_symbol_count": 15
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/stack.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 14,
+              "reserved_size": 178,
+              "renamed_symbol_count": 202
             }
           },
           {
@@ -655,56 +615,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/bitwise.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 12,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/config.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/MutableRef.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 4,
-              "reserved_size": 49,
-              "renamed_symbol_count": 23
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core-effect.js",
-            "stats": {
-              "slot_count": 13,
-              "slot_name_length_sum": 13,
-              "name_counter_final": 24,
-              "reserved_size": 345,
-              "renamed_symbol_count": 370
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Context.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/HashMap.js",
             "stats": {
               "slot_count": 1,
@@ -712,6 +622,16 @@
               "name_counter_final": 1,
               "reserved_size": 82,
               "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/blockedRequests.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 86,
+              "renamed_symbol_count": 76
             }
           },
           {
@@ -725,6 +645,86 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/bitwise.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/stack.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 14,
+              "reserved_size": 114,
+              "renamed_symbol_count": 216
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/config.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/contextPatch.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 9,
+              "reserved_size": 45,
+              "renamed_symbol_count": 27
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/array.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 9,
+              "renamed_symbol_count": 15
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core-effect.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 24,
+              "reserved_size": 345,
+              "renamed_symbol_count": 370
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 7,
+              "reserved_size": 127,
+              "renamed_symbol_count": 120
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/RegExp.js",
             "stats": {
               "slot_count": 1,
@@ -732,6 +732,16 @@
               "name_counter_final": 1,
               "reserved_size": 5,
               "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/node.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 21,
+              "reserved_size": 53,
+              "renamed_symbol_count": 109
             }
           },
           {
@@ -745,13 +755,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/cause.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Context.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 14,
-              "reserved_size": 178,
-              "renamed_symbol_count": 202
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -775,53 +785,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/node.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core.js",
             "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 21,
-              "reserved_size": 53,
-              "renamed_symbol_count": 109
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/version.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/List.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 15,
-              "reserved_size": 137,
-              "renamed_symbol_count": 121
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/either.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 42,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/context.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 89,
-              "renamed_symbol_count": 57
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 12,
+              "reserved_size": 590,
+              "renamed_symbol_count": 424
             }
           },
           {
@@ -835,23 +805,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/context.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
-              "name_counter_final": 7,
-              "reserved_size": 127,
-              "renamed_symbol_count": 120
+              "name_counter_final": 6,
+              "reserved_size": 89,
+              "renamed_symbol_count": 57
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Number.js",
             "stats": {
               "slot_count": 7,
               "slot_name_length_sum": 7,
-              "name_counter_final": 12,
-              "reserved_size": 590,
-              "renamed_symbol_count": 424
+              "name_counter_final": 9,
+              "reserved_size": 63,
+              "renamed_symbol_count": 24
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/List.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 15,
+              "reserved_size": 137,
+              "renamed_symbol_count": 121
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Order.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 60,
+              "renamed_symbol_count": 66
             }
           },
           {
@@ -861,6 +851,16 @@
               "slot_name_length_sum": 3,
               "name_counter_final": 3,
               "reserved_size": 9,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/option.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 34,
               "renamed_symbol_count": 6
             }
           },
@@ -875,23 +875,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/effectable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/either.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 37,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Order.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 8,
-              "reserved_size": 60,
-              "renamed_symbol_count": 66
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 42,
+              "renamed_symbol_count": 11
             }
           },
           {
@@ -905,16 +895,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Duration.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 10,
-              "reserved_size": 147,
-              "renamed_symbol_count": 159
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/GlobalValue.js",
             "stats": {
               "slot_count": 2,
@@ -925,13 +905,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Number.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/effect.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 9,
-              "reserved_size": 63,
-              "renamed_symbol_count": 24
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Duration.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 147,
+              "renamed_symbol_count": 159
             }
           },
           {
@@ -945,33 +935,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Chunk.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/effectable.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 12,
-              "reserved_size": 220,
-              "renamed_symbol_count": 120
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 37,
+              "renamed_symbol_count": 7
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Inspectable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Equivalence.js",
             "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 14,
-              "reserved_size": 45,
-              "renamed_symbol_count": 27
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Utils.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 13,
-              "reserved_size": 68,
-              "renamed_symbol_count": 42
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 7,
+              "reserved_size": 46,
+              "renamed_symbol_count": 36
             }
           },
           {
@@ -985,13 +965,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Option.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Utils.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 4,
-              "reserved_size": 148,
-              "renamed_symbol_count": 65
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 13,
+              "reserved_size": 68,
+              "renamed_symbol_count": 42
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Inspectable.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 14,
+              "reserved_size": 45,
+              "renamed_symbol_count": 27
             }
           },
           {
@@ -1005,13 +995,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Function.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Chunk.js",
             "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 15,
-              "reserved_size": 50,
-              "renamed_symbol_count": 32
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 12,
+              "reserved_size": 220,
+              "renamed_symbol_count": 120
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Option.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 4,
+              "reserved_size": 148,
+              "renamed_symbol_count": 65
             }
           },
           {
@@ -1042,6 +1042,24 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 15519
+        },
+        "unified": {
+          "phase_a": {
+            "slot_count": 10136,
+            "slot_name_length_sum": 26851,
+            "name_counter_final": 10145,
+            "reserved_size": 10136,
+            "renamed_symbol_count": 10136
+          },
+          "phase_b_totals": {
+            "slot_count": 2144,
+            "slot_name_length_sum": 6432,
+            "name_counter_final": 0,
+            "reserved_size": 0,
+            "renamed_symbol_count": 18999
+          },
+          "total_renames": 29134,
+          "module_count": 601
         }
       },
       "nested_module_count": 102,
@@ -1066,27 +1084,7 @@
         "top_level_reserved_pool": 1556,
         "nested": [
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObjectLike.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_root.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArray.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Symbol.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -1106,37 +1104,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseToString.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObject.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 16,
+              "reserved_size": 2,
               "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_shortOut.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 8,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nativeKeys.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/noop.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArray.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -1156,37 +1134,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_coreJsData.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/keys.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 8,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObject.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseToString.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 2,
+              "reserved_size": 16,
               "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArrayLike.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_objectToString.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
@@ -1196,73 +1154,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseKeys.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 10,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/constant.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isSymbol.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 2,
+              "reserved_size": 8,
               "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setToArray.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapToArray.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 2,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalObjects.js",
-            "stats": {
-              "slot_count": 22,
-              "slot_name_length_sum": 22,
-              "name_counter_final": 22,
-              "reserved_size": 10,
-              "renamed_symbol_count": 22
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_cacheHas.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseUniq.js",
-            "stats": {
-              "slot_count": 13,
-              "slot_name_length_sum": 13,
-              "name_counter_final": 13,
-              "reserved_size": 16,
-              "renamed_symbol_count": 13
             }
           },
           {
@@ -1276,63 +1174,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalByTag.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/groupBy.js",
             "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 11,
-              "reserved_size": 44,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_lodash-es.ts",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/lodash.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createSet.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
               "reserved_size": 10,
-              "renamed_symbol_count": 1
+              "renamed_symbol_count": 3
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createAggregator.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/sortBy.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
               "reserved_size": 10,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseForOwn.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -1346,73 +1204,63 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareMultiple.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseEach.js",
             "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 10,
-              "reserved_size": 4,
-              "renamed_symbol_count": 10
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createBaseEach.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 4,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/groupBy.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 10,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMap.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createAggregator.js",
             "stats": {
               "slot_count": 6,
               "slot_name_length_sum": 6,
               "name_counter_final": 6,
-              "reserved_size": 6,
-              "renamed_symbol_count": 7
+              "reserved_size": 10,
+              "renamed_symbol_count": 6
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIteratee.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseOrderBy.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 20,
+              "renamed_symbol_count": 14
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/lodash.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseSortBy.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createSet.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 12,
+              "reserved_size": 10,
               "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalArrays.js",
-            "stats": {
-              "slot_count": 17,
-              "slot_name_length_sum": 17,
-              "name_counter_final": 18,
-              "reserved_size": 12,
-              "renamed_symbol_count": 19
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayAggregator.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 2,
-              "renamed_symbol_count": 7
             }
           },
           {
@@ -1426,17 +1274,37 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/property.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMap.js",
             "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 10,
-              "renamed_symbol_count": 1
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/hasIn.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseUniq.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 13,
+              "reserved_size": 16,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createBaseEach.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 4,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseForOwn.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
@@ -1456,53 +1324,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMatchesProperty.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_lodash-es.ts",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 20,
-              "renamed_symbol_count": 4
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_basePropertyDeep.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareMultiple.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
               "reserved_size": 4,
-              "renamed_symbol_count": 2
+              "renamed_symbol_count": 10
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseHasIn.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareAscending.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseSortBy.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseOrderBy.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 20,
-              "renamed_symbol_count": 14
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 4,
+              "renamed_symbol_count": 10
             }
           },
           {
@@ -1516,22 +1364,22 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheHas.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayAggregator.js",
             "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
               "reserved_size": 2,
-              "renamed_symbol_count": 1
+              "renamed_symbol_count": 7
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isStrictComparable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIteratee.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 4,
+              "reserved_size": 12,
               "renamed_symbol_count": 1
             }
           },
@@ -1546,103 +1394,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsMatch.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_basePropertyDeep.js",
             "stats": {
-              "slot_count": 13,
-              "slot_name_length_sum": 13,
-              "name_counter_final": 14,
-              "reserved_size": 10,
-              "renamed_symbol_count": 13
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheAdd.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMatchesProperty.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 20,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/hasIn.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/property.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Set.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseEach.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getMatchData.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_SetCache.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 8,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqual.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Promise.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/sortBy.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
               "reserved_size": 10,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Uint8Array.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -1656,7 +1444,207 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubArray.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isStrictComparable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hasPath.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 14,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseHasIn.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqual.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_matchesStrictComparable.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setToArray.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getMatchData.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsMatch.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 14,
+              "reserved_size": 10,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapToArray.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqualDeep.js",
+            "stats": {
+              "slot_count": 17,
+              "slot_name_length_sum": 17,
+              "name_counter_final": 20,
+              "reserved_size": 30,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_cacheHas.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalByTag.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 11,
+              "reserved_size": 44,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arraySome.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheHas.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Uint8Array.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheAdd.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalObjects.js",
+            "stats": {
+              "slot_count": 22,
+              "slot_name_length_sum": 22,
+              "name_counter_final": 22,
+              "reserved_size": 10,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getTag.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 38,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalArrays.js",
+            "stats": {
+              "slot_count": 17,
+              "slot_name_length_sum": 17,
+              "name_counter_final": 18,
+              "reserved_size": 12,
+              "renamed_symbol_count": 19
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_SetCache.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Set.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -1676,27 +1664,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hasPath.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 14,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_matchesStrictComparable.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_DataView.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubArray.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -1716,13 +1684,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackClear.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Promise.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_DataView.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackDelete.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -1736,13 +1724,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arraySome.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackGet.js",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
               "reserved_size": 2,
-              "renamed_symbol_count": 4
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -1756,13 +1744,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackGet.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackClear.js",
             "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFlatten.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 6,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayPush.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
               "reserved_size": 2,
-              "renamed_symbol_count": 1
+              "renamed_symbol_count": 5
             }
           },
           {
@@ -1783,106 +1791,6 @@
               "name_counter_final": 1,
               "reserved_size": 10,
               "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGet.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 6,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackSet.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 10,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareAscending.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 10,
-              "reserved_size": 4,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/toString.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqualDeep.js",
-            "stats": {
-              "slot_count": 17,
-              "slot_name_length_sum": 17,
-              "name_counter_final": 20,
-              "reserved_size": 30,
-              "renamed_symbol_count": 17
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Stack.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 14,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheHas.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toKey.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFlatten.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 6,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getTag.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 38,
-              "renamed_symbol_count": 4
             }
           },
           {
@@ -1916,7 +1824,27 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheGet.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Stack.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 14,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toKey.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/toString.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
@@ -1926,13 +1854,83 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayPush.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackSet.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 10,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/memoize.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheHas.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isKeyable.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
               "reserved_size": 2,
-              "renamed_symbol_count": 5
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGet.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 6,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_memoizeCapped.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Map.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheClear.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -1946,7 +1944,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheHas.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheSet.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheGet.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
@@ -1956,12 +1964,92 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackDelete.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_MapCache.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 12,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getMapData.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
               "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_assocIndexOf.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheDelete.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_ListCache.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 12,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashDelete.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
               "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheClear.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashHas.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashGet.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
               "renamed_symbol_count": 3
             }
           },
@@ -1976,7 +2064,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_assocIndexOf.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheGet.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
@@ -1996,127 +2084,27 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheClear.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheHas.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getMapData.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
               "reserved_size": 4,
-              "renamed_symbol_count": 3
+              "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isKeyable.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Map.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_memoizeCapped.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashSet.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
               "name_counter_final": 3,
               "reserved_size": 6,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashDelete.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheSet.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 4,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashGet.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 10,
               "renamed_symbol_count": 3
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseUnary.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashHas.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_overArg.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheGet.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 4,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubFalse.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashClear.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2136,7 +2124,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isTypedArray.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nativeKeys.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2156,67 +2144,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseTimes.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 4,
-              "reserved_size": 3,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheClear.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/memoize.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 6,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isLength.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArguments.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 12,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashSet.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 6,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsArguments.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/keys.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
@@ -2226,7 +2154,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashClear.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isTypedArray.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2236,13 +2164,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_overRest.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_overArg.js",
             "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 6,
-              "renamed_symbol_count": 8
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseKeys.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -2256,17 +2194,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheDelete.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubFalse.js",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 8,
-              "renamed_symbol_count": 4
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/eq.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseUnary.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
@@ -2276,73 +2214,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isPrototype.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayLikeKeys.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 4,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIndex.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 6,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_ListCache.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 12,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseRest.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_MapCache.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 12,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsNaN.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_defineProperty.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 2,
-              "reserved_size": 5,
-              "renamed_symbol_count": 1
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 18,
+              "renamed_symbol_count": 10
             }
           },
           {
@@ -2356,12 +2234,172 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getNative.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArguments.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 12,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIterateeCall.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 10,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsTypedArray.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 58,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsArguments.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseTimes.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 4,
+              "reserved_size": 3,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArrayLike.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isPrototype.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isLength.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayIncludes.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseRest.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_overRest.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 6,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIndex.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
               "name_counter_final": 3,
               "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseAssignValue.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsNaN.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_strictIndexOf.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/eq.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIndexOf.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
               "renamed_symbol_count": 3
             }
           },
@@ -2376,12 +2414,62 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_strictIndexOf.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setToString.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_defineProperty.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 2,
+              "reserved_size": 5,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/constant.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseSetToString.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/noop.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_shortOut.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
               "name_counter_final": 5,
-              "reserved_size": 2,
+              "reserved_size": 8,
               "renamed_symbol_count": 5
             }
           },
@@ -2396,73 +2484,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toSource.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 2,
-              "reserved_size": 7,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseAssignValue.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_apply.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
               "name_counter_final": 3,
-              "reserved_size": 4,
+              "reserved_size": 2,
               "renamed_symbol_count": 3
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIndexOf.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getNative.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
               "name_counter_final": 3,
-              "reserved_size": 8,
+              "reserved_size": 6,
               "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setToString.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_objectToString.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isMasked.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Symbol.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
             }
           },
           {
@@ -2476,7 +2514,77 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toSource.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 2,
+              "reserved_size": 7,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_coreJsData.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsNative.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 24,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isFunction.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 14,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isMasked.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObjectLike.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_freeGlobal.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_root.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2492,96 +2600,6 @@
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
               "reserved_size": 14,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIterateeCall.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 10,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayIncludes.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 4,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsTypedArray.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 58,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayLikeKeys.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 10,
-              "reserved_size": 18,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseSetToString.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isFunction.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 14,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsNative.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 24,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_apply.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isSymbol.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 8,
               "renamed_symbol_count": 1
             }
           },
@@ -2603,6 +2621,24 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 1691
+        },
+        "unified": {
+          "phase_a": {
+            "slot_count": 1214,
+            "slot_name_length_sum": 2374,
+            "name_counter_final": 1220,
+            "reserved_size": 1214,
+            "renamed_symbol_count": 1214
+          },
+          "phase_b_totals": {
+            "slot_count": 1913,
+            "slot_name_length_sum": 3826,
+            "name_counter_final": 0,
+            "reserved_size": 0,
+            "renamed_symbol_count": 2054
+          },
+          "total_renames": 3257,
+          "module_count": 641
         }
       },
       "nested_module_count": 153,
@@ -2637,16 +2673,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/locales/en.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 8,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/errors.js",
             "stats": {
               "slot_count": 1,
@@ -2664,6 +2690,16 @@
               "name_counter_final": 6,
               "reserved_size": 9,
               "renamed_symbol_count": 25
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/locales/en.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -2687,7 +2723,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_zod.ts",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/index.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2697,7 +2733,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/index.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_zod.ts",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2724,6 +2760,24 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 869
+        },
+        "unified": {
+          "phase_a": {
+            "slot_count": 139,
+            "slot_name_length_sum": 224,
+            "name_counter_final": 140,
+            "reserved_size": 139,
+            "renamed_symbol_count": 139
+          },
+          "phase_b_totals": {
+            "slot_count": 33,
+            "slot_name_length_sum": 66,
+            "name_counter_final": 0,
+            "reserved_size": 0,
+            "renamed_symbol_count": 730
+          },
+          "total_renames": 869,
+          "module_count": 11
         }
       },
       "nested_module_count": 9,
@@ -2758,23 +2812,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/arrRemove.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/config.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/symbol/observable.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/reportUnhandledError.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/NotificationFactories.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/UnsubscriptionError.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 3,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -2788,33 +2862,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subscription.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/errorContext.js",
             "stats": {
-              "slot_count": 14,
-              "slot_name_length_sum": 14,
-              "name_counter_final": 21,
-              "reserved_size": 26,
-              "renamed_symbol_count": 37
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zipAll.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeoutWith.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
               "reserved_size": 8,
               "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/arrRemove.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -2824,6 +2888,16 @@
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
               "reserved_size": 9,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zipAll.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
               "renamed_symbol_count": 1
             }
           },
@@ -2838,66 +2912,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throttleTime.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 8,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zip.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 17,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeWhile.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 6,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timestamp.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchAll.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeUntil.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 10,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowToggle.js",
             "stats": {
               "slot_count": 9,
@@ -2908,33 +2922,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchScan.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throttleTime.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 7,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipWhile.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/withLatestFrom.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 14,
-              "reserved_size": 25,
-              "renamed_symbol_count": 18
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
             }
           },
           {
@@ -2948,13 +2942,53 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/window.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeoutWith.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 12,
-              "renamed_symbol_count": 7
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zip.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeUntil.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 10,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowTime.js",
+            "stats": {
+              "slot_count": 12,
+              "slot_name_length_sum": 12,
+              "name_counter_final": 12,
+              "reserved_size": 18,
+              "renamed_symbol_count": 31
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timestamp.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
             }
           },
           {
@@ -2978,13 +3012,83 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowTime.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchScan.js",
             "stats": {
-              "slot_count": 12,
-              "slot_name_length_sum": 12,
-              "name_counter_final": 12,
-              "reserved_size": 18,
-              "renamed_symbol_count": 31
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 7,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchAll.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeInterval.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 10,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/withLatestFrom.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 14,
+              "reserved_size": 25,
+              "renamed_symbol_count": 18
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/window.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 12,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeWhile.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/startWith.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/shareReplay.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 6,
+              "renamed_symbol_count": 8
             }
           },
           {
@@ -2994,6 +3098,36 @@
               "slot_name_length_sum": 5,
               "name_counter_final": 5,
               "reserved_size": 10,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchMap.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipLast.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 8,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipWhile.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
               "renamed_symbol_count": 6
             }
           },
@@ -3008,26 +3142,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeInterval.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 10,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowWhen.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 10,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/index.js",
             "stats": {
               "slot_count": 1,
@@ -3035,36 +3149,6 @@
               "name_counter_final": 1,
               "reserved_size": 342,
               "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchMap.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 8,
-              "renamed_symbol_count": 12
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/startWith.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 8,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sampleTime.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
             }
           },
           {
@@ -3078,46 +3162,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/shareReplay.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 6,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipLast.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 8,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sequenceEqual.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 9,
-              "reserved_size": 12,
-              "renamed_symbol_count": 16
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/raceWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 19,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/scan.js",
             "stats": {
               "slot_count": 2,
@@ -3128,13 +3172,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retryWhen.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sampleTime.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 10,
-              "renamed_symbol_count": 8
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
             }
           },
           {
@@ -3148,13 +3192,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sample.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishReplay.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
               "name_counter_final": 5,
-              "reserved_size": 10,
-              "renamed_symbol_count": 7
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
             }
           },
           {
@@ -3168,42 +3212,102 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishReplay.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sequenceEqual.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 8,
-              "renamed_symbol_count": 6
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 9,
+              "reserved_size": 12,
+              "renamed_symbol_count": 16
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/share.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/single.js",
             "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 22,
-              "reserved_size": 23,
-              "renamed_symbol_count": 35
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 8
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/min.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 8,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/repeatWhen.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retry.js",
             "stats": {
               "slot_count": 11,
               "slot_name_length_sum": 11,
               "name_counter_final": 11,
+              "reserved_size": 12,
+              "renamed_symbol_count": 18
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/raceWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 19,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/pairwise.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 7,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowWhen.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
               "reserved_size": 10,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retryWhen.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 10,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/onErrorResumeNextWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sample.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/merge.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 21,
               "renamed_symbol_count": 11
             }
           },
@@ -3218,23 +3322,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publish.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/min.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
               "reserved_size": 8,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/single.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 12,
-              "renamed_symbol_count": 8
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -3248,66 +3342,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/max.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 8,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 15,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/pairwise.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 7,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMapTo.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 6,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/onErrorResumeNextWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 17,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/multicast.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 8,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeScan.js",
             "stats": {
               "slot_count": 6,
@@ -3318,23 +3352,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retry.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/repeatWhen.js",
             "stats": {
               "slot_count": 11,
               "slot_name_length_sum": 11,
               "name_counter_final": 11,
-              "reserved_size": 12,
-              "renamed_symbol_count": 18
+              "reserved_size": 10,
+              "renamed_symbol_count": 11
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/isEmpty.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publish.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -3348,63 +3382,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/materialize.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeWith.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/merge.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 10,
-              "reserved_size": 21,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeLast.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 10,
-              "reserved_size": 14,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/find.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
               "name_counter_final": 8,
-              "reserved_size": 9,
-              "renamed_symbol_count": 10
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/findIndex.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/max.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/last.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 16,
-              "renamed_symbol_count": 4
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -3418,13 +3412,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/first.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/isEmpty.js",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 16,
-              "renamed_symbol_count": 4
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
             }
           },
           {
@@ -3438,23 +3432,53 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/expand.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/last.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 5
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 16,
+              "renamed_symbol_count": 4
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/groupBy.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/findIndex.js",
             "stats": {
-              "slot_count": 14,
-              "slot_name_length_sum": 14,
-              "name_counter_final": 14,
-              "reserved_size": 12,
-              "renamed_symbol_count": 29
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/multicast.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/share.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 22,
+              "reserved_size": 23,
+              "renamed_symbol_count": 35
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/first.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 16,
+              "renamed_symbol_count": 4
             }
           },
           {
@@ -3468,13 +3492,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throwIfEmpty.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/materialize.js",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 10,
-              "renamed_symbol_count": 5
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/endWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/find.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 8,
+              "reserved_size": 9,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMapTo.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -3488,43 +3542,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinctUntilChanged.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/elementAt.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 8,
-              "reserved_size": 12,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/every.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/exhaustMap.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 8,
-              "reserved_size": 13,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/endWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 17,
-              "renamed_symbol_count": 8
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 14,
+              "renamed_symbol_count": 4
             }
           },
           {
@@ -3548,22 +3572,22 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/elementAt.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throwIfEmpty.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 14,
-              "renamed_symbol_count": 4
+              "reserved_size": 10,
+              "renamed_symbol_count": 5
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/delayWhen.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/expand.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 14,
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
               "renamed_symbol_count": 5
             }
           },
@@ -3578,16 +3602,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mapTo.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/count.js",
             "stats": {
               "slot_count": 3,
@@ -3598,53 +3612,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromSubscribable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/every.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 4,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/ignoreElements.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineAll.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/take.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 8,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatMapTo.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
               "reserved_size": 6,
-              "renamed_symbol_count": 2
+              "renamed_symbol_count": 6
             }
           },
           {
@@ -3658,13 +3632,123 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestWith.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeLast.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 10,
+              "reserved_size": 14,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/delayWhen.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 14,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinctUntilChanged.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
               "name_counter_final": 8,
-              "reserved_size": 15,
-              "renamed_symbol_count": 7
+              "reserved_size": 12,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounceTime.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/take.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromSubscribable.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatMapTo.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mapTo.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/ignoreElements.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/connect.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 12,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineAll.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/groupBy.js",
+            "stats": {
+              "slot_count": 14,
+              "slot_name_length_sum": 14,
+              "name_counter_final": 14,
+              "reserved_size": 12,
+              "renamed_symbol_count": 29
             }
           },
           {
@@ -3678,6 +3762,16 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounce.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 10,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatest.js",
             "stats": {
               "slot_count": 3,
@@ -3688,13 +3782,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounceTime.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestWith.js",
             "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 8,
-              "renamed_symbol_count": 13
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestAll.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -3718,36 +3822,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/joinAllInternals.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 12,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounce.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 10,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/connect.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 12,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/toArray.js",
             "stats": {
               "slot_count": 2,
@@ -3755,26 +3829,6 @@
               "name_counter_final": 2,
               "reserved_size": 8,
               "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferWhen.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 11,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/buffer.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 11,
-              "renamed_symbol_count": 5
             }
           },
           {
@@ -3788,6 +3842,36 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/exhaustMap.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 13,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferWhen.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/joinAllInternals.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/types.js",
             "stats": {
               "slot_count": 0,
@@ -3795,46 +3879,6 @@
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/using.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 8,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/catchError.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 8,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferToggle.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 10,
-              "reserved_size": 20,
-              "renamed_symbol_count": 16
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/scanInternals.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 11,
-              "reserved_size": 5,
-              "renamed_symbol_count": 11
             }
           },
           {
@@ -3848,43 +3892,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestAll.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/audit.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 8,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/zip.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferToggle.js",
             "stats": {
               "slot_count": 7,
               "slot_name_length_sum": 7,
-              "name_counter_final": 12,
-              "reserved_size": 25,
-              "renamed_symbol_count": 20
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/partition.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 8,
-              "renamed_symbol_count": 3
+              "name_counter_final": 10,
+              "reserved_size": 20,
+              "renamed_symbol_count": 16
             }
           },
           {
@@ -3898,93 +3912,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/filter.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferCount.js",
-            "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 20,
-              "reserved_size": 14,
-              "renamed_symbol_count": 25
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/interval.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/pairs.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 4,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/never.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/iif.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 4,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferTime.js",
-            "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 14,
-              "reserved_size": 22,
-              "renamed_symbol_count": 30
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/merge.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 12,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/not.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/buffer.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 2,
-              "renamed_symbol_count": 4
+              "reserved_size": 11,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/partition.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -3998,13 +3942,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatAll.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/catchError.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 8,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/not.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferCount.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 20,
+              "reserved_size": 14,
+              "renamed_symbol_count": 25
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/audit.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 11
             }
           },
           {
@@ -4018,12 +3992,192 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/never.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/pairs.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/iif.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/zip.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 12,
+              "reserved_size": 25,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferTime.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 14,
+              "reserved_size": 22,
+              "renamed_symbol_count": 30
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/using.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/merge.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 12,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/scanInternals.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 11,
+              "reserved_size": 5,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromEvent.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 13,
+              "reserved_size": 36,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/onErrorResumeNext.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 12,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatAll.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/interval.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/timer.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/forkJoin.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 16,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/defer.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
               "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/connectable.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 10,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/generate.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 14,
+              "reserved_size": 20,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromEventPattern.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 9,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/concat.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
               "renamed_symbol_count": 2
             }
           },
@@ -4038,67 +4192,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/forkJoin.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 16,
-              "renamed_symbol_count": 17
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/timer.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 11,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/generate.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 14,
-              "reserved_size": 20,
-              "renamed_symbol_count": 17
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/concat.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/onErrorResumeNext.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 12,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/connectable.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 10,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/map.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/filter.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
@@ -4118,16 +4212,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isDate.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindNodeCallback.js",
             "stats": {
               "slot_count": 3,
@@ -4135,36 +4219,6 @@
               "name_counter_final": 3,
               "reserved_size": 4,
               "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromEventPattern.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 9,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMap.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 15,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/SequenceError.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
             }
           },
           {
@@ -4178,13 +4232,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindCallbackInternals.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMap.js",
             "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 16,
-              "reserved_size": 25,
-              "renamed_symbol_count": 25
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 15,
+              "renamed_symbol_count": 6
             }
           },
           {
@@ -4198,27 +4252,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/firstValueFrom.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 6,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ArgumentOutOfRangeError.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/NotFoundError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/SequenceError.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
@@ -4228,33 +4262,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/mapOneOrManyArgs.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/EmptyError.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 19,
-              "renamed_symbol_count": 9
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/lastValueFrom.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeInternals.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 4,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeout.js",
-            "stats": {
-              "slot_count": 12,
-              "slot_name_length_sum": 12,
-              "name_counter_final": 12,
-              "reserved_size": 18,
-              "renamed_symbol_count": 24
+              "slot_count": 15,
+              "slot_name_length_sum": 15,
+              "name_counter_final": 15,
+              "reserved_size": 8,
+              "renamed_symbol_count": 22
             }
           },
           {
@@ -4268,17 +4292,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/combineLatest.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 10,
-              "reserved_size": 25,
-              "renamed_symbol_count": 24
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/EmptyError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ArgumentOutOfRangeError.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
@@ -4298,33 +4312,73 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromEvent.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindCallbackInternals.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 13,
-              "reserved_size": 36,
-              "renamed_symbol_count": 23
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 16,
+              "reserved_size": 25,
+              "renamed_symbol_count": 25
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleObservable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/map.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/NotFoundError.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 8,
+              "reserved_size": 2,
               "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeInternals.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/lastValueFrom.js",
             "stats": {
-              "slot_count": 15,
-              "slot_name_length_sum": 15,
-              "name_counter_final": 15,
-              "reserved_size": 8,
-              "renamed_symbol_count": 22
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 4,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isDate.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/firstValueFrom.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/mapOneOrManyArgs.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 19,
+              "renamed_symbol_count": 9
             }
           },
           {
@@ -4338,6 +4392,26 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeout.js",
+            "stats": {
+              "slot_count": 12,
+              "slot_name_length_sum": 12,
+              "name_counter_final": 12,
+              "reserved_size": 18,
+              "renamed_symbol_count": 24
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/combineLatest.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 10,
+              "reserved_size": 25,
+              "renamed_symbol_count": 24
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/from.js",
             "stats": {
               "slot_count": 2,
@@ -4348,12 +4422,22 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/observeOn.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduled.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 28,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/throwError.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 8,
+              "reserved_size": 6,
               "renamed_symbol_count": 6
             }
           },
@@ -4368,6 +4452,26 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleIterable.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/subscribeOn.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/schedulePromise.js",
             "stats": {
               "slot_count": 2,
@@ -4375,16 +4479,6 @@
               "name_counter_final": 2,
               "reserved_size": 8,
               "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/throwUnobservableError.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
             }
           },
           {
@@ -4408,33 +4502,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/subscribeOn.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/observeOn.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 4,
-              "renamed_symbol_count": 4
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isAsyncIterable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isInteropObservable.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 4,
+              "reserved_size": 6,
               "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleIterable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/throwUnobservableError.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 10,
-              "renamed_symbol_count": 8
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -4448,6 +4542,26 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleObservable.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/executeSchedule.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 2,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isArrayLike.js",
             "stats": {
               "slot_count": 0,
@@ -4458,13 +4572,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduled.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleArray.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 28,
-              "renamed_symbol_count": 2
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 5,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isReadableStreamLike.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 16,
+              "reserved_size": 25,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isAsyncIterable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -4488,26 +4622,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/executeSchedule.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 2,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isScheduler.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/animationFrame.js",
             "stats": {
               "slot_count": 0,
@@ -4515,86 +4629,6 @@
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameScheduler.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 9,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/args.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 12,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/asap.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleArray.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 5,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/throwError.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isReadableStreamLike.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 16,
-              "reserved_size": 25,
-              "renamed_symbol_count": 23
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isInteropObservable.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameAction.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 11,
-              "renamed_symbol_count": 15
             }
           },
           {
@@ -4618,13 +4652,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Scheduler.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/async.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/args.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isScheduler.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
               "reserved_size": 4,
-              "renamed_symbol_count": 6
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -4638,7 +4692,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/async.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/asap.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -4658,23 +4712,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/innerFrom.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 23,
-              "reserved_size": 60,
-              "renamed_symbol_count": 56
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsapScheduler.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameScheduler.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
               "reserved_size": 9,
               "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameAction.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 15
             }
           },
           {
@@ -4688,91 +4742,11 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/Immediate.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsapScheduler.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/immediateProvider.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 17,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ObjectUnsubscribedError.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsyncAction.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 14,
-              "renamed_symbol_count": 29
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/performanceTimestampProvider.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/intervalProvider.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 10,
-              "reserved_size": 11,
-              "renamed_symbol_count": 12
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/AsyncSubject.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 9,
-              "renamed_symbol_count": 18
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/dateTimestampProvider.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/Action.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
               "reserved_size": 9,
               "renamed_symbol_count": 8
             }
@@ -4788,53 +4762,113 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/identity.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Scheduler.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 6
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/dom/animationFrames.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/innerFrom.js",
             "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 23,
+              "reserved_size": 60,
+              "renamed_symbol_count": 56
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/immediateProvider.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
               "name_counter_final": 8,
-              "reserved_size": 12,
-              "renamed_symbol_count": 9
+              "reserved_size": 17,
+              "renamed_symbol_count": 10
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/ReplaySubject.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/intervalProvider.js",
             "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 9,
-              "reserved_size": 12,
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 11,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsyncAction.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 14,
               "renamed_symbol_count": 29
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/symbol/observable.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isFunction.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ObjectUnsubscribedError.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
               "reserved_size": 2,
               "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/Action.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 9,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/Immediate.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/dateTimestampProvider.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/AsyncSubject.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 9,
+              "renamed_symbol_count": 18
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/performanceTimestampProvider.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -4848,13 +4882,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/reportUnhandledError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/identity.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -4868,13 +4902,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/ConnectableObservable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/ReplaySubject.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 9,
+              "reserved_size": 12,
+              "renamed_symbol_count": 29
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/BehaviorSubject.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 17,
-              "renamed_symbol_count": 14
+              "reserved_size": 9,
+              "renamed_symbol_count": 13
             }
           },
           {
@@ -4888,33 +4932,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/NotificationFactories.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/lift.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
               "reserved_size": 6,
               "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subject.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 10,
-              "reserved_size": 25,
-              "renamed_symbol_count": 53
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 11,
-              "renamed_symbol_count": 23
             }
           },
           {
@@ -4928,13 +4952,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/errorContext.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subscriber.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 8,
-              "renamed_symbol_count": 6
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 37,
+              "renamed_symbol_count": 38
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subject.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 10,
+              "reserved_size": 25,
+              "renamed_symbol_count": 53
             }
           },
           {
@@ -4948,43 +4982,63 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subscriber.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isFunction.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 37,
-              "renamed_symbol_count": 38
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/lift.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/dom/animationFrames.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 5
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 9
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/UnsubscriptionError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/config.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 3,
-              "renamed_symbol_count": 3
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/BehaviorSubject.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/ConnectableObservable.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 9,
-              "renamed_symbol_count": 13
+              "reserved_size": 17,
+              "renamed_symbol_count": 14
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subscription.js",
+            "stats": {
+              "slot_count": 14,
+              "slot_name_length_sum": 14,
+              "name_counter_final": 21,
+              "reserved_size": 26,
+              "renamed_symbol_count": 37
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 11,
+              "renamed_symbol_count": 23
             }
           }
         ],
@@ -4995,6 +5049,24 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 2876
+        },
+        "unified": {
+          "phase_a": {
+            "slot_count": 1080,
+            "slot_name_length_sum": 2106,
+            "name_counter_final": 1086,
+            "reserved_size": 1080,
+            "renamed_symbol_count": 1080
+          },
+          "phase_b_totals": {
+            "slot_count": 953,
+            "slot_name_length_sum": 1906,
+            "name_counter_final": 0,
+            "reserved_size": 0,
+            "renamed_symbol_count": 1796
+          },
+          "total_renames": 2876,
+          "module_count": 224
         }
       },
       "nested_module_count": 224,
@@ -5046,6 +5118,24 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 8201
+        },
+        "unified": {
+          "phase_a": {
+            "slot_count": 1080,
+            "slot_name_length_sum": 2106,
+            "name_counter_final": 1086,
+            "reserved_size": 1080,
+            "renamed_symbol_count": 1080
+          },
+          "phase_b_totals": {
+            "slot_count": 100,
+            "slot_name_length_sum": 200,
+            "name_counter_final": 0,
+            "reserved_size": 0,
+            "renamed_symbol_count": 7134
+          },
+          "total_renames": 8214,
+          "module_count": 2
         }
       },
       "nested_module_count": 2,
@@ -5117,6 +5207,24 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 414
+        },
+        "unified": {
+          "phase_a": {
+            "slot_count": 38,
+            "slot_name_length_sum": 38,
+            "name_counter_final": 38,
+            "reserved_size": 38,
+            "renamed_symbol_count": 38
+          },
+          "phase_b_totals": {
+            "slot_count": 80,
+            "slot_name_length_sum": 144,
+            "name_counter_final": 0,
+            "reserved_size": 0,
+            "renamed_symbol_count": 376
+          },
+          "total_renames": 414,
+          "module_count": 4
         }
       },
       "nested_module_count": 4,

--- a/tests/benchmark/mangler-property.ts
+++ b/tests/benchmark/mangler-property.ts
@@ -43,12 +43,20 @@ interface NestedEntry {
   stats: ManglerStats;
 }
 
+interface UnifiedSummary {
+  phase_a: ManglerStats;
+  phase_b_totals: ManglerStats;
+  total_renames: number;
+  module_count: number;
+}
+
 interface ManglerReport {
   top_level: ManglerStats;
   top_level_reserved_pool: number;
   nested: NestedEntry[];
   bundle_size_bytes: number;
   totals: ManglerStats;
+  unified?: UnifiedSummary;
 }
 
 interface FixtureResult {
@@ -127,13 +135,42 @@ function formatStats(s: ManglerStats): string {
   return `slots=${s.slot_count} nameLen=${s.slot_name_length_sum} rename=${s.renamed_symbol_count}`;
 }
 
+function unifiedCombined(u: UnifiedSummary): ManglerStats {
+  return {
+    slot_count: u.phase_a.slot_count + u.phase_b_totals.slot_count,
+    slot_name_length_sum: u.phase_a.slot_name_length_sum + u.phase_b_totals.slot_name_length_sum,
+    name_counter_final: 0,
+    reserved_size: 0,
+    renamed_symbol_count: u.phase_a.renamed_symbol_count + u.phase_b_totals.renamed_symbol_count,
+  };
+}
+
+function deltaPct(base: number, cur: number): string {
+  if (base === 0) return cur === 0 ? "+0.00%" : "+∞";
+  const pct = ((cur - base) / base) * 100;
+  return `${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%`;
+}
+
 function printFixture(r: FixtureResult): void {
   const top = r.report.top_level;
   const nest = r.nested_totals;
   console.log(`\n## ${r.name}`);
   console.log(`  bundle_size: ${r.report.bundle_size_bytes} B`);
-  console.log(`  top_level:   ${formatStats(top)} (pool=${r.report.top_level_reserved_pool})`);
-  console.log(`  nested(${r.nested_module_count} mod): ${formatStats(nest)}`);
+  console.log(`  two-phase top:    ${formatStats(top)} (pool=${r.report.top_level_reserved_pool})`);
+  console.log(`  two-phase nested: (${r.nested_module_count} mod) ${formatStats(nest)}`);
+  if (r.report.unified) {
+    const u = r.report.unified;
+    const combined = unifiedCombined(u);
+    const tp_total = r.report.totals;
+    console.log(`  unified phase A:  ${formatStats(u.phase_a)}`);
+    console.log(`  unified phase B:  (${u.module_count} mod) ${formatStats(u.phase_b_totals)}`);
+    console.log(
+      `  unified total:    ${formatStats(combined)}  ` +
+        `(vs two-phase: slots ${deltaPct(tp_total.slot_count, combined.slot_count)}, ` +
+        `nameLen ${deltaPct(tp_total.slot_name_length_sum, combined.slot_name_length_sum)}, ` +
+        `rename ${deltaPct(tp_total.renamed_symbol_count, combined.renamed_symbol_count)})`,
+    );
+  }
 }
 
 type Check = { ok: boolean; label: string; detail: string };


### PR DESCRIPTION
## Summary

`--mangle-report` 가 켜져 있으면 기존 two-phase `computeMangling` 직전에 `mangleAll()` 을 한 번 더 실행해 같은 번들에 대한 unified 경로 수치를 report JSON 의 `unified` 섹션에 기록. 실제 번들 출력에는 영향 없음 — 비교 baseline 용.

- `Linker.collectUnifiedInput()` — 기존 `collectManglingCandidates` 와 같은 exported/imported/1-char/default 필터를 재적용하되 이름별 집계 대신 `(module, symbol)` 단위 candidate 를 개별 생성. (Step 3 에서 두 함수 통합 예정)
- `MangleReportCollector.unified: ?UnifiedSummary` — `phase_a` / `phase_b_totals` / `total_renames` / `module_count`. writeJson 에 섹션 추가.
- `bundler.runUnifiedShadow()` — shadow 실패 시 warn 만 남기고 번들은 계속 진행.
- TS runner — unified phase A/B 통계 + two-phase 대비 slot/length/rename 델타 출력.

## 6 fixture 실측

| fixture | Phase A slots (tp→un) | name_length_sum | Phase B 모듈 수 (tp→un) |
|---------|----------------------|-----------------|------------------------|
| rxjs    | 1080 → 1080 (동일)    | 2129 → 2106 (−1.1%)   | 224 → 224 |
| three   | 1080 → 1080 (동일)    | 2136 → 2106 (−1.4%)   | 2 → 2 |
| react   | 38 → 38 (동일)        | 38 → 38 (동일)         | 4 → 4 |
| zod     | 139 → 139 (동일)      | 237 → 224 (−5.5%)     | 9 → 11 |
| effect  | 10135 → 10136 (+1)    | 27038 → 26851 (−0.7%) | 102 → 601 |
| lodash  | 1203 → 1214 (+11)     | 2354 → 2374 (+0.8%)   | 153 → 641 |

**관찰**:
- Phase A slot count 는 사실상 동일 (scope hoisting 후 cross-module top-level 이름 중복이 드묾 = name aggregation 차이가 미미).
- unified 의 Phase A name_length_sum 이 오히려 **약간 유리** — reserved pool 이 작아 더 짧은 base54 이름 배정 (이슈 본문 "정보 비대칭" 가설의 실측 신호).
- `effect/lodash-es` 의 Phase B 모듈 수 차이는 **tree-shaking 범위 차이** 때문 — two-phase `nested` 는 emit 된 모듈만 집계, unified 는 `linker.modules` 전체 순회. Step 3 (호출부 교체) 에서 자연 해소.

## Test plan

- [x] `zig build test` 통과
- [x] `--mangle-report=<path>` smoke test — 6 fixture 모두 unified 섹션 출력 확인
- [x] baseline 갱신 후 `bun run tests/benchmark/mangler-property.ts` 재실행 → 0.00% diff
- [x] `/simplify` 실행: `UnifiedCollect` lifetime 주석 강화, filter 통합 계획 주석 명시

Refs #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)