### PR TITLE
refactor(ast): flow_match_expression arm 을 flow_match_arm tag 로 분리 (#1822)

### DIFF
--- a/scripts/audit_addnode_variants.ts
+++ b/scripts/audit_addnode_variants.ts
@@ -57,13 +57,10 @@ const ALL_DATA_VARIANTS = new Set([...LEAF_VARIANTS, "unary", "binary", "ternary
 /**
  * cosmetic fail-gate 예외 — `--strict-cosmetic` 모드에서 허용되는 의도된 mismatch.
  *
- * - `flow_match_expression`: outer expression 은 `.extra` (discriminant + arms
- *   list), 각 arm 은 `.binary` (pattern + body) 로 **동일 tag 를 dual-site 재사용**.
- *   transformer `visitFlowMatch` 가 두 구조를 모두 읽는다. 단일 layout 선택
- *   불가능. 해결책은 arm tag 를 분리 (예: `flow_match_arm`) 하는 것이나
- *   audit 정리 범위 밖.
+ * #1822 에서 `flow_match_expression` 의 arm 을 별도 `flow_match_arm` tag 로
+ * 분리하며 이 세트는 비어 있음. 새 exemption 이 필요할 경우 정당화와 함께 추가.
  */
-const COSMETIC_EXEMPT_TAGS = new Set(["flow_match_expression"]);
+const COSMETIC_EXEMPT_TAGS = new Set<string>();
 
 
 function findMatchingBrace(text: string, openIdx: number): number {

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -360,6 +360,10 @@ pub const Node = struct {
         flow_exact_object_type,
         /// match (expr) { ... } — Flow match expression
         flow_match_expression,
+        /// match expression 의 개별 arm: `pattern => body`. binary = { left=pattern,
+        /// right=body }. `visitFlowMatch` 가 arms list 를 iterate 하며 각 arm 의
+        /// binary.left/right 를 읽는다. `#1822` 에서 outer expr 와 tag 분리.
+        flow_match_arm,
         /// Flow component with ref → React.forwardRef wrapper
         /// extra = [func_decl, const_decl]
         /// func_decl: function Name_withRef({...props}, ref) { body }
@@ -565,6 +569,9 @@ pub const Node = struct {
                 // ESM `import ... with { type: "json" }` 의 각 attr. key/value 가
                 // 실존하므로 leaf 가 아닌 binary layout.
                 .import_attribute,
+                // flow_match_arm: binary = { left=pattern, right=body, flags }
+                // outer flow_match_expression (extra layout) 의 arms list 구성원.
+                .flow_match_arm,
                 => .{ .kind = .binary },
 
                 // === ternary ===

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1449,17 +1449,17 @@ pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
             _ = try self.eat(.comma);
         }
 
-        // arm: binary { left=pattern, right=body }. outer expr 는 extra layout
-        // (discriminant + arms_start + arms_len) 이지만 여기 arm 은 `.binary` 로
-        // 저장. transformer `visitFlowMatch` (transformer.zig:~1937) 가 각 arm 에서
-        // `data.binary.left` (pattern) / `data.binary.right` (body) 를 실제로 읽는다.
-        // audit 에 "cosmetic" 으로 나타나더라도 이 arm 의 저장은 유지 — `.extra` 로
-        // 치환하면 silent failure (#1797 류).
-        const arm = try self.ast.addNode(.{
-            .tag = .flow_match_expression, // arm 도 같은 태그 재사용 (구분은 위치로)
-            .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = pattern, .right = body, .flags = 0 } },
-        });
+        // arm: binary { left=pattern, right=body }. 별도 tag (`flow_match_arm`)
+        // 로 outer `flow_match_expression` (extra layout) 과 분리 — 이전엔 tag
+        // 를 재사용해서 audit cosmetic exemption 이 필요했다 (#1802). #1822
+        // 에서 분리 후 audit exemption 제거.
+        const arm = try self.ast.addBinaryNode(
+            .flow_match_arm,
+            .{ .start = loop_guard_pos, .end = self.currentSpan().start },
+            pattern,
+            body,
+            0,
+        );
         try self.scratch.append(self.allocator, arm);
 
         if (try self.ensureLoopProgress(loop_guard_pos)) break;


### PR DESCRIPTION
## Summary

#1822 이슈 구현 — `flow_match_expression` 의 dual-site tag reuse 제거. arm 을 신규 `flow_match_arm` tag 로 분리해 outer=`.extra` / arm=`.binary` 각자 단일 layout.

**효과**: audit `COSMETIC_EXEMPT_TAGS` 에서 `flow_match_expression` 제거 가능 → #1802 의 진짜 완결 (exemption 0, cosmetic 0).

## 변경

- `src/parser/ast.zig::Node.Tag`: `flow_match_arm` enum value 추가
- `getLayout`: `flow_match_arm => .binary` 등록
- `src/parser/flow.zig::parseMatchExpression`: arm 을 `.flow_match_arm` 으로 저장 + `addBinaryNode` typed helper 사용
- `scripts/audit_addnode_variants.ts`: `COSMETIC_EXEMPT_TAGS` 비움

## transformer 호환성

`visitFlowMatch` 가 arm 을 인덱스로 꺼내 `arm.data.binary.left/right` 를 직접 읽음 (tag 체크 없음) → arm tag 변경에 영향 없음. `ast_walk` 는 layout-driven 이므로 binary layout 의 left/right 자동 순회.

## Test plan

- [x] `zig build test`: 3647/3647 green
- [x] `bun test tests/downlevel*.test.ts tests/tsc/*.test.ts tests/bundle-smoke.test.ts tests/flow-rn.test.ts`: **2724/2724 green**
- [x] `bun scripts/audit_addnode_variants.ts --strict-cosmetic`: exit 0 with **0 exemption, 0 cosmetic**

Closes #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)