### PR TITLE
fix(graph): deduplicate init/exports var names across wrapped modules

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -33,5 +33,6 @@ comptime {
     _ = @import("bundler_test/function_map.zig");
     _ = @import("bundler_test/virtual_ns_treeshake.zig");
     _ = @import("bundler_test/ns_member_shadow.zig");
+    _ = @import("bundler_test/exports_name_dedup.zig");
     _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/bundler_test/exports_name_dedup.zig
+++ b/src/bundler/bundler_test/exports_name_dedup.zig
@@ -1,0 +1,93 @@
+//! Regression: bun lockfile 의 hash 기반 dedup 으로 같은 패키지가 여러 사본
+//! (`node_modules/.bun/<HASH>/node_modules/<pkg>/...`) 으로 설치되면, 두 사본의
+//! 같은 모듈 (예: `expo/src/launch/registerRootComponent.tsx`) 이 모두 wrap 되면서
+//! `makeVarNameWithPrefix` 가 path 의 마지막 `node_modules/` 이후만 보고 동일한
+//! `exports_<pkg>_<...>` / `init_<pkg>_<...>` 변수 이름을 만들어 충돌.
+//! 같은 export object 의 'default' getter 두 번 정의 → 두번째가 첫번째를 덮어씀
+//! → 실제 사용처 chain 에 init 안 되어 undefined 참조 (`registerRootComponent is
+//! not a function`).
+
+const std = @import("std");
+const testing = std.testing;
+const helpers = @import("../test_helpers.zig");
+const writeFile = helpers.writeFile;
+
+fn bundleEntry(backing: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !helpers.Bundled {
+    return helpers.bundleEntry(backing, tmp, entry_name, .{ .dev_mode = true });
+}
+
+// 두 디렉토리에 같은 basename 모듈 → wrap 시 exports/init 변수가 deconflict.
+test "exports name dedup: 같은 basename 두 사본의 변수가 충돌하지 않음" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "dir-a/foo.js", "export function value() { return 'a'; }");
+    try writeFile(tmp.dir, "dir-b/foo.js", "export function value() { return 'b'; }");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as a from './dir-a/foo.js';
+        \\import * as b from './dir-b/foo.js';
+        \\globalThis.__out = a.value() + ':' + b.value();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // 첫 사본: 그대로 base 이름
+    try testing.expect(std.mem.indexOf(u8, code, "var exports_foo = {}") != null);
+    try testing.expect(std.mem.indexOf(u8, code, "var init_foo = __esm") != null);
+
+    // 두번째 사본: $2 suffix 로 deconflict
+    try testing.expect(std.mem.indexOf(u8, code, "var exports_foo$2 = {}") != null);
+    try testing.expect(std.mem.indexOf(u8, code, "var init_foo$2 = __esm") != null);
+
+    // 같은 변수가 두 번 선언되면 codegen 의 두번째 `__export` 가 첫 getter 를 덮어씀.
+    var count_decl: usize = 0;
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, code, search, "var exports_foo = {}")) |idx| {
+        count_decl += 1;
+        search = idx + 1;
+    }
+    try testing.expectEqual(@as(usize, 1), count_decl);
+}
+
+// 세 사본이면 base, $2, $3 — incremental suffix.
+test "exports name dedup: 세 사본은 base, $2, $3 으로 incremental" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a/mod.js", "export const x = 1;");
+    try writeFile(tmp.dir, "b/mod.js", "export const x = 2;");
+    try writeFile(tmp.dir, "c/mod.js", "export const x = 3;");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as a from './a/mod.js';
+        \\import * as b from './b/mod.js';
+        \\import * as c from './c/mod.js';
+        \\globalThis.__out = a.x + b.x + c.x;
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    try testing.expect(std.mem.indexOf(u8, code, "var exports_mod = {}") != null);
+    try testing.expect(std.mem.indexOf(u8, code, "var exports_mod$2 = {}") != null);
+    try testing.expect(std.mem.indexOf(u8, code, "var exports_mod$3 = {}") != null);
+}
+
+// 충돌 없는 단일 모듈은 base 이름 유지 (over-fix 방지).
+test "exports name dedup: 단일 사본은 suffix 없이 base 이름" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lonely.js", "export const v = 42;");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as m from './lonely.js';
+        \\globalThis.__out = m.v;
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    try testing.expect(std.mem.indexOf(u8, code, "var exports_lonely = {}") != null);
+    // suffix 가 붙은 인스턴스가 있으면 안 됨
+    try testing.expect(std.mem.indexOf(u8, code, "exports_lonely$") == null);
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1678,17 +1678,42 @@ pub const ModuleGraph = struct {
     /// 심볼을 semantic 공간에 등록한다. Emitter/linker가 Module.getInitName/
     /// getExportsName으로 이름을 조회해 중복 할당을 피한다.
     /// OOM/semantic 없음 → 조용히 skip, fallback 경로가 기존 동작 유지.
+    ///
+    /// `makeVarNameWithPrefix` 는 path 의 마지막 `node_modules/` 이후만 사용해 이름을
+    /// 생성하므로, bun lockfile 처럼 `node_modules/.bun/<HASH>/node_modules/<pkg>/...`
+    /// 형태로 같은 패키지의 다른 hash 사본이 동시에 존재하면 두 사본의 init/exports
+    /// 변수 이름이 동일해진다. emitter 가 같은 변수를 두 번 선언 + 같은 export object 의
+    /// getter 를 두 번 정의 → 두번째가 첫번째를 덮어써서 사용처에서 undefined 참조.
+    /// 충돌 감지 시 `$<N>` suffix 로 deconflict.
     fn registerWrapperSymbols(self: *ModuleGraph) void {
+        // key 들은 module 의 parse_arena (graph teardown 까지 살아있음 — `Module.deinit`
+        // 까지) 에서 빌리거나 본 함수 안의 arena 에서 새로 할당. used_names 는 이 함수
+        // 안에서 defer deinit 되므로 모든 키가 map 보다 오래 산다.
+        var used_names: std.StringHashMap(u32) = std.StringHashMap(u32).init(self.allocator);
+        defer used_names.deinit();
+
+        // 이미 등록된 모듈 (incremental rebuild) 의 이름을 먼저 seed — 새 모듈이 같은
+        // base 를 쓰면 collision 이 재발하므로. seed 후 카운터는 1 (다음 충돌 시 $2 부여).
+        // base 자체가 이미 suffix 형태일 수도 있지만 contains-check 만 쓰는 uniqueName
+        // 의 retry 루프로 안전하게 처리.
+        var seed_it = self.modules.iterator(0);
+        while (seed_it.next()) |m| {
+            if (m.wrap_kind == .none) continue;
+            if (m.getInitName()) |n| _ = used_names.put(n, 1) catch {};
+            if (m.getExportsName()) |n| _ = used_names.put(n, 1) catch {};
+        }
+
         var it = self.modules.iterator(0);
         while (it.next()) |m| {
             if (m.wrap_kind == .none) continue;
-            // incremental rebuild: 이미 등록된 모듈은 skip.
             if (m.init_symbol != null or m.exports_symbol != null) continue;
             const sem_ptr = if (m.semantic) |*s| s else continue;
             const arena = if (m.parse_arena) |*a| a.allocator() else continue;
 
-            const init_name = types.makeInitVarName(arena, m.path) catch continue;
-            const exports_name = types.makeExportsVarName(arena, m.path) catch continue;
+            const init_base = types.makeInitVarName(arena, m.path) catch continue;
+            const exports_base = types.makeExportsVarName(arena, m.path) catch continue;
+            const init_name = uniqueName(arena, init_base, &used_names) catch continue;
+            const exports_name = uniqueName(arena, exports_base, &used_names) catch continue;
 
             m.init_symbol = semantic_symbol.extendSymbol(
                 arena,
@@ -1707,6 +1732,28 @@ pub const ModuleGraph = struct {
                 exports_name,
                 Span.EMPTY,
             ) catch null;
+        }
+    }
+
+    /// 같은 base name 이 여러 모듈에서 나오면 `$2`, `$3`... suffix 로 unique 화.
+    /// 이미 등록된 suffix 와도 충돌하면 다음 N 으로 retry — incremental rebuild 에서
+    /// `{base, base$2}` 가 이미 seed 된 상태에서 새 모듈이 들어오면 `$3` 으로 회피.
+    fn uniqueName(
+        name_arena: std.mem.Allocator,
+        base: []const u8,
+        used: *std.StringHashMap(u32),
+    ) std.mem.Allocator.Error![]const u8 {
+        if (!used.contains(base)) {
+            try used.put(base, 1);
+            return base;
+        }
+        var n: u32 = 2;
+        while (true) : (n += 1) {
+            const candidate = try std.fmt.allocPrint(name_arena, "{s}${d}", .{ base, n });
+            if (!used.contains(candidate)) {
+                try used.put(candidate, 1);
+                return candidate;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

bun lockfile / pnpm / nested npm 환경에서 같은 패키지가 여러 사본 (다른 hash) 으로 설치될 때, ZTS 가 두 사본의 같은 모듈을 모두 wrap 하면서 같은 `exports_<X>` / `init_<X>` 변수 이름을 만들어 충돌하던 버그 수정.

## 증상 (실측)

bungae + iOS sim, expo-router 부팅:

```
0,expo_1$3.registerRootComponent is not a function (it is undefined)
```

두 `expo@55.0.15` 사본 (`+ac536320e6ee7140`, `+69503d57a55eb0c1`) 이 동시 설치 → 둘 다 `expo/src/launch/registerRootComponent.tsx` wrap → 둘 다 `exports_expo_src_launch_registerRootComponent` 사용 → 두번째 `__export(..., { default: () => registerRootComponent\$1 })` 가 첫번째 getter 를 덮어씀 → 사용자 init chain 에 두번째 사본의 init 안 호출 → `registerRootComponent$1` 이 `undefined` → 사용처에서 crash.

## Root cause

`types.makeVarNameWithPrefix` 가 path 의 마지막 `node_modules/` 이후만 사용:

```zig
const significant = if (std.mem.lastIndexOf(u8, path, nm)) |pos|
    path[pos + nm.len ..]
else
    std.fs.path.basename(path);
```

bun lockfile path: `node_modules/.bun/expo@HASH/node_modules/expo/src/launch/registerRootComponent.tsx`
→ 마지막 `node_modules/` 이후 = `expo/src/launch/registerRootComponent.tsx`
→ **hash 정보 누락 → 두 사본 동일 이름**.

다른 번들러는 이 충돌을 자체 식별자 전략으로 회피:
- Metro / Webpack: numeric module ID
- esbuild / Rollup / Rolldown: full-path 기반 identifier

ZTS 는 짧고 가독성 좋은 이름을 쓰는 design choice 인데 deconflict pass 가 누락.

## Fix

`graph.zig:registerWrapperSymbols` 에 deconflict pass 추가:

1. \`StringHashMap(u32)\` 로 사용된 이름 추적 + 충돌 시 \`\$<N>\` suffix (esbuild / Bun 스타일).
2. **incremental rebuild seed**: 이미 등록된 모듈의 이름을 먼저 seed → 새로 추가된 사본이 기존 이름과 재충돌 안 함.
3. **suffix retry**: 첫 collision 회피용 \`\$2\` 도 이미 used 면 \`\$3\` 등으로 retry.

```zig
fn uniqueName(name_arena, base, used) {
    if (!used.contains(base)) { try used.put(base, 1); return base; }
    var n: u32 = 2;
    while (true) : (n += 1) {
        const candidate = try std.fmt.allocPrint(name_arena, \"{s}\${d}\", .{ base, n });
        if (!used.contains(candidate)) {
            try used.put(candidate, 1);
            return candidate;
        }
    }
}
```

## 결과 비교

**Before**:
```js
var exports_expo_src_launch_registerRootComponent = {};
__export(...{ \"default\": () => registerRootComponent });
// ...같은 이름이 다시 declared + getter overwrite
var exports_expo_src_launch_registerRootComponent = {};
__export(...{ \"default\": () => registerRootComponent\$1 });
```

**After**:
```js
var exports_expo_src_launch_registerRootComponent = {};
__export(...{ \"default\": () => registerRootComponent });
var exports_expo_src_launch_registerRootComponent\$2 = {};
__export(...{ \"default\": () => registerRootComponent\$1 });
```

## Test plan

- [x] 3 회귀 테스트 (\`bundler_test/exports_name_dedup.zig\`):
  - 두 same-basename 모듈 → 두번째 \`\$2\`
  - 세 사본 → base, \`\$2\`, \`\$3\` incremental
  - 단일 사본 → suffix 없이 base (over-fix 방지)
- [x] 전체 unit/regression suite (\`zig build test\`) **3662 passed**
- [x] bungae monorepo + iOS 26.4 시뮬레이터 부팅에서 \`registerRootComponent is not a function\` 사라짐 실측 확인. (그 다음 단계의 새 에러 - URL parser - 는 별도 추적)

## 매니저 영향

| 매니저 | 영향 |
|---|---|
| bun (`.bun/<HASH>/...`) | ✅ 본 케이스 — 직접 해결 |
| pnpm (`.pnpm/<pkg>@<ver>_<peer-hash>/...`) | ✅ peer hash 기반 사본 다수 → 더 자주 발생하던 잠재 버그 해결 |
| yarn / npm (nested `node_modules`) | ✅ hoisting 실패 시 nested 사본 → deconflict |
| yarn berry PnP | ✅ 같은 패턴 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)