### PR TITLE
refactor(ast): cosmetic 카테고리 C — list 정규화 (11/17) (#1802)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -558,6 +558,10 @@ pub const Node = struct {
                 // ts_module_declaration: binary = { left=name, right=body_or_inner, flags }
                 // codegen::emitNamespaceIIFEInner 가 data.binary.left/right 를 읽는다.
                 .ts_module_declaration,
+                // ts_import_equals_declaration: binary = { left=name, right=value, flags }
+                // transformer::visitImportEqualsDeclaration 가 data.binary.left/right
+                // 를 읽어 `const X = require(...)` 런타임 코드로 변환한다.
+                .ts_import_equals_declaration,
                 => .{ .kind = .binary },
 
                 // === ternary ===
@@ -676,7 +680,6 @@ pub const Node = struct {
                 .ts_getter_signature,
                 .ts_setter_signature,
                 .ts_enum_declaration,
-                .ts_import_equals_declaration,
                 .ts_external_module_reference,
                 .ts_export_assignment,
                 .ts_namespace_export_declaration,

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1021,11 +1021,13 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                 else blk: {
                     const tmpl_span = self.currentSpan();
                     try self.advance();
-                    break :blk try self.ast.addNode(.{
-                        .tag = .template_literal,
-                        .span = tmpl_span,
-                        .data = .{ .none = 0 },
-                    });
+                    // no-substitution template — text 는 span 에서 직접 읽으므로
+                    // 자식 리스트는 비어 있다. layout=.list 에 맞춰 빈 NodeList 저장.
+                    break :blk try self.ast.addListNode(
+                        .template_literal,
+                        tmpl_span,
+                        .{ .start = 0, .len = 0 },
+                    );
                 };
                 {
                     const te = try self.ast.addExtras(&.{ @intFromEnum(expr), @intFromEnum(tmpl), 0 });
@@ -1494,11 +1496,13 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                 try self.addErrorCode(span, "Invalid escape sequence in template literal", .template_invalid_escape);
             }
             try self.advance();
-            return try self.ast.addNode(.{
-                .tag = .template_literal,
-                .span = span,
-                .data = .{ .none = 0 },
-            });
+            // no-substitution template — text 는 span 에서 직접 읽으므로
+            // 자식 리스트는 비어 있다. layout=.list 에 맞춰 빈 NodeList 저장.
+            return try self.ast.addListNode(
+                .template_literal,
+                span,
+                .{ .start = 0, .len = 0 },
+            );
         },
         .template_head => {
             // 보간 있는 템플릿 리터럴: `text${expr}...`

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -124,40 +124,50 @@ pub fn parseType(self: *Parser) ParseError2!NodeIndex {
 /// 선행 | 허용: | A | B
 fn parseUnionType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .pipe) try self.advance();
-    var left = try parseIntersectionType(self);
+    const first = try parseIntersectionType(self);
+    if (self.current() != .pipe) return first;
 
+    // `A | B | C` — flat NodeList 로 저장 (layout=.list).
+    const scratch_top = self.saveScratch();
+    defer self.restoreScratch(scratch_top);
+    try self.scratch.append(self.allocator, first);
+    const start = self.ast.getNode(first).span.start;
     while (self.current() == .pipe) {
-        const start = self.ast.getNode(left).span.start;
         try self.advance();
-        const right = try parseIntersectionType(self);
-        left = try self.ast.addNode(.{
-            .tag = .flow_union_type,
-            .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = left, .right = right, .flags = 0 } },
-        });
+        const next = try parseIntersectionType(self);
+        try self.scratch.append(self.allocator, next);
     }
-
-    return left;
+    const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    return try self.ast.addListNode(
+        .flow_union_type,
+        .{ .start = start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
 /// Intersection 타입: A & B & C
 /// 선행 & 허용: & A & B
 fn parseIntersectionType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .amp) try self.advance();
-    var left = try parsePrefixType(self);
+    const first = try parsePrefixType(self);
+    if (self.current() != .amp) return first;
 
+    // `A & B & C` — flat NodeList 로 저장 (layout=.list).
+    const scratch_top = self.saveScratch();
+    defer self.restoreScratch(scratch_top);
+    try self.scratch.append(self.allocator, first);
+    const start = self.ast.getNode(first).span.start;
     while (self.current() == .amp) {
-        const start = self.ast.getNode(left).span.start;
         try self.advance();
-        const right = try parsePrefixType(self);
-        left = try self.ast.addNode(.{
-            .tag = .flow_intersection_type,
-            .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = left, .right = right, .flags = 0 } },
-        });
+        const next = try parsePrefixType(self);
+        try self.scratch.append(self.allocator, next);
     }
-
-    return left;
+    const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    return try self.ast.addListNode(
+        .flow_intersection_type,
+        .{ .start = start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
 // ================================================================
@@ -486,13 +496,13 @@ pub fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
 
     try self.expectClosingAngleBracket();
     const items = self.scratch.items[scratch_top..];
-    const extra = try self.ast.addNodeList(items);
+    const list = try self.ast.addNodeList(items);
     self.scratch.shrinkRetainingCapacity(scratch_top);
-    return try self.ast.addNode(.{
-        .tag = .flow_type_parameter_instantiation,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .extra = extra.start },
-    });
+    return try self.ast.addListNode(
+        .flow_type_parameter_instantiation,
+        .{ .start = start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
 /// 타입 인자 (식 컨텍스트, speculative).
@@ -522,13 +532,13 @@ pub fn parseTypeParameterDeclaration(self: *Parser) ParseError2!NodeIndex {
 
     try self.expectClosingAngleBracket();
     const items = self.scratch.items[scratch_top..];
-    const extra = try self.ast.addNodeList(items);
+    const list = try self.ast.addNodeList(items);
     self.scratch.shrinkRetainingCapacity(scratch_top);
-    return try self.ast.addNode(.{
-        .tag = .flow_type_parameter_declaration,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .extra = extra.start },
-    });
+    return try self.ast.addListNode(
+        .flow_type_parameter_declaration,
+        .{ .start = start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
 /// 개별 타입 파라미터: T, T: SuperType, T = DefaultType, +T, -T
@@ -775,11 +785,12 @@ fn parseExactObjectType(self: *Parser) ParseError2!NodeIndex {
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
 
-    return try self.ast.addNode(.{
-        .tag = .flow_exact_object_type,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .none = 0 },
-    });
+    // strip-only — 내부 멤버는 파싱 후 버리므로 빈 NodeList 저장 (layout=.list).
+    return try self.ast.addListNode(
+        .flow_exact_object_type,
+        .{ .start = start, .end = self.currentSpan().start },
+        .{ .start = 0, .len = 0 },
+    );
 }
 
 // ================================================================
@@ -802,13 +813,13 @@ fn parseTupleType(self: *Parser) ParseError2!NodeIndex {
 
     try self.expect(.r_bracket);
     const items = self.scratch.items[scratch_top..];
-    const extra = try self.ast.addNodeList(items);
+    const list = try self.ast.addNodeList(items);
     self.scratch.shrinkRetainingCapacity(scratch_top);
-    return try self.ast.addNode(.{
-        .tag = .flow_tuple_type,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .extra = extra.start },
-    });
+    return try self.ast.addListNode(
+        .flow_tuple_type,
+        .{ .start = start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
 // ================================================================

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -247,14 +247,11 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
         if (next == .eq) {
             // import-equals는 TS CJS 호환 구문 → module syntax로 취급하지 않음.
             //
-            // NOTE: ts_import_equals_declaration 은 strip target 이 *아님* —
+            // ts_import_equals_declaration 은 strip target 이 *아님* —
             // `transformer.zig::visitImportEqualsDeclaration` (:2540) 이
             // `data.binary.left` (name) 와 `data.binary.right` (value) 를 읽어
-            // `const F = require("x")` 런타임 코드로 변환한다. `getLayout` 이
-            // `.extra` 로 선언되어 있지만 실체 저장은 `.binary` 로 유지해야 한다
-            // (extern union offset aliasing). audit cosmetic 에 걸려도 절대 empty
-            // `.extra` 로 치환 금지 — #1802 B2 리뷰 시 실제로 이 사례가 뒤늦게
-            // surface 됨 (audit 이 codegen 만 스캔하고 transformer 는 안 봄).
+            // `const F = require("x")` 런타임 코드로 변환한다. layout=`.binary`
+            // (ast.zig getLayout) 와 일치.
             const name_span = self.currentSpan();
             try self.advance(); // skip name
             try self.advance(); // skip =

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -641,40 +641,49 @@ pub fn parseType(self: *Parser) ParseError2!NodeIndex {
 fn parseUnionType(self: *Parser) ParseError2!NodeIndex {
     // 선행 | 허용: | A | B (oxc L247)
     if (self.current() == .pipe) try self.advance();
-    var left = try parseIntersectionType(self);
+    const first = try parseIntersectionType(self);
+    if (self.current() != .pipe) return first;
 
+    // `A | B | C` — flat NodeList 로 저장 (layout=.list).
+    const scratch_top = self.saveScratch();
+    defer self.restoreScratch(scratch_top);
+    try self.scratch.append(self.allocator, first);
+    const start = self.ast.getNode(first).span.start;
     while (self.current() == .pipe) {
-        const start = self.ast.getNode(left).span.start;
         try self.advance();
-        const right = try parseIntersectionType(self);
-        left = try self.ast.addNode(.{
-            .tag = .ts_union_type,
-            .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = left, .right = right, .flags = 0 } },
-        });
+        const next = try parseIntersectionType(self);
+        try self.scratch.append(self.allocator, next);
     }
-
-    return left;
+    const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    return try self.ast.addListNode(
+        .ts_union_type,
+        .{ .start = start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
 fn parseIntersectionType(self: *Parser) ParseError2!NodeIndex {
     // 선행 & 허용: & A & B
     if (self.current() == .amp) try self.advance();
-    var left = try parseTypeOperatorOrHigher(self);
+    const first = try parseTypeOperatorOrHigher(self);
+    if (self.current() != .amp) return first;
 
-    // 인터섹션: A & B & C
+    // `A & B & C` — flat NodeList 로 저장 (layout=.list).
+    const scratch_top = self.saveScratch();
+    defer self.restoreScratch(scratch_top);
+    try self.scratch.append(self.allocator, first);
+    const start = self.ast.getNode(first).span.start;
     while (self.current() == .amp) {
-        const start = self.ast.getNode(left).span.start;
         try self.advance(); // skip &
-        const right = try parseTypeOperatorOrHigher(self);
-        left = try self.ast.addNode(.{
-            .tag = .ts_intersection_type,
-            .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = left, .right = right, .flags = 0 } },
-        });
+        const next = try parseTypeOperatorOrHigher(self);
+        try self.scratch.append(self.allocator, next);
     }
-
-    return left;
+    const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    return try self.ast.addListNode(
+        .ts_intersection_type,
+        .{ .start = start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
 /// oxc parse_type_operator_or_higher: keyof/unique/readonly/infer → postfix


### PR DESCRIPTION
## Summary

#1802 의 4번째 PR. `getLayout=.list` 로 선언됐지만 parser 가 다른 variant 로 저장하던 9건을 `addListNode` 로 통일하고, `ts_import_equals_declaration` 는 `getLayout` 을 `.binary` 로 옮겨 reader 와 일치. **audit cosmetic 17 → 6 (-11), REAL 0 유지**.

## 변경 대상

### A. Parser → `.list` 통일 (9건)

**chain → flat NodeList 전환** (4건):
- `ts_union_type` / `ts_intersection_type` (ts.zig:641, 660) — `((A|B)|C)|D` binary tree → flat `[A,B,C,D]`. 단일 operand 는 래핑 없이 직접 반환 (fast path 보존).
- `flow_union_type` / `flow_intersection_type` (flow.zig:125, 145) — 동일 패턴.

**`.extra = start` (len 분실) → 제대로 된 NodeList** (3건, latent bug fix):
- `flow_type_parameter_instantiation` (flow.zig:486)
- `flow_type_parameter_declaration` (flow.zig:522)
- `flow_tuple_type` (flow.zig:790)

parser 가 이미 scratch 로 children 을 수집하고 있었는데 저장할 때 `.data = .{ .extra = extra.start }` 로 `.len` 을 **완전히 잃고** 있었다. 현재 consumer (`transformer::isFlowTypeNode`) 가 `data.list.len` 을 읽지 않아 **dead-code bug** 로 드러나지 않았지만 type strip 이 아닌 다른 용도가 생기는 순간 silent failure. 이번에 `addListNode` 로 전환하며 교정.

**empty NodeList 저장** (2건):
- `template_literal` (expression.zig:1024, 1497) — no-substitution 사이트. text 는 span 에서 직접 추출하므로 자식 리스트 빈 채.
- `flow_exact_object_type` (flow.zig:755) — strip-only.

### B. Layout 이동 1건

- `ts_import_equals_declaration`: `getLayout` 을 `.extra` → `.binary` 로 이동. transformer `visitImportEqualsDeclaration` 이 이미 `data.binary.left/right` 를 읽고 parser 도 `.binary` 저장 중이라 layout 만 현실화. module.zig 의 `#1802 B2` 당시 추가된 긴 경고 주석은 축약 (이제 layout 자체가 self-documenting).

## 정당성

전환 대상 tag 모두 **strip-only** (transformer::isTypeOnlyDeclaration / isFlowTypeNode 에 나열된 tag). chain→flat 변경이 외부 semantic 에 영향 없음 확인. 기존 `feedback_flow_independent_tags` 에 따라 flow_/ts_ 독립 helper 유지 (공통 chain-to-list helper 추출은 하지 않음 — follow-up 후보).

## /simplify 리뷰 반영 (findings 없음)

- **reuse**: `NodeList.empty` constant 는 코드베이스에 없고 다른 13+ 사이트에서도 `.{ .start = 0, .len = 0 }` literal 사용 중 → 일관성 위해 별도 follow-up 이슈로 남김.
- **quality**: latent bug (flow_type_parameter_* len 분실) 발견. 현재 dead-code 이지만 fix 유지.
- **efficiency**: chain→list 는 net memory 감소 (N operand = N-1 Node 절약, 대신 N u32 extra_data).

## Test plan

- [x] `bun scripts/audit_addnode_variants.ts`: 17 → **6 cosmetic**, REAL 0 유지
- [x] `zig build test`: 3647/3647 green
- [x] `bun test tests/tsc/*.test.ts tests/downlevel*.test.ts tests/bundle-smoke.test.ts`: 2658 pass / 0 fail

## 남은 cosmetic 6건 (special case)

- `parenthesized_expression` (unary stored=none, audit noise)
- `flow_match_expression` (dual-site tag reuse — outer extra + arm binary)
- `import_attribute` (leaf stored=binary)
- `ts_rest_type` / `ts_property_signature` (shared-line 감지)
- `ts_type_alias_declaration` (transformer_test.zig 테스트 fixture)

→ 각각 개별 조사 필요 (다음 PR 에서).

Part of #1802 (전체 close 는 마지막 PR 에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)