### PR TITLE
refactor(bundler): ModuleGraph 의 SegmentedList 타입을 ModuleList 상수로 추출

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -54,10 +54,9 @@ pub const LinkAccessor = phase_mod.LinkAccessor;
 pub const ModuleGraph = struct {
     allocator: std.mem.Allocator,
     /// Module storage. SegmentedList 는 append 시에도 기존 포인터를 무효화하지
-    /// 않아서 worker race-safety 를 보장한다 (#1779 PR #3). prealloc_item_count=0
-    /// 은 전량 heap chunk 사용 — hot path 에서 static 영역을 쓸 수 없는 ModuleGraph
-    /// 특성상 기본값으로 충분.
-    modules: std.SegmentedList(Module, 0) = .{},
+    /// 않아서 worker race-safety 를 보장한다 (#1779 PR #3). prealloc=0 은 전량
+    /// heap chunk — Module 이 수백 바이트라 stack pre-alloc 비효율.
+    modules: ModuleList = .{},
     path_to_module: std.StringHashMap(ModuleIndex),
     diagnostics: std.ArrayList(BundlerDiagnostic),
     resolve_cache: *ResolveCache,
@@ -228,7 +227,9 @@ pub const ModuleGraph = struct {
         return self.modules.constIterator(0);
     }
 
-    pub const ModulesIterator = std.SegmentedList(Module, 0).ConstIterator;
+    /// modules storage 타입. prealloc_item_count 변경은 여기 한 곳만 수정.
+    pub const ModuleList = std.SegmentedList(Module, 0);
+    pub const ModulesIterator = ModuleList.ConstIterator;
 
     /// 확장자에 대한 로더를 결정한다.
     /// --loader 오버라이드가 있으면 우선 사용, 없으면 확장자 기본값.


### PR DESCRIPTION
## Summary

PR #1783 (#1779 Phase 3) 의 post-merge /simplify 검토 반영. 매우 작은 cleanup.

## 문제

`std.SegmentedList(Module, 0)` 이 `graph.zig` 의 field 선언 + `ModulesIterator` alias 2곳에 하드코딩. 향후 `prealloc_item_count` 를 튜닝하려면 두 곳 모두 수정해야 함 — 누락 위험.

## 변경

```zig
// Before
modules: std.SegmentedList(Module, 0) = .{},
...
pub const ModulesIterator = std.SegmentedList(Module, 0).ConstIterator;

// After
pub const ModuleList = std.SegmentedList(Module, 0);
pub const ModulesIterator = ModuleList.ConstIterator;
modules: ModuleList = .{},
```

이제 prealloc 변경은 `ModuleList` 정의 한 줄만 수정.

## Post-merge simplify note

/simplify 를 PR #1783 올리기 **전** 에 실수로 skip 한 것을 사후 보완. review 에서 발견된 다른 항목은 모두 false positive 또는 measure-후-최적화 대상 (`feedback_measure_before_optimize`) 이라 skip.

## Test plan
- [x] `zig build` / `zig build test` 통과 (동작 변화 없음)

Refs #1779