### PR TITLE
fix(bundler): #1579 Phase 4 follow-up — require.context IIFE 의 raw require 제거

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -960,8 +960,12 @@ test "Bundler: require.context normalizes trailing slash and missing ./" {
     defer result.deinit(alloc);
     try std.testing.expect(!result.hasErrors());
 
-    // `./pages/` + `nested/a.tsx` → `./pages/nested/a.tsx` (정확히 slash 하나).
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/nested/a.tsx\")") != null);
+    // plugin 이 dot-slash 없이 반환 → key 도 그대로. value 는 __zts_modules wrapper (#1579 follow-up).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"nested/a.tsx\":function()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zts_modules[") != null);
+    // raw `require(./...)` 는 IIFE 안에 없어야 — RN/Hermes runtime 호환.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/") == null);
+    // emitJoinedPath 가 중복 slash 안 만들어야.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "./pages//") == null);
 }
 
@@ -1019,11 +1023,13 @@ test "Bundler: multiple require.context calls resolve to distinct maps (span mat
     try std.testing.expect(!result.hasErrors());
 
     // 첫 호출 (./pages) 는 first.tsx 만, 둘째 호출 (./other) 는 second.tsx 만.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/first.tsx\")") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./other/second.tsx\")") != null);
-    // cross-contamination 없음.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/second.tsx\")") == null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./other/first.tsx\")") == null);
+    // matches key (relative) + __zts_modules wrapper (raw require 회피, #1579 follow-up).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./first.tsx\":function()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./second.tsx\":function()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zts_modules[") != null);
+    // cross-contamination 또는 raw require 없음.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./other/") == null);
 }
 
 test "Bundler: require.context coexists with import.meta.glob" {
@@ -1221,6 +1227,53 @@ test "Bundler: no require.context in source → no webpackContext template emitt
 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "Object.keys(map)") == null);
+}
+
+// RN/Hermes runtime 호환성 invariant: webpackContext IIFE 안에 raw `require(` 호출이
+// 절대 없어야 한다. RN runtime 에는 `require` global 이 없으므로 raw require 가 emit 되면
+// 사용자 앱이 `Property 'require' doesn't exist` 로 폭발 (이전 회귀 사례, #1579 follow-up).
+test "Bundler: require.context IIFE has no raw require call (RN runtime invariant)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var ts = threadSafeArena(&arena);
+    const alloc = ts.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("pages");
+    try writeFile(tmp.dir, "pages/a.tsx", "export const a = 1;");
+    try writeFile(tmp.dir, "pages/b.tsx", "export const b = 2;");
+    try writeFile(tmp.dir, "entry.ts", "const ctx = require.context('./pages');\nconsole.log(ctx.keys());");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcScanDir }};
+    var b = Bundler.init(alloc, .{ .entry_points = &.{entry}, .plugins = &plugins });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+
+    // 모든 webpackContext IIFE 영역에 대해 raw require 부재 검증.
+    // IIFE 시작 마커: `(function(){var map={` (codegen.tryEmitRequireContextObject).
+    var pos: usize = 0;
+    var found_iife = false;
+    const start_marker = "(function(){var map={";
+    while (std.mem.indexOfPos(u8, result.output, pos, start_marker)) |start| {
+        found_iife = true;
+        const end = std.mem.indexOfPos(u8, result.output, start, "})()") orelse break;
+        const iife = result.output[start..end];
+        // raw require 호출 패턴 (앞에 `.` 같은 멤버 access 없는 경우만 검사 — `__zts_modules[...]`
+        // 같은 정상 호출은 require 와 무관).
+        try std.testing.expect(std.mem.indexOf(u8, iife, "return require(") == null);
+        try std.testing.expect(std.mem.indexOf(u8, iife, " require(\"./") == null);
+        // 정상 emit 검증: __zts_modules wrapper 호출.
+        try std.testing.expect(std.mem.indexOf(u8, iife, "__zts_modules[") != null);
+        pos = end + 4;
+    }
+    try std.testing.expect(found_iife);
 }
 
 test "Bundler: UMD external dependencies in wrapper" {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -2550,16 +2550,34 @@ fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
             ) catch null;
             if (matches) |m| {
                 record.context_matches = m;
-                // match 별로 일반 require record 생성해 별도 slice 에 저장 —
-                // import_records 를 건드리지 않아 index-based 참조 (import_bindings 등) 안전.
-                for (m) |match_path| {
-                    const joined = joinContextPath(arena_alloc, record.specifier, match_path) orelse continue;
+                // 매치별 abs path resolve 결과를 record.context_resolved_paths 에 1:1 저장.
+                // codegen 이 webpackContext IIFE 의 module wrapper 호출 (`__zts_modules[<abs>]`) 에 사용.
+                // null 슬롯 = resolve 실패 — codegen 이 throw stub 으로 emit.
+                const source_dir = std.fs.path.dirname(module_path) orelse ".";
+                const resolved_paths_opt: ?[]?[]const u8 = arena_alloc.alloc(?[]const u8, m.len) catch null;
+                for (m, 0..) |match_path, i| {
+                    const joined = joinContextPath(arena_alloc, record.specifier, match_path) orelse {
+                        if (resolved_paths_opt) |paths| paths[i] = null;
+                        continue;
+                    };
+                    if (resolved_paths_opt) |paths| {
+                        const r = self.resolve_cache.resolveThreadSafe(source_dir, joined, .require) catch null;
+                        if (r) |res| {
+                            // resolve_cache 가 self.allocator 로 path 할당 → arena 로 dupe 후 free.
+                            paths[i] = arena_alloc.dupe(u8, res.path) catch null;
+                            self.allocator.free(res.path);
+                        } else {
+                            paths[i] = null;
+                        }
+                    }
+                    // graph dep 등록은 applyContextDepResults 에서 (cache hit 라 빠름).
                     expansion.append(arena_alloc, .{
                         .specifier = joined,
                         .kind = .require,
                         .span = record.span,
                     }) catch {};
                 }
+                if (resolved_paths_opt) |paths| record.context_resolved_paths = paths;
                 continue;
             }
         }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -421,6 +421,12 @@ pub const ImportRecord = struct {
     /// graph 단계에서 채운다. codegen 이 이 목록을 보고 webpackContext 함수를 emit (Phase 3).
     /// null = 아직 평가 안 됨, &.{} = 매칭 0개 (empty context).
     context_matches: ?[]const []const u8 = null,
+    /// require.context: context_matches 와 1:1 매핑되는 resolved abs path. Phase 4 의
+    /// `applyContextDepResults` 가 채움 (parse_arena 소유). codegen 의 webpackContext IIFE 가
+    /// 매치별 `__zts_modules[<abs_path>].fn()` 호출에 사용. RN/Hermes runtime 이 raw `require()` 를
+    /// 못 받기 때문에 wrapper module 호출로 emit (#1579 Phase 4 follow-up).
+    /// element 가 null = 해당 매치 resolve 실패 (codegen 이 throw stub 으로 emit).
+    context_resolved_paths: []const ?[]const u8 = &.{},
 };
 
 // ============================================================

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2016,9 +2016,25 @@ pub const Codegen = struct {
                 if (i > 0) try self.writeByte(',');
                 try self.writeByte('"');
                 try self.writeJsStringContent(match_path);
-                try self.write("\":function(){return require(\"");
-                try self.emitJoinedPath(rec.specifier, match_path);
-                try self.write("\");}");
+                try self.write("\":function(){return ");
+                // RN/Hermes runtime 에는 `require` global 이 없으므로 graph 에 등록된
+                // module wrapper 호출로 emit. abs path 가 있으면 직접 호출, 없으면
+                // (resolve 실패 등) throw — raw `require()` fallback 은 런타임 폭발 유발.
+                const resolved_abs: ?[]const u8 = if (i < rec.context_resolved_paths.len)
+                    rec.context_resolved_paths[i]
+                else
+                    null;
+                if (resolved_abs) |abs| {
+                    try self.write("__zts_modules[\"");
+                    try self.writeJsStringContent(abs);
+                    try self.write("\"].fn()");
+                } else {
+                    try self.write("(function(){throw new Error(\"require.context match unresolved: \"+");
+                    try self.writeByte('"');
+                    try self.writeJsStringContent(match_path);
+                    try self.write("\");})()");
+                }
+                try self.write(";}");
             }
         }
         try self.write(


### PR DESCRIPTION
## 문제

사용자가 bungae ExpoApp 실행 시 발견:
```
[runtime not ready]: ReferenceError: Property 'require' doesn't exist
  at react-native-screens/.../prepareHeaderBarButtonItems.ts:105521:27
  at expo-router/build/screensFeatureFlags.js (__require)
  at expo-router/build/ExpoRoot.js (__require)
  ...
```

## Root cause

Phase 3 (#1775) 의 webpackContext IIFE codegen 이 매치별 map 함수를 raw `require()` 로 emit:
```js
"./path.tsx": function(){ return require("../../path.tsx"); }
```

Bun 테스트 환경은 `require` global 이라 통과했지만 **RN/Hermes runtime 에는 `require` global 이 없음** → raw require 호출 시 `Property 'require' doesn't exist` panic.

Phase 4 (#1786) 가 매치 파일을 graph 에 등록한 이후에야 IIFE 가 **실제로 trigger** 됨 (이전엔 매치 파일이 graph 에 없어 다른 경로로 fail 또는 silent).

## Fix

IIFE 의 map 함수를 `__zts_modules[<abs_path>].fn()` 호출로 교체:

```diff
 "./path.tsx": function(){
-  return require("../../path.tsx");
+  return __zts_modules["/abs/path/app/path.tsx"].fn();
 }
```

abs path 는 `expandRequireContextRecords` 가 매치별 미리 resolve 해 `ImportRecord.context_resolved_paths` 에 저장.

### 변경 파일
- **types.zig**: `ImportRecord.context_resolved_paths: []const ?[]const u8` 추가 (null = resolve 실패)
- **graph.zig**: `expandRequireContextRecords` 가 매치별 `resolveThreadSafe` + arena dupe
- **codegen.zig**: IIFE map value 를 `__zts_modules[<abs>].fn()` 로. resolve 실패 슬롯은 throw stub
- **bundler_test/basic.zig**: 기존 3 테스트 update + **RN runtime invariant 새 테스트 1건 추가** (webpackContext IIFE 내 raw require 부재 검증)

## 방지책 — 왜 8 PR 동안 못 잡혔나

| 갭 | 해결 |
|---|------|
| ZTS 단위 테스트가 bun 환경 → raw require 통과 | 새 invariant 테스트가 IIFE 내부 raw require 정적 검증 |
| Phase 3 단독 trigger 안 됨 (Phase 4 후 폭발) | invariant 가 Phase 와 무관하게 codegen 수준 검증 |
| bungae 스모크가 PR unchecked checkbox | (follow-up) PR template 개선 필요 |
| oxc/esbuild emit 비교 미수행 | (follow-up) codegen 변경 PR 에 reference 비교 강제 |

## 검증

- `zig build test` 통과 (3620 tests, 새 invariant 포함)
- bungae/zts sync 후 재빌드:
  - 번들 size: 8352363 → 8352548 (+185B, abs path > relative)
  - `grep "return require("` IIFE 내부: **0건**
  - `__zts_modules["/abs/path"].fn()` 호출: route 5개 모두 변환 확인
- 새 invariant 테스트: `Bundler: require.context IIFE has no raw require call (RN runtime invariant)` 통과

## Follow-up (별개 이슈)

번들에 다른 raw require 도 있음 (require.context 와 무관한 별개 버그):
- `require("@react-native-masked-view/masked-view")` — conditional try/catch require
- `require("react-native-screens/types")` — TypeScript type-only import 가 raw require 로 emit

이들은 별도 GH issue 로 분리 예정.

## Test plan
- [x] `zig build test` 통과
- [x] bungae/zts sync + 번들 검증 (`__zts_modules` wrapper 호출 확인)
- [ ] 머지 후 submodule update + bungae ExpoApp iOS 실행 → `Property 'require' doesn't exist` 사라짐 확인

Refs #1579