### PR TITLE
fix(transformer): for-of + let closure body 가 단일 statement 일 때 block wrapping (#1807)

### DIFF
--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -217,6 +217,21 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
                 transformed_body = try transformControlFlow(self, visited_body, flow);
             }
 
+            // #1807: FunctionExpression.body 는 spec 상 BlockStatement 여야 하므로
+            // braces 없는 단일 statement body (e.g. `for (..) if (..)`) 는 감싸야
+            // codegen 이 `function(x) { if (..) }` 로 emit 한다.
+            if (!transformed_body.isNone()) {
+                const body_node = self.ast.getNode(transformed_body);
+                if (body_node.tag != .block_statement) {
+                    const wrapped_list = try self.ast.addNodeList(&.{transformed_body});
+                    transformed_body = try self.ast.addNode(.{
+                        .tag = .block_statement,
+                        .span = body_node.span,
+                        .data = .{ .list = wrapped_list },
+                    });
+                }
+            }
+
             // --- function params: 캡처된 변수 ---
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1462,6 +1462,107 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("60");
     });
 
+    // #1807: for-of + let + closure capture + braces 없는 single statement body
+    // → `_loop` 함수 body 가 block_statement 로 감싸지지 않아 SyntaxError.
+    // 현업 케이스: esbuild 의 `__copyProps` (@radix-ui 등) 가 이 패턴을 그대로 사용.
+
+    test("for-of + let closure: expression_statement body (#1807)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const arr = [1, 2, 3];
+            const fns: Array<() => number> = [];
+            for (let x of arr) fns.push(() => x);
+            console.log(fns.map(f => f()).join(','));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1,2,3");
+    });
+
+    test("for-of + let closure: if_statement body (#1807)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const from: Record<string, string> = { a: 'A', b: 'B', c: 'C' };
+            const to: Record<string, string> = {};
+            const except = 'skip';
+            for (let key of Object.getOwnPropertyNames(from))
+              if (key !== except)
+                Object.defineProperty(to, key, { get: () => from[key], enumerable: true });
+            console.log(to.a + to.b + to.c);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("ABC");
+    });
+
+    test("for-of + let closure: while_statement body (#1807)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const arr = [2, 3];
+            const fns: Array<() => number> = [];
+            for (let x of arr)
+              while (x-- > 0) fns.push(() => x);
+            console.log(fns.length);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      // x=2 → x--=1,0 (2 pushes); x=3 → x--=2,1,0 (3 pushes) → 5
+      expect(result.runOutput).toBe("5");
+    });
+
+    test("for-of + let closure: nested for-of body (#1807)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const a = [1, 2];
+            const b = [10, 20];
+            const fns: Array<() => number> = [];
+            for (let x of a)
+              for (let y of b) fns.push(() => x + y);
+            console.log(fns.map(f => f()).join(','));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("11,21,12,22");
+    });
+
+    test("for-of + let closure: block_statement body stays correct (#1807)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const arr = [1, 2, 3];
+            const fns: Array<() => number> = [];
+            for (let x of arr) { fns.push(() => x); }
+            console.log(fns.map(f => f()).join(','));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1,2,3");
+    });
+
     // --- SWC 대비 추가 테스트: Spread ---
 
     // #783: spread in new에서 bind.apply()를 괄호로 감싸기


### PR DESCRIPTION
## Summary

- `buildLoopClosureWithFlow` 가 `_loop = function(x) <body>` 를 조립할 때 body 가 이미 `block_statement` 라고 가정 — braces 없는 단일 statement (if / expression / while / 중첩 for-of / empty) 는 그대로 함수 body 에 붙어 `function(x) if (..) ..;` 형태로 emit → **SyntaxError**.
- 수정: FunctionExpression.body 는 spec 상 BlockStatement 여야 한다는 문법 제약을 `transformed_body` 가 function 에 주입되기 직전에 단일 지점에서 강제. 이미 block 이면 no-op.
- downlevel 통합 테스트 5종 추가 (expression / if / while / 중첩 for-of / block no-regression).

## 왜 이 위치가 근본 수정인가

위반 불변식은 "FunctionExpression.body must be BlockStatement". 위반이 발생하는 정확한 지점이 `buildLoopClosureWithFlow` 의 `func_extra` 조립 직전 — 그 전까지 `transformed_body` 는 임의 statement 이고 그 줄부터 "function body" 역할이 부여됨. 이 경계에 wrap 을 두는 것이 가장 좁고 정확한 fix.

**대안 검토**:
- `lowerForOfStatementLabeled` 의 `new_body` 에서 wrap → closure 추출 분기 없는 일반 for_statement body 까지 쓸데없이 감싸게 됨. JS 문법상 for_statement body 는 block 이 아니어도 합법.
- codegen 에서 `{`/`}` 강제 출력 → spec 위반 AST 를 emitter 가 가림. 다른 consumer (plugin / semantic / transformer pass) 가 동일 피해를 입음.

## 현업 impact

esbuild `__copyProps` (`@radix-ui/*`, `@floating-ui/*` 등 minify 안 된 dist) 가 정확히 이 "for-of + let + closure + single-statement if body" 패턴을 사용. React Native 프로젝트가 해당 라이브러리 의존 추가 즉시 앱 부팅 단계에서 번들 parse 실패.

```
[runtime not ready]: Error: Non-js exception: Compiling JS failed:
  '{' expected in function expression
```

## Test plan

- [x] `zig build test` (Zig 유닛) green
- [x] `bun test ./tests/downlevel.test.ts ./tests/downlevel-edge.test.ts` (330 tests) 모두 통과
- [x] 새 테스트 5종 (#1807) 모두 통과
- [x] `bun scripts/audit_addnode_variants.ts` — 0 REAL / 74 cosmetic 유지 (회귀 없음)
- [x] 원본 재현 케이스 (`for (let key of ...) if (...) defineProperty(...)`) `node` 로 실행 → `A B C` 출력 확인

## Follow-up (scope 밖)

동일 "wrap single statement in block_statement if not already block" 패턴이 3곳 (`transformer.zig:1714 buildForBodyWithPrefix`, `es2015_arrow.zig:56 lowerArrow`, 이 PR) 에 중복. `ensureBlockStatement(idx, span)` helper 로 DRY 가능하나 버그 수정 scope 밖 — 별도 리팩터 이슈 권장.

Closes #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)