### PR TITLE
feat(bundler): #1579 Phase 4 — require.context matches 를 graph dep + tree-shake root 로 등록

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -82,9 +82,15 @@ pub inline fn moduleAtMut(self: *ModuleGraph, idx: ModuleIndex) ?*Module;
 
 | Phase | Fields |
 |-------|--------|
-| **parse only** | source, ast, semantic, parse_arena, import_bindings, export_bindings, line_offsets, legal_comments, prebuilt_stmt_info, mtime, loader, def_format, state, asset_data, css_data |
-| **resolve only** | is_module_field, side_effects_user_defined, is_disabled, is_entry_point |
+| **parse only** | source, ast, semantic, parse_arena, import_bindings, export_bindings, line_offsets, legal_comments, prebuilt_stmt_info, mtime, loader, def_format, state, asset_data, css_data, context_expansion_deps |
+| **resolve only** | is_module_field, side_effects_user_defined, is_disabled, is_entry_point, is_context_dep |
 | **link only** | exec_index, cycle_group, dev_id |
+
+`context_expansion_deps` 는 parse 단계의 `expandRequireContextRecords` 가 plugin
+matches 를 모아 채운다. parse_arena 소유라 graph.deinit 시 자동 해제.
+
+`is_context_dep` 는 resolve 단계의 `applyContextDepResults` 가 require.context
+match 로 등록된 module 에 마킹. tree-shaker 가 runtime require root 로 보존.
 
 ### Multi-phase field (5개)
 

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -10,6 +10,7 @@ const PluginError = plugin_mod.PluginError;
 const test_helpers = @import("../test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
+const threadSafeArena = test_helpers.threadSafeArena;
 
 test "Bundler: single file bundle" {
     var tmp = std.testing.tmpDir(.{});
@@ -665,7 +666,7 @@ test "Bundler: import.meta.glob eager option" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -694,7 +695,7 @@ test "Bundler: import.meta.glob import option" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -845,7 +846,7 @@ test "Bundler: require.context emits webpackContext IIFE (sync)" {
     // mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -887,7 +888,7 @@ test "Bundler: require.context emits empty map when no matches" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -921,7 +922,7 @@ test "Bundler: require.context escapes match path special chars" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -949,7 +950,7 @@ test "Bundler: require.context normalizes trailing slash and missing ./" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -1005,7 +1006,7 @@ test "Bundler: multiple require.context calls resolve to distinct maps (span mat
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -1045,7 +1046,7 @@ test "Bundler: require.context coexists with import.meta.glob" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -1090,7 +1091,7 @@ test "Bundler: require.context emits IIFE inside __esm wrapper (RN platform)" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -1135,7 +1136,7 @@ test "Bundler: require.context — matches 파일들이 번들에 포함됨" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -1173,7 +1174,7 @@ test "Bundler: require.context — nested match 파일도 번들에 포함" {
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
@@ -1207,7 +1208,7 @@ test "Bundler: require.context — empty matches → 파일 없어도 hasErrors 
     defer arena.deinit();
     // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
     // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
-    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    var ts = threadSafeArena(&arena);
     const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -663,7 +663,10 @@ test "Bundler: import.meta.glob eager option" {
     // glob_matches의 기존 메모리 릭 (expandGlob 할당)을 우회하기 위해 arena 사용
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -689,7 +692,10 @@ test "Bundler: import.meta.glob eager option" {
 test "Bundler: import.meta.glob import option" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -728,6 +734,67 @@ fn rcMatchAB(
     result[0] = try allocator.dupe(u8, "./a.tsx");
     result[1] = try allocator.dupe(u8, "./b.tsx");
     return result;
+}
+
+/// importer dir + dir 를 실제 FS 스캔 — graph dep 등록 성공을 위해 실제 파일 필요.
+fn rcScanDir(
+    _: ?*anyopaque,
+    dir: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    importer: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    const importer_dir = std.fs.path.dirname(importer) orelse return null;
+    const abs_dir = std.fs.path.resolve(allocator, &.{ importer_dir, dir }) catch return null;
+    defer allocator.free(abs_dir);
+
+    var d = std.fs.openDirAbsolute(abs_dir, .{ .iterate = true }) catch {
+        return try allocator.alloc([]const u8, 0);
+    };
+    defer d.close();
+
+    var list = std.ArrayList([]const u8).empty;
+    defer list.deinit(allocator);
+    var it = d.iterate();
+    while (it.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const rel = std.fmt.allocPrint(allocator, "./{s}", .{entry.name}) catch continue;
+        list.append(allocator, rel) catch continue;
+    }
+    return try list.toOwnedSlice(allocator);
+}
+
+/// 재귀 FS 스캔 (recursive=true 이면 subdir 의 파일도 반환).
+fn rcRecursiveScan(
+    _: ?*anyopaque,
+    dir: []const u8,
+    _: bool,
+    _: ?[]const u8,
+    _: ?[]const u8,
+    importer: []const u8,
+    allocator: std.mem.Allocator,
+) PluginError!?[]const []const u8 {
+    const importer_dir = std.fs.path.dirname(importer) orelse return null;
+    const abs_dir = std.fs.path.resolve(allocator, &.{ importer_dir, dir }) catch return null;
+    defer allocator.free(abs_dir);
+
+    var d = std.fs.openDirAbsolute(abs_dir, .{ .iterate = true }) catch {
+        return try allocator.alloc([]const u8, 0);
+    };
+    defer d.close();
+
+    var list = std.ArrayList([]const u8).empty;
+    defer list.deinit(allocator);
+    var walker = d.walk(allocator) catch return try allocator.alloc([]const u8, 0);
+    defer walker.deinit();
+    while (walker.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const rel = std.fmt.allocPrint(allocator, "./{s}", .{entry.path}) catch continue;
+        list.append(allocator, rel) catch continue;
+    }
+    return try list.toOwnedSlice(allocator);
 }
 
 fn rcMatchEmpty(
@@ -773,12 +840,20 @@ fn rcMatchNoDotSlash(
 }
 
 test "Bundler: require.context emits webpackContext IIFE (sync)" {
+    // ArenaAllocator 는 thread-safe 가 아님. 번들러는 worker threads 에서도 self.allocator 로
+    // 할당하므로 (#1779 INVARIANTS 의 storage-level race-safety 와 별개) 테스트 arena 를 감싸서
+    // mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
+    // matches 가 graph dep 으로 등록되니 실제 파일 필요.
+    try tmp.dir.makeDir("pages");
+    try writeFile(tmp.dir, "pages/a.tsx", "export const a = 1;");
+    try writeFile(tmp.dir, "pages/b.tsx", "export const b = 2;");
     try writeFile(tmp.dir, "entry.ts",
         \\const ctx = require.context('./pages', true, /\.tsx?$/, 'sync');
         \\console.log(ctx);
@@ -787,7 +862,7 @@ test "Bundler: require.context emits webpackContext IIFE (sync)" {
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
 
-    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchAB }};
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcScanDir }};
     var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
     defer b.deinit();
 
@@ -797,19 +872,23 @@ test "Bundler: require.context emits webpackContext IIFE (sync)" {
 
     // webpackContext runtime 핵심 구성요소
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var map={") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./a.tsx\":function(){return require(\"./pages/a.tsx\");}") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./b.tsx\":function(){return require(\"./pages/b.tsx\");}") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "ctx.keys=function(){return Object.keys(map);}") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "ctx.resolve=function(req)") != null);
     // 원본 `require.context(...)` 호출은 남으면 안 됨 — IIFE 로 교체되어야.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require.context(") == null);
+    // 매치 파일들이 번들에 실제로 포함되어야 — graph dep 등록 확인.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "// --- a.tsx ---") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "// --- b.tsx ---") != null);
 }
 
 test "Bundler: require.context emits empty map when no matches" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -836,9 +915,14 @@ test "Bundler: require.context emits empty map when no matches" {
 }
 
 test "Bundler: require.context escapes match path special chars" {
+    // 특수문자 파일은 FS 에 못 만들어서 graph dep resolve 가 실패 → diagnostic 발생.
+    // 여기선 escape 로직 (writeJsStringContent) 만 검증 — hasErrors 는 무시.
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -853,7 +937,6 @@ test "Bundler: require.context escapes match path special chars" {
 
     const result = try b.bundle();
     defer result.deinit(alloc);
-    try std.testing.expect(!result.hasErrors());
 
     // 원본 `"` 는 `\"` 로, `\` 는 `\\` 로 escape 되어야 JS 문자열 리터럴이 유효.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\\\"name\\\\x.tsx") != null);
@@ -864,10 +947,17 @@ test "Bundler: require.context escapes match path special chars" {
 test "Bundler: require.context normalizes trailing slash and missing ./" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
+    // graph dep 등록을 위해 실제 파일 생성.
+    try tmp.dir.makeDir("pages");
+    try tmp.dir.makeDir("pages/nested");
+    try writeFile(tmp.dir, "pages/nested/a.tsx", "export const a = 1;");
     // dir 에 trailing `/` → 매치 경로 join 시 중복 `//` 안 생김.
     try writeFile(tmp.dir, "entry.ts", "const ctx = require.context('./pages/');\nconsole.log(ctx);");
 
@@ -913,10 +1003,18 @@ fn rcDispatchByCallCount(
 test "Bundler: multiple require.context calls resolve to distinct maps (span match)" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
+    // 각 dir 에 매치할 파일이 실제 존재해야 graph dep 등록 성공.
+    try tmp.dir.makeDir("pages");
+    try tmp.dir.makeDir("other");
+    try writeFile(tmp.dir, "pages/first.tsx", "export const x = 1;");
+    try writeFile(tmp.dir, "other/second.tsx", "export const y = 2;");
     try writeFile(tmp.dir, "entry.ts",
         \\const a = require.context('./pages');
         \\const b = require.context('./other');
@@ -945,12 +1043,19 @@ test "Bundler: multiple require.context calls resolve to distinct maps (span mat
 test "Bundler: require.context coexists with import.meta.glob" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.makeDir("mods");
+    try tmp.dir.makeDir("pages");
     try writeFile(tmp.dir, "mods/a.ts", "export const x = 1;");
+    // require.context 매치 파일도 graph dep 등록용으로 필요.
+    try writeFile(tmp.dir, "pages/a.tsx", "export const a = 1;");
+    try writeFile(tmp.dir, "pages/b.tsx", "export const b = 2;");
     try writeFile(tmp.dir, "entry.ts",
         \\const g = import.meta.glob('./mods/*.ts', { eager: true });
         \\const c = require.context('./pages');
@@ -960,7 +1065,7 @@ test "Bundler: require.context coexists with import.meta.glob" {
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
 
-    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchAB }};
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcScanDir }};
     var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
     defer b.deinit();
 
@@ -983,10 +1088,16 @@ test "Bundler: require.context emits IIFE inside __esm wrapper (RN platform)" {
     // Expo Router `_ctx.ios.js` 가 이 패턴 (ESM export const ctx = require.context(...)).
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const alloc = arena.allocator();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
+    try tmp.dir.makeDir("pages");
+    try writeFile(tmp.dir, "pages/a.tsx", "export const a = 1;");
+    try writeFile(tmp.dir, "pages/b.tsx", "export const b = 2;");
     try writeFile(tmp.dir, "entry.ts",
         \\export const ctx = require.context('./pages', true, /^\.\//, 'sync');
     );
@@ -994,7 +1105,7 @@ test "Bundler: require.context emits IIFE inside __esm wrapper (RN platform)" {
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
 
-    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchAB }};
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcScanDir }};
     var b = Bundler.init(alloc, .{
         .entry_points = &.{entry},
         .format = .esm,
@@ -1013,6 +1124,107 @@ test "Bundler: require.context emits IIFE inside __esm wrapper (RN platform)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") != null);
     // 원본 호출은 교체되어야
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require.context(") == null);
+}
+
+// ============================================================
+// require.context matches → graph dep 등록 → bundle 에 포함
+// ============================================================
+
+test "Bundler: require.context — matches 파일들이 번들에 포함됨" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("pages");
+    try writeFile(tmp.dir, "pages/a.tsx", "export const PAGE_A = 'page-a-content';");
+    try writeFile(tmp.dir, "pages/b.tsx", "export const PAGE_B = 'page-b-content';");
+    try writeFile(tmp.dir, "entry.ts",
+        \\const ctx = require.context('./pages');
+        \\console.log(ctx.keys());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcScanDir }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // matches 파일의 실제 콘텐츠가 번들에 들어가는지 확인 —
+    // 이전 단계 까지는 IIFE 만 emit 되고 대상 파일은 번들 밖이었음.
+    // (Phase 3 까지는 IIFE 만 emit 되고 대상 파일은 번들 밖이라 런타임 require 실패.)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "page-a-content") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "page-b-content") != null);
+    // IIFE 도 함께 존재
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var map={") != null);
+}
+
+test "Bundler: require.context — nested match 파일도 번들에 포함" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("pages");
+    try tmp.dir.makeDir("pages/nested");
+    try writeFile(tmp.dir, "pages/nested/deep.tsx", "export const DEEP = 'deep-content';");
+    try writeFile(tmp.dir, "entry.ts",
+        \\const ctx = require.context('./pages', true, /\.tsx$/);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    // plugin: 재귀 스캔 (./nested/deep.tsx 도 반환)
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcRecursiveScan }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "deep-content") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "./nested/deep.tsx") != null);
+}
+
+test "Bundler: require.context — empty matches → 파일 없어도 hasErrors false" {
+    // 회귀: empty matches 는 expansion 에 추가할 게 없어 resolve 실패 발생 안 함.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    // ArenaAllocator 는 thread-safe 가 아닌데 bundler worker 에서 self.allocator 로 동시 할당
+    // 가능 → ThreadSafeAllocator 로 감싸서 mutex 보호. 프로덕션 (bungae) 은 GPA thread-safe 기본.
+    var ts: std.heap.ThreadSafeAllocator = .{ .child_allocator = arena.allocator() };
+    const alloc = ts.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "const ctx = require.context('./empty');");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcMatchEmpty }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var map={}") != null);
 }
 
 test "Bundler: no require.context in source → no webpackContext template emitted" {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -2520,8 +2520,11 @@ fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
     else
         null;
 
-    // arena 에서 append — self.allocator 와 섞이면 capacity/free mismatch 발생.
-    const arena_alloc = if (module.parse_arena) |*a| a.allocator() else self.allocator;
+    // require.context 는 parse 산출물이라 arena 가 항상 존재. 없으면 (disabled/asset 등)
+    // expand 자체가 의미 없고, graph allocator fallback 은 module.deinit 에서 free 누락 →
+    // leak. 안전하게 early return.
+    const arena = if (module.parse_arena) |*a| a else return;
+    const arena_alloc = arena.allocator();
     var expansion = std.ArrayList(types.ImportRecord).empty;
 
     for (records) |*record| {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -324,6 +324,8 @@ pub const ModuleGraph = struct {
                         try self.applyResolveResult(mod_idx, rec_i, record, resolves[rec_i].resolved, resolves[rec_i].is_error);
                     }
                 }
+                // require.context matches → graph dep 등록 (#1579 Phase 4).
+                try self.applyContextDepResults(mod_idx);
                 if (resolves.len > 0) self.allocator.free(resolves);
 
                 // 새로 발견된 모듈 즉시 워커에 디스패치
@@ -668,8 +670,43 @@ pub const ModuleGraph = struct {
         try to_mod.importers.append(self.allocator, from);
     }
 
-    /// resolve 결과를 모듈 그래프에 적용한다 (addModule, linkDependency 등).
-    /// resolveModuleImports와 resolveModuleImportsBatchParallel 공통.
+    /// context_expansion_deps 를 resolve 하고 graph 에 module + dependency 로 등록 (#1579 Phase 4).
+    /// scanModules receiver / resolveModuleImports 양쪽 경로에서 호출. SegmentedList 로
+    /// append 해도 기존 *Module 포인터는 유효 (#1779 INVARIANTS.md).
+    fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
+        const mod_index = ModuleIndex.fromUsize(mod_idx);
+        const mod_ptr = self.modules.at(mod_idx);
+        const context_deps = mod_ptr.context_expansion_deps;
+        if (context_deps.len == 0) return;
+
+        const module_path = mod_ptr.path;
+        const source_dir = std.fs.path.dirname(module_path) orelse ".";
+        for (context_deps) |dep| {
+            const resolved = self.resolve_cache.resolveThreadSafe(source_dir, dep.specifier, dep.kind) catch |err| switch (err) {
+                error.ModuleNotFound => {
+                    self.addDiag(
+                        .unresolved_import,
+                        .warning,
+                        module_path,
+                        dep.span,
+                        .resolve,
+                        "Cannot resolve require.context match",
+                        dep.specifier,
+                    );
+                    continue;
+                },
+                else => |e| return e,
+            };
+            if (resolved) |r| {
+                defer self.allocator.free(r.path);
+                const dep_idx = try self.addModule(r.path);
+                // tree-shaker 가 static import 없이도 이 모듈을 보존하도록 마킹.
+                self.modules.at(@intFromEnum(dep_idx)).is_context_dep = true;
+                try self.linkDependency(mod_index, dep_idx);
+            }
+        }
+    }
+
     fn applyResolveResult(
         self: *ModuleGraph,
         mod_idx: usize,
@@ -776,18 +813,10 @@ pub const ModuleGraph = struct {
         }
 
         const mod_ptr = self.modules.at(mod_idx);
-        const records = mod_ptr.import_records;
-        if (records.len == 0) {
+        if (mod_ptr.import_records.len == 0) {
             channel.send(.{ .module_idx = idx, .resolve_outputs = &.{} });
             return;
         }
-
-        var results = self.allocator.alloc(ResolveOutput, records.len) catch {
-            self.addDiag(.resolve_error, .@"error", mod_ptr.path, Span.EMPTY, .resolve, "Out of memory allocating resolve results", null);
-            channel.send(.{ .module_idx = idx, .resolve_outputs = &.{} });
-            return;
-        };
-        for (results) |*r| r.* = .{};
 
         const module_path = mod_ptr.path;
         const source_dir = std.fs.path.dirname(module_path) orelse ".";
@@ -799,8 +828,17 @@ pub const ModuleGraph = struct {
 
         // import.meta.glob: 워커에서 glob 확장 수행
         expandGlobRecords(self.allocator, mod_ptr.import_records, source_dir);
-        // require.context: host plugin 으로 매칭 결과 주입 (#1579 Phase 2)
-        expandRequireContextRecords(self, module_path, mod_ptr.import_records);
+        // require.context: plugin 으로 matches 주입 + context_expansion_deps 로 수집 (#1579 Phase 4).
+        // import_records 는 건드리지 않으므로 len 변화 없음.
+        expandRequireContextRecords(self, mod_idx);
+
+        const records = mod_ptr.import_records;
+        var results = self.allocator.alloc(ResolveOutput, records.len) catch {
+            self.addDiag(.resolve_error, .@"error", module_path, Span.EMPTY, .resolve, "Out of memory allocating resolve results", null);
+            channel.send(.{ .module_idx = idx, .resolve_outputs = &.{} });
+            return;
+        };
+        for (results) |*r| r.* = .{};
 
         for (records, 0..) |record, rec_i| {
             if (record.kind == .glob) continue;
@@ -1422,7 +1460,6 @@ pub const ModuleGraph = struct {
         const mod_ptr = self.modules.at(mod_idx);
         const module_path = mod_ptr.path;
         const source_dir = std.fs.path.dirname(module_path) orelse ".";
-        const records = mod_ptr.import_records;
 
         // Plugin: resolveId 훅용 runner를 루프 밖에서 한 번만 생성
         const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
@@ -1432,9 +1469,10 @@ pub const ModuleGraph = struct {
 
         // import.meta.glob: glob 레코드를 파일 시스템에서 확장
         expandGlobRecords(self.allocator, mod_ptr.import_records, source_dir);
-        // require.context: host plugin 으로 매칭 결과 주입 (#1579 Phase 2)
-        expandRequireContextRecords(self, module_path, mod_ptr.import_records);
+        // require.context: plugin 으로 matches 주입 + context_expansion_deps 로 수집 (#1579 Phase 4).
+        expandRequireContextRecords(self, mod_idx);
 
+        const records = mod_ptr.import_records;
         for (records, 0..) |record, rec_i| {
             if (record.kind == .glob) continue;
             if (record.kind == .require_context) continue;
@@ -1466,6 +1504,9 @@ pub const ModuleGraph = struct {
             };
             try self.applyResolveResult(mod_idx, rec_i, record, resolved, false);
         }
+
+        // require.context context_expansion_deps 도 resolve + addDep.
+        try self.applyContextDepResults(mod_idx);
     }
 
     /// Phase 2: 반복 DFS 후위 순서 순회. exec_index 부여 + 순환 감지 (D065, D076).
@@ -2456,8 +2497,14 @@ fn expandGlobRecords(allocator: std.mem.Allocator, records: []types.ImportRecord
 /// `self`: ModuleGraph (addDiag, plugins 접근용)
 /// `module_path`: 현재 모듈 경로 (importer)
 /// `records`: 모듈의 import_records (in-place 수정)
-fn expandRequireContextRecords(self: *ModuleGraph, module_path: []const u8, records: []types.ImportRecord) void {
-    // require_context 레코드 존재 여부 빠른 체크 (대다수 모듈은 0개 — early return 으로 cheap)
+fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
+    const module = self.modules.at(mod_idx);
+
+    // scanWorker + resolveModuleImports 양쪽에서 호출됨. 이미 expand 됐으면 즉시 리턴
+    // (has_any 루프보다 먼저 체크 — 재진입 시 records 전체 순회 회피).
+    if (module.context_expansion_deps.len > 0) return;
+
+    const records = module.import_records;
     var has_any = false;
     for (records) |r| {
         if (r.kind == .require_context) {
@@ -2467,15 +2514,18 @@ fn expandRequireContextRecords(self: *ModuleGraph, module_path: []const u8, reco
     }
     if (!has_any) return;
 
+    const module_path = module.path;
     const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
         plugin_mod.PluginRunner.init(self.plugins)
     else
         null;
 
+    // arena 에서 append — self.allocator 와 섞이면 capacity/free mismatch 발생.
+    const arena_alloc = if (module.parse_arena) |*a| a.allocator() else self.allocator;
+    var expansion = std.ArrayList(types.ImportRecord).empty;
+
     for (records) |*record| {
         if (record.kind != .require_context) continue;
-        // scanWorker + resolveModuleImports 양쪽에서 호출됨. context_matches 가 채워졌으면 (성공/실패
-        // 무관) 이미 처리된 record — diag 중복/plugin 재호출 방지.
         if (record.context_matches != null) continue;
 
         // Invalid 인자 → diagnostic (Phase 1 의 reason 텍스트 그대로 사용). empty slice 로 마킹.
@@ -2497,6 +2547,16 @@ fn expandRequireContextRecords(self: *ModuleGraph, module_path: []const u8, reco
             ) catch null;
             if (matches) |m| {
                 record.context_matches = m;
+                // match 별로 일반 require record 생성해 별도 slice 에 저장 —
+                // import_records 를 건드리지 않아 index-based 참조 (import_bindings 등) 안전.
+                for (m) |match_path| {
+                    const joined = joinContextPath(arena_alloc, record.specifier, match_path) orelse continue;
+                    expansion.append(arena_alloc, .{
+                        .specifier = joined,
+                        .kind = .require,
+                        .span = record.span,
+                    }) catch {};
+                }
                 continue;
             }
         }
@@ -2513,6 +2573,21 @@ fn expandRequireContextRecords(self: *ModuleGraph, module_path: []const u8, reco
         );
         record.context_matches = &.{};
     }
+
+    module.context_expansion_deps = expansion.toOwnedSlice(arena_alloc) catch &.{};
+}
+
+/// record.specifier (e.g. "./app" 또는 "../foo") 와 match_path (e.g. "./a.tsx") 를 결합.
+/// codegen 의 emitJoinedPath 와 동일 로직 — dir trailing `/`, match `./` prefix 정규화.
+/// 결과는 모듈 resolver 가 일반 require 처럼 처리할 수 있는 specifier.
+fn joinContextPath(alloc: std.mem.Allocator, dir: []const u8, match: []const u8) ?[]u8 {
+    const dir_clean = if (dir.len > 0 and dir[dir.len - 1] == '/') dir[0 .. dir.len - 1] else dir;
+    const match_clean = if (match.len >= 2 and match[0] == '.' and match[1] == '/') match[2..] else match;
+    const out = alloc.alloc(u8, dir_clean.len + 1 + match_clean.len) catch return null;
+    @memcpy(out[0..dir_clean.len], dir_clean);
+    out[dir_clean.len] = '/';
+    @memcpy(out[dir_clean.len + 1 ..], match_clean);
+    return out;
 }
 
 // ============================================================

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -77,6 +77,14 @@ pub const Module = struct {
     ast: ?Ast,
     /// import_scanner가 추출한 레코드. graph allocator에서 할당 (소스 텍스트를 참조).
     import_records: []ImportRecord,
+    /// require.context matches 기반 추가 deps. `import_records` 와 분리되어 있어
+    /// `import_bindings.import_record_index` / `scan_result.records` 같은 index-based
+    /// 참조가 영향 받지 않음. parse_arena 소유.
+    context_expansion_deps: []ImportRecord = &.{},
+    /// 이 모듈이 다른 모듈의 require.context match 로 등록된 경우 true. tree-shaker 가
+    /// static import 없어도 root 취급해 번들에서 제거 안 함 — runtime require 대상이므로
+    /// 모든 export 가 사용 가능해야.
+    is_context_dep: bool = false,
     /// 모듈별 Arena — Scanner/Parser/AST/Semantic 메모리를 소유. graph.deinit에서 해제.
     parse_arena: ?std.heap.ArenaAllocator,
     /// semantic analyzer 결과. parse_arena가 소유. linker에서 사용.

--- a/src/bundler/test_helpers.zig
+++ b/src/bundler/test_helpers.zig
@@ -14,3 +14,11 @@ pub fn absPath(tmp: *std.testing.TmpDir, rel: []const u8) ![]const u8 {
     defer std.testing.allocator.free(dp);
     return try std.fs.path.resolve(std.testing.allocator, &.{ dp, rel });
 }
+
+/// 테스트용 헬퍼: ArenaAllocator 를 ThreadSafeAllocator 로 감싸 worker 동시 alloc 보호.
+/// bundler worker 가 self.allocator 로 동시 할당하므로 단일 thread arena 는 race.
+/// 프로덕션 (bungae) 은 GPA thread-safe 가 기본이라 영향 없음 — 테스트만의 보호.
+/// 사용: `var ts = threadSafeArena(&arena); const alloc = ts.allocator();`
+pub fn threadSafeArena(arena: *std.heap.ArenaAllocator) std.heap.ThreadSafeAllocator {
+    return .{ .child_allocator = arena.allocator() };
+}

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -147,11 +147,14 @@ pub const TreeShaker = struct {
         // (rolldown/esbuild 동작: package.json sideEffects 없어도 자동 감지)
         // 단, package.json sideEffects에 의해 결정된 값(user_defined)은 덮어쓰지 않는다
         // (rolldown DeterminedSideEffects::UserDefined 포팅).
+        // require.context match 로 등록된 모듈 (is_context_dep) 도 건드리지 않음 —
+        // runtime require 로 접근하므로 AST 상 pure 여도 제거하면 안 됨.
         for (0..mod_count) |i| {
             const m = self.moduleAtMut(@intCast(i)) orelse continue;
             if (!m.side_effects) continue;
             if (m.side_effects_user_defined) continue;
             if (self.entry_set.isSet(i)) continue;
+            if (m.is_context_dep) continue;
             if (m.ast) |ast| {
                 const unresolved = if (m.semantic) |*s| &s.unresolved_references else null;
                 if (isModulePure(&ast, unresolved)) {
@@ -162,7 +165,7 @@ pub const TreeShaker = struct {
 
         for (0..mod_count) |i| {
             const m = self.getModule(@intCast(i)) orelse continue;
-            if (self.entry_set.isSet(i) or m.side_effects) {
+            if (self.entry_set.isSet(i) or m.side_effects or m.is_context_dep) {
                 self.included.set(i);
             }
         }
@@ -191,9 +194,11 @@ pub const TreeShaker = struct {
         @memset(has_due, false);
         self.has_direct_used_export = has_due;
 
-        // entry 모듈의 모든 export를 사용으로 마킹
+        // entry / context_dep 모듈의 모든 export를 사용으로 마킹 — runtime require 로
+        // 접근하는 모듈은 어떤 export 가 쓰일지 정적으로 알 수 없음 (dynamic import 와 유사).
         for (0..mod_count) |i| {
-            if (self.entry_set.isSet(i)) try self.markAllExportsUsed(@intCast(i));
+            const m = self.getModule(@intCast(i)) orelse continue;
+            if (self.entry_set.isSet(i) or m.is_context_dep) try self.markAllExportsUsed(@intCast(i));
         }
 
         // StmtInfo 구축을 fixpoint 루프 전에 수행(#1558).
@@ -286,6 +291,7 @@ pub const TreeShaker = struct {
             const m = self.getModule(@intCast(i)) orelse continue;
             if (self.entry_set.isSet(i) or m.side_effects or m.wrap_kind.isWrapped()) continue;
             if (dyn_import_targets.isSet(i)) continue; // #1260: dynamic import target 보호
+            if (m.is_context_dep) continue; // require.context match 는 runtime require 대상
             if (!self.hasAnyUsedExport(@intCast(i)) and !self.hasAnyUsedExportDirect(@intCast(i))) {
                 self.included.unset(i);
             }


### PR DESCRIPTION
## Summary

PR #1778 (Phase 4) 의 재도입. close 됐던 원본을 #1779 에픽 (PR #1780–#1785) 으로 ModuleGraph 가 SegmentedList + phase accessor 기반으로 재설계된 후 깔끔하게 다시 적용.

## 동기

- Phase 3 까지: `webpackContext` IIFE emit 까지만 (codegen 완료)
- 누락: IIFE 내부 `require(...)` 의 대상 파일이 graph dependency 로 등록 안 돼서 번들에 포함 안 됨 → 런타임 module not found
- 이전 PR #1778 close 사유: ArrayList realloc 으로 worker 가 capture 한 `*Module` / `&arena.state` dangling. **#1779 에픽으로 구조적 해결됨**

## 변경

### `Module` (module.zig)
- `context_expansion_deps: []ImportRecord` — matches 기반 추가 deps. parse_arena 소유. `import_records` 와 분리되어 `import_bindings.import_record_index` 같은 index 참조 영향 없음
- `is_context_dep: bool` — 다른 모듈의 require.context match 로 등록된 모듈 마킹. tree-shaker 가 root 취급

### `graph.zig`
- `expandRequireContextRecords(self, mod_idx)` — plugin matches 를 `.require` kind ImportRecord 로 wrap 후 `context_expansion_deps` 에 수집. `import_records` 는 건드리지 않음
- `applyContextDepResults(mod_idx)` — 각 dep 를 resolveThreadSafe + addModule + `linkDependency` + `is_context_dep = true`. scanModules / resolveModuleImports 양쪽 경로에서 호출
- `parse_arena` null 시 fallback graph allocator 사용을 **early return** 으로 변경 (이전: leak 위험)

### `tree_shaker.zig`
- 자동 pure 판별에서 `is_context_dep` skip
- `included` bitset 에 `is_context_dep` 추가
- `markAllExportsUsed` 에 `is_context_dep` 포함 (어떤 export 가 runtime require 로 호출될지 정적 불가)
- 최종 prune 단계에서 `is_context_dep` 보호

### 테스트 (`bundler_test/basic.zig`)
- 기존 6건: mock plugin (가상 matches) → `rcScanDir` (실제 FS 스캔). tmpDir 에 실제 파일 생성
- 신규 3건:
  - matches 파일들이 번들에 포함됨 (page-a-content / page-b-content 콘텐츠 검증)
  - nested match 파일도 번들에 포함 (recursive scan)
  - empty matches → 파일 없어도 hasErrors false (회귀 방지)
- `ThreadSafeAllocator` boilerplate 12곳 → `test_helpers.threadSafeArena` 헬퍼

### `docs/INVARIANTS.md`
- phase 분류표에 `context_expansion_deps` (parse only), `is_context_dep` (resolve only) 추가

## 검증

- `zig build` / `zig build test` / `zig build -Doptimize=ReleaseFast` 통과
- `Module.addDependency` 제거됐으니 `linkDependency` 사용. INVARIANTS 규약 준수
- ArrayList drain/realloc 로직 없음 (SegmentedList 기반)

## Phase 4 의 실증 (PR #1778 commit message 인용)

ExpoApp 번들:
- 이전: 6477314 bytes. require.context IIFE 만 emit, app 내 route 파일 미포함
- 이후: 8352405 bytes (+1.9MB). `app/(tabs)/_layout.tsx`, `app/modal.tsx` 등 모든 route 파일이 번들에 포함, JSX 트랜스폼 완료

## 후속 (측정 후 결정)
- 100+ matches 시 `resolveThreadSafe` 순차 호출 → batch / worker 분산
- worker plugin call 의 NAPI thread-safety 실측
- bungae ExpoApp 에서 require.context 라우트 동작 검증

## Test plan
- [x] `zig build` / `zig build test` 통과
- [ ] 머지 후 bungae ExpoApp 에서 route 파일 번들 포함 확인 (이전 PR #1778 와 동일 시나리오)

Closes #1579