### PR TITLE
fix(transformer): #1797 follow-up — return/typeof sentinel AST layout 수정

### DIFF
--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -647,14 +647,16 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
 
         /// { v: expr } 객체 리터럴을 생성한다 (return 변환용).
         fn buildReturnObject(self: *Transformer, value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            // object_property 는 `binary = { left=key, right=value, flags }` layout.
+            // 이전 구현은 `.extra` 로 생성해 codegen 의 `emitObjectProperty` 가
+            // `node.data.binary.left/right` 로 garbage 메모리를 읽어 panic (#1797 알려진
+            // 제약). 기존 `es_helpers.zig:31-35` 등 다른 object_property 생성 사이트와
+            // 동일한 binary layout 으로 수정.
             const key = try es_helpers.makeIdentifierRef(self, "v");
-            const prop_extra = try self.ast.addExtras(&.{
-                @intFromEnum(key), @intFromEnum(value), 0,
-            });
             const prop = try self.ast.addNode(.{
                 .tag = .object_property,
                 .span = span,
-                .data = .{ .extra = prop_extra },
+                .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
             });
             const obj_list = try self.ast.addNodeList(&.{prop});
             return self.ast.addNode(.{
@@ -682,10 +684,17 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             // if (typeof _ret === "object") return _ret.v;
             if (flow.has_return) {
                 const ret_ref = try es_helpers.makeIdentifierRef(self, "_ret");
+                // unary_expression 의 data layout 은 `.extra = [operand, operator]`.
+                // 기존 `.unary` variant 로 생성하면 codegen 이 operand 대신 operator 토큰
+                // 문자열(`<=`)을 출력 → `if (<= === "object")` 문법 에러.
+                const typeof_extra = try self.ast.addExtras(&.{
+                    @intFromEnum(ret_ref),
+                    @intFromEnum(token_mod.Kind.kw_typeof),
+                });
                 const typeof_expr = try self.ast.addNode(.{
                     .tag = .unary_expression,
                     .span = span,
-                    .data = .{ .unary = .{ .operand = ret_ref, .flags = @intFromEnum(token_mod.Kind.kw_typeof) } },
+                    .data = .{ .extra = typeof_extra },
                 });
                 const obj_str = try es_helpers.buildStringNode(self, "\"object\"", span);
                 const typeof_check = try self.ast.addNode(.{

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1101,6 +1101,77 @@ test "#1797 for-of + let + closure + break: 제어흐름 처리" {
     try std.testing.expect(std.mem.indexOf(u8, code, "return") != null);
 }
 
+test "#1797 for-of + let + closure + return: return expression 안의 closure 도 정상 변환" {
+    // 이전 알려진 제약: object_property 와 unary_expression 의 data layout 을
+    // 잘못 생성해 codegen panic / 잘못된 typeof emit. buildReturnObject 와
+    // buildControlFlowCheck 의 layout 수정으로 해소.
+    const source =
+        \\function find(arr) {
+        \\  for (let k of arr) {
+        \\    if (k === 'target') return () => k;
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // _loop 함수로 body 추출됨.
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // return sentinel 경로: typeof _ret === "object" 체크 emit.
+    try std.testing.expect(std.mem.indexOf(u8, code, "typeof _ret") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "\"object\"") != null);
+    // sentinel 객체 `{ v: ... }` 형태 — object_property 정상 emit.
+    try std.testing.expect(std.mem.indexOf(u8, code, "v:") != null or
+        std.mem.indexOf(u8, code, "v :") != null);
+}
+
+test "#1797 for-of + const + closure + return: const 도 동일 변환" {
+    const source =
+        \\function findConst(arr) {
+        \\  for (const x of arr) {
+        \\    if (x === 1) return () => x;
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "typeof _ret") != null);
+}
+
+test "#1797 for-loop + let + closure + return: for-loop 경로에도 동일 fix 적용" {
+    // visitForStatement 경로도 buildReturnObject / buildControlFlowCheck 를
+    // 공유하므로 같은 fix 로 panic 해소. 기존 숨어있던 버그.
+    const source =
+        \\function indexFind(arr) {
+        \\  for (let i = 0; i < arr.length; i++) {
+        \\    if (arr[i] === 'x') return () => arr[i];
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "typeof _ret") != null);
+}
+
 test "#1797 negative: for-of + let 인데 closure 없으면 _loop 변환 안 함" {
     // body 내부가 직접 값 사용 — closure capture 없음 → 기존 경로 유지.
     const source =


### PR DESCRIPTION
## Summary

PR #1798 머지 후 남겨둔 "알려진 제약" — `for-of + let + closure + return` / `for-loop + let + closure + return` 조합에서 codegen panic (`index out of bounds`) + 잘못된 문법 emit (`if (<= === "object")`) — 의 근본 원인을 AST layout 불일치로 규명하고 수정.

Closes #1797 follow-up.

## 근본 원인

`ES2015BlockScoping` 의 두 helper 가 AST 노드의 data variant 를 잘못 생성.

**1. `buildReturnObject` 의 `object_property`** (`es2015_block_scoping.zig:649`):
```zig
// 이전
data = .{ .extra = prop_extra },
```
하지만 `object_property` 의 data layout 은 `binary = { left=key, right=value, flags }`. `emitObjectProperty` (`codegen.zig:1674-1718`) 는 `node.data.binary.{left, right}` 로 읽음. 다른 object_property 생성 사이트 (`es_helpers.zig:31-35`, `es2015_computed.zig`, `es2015_class.zig`) 는 전부 binary. `.extra` 로 생성한 이 한 곳이 예외 → codegen 이 garbage 메모리 읽음 → panic.

**2. `buildControlFlowCheck` 의 `typeof _ret`** (`es2015_block_scoping.zig:687-691`):
```zig
// 이전
data = .{ .unary = .{ .operand = ret_ref, .flags = @intFromEnum(Kind.kw_typeof) } },
```
하지만 `unary_expression` 은 `.extra = [operand, operator]` layout (`es_helpers.makeUnaryNot` 참조). `emitUnary` (`codegen.zig:1511-1527`) 는 `extras[e]` 에서 operand, `extras[e+1]` 에서 operator 를 읽음. `.unary` variant 로 만들면 operator 토큰의 symbol (`<=`) 이 operand 자리에 그대로 emit → `if (<= === "object")`.

두 helper 는 `visitForStatement` (기존) 와 PR #1798 의 `lowerForOfStatementLabeled` 가 공유하므로, for-loop 경로에도 같은 제약이 숨어있었음. 이번 fix 가 for-of / for-loop 모두 해소.

## 실증 (수정 후)

```js
// entry.js
function find(arr) {
  for (let k of arr) {
    if (k === 'target') return () => k;
  }
}
console.log(find(['a', 'b', 'target', 'd'])());
```

**이전 (PR #1798 직후)**:
- `zts --bundle --platform=react-native` → `fatal: index out of bounds`
- layout 수정 후 1차 시도 → `SyntaxError: Unexpected token '<='`

**이번 수정 후**:
- 번들 성공 → `node out.js` → `target` ✓

## 변경점

- `src/transformer/es2015_block_scoping.zig::buildReturnObject` → `object_property` 를 `.binary` layout 으로 생성
- `src/transformer/es2015_block_scoping.zig::buildControlFlowCheck` 의 `typeof _ret` → `.extra = [operand, Kind.kw_typeof]` layout 으로 생성

## 회귀 방지 테스트 3 추가 (`transformer_test.zig`)

- `for-of + let + closure + return` — `_loop` 함수 생성 + `typeof _ret === "object"` 체크 + sentinel `{ v: ... }` 구조 모두 emit 되는지 확인
- `for-of + const + closure + return` — const 도 lexical 이라 동일 변환
- `for-loop + let + closure + return` — 공유 helper fix 가 for-loop 경로에도 적용

## Test plan

- [x] `zig build test` 3647/3647 통과 (#1797 PR #1798 의 9 case + 이번 PR 3 case)
- [x] `packages/core bun test` 311/311
- [x] Standalone repro 실측: `node out.js` 가 `target` 반환 (panic 없이 올바른 iteration-local key 반환)
- [x] 6 edge case (`A~F`) 모두 정상 번들링 확인