### PR TITLE
fix(semantic): resolve lowercase root of JSX member tag (`<ns.Comp/>`)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1299,9 +1299,19 @@ pub const SemanticAnalyzer = struct {
                     self.resolveIdentifier(name, idx, .{ .read = true });
                 }
             },
-            // JSX member expression: <Foo.Bar> → left(Foo)를 재귀 방문하여 symbol 등록
+            // <Foo.Bar> / <foo.bar>: root 식별자는 항상 변수 reference (대소문자 무관).
+            // 위 .jsx_identifier 분기는 단독 태그(<x>)의 intrinsic 구별을 위해 대문자만
+            // resolve 하므로 member context 에서는 별도로 처리. 누락 시 lowerJSXMemberExpr 의
+            // propagateSymbolId 가 null 을 복사 → 번들러 rename 미적용으로 ReferenceError
+            // (예: `<react_native_safe_area_context_1.SafeAreaProvider>`).
             .jsx_member_expression => {
-                try self.visitNode(node.data.binary.left);
+                var cur_idx = node.data.binary.left;
+                while (self.ast.getNode(cur_idx).tag == .jsx_member_expression) {
+                    cur_idx = self.ast.getNode(cur_idx).data.binary.left;
+                }
+                const root = self.ast.getNode(cur_idx);
+                std.debug.assert(root.tag == .jsx_identifier);
+                self.resolveIdentifier(self.ast.getSourceText(root.span), cur_idx, .{ .read = true });
             },
 
             // ---- 일반 표현식 순회 (private name 참조 등을 위해) ----

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1274,11 +1274,18 @@ const RefFixture = struct {
     parser: Parser,
     ana: SemanticAnalyzer,
 
+    const Options = struct { jsx: bool = false };
+
     fn init(source: []const u8) !RefFixture {
+        return initOpts(source, .{});
+    }
+
+    fn initOpts(source: []const u8, opts: Options) !RefFixture {
         var scanner = try Scanner.init(std.testing.allocator, source);
         errdefer scanner.deinit();
         var parser = Parser.init(std.testing.allocator, &scanner);
         errdefer parser.deinit();
+        parser.is_jsx = opts.jsx;
         _ = try parser.parse();
         var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
         errdefer ana.deinit();
@@ -1551,4 +1558,55 @@ test "Redecl: module top-level duplicate function" {
 
 test "Redecl: strict IIFE block const vs var" {
     try analyzeHasError("(function() { 'use strict'; { const f = 1; var f; } })", "already been declared");
+}
+
+// ============================================================
+// JSX member tag root resolution
+// ============================================================
+
+// JSX `<ns.Comp />` root resolved regardless of case — otherwise propagateSymbolId
+// copies null → bundler skips rename → ReferenceError (ExpoRoot.js case).
+test "JSX: lowercase root of <ns.Comp/> resolves as variable ref" {
+    var fx = try RefFixture.initOpts(
+        "var ns = require('x'); function F() { return <ns.Comp />; }",
+        .{ .jsx = true },
+    );
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("ns", &refs);
+
+    try std.testing.expectEqual(@as(usize, 1), refs.items.len);
+    try std.testing.expect(refs.items[0].flags.read);
+}
+
+test "JSX: lowercase root of nested <a.b.Comp/> resolves" {
+    var fx = try RefFixture.initOpts(
+        "var a = { b: { Comp: function () {} } }; function F() { return <a.b.Comp />; }",
+        .{ .jsx = true },
+    );
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("a", &refs);
+
+    try std.testing.expectEqual(@as(usize, 1), refs.items.len);
+    try std.testing.expect(refs.items[0].flags.read);
+}
+
+// Bare `<div />` stays an intrinsic — guards the member-branch fix from over-reaching.
+test "JSX: bare lowercase tag <div/> is intrinsic, not a variable ref" {
+    var fx = try RefFixture.initOpts(
+        "var div = 1; function F() { return <div />; }",
+        .{ .jsx = true },
+    );
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("div", &refs);
+
+    try std.testing.expectEqual(@as(usize, 0), refs.items.len);
 }


### PR DESCRIPTION
## Summary

JSX member tag (`<ns.Comp/>`) 의 root 식별자가 **소문자로 시작**할 때 semantic 이 symbol 을 매기지 않아, 번들러 rename 이 누락되고 런타임에 `ReferenceError` 가 발생하던 버그를 고칩니다.

## 증상 (실측)

`expo-router/build/ExpoRoot.js` 에서:

```js
var react_native_safe_area_context_1$5 = (...);   // 정의: rename 됨

function ExpoRoot(_f) {
  ...
  return _jsxDEV(react_native_safe_area_context_1.SafeAreaProvider, ...);
  //              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 사용처: rename 안 됨 → ReferenceError
}
```

같은 모듈에서 정의(`$5`)와 사용(suffix 없음)이 어긋나 부팅 실패.

## Root cause

`SemanticAnalyzer.visitNode` 의 `.jsx_identifier` arm 은 단독 태그(`<x>`) 에서 intrinsic 과 컴포넌트를 구별하기 위해 **대문자 시작만** `resolveIdentifier` 를 호출합니다. 그런데 기존 `.jsx_member_expression` arm 은 단순히 `visitNode(left)` 로 위임 → 같은 intrinsic-aware 경로를 다시 타게 되어 **소문자 root 가 silently skip**.

Member context 에서 root 는 항상 변수 reference (intrinsic 불가). symbol_id 가 없으면 `lowerJSXMemberExpr.propagateSymbolId` 가 null 을 복사 → 번들러가 rename 을 적용하지 못함.

## Fix

`.jsx_member_expression` arm 을 case-aware 분기를 우회하도록 수정: chain 을 타고 내려가 root identifier 를 찾고, 직접 `resolveIdentifier` 로 매김. 단독 태그 동작은 그대로.

```zig
.jsx_member_expression => {
    var cur_idx = node.data.binary.left;
    while (self.ast.getNode(cur_idx).tag == .jsx_member_expression) {
        cur_idx = self.ast.getNode(cur_idx).data.binary.left;
    }
    const root = self.ast.getNode(cur_idx);
    std.debug.assert(root.tag == .jsx_identifier);
    self.resolveIdentifier(self.ast.getSourceText(root.span), cur_idx, .{ .read = true });
},
```

## Test plan

- [x] 추가된 회귀 테스트 3개 (`RefFixture.initOpts({ jsx: true })`):
  - `<ns.Comp/>` lowercase root → reference 등록
  - `<a.b.Comp/>` 중첩 root → reference 등록
  - `<div/>` bare lowercase intrinsic → reference 미등록 (over-reach 방지)
- [x] 전체 unit/regression suite 통과 (`zig build test`: **3652/3652**)
- [x] bungae monorepo 의 expo-router 부팅에서 ExpoRoot.js 의 모든 lowercase JSX member root (`react_native_safe_area_context_1`, `react_native_1`, `storeContext_1`, `primitives_1`) 가 일관된 suffix 로 emit 되는 것 실측 확인

## 범위 외

- expo-router 부팅 시 발견된 별개의 ZTS 버그 (LogBox `LogBoxStyle.getWarningColor` 가 무관한 모듈 변수로 매핑되는 namespace member rewrite 이슈) 는 이 PR 에 포함하지 않음 — `linker.zig` 쪽 별도 수정 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)