### PR TITLE
feat(bundler): #1579 Phase 1 — require.context AST detection + literal eval

### DIFF
--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -28,6 +28,8 @@ const std = @import("std");
 const Ast = @import("../parser/ast.zig").Ast;
 const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const CallFlags = @import("../parser/ast.zig").CallFlags;
+const MemberFlags = @import("../parser/ast.zig").MemberFlags;
 const Span = @import("../lexer/token.zig").Span;
 const types = @import("types.zig");
 const ImportRecord = types.ImportRecord;
@@ -85,7 +87,12 @@ pub fn extractImportsWithCjsDetection(allocator: std.mem.Allocator, ast: *const 
                 }
             },
             .call_expression => {
-                if (tryExtractRequire(ast, node)) |record| {
+                // Order: require.context (specific, callee=member) → require (callee=ident) → glob (callee=meta).
+                // 더 specific 한 패턴 먼저 시도해야 일반 require 가 require.context 를 가리지 않는다.
+                if (tryExtractRequireContext(ast, node)) |record| {
+                    has_cjs_require = true;
+                    try records.append(allocator, record);
+                } else if (tryExtractRequire(ast, node)) |record| {
                     has_cjs_require = true;
                     try records.append(allocator, record);
                 } else if (tryExtractGlob(ast, node)) |record| {
@@ -196,6 +203,181 @@ fn tryExtractDynamicImport(ast: *const Ast, node: Node) ?ImportRecord {
         .kind = .dynamic_import,
         .span = arg_node.span,
     };
+}
+
+/// require.context(dir, recursive?, filter?, mode?) 호출 감지 (#1579 Phase 1).
+/// callee 가 static_member_expression `require.context` 인 경우만 처리.
+/// 4 인자를 literal 정적 평가 (string/bool/regex/mode string literal). undefined 는 default 폴백.
+/// invalid 인자는 record 의 context_invalid_reason 에 기록 (graph 단계에서 diagnostic emit).
+/// 다른 callee (Symbol.context, require['context'], require?.context 등) 는 무시 — null 리턴.
+///
+/// `tryExtractGlob` 와 같은 모양. Reference: Metro `processRequireContextCall`
+/// (`metro/src/ModuleGraph/worker/collectDependencies.js`).
+fn tryExtractRequireContext(ast: *const Ast, node: Node) ?ImportRecord {
+    if (node.tag != .call_expression) return null;
+    const e = node.data.extra;
+    // call_expression extra: [callee, args_start, args_len, flags]
+    if (!ast.hasExtra(e, 3)) return null;
+
+    const callee_idx = ast.readExtraNode(e, 0);
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    const call_flags = ast.readExtra(e, 3);
+
+    // `require?.context(...)` 무시
+    if (call_flags & CallFlags.optional_chain != 0) return null;
+
+    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return null;
+    const callee = ast.getNode(callee_idx);
+
+    // callee 는 static_member_expression `require.context` 여야 한다
+    if (callee.tag != .static_member_expression) return null;
+    if (!ast.hasExtra(callee.data.extra, 2)) return null;
+
+    const member_obj_idx = ast.readExtraNode(callee.data.extra, 0);
+    const member_prop_idx = ast.readExtraNode(callee.data.extra, 1);
+    const member_flags = ast.readExtra(callee.data.extra, 2);
+
+    // `require?.context` 무시
+    if (member_flags & MemberFlags.optional_chain != 0) return null;
+
+    if (member_obj_idx.isNone() or member_prop_idx.isNone()) return null;
+    if (@intFromEnum(member_obj_idx) >= ast.nodes.items.len or @intFromEnum(member_prop_idx) >= ast.nodes.items.len) return null;
+    const obj_node = ast.getNode(member_obj_idx);
+    const prop_node = ast.getNode(member_prop_idx);
+
+    // object: identifier_reference "require"
+    if (obj_node.tag != .identifier_reference) return null;
+    if (!std.mem.eql(u8, ast.getText(obj_node.span), "require")) return null;
+
+    // property: text 가 "context" 여야 함 (identifier 또는 escaped_keyword)
+    if (!std.mem.eql(u8, ast.getText(prop_node.span), "context")) return null;
+
+    // 여기까지 왔으면 require.context(...) 호출 확정. record 생성 + 인자 평가.
+    var record = ImportRecord{
+        .specifier = "",
+        .kind = .require_context,
+        .span = node.span,
+    };
+
+    // 인자 0개 → invalid (no args)
+    if (args_len == 0) {
+        record.context_invalid_reason = "require.context requires at least one argument (directory)";
+        return record;
+    }
+
+    // 인자 5개 이상 → invalid (too many args)
+    if (args_len > 4) {
+        record.context_invalid_reason = "require.context expects at most 4 arguments";
+        return record;
+    }
+
+    if (args_start + args_len > ast.extra_data.items.len) return null;
+
+    // spread element 검사 (전체 인자 사전 스캔)
+    var i: u32 = 0;
+    while (i < args_len) : (i += 1) {
+        const arg_idx = ast.readExtraNode(args_start, i);
+        if (@intFromEnum(arg_idx) >= ast.nodes.items.len) return null;
+        if (ast.getNode(arg_idx).tag == .spread_element) {
+            record.context_invalid_reason = "require.context arguments cannot use spread";
+            return record;
+        }
+    }
+
+    // arg[0]: directory (string literal, 필수)
+    {
+        const arg_idx = ast.readExtraNode(args_start, 0);
+        if (getStringLiteralText(ast, arg_idx)) |s| {
+            record.specifier = s;
+        } else {
+            record.context_invalid_reason = "require.context first argument must be a string literal (directory)";
+            return record;
+        }
+    }
+
+    // arg[1]: recursive (boolean literal, default true). undefined 는 default 폴백.
+    if (args_len >= 2) {
+        const arg_idx = ast.readExtraNode(args_start, 1);
+        const arg_node = ast.getNode(arg_idx);
+        if (isUndefinedLiteral(ast, arg_node)) {
+            // default true 유지
+        } else if (arg_node.tag == .boolean_literal) {
+            record.context_recursive = std.mem.eql(u8, ast.getText(arg_node.span), "true");
+        } else {
+            record.context_invalid_reason = "require.context second argument must be a boolean literal (recursive)";
+            return record;
+        }
+    }
+
+    // arg[2]: filter (regex literal, default null). undefined 는 default 폴백.
+    if (args_len >= 3) {
+        const arg_idx = ast.readExtraNode(args_start, 2);
+        const arg_node = ast.getNode(arg_idx);
+        if (isUndefinedLiteral(ast, arg_node)) {
+            // default null 유지
+        } else if (arg_node.tag == .regexp_literal) {
+            if (parseRegexLiteral(ast.getText(arg_node.span))) |parts| {
+                record.context_filter = parts.pattern;
+                if (parts.flags.len > 0) {
+                    record.context_filter_flags = parts.flags;
+                }
+            } else {
+                record.context_invalid_reason = "require.context third argument must be a regular expression literal (filter)";
+                return record;
+            }
+        } else {
+            record.context_invalid_reason = "require.context third argument must be a regular expression literal (filter)";
+            return record;
+        }
+    }
+
+    // arg[3]: mode (string literal one of sync/eager/lazy/lazy-once, default 'sync'). undefined 폴백.
+    if (args_len >= 4) {
+        const arg_idx = ast.readExtraNode(args_start, 3);
+        const arg_node = ast.getNode(arg_idx);
+        if (isUndefinedLiteral(ast, arg_node)) {
+            // default sync 유지
+        } else if (getStringLiteralText(ast, arg_idx)) |mode_str| {
+            const mode = parseRequireContextMode(mode_str) orelse {
+                record.context_invalid_reason = "require.context fourth argument must be 'sync', 'eager', 'lazy', or 'lazy-once'";
+                return record;
+            };
+            record.context_mode = mode;
+        } else {
+            record.context_invalid_reason = "require.context fourth argument must be a string literal (mode)";
+            return record;
+        }
+    }
+
+    return record;
+}
+
+/// `undefined` identifier 리터럴 여부. 글로벌 undefined 가 가려진 경우는 무시 (관례).
+fn isUndefinedLiteral(ast: *const Ast, node: Node) bool {
+    if (node.tag != .identifier_reference) return false;
+    return std.mem.eql(u8, ast.getText(node.span), "undefined");
+}
+
+/// `/pattern/flags` 형태의 regex literal 텍스트를 분해. 마지막 `/` 이후를 flags 로 취급.
+fn parseRegexLiteral(text: []const u8) ?struct { pattern: []const u8, flags: []const u8 } {
+    if (text.len < 2 or text[0] != '/') return null;
+    var i: usize = text.len;
+    while (i > 1) : (i -= 1) {
+        if (text[i - 1] == '/') {
+            return .{ .pattern = text[1 .. i - 1], .flags = text[i..] };
+        }
+    }
+    return null;
+}
+
+fn parseRequireContextMode(s: []const u8) ?@import("types.zig").RequireContextMode {
+    const Mode = @import("types.zig").RequireContextMode;
+    if (std.mem.eql(u8, s, "sync")) return Mode.sync;
+    if (std.mem.eql(u8, s, "eager")) return Mode.eager;
+    if (std.mem.eql(u8, s, "lazy")) return Mode.lazy;
+    if (std.mem.eql(u8, s, "lazy-once")) return Mode.lazy_once;
+    return null;
 }
 
 /// require("string_literal") 호출을 감지하여 ImportRecord로 변환.

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -7,6 +7,7 @@ const stripQuotes = import_scanner.stripQuotes;
 const types = @import("types.zig");
 const ImportRecord = types.ImportRecord;
 const ImportKind = types.ImportKind;
+const RequireContextMode = types.RequireContextMode;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 
@@ -332,4 +333,687 @@ test "glob: import.meta.glob with import option" {
     try std.testing.expect(result.records[0].glob_import_name != null);
     try std.testing.expectEqualStrings("setup", result.records[0].glob_import_name.?);
     try std.testing.expect(!result.records[0].glob_eager);
+}
+
+// ============================================================
+// require.context (#1579 Phase 1)
+// Reference: Metro `collectDependencies-test.js`,
+//            ZTS 의 기존 tryExtractGlob mirror 패턴
+// ============================================================
+
+/// require_context kind 인 첫 record 만 반환.
+fn findContextRecord(records: []const ImportRecord) ?ImportRecord {
+    for (records) |r| {
+        if (r.kind == .require_context) return r;
+    }
+    return null;
+}
+
+/// 모든 require_context record 개수.
+fn countContextRecords(records: []const ImportRecord) usize {
+    var n: usize = 0;
+    for (records) |r| {
+        if (r.kind == .require_context) n += 1;
+    }
+    return n;
+}
+
+/// valid require.context record 검증 (invalid_reason==null + 필드 일치).
+fn expectValidContext(
+    record: ImportRecord,
+    dir: []const u8,
+    recursive: bool,
+    filter: ?[]const u8,
+    filter_flags: ?[]const u8,
+    mode: RequireContextMode,
+) !void {
+    try std.testing.expectEqual(ImportKind.require_context, record.kind);
+    try std.testing.expect(record.context_invalid_reason == null);
+    try std.testing.expectEqualStrings(dir, record.specifier);
+    try std.testing.expectEqual(recursive, record.context_recursive);
+    if (filter) |f| {
+        try std.testing.expect(record.context_filter != null);
+        try std.testing.expectEqualStrings(f, record.context_filter.?);
+    } else {
+        try std.testing.expect(record.context_filter == null);
+    }
+    if (filter_flags) |ff| {
+        try std.testing.expect(record.context_filter_flags != null);
+        try std.testing.expectEqualStrings(ff, record.context_filter_flags.?);
+    } else {
+        // null 또는 빈 string 둘 다 허용
+        if (record.context_filter_flags) |actual| {
+            try std.testing.expectEqualStrings("", actual);
+        }
+    }
+    try std.testing.expectEqual(mode, record.context_mode);
+}
+
+// ─── A. 기본 인지 + 정상 평가 ────────────────────────────
+
+test "require.context: bare call — all defaults" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "const ctx = require.context('./pages');");
+    defer alloc.free(records);
+
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+test "require.context: explicit recursive=false" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./pages', false);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", false, null, null, .sync);
+}
+
+test "require.context: explicit recursive=true" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./pages', true);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+test "require.context: filter regex without flags" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', true, /foo/);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, "foo", null, .sync);
+}
+
+test "require.context: filter regex with single flag" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', true, /custom/i);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, "custom", "i", .sync);
+}
+
+test "require.context: filter regex with multiple flags" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', true, /foo/im);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, "foo", "im", .sync);
+}
+
+test "require.context: filter regex complex pattern" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./app', true, /\\.tsx?$/);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./app", true, "\\.tsx?$", null, .sync);
+}
+
+test "require.context: mode 'sync' explicit" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', true, /.*/, 'sync');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, ".*", null, .sync);
+}
+
+test "require.context: mode 'eager'" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', true, /.*/, 'eager');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, ".*", null, .eager);
+}
+
+test "require.context: mode 'lazy'" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', true, /.*/, 'lazy');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, ".*", null, .lazy);
+}
+
+test "require.context: mode 'lazy-once'" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', true, /.*/, 'lazy-once');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, ".*", null, .lazy_once);
+}
+
+// ─── B. undefined 명시 → default 폴백 ────────────────────
+
+test "require.context: explicit undefined for all optional args" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./', undefined, undefined, undefined);",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, null, null, .sync);
+}
+
+test "require.context: undefined filter only" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./', false, undefined, 'eager');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", false, null, null, .eager);
+}
+
+test "require.context: undefined mode only" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./', true, /foo/, undefined);",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, "foo", null, .sync);
+}
+
+// ─── C. directory 형태 변형 ───────────────────────────────
+
+test "require.context: directory '.'" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('.');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, ".", true, null, null, .sync);
+}
+
+test "require.context: directory './'" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./", true, null, null, .sync);
+}
+
+test "require.context: directory '../parent'" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('../parent');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "../parent", true, null, null, .sync);
+}
+
+test "require.context: directory deep nested './a/b/c'" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./a/b/c');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./a/b/c", true, null, null, .sync);
+}
+
+// ─── D. string literal 형태 ───────────────────────────────
+
+test "require.context: directory with double quotes" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context(\"./pages\");");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+test "require.context: trailing comma in args" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./pages',);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+// ─── E. TS 통합 ────────────────────────────────────────────
+
+test "require.context: TS generic on callee" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "const ctx = require.context<unknown>('./pages');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+// ─── F. 사용처 (어디서든 인지) ─────────────────────────────
+
+test "require.context: in function body" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "function makeCtx() { return require.context('./pages'); }",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+test "require.context: in arrow function body" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "const f = () => require.context('./pages');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+test "require.context: in export const declaration" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "export const ctx = require.context('./pages');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+test "require.context: as argument to another call" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "registerCtx(require.context('./pages'));",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+// ─── G. 격리 / 무시 (다른 callee 는 require_context 가 아님) ───────
+
+test "require.context: plain require is not require_context" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "const x = require('./pages');");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), countContextRecords(records));
+    // 일반 require record 는 있어야 함
+    var has_require = false;
+    for (records) |r| if (r.kind == .require) {
+        has_require = true;
+    };
+    try std.testing.expect(has_require);
+}
+
+test "require.context: Symbol.context is ignored" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "Symbol.context('./pages');");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), countContextRecords(records));
+}
+
+test "require.context: req.context (different identifier) is ignored" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "const req = {}; req.context('./pages');",
+    );
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), countContextRecords(records));
+}
+
+test "require.context: require['context'] (computed access) is ignored" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require['context']('./pages');");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), countContextRecords(records));
+}
+
+test "require.context: require?.context (optional chaining) is ignored" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require?.context('./pages');");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), countContextRecords(records));
+}
+
+test "require.context: require.contextFoo (different prop) is ignored" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.contextFoo('./pages');");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), countContextRecords(records));
+}
+
+test "require.context: require.context.foo (deep member call) is ignored" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context.foo('./pages');");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), countContextRecords(records));
+}
+
+// ─── H. Multiple calls — 각각 별개 record ─────────────────
+
+test "require.context: same dir twice — two records" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc,
+        \\require.context('./pages');
+        \\require.context('./pages');
+    );
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 2), countContextRecords(records));
+}
+
+test "require.context: different dirs — two records" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc,
+        \\require.context('./a');
+        \\require.context('./b');
+    );
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 2), countContextRecords(records));
+}
+
+test "require.context: mixed with plain require — both kinds present" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc,
+        \\const ctx = require.context('./pages');
+        \\const lib = require('./lib');
+    );
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 1), countContextRecords(records));
+    var has_require = false;
+    for (records) |r| if (r.kind == .require) {
+        has_require = true;
+    };
+    try std.testing.expect(has_require);
+}
+
+// ─── I. 호출 결과 chaining ─────────────────────────────────
+
+test "require.context: chained .keys() — context call still recognized" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "const k = require.context('./pages').keys();");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+test "require.context: immediately invoked result — context call still recognized" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "const m = require.context('./pages')('./foo');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+// ─── J. 에러 케이스 (context_invalid_reason 채워짐) ────────
+
+test "require.context: no args — invalid (no directory)" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context();");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: numeric directory — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context(42);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: null directory — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context(null);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: boolean directory — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context(true);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: template literal directory — invalid (literal-only policy)" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context(`./pages`);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: identifier directory — invalid (literal-only policy)" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "const dir = './pages'; require.context(dir);",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: string recursive — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', 'hey');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: numeric recursive — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', 0);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: NewExpression as filter — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./', false, new RegExp('foo'));",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: string filter — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', false, 'foo');");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: numeric mode — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "require.context('./', false, /foo/, 42);");
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: invalid mode value 'invalid' — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./', false, /foo/, 'invalid');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: too many args (5) — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./', false, /foo/, 'sync', 'extra');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: spread argument — invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "const args = ['./']; require.context(...args);",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+// ─── K. Expo Router 실제 사용 패턴 ───────────────────────
+
+test "require.context: Expo Router _ctx.ios.js pattern (filter regex with negative lookahead)" {
+    // expo-router/_ctx.ios.tsx 의 실제 호출. process.env 인자는 Phase 1 이후 다룸.
+    // 여기서는 인자가 모두 literal 인 변형으로 검증.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./app', true, /^(?:\\.\\/)(?!.*\\+api).*\\.[tj]sx?$/, 'sync');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(
+        r,
+        "./app",
+        true,
+        "^(?:\\.\\/)(?!.*\\+api).*\\.[tj]sx?$",
+        null,
+        .sync,
+    );
+}
+
+// ─── L. Edge — JSX/TSX 컨텍스트 ──────────────────────────
+
+test "require.context: inside JSX expression container" {
+    const alloc = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var scanner = try Scanner.init(arena_alloc, "const e = <div>{require.context('./pages')}</div>;");
+    var parser = Parser.init(arena_alloc, &scanner);
+    parser.is_module = true;
+    parser.is_jsx = true;
+    scanner.is_module = true;
+    _ = try parser.parse();
+    const records = try extractImports(alloc, &parser.ast);
+    defer alloc.free(records);
+
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+// ─── M. babel-plugin-transform-require-context (asapach) 추가 케이스 ────
+
+test "require.context: bare member access without invocation is ignored" {
+    // `const x = require.context;` — call_expression 이 아니므로 인지 안 함.
+    // babel-plugin 의 "doesn't transform require.context property" 와 동일.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "const x = require.context;");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), countContextRecords(records));
+}
+
+test "require.context: shadowed `require` parameter — currently still recognized" {
+    // babel-plugin 은 scope tracking 으로 shadowing 시 무시. ZTS 의 tryExtractRequire 도
+    // scope 추적 안 하므로 일관성 차원에서 인지함. shadowing 시 무시는 별도 정책 결정 필요
+    // (Phase 2 또는 별도 이슈). 이 테스트는 현재 정책 (인지) 을 명시한다.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc,
+        \\function test(require) {
+        \\  const ctx = require.context('foo', false);
+        \\}
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "foo", false, null, null, .sync);
+}
+
+test "require.context: babel-plugin chained result pattern `requireAll(require.context(...))`" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "var modules = requireAll(require.context('./spec', true, /^\\.\\/.*\\.js$/));",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./spec", true, "^\\.\\/.*\\.js$", null, .sync);
+}
+
+// ─── N. Expo Router 실제 _ctx 시리즈 (literal-only 변형) ──────────────
+
+test "require.context: Expo Router _ctx-html.js pattern (recursive=false + +html regex + 'sync')" {
+    // packages/expo-router/_ctx-html.js 의 실제 호출. EXPO_ROUTER_APP_ROOT 만 literal 로 치환.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "export const ctx = require.context('./app', false, /\\+html\\.[tj]sx?$/, 'sync');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./app", false, "\\+html\\.[tj]sx?$", null, .sync);
+}
+
+test "require.context: Expo Router _ctx.android.js pattern (.android|.ios|.native variant)" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./app', true, /^(?:\\.\\/)(?!(?:(?:(?:.*\\+api)|(?:\\+middleware)|(?:\\+(html|native-intent))))\\.[tj]sx?$).*(?:\\.android|\\.ios|\\.native)?\\.[tj]sx?$/, 'sync');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expectEqual(ImportKind.require_context, r.kind);
+    try std.testing.expect(r.context_invalid_reason == null);
+    try std.testing.expectEqualStrings("./app", r.specifier);
+    try std.testing.expectEqual(true, r.context_recursive);
+    try std.testing.expectEqual(RequireContextMode.sync, r.context_mode);
+}
+
+test "require.context: Expo Router _ctx.web.js pattern (.android|.web variant)" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./app', true, /^(?:\\.\\/)(?!(?:(?:(?:.*\\+api)|(?:\\+html)|(?:\\+middleware)))\\.[tj]sx?$).*(?:\\.android|\\.web)?\\.[tj]sx?$/, 'sync');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expectEqual(ImportKind.require_context, r.kind);
+    try std.testing.expect(r.context_invalid_reason == null);
+    try std.testing.expectEqualStrings("./app", r.specifier);
+}
+
+// ─── O. Phase 2 candidate — process.env.* 인자 (현재는 invalid) ───────
+
+test "require.context: process.env.EXPO_ROUTER_APP_ROOT directory — Phase 1 invalid (Phase 2 valid via define)" {
+    // expo-router/_ctx.ios.js 의 원본 형태. Phase 1 에서는 identifier-like 이므로 invalid.
+    // Phase 2 에서 define 치환 후 string literal 로 평가되어 valid 되도록 발전 예정.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context(process.env.EXPO_ROUTER_APP_ROOT, true, /.*/, 'sync');",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: process.env.EXPO_ROUTER_IMPORT_MODE mode — Phase 1 invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(
+        alloc,
+        "require.context('./app', true, /.*/, process.env.EXPO_ROUTER_IMPORT_MODE);",
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
 }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -100,6 +100,20 @@ pub const ImportKind = enum {
     worker,
     /// import.meta.glob("./pages/*.tsx") — Vite 호환
     glob,
+    /// require.context("./pages", true, /\.tsx$/, "sync") — webpack/Metro 호환 (#1579)
+    require_context,
+};
+
+/// require.context mode. Metro/webpack 명세상 4가지.
+pub const RequireContextMode = enum {
+    /// 즉시 모든 매칭 파일 require (default, Expo Router 등)
+    sync,
+    /// dynamic import 로 포함하지만 번들엔 동기 로드 (sync 와 사실상 동일)
+    eager,
+    /// 각 파일이 개별 chunk (code splitting 필요)
+    lazy,
+    /// 전체가 하나의 chunk
+    lazy_once,
 };
 
 // ============================================================
@@ -385,6 +399,19 @@ pub const ImportRecord = struct {
     glob_import_name: ?[]const u8 = null,
     /// glob: 확장된 매칭 파일 목록 (resolve 후 graph가 설정)
     glob_matches: ?[]const []const u8 = null,
+    /// require.context: recursive flag (default true) — `require.context(dir, recursive)` 두 번째 인자
+    context_recursive: bool = true,
+    /// require.context: filter regex 패턴 본문 (slashes 제외, default `^\./.*$`).
+    /// `/foo\.tsx?$/i` 의 `foo\.tsx?$` 부분.
+    context_filter: ?[]const u8 = null,
+    /// require.context: filter regex flags (default 빈 string).
+    /// `/foo/im` 의 `im` 부분. flags 차이로 dependency identity 가 달라진다 (Metro 동작).
+    context_filter_flags: ?[]const u8 = null,
+    /// require.context: code splitting mode (default sync)
+    context_mode: RequireContextMode = .sync,
+    /// require.context: invalid arguments 발견 시 reason. graph 단계에서 BundlerDiagnostic 으로
+    /// 변환되어 사용자에게 표시. null 이면 valid.
+    context_invalid_reason: ?[]const u8 = null,
 };
 
 // ============================================================


### PR DESCRIPTION
## 배경

[#1579](https://github.com/ohah/zts/issues/1579) `require.context` 의 첫 단계. webpack/Metro 호환의 `require.context(dir, recursive?, filter?, mode?)` 호출을 import_scanner 에서 인지 + 4 인자 정적 평가 + ImportRecord 로 변환.

[#1582](https://github.com/ohah/zts/issues/1582) **Tier 2 (Expo Router) 진입의 prerequisite**. Expo Router 의 `_ctx.ios.tsx`/`_ctx.web.tsx` 등이 require.context 에 의존.

## Phase 1 범위 (이번 PR)

### AST 인지
`call_expression` 에서 callee 가 `static_member_expression` `require.context` 인 경우만 처리. 다음은 **무시**:
- `Symbol.context(...)`, `req.context(...)`, `require['context'](...)`, `require?.context(...)`
- `require.contextFoo(...)`, `require.context.foo(...)`, `require.context` (호출 없음)

### Literal 평가
| 인자 | 타입 | default | undefined 허용 |
| --- | --- | --- | --- |
| 0: directory | string literal | (필수) | ❌ |
| 1: recursive | boolean literal | `true` | ✅ |
| 2: filter | regex literal | `null` (= no filter) | ✅ |
| 3: mode | `'sync'`/`'eager'`/`'lazy'`/`'lazy-once'` | `'sync'` | ✅ |

5 인자 이상, spread, non-literal 인자는 invalid.

### Invalid 처리
parser/scanner 단에선 `record.context_invalid_reason` 에 메시지만 기록. **graph 단계에서 BundlerDiagnostic 으로 변환해 사용자 emit** 은 Phase 2 책임 (책임 분리).

### ImportRecord 확장
- `ImportKind.require_context`
- `RequireContextMode` enum (`sync`/`eager`/`lazy`/`lazy_once`)
- 5 필드: `context_recursive`, `context_filter`, `context_filter_flags`, `context_mode`, `context_invalid_reason`
- 기존 `glob_eager`/`glob_import_name` 패턴 mirror

## Phase 1 비범위 (별도 PR)

- 실제 디렉토리 스캔 (FS access) — Phase 2
- 가상 모듈 emit + runtime template (`webpackContext` 함수) — Phase 3
- watch 모드 — Phase 4
- `process.env.EXPO_ROUTER_APP_ROOT` 등 define 치환 후 평가 — Phase 2
- `unstable_allowRequireContext` 옵션 게이팅 — Phase 2 graph 단
- const reference 평가 — 현재 invalid (정책)
- shadowed `require` (function param) — scope tracking 별도 이슈

## Reference

- **Metro `processRequireContextCall`** (`metro/src/ModuleGraph/worker/collectDependencies.js`) — 20 invariants 케이스를 ZTS 테스트로 이식
- **Expo Router `_ctx.{ios,android,web}.tsx`, `_ctx-html.js`** — 실제 사용 패턴 fixture
- **babel-plugin-transform-require-context (asapach)** — bare member access / shadowed require 케이스
- ZTS 의 기존 **`tryExtractGlob`** (Vite `import.meta.glob`) — 구조 mirror

## 검증

### 테스트 (61 케이스, 전부 통과)
| 섹션 | 개수 |
| --- | --- |
| 기본 인지 + literal 평가 | 11 |
| undefined → default 폴백 | 3 |
| directory/literal 형태 변형 | 6 |
| TS generic | 1 |
| 사용처 (function/arrow/export const/argument) | 4 |
| 격리 / 무시 (Symbol.context, computed access, optional chain 등) | 7 |
| Multiple calls | 3 |
| 호출 결과 chaining | 2 |
| 에러 케이스 (`context_invalid_reason`) | 14 |
| Expo Router 실제 패턴 (`_ctx-html.js`, .android, .web, .ios literal) | 4 |
| babel-plugin (asapach) | 3 |
| Phase 2 candidate (process.env 사용 — 현재 invalid) | 2 |
| JSX expression container | 1 |

`zig build test` 전체 통과.

## /simplify 적용

- 매직 넘버 (`0x02`, `0x01`) → `CallFlags.optional_chain`, `MemberFlags.optional_chain` import
- `extras[e+N]` 직접 인덱스 접근 → `ast.readExtra` / `ast.readExtraNode` 통일 (기존 `tryExtractRequire` 패턴)
- `arg[3]` 의 이중 enum 변환 → `arg[0]` 패턴으로 일관 처리
- dispatch 순서 주석 추가

## Follow-up

[#1769](https://github.com/ohah/zts/issues/1769) 에 잔여 정리 항목 트래킹:
- (1) callee-tag 기반 `call_expression` dispatch 재구성 (perf)
- (2) `regexp_literal` 노드에 pattern/flags 직접 저장 (parser)
- (3) `context_invalid_reason` 을 `BundlerDiagnostic` 으로 통합 (Phase 2 와 함께)

Refs: #1579, #1582
Follow-up: #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)