### PR TITLE
fix(bundler): #1791 IIFE 포맷 unresolved import build-time 에러 보고

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -361,6 +361,28 @@ pub const BundleResult = struct {
     }
 };
 
+/// BundlerDiagnostic 을 allocator-owned OwnedDiagnostic 으로 deep copy 해 `dest` 에 채운다.
+/// `filled` 는 이미 채워진 item 수 — 루프 내부에서 매 entry 성공 후 증가한다 (호출자의
+/// errdefer 가 부분 할당분을 정확히 해제할 수 있도록).
+fn copyDiagnostics(
+    allocator: std.mem.Allocator,
+    dest: []BundleResult.OwnedDiagnostic,
+    src: []const types.BundlerDiagnostic,
+    filled: *usize,
+) !void {
+    for (src) |d| {
+        dest[filled.*] = .{
+            .code = d.code,
+            .severity = d.severity,
+            .message = try allocator.dupe(u8, d.message),
+            .file_path = try allocator.dupe(u8, d.file_path),
+            .step = d.step,
+            .suggestion = if (d.suggestion) |s| try allocator.dupe(u8, s) else null,
+        };
+        filled.* += 1;
+    }
+}
+
 pub const Bundler = struct {
     allocator: std.mem.Allocator,
     options: BundleOptions,
@@ -1003,9 +1025,12 @@ pub const Bundler = struct {
         // 이 `t_graph/t_link/t_shake/t_emit` 은 `BundleResult.timings` 를 채워
         // NAPI `WatchRebuildEvent.phaseDurations` 로 노출 (HMR 관측성).
 
-        // 4. 진단 메시지 deep copy (graph.deinit 후에도 문자열 유효하도록)
-        const diagnostics: ?[]BundleResult.OwnedDiagnostic = if (graph.diagnostics.items.len > 0) blk: {
-            const diags = try self.allocator.alloc(BundleResult.OwnedDiagnostic, graph.diagnostics.items.len);
+        // 4. 진단 메시지 deep copy (graph.deinit 후에도 문자열 유효하도록).
+        // graph.diagnostics + linker.fatal_diagnostics (IIFE unresolved 등, #1791) 병합.
+        const link_diag_len = if (linker) |*l| l.fatal_diagnostics.items.len else 0;
+        const diagnostics: ?[]BundleResult.OwnedDiagnostic = if (graph.diagnostics.items.len > 0 or link_diag_len > 0) blk: {
+            const total = graph.diagnostics.items.len + link_diag_len;
+            const diags = try self.allocator.alloc(BundleResult.OwnedDiagnostic, total);
             errdefer self.allocator.free(diags);
             // M1 수정: 부분 할당 후 OOM 시 이미 복사한 문자열 해제
             var filled: usize = 0;
@@ -1014,16 +1039,9 @@ pub const Bundler = struct {
                 self.allocator.free(d.file_path);
                 if (d.suggestion) |s| self.allocator.free(s);
             };
-            for (graph.diagnostics.items, 0..) |d, i| {
-                diags[i] = .{
-                    .code = d.code,
-                    .severity = d.severity,
-                    .message = try self.allocator.dupe(u8, d.message),
-                    .file_path = try self.allocator.dupe(u8, d.file_path),
-                    .step = d.step,
-                    .suggestion = if (d.suggestion) |s| try self.allocator.dupe(u8, s) else null,
-                };
-                filled = i + 1;
+            try copyDiagnostics(self.allocator, diags, graph.diagnostics.items, &filled);
+            if (linker) |*l| {
+                try copyDiagnostics(self.allocator, diags, l.fatal_diagnostics.items, &filled);
             }
             break :blk diags;
         } else null;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1047,6 +1047,20 @@ pub fn emitModule(
         if (override_syms) |syms| {
             md.symbol_ids = syms;
         }
+        // #1791 IIFE unresolved build-time diag 를 linker 의 공용 `fatal_diagnostics`
+        // 로 소유권 이전. mutex 는 공용 리스트의 append 만 보호 — `md.pending_diagnostics`
+        // 자체는 per-module 이라 경쟁 없음. `@constCast` 는 `ns_cache_mutex` (linker.zig:1877)
+        // 와 동일 관행. free 후 필드를 비워 md.deinit 의 double-free 방지.
+        if (md.pending_diagnostics.len > 0) {
+            const linker_mut = @constCast(l);
+            linker_mut.diagnostics_mutex.lock();
+            defer linker_mut.diagnostics_mutex.unlock();
+            for (md.pending_diagnostics) |d| {
+                try linker_mut.fatal_diagnostics.append(l.allocator, d);
+            }
+            l.allocator.free(md.pending_diagnostics);
+            md.pending_diagnostics = &.{};
+        }
         // statement-level tree-shaking: StmtInfo 기반 도달성 분석으로 미사용 statement 제거.
         // rolldown 방식: 심볼 인덱스로 추적하여 linker rename 후에도 정확한 판정.
         //

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -203,6 +203,11 @@ pub const LinkingMetadata = struct {
     /// 기본값 true 는 현재 모든 생성 지점이 번들러(`buildMetadataForAst` 계열)라는 사실에
     /// 의존한다. 비-번들러 생성 지점을 추가할 때는 반드시 false 를 명시할 것.
     is_bundle_context: bool = true,
+    /// #1791: build-time 에러 (e.g. IIFE 포맷 + unresolved import). `buildMetadataForAst`
+    /// 가 병렬 호출되므로 직접 `linker.diagnostics` 에 append 하면 race. 대신 이 리스트에
+    /// 쌓고 emitter 가 serial 경로에서 `linker.fatal_diagnostics` 로 flush.
+    /// item.message 는 allocator 소유 — flush 시 소유권 이전, deinit 에서 free.
+    pending_diagnostics: []const BundlerDiagnostic = &.{},
     allocator: std.mem.Allocator,
 
     pub const NsMemberRewrites = struct {
@@ -283,6 +288,12 @@ pub const LinkingMetadata = struct {
             for (vars) |v| self.allocator.free(v);
             self.allocator.free(vars);
         }
+        // Ownership: 정상 경로는 emitter 가 message 소유권을 `linker.fatal_diagnostics`
+        // 로 이전한 후 slice 를 비우므로 여기서 no-op. flush 전 에러 경로에서만 해제.
+        if (self.pending_diagnostics.len > 0) {
+            for (self.pending_diagnostics) |d| self.allocator.free(d.message);
+            self.allocator.free(self.pending_diagnostics);
+        }
     }
 };
 
@@ -318,6 +329,14 @@ pub const Linker = struct {
     resolved_bindings: std.AutoHashMap(BindingKey, ResolvedBinding),
 
     diagnostics: std.ArrayList(BundlerDiagnostic),
+    /// #1791 사용자 노출용 치명 진단 (예: IIFE 포맷에서 unresolved import).
+    /// 기존 `diagnostics` 는 내부/테스트 전용 — bundler 가 BundleResult 로 wire 하지
+    /// 않는다. 이 필드로 들어온 항목만 사용자에게 `build error` 로 노출된다.
+    /// message 는 allocator 소유 (allocPrint) — linker.deinit 에서 일괄 해제.
+    fatal_diagnostics: std.ArrayList(BundlerDiagnostic) = .empty,
+    /// #1791 emitter 가 `emitModuleThread` 로 병렬 emit 중 `LinkingMetadata.pending_diagnostics`
+    /// 를 linker 의 `fatal_diagnostics` 버퍼로 flush. 병렬 append 보호.
+    diagnostics_mutex: std.Thread.Mutex = .{},
 
     /// semantic.Symbol.canonical_name 슬라이스의 backing 저장소. linker가 소유 —
     /// deinit에서 일괄 해제. AliasTable.canonical_name은 caller-owned (별도 모델).
@@ -470,6 +489,9 @@ pub const Linker = struct {
         var nic_it = self.ns_inline_cache.valueIterator();
         while (nic_it.next()) |v| self.allocator.free(v.*);
         self.ns_inline_cache.deinit(self.allocator);
+        // #1791 fatal diag message 해제 (allocPrint owned)
+        for (self.fatal_diagnostics.items) |d| self.allocator.free(d.message);
+        self.fatal_diagnostics.deinit(self.allocator);
         self.diagnostics.deinit(self.allocator);
     }
 

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -192,6 +192,18 @@ pub fn buildMetadataForAst(
         ns_var_list.deinit(self.allocator);
     }
 
+    // #1791 IIFE unresolved build-time diag. 정상 경로에서는 emitter 가 serial 로
+    // `linker.fatal_diagnostics` 에 flush. item.message 는 allocator 소유.
+    var pending_diags: std.ArrayListUnmanaged(@import("../types.zig").BundlerDiagnostic) = .empty;
+    errdefer {
+        for (pending_diags.items) |d| self.allocator.free(d.message);
+        pending_diags.deinit(self.allocator);
+    }
+    // IIFE dedupe 맵은 실제 IIFE 포맷 + unresolved 발생 시에만 lazy init — ESM/CJS
+    // 빌드 (실측 99%+ 모듈) 에서 해시맵 backing alloc 비용을 피한다.
+    var iife_diag_seen: ?std.StringHashMap(void) = null;
+    defer if (iife_diag_seen) |*seen_map| seen_map.deinit();
+
     // namespace import / inline object 캐시는 linker 전역 필드(`self.ns_export_cache`,
     // `self.ns_inline_cache`) 로 이동 — 같은 target 을 여러 모듈이 namespace import 해도
     // collectExportsRecursive DFS 를 한 번만 수행하도록 공유 (#1734).
@@ -242,8 +254,34 @@ pub fn buildMetadataForAst(
                             try preamble.write(ib.imported_name);
                             try preamble.write(";\n");
                         }
+                    } else if (self.format == .iife and !ib.isSynthetic()) {
+                        // #1791 IIFE: unresolved external 은 의미 자체가 성립 안 함
+                        // (factory 스코프에 require 없음, top-level import 도 불가).
+                        // build-time 에러로 pending_diagnostics 에 쌓고 emitter 가 flush.
+                        // specifier 단위로 dedupe — 같은 spec 의 binding 여러 개에 대해 한 번만.
+                        if (iife_diag_seen == null) iife_diag_seen = std.StringHashMap(void).init(self.allocator);
+                        const seen_gop = try iife_diag_seen.?.getOrPut(rec.specifier);
+                        if (!seen_gop.found_existing) {
+                            const msg = try std.fmt.allocPrint(
+                                self.allocator,
+                                "unresolved import \"{s}\" cannot be emitted in IIFE format (no require/import available in factory scope)",
+                                .{rec.specifier},
+                            );
+                            errdefer self.allocator.free(msg);
+                            try pending_diags.append(self.allocator, .{
+                                .code = .unresolved_import,
+                                .severity = .@"error",
+                                .message = msg,
+                                .file_path = m.path,
+                                .span = rec.span,
+                                .step = .resolve,
+                                .suggestion = null,
+                            });
+                        }
                     } else {
-                        // ESM/CJS/IIFE: require() preamble 생성
+                        // ESM/CJS: require() preamble 생성. ESM 출력에서도 esbuild 호환으로
+                        // require() 를 유지 — Node.js 가 `import` 없는 출력을 CJS 로 파싱하여
+                        // `var X; var X;` 재선언을 허용하게 한다 (`emitter.zig` 상단 주석 참조).
                         if (is_synthetic_esm) {
                             try preamble.writeUnresolvedRequireAssignOnly(preamble_name, rec.specifier, ib.imported_name, ib.kind == .namespace);
                         } else {
@@ -561,6 +599,12 @@ pub fn buildMetadataForAst(
     else
         null;
 
+    // #1791 IIFE unresolved 진단 소유권 이전
+    const pending_diags_slice: []const @import("../types.zig").BundlerDiagnostic = if (pending_diags.items.len > 0)
+        try pending_diags.toOwnedSlice(self.allocator)
+    else
+        &.{};
+
     return .{
         .skip_nodes = skip_nodes,
         .renames = renames,
@@ -575,6 +619,7 @@ pub fn buildMetadataForAst(
         .export_getter_overrides = export_getter_overrides,
         .owned_rename_values = owned_nested_renames,
         .dev_ns_vars = dev_ns_vars,
+        .pending_diagnostics = pending_diags_slice,
         .allocator = self.allocator,
     };
 }


### PR DESCRIPTION
## Summary

- IIFE 포맷에서 resolve 되지 않은 external import 가 codegen 의 bare `require("...")` fallback 으로 emit 되던 회귀를 build-time 에러로 승격 (factory 스코프엔 `require` 도 top-level `import` 도 없어 무조건 ReferenceError)
- `LinkingMetadata.pending_diagnostics` → `Linker.fatal_diagnostics` serial flush 경로 (`buildMetadataForAst` 병렬 호출 제약을 mutex 로 해결, 기존 `ns_cache_mutex` 관행과 동일)
- 기존 silent `linker.diagnostics` 와 분리된 `fatal_diagnostics` 필드로만 `BundleResult` 에 wire — 기존 `addDiag` 경로의 회귀 노출 방지

Closes #1791

## Scope note (근본으로 좁힘)

이슈 본문의 "ESM=원형 유지 (top-level import hoist)" 아이디어는 ZTS 의 기존 설계 — "ESM 출력도 require preamble 을 유지해 Node 가 CJS 로 파싱하도록 유도, `var X; var X;` 재선언 허용" (`emitter.zig:352-354`, `typescript_format.zig` 의 `ESM external: require preamble (esbuild compatible, no import)` 테스트) — 와 충돌했다. 이 PR 에서는 **IIFE 만 근본 수정** (실제 run-time 에 정의 불가능한 케이스) 하고, ESM/CJS 는 기존 동작을 유지한다.

bungae RN 의 실제 crash 경로는 RN factory 스코프에서 bare `require` 가 ReferenceError 나는 문제 — 이는 consumer 가 내부 require symbol (`__r(dep_idx)` 등) 로 rewrite 할 수 있게 하는 **NAPI `unresolvedImportStrategy` 옵션** (follow-up) 으로 제대로 해결한다.

## 변경점

- `src/bundler/linker/metadata.zig`: IIFE 분기에서 specifier 단위 dedupe 후 `pending_diagnostics` 수집. `iife_diag_seen` 은 실제 IIFE + unresolved 발생 시에만 lazy init
- `src/bundler/linker.zig`: `LinkingMetadata.pending_diagnostics`, `Linker.fatal_diagnostics` + `diagnostics_mutex` 필드 추가
- `src/bundler/emitter.zig`: `emitModule` 에서 metadata 생성 직후 pending → fatal flush
- `src/bundler/bundler.zig`: `BundleResult` 로 `graph.diagnostics` + `linker.fatal_diagnostics` 병합. 두 개의 deep-copy 루프를 `copyDiagnostics(dest, src, &filled)` helper 로 unify

## Test plan

- [x] `zig build` (Debug) 통과
- [x] `zig build test` — 3627 tests 모두 통과 (기존 회귀 없음)
- [x] repro: `zts entry.ts --bundle --format=iife --external ./unresolved` → `[error] ... unresolved import "./unresolved" cannot be emitted in IIFE format ...` + exit 1
- [x] ESM/CJS 동작 불변 확인 (require preamble 유지, exit 0)
- [x] 같은 specifier 의 여러 binding → diag dedupe 확인
- [x] /simplify 통과 — blocker 없음, 주요 개선 반영