### PR TITLE
refactor(bundler): #1779 Phase 1b — modules.items call site 를 accessor 경유로 교체

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -15,6 +15,7 @@ const std = @import("std");
 const plugin_mod = @import("plugin.zig");
 const types = @import("types.zig");
 const BundlerDiagnostic = types.BundlerDiagnostic;
+const ModuleIndex = types.ModuleIndex;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
 const ResolveCache = @import("resolve_cache.zig").ResolveCache;
 const Platform = @import("resolve_cache.zig").Platform;
@@ -477,7 +478,7 @@ pub const Bundler = struct {
         defer spec_to_filename.deinit();
         for (graph.worker_entries.items) |we| {
             const filename = worker_map.get(we.resolved_path) orelse continue;
-            const mod = &graph.modules.items[@intFromEnum(we.source_module)];
+            const mod = graph.getModule(we.source_module) orelse continue;
             if (we.record_index >= mod.import_records.len) continue;
             try spec_to_filename.put(mod.import_records[we.record_index].specifier, filename);
         }
@@ -700,8 +701,7 @@ pub const Bundler = struct {
                 if (inc_result.reparsed_indices.len > 0) {
                     const list = try self.allocator.alloc([]const u8, inc_result.reparsed_indices.len);
                     for (inc_result.reparsed_indices, 0..) |mod_idx, i| {
-                        const mi = @intFromEnum(mod_idx);
-                        const src = if (mi < graph.modules.items.len) graph.modules.items[mi].path else "";
+                        const src = if (graph.getModule(mod_idx)) |m| m.path else "";
                         list[i] = try self.allocator.dupe(u8, src);
                     }
                     reparsed_paths_out = list;
@@ -912,8 +912,11 @@ pub const Bundler = struct {
             dev_emit_opts.polyfills = polyfill_entries.items;
             dev_emit_opts.run_before_main = self.options.run_before_main;
 
-            for (graph.modules.items) |*m| {
-                m.dev_id = emitter.makeModuleId(m.path, self.options.root_dir);
+            const la = graph.linkAccessor();
+            for (0..graph.moduleCount()) |i| {
+                const idx = ModuleIndex.fromUsize(i);
+                const m = graph.getModule(idx) orelse continue;
+                la.setDevId(idx, emitter.makeModuleId(m.path, self.options.root_dir));
             }
 
             const emit_result = try emitter.emitWithTreeShaking(
@@ -1026,12 +1029,13 @@ pub const Bundler = struct {
         } else null;
 
         // 5. 모듈 경로 수집 (dev server watch용)
-        const module_paths: ?[]const []const u8 = if (graph.modules.items.len > 0) blk: {
-            const paths = try self.allocator.alloc([]const u8, graph.modules.items.len);
+        const module_paths: ?[]const []const u8 = if (graph.moduleCount() > 0) blk: {
+            const paths = try self.allocator.alloc([]const u8, graph.moduleCount());
             errdefer self.allocator.free(paths);
             var path_count: usize = 0;
             errdefer for (paths[0..path_count]) |p| self.allocator.free(p);
-            for (graph.modules.items) |m| {
+            var it = graph.modulesIterator();
+            while (it.next()) |m| {
                 paths[path_count] = try self.allocator.dupe(u8, m.path);
                 path_count += 1;
             }
@@ -1043,15 +1047,19 @@ pub const Bundler = struct {
         // RN 런타임이 해상도별 파일을 로드할 수 있게 한다.
         const asset_outputs: ?[]OutputFile = blk: {
             var asset_count: usize = 0;
-            for (graph.modules.items) |m| {
-                if (m.asset_data) |ad| asset_count += 1 + ad.scale_variants.len;
+            {
+                var it = graph.modulesIterator();
+                while (it.next()) |m| {
+                    if (m.asset_data) |ad| asset_count += 1 + ad.scale_variants.len;
+                }
             }
             if (asset_count == 0) break :blk null;
 
             const outs = try self.allocator.alloc(OutputFile, asset_count);
             errdefer self.allocator.free(outs);
             var idx: usize = 0;
-            for (graph.modules.items) |m| {
+            var it = graph.modulesIterator();
+            while (it.next()) |m| {
                 if (m.asset_data) |ad| {
                     outs[idx] = .{
                         .path = try self.allocator.dupe(u8, ad.output_name),
@@ -1151,7 +1159,10 @@ pub const Bundler = struct {
         // putModule이 parse_arena 소유권을 store로 가져가므로
         // graph.deinit()에서 이중 해제가 발생하지 않는다.
         if (self.options.module_store) |store| {
-            for (graph.modules.items) |*m| {
+            for (0..graph.moduleCount()) |i| {
+                // store transfer 가 m.parse_arena 소유권 이동 → *Module mutable 필요.
+                // TODO #1c: store transfer 전용 accessor 메서드 도입 검토.
+                const m = graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
                 if (m.parse_arena == null) continue; // disabled 등 arena 없는 모듈 스킵
                 // mtime 은 buildIncremental / build 가 이미 module.mtime 에 기록. 여기서 재-stat
                 // 하면 watcher-driven mtime cache 효과가 half-revert 됨 (Issue #1727 §3).
@@ -1199,7 +1210,8 @@ fn generateMetafileJson(
 
     // inputs
     var first_input = true;
-    for (graph.modules.items) |m| {
+    var mod_it = graph.modulesIterator();
+    while (mod_it.next()) |m| {
         if (m.path.len == 0) continue;
         if (!first_input) try buf.appendSlice(allocator, ",");
         first_input = false;
@@ -1213,12 +1225,11 @@ fn generateMetafileJson(
         for (m.import_records) |rec| {
             if (rec.is_external) continue;
             if (rec.resolved.isNone()) continue;
-            const dep_idx = @intFromEnum(rec.resolved);
-            if (dep_idx >= graph.modules.items.len) continue;
+            const dep = graph.getModule(rec.resolved) orelse continue;
             if (!first_imp) try buf.appendSlice(allocator, ", ");
             first_imp = false;
             try buf.appendSlice(allocator, "{ \"path\": ");
-            try appendJsonString(&buf, allocator, graph.modules.items[dep_idx].path);
+            try appendJsonString(&buf, allocator, dep.path);
             try buf.appendSlice(allocator, ", \"kind\": ");
             try appendJsonString(&buf, allocator, @tagName(rec.kind));
             try buf.appendSlice(allocator, " }");

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -354,7 +354,8 @@ test "CJS: ExportsKind promotion — .js required becomes CJS" {
 
     // graph에서 plain.js 모듈을 찾아서 exports_kind 확인
     var plain_found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "plain.js")) {
             // require()로 소비되었으므로 CJS로 승격되어야 함
             try std.testing.expectEqual(types.ExportsKind.commonjs, m.exports_kind);
@@ -452,7 +453,8 @@ test "CJS: require overrides ESM promotion (both import and require same module)
 
     // shared.js는 import와 require 모두로 소비됨 → require가 우선이므로 CJS
     var shared_found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "shared.js")) {
             try std.testing.expectEqual(types.ExportsKind.commonjs, m.exports_kind);
             try std.testing.expectEqual(types.WrapKind.cjs, m.wrap_kind);
@@ -557,7 +559,8 @@ test "CJS: esm_with_dynamic_fallback module required — promoted to ESM wrap (g
 
     // hybrid.js: esm_with_dynamic_fallback + require 소비 → WrapKind.esm
     var hybrid_found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "hybrid.js")) {
             try std.testing.expectEqual(types.ExportsKind.esm_with_dynamic_fallback, m.exports_kind);
             try std.testing.expectEqual(types.WrapKind.esm, m.wrap_kind);
@@ -736,7 +739,8 @@ test "ESM wrap: pure ESM module required — WrapKind.esm (graph)" {
     try graph.build(&.{entry});
 
     var found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "esm-mod.js")) {
             try std.testing.expectEqual(types.ExportsKind.esm, m.exports_kind);
             try std.testing.expectEqual(types.WrapKind.esm, m.wrap_kind);
@@ -766,7 +770,8 @@ test "ESM wrap: CJS module required — still WrapKind.cjs (graph)" {
     try graph.build(&.{entry});
 
     var found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "cjs-mod.js")) {
             try std.testing.expectEqual(types.ExportsKind.commonjs, m.exports_kind);
             try std.testing.expectEqual(types.WrapKind.cjs, m.wrap_kind);
@@ -796,7 +801,8 @@ test "ESM wrap: none module required — WrapKind.cjs (graph)" {
     try graph.build(&.{entry});
 
     var found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "plain.js")) {
             try std.testing.expectEqual(types.ExportsKind.commonjs, m.exports_kind);
             try std.testing.expectEqual(types.WrapKind.cjs, m.wrap_kind);
@@ -879,7 +885,8 @@ test "ESM wrap: 2-pass promotion — require before import" {
 
     // shared.js: ESM + require 소비 → WrapKind.esm (import가 CJS로 덮어쓰지 않음)
     var found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "shared.js")) {
             try std.testing.expectEqual(types.WrapKind.esm, m.wrap_kind);
             found = true;
@@ -1462,7 +1469,8 @@ test "CJS: Flow import typeof does not make CJS module ESM (regression)" {
     try graph.build(&.{entry});
 
     var found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "rn.js")) {
             try std.testing.expectEqual(types.ExportsKind.commonjs, m.exports_kind);
             try std.testing.expectEqual(types.WrapKind.cjs, m.wrap_kind);
@@ -1516,7 +1524,8 @@ test "CJS: TS import type does not make CJS module ESM" {
     try graph.build(&.{entry});
 
     var found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "lib.js")) {
             try std.testing.expectEqual(types.ExportsKind.commonjs, m.exports_kind);
             try std.testing.expectEqual(types.WrapKind.cjs, m.wrap_kind);
@@ -1549,7 +1558,8 @@ test "CJS: export type re-export + module.exports stays CJS (regression)" {
     try graph.build(&.{entry});
 
     var found = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (std.mem.endsWith(u8, m.path, "rn-private.js")) {
             try std.testing.expectEqual(types.ExportsKind.commonjs, m.exports_kind);
             try std.testing.expectEqual(types.WrapKind.cjs, m.wrap_kind);

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -213,7 +213,8 @@ pub fn emitWithTreeShaking(
     var sorted: std.ArrayList(*const Module) = .empty;
     defer sorted.deinit(allocator);
 
-    for (graph.modules.items, 0..) |*m, i| {
+    for (0..graph.moduleCount()) |i| {
+        const m = graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
         const is_asset = m.loader.isAsset() and m.source.len > 0;
         const is_js = (m.module_type == .javascript or m.module_type == .json) and (m.ast != null or m.is_disabled or is_asset);
         if (is_js) {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -909,7 +909,8 @@ pub fn computeAllUsedNames(
     }
 
     // 모든 모듈의 import_bindings + export_bindings(re-export)를 순회하여 역방향 맵 구축
-    for (graph.modules.items) |*importer| {
+    var mod_it = graph.modulesIterator();
+    while (mod_it.next()) |importer| {
         const imp_i: u32 = importer.index.toU32();
 
         // export_bindings 중 re_export / re_export_all → 타겟 모듈로 역매핑

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -5,6 +5,8 @@ const EmitOptions = emitter.EmitOptions;
 const appendRuntimeHelpers = emitter.appendRuntimeHelpers;
 const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
+const types = @import("types.zig");
+const ModuleIndex = types.ModuleIndex;
 const chunk_mod = @import("chunk.zig");
 const resolve_cache_mod = @import("resolve_cache.zig");
 const writeFile = @import("test_helpers.zig").writeFile;
@@ -1492,10 +1494,12 @@ test "emitter: lazy_sourcemap dev mode — ModuleDevCode.sm_builder 채워지고
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    for (result.graph.modules.items) |*m| {
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         m.dev_id = try std.testing.allocator.dupe(u8, m.path);
     }
-    defer for (result.graph.modules.items) |*m| {
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
         m.dev_id = "";
     };
@@ -1526,10 +1530,12 @@ test "emitter: per-module sm_builder lazy/eager JSON 바이트 동등" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    for (result.graph.modules.items) |*m| {
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         m.dev_id = try std.testing.allocator.dupe(u8, m.path);
     }
-    defer for (result.graph.modules.items) |*m| {
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
         m.dev_id = "";
     };
@@ -1616,10 +1622,12 @@ test "emitter: dev_mode + sourcemap 활성 시 per-module code 끝에 sourceURL 
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    for (result.graph.modules.items) |*m| {
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         m.dev_id = try std.testing.allocator.dupe(u8, m.path);
     }
-    defer for (result.graph.modules.items) |*m| {
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
         m.dev_id = "";
     };
@@ -1650,10 +1658,12 @@ test "emitter: dev_mode + sourcemap 비활성 시 sourceURL 주석 없음" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    for (result.graph.modules.items) |*m| {
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         m.dev_id = try std.testing.allocator.dupe(u8, m.path);
     }
-    defer for (result.graph.modules.items) |*m| {
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
         m.dev_id = "";
     };
@@ -1681,10 +1691,12 @@ test "emitter: multi-module 각각에 고유 sourceURL 포함" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    for (result.graph.modules.items) |*m| {
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         m.dev_id = try std.testing.allocator.dupe(u8, m.path);
     }
-    defer for (result.graph.modules.items) |*m| {
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
         m.dev_id = "";
     };
@@ -1730,10 +1742,12 @@ test "emitter: root_dir 설정 시 sourceURL 이 상대경로" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    for (result.graph.modules.items) |*m| {
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         m.dev_id = try std.testing.allocator.dupe(u8, m.path);
     }
-    defer for (result.graph.modules.items) |*m| {
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
         m.dev_id = "";
     };
@@ -1790,10 +1804,12 @@ test "emitter: sourceURL 은 IIFE 뒤에 위치 — HMR_PREAMBLE_LINES 오프셋
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    for (result.graph.modules.items) |*m| {
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         m.dev_id = try std.testing.allocator.dupe(u8, m.path);
     }
-    defer for (result.graph.modules.items) |*m| {
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
         m.dev_id = "";
     };

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -4,6 +4,7 @@ const ModuleGraph = graph_mod.ModuleGraph;
 const determineExportsKind = graph_mod.determineExportsKind;
 const Module = @import("module.zig").Module;
 const types = @import("types.zig");
+const ModuleIndex = types.ModuleIndex;
 const import_scanner = @import("import_scanner.zig");
 const resolve_cache_mod = @import("resolve_cache.zig");
 const module_store_mod = @import("module_store.zig");
@@ -39,9 +40,9 @@ test "graph: single module, no imports" {
 
     try graph.build(&.{entry});
 
-    try std.testing.expectEqual(@as(usize, 1), graph.modules.items.len);
-    try std.testing.expectEqual(@as(u32, 0), graph.modules.items[0].exec_index);
-    try std.testing.expectEqual(Module.State.ready, graph.modules.items[0].state);
+    try std.testing.expectEqual(@as(usize, 1), graph.moduleCount());
+    try std.testing.expectEqual(@as(u32, 0), graph.getModule(ModuleIndex.fromUsize(0)).?.exec_index);
+    try std.testing.expectEqual(Module.State.ready, graph.getModule(ModuleIndex.fromUsize(0)).?.state);
 }
 
 test "graph: A imports B — correct exec order" {
@@ -62,11 +63,11 @@ test "graph: A imports B — correct exec order" {
 
     try graph.build(&.{entry});
 
-    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
+    try std.testing.expectEqual(@as(usize, 2), graph.moduleCount());
 
     // DFS 후위: B가 먼저 (exec_index=0), A가 나중 (exec_index=1)
-    const a_mod = graph.modules.items[0]; // a.ts가 먼저 addModule됨
-    const b_mod = graph.modules.items[1];
+    const a_mod = graph.getModule(ModuleIndex.fromUsize(0)).?; // a.ts가 먼저 addModule됨
+    const b_mod = graph.getModule(ModuleIndex.fromUsize(1)).?;
     try std.testing.expect(b_mod.exec_index < a_mod.exec_index);
 }
 
@@ -89,12 +90,12 @@ test "graph: chain A → B → C — correct exec order" {
 
     try graph.build(&.{entry});
 
-    try std.testing.expectEqual(@as(usize, 3), graph.modules.items.len);
+    try std.testing.expectEqual(@as(usize, 3), graph.moduleCount());
 
     // C=0, B=1, A=2 (후위 순서)
-    const a = graph.modules.items[0];
-    const b = graph.modules.items[1];
-    const c = graph.modules.items[2];
+    const a = graph.getModule(ModuleIndex.fromUsize(0)).?;
+    const b = graph.getModule(ModuleIndex.fromUsize(1)).?;
+    const c = graph.getModule(ModuleIndex.fromUsize(2)).?;
     try std.testing.expect(c.exec_index < b.exec_index);
     try std.testing.expect(b.exec_index < a.exec_index);
 }
@@ -120,12 +121,13 @@ test "graph: diamond A→B,C; B→D; C→D — no duplicate" {
     try graph.build(&.{entry});
 
     // D가 중복 없이 4개 모듈
-    try std.testing.expectEqual(@as(usize, 4), graph.modules.items.len);
+    try std.testing.expectEqual(@as(usize, 4), graph.moduleCount());
 
     // D가 가장 먼저 실행 (exec_index 최소)
     var min_exec: u32 = std.math.maxInt(u32);
     var min_path: []const u8 = "";
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         if (m.exec_index < min_exec) {
             min_exec = m.exec_index;
             min_path = m.path;
@@ -153,7 +155,7 @@ test "graph: circular dependency — warning emitted" {
     try graph.build(&.{entry});
 
     // 2개 모듈, 순환 경고 존재
-    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
+    try std.testing.expectEqual(@as(usize, 2), graph.moduleCount());
 
     var has_circular_warning = false;
     for (graph.diagnostics.items) |d| {
@@ -180,7 +182,7 @@ test "graph: external module — not in graph" {
     try graph.build(&.{entry});
 
     // react는 external이므로 그래프에 안 들어감
-    try std.testing.expectEqual(@as(usize, 1), graph.modules.items.len);
+    try std.testing.expectEqual(@as(usize, 1), graph.moduleCount());
 }
 
 test "graph: unresolved import — error diagnostic" {
@@ -227,9 +229,9 @@ test "graph: bidirectional edges (D078)" {
     try graph.build(&.{entry});
 
     // A.dependencies에 B
-    try std.testing.expectEqual(@as(usize, 1), graph.modules.items[0].dependencies.items.len);
+    try std.testing.expectEqual(@as(usize, 1), graph.getModule(ModuleIndex.fromUsize(0)).?.dependencies.items.len);
     // B.importers에 A
-    try std.testing.expectEqual(@as(usize, 1), graph.modules.items[1].importers.items.len);
+    try std.testing.expectEqual(@as(usize, 1), graph.getModule(ModuleIndex.fromUsize(1)).?.importers.items.len);
 }
 
 test "graph: re-export adds dependency" {
@@ -250,8 +252,8 @@ test "graph: re-export adds dependency" {
 
     try graph.build(&.{entry});
 
-    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
-    try std.testing.expectEqual(@as(usize, 1), graph.modules.items[0].dependencies.items.len);
+    try std.testing.expectEqual(@as(usize, 2), graph.moduleCount());
+    try std.testing.expectEqual(@as(usize, 1), graph.getModule(ModuleIndex.fromUsize(0)).?.dependencies.items.len);
 }
 
 test "graph: multiple entry points" {
@@ -274,10 +276,10 @@ test "graph: multiple entry points" {
 
     try graph.build(&.{ e1, e2 });
 
-    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
+    try std.testing.expectEqual(@as(usize, 2), graph.moduleCount());
     // 둘 다 exec_index가 할당됨 (maxInt 아님)
-    try std.testing.expect(graph.modules.items[0].exec_index != std.math.maxInt(u32));
-    try std.testing.expect(graph.modules.items[1].exec_index != std.math.maxInt(u32));
+    try std.testing.expect(graph.getModule(ModuleIndex.fromUsize(0)).?.exec_index != std.math.maxInt(u32));
+    try std.testing.expect(graph.getModule(ModuleIndex.fromUsize(1)).?.exec_index != std.math.maxInt(u32));
 }
 
 test "graph: dynamic import stored in dynamic_imports" {
@@ -298,10 +300,10 @@ test "graph: dynamic import stored in dynamic_imports" {
 
     try graph.build(&.{entry});
 
-    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
+    try std.testing.expectEqual(@as(usize, 2), graph.moduleCount());
     // 동적 import는 dynamic_imports에, dependencies에는 없음
-    try std.testing.expectEqual(@as(usize, 0), graph.modules.items[0].dependencies.items.len);
-    try std.testing.expectEqual(@as(usize, 1), graph.modules.items[0].dynamic_imports.items.len);
+    try std.testing.expectEqual(@as(usize, 0), graph.getModule(ModuleIndex.fromUsize(0)).?.dependencies.items.len);
+    try std.testing.expectEqual(@as(usize, 1), graph.getModule(ModuleIndex.fromUsize(0)).?.dynamic_imports.items.len);
 }
 
 test "graph: JSON module — no AST, in graph" {
@@ -322,9 +324,9 @@ test "graph: JSON module — no AST, in graph" {
 
     try graph.build(&.{entry});
 
-    try std.testing.expectEqual(@as(usize, 2), graph.modules.items.len);
+    try std.testing.expectEqual(@as(usize, 2), graph.moduleCount());
     // JSON 모듈은 ESM AST로 변환됨 (export default <json>)
-    const json_mod = graph.modules.items[1];
+    const json_mod = graph.getModule(ModuleIndex.fromUsize(1)).?;
     try std.testing.expect(json_mod.ast != null);
     try std.testing.expectEqual(types.ModuleType.json, json_mod.module_type);
     try std.testing.expectEqual(types.ExportsKind.esm, json_mod.exports_kind);
@@ -347,7 +349,7 @@ test "graph: semantic data preserved after build" {
 
     try graph.build(&.{entry});
 
-    const m = graph.modules.items[0];
+    const m = graph.getModule(ModuleIndex.fromUsize(0)).?;
     // semantic 데이터가 보존되어야 함
     try std.testing.expect(m.semantic != null);
     const sem = m.semantic.?;
@@ -379,9 +381,9 @@ test "graph: semantic data null for non-JS modules" {
     try graph.build(&.{entry});
 
     // a.ts는 semantic 있음
-    try std.testing.expect(graph.modules.items[0].semantic != null);
+    try std.testing.expect(graph.getModule(ModuleIndex.fromUsize(0)).?.semantic != null);
     // data.json도 ESM AST로 변환되므로 semantic 있음
-    try std.testing.expect(graph.modules.items[1].semantic != null);
+    try std.testing.expect(graph.getModule(ModuleIndex.fromUsize(1)).?.semantic != null);
 }
 
 test "graph: semantic exported_names tracks default export" {
@@ -401,7 +403,7 @@ test "graph: semantic exported_names tracks default export" {
 
     try graph.build(&.{entry});
 
-    const sem = graph.modules.items[0].semantic.?;
+    const sem = graph.getModule(ModuleIndex.fromUsize(0)).?.semantic.?;
     try std.testing.expect(sem.exported_names.get("default") != null);
 }
 
@@ -424,7 +426,7 @@ test "graph: import/export bindings preserved after build" {
     try graph.build(&.{entry});
 
     // a.ts: import_bindings에 x가 있어야 함
-    const a = graph.modules.items[0];
+    const a = graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(a.import_bindings.len > 0);
     try std.testing.expectEqualStrings("x", a.import_bindings[0].local_name);
     try std.testing.expectEqualStrings("x", a.import_bindings[0].imported_name);
@@ -434,7 +436,7 @@ test "graph: import/export bindings preserved after build" {
     try std.testing.expectEqualStrings("y", a.export_bindings[0].exported_name);
 
     // b.ts: export_bindings에 x가 있어야 함
-    const b = graph.modules.items[1];
+    const b = graph.getModule(ModuleIndex.fromUsize(1)).?;
     try std.testing.expect(b.export_bindings.len > 0);
     try std.testing.expectEqualStrings("x", b.export_bindings[0].exported_name);
 }
@@ -601,7 +603,8 @@ fn populateStoreForChangedFilesTest(
     var graph = ModuleGraph.init(std.testing.allocator, cache);
     defer graph.deinit();
     try graph.build(&.{entry});
-    for (graph.modules.items) |*m| {
+    for (0..graph.moduleCount()) |i| {
+        const m = graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.parse_arena == null) continue;
         store.putModule(m.path, m, m.mtime);
     }
@@ -729,8 +732,8 @@ test "buildIncremental: changed_files=empty + cache miss (new module) → 강제
 
     // changed_files 에 없지만 store 에도 없으므로 skip 조건 불성립 → stat → 신규 파싱.
     try std.testing.expectEqual(@as(usize, 1), r.reparsed_indices.len);
-    try std.testing.expectEqual(@as(usize, 1), graph.modules.items.len);
-    try std.testing.expectEqual(Module.State.ready, graph.modules.items[0].state);
+    try std.testing.expectEqual(@as(usize, 1), graph.moduleCount());
+    try std.testing.expectEqual(Module.State.ready, graph.getModule(ModuleIndex.fromUsize(0)).?.state);
 }
 
 // ============================================================================

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -41,7 +41,7 @@ test "linker: direct import resolves to export" {
     defer r.cache.deinit();
 
     // a.ts의 import x가 b.ts의 export x에 연결
-    const a = r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(a.import_bindings.len > 0);
     const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
@@ -62,7 +62,7 @@ test "linker: re-export chain resolved" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const a = r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // chain: a→b→c, canonical은 c(index 2)
@@ -100,7 +100,7 @@ test "linker: export * resolves through re-export all" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const a = r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // export * → c.ts(index 2)
@@ -123,14 +123,14 @@ test "linker: export * from CJS resolves to CJS module" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const a = r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // c.js는 CJS이므로, resolveExportChain이 c.js(index 2)를 반환
     try std.testing.expectEqual(@as(u32, 2), @intFromEnum(binding.?.canonical.module_index));
     try std.testing.expectEqualStrings("x", binding.?.canonical.export_name);
     // c.js가 실제로 CJS로 감지되었는지 확인
-    try std.testing.expectEqual(types.WrapKind.cjs, r.graph.modules.items[2].wrap_kind);
+    try std.testing.expectEqual(types.WrapKind.cjs, r.graph.getModule(ModuleIndex.fromUsize(2)).?.wrap_kind);
 }
 
 test "linker: namespace re-export resolves to local binding" {
@@ -149,7 +149,7 @@ test "linker: namespace re-export resolves to local binding" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const a = r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // namespace re-export는 b.ts(index 1)의 로컬 바인딩을 반환
@@ -183,7 +183,7 @@ test "linker: resolveExportChain on CJS module returns null for named exports" {
     try linker.link();
 
     // b.js가 CJS로 감지됨
-    try std.testing.expectEqual(types.WrapKind.cjs, graph.modules.items[1].wrap_kind);
+    try std.testing.expectEqual(types.WrapKind.cjs, graph.getModule(ModuleIndex.fromUsize(1)).?.wrap_kind);
 
     // CJS 모듈(index 1)에 직접 resolveExportChain 호출 → null
     // CJS는 정적 export가 없으므로 named export를 찾을 수 없다
@@ -202,7 +202,7 @@ test "linker: default import resolves" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const a = r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     try std.testing.expectEqualStrings("default", binding.?.canonical.export_name);
@@ -334,7 +334,7 @@ test "rename: getCanonicalName returns renamed" {
 
     // 하나는 getCanonicalName으로 리네임 조회 가능
     var found_rename = false;
-    for (r.graph.modules.items, 0..) |_, i| {
+    for (0..r.graph.moduleCount()) |i| {
         if (r.linker.getCanonicalName(@intCast(i), "count")) |renamed| {
             try std.testing.expect(std.mem.startsWith(u8, renamed, "count$"));
             found_rename = true;
@@ -344,7 +344,7 @@ test "rename: getCanonicalName returns renamed" {
 
     // 원본 유지되는 모듈은 getCanonicalName이 null
     var found_original = false;
-    for (r.graph.modules.items, 0..) |_, i| {
+    for (0..r.graph.moduleCount()) |i| {
         if (r.linker.getCanonicalName(@intCast(i), "count") == null) {
             found_original = true;
         }
@@ -429,7 +429,7 @@ test "linker: deep re-export chain (near depth limit)" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const a = r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, a.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // canonical은 e.ts(마지막 모듈)
@@ -540,7 +540,7 @@ test "computeRenamesForModules: 지정된 모듈만 대상으로 충돌 감지" 
     // 전체 3개 모듈을 글로벌 rename — 2개가 rename됨
     try linker.computeRenames();
     var global_rename_count: usize = 0;
-    for (graph.modules.items, 0..) |_, i| {
+    for (0..graph.moduleCount()) |i| {
         if (linker.getCanonicalName(@intCast(i), "x") != null) global_rename_count += 1;
     }
     try std.testing.expectEqual(@as(usize, 2), global_rename_count);
@@ -549,7 +549,7 @@ test "computeRenamesForModules: 지정된 모듈만 대상으로 충돌 감지" 
     const subset = &[_]ModuleIndex{ @enumFromInt(0), @enumFromInt(1) };
     try linker.computeRenamesForModules(subset, &.{});
     var subset_rename_count: usize = 0;
-    for (graph.modules.items, 0..) |_, i| {
+    for (0..graph.moduleCount()) |i| {
         if (linker.getCanonicalName(@intCast(i), "x") != null) subset_rename_count += 1;
     }
     try std.testing.expectEqual(@as(usize, 1), subset_rename_count);
@@ -602,7 +602,7 @@ test "namespace: import * as creates namespace object preamble" {
 
     // namespace import는 resolved_bindings에 등록되지 않음 (resolveImports에서 skip)
     // 대신 buildMetadataForAst에서 preamble로 처리
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
 }
@@ -621,7 +621,7 @@ test "namespace: export * from re-exports collected in namespace" {
     defer r.cache.deinit();
 
     // barrel 모듈에서 export * 로 a, b의 export를 수집
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
 }
@@ -644,7 +644,7 @@ test "re-export alias: export { J as render } resolves to J" {
     defer r.cache.deinit();
 
     // entry의 import { render }가 impl.ts의 J에 연결
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, entry.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // canonical은 impl.ts의 "J" — re-export 체인을 따라 최종 모듈의 export 이름
@@ -668,7 +668,7 @@ test "re-export alias: export { default as groupBy } — function declaration" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, entry.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // canonical은 impl.ts의 "default" → local_name = "hello" (함수명)
@@ -689,7 +689,7 @@ test "re-export alias: export { default as X } — identifier reuses original na
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, entry.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // export default groupBy → local_name = "groupBy" (identifier 이름 재사용)
@@ -744,7 +744,7 @@ test "namespace: diamond export * dedup" {
     defer r.cache.deinit();
 
     // entry에서 namespace import로 ns를 가져옴 — 무한 루프 없이 완료
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
 }
@@ -763,7 +763,7 @@ test "namespace: circular export * no infinite loop" {
     defer r.cache.deinit();
 
     // 무한 루프 없이 완료되면 성공
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
 }
@@ -780,7 +780,7 @@ test "namespace: mixed named + default exports" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
 }
@@ -798,7 +798,7 @@ test "namespace: re-export alias in namespace" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
 }
@@ -821,7 +821,7 @@ test "re-export alias: double-hop chain (z -> y -> x)" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, entry.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // 3-hop chain → 최종 origin.ts의 "x"
@@ -844,7 +844,7 @@ test "re-export alias: default class declaration resolves to class name" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, entry.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     // default class declaration → local_name = "MyWidget"
@@ -916,7 +916,7 @@ test "export * as: basic namespace re-export" {
     defer r.cache.deinit();
 
     // entry의 import { math }가 barrel의 "math" export에 연결
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     const binding = r.linker.getResolvedBinding(0, entry.import_bindings[0].local_span);
     try std.testing.expect(binding != null);
     try std.testing.expectEqualStrings("math", binding.?.canonical.export_name);
@@ -936,7 +936,8 @@ test "export * as: binding_scanner registers named export" {
 
     // barrel 모듈(index 1)의 export_bindings에 "utils" 이름이 등록됨
     var has_utils_export = false;
-    for (r.graph.modules.items) |m| {
+    var it = r.graph.modulesIterator();
+    while (it.next()) |m| {
         for (m.export_bindings) |eb| {
             if (std.mem.eql(u8, eb.exported_name, "utils")) {
                 has_utils_export = true;
@@ -964,7 +965,7 @@ test "namespace rewrite: ns.prop resolved in ns_member_rewrites" {
     defer r.cache.deinit();
 
     // ns.prop만 사용 → ns_member_rewrites에 매핑 등록
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
 }
@@ -1052,7 +1053,7 @@ test "export * as: does not pollute parent seen (name collision)" {
     defer r.cache.deinit();
 
     // entry의 namespace import 확인
-    const entry = r.graph.modules.items[0];
+    const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
 }
@@ -1088,7 +1089,7 @@ test "preamble: CJS module import — named import generates require_xxx" {
     defer r.cache.deinit();
 
     // c.js가 CJS로 감지되었는지 확인
-    try std.testing.expectEqual(types.WrapKind.cjs, r.graph.modules.items[1].wrap_kind);
+    try std.testing.expectEqual(types.WrapKind.cjs, r.graph.getModule(ModuleIndex.fromUsize(1)).?.wrap_kind);
 
     var md = try buildMetadataForModule(&r, 0, true);
     defer md.deinit();
@@ -1187,7 +1188,7 @@ test "preamble: dev mode — named import uses namespace access pattern" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const ast: *const Ast = &(r.graph.modules.items[0].ast orelse unreachable);
+    const ast: *const Ast = &(r.graph.getModule(ModuleIndex.fromUsize(0)).?.ast orelse unreachable);
     var md = try r.linker.buildDevMetadataForAst(ast, 0);
     defer md.deinit();
 
@@ -1225,7 +1226,7 @@ test "preamble: dev mode — default import uses .default" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const ast: *const Ast = &(r.graph.modules.items[0].ast orelse unreachable);
+    const ast: *const Ast = &(r.graph.getModule(ModuleIndex.fromUsize(0)).?.ast orelse unreachable);
     var md = try r.linker.buildDevMetadataForAst(ast, 0);
     defer md.deinit();
 
@@ -1246,7 +1247,7 @@ test "preamble: dev mode — namespace import without .default" {
     defer r.graph.deinit();
     defer r.cache.deinit();
 
-    const ast: *const Ast = &(r.graph.modules.items[0].ast orelse unreachable);
+    const ast: *const Ast = &(r.graph.getModule(ModuleIndex.fromUsize(0)).?.ast orelse unreachable);
     var md = try r.linker.buildDevMetadataForAst(ast, 0);
     defer md.deinit();
 
@@ -1330,7 +1331,7 @@ test "populateSymbolRefCounts: import이 source default symbol의 ref_count 증�
 
     // b.ts의 synthetic_default symbol이 참조되어 ref_count == 1.
     // #1328 Phase 4e-2b: _default는 semantic 공간에 등록됨.
-    const b = &r.graph.modules.items[1];
+    const b = r.graph.getModule(ModuleIndex.fromUsize(1)).?;
     const b_sem = b.semantic orelse return error.NoSemantic;
     var found_ref: u32 = 0;
     for (b_sem.symbols.items) |sym| {
@@ -1359,7 +1360,7 @@ test "populateSymbolRefCounts: 아무도 안 쓰는 export는 ref_count 0" {
     r.linker.populateImportSymbols(r.graph.modules.items);
     r.linker.populateSymbolRefCounts(r.graph.modules.items);
 
-    const b = &r.graph.modules.items[1];
+    const b = r.graph.getModule(ModuleIndex.fromUsize(1)).?;
     const b_sem = b.semantic orelse return error.NoSemantic;
     var found_ref: u32 = 0;
     var found_default = false;
@@ -1391,7 +1392,7 @@ test "getCanonicalByRef: alias symbol의 canonical_name 반환" {
     r.linker.populateImportSymbols(r.graph.modules.items);
 
     // a.ts의 barrel re-export alias symbol 찾기
-    const a = &r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     var alias_ref: ?@import("symbol.zig").SymbolRef = null;
     for (a.export_bindings) |eb| {
         if (eb.kind == .re_export and std.mem.eql(u8, eb.exported_name, "Foo")) {
@@ -1423,7 +1424,8 @@ test "computeRenames: rename된 심볼의 canonical_name이 semantic.Symbol에 �
 
     // m1 또는 m2 중 하나의 'x' 심볼이 canonical_name을 갖춰야 함
     var renamed_count: u32 = 0;
-    for (r.graph.modules.items) |m| {
+    var it = r.graph.modulesIterator();
+    while (it.next()) |m| {
         const sem = m.semantic orelse continue;
         if (sem.scope_maps.len == 0) continue;
         const sym_idx = sem.scope_maps[0].get("x") orelse continue;
@@ -1491,7 +1493,7 @@ test "populateImportSymbols: named import의 local_symbol이 현재 모듈 seman
 
     r.linker.populateImportSymbols(r.graph.modules.items);
 
-    const a = &r.graph.modules.items[0];
+    const a = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     var found = false;
     for (a.import_bindings) |ib| {
         if (std.mem.eql(u8, ib.local_name, "x")) {

--- a/src/bundler/phase.zig
+++ b/src/bundler/phase.zig
@@ -256,6 +256,11 @@ pub const LinkAccessor = struct {
     pub inline fn setCycleGroup(self: LinkAccessor, idx: ModuleIndex, value: u32) void {
         if (self.graph.moduleAtMut(idx)) |m| m.cycle_group = value;
     }
+
+    /// dev mode 모듈 ID. bundler 가 build() 끝 emit 직전 단계에서 한 번만 write.
+    pub inline fn setDevId(self: LinkAccessor, idx: ModuleIndex, dev_id: []const u8) void {
+        if (self.graph.moduleAtMut(idx)) |m| m.dev_id = dev_id;
+    }
 };
 
 // ============================================================

--- a/src/bundler/require_context_resolve_test.zig
+++ b/src/bundler/require_context_resolve_test.zig
@@ -331,7 +331,8 @@ test "graph: require.context with plugin → context_matches populated, no diagn
 
     // record.context_matches 채워졌는지 확인. 메모리는 module.deinit 가 자동 free.
     var found_matches = false;
-    for (graph.modules.items) |m| {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
         for (m.import_records) |r| {
             if (r.kind == .require_context and r.context_matches != null and r.context_matches.?.len == 3) {
                 found_matches = true;

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -4,6 +4,8 @@ const TreeShaker = tree_shaker_mod.TreeShaker;
 const ALL_EXPORTS_SENTINEL = tree_shaker_mod.ALL_EXPORTS_SENTINEL;
 const Linker = @import("linker.zig").Linker;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
+const types = @import("types.zig");
+const ModuleIndex = types.ModuleIndex;
 const resolve_cache_mod = @import("resolve_cache.zig");
 const writeFile = @import("test_helpers.zig").writeFile;
 
@@ -22,7 +24,8 @@ const TestResult = struct {
 
     /// 모듈 경로 접미사로 인덱스 조회. 못 찾으면 null.
     fn findModule(self: *const TestResult, suffix: []const u8) ?u32 {
-        for (self.graph.modules.items, 0..) |m, i| {
+        for (0..self.graph.moduleCount()) |i| {
+            const m = self.graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
             if (std.mem.endsWith(u8, m.path, suffix)) return @intCast(i);
         }
         return null;
@@ -50,7 +53,8 @@ fn buildAndShakeWithOpts(
     var graph = ModuleGraph.init(allocator, &cache);
     try graph.build(&.{entry});
 
-    for (graph.modules.items) |*m| {
+    for (0..graph.moduleCount()) |i| {
+        const m = graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         for (no_side_effects) |suffix| {
             if (std.mem.endsWith(u8, m.path, suffix)) {
                 m.side_effects = false;
@@ -192,7 +196,7 @@ test "tree-shaking: included module's dependencies are propagated" {
     defer r.deinit();
 
     // a, b, c 모두 포함
-    for (r.graph.modules.items, 0..) |_, i| {
+    for (0..r.graph.moduleCount()) |i| {
         try std.testing.expect(r.shaker.isIncluded(@intCast(i)));
     }
 }
@@ -228,7 +232,7 @@ test "tree-shaking: diamond dependency — shared module included once" {
     var r = try buildAndShake(std.testing.allocator, &tmp, "a.ts");
     defer r.deinit();
 
-    for (r.graph.modules.items, 0..) |_, i| {
+    for (0..r.graph.moduleCount()) |i| {
         try std.testing.expect(r.shaker.isIncluded(@intCast(i)));
     }
     try std.testing.expect(r.shaker.isExportUsed(r.findModule("d.ts").?, "shared"));
@@ -303,7 +307,8 @@ test "esbuild: namespace import marks all exports as used" {
     defer r.deinit();
 
     var lib_idx: u32 = 0;
-    for (r.graph.modules.items, 0..) |m, i| {
+    for (0..r.graph.moduleCount()) |i| {
+        const m = r.graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
         if (std.mem.endsWith(u8, m.path, "lib.ts")) {
             lib_idx = @intCast(i);
             break;
@@ -337,7 +342,8 @@ test "rolldown: re-export chain preserves side-effect module" {
     defer r.deinit();
 
     // 모든 모듈 포함 (side_effects=true 기본이므로)
-    for (r.graph.modules.items, 0..) |m, i| {
+    for (0..r.graph.moduleCount()) |i| {
+        const m = r.graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
         if (std.mem.endsWith(u8, m.path, "sideeffect.ts")) {
             try std.testing.expect(r.shaker.isIncluded(@intCast(i)));
         }
@@ -380,7 +386,8 @@ test "rolldown: barrel file — only used re-exports tracked" {
     // mod-a의 a는 사용됨
     var mod_a_idx: u32 = 0;
     var mod_b_idx: u32 = 0;
-    for (r.graph.modules.items, 0..) |m, i| {
+    for (0..r.graph.moduleCount()) |i| {
+        const m = r.graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
         if (std.mem.endsWith(u8, m.path, "mod-a.ts")) mod_a_idx = @intCast(i);
         if (std.mem.endsWith(u8, m.path, "mod-b.ts")) mod_b_idx = @intCast(i);
     }
@@ -401,7 +408,8 @@ test "rolldown: export * — only used names tracked through star" {
     defer r.deinit();
 
     var lib_idx: u32 = 0;
-    for (r.graph.modules.items, 0..) |m, i| {
+    for (0..r.graph.moduleCount()) |i| {
+        const m = r.graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
         if (std.mem.endsWith(u8, m.path, "lib.ts")) {
             lib_idx = @intCast(i);
             break;
@@ -429,7 +437,8 @@ test "rollup: deconflict after tree-shaking" {
     defer r.deinit();
 
     var used_idx: u32 = 0;
-    for (r.graph.modules.items, 0..) |m, i| {
+    for (0..r.graph.moduleCount()) |i| {
+        const m = r.graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
         if (std.mem.endsWith(u8, m.path, "used.ts")) {
             used_idx = @intCast(i);
             break;
@@ -454,7 +463,8 @@ test "rollup: module with class instantiation has side effects" {
     defer r.deinit();
 
     // effects.ts는 side_effects=true (기본) → 포함
-    for (r.graph.modules.items, 0..) |m, i| {
+    for (0..r.graph.moduleCount()) |i| {
+        const m = r.graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
         if (std.mem.endsWith(u8, m.path, "effects.ts")) {
             try std.testing.expect(r.shaker.isIncluded(@intCast(i)));
         }
@@ -721,7 +731,8 @@ test "re-export-local: import then export { x } passes through" {
     defer r.deinit();
 
     // entry가 x를 사용 → mid 포함 → leaf 포함
-    for (r.graph.modules.items, 0..) |m, i| {
+    for (0..r.graph.moduleCount()) |i| {
+        const m = r.graph.getModule(ModuleIndex.fromUsize(i)) orelse continue;
         if (std.mem.endsWith(u8, m.path, "leaf.ts")) {
             try std.testing.expect(r.shaker.isIncluded(@intCast(i)));
         }
@@ -2099,7 +2110,7 @@ test "#1558 Phase 5: live export가 내부 private helper를 참조하면 dead �
 
     // privateHelper는 export는 아니지만 lib 모듈 내 선언이 reachable이어야
     // linker가 dangling reference 없이 번들 가능.
-    const lib_mod = r.graph.modules.items[lib];
+    const lib_mod = r.graph.getModule(ModuleIndex.fromUsize(lib)).?;
     const infos = r.shaker.getModuleStmtInfos(lib) orelse return error.NoStmtInfo;
     const sem = lib_mod.semantic orelse return error.NoSemantic;
     const helper_sym = sem.scope_maps[0].get("privateHelper") orelse return error.NoSym;

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -58,6 +58,11 @@ pub const ModuleIndex = enum(u32) {
     pub inline fn toUsize(self: ModuleIndex) usize {
         return @intCast(@intFromEnum(self));
     }
+
+    /// iteration 시 usize → ModuleIndex 변환. `for (0..graph.moduleCount()) |i|` 패턴용.
+    pub inline fn fromUsize(i: usize) ModuleIndex {
+        return @enumFromInt(@as(u32, @intCast(i)));
+    }
 };
 
 // ============================================================


### PR DESCRIPTION
## Summary
- PR #1780 (#1a) 에서 도입한 ModuleGraph accessor API 를 실제 call site 에 적용하는 기계적 리팩터
- 총 ~117곳 교체 (prod 14 + test ~103)
- slice 를 함수 인자로 전달하는 ~88곳은 PR #2 (linker/Module 시그니처 변경) 에서 처리
- 동작 변화 없음 (순수 리팩터), `zig build test` 통과

## 변경 요약

### commit 1: prod 코드 (5 파일, +41/-18)
- `src/bundler/types.zig`: `ModuleIndex.fromUsize` 헬퍼 추가
- `src/bundler/phase.zig`: `LinkAccessor.setDevId` 추가 (build() 끝 dev_id 부여용)
- `src/bundler/bundler.zig`: 13곳
- `src/bundler/emitter.zig`: 1곳
- `src/bundler/emitter/chunks.zig`: 1곳

### commit 2: 테스트 코드 (6 파일, +152/-109)
- `linker_test.zig` 37곳, `emitter_test.zig` 14곳 (setup + defer cleanup 블록)
- `graph_test.zig` 29곳, `tree_shaker_test.zig` 12곳
- `bundler_test/cjs_esm.zig` 10곳, `require_context_resolve_test.zig` 1곳

## 교체 패턴

| 기존 | 새 코드 |
|------|--------|
| `graph.modules.items.len` | `graph.moduleCount()` |
| `graph.modules.items[idx].foo` (read) | `graph.getModule(idx).?.foo` |
| `&graph.modules.items[idx]` (read) | `graph.getModule(idx).?` |
| `for (graph.modules.items) \|m\|` | `var it = graph.modulesIterator(); while (it.next()) \|m\|` |
| `for (graph.modules.items) \|*m\|` (mutate) | `for (0..graph.moduleCount()) \|i\| { const m = graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue; ... }` |
| `m.dev_id = ...` | `graph.linkAccessor().setDevId(idx, ...)` |

## 제외된 케이스 (#2 에서 처리)

`graph.modules.items` 를 `[]Module` slice 로 다른 함수에 전달하는 경우:
- `Linker.init(..., graph.modules.items, ...)`
- `linker.populateReExportAliases(graph.modules.items)` (및 `populateImportSymbols` / `populateNamespaceAccesses` / `populateSymbolRefCounts`)
- `TreeShaker.init(..., graph.modules.items, ...)`
- `cache_mod.computeInputHash(..., graph.modules.items)`
- `chunk_mod.computeCrossChunkLinks(..., graph.modules.items, ...)`
- `areAllReExportNsConsumersPrecise(graph.modules.items, ...)`

이들은 함수 시그니처 변경이 필요하므로 PR #2 에서 `*ModuleGraph` + iterator 로 리팩터.

## 참고

- `chunk.modules.items` (`Chunk` 의 `ArrayList(ModuleIndex)`) 는 `ModuleGraph.modules` 와 무관 — 건드리지 않음
- `graph.zig` 자체의 내부 접근은 storage owner 라 그대로 (PR #3 에서 SegmentedList 로 교체 시 같이)
- 테스트의 `moduleAtMut` 직접 호출은 phase 강제 대상이 아님 (테스트는 편의 우선)

## Test plan
- [x] `zig build` 통과
- [x] `zig build test` 통과

Refs #1779