### PR TITLE
feat(codegen): #1579 Phase 3 — require.context webpackContext IIFE emit

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -4,6 +4,9 @@ const types = @import("../types.zig");
 const emitter = @import("../emitter.zig");
 const ResolveCache = @import("../resolve_cache.zig").ResolveCache;
 const ModuleGraph = @import("../graph.zig").ModuleGraph;
+const plugin_mod = @import("../plugin.zig");
+const Plugin = plugin_mod.Plugin;
+const PluginError = plugin_mod.PluginError;
 const test_helpers = @import("../test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
@@ -705,6 +708,292 @@ test "Bundler: import.meta.glob import option" {
     try std.testing.expect(!result.hasErrors());
 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "m.setup") != null);
+}
+
+// ============================================================
+// require.context emit (#1579 Phase 3) — webpackContext IIFE
+// ============================================================
+
+fn rcMatchAB(
+    _: ?*anyopaque,
+    _: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    _: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    // Plugin contract: outer + inner 모두 allocator 소유 (graph 가 free).
+    const result = try allocator.alloc([]const u8, 2);
+    result[0] = try allocator.dupe(u8, "./a.tsx");
+    result[1] = try allocator.dupe(u8, "./b.tsx");
+    return result;
+}
+
+fn rcMatchEmpty(
+    _: ?*anyopaque,
+    _: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    _: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    return try allocator.alloc([]const u8, 0);
+}
+
+/// escape 검증용 — 매치 경로에 `"`, `\`, 개행을 포함시켜 writeJsStringContent 적용 확인.
+fn rcMatchSpecialChars(
+    _: ?*anyopaque,
+    _: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    _: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    const result = try allocator.alloc([]const u8, 1);
+    result[0] = try allocator.dupe(u8, "./weird\"name\\x.tsx");
+    return result;
+}
+
+fn rcMatchNoDotSlash(
+    _: ?*anyopaque,
+    _: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    _: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    // dot-slash prefix 없는 경로도 emitJoinedPath 가 정규화하는지 확인.
+    const result = try allocator.alloc([]const u8, 1);
+    result[0] = try allocator.dupe(u8, "nested/a.tsx");
+    return result;
+}
+
+test "Bundler: require.context emits webpackContext IIFE (sync)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const ctx = require.context('./pages', true, /\.tsx?$/, 'sync');
+        \\console.log(ctx);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchAB }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // webpackContext runtime 핵심 구성요소
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var map={") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./a.tsx\":function(){return require(\"./pages/a.tsx\");}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./b.tsx\":function(){return require(\"./pages/b.tsx\");}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ctx.keys=function(){return Object.keys(map);}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ctx.resolve=function(req)") != null);
+    // 원본 `require.context(...)` 호출은 남으면 안 됨 — IIFE 로 교체되어야.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require.context(") == null);
+}
+
+test "Bundler: require.context emits empty map when no matches" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const ctx = require.context('./empty-dir');
+        \\console.log(ctx);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchEmpty }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // map 은 비었지만 ctx 함수는 여전히 emit — keys() 는 [] 반환, ctx(x) 는 throw.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var map={}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ctx.keys=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") != null);
+}
+
+test "Bundler: require.context escapes match path special chars" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "const ctx = require.context('./pages');\nconsole.log(ctx);");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchSpecialChars }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // 원본 `"` 는 `\"` 로, `\` 는 `\\` 로 escape 되어야 JS 문자열 리터럴이 유효.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\\\"name\\\\x.tsx") != null);
+    // raw unescaped `"name` 는 없어야 (map 키 내부에 그대로 들어가면 JS 파싱 불가).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "weird\"name") == null);
+}
+
+test "Bundler: require.context normalizes trailing slash and missing ./" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // dir 에 trailing `/` → 매치 경로 join 시 중복 `//` 안 생김.
+    try writeFile(tmp.dir, "entry.ts", "const ctx = require.context('./pages/');\nconsole.log(ctx);");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchNoDotSlash }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // `./pages/` + `nested/a.tsx` → `./pages/nested/a.tsx` (정확히 slash 하나).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/nested/a.tsx\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "./pages//") == null);
+}
+
+/// 호출 순서에 따라 다른 matches 를 돌려주는 callback — span 매칭 정확성 검증용.
+fn rcDispatchByCallCount(
+    _: ?*anyopaque,
+    _: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    _: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    const S = struct {
+        var count: u32 = 0;
+    };
+    S.count += 1;
+    const result = try allocator.alloc([]const u8, 1);
+    if (S.count == 1) {
+        result[0] = try allocator.dupe(u8, "./first.tsx");
+    } else {
+        result[0] = try allocator.dupe(u8, "./second.tsx");
+    }
+    return result;
+}
+
+test "Bundler: multiple require.context calls resolve to distinct maps (span match)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const a = require.context('./pages');
+        \\const b = require.context('./other');
+        \\console.log(a, b);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcDispatchByCallCount }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // 첫 호출 (./pages) 는 first.tsx 만, 둘째 호출 (./other) 는 second.tsx 만.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/first.tsx\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./other/second.tsx\")") != null);
+    // cross-contamination 없음.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/second.tsx\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./other/first.tsx\")") == null);
+}
+
+test "Bundler: require.context coexists with import.meta.glob" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("mods");
+    try writeFile(tmp.dir, "mods/a.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "entry.ts",
+        \\const g = import.meta.glob('./mods/*.ts', { eager: true });
+        \\const c = require.context('./pages');
+        \\console.log(g, c);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchAB }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // 양쪽 모두 AST 수준에서 교체되어야 — 원본 호출 둘 다 없음.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import.meta.glob(") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require.context(") == null);
+    // glob: eager → `await import(` / require.context: webpackContext IIFE.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "await import(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") != null);
+}
+
+test "Bundler: no require.context in source → no webpackContext template emitted" {
+    // fast-path 플래그 검증: require.context 없으면 어떤 call expression 도 IIFE 로 변환되지 않음.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "function ctx(){return 1;}console.log(ctx());\n");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Object.keys(map)") == null);
 }
 
 test "Bundler: UMD external dependencies in wrapper" {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -184,6 +184,10 @@ pub const Codegen = struct {
     /// parent emit(VariableDeclarator, Assignment, ObjectProperty 등)에서 설정,
     /// emitFunction/emitArrow/emitClass 진입 시 소비 후 null 로 초기화.
     pending_fn_name: ?[]const u8 = null,
+    /// hot-path fast-exit 플래그. tryEmitGlobObject/tryEmitRequireContextObject 가
+    /// 모든 call expression 에 대해 호출되므로, 해당 종류의 record 가 없으면 O(1) 로 빠짐.
+    has_glob_records: bool = false,
+    has_require_context_records: bool = false,
 
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
@@ -196,6 +200,18 @@ pub const Codegen = struct {
             builder.sources_content = options.sources_content;
         }
         const fm = if (options.sourcemap_function_map) FunctionMapBuilder.init(allocator) else null;
+
+        var has_glob = false;
+        var has_ctx = false;
+        for (options.import_records) |rec| {
+            switch (rec.kind) {
+                .glob => has_glob = true,
+                .require_context => has_ctx = true,
+                else => {},
+            }
+            if (has_glob and has_ctx) break;
+        }
+
         return .{
             .ast = ast,
             .allocator = allocator,
@@ -206,6 +222,8 @@ pub const Codegen = struct {
             .fn_map_builder = fm,
             .gen_line = 0,
             .gen_col = 0,
+            .has_glob_records = has_glob,
+            .has_require_context_records = has_ctx,
             // JSX 필드 제거: Transformer가 JSX lowering 담당
         };
     }
@@ -1886,11 +1904,9 @@ pub const Codegen = struct {
         const is_optional = (flags & CallFlags.optional_chain) != 0;
         const is_pure = (flags & CallFlags.is_pure) != 0;
 
-        // CJS require() 치환: require('specifier') → require_xxx()
         if (try self.tryRewriteRequire(callee, args_start, args_len)) return;
-
-        // import.meta.glob() → 객체 리터럴 직접 출력
         if (try self.tryEmitGlobObject(callee, args_start, args_len)) return;
+        if (try self.tryEmitRequireContextObject(node)) return;
 
         if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
         try self.emitNode(callee);
@@ -1900,13 +1916,11 @@ pub const Codegen = struct {
         try self.writeByte(')');
     }
 
-    /// import.meta.glob("pattern") 호출을 감지하고 매칭 파일 객체 리터럴을 직접 출력한다.
-    /// AST 수준 교체: 문자열 후처리보다 안전 (minify, 문자열 리터럴 내 패턴에 영향 안 받음).
+    /// AST 수준 교체 — 문자열 후처리보다 안전 (minify, 문자열 리터럴 내 패턴에 영향 안 받음).
     fn tryEmitGlobObject(self: *Codegen, callee: ast_mod.NodeIndex, args_start: u32, args_len: u32) !bool {
-        if (self.options.import_records.len == 0) return false;
+        if (!self.has_glob_records) return false;
         if (callee.isNone() or @intFromEnum(callee) >= self.ast.nodes.items.len) return false;
 
-        // callee: static_member_expression(import.meta.glob)
         const callee_node = self.ast.getNode(callee);
         if (callee_node.tag != .static_member_expression) return false;
 
@@ -1925,7 +1939,6 @@ pub const Codegen = struct {
         const prop_name = self.ast.getText(prop_node.span);
         if (!std.mem.eql(u8, prop_name, "glob")) return false;
 
-        // 첫 번째 인수에서 패턴 추출
         if (args_len == 0 or args_start >= extras.len) return false;
         const arg0_idx = @as(ast_mod.NodeIndex, @enumFromInt(extras[args_start]));
         if (arg0_idx.isNone() or @intFromEnum(arg0_idx) >= self.ast.nodes.items.len) return false;
@@ -1934,46 +1947,39 @@ pub const Codegen = struct {
         const raw = self.ast.getText(arg0_node.span);
         const pattern = Ast.stripStringQuotes(raw);
 
-        // import_records에서 매칭되는 glob 레코드 찾기
-        const ImportRecord = @import("../bundler/types.zig").ImportRecord;
         for (self.options.import_records) |rec| {
             if (rec.kind != .glob) continue;
             if (!std.mem.eql(u8, rec.specifier, pattern)) continue;
 
-            // 매칭 → 객체 리터럴 출력
             if (rec.glob_matches) |matches| {
                 try self.write("{\n");
                 for (matches, 0..) |match_path, i| {
                     if (i > 0) try self.write(",\n");
                     try self.write("  \"");
-                    try self.write(match_path);
+                    try self.writeJsStringContent(match_path);
                     try self.write("\": ");
 
                     if (rec.glob_eager) {
                         if (rec.glob_import_name) |import_name| {
-                            // eager + import: (await import("./a.ts")).setup
                             try self.write("(await import(\"");
-                            try self.write(match_path);
+                            try self.writeJsStringContent(match_path);
                             try self.write("\")).");
                             try self.write(import_name);
                         } else {
-                            // eager: await import("./a.ts")
                             try self.write("await import(\"");
-                            try self.write(match_path);
+                            try self.writeJsStringContent(match_path);
                             try self.write("\")");
                         }
                     } else {
                         if (rec.glob_import_name) |import_name| {
-                            // lazy + import: () => import("./a.ts").then(m => m.setup)
                             try self.write("() => import(\"");
-                            try self.write(match_path);
+                            try self.writeJsStringContent(match_path);
                             try self.write("\").then(m => m.");
                             try self.write(import_name);
                             try self.write(")");
                         } else {
-                            // lazy (default): () => import("./a.ts")
                             try self.write("() => import(\"");
-                            try self.write(match_path);
+                            try self.writeJsStringContent(match_path);
                             try self.write("\")");
                         }
                     }
@@ -1984,9 +1990,84 @@ pub const Codegen = struct {
             }
             return true;
         }
-        _ = ImportRecord;
 
         return false;
+    }
+
+    /// `require.context(...)` 호출을 webpackContext IIFE 로 emit.
+    /// Metro `contextModuleTemplates.js` 의 sync mode 패턴 mirror.
+    /// 매칭은 record.span (= call_expression span) 으로 — `tryExtractRequireContextFromCallee`
+    /// 가 record.span 을 call_span 으로 채우는 invariant 에 의존.
+    fn tryEmitRequireContextObject(self: *Codegen, node: Node) !bool {
+        if (!self.has_require_context_records) return false;
+
+        const ImportRecord = @import("../bundler/types.zig").ImportRecord;
+        const rec: *const ImportRecord = blk: {
+            for (self.options.import_records) |*r| {
+                if (r.kind == .require_context and std.meta.eql(r.span, node.span))
+                    break :blk r;
+            }
+            return false;
+        };
+
+        try self.write("(function(){var map={");
+        if (rec.context_matches) |matches| {
+            for (matches, 0..) |match_path, i| {
+                if (i > 0) try self.writeByte(',');
+                try self.writeByte('"');
+                try self.writeJsStringContent(match_path);
+                try self.write("\":function(){return require(\"");
+                try self.emitJoinedPath(rec.specifier, match_path);
+                try self.write("\");}");
+            }
+        }
+        try self.write(
+            \\};function ctx(req){var fn=map[req];if(!fn){var e=new Error("Cannot find module '"+req+"'");e.code="MODULE_NOT_FOUND";throw e;}return fn();}ctx.keys=function(){return Object.keys(map);};ctx.resolve=function(req){if(!(req in map)){var e=new Error("Cannot find module '"+req+"'");e.code="MODULE_NOT_FOUND";throw e;}return req;};return ctx;})()
+        );
+        return true;
+    }
+
+    /// dir="./pages", match="./a.tsx" → "./pages/a.tsx" (trailing `/`, leading `./` 정규화).
+    /// Escape 포함 — 경로 세그먼트에 `"`/`\` 가 들어와도 JS 문자열 리터럴이 깨지지 않음.
+    fn emitJoinedPath(self: *Codegen, dir: []const u8, match: []const u8) !void {
+        const dir_clean = if (dir.len > 0 and dir[dir.len - 1] == '/') dir[0 .. dir.len - 1] else dir;
+        const match_clean = if (match.len >= 2 and match[0] == '.' and match[1] == '/') match[2..] else match;
+        try self.writeJsStringContent(dir_clean);
+        try self.writeByte('/');
+        try self.writeJsStringContent(match_clean);
+    }
+
+    /// JS string 내용 부분 (따옴표 제외) 를 escape 해서 출력.
+    /// `\`, `"`, 제어 문자를 처리 — resolver/FS 경로가 예외적으로 포함할 수 있는 문자 대비.
+    /// 기존 `writeStringLiteral` 은 이미 quoted 소스 span 을 처리하는 용도라 raw string 에 부적합.
+    fn writeJsStringContent(self: *Codegen, s: []const u8) !void {
+        var flush_start: usize = 0;
+        var i: usize = 0;
+        while (i < s.len) : (i += 1) {
+            const c = s[i];
+            const esc: ?[]const u8 = switch (c) {
+                '\\' => "\\\\",
+                '"' => "\\\"",
+                '\n' => "\\n",
+                '\r' => "\\r",
+                '\t' => "\\t",
+                0x08 => "\\b",
+                0x0C => "\\f",
+                else => null,
+            };
+            if (esc) |e| {
+                if (i > flush_start) try self.write(s[flush_start..i]);
+                try self.write(e);
+                flush_start = i + 1;
+            } else if (c < 0x20) {
+                if (i > flush_start) try self.write(s[flush_start..i]);
+                const hex = "0123456789abcdef";
+                var buf: [6]u8 = .{ '\\', 'u', '0', '0', hex[(c >> 4) & 0xF], hex[c & 0xF] };
+                try self.write(&buf);
+                flush_start = i + 1;
+            }
+        }
+        if (flush_start < s.len) try self.write(s[flush_start..]);
     }
 
     /// string_literal 노드에서 specifier를 추출하고 require_rewrites 맵에서 조회.


### PR DESCRIPTION
## Summary

- `require.context(...)` 호출을 번들 출력 시점에 inline **webpackContext IIFE** 로 교체 (Metro `contextModuleTemplates.js` sync mode mirror)
- Phase 2.5/2.6 까지 수집한 `record.context_matches` 를 `map` 엔트리로 펼치고 `ctx()`/`ctx.keys()`/`ctx.resolve()` 런타임 동반 emit
- glob/require_context 공통 hot-path O(1) fast-exit 플래그 도입 — 해당 종류 레코드가 없으면 call expression 마다 선형 스캔 회피

Closes #1579 (Phase 3, 최종 단계)

## Details

### webpackContext IIFE 구조
```js
(function(){var map={
  "./a.tsx":function(){return require("./pages/a.tsx");}
};function ctx(req){var fn=map[req];if(!fn){var e=new Error("Cannot find module '"+req+"'");e.code="MODULE_NOT_FOUND";throw e;}return fn();}
ctx.keys=function(){return Object.keys(map);};
ctx.resolve=function(req){if(!(req in map)){...throw...};return req;};
return ctx;})()
```

매칭은 `record.span` (= `call_expression` span) 기준 — `tryExtractRequireContextFromCallee` 가 Phase 2 에서 설정하는 invariant 에 의존.

### Cleanup 동반
- `writeJsStringContent` 공용 escape 헬퍼 — `\`, `"`, 개행/제어문자 처리. glob 의 `match_path` 출력에도 적용 (잠재 버그 예방)
- `has_glob_records` / `has_require_context_records` 플래그 — `Codegen.initWithOptions` 에서 1회 스캔 후 `tryEmitGlobObject` / `tryEmitRequireContextObject` 시작에서 O(1) 조기 종료
- `tryEmitGlobObject` 의 dead `const ImportRecord = @import(...)` / `_ = ImportRecord;` 제거
- WHAT-서술 주석 정리

### 테스트 (`src/bundler/bundler_test/basic.zig`, 7건)
- `require.context emits webpackContext IIFE (sync)` — map/ctx/keys/resolve/MODULE_NOT_FOUND 확인
- `empty map when no matches` — plugin 이 `[]` 반환 시 `map={}` + ctx 함수 동반 emit
- `escapes match path special chars` — `"`, `\` → `\"`, `\\` 변환 확인
- `normalizes trailing slash and missing ./` — `./pages/` + `nested/a.tsx` → `./pages/nested/a.tsx`
- `multiple require.context calls resolve to distinct maps (span match)` — 두 호출이 각자 자기 matches 를 받는지 검증, cross-contamination 없음
- `coexists with import.meta.glob` — 같은 파일에 두 기능 공존, 서로 간섭 없음
- `no require.context in source → no webpackContext template emitted` — fast-path 플래그 검증

## Test plan

- [x] `zig build` 통과
- [x] `zig build test` 전체 통과 (신규 7 + glob 기존 2 포함)
- [ ] 번개 ExpoApp 번들 실측으로 실제 require.context 동작 확인 (머지 후 submodule sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)