### PR TITLE
fix(transformer): #1797 for-of + let closure capture — body 를 _loop 함수로 추출

### DIFF
--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -44,6 +44,7 @@ const Tag = Node.Tag;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
+const es2015_block_scoping = @import("es2015_block_scoping.zig");
 
 pub fn ES2015ForOf(comptime Transformer: type) type {
     return struct {
@@ -169,11 +170,46 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
             // var x = _e.value
             const elem_assign = try es_helpers.buildForOfLoopVarAssign(self, left, step_value, span);
 
+            // #1797: ES5 down-level 시 `for (let x of ...)` 의 body 가 closure (arrow /
+            // function expression) 로 `x` 를 캡처하면, `var x = _e.value` 로 단순 치환
+            // 시 per-iteration fresh binding semantics 가 깨져 모든 closure 가 마지막
+            // iteration 값을 공유한다 (`__copyProps` 의 getter 가 항상 마지막 key 를
+            // 반환 → RN 에서 `React.forwardRef is not a function (it is '19.2.0')`).
+            //
+            // block_scoping down-level 이 활성이고 left 가 let/const 이고 body 에 capture
+            // 가 있으면 body 를 `var _loopN = function(x) { ...body... }` 로 추출하고
+            // 루프 내부는 `_loopN(x);` 만 호출하도록 변환. break/continue/return 제어
+            // 흐름도 `buildLoopClosureWithFlow` 가 함께 처리.
+            var loop_fn_decl: ?NodeIndex = null;
+            var body_after_closure = new_body;
+            if (self.options.unsupported.block_scoping) {
+                const BlockScoping = es2015_block_scoping.ES2015BlockScoping(@TypeOf(self.*));
+                var lexical_names = try BlockScoping.collectLexicalVarNames(self, left);
+                defer lexical_names.deinit(self.allocator);
+
+                if (lexical_names.items.len > 0 and BlockScoping.hasCapturedClosure(self, body, lexical_names.items)) {
+                    var flow = BlockScoping.FlowResult{};
+                    flow.labels = .empty;
+                    defer flow.labels.deinit(self.allocator);
+                    BlockScoping.analyzeControlFlow(self, body, &flow, 0, 0);
+
+                    const result = try BlockScoping.buildLoopClosureWithFlow(
+                        self,
+                        new_body,
+                        lexical_names.items,
+                        &flow,
+                        span,
+                    );
+                    loop_fn_decl = result.loop_fn;
+                    body_after_closure = result.call_and_check;
+                }
+            }
+
             // prepend to body
-            const final_body = if (!new_body.isNone())
-                try self.prependStatementsToBody(new_body, &.{elem_assign})
+            const final_body = if (!body_after_closure.isNone())
+                try self.prependStatementsToBody(body_after_closure, &.{elem_assign})
             else
-                new_body;
+                body_after_closure;
 
             // --- for_statement ---
             const for_extra = try self.ast.addExtras(&.{
@@ -358,9 +394,14 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                 .data = .{ .ternary = .{ .a = try_block, .b = catch_clause, .c = outer_finally_block } },
             });
 
-            // 4개 statement를 block으로 래핑하여 단일 노드로 반환.
+            // 4(+1)개 statement를 block으로 래핑하여 단일 노드로 반환.
             // pending_nodes를 쓰면 중첩 for-of에서 inner가 outer body 밖으로 빠져나감.
-            const wrapper_list = try self.ast.addNodeList(&.{ inc_decl, die_decl, ie_decl, try_catch_finally });
+            // loop_fn_decl 이 있으면 try-catch 밖 가장 앞에 삽입 — 루프가 매 iteration
+            // 마다 이 함수를 호출해 캡처 변수를 파라미터로 받아 fresh binding 효과를 낸다.
+            const wrapper_list = if (loop_fn_decl) |decl|
+                try self.ast.addNodeList(&.{ decl, inc_decl, die_decl, ie_decl, try_catch_finally })
+            else
+                try self.ast.addNodeList(&.{ inc_decl, die_decl, ie_decl, try_catch_finally });
             return self.ast.addNode(.{
                 .tag = .block_statement,
                 .span = span,

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -994,6 +994,197 @@ test "ES5 downlevel: labeled non-for-of statement unchanged" {
 }
 
 // ================================================================
+// #1797 for-of + let closure capture — ES5 down-level 시 per-iteration fresh
+// binding semantics 유지 (body 를 `var _loopN = function(key){...}` 로 추출).
+// 회귀 시 `for (let k of ...) arr.push(() => k)` 가 모든 클로저에서 마지막
+// k 를 공유 → bungae 의 `@radix-ui/react-slot __copyProps` 가 getter 로
+// 마지막 key 만 반환해 `React.forwardRef is not a function (it is '19.2.0')`.
+// ================================================================
+
+test "#1797 for-of + let + arrow closure: body 를 _loop 함수로 추출" {
+    const source =
+        \\for (let key of keys) {
+        \\  arr.push(() => from[key]);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // body 가 _loop 함수로 추출되고 루프 내부는 _loop(key) 호출만 남음.
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "function(key)") != null or
+        std.mem.indexOf(u8, code, "function (key)") != null);
+    // 루프 내부에 arr.push 가 직접 emit 되면 회귀 — _loop 안으로 들어가야.
+    const push_pos = std.mem.indexOf(u8, code, "arr.push") orelse unreachable;
+    const loop_pos = std.mem.indexOf(u8, code, "_loop") orelse unreachable;
+    try std.testing.expect(push_pos > loop_pos);
+}
+
+test "#1797 for-of + let + function expression closure: 동일 변환" {
+    const source =
+        \\for (let k of arr) {
+        \\  cbs.push(function() { return k; });
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // 파라미터로 k 가 전달
+    try std.testing.expect(std.mem.indexOf(u8, code, "(k)") != null);
+}
+
+test "#1797 for-of + const + closure: const 도 lexical 이므로 동일 변환" {
+    const source =
+        \\for (const k of arr) {
+        \\  cbs.push(() => k);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+}
+
+test "#1797 for-of + let destructuring + closure: 여러 binding 모두 params" {
+    const source =
+        \\for (let { a, b } of arr) {
+        \\  cbs.push(() => a + b);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // 두 binding (a, b) 모두 _loop 파라미터로.
+    try std.testing.expect(std.mem.indexOf(u8, code, "a, b") != null or
+        std.mem.indexOf(u8, code, "a,b") != null);
+}
+
+test "#1797 for-of + let + closure + break: 제어흐름 처리" {
+    const source =
+        \\for (let k of arr) {
+        \\  if (k === 'stop') break;
+        \\  cbs.push(() => k);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // buildLoopClosureWithFlow 가 break 를 return sentinel 로 변환.
+    try std.testing.expect(std.mem.indexOf(u8, code, "return") != null);
+}
+
+test "#1797 negative: for-of + let 인데 closure 없으면 _loop 변환 안 함" {
+    // body 내부가 직접 값 사용 — closure capture 없음 → 기존 경로 유지.
+    const source =
+        \\for (let k of arr) {
+        \\  total = total + k;
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") == null);
+    // body 는 여전히 var k = _e.value; total = total + k; 형태.
+    try std.testing.expect(std.mem.indexOf(u8, code, "var k") != null);
+}
+
+test "#1797 negative: for-of + var (non-lexical) + closure → 변환 안 함" {
+    // var 는 function scope 이므로 원래 per-iteration fresh binding 이 없다.
+    // 개발자가 var 를 쓴 의도 존중 — _loop 변환 비활성.
+    const source =
+        \\for (var k of arr) {
+        \\  cbs.push(() => k);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") == null);
+}
+
+test "#1797 negative: for-of down-level 꺼져있으면 변환 자체 비활성" {
+    // for_of=false 이면 ES2015 native for-of 유지 — closure capture 변환 불필요.
+    const source =
+        \\for (let k of arr) cbs.push(() => k);
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = false } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "for (let k of") != null);
+}
+
+test "#1797 bungae __copyProps pattern: getter 가 iteration-local key 캡처" {
+    // @radix-ui/react-slot 이 esbuild 로 빌드한 `__copyProps` 의 정확한 패턴.
+    // RN Hermes 에서 `React$250 = '19.2.0'` crash 를 재현한 입력.
+    const source =
+        \\for (let key of __getOwnPropNames(from)) {
+        \\  if (!__hasOwnProp.call(to, key) && key !== except)
+        \\    __defProp(to, key, {
+        \\      get: () => from[key],
+        \\      enumerable: true,
+        \\    });
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // 루프 body 에서 직접 __defProp 가 호출되면 회귀 (closure 공유) — _loop 함수 내부로.
+    const defprop_pos = std.mem.indexOf(u8, code, "__defProp") orelse unreachable;
+    const loop_pos = std.mem.indexOf(u8, code, "_loop") orelse unreachable;
+    try std.testing.expect(defprop_pos > loop_pos);
+}
+
+// ================================================================
 // ES2022 top-level await (#1384)
 // ================================================================
 


### PR DESCRIPTION
## Summary

ES5 down-level 시 `for (let key of ...)` 의 body 가 closure 로 `key` 를 캡처하면 per-iteration fresh binding semantics 가 깨져 모든 closure 가 마지막 iteration 의 값을 공유 — `@radix-ui/react-slot __copyProps` 의 getter 가 항상 `version` 만 반환해 bungae RN 에서 `React.forwardRef is not a function (it is '19.2.0')` crash 를 유발.

`ES2015BlockScoping.hasCapturedClosure` / `buildLoopClosureWithFlow` 도구는 이미 있었고 `visitForStatement` 에선 쓰이지만 `lowerForOfStatementLabeled` 에 연결이 누락된 것이 근본 공백. 이번 PR 에서 for-of 경로에도 동일 pass 를 적용 — body 를 `var _loopN = function(key) { ...body... }` 로 추출하고 루프 내부는 `_loopN(key)` 호출만 남긴다.

Closes #1797.

## 수정 전후

### 수정 전 (ZTS 출력)
```js
for (var _d = Object.getOwnPropertyNames(from)[Symbol.iterator](), _e;
     !(_a = (_e = _d.next()).done); _a = true) {
    var key = _e.value;
    Object.defineProperty(to, key, { get: function() { return from[key]; } });
}
// → 모든 getter 가 loop-shared `key` 참조, 종료 시 `key = "c"`
// $ node out.js → C C C
```

### 수정 후
```js
var _loop = function(key) {
    Object.defineProperty(to, key, { get: function() { return from[key]; } });
};
for (var _d = ..., _e; !(_a = (_e = _d.next()).done); _a = true) {
    var key = _e.value;
    _loop(key);
}
// → 각 iteration 이 자신의 key 를 파라미터로 받아 closure capture 가 iteration-local
// $ node out.js → A B C
```

## 변경점

- `src/transformer/es2015_for_of.zig::lowerForOfStatementLabeled`:
  - `self.options.unsupported.block_scoping` 활성 + `left` 가 `let`/`const` + body 에 captured closure 가 있으면
  - `collectLexicalVarNames` → `hasCapturedClosure` → `analyzeControlFlow` → `buildLoopClosureWithFlow` 체인 호출
  - `loop_fn_decl` 을 try-catch 블록 바깥 맨 앞에 prepend, 루프 body 는 `var key = _e.value; <_loop call>` 구조
  - `es2015_block_scoping` import 추가

## 회귀 방지 테스트 9 case (`transformer_test.zig`)

**Positive** (변환 활성):
- `let + arrow closure` — 기본 케이스
- `let + function expression closure` — named function 도 동일
- `const + closure` — const 도 lexical
- `let destructuring ({a, b}) + closure` — 여러 binding 모두 params 로
- `let + closure + break` — 제어흐름 sentinel 처리

**Negative** (변환 비활성, 회귀 방어):
- `let 인데 closure 없음` — 기존 경로 유지, `_loop` 없음
- `var (non-lexical) + closure` — `var` 는 function scope 이므로 변환 안 함
- `for_of down-level 꺼짐` — native for-of 유지

**bungae repro**:
- `@radix-ui/react-slot __copyProps` 의 정확한 `Object.defineProperty({ get: () => from[key] })` 패턴 — `__defProp` 위치가 `_loop` 이후여야 함 (직접 루프 안이면 회귀)

## 알려진 제약 (follow-up 이슈)

`for-of + let + closure + return`: `function f() { for (let k of arr) { if (cond) return () => k; } }` 조합은 `buildLoopClosureWithFlow` 의 return sentinel 경로와 잘 맞지 않아 codegen panic. 기존 `visitForStatement` 경로에도 잠재할 가능성이 커 별도 이슈로 추적. 이번 PR 은 break / 일반 캡처 케이스 확실히 커버.

## Test plan

- [x] `zig build` / `zig build test` — 3644/3644 통과
- [x] `zig build napi` + `packages/core bun test` — 311/311
- [x] Standalone repro: `zts --bundle entry.js --platform=react-native` → `node out.js` 가 `A B C` 반환 (회귀 시 `C C C`)
- [ ] bungae submodule sync + ExampleApp 부팅 → `React.forwardRef is not a function` crash 사라졌는지 확인 (머지 후)