### PR TITLE
fix(emitter): esm_wrap Codegen init 에 import_records 전파 — require.context IIFE emit

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -976,6 +976,45 @@ test "Bundler: require.context coexists with import.meta.glob" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") != null);
 }
 
+test "Bundler: require.context emits IIFE inside __esm wrapper (RN platform)" {
+    // 회귀: esm_wrap.zig 의 body/func/hoist Codegen init 에 import_records 를 안 넘겨서
+    // __esm wrap 경로에서 has_require_context_records=false → IIFE 미emit → 원본
+    // `require.context(...)` 호출이 런타임 require 를 찾다가 ReferenceError.
+    // Expo Router `_ctx.ios.js` 가 이 패턴 (ESM export const ctx = require.context(...)).
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export const ctx = require.context('./pages', true, /^\.\//, 'sync');
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchAB }};
+    var b = Bundler.init(alloc, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .platform = .react_native, // __esm wrapping 강제
+        .plugins = &plugins,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // __esm wrap + IIFE 둘 다 존재
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__esm(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var map={") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") != null);
+    // 원본 호출은 교체되어야
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require.context(") == null);
+}
+
 test "Bundler: no require.context in source → no webpackContext template emitted" {
     // fast-path 플래그 검증: require.context 없으면 어떤 call expression 도 IIFE 로 변환되지 않음.
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -329,6 +329,7 @@ pub fn emitEsmWrappedModule(
             .sourcemap = options.sourcemap.enable,
             .source_root = options.sourcemap.source_root orelse "",
             .sources_content = options.sourcemap.sources_content,
+            .import_records = module.import_records,
         });
         if (options.sourcemap.enable) {
             hoist_cg.line_offsets = module.line_offsets;
@@ -528,6 +529,7 @@ pub fn emitEsmWrappedModule(
         .sourcemap = options.sourcemap.enable,
         .source_root = options.sourcemap.source_root orelse "",
         .sources_content = options.sourcemap.sources_content,
+        .import_records = module.import_records,
     });
     // 소스맵: 소스 파일 등록 + line_offsets 설정
     if (options.sourcemap.enable) {
@@ -551,6 +553,7 @@ pub fn emitEsmWrappedModule(
             .sourcemap = options.sourcemap.enable,
             .source_root = options.sourcemap.source_root orelse "",
             .sources_content = options.sourcemap.sources_content,
+            .import_records = module.import_records,
         });
         if (options.sourcemap.enable) {
             func_cg.line_offsets = module.line_offsets;


### PR DESCRIPTION
## Summary

RN + ESM + dev mode 에서 \`__esm({...})\` wrapper 로 감싸진 모듈 안의 \`require.context(...)\` 호출이 webpackContext IIFE 로 교체되지 않던 문제. Expo Router \`_ctx.ios.js\` 구동 실패 원인.

## Repro

ExpoApp 번들 실행 시 iOS Hermes:

\`\`\`
[runtime not ready]: ReferenceError: Property 'require' doesn't exist
  expo-router/_ctx.ios.js
\`\`\`

bundle output:

\`\`\`js
var init_expo_router__ctx_ios = __esm({
  "..._ctx.ios.js"() {
    ctx = require.context("./app", true, /.../, "sync");  // ← 그대로 남음!
  }
});
\`\`\`

webpackContext IIFE 로 교체되지 않아 wrapped scope 의 없는 \`require\` 를 참조.

## Cause

\`src/bundler/emitter/esm_wrap.zig\` 의 세 \`Codegen.initWithOptions\` (hoist / body / func) 가 \`.import_records\` 옵션을 누락. 결과:

1. \`Codegen.has_require_context_records = false\` (init 시 import_records scan 결과)
2. \`tryEmitRequireContextObject\` 가 early-return (O(1) fast-path)
3. 원본 \`require.context(...)\` call_expression 이 일반 경로로 emit 되어 bundle 에 그대로 남음

## Fix

세 init 사이트 모두 \`.import_records = module.import_records\` 추가.

## Test

\`bundler_test/basic.zig\`:

\`\`\`zig
test "Bundler: require.context emits IIFE inside __esm wrapper (RN platform)" {
    // ESM export + react_native platform 조합에서 IIFE 가 정상 emit 되는지.
\`\`\`

## Test plan

- [x] 회귀 테스트 추가 + \`zig build test\` 통과
- [x] \`/tmp/rc-env\` 직접 재현 → 수정 후 IIFE emit 확인
- [ ] ExpoApp 번들에서 Hermes ReferenceError 사라지는지 (머지 후 submodule sync 로 검증)

Refs #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)