### PR TITLE
feat(bundler): #1579 Phase 2 — require.context host plugin hook + graph processing

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -728,9 +728,12 @@ pub const ModuleGraph = struct {
 
         // import.meta.glob: 워커에서 glob 확장 수행
         expandGlobRecords(self.allocator, self.modules.items[mod_idx].import_records, source_dir);
+        // require.context: host plugin 으로 매칭 결과 주입 (#1579 Phase 2)
+        expandRequireContextRecords(self, module_path, self.modules.items[mod_idx].import_records);
 
         for (records, 0..) |record, rec_i| {
             if (record.kind == .glob) continue;
+            if (record.kind == .require_context) continue;
 
             if (plugin_runner) |runner| {
                 const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
@@ -1095,6 +1098,7 @@ pub const ModuleGraph = struct {
             };
             for (scan_records, 0..) |sr, i| {
                 const ik: ImportKind = @enumFromInt(@intFromEnum(sr.kind));
+                const ctx_mode: types.RequireContextMode = @enumFromInt(@intFromEnum(sr.context_mode));
                 records[i] = .{
                     .specifier = sr.specifier,
                     .kind = ik,
@@ -1102,6 +1106,11 @@ pub const ModuleGraph = struct {
                     .url_span = sr.url_span,
                     .glob_eager = sr.glob_eager,
                     .glob_import_name = sr.glob_import_name,
+                    .context_recursive = sr.context_recursive,
+                    .context_filter = sr.context_filter,
+                    .context_filter_flags = sr.context_filter_flags,
+                    .context_mode = ctx_mode,
+                    .context_invalid_reason = sr.context_invalid_reason,
                 };
             }
             module.import_records = records;
@@ -1349,9 +1358,12 @@ pub const ModuleGraph = struct {
 
         // import.meta.glob: glob 레코드를 파일 시스템에서 확장
         expandGlobRecords(self.allocator, self.modules.items[mod_idx].import_records, source_dir);
+        // require.context: host plugin 으로 매칭 결과 주입 (#1579 Phase 2)
+        expandRequireContextRecords(self, module_path, self.modules.items[mod_idx].import_records);
 
         for (records, 0..) |record, rec_i| {
             if (record.kind == .glob) continue;
+            if (record.kind == .require_context) continue;
 
             // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
             if (plugin_runner) |runner| {
@@ -2335,6 +2347,76 @@ fn expandGlobRecords(allocator: std.mem.Allocator, records: []types.ImportRecord
         if (record.kind == .glob) {
             record.glob_matches = expandGlob(allocator, source_dir, record.specifier) catch &.{};
         }
+    }
+}
+
+/// require.context(...) 레코드의 매칭 파일 목록을 host plugin (resolveContext) 으로 채운다.
+/// (#1579 Phase 2). ZTS 자체 regex executor 가 없어서 host runtime 의 RegExp 위임 (#1771).
+///
+/// 처리 순서:
+///   1. invalid record (`context_invalid_reason != null`) → require_context_invalid error.
+///   2. plugin runner 호출 (first non-null wins) → 결과를 record.context_matches 에 저장.
+///   3. plugin 미구현 → require_context_no_handler warning (record.context_matches 는 null 유지).
+///
+/// `self`: ModuleGraph (addDiag, plugins 접근용)
+/// `module_path`: 현재 모듈 경로 (importer)
+/// `records`: 모듈의 import_records (in-place 수정)
+fn expandRequireContextRecords(self: *ModuleGraph, module_path: []const u8, records: []types.ImportRecord) void {
+    // require_context 레코드 존재 여부 빠른 체크 (대다수 모듈은 0개 — early return 으로 cheap)
+    var has_any = false;
+    for (records) |r| {
+        if (r.kind == .require_context) {
+            has_any = true;
+            break;
+        }
+    }
+    if (!has_any) return;
+
+    const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
+        plugin_mod.PluginRunner.init(self.plugins)
+    else
+        null;
+
+    for (records) |*record| {
+        if (record.kind != .require_context) continue;
+        // scanWorker + resolveModuleImports 양쪽에서 호출됨. context_matches 가 채워졌으면 (성공/실패
+        // 무관) 이미 처리된 record — diag 중복/plugin 재호출 방지.
+        if (record.context_matches != null) continue;
+
+        // Invalid 인자 → diagnostic (Phase 1 의 reason 텍스트 그대로 사용). empty slice 로 마킹.
+        if (record.context_invalid_reason) |reason| {
+            self.addDiag(.require_context_invalid, .@"error", module_path, record.span, .resolve, reason, null);
+            record.context_matches = &.{};
+            continue;
+        }
+
+        // Plugin 호출
+        if (plugin_runner) |runner| {
+            const matches = runner.runResolveContext(
+                record.specifier,
+                record.context_recursive,
+                record.context_filter,
+                record.context_filter_flags,
+                module_path,
+                self.allocator,
+            ) catch null;
+            if (matches) |m| {
+                record.context_matches = m;
+                continue;
+            }
+        }
+
+        // Plugin 미구현 → warning. empty slice 로 마킹 (Phase 3 codegen 이 빈 stub 으로 emit).
+        self.addDiag(
+            .require_context_no_handler,
+            .warning,
+            module_path,
+            record.span,
+            .resolve,
+            "require.context requires a host plugin to match files (ZTS regex executor not yet implemented — see #1771)",
+            null,
+        );
+        record.context_matches = &.{};
     }
 }
 

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -213,7 +213,7 @@ fn tryExtractDynamicImport(ast: *const Ast, node: Node) ?ImportRecord {
 ///
 /// `tryExtractGlob` 와 같은 모양. Reference: Metro `processRequireContextCall`
 /// (`metro/src/ModuleGraph/worker/collectDependencies.js`).
-fn tryExtractRequireContext(ast: *const Ast, node: Node) ?ImportRecord {
+pub fn tryExtractRequireContext(ast: *const Ast, node: Node) ?ImportRecord {
     if (node.tag != .call_expression) return null;
     const e = node.data.extra;
     // call_expression extra: [callee, args_start, args_len, flags]
@@ -227,8 +227,21 @@ fn tryExtractRequireContext(ast: *const Ast, node: Node) ?ImportRecord {
     // `require?.context(...)` 무시
     if (call_flags & CallFlags.optional_chain != 0) return null;
 
+    return tryExtractRequireContextFromCallee(ast, callee_idx, args_start, args_len, node.span);
+}
+
+/// `tryExtractRequireContext` 의 callee+args 직접 받는 변형. (#1579 Phase 2)
+/// parser inline scan (call_expression 노드 만들기 *전*에 호출) 에서 사용.
+pub fn tryExtractRequireContextFromCallee(
+    ast: *const Ast,
+    callee_idx: NodeIndex,
+    args_start: u32,
+    args_len: u32,
+    call_span: Span,
+) ?ImportRecord {
     if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return null;
     const callee = ast.getNode(callee_idx);
+    const extras = ast.extra_data.items;
 
     // callee 는 static_member_expression `require.context` 여야 한다
     if (callee.tag != .static_member_expression) return null;
@@ -257,7 +270,7 @@ fn tryExtractRequireContext(ast: *const Ast, node: Node) ?ImportRecord {
     var record = ImportRecord{
         .specifier = "",
         .kind = .require_context,
-        .span = node.span,
+        .span = call_span,
     };
 
     // 인자 0개 → invalid (no args)
@@ -272,7 +285,7 @@ fn tryExtractRequireContext(ast: *const Ast, node: Node) ?ImportRecord {
         return record;
     }
 
-    if (args_start + args_len > ast.extra_data.items.len) return null;
+    if (args_start + args_len > extras.len) return null;
 
     // spread element 검사 (전체 인자 사전 스캔)
     var i: u32 = 0;

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -119,6 +119,7 @@ test {
     _ = @import("types_test.zig");
     _ = @import("module_test.zig");
     _ = @import("plugin_test.zig");
+    _ = @import("require_context_resolve_test.zig");
     _ = asset_meta;
     _ = block_list;
     _ = incremental;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -357,6 +357,13 @@ pub const Module = struct {
         self.importers.deinit(allocator);
         self.dynamic_imports.deinit(allocator);
         if (self.alias_table) |*t| t.deinit();
+        // require.context: plugin 이 채운 outer slice free (#1579 Phase 2).
+        // inner []const u8 은 plugin 책임 (source slice / static / plugin lifetime).
+        for (self.import_records) |record| {
+            if (record.kind == .require_context) {
+                if (record.context_matches) |matches| allocator.free(matches);
+            }
+        }
         // parse_arena가 Scanner/Parser/AST/source 메모리를 전부 소유.
         // ast.deinit()는 불필요 — arena.deinit()이 일괄 해제.
         if (self.parse_arena) |*arena| arena.deinit();

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -25,6 +25,17 @@ pub const PluginError = error{
     OutOfMemory,
 };
 
+/// `Plugin.resolveContext` hook signature. (#1579 Phase 2)
+pub const ResolveContextFn = ?*const fn (
+    ctx: ?*anyopaque,
+    dir: []const u8,
+    recursive: bool,
+    filter_pattern: ?[]const u8,
+    filter_flags: ?[]const u8,
+    importer: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8;
+
 /// Rollup 호환 플러그인 인터페이스. 각 훅은 optional 함수 포인터 — null이면 해당 훅을 구현하지 않음.
 /// builtin 플러그인(worklet 등) 전용. JS 플러그인은 @zts/core NAPI 경로에서 처리된다.
 pub const Plugin = struct {
@@ -50,6 +61,22 @@ pub const Plugin = struct {
 
     /// 번들 생성 완료 알림. 모든 플러그인에 호출됨.
     generateBundle: ?*const fn (ctx: ?*anyopaque, output_files: []const OutputFile) void = null,
+
+    /// `require.context(dir, recursive, filter)` 매칭 결과 주입 (#1579 Phase 2).
+    /// ZTS 자체 regex executor 가 없어서 (#1771) host runtime 의 RegExp 에 위임.
+    ///
+    /// **mode 인자 미포함**: Metro/webpack 모두 매칭 자체엔 mode 영향 없음 (mode 는 codegen
+    /// 단계의 chunk 분할 결정만 좌우). 따라서 host plugin 은 파일 매칭에만 집중하고, mode 는
+    /// `record.context_mode` 로 codegen (Phase 3) 에서 직접 활용.
+    ///
+    /// **메모리 소유권**:
+    ///   - **outer slice** (`[]const u8`): `allocator` 로 할당 — Module.deinit 시 graph 가 free.
+    ///   - **inner `[]const u8`** (각 파일 경로): plugin 책임. source slice 참조, static literal,
+    ///     또는 plugin 자체 lifetime — 무엇이든 OK. graph 는 free 안 함.
+    ///
+    /// null 반환: 이 plugin 이 처리 안 함 (다음 plugin 시도 또는 graph 가 diagnostic emit).
+    /// 빈 슬라이스 `&.{}`: "매칭 0개 (empty context)" — 정상 동작.
+    resolveContext: ResolveContextFn = null,
 
     // ─── AST 훅 (transformer 내부에서 AST 노드 방문 시 호출) ───
 
@@ -139,6 +166,27 @@ pub const PluginRunner = struct {
         for (self.plugins) |p| {
             if (p.resolveId) |hook| {
                 if (try hook(p.context, specifier, importer, allocator)) |result| {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// resolveContext: first 모드 — 첫 번째 non-null 반환값 사용. (#1579 Phase 2)
+    /// 모든 플러그인이 null 반환 시 null (graph 가 diagnostic 으로 처리).
+    pub fn runResolveContext(
+        self: *const PluginRunner,
+        dir: []const u8,
+        recursive: bool,
+        filter_pattern: ?[]const u8,
+        filter_flags: ?[]const u8,
+        importer: []const u8,
+        allocator: std.mem.Allocator,
+    ) PluginError!?[]const []const u8 {
+        for (self.plugins) |p| {
+            if (p.resolveContext) |hook| {
+                if (try hook(p.context, dir, recursive, filter_pattern, filter_flags, importer, allocator)) |result| {
                     return result;
                 }
             }

--- a/src/bundler/require_context_resolve_test.zig
+++ b/src/bundler/require_context_resolve_test.zig
@@ -1,0 +1,368 @@
+//! require.context Phase 2 — host plugin (resolveContext) hook + graph diagnostic 테스트.
+//! Reference: glob 의 expandGlobRecords + codegen inline expansion 모델.
+//! Phase 2 산출물:
+//!   1. Plugin.resolveContext hook 정의 + PluginRunner.runResolveContext
+//!   2. expandRequireContextRecords (plugin hook 호출 + record.context_matches 채움)
+//!   3. record.context_invalid_reason → BundlerDiagnostic.require_context_invalid
+//!   4. plugin 미구현 → BundlerDiagnostic.require_context_no_handler (warning)
+//!   5. graph resolve loop 에서 require_context kind skip (glob 와 동일)
+//!
+//! 매칭 후 dep 등록 / 가상 모듈 emit 은 Phase 3.
+
+const std = @import("std");
+const types = @import("types.zig");
+const ImportRecord = types.ImportRecord;
+const ImportKind = types.ImportKind;
+const plugin_mod = @import("plugin.zig");
+const Plugin = plugin_mod.Plugin;
+const PluginRunner = plugin_mod.PluginRunner;
+const PluginError = plugin_mod.PluginError;
+const ModuleGraph = @import("graph.zig").ModuleGraph;
+const Span = @import("../lexer/token.zig").Span;
+const writeFile = @import("test_helpers.zig").writeFile;
+const resolve_cache_mod = @import("resolve_cache.zig");
+
+// ============================================================
+// A. PluginRunner.runResolveContext — pure unit
+// ============================================================
+
+const RecordedCall = struct {
+    var dir_buf: [256]u8 = undefined;
+    var dir_len: usize = 0;
+    var recursive: bool = false;
+    var filter: ?[]const u8 = null;
+    var flags: ?[]const u8 = null;
+    var importer_buf: [256]u8 = undefined;
+    var importer_len: usize = 0;
+    var call_count: u32 = 0;
+
+    fn reset() void {
+        dir_len = 0;
+        recursive = false;
+        filter = null;
+        flags = null;
+        importer_len = 0;
+        call_count = 0;
+    }
+
+    fn dir() []const u8 {
+        return dir_buf[0..dir_len];
+    }
+    fn importer() []const u8 {
+        return importer_buf[0..importer_len];
+    }
+};
+
+fn captureCallback(
+    _: ?*anyopaque,
+    dir: []const u8,
+    recursive: bool,
+    filter_pattern: ?[]const u8,
+    filter_flags: ?[]const u8,
+    importer: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    RecordedCall.call_count += 1;
+    RecordedCall.dir_len = @min(dir.len, RecordedCall.dir_buf.len);
+    @memcpy(RecordedCall.dir_buf[0..RecordedCall.dir_len], dir[0..RecordedCall.dir_len]);
+    RecordedCall.recursive = recursive;
+    RecordedCall.filter = filter_pattern;
+    RecordedCall.flags = filter_flags;
+    RecordedCall.importer_len = @min(importer.len, RecordedCall.importer_buf.len);
+    @memcpy(RecordedCall.importer_buf[0..RecordedCall.importer_len], importer[0..RecordedCall.importer_len]);
+
+    return try allocator.alloc([]const u8, 0); // 매칭 0개 (capture 만 검증)
+}
+
+fn matchingCallback(
+    _: ?*anyopaque,
+    _: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    _: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    const result = try allocator.alloc([]const u8, 3);
+    result[0] = "./a.tsx";
+    result[1] = "./b.tsx";
+    result[2] = "./c.tsx";
+    return result;
+}
+
+fn nullCallback(
+    _: ?*anyopaque,
+    _: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    _: []const u8,
+    _: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    return null;
+}
+
+fn errorCallback(
+    _: ?*anyopaque,
+    _: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    _: []const u8,
+    _: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    return error.PluginFailed;
+}
+
+test "runResolveContext: empty plugins → null" {
+    const runner = PluginRunner.init(&.{});
+    const result = try runner.runResolveContext("./pages", true, null, null, "/tmp/foo.ts", std.testing.allocator);
+    try std.testing.expect(result == null);
+}
+
+test "runResolveContext: plugin without hook → null" {
+    const plugins = [_]Plugin{.{ .name = "noop" }};
+    const runner = PluginRunner.init(&plugins);
+    const result = try runner.runResolveContext("./pages", true, null, null, "/tmp/foo.ts", std.testing.allocator);
+    try std.testing.expect(result == null);
+}
+
+test "runResolveContext: hook called with all args propagated" {
+    RecordedCall.reset();
+    const plugins = [_]Plugin{.{ .name = "capture", .resolveContext = captureCallback }};
+    const runner = PluginRunner.init(&plugins);
+    const result = try runner.runResolveContext("./app", true, "\\.tsx?$", "i", "/proj/index.ts", std.testing.allocator);
+    try std.testing.expect(result != null);
+    defer std.testing.allocator.free(result.?);
+
+    try std.testing.expectEqual(@as(u32, 1), RecordedCall.call_count);
+    try std.testing.expectEqualStrings("./app", RecordedCall.dir());
+    try std.testing.expectEqual(true, RecordedCall.recursive);
+    try std.testing.expectEqualStrings("\\.tsx?$", RecordedCall.filter.?);
+    try std.testing.expectEqualStrings("i", RecordedCall.flags.?);
+    try std.testing.expectEqualStrings("/proj/index.ts", RecordedCall.importer());
+}
+
+test "runResolveContext: first non-null wins (multiple plugins)" {
+    const plugins = [_]Plugin{
+        .{ .name = "null", .resolveContext = nullCallback },
+        .{ .name = "match", .resolveContext = matchingCallback },
+        .{ .name = "should-not-call", .resolveContext = matchingCallback },
+    };
+    const runner = PluginRunner.init(&plugins);
+    const result = try runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator);
+    try std.testing.expect(result != null);
+    defer std.testing.allocator.free(result.?);
+    try std.testing.expectEqual(@as(usize, 3), result.?.len);
+}
+
+test "runResolveContext: all plugins null → null" {
+    const plugins = [_]Plugin{
+        .{ .name = "null1", .resolveContext = nullCallback },
+        .{ .name = "null2", .resolveContext = nullCallback },
+    };
+    const runner = PluginRunner.init(&plugins);
+    const result = try runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator);
+    try std.testing.expect(result == null);
+}
+
+test "runResolveContext: plugin returns empty slice (matched 0 files) — valid" {
+    RecordedCall.reset();
+    const plugins = [_]Plugin{.{ .name = "empty", .resolveContext = captureCallback }};
+    const runner = PluginRunner.init(&plugins);
+    const result = try runner.runResolveContext("./empty-dir", true, null, null, "/proj/index.ts", std.testing.allocator);
+    try std.testing.expect(result != null);
+    defer std.testing.allocator.free(result.?);
+    try std.testing.expectEqual(@as(usize, 0), result.?.len);
+}
+
+test "runResolveContext: plugin error propagated" {
+    const plugins = [_]Plugin{.{ .name = "err", .resolveContext = errorCallback }};
+    const runner = PluginRunner.init(&plugins);
+    try std.testing.expectError(
+        error.PluginFailed,
+        runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator),
+    );
+}
+
+// ============================================================
+// B. ImportRecord.context_matches 필드 + 기본값
+// ============================================================
+
+test "ImportRecord: context_matches default is null" {
+    const r = ImportRecord{
+        .specifier = "./pages",
+        .kind = .require_context,
+        .span = Span.EMPTY,
+    };
+    try std.testing.expect(r.context_matches == null);
+}
+
+test "ImportRecord: context_matches can be assigned slice" {
+    const matches = [_][]const u8{ "./a.tsx", "./b.tsx" };
+    const r = ImportRecord{
+        .specifier = "./pages",
+        .kind = .require_context,
+        .span = Span.EMPTY,
+        .context_matches = &matches,
+    };
+    try std.testing.expect(r.context_matches != null);
+    try std.testing.expectEqual(@as(usize, 2), r.context_matches.?.len);
+}
+
+test "ImportRecord: context_matches empty slice is valid (matched 0)" {
+    const matches: []const []const u8 = &.{};
+    const r = ImportRecord{
+        .specifier = "./empty",
+        .kind = .require_context,
+        .span = Span.EMPTY,
+        .context_matches = matches,
+    };
+    try std.testing.expect(r.context_matches != null);
+    try std.testing.expectEqual(@as(usize, 0), r.context_matches.?.len);
+}
+
+// ============================================================
+// C. BundlerDiagnostic.ErrorCode 확장
+// ============================================================
+
+test "BundlerDiagnostic.ErrorCode: require_context_invalid exists" {
+    const code: types.BundlerDiagnostic.ErrorCode = .require_context_invalid;
+    _ = code;
+}
+
+test "BundlerDiagnostic.ErrorCode: require_context_no_handler exists" {
+    const code: types.BundlerDiagnostic.ErrorCode = .require_context_no_handler;
+    _ = code;
+}
+
+// ============================================================
+// D. Graph integration — require.context 가 dep 로 안 들어감 + diagnostic
+// ============================================================
+
+fn dirPath(tmp: *std.testing.TmpDir) ![]const u8 {
+    return try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+}
+
+test "graph: require.context invalid_reason → require_context_invalid diagnostic" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // require.context(42) — invalid (numeric directory)
+    try writeFile(tmp.dir, "index.ts", "const ctx = require.context(42);");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    var has_invalid_diag = false;
+    for (graph.diagnostics.items) |d| {
+        if (d.code == .require_context_invalid) {
+            has_invalid_diag = true;
+            break;
+        }
+    }
+    try std.testing.expect(has_invalid_diag);
+}
+
+test "graph: require.context valid + no plugin → require_context_no_handler diagnostic" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "index.ts", "const ctx = require.context('./pages', true, /\\.tsx?$/, 'sync');");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    var has_no_handler_diag = false;
+    for (graph.diagnostics.items) |d| {
+        if (d.code == .require_context_no_handler) {
+            has_no_handler_diag = true;
+            break;
+        }
+    }
+    try std.testing.expect(has_no_handler_diag);
+}
+
+test "graph: require.context with plugin → context_matches populated, no diagnostic" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "index.ts", "const ctx = require.context('./pages', true, /\\.tsx?$/, 'sync');");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    const plugins = [_]Plugin{.{ .name = "match", .resolveContext = matchingCallback }};
+    graph.plugins = &plugins;
+
+    try graph.build(&.{entry});
+
+    // record.context_matches 채워졌는지 확인. 메모리는 module.deinit 가 자동 free.
+    var found_matches = false;
+    for (graph.modules.items) |m| {
+        for (m.import_records) |r| {
+            if (r.kind == .require_context and r.context_matches != null and r.context_matches.?.len == 3) {
+                found_matches = true;
+            }
+        }
+    }
+    try std.testing.expect(found_matches);
+
+    // require_context 관련 diagnostic 없어야
+    for (graph.diagnostics.items) |d| {
+        try std.testing.expect(d.code != .require_context_invalid);
+        try std.testing.expect(d.code != .require_context_no_handler);
+    }
+}
+
+test "graph: require.context kind skipped in resolve loop (no module_not_found)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // require.context 의 specifier ('./nonexistent-dir') 가 일반 require 였으면 unresolved.
+    // require_context 는 skip 되어야 하므로 unresolved_import diagnostic 안 나와야.
+    try writeFile(tmp.dir, "index.ts", "const ctx = require.context('./nonexistent-dir');");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    // require.context 가 일반 resolve 경로 안 탐 → unresolved_import 없음.
+    // (require_context_no_handler 는 plugin 없어서 나올 수 있음 — 그건 OK)
+    for (graph.diagnostics.items) |d| {
+        try std.testing.expect(d.code != .unresolved_import);
+    }
+}

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -412,6 +412,10 @@ pub const ImportRecord = struct {
     /// require.context: invalid arguments 발견 시 reason. graph 단계에서 BundlerDiagnostic 으로
     /// 변환되어 사용자에게 표시. null 이면 valid.
     context_invalid_reason: ?[]const u8 = null,
+    /// require.context: 매칭된 파일 목록. host plugin (`resolveContext`) 또는 내장 fallback 이
+    /// graph 단계에서 채운다. codegen 이 이 목록을 보고 webpackContext 함수를 emit (Phase 3).
+    /// null = 아직 평가 안 됨, &.{} = 매칭 0개 (empty context).
+    context_matches: ?[]const []const u8 = null,
 };
 
 // ============================================================
@@ -455,6 +459,10 @@ pub const BundlerDiagnostic = struct {
         json_parse_error,
         /// 확장자에 대한 로더 미설정 (esbuild 호환: "No loader is configured for ...")
         no_loader,
+        /// require.context 인자가 invalid (Phase 1 의 context_invalid_reason 노출). #1579
+        require_context_invalid,
+        /// require.context 매칭 핸들러 미구현 (host plugin resolveContext hook 없음). #1579 / #1771
+        require_context_no_handler,
     };
 
     pub const Severity = enum {

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -874,14 +874,16 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                 });
 
                 // Inline scan: require("specifier") → CJS import record
+                const call_span = Span{ .start = expr_start, .end = self.currentSpan().start };
                 if (self.enable_scan) {
                     scanRequireCall(self, expr, arg_list);
                     scanGlobCall(self, expr, arg_list);
+                    scanRequireContextCall(self, expr, arg_list, call_span);
                 }
 
                 expr = try self.ast.addNode(.{
                     .tag = .call_expression,
-                    .span = .{ .start = expr_start, .end = self.currentSpan().start },
+                    .span = call_span,
                     .data = .{ .extra = call_extra },
                 });
             },
@@ -2245,6 +2247,32 @@ fn scanGlobCall(self: *Parser, callee: NodeIndex, arg_list: NodeList) void {
         .glob_eager = opts.eager,
         .glob_import_name = opts.import_name,
     }) catch {};
+}
+
+/// require.context(...) 호출을 감지하여 require_context 레코드를 생성한다. (#1579)
+/// inline scan 시점에는 call_expression 노드가 아직 안 만들어져 있어 callee+args 직접 전달.
+/// import_scanner.tryExtractRequireContextFromCallee 에 위임 후 ScanImportRecord 로 변환.
+fn scanRequireContextCall(self: *Parser, callee: NodeIndex, arg_list: NodeList, call_span: Span) void {
+    const ir = import_scanner.tryExtractRequireContextFromCallee(
+        &self.ast,
+        callee,
+        arg_list.start,
+        arg_list.len,
+        call_span,
+    ) orelse return;
+
+    const mode: scan_results_mod.RequireContextMode = @enumFromInt(@intFromEnum(ir.context_mode));
+    self.scan_import_records.append(self.allocator, .{
+        .specifier = ir.specifier,
+        .kind = .require_context,
+        .span = ir.span,
+        .context_recursive = ir.context_recursive,
+        .context_filter = ir.context_filter,
+        .context_filter_flags = ir.context_filter_flags,
+        .context_mode = mode,
+        .context_invalid_reason = ir.context_invalid_reason,
+    }) catch {};
+    self.scan_result.has_cjs_require = true;
 }
 
 /// assignment_expression의 left에서 module.exports = ... / exports.x = ... 패턴을 감지한다.

--- a/src/parser/scan_results.zig
+++ b/src/parser/scan_results.zig
@@ -18,6 +18,15 @@ pub const ImportKind = enum {
     require,
     worker,
     glob,
+    require_context,
+};
+
+/// require.context mode — bundler types.RequireContextMode와 1:1.
+pub const RequireContextMode = enum {
+    sync,
+    eager,
+    lazy,
+    lazy_once,
 };
 
 /// 파서가 수집하는 import 레코드. bundler ImportRecord의 경량 버전.
@@ -34,6 +43,16 @@ pub const ScanImportRecord = struct {
     glob_eager: bool = false,
     /// import.meta.glob: named export 추출 (e.g., "setup")
     glob_import_name: ?[]const u8 = null,
+    /// require.context: recursive 인자 (default true). #1579
+    context_recursive: bool = true,
+    /// require.context: filter regex 패턴 본문 (slashes 제외)
+    context_filter: ?[]const u8 = null,
+    /// require.context: filter regex flags
+    context_filter_flags: ?[]const u8 = null,
+    /// require.context: 매칭 mode (default sync)
+    context_mode: RequireContextMode = .sync,
+    /// require.context: invalid 인자 reason (graph 가 BundlerDiagnostic 으로 변환)
+    context_invalid_reason: ?[]const u8 = null,
 };
 
 /// import 바인딩 종류.


### PR DESCRIPTION
## 배경

[#1579](https://github.com/ohah/zts/issues/1579) Phase 2. Phase 1 ([#1770](https://github.com/ohah/zts/pull/1770) 머지됨) 이 AST 인지 + literal 평가까지 했다면, Phase 2 는 그 record 가 graph 단계에서 매칭 결과를 받아 처리되도록.

## 핵심 architectural 결정 — host runtime regex 위임

ZTS 의 `src/regexp/` 모듈은 validator + parser + AST 까지만, **regex executor 가 없음**. require.context filter 매칭 (예: Expo Router 의 negative lookahead 패턴) 에 ECMAScript regex 호환 executor 필수. 검토한 옵션:

| 옵션 | 결정 |
| --- | --- |
| ZTS 자체 regex executor 구현 | 별도 epic — [#1771](https://github.com/ohah/zts/issues/1771) 로 분리 (수개월) |
| PCRE2 외부 link | #1771 의 권장 옵션 (~2주, 95~98% ECMAScript 호환) |
| Rust regex / RE2 | lookaround 미지원 → ECMAScript 비호환 |
| JSC YARR 추출 / V8 Irregexp | 의존 얽힘으로 사실상 불가 |
| **host runtime regex 위임** ⭐ | **이번 PR 의 결정**. Metro/webpack/Expo 의 검증된 모델 |

webpack/Metro 모두 결국 Node V8 의 RegExp 로 매칭. Bungae 가 Bun JSC 의 RegExp 를 빌려쓰는 패턴이 자연. ZTS 는 인지/메타만, host 는 매칭/스캔.

## 산출물

### 1. Plugin hook (`Plugin.resolveContext`)
```zig
resolveContext: ?*const fn (
    ctx: ?*anyopaque,
    dir: []const u8,
    recursive: bool,
    filter_pattern: ?[]const u8,
    filter_flags: ?[]const u8,
    importer: []const u8,
    allocator: std.mem.Allocator,
) PluginError!?[]const []const u8 = null,
```
- **mode 인자 미포함**: Metro/webpack 모두 매칭에 mode 영향 없음. mode 는 codegen 단계의 chunk 분할 결정만 좌우 → `record.context_mode` 로 Phase 3 에서 활용.
- first non-null wins (`resolveId`/`load` 와 동일 패턴)
- `PluginRunner.runResolveContext` 추가

### 2. graph 단계 처리 (`expandRequireContextRecords`)
- `scanWorker` / `resolveModuleImports` 두 worker 양쪽에서 호출 (glob 와 동일 모델)
- `record.context_invalid_reason` → `require_context_invalid` (error) diagnostic
- plugin 결과 → `record.context_matches` 에 저장
- plugin 미구현 → `require_context_no_handler` (warning) diagnostic
- **멱등성**: `context_matches != null` 이면 skip. 두 worker 중복 호출 + invalid/no_handler 도 empty slice 마킹으로 안전

### 3. Memory ownership (명확화)
- `context_matches` **outer slice** = graph allocator 소유, `Module.deinit` 시 free
- **inner `[]const u8`** = plugin 책임 (source slice / static literal / plugin 자체 lifetime)

### 4. ImportRecord + ErrorCode 확장
- `ImportRecord.context_matches: ?[]const []const u8 = null`
- `BundlerDiagnostic.ErrorCode.require_context_invalid`, `require_context_no_handler`

## 부수 fix — Phase 1 parser inline scan 누락

Phase 1 의 `tryExtractRequireContext` 가 `import_scanner.extractImportsWithCjsDetection` 경로에서만 호출되고, **.ts 모듈의 parser inline scan (`parser.scan_import_records`) 에선 미호출**이었음. 결과적으로 일반 .ts 파일의 `require.context` 가 graph 에 record 로 들어가지 않음 (단위 테스트는 `import_scanner` 직접 호출이라 통과했지만 실 동작 X — Phase 2 통합 테스트로 발견).

Phase 2 안에서 같이 fix:
- `import_scanner.tryExtractRequireContextFromCallee` 분리 — call_expression 노드 생성 *전* 호출 가능하도록 callee+args 직접 받음
- `parser/expression.zig` 의 `scanRequireContextCall` 추가 (`scanRequireCall`/`scanGlobCall` 옆), scan loop hook
- `parser/scan_results.zig` 에 `RequireContextMode` enum + 5 context_* 필드 추가
- `graph.zig:1099` ScanRecord → ImportRecord 변환에 5 필드 복사 추가

## Tests

`src/bundler/require_context_resolve_test.zig` (신규, 16 케이스):

| 섹션 | 케이스 |
| --- | --- |
| A. `PluginRunner.runResolveContext` unit | 7 (empty / no-hook / args propagated / first-non-null / all-null / empty-slice / error) |
| B. `ImportRecord.context_matches` 필드 | 3 |
| C. `BundlerDiagnostic.ErrorCode` 확장 | 2 |
| D. Graph integration | 4 (invalid → diagnostic / no plugin → no_handler / with plugin → matches populated / require_context kind skipped in resolve loop) |

전체 테스트 통과 + 누수 0.

## /simplify 적용

두 라운드 모두 적용:
- `mode` 파라미터 제거 (Phase 1 의 정책 — 매칭 자체엔 mode 무관)
- `ResolveContextFn` typedef
- `RequireContextMode` import 중복 제거
- 메모리 누수 fix (`Module.deinit` 에 `context_matches` free)
- 멱등성 guard (중복 호출 시 plugin 재호출 + diag 중복 방지)
- Plugin contract doc 명확화 (outer = graph, inner = plugin)

## 비범위 (별도 PR)

- **Phase 2.5** — NAPI bridge: `packages/core` 의 `BundleOptions` 에 `resolveContext` callback 노출 + Zig `Plugin.resolveContext` 로 wiring. bungae JS plugin 이 사용하는 진입점.
- **Phase 3** — 가상 모듈 emit + `webpackContext` runtime template (codegen 이 `record.context_matches` 보고 inline expansion. glob 의 `codegen.zig:1944` 모델 mirror).
- **bungae 측 PR** — JS plugin 구현 (`fs.readdirSync` + Bun JSC `RegExp.test`).

## 관련

- #1579 require.context 메인 트래킹
- #1582 Expo 로드맵 (Tier 2)
- #1769 Phase 1 follow-up
- #1771 regex executor epic (PCRE2 link 또는 자체 구현 — 이 PR 의 host 위임을 default → fallback 으로 강등하는 점진적 마이그레이션 경로 명시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)