### PR TITLE
refactor(ast): variant-typed addNode helper + debug assertion (#1797 근본 보강)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -866,6 +866,12 @@ pub const Ast = struct {
     }
 
     /// 노드를 추가하고 인덱스를 반환한다.
+    ///
+    /// 가능하면 `addBinaryNode` / `addUnaryNode` / `addTernaryNode` / `addExtraNode` /
+    /// `addListNode` / `addLeafNode` 같은 variant-typed helper 를 사용할 것. Debug
+    /// 빌드에서 tag 의 `dataKind()` 와 전달한 variant 의 매칭을 assertion 으로 검증해
+    /// `object_property` 에 `.extra` 를, `unary_expression` 에 `.unary` 를 쓰는 식의
+    /// silent failure (#1797) 를 조기 포착. release 에선 zero-cost.
     pub fn addNode(self: *Ast, node: Node) !NodeIndex {
         const index: u32 = @intCast(self.nodes.items.len);
         try self.nodes.append(self.allocator, node);
@@ -878,6 +884,76 @@ pub const Ast = struct {
             );
         }
         return @enumFromInt(index);
+    }
+
+    /// `binary` variant 를 쓰는 노드 (object_property, assignment_expression 등) 를
+    /// 안전하게 추가. Debug 빌드에서 tag↔variant 매칭 assertion.
+    pub fn addBinaryNode(self: *Ast, tag: Node.Tag, span: Span, left: NodeIndex, right: NodeIndex, flags: u16) !NodeIndex {
+        assertDataKind(tag, .binary);
+        return self.addNode(.{
+            .tag = tag,
+            .span = span,
+            .data = .{ .binary = .{ .left = left, .right = right, .flags = flags } },
+        });
+    }
+
+    /// `unary` variant 를 쓰는 노드 (return_statement, expression_statement 등).
+    pub fn addUnaryNode(self: *Ast, tag: Node.Tag, span: Span, operand: NodeIndex, flags: u16) !NodeIndex {
+        assertDataKind(tag, .unary);
+        return self.addNode(.{
+            .tag = tag,
+            .span = span,
+            .data = .{ .unary = .{ .operand = operand, .flags = flags } },
+        });
+    }
+
+    /// `ternary` variant 를 쓰는 노드 (if_statement, conditional_expression 등).
+    pub fn addTernaryNode(self: *Ast, tag: Node.Tag, span: Span, a: NodeIndex, b: NodeIndex, c: NodeIndex) !NodeIndex {
+        assertDataKind(tag, .ternary);
+        return self.addNode(.{
+            .tag = tag,
+            .span = span,
+            .data = .{ .ternary = .{ .a = a, .b = b, .c = c } },
+        });
+    }
+
+    /// `extra` variant 를 쓰는 노드 (function_declaration, call_expression 등).
+    /// `extra_idx` 는 사전에 `addExtras` 로 얻은 인덱스.
+    pub fn addExtraNode(self: *Ast, tag: Node.Tag, span: Span, extra_idx: u32) !NodeIndex {
+        assertDataKind(tag, .extra);
+        return self.addNode(.{
+            .tag = tag,
+            .span = span,
+            .data = .{ .extra = extra_idx },
+        });
+    }
+
+    /// `list` variant 를 쓰는 노드 (block_statement, array_expression 등).
+    pub fn addListNode(self: *Ast, tag: Node.Tag, span: Span, list: NodeList) !NodeIndex {
+        assertDataKind(tag, .list);
+        return self.addNode(.{
+            .tag = tag,
+            .span = span,
+            .data = .{ .list = list },
+        });
+    }
+
+    /// `leaf` variant (자식 없음) — `none` / `string_ref` / `number_bytes` 서브 variant
+    /// 중 하나. 호출자가 이미 Data union 을 구성해 전달.
+    pub fn addLeafNode(self: *Ast, tag: Node.Tag, span: Span, data: Node.Data) !NodeIndex {
+        assertDataKind(tag, .leaf);
+        return self.addNode(.{ .tag = tag, .span = span, .data = data });
+    }
+
+    inline fn assertDataKind(tag: Node.Tag, expected: Node.Tag.DataKind) void {
+        if (@import("builtin").mode != .Debug) return;
+        const actual = tag.dataKind();
+        if (actual != expected) {
+            std.debug.panic(
+                "addNode: tag '{s}' expects dataKind .{s} but .{s} was passed",
+                .{ @tagName(tag), @tagName(actual), @tagName(expected) },
+            );
+        }
     }
 
     /// Debug-only invariant 검증 (D1 디버깅 인프라).

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -647,23 +647,13 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
 
         /// { v: expr } 객체 리터럴을 생성한다 (return 변환용).
         fn buildReturnObject(self: *Transformer, value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            // object_property 는 `binary = { left=key, right=value, flags }` layout.
-            // 이전 구현은 `.extra` 로 생성해 codegen 의 `emitObjectProperty` 가
-            // `node.data.binary.left/right` 로 garbage 메모리를 읽어 panic (#1797 알려진
-            // 제약). 기존 `es_helpers.zig:31-35` 등 다른 object_property 생성 사이트와
-            // 동일한 binary layout 으로 수정.
+            // variant-typed helper — tag 에 맞는 variant 를 debug 빌드에서 assertion.
+            // (이전에는 `addNode` 직접 호출로 `object_property` 에 `.extra` variant 를
+            // 잘못 써서 codegen panic — #1797.)
             const key = try es_helpers.makeIdentifierRef(self, "v");
-            const prop = try self.ast.addNode(.{
-                .tag = .object_property,
-                .span = span,
-                .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
-            });
+            const prop = try self.ast.addBinaryNode(.object_property, span, key, value, 0);
             const obj_list = try self.ast.addNodeList(&.{prop});
-            return self.ast.addNode(.{
-                .tag = .object_expression,
-                .span = span,
-                .data = .{ .list = obj_list },
-            });
+            return self.ast.addListNode(.object_expression, span, obj_list);
         }
 
         /// _loop() 호출 후 제어 흐름 체크 코드를 생성한다.
@@ -684,18 +674,14 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             // if (typeof _ret === "object") return _ret.v;
             if (flow.has_return) {
                 const ret_ref = try es_helpers.makeIdentifierRef(self, "_ret");
-                // unary_expression 의 data layout 은 `.extra = [operand, operator]`.
-                // 기존 `.unary` variant 로 생성하면 codegen 이 operand 대신 operator 토큰
-                // 문자열(`<=`)을 출력 → `if (<= === "object")` 문법 에러.
+                // variant-typed helper — `unary_expression` 은 `.extra = [operand, op]`
+                // layout. (이전엔 `.unary` variant 로 잘못 써서 `if (<= === "object")`
+                // syntax error — #1797.)
                 const typeof_extra = try self.ast.addExtras(&.{
                     @intFromEnum(ret_ref),
                     @intFromEnum(token_mod.Kind.kw_typeof),
                 });
-                const typeof_expr = try self.ast.addNode(.{
-                    .tag = .unary_expression,
-                    .span = span,
-                    .data = .{ .extra = typeof_extra },
-                });
+                const typeof_expr = try self.ast.addExtraNode(.unary_expression, span, typeof_extra);
                 const obj_str = try es_helpers.buildStringNode(self, "\"object\"", span);
                 const typeof_check = try self.ast.addNode(.{
                     .tag = .binary_expression,


### PR DESCRIPTION
## Summary

AST `Node.data` 의 `extern union` 은 24B fixed / cache locality / C ABI 호환이라는 성능 이점을 주는 대신 `Tag ↔ variant` 매칭을 **관행**으로만 관리한다. `object_property` 에 `.extra` / `unary_expression` 에 `.unary` 같은 mismatch 가 codegen panic 직전까지 드러나지 않는 #1797 류 silent failure 의 근본 원인.

Rust 계열 번들러 (oxc / rolldown / swc / rspack) 는 `enum` struct variants 로 rustc 가 원천 차단하지만 Zig `extern union` 에선 동급 보장이 불가능. 타협점으로 **variant-typed `addNode` helper + Debug assertion** 도입.

## 추가된 API (`src/parser/ast.zig`)

```zig
pub fn addBinaryNode(self: *Ast, tag: Tag, span: Span, left: NodeIndex, right: NodeIndex, flags: u16) !NodeIndex;
pub fn addUnaryNode(self: *Ast, tag: Tag, span: Span, operand: NodeIndex, flags: u16) !NodeIndex;
pub fn addTernaryNode(self: *Ast, tag: Tag, span: Span, a: NodeIndex, b: NodeIndex, c: NodeIndex) !NodeIndex;
pub fn addExtraNode(self: *Ast, tag: Tag, span: Span, extra_idx: u32) !NodeIndex;
pub fn addListNode(self: *Ast, tag: Tag, span: Span, list: NodeList) !NodeIndex;
pub fn addLeafNode(self: *Ast, tag: Tag, span: Span, data: Data) !NodeIndex;
```

각 helper 내부의 `assertDataKind(tag, expected)` 는 Debug 빌드에서 `tag.dataKind()` 와 variant 를 비교해 불일치 시 **tag / expected / actual 을 포함한 panic**. Release 빌드는 `@import("builtin").mode` 체크로 코드 자체가 사라짐 (zero-cost).

## 사용 예시 (migration)

`es2015_block_scoping.zig::buildReturnObject` / `buildControlFlowCheck` — #1797 에서 layout 버그 직접 fix 한 지점을 새 helper 로 재작성해 **재회귀 시 assertion 이 즉시 panic**:

```zig
// Before (#1797 의 bug-fix 한 직접 construction)
const prop = try self.ast.addNode(.{
    .tag = .object_property,
    .span = span,
    .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
});

// After (variant-typed helper — debug 에서 assertion)
const prop = try self.ast.addBinaryNode(.object_property, span, key, value, 0);
```

`unary_expression` / `object_expression` 도 각각 `addExtraNode` / `addListNode` 로 변경.

## 보장 수준 비교

| 번들러 | AST 스타일 | variant mismatch 방지 | 런타임 비용 |
|--------|-----------|---------------------|-----------|
| oxc / swc / rspack / rolldown | Rust enum struct variants | 컴파일 에러 | 0 |
| webpack | estree (JS object) | **없음** (JSDoc 뿐) | 0 |
| **ZTS (기존)** | Zig extern union + 관행 | **없음** (silent failure) | 0 |
| **ZTS (이 PR)** | Zig extern union + typed helper | **Debug panic, Release 0-cost** | 0 (release) |

Zig 의 `extern union` 제약 안에서 가능한 최대 안전성. Rust enum 수준의 컴파일 타임 보장은 원리상 불가능하지만 Debug build 에서 audit + 조기 포착.

## 변경 범위

- `src/parser/ast.zig`: helper 6 개 추가 (+76 라인)
- `src/transformer/es2015_block_scoping.zig`: #1797 fix 지점 2 곳 helper 로 migration (+4, -23 라인)

기존 모든 `addNode` 직접 호출 사이트의 migration 은 범위가 크므로 점진 follow-up. 이 PR 은 **인프라 + 사용 예시 + 첫 migration** 까지.

## Test plan

- [x] `zig build test` 3647/3647 통과
- [x] Debug 빌드에서 의도적으로 variant mismatch 테스트 — `addBinaryNode(.unary_expression, ...)` 호출 시 `addNode: tag 'unary_expression' expects dataKind .extra but .binary was passed` panic 확인
- [x] `packages/core bun test` 311/311

## Follow-up (별도 이슈로 추적 권장)

- 기존 `addNode` 직접 호출 사이트 (parser / transformer / codegen 전역 ~수백 곳) 의 점진 migration
- 순수 helper (Rust enum 수준) 가 필요한 경우 SoA 리디자인 검토 (현재는 24B fixed 성능 트레이드오프로 보류)