### PR TITLE
fix(linker): skip ns_member_rewrites when importer scope shadows export

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -32,5 +32,6 @@ comptime {
     _ = @import("bundler_test/plugin_misc.zig");
     _ = @import("bundler_test/function_map.zig");
     _ = @import("bundler_test/virtual_ns_treeshake.zig");
+    _ = @import("bundler_test/ns_member_shadow.zig");
     _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/bundler_test/ns_member_shadow.zig
+++ b/src/bundler/bundler_test/ns_member_shadow.zig
@@ -1,0 +1,235 @@
+//! Regression: `import * as M from 'mod'` + `M.x` 의 inline 결과가 importer scope 의
+//! 같은 이름 binding 과 self-shadow 하던 무한 재귀.
+//! 실제 사례: `react-native/.../LogBox/LogBoxNotificationContainer.js` 의
+//! `const setSelectedLog = (i) => LogBoxData.setSelectedLog(i)`.
+
+const std = @import("std");
+const testing = std.testing;
+const helpers = @import("../test_helpers.zig");
+const writeFile = helpers.writeFile;
+
+fn bundleEntry(backing: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !helpers.Bundled {
+    return helpers.bundleEntry(backing, tmp, entry_name, .{});
+}
+
+test "ns shadow: importer 의 nested binding 과 충돌하는 member access 는 ns 객체로 emit" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "data.js",
+        \\export function setSelectedLog(idx) { return "real:" + idx; }
+    );
+    try writeFile(tmp.dir, "container.js",
+        \\import * as LogBoxData from './data.js';
+        \\export function Container(props) {
+        \\  const setSelectedLog = (i) => LogBoxData.setSelectedLog(i);
+        \\  return setSelectedLog(props.idx);
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { Container } from './container.js';
+        \\globalThis.__out = Container({ idx: 7 });
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // self-shadow regression: 같은 줄에 const setSelectedLog 정의 + setSelectedLog(i) 호출이
+    // 함께 있으면 안 됨. inline 결과는 namespace 객체 access (something.setSelectedLog) 여야 함.
+    try testing.expect(std.mem.indexOf(u8, code, "return setSelectedLog(i)") == null);
+    try testing.expect(std.mem.indexOf(u8, code, ".setSelectedLog(i)") != null);
+}
+
+test "ns shadow: 충돌 없는 member 는 그대로 inline 유지 (불필요한 ns 객체 access 회피)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "data.js",
+        \\export function uniqueName(x) { return x + 1; }
+    );
+    try writeFile(tmp.dir, "user.js",
+        \\import * as M from './data.js';
+        \\export function compute(v) { return M.uniqueName(v); }
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { compute } from './user.js';
+        \\globalThis.__out = compute(10);
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // 충돌 없으면 inline 유지: M.uniqueName(v) → uniqueName(v)
+    try testing.expect(std.mem.indexOf(u8, code, "return uniqueName(v)") != null);
+    // namespace 객체 access 는 만들지 않음
+    try testing.expect(std.mem.indexOf(u8, code, "M_ns.uniqueName") == null);
+}
+
+test "ns shadow: nested function 안의 binding 도 충돌로 인식" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "data.js",
+        \\export function helper(x) { return "data:" + x; }
+    );
+    try writeFile(tmp.dir, "deep.js",
+        \\import * as Mod from './data.js';
+        \\export function outer() {
+        \\  function inner() {
+        \\    const helper = (x) => Mod.helper(x);
+        \\    return helper(1);
+        \\  }
+        \\  return inner();
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { outer } from './deep.js';
+        \\globalThis.__out = outer();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // inner 안의 const helper 는 nested binding → Mod.helper 는 inline 되면 안 됨
+    try testing.expect(std.mem.indexOf(u8, code, "(x) => helper(x)") == null);
+    try testing.expect(std.mem.indexOf(u8, code, ".helper(x)") != null);
+}
+
+// 한 namespace 의 일부 export 만 충돌하면 그것만 fallback, 나머지는 inline 유지.
+// 구분 가능한 이름 (`shadowed` vs `safe_*`) 으로 두 path 가 모두 활성화되는지 검증.
+test "ns shadow: 부분 충돌 — shadowed member 는 fallback, 나머지는 inline" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "data.js",
+        \\export function shadowed(x) { return "shadow:" + x; }
+        \\export function safeOne(x) { return "one:" + x; }
+        \\export function safeTwo(x) { return "two:" + x; }
+    );
+    try writeFile(tmp.dir, "user.js",
+        \\import * as M from './data.js';
+        \\export function go() {
+        \\  const shadowed = (i) => M.shadowed(i);
+        \\  return shadowed(1) + M.safeOne(2) + M.safeTwo(3);
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { go } from './user.js';
+        \\globalThis.__out = go();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // shadowed: 충돌 → ns 객체 access
+    try testing.expect(std.mem.indexOf(u8, code, "(i) => shadowed(i)") == null);
+    try testing.expect(std.mem.indexOf(u8, code, ".shadowed(i)") != null);
+    // safeOne / safeTwo: 비충돌 → inline 유지 (M_ns.safeOne 형태로 가지 않음)
+    try testing.expect(std.mem.indexOf(u8, code, "safeOne(2)") != null);
+    try testing.expect(std.mem.indexOf(u8, code, "safeTwo(3)") != null);
+    try testing.expect(std.mem.indexOf(u8, code, ".safeOne(2)") == null);
+    try testing.expect(std.mem.indexOf(u8, code, ".safeTwo(3)") == null);
+}
+
+// nested binding 외에도 함수 매개변수 / catch 매개변수 같은 다른 binding kind 도
+// `nested_name_sets` 에 포함되어야 충돌이 잡힘.
+test "ns shadow: 함수 매개변수 binding 도 충돌로 인식" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "data.js",
+        \\export function clear(x) { return "data:" + x; }
+    );
+    try writeFile(tmp.dir, "user.js",
+        \\import * as Data from './data.js';
+        \\export function wrap(clear) {
+        \\  return clear() + Data.clear(0);
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { wrap } from './user.js';
+        \\globalThis.__out = wrap(() => "param");
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // wrap 의 매개변수 clear 와 충돌 → Data.clear(0) 는 ns 객체 access 로 emit
+    try testing.expect(std.mem.indexOf(u8, code, ".clear(0)") != null);
+    // 매개변수 호출 clear() 는 그대로
+    try testing.expect(std.mem.indexOf(u8, code, "clear()") != null);
+}
+
+// 여러 namespace import 가 같은 local binding 과 충돌하면 둘 다 fallback 처리.
+// 한 importer 모듈 안에서 namespace 별 독립적으로 shadow detection 이 작동하는지 검증.
+test "ns shadow: 여러 namespace import 가 같은 이름과 충돌해도 각각 처리" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.js",
+        \\export function foo(x) { return "a:" + x; }
+    );
+    try writeFile(tmp.dir, "b.js",
+        \\export function foo(x) { return "b:" + x; }
+    );
+    try writeFile(tmp.dir, "user.js",
+        \\import * as A from './a.js';
+        \\import * as B from './b.js';
+        \\export function go() {
+        \\  const foo = (i) => A.foo(i) + B.foo(i);
+        \\  return foo(1);
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { go } from './user.js';
+        \\globalThis.__out = go();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // 두 namespace 모두 ns 객체로 emit — `(i) => foo(i)` 자기 호출 패턴이 있으면 안 됨
+    try testing.expect(std.mem.indexOf(u8, code, "(i) => foo(i)") == null);
+    // 두 access 모두 .foo(i) 형태 — 최소 2번 등장해야 함
+    var count: usize = 0;
+    var search_start: usize = 0;
+    while (std.mem.indexOfPos(u8, code, search_start, ".foo(i)")) |idx| {
+        count += 1;
+        search_start = idx + 1;
+    }
+    try testing.expect(count >= 2);
+}
+
+// `export * from './inner'` chain 을 통한 export 도 shadowing 으로 잡혀야 함.
+// 회귀 가드 (simplify 단계에서 발견): 이전 구현은 cache-miss path 에서
+// `export * from` 을 skip 해 false negative 였음. 지금은 `cached_exports` (DFS 결과)
+// 단일 진실로 사용하므로 chain 을 따라간 export 도 정확히 잡힘.
+test "ns shadow: export * 체인 통한 export 도 shadowing 으로 인식" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "inner.js",
+        \\export function chained(x) { return "inner:" + x; }
+    );
+    try writeFile(tmp.dir, "barrel.js",
+        \\export * from './inner.js';
+    );
+    try writeFile(tmp.dir, "user.js",
+        \\import * as M from './barrel.js';
+        \\export function go() {
+        \\  const chained = (i) => M.chained(i);
+        \\  return chained(1);
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { go } from './user.js';
+        \\globalThis.__out = go();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // chained 이 self-reference 로 가면 안 됨
+    try testing.expect(std.mem.indexOf(u8, code, "(i) => chained(i)") == null);
+    try testing.expect(std.mem.indexOf(u8, code, ".chained(i)") != null);
+}

--- a/src/bundler/bundler_test/virtual_ns_treeshake.zig
+++ b/src/bundler/bundler_test/virtual_ns_treeshake.zig
@@ -4,47 +4,14 @@
 
 const std = @import("std");
 const testing = std.testing;
-const Bundler = @import("../bundler.zig").Bundler;
-const BundleResult = @import("../bundler.zig").BundleResult;
-const resolve_cache_mod = @import("../resolve_cache.zig");
-const writeFile = @import("../test_helpers.zig").writeFile;
+const helpers = @import("../test_helpers.zig");
+const writeFile = helpers.writeFile;
 
-/// 테스트 전용 랩퍼: BundleResult + arena (linker 관련 로컬 할당 수명 보장).
-const Bundled = struct {
-    arena: std.heap.ArenaAllocator,
-    result: BundleResult,
-
-    fn code(self: *const Bundled) []const u8 {
-        return self.result.output;
-    }
-
-    fn deinit(self: *Bundled) void {
-        self.result.deinit(self.arena.child_allocator);
-        self.arena.deinit();
-    }
-};
-
-fn bundleEntry(backing: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !Bundled {
-    var arena = std.heap.ArenaAllocator.init(backing);
-    errdefer arena.deinit();
-    const arena_alloc = arena.allocator();
-
-    const dp = try tmp.dir.realpathAlloc(arena_alloc, ".");
-    const entry = try std.fs.path.resolve(arena_alloc, &.{ dp, entry_name });
-
-    var cache = resolve_cache_mod.ResolveCache.init(backing, .{});
-    defer cache.deinit();
-
-    var bundler = Bundler.initWithResolveCache(backing, .{
-        .entry_points = &.{entry},
-        .format = .iife,
+fn bundleEntry(backing: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !helpers.Bundled {
+    return helpers.bundleEntry(backing, tmp, entry_name, .{
         .scope_hoist = true,
         .tree_shaking = true,
-    }, &cache);
-    defer bundler.deinit();
-
-    const result = try bundler.bundle();
-    return .{ .arena = arena, .result = result };
+    });
 }
 
 test "virtual ns (#1603): import { M } from re_export_namespace — 미사용 member prune" {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -408,6 +408,9 @@ pub const Linker = struct {
     /// 키: target_mod_idx. 같은 타겟을 여러 모듈이 namespace import 할 때
     /// `collectExportsRecursive` DFS 를 한 번만 수행하도록 linker 전역 공유.
     /// 값 slice 와 `owned=true` 인 local 문자열 모두 linker 소유 — deinit 에서 일괄 해제.
+    /// Invariant: metadata 단계에서 append-only (put 만, remove/replace 없음).
+    /// 슬라이스는 `allocator.dupe` 한 독립 할당이라 다른 키의 put 으로도 무효화되지 않음 —
+    /// lock 해제 후에도 안전하게 읽기 가능.
     ns_export_cache: std.AutoHashMapUnmanaged(u32, []NsExportPair) = .{},
     /// buildInlineObjectStr 결과 캐시. 키: target_mod_idx. 값 문자열 linker 소유.
     ns_inline_cache: std.AutoHashMapUnmanaged(u32, []const u8) = .{},
@@ -1876,10 +1879,15 @@ pub const Linker = struct {
     /// buildMetadataForAst 내 3곳에서 동일 패턴을 공유. 캐시는 linker 전역
     /// (`self.ns_export_cache` / `self.ns_inline_cache`) — 같은 target 을 여러
     /// importer 가 namespace import 할 때 collectExportsRecursive DFS 를 단 한 번만 수행.
+    ///
+    /// `force_inline`: caller 가 isNamespaceUsedAsValue / exported_locals 등으로 결정한
+    /// 강제 inline 신호. shadow 충돌은 함수 안에서 자체 감지하여 ns_inline_list 를 활성화.
     pub fn registerNamespaceRewrites(
         self: *const Linker,
         ns_rewrite_list: *std.ArrayList(LinkingMetadata.NsMemberRewrites.Entry),
-        ns_inline_list: ?*std.ArrayList(LinkingMetadata.NsInlineObjects.Entry),
+        ns_inline_list: *std.ArrayList(LinkingMetadata.NsInlineObjects.Entry),
+        force_inline: bool,
+        importer_mod_idx: u32,
         symbol_id: u32,
         target_mod_idx: u32,
         var_name: []const u8,
@@ -1927,10 +1935,17 @@ pub const Linker = struct {
             break :blk owned_slice;
         };
 
-        // 캐시된 exports로 inner_map 구축.
-        // owned 문자열은 캐시가 소유하므로, inner_map에서 사용할 복사본 생성.
+        // importer 의 nested binding 과 충돌하는 export 는 inline 시 self-shadow 무한
+        // 재귀 위험 → 매핑 등록을 건너뛰고 has_shadow 로 추적.
+        // (예: `const setSelectedLog = (i) => LogBoxData.setSelectedLog(i);` 가
+        //  `const setSelectedLog = (i) => setSelectedLog(i);` 로 inline 되는 케이스)
         var inner_map = std.StringHashMap([]const u8).init(self.allocator);
+        var has_shadow = false;
         for (cached_exports) |exp| {
+            if (self.hasNestedBinding(importer_mod_idx, exp.exported)) {
+                has_shadow = true;
+                continue;
+            }
             const local = if (exp.owned)
                 try self.allocator.dupe(u8, exp.local)
             else
@@ -1942,16 +1957,17 @@ pub const Linker = struct {
             .map = inner_map,
         });
 
-        if (ns_inline_list) |list| {
+        // ns_inline_list 활성화 조건: caller 가 명시 (force_inline) 또는 shadow 충돌 발생.
+        // 후자의 경우 codegen fallback 이 namespace 객체 access 로 emit 할 수 있도록 객체가 필요.
+        if (force_inline or has_shadow) {
             const obj_str = try self.buildInlineObjectStr(target_mod_idx, 0);
-            // seen 맵 재구성 — makeUniqueNsVarName에서 export 이름 충돌 확인용
             var seen = std.StringHashMap(void).init(self.allocator);
             defer seen.deinit();
             for (cached_exports) |exp| {
                 try seen.put(exp.exported, {});
             }
             const ns_var_name = try self.makeUniqueNsVarName(var_name, &seen);
-            try list.append(self.allocator, .{
+            try ns_inline_list.append(self.allocator, .{
                 .symbol_id = symbol_id,
                 .object_literal = obj_str,
                 .var_name = ns_var_name,

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -425,11 +425,14 @@ pub fn buildMetadataForAst(
 
                 // esbuild 방식: ns.prop → 직접 치환, ns 값 사용 → 변수 선언 + 참조.
                 // export { ns } 패턴도 값 사용 — namespace 객체를 preamble 변수로 생성 필요.
-                const need_inline = isNamespaceUsedAsValue(self.allocator, ast, effective_syms, ns_sym_id) or
+                // shadow 충돌은 registerNamespaceRewrites 가 자체 감지해 ns_inline_list 활성화.
+                const force_inline = isNamespaceUsedAsValue(self.allocator, ast, effective_syms, ns_sym_id) or
                     exported_locals.contains(local_name);
                 try self.registerNamespaceRewrites(
                     &ns_rewrite_list,
-                    if (need_inline) &ns_inline_list else null,
+                    &ns_inline_list,
+                    force_inline,
+                    module_index,
                     ns_sym_id,
                     @intCast(canonical_mod),
                     local_name,
@@ -488,6 +491,8 @@ pub fn buildMetadataForAst(
                                             try self.registerNamespaceRewrites(
                                                 &ns_rewrite_list,
                                                 &ns_inline_list,
+                                                true,
+                                                module_index,
                                                 @intCast(import_sym_id),
                                                 @intFromEnum(src),
                                                 ib.local_name,
@@ -514,6 +519,8 @@ pub fn buildMetadataForAst(
                                 try self.registerNamespaceRewrites(
                                     &ns_rewrite_list,
                                     &ns_inline_list,
+                                    true,
+                                    module_index,
                                     @intCast(imp_sym),
                                     @intCast(ns_target_mod),
                                     ib.local_name,

--- a/src/bundler/test_helpers.zig
+++ b/src/bundler/test_helpers.zig
@@ -1,4 +1,56 @@
 const std = @import("std");
+const Bundler = @import("bundler.zig").Bundler;
+const BundleResult = @import("bundler.zig").BundleResult;
+const BundleOptions = @import("bundler.zig").BundleOptions;
+const resolve_cache_mod = @import("resolve_cache.zig");
+
+/// 테스트용 번들 결과 wrapper: arena 가 linker 관련 로컬 할당의 수명을 보장.
+pub const Bundled = struct {
+    arena: std.heap.ArenaAllocator,
+    result: BundleResult,
+
+    pub fn code(self: *const Bundled) []const u8 {
+        return self.result.output;
+    }
+
+    pub fn deinit(self: *Bundled) void {
+        self.result.deinit(self.arena.child_allocator);
+        self.arena.deinit();
+    }
+};
+
+/// tmpDir 의 entry 파일을 IIFE 로 번들링. `extra` 로 scope_hoist / tree_shaking 등 추가 옵션 전달.
+/// `entry_points` / `format` 은 헬퍼가 강제로 채우므로 caller 는 나머지 필드만 명시.
+pub fn bundleEntry(
+    backing: std.mem.Allocator,
+    tmp: *std.testing.TmpDir,
+    entry_name: []const u8,
+    extra: anytype,
+) !Bundled {
+    var arena = std.heap.ArenaAllocator.init(backing);
+    errdefer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const dp = try tmp.dir.realpathAlloc(arena_alloc, ".");
+    const entry = try std.fs.path.resolve(arena_alloc, &.{ dp, entry_name });
+
+    var cache = resolve_cache_mod.ResolveCache.init(backing, .{});
+    defer cache.deinit();
+
+    const entries: []const []const u8 = &.{entry};
+    var opts: BundleOptions = .{ .entry_points = entries, .format = .iife };
+    inline for (@typeInfo(@TypeOf(extra)).@"struct".fields) |f| {
+        if (comptime std.mem.eql(u8, f.name, "entry_points")) continue;
+        if (comptime std.mem.eql(u8, f.name, "format")) continue;
+        @field(opts, f.name) = @field(extra, f.name);
+    }
+
+    var bundler = Bundler.initWithResolveCache(backing, opts, &cache);
+    defer bundler.deinit();
+
+    const result = try bundler.bundle();
+    return .{ .arena = arena, .result = result };
+}
 
 /// 테스트용 헬퍼: tmpDir에 파일 생성 + 내용 쓰기 (부모 디렉토리 자동 생성)
 pub fn writeFile(dir: std.fs.Dir, path: []const u8, data: []const u8) !void {


### PR DESCRIPTION
## Summary

`import * as M from 'mod'; const x = (i) => M.x(i);` 가 `const x = (i) => x(i);` 로 inline 되면서 namespace 멤버 호출이 자기 호출이 되어 **무한 재귀** 가 발생하던 버그 수정.

## 증상 (실측)

`react-native/Libraries/LogBox/LogBoxNotificationContainer.js` 의:

```js
import * as LogBoxData from './Data/LogBoxData';

function _LogBoxNotificationContainer() {
  const setSelectedLog = (index) => {
    LogBoxData.setSelectedLog(index);    // ← inline 결과: setSelectedLog(index)
  };
  ...
}
```

LogBox notification 클릭 → `RangeError: Maximum call stack size exceeded` (스택 1 만 프레임 동일 함수).

## Root cause

`registerNamespaceRewrites` 가 `(exported_name → local_name)` 매핑을 만들 때, importer 의 nested scope 에 같은 이름의 binding 이 있는지 체크하지 않음. codegen 이 inline 한 결과가 local binding 을 self-shadow → 자기 호출.

## Fix

`linker.zig` `registerNamespaceRewrites`:

1. `inner_map.put` 직전 `hasNestedBinding(importer_mod_idx, exp.exported)` 체크. 충돌 시 매핑 등록을 skip.
2. 충돌이 하나라도 발견되면 (`has_shadow`) `ns_inline_list` 를 자동 활성화 — codegen fallback path 가 `M_ns.prop` (namespace 객체 access) 으로 emit 할 수 있도록.

`metadata.zig` 호출자 (3 곳) 에 `importer_mod_idx` + caller 결정 `force_inline` 신호 전달.

`registerNamespaceRewrites` 가 `cached_exports` (`collectExportsRecursive` 결과) 를 단일 진실로 사용하므로 `export * from` 체인을 통한 export 도 정확히 잡힘.

## 코드 비교

**Before** (LogBoxNotificationContainer.js bundled):
\`\`\`js
var setSelectedLog = function(index) {
    setSelectedLog(index);   // self-shadow → 무한 재귀
};
\`\`\`

**After**:
\`\`\`js
var LogBoxData_ns = { get setSelectedLog() { return setSelectedLog; }, ... };
var setSelectedLog = function(index) {
    LogBoxData_ns.setSelectedLog(index);   // namespace 객체 access
};
\`\`\`

## Test plan

- [x] 7 회귀 테스트 (`bundler_test/ns_member_shadow.zig`):
  - LogBox 스타일 self-shadow
  - 비충돌 케이스 inline 유지 (over-fix 방지)
  - 중첩 함수 binding 충돌
  - 부분 충돌 (shadowed member 만 fallback, 나머지 inline)
  - 함수 매개변수 binding 충돌
  - 여러 namespace import 가 같은 이름과 충돌 시 각각 독립 처리
  - `export *` 체인을 통한 export 도 shadowing 으로 인식
- [x] 전체 unit/regression suite (`zig build test`) **3658 passed / 1 skipped**
- [x] bungae monorepo 의 expo-router 부팅 + LogBox notification 클릭에서 무한 재귀 사라짐 실측 확인 (Metro 동등 동작)

## Refactor

`Bundled` / `bundleEntry` 테스트 헬퍼를 `bundler/test_helpers.zig` 로 추출 (`virtual_ns_treeshake.zig` 와 새 `ns_member_shadow.zig` 가 공유).

🤖 Generated with [Claude Code](https://claude.com/claude-code)