### PR TITLE
refactor(mangler): #1760 Step 3b — prune shadow-collect infra

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -759,12 +759,6 @@ pub const Bundler = struct {
             if (!self.options.code_splitting) {
                 try l.computeRenames();
                 if (self.options.minify_identifiers) {
-                    // #1760 Step 2 shadow: computeMangling 전에 unified 도 돌려 수치 수집.
-                    if (mangle_report_enabled) {
-                        runUnifiedShadow(self.allocator, &l, &mangle_collector) catch |err| {
-                            std.log.warn("mangle-report: unified shadow failed: {s}", .{@errorName(err)});
-                        };
-                    }
                     try l.computeMangling();
                 }
             }
@@ -1186,39 +1180,6 @@ pub const Bundler = struct {
         };
     }
 };
-
-/// #1760 Step 2 shadow — `mangleAll()` 을 같은 번들에 돌려 `collector.unified`
-/// 에 요약을 기록. 실제 번들 출력에는 영향 없음.
-fn runUnifiedShadow(
-    allocator: std.mem.Allocator,
-    linker: *Linker,
-    collector: *MangleReportCollector,
-) !void {
-    const um = @import("../codegen/unified_mangler.zig");
-    const ManglerStats = @import("../codegen/mangler.zig").ManglerStats;
-
-    var collected = try linker.collectUnifiedInput();
-    defer collected.deinit();
-
-    var res = try um.mangleAll(allocator, .{
-        .modules = collected.modules,
-        .top_level_candidates = collected.top_level_candidates,
-    });
-    defer res.deinit();
-
-    var phase_b_totals: ManglerStats = .{};
-    for (res.phase_b_modules) |s| {
-        phase_b_totals.slot_count += s.slot_count;
-        phase_b_totals.slot_name_length_sum += s.slot_name_length_sum;
-        phase_b_totals.renamed_symbol_count += s.renamed_symbol_count;
-    }
-    collector.unified = .{
-        .phase_a = res.phase_a,
-        .phase_b_totals = phase_b_totals,
-        .total_renames = res.renames.count(),
-        .module_count = res.phase_b_modules.len,
-    };
-}
 
 /// metafile JSON을 생성한다 (esbuild 호환 형식).
 /// inputs: 각 모듈의 경로, 바이트 수, import 목록

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -77,24 +77,10 @@ pub const MangleReportCollector = struct {
     /// Bundle emit 후 채움.
     bundle_size_bytes: usize = 0,
 
-    /// #1760 Step 2 shadow mode — `mangleAll()` 을 같은 번들에 대해 한 번 더
-    /// 돌려 수집한 수치. 실제 번들 출력에는 영향 없음, 비교 용도.
-    unified: ?UnifiedSummary = null,
-
     pub const NestedEntry = struct {
         /// linker 생명주기 내 유효 (module.path 차용).
         module_path: []const u8,
         stats: ManglerStats,
-    };
-
-    pub const UnifiedSummary = struct {
-        phase_a: ManglerStats,
-        /// 모든 모듈 Phase B stats 의 합 (slot/length/renamed).
-        phase_b_totals: ManglerStats,
-        /// 전체 renames 개수 (Phase A + Phase B 합).
-        total_renames: usize,
-        /// 모듈 수 (phase_b_modules 길이).
-        module_count: usize,
     };
 
     pub fn init(allocator: std.mem.Allocator) MangleReportCollector {
@@ -138,15 +124,6 @@ pub const MangleReportCollector = struct {
         try writer.writeAll(if (self.nested.items.len == 0) "]" else "\n  ]");
         try writer.print(",\n  \"bundle_size_bytes\": {d},\n  \"totals\": ", .{self.bundle_size_bytes});
         try writeStatsJson(writer, totals);
-
-        if (self.unified) |u| {
-            try writer.writeAll(",\n  \"unified\": {\n    \"phase_a\": ");
-            try writeStatsJson(writer, u.phase_a);
-            try writer.writeAll(",\n    \"phase_b_totals\": ");
-            try writeStatsJson(writer, u.phase_b_totals);
-            try writer.print(",\n    \"total_renames\": {d},\n    \"module_count\": {d}\n  }}", .{ u.total_renames, u.module_count });
-        }
-
         try writer.writeAll("\n}\n");
     }
 
@@ -770,137 +747,9 @@ pub const Linker = struct {
         }
     }
 
-    const NameEntry = struct {
-        name: []const u8,
-        total_refs: u32,
-    };
-
-    /// mangling 후보 수집 결과. computeMangling()에서 사용.
-    const ManglingCandidates = struct {
-        /// mangling 제외 대상 (export/import binding 이름)
-        exported: std.StringHashMap(void),
-        /// 빈도순 정렬된 mangling 후보 목록
-        entries: std.ArrayListUnmanaged(NameEntry),
-        /// scope_maps에 없는 합성 default export 심볼들. dirty list에도 없으므로
-        /// rename 단계에서 별도로 assignSymbolCanonical이 필요하다 (#1585).
-        synthetic_defaults: std.ArrayListUnmanaged(*semantic_symbol.Symbol),
-
-        fn deinit(mc: *ManglingCandidates, allocator: std.mem.Allocator) void {
-            mc.exported.deinit();
-            mc.entries.deinit(allocator);
-            mc.synthetic_defaults.deinit(allocator);
-        }
-    };
-
-    /// 모든 모듈의 top-level 심볼을 수집하고 reference_count 빈도순으로 정렬.
-    /// mangling 제외 대상(export/import binding)도 함께 수집한다.
-    fn collectManglingCandidates(self: *const Linker) !ManglingCandidates {
-        var name_refs = std.StringHashMap(u32).init(self.allocator);
-        defer name_refs.deinit();
-
-        var synthetic_defaults: std.ArrayListUnmanaged(*semantic_symbol.Symbol) = .empty;
-        errdefer synthetic_defaults.deinit(self.allocator);
-
-        // mangling 제외 대상 수집 (public API 경계) — #1581:
-        //   - entry 모듈의 export: 번들 외부 소비자에게 노출되는 public API
-        //   - external import의 local binding: 번들 밖에서 해소되므로 원본 이름이 정답
-        // 중간 모듈의 export 이름은 scope hoisting 후 bundle 내부에서만 소비되므로
-        // 자유롭게 축약 가능. esbuild/rolldown도 동일한 boundary로 동작.
-        var exported = std.StringHashMap(void).init(self.allocator);
-        errdefer exported.deinit();
-        for (self.modules) |m| {
-            if (m.is_entry_point) {
-                for (m.export_bindings) |eb| {
-                    try exported.put(eb.exported_name, {});
-                    try exported.put(m.exportBindingLocalName(eb), {});
-                }
-            }
-            for (m.import_bindings) |ib| {
-                if (ib.import_record_index >= m.import_records.len) continue;
-                if (!m.import_records[ib.import_record_index].is_external) continue;
-                try exported.put(m.importBindingLocalName(ib), {});
-            }
-        }
-
-        // top-level scope(scope_maps[0])의 심볼 reference_count를 이름별로 합산
-        for (self.modules) |m| {
-            const sem = m.semantic orelse continue;
-            if (sem.scope_maps.len == 0) continue;
-            // direct eval / with이 이 모듈 내부 어디든 있으면 top-level 바인딩도
-            // 동적으로 참조될 수 있으므로 전체 스킵 (#1258). rolldown/oxc 방식.
-            if (sem.scopes.len > 0 and sem.scopes[0].blocksMangling()) continue;
-            var sit = sem.scope_maps[0].iterator();
-            while (sit.next()) |entry| {
-                const sym_name = entry.key_ptr.*;
-                const sym_idx = entry.value_ptr.*;
-
-                // mangling 제외 대상
-                if (exported.contains(sym_name)) continue;
-                if (sym_name.len <= 1) continue;
-                if (std.mem.eql(u8, sym_name, "default")) continue;
-                if (std.mem.eql(u8, sym_name, "arguments")) continue;
-
-                if (sym_idx >= sem.symbols.items.len) continue;
-                const sym = &sem.symbols.items[sym_idx];
-                // import binding은 mangling 대상이 아님 (#1623). 후보로 잡으면 자체 mangled
-                // 이름이 부여되고, buildMetadataForAst의 self-rename 루프가 그 이름으로
-                // cross-module rename(target export의 canonical name)을 덮어써 reference가 깨진다.
-                if (sym.kind == .import_binding) continue;
-                // canonical_name이 이미 할당된 상태(충돌 해결 후 `_default$1` 등)라면
-                // dirty list 치환이 그 canonical_name으로 lookup하므로 name_refs도
-                // 그 키로 맞춰야 rename이 연결된다 (#1585).
-                const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym_name;
-                if (key.len <= 1) continue;
-                if (exported.contains(key)) continue;
-                const prev = name_refs.get(key) orelse 0;
-                try name_refs.put(key, prev + sym.reference_count);
-            }
-
-            // 합성 default export 심볼(`_default`)도 후보에 포함 (#1585).
-            // scope_maps에 등록되지 않은 합성 심볼은 위 순회에서 누락된다.
-            // populateSyntheticSymbols(#1338)가 semantic 공간에 extend한 심볼만 대상.
-            // 수집한 포인터는 synthetic_defaults로 보관하여 3-b rename 단계에서 재사용.
-            for (sem.symbols.items) |*sym| {
-                const sk = sym.synthetic_kind orelse continue;
-                if (sk != .default_export) continue;
-                const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym.synthetic_name;
-                if (key.len <= 1) continue;
-                if (exported.contains(key)) continue;
-                try synthetic_defaults.append(self.allocator, sym);
-                const prev = name_refs.get(key) orelse 0;
-                try name_refs.put(key, prev + sym.reference_count);
-            }
-        }
-
-        // 빈도순 정렬
-        var entries: std.ArrayListUnmanaged(NameEntry) = .empty;
-        errdefer entries.deinit(self.allocator);
-        {
-            var it = name_refs.iterator();
-            while (it.next()) |entry| {
-                try entries.append(self.allocator, .{
-                    .name = entry.key_ptr.*,
-                    .total_refs = entry.value_ptr.*,
-                });
-            }
-        }
-        std.mem.sortUnstable(NameEntry, entries.items, {}, struct {
-            fn cmp(_: void, a: NameEntry, b: NameEntry) bool {
-                if (a.total_refs != b.total_refs) return a.total_refs > b.total_refs;
-                return std.mem.lessThan(u8, a.name, b.name);
-            }
-        }.cmp);
-
-        return .{ .exported = exported, .entries = entries, .synthetic_defaults = synthetic_defaults };
-    }
-
-    /// #1760 shadow mode: unified_mangler.mangleAll() 을 호출하기 위한 입력 수집.
-    /// `collectManglingCandidates` 와 같은 필터 (exported/imported/1-char/default)
-    /// 를 적용하지만 이름별 집계 대신 `(module_index, symbol_id)` 단위 후보를
-    /// 개별 생성한다. 결과는 caller 가 `deinit` 해야 함.
-    ///
-    /// Step 3 (unified 경로로 전환) 시 이 필터 체인과 `collectManglingCandidates`
-    /// 가 통합되며, 이 함수가 기본 경로로 남고 구 함수는 제거 예정.
+    /// unified_mangler.mangleAll() 을 호출하기 위한 입력 수집. `(module_index,
+    /// symbol_id)` 단위 후보를 개별 생성한다 (이름별 집계 없음). 결과는
+    /// caller 가 `deinit` 해야 함.
     pub fn collectUnifiedInput(self: *const Linker) !UnifiedCollect {
         const um = @import("../codegen/unified_mangler.zig");
 

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -41,8 +41,7 @@ pub const ModuleMangleInput = struct {
 };
 
 /// Phase A 의 mangling 후보. 호출부가 빈도/필터링을 수행해 넘긴다
-/// (현재 `linker.collectManglingCandidates` 와 동일 범주: exported/imported/
-/// 길이 1 이하 제외).
+/// (범주: exported/imported/1-char/default/arguments/import binding 제외).
 pub const TopLevelCandidate = struct {
     module_index: u32,
     symbol_id: u32,

--- a/tests/benchmark/baselines/mangler-property.json
+++ b/tests/benchmark/baselines/mangler-property.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-04-22T20:41:33.089Z",
+  "generated_at": "2026-04-22T20:49:44.463Z",
   "fixtures": [
     {
       "name": "effect",
@@ -25,16 +25,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Equivalence.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 7,
-              "reserved_size": 45,
-              "renamed_symbol_count": 36
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Function.js",
             "stats": {
               "slot_count": 9,
@@ -45,6 +35,16 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Scope.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/request.js",
             "stats": {
               "slot_count": 4,
@@ -52,6 +52,86 @@
               "name_counter_final": 4,
               "reserved_size": 40,
               "renamed_symbol_count": 25
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/state.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 68,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/effectable.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 34,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/keyType.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 70,
+              "renamed_symbol_count": 19
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberMessage.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 16,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/boundaries.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 23,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/completedRequestMap.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/supervisor/patch.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 30,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberScope.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 15,
+              "renamed_symbol_count": 8
             }
           },
           {
@@ -75,66 +155,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Either.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 5,
-              "reserved_size": 97,
-              "renamed_symbol_count": 42
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/effectable.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 34,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Scope.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/boundaries.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 23,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/key.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 38,
-              "renamed_symbol_count": 19
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/keyType.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 70,
-              "renamed_symbol_count": 19
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/registry.js",
             "stats": {
               "slot_count": 3,
@@ -142,56 +162,6 @@
               "name_counter_final": 3,
               "reserved_size": 14,
               "renamed_symbol_count": 20
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/state.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 68,
-              "renamed_symbol_count": 23
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/completedRequestMap.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberMessage.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 16,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Duration.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 10,
-              "reserved_size": 139,
-              "renamed_symbol_count": 159
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_effect.ts",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
             }
           },
           {
@@ -215,36 +185,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberScope.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 15,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/supervisor/patch.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 30,
-              "renamed_symbol_count": 22
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/logSpan.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberStatus.js",
             "stats": {
               "slot_count": 2,
@@ -265,6 +205,16 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/key.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 38,
+              "renamed_symbol_count": 19
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/label.js",
             "stats": {
               "slot_count": 2,
@@ -272,26 +222,6 @@
               "name_counter_final": 2,
               "reserved_size": 15,
               "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRefs/patch.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 22,
-              "renamed_symbol_count": 20
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/hook.js",
-            "stats": {
-              "slot_count": 18,
-              "slot_name_length_sum": 18,
-              "name_counter_final": 24,
-              "reserved_size": 42,
-              "renamed_symbol_count": 103
             }
           },
           {
@@ -305,6 +235,26 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/logSpan.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRefs/patch.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 22,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/FiberRefs.js",
             "stats": {
               "slot_count": 0,
@@ -312,6 +262,36 @@
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_effect.ts",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric/hook.js",
+            "stats": {
+              "slot_count": 18,
+              "slot_name_length_sum": 18,
+              "name_counter_final": 24,
+              "reserved_size": 42,
+              "renamed_symbol_count": 103
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/tracer.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 7,
+              "reserved_size": 24,
+              "renamed_symbol_count": 31
             }
           },
           {
@@ -325,7 +305,27 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/defaultServices/console.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/config.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/configError.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -345,106 +345,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/configError.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 7,
-              "reserved_size": 106,
-              "renamed_symbol_count": 117
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/tracer.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 7,
-              "reserved_size": 24,
-              "renamed_symbol_count": 31
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/defaultServices/console.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 20
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider/pathPatch.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 20,
-              "renamed_symbol_count": 13
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Micro.js",
-            "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 27,
-              "reserved_size": 442,
-              "renamed_symbol_count": 456
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtime.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 96,
-              "renamed_symbol_count": 84
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/clock.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 22,
-              "renamed_symbol_count": 12
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/deferred.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/deferred.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 12,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/random.js",
             "stats": {
               "slot_count": 4,
@@ -452,6 +352,16 @@
               "name_counter_final": 6,
               "reserved_size": 27,
               "renamed_symbol_count": 28
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/logger.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 22,
+              "reserved_size": 97,
+              "renamed_symbol_count": 113
             }
           },
           {
@@ -465,23 +375,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiber.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/clock.js",
             "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 14,
-              "reserved_size": 107,
-              "renamed_symbol_count": 64
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 22,
+              "renamed_symbol_count": 12
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/cause.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/metric.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 7,
+              "reserved_size": 106,
+              "renamed_symbol_count": 117
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider/pathPatch.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 20,
+              "renamed_symbol_count": 13
             }
           },
           {
@@ -505,7 +425,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/RuntimeFlagsPatch.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/deferred.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -515,63 +435,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/defaultServices.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/cause.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 62,
-              "renamed_symbol_count": 33
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/logger.js",
-            "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 22,
-              "reserved_size": 97,
-              "renamed_symbol_count": 113
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlagsPatch.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 38,
-              "renamed_symbol_count": 22
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/hashSetPatch.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 36,
-              "renamed_symbol_count": 21
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/data.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/deferred.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 11,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlags.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 65,
-              "renamed_symbol_count": 42
+              "reserved_size": 12,
+              "renamed_symbol_count": 2
             }
           },
           {
@@ -585,13 +465,103 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/readonlyArrayPatch.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/RuntimeFlagsPatch.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 8,
-              "reserved_size": 41,
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlagsPatch.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 38,
               "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Micro.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 27,
+              "reserved_size": 442,
+              "renamed_symbol_count": 456
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/defaultServices.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 62,
+              "renamed_symbol_count": 33
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtimeFlags.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 65,
+              "renamed_symbol_count": 42
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/data.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 11,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiber.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 14,
+              "reserved_size": 107,
+              "renamed_symbol_count": 64
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/runtime.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 96,
+              "renamed_symbol_count": 84
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/hashSetPatch.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 36,
+              "renamed_symbol_count": 21
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core-effect.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 24,
+              "reserved_size": 328,
+              "renamed_symbol_count": 370
             }
           },
           {
@@ -605,36 +575,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 40,
-              "renamed_symbol_count": 66
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 14,
-              "reserved_size": 106,
-              "renamed_symbol_count": 216
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/MutableRef.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 4,
-              "reserved_size": 45,
-              "renamed_symbol_count": 23
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/contextPatch.js",
             "stats": {
               "slot_count": 6,
@@ -645,12 +585,62 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 40,
+              "renamed_symbol_count": 66
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/cause.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 14,
+              "reserved_size": 161,
+              "renamed_symbol_count": 202
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/differ/readonlyArrayPatch.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 8,
+              "reserved_size": 41,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/HashMap.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
               "reserved_size": 82,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/array.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 9,
+              "renamed_symbol_count": 15
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/stack.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
               "renamed_symbol_count": 2
             }
           },
@@ -665,33 +655,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/array.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/blockedRequests.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 9,
-              "renamed_symbol_count": 15
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/HashSet.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 55,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/stack.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 80,
+              "renamed_symbol_count": 76
             }
           },
           {
@@ -705,23 +675,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashSet.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/MutableRef.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 7,
-              "reserved_size": 76,
-              "renamed_symbol_count": 63
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 4,
+              "reserved_size": 45,
+              "renamed_symbol_count": 23
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/blockedRequests.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/configProvider.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 8,
-              "reserved_size": 80,
-              "renamed_symbol_count": 76
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 14,
+              "reserved_size": 106,
+              "renamed_symbol_count": 216
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/HashSet.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 55,
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -745,23 +725,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/cause.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashSet.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 14,
-              "reserved_size": 161,
-              "renamed_symbol_count": 202
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 7,
+              "reserved_size": 76,
+              "renamed_symbol_count": 63
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core-effect.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/node.js",
             "stats": {
-              "slot_count": 13,
-              "slot_name_length_sum": 13,
-              "name_counter_final": 24,
-              "reserved_size": 328,
-              "renamed_symbol_count": 370
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 21,
+              "reserved_size": 42,
+              "renamed_symbol_count": 109
             }
           },
           {
@@ -772,26 +752,6 @@
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Order.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 8,
-              "reserved_size": 59,
-              "renamed_symbol_count": 66
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/List.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 15,
-              "reserved_size": 125,
-              "renamed_symbol_count": 121
             }
           },
           {
@@ -815,46 +775,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/context.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 79,
-              "renamed_symbol_count": 57
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/option.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 29,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap/node.js",
-            "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 21,
-              "reserved_size": 42,
-              "renamed_symbol_count": 109
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Tuple.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 28,
-              "renamed_symbol_count": 16
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Number.js",
             "stats": {
               "slot_count": 7,
@@ -865,23 +785,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/context.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
-              "name_counter_final": 7,
-              "reserved_size": 115,
-              "renamed_symbol_count": 120
+              "name_counter_final": 6,
+              "reserved_size": 79,
+              "renamed_symbol_count": 57
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/effect.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Duration.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 139,
+              "renamed_symbol_count": 159
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Order.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 59,
+              "renamed_symbol_count": 66
             }
           },
           {
@@ -895,63 +825,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/GlobalValue.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Option.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/errors.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Equal.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
               "name_counter_final": 4,
-              "reserved_size": 16,
-              "renamed_symbol_count": 9
+              "reserved_size": 140,
+              "renamed_symbol_count": 65
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Effect.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/List.js",
             "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 14,
-              "reserved_size": 691,
-              "renamed_symbol_count": 75
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 15,
+              "reserved_size": 125,
+              "renamed_symbol_count": 121
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/opCodes/effect.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 12,
-              "reserved_size": 565,
-              "renamed_symbol_count": 424
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Hash.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/hashMap.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 36,
-              "renamed_symbol_count": 10
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 7,
+              "reserved_size": 115,
+              "renamed_symbol_count": 120
             }
           },
           {
@@ -965,6 +875,96 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Tuple.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 28,
+              "renamed_symbol_count": 16
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/option.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 29,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Effect.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 14,
+              "reserved_size": 691,
+              "renamed_symbol_count": 75
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Equal.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 16,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/errors.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/GlobalValue.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Hash.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 36,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Chunk.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 12,
+              "reserved_size": 209,
+              "renamed_symbol_count": 120
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRuntime.js",
+            "stats": {
+              "slot_count": 23,
+              "slot_name_length_sum": 23,
+              "name_counter_final": 34,
+              "reserved_size": 311,
+              "renamed_symbol_count": 679
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Inspectable.js",
             "stats": {
               "slot_count": 9,
@@ -972,6 +972,26 @@
               "name_counter_final": 14,
               "reserved_size": 44,
               "renamed_symbol_count": 27
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Either.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 5,
+              "reserved_size": 97,
+              "renamed_symbol_count": 42
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/core.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 12,
+              "reserved_size": 565,
+              "renamed_symbol_count": 424
             }
           },
           {
@@ -985,23 +1005,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Option.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Equivalence.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 4,
-              "reserved_size": 140,
-              "renamed_symbol_count": 65
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/Chunk.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 12,
-              "reserved_size": 209,
-              "renamed_symbol_count": 120
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 7,
+              "reserved_size": 45,
+              "renamed_symbol_count": 36
             }
           },
           {
@@ -1023,16 +1033,6 @@
               "reserved_size": 299,
               "renamed_symbol_count": 229
             }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/effect@3.21.0/node_modules/effect/dist/esm/internal/fiberRuntime.js",
-            "stats": {
-              "slot_count": 23,
-              "slot_name_length_sum": 23,
-              "name_counter_final": 34,
-              "reserved_size": 311,
-              "renamed_symbol_count": 679
-            }
           }
         ],
         "bundle_size_bytes": 140900,
@@ -1042,24 +1042,6 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 15519
-        },
-        "unified": {
-          "phase_a": {
-            "slot_count": 10135,
-            "slot_name_length_sum": 26848,
-            "name_counter_final": 10144,
-            "reserved_size": 10135,
-            "renamed_symbol_count": 10135
-          },
-          "phase_b_totals": {
-            "slot_count": 2144,
-            "slot_name_length_sum": 6432,
-            "name_counter_final": 0,
-            "reserved_size": 0,
-            "renamed_symbol_count": 18999
-          },
-          "total_renames": 29134,
-          "module_count": 601
         }
       },
       "nested_module_count": 102,
@@ -1084,7 +1066,7 @@
         "top_level_reserved_pool": 1203,
         "nested": [
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Symbol.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_root.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -1094,103 +1076,63 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_objectToString.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArray.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/identity.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 6,
+              "reserved_size": 2,
               "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayMap.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isFunction.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMap.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 4,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseUniq.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 13,
+              "reserved_size": 10,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayIncludesWith.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
               "name_counter_final": 5,
               "reserved_size": 2,
               "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObjectLike.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_coreJsData.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getRawTag.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 12,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObject.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGetTag.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 11,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isSymbol.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_lodash-es.ts",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/uniq.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 3,
-              "renamed_symbol_count": 1
             }
           },
           {
@@ -1214,36 +1156,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayIncludesWith.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 2,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareAscending.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 10,
-              "reserved_size": 3,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/lodash.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseOrderBy.js",
             "stats": {
               "slot_count": 6,
@@ -1254,82 +1166,12 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseUniq.js",
-            "stats": {
-              "slot_count": 13,
-              "slot_name_length_sum": 13,
-              "name_counter_final": 13,
-              "reserved_size": 10,
-              "renamed_symbol_count": 13
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFor.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMap.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 4,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/property.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/uniq.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseEach.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/groupBy.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 8,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createSet.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 7,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIteratee.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 7,
+              "reserved_size": 3,
               "renamed_symbol_count": 1
             }
           },
@@ -1344,6 +1186,16 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/groupBy.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseForOwn.js",
             "stats": {
               "slot_count": 2,
@@ -1354,27 +1206,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_basePropertyDeep.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 3,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseProperty.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareMultiple.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareAscending.js",
             "stats": {
               "slot_count": 10,
               "slot_name_length_sum": 10,
@@ -1384,33 +1216,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hasPath.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_lodash-es.ts",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 8,
-              "renamed_symbol_count": 7
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMatches.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseEach.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 5,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isStrictComparable.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 3,
-              "renamed_symbol_count": 1
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -1424,16 +1246,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createAggregator.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createBaseEach.js",
             "stats": {
               "slot_count": 7,
@@ -1444,53 +1256,123 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_matchesStrictComparable.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_cacheHas.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/hasIn.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 4,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arraySome.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 2,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheHas.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/property.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 2,
+              "reserved_size": 6,
               "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFor.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_basePropertyDeep.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 3,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayAggregator.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 2,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_compareMultiple.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 10,
+              "reserved_size": 3,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseHasIn.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createSet.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 7,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/lodash.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMatchesProperty.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 13,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIteratee.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 7,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isStrictComparable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 3,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseProperty.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
             }
           },
           {
@@ -1504,13 +1386,63 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Uint8Array.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_createAggregator.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapToArray.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_matchesStrictComparable.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheAdd.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheHas.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/hasIn.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 4,
+              "renamed_symbol_count": 2
             }
           },
           {
@@ -1524,7 +1456,107 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayAggregator.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hasPath.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 8,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalArrays.js",
+            "stats": {
+              "slot_count": 17,
+              "slot_name_length_sum": 17,
+              "name_counter_final": 17,
+              "reserved_size": 9,
+              "renamed_symbol_count": 19
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Uint8Array.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Promise.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Set.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMatches.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 5,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqual.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 4,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_cacheHas.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsMatch.js",
+            "stats": {
+              "slot_count": 13,
+              "slot_name_length_sum": 13,
+              "name_counter_final": 13,
+              "reserved_size": 8,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGetAllKeys.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayFilter.js",
             "stats": {
               "slot_count": 7,
               "slot_name_length_sum": 7,
@@ -1544,6 +1576,16 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackHas.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_SetCache.js",
             "stats": {
               "slot_count": 3,
@@ -1551,96 +1593,6 @@
               "name_counter_final": 3,
               "reserved_size": 5,
               "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseHasIn.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapToArray.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 2,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setCacheAdd.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqual.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 4,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getSymbols.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 10,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayFilter.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 2,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Stack.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalByTag.js",
-            "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 11,
-              "reserved_size": 38,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsMatch.js",
-            "stats": {
-              "slot_count": 13,
-              "slot_name_length_sum": 13,
-              "name_counter_final": 13,
-              "reserved_size": 8,
-              "renamed_symbol_count": 13
             }
           },
           {
@@ -1654,33 +1606,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Set.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackSet.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 7,
+              "renamed_symbol_count": 4
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubArray.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arraySome.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getAllKeys.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getTag.js",
             "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 5,
-              "renamed_symbol_count": 1
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 5,
+              "reserved_size": 31,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalObjects.js",
+            "stats": {
+              "slot_count": 22,
+              "slot_name_length_sum": 22,
+              "name_counter_final": 22,
+              "reserved_size": 9,
+              "renamed_symbol_count": 22
             }
           },
           {
@@ -1694,26 +1656,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackHas.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGetAllKeys.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 4,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackDelete.js",
             "stats": {
               "slot_count": 3,
@@ -1724,12 +1666,72 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseMatchesProperty.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubArray.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getSymbols.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 10,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getAllKeys.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 5,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/memoize.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 5,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/toString.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 3,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalByTag.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 11,
+              "reserved_size": 38,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_MapCache.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 13,
+              "reserved_size": 7,
               "renamed_symbol_count": 4
             }
           },
@@ -1744,117 +1746,37 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getTag.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 5,
-              "reserved_size": 31,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGet.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 4,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Promise.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqualDeep.js",
-            "stats": {
-              "slot_count": 17,
-              "slot_name_length_sum": 17,
-              "name_counter_final": 18,
-              "reserved_size": 22,
-              "renamed_symbol_count": 17
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalObjects.js",
-            "stats": {
-              "slot_count": 22,
-              "slot_name_length_sum": 22,
-              "name_counter_final": 22,
-              "reserved_size": 9,
-              "renamed_symbol_count": 22
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFlatten.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 4,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_equalArrays.js",
-            "stats": {
-              "slot_count": 17,
-              "slot_name_length_sum": 17,
-              "name_counter_final": 17,
-              "reserved_size": 9,
-              "renamed_symbol_count": 19
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isFlattenable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheHas.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 7,
+              "reserved_size": 3,
               "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toKey.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_castPath.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 5,
+              "reserved_size": 6,
               "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/get.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Stack.js",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 3,
-              "renamed_symbol_count": 4
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_stackSet.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 7,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/toString.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheGet.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
@@ -1874,23 +1796,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_castPath.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_memoizeCapped.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 5,
+              "renamed_symbol_count": 4
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheHas.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Map.js",
             "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 3,
-              "renamed_symbol_count": 1
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -1904,37 +1826,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_memoizeCapped.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheSet.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 5,
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 3,
               "renamed_symbol_count": 4
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/memoize.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 5,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheGet.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 3,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheClear.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheClear.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -1954,6 +1856,46 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/get.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 3,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheGet.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 3,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toKey.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 5,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsEqualDeep.js",
+            "stats": {
+              "slot_count": 17,
+              "slot_name_length_sum": 17,
+              "name_counter_final": 18,
+              "reserved_size": 22,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getMapData.js",
             "stats": {
               "slot_count": 3,
@@ -1964,12 +1906,62 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_MapCache.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isKeyable.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_ListCache.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
               "reserved_size": 7,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFlatten.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 4,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashClear.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nativeCreate.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGet.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
               "renamed_symbol_count": 4
             }
           },
@@ -1984,17 +1976,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheGet.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/keys.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 3,
-              "renamed_symbol_count": 3
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 5,
+              "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Map.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_mapCacheClear.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2004,7 +1996,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isKeyable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashDelete.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
@@ -2024,16 +2016,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheClear.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_assocIndexOf.js",
             "stats": {
               "slot_count": 3,
@@ -2044,32 +2026,22 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Hash.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isFlattenable.js",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 5,
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
               "reserved_size": 7,
-              "renamed_symbol_count": 4
+              "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_ListCache.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 7,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashDelete.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashHas.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 2,
+              "reserved_size": 7,
               "renamed_symbol_count": 2
             }
           },
@@ -2084,17 +2056,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_listCacheSet.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Hash.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 3,
+              "name_counter_final": 5,
+              "reserved_size": 7,
               "renamed_symbol_count": 4
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashClear.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nativeKeys.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2114,13 +2086,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashGet.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isTypedArray.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 9,
-              "renamed_symbol_count": 3
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -2134,12 +2106,22 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/keys.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashGet.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 9,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsArguments.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 5,
+              "reserved_size": 6,
               "renamed_symbol_count": 1
             }
           },
@@ -2154,7 +2136,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nativeCreate.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isBuffer.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2164,23 +2146,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_hashHas.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIterateeCall.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 7,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_nativeKeys.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 6,
+              "renamed_symbol_count": 4
             }
           },
           {
@@ -2194,7 +2166,17 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isTypedArray.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArguments.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 10,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubFalse.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2211,36 +2193,6 @@
               "name_counter_final": 2,
               "reserved_size": 2,
               "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isBuffer.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/stubFalse.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArguments.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 10,
-              "renamed_symbol_count": 1
             }
           },
           {
@@ -2264,36 +2216,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArrayLike.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIterateeCall.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 6,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isPrototype.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 4,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsTypedArray.js",
             "stats": {
               "slot_count": 1,
@@ -2304,12 +2226,22 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIsArguments.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/eq.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArrayLike.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 6,
+              "reserved_size": 4,
               "renamed_symbol_count": 1
             }
           },
@@ -2334,23 +2266,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/eq.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isPrototype.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_overRest.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 5,
-              "renamed_symbol_count": 8
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -2364,6 +2286,16 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_overRest.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 5,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isIndex.js",
             "stats": {
               "slot_count": 3,
@@ -2371,16 +2303,6 @@
               "name_counter_final": 3,
               "reserved_size": 6,
               "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setToString.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
             }
           },
           {
@@ -2404,46 +2326,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_strictIndexOf.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 2,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIndexOf.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 5,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseSetToString.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 5,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayIncludes.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 3,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseFindIndex.js",
             "stats": {
               "slot_count": 6,
@@ -2464,6 +2346,46 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseSetToString.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 5,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_strictIndexOf.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseIndexOf.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 5,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayIncludes.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 3,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/constant.js",
             "stats": {
               "slot_count": 1,
@@ -2474,7 +2396,107 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_setToString.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_WeakMap.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getValue.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_apply.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getNative.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_shortOut.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 8,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObject.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseToString.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 12,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toSource.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 2,
+              "reserved_size": 7,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isMasked.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 5,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_coreJsData.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2494,47 +2516,37 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_shortOut.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 8,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getNative.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 4,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getValue.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_toSource.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isSymbol.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
-              "name_counter_final": 2,
-              "reserved_size": 7,
+              "name_counter_final": 1,
+              "reserved_size": 6,
               "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isArray.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_arrayMap.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 2,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_objectToString.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_Symbol.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -2544,7 +2556,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/identity.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isObjectLike.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
@@ -2554,23 +2566,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_isMasked.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseGetTag.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 5,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/isFunction.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 12,
-              "renamed_symbol_count": 2
+              "reserved_size": 11,
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -2584,33 +2586,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_baseToString.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_getRawTag.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
               "reserved_size": 12,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_apply.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/lodash-es@4.17.23/node_modules/lodash-es/_root.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
+              "renamed_symbol_count": 5
             }
           }
         ],
@@ -2621,24 +2603,6 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 1691
-        },
-        "unified": {
-          "phase_a": {
-            "slot_count": 1203,
-            "slot_name_length_sum": 2352,
-            "name_counter_final": 1209,
-            "reserved_size": 1203,
-            "renamed_symbol_count": 1203
-          },
-          "phase_b_totals": {
-            "slot_count": 1913,
-            "slot_name_length_sum": 3826,
-            "name_counter_final": 0,
-            "reserved_size": 0,
-            "renamed_symbol_count": 2054
-          },
-          "total_renames": 3257,
-          "module_count": 641
         }
       },
       "nested_module_count": 153,
@@ -2663,16 +2627,6 @@
         "top_level_reserved_pool": 139,
         "nested": [
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/errors.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 7,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/helpers/errorUtil.js",
             "stats": {
               "slot_count": 1,
@@ -2680,26 +2634,6 @@
               "name_counter_final": 1,
               "reserved_size": 2,
               "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/locales/en.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 5,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 10,
-              "reserved_size": 27,
-              "renamed_symbol_count": 31
             }
           },
           {
@@ -2720,6 +2654,36 @@
               "name_counter_final": 7,
               "reserved_size": 12,
               "renamed_symbol_count": 30
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/errors.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 7,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/locales/en.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 5,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 10,
+              "reserved_size": 27,
+              "renamed_symbol_count": 31
             }
           },
           {
@@ -2760,24 +2724,6 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 869
-        },
-        "unified": {
-          "phase_a": {
-            "slot_count": 139,
-            "slot_name_length_sum": 224,
-            "name_counter_final": 140,
-            "reserved_size": 139,
-            "renamed_symbol_count": 139
-          },
-          "phase_b_totals": {
-            "slot_count": 33,
-            "slot_name_length_sum": 66,
-            "name_counter_final": 0,
-            "reserved_size": 0,
-            "renamed_symbol_count": 730
-          },
-          "total_renames": 869,
-          "module_count": 11
         }
       },
       "nested_module_count": 9,
@@ -2802,23 +2748,23 @@
         "top_level_reserved_pool": 1080,
         "nested": [
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/reportUnhandledError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/timeoutProvider.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 11,
+              "renamed_symbol_count": 12
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/symbol/observable.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 4
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
@@ -2832,133 +2778,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/noop.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/timeoutProvider.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Observable.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
-              "name_counter_final": 10,
-              "reserved_size": 11,
-              "renamed_symbol_count": 12
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ObjectUnsubscribedError.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/pipe.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subscription.js",
-            "stats": {
-              "slot_count": 14,
-              "slot_name_length_sum": 14,
-              "name_counter_final": 22,
-              "reserved_size": 24,
+              "name_counter_final": 5,
+              "reserved_size": 23,
               "renamed_symbol_count": 37
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subject.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleIterable.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 11,
-              "reserved_size": 25,
-              "renamed_symbol_count": 53
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/dom/animationFrames.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 12,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_rxjs.ts",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 9,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/index.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 342,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zipWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 15,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zip.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 17,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zipAll.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/withLatestFrom.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 14,
-              "reserved_size": 25,
-              "renamed_symbol_count": 18
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 8
             }
           },
           {
@@ -2972,6 +2808,56 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zipWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeInterval.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 10,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zip.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throttleTime.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindCallbackInternals.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 16,
+              "reserved_size": 25,
+              "renamed_symbol_count": 25
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowToggle.js",
             "stats": {
               "slot_count": 9,
@@ -2982,23 +2868,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowTime.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeoutWith.js",
             "stats": {
-              "slot_count": 12,
-              "slot_name_length_sum": 12,
-              "name_counter_final": 12,
-              "reserved_size": 18,
-              "renamed_symbol_count": 31
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowCount.js",
-            "stats": {
-              "slot_count": 12,
-              "slot_name_length_sum": 12,
-              "name_counter_final": 17,
-              "reserved_size": 15,
-              "renamed_symbol_count": 17
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
             }
           },
           {
@@ -3022,43 +2898,53 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeoutWith.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowCount.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 8,
-              "renamed_symbol_count": 6
+              "slot_count": 12,
+              "slot_name_length_sum": 12,
+              "name_counter_final": 17,
+              "reserved_size": 15,
+              "renamed_symbol_count": 17
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeInterval.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeUntil.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
               "reserved_size": 10,
-              "renamed_symbol_count": 10
+              "renamed_symbol_count": 3
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throttleTime.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/withLatestFrom.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 14,
+              "reserved_size": 25,
+              "renamed_symbol_count": 18
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/tests/benchmark/_mangle_entry_rxjs.ts",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 9,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/startWith.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
               "reserved_size": 8,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throttle.js",
-            "stats": {
-              "slot_count": 17,
-              "slot_name_length_sum": 17,
-              "name_counter_final": 17,
-              "reserved_size": 8,
-              "renamed_symbol_count": 20
+              "renamed_symbol_count": 5
             }
           },
           {
@@ -3072,23 +2958,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeWhile.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/zipAll.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
               "reserved_size": 6,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeUntil.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 10,
-              "renamed_symbol_count": 3
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -3112,53 +2988,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchAll.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skip.js",
             "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchMap.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 8,
-              "renamed_symbol_count": 12
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/startWith.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 8,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipUntil.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 10,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipWhile.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 5,
+              "renamed_symbol_count": 2
             }
           },
           {
@@ -3172,43 +3008,53 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skip.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipWhile.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/windowTime.js",
+            "stats": {
+              "slot_count": 12,
+              "slot_name_length_sum": 12,
+              "name_counter_final": 12,
+              "reserved_size": 18,
+              "renamed_symbol_count": 31
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/scan.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 5,
+              "reserved_size": 6,
               "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/repeatWhen.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchAll.js",
             "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 11,
-              "reserved_size": 10,
-              "renamed_symbol_count": 11
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retryWhen.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throttle.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 10,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retry.js",
-            "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 11,
-              "reserved_size": 12,
-              "renamed_symbol_count": 18
+              "slot_count": 17,
+              "slot_name_length_sum": 17,
+              "name_counter_final": 17,
+              "reserved_size": 8,
+              "renamed_symbol_count": 20
             }
           },
           {
@@ -3222,6 +3068,66 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/switchMap.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/shareReplay.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 6,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/skipUntil.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sampleTime.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/takeWhile.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sample.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publish.js",
             "stats": {
               "slot_count": 2,
@@ -3232,13 +3138,33 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/repeat.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishLast.js",
             "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishBehavior.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retry.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 11,
               "reserved_size": 12,
-              "renamed_symbol_count": 13
+              "renamed_symbol_count": 18
             }
           },
           {
@@ -3252,7 +3178,137 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/scan.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/repeat.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/retryWhen.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 10,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/raceWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 19,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/flatMap.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/multicast.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/share.js",
+            "stats": {
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 22,
+              "reserved_size": 23,
+              "renamed_symbol_count": 35
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/onErrorResumeNextWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/repeatWhen.js",
+            "stats": {
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 11,
+              "reserved_size": 10,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/pluck.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 7,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/min.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/merge.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 21,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishReplay.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/findIndex.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
@@ -3272,126 +3328,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/raceWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 19,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishReplay.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 8,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sampleTime.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishBehavior.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 6,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/onErrorResumeNextWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 17,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/min.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 8,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/pluck.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 7,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/flatMap.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMapTo.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 6,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/max.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 8,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/sample.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 10,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/shareReplay.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 6,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/isEmpty.js",
             "stats": {
               "slot_count": 2,
@@ -3399,106 +3335,6 @@
               "name_counter_final": 2,
               "reserved_size": 6,
               "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/publishLast.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/multicast.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 8,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/materialize.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/finalize.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 4,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 15,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/merge.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 10,
-              "reserved_size": 21,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/expand.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/share.js",
-            "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 22,
-              "reserved_size": 23,
-              "renamed_symbol_count": 35
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/findIndex.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/first.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 16,
-              "renamed_symbol_count": 4
             }
           },
           {
@@ -3512,23 +3348,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/find.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/max.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 8,
-              "reserved_size": 9,
-              "renamed_symbol_count": 10
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 8,
+              "renamed_symbol_count": 1
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/groupBy.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMapTo.js",
             "stats": {
-              "slot_count": 14,
-              "slot_name_length_sum": 14,
-              "name_counter_final": 14,
-              "reserved_size": 12,
-              "renamed_symbol_count": 29
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 6,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/finalize.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 4,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/expand.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 5
             }
           },
           {
@@ -3552,6 +3408,26 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/first.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 16,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/materialize.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/last.js",
             "stats": {
               "slot_count": 4,
@@ -3562,13 +3438,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/endWith.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinctUntilKeyChanged.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/find.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
               "name_counter_final": 8,
-              "reserved_size": 17,
-              "renamed_symbol_count": 8
+              "reserved_size": 9,
+              "renamed_symbol_count": 10
             }
           },
           {
@@ -3602,16 +3488,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinctUntilKeyChanged.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/throwIfEmpty.js",
             "stats": {
               "slot_count": 4,
@@ -3619,6 +3495,46 @@
               "name_counter_final": 4,
               "reserved_size": 10,
               "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinctUntilChanged.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/delay.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/exhaustMap.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 8,
+              "reserved_size": 13,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/groupBy.js",
+            "stats": {
+              "slot_count": 14,
+              "slot_name_length_sum": 14,
+              "name_counter_final": 14,
+              "reserved_size": 12,
+              "renamed_symbol_count": 29
             }
           },
           {
@@ -3642,13 +3558,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/delay.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinct.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 10,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/endWith.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 8,
-              "renamed_symbol_count": 3
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 8
             }
           },
           {
@@ -3659,16 +3585,6 @@
               "name_counter_final": 1,
               "reserved_size": 4,
               "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinctUntilChanged.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 8,
-              "reserved_size": 12,
-              "renamed_symbol_count": 8
             }
           },
           {
@@ -3692,13 +3608,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/exhaustMap.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounce.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 8,
-              "reserved_size": 13,
-              "renamed_symbol_count": 10
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 7,
+              "reserved_size": 10,
+              "renamed_symbol_count": 9
             }
           },
           {
@@ -3712,26 +3628,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/count.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 5,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounce.js",
-            "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 7,
-              "reserved_size": 10,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/fromSubscribable.js",
             "stats": {
               "slot_count": 2,
@@ -3739,46 +3635,6 @@
               "name_counter_final": 2,
               "reserved_size": 4,
               "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounceTime.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 8,
-              "renamed_symbol_count": 13
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatWith.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 15,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/distinct.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 10,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/connect.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 12,
-              "renamed_symbol_count": 6
             }
           },
           {
@@ -3792,16 +3648,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatest.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 25,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineAll.js",
             "stats": {
               "slot_count": 0,
@@ -3812,17 +3658,27 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestAll.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatMapTo.js",
             "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
               "reserved_size": 6,
-              "renamed_symbol_count": 1
+              "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestWith.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concat.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 9,
+              "reserved_size": 21,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatWith.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
@@ -3832,13 +3688,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatMapTo.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/debounceTime.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/index.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 342,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -3862,13 +3728,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/auditTime.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/joinAllInternals.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
+              "reserved_size": 12,
+              "renamed_symbol_count": 3
             }
           },
           {
@@ -3882,6 +3748,36 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestWith.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 15,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatestAll.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/connect.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 12,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/scanInternals.js",
             "stats": {
               "slot_count": 10,
@@ -3892,93 +3788,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concat.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 9,
-              "reserved_size": 21,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferWhen.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 11,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/types.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/joinAllInternals.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 12,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/race.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 14,
-              "renamed_symbol_count": 7
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/using.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 8,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/partition.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/count.js",
             "stats": {
               "slot_count": 3,
               "slot_name_length_sum": 3,
               "name_counter_final": 3,
-              "reserved_size": 8,
+              "reserved_size": 5,
               "renamed_symbol_count": 3
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/audit.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/combineLatest.js",
             "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 8,
-              "renamed_symbol_count": 11
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferTime.js",
-            "stats": {
-              "slot_count": 11,
-              "slot_name_length_sum": 11,
-              "name_counter_final": 14,
-              "reserved_size": 22,
-              "renamed_symbol_count": 30
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 25,
+              "renamed_symbol_count": 10
             }
           },
           {
@@ -3992,13 +3818,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferCount.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/types.js",
             "stats": {
-              "slot_count": 16,
-              "slot_name_length_sum": 16,
-              "name_counter_final": 21,
-              "reserved_size": 14,
-              "renamed_symbol_count": 25
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/audit.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 8,
+              "renamed_symbol_count": 11
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/auditTime.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/using.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
             }
           },
           {
@@ -4012,13 +3868,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/argsOrArgArray.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferTime.js",
             "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
+              "slot_count": 11,
+              "slot_name_length_sum": 11,
+              "name_counter_final": 14,
+              "reserved_size": 22,
+              "renamed_symbol_count": 30
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferWhen.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 7
             }
           },
           {
@@ -4032,13 +3898,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferToggle.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/filter.js",
             "stats": {
-              "slot_count": 7,
-              "slot_name_length_sum": 7,
-              "name_counter_final": 10,
-              "reserved_size": 20,
-              "renamed_symbol_count": 16
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
             }
           },
           {
@@ -4052,12 +3918,32 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/interval.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/argsOrArgArray.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/partition.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 8,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/pairs.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 6,
+              "reserved_size": 4,
               "renamed_symbol_count": 2
             }
           },
@@ -4072,93 +3958,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/pairs.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/interval.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 4,
+              "reserved_size": 6,
               "renamed_symbol_count": 2
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/filter.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/zip.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferToggle.js",
             "stats": {
               "slot_count": 7,
               "slot_name_length_sum": 7,
-              "name_counter_final": 12,
-              "reserved_size": 25,
-              "renamed_symbol_count": 20
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatAll.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeAll.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/forkJoin.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 16,
-              "renamed_symbol_count": 17
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/connectable.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 10,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMap.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 15,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/timer.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 11,
-              "renamed_symbol_count": 6
+              "name_counter_final": 10,
+              "reserved_size": 20,
+              "renamed_symbol_count": 16
             }
           },
           {
@@ -4172,6 +3988,26 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/timer.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/forkJoin.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 16,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/iif.js",
             "stats": {
               "slot_count": 3,
@@ -4182,23 +4018,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/concat.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/race.js",
             "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/generate.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 14,
-              "reserved_size": 20,
-              "renamed_symbol_count": 17
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 14,
+              "renamed_symbol_count": 7
             }
           },
           {
@@ -4222,33 +4048,63 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/createObject.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/bufferCount.js",
             "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 3,
-              "renamed_symbol_count": 4
+              "slot_count": 16,
+              "slot_name_length_sum": 16,
+              "name_counter_final": 21,
+              "reserved_size": 14,
+              "renamed_symbol_count": 25
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/map.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/zip.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 12,
+              "reserved_size": 25,
+              "renamed_symbol_count": 20
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/concatAll.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeMap.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 15,
               "renamed_symbol_count": 6
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/SequenceError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/concat.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 2,
+              "reserved_size": 8,
               "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/generate.js",
+            "stats": {
+              "slot_count": 10,
+              "slot_name_length_sum": 10,
+              "name_counter_final": 14,
+              "reserved_size": 20,
+              "renamed_symbol_count": 17
             }
           },
           {
@@ -4262,16 +4118,6 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/NotFoundError.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 2,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindNodeCallback.js",
             "stats": {
               "slot_count": 3,
@@ -4282,23 +4128,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/EmptyError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/connectable.js",
             "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 2,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isObservable.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 10,
+              "renamed_symbol_count": 9
             }
           },
           {
@@ -4312,43 +4148,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/mapOneOrManyArgs.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 19,
-              "renamed_symbol_count": 9
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/from.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/bindCallbackInternals.js",
-            "stats": {
-              "slot_count": 10,
-              "slot_name_length_sum": 10,
-              "name_counter_final": 16,
-              "reserved_size": 25,
-              "renamed_symbol_count": 25
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ArgumentOutOfRangeError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeAll.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
-              "reserved_size": 2,
+              "reserved_size": 6,
               "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/createObject.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 3,
+              "renamed_symbol_count": 4
             }
           },
           {
@@ -4362,23 +4178,53 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeInternals.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/map.js",
             "stats": {
-              "slot_count": 15,
-              "slot_name_length_sum": 15,
-              "name_counter_final": 15,
-              "reserved_size": 8,
-              "renamed_symbol_count": 22
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleReadableStreamLike.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/EmptyError.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/SequenceError.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 6,
+              "reserved_size": 2,
               "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/mapOneOrManyArgs.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 19,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isObservable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
             }
           },
           {
@@ -4392,6 +4238,86 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ArgumentOutOfRangeError.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/firstValueFrom.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 6,
+              "renamed_symbol_count": 7
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/NotFoundError.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 2,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/from.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/throwError.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleReadableStreamLike.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Notification.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 9,
+              "reserved_size": 14,
+              "renamed_symbol_count": 33
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/argsArgArrayOrObject.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 12,
+              "renamed_symbol_count": 5
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleAsyncIterable.js",
             "stats": {
               "slot_count": 4,
@@ -4399,6 +4325,26 @@
               "name_counter_final": 4,
               "reserved_size": 6,
               "renamed_symbol_count": 5
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/mergeInternals.js",
+            "stats": {
+              "slot_count": 15,
+              "slot_name_length_sum": 15,
+              "name_counter_final": 15,
+              "reserved_size": 8,
+              "renamed_symbol_count": 22
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/executeSchedule.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 2,
+              "renamed_symbol_count": 6
             }
           },
           {
@@ -4412,12 +4358,32 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/throwError.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleObservable.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 8,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleArray.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 5,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/observeOn.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 6,
+              "reserved_size": 8,
               "renamed_symbol_count": 6
             }
           },
@@ -4432,13 +4398,93 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/firstValueFrom.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/symbol/iterator.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isAsyncIterable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isInteropObservable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
               "reserved_size": 6,
-              "renamed_symbol_count": 7
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeout.js",
+            "stats": {
+              "slot_count": 12,
+              "slot_name_length_sum": 12,
+              "name_counter_final": 12,
+              "reserved_size": 18,
+              "renamed_symbol_count": 24
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduled.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 28,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isArrayLike.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isPromise.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 4,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isIterable.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 6,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/subscribeOn.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 4,
+              "renamed_symbol_count": 4
             }
           },
           {
@@ -4452,31 +4498,21 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleObservable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/innerFrom.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 22,
+              "reserved_size": 58,
+              "renamed_symbol_count": 56
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/args.js",
             "stats": {
               "slot_count": 2,
               "slot_name_length_sum": 2,
               "name_counter_final": 2,
-              "reserved_size": 8,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/executeSchedule.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 2,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/argsArgArrayOrObject.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
               "reserved_size": 12,
               "renamed_symbol_count": 5
             }
@@ -4492,47 +4528,7 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/subscribeOn.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 4,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/timeout.js",
-            "stats": {
-              "slot_count": 12,
-              "slot_name_length_sum": 12,
-              "name_counter_final": 12,
-              "reserved_size": 18,
-              "renamed_symbol_count": 24
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isPromise.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isScheduler.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 4,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/symbol/iterator.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/async.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -4542,42 +4538,42 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Notification.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameAction.js",
             "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 9,
-              "reserved_size": 14,
-              "renamed_symbol_count": 33
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 15
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/observeOn.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/queue.js",
             "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 8,
-              "renamed_symbol_count": 6
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isInteropObservable.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleIterable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/VirtualTimeScheduler.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
               "name_counter_final": 5,
-              "reserved_size": 10,
+              "reserved_size": 16,
+              "renamed_symbol_count": 30
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameScheduler.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 9,
               "renamed_symbol_count": 8
             }
           },
@@ -4592,143 +4588,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduled.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 28,
-              "renamed_symbol_count": 2
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isAsyncIterable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isScheduler.js",
             "stats": {
               "slot_count": 1,
               "slot_name_length_sum": 1,
               "name_counter_final": 1,
               "reserved_size": 4,
               "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isReadableStreamLike.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 16,
-              "reserved_size": 24,
-              "renamed_symbol_count": 23
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isArrayLike.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/queue.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/args.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 12,
-              "renamed_symbol_count": 5
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduled/scheduleArray.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 5,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/async.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameScheduler.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 9,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isIterable.js",
-            "stats": {
-              "slot_count": 1,
-              "slot_name_length_sum": 1,
-              "name_counter_final": 1,
-              "reserved_size": 6,
-              "renamed_symbol_count": 1
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/QueueScheduler.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 9,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/empty.js",
-            "stats": {
-              "slot_count": 2,
-              "slot_name_length_sum": 2,
-              "name_counter_final": 2,
-              "reserved_size": 6,
-              "renamed_symbol_count": 4
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/asap.js",
-            "stats": {
-              "slot_count": 0,
-              "slot_name_length_sum": 0,
-              "name_counter_final": 0,
-              "reserved_size": 0,
-              "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsapScheduler.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 9,
-              "renamed_symbol_count": 8
             }
           },
           {
@@ -4752,6 +4618,46 @@
             }
           },
           {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/empty.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 4
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/isReadableStreamLike.js",
+            "stats": {
+              "slot_count": 9,
+              "slot_name_length_sum": 9,
+              "name_counter_final": 16,
+              "reserved_size": 24,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/immediateProvider.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 8,
+              "reserved_size": 17,
+              "renamed_symbol_count": 10
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsyncAction.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 14,
+              "renamed_symbol_count": 29
+            }
+          },
+          {
             "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/dateTimestampProvider.js",
             "stats": {
               "slot_count": 0,
@@ -4772,83 +4678,23 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsapAction.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/QueueScheduler.js",
             "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 11,
-              "renamed_symbol_count": 15
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/QueueAction.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
               "reserved_size": 9,
-              "renamed_symbol_count": 14
+              "renamed_symbol_count": 4
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/performanceTimestampProvider.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/asap.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
               "name_counter_final": 0,
               "reserved_size": 0,
               "renamed_symbol_count": 0
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/immediateProvider.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 8,
-              "reserved_size": 17,
-              "renamed_symbol_count": 10
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/BehaviorSubject.js",
-            "stats": {
-              "slot_count": 4,
-              "slot_name_length_sum": 4,
-              "name_counter_final": 4,
-              "reserved_size": 9,
-              "renamed_symbol_count": 13
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsyncAction.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 14,
-              "renamed_symbol_count": 29
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/Action.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 9,
-              "renamed_symbol_count": 8
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/ReplaySubject.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 9,
-              "reserved_size": 12,
-              "renamed_symbol_count": 29
             }
           },
           {
@@ -4862,33 +4708,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/innerFrom.js",
-            "stats": {
-              "slot_count": 9,
-              "slot_name_length_sum": 9,
-              "name_counter_final": 22,
-              "reserved_size": 58,
-              "renamed_symbol_count": 56
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AnimationFrameAction.js",
-            "stats": {
-              "slot_count": 6,
-              "slot_name_length_sum": 6,
-              "name_counter_final": 6,
-              "reserved_size": 11,
-              "renamed_symbol_count": 15
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/ConnectableObservable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsapScheduler.js",
             "stats": {
               "slot_count": 4,
               "slot_name_length_sum": 4,
               "name_counter_final": 4,
-              "reserved_size": 17,
-              "renamed_symbol_count": 14
+              "reserved_size": 9,
+              "renamed_symbol_count": 8
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/performanceTimestampProvider.js",
+            "stats": {
+              "slot_count": 0,
+              "slot_name_length_sum": 0,
+              "name_counter_final": 0,
+              "reserved_size": 0,
+              "renamed_symbol_count": 0
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/ObjectUnsubscribedError.js",
+            "stats": {
+              "slot_count": 1,
+              "slot_name_length_sum": 1,
+              "name_counter_final": 1,
+              "reserved_size": 2,
+              "renamed_symbol_count": 1
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/Action.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 9,
+              "renamed_symbol_count": 8
             }
           },
           {
@@ -4912,7 +4768,57 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/symbol/observable.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/intervalProvider.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 10,
+              "reserved_size": 11,
+              "renamed_symbol_count": 12
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/refCount.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 5,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/ReplaySubject.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 9,
+              "reserved_size": 12,
+              "renamed_symbol_count": 29
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/errorContext.js",
+            "stats": {
+              "slot_count": 5,
+              "slot_name_length_sum": 5,
+              "name_counter_final": 6,
+              "reserved_size": 8,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/pipe.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 6
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/noop.js",
             "stats": {
               "slot_count": 0,
               "slot_name_length_sum": 0,
@@ -4922,13 +4828,43 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/intervalProvider.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/dom/animationFrames.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 10,
-              "reserved_size": 11,
-              "renamed_symbol_count": 12
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 12,
+              "renamed_symbol_count": 9
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subject.js",
+            "stats": {
+              "slot_count": 7,
+              "slot_name_length_sum": 7,
+              "name_counter_final": 11,
+              "reserved_size": 25,
+              "renamed_symbol_count": 53
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/reportUnhandledError.js",
+            "stats": {
+              "slot_count": 2,
+              "slot_name_length_sum": 2,
+              "name_counter_final": 2,
+              "reserved_size": 6,
+              "renamed_symbol_count": 2
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/observable/ConnectableObservable.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 17,
+              "renamed_symbol_count": 14
             }
           },
           {
@@ -4942,13 +4878,73 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/VirtualTimeScheduler.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/BehaviorSubject.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 9,
+              "renamed_symbol_count": 13
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/AsapAction.js",
+            "stats": {
+              "slot_count": 6,
+              "slot_name_length_sum": 6,
+              "name_counter_final": 6,
+              "reserved_size": 11,
+              "renamed_symbol_count": 15
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/QueueAction.js",
+            "stats": {
+              "slot_count": 4,
+              "slot_name_length_sum": 4,
+              "name_counter_final": 4,
+              "reserved_size": 9,
+              "renamed_symbol_count": 14
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/arrRemove.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 3
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/animationFrameProvider.js",
             "stats": {
               "slot_count": 5,
               "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 16,
-              "renamed_symbol_count": 30
+              "name_counter_final": 10,
+              "reserved_size": 13,
+              "renamed_symbol_count": 17
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js",
+            "stats": {
+              "slot_count": 8,
+              "slot_name_length_sum": 8,
+              "name_counter_final": 8,
+              "reserved_size": 11,
+              "renamed_symbol_count": 23
+            }
+          },
+          {
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/createErrorClass.js",
+            "stats": {
+              "slot_count": 3,
+              "slot_name_length_sum": 3,
+              "name_counter_final": 3,
+              "reserved_size": 2,
+              "renamed_symbol_count": 4
             }
           },
           {
@@ -4972,43 +4968,13 @@
             }
           },
           {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/scheduler/animationFrameProvider.js",
+            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Subscription.js",
             "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 10,
-              "reserved_size": 13,
-              "renamed_symbol_count": 17
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/arrRemove.js",
-            "stats": {
-              "slot_count": 3,
-              "slot_name_length_sum": 3,
-              "name_counter_final": 3,
-              "reserved_size": 2,
-              "renamed_symbol_count": 3
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/Observable.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 23,
+              "slot_count": 14,
+              "slot_name_length_sum": 14,
+              "name_counter_final": 22,
+              "reserved_size": 24,
               "renamed_symbol_count": 37
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/OperatorSubscriber.js",
-            "stats": {
-              "slot_count": 8,
-              "slot_name_length_sum": 8,
-              "name_counter_final": 8,
-              "reserved_size": 11,
-              "renamed_symbol_count": 23
             }
           },
           {
@@ -5020,26 +4986,6 @@
               "reserved_size": 37,
               "renamed_symbol_count": 38
             }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/util/errorContext.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 6,
-              "reserved_size": 8,
-              "renamed_symbol_count": 6
-            }
-          },
-          {
-            "module_path": "/Users/yoonhb/Documents/workspace/zts/node_modules/.bun/rxjs@7.8.2/node_modules/rxjs/dist/cjs/internal/operators/refCount.js",
-            "stats": {
-              "slot_count": 5,
-              "slot_name_length_sum": 5,
-              "name_counter_final": 5,
-              "reserved_size": 6,
-              "renamed_symbol_count": 6
-            }
           }
         ],
         "bundle_size_bytes": 211338,
@@ -5049,24 +4995,6 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 2876
-        },
-        "unified": {
-          "phase_a": {
-            "slot_count": 1080,
-            "slot_name_length_sum": 2106,
-            "name_counter_final": 1086,
-            "reserved_size": 1080,
-            "renamed_symbol_count": 1080
-          },
-          "phase_b_totals": {
-            "slot_count": 953,
-            "slot_name_length_sum": 1906,
-            "name_counter_final": 0,
-            "reserved_size": 0,
-            "renamed_symbol_count": 1796
-          },
-          "total_renames": 2876,
-          "module_count": 224
         }
       },
       "nested_module_count": 224,
@@ -5118,24 +5046,6 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 8214
-        },
-        "unified": {
-          "phase_a": {
-            "slot_count": 1080,
-            "slot_name_length_sum": 2106,
-            "name_counter_final": 1086,
-            "reserved_size": 1080,
-            "renamed_symbol_count": 1080
-          },
-          "phase_b_totals": {
-            "slot_count": 100,
-            "slot_name_length_sum": 200,
-            "name_counter_final": 0,
-            "reserved_size": 0,
-            "renamed_symbol_count": 7134
-          },
-          "total_renames": 8214,
-          "module_count": 2
         }
       },
       "nested_module_count": 2,
@@ -5207,24 +5117,6 @@
           "name_counter_final": 0,
           "reserved_size": 0,
           "renamed_symbol_count": 414
-        },
-        "unified": {
-          "phase_a": {
-            "slot_count": 38,
-            "slot_name_length_sum": 38,
-            "name_counter_final": 38,
-            "reserved_size": 38,
-            "renamed_symbol_count": 38
-          },
-          "phase_b_totals": {
-            "slot_count": 80,
-            "slot_name_length_sum": 144,
-            "name_counter_final": 0,
-            "reserved_size": 0,
-            "renamed_symbol_count": 376
-          },
-          "total_renames": 414,
-          "module_count": 4
         }
       },
       "nested_module_count": 4,

--- a/tests/benchmark/mangler-property.ts
+++ b/tests/benchmark/mangler-property.ts
@@ -43,20 +43,12 @@ interface NestedEntry {
   stats: ManglerStats;
 }
 
-interface UnifiedSummary {
-  phase_a: ManglerStats;
-  phase_b_totals: ManglerStats;
-  total_renames: number;
-  module_count: number;
-}
-
 interface ManglerReport {
   top_level: ManglerStats;
   top_level_reserved_pool: number;
   nested: NestedEntry[];
   bundle_size_bytes: number;
   totals: ManglerStats;
-  unified?: UnifiedSummary;
 }
 
 interface FixtureResult {
@@ -135,42 +127,11 @@ function formatStats(s: ManglerStats): string {
   return `slots=${s.slot_count} nameLen=${s.slot_name_length_sum} rename=${s.renamed_symbol_count}`;
 }
 
-function unifiedCombined(u: UnifiedSummary): ManglerStats {
-  return {
-    slot_count: u.phase_a.slot_count + u.phase_b_totals.slot_count,
-    slot_name_length_sum: u.phase_a.slot_name_length_sum + u.phase_b_totals.slot_name_length_sum,
-    name_counter_final: 0,
-    reserved_size: 0,
-    renamed_symbol_count: u.phase_a.renamed_symbol_count + u.phase_b_totals.renamed_symbol_count,
-  };
-}
-
-function deltaPct(base: number, cur: number): string {
-  if (base === 0) return cur === 0 ? "+0.00%" : "+∞";
-  const pct = ((cur - base) / base) * 100;
-  return `${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%`;
-}
-
 function printFixture(r: FixtureResult): void {
-  const top = r.report.top_level;
-  const nest = r.nested_totals;
   console.log(`\n## ${r.name}`);
   console.log(`  bundle_size: ${r.report.bundle_size_bytes} B`);
-  console.log(`  two-phase top:    ${formatStats(top)} (pool=${r.report.top_level_reserved_pool})`);
-  console.log(`  two-phase nested: (${r.nested_module_count} mod) ${formatStats(nest)}`);
-  if (r.report.unified) {
-    const u = r.report.unified;
-    const combined = unifiedCombined(u);
-    const tp_total = r.report.totals;
-    console.log(`  unified phase A:  ${formatStats(u.phase_a)}`);
-    console.log(`  unified phase B:  (${u.module_count} mod) ${formatStats(u.phase_b_totals)}`);
-    console.log(
-      `  unified total:    ${formatStats(combined)}  ` +
-        `(vs two-phase: slots ${deltaPct(tp_total.slot_count, combined.slot_count)}, ` +
-        `nameLen ${deltaPct(tp_total.slot_name_length_sum, combined.slot_name_length_sum)}, ` +
-        `rename ${deltaPct(tp_total.renamed_symbol_count, combined.renamed_symbol_count)})`,
-    );
-  }
+  console.log(`  top:    ${formatStats(r.report.top_level)} (pool=${r.report.top_level_reserved_pool})`);
+  console.log(`  nested: (${r.nested_module_count} mod) ${formatStats(r.nested_totals)}`);
 }
 
 type Check = { ok: boolean; label: string; detail: string };

--- a/tests/benchmark/mangler-property.ts
+++ b/tests/benchmark/mangler-property.ts
@@ -130,7 +130,9 @@ function formatStats(s: ManglerStats): string {
 function printFixture(r: FixtureResult): void {
   console.log(`\n## ${r.name}`);
   console.log(`  bundle_size: ${r.report.bundle_size_bytes} B`);
-  console.log(`  top:    ${formatStats(r.report.top_level)} (pool=${r.report.top_level_reserved_pool})`);
+  console.log(
+    `  top:    ${formatStats(r.report.top_level)} (pool=${r.report.top_level_reserved_pool})`,
+  );
   console.log(`  nested: (${r.nested_module_count} mod) ${formatStats(r.nested_totals)}`);
 }
 


### PR DESCRIPTION
## Summary

Step 3a 이후 호출처가 0 이 된 구 경로와 shadow 전용 infra 정리. **기능 변경 0** — property harness 18 check 모두 0.00% diff, bundle 크기 동일.

### 제거

- `Linker.collectManglingCandidates()` + `NameEntry` + `ManglingCandidates` struct (Step 3a 에서 `collectUnifiedInput` 으로 완전 대체됨).
- `bundler.runUnifiedShadow()` 헬퍼 + `computeMangling` 직전의 shadow 호출. shadow 는 computeMangling 이 이미 unified 를 쓰는 지금 무의미.
- `MangleReportCollector.unified: ?UnifiedSummary` 필드 + `UnifiedSummary` 타입 + writeJson 의 unified 섹션.
- `mangler-property.ts` 의 `UnifiedSummary` 인터페이스 + `unifiedCombined` + `deltaPct` + printFixture 의 unified 비교 행. baseline JSON 도 unified 섹션 없이 재생성.
- `unified_mangler.zig` doc 주석의 stale `collectManglingCandidates` 참조 정리.

## 다음

- nested mangler 교체 (`metadata.zig` 의 `Mangler.mangle` 제거 → Phase B 결과 사용)
- `Symbol.canonical_name` 필드 제거 + `nested_mangling_enabled` 플래그 제거

## Test plan

- [x] `zig build test` 통과
- [x] `bun run tests/benchmark/mangler-property.ts` 2회 연속 0.00% diff

Refs #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)