### PR TITLE
test(bundler): StableSegmentedList concurrent reader race-safety 테스트

### DIFF
--- a/src/bundler/module_list.zig
+++ b/src/bundler/module_list.zig
@@ -246,12 +246,15 @@ test "StableSegmentedList: concurrent reader survives grower appends (race-safet
     var list = StableSegmentedList(u64){};
     defer list.deinit(allocator);
 
-    // 초기 items 100 개 — reader 가 이 slot 들을 불변으로 관찰.
-    const N_INITIAL: u64 = 100;
+    const N_INITIAL: usize = 100;
+    const N_READERS: usize = 4;
+    const FINAL_SIZE: usize = 10_000;
+
+    // 초기 items — reader 가 이 slot 들을 불변으로 관찰.
     {
-        var i: u64 = 0;
+        var i: usize = 0;
         while (i < N_INITIAL) : (i += 1) {
-            try list.append(allocator, i);
+            try list.append(allocator, @intCast(i));
         }
     }
 
@@ -261,30 +264,31 @@ test "StableSegmentedList: concurrent reader survives grower appends (race-safet
     const readerFn = struct {
         fn run(l: *StableSegmentedList(u64), m: *std.atomic.Value(bool), s: *std.atomic.Value(bool)) void {
             while (!s.load(.acquire)) {
-                var k: u64 = 0;
+                var k: usize = 0;
                 while (k < N_INITIAL) : (k += 1) {
-                    const p = l.at(@intCast(k));
-                    if (p.* != k) {
+                    const p = l.at(k);
+                    if (p.* != @as(u64, @intCast(k))) {
                         m.store(true, .release);
                         return;
                     }
                 }
+                // busy-wait 회피 — graph_test.zig:935 parallelWorker 와 동일 패턴.
+                std.Thread.yield() catch {};
             }
         }
     }.run;
 
-    const N_READERS = 4;
     var readers: [N_READERS]std.Thread = undefined;
     for (&readers) |*r| {
         r.* = try std.Thread.spawn(.{}, readerFn, .{ &list, &mismatch, &stop });
     }
 
-    // Main 이 동시에 append — 100 → 10000 (shelves 7-13 신규 alloc 유발).
-    // std.SegmentedList 라면 이 시점에 dynamic_segments realloc 여러 번 발생.
+    // Main 이 동시에 append 로 shelf grow 유발. std.SegmentedList 였으면 이 시점에
+    // dynamic_segments realloc 여러 번 → reader 의 shelf pointer stale.
     {
-        var i: u64 = N_INITIAL;
-        while (i < 10_000) : (i += 1) {
-            try list.append(allocator, i);
+        var i: usize = N_INITIAL;
+        while (i < FINAL_SIZE) : (i += 1) {
+            try list.append(allocator, @intCast(i));
         }
     }
 
@@ -292,7 +296,7 @@ test "StableSegmentedList: concurrent reader survives grower appends (race-safet
     for (&readers) |r| r.join();
 
     try std.testing.expect(!mismatch.load(.acquire));
-    try std.testing.expectEqual(@as(usize, 10_000), list.count());
+    try std.testing.expectEqual(FINAL_SIZE, list.count());
     try std.testing.expectEqual(@as(u64, 0), list.at(0).*);
-    try std.testing.expectEqual(@as(u64, 9_999), list.at(9_999).*);
+    try std.testing.expectEqual(@as(u64, FINAL_SIZE - 1), list.at(FINAL_SIZE - 1).*);
 }

--- a/src/bundler/module_list.zig
+++ b/src/bundler/module_list.zig
@@ -236,3 +236,63 @@ test "StableSegmentedList: mutable iterator" {
     try std.testing.expectEqual(@as(u32, 20), list.at(1).*);
     try std.testing.expectEqual(@as(u32, 30), list.at(2).*);
 }
+
+// #1779 CI fail 의 정확한 reproduction: worker thread 가 at(i) 반복 read 하는 동안
+// main thread 가 append 로 shelf grow 유발. std.SegmentedList 였으면 dynamic_segments
+// 가 ArrayListUnmanaged realloc → reader 의 pointer stale → segfault 또는 value 불일치.
+// StableSegmentedList 는 shelves 배열 고정이라 read 가 항상 안전해야 함.
+test "StableSegmentedList: concurrent reader survives grower appends (race-safety)" {
+    const allocator = std.testing.allocator;
+    var list = StableSegmentedList(u64){};
+    defer list.deinit(allocator);
+
+    // 초기 items 100 개 — reader 가 이 slot 들을 불변으로 관찰.
+    const N_INITIAL: u64 = 100;
+    {
+        var i: u64 = 0;
+        while (i < N_INITIAL) : (i += 1) {
+            try list.append(allocator, i);
+        }
+    }
+
+    var stop = std.atomic.Value(bool).init(false);
+    var mismatch = std.atomic.Value(bool).init(false);
+
+    const readerFn = struct {
+        fn run(l: *StableSegmentedList(u64), m: *std.atomic.Value(bool), s: *std.atomic.Value(bool)) void {
+            while (!s.load(.acquire)) {
+                var k: u64 = 0;
+                while (k < N_INITIAL) : (k += 1) {
+                    const p = l.at(@intCast(k));
+                    if (p.* != k) {
+                        m.store(true, .release);
+                        return;
+                    }
+                }
+            }
+        }
+    }.run;
+
+    const N_READERS = 4;
+    var readers: [N_READERS]std.Thread = undefined;
+    for (&readers) |*r| {
+        r.* = try std.Thread.spawn(.{}, readerFn, .{ &list, &mismatch, &stop });
+    }
+
+    // Main 이 동시에 append — 100 → 10000 (shelves 7-13 신규 alloc 유발).
+    // std.SegmentedList 라면 이 시점에 dynamic_segments realloc 여러 번 발생.
+    {
+        var i: u64 = N_INITIAL;
+        while (i < 10_000) : (i += 1) {
+            try list.append(allocator, i);
+        }
+    }
+
+    stop.store(true, .release);
+    for (&readers) |r| r.join();
+
+    try std.testing.expect(!mismatch.load(.acquire));
+    try std.testing.expectEqual(@as(usize, 10_000), list.count());
+    try std.testing.expectEqual(@as(u64, 0), list.at(0).*);
+    try std.testing.expectEqual(@as(u64, 9_999), list.at(9_999).*);
+}


### PR DESCRIPTION
## Summary

PR #1789 (`StableSegmentedList` 근본 해결) 의 follow-up. CI 에서 발견된 race 를 **단위 테스트로 명시적 reproduction** — 회귀 방지.

## 배경

PR #1789 가 `std.SegmentedList` → `StableSegmentedList` 교체로 근본 해결. 다만 테스트는 sequential pointer stability 까지만 검증. 실제 race (worker `at(i)` + main `append` 동시) 는 검증 안 됨.

## 추가 테스트

`StableSegmentedList: concurrent reader survives grower appends (race-safety)`:

- 초기 100 items append → reader 가 이 slot 들을 불변으로 관찰
- 4 reader threads 가 `at(0..100)` 반복 read (spin loop)
- Main 이 100 → 10000 까지 append (shelves 7-13 신규 alloc 유발)
- `std.SegmentedList` 였으면 `dynamic_segments` 여러 번 realloc → reader pointer stale → value 불일치 또는 segfault
- `StableSegmentedList` 는 shelves 고정이라 read 안전
- reader 가 value 불일치 감지 시 atomic flag → 테스트 fail

## 효과

- 향후 `ModuleList` 또는 유사 container 에 회귀 도입 시 이 테스트가 즉시 catch
- PR #1789 의 "race-safety 증명" 을 runtime 으로 empirical 검증
- `std.Thread` + atomic 으로 Zig stdlib 범위 안에서 구현 (외부 의존 없음)

## Test plan
- [x] `zig build test` 통과 (새 테스트 포함)
- [x] Threads: 4, iterations: main append 9900회 + reader N×100회

Refs #1779