### PR TITLE
fix(parser): support computed property key in TS object type literal

### DIFF
--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -176,6 +176,8 @@ pub const Code = enum(u16) {
     ts_type_expected = 912,
     ts_mapped_type_in = 913,
     flow_opaque_type = 914,
+    ts_index_sig_modifier = 915,
+    ts_index_sig_optional = 916,
 
     // ═══════════════════════════════════════════════════════
     // 1000-1099: 시맨틱 — 재선언/스코프
@@ -385,6 +387,8 @@ pub const Code = enum(u16) {
             .ts_type_expected => "Type expected",
             .ts_mapped_type_in => "Expected 'in' in mapped type",
             .flow_opaque_type => "Expected 'type' after 'opaque'",
+            .ts_index_sig_modifier => "Modifiers cannot appear on index signature parameters",
+            .ts_index_sig_optional => "An index signature parameter cannot have a question mark",
             // 시맨틱: 재선언
             .identifier_redeclared => "Identifier has already been declared",
             .binding_strict_mode => "Cannot be used as a binding identifier in strict mode",

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2646,6 +2646,24 @@ fn expectNoParseErrorWithExt(source: []const u8, ext: []const u8) !void {
     try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
 }
 
+fn expectParseErrorWithExt(source: []const u8, ext: []const u8, check: ErrorCheck) !void {
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    parser.configureFromExtension(ext);
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len > 0);
+
+    for (parser.errors.items) |err| {
+        const msg_match = if (check.message) |m| std.mem.eql(u8, err.message, m) else true;
+        const contains_match = if (check.message_contains) |c| std.mem.indexOf(u8, err.message, c) != null else true;
+        if (msg_match and contains_match) return;
+    }
+    return error.TestUnexpectedResult;
+}
+
 fn expectNoParseErrorBundler(source: []const u8, ext: []const u8) !void {
     var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
@@ -3216,5 +3234,46 @@ test "TS object type: mix of index signature and plain members" {
         \\  normal: number;
         \\  readonly ro?: string;
         \\};
+    , ".ts");
+}
+
+// Error recovery — TS 공식 `isUnambiguouslyIndexSignature` 가 parse 는 통과시키는 케이스들.
+// ZTS 는 tsc 수준의 semantic checker 가 없으므로, invalid syntax 가 조용히 통과하지
+// 않도록 parser 단에서 diagnostic 을 찍고 토큰은 skip 해서 나머지 파싱은 계속한다.
+
+test "TS index signature: optional param `[k?: T]: V` is error" {
+    try expectParseErrorWithExt(
+        \\interface D { [k?: string]: number; }
+    , ".ts", .{ .message_contains = "question mark" });
+}
+
+test "TS index signature: optional param without type `[k?]: V` is error" {
+    try expectParseErrorWithExt(
+        \\interface D { [k?]: number; }
+    , ".ts", .{ .message_contains = "question mark" });
+}
+
+test "TS index signature: modifier `public` before param is error" {
+    try expectParseErrorWithExt(
+        \\interface D { [public k: string]: number; }
+    , ".ts", .{ .message_contains = "Modifiers cannot appear" });
+}
+
+test "TS index signature: modifier `private` before param is error" {
+    try expectParseErrorWithExt(
+        \\interface D { [private k: string]: number; }
+    , ".ts", .{ .message_contains = "Modifiers cannot appear" });
+}
+
+test "TS index signature: modifier `protected` before param is error" {
+    try expectParseErrorWithExt(
+        \\interface D { [protected k: string]: number; }
+    , ".ts", .{ .message_contains = "Modifiers cannot appear" });
+}
+
+test "TS object type: computed key with member access `[ns.k]`" {
+    try expectNoParseErrorWithExt(
+        \\declare const ns: { k: unique symbol };
+        \\interface A { [ns.k]: string; }
     , ".ts");
 }

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3162,3 +3162,59 @@ test "Object literal inside class field: private generator is error" {
 test "Object literal inside class field: private async is error" {
     try expectParseError("class C { field = { async #m() {} } }", .{ .message_contains = "Private identifier" });
 }
+
+// ============================================================
+// TS object type literal: computed property key (#1767)
+// ============================================================
+
+test "TS object type: computed property key with symbol ref" {
+    try expectNoParseErrorWithExt(
+        \\declare const sym: unique symbol;
+        \\interface A { [sym]: string; }
+    , ".ts");
+}
+
+test "TS object type: optional computed property key" {
+    try expectNoParseErrorWithExt(
+        \\declare const sym: unique symbol;
+        \\interface A { [sym]?: boolean; }
+    , ".ts");
+}
+
+test "TS object type: computed property key in intersection type" {
+    try expectNoParseErrorWithExt(
+        \\const polyfillSymbol = Symbol.for('test');
+        \\function f(fetch: Function & { [polyfillSymbol]?: boolean }) { return fetch; }
+    , ".ts");
+}
+
+test "TS object type: computed property key in type literal" {
+    try expectNoParseErrorWithExt(
+        \\const s = Symbol();
+        \\type T = { [s]?: boolean };
+    , ".ts");
+}
+
+test "TS object type: index signature still parses" {
+    try expectNoParseErrorWithExt(
+        \\interface Dict { [key: string]: number; }
+        \\interface RO { readonly [i: number]: string; }
+    , ".ts");
+}
+
+test "TS object type: mapped type still parses" {
+    try expectNoParseErrorWithExt(
+        \\type Partial<T> = { [K in keyof T]?: T[K] };
+        \\type Readonly<T> = { readonly [K in keyof T]: T[K] };
+    , ".ts");
+}
+
+test "TS object type: mix of index signature and plain members" {
+    try expectNoParseErrorWithExt(
+        \\type Mixed = {
+        \\  [key: string]: any;
+        \\  normal: number;
+        \\  readonly ro?: string;
+        \\};
+    , ".ts");
+}

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -1606,35 +1606,77 @@ fn parseTypeMemberParam(self: *Parser) ParseError2!NodeIndex {
     });
 }
 
-/// 인덱스 시그니처 여부 판별: `[key: Type]` 또는 `[...rest]` 패턴.
-/// Computed property key (`[identRef]?: T`) 와 구분하기 위해 2-step lookahead 로
-/// `[ident` 뒤에 `:` 가 실제로 오는지 확인한다. 매핑 타입 `[K in T]`은 이 함수 호출
-/// 전에 isMappedType 에서 먼저 걸러진다. (#1767)
+/// Index signature 파라미터 앞에 올 수 있는 modifier 토큰 (error recovery 용).
+/// 정상 문법에선 index signature 에 modifier 불허지만 `[public k: T]: V` 같은
+/// malformed 입력을 index signature 로 파싱해야 의미 있는 에러 메시지가 나온다.
+/// TS 공식 parser 의 isModifierKind 상응.
+fn isIndexSignatureModifier(kind: Kind) bool {
+    return switch (kind) {
+        .kw_public, .kw_private, .kw_protected, .kw_static => true,
+        else => false,
+    };
+}
+
+/// 인덱스 시그니처 여부 판별. TS 공식 `isUnambiguouslyIndexSignature` (parser.ts) 이식.
+/// Computed property key (`[identRef]?: T`) 와 구분하기 위해 2~3-step lookahead.
+/// 매핑 타입 `[K in T]` 은 이 함수 호출 전에 isMappedType 에서 먼저 걸러진다. (#1767)
+///
+/// 허용 패턴:
+///   [...            [] (error recovery)
+///   [modifier id    (error recovery — [public id, [private id, [protected id, [static id)
+///   [id:   [id,     (정상 + error recovery)
+///   [id?:  [id?,  [id?]  (optional index param error recovery)
 fn isIndexSignature(self: *Parser) ParseError2!bool {
     const saved = self.saveState();
     defer self.restoreState(saved);
 
     try self.advance(); // skip [
 
-    // [...rest]
-    if (self.current() == .dot3) return true;
+    // [...rest] 또는 [] (error recovery)
+    if (self.current() == .dot3 or self.current() == .r_bracket) return true;
 
-    // identifier/this 가 아니면 index signature 아님 (computed key 경로로 폴백)
+    // [public id / [private id / [protected id / [static id (error recovery)
+    if (isIndexSignatureModifier(self.current())) {
+        try self.advance();
+        return self.current() == .identifier;
+    }
+
+    // identifier/this 가 아니면 computed key 경로로 폴백
     if (self.current() != .identifier and self.current() != .kw_this) return false;
 
     try self.advance(); // skip identifier/this
 
-    // [ident: Type] 만 index signature. 그 외 [ident], [ident.foo], [ident()] 등은
-    // computed property key 로 흘려보낸다.
-    return self.current() == .colon;
+    // [id: 또는 [id,
+    if (self.current() == .colon or self.current() == .comma) return true;
+
+    // [id? 뒤에 :, ,, ] 가 오면 optional index parameter (error recovery)
+    if (self.current() != .question) return false;
+
+    try self.advance(); // skip ?
+    return self.current() == .colon or self.current() == .comma or self.current() == .r_bracket;
 }
 
-/// 인덱스 시그니처 파싱: [key: string]: Type
+/// 인덱스 시그니처 파싱: `[key: string]: Type`.
+/// Error recovery 로 `[public k: T]`, `[k?: T]`, `[k?]` 같은 malformed 입력도
+/// 수용하여 의미 있는 semantic 에러 경로로 흘려보낸다. (#1767)
 pub fn parseIndexSignature(self: *Parser, start: u32, is_readonly: bool) ParseError2!NodeIndex {
     try self.advance(); // skip [
+
+    // Error recovery — index sig parameter 앞 modifier 에러 후 skip ([public k: T] 등)
+    if (isIndexSignatureModifier(self.current())) {
+        try self.addErrorCode(self.currentSpan(), "Modifiers cannot appear on index signature parameters", .ts_index_sig_modifier);
+        try self.advance();
+    }
+
     // 파라미터: key: Type
     const param_start = self.currentSpan().start;
     const param_name = try self.parsePropertyKey();
+
+    // Error recovery — optional marker 에러 후 skip ([k?: T], [k?])
+    if (self.current() == .question) {
+        try self.addErrorCode(self.currentSpan(), "An index signature parameter cannot have a question mark", .ts_index_sig_optional);
+        try self.advance();
+    }
     var param_type = NodeIndex.none;
     if (try self.eat(.colon)) {
         param_type = try parseType(self);

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -1606,18 +1606,27 @@ fn parseTypeMemberParam(self: *Parser) ParseError2!NodeIndex {
     });
 }
 
-/// 인덱스 시그니처 여부 판별: [key: string] 패턴
-/// (매핑 타입 [K in T]과 구분)
+/// 인덱스 시그니처 여부 판별: `[key: Type]` 또는 `[...rest]` 패턴.
+/// Computed property key (`[identRef]?: T`) 와 구분하기 위해 2-step lookahead 로
+/// `[ident` 뒤에 `:` 가 실제로 오는지 확인한다. 매핑 타입 `[K in T]`은 이 함수 호출
+/// 전에 isMappedType 에서 먼저 걸러진다. (#1767)
 fn isIndexSignature(self: *Parser) ParseError2!bool {
-    // [ 다음 토큰이 identifier이고, 그 다음이 : 또는 , 이면 인덱스 시그니처
-    // [ 다음이 ...이면 인덱스 시그니처
-    const next = try self.peekNextKind();
-    if (next == .dot3) return true;
-    // identifier가 아니면 인덱스 시그니처 아님
-    if (next != .identifier and next != .kw_this) return false;
-    // identifier 다음 토큰을 확인하려면 더 봐야 하지만,
-    // 매핑 타입은 isMappedType에서 먼저 걸러지므로 여기서는 true 반환
-    return true;
+    const saved = self.saveState();
+    defer self.restoreState(saved);
+
+    try self.advance(); // skip [
+
+    // [...rest]
+    if (self.current() == .dot3) return true;
+
+    // identifier/this 가 아니면 index signature 아님 (computed key 경로로 폴백)
+    if (self.current() != .identifier and self.current() != .kw_this) return false;
+
+    try self.advance(); // skip identifier/this
+
+    // [ident: Type] 만 index signature. 그 외 [ident], [ident.foo], [ident()] 등은
+    // computed property key 로 흘려보낸다.
+    return self.current() == .colon;
 }
 
 /// 인덱스 시그니처 파싱: [key: string]: Type

--- a/tests/integration/tests/tsc/__snapshots__/es6-Symbols.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-Symbols.test.ts.snap
@@ -95,6 +95,15 @@ exports[`TSC: es6/Symbols symbolDeclarationEmit4 1`] = `
 "
 `;
 
+exports[`TSC: es6/Symbols symbolDeclarationEmit5 1`] = `""`;
+
+exports[`TSC: es6/Symbols symbolDeclarationEmit6 1`] = `""`;
+
+exports[`TSC: es6/Symbols symbolDeclarationEmit7 1`] = `
+"var obj;
+"
+`;
+
 exports[`TSC: es6/Symbols symbolDeclarationEmit8 1`] = `
 "var obj = { [Symbol.isConcatSpreadable]: 0 };
 "
@@ -112,6 +121,79 @@ var x = { [s]: 0, [s]() {
 }, get [s]() {
 	return 0;
 } };
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty10 1`] = `
+"class C {
+	[Symbol.iterator];
+}
+var i;
+i = new C();
+var c = i;
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty11 1`] = `
+"class C {
+}
+var i;
+i = new C();
+var c = i;
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty12 1`] = `
+"class C {
+	[Symbol.iterator];
+}
+var i;
+i = new C();
+var c = i;
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty13 1`] = `
+"class C {
+	[Symbol.iterator];
+}
+foo(new C());
+var i;
+bar(i);
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty14 1`] = `
+"class C {
+	[Symbol.iterator];
+}
+foo(new C());
+var i;
+bar(i);
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty15 1`] = `
+"class C {
+}
+foo(new C());
+var i;
+bar(i);
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty16 1`] = `
+"class C {
+	[Symbol.iterator];
+}
+foo(new C());
+var i;
+bar(i);
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty17 1`] = `
+"var it = i[Symbol.iterator];
 "
 `;
 
@@ -141,6 +223,50 @@ var x = { [s]: 0, [s]() {
 }, get [s]() {
 	return 0;
 } };
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty20 1`] = `
+"var i = { [Symbol.iterator]: (s) => s, [Symbol.toStringTag](n) {
+	return n;
+} };
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty21 1`] = `
+"foo({ [Symbol.isConcatSpreadable]: "", [Symbol.toPrimitive]: 0, [Symbol.unscopables]: true });
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty22 1`] = `
+"foo("", { [Symbol.unscopables]: (s) => s.length });
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty23 1`] = `
+"class C {
+	[Symbol.toPrimitive]() {
+		return true;
+	}
+}
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty24 1`] = `
+"class C {
+	[Symbol.toPrimitive]() {
+		return "";
+	}
+}
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty25 1`] = `
+"class C {
+	[Symbol.toStringTag]() {
+		return "";
+	}
+}
 "
 `;
 
@@ -256,10 +382,16 @@ class C2 {
 "
 `;
 
+exports[`TSC: es6/Symbols symbolProperty35 1`] = `""`;
+
 exports[`TSC: es6/Symbols symbolProperty36 1`] = `
 "var x = { [Symbol.isConcatSpreadable]: 0, [Symbol.isConcatSpreadable]: 1 };
 "
 `;
+
+exports[`TSC: es6/Symbols symbolProperty37 1`] = `""`;
+
+exports[`TSC: es6/Symbols symbolProperty38 1`] = `""`;
 
 exports[`TSC: es6/Symbols symbolProperty39 1`] = `
 "class C {
@@ -458,6 +590,8 @@ exports[`TSC: es6/Symbols symbolProperty58 1`] = `
 "
 `;
 
+exports[`TSC: es6/Symbols symbolProperty59 1`] = `""`;
+
 exports[`TSC: es6/Symbols symbolProperty6 1`] = `
 "class C {
 	[Symbol.iterator] = 0;
@@ -471,6 +605,31 @@ exports[`TSC: es6/Symbols symbolProperty6 1`] = `
 "
 `;
 
+exports[`TSC: es6/Symbols symbolProperty60 1`] = `
+"// https://github.com/Microsoft/TypeScript/issues/20146
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty61 1`] = `
+"const observable = Symbol.obs;
+export class MyObservable {
+	constructor(_val) {
+		this._val = _val;
+	}
+	subscribe(next) {
+		next(this._val);
+	}
+	[observable]() {
+		return this;
+	}
+}
+function from(obs) {
+	return obs[Symbol.obs]();
+}
+from(new MyObservable(42));
+"
+`;
+
 exports[`TSC: es6/Symbols symbolProperty7 1`] = `
 "class C {
 	[Symbol()] = 0;
@@ -481,6 +640,18 @@ exports[`TSC: es6/Symbols symbolProperty7 1`] = `
 		return 0;
 	}
 }
+"
+`;
+
+exports[`TSC: es6/Symbols symbolProperty8 1`] = `""`;
+
+exports[`TSC: es6/Symbols symbolProperty9 1`] = `
+"class C {
+	[Symbol.iterator];
+}
+var i;
+i = new C();
+var c = i;
 "
 `;
 

--- a/tests/integration/tests/tsc/__snapshots__/es6-computedProperties.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-computedProperties.test.ts.snap
@@ -778,6 +778,20 @@ class C {
 "
 `;
 
+exports[`TSC: es6/computedProperties computedPropertyNames35_ES5 1`] = `
+"function foo() {
+	return "";
+}
+"
+`;
+
+exports[`TSC: es6/computedProperties computedPropertyNames35_ES6 1`] = `
+"function foo() {
+	return "";
+}
+"
+`;
+
 exports[`TSC: es6/computedProperties computedPropertyNames36_ES5 1`] = `
 "class Foo {
 	x;

--- a/tests/integration/tests/tsc/__snapshots__/es6-for-ofStatements.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-for-ofStatements.test.ts.snap
@@ -273,6 +273,13 @@ for (var v of new MyStringIterator()) {
 "
 `;
 
+exports[`TSC: es6/for-ofStatements for-of29 1`] = `
+"//@target: ES6
+for (var v of iterableWithOptionalIterator) {
+}
+"
+`;
+
 exports[`TSC: es6/for-ofStatements for-of30 1`] = `
 "//@target: ES6
 class MyStringIterator {

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -5319,6 +5319,45 @@ var r = a instanceof a;
 "
 `;
 
+exports[`TSC: expressions instanceofOperatorWithInvalidOperands.es2015 1`] = `
+"class C {
+	foo() {
+	}
+}
+var x;
+// invalid left operand
+// the left operand is required to be of type Any, an object type, or a type parameter type
+var a4;
+var ra1 = a1 instanceof x;
+var ra2 = a2 instanceof x;
+var ra3 = a3 instanceof x;
+var ra4 = a4 instanceof x;
+var ra5 = 0 instanceof x;
+var ra6 = true instanceof x;
+var ra7 = "" instanceof x;
+var ra8 = null instanceof x;
+var ra9 = undefined instanceof x;
+// invalid right operand
+// the right operand to be of type Any or a subtype of the 'Function' interface type
+var b4;
+var rb1 = x instanceof b1;
+var rb2 = x instanceof b2;
+var rb3 = x instanceof b3;
+var rb4 = x instanceof b4;
+var rb5 = x instanceof 0;
+var rb6 = x instanceof true;
+var rb7 = x instanceof "";
+var rb8 = x instanceof o1;
+var rb9 = x instanceof o2;
+var rb10 = x instanceof o3;
+// both operands are invalid
+var rc1 = "" instanceof {};
+var ra10 = o5 instanceof o4;
+// invalid @@hasInstance method return type on RHS
+var rb11 = x instanceof o6;
+"
+`;
+
 exports[`TSC: expressions instanceofOperatorWithInvalidOperands 1`] = `
 "class C {
 	foo() {
@@ -5388,6 +5427,84 @@ exports[`TSC: expressions instanceofOperatorWithLHSIsTypeParameter 1`] = `
 	var x;
 	var r = t instanceof x;
 }
+"
+`;
+
+exports[`TSC: expressions instanceofOperatorWithRHSHasSymbolHasInstance 1`] = `
+"lhs0 instanceof rhs0 && lhs0;
+lhs0 instanceof rhs1 && lhs0;
+lhs0 instanceof rhs2 && lhs0;
+lhs0 instanceof rhs3 && lhs0;
+lhs0 instanceof rhs4 && lhs0;
+lhs0 instanceof rhs5 && lhs0;
+lhs0 instanceof rhs6 && lhs0;
+lhs0 instanceof Rhs7 && lhs0;
+lhs0 instanceof Rhs8 && lhs0;
+lhs0 instanceof Rhs9 && lhs0;
+lhs0 instanceof Rhs10 && lhs0;
+lhs0 instanceof Rhs11 && lhs0;
+lhs0 instanceof Rhs12 && lhs0;
+lhs0 instanceof Rhs13 && lhs0;
+lhs1 instanceof rhs0 && lhs1;
+lhs1 instanceof rhs1 && lhs1;
+lhs1 instanceof rhs2 && lhs1;
+lhs1 instanceof Rhs7 && lhs1;
+lhs1 instanceof Rhs8 && lhs1;
+lhs1 instanceof Rhs9 && lhs1;
+lhs2 instanceof rhs0 && lhs2;
+lhs2 instanceof rhs1 && lhs2;
+lhs2 instanceof rhs2 && lhs2;
+lhs2 instanceof rhs3 && lhs2;
+lhs2 instanceof rhs4 && lhs2;
+lhs2 instanceof rhs5 && lhs2;
+lhs2 instanceof Rhs7 && lhs2;
+lhs2 instanceof Rhs8 && lhs2;
+lhs2 instanceof Rhs9 && lhs2;
+lhs2 instanceof Rhs10 && lhs2;
+lhs2 instanceof Rhs11 && lhs2;
+lhs2 instanceof Rhs12 && lhs2;
+lhs3 instanceof rhs0 && lhs3;
+lhs3 instanceof rhs1 && lhs3;
+lhs3 instanceof rhs2 && lhs3;
+lhs3 instanceof rhs3 && lhs3;
+lhs3 instanceof rhs4 && lhs3;
+lhs3 instanceof rhs5 && lhs3;
+lhs3 instanceof rhs6 && lhs3;
+lhs3 instanceof Rhs7 && lhs3;
+lhs3 instanceof Rhs8 && lhs3;
+lhs3 instanceof Rhs9 && lhs3;
+lhs3 instanceof Rhs10 && lhs3;
+lhs3 instanceof Rhs11 && lhs3;
+lhs3 instanceof Rhs12 && lhs3;
+lhs3 instanceof Rhs13 && lhs3;
+lhs4 instanceof rhs0 && lhs4;
+lhs4 instanceof rhs1 && lhs4;
+lhs4 instanceof rhs2 && lhs4;
+lhs4 instanceof rhs3 && lhs4;
+lhs4 instanceof rhs4 && lhs4;
+lhs4 instanceof rhs5 && lhs4;
+lhs4 instanceof Rhs7 && lhs4;
+lhs4 instanceof Rhs8 && lhs4;
+lhs4 instanceof Rhs9 && lhs4;
+lhs4 instanceof Rhs10 && lhs4;
+lhs4 instanceof Rhs11 && lhs4;
+lhs4 instanceof Rhs12 && lhs4;
+// approximation of \`getInstanceType\` behavior, with one caveat: the checker versions unions the return types of
+// all construct signatures, but we have no way of extracting individual construct signatures from a type.
+// <- tests whether 'U' is 'any'
+if (obj instanceof A) {
+	obj;
+}
+// A
+if (obj instanceof B) {
+	obj;
+}
+// B
+// intersections
+// https://github.com/microsoft/TypeScript/issues/56536
+lhs0 instanceof rhs14 && lhs0;
+// unions
+lhs0 instanceof rhs15 && lhs0;
 "
 `;
 
@@ -12395,6 +12512,112 @@ if (obj14 instanceof G) {
 // a type with a prototype that has any type
 // high priority, but any type is ignored. interface has implicit \`prototype: any\`.
 // low priority
+if (obj15 instanceof H) {
+	// narrowed to H.
+	obj15.foo;
+	obj15.bar;
+}
+if (obj16 instanceof H) {
+	obj16.foo1;
+	obj16.foo2;
+}
+if (obj17 instanceof Object) {
+	// can't narrow type from 'any' to 'Object'
+	obj17.foo1;
+	obj17.foo2;
+}
+if (obj18 instanceof Function) {
+	// can't narrow type from 'any' to 'Function'
+	obj18.foo1;
+	obj18.foo2;
+}
+"
+`;
+
+exports[`TSC: expressions typeGuardsWithInstanceOfBySymbolHasInstance 1`] = `
+"if (obj1 instanceof A) {
+	// narrowed to A.
+	obj1.foo;
+	obj1.bar;
+}
+if (obj2 instanceof A) {
+	obj2.foo;
+	obj2.bar;
+}
+// a construct signature with generics
+if (obj3 instanceof B) {
+	// narrowed to B<number>.
+	obj3.foo = 1;
+	obj3.foo = "str";
+	obj3.bar = "str";
+}
+if (obj4 instanceof B) {
+	obj4.foo = "str";
+	obj4.foo = 1;
+	obj4.bar = "str";
+}
+// has multiple construct signature
+if (obj5 instanceof C) {
+	// narrowed to C1.
+	obj5.foo;
+	obj5.c;
+	obj5.bar1;
+	obj5.bar2;
+}
+if (obj6 instanceof C) {
+	obj6.foo;
+	obj6.bar1;
+	obj6.bar2;
+}
+// with object type literal
+if (obj7 instanceof D) {
+	// narrowed to D.
+	obj7.foo;
+	obj7.bar;
+}
+if (obj8 instanceof D) {
+	obj8.foo;
+	obj8.bar;
+}
+// a construct signature that returns a union type
+if (obj9 instanceof E) {
+	// narrowed to E1
+	obj9.foo;
+	obj9.bar1;
+	obj9.bar2;
+}
+if (obj10 instanceof E) {
+	obj10.foo;
+	obj10.bar1;
+	obj10.bar2;
+}
+// a construct signature that returns any
+if (obj11 instanceof F) {
+	// can't type narrowing, construct signature returns any.
+	obj11.foo;
+	obj11.bar;
+}
+if (obj12 instanceof F) {
+	obj12.foo;
+	obj12.bar;
+}
+// a type with a prototype, it overrides the construct signature
+// high priority
+// low priority
+// overrides priority
+if (obj13 instanceof G) {
+	// narrowed to G1. G1 is return type of prototype property.
+	obj13.foo1;
+	obj13.foo2;
+}
+if (obj14 instanceof G) {
+	obj14.foo1;
+	obj14.foo2;
+}
+// a type with a prototype that has any type
+// high priority, but any type is ignored. interface has implicit \`prototype: any\`.
+// low priority
+// overrides priority
 if (obj15 instanceof H) {
 	// narrowed to H.
 	obj15.foo;

--- a/tests/integration/tests/tsc/es6-Symbols.test.ts
+++ b/tests/integration/tests/tsc/es6-Symbols.test.ts
@@ -93,7 +93,7 @@ describe("TSC: es6/Symbols", () => {
     );
   });
   test("symbolDeclarationEmit5", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.isConcatSpreadable](): string;
 }`,
@@ -101,7 +101,7 @@ describe("TSC: es6/Symbols", () => {
     );
   });
   test("symbolDeclarationEmit6", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.isConcatSpreadable]: string;
 }`,
@@ -109,7 +109,7 @@ describe("TSC: es6/Symbols", () => {
     );
   });
   test("symbolDeclarationEmit7", async () => {
-    await expectError(
+    await expectPass(
       `var obj: {
     [Symbol.isConcatSpreadable]: string;
 }`,
@@ -146,7 +146,7 @@ var x = {
     );
   });
   test("symbolProperty10", async () => {
-    await expectError(
+    await expectPass(
       `class C {
     [Symbol.iterator]: { x; y };
 }
@@ -161,7 +161,7 @@ var c: C = i;`,
     );
   });
   test("symbolProperty11", async () => {
-    await expectError(
+    await expectPass(
       `class C { }
 interface I {
     [Symbol.iterator]?: { x };
@@ -174,7 +174,7 @@ var c: C = i;`,
     );
   });
   test("symbolProperty12", async () => {
-    await expectError(
+    await expectPass(
       `class C {
     private [Symbol.iterator]: { x };
 }
@@ -189,7 +189,7 @@ var c: C = i;`,
     );
   });
   test("symbolProperty13", async () => {
-    await expectError(
+    await expectPass(
       `class C {
     [Symbol.iterator]: { x; y };
 }
@@ -210,7 +210,7 @@ bar(i);`,
     );
   });
   test("symbolProperty14", async () => {
-    await expectError(
+    await expectPass(
       `class C {
     [Symbol.iterator]: { x; y };
 }
@@ -231,7 +231,7 @@ bar(i);`,
     );
   });
   test("symbolProperty15", async () => {
-    await expectError(
+    await expectPass(
       `class C { }
 interface I {
     [Symbol.iterator]?: { x };
@@ -250,7 +250,7 @@ bar(i);`,
     );
   });
   test("symbolProperty16", async () => {
-    await expectError(
+    await expectPass(
       `class C {
     private [Symbol.iterator]: { x };
 }
@@ -271,7 +271,7 @@ bar(i);`,
     );
   });
   test("symbolProperty17", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.iterator]: number;
     [s: symbol]: string;
@@ -323,7 +323,7 @@ var x = {
     );
   });
   test("symbolProperty20", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.iterator]: (s: string) => string;
     [Symbol.toStringTag](s: number): number;
@@ -337,7 +337,7 @@ var i: I = {
     );
   });
   test("symbolProperty21", async () => {
-    await expectError(
+    await expectPass(
       `interface I<T, U> {
     [Symbol.unscopables]: T;
     [Symbol.isConcatSpreadable]: U;
@@ -354,7 +354,7 @@ foo({
     );
   });
   test("symbolProperty22", async () => {
-    await expectError(
+    await expectPass(
       `interface I<T, U> {
     [Symbol.unscopables](x: T): U;
 }
@@ -366,7 +366,7 @@ foo("", { [Symbol.unscopables]: s => s.length });`,
     );
   });
   test("symbolProperty23", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.toPrimitive]: () => boolean;
 }
@@ -380,7 +380,7 @@ class C implements I {
     );
   });
   test("symbolProperty24", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.toPrimitive]: () => boolean;
 }
@@ -394,7 +394,7 @@ class C implements I {
     );
   });
   test("symbolProperty25", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.toPrimitive]: () => boolean;
 }
@@ -542,7 +542,7 @@ class C2 {
     );
   });
   test("symbolProperty35", async () => {
-    await expectError(
+    await expectPass(
       `interface I1 {
     [Symbol.toStringTag](): { x: string }
 }
@@ -564,7 +564,7 @@ interface I3 extends I1, I2 { }`,
     );
   });
   test("symbolProperty37", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.isConcatSpreadable]: string;
     [Symbol.isConcatSpreadable]: string;
@@ -573,7 +573,7 @@ interface I3 extends I1, I2 { }`,
     );
   });
   test("symbolProperty38", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.isConcatSpreadable]: string;
 }
@@ -867,7 +867,7 @@ var obj = {
     );
   });
   test("symbolProperty59", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.keyFor]: string;
 }`,
@@ -888,7 +888,7 @@ var obj = {
     );
   });
   test("symbolProperty60", async () => {
-    await expectError(
+    await expectPass(
       `// https://github.com/Microsoft/TypeScript/issues/20146
 interface I1 {
     [Symbol.toStringTag]: string;
@@ -915,7 +915,7 @@ interface I4 {
     );
   });
   test("symbolProperty61", async () => {
-    await expectError(
+    await expectPass(
       `
 declare global {
   interface SymbolConstructor {
@@ -963,7 +963,7 @@ from(new MyObservable(42))`,
     );
   });
   test("symbolProperty8", async () => {
-    await expectError(
+    await expectPass(
       `interface I {
     [Symbol.unscopables]: number;
     [Symbol.toPrimitive]();
@@ -972,7 +972,7 @@ from(new MyObservable(42))`,
     );
   });
   test("symbolProperty9", async () => {
-    await expectError(
+    await expectPass(
       `class C {
     [Symbol.iterator]: { x; y };
 }

--- a/tests/integration/tests/tsc/es6-computedProperties.test.ts
+++ b/tests/integration/tests/tsc/es6-computedProperties.test.ts
@@ -837,7 +837,8 @@ class C<T> {
     );
   });
   test("computedPropertyNames35_ES5", async () => {
-    await expectError(
+    // tsc type-check error only — parse level 통과. (#1767)
+    await expectPass(
       `function foo<T>() { return '' }
 interface I<T> {
     bar(): string;
@@ -847,7 +848,8 @@ interface I<T> {
     );
   });
   test("computedPropertyNames35_ES6", async () => {
-    await expectError(
+    // tsc type-check error only — parse level 통과. (#1767)
+    await expectPass(
       `function foo<T>() { return '' }
 interface I<T> {
     bar(): string;

--- a/tests/integration/tests/tsc/es6-for-ofStatements.test.ts
+++ b/tests/integration/tests/tsc/es6-for-ofStatements.test.ts
@@ -322,7 +322,8 @@ for (var v of new MyStringIterator) { }`,
     );
   });
   test("for-of29", async () => {
-    await expectError(
+    // tsc type-check error only — parse level 통과 (optional computed method signature). (#1767)
+    await expectPass(
       `//@target: ES6
 declare var iterableWithOptionalIterator: {
     [Symbol.iterator]?(): Iterator<string>

--- a/tests/integration/tests/tsc/expressions.test.ts
+++ b/tests/integration/tests/tsc/expressions.test.ts
@@ -6550,7 +6550,10 @@ var r: boolean = a instanceof a;`,
     );
   });
   test("instanceofOperatorWithInvalidOperands.es2015", async () => {
-    await expectError(
+    // tsc 의 type-check 단계 전용 에러. parse 수준에서는 valid TS 이므로 통과해야 맞다.
+    // #1767 이전에는 computed property key (`[Symbol.hasInstance]`) 를 index signature 로
+    // 오분류해 parse 가 깨졌기 때문에 expectError 가 우연히 pass 했던 것.
+    await expectPass(
       `class C {
     foo() { }
 }
@@ -6605,7 +6608,6 @@ var ra10 = o5 instanceof o4;
 // invalid @@hasInstance method return type on RHS
 declare var o6: {[Symbol.hasInstance](value: unknown): number;};
 var rb11 = x instanceof o6;`,
-      [],
     );
   });
   test("instanceofOperatorWithInvalidOperands", async () => {
@@ -6714,7 +6716,10 @@ var r4 = d instanceof x1;`,
     );
   });
   test("instanceofOperatorWithRHSHasSymbolHasInstance", async () => {
-    await expectError(
+    // tsc 의 type-check 단계 전용 에러. parse 수준에서는 valid TS 이므로 통과해야 맞다.
+    // #1767 이전에는 computed property key (`[Symbol.hasInstance]`) 를 index signature 로
+    // 오분류해 parse 가 깨졌기 때문에 expectError 가 우연히 pass 했던 것.
+    await expectPass(
       `
 interface Point { x: number, y: number }
 interface Point3D { x: number, y: number, z: number }
@@ -6848,7 +6853,6 @@ type Rhs15 = HasInstanceOf1 | HasInstanceOf2;
 declare const rhs15: Rhs15;
 lhs0 instanceof rhs15 && lhs0;
 `,
-      [],
     );
   });
   test("instanceofOperatorWithRHSIsSubtypeOfFunction", async () => {
@@ -16640,7 +16644,8 @@ if (obj18 instanceof Function) { // can't narrow type from 'any' to 'Function'
     );
   });
   test("typeGuardsWithInstanceOfBySymbolHasInstance", async () => {
-    await expectError(
+    // tsc type-check error only — parse level 통과 ([Symbol.hasInstance] computed method). (#1767)
+    await expectPass(
       `
 interface AConstructor {
     new (): A;


### PR DESCRIPTION
## 배경

Tier 1 Expo 스모크 (#1582) 중 발견. `@expo/metro-runtime/src/location/install.native.ts` 파싱 실패로 Expo Router 부팅 이전 단계에서 ZTS 가 막혔다. 원인은 TS object type literal 안의 **computed property key** (`[identRef]?: T`) 미지원.

## 원인

`parseTypeMember` 의 `[` 분기에서 `isIndexSignature()` 가 1-step lookahead 로 `[ 다음이 identifier` 면 무조건 index signature 로 판정했다. 따라서 `{ [polyfillSymbol]?: boolean }` 같은 computed key 도 index signature 경로로 가서 `]` 다음에 `:` 를 기대하다 `?` 만나고 `Expression expected` 로 깨졌다.

## 수정

**TypeScript 공식 parser 의 `isUnambiguouslyIndexSignature` 를 그대로 이식** (microsoft/TypeScript `src/compiler/parser.ts:4205`). Parse 수준 동작이 TS 공식과 완전 일치하며, TS 가 error recovery 목적으로 `true` 로 수용하는 패턴들도 전부 커버한다.

`isIndexSignature` 를 3-step lookahead 로 확장 (saveState/defer restoreState):

| 패턴 | 결과 |
| --- | --- |
| `[...` | index sig (rest) |
| `[]` | index sig (error recovery, 빈 파라미터) |
| `[public/private/protected/static id` | index sig (error recovery, modifier) |
| `[id:` `[id,` | index sig |
| `[id?:` `[id?,` `[id?]` | index sig (error recovery, optional param) |
| 그 외 | computed key 경로로 폴백 |

`parseTypeMember` 의 fall-through 경로 (`parsePropertyKey → eat(?) → eat(:)`) 는 이미 computed key 를 처리하므로 별도 분기 추가 불필요.

### Semantic-level 방어

ZTS 는 tsc 수준의 semantic checker 가 없다. Parse 만 통과시키면 `[public k: T]` 나 `[k?]: T` 같은 invalid TS 가 조용히 통과한다. 따라서 `parseIndexSignature` 안에서 invalid 토큰 (modifier, optional marker) 을 만나면:

- **ZTS0915** `Modifiers cannot appear on index signature parameters`
- **ZTS0916** `An index signature parameter cannot have a question mark`

로 diagnostic 을 찍은 뒤 해당 토큰만 skip 하고 파싱은 계속. tsc 의 error recovery 와 동등한 UX.

## 검증

### 최소 재현

```ts
const polyfillSymbol = Symbol.for('test');
function f(fetch: Function & { [polyfillSymbol]?: boolean }) { return fetch; }
```
- Before: `Expression expected [ZTS0600]`
- After: 정상 transpile

### 전체 매트릭스 (TS 공식과 일치)

| 케이스 | ZTS |
| --- | --- |
| Valid TS — computed key (simple/optional/intersection/member access) | ✅ OK |
| Valid TS — index signature / readonly / mapped type | ✅ OK |
| Invalid — `[k?: T]` (optional param) | ❌ ZTS0916 |
| Invalid — `[k?]` (optional no type) | ❌ ZTS0916 |
| Invalid — `[public/private/protected k: T]` (modifier) | ❌ ZTS0915 |

### 단위 테스트

`src/parser/parser_test.zig` 에 12 케이스 (valid 7 + error 5) 추가. `expectParseErrorWithExt` 헬퍼 신규.

### 실제 Expo App 번들

`examples/ExpoApp` (Expo Router 템플릿) 을 bungae 로 bundle:
- 수정 전: `install.native.ts` parse error → 번들 실패
- 수정 후: 해당 에러 완전 소멸. 남는 에러는 bungae resolver 측 B/C 이슈 (`react-native-screens/types` subpath, try/catch optional require) 로 이 PR 범위 밖.

`zig build test` 전체 통과.

## 성능 노트

`isIndexSignature` 가 object type member 당 한 번 호출되고 advance 가 1~2회 늘어난다 (원래 1 → 최대 3). 대규모 `.d.ts` 파일에서 누적 비용이 있을 수 있어 추후 `peek2NextKind`/`peek3NextKind` 같은 헬퍼로 최적화할 여지는 있으나, 이 PR 범위는 correctness 로 한정. 별도 최적화 기회로 기록.

Closes #1767

Ref: #1582 (Tier 1 블로커 A 해소)

🤖 Generated with [Claude Code](https://claude.com/claude-code)