### PR TITLE
fix(transformer): JSX attribute 이름이 non-identifier 면 string_literal 로 lower

### DIFF
--- a/src/codegen/codegen_test/features.zig
+++ b/src/codegen/codegen_test/features.zig
@@ -323,6 +323,74 @@ test "Codegen: JSX fragment" {
     try std.testing.expectEqualStrings("const x=React.createElement(React.Fragment,null,\"hello\");", r.output);
 }
 
+// --- JSX: attribute name quoting (hyphenated / non-identifier props) ---
+
+test "JSX: aria- prop quoted as string key" {
+    var r = try e2eJSX(std.testing.allocator, "const x = <button aria-label=\"Copy\" />;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"aria-label\":\"Copy\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "aria-label:") == null);
+}
+
+test "JSX: data- prop quoted as string key" {
+    var r = try e2eJSX(std.testing.allocator, "const x = <div data-testid=\"root\" />;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"data-testid\":\"root\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "data-testid:") == null);
+}
+
+test "JSX: normal prop stays as bare identifier" {
+    var r = try e2eJSX(std.testing.allocator, "const x = <div className=\"c\" />;");
+    defer r.deinit();
+    // className 은 valid identifier 라 quote 불필요 — 회귀 방지
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "className:\"c\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"className\":") == null);
+}
+
+test "JSX: mixed hyphenated and normal props" {
+    var r = try e2eJSX(std.testing.allocator, "const x = <button onClick={f} aria-label=\"x\" />;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "onClick:f") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"aria-label\":\"x\"") != null);
+}
+
+test "JSX: hyphenated prop with expression value" {
+    var r = try e2eJSX(std.testing.allocator, "const x = <div aria-hidden={isHidden} />;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"aria-hidden\":isHidden") != null);
+}
+
+test "JSX: hyphenated boolean shorthand prop" {
+    var r = try e2eJSX(std.testing.allocator, "const x = <div data-x />;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"data-x\":true") != null);
+}
+
+test "JSX: dollar/underscore identifiers stay bare" {
+    var r = try e2eJSX(std.testing.allocator, "const x = <div $foo=\"a\" _bar=\"b\" />;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "$foo:\"a\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_bar:\"b\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"$foo\"") == null);
+}
+
+test "JSX: multiple hyphenated props on same element" {
+    var r = try e2eJSX(std.testing.allocator, "const x = <input data-a=\"1\" data-b=\"2\" aria-busy=\"true\" />;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"data-a\":\"1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"data-b\":\"2\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"aria-busy\":\"true\"") != null);
+}
+
+test "JSX: reserved word as bare identifier key (legal in object literal)" {
+    // JSX attribute 이름이 JS 예약어 (for, class) 라도 object literal key 로 허용되므로
+    // identifier_reference 로 유지 — 회귀 방지 (isValidIdentifierName 이 reserved word 체크 X)
+    var r = try e2eJSX(std.testing.allocator, "const x = <label for=\"id\" />;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "for:\"id\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"for\":") == null);
+}
+
 // --- JSX: closing tag 뒤 텍스트 (children 모드 복원) ---
 
 test "JSX: text after closing child element" {

--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -656,13 +656,25 @@ pub fn JsxLowering(comptime Transformer: type) type {
             const name_node = self.ast.getNode(name_idx);
             const name_text = self.ast.getText(name_node.span);
 
-            // key: identifier_reference로 생성
-            const key_span = try self.ast.addString(name_text);
-            const key_node = try self.ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = key_span,
-                .data = .{ .string_ref = key_span },
-            });
+            // key: `aria-label`/`data-x` 등 valid JS identifier 가 아니면 string_literal 로
+            // 생성해야 object literal property key 로 유효. 그렇지 않으면 codegen 이
+            // raw 로 뱉어 `aria-label: ...` 같은 파싱 불가한 JS 를 만듦.
+            const key_node = if (isValidIdentifierName(name_text)) blk: {
+                const key_span = try self.ast.addString(name_text);
+                break :blk try self.ast.addNode(.{
+                    .tag = .identifier_reference,
+                    .span = key_span,
+                    .data = .{ .string_ref = key_span },
+                });
+            } else blk: {
+                const quoted = try quoteString(self, name_text);
+                const str_span = try self.ast.addString(quoted);
+                break :blk try self.ast.addNode(.{
+                    .tag = .string_literal,
+                    .span = str_span,
+                    .data = .{ .string_ref = str_span },
+                });
+            };
 
             // value: 없으면 true
             const val_node = if (value_idx.isNone()) blk: {
@@ -1015,6 +1027,22 @@ pub fn JsxLowering(comptime Transformer: type) type {
             }
 
             return buf[0..out_len];
+        }
+
+        /// ASCII 식별자 (ES IdentifierName) 규칙으로 JSX attribute name 검증.
+        /// object literal property key 는 reserved word 도 허용하므로 키워드 체크 불필요.
+        fn isValidIdentifierName(text: []const u8) bool {
+            if (text.len == 0) return false;
+            const first = text[0];
+            const first_ok = (first >= 'a' and first <= 'z') or
+                (first >= 'A' and first <= 'Z') or first == '_' or first == '$';
+            if (!first_ok) return false;
+            for (text[1..]) |c| {
+                const ok = (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
+                    (c >= '0' and c <= '9') or c == '_' or c == '$';
+                if (!ok) return false;
+            }
+            return true;
         }
 
         /// 텍스트를 "..."로 감싸고 특수 문자를 이스케이프.


### PR DESCRIPTION
## Summary

`<button aria-label="Copy" />` 같이 `-` 포함 JSX attribute 가 Hermes/JSC 에서 `SyntaxError` 를 일으키는 문제 수정.

`lowerJSXAttribute` 가 모든 attribute name 을 `identifier_reference` 로 만들어서 codegen 에서 raw 로 출력되었고, `{ aria-label: "Copy" }` 같이 JS object literal 로 파싱 불가한 코드가 생성됨.

## Repro

번개 ExpoApp 구동 시 iOS 시뮬레이터에서:

```
[runtime not ready]: Error: Non-js exception: Compiling JS failed:
  89420:10:':' expected in property initialization
```

해당 줄의 bundle output:
```js
headerAction: _jsxDEV("button", {
  className: ...,
  onClick: function() { ... },
  aria-label: "Copy content",   ← 여기
  children: [...]
})
```

source (`@expo/log-box/src/overlay/CodeFrame.tsx:48`):
```jsx
<button aria-label="Copy content">
```

## Fix

- `isValidIdentifierName(text)` helper 추가 — ASCII 식별자 규칙 `[A-Za-z_$][A-Za-z0-9_$]*`. object literal property key 는 reserved word 허용하므로 키워드 체크 없음.
- `lowerJSXAttribute` 가 name 검사 후:
  - valid → 기존 `identifier_reference` (rename symbol_id 전파 등 유지)
  - invalid → `quoteString` + `string_literal`

## 테스트 (`codegen_test/features.zig`, 9건)

| 테스트 | 검증 |
|---|---|
| aria- prop | `\"aria-label\":\"Copy\"` |
| data- prop | `\"data-testid\":\"root\"` |
| className | `className:\"c\"` (bare, 회귀 방지) |
| mixed (onClick + aria-) | 양쪽 모두 올바른 형식 |
| hyphenated + expression value | `\"aria-hidden\":isHidden` |
| hyphenated boolean shorthand | `\"data-x\":true` |
| `$foo` / `_bar` | bare identifier |
| multiple hyphenated (data-a/b, aria-busy) | 모두 quoted |
| reserved word (`for`) | bare (object key 는 reserved 허용) |

## Test plan

- [x] `zig build test` 전체 통과
- [ ] ExpoApp 재번들 후 89420 줄 `\"aria-label\":...` 로 변경 + Hermes 파싱 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)