### PR TITLE
fix(docs): Starlight 레이어 선언 위치 조정 — Tailwind utilities 가 reset 이기도록

### DIFF
--- a/documents/src/styles/tailwind.css
+++ b/documents/src/styles/tailwind.css
@@ -1,3 +1,4 @@
+@layer starlight.base, starlight.reset, starlight.core, starlight.content, starlight.components, starlight.utils;
 @import "tailwindcss";
 
 @theme {


### PR DESCRIPTION
## Summary
사용자가 devtools 에서 바로 짚어낸 근본 원인 해결. 히어로 `.mx-auto` 가 starlight.reset 의 `* { margin: 0 }` 에 덮여서 가운데 정렬 안 되던 문제.

## Root cause
Starlight 의 `reset.css`:
```css
@layer starlight.reset {
  * { margin: 0; }
}
```

배포된 CSS 의 레이어 선언 순서:
```
properties, theme, base, components, utilities,
starlight.base, starlight.reset, starlight.core, ...
```

**CSS cascade layers: 나중에 선언된 레이어가 이김.** starlight.reset 이 utilities 뒤 → `* { margin: 0 }` 이 `.mx-auto { margin-inline: auto }` 를 이김. 결과: 히어로 `.mx-auto.max-w-6xl` div 의 auto 가 0 으로 바뀌어 가운데 정렬 실패.

PR #1808 의 `head:` 주입으로 sl-container 는 100% 가 됐지만, 그 안의 `.mx-auto` 가 여전히 starlight.reset 에 당해서 자식 div 가 왼쪽 붙어있었음.

## Fix
`tailwind.css` 맨 위에 starlight 서브레이어를 **미리 선언**:
```css
@layer starlight.base, starlight.reset, starlight.core, starlight.content, starlight.components, starlight.utils;
@import "tailwindcss";
```

이 선언이 starlight 레이어의 포지션을 먼저 확정. 이후 `@import "tailwindcss"` 가 `theme, base, components, utilities` 를 선언하면 이들이 starlight 뒤에 위치.

**새 순서:**
```
properties,
starlight.base, starlight.reset, starlight.core, starlight.content,
starlight.components, starlight.utils,
theme, base, components, utilities  ← Tailwind 이제 뒤
```

Tailwind utilities 가 최종 위치 → `.mx-auto` 가 `* { margin: 0 }` 이김 → 히어로 정상 중앙 정렬.

## Verification
```
$ grep -oE '@layer[^{]{0,200}' dist/_astro/middleware*.css | head
@layer properties
@layer starlight.base,starlight.reset,...,starlight.utils;@layer theme
@layer base
@layer components;@layer utilities
@layer starlight.base,starlight.reset,...,starlight.utils;@layer starlight.base
...
```

선언 순서가 의도대로 변경 확인.

## Test plan
- [x] `bun run build` · 340 페이지 통과
- [x] dist CSS 레이어 순서에서 starlight.* 가 utilities 앞에 위치
- [ ] 배포 후 https://ohah.github.io/zts/ 에서 히어로 가운데 정렬
- [ ] 일반 docs 페이지의 리셋 동작이 깨지지 않는지 (Tailwind preflight 이제 starlight.reset 이김 — 마크다운 h1/p 기본 여백이 0 이지만 Starlight 가 `.sl-markdown-content` 스코프에서 `--sl-content-gap-y` 로 따로 처리하므로 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)