### PR TITLE
refactor(ast): cosmetic 카테고리 B2 — TS/Flow strip-target empty extras (#1802)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -936,6 +936,21 @@ pub const Ast = struct {
         });
     }
 
+    /// 자식 없는 `extra` 노드 — TS/Flow strip-target 타입 표기 전용 (#1802 B2).
+    /// getLayout 이 `.extra, child_offsets = &.{}` 로 선언되어 있고 codegen/
+    /// transformer/semantic 어디도 data 를 읽지 않는 tag 에 사용. parse 부수효과
+    /// (advance, parseX) 만 필요한 경우 이 helper 로 node 만 등록.
+    /// empty `addExtras` 호출은 zero-alloc (ensureUnusedCapacity(0) no-op).
+    pub fn addEmptyExtraNode(self: *Ast, tag: Node.Tag, span: Span) !NodeIndex {
+        assertDataKind(tag, .extra);
+        const extra_idx = try self.addExtras(&.{});
+        return self.addNode(.{
+            .tag = tag,
+            .span = span,
+            .data = .{ .extra = extra_idx },
+        });
+    }
+
     /// `list` variant 를 쓰는 노드 (block_statement, array_expression 등).
     pub fn addListNode(self: *Ast, tag: Node.Tag, span: Span, list: NodeList) !NodeIndex {
         assertDataKind(tag, .list);

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -192,11 +192,10 @@ fn parsePostfixType(self: *Parser) ParseError2!NodeIndex {
                 // 배열 타입: T[]
                 try self.advance(); // [
                 try self.advance(); // ]
-                base = try self.ast.addNode(.{
-                    .tag = .flow_array_type,
-                    .span = .{ .start = start, .end = self.currentSpan().start },
-                    .data = .{ .unary = .{ .operand = base, .flags = 0 } },
-                });
+                base = try self.ast.addEmptyExtraNode(
+                    .flow_array_type,
+                    .{ .start = start, .end = self.currentSpan().start },
+                );
             } else {
                 // Indexed access type: Type['key'] / Type[number]
                 try self.advance(); // skip [
@@ -395,12 +394,11 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         // typeof T
         .kw_typeof => {
             try self.advance();
-            const operand = try parseTypeReference(self);
-            return try self.ast.addNode(.{
-                .tag = .flow_type_query,
-                .span = .{ .start = span.start, .end = self.currentSpan().start },
-                .data = .{ .unary = .{ .operand = operand, .flags = 0 } },
-            });
+            _ = try parseTypeReference(self);
+            return try self.ast.addEmptyExtraNode(
+                .flow_type_query,
+                .{ .start = span.start, .end = self.currentSpan().start },
+            );
         },
         // 음수 리터럴 타입: -1
         .minus => {
@@ -538,12 +536,7 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
     const span = self.currentSpan();
 
     // variance: +T (covariant) 또는 -T (contravariant)
-    var flags: u16 = 0;
-    if (self.current() == .plus) {
-        flags = 1; // covariant
-        try self.advance();
-    } else if (self.current() == .minus) {
-        flags = 2; // contravariant
+    if (self.current() == .plus or self.current() == .minus) {
         try self.advance();
     }
 
@@ -555,13 +548,9 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
     try self.advance(); // type param name
 
     // constraint: T: Type (Flow 클래식) 또는 T extends Type (Flow 최신, RN 0.76+)
-    var constraint = NodeIndex.none;
-    if (self.current() == .colon) {
+    if (self.current() == .colon or self.current() == .kw_extends) {
         try self.advance();
-        constraint = try parseType(self);
-    } else if (self.current() == .kw_extends) {
-        try self.advance();
-        constraint = try parseType(self);
+        _ = try parseType(self);
     }
 
     // default: T = Type
@@ -569,11 +558,10 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
         _ = try parseType(self); // default type (파싱만 하고 스킵)
     }
 
-    return try self.ast.addNode(.{
-        .tag = .flow_type_parameter,
-        .span = .{ .start = span.start, .end = self.currentSpan().start },
-        .data = .{ .unary = .{ .operand = constraint, .flags = flags } },
-    });
+    return try self.ast.addEmptyExtraNode(
+        .flow_type_parameter,
+        .{ .start = span.start, .end = self.currentSpan().start },
+    );
 }
 
 // ================================================================
@@ -1450,9 +1438,14 @@ pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
             _ = try self.eat(.comma);
         }
 
-        // arm: binary { left=pattern, right=body }
+        // arm: binary { left=pattern, right=body }. outer expr 는 extra layout
+        // (discriminant + arms_start + arms_len) 이지만 여기 arm 은 `.binary` 로
+        // 저장. transformer `visitFlowMatch` (transformer.zig:~1937) 가 각 arm 에서
+        // `data.binary.left` (pattern) / `data.binary.right` (body) 를 실제로 읽는다.
+        // audit 에 "cosmetic" 으로 나타나더라도 이 arm 의 저장은 유지 — `.extra` 로
+        // 치환하면 silent failure (#1797 류).
         const arm = try self.ast.addNode(.{
-            .tag = .flow_match_expression, // arm도 같은 태그 재사용 (구분은 위치로)
+            .tag = .flow_match_expression, // arm 도 같은 태그 재사용 (구분은 위치로)
             .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
             .data = .{ .binary = .{ .left = pattern, .right = body, .flags = 0 } },
         });

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -245,7 +245,16 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     {
         const next = try self.peekNextKind();
         if (next == .eq) {
-            // import-equals는 TS CJS 호환 구문 → module syntax로 취급하지 않음
+            // import-equals는 TS CJS 호환 구문 → module syntax로 취급하지 않음.
+            //
+            // NOTE: ts_import_equals_declaration 은 strip target 이 *아님* —
+            // `transformer.zig::visitImportEqualsDeclaration` (:2540) 이
+            // `data.binary.left` (name) 와 `data.binary.right` (value) 를 읽어
+            // `const F = require("x")` 런타임 코드로 변환한다. `getLayout` 이
+            // `.extra` 로 선언되어 있지만 실체 저장은 `.binary` 로 유지해야 한다
+            // (extern union offset aliasing). audit cosmetic 에 걸려도 절대 empty
+            // `.extra` 로 치환 금지 — #1802 B2 리뷰 시 실제로 이 사례가 뒤늦게
+            // surface 됨 (audit 이 codegen 만 스캔하고 transformer 는 안 봄).
             const name_span = self.currentSpan();
             try self.advance(); // skip name
             try self.advance(); // skip =

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -712,14 +712,12 @@ fn parseTypeOperatorOrHigher(self: *Parser) ParseError2!NodeIndex {
             const span = self.currentSpan();
             try self.advance(); // skip 'infer'
             // infer의 타입 파라미터 이름
-            const name_span = self.currentSpan();
             try self.advance(); // type param name
             // 선택적 constraint: infer T extends U (TS 4.7+)
             // oxc try_parse_constraint_of_infer_type 대응:
             // speculative 파싱으로 constraint 시도. extends 뒤에 타입을 파싱하되,
             // 외부가 disallow_conditional_types가 아닌데 ? 가 오면 rollback
             // (그 extends는 조건부 타입의 extends이므로 infer constraint가 아님)
-            var constraint = NodeIndex.none;
             if (self.current() == .kw_extends) {
                 const infer_saved = self.saveState();
                 const infer_err_count = self.errors.items.len;
@@ -727,24 +725,18 @@ fn parseTypeOperatorOrHigher(self: *Parser) ParseError2!NodeIndex {
                 // constraint 타입: parseType with disallow_conditional_types=true
                 const ctx_saved = self.ctx;
                 self.ctx.disallow_conditional_types = true;
-                constraint = try parseType(self);
+                _ = try parseType(self);
                 self.ctx = ctx_saved;
                 // 외부 컨텍스트가 disallow가 아닌데 ? 가 오면 → extends는 조건부 타입의 것
                 if (!ctx_saved.disallow_conditional_types and self.current() == .question) {
                     self.restoreState(infer_saved);
                     self.rollbackErrors(infer_err_count);
-                    constraint = NodeIndex.none;
                 }
             }
-            return try self.ast.addNode(.{
-                .tag = .ts_infer_type,
-                .span = .{ .start = span.start, .end = self.currentSpan().start },
-                .data = .{ .binary = .{ .left = try self.ast.addNode(.{
-                    .tag = .ts_type_parameter,
-                    .span = name_span,
-                    .data = .{ .unary = .{ .operand = constraint, .flags = 0 } },
-                }), .right = constraint, .flags = 0 } },
-            });
+            return try self.ast.addEmptyExtraNode(
+                .ts_infer_type,
+                .{ .start = span.start, .end = self.currentSpan().start },
+            );
         }
     }
 
@@ -769,21 +761,19 @@ fn parsePostfixType(self: *Parser) ParseError2!NodeIndex {
                 // 배열 타입: T[]
                 try self.advance(); // [
                 try self.advance(); // ]
-                base = try self.ast.addNode(.{
-                    .tag = .ts_array_type,
-                    .span = .{ .start = start, .end = self.currentSpan().start },
-                    .data = .{ .unary = .{ .operand = base, .flags = 0 } },
-                });
+                base = try self.ast.addEmptyExtraNode(
+                    .ts_array_type,
+                    .{ .start = start, .end = self.currentSpan().start },
+                );
             } else {
                 // 인덱스 접근 타입: T[K]
                 try self.advance(); // [
-                const index_type = try parseType(self);
+                _ = try parseType(self);
                 try self.expect(.r_bracket);
-                base = try self.ast.addNode(.{
-                    .tag = .ts_indexed_access_type,
-                    .span = .{ .start = start, .end = self.currentSpan().start },
-                    .data = .{ .binary = .{ .left = base, .right = index_type, .flags = 0 } },
-                });
+                base = try self.ast.addEmptyExtraNode(
+                    .ts_indexed_access_type,
+                    .{ .start = start, .end = self.currentSpan().start },
+                );
             }
         } else if (self.current() == .bang and !self.scanner.token.has_newline_before) {
             // JSDoc-style postfix !: `number!`
@@ -929,12 +919,11 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
             if (self.current() == .kw_import) {
                 return try parseImportType(self, span.start);
             }
-            const operand = try parseTypeReference(self);
-            return try self.ast.addNode(.{
-                .tag = .ts_type_query,
-                .span = .{ .start = span.start, .end = self.currentSpan().start },
-                .data = .{ .unary = .{ .operand = operand, .flags = 0 } },
-            });
+            _ = try parseTypeReference(self);
+            return try self.ast.addEmptyExtraNode(
+                .ts_type_query,
+                .{ .start = span.start, .end = self.currentSpan().start },
+            );
         },
         // import("module").Type
         .kw_import => return try parseImportType(self, span.start),
@@ -1104,12 +1093,11 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
         // 빈 괄호 + => → 함수 타입 () => R (tryParse에서 이미 처리되므로 여기 안 옴)
         if (self.current() == .arrow) {
             try self.advance();
-            const return_type = try parseTypeOrTypePredicate(self);
-            return try self.ast.addNode(.{
-                .tag = .ts_function_type,
-                .span = .{ .start = start, .end = self.currentSpan().start },
-                .data = .{ .unary = .{ .operand = return_type, .flags = 0 } },
-            });
+            _ = try parseTypeOrTypePredicate(self);
+            return try self.ast.addEmptyExtraNode(
+                .ts_function_type,
+                .{ .start = start, .end = self.currentSpan().start },
+            );
         }
         return try self.ast.addNode(.{ .tag = .ts_void_keyword, .span = .{ .start = start, .end = self.currentSpan().start }, .data = .{ .none = 0 } });
     }
@@ -1149,11 +1137,10 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
                 .data = .{ .extra = extra },
             });
         }
-        return try self.ast.addNode(.{
-            .tag = .ts_parenthesized_type,
-            .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .unary = .{ .operand = inner, .flags = 0 } },
-        });
+        return try self.ast.addEmptyExtraNode(
+            .ts_parenthesized_type,
+            .{ .start = start, .end = self.currentSpan().start },
+        );
     }
 
     if (self.current() == .r_paren) {
@@ -1165,11 +1152,10 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     // 괄호 타입: (Type)
     // 참고: (Type) => R 은 tryParseFunctionTypeWithBacktracking에서 처리됨.
     // 여기서는 => 를 소비하지 않는다.
-    return try self.ast.addNode(.{
-        .tag = .ts_parenthesized_type,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .unary = .{ .operand = inner, .flags = 0 } },
-    });
+    return try self.ast.addEmptyExtraNode(
+        .ts_parenthesized_type,
+        .{ .start = start, .end = self.currentSpan().start },
+    );
 }
 
 /// 함수 타입 파라미터로 파싱을 시도한다 (backtracking).
@@ -1188,12 +1174,11 @@ fn tryParseFunctionTypeWithBacktracking(self: *Parser, start: u32) ParseError2!?
         try self.advance();
         if (self.current() == .arrow) {
             try self.advance();
-            const return_type = try parseTypeOrTypePredicate(self);
-            return try self.ast.addNode(.{
-                .tag = .ts_function_type,
-                .span = .{ .start = start, .end = self.currentSpan().start },
-                .data = .{ .unary = .{ .operand = return_type, .flags = 0 } },
-            });
+            _ = try parseTypeOrTypePredicate(self);
+            return try self.ast.addEmptyExtraNode(
+                .ts_function_type,
+                .{ .start = start, .end = self.currentSpan().start },
+            );
         }
         // () 뒤에 => 없음 — 복원
         self.ast.nodes.items.len = nodes_before;
@@ -1248,7 +1233,6 @@ fn tryParseFunctionTypeWithBacktracking(self: *Parser, start: u32) ParseError2!?
     // esbuild: trySkipTypeScriptArrowArgsWithBacktracking에서
     // skipTypeScriptFnArgs가 `x)` 를 파라미터로 파싱하고 => 를 기대
     if (self.current() == .identifier or self.current().isKeyword()) {
-        const id_span = self.currentSpan();
         try self.advance(); // skip identifier
 
         // identifier 뒤에 바로 ) 가 오면 단일 무타입 파라미터
@@ -1257,17 +1241,11 @@ fn tryParseFunctionTypeWithBacktracking(self: *Parser, start: u32) ParseError2!?
             if (self.current() == .arrow) {
                 // 함수 타입 확정: (x) => R
                 try self.advance(); // skip =>
-                const return_type = try parseTypeOrTypePredicate(self);
-                const param_node = try self.ast.addNode(.{
-                    .tag = .ts_type_reference,
-                    .span = id_span,
-                    .data = .{ .string_ref = id_span },
-                });
-                return try self.ast.addNode(.{
-                    .tag = .ts_function_type,
-                    .span = .{ .start = start, .end = self.currentSpan().start },
-                    .data = .{ .binary = .{ .left = param_node, .right = return_type, .flags = 0 } },
-                });
+                _ = try parseTypeOrTypePredicate(self);
+                return try self.ast.addEmptyExtraNode(
+                    .ts_function_type,
+                    .{ .start = start, .end = self.currentSpan().start },
+                );
             }
         }
 
@@ -1433,16 +1411,15 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
         const next = try self.peekNextKind();
         if (isFollowedByTypeMemberName(next)) {
             try self.advance(); // skip 'get'
-            const key = try self.parsePropertyKey();
+            _ = try self.parsePropertyKey();
             // 파라미터 파싱 (getter는 파라미터 없어야 함)
             try self.expect(.l_paren);
             try self.expect(.r_paren);
-            const return_type = try tryParseReturnType(self);
-            return try self.ast.addNode(.{
-                .tag = .ts_getter_signature,
-                .span = .{ .start = start, .end = self.currentSpan().start },
-                .data = .{ .binary = .{ .left = key, .right = return_type, .flags = 0 } },
-            });
+            _ = try tryParseReturnType(self);
+            return try self.ast.addEmptyExtraNode(
+                .ts_getter_signature,
+                .{ .start = start, .end = self.currentSpan().start },
+            );
         }
     }
 
@@ -1451,17 +1428,16 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
         const next = try self.peekNextKind();
         if (isFollowedByTypeMemberName(next)) {
             try self.advance(); // skip 'set'
-            const key = try self.parsePropertyKey();
+            _ = try self.parsePropertyKey();
             // 파라미터 파싱 (setter는 파라미터 1개)
             try self.expect(.l_paren);
             _ = try parseTypeMemberParam(self);
             try self.expect(.r_paren);
-            const return_type = try tryParseReturnType(self);
-            return try self.ast.addNode(.{
-                .tag = .ts_setter_signature,
-                .span = .{ .start = start, .end = self.currentSpan().start },
-                .data = .{ .binary = .{ .left = key, .right = return_type, .flags = 0 } },
-            });
+            _ = try tryParseReturnType(self);
+            return try self.ast.addEmptyExtraNode(
+                .ts_setter_signature,
+                .{ .start = start, .end = self.currentSpan().start },
+            );
         }
     }
 
@@ -1496,20 +1472,18 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
 
     // 7. 프로퍼티 시그니처: key: Type
     if (try self.eat(.colon)) {
-        const value_type = try parseType(self);
-        return try self.ast.addNode(.{
-            .tag = .ts_property_signature,
-            .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = key, .right = value_type, .flags = if (is_readonly) @as(u2, 1) else 0 } },
-        });
+        _ = try parseType(self);
+        return try self.ast.addEmptyExtraNode(
+            .ts_property_signature,
+            .{ .start = start, .end = self.currentSpan().start },
+        );
     }
 
     // 타입 어노테이션 없는 프로퍼티 (예: interface에서 `foo;` 또는 `foo?;`)
-    return try self.ast.addNode(.{
-        .tag = .ts_property_signature,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .binary = .{ .left = key, .right = NodeIndex.none, .flags = if (is_readonly) @as(u2, 1) else 0 } },
-    });
+    return try self.ast.addEmptyExtraNode(
+        .ts_property_signature,
+        .{ .start = start, .end = self.currentSpan().start },
+    );
 }
 
 /// 콜/컨스트럭트 시그니처 공통 파싱
@@ -1670,16 +1644,15 @@ pub fn parseIndexSignature(self: *Parser, start: u32, is_readonly: bool) ParseEr
 
     // 파라미터: key: Type
     const param_start = self.currentSpan().start;
-    const param_name = try self.parsePropertyKey();
+    _ = try self.parsePropertyKey();
 
     // Error recovery — optional marker 에러 후 skip ([k?: T], [k?])
     if (self.current() == .question) {
         try self.addErrorCode(self.currentSpan(), "An index signature parameter cannot have a question mark", .ts_index_sig_optional);
         try self.advance();
     }
-    var param_type = NodeIndex.none;
     if (try self.eat(.colon)) {
-        param_type = try parseType(self);
+        _ = try parseType(self);
     }
     try self.expect(.r_bracket);
 
@@ -1689,12 +1662,12 @@ pub fn parseIndexSignature(self: *Parser, start: u32, is_readonly: bool) ParseEr
         value_type = try parseType(self);
     }
 
+    const prop_sig = try self.ast.addEmptyExtraNode(
+        .ts_property_signature,
+        .{ .start = param_start, .end = self.currentSpan().start },
+    );
     const extra = try self.ast.addExtras(&.{
-        @intFromEnum(try self.ast.addNode(.{
-            .tag = .ts_property_signature,
-            .span = .{ .start = param_start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = param_name, .right = param_type, .flags = 0 } },
-        })),
+        @intFromEnum(prop_sig),
         @intFromEnum(value_type),
         @as(u32, if (is_readonly) 1 else 0),
     });
@@ -1776,19 +1749,13 @@ fn parseTupleElementInner(self: *Parser) ParseError2!NodeIndex {
         if (is_labeled) {
             const name_span = self.currentSpan();
             try self.advance(); // skip name
-            const optional = try self.eat(.question);
+            _ = try self.eat(.question);
             try self.expect(.colon);
-            const ty = try parseType(self);
-            // flags: bit 0 = optional
-            return try self.ast.addNode(.{
-                .tag = .ts_named_tuple_member,
-                .span = .{ .start = name_span.start, .end = self.currentSpan().start },
-                .data = .{ .binary = .{ .left = try self.ast.addNode(.{
-                    .tag = .identifier_reference,
-                    .span = name_span,
-                    .data = .{ .none = 0 },
-                }), .right = ty, .flags = if (optional) 1 else 0 } },
-            });
+            _ = try parseType(self);
+            return try self.ast.addEmptyExtraNode(
+                .ts_named_tuple_member,
+                .{ .start = name_span.start, .end = self.currentSpan().start },
+            );
         }
     }
 
@@ -1882,7 +1849,7 @@ fn parseMappedType(self: *Parser) ParseError2!NodeIndex {
     } else {
         try self.addErrorCode(self.currentSpan(), "Expected 'in' in mapped type", .ts_mapped_type_in);
     }
-    const constraint = try parseType(self);
+    _ = try parseType(self); // constraint
     // 선택적 as 절: [K in T as NewKey]
     var name_type = NodeIndex.none;
     if (self.current() == .identifier and self.isContextual("as")) {
@@ -1908,12 +1875,9 @@ fn parseMappedType(self: *Parser) ParseError2!NodeIndex {
     _ = try self.eat(.semicolon);
     try self.expect(.r_curly);
 
+    const type_param_node = try self.ast.addEmptyExtraNode(.ts_type_parameter, param_span);
     const extra = try self.ast.addExtras(&.{
-        @intFromEnum(try self.ast.addNode(.{
-            .tag = .ts_type_parameter,
-            .span = param_span,
-            .data = .{ .unary = .{ .operand = constraint, .flags = 0 } },
-        })),
+        @intFromEnum(type_param_node),
         @intFromEnum(value_type),
         @intFromEnum(name_type),
     });
@@ -1930,7 +1894,7 @@ fn parseMappedType(self: *Parser) ParseError2!NodeIndex {
 fn parseImportType(self: *Parser, start: u32) ParseError2!NodeIndex {
     try self.advance(); // skip 'import'
     try self.expect(.l_paren);
-    const module_type = try parseType(self);
+    _ = try parseType(self); // module specifier
     // import attributes: import("module", { assert: { ... } })
     // 2번째 인자는 옵션 객체. 타입 스트리핑에서 제거되므로 파싱만 하고 버린다.
     if (try self.eat(.comma)) {
@@ -1938,11 +1902,10 @@ fn parseImportType(self: *Parser, start: u32) ParseError2!NodeIndex {
     }
     try self.expect(.r_paren);
     // 선택적 .member 접근
-    var result = try self.ast.addNode(.{
-        .tag = .ts_import_type,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .unary = .{ .operand = module_type, .flags = 0 } },
-    });
+    var result = try self.ast.addEmptyExtraNode(
+        .ts_import_type,
+        .{ .start = start, .end = self.currentSpan().start },
+    );
     // .Foo.Bar 체인
     while (self.current() == .dot) {
         try self.advance(); // skip .
@@ -2011,11 +1974,10 @@ fn parseTemplateLiteralType(self: *Parser) ParseError2!NodeIndex {
         }
     }
 
-    const types = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    _ = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     self.restoreScratch(scratch_top);
-    return try self.ast.addNode(.{
-        .tag = .ts_template_literal_type,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .list = types },
-    });
+    return try self.ast.addEmptyExtraNode(
+        .ts_template_literal_type,
+        .{ .start = start, .end = self.currentSpan().start },
+    );
 }

--- a/tests/integration/tests/tsc/ts-import-equals.test.ts
+++ b/tests/integration/tests/tsc/ts-import-equals.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from "bun:test";
+import { createFixture, runZts } from "../helpers";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// #1802 B2 리뷰 중 surface 된 케이스 회귀 방지.
+//
+// `ts_import_equals_declaration` 은 audit 스크립트에 "cosmetic" 으로 보이지만
+// (layout=.extra, parser stored=.binary), 실제로는 transformer 가
+// `data.binary.left/right` 를 읽어서 `const X = require("...")` 런타임 코드를
+// 생성한다 → strip target 이 아님. parser 를 empty `.extra` 로 바꾸면
+// silent failure (`const <none> = <none>` emit 또는 visitNode(.none) crash).
+//
+// audit 이 codegen 만 스캔하고 transformer 는 안 보는 한계 때문에 놓치기 쉬운
+// 케이스 — 통합 테스트로 고정.
+
+describe("TSC: import-equals declaration (#1802 follow-up)", () => {
+  test("import X = require('fs') emit 에서 binary.left(name) / binary.right(value) 보존", async () => {
+    // transformer 가 빈 `.extra` 를 받으면 `const <none> = <none>` 이 찍혀 emit 에
+    // `= require` 자체가 누락되거나 변수명이 사라진다. 이 테스트는 emit 문자열로
+    // 해당 silent failure 를 고정 (런타임 실행은 이후 Namespace 테스트가 커버).
+    const { dir, cleanup } = await createFixture({
+      "index.ts": `
+        import Fs = require("fs");
+        console.log(typeof Fs);
+      `,
+    });
+    const outFile = join(dir, "out.js");
+    const transpile = await runZts([join(dir, "index.ts"), "-o", outFile]);
+    expect(transpile.exitCode).toBe(0);
+
+    const out = readFileSync(outFile, "utf-8");
+    // 변수명 + require 호출 + specifier 모두 살아있어야 한다.
+    expect(out).toMatch(/(?:const|var)\s+Fs\s*=\s*require\s*\(\s*["']fs["']\s*\)/);
+    await cleanup();
+  });
+
+  test("import X = Namespace.Member → const X = Namespace.Member", async () => {
+    const { dir, cleanup } = await createFixture({
+      "index.ts": `
+        namespace NS {
+          export const value = 42;
+          export namespace Inner {
+            export const nested = 7;
+          }
+        }
+        import Root = NS;
+        import Deep = NS.Inner;
+        console.log(Root.value, Deep.nested);
+      `,
+    });
+    const outFile = join(dir, "out.js");
+    const transpile = await runZts([join(dir, "index.ts"), "-o", outFile]);
+    expect(transpile.exitCode).toBe(0);
+
+    const out = readFileSync(outFile, "utf-8");
+    // transformer 가 binary.left(name) / binary.right(value) 를 읽어 const 선언 생성.
+    // empty `.extra` 로 치환되면 `const <none> = <none>` 또는 crash.
+    expect(out).toContain("Root");
+    expect(out).toContain("Deep");
+    expect(out).toContain("NS.Inner");
+    await cleanup();
+  });
+
+  test("import X = require('fs') 가 ESM import 가 아닌 const 로 emit", async () => {
+    const { dir, cleanup } = await createFixture({
+      "index.ts": `
+        import Fs = require("fs");
+        console.log(typeof Fs);
+      `,
+    });
+    const outFile = join(dir, "out.js");
+    const transpile = await runZts([join(dir, "index.ts"), "-o", outFile]);
+    expect(transpile.exitCode).toBe(0);
+
+    const out = readFileSync(outFile, "utf-8");
+    // TS CJS 호환 구문이라 ESM import 로 변환되면 안 된다.
+    expect(out).not.toContain('import Fs from "fs"');
+    // const 선언 + require 호출이 있어야 한다.
+    expect(out).toMatch(/(?:const|var)\s+Fs\s*=/);
+    expect(out).toMatch(/require\s*\(\s*["']fs["']\s*\)/);
+    await cleanup();
+  });
+});


### PR DESCRIPTION
## Summary

#1802 의 3번째 PR. TS/Flow strip-target tag 24건의 parser 저장을 `getLayout` 정의와 일치하도록 empty `.extra` 로 통일. 리뷰 과정에서 **audit false-negative 2건을 surface 하고 보호 장치 추가**.

- audit cosmetic **40 → 17** (-23)
- `Ast.addEmptyExtraNode(tag, span)` typed helper 추가 (22+ 사이트 정리)
- 회귀 테스트 3건 추가 (ts-import-equals)

## 주요 변경

### 1. strip-target 24건 → empty `.extra`

`layout = .extra, child_offsets = &.{}` 지만 parser 가 `.unary/.binary/.list/.string_ref` 저장하던 tag 들. codegen/transformer/semantic 이 data 를 읽지 않음을 확인 후 empty `.extra` 로 통일. parse 부수효과는 `_ = try ...` 로 보존.

### 2. `Ast.addEmptyExtraNode(tag, span)` helper

22+ 사이트의 `addExtras(&.{}) → local → addExtraNode(..., local)` 3줄 패턴 → 1줄. `assertDataKind(tag, .extra)` 가 Debug build 에서 오용 차단. empty addExtras 는 zero-alloc (`ensureUnusedCapacity(0)` no-op).

### 3. **audit false-negative 2건 — revert + 경고 주석**

/simplify 리뷰 agent 가 발견한 중요 사례. audit 이 codegen 만 스캔하고 transformer data access 는 스캔하지 않는 한계로 "cosmetic" 으로 나타나지만 실제로는 transformer 가 `data.binary` 를 읽는 tag:

**`ts_import_equals_declaration`** (module.zig:246):
- transformer `visitImportEqualsDeclaration` 이 `data.binary.left` (name) / `.right` (value) 를 읽어 `const F = require(\"x\")` 런타임 코드 생성.
- agent 가 일괄 변환 시도 → PR 리뷰 중 발견 → revert.
- #1797-class silent failure 직전 차단.

**`flow_match_expression` arm** (flow.zig:1441):
- outer expression 은 `.extra` 지만 arm 노드가 같은 tag 재사용하며 `.binary` 저장.
- transformer `visitFlowMatch` 가 각 arm 에서 pattern/body 읽음.

두 사이트 모두 \"DO NOT convert to empty extra\" 경고 + transformer 읽기 경로 파일:라인 reference 주석 추가.

### 4. 회귀 테스트: `tsc/ts-import-equals.test.ts` (3건)

1. `import Fs = require(\"fs\")` emit 에서 `const Fs = require(\"fs\")` 형태 보존
2. `import Root = NS` / `import Deep = NS.Inner` namespace 참조 체인 보존
3. ESM import 로 잘못 변환되지 않는지 negative check

audit 이 놓친 silent failure 를 통합 테스트로 고정.

## Cross-file 검증

24 strip-target tag 모두 consumer 에서 data 접근 없음 수기 확인:
- `codegen.zig` — arm 없거나 tag predicate only
- `transformer.zig` — `isTypeOnlyNode` / `isTypeOnlyDeclaration` tag predicate only
- `semantic/analyzer.zig` — 동일

## /simplify 리뷰 반영

- **reuse**: `addEmptyExtraNode` helper 도입 (22× 반복 패턴)
- **quality**: `ts_import_equals_declaration` revert (agent 발견), 경고 주석 강화
- **efficiency**: empty addExtras zero-alloc 확인, `ts_infer_type` 내부 dead node 제거 (net win)

## Test plan

- [x] `bun scripts/audit_addnode_variants.ts`: 40 → 17 cosmetic, REAL 0
- [x] `zig build test`: 3647/3647 green
- [x] `bun test tests/downlevel*.test.ts tests/tsc/*.test.ts tests/bundle-smoke.test.ts`: 2664/2664 green

## 남은 작업

- **PR C** (list 정규화, 11건): `template_literal`, `ts_union/intersection_type`, `flow_union/intersection_type`, `flow_exact_object_type`, `flow_tuple_type`, `flow_type_parameter_declaration/instantiation`, `ts_template_literal_type`
- **특수 2건**: `parenthesized_expression`, `import_attribute`
- **audit 확장**: transformer/semantic data access 도 스캔 — false-negative 방지

Part of #1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)