### PR TITLE
chore(ci): #1802 최종 close — --strict-cosmetic CI fail-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,17 +67,17 @@ jobs:
         run: zig fmt --check src/
 
       # #1797 follow-up — AST Tag↔variant mismatch static audit.
-      # Detects #1797 class silent failures (codegen reads `data.X` while
-      # parser stores a different variant). Exits non-zero on real mismatch.
-      # Cosmetic mismatches (layout-only) are reported but not fatal yet
-      # — tracked in #1802.
+      # Detects #1797 class silent failures (readers consume `data.X` while
+      # parser stores a different variant). --strict-cosmetic (#1802) 도
+      # 활성 — 의도된 exemption (COSMETIC_EXEMPT_TAGS) 외 모든 layout
+      # mismatch 를 CI fail 로 승격.
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Audit AST addNode variants (#1797)
-        run: bun scripts/audit_addnode_variants.ts
+      - name: Audit AST addNode variants (#1797, #1802)
+        run: bun scripts/audit_addnode_variants.ts --strict-cosmetic
 
   napi:
     name: NAPI Build & Test

--- a/scripts/audit_addnode_variants.ts
+++ b/scripts/audit_addnode_variants.ts
@@ -50,6 +50,17 @@ const LEAF_VARIANTS = new Set(["none", "string_ref", "number_bytes"]);
 const KINDS = new Set(["leaf", "unary", "binary", "ternary", "list", "extra"]);
 const ALL_DATA_VARIANTS = new Set([...LEAF_VARIANTS, "unary", "binary", "ternary", "list", "extra"]);
 
+/**
+ * cosmetic fail-gate 예외 — `--strict-cosmetic` 모드에서 허용되는 의도된 mismatch.
+ *
+ * - `flow_match_expression`: outer expression 은 `.extra` (discriminant + arms
+ *   list), 각 arm 은 `.binary` (pattern + body) 로 **동일 tag 를 dual-site 재사용**.
+ *   transformer `visitFlowMatch` 가 두 구조를 모두 읽는다. 단일 layout 선택
+ *   불가능. 해결책은 arm tag 를 분리 (예: `flow_match_arm`) 하는 것이나
+ *   audit 정리 범위 밖.
+ */
+const COSMETIC_EXEMPT_TAGS = new Set(["flow_match_expression"]);
+
 
 function findMatchingBrace(text: string, openIdx: number): number {
 	let depth = 0;
@@ -428,6 +439,7 @@ function walk(dir: string): string[] {
 
 function main(): number {
 	const verbose = process.argv.includes("--verbose") || process.argv.includes("-v");
+	const strictCosmetic = process.argv.includes("--strict-cosmetic");
 	const layout = parseLayoutTable(readFileSync(AST_FILE, "utf8"));
 	const readerFiles = DATA_READER_DIRS.flatMap((d) => walk(d));
 	const dataReads = analyzeDataReaders(readerFiles);
@@ -489,19 +501,40 @@ function main(): number {
 		}
 	}
 
-	if (real.length === 0) {
-		console.log("\n✓ 0 REAL mismatches (#1797 class silent failures)");
-		return 0;
+	if (real.length > 0) {
+		console.log(`\n✗ ${real.length} REAL mismatch(es):\n`);
+		for (const { path, lineNo, tag, variant, expected, reads } of real) {
+			const rel = relative(ROOT, path);
+			const readsS = Array.from(reads).sort().join(", ");
+			console.log(`  ${rel}:${lineNo}`);
+			console.log(`    tag=.${tag}  stored=.${variant}  layout=.${expected}  readers use: {${readsS}}`);
+		}
+		return 1;
 	}
+	console.log("\n✓ 0 REAL mismatches (#1797 class silent failures)");
 
-	console.log(`\n✗ ${real.length} REAL mismatch(es):\n`);
-	for (const { path, lineNo, tag, variant, expected, reads } of real) {
-		const rel = relative(ROOT, path);
-		const readsS = Array.from(reads).sort().join(", ");
-		console.log(`  ${rel}:${lineNo}`);
-		console.log(`    tag=.${tag}  stored=.${variant}  layout=.${expected}  readers use: {${readsS}}`);
+	// --strict-cosmetic: #1802 최종 gate — 의도된 예외 (`COSMETIC_EXEMPT_TAGS`)
+	// 를 제외한 cosmetic 이 0 이어야 한다. 신규 PR 이 cosmetic mismatch 를
+	// 도입하면 CI 실패.
+	if (strictCosmetic) {
+		const unexpected = cosmeticList.filter((m) => !COSMETIC_EXEMPT_TAGS.has(m.tag));
+		if (unexpected.length > 0) {
+			console.log(
+				`\n✗ --strict-cosmetic: ${unexpected.length} unexempted cosmetic mismatch(es) — ` +
+					`add to COSMETIC_EXEMPT_TAGS only with justification.`,
+			);
+			for (const { path, lineNo, tag, variant, expected } of unexpected) {
+				console.log(`  ${relative(ROOT, path)}:${lineNo}  tag=.${tag}  stored=.${variant}  layout=.${expected}`);
+			}
+			return 1;
+		}
+		const exemptCount = cosmeticList.length;
+		console.log(
+			`✓ --strict-cosmetic: 0 unexempted cosmetic (${exemptCount} exempted by design: ` +
+				`${Array.from(COSMETIC_EXEMPT_TAGS).join(", ")})`,
+		);
 	}
-	return 1;
+	return 0;
 }
 
 process.exit(main());


### PR DESCRIPTION
## Summary

#1802 이슈 본문 최종 목표 — \"audit 스크립트의 cosmetic count 도 CI fail 로 승격\" — 실행. 이 PR 머지 시 **#1802 close**.

## 변경

### audit 스크립트

1. `COSMETIC_EXEMPT_TAGS` 상수 — 해결 불가능한 의도된 mismatch 화이트리스트.
   - **현재 1 entry**: `flow_match_expression` (outer=.extra, arm=.binary dual-site tag reuse — 단일 layout 선택 불가).
2. `--strict-cosmetic` 플래그 — exemption 외 cosmetic 1건이라도 있으면 exit 1.

### CI

`bun scripts/audit_addnode_variants.ts` → `bun scripts/audit_addnode_variants.ts --strict-cosmetic`. 신규 PR 이 layout 정합성 깨면 자동 차단.

## #1802 전체 진행 요약

| Step | cosmetic | 주요 성과 |
|------|----------|-----------|
| 시작 | 74 | - |
| #1810 (PR A: leaf) | 47 | this_expression + literal_type 27건 |
| #1811 (PR B: codegen-align) | 40 | ts_as_expression 류 REAL 3건 발견 & 차단 |
| #1816 (PR B2: strip-target) | 17 | ts_import_equals REAL 1건 차단 |
| #1817 (audit 확장) | 17 | transformer/semantic 스캔 + propagation 근본 해결 |
| #1818 (PR C: list 정규화) | 6 | flow_type_parameter_* len 분실 latent bug fix |
| #1819 (특수 6건) | 1 | import_attribute / ts_rest_type 분기 |
| **이 PR** | 1 (exempted) | CI fail-gate |

## Test plan

- [x] \`bun scripts/audit_addnode_variants.ts --strict-cosmetic\`: exit 0 (0 REAL + 0 unexempted + 1 exempted)
- [x] strict 모드에서 exemption 외 mismatch 시 exit 1 (수기 테스트)

## 보호 효과

- **신규 PR 이 Tag/layout/parser/reader 불일치 도입 시 자동 차단** — audit script 가 #1802 의 감시 장치로 지속 동작.
- \`flow_match_expression\` dual-site 재사용만 예외. 구조적 해결 원하면 follow-up 이슈 (arm tag 분리 \`flow_match_arm\`).

Closes #1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)