### PR TITLE
refactor(ast): cosmetic 카테고리 B — codegen-read aligned layout (#1802)

### DIFF
--- a/scripts/audit_addnode_variants.ts
+++ b/scripts/audit_addnode_variants.ts
@@ -27,6 +27,8 @@ const CODEGEN_FILE = join(ROOT, "src", "codegen", "codegen.zig");
 
 const DATA_VARIANT_RE = /\.data\s*=\s*\.\{\s*\.(\w+)\s*=/;
 const TAG_RE = /\.tag\s*=\s*\.(\w+)\s*,/;
+/** `.tag = someVar,` — variable-typed tag (needs backward lookup). */
+const TAG_VAR_RE = /\.tag\s*=\s*([a-zA-Z_][a-zA-Z_0-9]*)\s*,/;
 const ADDNODE_START_RE = /\.addNode\(\s*\.\{/g;
 const DATA_ACCESS_RE = /\.data\.(\w+)\b/g;
 
@@ -290,8 +292,35 @@ function extractStructLiteral(text: string, startDotBrace: number): { literal: s
 	return { literal: text.slice(startDotBrace, end), end };
 }
 
-function auditFile(path: string): { lineNo: number; tag: string; variant: string }[] {
+/**
+ * `.tag = someVar,` 로 쓰인 경우, 호출 사이트 위쪽 function scope 내에서
+ * `const <var>: ... = if (...) .tagA else .tagB;` 또는
+ * `const <var> = .tagA;` 패턴을 찾아 가능한 tag 값들을 돌려준다.
+ *
+ * `cleanText` 는 `stripStringsAndComments` 결과. 오프셋이 `fileText` 와 동일하게
+ * 유지되므로 문자열/주석 안의 false-positive 를 차단하면서도 `lastIndexOf` /
+ * regex 결과를 그대로 인덱스로 쓸 수 있다.
+ */
+function resolveTagVariable(cleanText: string, callStart: number, varName: string): string[] {
+	const fnStart = Math.max(cleanText.lastIndexOf("\nfn ", callStart), cleanText.lastIndexOf("\npub fn ", callStart), 0);
+	const scope = cleanText.slice(fnStart, callStart);
+	const re = new RegExp(
+		`\\bconst\\s+${varName}\\b[^=]*=\\s*([^;]+?);`,
+		"s",
+	);
+	const m = re.exec(scope);
+	if (!m) return [];
+	const rhs = m[1];
+	const tags = Array.from(rhs.matchAll(/\.([a-zA-Z_][a-zA-Z_0-9]*)\b/g), (x) => x[1]);
+	// variant/kind 이름은 걸러냄. identifier fragments 가 섞일 수 있어 getLayout 에
+	// 등록된 이름만 추린다 (호출자가 필터).
+	return tags.filter((t) => !KINDS.has(t) && !ALL_DATA_VARIANTS.has(t));
+}
+
+function auditFile(path: string, layout: Map<string, string>): { lineNo: number; tag: string; variant: string }[] {
 	const text = readFileSync(path, "utf8");
+	// 파일당 1회만 string/comment strip — 변수형 tag 리졸브가 매번 재작업하지 않도록.
+	let cleanText: string | null = null;
 	const findings: { lineNo: number; tag: string; variant: string }[] = [];
 	for (const m of text.matchAll(ADDNODE_START_RE)) {
 		const start = m.index!;
@@ -307,12 +336,22 @@ function auditFile(path: string): { lineNo: number; tag: string; variant: string
 			continue;
 		}
 
-		const tagMatch = TAG_RE.exec(lit);
 		const varMatch = DATA_VARIANT_RE.exec(lit);
-		if (!tagMatch || !varMatch) continue;
+		if (!varMatch) continue;
 
 		const lineNo = text.slice(0, start).split("\n").length;
-		findings.push({ lineNo, tag: tagMatch[1], variant: varMatch[1] });
+		const tagMatch = TAG_RE.exec(lit);
+		if (tagMatch) {
+			findings.push({ lineNo, tag: tagMatch[1], variant: varMatch[1] });
+			continue;
+		}
+		// Fallback: variable-typed `.tag = name,`. 가능한 tag 값 전개.
+		const tagVarMatch = TAG_VAR_RE.exec(lit);
+		if (!tagVarMatch) continue;
+		if (cleanText === null) cleanText = stripStringsAndComments(text);
+		for (const t of resolveTagVariable(cleanText, start, tagVarMatch[1])) {
+			if (layout.has(t)) findings.push({ lineNo, tag: t, variant: varMatch[1] });
+		}
 	}
 	ADDNODE_START_RE.lastIndex = 0;
 	return findings;
@@ -348,7 +387,7 @@ function main(): number {
 
 	for (const path of walk(join(ROOT, "src")).sort()) {
 		if (path === AST_FILE) continue;
-		for (const { lineNo, tag, variant } of auditFile(path)) {
+		for (const { lineNo, tag, variant } of auditFile(path, layout)) {
 			const expected = layout.get(tag);
 			if (!expected) continue;
 			const actualKind = resolveKind(variant);

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -518,6 +518,15 @@ pub const Node = struct {
                 .ts_type_operator,
                 .ts_non_null_expression,
                 .flow_nullable_type,
+                // TS/Flow type-cast / assertion expressions — codegen emitter 가
+                // data.unary.operand 만 출력 (type 부분 스트리핑).
+                // codegen.zig::emitExpression 의 .ts_as_expression 등 arm 참고.
+                .ts_as_expression,
+                .ts_satisfies_expression,
+                .ts_type_assertion,
+                .ts_instantiation_expression,
+                .flow_as_expression,
+                .flow_type_cast_expression,
                 => .{ .kind = .unary },
 
                 // === binary ===
@@ -546,6 +555,9 @@ pub const Node = struct {
                 .ts_type_predicate,
                 .ts_enum_member,
                 .flow_qualified_name,
+                // ts_module_declaration: binary = { left=name, right=body_or_inner, flags }
+                // codegen::emitNamespaceIIFEInner 가 data.binary.left/right 를 읽는다.
+                .ts_module_declaration,
                 => .{ .kind = .binary },
 
                 // === ternary ===
@@ -664,7 +676,6 @@ pub const Node = struct {
                 .ts_getter_signature,
                 .ts_setter_signature,
                 .ts_enum_declaration,
-                .ts_module_declaration,
                 .ts_import_equals_declaration,
                 .ts_external_module_reference,
                 .ts_export_assignment,
@@ -672,10 +683,6 @@ pub const Node = struct {
                 .ts_type_parameter,
                 .ts_this_parameter,
                 .ts_class_implements,
-                .ts_as_expression,
-                .ts_satisfies_expression,
-                .ts_type_assertion,
-                .ts_instantiation_expression,
                 => .{ .kind = .extra, .child_offsets = &.{} },
                 // Flow declarations — 타입 전용
                 .flow_type_reference,
@@ -688,8 +695,6 @@ pub const Node = struct {
                 .flow_type_alias_declaration,
                 .flow_opaque_type,
                 .flow_interface_declaration,
-                .flow_as_expression,
-                .flow_type_cast_expression,
                 .flow_match_expression,
                 => .{ .kind = .extra, .child_offsets = &.{} },
             };

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -815,18 +815,21 @@ fn parsePostfixExpression(self: *Parser) ParseError2!NodeIndex {
         if (!is_as and !is_satisfies) break;
         const expr_start = self.ast.getNode(expr).span.start;
         try self.advance();
-        const ty = try self.parseType();
+        _ = try self.parseType();
         const tag: @import("ast.zig").Node.Tag = if (is_satisfies)
             .ts_satisfies_expression
         else if (self.is_flow)
             .flow_as_expression
         else
             .ts_as_expression;
-        expr = try self.ast.addNode(.{
-            .tag = tag,
-            .span = .{ .start = expr_start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = expr, .right = ty, .flags = 0 } },
-        });
+        // codegen 은 operand 만 출력하고 type annotation 은 스트리핑하므로
+        // type 참조는 저장하지 않는다. layout=.unary (ast.zig getLayout 참고).
+        expr = try self.ast.addUnaryNode(
+            tag,
+            .{ .start = expr_start, .end = self.currentSpan().start },
+            expr,
+            0,
+        );
     }
 
     return expr;


### PR DESCRIPTION
## Summary

#1802 두 번째 PR. codegen 이 실제로 `data` 를 읽는 TS/Flow tag 들의 `getLayout` 을 실사용 variant 에 맞춰 재배치. audit 스크립트 false-negative 도 보강해 이번 작업 중 **실제 #1797-class silent failure 하나를 surface 하고 fix**.

## 주요 변경

### `ts_module_declaration` → layout .binary (parser/codegen 이미 binary 사용)
`codegen.zig::emitNamespaceIIFEInner` 가 `node.data.binary.left/right` 로 namespace name/body 를 읽는데 `getLayout` 만 `.extra` 였음. layout 을 실사용에 맞춤.

### `ts_as_expression` / `ts_satisfies_expression` / `flow_as_expression` — 숨어있던 REAL mismatch

codegen 은 7개 tag (`.ts_as_expression`, `.ts_satisfies_expression`, `.ts_non_null_expression`, `.ts_type_assertion`, `.ts_instantiation_expression`, `.flow_as_expression`, `.flow_type_cast_expression`) 을 동일 arm 에서:

\`\`\`zig
=> try self.emitNode(node.data.unary.operand),
\`\`\`

로 emit. 그러나 parser (`src/parser/expression.zig:825`) 는 `ts_as` / `ts_satisfies` / `flow_as` 에 대해 \`.data = .{ .binary = { .left = expr, .right = ty, .flags = 0 } }\` 저장. 실제로는 extern union offset 0 aliasing 덕에 \`.binary.left\` == \`.unary.operand\` 비트가 겹쳐 우연히 동작. 이건 #1797 류 **silent failure** 로, Data union layout 이 바뀌거나 다른 reader 가 추가되면 즉시 깨진다.

**수정**: parser 를 \`.unary\` 저장 + \`addUnaryNode\` typed helper 로 전환. Debug build 에서 \`assertDataKind\` 가 즉시 panic 하도록 하여 재회귀 차단.

### `ts_type_assertion` / `flow_type_cast_expression` / `ts_instantiation_expression` → layout .unary

codegen 이 `.unary.operand` 를 읽고 parser 도 이미 `.unary` 저장. layout 만 `.extra` 였던 케이스. layout 정정.

## audit 스크립트 false-negative 보강

기존 `TAG_RE` 는 `.tag = .literalName,` 만 매칭. 위 `parsePostfixExpression` 의:

\`\`\`zig
const tag: Tag = if (is_satisfies) .ts_satisfies_expression
                 else if (self.is_flow) .flow_as_expression
                 else .ts_as_expression;
_ = try self.ast.addNode(.{ .tag = tag, ... });
\`\`\`

패턴은 놓쳤다 (tag 가 변수). `TAG_VAR_RE` + `resolveTagVariable` 추가로 `.tag = name,` 일 때 호출 사이트 위쪽 function scope 의 \`const name = ...;\` RHS 를 분석해 가능한 tag 값 전개.

성능: `stripStringsAndComments(text)` 결과를 `auditFile` 당 lazy 1회 계산 + 캐시. 변수형 tag 여러 사이트 있는 파일에서 O(N×fileLen) 재작업 방지. /simplify 리뷰 반영.

코드 개선 (/simplify 리뷰 반영):
- parser 의 raw `addNode` → `addUnaryNode` typed helper 로 전환 → Debug assertion 확보
- `resolveTagVariable` 이 `cleanText` 를 받도록 변경 → string/comment 안 false-positive 차단 + 캐시 활용

## Cross-file 검증

- `codegen.zig:1043-1050` — 7 tag arm 의 `.unary.operand` 읽기 경로 확인 ✓
- `codegen.zig:3519-` — `emitNamespaceIIFEInner` 의 `.binary.left/right` 읽기 경로 확인 ✓
- `transformer.zig:4349` 이하 — TS/Flow strip tag predicate, data 접근 없음 ✓
- `semantic/analyzer.zig:1560` 이하 — tag predicate, data 접근 없음 ✓

## Test plan

- [x] \`zig build test\` — 3647/3647 green
- [x] \`bun test tests/tsc/*.test.ts tests/downlevel*.test.ts tests/bundle-smoke.test.ts\` — 2644/2644 green
- [x] \`bun scripts/audit_addnode_variants.ts\`: 47 → 40 cosmetic, REAL 0

## 후속

- **PR C**: list 정규화 (~11건) — `flow_union_type`, `flow_intersection_type`, `ts_union_type`, `ts_intersection_type`, `template_literal`, `flow_exact_object_type`, `flow_tuple_type`, `flow_type_parameter_instantiation`, `flow_type_parameter_declaration`, `ts_template_literal_type`.
- **PR B2** (후속): pure TS/Flow strip-target tag 29건 정리 — parser 를 빈 extra 로 통일. 이번 PR 대비 mechanical.

Part of #1802 (전체 close 는 마지막 PR 에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)