### PR TITLE
refactor(ast): cosmetic 카테고리 A — leaf 통일 (27/74) (#1802)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -484,6 +484,11 @@ pub const Node = struct {
                 .flow_this_type,
                 .flow_mixed_keyword,
                 .flow_empty_keyword,
+                // literal type: 파서가 키워드 리터럴(true/false)일 때 .none,
+                // 값 리터럴(string/number/bigint/template)일 때 .string_ref 로 저장.
+                // 실체가 leaf 이며 codegen 이 data 를 읽지 않음 (TS/Flow strip 대상).
+                .ts_literal_type,
+                .flow_literal_type,
                 => .{ .kind = .leaf },
 
                 // === unary ===
@@ -538,11 +543,9 @@ pub const Node = struct {
                 .jsx_namespaced_name,
                 .jsx_member_expression,
                 .ts_qualified_name,
-                .ts_literal_type,
                 .ts_type_predicate,
                 .ts_enum_member,
                 .flow_qualified_name,
-                .flow_literal_type,
                 => .{ .kind = .binary },
 
                 // === ternary ===

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -180,7 +180,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // 1. __classCallCheck(this, ClassName) — constructor body 맨 앞
             {
                 const check_id = try es_helpers.makeRuntimeHelperRef(self, "__classCallCheck");
-                const this_expr = try self.ast.addNode(.{ .tag = .this_expression, .span = span, .data = .{ .unary = .{ .operand = .none, .flags = 0 } } });
+                const this_expr = try self.ast.addNode(.{ .tag = .this_expression, .span = span, .data = .{ .none = 0 } });
                 const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
                 const call = try es_helpers.makeCallExpr(self, check_id, &.{ this_expr, class_ref }, span);
                 func_node = try prependToFunctionBody(self, func_node, &.{try es_helpers.makeExprStmt(self, call, span)});
@@ -387,7 +387,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             {
                 const check_id = try es_helpers.makeRuntimeHelperRef(self, "__classCallCheck");
-                const this_expr = try self.ast.addNode(.{ .tag = .this_expression, .span = span, .data = .{ .unary = .{ .operand = .none, .flags = 0 } } });
+                const this_expr = try self.ast.addNode(.{ .tag = .this_expression, .span = span, .data = .{ .none = 0 } });
                 const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
                 const call = try es_helpers.makeCallExpr(self, check_id, &.{ this_expr, class_ref }, span);
                 func_node = try prependToFunctionBody(self, func_node, &.{try es_helpers.makeExprStmt(self, call, span)});
@@ -421,7 +421,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // classCallCheck
             {
                 const check_id = try es_helpers.makeRuntimeHelperRef(self, "__classCallCheck");
-                const this_expr = try self.ast.addNode(.{ .tag = .this_expression, .span = span, .data = .{ .unary = .{ .operand = .none, .flags = 0 } } });
+                const this_expr = try self.ast.addNode(.{ .tag = .this_expression, .span = span, .data = .{ .none = 0 } });
                 const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
                 const call = try es_helpers.makeCallExpr(self, check_id, &.{ this_expr, class_ref }, span);
                 func_node = try prependToFunctionBody(self, func_node, &.{try es_helpers.makeExprStmt(self, call, span)});

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -969,7 +969,7 @@ fn makeThisPrivateField(self: *Transformer, storage_span: Span) Error!NodeIndex 
     const this_node = try self.ast.addNode(.{
         .tag = .this_expression,
         .span = zero_span,
-        .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+        .data = .{ .none = 0 },
     });
     const storage_ref = try self.ast.addNode(.{
         .tag = .private_identifier,
@@ -2060,7 +2060,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     const this_node = try self.ast.addNode(.{
                         .tag = .this_expression,
                         .span = zero_span,
-                        .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+                        .data = .{ .none = 0 },
                     });
                     const callee = try makeIdentifier(self, "__runInitializers");
                     const init_arr = try makeIdentifier(self, init_name);
@@ -2147,7 +2147,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                             const this_node = try self.ast.addNode(.{
                                 .tag = .this_expression,
                                 .span = zero_span,
-                                .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+                                .data = .{ .none = 0 },
                             });
                             const callee = try makeIdentifier(self, "__runInitializers");
                             const init_arr_ref = try makeIdentifier(self, names.init_name);
@@ -2254,7 +2254,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         const this_node = try self.ast.addNode(.{
             .tag = .this_expression,
             .span = zero_span,
-            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+            .data = .{ .none = 0 },
         });
         const assign = try self.ast.addNode(.{
             .tag = .assignment_expression,
@@ -2390,7 +2390,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
         const this_node = try self.ast.addNode(.{
             .tag = .this_expression,
             .span = zero_span,
-            .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+            .data = .{ .none = 0 },
         });
         const run_init = try self.buildRunInitializersCall2(this_node, ctor_init_name);
         const run_init_stmt = try self.ast.addNode(.{
@@ -2703,7 +2703,7 @@ pub fn buildEsDecorateCall(self: *Transformer, info: Stage3MemberInfo) Error!Nod
     const arg1 = if (std.mem.eql(u8, info.kind, "field"))
         try makeIdentifier(self, "null")
     else
-        try self.ast.addNode(.{ .tag = .this_expression, .span = zero_span, .data = .{ .unary = .{ .operand = .none, .flags = 0 } } });
+        try self.ast.addNode(.{ .tag = .this_expression, .span = zero_span, .data = .{ .none = 0 } });
 
     // arg2: null (public) 또는 _descriptor = { value: __setFunctionName(fn, "#name") } (private method)
     const arg2 = if (info.descriptor_name) |dname| blk: {
@@ -3521,7 +3521,7 @@ fn buildPiggybackedInitCall(self: *Transformer, prev_extra_name: []const u8, ini
     const prev_this = try self.ast.addNode(.{
         .tag = .this_expression,
         .span = zero_span,
-        .data = .{ .unary = .{ .operand = .none, .flags = 0 } },
+        .data = .{ .none = 0 },
     });
     const prev_callee = try makeIdentifier(self, "__runInitializers");
     const prev_arr = try makeIdentifier(self, prev_extra_name);


### PR DESCRIPTION
## Summary

- #1801 static audit surface 된 74 cosmetic mismatch 중 **leaf 계열 27건** 정리.
- `this_expression` 10건: transformer 측 `.unary = { .none, 0 }` → `.none = 0`. layout (`.leaf`) 과 일치.
- `ts_literal_type` 4건 / `flow_literal_type` 13건: parser 저장이 `.none` / `.string_ref` 인데 layout 은 `.binary` 였던 것을 layout 을 **`.leaf`** 섹션으로 이동. parser 코드 변경 없음.
- audit cosmetic count **74 → 47** (-27), REAL 0 유지.

## 수정 방향 결정 근거 (per #1802)

이슈 본문의 3가지 ground-truth 판정 방식 중:

- `this_expression`: codegen 이 `.data` 를 읽지 않음 → **getLayout 기준으로 통일** (layout=.leaf 이므로 parser 를 .none 으로).
- `*_literal_type`: codegen 이 읽지 않고 parser 가 variant 별로 `.none` / `.string_ref` 혼재 → **일관된 leaf 로 통일**. `.none` 과 `.string_ref` 는 둘 다 leaf variant 이므로 getLayout 을 `.leaf` 섹션으로 이동하면 parser 코드 수정 없이 양쪽 경로 모두 합법.

## Cross-file 검증

layout 변경 tag (`ts_literal_type`, `flow_literal_type`) 을 consumer 에서 `.data.binary` 로 읽는지 확인:
- `src/transformer/transformer.zig:4357, 4406` — tag predicate (`isTypeOnlyDeclaration` 계열) 로만 사용, `.data` 접근 없음.
- `src/semantic/analyzer.zig:1567` — tag predicate 로만 사용.
- codegen 에는 대응 emit 경로 없음 (TS/Flow strip).

`this_expression` 의 경우:
- `src/codegen/codegen.zig:953` — `write(\"this\")` 만 수행, `.data` 접근 없음.
- `src/transformer/*` — 대부분 tag 매칭 후 교체/삭제, `.data.unary.operand` 읽는 곳 없음.

## Test plan

- [x] `zig build test` — 3647/3647 green
- [x] `bun test ./tests/tsc/*.test.ts` — 2177/2177 green (TS 경로 회귀 없음)
- [x] `bun test ./tests/downlevel*.test.ts ./tests/bundle-smoke.test.ts` — 전체 green
- [x] `bun scripts/audit_addnode_variants.ts` — 74 → 47 cosmetic, REAL 0

## 후속 (시리즈)

- **PR B**: TS/Flow extra 통일 (~32건) — parser 를 빈 extra 로 변환
- **PR C**: list 정규화 (~15건) — parser 의 binary/extra/none 을 list 로 변환 + template_literal dead `.none` 경로 확인

3개 PR 모두 머지 시 cosmetic 0 달성 → audit 스크립트에서 cosmetic 도 fail 로 승격 가능.

Part of #1802 (전체 close 는 PR C 에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)