### PR TITLE
fix(transformer): #1791 type-only import binding elision (babel 식 usage scan)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -778,6 +778,8 @@ pub const Bundler = struct {
             l.dev_mode = self.options.dev_mode;
             // #1621: preamble/metadata 가 __toESM/__toCommonJS 를 축약 이름으로 emit.
             l.minify_whitespace = self.options.minify_whitespace;
+            // #1791 Phase D: value-ref 0 binding elision 정책을 transformer 와 동기화.
+            l.verbatim_module_syntax = self.options.verbatim_module_syntax;
             if (mangle_report_enabled) l.mangle_report = &mangle_collector;
             try l.link();
             if (!self.options.code_splitting) {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -370,6 +370,11 @@ pub const Linker = struct {
     /// --shim-missing-exports: missing export에 대해 `var xxx = void 0;` shim 생성.
     shim_missing_exports: bool = false,
 
+    /// #1791 Phase D: value 참조가 0 인 import binding 을 preamble 생성에서 elide할지.
+    /// tsconfig `verbatimModuleSyntax=true` 일 때는 transformer 와 동일하게 유지해
+    /// 사용자 의도 (원본 import 보존) 를 존중한다. bundler 가 init 후 설정.
+    verbatim_module_syntax: bool = false,
+
     /// --mangle-report 수집기 (#1760). `null` 이면 instrumentation skip.
     /// Bundler 가 생성 및 소유. Linker 는 참조만 보유.
     mangle_report: ?*MangleReportCollector = null,

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -27,6 +27,21 @@ const isReservedName = Linker.isReservedName;
 const NamePair = PreambleWriter.NamePair;
 const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
 
+/// #1791 Phase D: import binding 의 local 이 value 로 참조된 적이 없는지. semantic.analyzer
+/// 는 TS type node 를 순회하지 않아 type 위치의 identifier 는 reference_count 에 집계되지
+/// 않는다 — `reference_count == 0` 이 "type 전용 사용" 과 "완전 미사용" 을 모두 포괄한다.
+/// true 이면 preamble 생성과 canonical rename 을 생략해 bare `require()` fallback (RN factory
+/// ReferenceError) 을 방지.
+///
+/// synthetic binding (JSX runtime 등) 은 semantic 이 추적하지 않으므로 "사용 중" 간주.
+/// 호출자가 `verbatim_module_syntax` 를 먼저 확인해 true 이면 이 경로를 bypass.
+inline fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
+    if (ib.isSynthetic()) return false;
+    const sym_idx = ib.local_symbol.semanticIndex() orelse return false;
+    if (sym_idx >= sem.symbols.items.len) return false;
+    return sem.symbols.items[sym_idx].reference_count == 0;
+}
+
 pub fn buildSkipNodes(allocator: std.mem.Allocator, ast: *const Ast, skip_imports: bool) !std.DynamicBitSet {
     const node_count = ast.nodes.items.len;
     var skip_nodes = try std.DynamicBitSet.initEmpty(allocator, node_count);
@@ -222,6 +237,10 @@ pub fn buildMetadataForAst(
         for (m.import_bindings) |ib| {
             if (ib.import_record_index >= m.import_records.len) continue;
             const rec = m.import_records[ib.import_record_index];
+
+            // Phase D elision: transformer 가 AST 에서 specifier 를 drop 하는 것과 대칭으로
+            // linker 도 preamble 생성을 건너뛴다. verbatim_module_syntax=true 면 양쪽 모두 보존.
+            if (!self.verbatim_module_syntax and isImportBindingTypeOnly(&sem, ib)) continue;
 
             // resolve 미완료: external 또는 resolve 실패.
             if (rec.resolved.isNone()) {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1347,11 +1347,18 @@ pub const Transformer = struct {
             },
 
             // === import/export specifiers ===
-            .import_specifier => if (node.data.binary.flags & 1 != 0) .none else self.visitBinaryNode(idx),
+            // inline `type` modifier (flags&1) 또는 value-ref==0 → elision.
+            // visitExtraList 가 `.none` 을 필터링하여 specifier list 에서 제거.
+            .import_specifier => blk: {
+                if (node.data.binary.flags & 1 != 0) break :blk NodeIndex.none;
+                if (self.shouldElideImportSpecifier(idx, node)) break :blk NodeIndex.none;
+                break :blk self.visitBinaryNode(idx);
+            },
             .export_specifier => if (node.data.binary.flags & 1 != 0) .none else self.visitBinaryNode(idx),
             // default/namespace specifier는 string_ref(span) 복사 — 자식 노드 없음
             .import_default_specifier,
             .import_namespace_specifier,
+            => if (self.shouldElideImportSpecifier(idx, node)) NodeIndex.none else self.copyNodeDirect(idx),
             .import_attribute,
             => self.copyNodeDirect(idx),
 
@@ -4202,30 +4209,42 @@ pub const Transformer = struct {
             if (spec_node.tag == .import_specifier and spec_node.data.binary.flags & 1 != 0) continue;
             if (spec_node.tag == .export_specifier) continue; // 방어적: export specifier는 여기 없지만
 
-            // 심볼 ID를 찾을 노드 인덱스 결정
-            const sym_node_idx: u32 = switch (spec_node.tag) {
-                // import_specifier: binary.right가 local name 노드
-                .import_specifier => blk: {
-                    const local_idx = spec_node.data.binary.right;
-                    break :blk if (!local_idx.isNone()) @intFromEnum(local_idx) else @intFromEnum(spec_idx);
-                },
-                // import_default_specifier, import_namespace_specifier: spec 노드 자체가 심볼
-                else => @intFromEnum(spec_idx),
-            };
-
-            // symbol_ids에서 심볼 ID 조회
-            if (sym_node_idx < self.symbol_ids.items.len) {
-                if (self.symbol_ids.items[sym_node_idx]) |sym_id| {
-                    if (sym_id < self.symbols.len) {
-                        if (self.symbols[sym_id].reference_count > 0) return false;
-                        continue; // 미사용 — 다음 specifier 확인
-                    }
-                }
-            }
-            // symbol_id를 찾지 못하면 보수적으로 유지 (사용 중으로 간주)
-            return false;
+            if (!self.isImportSpecifierUnused(spec_idx, spec_node)) return false;
         }
         return true;
+    }
+
+    /// visit switch 용 wrapper — `verbatim_module_syntax` 와 symbol table 준비 여부를
+    /// 먼저 가드한 뒤 `isImportSpecifierUnused` 에 위임. #1791 Phase D 의 elision 조건을
+    /// default/named/namespace 세 switch arm 이 동일하게 적용하도록 모아둔다.
+    fn shouldElideImportSpecifier(self: *const Transformer, spec_idx: NodeIndex, spec_node: Node) bool {
+        if (self.options.verbatim_module_syntax) return false;
+        if (self.symbols.len == 0) return false;
+        return self.isImportSpecifierUnused(spec_idx, spec_node);
+    }
+
+    /// 단일 import specifier 의 local binding 이 value 로 참조된 적이 있는지 조회.
+    /// babel 식 type-only usage elision — type 위치에서만 쓰이는 binding 은 analyzer 가
+    /// reference 에 포함시키지 않아 `reference_count == 0`. `areAllSpecifiersUnused` (전체
+    /// drop) 와 개별 specifier elision (visit switch) 양쪽에서 공유.
+    ///
+    /// symbol_id 조회 실패 시 보수적으로 "사용 중" 간주 — 한 번이라도 누락하면 프로덕션
+    /// 런타임 에러가 나므로 불확실하면 유지한다.
+    fn isImportSpecifierUnused(self: *const Transformer, spec_idx: NodeIndex, spec_node: Node) bool {
+        // 심볼 ID 조회 대상 노드: named 는 binary.right (local), default/namespace 는 specifier 자체
+        const sym_node_idx: u32 = switch (spec_node.tag) {
+            .import_specifier => blk: {
+                const local_idx = spec_node.data.binary.right;
+                break :blk if (!local_idx.isNone()) @intFromEnum(local_idx) else @intFromEnum(spec_idx);
+            },
+            .import_default_specifier, .import_namespace_specifier => @intFromEnum(spec_idx),
+            else => return false,
+        };
+
+        if (sym_node_idx >= self.symbol_ids.items.len) return false;
+        const sym_id = self.symbol_ids.items[sym_node_idx] orelse return false;
+        if (sym_id >= self.symbols.len) return false;
+        return self.symbols[sym_id].reference_count == 0;
     }
 
     /// export_named_declaration: extra_data = [declaration, specifiers_start, specifiers_len, source]


### PR DESCRIPTION
## Summary

- TS type 위치에서만 쓰이는 import specifier (e.g. `import { HeaderBarButtonItem } from 'x'` 를 `function f(a: HeaderBarButtonItem) {}` 에만 사용) 를 babel 방식으로 elide
- transformer: 개별 specifier `.none` 반환 → `visitExtraList` 가 필터 (default/named/namespace 모두). 모두 drop 되면 `areAllSpecifiersUnused` 가 declaration 전체 drop
- linker: `buildMetadataForAst` 의 import_bindings 루프에서 동일 판정 — preamble 과 canonical rename 모두 skip (transformer 가 AST 에서 specifier 를 drop 한 것과 대칭). bungae RN 의 실제 crash (`var HeaderBarButtonItem = require("…").HeaderBarButtonItem;` → RN factory 스코프 ReferenceError) 의 근본 원인 제거
- `verbatimModuleSyntax=true` 면 transformer + linker 모두 bypass — 사용자가 원본 import 보존을 명시한 경우

Closes #1791

## 동작 근거

`semantic.analyzer` 의 `visitNode` 는 TS type tag (ast.zig:262-311 의 ~25개 노드) 를 default 로 skip 하므로 type 위치의 identifier 는 `Symbol.reference_count` 에 집계되지 않는다. 따라서 `reference_count == 0` 은 곧 "value 로 참조되지 않은 binding" — type 전용 사용과 완전 미사용을 모두 포괄. 이 조건을 import specifier elision 의 트리거로 사용.

## 변경점

- `src/transformer/transformer.zig`:
  - visit switch 의 `.import_specifier` / `.import_default_specifier` / `.import_namespace_specifier` arm 에 `shouldElideImportSpecifier` 가드 추가
  - `shouldElideImportSpecifier` = (`!verbatim_module_syntax` && `symbols.len > 0` && `isImportSpecifierUnused`)
  - `areAllSpecifiersUnused` 의 symbol-lookup 로직을 `isImportSpecifierUnused` 로 추출해 재사용
- `src/bundler/linker.zig`: `Linker.verbatim_module_syntax` 필드 추가 (`minify_whitespace` / `shim_missing_exports` 와 동일 패턴)
- `src/bundler/bundler.zig`: Linker init 직후 `verbatim_module_syntax` 전달
- `src/bundler/linker/metadata.zig`: `isImportBindingTypeOnly` 파일-로컬 helper. import_bindings 루프 맨 앞에서 unused binding skip

## 실증 (repro)

```ts
// entry.ts
import { HeaderBarButtonItem, Used } from "./lib";
export function f(x: HeaderBarButtonItem): void {}  // type 위치에서만 사용
export const u = Used();                              // value 사용
```

| 경로 | Before | After |
|------|--------|-------|
| `zts entry.ts` | `import { HeaderBarButtonItem, Used } from "./lib";` | `import { Used } from "./lib";` |
| `zts entry.ts --bundle --external ./lib` | `var HeaderBarButtonItem = require("./lib").HeaderBarButtonItem; var Used = ...` (RN 에서 crash) | `var Used = require("./lib").Used;` |
| `zts entry.ts --verbatim-module-syntax` | (보존) | (보존, 변경 없음) |
| 전체 type-only (`import { A }` + A 만 type 사용) | `import { A } from "./lib";` + 본문 | import 전체 drop |

## Test plan

- [x] `zig build` (Debug) 통과
- [x] `zig build test` — 3627 tests 모두 통과 (기존 회귀 없음)
- [x] 경계 케이스: default type-only / namespace type-only / 전체 type-only (전체 drop) / mixed (value 만 남김) / verbatim 보존 / alias (`import { X as Y }`) 모두 확인
- [x] /simplify 통과 — helper 추출로 switch arm 중복 가드 제거

## 후속 작업

- PR #4 (Phase E): babel `imports/elision/`, `elide-typeof/`, `import-named-type/` fixture 포팅 — 회귀 방지용 통합 테스트