### PR TITLE
fix(docs): 랜딩 전폭 레이아웃 — :has() 대신 head 주입 + PageTitle override

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -134,6 +134,9 @@ export default defineConfig({
         },
       ],
       customCss: ["./src/styles/tailwind.css", "./src/styles/custom.css"],
+      components: {
+        PageTitle: "./src/overrides/PageTitle.astro",
+      },
     }),
     react(),
   ],

--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -2,6 +2,13 @@
 title: ZTS
 description: A TypeScript Transpiler & Bundler written in Zig
 template: splash
+head:
+  - tag: style
+    content: |
+      main > .content-panel:first-child { display: none; }
+      main > .content-panel { padding: 0; border-top: 0; }
+      main > .content-panel > .sl-container { max-width: 100%; margin-inline: 0; }
+      main > .content-panel > .sl-container > .sl-markdown-content { max-width: 100%; }
 ---
 
 import Hero from "../../../components/landing/Hero.astro";

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -2,6 +2,13 @@
 title: ZTS
 description: Zig로 작성한 TypeScript 트랜스파일러 & 번들러
 template: splash
+head:
+  - tag: style
+    content: |
+      main > .content-panel:first-child { display: none; }
+      main > .content-panel { padding: 0; border-top: 0; }
+      main > .content-panel > .sl-container { max-width: 100%; margin-inline: 0; }
+      main > .content-panel > .sl-container > .sl-markdown-content { max-width: 100%; }
 ---
 
 import Hero from "../../components/landing/Hero.astro";

--- a/documents/src/overrides/PageTitle.astro
+++ b/documents/src/overrides/PageTitle.astro
@@ -1,0 +1,8 @@
+---
+import Default from "@astrojs/starlight/components/PageTitle.astro";
+
+const { entry } = Astro.locals.starlightRoute;
+const isSplash = entry.data.template === "splash";
+---
+
+{!isSplash && <Default />}

--- a/documents/src/styles/custom.css
+++ b/documents/src/styles/custom.css
@@ -62,25 +62,6 @@
   }
 }
 
-/* 자작 랜딩 (splash + sl-markdown-content 의 첫 자식이 .not-content section):
-   기본 PageTitle h1 컨테이너 숨기고, 뒤따르는 content-panel 은 전폭 해제. */
-main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel:first-child {
-  display: none;
-}
-
-main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel {
-  padding: 0;
-  border-top: 0;
-}
-
-main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel > .sl-container {
-  max-width: 100%;
-  margin-inline: 0;
-}
-
-main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel > .sl-container > .sl-markdown-content {
-  max-width: 100%;
-}
 
 starlight-toc a {
   white-space: normal;


### PR DESCRIPTION
## Summary
PR #1805 의 `:has()` 기반 landing 감지가 실제 배포에서 먹지 않아 히어로가 여전히 45rem sl-container 안에 갇혀있는 증상 해결. `:has()` 의존 제거하고 두 개 메커니즘으로 대체:
1. **PageTitle component override** — splash template 에서만 null 렌더
2. **MDX frontmatter `head:` 에 인라인 <style>** — 해당 페이지에만 단순 선택자 CSS 주입

## Root cause
PR #1805 에서 `main:has(.sl-markdown-content > section.not-content:first-child) > .content-panel > .sl-container { max-width: 100% }` 규칙을 썼는데 브라우저/렌더 상황에 따라 매치 실패. 특히 72rem 미만 viewport 에선 Starlight 기본 `.sl-container` (max-width 45rem, left-aligned) 가 유지되어 Hero 가 왼쪽에 치우침.

## Fix
### 1. PageTitle override
`src/overrides/PageTitle.astro`:
```astro
---
import Default from "@astrojs/starlight/components/PageTitle.astro";
const { entry } = Astro.locals.starlightRoute;
const isSplash = entry.data.template === "splash";
---
{!isSplash && <Default />}
```
`astro.config.mjs` 의 `components.PageTitle` 슬롯에 등록.

### 2. Page-scoped head 주입
`index.mdx` (ko/en 양쪽) frontmatter:
```yaml
head:
  - tag: style
    content: |
      main > .content-panel:first-child { display: none; }
      main > .content-panel { padding: 0; border-top: 0; }
      main > .content-panel > .sl-container { max-width: 100%; margin-inline: 0; }
      main > .content-panel > .sl-container > .sl-markdown-content { max-width: 100%; }
```

단순 자식 선택자(`>`)만 사용 → 모든 브라우저에서 확실히 매치. 이 스타일은 Astro 가 해당 MDX 의 `<head>` 에만 인라인 주입하므로 일반 docs 페이지에 영향 없음 (검증: `dist/guides/introduction/index.html` 에서 해당 CSS 미포함 확인).

### 3. 잔여 해킹 제거
- `custom.css` 의 :has() 랜딩 규칙 삭제
- `Section.astro` / `Hero.astro` 의 `landing-bleed` transform 트릭 제거 (head 주입이 sl-container 를 이미 전폭화하므로 불필요)

## Test plan
- [x] `bun run build` · 340 페이지 · 링크 검증 통과
- [x] `dist/index.html` 에 inline `<style>` 포함, `dist/guides/introduction/index.html` 에는 미포함
- [x] PageTitle `id="_top"` h1 가 splash 에선 render 안 됨
- [ ] 배포 후 https://ohah.github.io/zts/ 에서 히어로 viewport 센터 정렬
- [ ] 72rem 미만 (노트북/태블릿) viewport 에서도 정상 센터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)