### PR TITLE
feat(parser): #1579 Phase 2.6 — define table evaluator for require.context (process.env.X)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -660,6 +660,8 @@ pub const Bundler = struct {
         var graph_scope = profile.begin(.graph);
         var graph = ModuleGraph.init(self.allocator, self.getResolveCache());
         graph.dev_mode = self.options.dev_mode;
+        // require.context 등 parser inline scan 의 build-time 정적 평가에 사용 (#1579 Phase 2.6)
+        graph.defines = self.options.define;
         // #1621: binary loader 의 `$tb(...)` 축약 활성화.
         graph.minify_whitespace = self.options.minify_whitespace;
         graph.loader_overrides = self.options.loader_overrides;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -69,6 +69,9 @@ pub const ModuleGraph = struct {
 
     /// dev mode: HMR을 위해 모든 모듈을 강제 래핑 (__esm).
     dev_mode: bool = false,
+    /// build-time 정적 평가 entries. parser inline scan (require.context 등 #1579 Phase 2.6) 활용.
+    /// bundler 가 BundleOptions.define 으로 설정. transformer 의 define 치환과 동일 entries.
+    defines: []const @import("../parser/scan_results.zig").DefineEntry = &.{},
     /// #1621: binary loader 가 생성하는 `__toBinary(...)` 소스에서 축약 이름 사용.
     /// bundler 에서 self.options.minify_whitespace 를 주입.
     minify_whitespace: bool = false,
@@ -1000,6 +1003,8 @@ pub const ModuleGraph = struct {
         }
         // Inline scanning: 파서가 AST를 구축하면서 import/export 레코드를 동시 수집
         parser.enable_scan = true;
+        // require.context 등 build-time 정적 평가용 define entries 전달 (#1579 Phase 2.6)
+        parser.scan_defines = self.defines;
         setup_scope.end();
         _ = parser.parse() catch {
             self.addDiag(.parse_error, .@"error", module.path, Span.EMPTY, .parse, "Parse failed", null);

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -30,6 +30,8 @@ const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const CallFlags = @import("../parser/ast.zig").CallFlags;
 const MemberFlags = @import("../parser/ast.zig").MemberFlags;
+const scan_results = @import("../parser/scan_results.zig");
+const DefineEntry = scan_results.DefineEntry;
 const Span = @import("../lexer/token.zig").Span;
 const types = @import("types.zig");
 const ImportRecord = types.ImportRecord;
@@ -52,6 +54,16 @@ pub const ScanResult = struct {
 /// AST를 순회하여 import/export/require를 추출하고 CJS 신호를 감지한다.
 /// ESM과 CJS 판별에 필요한 모든 정보를 한 번의 순회로 수집.
 pub fn extractImportsWithCjsDetection(allocator: std.mem.Allocator, ast: *const Ast) !ScanResult {
+    return extractImportsWithCjsDetectionAndDefines(allocator, ast, &.{});
+}
+
+/// `extractImportsWithCjsDetection` 의 defines 받는 버전. (#1579 Phase 2.6)
+/// require.context 의 `process.env.X` 같은 인자를 build-time 정적 평가.
+pub fn extractImportsWithCjsDetectionAndDefines(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    defines: []const DefineEntry,
+) !ScanResult {
     var records: std.ArrayList(ImportRecord) = .empty;
     var has_esm_syntax = false;
     var has_cjs_require = false;
@@ -89,7 +101,7 @@ pub fn extractImportsWithCjsDetection(allocator: std.mem.Allocator, ast: *const 
             .call_expression => {
                 // Order: require.context (specific, callee=member) → require (callee=ident) → glob (callee=meta).
                 // 더 specific 한 패턴 먼저 시도해야 일반 require 가 require.context 를 가리지 않는다.
-                if (tryExtractRequireContext(ast, node)) |record| {
+                if (tryExtractRequireContextWithDefines(ast, node, defines)) |record| {
                     has_cjs_require = true;
                     try records.append(allocator, record);
                 } else if (tryExtractRequire(ast, node)) |record| {
@@ -214,9 +226,17 @@ fn tryExtractDynamicImport(ast: *const Ast, node: Node) ?ImportRecord {
 /// `tryExtractGlob` 와 같은 모양. Reference: Metro `processRequireContextCall`
 /// (`metro/src/ModuleGraph/worker/collectDependencies.js`).
 pub fn tryExtractRequireContext(ast: *const Ast, node: Node) ?ImportRecord {
+    return tryExtractRequireContextWithDefines(ast, node, &.{});
+}
+
+/// `tryExtractRequireContext` 의 defines 받는 버전. (#1579 Phase 2.6)
+pub fn tryExtractRequireContextWithDefines(
+    ast: *const Ast,
+    node: Node,
+    defines: []const DefineEntry,
+) ?ImportRecord {
     if (node.tag != .call_expression) return null;
     const e = node.data.extra;
-    // call_expression extra: [callee, args_start, args_len, flags]
     if (!ast.hasExtra(e, 3)) return null;
 
     const callee_idx = ast.readExtraNode(e, 0);
@@ -224,20 +244,22 @@ pub fn tryExtractRequireContext(ast: *const Ast, node: Node) ?ImportRecord {
     const args_len = ast.readExtra(e, 2);
     const call_flags = ast.readExtra(e, 3);
 
-    // `require?.context(...)` 무시
     if (call_flags & CallFlags.optional_chain != 0) return null;
 
-    return tryExtractRequireContextFromCallee(ast, callee_idx, args_start, args_len, node.span);
+    return tryExtractRequireContextFromCallee(ast, callee_idx, args_start, args_len, node.span, defines);
 }
 
 /// `tryExtractRequireContext` 의 callee+args 직접 받는 변형. (#1579 Phase 2)
 /// parser inline scan (call_expression 노드 만들기 *전*에 호출) 에서 사용.
+/// `defines`: build-time 정적 평가용 — `process.env.X` 같은 member chain 을 string 으로
+/// 평가 (Metro `path.evaluate()` 와 동등 능력). 비어있으면 evaluator 가 literal 만 처리. (#1579 Phase 2.6)
 pub fn tryExtractRequireContextFromCallee(
     ast: *const Ast,
     callee_idx: NodeIndex,
     args_start: u32,
     args_len: u32,
     call_span: Span,
+    defines: []const DefineEntry,
 ) ?ImportRecord {
     if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return null;
     const callee = ast.getNode(callee_idx);
@@ -298,10 +320,10 @@ pub fn tryExtractRequireContextFromCallee(
         }
     }
 
-    // arg[0]: directory (string literal, 필수)
+    // arg[0]: directory (string literal 또는 define-replaced string, 필수)
     {
         const arg_idx = ast.readExtraNode(args_start, 0);
-        if (getStringLiteralText(ast, arg_idx)) |s| {
+        if (evalToString(ast, arg_idx, defines)) |s| {
             record.specifier = s;
         } else {
             record.context_invalid_reason = "require.context first argument must be a string literal (directory)";
@@ -351,7 +373,7 @@ pub fn tryExtractRequireContextFromCallee(
         const arg_node = ast.getNode(arg_idx);
         if (isUndefinedLiteral(ast, arg_node)) {
             // default sync 유지
-        } else if (getStringLiteralText(ast, arg_idx)) |mode_str| {
+        } else if (evalToString(ast, arg_idx, defines)) |mode_str| {
             const mode = parseRequireContextMode(mode_str) orelse {
                 record.context_invalid_reason = "require.context fourth argument must be 'sync', 'eager', 'lazy', or 'lazy-once'";
                 return record;
@@ -364,6 +386,48 @@ pub fn tryExtractRequireContextFromCallee(
     }
 
     return record;
+}
+
+/// Identifier / member access / string literal 을 string 으로 정적 평가. (#1579 Phase 2.6)
+/// - `string_literal` → text (quotes 제거)
+/// - `identifier_reference` / `static_member_expression` → defines lookup 후 unquoted string
+/// - 그 외 → null (evaluator 가 처리 못하는 표현식)
+///
+/// Metro `path.evaluate()` 와 동등 능력 — `process.env.NODE_ENV` 같은 build-time 상수 평가.
+fn evalToString(ast: *const Ast, idx: NodeIndex, defines: []const DefineEntry) ?[]const u8 {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+
+    // 1. String literal — 직접 추출
+    if (getStringLiteralText(ast, idx)) |s| return s;
+
+    // 2. Identifier 또는 member access — defines lookup
+    if (defines.len == 0) return null;
+    const node = ast.getNode(idx);
+    const text = switch (node.tag) {
+        .identifier_reference, .static_member_expression => ast.getText(node.span),
+        else => return null,
+    };
+    for (defines) |def| {
+        if (std.mem.eql(u8, def.key, text)) {
+            return parseDefineStringValue(def.value);
+        }
+    }
+    return null;
+}
+
+/// Define value 가 quoted JS string (`"..."`, `'...'`, `` `...` `` template) 이면 unquote.
+/// 기타 (bool/number/표현식) 은 null — 호출자가 string 컨텍스트가 아니라고 판정.
+fn parseDefineStringValue(value: []const u8) ?[]const u8 {
+    if (value.len < 2) return null;
+    const first = value[0];
+    const last = value[value.len - 1];
+    if ((first == '"' and last == '"') or
+        (first == '\'' and last == '\'') or
+        (first == '`' and last == '`'))
+    {
+        return value[1 .. value.len - 1];
+    }
+    return null;
 }
 
 /// `undefined` identifier 리터럴 여부. 글로벌 undefined 가 가려진 경우는 무시 (관례).

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -894,6 +894,123 @@ test "require.context: Expo Router _ctx.ios.js pattern (filter regex with negati
 
 // ─── L. Edge — JSX/TSX 컨텍스트 ──────────────────────────
 
+// ─── P. Define table evaluator (#1579 Phase 2.6) ─────────
+
+const DefineEntry = @import("../parser/scan_results.zig").DefineEntry;
+
+fn parseAndExtractWithDefines(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    defines: []const DefineEntry,
+) ![]ImportRecord {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var scanner = try Scanner.init(arena_alloc, source);
+    var parser = Parser.init(arena_alloc, &scanner);
+    parser.is_module = true;
+    scanner.is_module = true;
+    parser.scan_defines = defines;
+    _ = try parser.parse();
+
+    const result = try import_scanner.extractImportsWithCjsDetectionAndDefines(allocator, &parser.ast, defines);
+    return result.records;
+}
+
+test "require.context: process.env.X with define → string literal evaluation" {
+    const defines = [_]DefineEntry{
+        .{ .key = "process.env.EXPO_ROUTER_APP_ROOT", .value = "\"./app\"" },
+    };
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithDefines(
+        alloc,
+        "require.context(process.env.EXPO_ROUTER_APP_ROOT, true, /\\.tsx?$/, 'sync');",
+        &defines,
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./app", true, "\\.tsx?$", null, .sync);
+}
+
+test "require.context: process.env.X without define → invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithDefines(
+        alloc,
+        "require.context(process.env.EXPO_ROUTER_APP_ROOT, true, /.*/, 'sync');",
+        &.{},
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: process.env mode with define" {
+    const defines = [_]DefineEntry{
+        .{ .key = "process.env.EXPO_ROUTER_IMPORT_MODE", .value = "\"eager\"" },
+    };
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithDefines(
+        alloc,
+        "require.context('./app', true, /.*/, process.env.EXPO_ROUTER_IMPORT_MODE);",
+        &defines,
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./app", true, ".*", null, .eager);
+}
+
+test "require.context: identifier reference with define" {
+    const defines = [_]DefineEntry{
+        .{ .key = "MY_DIR", .value = "\"./pages\"" },
+    };
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithDefines(
+        alloc,
+        "require.context(MY_DIR);",
+        &defines,
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try expectValidContext(r, "./pages", true, null, null, .sync);
+}
+
+test "require.context: define with non-string value (bool) → invalid" {
+    // value 가 quoted string 아니므로 evaluator 가 매칭 못 함
+    const defines = [_]DefineEntry{
+        .{ .key = "MY_FLAG", .value = "true" },
+    };
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithDefines(
+        alloc,
+        "require.context(MY_FLAG);",
+        &defines,
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expect(r.context_invalid_reason != null);
+}
+
+test "require.context: Expo Router _ctx.ios.js full pattern with defines" {
+    const defines = [_]DefineEntry{
+        .{ .key = "process.env.EXPO_ROUTER_APP_ROOT", .value = "\"./app\"" },
+        .{ .key = "process.env.EXPO_ROUTER_IMPORT_MODE", .value = "\"sync\"" },
+    };
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithDefines(
+        alloc,
+        "export const ctx = require.context(process.env.EXPO_ROUTER_APP_ROOT, true, /^(?:\\.\\/)(?!.*\\+api).*\\.[tj]sx?$/, process.env.EXPO_ROUTER_IMPORT_MODE);",
+        &defines,
+    );
+    defer alloc.free(records);
+    const r = findContextRecord(records) orelse return error.TestExpectedRecord;
+    try std.testing.expectEqual(ImportKind.require_context, r.kind);
+    try std.testing.expect(r.context_invalid_reason == null);
+    try std.testing.expectEqualStrings("./app", r.specifier);
+    try std.testing.expectEqual(true, r.context_recursive);
+    try std.testing.expectEqual(RequireContextMode.sync, r.context_mode);
+}
+
 test "require.context: inside JSX expression container" {
     const alloc = std.testing.allocator;
     var arena = std.heap.ArenaAllocator.init(alloc);

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -2259,6 +2259,7 @@ fn scanRequireContextCall(self: *Parser, callee: NodeIndex, arg_list: NodeList, 
         arg_list.start,
         arg_list.len,
         call_span,
+        self.scan_defines,
     ) orelse return;
 
     const mode: scan_results_mod.RequireContextMode = @enumFromInt(@intFromEnum(ir.context_mode));

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -74,6 +74,11 @@ pub const Parser = struct {
     /// Enable inline scanning. Set to true by bundler before parsing.
     enable_scan: bool = false,
 
+    /// Define entries — `process.env.X` 같은 member access 를 string literal 로 평가.
+    /// require.context 인자 평가 (Phase 2.6) 와 미래 build-time 정적 평가에 활용.
+    /// bundler 가 parse 전 설정. 비어있으면 evaluator 가 define lookup 안 함. (#1579)
+    scan_defines: []const scan_results_mod.DefineEntry = &.{},
+
     /// arrow 파라미터 중복 검사용 임시 이름 수집 버퍼.
     param_name_spans: std.ArrayList(Span),
 

--- a/src/parser/scan_results.zig
+++ b/src/parser/scan_results.zig
@@ -29,6 +29,16 @@ pub const RequireContextMode = enum {
     lazy_once,
 };
 
+/// Define entry — bundler/transformer 의 DefineEntry 와 동일 layout.
+/// parser 가 bundler dep 없이 정적 평가에 사용. (#1579 Phase 2.6)
+pub const DefineEntry = struct {
+    /// 키: `process.env.NODE_ENV` 같은 식별자/멤버 체인 텍스트.
+    key: []const u8,
+    /// 치환 값: JS 표현식 문자열. 예: `"\"production\""` (JSON 인용 string),
+    /// `"true"` (bool), `"42"` (number) 등. evaluator 가 형식별로 해석.
+    value: []const u8,
+};
+
 /// 파서가 수집하는 import 레코드. bundler ImportRecord의 경량 버전.
 pub const ScanImportRecord = struct {
     /// 원본 import 경로 (따옴표 제거됨, 소스 코드 참조)

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -62,10 +62,8 @@ const plugin_mod = @import("../bundler/plugin.zig");
 pub const Plugin = plugin_mod.Plugin;
 
 /// define 치환 엔트리. key=식별자 텍스트, value=치환 문자열.
-pub const DefineEntry = struct {
-    key: []const u8,
-    value: []const u8,
-};
+/// `parser.scan_results.DefineEntry` 와 동일 정의 — parser 의 inline scan 도 같은 entries 사용.
+pub const DefineEntry = @import("../parser/scan_results.zig").DefineEntry;
 
 /// 정규화 버퍼 크기. `process.env.NODE_ENV`류 식별자 체인은 훨씬 짧지만 여유.
 /// 초과 시 normalizeOptionalChain은 null을 반환해 치환을 스킵한다.


### PR DESCRIPTION
## 배경

[#1579](https://github.com/ohah/zts/issues/1579) Phase 2.6. Phase 2.5 ([#1773](https://github.com/ohah/zts/pull/1773)) 머지 후 ExpoApp 검증에서 발견된 새 블로커:

```
expo-router/_ctx.ios.js: require.context first argument must be a string literal
```

Expo Router 의 실제 fixture:
```js
export const ctx = require.context(
  process.env.EXPO_ROUTER_APP_ROOT,    // ← string literal 아님
  true,
  /^(?:\.\/)(?!.*\+api).*\.[tj]sx?$/,
  process.env.EXPO_ROUTER_IMPORT_MODE
);
```

`process.env.X` 가 raw 인 상태로 import_scanner 가 봄 → invalid 처리 → host plugin 호출 못함.

## Architectural 결정

Metro 의 babel chain 흐름:
```
babel-plugin-transform-define (먼저)
  process.env.EXPO_ROUTER_APP_ROOT → "./app"  (string literal 치환)
metro 의 collectDependencies (그 다음)
  require.context(...) 만남 → path.evaluate() 로 인자 평가
```

ZTS 는 single-pass 라 같은 chain 못 함. **import_scanner 의 평가 단계에 define table 참조** — Metro `path.evaluate()` 와 동등 능력.

대안 비교 (전부 검토):
| 옵션 | 위치 | 일관성 | 장기 활용 |
| --- | --- | --- | --- |
| **A** ZTS evaluator (이 PR) | 본체 인프라 | ✅ esbuild-like | ✅ Tier 3, dynamic import 패턴, constant folding 등 재사용 |
| B onLoad 부분 babel | bungae fixture별 hack | ❌ 누적 | ❌ 1회용 |
| C `_ctx` 통째 대체 | bungae | ❌ fragile | ❌ |
| D 전체 babel chain | bungae 모든 source | ❌ Metro 모델 (성능 ↓) | ✅ but ZTS 강점 손상 |

→ A 가 근본 + 미래 활용 ↑ (#1579 본문에 명시된 정상 경로).

## 산출물

### 1. `parser.scan_defines: []const DefineEntry`
- bundler 가 parse 전 설정. transformer 와 동일 entries
- `DefineEntry` 를 `transformer.zig` + `parser/scan_results.zig` 에 단일 정의 (parser 가 bundler dep 안 갖도록 scan_results 가 source, transformer 가 alias)

### 2. `import_scanner.evalToString(ast, idx, defines) ?[]const u8`
- string_literal → text
- identifier_reference / static_member_expression → defines lookup → unquoted string
- `parseDefineStringValue`: `"..."` / `'...'` / template → 내용 추출

### 3. `tryExtractRequireContextFromCallee` 의 arg[0] (dir), arg[3] (mode) 평가에 적용
- 시그니처에 `defines` 추가
- public wrappers: `tryExtractRequireContext` (defines 없음, back-compat) + `tryExtractRequireContextWithDefines` (신규, 명시적 defines)
- `extractImportsWithCjsDetectionAndDefines` 도 신규 (graph 가 호출)

### 4. `graph.defines` + parseModule 에서 `parser.scan_defines = self.defines` 전달
- `bundler.zig` 가 `BundleOptions.define` → `graph.defines` 직접 wiring

## Tests

`src/bundler/import_scanner_test.zig` (+6 케이스):

| 테스트 | 검증 |
| --- | --- |
| process.env.X with define | string literal 로 평가 |
| process.env.X without define | invalid (back-compat) |
| process.env mode (arg[3]) with define | mode enum |
| 단순 identifier (`MY_DIR`) with define | string literal 평가 |
| non-string define value (`true`) | invalid |
| Expo Router `_ctx.ios.js` 실제 패턴 | 모두 통과 (process.env 두 개 + 복잡 regex) |

전체 회귀 0.

## 실제 ExpoApp 검증

| 단계 | 결과 |
| --- | --- |
| Phase 2.5 머지 후 | `_ctx.ios.js: require.context first argument must be a string literal` |
| **Phase 2.6 + bungae define entries (지금)** | **해당 에러 완전 소멸**. require.context 가 정상 인지 + 평가 + bungae plugin 호출 |
| 남은 에러 | Tier 1.B/C (bungae resolver — `react-native-screens` subpath, try/catch optional require) — require.context 와 무관 |

## bungae 측 (별도 레포 PR)

`packages/bungae/src/bundler/zts-bundler/napi-build.ts` 에:
```js
define['process.env.EXPO_ROUTER_APP_ROOT'] = '"./app"';
define['process.env.EXPO_ROUTER_IMPORT_MODE'] = '"sync"';
define['process.env.EXPO_OS'] = `"${platform}"`;
```

검증 완료. bungae 측 별도 commit 예정.

## #1579 require.context 시리즈 완성

| Phase | PR | 내용 |
| --- | --- | --- |
| 1 | #1770 ✅ | AST 인지 + literal 평가 |
| 2 | #1772 ✅ | graph plugin hook + diagnostic |
| 2.5 | #1773 ✅ | NAPI bridge (onResolveContext) |
| **2.6** | **이 PR** | **define table evaluator** |
| 3 | (별도 PR) | codegen webpackContext emit |

## 근본성 (장기 가치)

이번 evaluator 인프라는 require.context 외에도 향후 활용:
- **Tier 3** `.web.*` host-aware 처리 (option 정적 평가)
- 미래 **dynamic import 패턴** (`import(\`./pages/${dynamicName}\`)`)
- **build-time constant folding** (define-aware optimization)
- Metro `path.evaluate()` 의 ZTS native 등가물 — 다른 build-time 인지 기능 추가 시 같은 인프라 활용

## 관련

- #1579 require.context 메인 트래킹
- #1582 Expo 로드맵 (Tier 2)
- #1769 Phase 1 follow-up
- #1771 regex executor epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)