### PR TITLE
fix(semantic,transformer,linker): #1791 Phase D 재구현 — per-reference type-context flag

### DIFF
--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -833,3 +833,105 @@ test "TypeScript: verbatimModuleSyntax=true preserves external type-only preambl
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var TypeAlpha = require(\"external-lib\").TypeAlpha") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var useValue = require(\"external-lib\").useValue") != null);
 }
+
+test "TypeScript: external + export re-export → preamble require 유지 (#1793 revert 원인)" {
+    // `import { X } from 'ext'; export { X };` 에서 X 는 analyzer 가 value 참조로
+    // 등록해야 Phase D 가 drop 하지 않음. #1793 revert 의 직접 실패 경로.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { ExportMe } from "external-pkg";
+        \\export { ExportMe };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"external-pkg"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var ExportMe = require(\"external-pkg\").ExportMe") != null);
+}
+
+test "TypeScript: external + namespace member access → preamble 유지 (namespace 는 elision 제외)" {
+    // `import * as React; React.forwardRef()` — Phase D 는 namespace 를 elision 대상에서
+    // 제외. bungae 의 React$250='19.2.0' crash 회귀 방지.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import * as React from "react";
+        \\export const Slot = React.forwardRef((a: any, r: any) => null);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // namespace import 는 preamble 에 유지되어 React.forwardRef 호출 가능.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "React") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "forwardRef") != null);
+}
+
+test "TypeScript: external + default import → Phase D 는 default 를 elide 하지 않음" {
+    // JSX pragma / CSS-in-JS default export 등 implicit value use 가 많아 default 는
+    // elision 제외. 회귀 방지.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import DefaultX from "external-mod";
+        \\export function f(x: DefaultX): void {}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"external-mod"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"external-mod\")") != null);
+}
+
+test "TypeScript: external + named mixed → type-only 만 elide, value-used 유지" {
+    // Phase D 의 핵심 기능 — bundle 레벨에서 confirm.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { TypeX, UtilY, TypeZ } from "external-kit";
+        \\export function f(a: TypeX, b: TypeZ): void {}
+        \\export const v = UtilY();
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"external-kit"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // value-used 만 preamble 에 남음.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var UtilY = require(\"external-kit\").UtilY") != null);
+    // type-only 는 preamble 에 없음.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TypeX") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TypeZ") == null);
+}

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -991,6 +991,7 @@ pub fn emitModule(
     if (module.semantic) |sem| {
         transformer.initSymbolIds(sem.symbol_ids) catch return error.OutOfMemory;
         transformer.symbols = sem.symbols.items;
+        transformer.references = sem.references;
     }
     // jsxDEV source info 계산용 line offsets
     transformer.line_offsets = module.line_offsets;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -27,19 +27,32 @@ const isReservedName = Linker.isReservedName;
 const NamePair = PreambleWriter.NamePair;
 const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
 
-/// #1791 Phase D: import binding 의 local 이 value 로 참조된 적이 없는지. semantic.analyzer
-/// 는 TS type node 를 순회하지 않아 type 위치의 identifier 는 reference_count 에 집계되지
-/// 않는다 — `reference_count == 0` 이 "type 전용 사용" 과 "완전 미사용" 을 모두 포괄한다.
-/// true 이면 preamble 생성과 canonical rename 을 생략해 bare `require()` fallback (RN factory
+/// #1791 Phase D: import binding 의 local 이 value 로 참조된 적이 있는지 조회 (oxc 식).
+/// analyzer 가 각 Reference 에 `type_context` / `value_as_type` flag 를 기록하므로,
+/// symbol 의 Reference 들 중 **순수 value read** 가 하나라도 있으면 false. 하나도 없으면
+/// true → preamble / canonical rename 을 skip 해 bare `require()` fallback (RN factory
 /// ReferenceError) 을 방지.
 ///
+/// 기존 `reference_count == 0` 접근은 mangler 전용 카운트를 재활용해 false positive 가
+/// 났음 (#1793 revert). 이제 Reference 단위로 value/type 문맥을 구분.
+///
 /// synthetic binding (JSX runtime 등) 은 semantic 이 추적하지 않으므로 "사용 중" 간주.
-/// 호출자가 `verbatim_module_syntax` 를 먼저 확인해 true 이면 이 경로를 bypass.
+/// `references` 가 비어있어도 보수적 보존. 호출자가 `verbatim_module_syntax` 를 먼저
+/// 확인해 true 이면 이 경로를 bypass.
 inline fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
     if (ib.isSynthetic()) return false;
+    // named 한정 — default / namespace 는 JSX pragma 등 implicit value use 위험이
+    // 큼 (#1793 revert 원인). transformer 와 동일 제한.
+    if (ib.kind != .named) return false;
     const sym_idx = ib.local_symbol.semanticIndex() orelse return false;
     if (sym_idx >= sem.symbols.items.len) return false;
-    return sem.symbols.items[sym_idx].reference_count == 0;
+    for (sem.references) |r| {
+        if (@intFromEnum(r.symbol_id) != sym_idx) continue;
+        if (r.flags.declare) continue;
+        if (r.flags.type_context or r.flags.value_as_type) continue;
+        return false;
+    }
+    return true;
 }
 
 pub fn buildSkipNodes(allocator: std.mem.Allocator, ast: *const Ast, skip_imports: bool) !std.DynamicBitSet {

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -46,11 +46,12 @@ inline fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSem
     if (ib.kind != .named) return false;
     const sym_idx = ib.local_symbol.semanticIndex() orelse return false;
     if (sym_idx >= sem.symbols.items.len) return false;
+    // 판정 로직은 `Reference.isValueUse` 에 집약 — transformer 의
+    // `isImportSpecifierUnused` 와 동일 기준. TODO #1791: `references` 를 매번 linear
+    // scan 하는 대신 모듈별 `symbol_id → Reference indices` 맵 사전 구축 고려 (실측 후).
     for (sem.references) |r| {
         if (@intFromEnum(r.symbol_id) != sym_idx) continue;
-        if (r.flags.declare) continue;
-        if (r.flags.type_context or r.flags.value_as_type) continue;
-        return false;
+        if (r.isValueUse()) return false;
     }
     return true;
 }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -27,7 +27,7 @@ const isReservedName = Linker.isReservedName;
 const NamePair = PreambleWriter.NamePair;
 const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
 
-/// #1791 Phase D: import binding 의 local 이 value 로 참조된 적이 있는지 조회 (oxc 식).
+/// #1791 Phase D: import binding 의 local 이 value 로 참조된 적이 있는지 조회.
 /// analyzer 가 각 Reference 에 `type_context` / `value_as_type` flag 를 기록하므로,
 /// symbol 의 Reference 들 중 **순수 value read** 가 하나라도 있으면 false. 하나도 없으면
 /// true → preamble / canonical rename 을 skip 해 bare `require()` fallback (RN factory

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -11,6 +11,7 @@
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
+const ast_walk = @import("../parser/ast_walk.zig");
 const Node = ast_mod.Node;
 const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
@@ -141,6 +142,17 @@ pub const SemanticAnalyzer = struct {
     /// ECMAScript B.3.2/B.3.3: "If replacing the FunctionDeclaration with a VariableStatement
     /// would produce an Early Error, the extension is not applied."
     in_annex_b_context: bool = false,
+
+    /// #1791 oxc 식 type-context 추적. 양수이면 현재 방문 중인 식별자가 TypeScript type
+    /// 문맥 (`x: T`, `interface I extends T`, `T[]` 등) 내에 있음. `resolveIdentifier` 가
+    /// 생성하는 `Reference.flags` 에 `type_context=true` 로 반영되어, import binding
+    /// elision (#1791 Phase D) 이 value-use 와 type-use 를 구분할 수 있게 한다.
+    /// 중첩 (`A<B<C>>`) 을 위해 counter. enter/exit 을 짝으로 호출.
+    type_context_depth: u16 = 0,
+    /// `typeof X` / `keyof X` 처럼 **value 식별자를 type 으로 사용** 할 때 양수. 별도
+    /// bit 로 관리해 isolated declarations 등 downstream 에서 구분 가능. Phase D 판정에선
+    /// `type_context` 와 동일 취급.
+    value_as_type_depth: u16 = 0,
 
     // ================================================================
     // StmtInfo 사전 수집 (번들러 최적화)
@@ -780,15 +792,27 @@ pub const SemanticAnalyzer = struct {
     fn resolveIdentifier(self: *SemanticAnalyzer, name: []const u8, node_idx: NodeIndex, flags: symbol_mod.ReferenceFlags) void {
         var scope_id = self.current_scope;
 
+        // #1791 caller 의 flags 에 현재 type-context 상태를 얹어 per-reference 기록.
+        // mangler 용 reference_count / write_count 는 영향 받지 않음 (bit 만 추가).
+        var effective = flags;
+        if (self.type_context_depth > 0) effective.type_context = true;
+        if (self.value_as_type_depth > 0) effective.value_as_type = true;
+
         // 스코프 체인을 따라 올라가며 심볼 검색
         while (!scope_id.isNone()) {
             const idx = scope_id.toIndex();
             if (idx >= self.scope_maps.items.len) break;
 
             if (self.scope_maps.items[idx].get(name)) |sym_idx| {
-                // 심볼을 찾음 — reference_count 증가
-                self.symbols.items[sym_idx].reference_count += 1;
-                if (flags.write) self.symbols.items[sym_idx].write_count += 1;
+                // reference_count / write_count 는 value 참조만 집계 (#1791 호환).
+                // mangler / tree-shaker 는 이 카운트를 "runtime 에 살아있는 참조 수" 로
+                // 사용하므로, type 문맥 (TS type annotation 등) 의 식별자는 runtime 에
+                // 존재하지 않으니 카운트에서 제외. per-reference 기록은 항상 수행.
+                const is_type_only_use = effective.type_context or effective.value_as_type;
+                if (!is_type_only_use) {
+                    self.symbols.items[sym_idx].reference_count += 1;
+                    if (flags.write) self.symbols.items[sym_idx].write_count += 1;
+                }
                 // symbol_ids + references 기록. node_idx 는 non-none 으로 강제 (NodeIndex
                 // 타입). nullable 경로를 우회하면 mangler liveness 에 silent 누락이 생기므로
                 // 타입 수준에서 차단한다.
@@ -802,7 +826,7 @@ pub const SemanticAnalyzer = struct {
                     .symbol_id = @enumFromInt(sym_idx),
                     .stmt_idx = self.current_top_stmt_idx orelse symbol_mod.Reference.NO_STMT,
                     .scope_stmt_idx = self.current_stmt_idx,
-                    .flags = flags,
+                    .flags = effective,
                 }) catch {};
 
                 return;
@@ -1501,8 +1525,73 @@ pub const SemanticAnalyzer = struct {
                 try self.visitAsWriteTarget(idx);
             },
 
-            // ---- 스킵 (TS 타입 노드, 리터럴, 식별자 등) ----
+            // #1791 TypeScript type 문맥 진입 — 내부 식별자를 Reference 로 기록하되
+            // `type_context=true` flag 와 함께. `typeof` (ts_type_query) 는 별도
+            // `value_as_type` bit 로 구분. type_context_depth / value_as_type_depth 가
+            // 중첩을 지원.
+            .ts_type_reference,
+            .ts_qualified_name,
+            .ts_array_type,
+            .ts_tuple_type,
+            .ts_named_tuple_member,
+            .ts_union_type,
+            .ts_intersection_type,
+            .ts_conditional_type,
+            .ts_type_operator,
+            .ts_optional_type,
+            .ts_rest_type,
+            .ts_indexed_access_type,
+            .ts_type_literal,
+            .ts_function_type,
+            .ts_constructor_type,
+            .ts_mapped_type,
+            .ts_template_literal_type,
+            .ts_infer_type,
+            .ts_parenthesized_type,
+            .ts_import_type,
+            .ts_literal_type,
+            .ts_type_predicate,
+            .ts_type_alias_declaration,
+            .ts_interface_declaration,
+            .ts_interface_body,
+            .ts_property_signature,
+            .ts_method_signature,
+            .ts_call_signature,
+            .ts_construct_signature,
+            .ts_index_signature,
+            .ts_getter_signature,
+            .ts_setter_signature,
+            .ts_type_parameter,
+            .ts_type_parameter_declaration,
+            .ts_type_parameter_instantiation,
+            .ts_class_implements,
+            => {
+                try self.visitTypeContextNode(idx, node);
+            },
+            .ts_type_query => {
+                // typeof X — 자식 identifier 는 value identifier 지만 type 으로 사용
+                self.value_as_type_depth += 1;
+                defer self.value_as_type_depth -= 1;
+                try self.visitTypeContextNode(idx, node);
+            },
+
+            // ---- 스킵 (TS 타입 keyword, 리터럴, 식별자 등) ----
             else => {},
+        }
+    }
+
+    /// TS type node 의 children 을 `type_context_depth` 를 올린 채 순회.
+    /// `ast_walk.children` iterator 로 각 child NodeIndex 를 얻어 재귀 visit —
+    /// 내부에 도달한 `identifier_reference` 는 `resolveIdentifier` 가 type_context
+    /// flag 와 함께 Reference 에 기록.
+    fn visitTypeContextNode(self: *SemanticAnalyzer, idx: NodeIndex, node: Node) AllocError!void {
+        _ = idx;
+        self.type_context_depth += 1;
+        defer self.type_context_depth -= 1;
+        var it = ast_walk.children(self.ast, node);
+        while (it.next()) |child| {
+            if (child.isNone()) continue;
+            try self.visitNode(child);
         }
     }
 

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -143,7 +143,7 @@ pub const SemanticAnalyzer = struct {
     /// would produce an Early Error, the extension is not applied."
     in_annex_b_context: bool = false,
 
-    /// #1791 oxc 식 type-context 추적. 양수이면 현재 방문 중인 식별자가 TypeScript type
+    /// #1791 type-context 추적. 양수이면 현재 방문 중인 식별자가 TypeScript type
     /// 문맥 (`x: T`, `interface I extends T`, `T[]` 등) 내에 있음. `resolveIdentifier` 가
     /// 생성하는 `Reference.flags` 에 `type_context=true` 로 반영되어, import binding
     /// elision (#1791 Phase D) 이 value-use 와 type-use 를 구분할 수 있게 한다.

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1529,7 +1529,22 @@ pub const SemanticAnalyzer = struct {
             // `type_context=true` flag 와 함께. `typeof` (ts_type_query) 는 별도
             // `value_as_type` bit 로 구분. type_context_depth / value_as_type_depth 가
             // 중첩을 지원.
-            .ts_type_reference,
+            //
+            // 대부분의 TS type node 는 `ast.zig` 의 `child_offsets = &.{}` 로 선언되어
+            // ast_walk.children 으로는 내부 식별자에 도달할 수 없다 (런타임 워커 가정).
+            // `ts_type_reference` 는 extra = [name_start, name_end, type_args] 로
+            // raw span 을 저장하므로 analyzer 가 직접 name 을 resolve 한다.
+            .ts_type_reference => {
+                self.type_context_depth += 1;
+                defer self.type_context_depth -= 1;
+                try self.visitTypeReferenceNode(idx, node);
+            },
+            .ts_type_query => {
+                // typeof X — 자식 identifier 는 value identifier 지만 type 으로 사용
+                self.value_as_type_depth += 1;
+                defer self.value_as_type_depth -= 1;
+                try self.visitTypeContextNode(idx, node);
+            },
             .ts_qualified_name,
             .ts_array_type,
             .ts_tuple_type,
@@ -1568,12 +1583,6 @@ pub const SemanticAnalyzer = struct {
             => {
                 try self.visitTypeContextNode(idx, node);
             },
-            .ts_type_query => {
-                // typeof X — 자식 identifier 는 value identifier 지만 type 으로 사용
-                self.value_as_type_depth += 1;
-                defer self.value_as_type_depth -= 1;
-                try self.visitTypeContextNode(idx, node);
-            },
 
             // ---- 스킵 (TS 타입 keyword, 리터럴, 식별자 등) ----
             else => {},
@@ -1593,6 +1602,33 @@ pub const SemanticAnalyzer = struct {
             if (child.isNone()) continue;
             try self.visitNode(child);
         }
+    }
+
+    /// `ts_type_reference` 는 `extra = [name_start, name_end, type_args_idx]` layout
+    /// 으로 이름을 raw span 으로 저장 (`ast.zig` `child_offsets = &.{}`). analyzer 가
+    /// 직접 source 에서 name 을 추출해 `resolveIdentifier` 로 scope 조회하고, 찾은
+    /// symbol 의 Reference 에 `type_context=true` 를 기록. type arguments (generic
+    /// `T<U>`) 는 재귀 방문.
+    fn visitTypeReferenceNode(self: *SemanticAnalyzer, idx: NodeIndex, node: Node) AllocError!void {
+        const e = node.data.extra;
+        const extras = self.ast.extra_data.items;
+        if (e + 2 >= extras.len) return;
+        const name_start = extras[e];
+        const name_end = extras[e + 1];
+        if (name_start <= name_end and name_end <= self.ast.source.len) {
+            const name = self.ast.source[name_start..name_end];
+            // qualified name (Foo.Bar) 은 `.` 기준으로 base segment 만 resolve —
+            // `Bar` 는 `Foo` 의 property 이므로 scope 에는 없음.
+            const base = if (std.mem.indexOfScalar(u8, name, '.')) |dot|
+                name[0..dot]
+            else
+                name;
+            if (base.len > 0) {
+                self.resolveIdentifier(base, idx, .{ .read = true });
+            }
+        }
+        const type_args: NodeIndex = @enumFromInt(extras[e + 2]);
+        if (!type_args.isNone()) try self.visitNode(type_args);
     }
 
     fn visitNodeList(self: *SemanticAnalyzer, list: NodeList) AllocError!void {
@@ -2876,6 +2912,11 @@ pub const SemanticAnalyzer = struct {
                                 // transpile 에서 이름을 보존하고, specifier 출력이 원본 이름을
                                 // 그대로 쓰더라도 참조 정합성이 유지된다.
                                 self.markSymbolExported(local_name, false);
+                                // #1791: export specifier 의 local 은 value 참조.
+                                // 기존 analyzer 는 존재 검증만 하고 Reference 를 만들지
+                                // 않았는데, 이 경우 Phase D 가 `export { X }` 의 X 를
+                                // 미사용으로 오판 → import drop → ReferenceError.
+                                self.resolveIdentifier(local_name, local_idx, .{ .read = true });
                             }
                         }
                     }

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -368,7 +368,7 @@ pub const Reference = struct {
 ///   - `{ .declare = true }`            — 선언 위치 (#1669 부터 모든 scope). node_index 는 NodeIndex.none
 ///     (선언 span 을 Reference 에 싣지 않음 — buildFromSemantic 은 scope_id==0 + stmt_idx 로 bucket 분배)
 ///
-/// #1791 type-context flag (oxc 식 `ReferenceFlags::Type` / `ValueAsType` 에 대응):
+/// #1791 type-context flag:
 ///   - `{ .read = true, .type_context = true }` — `x: T`, `interface I extends T` 등 type 문맥 내 참조
 ///   - `{ .read = true, .value_as_type = true }` — `typeof x`, `keyof x` — value id 를 type 으로 사용
 ///   - 두 flag 모두 false 인 `.read` 는 "값으로 참조됨" — import binding elision (#1791 Phase D)

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -357,9 +357,24 @@ pub const Reference = struct {
 ///   - `{ .read = true, .write = true }` — `x += 1`, `x++`, `--x` 등 compound/update
 ///   - `{ .declare = true }`            — 선언 위치 (#1669 부터 모든 scope). node_index 는 NodeIndex.none
 ///     (선언 span 을 Reference 에 싣지 않음 — buildFromSemantic 은 scope_id==0 + stmt_idx 로 bucket 분배)
+///
+/// #1791 type-context flag (oxc 식 `ReferenceFlags::Type` / `ValueAsType` 에 대응):
+///   - `{ .read = true, .type_context = true }` — `x: T`, `interface I extends T` 등 type 문맥 내 참조
+///   - `{ .read = true, .value_as_type = true }` — `typeof x`, `keyof x` — value id 를 type 으로 사용
+///   - 두 flag 모두 false 인 `.read` 는 "값으로 참조됨" — import binding elision (#1791 Phase D)
+///     판정의 근거. `reference_count` 는 mangler 전용이라 이 판정에는 부적절 (false positive).
 pub const ReferenceFlags = packed struct(u8) {
     read: bool = false,
     write: bool = false,
     declare: bool = false,
-    _reserved: u5 = 0,
+    /// 참조가 TypeScript type 문맥 (`x: T`, `extends T`, `T[]` 등) 내에서 발생.
+    /// 기존 analyzer 가 type node 를 순회하지 않아 이 플래그는 현재 미사용이지만, #1791 에서
+    /// type node 진입 시 식별자를 기록할 때 세팅할 예정. Phase D 는 "모든 read 가 이 bit 를
+    /// 가지면 value 미사용" 으로 판정.
+    type_context: bool = false,
+    /// `typeof X` / `keyof X` 처럼 **value 식별자를 type 으로 사용**. `type_context` 와는
+    /// 별개 bit — 회색지대 분석 (isolated declarations 등) 에서 구분이 필요할 수 있음.
+    /// Phase D 판정에선 `type_context` 와 동일하게 "value 사용 아님" 취급.
+    value_as_type: bool = false,
+    _reserved: u3 = 0,
 };

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -347,6 +347,16 @@ pub const Reference = struct {
     flags: ReferenceFlags = .{},
 
     pub const NO_STMT: u32 = std.math.maxInt(u32);
+
+    /// #1791: runtime 에 값이 실제로 필요한 참조인지 판정.
+    /// `declare` 는 선언 위치 (값 사용 아님), `type_context` / `value_as_type` 는 TS
+    /// type 문맥 (런타임 제거됨). 셋 다 false 인 read/write 만 "value-use" 로 취급.
+    /// Phase D 가 transformer/linker 양쪽에서 동일 기준으로 공유.
+    pub fn isValueUse(self: Reference) bool {
+        if (self.flags.declare) return false;
+        if (self.flags.type_context or self.flags.value_as_type) return false;
+        return self.flags.read or self.flags.write;
+    }
 };
 
 /// 참조 종류 플래그 (packed bitset).

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -262,6 +262,12 @@ pub const Transformer = struct {
     /// 비어 있으면 unused import 제거 비활성.
     symbols: []const Symbol = &.{},
 
+    /// #1791 per-reference 기록 (`semantic/analyzer::SemanticAnalyzer.references`).
+    /// import binding elision 판정은 `Symbol.reference_count` 대신 여기서 symbol 별
+    /// Reference 를 돌며 **value-use 가 하나라도 있는지** 로 판단한다. 비어있으면
+    /// elision 비활성 (보수적 보존). caller 가 symbols 와 함께 설정.
+    references: []const @import("../semantic/symbol.zig").Reference = &.{},
+
     /// define value의 string_table Span 캐시. options.define과 동일 인덱스.
     /// transform() 시작 시 한 번 빌드하여, tryDefineReplace에서 addString 중복 호출을 방지.
     define_spans: []Span = &.{},
@@ -1347,8 +1353,10 @@ pub const Transformer = struct {
             },
 
             // === import/export specifiers ===
-            // inline `type` modifier (flags&1) 또는 value-ref==0 → elision.
-            // visitExtraList 가 `.none` 을 필터링하여 specifier list 에서 제거.
+            // #1791 Phase D: inline `type` modifier (flags&1) 또는 named specifier 의
+            // value-ref 0 (type 위치에서만 사용) 이면 elide. visitExtraList 가 `.none` 을
+            // 필터링. default/namespace 는 JSX pragma 등 implicit value use 위험이 커
+            // `shouldElideImportSpecifier` 에서 이미 false 를 반환하므로 elision 비활성.
             .import_specifier => blk: {
                 if (node.data.binary.flags & 1 != 0) break :blk NodeIndex.none;
                 if (self.shouldElideImportSpecifier(idx, node)) break :blk NodeIndex.none;
@@ -1358,7 +1366,6 @@ pub const Transformer = struct {
             // default/namespace specifier는 string_ref(span) 복사 — 자식 노드 없음
             .import_default_specifier,
             .import_namespace_specifier,
-            => if (self.shouldElideImportSpecifier(idx, node)) NodeIndex.none else self.copyNodeDirect(idx),
             .import_attribute,
             => self.copyNodeDirect(idx),
 
@@ -4224,27 +4231,36 @@ pub const Transformer = struct {
     }
 
     /// 단일 import specifier 의 local binding 이 value 로 참조된 적이 있는지 조회.
-    /// babel 식 type-only usage elision — type 위치에서만 쓰이는 binding 은 analyzer 가
-    /// reference 에 포함시키지 않아 `reference_count == 0`. `areAllSpecifiersUnused` (전체
-    /// drop) 와 개별 specifier elision (visit switch) 양쪽에서 공유.
+    /// #1791 oxc 식 판정: symbol 의 Reference 들 중 **type_context / value_as_type 이
+    /// 모두 false 인 read** (= 순수 value 사용) 가 하나라도 있으면 false. 하나도 없으면
+    /// true (= elide 가능).
     ///
-    /// symbol_id 조회 실패 시 보수적으로 "사용 중" 간주 — 한 번이라도 누락하면 프로덕션
-    /// 런타임 에러가 나므로 불확실하면 유지한다.
+    /// 기존 `reference_count` 기반 접근은 false positive — `export { X }` / JSX tag /
+    /// namespace member access 같은 경로가 analyzer 에서 카운트되지 않아 value-use 가
+    /// 있음에도 "미사용" 으로 오판했음 (PR #1793 revert 원인).
+    ///
+    /// `self.references` 가 비어있으면 보수적으로 "사용 중" 간주. symbol_id 조회 실패도 동일.
     fn isImportSpecifierUnused(self: *const Transformer, spec_idx: NodeIndex, spec_node: Node) bool {
-        // 심볼 ID 조회 대상 노드: named 는 binary.right (local), default/namespace 는 specifier 자체
-        const sym_node_idx: u32 = switch (spec_node.tag) {
-            .import_specifier => blk: {
-                const local_idx = spec_node.data.binary.right;
-                break :blk if (!local_idx.isNone()) @intFromEnum(local_idx) else @intFromEnum(spec_idx);
-            },
-            .import_default_specifier, .import_namespace_specifier => @intFromEnum(spec_idx),
-            else => return false,
-        };
+        // #1791: Phase D 를 **named specifier 한정**. default/namespace 는 JSX pragma,
+        // CSS-in-JS default export, namespace member access 같은 implicit value use 가
+        // 많아 false positive 위험이 큼 (#1793 revert 원인). bungae 의 실제 crash 경로
+        // (`import { HeaderBarButtonItem }`) 는 named 이므로 이 제한으로도 해결.
+        if (spec_node.tag != .import_specifier) return false;
+        const local_idx = spec_node.data.binary.right;
+        const sym_node_idx: u32 = if (!local_idx.isNone()) @intFromEnum(local_idx) else @intFromEnum(spec_idx);
 
         if (sym_node_idx >= self.symbol_ids.items.len) return false;
         const sym_id = self.symbol_ids.items[sym_node_idx] orelse return false;
         if (sym_id >= self.symbols.len) return false;
-        return self.symbols[sym_id].reference_count == 0;
+
+        // Reference 들 중 value-use 하나라도 있으면 keep.
+        for (self.references) |r| {
+            if (@intFromEnum(r.symbol_id) != sym_id) continue;
+            if (r.flags.declare) continue;
+            if (r.flags.type_context or r.flags.value_as_type) continue;
+            return false;
+        }
+        return true;
     }
 
     /// export_named_declaration: extra_data = [declaration, specifiers_start, specifiers_len, source]

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -4231,7 +4231,7 @@ pub const Transformer = struct {
     }
 
     /// 단일 import specifier 의 local binding 이 value 로 참조된 적이 있는지 조회.
-    /// #1791 oxc 식 판정: symbol 의 Reference 들 중 **type_context / value_as_type 이
+    /// #1791 Phase D 판정: symbol 의 Reference 들 중 **type_context / value_as_type 이
     /// 모두 false 인 read** (= 순수 value 사용) 가 하나라도 있으면 false. 하나도 없으면
     /// true (= elide 가능).
     ///

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -4253,12 +4253,11 @@ pub const Transformer = struct {
         const sym_id = self.symbol_ids.items[sym_node_idx] orelse return false;
         if (sym_id >= self.symbols.len) return false;
 
-        // Reference 들 중 value-use 하나라도 있으면 keep.
+        // Reference 들 중 value-use 하나라도 있으면 keep. 판정은 `Reference.isValueUse`
+        // 가 공통으로 수행 — linker 의 `isImportBindingTypeOnly` 와 동일 기준.
         for (self.references) |r| {
             if (@intFromEnum(r.symbol_id) != sym_id) continue;
-            if (r.flags.declare) continue;
-            if (r.flags.type_context or r.flags.value_as_type) continue;
-            return false;
+            if (r.isValueUse()) return false;
         }
         return true;
     }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1214,64 +1214,43 @@ test "verbatimModuleSyntax=true: 미사용 default import 보존" {
 }
 
 // ============================================================
-// type-only import binding elision (#1791)
-// analyzer 가 TS type node 를 순회하지 않아 type 위치 identifier 는
-// reference_count == 0 이 된다. inline `type` modifier 없이도 "값으로
-// 참조되지 않는 binding" 을 import 레벨에서 drop.
+// type-only import binding elision (#1791, oxc-style Reference flags)
+//
+// analyzer 가 TS type node 에 진입할 때 `type_context_depth` 를 올려 내부 식별자의
+// Reference 에 `flags.type_context=true` 를 기록한다. Phase D 는 이 flag 를 근거로
+// **named specifier** 에 한정해 "value 참조 0" 인 binding 을 drop.
+//
+// 회귀 방지 설계 (#1793 revert 원인):
+// - default/namespace import 는 JSX pragma / CSS-in-JS default export / namespace
+//   member access 같은 implicit value use 가 많아 elision 대상에서 제외
+// - `export { X }` re-export 의 local 은 analyzer 가 value 참조로 등록 (이전에는
+//   검증만 하고 Reference 를 만들지 않아 Phase D 가 오판)
+// - `typeof X` / `keyof X` 는 `value_as_type` bit 로 구분 — type 전용 사용 간주
 // ============================================================
 
-test "type-only usage elision: named/default/namespace/alias + verbatim 보존" {
+test "#1791 type-only elision: positive + negative cases" {
     const Case = struct {
         name: []const u8,
         src: []const u8,
+        path: []const u8 = "input.ts",
         verbatim: bool = false,
         must_contain: []const []const u8 = &.{},
         must_not_contain: []const []const u8 = &.{},
     };
     const cases = [_]Case{
+        // ---------- POSITIVE: elide 되어야 할 것 ----------
         .{
-            // named 중 type 위치에서만 쓰이는 specifier 만 선택적으로 drop.
-            .name = "named specifier elide (mixed)",
+            .name = "named mixed: type-only specifier 만 drop",
             .src =
             \\import { A, B } from "./lib";
             \\export function f(x: A): void {}
             \\export const v = B();
             ,
             .must_contain = &.{"import { B } from \"./lib\""},
-            .must_not_contain = &.{ " A,", ", A " },
+            .must_not_contain = &.{ " A,", ", A ", "{ A," },
         },
         .{
-            // default binding 이 type 으로만 쓰이면 declaration 전체 drop.
-            .name = "default drop",
-            .src =
-            \\import Foo from "./lib";
-            \\export function f(x: Foo): void {}
-            ,
-            .must_not_contain = &.{ "import", "./lib" },
-        },
-        .{
-            // namespace binding 이 type 으로만 쓰이면 drop.
-            .name = "namespace drop",
-            .src =
-            \\import * as NS from "./lib";
-            \\export function f(x: NS.Foo): void {}
-            ,
-            .must_not_contain = &.{ "import", "./lib", "NS" },
-        },
-        .{
-            // alias 의 local 이 type 으로만 쓰이면 해당 specifier 만 drop.
-            .name = "alias local-type-only",
-            .src =
-            \\import { X as Y, Z } from "./lib";
-            \\export function f(x: Y): void {}
-            \\export const v = Z();
-            ,
-            .must_contain = &.{"import { Z } from \"./lib\""},
-            .must_not_contain = &.{ " Y,", "X as Y" },
-        },
-        .{
-            // 모든 named specifier 가 type-only 사용 → declaration 전체 drop.
-            .name = "all-named drop",
+            .name = "named all type-only → declaration 전체 drop",
             .src =
             \\import { A, B } from "./lib";
             \\export function f(x: A): B { return undefined; }
@@ -1279,8 +1258,122 @@ test "type-only usage elision: named/default/namespace/alias + verbatim 보존" 
             .must_not_contain = &.{ "import", "./lib" },
         },
         .{
-            // verbatim=true: 사용자가 원본 import 유지를 명시 → elision skip.
-            .name = "verbatim preserves type-only usage",
+            .name = "named alias: local 이 type-only 면 해당 specifier 만 drop",
+            .src =
+            \\import { X as Y, Z } from "./lib";
+            \\export function f(x: Y): void {}
+            \\export const v = Z();
+            ,
+            .must_contain = &.{"import { Z } from \"./lib\""},
+            .must_not_contain = &.{ "X as Y", " Y,", "{ Y," },
+        },
+        .{
+            .name = "nested generic: Array<Map<string, A>> 안의 A 는 type-only",
+            .src =
+            \\import { A, Util } from "./lib";
+            \\export type T = Array<Map<string, A>>;
+            \\export const v = Util();
+            ,
+            .must_contain = &.{"import { Util } from \"./lib\""},
+            .must_not_contain = &.{"{ A,"},
+        },
+        .{
+            .name = "typeof X: value_as_type 로 분류되어 drop",
+            .src =
+            \\import { X, Used } from "./lib";
+            \\export type T = typeof X;
+            \\export const v = Used();
+            ,
+            .must_contain = &.{"import { Used } from \"./lib\""},
+            .must_not_contain = &.{"{ X,"},
+        },
+
+        // ---------- NEGATIVE: keep 되어야 할 것 (false positive 방지) ----------
+        .{
+            // #1793 revert 의 직접 원인 — `export { React }` 의 React 가 value 참조.
+            // analyzer 가 이 local 을 resolveIdentifier 로 등록하므로 Phase D 가 유지.
+            .name = "export re-export: named specifier 는 유지",
+            .src =
+            \\import { A, B } from "./lib";
+            \\export { A, B };
+            ,
+            .must_contain = &.{"import { A, B } from \"./lib\""},
+        },
+        .{
+            // default 는 JSX pragma / CSS-in-JS default 등 implicit value use 가 많아
+            // Phase D elision 대상에서 제외 — 설령 type 위치에서만 보여도 유지.
+            .name = "default binding: type-only 사용 이어도 유지",
+            .src =
+            \\import Foo from "./lib";
+            \\export function f(x: Foo): void {}
+            ,
+            .must_contain = &.{"import Foo from \"./lib\""},
+        },
+        .{
+            .name = "namespace binding: type-only 사용 이어도 유지",
+            .src =
+            \\import * as NS from "./lib";
+            \\export function f(x: NS.Foo): void {}
+            ,
+            .must_contain = &.{"import * as NS from \"./lib\""},
+        },
+        .{
+            .name = "namespace member access: value 참조로 유지",
+            .src =
+            \\import * as React from "react";
+            \\export const C = React.forwardRef((a: any, r: any) => null);
+            ,
+            .must_contain = &.{"import * as React from \"react\""},
+        },
+        .{
+            .name = "class extends: base 는 value 참조로 유지",
+            .src =
+            \\import { Base } from "./lib";
+            \\export class Derived extends Base {}
+            ,
+            .must_contain = &.{"import { Base } from \"./lib\""},
+        },
+        .{
+            // 함수 호출의 인자 — 가장 일반적인 value 참조.
+            .name = "function argument: value 참조로 유지",
+            .src =
+            \\import { handler, Token } from "./di";
+            \\export const result = handler(Token);
+            ,
+            .must_contain = &.{"import { handler, Token } from \"./di\""},
+        },
+        .{
+            // 조건식 / 연산 — value 참조.
+            .name = "conditional expression: value 참조로 유지",
+            .src =
+            \\import { flag, fallback } from "./lib";
+            \\export const v = flag ? 1 : fallback();
+            ,
+            .must_contain = &.{"import { flag, fallback } from \"./lib\""},
+        },
+        .{
+            // `import type { X }` 전체 type-only 는 parse 단계에서 drop.
+            .name = "import type 전체 선언은 parse 단계에서 drop",
+            .src =
+            \\import type { A } from "./lib";
+            \\export const x = 1;
+            ,
+            .must_not_contain = &.{ "import", "./lib" },
+        },
+        .{
+            // `import { type X, Y }` inline type modifier — X 만 drop.
+            .name = "inline type modifier: 해당 specifier 만 drop",
+            .src =
+            \\import { type A, B } from "./lib";
+            \\export function f(x: A): void { B(); }
+            ,
+            .must_contain = &.{"import { B } from \"./lib\""},
+            .must_not_contain = &.{ "type A", "{ A,", ", A }" },
+        },
+
+        // ---------- VERBATIM: 명시적 보존 ----------
+        .{
+            .name = "verbatim=true: named type-only 도 보존",
             .src =
             \\import { A, B } from "./lib";
             \\export function f(x: A): void { B(); }
@@ -1288,12 +1381,57 @@ test "type-only usage elision: named/default/namespace/alias + verbatim 보존" 
             .verbatim = true,
             .must_contain = &.{"import { A, B } from \"./lib\""},
         },
+        .{
+            .name = "verbatim=true: 완전 unused named 도 보존",
+            .src =
+            \\import { A } from "./lib";
+            \\export const x = 1;
+            ,
+            .verbatim = true,
+            .must_contain = &.{"import { A } from \"./lib\""},
+        },
+
+        // ---------- UNUSED (Phase D 가 value-unused 도 포괄) ----------
+        .{
+            // named binding 이 아예 참조되지 않은 경우 — declare Reference 만 존재.
+            // value read 가 없으므로 elide. value-unused 경로 검증.
+            .name = "named completely unused: drop",
+            .src =
+            \\import { A } from "./lib";
+            \\export const x = 1;
+            ,
+            .must_not_contain = &.{ "import", "./lib" },
+        },
+
+        // ---------- SIDE-EFFECT IMPORT: 항상 유지 ----------
+        .{
+            .name = "side-effect import: 항상 유지",
+            .src =
+            \\import "./side-effect";
+            \\export const x = 1;
+            ,
+            .must_contain = &.{"./side-effect"},
+        },
+
+        // ---------- JSX: default import 유지 확인 (.tsx) ----------
+        .{
+            // JSX classic transform 은 `React.createElement` 를 주입 — React 가 value
+            // 참조. Phase D 가 default 를 건드리지 않으므로 직접 드롭되지 않지만,
+            // 회귀 방지 차원에서 명시 확인.
+            .name = "JSX pragma: default React 는 JSX 있는 파일에서 유지",
+            .src =
+            \\import React from "react";
+            \\export const App = () => <div />;
+            ,
+            .path = "input.tsx",
+            .must_contain = &.{"import React from \"react\""},
+        },
     };
     for (cases) |c| {
         var result = try transpile_mod.transpile(
             std.testing.allocator,
             c.src,
-            "input.ts",
+            c.path,
             .{ .verbatim_module_syntax = c.verbatim },
         );
         defer result.deinit(std.testing.allocator);

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1214,7 +1214,7 @@ test "verbatimModuleSyntax=true: 미사용 default import 보존" {
 }
 
 // ============================================================
-// type-only import binding elision (#1791, oxc-style Reference flags)
+// type-only import binding elision (#1791)
 //
 // analyzer 가 TS type node 에 진입할 때 `type_context_depth` 를 올려 내부 식별자의
 // Reference 에 `flags.type_context=true` 를 기록한다. Phase D 는 이 flag 를 근거로

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -389,6 +389,7 @@ pub fn transpileWithCallback(
     });
     transformer.initSymbolIds(analyzer.symbol_ids.items) catch return error.TransformError;
     transformer.symbols = analyzer.symbols.items;
+    transformer.references = analyzer.references.items;
     transformer.line_offsets = scanner.line_offsets.items;
     const root = transformer.transform() catch return error.TransformError;
 


### PR DESCRIPTION
## Summary

PR #1793 (Phase D 1차) 가 `Symbol.reference_count == 0` 을 "value 미사용" 으로 등치해 false positive 다수 발생 (packages/core 5 tests + bungae RN `React$250.forwardRef is not a function (it is '19.2.0')` crash). revert 대신 main 에서 **oxc / TypeScript 식 per-reference context flag** 방식으로 재구현.

- `ReferenceFlags` 에 `type_context` / `value_as_type` bit 추가 (`_reserved: u5` 여유에서 2 bit 소비)
- analyzer 가 TS type node 에 진입할 때 `type_context_depth` 스택으로 카운트, 내부 identifier 는 `type_context=true` 인 Reference 로 기록. `reference_count` 는 value 참조만 계속 집계 → mangler 불변
- `ts_type_reference` 는 extra 에 raw name span 을 저장 (ast `child_offsets = &.{}`) 이라 `ast_walk.children` 으로 못 닿음 → `visitTypeReferenceNode` helper 로 source 에서 직접 이름 추출 후 scope 조회
- `export { X }` (source 없음) 의 local 을 analyzer 가 value 참조로 등록 (기존 `checkExportBinding` 검증만 하고 Reference 를 안 만들어 Phase D 가 오판 → #1793 revert 의 직접 실패 경로)
- Phase D 판정을 `Reference.isValueUse()` (declare 제외 + type_context/value_as_type 제외 + read/write 이어야) 로 통합. transformer + linker 가 동일 기준 공유
- **Scope 축소**: Phase D 를 **named specifier 한정** — default / namespace 는 JSX pragma, CSS-in-JS default export, namespace member access 같은 implicit value use 가 많아 false positive 위험이 큼. bungae 의 실제 crash 경로 (`import { HeaderBarButtonItem }`) 는 named 이므로 이 제한으로도 해결

Refs #1791. PR #1793 + #1794 의 회귀를 해소하면서 원본 crash 도 유지.

## 회귀 방지 (이전 실패 전부 재확인)

- `packages/core/index.test.ts`: 311/311 통과 (이전 5 실패 → 0)
  - `loader + packagesExternal 조합` (`import React; export { React }`)
  - `CSS Library Smoke — @emotion/react` / `styled-components` x 2
  - `배치 E: CLI 옵션 --packages=external`
- `zig build test`: 3629/3629 통과
- `transformer_test.zig::#1791 type-only elision: positive + negative cases`: 18 case 표-드리븐 — named mixed / all-type-only drop / alias / nested generic / typeof / export re-export / default keep / namespace keep / namespace member access / class extends / function arg / conditional / import type 전체 drop / inline type modifier / verbatim 보존 2 case / 완전 unused / side-effect / JSX pragma
- `bundler_test/resolution.zig`: bundle-level 5 tests — external+type-only → preamble skip (bungae crash) / verbatim 보존 / export re-export / namespace member access / default import / named mixed

## 커밋 구조

```
docs: 코드 주석에서 외부 번들러 참조 표기 제거
refactor(semantic): Reference.isValueUse() helper 추출 — Phase D 판정 공통화
test(#1791): Phase D 회귀 방지 테스트 강화 — positive + negative + verbatim + 경계
fix(transformer,linker): #1791 Phase D — named specifier 한정 type-only elision
feat(semantic): ts_type_reference 직접 resolve + export specifier value-ref 등록
feat(semantic): TS type node 진입 시 type_context flag 기록
refactor(semantic): ReferenceFlags 에 type_context / value_as_type bit 추가
```

## 비교 근거

esbuild / rolldown / babel / oxc / TypeScript / swc / rspack 조사 결과 (reference 디렉토리 실측):

| 번들러 | 방식 | bungae 케이스 커버 |
|--------|------|-------------------|
| rolldown | 구문 마커 (`ImportOrExportKind`) | ❌ (inline `type` 없으면 miss) |
| esbuild | 구문 + resolution 휴리스틱 | 부분적 |
| babel | `binding.referencePaths` + `isInType()` | ✅ |
| **oxc** | `SymbolFlags::TypeImport` + `ReferenceFlags{Type,ValueAsType}` | ✅ |
| TypeScript | `SymbolFlags` Value/Type/Namespace | ✅ (너무 세밀) |
| swc | `id_type`/`id_value` set + `usage` | 중간 |

ZTS 에 가장 자연스럽게 이식 — `ReferenceFlags._reserved: u5` 여유에 bit 추가만으로 oxc 수준 정밀도 확보. TypeScript 처럼 3-way Symbol 분류까지 가지 않아도 Phase D 판정엔 충분.

## 근본 원인 기록 (향후 참조)

`Symbol.reference_count` 는 설계상 **mangler 전용** (project_tree_shaker_1558). PR #1793 이 이 카운트를 type-only 판정으로 재활용해 "반드시 mangler 와 동일한 의미" 로 등치한 게 근본 오류. 새 구현은 per-reference flag 를 별도 경로로 두어 이 경계를 존중.

Closes #1791 (재).

## Test plan

- [x] `zig build` / `zig build test` 통과
- [x] `zig build napi` + `packages/core bun test` 311/311
- [x] standalone transpile 실측: named type-only elide / default keep / namespace keep / JSX keep / typeof drop 모두 확인
- [ ] bungae submodule sync + ExampleApp 부팅 — 머지 후 검증 예정
- [x] /simplify 적용 — `Reference.isValueUse()` helper 추출, 코드 주석 외부 참조 표기 제거