### PR TITLE
feat(parser): import attributes 라운드트립 — dynamic + export named

### DIFF
--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -202,7 +202,7 @@ fn tryExtractExportNamed(ast: *const Ast, node: Node) ?ImportRecord {
 /// import("./foo"): unary { operand=arg }
 /// operand가 string_literal이면 추출, 아니면 null (computed → 정적 분석 불가).
 fn tryExtractDynamicImport(ast: *const Ast, node: Node) ?ImportRecord {
-    const arg_idx = node.data.unary.operand;
+    const arg_idx = node.data.binary.left;
     if (arg_idx.isNone()) return null;
 
     const arg_node = ast.getNode(arg_idx);

--- a/src/bundler/json_to_esm.zig
+++ b/src/bundler/json_to_esm.zig
@@ -112,12 +112,13 @@ fn buildNamedExportsFromObject(ast: *Ast, value_node: NodeIndex, out_stmts: *std
             .data = .{ .extra = var_extra },
         });
 
-        // extras: [declaration, specifiers_start, specifiers_len, source]
+        // extras: [declaration, specifiers_start, specifiers_len, source, attrs_start, attrs_len]
         const none_node: u32 = @intFromEnum(NodeIndex.none);
         const export_extra = try ast.addExtras(&.{
             @intFromEnum(var_decl),
             0,         0, // specifiers empty
             none_node,
+            0, 0, // attrs empty
         });
         const export_node = try ast.addNode(.{
             .tag = .export_named_declaration,

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2255,7 +2255,11 @@ pub const Codegen = struct {
 
     fn emitImportExpr(self: *Codegen, node: Node) !void {
         try self.write("import(");
-        try self.emitNode(node.data.unary.operand);
+        try self.emitNode(node.data.binary.left);
+        if (!node.data.binary.right.isNone()) {
+            try self.write(if (self.options.minify_whitespace) "," else ", ");
+            try self.emitNode(node.data.binary.right);
+        }
         try self.writeByte(')');
     }
 
@@ -2990,42 +2994,41 @@ pub const Codegen = struct {
     }
 
     fn emitExportNamed(self: *Codegen, node: Node) !void {
-        const e = node.data.extra;
-        const extras = self.ast.extra_data.items[e .. e + 4];
-        const decl: NodeIndex = @enumFromInt(extras[0]);
-        const specs_start = extras[1];
-        const specs_len = extras[2];
-        const source: NodeIndex = @enumFromInt(extras[3]);
+        const x = module_parser.readExportNamedExtras(self.ast, node.data.extra);
 
         if (self.options.module_format == .cjs) {
-            return self.emitExportNamedCJS(decl, specs_start, specs_len, source);
+            return self.emitExportNamedCJS(x.decl, x.specs_start, x.specs_len, x.source);
         }
 
         // 번들 모드: export 키워드 생략, declaration만 출력.
         // 단일 파일 transpile 은 rename map 전달용으로만 linking_metadata 를 쓰므로 분기 제외.
         if (self.options.linking_metadata) |lm| {
-            if (lm.is_bundle_context and !decl.isNone()) {
-                try self.emitNode(decl);
+            if (lm.is_bundle_context and !x.decl.isNone()) {
+                try self.emitNode(x.decl);
                 return;
             }
         }
 
         try self.write("export ");
-        if (!decl.isNone()) {
-            try self.emitNode(decl);
+        if (!x.decl.isNone()) {
+            try self.emitNode(x.decl);
         } else {
             try self.writeByte('{');
             if (self.options.minify_whitespace) {
-                try self.emitNodeList(specs_start, specs_len, ",");
+                try self.emitNodeList(x.specs_start, x.specs_len, ",");
             } else {
                 try self.writeByte(' ');
-                try self.emitNodeList(specs_start, specs_len, ", ");
+                try self.emitNodeList(x.specs_start, x.specs_len, ", ");
                 try self.writeByte(' ');
             }
             try self.writeByte('}');
-            if (!source.isNone()) {
+            if (!x.source.isNone()) {
                 try self.write(" from ");
-                try self.emitNode(source);
+                try self.emitNode(x.source);
+                if (x.attrs_len > 0) {
+                    try self.write(" with ");
+                    try self.emitImportAttributes(x.attrs_start, x.attrs_len);
+                }
             }
             try self.writeByte(';');
         }

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -25,4 +25,5 @@ comptime {
     _ = @import("codegen_test/decorator.zig");
     _ = @import("codegen_test/function_map.zig");
     _ = @import("codegen_test/skip_nodes_blank.zig");
+    _ = @import("codegen_test/import_attributes.zig");
 }

--- a/src/codegen/codegen_test/import_attributes.zig
+++ b/src/codegen/codegen_test/import_attributes.zig
@@ -1,0 +1,126 @@
+//! ES2024 import attributes round-trip 테스트.
+//!
+//! Static `import ... with { type: "json" }` 은 이미 동작 (파싱 + AST + codegen).
+//! 본 파일은 현재 정보가 소실되는 두 경로의 라운드트립을 검증한다:
+//!   - dynamic `import("x", { with: {...} })` — 두 번째 인자
+//!   - `export ... from "x" with {...}` — re-export attributes
+//!
+//! `assert` (구버전) 는 파서가 `with` 로 자동 마이그레이션 — 같은 출력을 기대.
+
+const std = @import("std");
+const helpers = @import("helpers.zig");
+const e2e = helpers.e2e;
+
+// ============================================================
+// Static import attributes (이미 동작 — 회귀 가드)
+// ============================================================
+
+test "import attributes: static with clause round-trip" {
+    var r = try e2e(std.testing.allocator,
+        \\import data from "./data.json" with { type: "json" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"json\"") != null);
+}
+
+test "import attributes: static assert → with migration" {
+    // 파서는 assert 를 with 로 자동 변환 (ES2024 표준 호환)
+    var r = try e2e(std.testing.allocator,
+        \\import data from "./data.json" assert { type: "json" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "assert") == null);
+}
+
+test "import attributes: static multi-key preserved" {
+    var r = try e2e(std.testing.allocator,
+        \\import x from "./y" with { type: "css", foo: "bar" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"css\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"bar\"") != null);
+}
+
+// ============================================================
+// Dynamic import attributes (현재 소실 → 보존해야 함)
+// ============================================================
+
+test "import attributes: dynamic import 2nd arg preserved" {
+    var r = try e2e(std.testing.allocator,
+        \\const mod = import("./data.json", { with: { type: "json" } });
+    );
+    defer r.deinit();
+    // 현재는 import("./data.json") 으로만 출력. 두 번째 인자를 보존해야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"json\"") != null);
+}
+
+test "import attributes: dynamic import assert 2nd arg preserved" {
+    // 레거시 assert 구문도 두 번째 인자로 소비된 뒤 보존되어야 한다.
+    // (정적 import 와 달리 동적 import 두 번째 인자는 일반 object expression 이므로
+    //  assert/with 키 자체를 AST 가 그대로 보존해야 한다.)
+    var r = try e2e(std.testing.allocator,
+        \\const mod = import("./data.json", { assert: { type: "json" } });
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "assert") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"json\"") != null);
+}
+
+test "import attributes: dynamic import without 2nd arg stays unary" {
+    var r = try e2e(std.testing.allocator,
+        \\const mod = import("./data.json");
+    );
+    defer r.deinit();
+    // 두 번째 인자가 없으면 그대로.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "./data.json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") == null);
+}
+
+// ============================================================
+// Export re-export attributes (현재 소실 → 보존해야 함)
+// ============================================================
+
+test "import attributes: export named re-export with clause preserved" {
+    var r = try e2e(std.testing.allocator,
+        \\export { default as data } from "./data.json" with { type: "json" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"json\"") != null);
+}
+
+// TODO(export-all-attrs): `export * from "x" with {...}` / `export * as ns from "x" with {...}`
+// export_all_declaration 은 현재 .binary 레이아웃이라 attrs 를 담으려면 .extra 로 전환 필요.
+// 사용처(linker/bundler/semantic) 다수라 별도 PR 에서 처리. 본 PR 은 export_named 만.
+
+test "import attributes: export * from without clause stays intact (export-all baseline)" {
+    var r = try e2e(std.testing.allocator,
+        \\export * from "./other.json";
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "./other.json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") == null);
+}
+
+test "import attributes: export * as ns from without clause stays intact (export-all baseline)" {
+    var r = try e2e(std.testing.allocator,
+        \\export * as ns from "./other.json";
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "./other.json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") == null);
+}
+
+test "import attributes: export without source ignores attributes syntax" {
+    // export { x }; — source 없으므로 with 구문 자체 불허. 보통 출력.
+    var r = try e2e(std.testing.allocator,
+        \\const x = 1;
+        \\export { x };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "export") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") == null);
+}

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -508,7 +508,6 @@ pub const Node = struct {
                 .computed_property_key,
                 .break_statement,
                 .continue_statement,
-                .import_expression,
                 .static_block,
                 // unary_expression, update_expression → extra 섹션에서 처리
                 .assignment_target_rest,
@@ -569,6 +568,10 @@ pub const Node = struct {
                 // ESM `import ... with { type: "json" }` 의 각 attr. key/value 가
                 // 실존하므로 leaf 가 아닌 binary layout.
                 .import_attribute,
+                // import_expression: binary = { left=arg, right=options, flags }
+                // `import(x)` 는 right=none. `import(x, { with: {...} })` 는 options 를
+                // 일반 ObjectExpression 으로 보존. codegen 이 right 유무로 ", opts" 출력 결정.
+                .import_expression,
                 // flow_match_arm: binary = { left=pattern, right=body, flags }
                 // outer flow_match_expression (extra layout) 의 arms list 구성원.
                 .flow_match_arm,
@@ -654,7 +657,7 @@ pub const Node = struct {
                 // import_declaration: extra = [specs_start, specs_len, source(2), phase_flags, attrs_start, attrs_len]
                 // phase_flags: u32. low 4 bits = ImportPhase (0=none, 1=defer, 2=source)
                 .import_declaration => .{ .kind = .extra, .child_offsets = &.{2} },
-                // export_named: extra = [decl(0), specs_start, specs_len, source(3)]
+                // export_named: extra = [decl(0), specs_start, specs_len, source(3), attrs_start(4), attrs_len(5)]
                 .export_named_declaration => .{ .kind = .extra, .child_offsets = &.{ 0, 3 } },
                 // export_default: unary = { operand: decl, flags: 0 }
                 .export_default_declaration => .{ .kind = .unary },

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -77,6 +77,39 @@ fn finalizeImportDeclaration(
     });
 }
 
+/// `export_named_declaration` extra schema. codegen/transformer 읽기 사이트가
+/// 이 헬퍼를 통해서만 슬롯 의미를 알도록 강제한다 (`ImportDeclExtras` 와 동일 패턴).
+pub const ExportNamedExtras = struct {
+    decl: NodeIndex,
+    specs_start: u32,
+    specs_len: u32,
+    source: NodeIndex,
+    attrs_start: u32,
+    attrs_len: u32,
+};
+
+pub fn readExportNamedExtras(ast: anytype, e: u32) ExportNamedExtras {
+    const slots = ast.extra_data.items[e .. e + 6];
+    return .{
+        .decl = @enumFromInt(slots[0]),
+        .specs_start = slots[1],
+        .specs_len = slots[2],
+        .source = @enumFromInt(slots[3]),
+        .attrs_start = slots[4],
+        .attrs_len = slots[5],
+    };
+}
+
+/// dynamic `import(arg, options?)` 에서 `,` 소비 후 options 를 파싱.
+/// `(` 와 `arg` 는 caller 책임. options 가 없으면 `.none` 반환.
+fn parseImportCallOptions(self: *Parser) ParseError2!NodeIndex {
+    if (!try self.eat(.comma)) return .none;
+    if (self.current() == .r_paren) return .none;
+    const options = try self.parseAssignmentExpression();
+    _ = try self.eat(.comma); // trailing comma
+    return options;
+}
+
 /// import() / import.source() / import.defer() 호출의 인자를 파싱한다.
 /// `(` 를 소비하고, 1~2개 인자를 파싱하고, `)` 를 기대한다.
 /// import() 내부에서는 `in` 연산자를 허용 (+In context).
@@ -85,13 +118,9 @@ pub fn parseImportCallArgs(self: *Parser, start: u32) ParseError2!NodeIndex {
     const saved_ctx = self.enterAllowInContext(true);
     defer self.restoreContext(saved_ctx);
     const arg = try self.parseAssignmentExpression();
-    // 두 번째 인자 (import attributes/options) — 있으면 파싱하고 무시
-    if (try self.eat(.comma)) {
-        if (self.current() != .r_paren) {
-            _ = try self.parseAssignmentExpression();
-            _ = try self.eat(.comma); // trailing comma
-        }
-    }
+    // ES2024 dynamic import 두 번째 인자 (import attributes/options). AST 에 보존해
+    // codegen 에서 그대로 출력한다 (ESM 출력이 Node 런타임에 그대로 흘러갈 때 필요).
+    const options = try parseImportCallOptions(self);
     try self.expect(.r_paren);
 
     // Inline scan: dynamic import — 인자가 string_literal이면 레코드 추가
@@ -107,7 +136,7 @@ pub fn parseImportCallArgs(self: *Parser, start: u32) ParseError2!NodeIndex {
     return try self.ast.addNode(.{
         .tag = .import_expression,
         .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .unary = .{ .operand = arg, .flags = 0 } },
+        .data = .{ .binary = .{ .left = arg, .right = options, .flags = 0 } },
     });
 }
 
@@ -220,11 +249,12 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
         // 수동으로 import expression 생성.
         try self.expect(.l_paren);
         const arg = try self.parseAssignmentExpression();
+        const options = try parseImportCallOptions(self);
         try self.expect(.r_paren);
         const import_expr = try self.ast.addNode(.{
             .tag = .import_expression,
             .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .unary = .{ .operand = arg, .flags = 0 } },
+            .data = .{ .binary = .{ .left = arg, .right = options, .flags = 0 } },
         });
         // 후속 .then() 등의 member/call 체이닝 처리
         _ = try self.eat(.semicolon);
@@ -690,10 +720,10 @@ pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.N
 
         // re-export: export { a } from "module"
         var source_node = NodeIndex.none;
+        var attrs: NodeList = .{ .start = 0, .len = 0 };
         if (try self.eat(.kw_from)) {
             source_node = try parseModuleSource(self);
-            // export { x } from "..." with { ... } — attributes 소비 (AST 보존은 후속)
-            _ = try parseImportAttributes(self);
+            attrs = try parseImportAttributes(self);
         }
         try self.expectSemicolon();
 
@@ -778,12 +808,14 @@ pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.N
 
         if (is_type_only_export) return NodeIndex.none;
 
-        // extra_data layout: [declaration, specifiers_start, specifiers_len, source]
+        // extra_data layout: [declaration, specifiers_start, specifiers_len, source, attrs_start, attrs_len]
         const extra_start = try self.ast.addExtras(&.{
             @intFromEnum(NodeIndex.none), // declaration 없음
             specifiers.start,
             specifiers.len,
             @intFromEnum(source_node),
+            attrs.start,
+            attrs.len,
         });
 
         if (!is_export_equals) self.has_module_syntax = true;
@@ -835,12 +867,14 @@ pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.N
 
     if (!is_export_equals) self.has_module_syntax = true;
 
-    // extra_data layout: [declaration, specifiers_start, specifiers_len, source]
+    // extra_data layout: [declaration, specifiers_start, specifiers_len, source, attrs_start, attrs_len]
     const extra_start = try self.ast.addExtras(&.{
         @intFromEnum(decl),
         0, // specifiers_start (사용 안 함)
         0, // specifiers_len = 0
         @intFromEnum(NodeIndex.none), // source 없음
+        0, // attrs_start
+        0, // attrs_len
     });
     return try self.ast.addNode(.{
         .tag = .export_named_declaration,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -848,7 +848,6 @@ pub const Transformer = struct {
             .computed_property_key,
             .break_statement,
             .continue_statement,
-            .import_expression,
             .static_block,
             => self.visitUnaryNode(idx),
 
@@ -943,6 +942,8 @@ pub const Transformer = struct {
             .jsx_attribute,
             .jsx_namespaced_name,
             .jsx_member_expression,
+            // ES2024: import(x, opts) — binary { left=arg, right=options }
+            .import_expression,
             => self.visitBinaryNode(idx),
 
             // === member expression: extra = [object, property, flags] ===
@@ -4262,19 +4263,20 @@ pub const Transformer = struct {
         return true;
     }
 
-    /// export_named_declaration: extra_data = [declaration, specifiers_start, specifiers_len, source]
+    /// export_named_declaration: `module_parser.ExportNamedExtras` 참고.
+    /// attrs 는 string literal 쌍이라 visit 불필요 — 원본 리스트 그대로 전달.
     fn visitExportNamedDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
-        const e = node.data.extra;
-        const new_decl = try self.visitNode(self.readNodeIdx(e, 0));
-        const new_specs = try self.visitExtraList(.{ .start = self.readU32(e, 1), .len = self.readU32(e, 2) });
-        const new_source = try self.visitNode(self.readNodeIdx(e, 3));
+        const x = module_parser.readExportNamedExtras(self.ast, node.data.extra);
+        const new_decl = try self.visitNode(x.decl);
+        const new_specs = try self.visitExtraList(.{ .start = x.specs_start, .len = x.specs_len });
+        const new_source = try self.visitNode(x.source);
         // export interface/type alias 등 타입 선언만 있으면 빈 export {} 제거
         // export { type Foo } from './a' 같은 re-export는 source가 있으므로 유지
         if (new_decl.isNone() and new_specs.len == 0 and new_source.isNone()) {
             // `@dec export class Named`: Stage 3 decorator pass가 outer_var_decl을
             // pending_nodes로 hoist하고 `.none`을 반환한 경우 — 원본 class 이름으로
             // `export { Named };` specifier를 합성해 export 키워드가 drop되지 않게 한다.
-            const orig_decl_idx = self.readNodeIdx(e, 0);
+            const orig_decl_idx = x.decl;
             if (!orig_decl_idx.isNone()) {
                 const orig_decl = self.ast.getNode(orig_decl_idx);
                 if (orig_decl.tag == .class_declaration) {
@@ -4295,6 +4297,7 @@ pub const Transformer = struct {
                         const specs = try self.ast.addNodeList(&.{specifier});
                         return self.addExtraNode(.export_named_declaration, node.span, &.{
                             @intFromEnum(NodeIndex.none), specs.start, specs.len, @intFromEnum(NodeIndex.none),
+                            0, 0, // attrs empty
                         });
                     }
                 }
@@ -4303,6 +4306,7 @@ pub const Transformer = struct {
         }
         return self.addExtraNode(.export_named_declaration, node.span, &.{
             @intFromEnum(new_decl), new_specs.start, new_specs.len, @intFromEnum(new_source),
+            x.attrs_start,          x.attrs_len,
         });
     }
 


### PR DESCRIPTION
## Summary
ES2024 import attributes 가 **파싱만 되고 AST 에 담기지 않아** codegen 에서 사라지던 두 경로를 라운드트립 완성.

## 대상
- \`import(\"./x\", { with: {...} })\` — dynamic import 두 번째 인자 소실 → 보존
- \`import(\"./x\", { assert: {...} })\` — 레거시 assert 도 동일
- \`export { x } from \"./y\" with { ... }\` — re-export attributes 소실 → 보존
- \`export * from \"./y\" with {...}\` / \`export * as ns\` — out of scope (별도 PR)

## AST 변경
- \`import_expression\` layout 을 \`.unary\` → \`.binary\` 로 재분류. left=arg, right=options (.none 가능). 사용처 4곳 동기화 (parser/transformer/codegen/import_scanner).
- \`export_named_declaration\` extra 4 → 6 슬롯 (attrs_start, attrs_len). \`ImportDeclExtras\` 패턴과 동일하게 \`ExportNamedExtras\` + \`readExportNamedExtras\` 헬퍼 도입, codegen/transformer 이를 경유해 magic index 제거.

## 리팩터
- dynamic import 두 번째 인자 파싱 로직 중복 (parseImportCallArgs / parseImportDeclaration 의 l_paren 분기) 을 \`parseImportCallOptions\` 헬퍼로 추출.

## Test plan
신규 \`src/codegen/codegen_test/import_attributes.zig\` — 10 라운드트립 테스트:
- [x] Static with/assert/multi-key (3) — 회귀 가드
- [x] Dynamic with/assert/no-2nd-arg (3) — 본 PR 신규 동작
- [x] Export named with clause — 본 PR 신규 동작
- [x] Export without source / \`export *\` / \`export * as ns\` baseline (3) — out-of-scope 경로 동작 변경 없음 확인

## Out of scope (추후 PR)
- \`export_all_declaration\` 의 attributes (현재 .binary 레이아웃, 사용처 많아 별도 작업)
- Bundler attributes → loader override (확장자 기반 JSON loader 는 이미 동작 중)

🤖 Generated with [Claude Code](https://claude.com/claude-code)