### PR TITLE
fix(docs): splash 랜딩 레이아웃 풀폭 해제 + 기본 PageTitle 숨김

### DIFF
--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -2,8 +2,6 @@
 title: ZTS
 description: A TypeScript Transpiler & Bundler written in Zig
 template: splash
-hero:
-  tagline: " "
 ---
 
 import Hero from "../../../components/landing/Hero.astro";

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -2,8 +2,6 @@
 title: ZTS
 description: Zig로 작성한 TypeScript 트랜스파일러 & 번들러
 template: splash
-hero:
-  tagline: " "
 ---
 
 import Hero from "../../components/landing/Hero.astro";

--- a/documents/src/styles/custom.css
+++ b/documents/src/styles/custom.css
@@ -62,6 +62,26 @@
   }
 }
 
+/* 자작 랜딩 (splash + sl-markdown-content 의 첫 자식이 .not-content section):
+   기본 PageTitle h1 컨테이너 숨기고, 뒤따르는 content-panel 은 전폭 해제. */
+main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel:first-child {
+  display: none;
+}
+
+main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel {
+  padding: 0;
+  border-top: 0;
+}
+
+main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel > .sl-container {
+  max-width: 100%;
+  margin-inline: 0;
+}
+
+main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel > .sl-container > .sl-markdown-content {
+  max-width: 100%;
+}
+
 starlight-toc a {
   white-space: normal;
   word-break: break-word;


### PR DESCRIPTION
## Summary
배포된 https://ohah.github.io/zts/ 에서 히어로가 viewport 센터에 오지 않고 좁은 박스에 갇혀 보이던 레이아웃 버그 수정.

## Root cause
Starlight 의 splash 템플릿이 자체적으로 `.content-panel` 2 개를 렌더:
1. 첫 번째: `PageTitle` h1 ("ZTS")
2. 두 번째: MDX body (내 자작 Hero/Stats/Feature/CTA)

두 content-panel 모두 `.sl-container { max-width: var(--sl-content-width) }` 제약(기본 45rem) 하에 있어서 내 자작 Hero 의 `mx-auto max-w-6xl` (72rem) 이 이 좁은 박스 안에 갇힘. 결과적으로 2-col grid 가 narrow 폭으로 짜그라지고 viewport 기준 센터링도 안 됨.

## Fix (CSS only)

landing 감지:
```
main:has(.sl-markdown-content > section.not-content:first-child)
```

landing 에서만:
- 첫 번째 `.content-panel` (PageTitle h1) `display: none`
- 모든 `.content-panel` 의 `padding: 0` · `border-top: 0`
- 모든 `.sl-container` 와 `.sl-markdown-content` `max-width: 100%` + `margin-inline: 0`

자작 컴포넌트(Hero/StatsStrip/FeatureGrid/CtaCard) 수정 없음. 기존 `mx-auto max-w-6xl px-6` 이 viewport 기준으로 센터링 되어 정상 작동.

동시에 더 이상 필요없는 `hero: { tagline: " " }` 더미 frontmatter 를 ko/en MDX 양쪽에서 제거.

## Test plan
- [x] `bun run build` · 340 페이지 통과
- [x] dist/ CSS 에 `main:has(...)` 규칙 emit 확인
- [ ] 배포 후 https://ohah.github.io/zts/ 히어로가 viewport 센터에 맞춰 표시되는지
- [ ] 일반 docs 페이지(예: `/guides/introduction/`) 영향 없는지 확인 (landing 감지는 self-content 첫 자식 .not-content 기반이라 일반 docs 는 매치 안 됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)