### PR TITLE
refactor(ast): cosmetic 카테고리 special — layout/parser 세부 정리 (6/1) (#1802)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -451,7 +451,6 @@ pub const Node = struct {
                 .assignment_target_identifier,
                 .import_default_specifier,
                 .import_namespace_specifier,
-                .import_attribute,
                 .jsx_empty_expression,
                 .jsx_text,
                 .jsx_identifier,
@@ -562,6 +561,10 @@ pub const Node = struct {
                 // transformer::visitImportEqualsDeclaration 가 data.binary.left/right
                 // 를 읽어 `const X = require(...)` 런타임 코드로 변환한다.
                 .ts_import_equals_declaration,
+                // import_attribute: binary = { left=key, right=value, flags }
+                // ESM `import ... with { type: "json" }` 의 각 attr. key/value 가
+                // 실존하므로 leaf 가 아닌 binary layout.
+                .import_attribute,
                 => .{ .kind = .binary },
 
                 // === ternary ===

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1377,14 +1377,15 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
 
             try self.advance(); // skip (
 
-            // 빈 괄호: () → arrow function의 빈 파라미터 리스트
+            // 빈 괄호: () → arrow function의 빈 파라미터 리스트 (operand 없음).
             if (self.current() == .r_paren) {
                 try self.advance(); // skip )
-                return try self.ast.addNode(.{
-                    .tag = .parenthesized_expression,
-                    .span = .{ .start = span.start, .end = self.currentSpan().start },
-                    .data = .{ .none = 0 },
-                });
+                return try self.ast.addUnaryNode(
+                    .parenthesized_expression,
+                    .{ .start = span.start, .end = self.currentSpan().start },
+                    .none,
+                    0,
+                );
             }
 
             // `(a, ...b) => {}` 형태의 rest 파라미터를 cover grammar으로 지원.

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -13,7 +13,9 @@ const ast_mod = @import("ast.zig");
 const Node = ast_mod.Node;
 const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
-const Kind = @import("../lexer/token.zig").Kind;
+const token_mod = @import("../lexer/token.zig");
+const Kind = token_mod.Kind;
+const Span = token_mod.Span;
 
 /// TS 키워드 타입 이름 → AST Tag 매핑 (parsePrimaryType에서 사용)
 const ts_type_keywords = std.StaticStringMap(Tag).initComptime(.{
@@ -1558,18 +1560,14 @@ fn parseTypeMemberParam(self: *Parser) ParseError2!NodeIndex {
 
     // this 파라미터: this: Type
     // destructuring: [a, b]: Type, {x, y}: Type
-    const name = if (self.current() == .kw_this) blk: {
-        const this_span = self.currentSpan();
+    // 결과 NodeIndex 는 strip-only 대상이라 소비처 없음 — parser 진행용 부수효과만.
+    if (self.current() == .kw_this) {
         try self.advance();
-        break :blk try self.ast.addNode(.{
-            .tag = .this_expression,
-            .span = this_span,
-            .data = .{ .none = 0 },
-        });
-    } else if (self.current() == .l_bracket or self.current() == .l_curly)
-        try self.parseBindingName()
-    else
-        try self.parsePropertyKey();
+    } else if (self.current() == .l_bracket or self.current() == .l_curly) {
+        _ = try self.parseBindingName();
+    } else {
+        _ = try self.parsePropertyKey();
+    }
 
     _ = try self.eat(.question); // optional
     var type_ann = NodeIndex.none;
@@ -1581,12 +1579,16 @@ fn parseTypeMemberParam(self: *Parser) ParseError2!NodeIndex {
         _ = try self.parseAssignmentExpression();
     }
 
-    const tag: Tag = if (is_rest) .ts_rest_type else .ts_property_signature;
-    return try self.ast.addNode(.{
-        .tag = tag,
-        .span = .{ .start = param_start, .end = self.currentSpan().start },
-        .data = .{ .binary = .{ .left = name, .right = type_ann, .flags = 0 } },
-    });
+    // 두 tag 의 layout 이 다름:
+    //   ts_rest_type         = .unary (operand = rest 대상 타입)
+    //   ts_property_signature = .extra (strip-only; empty)
+    // 공통 NodeIndex 조합 (`name`/`type_ann`) 을 읽는 consumer 는 없으므로
+    // 각 layout 에 맞춰 분기 — audit cosmetic mismatch 해소.
+    const member_span: Span = .{ .start = param_start, .end = self.currentSpan().start };
+    if (is_rest) {
+        return try self.ast.addUnaryNode(.ts_rest_type, member_span, type_ann, 0);
+    }
+    return try self.ast.addEmptyExtraNode(.ts_property_signature, member_span);
 }
 
 /// Index signature 파라미터 앞에 올 수 있는 modifier 토큰 (error recovery 용).

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -41,12 +41,11 @@ test "Transformer: strip type alias declaration" {
     var old_ast = Ast.init(std_lib.testing.allocator, "type Foo = string;");
     defer old_ast.deinit();
 
-    // type alias node
-    const type_node = try old_ast.addNode(.{
-        .tag = .ts_type_alias_declaration,
-        .span = .{ .start = 0, .end = 18 },
-        .data = .{ .none = 0 },
-    });
+    // type alias node — layout=.extra (strip-target, empty children)
+    const type_node = try old_ast.addEmptyExtraNode(
+        .ts_type_alias_declaration,
+        .{ .start = 0, .end = 18 },
+    );
 
     const list = try old_ast.addNodeList(&.{type_node});
     _ = try old_ast.addNode(.{


### PR DESCRIPTION
## Summary

#1802 다섯 번째 PR. list 정규화 (PR C) 외 잔여 cosmetic 6건 중 **5건 해소**, dual-site tag reuse 1건만 유지.

cosmetic **6 → 1**, REAL 0.

## 변경

- **parenthesized_expression** (expression.zig): 빈 `()` 에서 `.none` → `addUnaryNode(..., operand=.none)`. layout `.unary` 와 일치.
- **import_attribute** (ast.zig): parser 가 이미 `.binary = { key, value }` 저장 중. layout 을 `.leaf` → `.binary` 로 이동. parser 변경 없음.
- **ts_rest_type + ts_property_signature** (ts.zig:parseTypeMemberParam): 동일 addNode 에서 두 tag 가 다른 layout 을 공유하는 bug → 두 갈래 분기.
  - ts_rest_type (layout=.unary): `addUnaryNode` with operand=type_ann
  - ts_property_signature (layout=.extra): `addEmptyExtraNode`
  - strip-only 대상이라 `name` 지역변수 drop. `this` 케이스도 `this_expression` 생성 제거 → param 당 -1 Node.
- **ts_type_alias_declaration** (transformer_test.zig): test fixture 를 `addEmptyExtraNode` 로 정정.
- **ts.zig imports**: `token_mod` alias 로 재구성 (Span 필요).

## Cross-file 검증 (/simplify 리뷰)

- ts_rest_type / ts_property_signature 둘 다 transformer 의 `isTypeOnlyDeclaration()` strip list. semantic analyzer 는 `ast_walk.children` 로 layout-driven 순회 — 새 layout 모두 올바르게 동작.
- import_attribute: parser 이미 binary 저장, layout 만 이동 → downstream 영향 없음.

## 남은 1건 (의도된 exemption)

**flow_match_expression** (flow.zig:1458) — **dual-site tag reuse**. outer expression 은 `.extra` (discriminant + arms 리스트), 각 arm 은 `.binary` (pattern + body) 로 같은 tag 재사용. 단일 layout 선택 불가이므로 cosmetic 으로 남기고 #1816 에서 추가된 주석으로 경고.

다음 PR 에서 CI fail-gate 도입 시 이 1건 예외 처리 (화이트리스트 또는 별도 audit 스크립트 옵션).

## Test plan

- [x] `bun scripts/audit_addnode_variants.ts`: 6 → 1 cosmetic, **REAL 0**
- [x] `zig build test`: 3647/3647 green
- [x] `bun test tests/tsc/*.test.ts tests/downlevel*.test.ts tests/bundle-smoke.test.ts`: 2664/2664 green

Part of #1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)