### PR TITLE
perf(transformer): non-fast-path class expression name 익명화 (#1596)

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -1733,6 +1733,162 @@ test "Minify: keep_names disables anonymization (#1587)" {
 }
 
 // ============================================================
+// Minify syntax: anonymize on non-fast-path (#1596)
+// ============================================================
+// #1587 의 fast path (useDefineForClassFields=true AND !experimentalDecorators) 외에도
+// body 멤버를 개별 분류하는 non-fast-path (visitClassWithAssignSemantics) 에서 동일 최적화.
+// 단, class name 런타임 참조 요소 (static field / static block 다운레벨 / decorator) 없을 때만.
+
+test "Minify non-fast-path: anonymize unreferenced class expression (#1596)" {
+    // useDefineForClassFields=false → non-fast-path 진입.
+    // static field / decorator 없으므로 익명화 가능.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const e = new (class StaleReactionError extends Error {
+        \\  name = "StaleReactionError";
+        \\})();
+        \\console.log(e);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+        .use_define_for_class_fields = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class StaleReactionError") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"StaleReactionError\"") != null);
+}
+
+test "Minify non-fast-path: self-reference keeps name (#1596)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const c = class SelfRef {
+        \\  static make() { return new SelfRef(); }
+        \\};
+        \\console.log(c.make());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+        .use_define_for_class_fields = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // static method 가 self-ref 하므로 이름 보존
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SelfRef") != null);
+}
+
+test "Minify non-fast-path: static field blocks anonymization (#1596)" {
+    // static field → `ClassName.x = ...` emit 필요하므로 익명화 불가.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const c = class WithStatic extends Error {
+        \\  static version = 1;
+        \\};
+        \\console.log(c);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+        .use_define_for_class_fields = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // static field 가 `WithStatic.version = 1` 형태로 emit 되므로 이름 참조 존재
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "WithStatic") != null);
+}
+
+test "Minify non-fast-path: experimental decorator blocks anonymization (#1596)" {
+    // @decorator 가 __decorateClass argument 로 class 를 받으므로 이름은 사실 optional 이나
+    // class member decorator 는 transformExperimentalDecorators 경로에서 class name 기반
+    // helper 를 생성할 수 있어 보수적으로 이름 유지.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\function Log(target: any, key?: any, kind?: any) { return target; }
+        \\const c = @Log class DecoratedExpr extends Error {
+        \\  @Log method() { return 1; }
+        \\};
+        \\console.log(new c().method());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+        .experimental_decorators = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // decorator 가 있으면 이름 유지
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DecoratedExpr") != null);
+}
+
+test "Minify non-fast-path: instance field allows anonymization (#1596)" {
+    // instance field (non-static) 는 constructor 로 이동되므로 class name 참조 불필요.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const e = new (class InstField extends Error {
+        \\  count = 0;
+        \\  label = "x";
+        \\})();
+        \\console.log(e);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+        .use_define_for_class_fields = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class InstField") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "InstField") == null);
+}
+
+// ============================================================
 // Asset Loader Tests
 // ============================================================
 

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -1793,12 +1793,11 @@ test "Minify non-fast-path: self-reference keeps name (#1596)" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // static method 가 self-ref 하므로 이름 보존
     try std.testing.expect(std.mem.indexOf(u8, result.output, "SelfRef") != null);
 }
 
 test "Minify non-fast-path: static field blocks anonymization (#1596)" {
-    // static field → `ClassName.x = ...` emit 필요하므로 익명화 불가.
+    // static field 가 `ClassName.x = ...` 형태로 emit 되므로 이름 참조가 살아남아야 한다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",
@@ -1822,14 +1821,12 @@ test "Minify non-fast-path: static field blocks anonymization (#1596)" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // static field 가 `WithStatic.version = 1` 형태로 emit 되므로 이름 참조 존재
     try std.testing.expect(std.mem.indexOf(u8, result.output, "WithStatic") != null);
 }
 
 test "Minify non-fast-path: experimental decorator blocks anonymization (#1596)" {
-    // @decorator 가 __decorateClass argument 로 class 를 받으므로 이름은 사실 optional 이나
-    // class member decorator 는 transformExperimentalDecorators 경로에서 class name 기반
-    // helper 를 생성할 수 있어 보수적으로 이름 유지.
+    // class 자체는 __decorateClass 의 argument 로 받아 이름 없이 써도 되지만,
+    // method decorator 의 member 접근 helper 가 class name 을 참조할 수 있어 보수적으로 보존.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",
@@ -1854,12 +1851,11 @@ test "Minify non-fast-path: experimental decorator blocks anonymization (#1596)"
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // decorator 가 있으면 이름 유지
     try std.testing.expect(std.mem.indexOf(u8, result.output, "DecoratedExpr") != null);
 }
 
 test "Minify non-fast-path: instance field allows anonymization (#1596)" {
-    // instance field (non-static) 는 constructor 로 이동되므로 class name 참조 불필요.
+    // instance field 는 constructor 로 이동되므로 class name 참조가 남지 않는다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -26,4 +26,5 @@ comptime {
     _ = @import("codegen_test/function_map.zig");
     _ = @import("codegen_test/skip_nodes_blank.zig");
     _ = @import("codegen_test/import_attributes.zig");
+    _ = @import("codegen_test/class_expr_anonymize.zig");
 }

--- a/src/codegen/codegen_test/class_expr_anonymize.zig
+++ b/src/codegen/codegen_test/class_expr_anonymize.zig
@@ -1,0 +1,208 @@
+//! class expression name 익명화 유닛 테스트 — #1587 (fast path) + #1596 (non-fast-path).
+//!
+//! 번들러 없이 scan → parse → semantic → transform → codegen 파이프라인을 직접 구성해
+//! 익명화 판정을 검증한다. semantic pass 가 없으면 reference_count 가 비어 익명화 자체가
+//! 조기 false 로 빠지므로 본 파일은 전용 헬퍼로 직접 semantic 을 돌린다.
+//! bundler 통합 테스트는 `src/bundler/bundler_test/minify_loader.zig` 에 별도 존재.
+
+const std = @import("std");
+const helpers = @import("helpers.zig");
+const Scanner = helpers.Scanner;
+const Parser = helpers.Parser;
+const Transformer = helpers.Transformer;
+const TransformOptions = helpers.TransformOptions;
+const Codegen = helpers.Codegen;
+const TestResult = helpers.TestResult;
+const SemanticAnalyzer = @import("../../semantic/analyzer.zig").SemanticAnalyzer;
+
+fn runSemanticPipeline(
+    backing_allocator: std.mem.Allocator,
+    source: []const u8,
+    t_options: TransformOptions,
+) !TestResult {
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
+    const allocator = arena.allocator();
+
+    var scanner = try Scanner.init(allocator, source);
+    var parser = Parser.init(allocator, &scanner);
+    parser.configureFromExtension(".ts");
+    _ = try parser.parse();
+
+    var analyzer = SemanticAnalyzer.init(allocator, &parser.ast);
+    analyzer.is_strict_mode = parser.is_strict_mode;
+    analyzer.is_module = parser.is_module;
+    analyzer.is_ts = parser.is_ts;
+    analyzer.is_flow = parser.is_flow;
+    try analyzer.analyze();
+
+    var transformer = try Transformer.init(allocator, &parser.ast, t_options);
+    try transformer.initSymbolIds(analyzer.symbol_ids.items);
+    transformer.symbols = analyzer.symbols.items;
+    transformer.references = analyzer.references.items;
+    transformer.line_offsets = scanner.line_offsets.items;
+    const root = try transformer.transform();
+
+    var cg = Codegen.initWithOptions(allocator, transformer.ast, .{ .minify_whitespace = true });
+    const output = try cg.generate(root);
+
+    return .{ .output = output, .arena = arena };
+}
+
+/// fast path (useDefineForClassFields=true AND !experimentalDecorators) 기준.
+fn eFast(allocator: std.mem.Allocator, source: []const u8) !TestResult {
+    return runSemanticPipeline(allocator, source, .{
+        .use_define_for_class_fields = true,
+        .minify_syntax = true,
+    });
+}
+
+/// non-fast-path via useDefineForClassFields=false.
+fn eAssign(allocator: std.mem.Allocator, source: []const u8) !TestResult {
+    return runSemanticPipeline(allocator, source, .{
+        .use_define_for_class_fields = false,
+        .minify_syntax = true,
+    });
+}
+
+/// non-fast-path via experimentalDecorators=true.
+fn eExpDeco(allocator: std.mem.Allocator, source: []const u8) !TestResult {
+    return runSemanticPipeline(allocator, source, .{
+        .experimental_decorators = true,
+        .minify_syntax = true,
+    });
+}
+
+fn eAssignKeepNames(allocator: std.mem.Allocator, source: []const u8) !TestResult {
+    return runSemanticPipeline(allocator, source, .{
+        .use_define_for_class_fields = false,
+        .minify_syntax = true,
+        .keep_names = true,
+    });
+}
+
+fn eAssignNoMinify(allocator: std.mem.Allocator, source: []const u8) !TestResult {
+    return runSemanticPipeline(allocator, source, .{
+        .use_define_for_class_fields = false,
+        .minify_syntax = false,
+    });
+}
+
+// ============================================================
+// fast path (#1587 회귀 가드)
+// ============================================================
+
+test "anonymize fast-path: unreferenced class expression (#1587)" {
+    var r = try eFast(std.testing.allocator,
+        \\const e = new (class StaleReactionError extends Error {})();
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "class StaleReactionError") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "StaleReactionError") == null);
+}
+
+test "anonymize fast-path: class declaration never anonymized (#1587)" {
+    var r = try eFast(std.testing.allocator,
+        \\class Box {}
+        \\const x = new Box();
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Box") != null);
+}
+
+// ============================================================
+// non-fast-path via useDefineForClassFields=false (#1596)
+// ============================================================
+
+test "anonymize non-fast-path: unreferenced class expression (#1596)" {
+    var r = try eAssign(std.testing.allocator,
+        \\const e = new (class StaleReactionError extends Error {
+        \\  name = "StaleReactionError";
+        \\})();
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "class StaleReactionError") == null);
+    // property string literal 은 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"StaleReactionError\"") != null);
+}
+
+test "anonymize non-fast-path: instance field only → anonymized (#1596)" {
+    // instance field 는 constructor 로 이동 → class name 런타임 참조 없음
+    var r = try eAssign(std.testing.allocator,
+        \\const e = new (class InstField extends Error {
+        \\  count = 0;
+        \\})();
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "InstField") == null);
+}
+
+test "anonymize non-fast-path: static field blocks (#1596)" {
+    // `ClassName.x = ...` emit 되므로 이름 필요
+    var r = try eAssign(std.testing.allocator,
+        \\const c = class WithStatic extends Error {
+        \\  static version = 1;
+        \\};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "WithStatic") != null);
+}
+
+test "anonymize non-fast-path: self-reference blocks (#1596)" {
+    var r = try eAssign(std.testing.allocator,
+        \\const c = class SelfRef {
+        \\  static make() { return new SelfRef(); }
+        \\};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "SelfRef") != null);
+}
+
+test "anonymize non-fast-path: keep_names disables (#1596)" {
+    var r = try eAssignKeepNames(std.testing.allocator,
+        \\const c = class KeepMe extends Error {};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "KeepMe") != null);
+}
+
+test "anonymize non-fast-path: minify_syntax=false disables (#1596)" {
+    var r = try eAssignNoMinify(std.testing.allocator,
+        \\const c = class UnusedName extends Error {};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "UnusedName") != null);
+}
+
+// ============================================================
+// non-fast-path via experimentalDecorators=true (#1596)
+// ============================================================
+
+test "anonymize non-fast-path: experimental_decorators flag without actual decorators → anonymized (#1596)" {
+    // 플래그만 true 이고 실제 decorator 가 없으면 익명화 가능
+    var r = try eExpDeco(std.testing.allocator,
+        \\const c = class NoDecorator extends Error {};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "NoDecorator") == null);
+}
+
+test "anonymize non-fast-path: class decorator blocks (#1596)" {
+    var r = try eExpDeco(std.testing.allocator,
+        \\function Log(target: any) { return target; }
+        \\const c = @Log class DecoratedClass extends Error {};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "DecoratedClass") != null);
+}
+
+test "anonymize non-fast-path: method decorator blocks (#1596)" {
+    var r = try eExpDeco(std.testing.allocator,
+        \\function Log(target: any, key: any) {}
+        \\const c = class WithMethodDeco {
+        \\  @Log method() {}
+        \\};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "WithMethodDeco") != null);
+}

--- a/src/codegen/codegen_test/class_expr_anonymize.zig
+++ b/src/codegen/codegen_test/class_expr_anonymize.zig
@@ -138,7 +138,6 @@ test "anonymize non-fast-path: instance field only → anonymized (#1596)" {
 }
 
 test "anonymize non-fast-path: static field blocks (#1596)" {
-    // `ClassName.x = ...` emit 되므로 이름 필요
     var r = try eAssign(std.testing.allocator,
         \\const c = class WithStatic extends Error {
         \\  static version = 1;
@@ -179,7 +178,6 @@ test "anonymize non-fast-path: minify_syntax=false disables (#1596)" {
 // ============================================================
 
 test "anonymize non-fast-path: experimental_decorators flag without actual decorators → anonymized (#1596)" {
-    // 플래그만 true 이고 실제 decorator 가 없으면 익명화 가능
     var r = try eExpDeco(std.testing.allocator,
         \\const c = class NoDecorator extends Error {};
     );

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -425,18 +425,15 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
         .data = .{ .list = body_list },
     });
 
-    // #1596: non-fast-path 에서도 미참조 class_expression name 익명화.
-    //   class name 이 런타임에 실제로 필요한 경우에만 보존:
-    //     - static field — `ClassName.x = ...` emit 필요
-    //     - static block 다운레벨 — block 내부 `this` 를 class name 으로 치환
-    //     - decorator (class/member/ctor param) — __decorateClass argument
-    //     - static private field — brand check helper 가 class name 참조 (해당 경로는 fast path 만 다운레벨 처리)
-    //   위 요소가 하나라도 있으면 익명화 불가. 그 외에는 fast path 와 동일.
+    const old_deco_len = self.readU32(e, ast_mod.ClassExtra.deco_len);
+    const has_any_decorator = old_deco_len > 0 or
+        member_decorators.items.len > 0 or
+        ctor_param_decos.items.len > 0;
+
+    // #1596: fast path (#1587) 와 동일 최적화를 non-fast-path 에도 적용.
+    // class name 이 runtime 에 참조되는 경우 — static field (`Foo.x=...`),
+    // static block 다운레벨 (`this` 치환), decorator 중 하나라도 있으면 보존.
     if (shouldDropClassExprName(self, node.tag, raw_name_idx)) {
-        const old_deco_len = self.readU32(e, ast_mod.ClassExtra.deco_len);
-        const has_any_decorator = old_deco_len > 0 or
-            member_decorators.items.len > 0 or
-            ctor_param_decos.items.len > 0;
         const has_static_extras = static_field_assignments.items.len > 0 or
             static_block_iifes.items.len > 0;
         if (!has_any_decorator and !has_static_extras) {
@@ -447,9 +444,8 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
     // experimentalDecorators — decorator를 class에서 제거하고 __decorateClass 호출 생성
     if (self.options.experimental_decorators) {
         const old_deco_start = self.readU32(e, ast_mod.ClassExtra.deco_start);
-        const old_deco_len = self.readU32(e, ast_mod.ClassExtra.deco_len);
 
-        if (old_deco_len > 0 or member_decorators.items.len > 0 or ctor_param_decos.items.len > 0) {
+        if (has_any_decorator) {
             return try self.transformExperimentalDecorators(
                 node,
                 new_name,
@@ -469,7 +465,7 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
 
     // decorator 리스트 복사 (experimental이 아닌 경우)
     const new_decos = if (!self.options.experimental_decorators)
-        try self.visitExtraList(.{ .start = self.readU32(e, ast_mod.ClassExtra.deco_start), .len = self.readU32(e, ast_mod.ClassExtra.deco_len) })
+        try self.visitExtraList(.{ .start = self.readU32(e, ast_mod.ClassExtra.deco_start), .len = old_deco_len })
     else
         NodeList{ .start = 0, .len = 0 };
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -261,12 +261,10 @@ fn wrapClassExprInIIFE(
 /// experimental decorator를 __decorateClass 호출로 변환한다.
 pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeIndex {
     // TODO(es2021): apply same IIFE wrapping for class_expression with private methods — see wrapClassExprInIIFE in fast path
-    // NOTE(#1587): class expression anonymization은 fast path에서만 적용한다. 이 경로는
-    //   experimental decorator / useDefineForClassFields=false 등으로 body를 멤버 단위로
-    //   분류하므로 reference_count 기반 판단을 재평가해야 한다. 후속 작업.
     const e = node.data.extra;
     const has_super = !self.readNodeIdx(e, ast_mod.ClassExtra.super).isNone();
-    const new_name = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.name));
+    const raw_name_idx = self.readNodeIdx(e, ast_mod.ClassExtra.name);
+    var new_name = try self.visitNode(raw_name_idx);
     const new_super = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.super));
 
     // 원본 class_body를 직접 순회
@@ -426,6 +424,25 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
         .span = body_node.span,
         .data = .{ .list = body_list },
     });
+
+    // #1596: non-fast-path 에서도 미참조 class_expression name 익명화.
+    //   class name 이 런타임에 실제로 필요한 경우에만 보존:
+    //     - static field — `ClassName.x = ...` emit 필요
+    //     - static block 다운레벨 — block 내부 `this` 를 class name 으로 치환
+    //     - decorator (class/member/ctor param) — __decorateClass argument
+    //     - static private field — brand check helper 가 class name 참조 (해당 경로는 fast path 만 다운레벨 처리)
+    //   위 요소가 하나라도 있으면 익명화 불가. 그 외에는 fast path 와 동일.
+    if (shouldDropClassExprName(self, node.tag, raw_name_idx)) {
+        const old_deco_len = self.readU32(e, ast_mod.ClassExtra.deco_len);
+        const has_any_decorator = old_deco_len > 0 or
+            member_decorators.items.len > 0 or
+            ctor_param_decos.items.len > 0;
+        const has_static_extras = static_field_assignments.items.len > 0 or
+            static_block_iifes.items.len > 0;
+        if (!has_any_decorator and !has_static_extras) {
+            new_name = NodeIndex.none;
+        }
+    }
 
     // experimentalDecorators — decorator를 class에서 제거하고 __decorateClass 호출 생성
     if (self.options.experimental_decorators) {


### PR DESCRIPTION
## Summary
- `#1587` 의 fast path (`useDefineForClassFields=true AND !experimentalDecorators`) 외에도 body 를 멤버 단위로 분류하는 non-fast-path (`visitClassWithAssignSemantics`) 에서 동일한 익명화 최적화 적용
- class name 이 런타임에 필요한 경우에만 보존 (static field / static block 다운레벨 / decorator)

## 동작
\`\`\`ts
// before (non-fast-path)
const e = new (class StaleReactionError extends Error {
  name = "StaleReactionError";
})();

// after
const e = new (class extends Error {
  name = "StaleReactionError";
})();
\`\`\`

## 안전 가드
body 분류가 끝난 후 아래 요소를 한 번에 체크:
- `old_deco_len > 0` — class decorator
- `member_decorators.items.len > 0` — method/field decorator
- `ctor_param_decos.items.len > 0` — ctor param decorator
- `static_field_assignments.items.len > 0` — \`Foo.x = ...\` emit 필요
- `static_block_iifes.items.len > 0` — static block 다운레벨 시 \`this\` → class name 치환

하나라도 있으면 skip. 그 외에는 fast path 와 동일하게 `shouldDropClassExprName` 판단 적용.

## Test plan
- [x] `zig build test` 전체 통과
- [x] `#1596` 추가 테스트 5개:
  - `anonymize unreferenced class expression` — `useDefineForClassFields=false` 에서 익명화
  - `self-reference keeps name` — body 내부 self-ref 있으면 보존
  - `static field blocks anonymization` — `static x = 1` 있으면 보존
  - `experimental decorator blocks anonymization` — decorator 있으면 보존
  - `instance field allows anonymization` — instance field 만 있으면 익명화 가능
- [x] `#1587` 기존 fast-path 테스트 4개 회귀 없음

Closes #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)