### PR TITLE
feat(bundler): IIFE + external + globals 매핑 지원 (#1824)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -122,6 +122,9 @@ pub const BundleOptions = struct {
     footer_js: ?[]const u8 = null,
     /// IIFE 포맷에서 export를 바인딩할 글로벌 변수명 (--global-name)
     global_name: ?[]const u8 = null,
+    /// IIFE external → 전역 식별자 매핑 (--globals, rollup `output.globals` 호환, #1824).
+    /// emitter 가 IIFE factory 호출 인자로 사용. 매핑되지 않은 external 은 에러.
+    globals: []const types.GlobalEntry = &.{},
     /// 출력 파일 확장자 오버라이드 (--out-extension:.js=.mjs)
     out_extension_js: ?[]const u8 = null,
     /// 소스맵 관련 옵션 묶음 (enable/debug_ids/function_map/lazy/source_root/sources_content).
@@ -466,6 +469,7 @@ pub const Bundler = struct {
             .banner_js = self.options.banner_js,
             .footer_js = self.options.footer_js,
             .global_name = self.options.global_name,
+            .globals = self.options.globals,
             .out_extension_js = self.options.out_extension_js,
             .sourcemap = self.options.sourcemap,
             .output_filename = self.options.output_filename,
@@ -780,6 +784,8 @@ pub const Bundler = struct {
             l.minify_whitespace = self.options.minify_whitespace;
             // #1791 Phase D: value-ref 0 binding elision 정책을 transformer 와 동기화.
             l.verbatim_module_syntax = self.options.verbatim_module_syntax;
+            // #1824: IIFE external globals 매핑 — linker 가 매핑 유무로 preamble 경로 분기.
+            l.iife_globals = self.options.globals;
             if (mangle_report_enabled) l.mangle_report = &mangle_collector;
             try l.link();
             if (!self.options.code_splitting) {

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1276,6 +1276,72 @@ test "Bundler: require.context IIFE has no raw require call (RN runtime invarian
     try std.testing.expect(found_iife);
 }
 
+test "Bundler: IIFE + --globals maps external to factory arg (#1824)" {
+    // 목표: rollup output.globals 호환 — IIFE factory 에 external 을 param 으로 수록하고
+    // 닫는 호출에 매핑된 전역 식별자를 인자로 전달. named import 는 `var useState = React.useState`
+    // preamble 로 linker 가 생성 (UMD/AMD 와 동일 경로).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.ts",
+        \\import { useState } from 'react';
+        \\import ReactDOM from 'react-dom';
+        \\console.log(useState, ReactDOM);
+    );
+    const entry = try absPath(&tmp, "app.ts");
+    defer std.testing.allocator.free(entry);
+
+    const globals = [_]types.GlobalEntry{
+        .{ .specifier = "react", .global_name = "React" },
+        .{ .specifier = "react-dom", .global_name = "ReactDOM" },
+    };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .iife,
+        .external = &.{ "react", "react-dom" },
+        .globals = &globals,
+        .global_name = "MyLib",
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const output = result.output;
+
+    // factory signature: `var MyLib = ((React, ReactDom) => {` (arrow, ES target 기본값)
+    try std.testing.expect(std.mem.indexOf(u8, output, "var MyLib = ((React, ReactDom) => {") != null);
+    // factory call args: 매핑된 전역 (`React, ReactDOM`)
+    try std.testing.expect(std.mem.endsWith(u8, output, "})(React, ReactDOM);\n"));
+    // named import preamble: `var useState = React.useState;`
+    try std.testing.expect(std.mem.indexOf(u8, output, "var useState = React.useState") != null);
+    // default import → factory param 직접 사용
+    try std.testing.expect(std.mem.indexOf(u8, output, "ReactDom") != null);
+    // body 에 bare require 없음
+    try std.testing.expect(std.mem.indexOf(u8, output, "require(\"react\")") == null);
+}
+
+test "Bundler: IIFE without --globals on external → error (#1824 regression)" {
+    // 매핑 안 된 external 은 기존 IIFE unresolved 에러 경로 유지.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.ts", "import { useState } from 'react';\nconsole.log(useState);");
+    const entry = try absPath(&tmp, "app.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .iife,
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    // globals 매핑이 없으므로 unresolved import 에러.
+    try std.testing.expect(result.hasErrors());
+}
+
 test "Bundler: UMD external dependencies in wrapper" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -89,7 +89,7 @@ pub const InputHasher = struct {
 /// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
 /// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
 /// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
-const expected_emit_options_field_count: usize = 43;
+const expected_emit_options_field_count: usize = 44;
 
 comptime {
     const actual = @typeInfo(EmitOptions).@"struct".fields.len;
@@ -140,6 +140,11 @@ pub fn hashEmitOptions(h: *InputHasher, options: EmitOptions) void {
     h.addOptStr(options.banner_js);
     h.addOptStr(options.footer_js);
     h.addOptStr(options.global_name);
+    // #1824 IIFE external globals 매핑 — spec/global 둘 다 hash 에 포함해 cache 분리.
+    for (options.globals) |g| {
+        h.addStr(g.specifier);
+        h.addStr(g.global_name);
+    }
     h.addOptStr(options.out_extension_js);
     h.addStr(options.output_filename);
     h.addBool(options.charset_utf8);

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -99,6 +99,10 @@ pub const EmitOptions = struct {
     footer_js: ?[]const u8 = null,
     /// IIFE 포맷에서 export를 바인딩할 글로벌 변수명
     global_name: ?[]const u8 = null,
+    /// IIFE external → 전역 식별자 매핑 (rollup `output.globals` 호환, #1824).
+    /// 예: `{ specifier="react", global_name="React" }` →
+    /// `var Lib = (function(react){...})(React);`. 비어있으면 IIFE 는 external 없이 emit.
+    globals: []const types.GlobalEntry = &.{},
     /// 출력 파일 확장자 오버라이드 (.mjs, .cjs 등)
     out_extension_js: ?[]const u8 = null,
     /// 출력 파일명 (소스맵 참조용, 예: "out.js")
@@ -249,20 +253,32 @@ pub fn emitWithTreeShaking(
     // arrow 전환이 시맨틱을 바꾸지 않는다. ES5 타겟처럼 arrow 미지원 환경에서만
     // 기존 `function` 형태를 유지 (#1580, esbuild 관행과 동일).
     const use_arrow = !options.unsupported.arrow;
-    const factory_fn = if (has_tla)
-        (if (use_arrow) "(async () => {\n" else "(async function() {\n")
-    else
-        (if (use_arrow) "(() => {\n" else "(function() {\n");
 
-    // UMD/AMD: external specifier 수집 (dependency array + factory params 생성용)
+    // UMD/AMD/IIFE: external specifier 수집 (dependency array + factory params 생성용).
+    // IIFE 는 globals 매핑된 spec 만 수집 — 매핑 안 된 external 은 unresolved 로 취급되어
+    // linker 가 fatal_diagnostics 로 에러 발행 (#1791).
     var ext_specifiers: std.ArrayList([]const u8) = .empty;
     defer ext_specifiers.deinit(allocator);
-    if (options.format == .umd or options.format == .amd) {
+    // IIFE 는 globals 매핑된 spec 에 대응되는 전역 인자를 수집한다. UMD/AMD 는 사용 안 함.
+    var iife_ext_globals: std.ArrayList([]const u8) = .empty;
+    defer iife_ext_globals.deinit(allocator);
+    const collect_externals = options.format == .umd or options.format == .amd or
+        (options.format == .iife and options.globals.len > 0);
+    if (collect_externals) {
         var seen = std.StringHashMap(void).init(allocator);
         defer seen.deinit();
         for (sorted.items) |m| {
             for (m.import_records) |rec| {
-                if (rec.is_external and !seen.contains(rec.specifier)) {
+                if (!rec.is_external or seen.contains(rec.specifier)) continue;
+                if (options.format == .iife) {
+                    // IIFE: globals 매핑이 있는 spec 만 factory 파라미터에 수록.
+                    // 매핑이 없는 external 은 linker 가 fatal diagnostic 으로 처리.
+                    if (types.GlobalEntry.lookup(options.globals, rec.specifier)) |gname| {
+                        try seen.put(rec.specifier, {});
+                        try ext_specifiers.append(allocator, rec.specifier);
+                        try iife_ext_globals.append(allocator, gname);
+                    }
+                } else {
                     try seen.put(rec.specifier, {});
                     try ext_specifiers.append(allocator, rec.specifier);
                 }
@@ -270,7 +286,7 @@ pub fn emitWithTreeShaking(
         }
     }
 
-    // UMD/AMD: specifier → factory 매개변수명 precompute
+    // specifier → factory 매개변수명 precompute (UMD/AMD/IIFE 공통)
     var ext_param_names: std.ArrayList([]const u8) = .empty;
     defer {
         for (ext_param_names.items) |n| allocator.free(n);
@@ -279,6 +295,35 @@ pub fn emitWithTreeShaking(
     for (ext_specifiers.items) |spec| {
         try ext_param_names.append(allocator, try types.specifierToParamName(allocator, spec));
     }
+
+    // IIFE + externals 가 있으면 factory_fn 을 param 포함 형태로 조립 (#1824).
+    // 예: `(function(React, ReactDom) {\n`. 그 외에는 정적 문자열 사용.
+    const factory_fn_static = if (has_tla)
+        (if (use_arrow) "(async () => {\n" else "(async function() {\n")
+    else
+        (if (use_arrow) "(() => {\n" else "(function() {\n");
+    const factory_fn_owned: ?[]const u8 = blk: {
+        if (options.format != .iife or ext_param_names.items.len == 0) break :blk null;
+        const prefix = if (has_tla)
+            (if (use_arrow) "(async (" else "(async function(")
+        else
+            (if (use_arrow) "((" else "(function(");
+        var buf: std.ArrayList(u8) = .empty;
+        errdefer buf.deinit(allocator);
+        try buf.appendSlice(allocator, prefix);
+        for (ext_param_names.items, 0..) |n, i| {
+            if (i > 0) try buf.appendSlice(allocator, ", ");
+            try buf.appendSlice(allocator, n);
+        }
+        if (use_arrow) {
+            try buf.appendSlice(allocator, ") => {\n");
+        } else {
+            try buf.appendSlice(allocator, ") {\n");
+        }
+        break :blk try buf.toOwnedSlice(allocator);
+    };
+    defer if (factory_fn_owned) |s| allocator.free(s);
+    const factory_fn: []const u8 = factory_fn_owned orelse factory_fn_static;
 
     // emit_prelude: 포맷 prologue + polyfill 주입 + runtime helper 준비.
     // emit_module_pass 시작점 (`Phase 1: used_names`) 직전에 end.
@@ -696,7 +741,7 @@ pub fn emitWithTreeShaking(
     }
 
     // 포맷별 epilogue
-    try emitFormatEpilogue(&output, allocator, options.format);
+    try emitFormatEpilogue(&output, allocator, options.format, iife_ext_globals.items);
 
     // legal comments (eof 모드): 모든 모듈의 legal comment를 파일 끝에 모아서 출력
     const lc_mode = resolveDefaultLegalComments(options.legal_comments, options.minify_whitespace);
@@ -1812,9 +1857,27 @@ fn writeParamList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, name
 }
 
 /// 포맷별 epilogue를 output에 추가한다.
-fn emitFormatEpilogue(output: *std.ArrayList(u8), allocator: std.mem.Allocator, format: types.Format) !void {
+/// `iife_globals_args` 는 IIFE + external globals 매핑이 있을 때만 non-empty —
+/// `})(React, ReactDom);` 형태로 factory 호출 인자를 부착한다 (#1824).
+fn emitFormatEpilogue(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    format: types.Format,
+    iife_globals_args: []const []const u8,
+) !void {
     switch (format) {
-        .iife => try output.appendSlice(allocator, "})();\n"),
+        .iife => {
+            if (iife_globals_args.len > 0) {
+                try output.appendSlice(allocator, "})(");
+                for (iife_globals_args, 0..) |arg, i| {
+                    if (i > 0) try output.appendSlice(allocator, ", ");
+                    try output.appendSlice(allocator, arg);
+                }
+                try output.appendSlice(allocator, ");\n");
+            } else {
+                try output.appendSlice(allocator, "})();\n");
+            }
+        },
         .umd, .amd => try output.appendSlice(allocator, "});\n"),
         .cjs, .esm => {},
     }

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -1166,6 +1166,30 @@ test "banner/footer — CJS format" {
 // globalName Tests
 // ============================================================
 
+test "IIFE + globals: epilogue emits factory call args (#1824)" {
+    // external 이 없는 그래프라도 `options.globals` 가 설정되어 있으면 external
+    // 수집이 활성화되지만 ext_specifiers 가 비어있으면 기존 `})();\n` 경로.
+    // 이 테스트는 "globals 옵션이 비어있을 때는 기존 epilogue 유지" 를 확인.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    // globals 비어있음 → 기존 IIFE 경로
+    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+        .format = .iife,
+        .globals = &.{},
+    }, null);
+    defer emit_result.deinit(std.testing.allocator);
+
+    // 정적 factory_fn ("(() => {\n") + 빈 factory call ("})();\n")
+    try std.testing.expect(std.mem.startsWith(u8, emit_result.output, "(() => {\n"));
+    try std.testing.expect(std.mem.endsWith(u8, emit_result.output, "})();\n"));
+}
+
 test "globalName — IIFE wrapping" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -375,6 +375,12 @@ pub const Linker = struct {
     /// 사용자 의도 (원본 import 보존) 를 존중한다. bundler 가 init 후 설정.
     verbatim_module_syntax: bool = false,
 
+    /// #1824 IIFE `--globals SPEC=GLOBAL` 매핑 (rollup `output.globals` 호환).
+    /// `format == .iife` 일 때만 의미 있음. 매핑된 external specifier 는 UMD/AMD 와
+    /// 동일한 factory-param preamble 경로로 처리되고, 매핑 안 된 external 은
+    /// 기존 IIFE unresolved 에러 경로를 탄다. bundler 가 init 후 설정 — borrowed.
+    iife_globals: []const types.GlobalEntry = &.{},
+
     /// --mangle-report 수집기 (#1760). `null` 이면 instrumentation skip.
     /// Bundler 가 생성 및 소유. Linker 는 참조만 보유.
     mangle_report: ?*MangleReportCollector = null,

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -39,6 +39,18 @@ const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
 /// synthetic binding (JSX runtime 등) 은 semantic 이 추적하지 않으므로 "사용 중" 간주.
 /// `references` 가 비어있어도 보수적 보존. 호출자가 `verbatim_module_syntax` 를 먼저
 /// 확인해 true 이면 이 경로를 bypass.
+/// #1824: IIFE + `--globals` 매핑된 external 판정. UMD/AMD 와 동일한 factory-param
+/// preamble 경로로 분기하기 위한 공용 predicate. buildMetadataForAst / buildRequireRewrites
+/// 둘 다 동일 조건을 쓴다.
+inline fn isIifeMappedExternal(
+    format: types.Format,
+    globals: []const types.GlobalEntry,
+    rec: types.ImportRecord,
+) bool {
+    return rec.is_external and format == .iife and
+        types.GlobalEntry.lookup(globals, rec.specifier) != null;
+}
+
 inline fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
     if (ib.isSynthetic()) return false;
     // named 한정 — default / namespace 는 JSX pragma 등 implicit value use 위험이
@@ -264,8 +276,11 @@ pub fn buildMetadataForAst(
                     // top-level에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨.
                     // init 함수 본문에서 `var`로 재선언하면 outer scope를 shadow → #1209.
                     const is_synthetic_esm = ib.isSynthetic() and m.wrap_kind == .esm;
-                    if (rec.is_external and (self.format == .umd or self.format == .amd)) {
-                        // UMD/AMD: factory 매개변수에서 직접 참조
+                    const is_iife_mapped = isIifeMappedExternal(self.format, self.iife_globals, rec);
+                    if (rec.is_external and (self.format == .umd or self.format == .amd or is_iife_mapped)) {
+                        // UMD/AMD/IIFE+globals: factory 매개변수에서 직접 참조.
+                        // 파라미터 이름은 UMD/AMD 관행대로 `specifierToParamName` 결과를 사용한다
+                        // (IIFE 도 emitter 쪽 factory 시그니처와 일치하는 이름 — #1824).
                         const param_name = try types.specifierToParamName(self.allocator, rec.specifier);
                         defer self.allocator.free(param_name);
                         if (ib.kind == .namespace or ib.importsDefault()) {
@@ -288,8 +303,9 @@ pub fn buildMetadataForAst(
                             try preamble.write(";\n");
                         }
                     } else if (self.format == .iife and !ib.isSynthetic()) {
-                        // #1791 IIFE: unresolved external 은 의미 자체가 성립 안 함
+                        // #1791 IIFE: 매핑 안 된 unresolved external 은 의미 자체가 성립 안 함
                         // (factory 스코프에 require 없음, top-level import 도 불가).
+                        // #1824: --globals 로 매핑된 external 은 위 `is_iife_mapped` 브랜치에서 처리됨.
                         // build-time 에러로 pending_diagnostics 에 쌓고 emitter 가 flush.
                         // specifier 단위로 dedupe — 같은 spec 의 binding 여러 개에 대해 한 번만.
                         if (iife_diag_seen == null) iife_diag_seen = std.StringHashMap(void).init(self.allocator);
@@ -664,9 +680,10 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
     const self_idx = m.index.toU32();
     for (m.import_records) |rec| {
         if (rec.resolved.isNone()) {
-            // UMD/AMD: external require → factory 매개변수 참조.
-            // require("react") → React (factory params에서 주입)
-            if (rec.is_external and (self.format == .umd or self.format == .amd)) {
+            // UMD/AMD/IIFE+globals: external require → factory 매개변수 참조.
+            // require("react") → React (factory params에서 주입, #1824 IIFE 확장)
+            const iife_mapped = isIifeMappedExternal(self.format, self.iife_globals, rec);
+            if (rec.is_external and (self.format == .umd or self.format == .amd or iife_mapped)) {
                 if (!require_rewrites.contains(rec.specifier)) {
                     const param = try types.specifierToParamName(self.allocator, rec.specifier);
                     defer self.allocator.free(param);

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -85,6 +85,26 @@ pub const FallbackEntry = struct {
     to: ?[]const u8,
 };
 
+/// IIFE 포맷 external 전역 매핑 (rollup `output.globals` 호환, #1824).
+/// `specifier` (예: "react") → `global_name` (예: "React"). IIFE prologue 의
+/// factory 호출 인자로 그대로 사용된다: `var Lib = (function(react){...})(React);`
+/// UMD/AMD 는 기존대로 `specifierToParamName` 만으로도 동작하며, 이 매핑은
+/// IIFE 에서 "어떤 external 을 어떤 전역에서 읽을지" 를 명시한다.
+pub const GlobalEntry = struct {
+    specifier: []const u8,
+    global_name: []const u8,
+
+    /// `entries` 에서 `specifier` 에 대응되는 전역 이름을 linear search.
+    /// 매핑은 보통 수 개 (`--globals react=React react-dom=ReactDOM`) 라
+    /// HashMap overhead 보다 linear 가 더 싸다.
+    pub fn lookup(entries: []const GlobalEntry, specifier: []const u8) ?[]const u8 {
+        for (entries) |g| {
+            if (std.mem.eql(u8, g.specifier, specifier)) return g.global_name;
+        }
+        return null;
+    }
+};
+
 // ============================================================
 // Import 종류
 // ============================================================

--- a/src/main.zig
+++ b/src/main.zig
@@ -187,6 +187,12 @@ const CliOptions = struct {
     preserve_modules: bool = false,
     /// --preserve-modules-root=<dir>: 출력 디렉토리 구조의 기준 경로
     preserve_modules_root: ?[]const u8 = null,
+    /// --globals=SPEC=GLOBAL (rollup output.globals 호환, #1824).
+    /// IIFE 포맷에서 external specifier → 전역 식별자 매핑. 반복/comma 분리 지원.
+    /// 예: `--globals react=React --globals react-dom=ReactDOM`
+    ///     `--globals=react=React,react-dom=ReactDOM`
+    /// ArrayList 로 보관하고 BundleOptions 에 slice 로 전달. dedupe/정규화는 emitter 단에서.
+    globals_list: std.ArrayList(lib.bundler.types.GlobalEntry) = .empty,
 
     const RnPlatform = enum {
         none,
@@ -235,8 +241,29 @@ const CliOptions = struct {
         self.watch_roots_list.deinit(alloc);
         self.watch_include_list.deinit(alloc);
         self.watch_exclude_list.deinit(alloc);
+        self.globals_list.deinit(alloc);
     }
 };
+
+/// `--globals SPEC=GLOBAL` 인자를 파싱하여 `opts.globals_list` 에 추가한다.
+/// comma 로 여러 항목 구분 가능. 유효하지 않으면 stderr 에 경고 후 무시.
+fn parseGlobalsArg(opts: *CliOptions, allocator: std.mem.Allocator, val: []const u8, stderr: anytype) !void {
+    var it = std.mem.splitScalar(u8, val, ',');
+    while (it.next()) |part| {
+        if (part.len == 0) continue;
+        const eq = std.mem.indexOfScalar(u8, part, '=') orelse {
+            try stderr.print("zts: --globals requires SPEC=GLOBAL format: '{s}' (skipped)\n", .{part});
+            continue;
+        };
+        const spec = part[0..eq];
+        const name = part[eq + 1 ..];
+        if (spec.len == 0 or name.len == 0) {
+            try stderr.print("zts: --globals empty spec or name: '{s}' (skipped)\n", .{part});
+            continue;
+        }
+        try opts.globals_list.append(allocator, .{ .specifier = spec, .global_name = name });
+    }
+}
 
 /// 엔진 타겟 문자열을 파싱. "chrome80,safari14,node16" → UnsupportedFeatures.
 fn parseEngineTargets(val: []const u8) ?lib.transformer.TransformOptions.compat.UnsupportedFeatures {
@@ -541,6 +568,15 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             if (val.len > 0) {
                 try opts.external_list.append(allocator, val);
             }
+        } else if (std.mem.eql(u8, arg, "--globals")) {
+            // --globals react=React (다음 인자)
+            if (i + 1 < args.len) {
+                i += 1;
+                try parseGlobalsArg(&opts, allocator, args[i], stderr);
+            }
+        } else if (std.mem.startsWith(u8, arg, "--globals=")) {
+            const val = arg["--globals=".len..];
+            if (val.len > 0) try parseGlobalsArg(&opts, allocator, val, stderr);
         } else if (std.mem.startsWith(u8, arg, "--conditions=")) {
             const val = arg["--conditions=".len..];
             // 쉼표로 분리된 조건 목록 (esbuild 호환: --conditions=production,development)
@@ -1717,6 +1753,7 @@ pub fn main() !void {
             .banner_js = opts.banner_js,
             .footer_js = opts.footer_js,
             .global_name = opts.global_name,
+            .globals = opts.globals_list.items,
             .out_extension_js = opts.out_extension_js,
             .charset_utf8 = opts.charset_utf8,
             .entry_names = opts.entry_names,
@@ -2557,6 +2594,8 @@ fn printUsage(writer: anytype) !void {
         \\  --preserve-modules               One file per module (library builds, requires --outdir)
         \\  --preserve-modules-root=<dir>    Root directory for output structure
         \\  --external <pkg>                 Exclude package (repeatable)
+        \\  --globals SPEC=GLOBAL            IIFE external → global mapping (rollup output.globals)
+        \\  --globals=SPEC=GLOBAL[,...]      Same, comma-separated form
         \\  --conditions=<cond,...>          Custom export conditions (e.g. production)
         \\  --platform=browser|node|neutral  Target platform (default: browser)
         \\  --rn-platform=ios|android        RN sub-platform (.ios.*/.android.* extensions)

--- a/tests/integration/tests/css-library-smoke.test.ts
+++ b/tests/integration/tests/css-library-smoke.test.ts
@@ -184,26 +184,34 @@ describe.skipIf(!hasEmotionReact)("CSS Library Smoke — @emotion/react", () => 
       "stylis",
     ]);
 
-    // `--format=esm` 명시: 라이브러리 번들링 의도. `--platform=browser` 기본이
-    // `is_bundle && !bundle_format_explicit` 일 때 IIFE 로 자동 승격되는데 (#1791),
-    // IIFE 는 factory 스코프에 require/import 가 없어 external react 를 담을 수
-    // 없다. 라이브러리 배포 포맷은 ESM/CJS 가 표준이므로 여기도 ESM 을 쓴다.
+    // #1824: `--format=iife` + `--globals` 로 external 을 factory-param 에 주입.
+    // rollup `output.globals` 호환 — React/ReactDOM 은 런타임에 전역에서 가져온다.
     const outFile = join(fixture.dir, "out.js");
     const bundle = await runZts([
       "--bundle",
       join(fixture.dir, "index.tsx"),
       "-o",
       outFile,
-      "--format=esm",
+      "--format=iife",
+      "--global-name=MyLib",
       "--external",
       "react",
       "--external",
       "react-dom",
+      "--globals",
+      "react=React",
+      "--globals",
+      "react-dom=ReactDOM",
     ]);
     expect(bundle.exitCode).toBe(0);
 
     const js = await readFile(outFile, "utf-8");
     expect(js).toContain("serializeStyles");
+    // IIFE factory: 실제 import 된 external 만 param 으로 수록.
+    // emotion 은 react 만 쓰므로 `var MyLib = ((React) => {` + `})(React);` 패턴.
+    // (react-dom import 가 없으면 globals 매핑이 있어도 factory 에서 생략)
+    expect(js).toMatch(/var MyLib = \(\(React\)? (?:=>|\)\s*=>)/);
+    expect(js).toMatch(/\}\)\(React[^)]*\);\s*$/);
     expect(js.length).toBeGreaterThan(10000);
   });
 });
@@ -291,18 +299,23 @@ describe.skipIf(!hasStyledComponents)("CSS Library Smoke — Styled-Components",
       "shallowequal",
     ]);
 
-    // `--format=esm` 명시: 라이브러리 번들링 의도 (#1791 follow-up, css-smoke).
+    // #1824: IIFE + --globals 로 rollup 호환 라이브러리 번들.
     const outFile = join(fixture.dir, "out.js");
     const bundle = await runZts([
       "--bundle",
       join(fixture.dir, "index.ts"),
       "-o",
       outFile,
-      "--format=esm",
+      "--format=iife",
+      "--global-name=Styled",
       "--external",
       "react",
       "--external",
       "react-dom",
+      "--globals",
+      "react=React",
+      "--globals",
+      "react-dom=ReactDOM",
     ]);
 
     expect(bundle.exitCode).toBe(0);
@@ -310,6 +323,8 @@ describe.skipIf(!hasStyledComponents)("CSS Library Smoke — Styled-Components",
     const js = await readFile(outFile, "utf-8");
     expect(js).toContain("styled");
     expect(js).toContain("stylis");
+    expect(js).toMatch(/var Styled = \(\(React/);
+    expect(js).toMatch(/\}\)\(React[^)]*\);\s*$/);
     expect(js.length).toBeGreaterThan(5000);
   });
 
@@ -335,18 +350,23 @@ describe.skipIf(!hasStyledComponents)("CSS Library Smoke — Styled-Components",
       "shallowequal",
     ]);
 
-    // `--format=esm` 명시: 라이브러리 번들링 의도 (#1791 follow-up, css-smoke).
+    // #1824: IIFE + --globals 로 rollup 호환 라이브러리 번들.
     const outFile = join(fixture.dir, "out.js");
     const bundle = await runZts([
       "--bundle",
       join(fixture.dir, "index.ts"),
       "-o",
       outFile,
-      "--format=esm",
+      "--format=iife",
+      "--global-name=StyledKf",
       "--external",
       "react",
       "--external",
       "react-dom",
+      "--globals",
+      "react=React",
+      "--globals",
+      "react-dom=ReactDOM",
     ]);
 
     expect(bundle.exitCode).toBe(0);
@@ -354,5 +374,7 @@ describe.skipIf(!hasStyledComponents)("CSS Library Smoke — Styled-Components",
     const js = await readFile(outFile, "utf-8");
     // keyframes 함수가 번들에 포함
     expect(js).toContain("keyframes");
+    expect(js).toMatch(/var StyledKf = \(\(React/);
+    expect(js).toMatch(/\}\)\(React[^)]*\);\s*$/);
   });
 });


### PR DESCRIPTION
## Summary

rollup `output.globals` 호환 — IIFE 포맷에서 external 을 factory-param 에 주입 가능. 기존엔 `--format=iife` + `--external` 조합이 build-time error (#1791).

```bash
zts --bundle src/index.ts -o lib.iife.js \
  --format=iife --global-name=MyLib \
  --external react --globals react=React \
  --external react-dom --globals react-dom=ReactDOM
```

출력:

```js
var MyLib = (function(React, ReactDom) {
  var useState = React.useState;
  ...
})(React, ReactDOM);
```

Consumer 는 `<script>` 태그로 React/ReactDOM 을 미리 로드한 환경에서 사용 (UMD-style 라이브러리 배포).

## 변경

1. **`types.GlobalEntry`** — `{ specifier, global_name }` + `lookup(entries, spec)` linear search
2. **CLI** — `--globals SPEC=GLOBAL[,SPEC2=GLOBAL2]` repeatable + comma. 기존 `--define`/`--alias`/`--loader` 스타일 준수
3. **Linker** — `isIifeMappedExternal` predicate 로 IIFE+매핑 external 을 UMD/AMD factory-param preamble 경로로 재사용. 매핑 없는 external 은 기존 #1791 fatal diagnostic 유지
4. **Emitter** — ext_specifiers 수집을 IIFE+globals 로 확장, factory_fn 을 param 포함 형태로 동적 조립, `emitFormatEpilogue` 에 `iife_globals_args` 추가해 `})(React, ReactDOM);` 형태 출력
5. **compiled_cache** — globals 매핑을 cache hash key 에 포함 (stale cache 방지)

## 테스트

- `emitter_test.zig`: IIFE+globals 매핑 회귀
- `bundler_test/basic.zig`: 정상 경로 + 미매핑 external 에러 경로 2건
- `css-library-smoke.test.ts`: `@emotion/react` 케이스를 ESM 회피 (#1814) 에서 **IIFE+globals 원래 의도로 복구**

## /simplify 반영

- `lookupGlobal` / `lookupIifeGlobal` 중복 → `types.GlobalEntry.lookup` 단일화
- `is_iife_mapped` predicate 중복 → `isIifeMappedExternal` helper 로 추출
- `CliOptions.GlobalEntry` re-export 제거 — `lib.bundler.types.GlobalEntry` 직접 사용

## Test plan

- [x] `zig build test`: 3647/3647 green
- [x] `bun scripts/audit_addnode_variants.ts --strict-cosmetic`: REAL 0 / cosmetic 0
- [x] `bun test tests/css-library-smoke.test.ts`: 9/9 green (IIFE 복구 포함)
- [x] `bun test tests/tsc/*.test.ts tests/downlevel*.test.ts tests/bundle-smoke.test.ts`: 2683/2683 green

Closes #1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)