### PR TITLE
fix(docs): light theme dark-bg 누수 + hero 모바일 센터 정렬

### DIFF
--- a/documents/src/components/landing/Hero.astro
+++ b/documents/src/components/landing/Hero.astro
@@ -35,11 +35,11 @@ const {
   </div>
   <div class="mx-auto max-w-6xl px-6 py-20 sm:py-24 lg:py-28">
     <div class="grid items-center gap-10 lg:grid-cols-2 lg:gap-14">
-      <div class="flex flex-col gap-6">
+      <div class="flex flex-col items-center gap-6 text-center lg:items-start lg:text-left">
         <p class="font-mono text-xs uppercase tracking-[0.2em] text-zig-400">
           {eyebrow}
         </p>
-        <h1 class="text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl">
+        <h1 class="whitespace-pre-line text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl">
           <span class="bg-gradient-to-br from-zig-200 via-zig-400 to-zig-600 bg-clip-text text-transparent">
             {title}
           </span>
@@ -47,13 +47,13 @@ const {
         <p class="max-w-xl text-lg leading-relaxed text-[color:var(--sl-color-gray-2)]">
           {subtitle}
         </p>
-        <div class="mt-2 flex flex-wrap gap-3">
+        <div class="mt-2 flex flex-wrap justify-center gap-3 lg:justify-start">
           {
             actions.map((a) => (
               <a
                 href={a.href}
                 class:list={[
-                  "inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold transition-colors",
+                  "inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold no-underline transition-colors",
                   a.primary
                     ? "bg-zig-500 text-zig-950 hover:bg-zig-400"
                     : "border border-[color:var(--sl-color-gray-5)] text-[color:var(--sl-color-white)] hover:border-zig-500 hover:text-zig-400",

--- a/documents/src/styles/custom.css
+++ b/documents/src/styles/custom.css
@@ -13,7 +13,9 @@
   --sl-font-mono:
     "JetBrains Mono Variable", "SFMono-Regular", Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
+}
 
+:root[data-theme="dark"] {
   --sl-color-bg: #0d0a07;
   --sl-color-bg-nav: var(--color-surface-950);
   --sl-color-bg-sidebar: var(--color-surface-950);


### PR DESCRIPTION
PR #1800 머지 후 발견된 두 가지 시각 버그 수정.

## Summary
- **라이트 테마**: `--sl-color-bg` 등이 다크 색으로 고정돼 라이트 모드에서도 배경이 어두웠음
- **Hero 모바일 정렬**: `lg:grid-cols-2` 가 1-col 로 붕괴하는 좁은 화면에서 텍스트/버튼이 left-aligned 유지돼 어색

## Root cause (light theme)
Starlight 의 `--sl-color-bg` 계열은 `var(--sl-color-black/gray-*)` 에서 파생되고, `[data-theme="light"]` 가 `--sl-color-black` 을 white 로 flip 하면 bg 도 자동으로 white 가 됨.

내가 `custom.css:17` 에 `--sl-color-bg: #0d0a07` 를 hex 로 hardcode 해버려서 이 파생 체인을 차단 → 라이트 모드에서도 `:root` 값이 살아남아 다크 배경 고정.

**Fix**: 다크 전용 bg / gray / hairline 오버라이드 13 개를 `:root[data-theme="dark"]` 스코프로 이동. 라이트 모드에서 Starlight 기본 파생이 그대로 작동.

## Root cause (hero alignment)
`<div class="flex flex-col gap-6">` 가 좁은 화면에서 width 전체를 차지하는데 자식 `items-center` 도 `text-center` 도 없어서 left-aligned 상태로 남음.

**Fix**:
```diff
- flex flex-col gap-6
+ flex flex-col items-center gap-6 text-center lg:items-start lg:text-left
- flex flex-wrap gap-3                       (actions)
+ flex flex-wrap justify-center gap-3 lg:justify-start
```

추가로 `whitespace-pre-line` 으로 타이틀의 `\n` 을 살려 의도한 줄바꿈 렌더링. hero action anchors 에 `no-underline` 추가 (Starlight 마크다운 스타일 누수 차단).

## Test plan
- [x] `bun run build` · 340 페이지 · 링크 검증 통과
- [ ] 배포 후 라이트 테마 토글 시 배경/카드/텍스트 색상 확인
- [ ] 모바일 / 태블릿 폭에서 hero 중앙 정렬 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)