### PR TITLE
fix(transformer): apply block-scoping rename to assignment_target_identifier

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -34,5 +34,6 @@ comptime {
     _ = @import("bundler_test/virtual_ns_treeshake.zig");
     _ = @import("bundler_test/ns_member_shadow.zig");
     _ = @import("bundler_test/exports_name_dedup.zig");
+    _ = @import("bundler_test/lowering_rename_leak.zig");
     _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/bundler_test/lowering_rename_leak.zig
+++ b/src/bundler/bundler_test/lowering_rename_leak.zig
@@ -18,6 +18,14 @@ const helpers = @import("../test_helpers.zig");
 const compat = @import("../../transformer/compat.zig");
 const writeFile = helpers.writeFile;
 
+/// fn 정의 한 개의 body 만 잘라낸다 — `function <sig>` ~ `return <ret>` 까지.
+/// 그 다음 정의로 spill 하지 않도록 trailing slack 없이 정확히 자른다.
+fn fnBody(code: []const u8, sig: []const u8, ret_marker: []const u8) ?[]const u8 {
+    const start = std.mem.indexOf(u8, code, sig) orelse return null;
+    const ret_idx = std.mem.indexOfPos(u8, code, start, ret_marker) orelse return null;
+    return code[start..ret_idx + ret_marker.len];
+}
+
 fn bundleEntry(backing: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !helpers.Bundled {
     // RN/Hermes 환경 시뮬레이션: block_scoping (let → var) 강제 lowering.
     return helpers.bundleEntry(backing, tmp, entry_name, .{
@@ -54,13 +62,10 @@ test "rename leak: assignment LHS 가 block-rename suffix 적용됨 (compound fo
 
     // `var acc$1 = 0` 정의 + `acc$1 = acc$1 + i` 로 양쪽 rename. 좌변 `acc =` (suffix 없음) 가
     // 함수 body 안에 있으면 BUG.
-    const fn_idx = std.mem.indexOf(u8, code, "function sum(n)") orelse return error.TestUnexpectedResult;
-    const fn_end = std.mem.indexOfPos(u8, code, fn_idx, "return acc") orelse code.len;
-    const fn_body = code[fn_idx..@min(fn_end + 20, code.len)];
-
-    try testing.expect(std.mem.indexOf(u8, fn_body, "var acc$1 = 0") != null);
-    try testing.expect(std.mem.indexOf(u8, fn_body, "acc = acc$1 + i") == null);
-    try testing.expect(std.mem.indexOf(u8, fn_body, "acc$1 = acc$1 + i") != null);
+    const body = fnBody(code, "function sum(n)", "return acc") orelse return error.TestUnexpectedResult;
+    try testing.expect(std.mem.indexOf(u8, body, "var acc$1 = 0") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "acc = acc$1 + i") == null);
+    try testing.expect(std.mem.indexOf(u8, body, "acc$1 = acc$1 + i") != null);
 }
 
 // for-of + template literal 조합 (실제 whatwg-url-minimum.mjs 패턴).
@@ -87,24 +92,13 @@ test "rename leak: for-of body 의 template literal compound assign 도 일관 r
     defer r.deinit();
     const code = r.code();
 
-    const fn_idx = std.mem.indexOf(u8, code, "function serializePath(e)") orelse return error.TestUnexpectedResult;
-    const fn_end = std.mem.indexOfPos(u8, code, fn_idx, "return t") orelse code.len;
-    const fn_body = code[fn_idx..@min(fn_end + 20, code.len)];
-
-    // 정의가 `var t$1 = ""` 으로 rename 되어야 + compound assign 좌변도 같은 suffix.
-    try testing.expect(std.mem.indexOf(u8, fn_body, "var t$1 = \"\"") != null);
-    // BUG 패턴: 좌변 `t +=` (suffix 없음) 가 함수 body 안에 있으면 안 됨.
-    // suffix 가 붙은 정의 (`t$1 +=`) 는 OK.
-    try testing.expect(std.mem.indexOf(u8, fn_body, "t$1 += ") != null);
-    // word-boundary 검사: `t += ...` 직전이 식별자 일부 (`$N` 등) 가 아닌 케이스만 BUG.
-    var search: usize = 0;
-    while (std.mem.indexOfPos(u8, fn_body, search, "t += ")) |idx| : (search = idx + 1) {
-        // 직전 문자가 alphanumeric / `$` / `_` 면 다른 식별자의 일부 (e.g. `t$1 += `).
-        if (idx == 0) return error.TestUnexpectedResult; // 함수 body 시작이 `t +=` 면 명백한 BUG.
-        const prev = fn_body[idx - 1];
-        const is_ident_char = std.ascii.isAlphanumeric(prev) or prev == '$' or prev == '_';
-        if (!is_ident_char) return error.TestUnexpectedResult;
-    }
+    const body = fnBody(code, "function serializePath(e)", "return t") orelse return error.TestUnexpectedResult;
+    // 정의 + compound assign 좌변 모두 `t$1` suffix.
+    // 좌변 `t +=` (suffix 없음) 검색은 substring 매칭이 식별자 경계를 자동으로 인식 —
+    // `t$1 += ` 는 `t += ` 와 매칭되지 않으므로 indexOf 만으로 충분.
+    try testing.expect(std.mem.indexOf(u8, body, "var t$1 = \"\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "t$1 += ") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "t += ") == null);
 }
 
 // 충돌 없는 단일 let 은 rename 없이 유지 (over-fix 방지).

--- a/src/bundler/bundler_test/lowering_rename_leak.zig
+++ b/src/bundler/bundler_test/lowering_rename_leak.zig
@@ -1,0 +1,137 @@
+//! Regression: ES2015 block scoping lowering 시 `block_rename_stack` 가 inner `let` 을
+//! `name$N` 으로 rename 하면, identifier_reference / binding_identifier 분기는
+//! rename 을 적용하는데 **`assignment_target_identifier` 분기가 누락** 되어 있었음.
+//! 결과: `acc = acc + n` 이 `acc = acc$1 + n` 으로 변환 (LHS 만 rename 누락) →
+//! strict-mode 에서 free variable `acc` 참조 → ReferenceError.
+//!
+//! 실제 사례: bungae + RN 환경의 `whatwg-url-minimum.mjs` `serializePath`:
+//! ```js
+//! let t = "";
+//! for (const r of e.path) { t += `/${r}`; }
+//! ```
+//! `t` 는 module-scope 의 다른 `t` 와 충돌해 `t$82` 로 rename. for body 의 `t += ...`
+//! 의 좌변이 누락되어 `t += "/" + r` 그대로 emit → ReferenceError.
+
+const std = @import("std");
+const testing = std.testing;
+const helpers = @import("../test_helpers.zig");
+const compat = @import("../../transformer/compat.zig");
+const writeFile = helpers.writeFile;
+
+fn bundleEntry(backing: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !helpers.Bundled {
+    // RN/Hermes 환경 시뮬레이션: block_scoping (let → var) 강제 lowering.
+    return helpers.bundleEntry(backing, tmp, entry_name, .{
+        .dev_mode = true,
+        .unsupported = compat.UnsupportedFeatures{ .block_scoping = true },
+    });
+}
+
+// outer module-scope `let acc` + inner function-scope `let acc` → block_rename_stack
+// 가 inner 를 `acc$1` 으로 rename. for-loop body 의 `acc = acc + i` 좌변/우변 모두
+// `acc$1` 으로 일관 rename 되어야.
+test "rename leak: assignment LHS 가 block-rename suffix 적용됨 (compound for-loop)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.js",
+        \\let acc = "module-level";
+        \\export function sum(n) {
+        \\  let acc = 0;
+        \\  for (let i = 0; i < n; i++) {
+        \\    acc = acc + i;
+        \\  }
+        \\  return acc;
+        \\}
+        \\export function getModuleAcc() { return acc; }
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { sum, getModuleAcc } from './lib.js';
+        \\sum(3); getModuleAcc();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // `var acc$1 = 0` 정의 + `acc$1 = acc$1 + i` 로 양쪽 rename. 좌변 `acc =` (suffix 없음) 가
+    // 함수 body 안에 있으면 BUG.
+    const fn_idx = std.mem.indexOf(u8, code, "function sum(n)") orelse return error.TestUnexpectedResult;
+    const fn_end = std.mem.indexOfPos(u8, code, fn_idx, "return acc") orelse code.len;
+    const fn_body = code[fn_idx..@min(fn_end + 20, code.len)];
+
+    try testing.expect(std.mem.indexOf(u8, fn_body, "var acc$1 = 0") != null);
+    try testing.expect(std.mem.indexOf(u8, fn_body, "acc = acc$1 + i") == null);
+    try testing.expect(std.mem.indexOf(u8, fn_body, "acc$1 = acc$1 + i") != null);
+}
+
+// for-of + template literal 조합 (실제 whatwg-url-minimum.mjs 패턴).
+test "rename leak: for-of body 의 template literal compound assign 도 일관 rename" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.js",
+        \\let t = "module-level";
+        \\export function serializePath(e) {
+        \\  let t = "";
+        \\  for (const r of e.path) {
+        \\    t += `/${r}`;
+        \\  }
+        \\  return t;
+        \\}
+        \\export function getModuleT() { return t; }
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { serializePath, getModuleT } from './lib.js';
+        \\serializePath({ path: ['a', 'b'] }); getModuleT();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    const fn_idx = std.mem.indexOf(u8, code, "function serializePath(e)") orelse return error.TestUnexpectedResult;
+    const fn_end = std.mem.indexOfPos(u8, code, fn_idx, "return t") orelse code.len;
+    const fn_body = code[fn_idx..@min(fn_end + 20, code.len)];
+
+    // 정의가 `var t$1 = ""` 으로 rename 되어야 + compound assign 좌변도 같은 suffix.
+    try testing.expect(std.mem.indexOf(u8, fn_body, "var t$1 = \"\"") != null);
+    // BUG 패턴: 좌변 `t +=` (suffix 없음) 가 함수 body 안에 있으면 안 됨.
+    // suffix 가 붙은 정의 (`t$1 +=`) 는 OK.
+    try testing.expect(std.mem.indexOf(u8, fn_body, "t$1 += ") != null);
+    // word-boundary 검사: `t += ...` 직전이 식별자 일부 (`$N` 등) 가 아닌 케이스만 BUG.
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, fn_body, search, "t += ")) |idx| : (search = idx + 1) {
+        // 직전 문자가 alphanumeric / `$` / `_` 면 다른 식별자의 일부 (e.g. `t$1 += `).
+        if (idx == 0) return error.TestUnexpectedResult; // 함수 body 시작이 `t +=` 면 명백한 BUG.
+        const prev = fn_body[idx - 1];
+        const is_ident_char = std.ascii.isAlphanumeric(prev) or prev == '$' or prev == '_';
+        if (!is_ident_char) return error.TestUnexpectedResult;
+    }
+}
+
+// 충돌 없는 단일 let 은 rename 없이 유지 (over-fix 방지).
+test "rename leak: 충돌 없는 let 은 suffix 없이 그대로" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.js",
+        \\export function lonely(n) {
+        \\  let counter = 0;
+        \\  for (let i = 0; i < n; i++) {
+        \\    counter = counter + i;
+        \\  }
+        \\  return counter;
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { lonely } from './lib.js';
+        \\lonely(3);
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    // suffix 없는 base 이름 유지
+    try testing.expect(std.mem.indexOf(u8, code, "var counter = 0") != null);
+    try testing.expect(std.mem.indexOf(u8, code, "counter = counter + i") != null);
+    // suffix 가 붙은 변형이 있으면 over-fix
+    try testing.expect(std.mem.indexOf(u8, code, "counter$") == null);
+}

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1290,15 +1290,15 @@ pub const Transformer = struct {
                         return new_idx;
                     }
                 }
-                if (try self.tryRenameIdentifierLike(idx, node, .identifier_reference)) |i| return i;
+                if (try self.tryRenameIdentifierLike(idx, .identifier_reference)) |i| return i;
                 return self.copyNodeDirect(idx);
             },
             .binding_identifier => {
-                if (try self.tryRenameIdentifierLike(idx, node, .binding_identifier)) |i| return i;
+                if (try self.tryRenameIdentifierLike(idx, .binding_identifier)) |i| return i;
                 return self.copyNodeDirect(idx);
             },
             .assignment_target_identifier => {
-                if (try self.tryRenameIdentifierLike(idx, node, .assignment_target_identifier)) |i| return i;
+                if (try self.tryRenameIdentifierLike(idx, .assignment_target_identifier)) |i| return i;
                 return self.copyNodeDirect(idx);
             },
             .template_element => blk: {
@@ -1408,11 +1408,11 @@ pub const Transformer = struct {
     fn tryRenameIdentifierLike(
         self: *Transformer,
         idx: NodeIndex,
-        node: Node,
         comptime tag: Tag,
     ) Error!?NodeIndex {
         if (!self.options.unsupported.block_scoping) return null;
         if (self.block_rename_stack.items.len == 0) return null;
+        const node = self.ast.getNode(idx);
         const text = self.ast.getText(node.data.string_ref);
         const new_name = self.lookupBlockRename(text) orelse return null;
         const new_span = try self.ast.addString(new_name);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1281,40 +1281,24 @@ pub const Transformer = struct {
                     if (std.mem.eql(u8, text, "arguments")) {
                         self.needs_arguments_var = true;
                         const args_span = try self.ast.addString("_arguments");
-                        return self.ast.addNode(.{
+                        const new_idx = try self.ast.addNode(.{
                             .tag = .identifier_reference,
                             .span = args_span,
                             .data = .{ .string_ref = args_span },
                         });
+                        self.propagateSymbolId(idx, new_idx);
+                        return new_idx;
                     }
                 }
-                // ES2015 block scoping 격리: 리네이밍된 변수 참조 교체
-                if (self.options.unsupported.block_scoping and self.block_rename_stack.items.len > 0) {
-                    const text = self.ast.getText(node.data.string_ref);
-                    if (self.lookupBlockRename(text)) |new_name| {
-                        const new_span = try self.ast.addString(new_name);
-                        return self.ast.addNode(.{
-                            .tag = .identifier_reference,
-                            .span = new_span,
-                            .data = .{ .string_ref = new_span },
-                        });
-                    }
-                }
+                if (try self.tryRenameIdentifierLike(idx, node, .identifier_reference)) |i| return i;
                 return self.copyNodeDirect(idx);
             },
             .binding_identifier => {
-                // ES2015 block scoping 격리: 리네이밍된 변수 선언 교체
-                if (self.options.unsupported.block_scoping and self.block_rename_stack.items.len > 0) {
-                    const text = self.ast.getText(node.data.string_ref);
-                    if (self.lookupBlockRename(text)) |new_name| {
-                        const new_span = try self.ast.addString(new_name);
-                        return self.ast.addNode(.{
-                            .tag = .binding_identifier,
-                            .span = new_span,
-                            .data = .{ .string_ref = new_span },
-                        });
-                    }
-                }
+                if (try self.tryRenameIdentifierLike(idx, node, .binding_identifier)) |i| return i;
+                return self.copyNodeDirect(idx);
+            },
+            .assignment_target_identifier => {
+                if (try self.tryRenameIdentifierLike(idx, node, .assignment_target_identifier)) |i| return i;
                 return self.copyNodeDirect(idx);
             },
             .template_element => blk: {
@@ -1341,7 +1325,6 @@ pub const Transformer = struct {
             .jsx_closing_element,
             .jsx_opening_fragment,
             .jsx_closing_fragment,
-            .assignment_target_identifier,
             => self.copyNodeDirect(idx),
 
             // JSX leaf — jsx_text는 별도 처리 (jsx_transform 시 lowerJSXText)
@@ -1415,6 +1398,31 @@ pub const Transformer = struct {
     fn copyNodeDirect(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
         _ = self;
         return idx;
+    }
+
+    /// ES2015 block scoping 격리: outer scope 와 충돌하는 inner `let`/`const` 가
+    /// `block_rename_stack` 에 등록되어 있으면 `name$N` 으로 치환된 새 노드 반환.
+    /// identifier_reference / binding_identifier / assignment_target_identifier 가 공유.
+    /// 호출 후 새 노드의 symbol_id 를 반드시 전파 — 누락 시 linker rename 미적용으로
+    /// 정의/사용 비대칭 (`acc = acc$1 + n` 같은 strict-mode ReferenceError) 발생.
+    fn tryRenameIdentifierLike(
+        self: *Transformer,
+        idx: NodeIndex,
+        node: Node,
+        comptime tag: Tag,
+    ) Error!?NodeIndex {
+        if (!self.options.unsupported.block_scoping) return null;
+        if (self.block_rename_stack.items.len == 0) return null;
+        const text = self.ast.getText(node.data.string_ref);
+        const new_name = self.lookupBlockRename(text) orelse return null;
+        const new_span = try self.ast.addString(new_name);
+        const new_idx = try self.ast.addNode(.{
+            .tag = tag,
+            .span = new_span,
+            .data = .{ .string_ref = new_span },
+        });
+        self.propagateSymbolId(idx, new_idx);
+        return new_idx;
     }
 
     /// 클래스 이름 노드에서 Span 추출. 익명 클래스(none)면 null 반환.


### PR DESCRIPTION
## Summary

ES2015 block scoping downlevel (`let`/`const` → `var`) 시 outer scope 와 충돌하는 inner 변수의 **assignment LHS 만 rename 누락** → strict-mode `ReferenceError`. 실제 RN/Hermes 환경에서 `whatwg-url-minimum.mjs serializePath` 부팅 실패.

## 증상 (실측)

bungae + iOS sim:
```
ReferenceError: Property 't' doesn't exist
    at serializePath (whatwg-url-minimum.mjs:1181:7)
    at get pathname (URL accessor)
    at fromDeepLink (extractPathFromURL.js:93)
```

ZTS 변환 결과:
```js
function serializePath(e) {
  ...
  var t$82 = "";          // ✓ 정의 rename
  ...
  for (...) {
    t += "/" + r;         // ✗ 좌변 누락 (free `t` 참조)
  }
  return t$82;            // ✓ rename
}
```

## Root cause

`transformer.zig` 의 식별자 처리 분기:

| arm | block_rename_stack lookup |
|---|---|
| `identifier_reference` | ✅ 적용 |
| `binding_identifier` | ✅ 적용 |
| `assignment_target_identifier` | ❌ **누락** (트리비얼 `copyNodeDirect` 그룹과 함께 묶여 있었음) |

같은 `acc = acc + n` expression 의 RHS `acc` (identifier_reference) 는 `acc$1` 로 rename, LHS `acc` (assignment_target_identifier) 는 옛 이름. ESM/strict 에서 declaration 없는 write → `ReferenceError`.

## Fix

1. `assignment_target_identifier` 분기를 별도 arm 으로 분리해 `identifier_reference` / `binding_identifier` 와 같은 rename path 적용.
2. 세 arm 의 공통 로직을 `tryRenameIdentifierLike(idx, node, comptime tag)` 헬퍼로 추출 — 향후 같은 종류 식별자 추가 시 1줄로 끝.
3. 헬퍼가 새 노드를 만들면 **반드시 `propagateSymbolId(idx, new_idx)` 호출** — 그렇지 않으면 linker rename 이 새 노드를 못 따라가서 같은 종류 비대칭이 재발. 이전부터 누락되어 있던 두 곳 (block_rename_stack, arrow `arguments` 캡처) 도 같이 보강.

## Before / After

**Before**:
```js
var acc$1 = 0;
for (var i = 0; i < n; i++) {
    acc = acc$1 + i;        // LHS rename 누락
}
return acc$1;
```

**After**:
```js
var acc$1 = 0;
for (var i = 0; i < n; i++) {
    acc$1 = acc$1 + i;      // 양쪽 일관
}
return acc$1;
```

## Test plan

- [x] 3 회귀 테스트 (`bundler_test/lowering_rename_leak.zig`, `unsupported.block_scoping = true` 강제 — RN/Hermes 환경 시뮬레이션):
  - compound assignment LHS 가 `$1` suffix 로 일관 rename (원본 버그)
  - `for-of` body + template literal `t += `/${r}`` 도 양쪽 일관
  - 충돌 없는 `let counter` 는 suffix 없이 유지 (over-fix 방지)
- [x] 전체 unit/regression suite (`zig build test`) **3665 passed**
- [x] bungae monorepo + iOS 26.4 시뮬레이터에서 `Property 't' doesn't exist` 사라짐 실측 확인

## 영향 범위

- ES5/ES2015 미만 target 에서 `unsupported.block_scoping = true` 일 때만 path 활성화 (RN/Hermes / 구형 브라우저 target)
- modern target 에선 lowering 자체 skip → 영향 없음
- `assignment_target_identifier` hot path 에 추가된 비용: `block_scoping` 비활성 시 단일 bool 분기 → 무시 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)