### PR TITLE
fix(test): CSS library smoke 3건 — --format=esm 명시로 IIFE auto-promote 회피

### DIFF
--- a/tests/integration/tests/css-library-smoke.test.ts
+++ b/tests/integration/tests/css-library-smoke.test.ts
@@ -184,12 +184,17 @@ describe.skipIf(!hasEmotionReact)("CSS Library Smoke — @emotion/react", () => 
       "stylis",
     ]);
 
+    // `--format=esm` 명시: 라이브러리 번들링 의도. `--platform=browser` 기본이
+    // `is_bundle && !bundle_format_explicit` 일 때 IIFE 로 자동 승격되는데 (#1791),
+    // IIFE 는 factory 스코프에 require/import 가 없어 external react 를 담을 수
+    // 없다. 라이브러리 배포 포맷은 ESM/CJS 가 표준이므로 여기도 ESM 을 쓴다.
     const outFile = join(fixture.dir, "out.js");
     const bundle = await runZts([
       "--bundle",
       join(fixture.dir, "index.tsx"),
       "-o",
       outFile,
+      "--format=esm",
       "--external",
       "react",
       "--external",
@@ -286,12 +291,14 @@ describe.skipIf(!hasStyledComponents)("CSS Library Smoke — Styled-Components",
       "shallowequal",
     ]);
 
+    // `--format=esm` 명시: 라이브러리 번들링 의도 (#1791 follow-up, css-smoke).
     const outFile = join(fixture.dir, "out.js");
     const bundle = await runZts([
       "--bundle",
       join(fixture.dir, "index.ts"),
       "-o",
       outFile,
+      "--format=esm",
       "--external",
       "react",
       "--external",
@@ -328,12 +335,14 @@ describe.skipIf(!hasStyledComponents)("CSS Library Smoke — Styled-Components",
       "shallowequal",
     ]);
 
+    // `--format=esm` 명시: 라이브러리 번들링 의도 (#1791 follow-up, css-smoke).
     const outFile = join(fixture.dir, "out.js");
     const bundle = await runZts([
       "--bundle",
       join(fixture.dir, "index.ts"),
       "-o",
       outFile,
+      "--format=esm",
       "--external",
       "react",
       "--external",


### PR DESCRIPTION
## Summary

main CI 의 `Integration & E2E` 에서 CSS smoke 3건 (@emotion/react / styled-components bundle / styled-components css helper) 이 `17ac66de` (#1791 IIFE unresolved import build-time error) 머지 이후 연속 실패. 근본 원인은 **테스트가 format 을 명시하지 않아 browser platform 기본값이 IIFE 로 auto-promote** 되었고, IIFE factory 스코프는 external import 를 담을 수 없어 build-time error (#1791 의 의도된 동작).

## 변경

3 테스트 `runZts(...)` 호출에 `--format=esm` 추가. 그 외 assertion 은 그대로.

## 의도 검증

CSS smoke 의 진짜 목적은 "라이브러리 consumer 용 포맷으로 번들 되는가". 라이브러리 배포 표준은 **ESM/CJS** 이고 IIFE 는 브라우저 `<script>` 용이므로 **부적합**. `--format=esm` 명시가 테스트 의도에 정확히 부합.

각 테스트의 기존 검증:
- `expect(bundle.exitCode).toBe(0)` — 빌드 성공
- 핵심 심볼 포함 (`serializeStyles` / `styled+stylis` / `keyframes`)
- 최소 사이즈 (`> 10000` / `> 5000` bytes)

ESM 출력에서도 모두 통과 확인.

## 타임라인 (CI History 기준)

| 시각 | SHA | 상태 |
|------|-----|------|
| 04-24 02:43 | `ba07296e` | ✅ 마지막 success |
| 04-24 03:54 | `17ac66de` | ❌ 첫 failure — #1791 IIFE external build-time error 승격 |
| 04-24 08:16 | `6c85fc02` | ❌ 계속 failure (CSS 3건만 상시 실패) |

#1791 이전 "CI success" 는 bare `require("react")` fallback 으로 인한 silent pass — 실제 RN 런타임에선 ReferenceError. #1791 이 이를 build-time 으로 surface 시킨 올바른 동작이고, 본 PR 은 테스트 포맷을 라이브러리 배포 표준에 맞춰 정정.

## 후속 (본 PR 스코프 밖)

IIFE + external + globals 매핑 (rollup `output.globals` 식) 은 별도 feature. 필요 시 #1791 후속 이슈로 track.

## Test plan

- [x] `bun test tests/css-library-smoke.test.ts`: 9/9 green
- [x] `bun test` (전체 integration): 3181/3181 (watch-stress 1건 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)