### PR TITLE
fix(docs): PR #1812 layer 예약선언 revert + 랜딩 섹션 margin 국지 복원

### DIFF
--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -5,10 +5,18 @@ template: splash
 head:
   - tag: style
     content: |
-      main > .content-panel:first-child { display: none; }
-      main > .content-panel { padding: 0; border-top: 0; }
-      main > .content-panel > .sl-container { max-width: 100%; margin-inline: 0; }
-      main > .content-panel > .sl-container > .sl-markdown-content { max-width: 100%; }
+      main > .content-panel:first-child { display: none !important; }
+      main > .content-panel { padding: 0 !important; border-top: 0 !important; }
+      main > .content-panel > .sl-container { max-width: 100% !important; margin-inline: 0 !important; }
+      main > .content-panel > .sl-container > .sl-markdown-content { max-width: 100% !important; }
+      section.not-content .mx-auto { margin-inline: auto !important; }
+      section.not-content .mt-2 { margin-top: .5rem !important; }
+      section.not-content .mt-6 { margin-top: 1.5rem !important; }
+      section.not-content .mb-2 { margin-bottom: .5rem !important; }
+      section.not-content .mb-3 { margin-bottom: .75rem !important; }
+      section.not-content .mb-8 { margin-bottom: 2rem !important; }
+      section.not-content .mb-12 { margin-bottom: 3rem !important; }
+      section.not-content .ml-2 { margin-left: .5rem !important; }
 ---
 
 import Hero from "../../../components/landing/Hero.astro";

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -5,10 +5,18 @@ template: splash
 head:
   - tag: style
     content: |
-      main > .content-panel:first-child { display: none; }
-      main > .content-panel { padding: 0; border-top: 0; }
-      main > .content-panel > .sl-container { max-width: 100%; margin-inline: 0; }
-      main > .content-panel > .sl-container > .sl-markdown-content { max-width: 100%; }
+      main > .content-panel:first-child { display: none !important; }
+      main > .content-panel { padding: 0 !important; border-top: 0 !important; }
+      main > .content-panel > .sl-container { max-width: 100% !important; margin-inline: 0 !important; }
+      main > .content-panel > .sl-container > .sl-markdown-content { max-width: 100% !important; }
+      section.not-content .mx-auto { margin-inline: auto !important; }
+      section.not-content .mt-2 { margin-top: .5rem !important; }
+      section.not-content .mt-6 { margin-top: 1.5rem !important; }
+      section.not-content .mb-2 { margin-bottom: .5rem !important; }
+      section.not-content .mb-3 { margin-bottom: .75rem !important; }
+      section.not-content .mb-8 { margin-bottom: 2rem !important; }
+      section.not-content .mb-12 { margin-bottom: 3rem !important; }
+      section.not-content .ml-2 { margin-left: .5rem !important; }
 ---
 
 import Hero from "../../components/landing/Hero.astro";

--- a/documents/src/styles/tailwind.css
+++ b/documents/src/styles/tailwind.css
@@ -1,4 +1,3 @@
-@layer base, starlight, theme, components, utilities;
 @import "tailwindcss";
 
 @theme {

--- a/documents/src/styles/tailwind.css
+++ b/documents/src/styles/tailwind.css
@@ -1,4 +1,4 @@
-@layer starlight.base, starlight.reset, starlight.core, starlight.content, starlight.components, starlight.utils;
+@layer base, starlight, theme, components, utilities;
 @import "tailwindcss";
 
 @theme {


### PR DESCRIPTION
## Summary
PR #1812 의 cascade layer 예약선언이 **Tailwind base (preflight) 까지** starlight.core 를 이기게 만들어서 Starlight 헤더/탭 layout 이 깨짐 (padding/margin 이 `* { padding: 0 }` 에 먹힘). Revert 하고, 히어로 정렬만 랜딩 페이지 국지적으로 복원하는 방식으로 전환.

## Changes
### 1. Layer 예약선언 revert
`tailwind.css` 에서 `@layer starlight.base, starlight.reset, ...` 선언 제거. Starlight 의 기본 cascade 원복 → 헤더/탭 padding 정상 복원.

### 2. 랜딩 MDX head 에 국지 CSS 주입 + !important
`index.mdx` ko/en 양쪽 frontmatter `head:` 에:
```css
section.not-content .mx-auto { margin-inline: auto !important; }
section.not-content .mt-2   { margin-top: .5rem !important; }
section.not-content .mt-6   { margin-top: 1.5rem !important; }
section.not-content .mb-2   { margin-bottom: .5rem !important; }
section.not-content .mb-3   { margin-bottom: .75rem !important; }
section.not-content .mb-8   { margin-bottom: 2rem !important; }
section.not-content .mb-12  { margin-bottom: 3rem !important; }
section.not-content .ml-2   { margin-left: .5rem !important; }
```

- `section.not-content` 스코프 → Hero / StatsStrip / FeatureGrid / CtaCard 섹션만 적용
- `!important` 로 starlight.reset 의 `* { margin: 0 }` 확실히 우회
- page-scoped head 주입이라 **랜딩(ko/en) 2 페이지만 영향**

### 3. 기존 layout head 규칙에도 !important 일괄 추가
`main > .content-panel` / `.sl-container` / `.sl-markdown-content` 의 width/padding override 도 `!important` 로 cascade 에서 확실히 살아남도록 강화.

## Scope verification
- `dist/guides/introduction/index.html` 에서 `section.not-content` 매치: **0건** (docs 본문 영향 없음)
- `dist/index.html` 에서: **8건** (8 개 margin utility 각 규칙)
- Playground (`.not-content` 루트) 는 자식에 `.mx-auto` / `.mt-*` / `.mb-*` 없음 — 영향 없음

## Test plan
- [x] `bun run build` · 340 페이지 통과
- [x] 스코프 검증: docs 페이지 0건, 랜딩 8건
- [ ] 배포 후 https://ohah.github.io/zts/ 에서:
  - 히어로 가운데 정렬 유지
  - Starlight 헤더/탭/사이드바 layout 정상 복원 (겹침 없음)
  - docs 페이지 (`/guides/introduction/` 등) 이전과 동일 렌더

🤖 Generated with [Claude Code](https://claude.com/claude-code)