### PR TITLE
feat(parser): export * from 'x' with {...} 라운드트립 (layout 전환)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -17,6 +17,7 @@ const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Span = @import("../lexer/token.zig").Span;
 const types = @import("types.zig");
+const module_parser = @import("../parser/module.zig");
 const ModuleIndex = types.ModuleIndex;
 const symbol_mod = @import("symbol.zig");
 const AliasTable = symbol_mod.AliasTable;
@@ -389,9 +390,9 @@ pub fn extractExportBindings(
                 });
             },
             .export_all_declaration => {
-                // binary { left=exported_name, right=source_node }
-                const exported_name_idx = node.data.binary.left;
-                const source_idx = node.data.binary.right;
+                const x = module_parser.readExportAllExtras(ast, node.data.extra);
+                const exported_name_idx = x.exported_name;
+                const source_idx = x.source;
                 if (source_idx.isNone()) continue;
                 const src_node = ast.getNode(source_idx);
                 const rec_idx = source_to_record.get(types.spanKey(src_node.span));

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -31,6 +31,7 @@ const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const CallFlags = @import("../parser/ast.zig").CallFlags;
 const MemberFlags = @import("../parser/ast.zig").MemberFlags;
 const scan_results = @import("../parser/scan_results.zig");
+const module_parser = @import("../parser/module.zig");
 const DefineEntry = scan_results.DefineEntry;
 const Span = @import("../lexer/token.zig").Span;
 const types = @import("types.zig");
@@ -168,7 +169,8 @@ fn tryExtractImportDecl(ast: *const Ast, node: Node) ?ImportRecord {
 
 /// export * from "./foo": binary { left=exported_name, right=source_node }
 fn tryExtractExportAll(ast: *const Ast, node: Node) ?ImportRecord {
-    const source_idx = node.data.binary.right;
+    const x = module_parser.readExportAllExtras(ast, node.data.extra);
+    const source_idx = x.source;
     const specifier = getStringLiteralText(ast, source_idx) orelse return null;
     const source_node = ast.getNode(source_idx);
 

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3276,23 +3276,27 @@ pub const Codegen = struct {
     }
 
     fn emitExportAll(self: *Codegen, node: Node) !void {
+        const x = module_parser.readExportAllExtras(self.ast, node.data.extra);
         if (self.options.module_format == .cjs) {
             // export * from './bar' → Object.assign(exports,require('./bar'));
             try self.write("Object.assign(exports,require(");
-            try self.emitNode(node.data.binary.right);
+            try self.emitNode(x.source);
             try self.write("));");
             return;
         }
-        // export * as ns from './foo' → left=ns, right=source
-        // export * from './foo'       → left=none, right=source
-        if (node.data.binary.left != .none) {
+        // export * as ns from './foo' / export * from './foo'
+        if (!x.exported_name.isNone()) {
             try self.write("export * as ");
-            try self.emitNode(node.data.binary.left);
+            try self.emitNode(x.exported_name);
             try self.write(" from ");
         } else {
             try self.write("export * from ");
         }
-        try self.emitNode(node.data.binary.right);
+        try self.emitNode(x.source);
+        if (x.attrs_len > 0) {
+            try self.write(" with ");
+            try self.emitImportAttributes(x.attrs_start, x.attrs_len);
+        }
         try self.writeByte(';');
     }
 

--- a/src/codegen/codegen_test/import_attributes.zig
+++ b/src/codegen/codegen_test/import_attributes.zig
@@ -92,11 +92,10 @@ test "import attributes: export named re-export with clause preserved" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\"json\"") != null);
 }
 
-// TODO(export-all-attrs): `export * from "x" with {...}` / `export * as ns from "x" with {...}`
-// export_all_declaration 은 현재 .binary 레이아웃이라 attrs 를 담으려면 .extra 로 전환 필요.
-// 사용처(linker/bundler/semantic) 다수라 별도 PR 에서 처리. 본 PR 은 export_named 만.
+// export_all_declaration 의 .extra layout 전환으로 attrs 슬롯 확보되어
+// export * / export * as ns 에도 with clause 라운드트립 가능.
 
-test "import attributes: export * from without clause stays intact (export-all baseline)" {
+test "import attributes: export * from without clause stays intact" {
     var r = try e2e(std.testing.allocator,
         \\export * from "./other.json";
     );
@@ -105,13 +104,31 @@ test "import attributes: export * from without clause stays intact (export-all b
     try std.testing.expect(std.mem.indexOf(u8, r.output, "with") == null);
 }
 
-test "import attributes: export * as ns from without clause stays intact (export-all baseline)" {
+test "import attributes: export * as ns from without clause stays intact" {
     var r = try e2e(std.testing.allocator,
         \\export * as ns from "./other.json";
     );
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "./other.json") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "with") == null);
+}
+
+test "import attributes: export * from with clause preserved" {
+    var r = try e2e(std.testing.allocator,
+        \\export * from "./other.json" with { type: "json" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"json\"") != null);
+}
+
+test "import attributes: export * as ns from with clause preserved" {
+    var r = try e2e(std.testing.allocator,
+        \\export * as ns from "./other.json" with { type: "json" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "with") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"json\"") != null);
 }
 
 test "import attributes: export without source ignores attributes syntax" {

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -549,7 +549,6 @@ pub const Node = struct {
                 .assignment_target_with_default,
                 .import_specifier,
                 .export_specifier,
-                .export_all_declaration,
                 .jsx_attribute,
                 .jsx_namespaced_name,
                 .jsx_member_expression,
@@ -659,6 +658,9 @@ pub const Node = struct {
                 .import_declaration => .{ .kind = .extra, .child_offsets = &.{2} },
                 // export_named: extra = [decl(0), specs_start, specs_len, source(3), attrs_start(4), attrs_len(5)]
                 .export_named_declaration => .{ .kind = .extra, .child_offsets = &.{ 0, 3 } },
+                // export_all: extra = [exported_name(0), source(1), attrs_start(2), attrs_len(3)]
+                // `export *` 은 exported_name = .none, `export * as ns` 는 namespace identifier.
+                .export_all_declaration => .{ .kind = .extra, .child_offsets = &.{ 0, 1 } },
                 // export_default: unary = { operand: decl, flags: 0 }
                 .export_default_declaration => .{ .kind = .unary },
                 // jsx_element: extra = [tag(0), attrs_start, attrs_len, children_start, children_len]

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -77,6 +77,26 @@ fn finalizeImportDeclaration(
     });
 }
 
+/// `export_all_declaration` extra schema.
+/// `export * from "x"` 는 exported_name = .none, `export * as ns from "x"` 는
+/// namespace identifier. `from "x" with { ... }` 의 attrs 는 하단 두 슬롯.
+pub const ExportAllExtras = struct {
+    exported_name: NodeIndex,
+    source: NodeIndex,
+    attrs_start: u32,
+    attrs_len: u32,
+};
+
+pub fn readExportAllExtras(ast: anytype, e: u32) ExportAllExtras {
+    const slots = ast.extra_data.items[e .. e + 4];
+    return .{
+        .exported_name = @enumFromInt(slots[0]),
+        .source = @enumFromInt(slots[1]),
+        .attrs_start = slots[2],
+        .attrs_len = slots[3],
+    };
+}
+
 /// `export_named_declaration` extra schema. codegen/transformer 읽기 사이트가
 /// 이 헬퍼를 통해서만 슬롯 의미를 알도록 강제한다 (`ImportDeclExtras` 와 동일 패턴).
 pub const ExportNamedExtras = struct {
@@ -658,8 +678,7 @@ pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.N
         }
         try self.expect(.kw_from);
         const source_node = try parseModuleSource(self);
-        // export *에서도 attributes 가능 (parser 진행을 위해 소비, AST 보존은 후속 작업)
-        _ = try parseImportAttributes(self);
+        const attrs = try parseImportAttributes(self);
         try self.expectSemicolon();
 
         if (is_type_only_export) return NodeIndex.none;
@@ -696,10 +715,16 @@ pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.N
         }
 
         if (!is_export_equals) self.has_module_syntax = true;
+        const extra_start = try self.ast.addExtras(&.{
+            @intFromEnum(exported_name),
+            @intFromEnum(source_node),
+            attrs.start,
+            attrs.len,
+        });
         return try self.ast.addNode(.{
             .tag = .export_all_declaration,
             .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = exported_name, .right = source_node, .flags = 0 } },
+            .data = .{ .extra = extra_start },
         });
     }
 

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -12,6 +12,7 @@
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const ast_walk = @import("../parser/ast_walk.zig");
+const module_parser = @import("../parser/module.zig");
 const Node = ast_mod.Node;
 const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
@@ -3034,8 +3035,8 @@ pub const SemanticAnalyzer = struct {
 
     /// export * as name — name을 등록한다.
     fn visitExportAllDeclaration(self: *SemanticAnalyzer, node: Node) AllocError!void {
-        // binary: { left = exported_name, right = source }
-        const name_idx = node.data.binary.left;
+        const x = module_parser.readExportAllExtras(self.ast, node.data.extra);
+        const name_idx = x.exported_name;
         if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
             const name_node = self.ast.getNode(name_idx);
             const name = self.ast.getText(name_node.span);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1189,7 +1189,7 @@ pub const Transformer = struct {
             .import_declaration => self.visitImportDeclaration(node),
             .export_named_declaration => self.visitExportNamedDeclaration(node),
             .export_default_declaration => self.visitExportDefaultDeclaration(node),
-            .export_all_declaration => self.visitBinaryNode(idx),
+            .export_all_declaration => self.visitExportAllDeclaration(node),
             .catch_clause => {
                 if (self.options.unsupported.optional_catch_binding) {
                     return es2019.ES2019(Transformer).lowerOptionalCatchBinding(self, node);
@@ -4261,6 +4261,20 @@ pub const Transformer = struct {
             if (r.isValueUse()) return false;
         }
         return true;
+    }
+
+    /// export_all_declaration: `module_parser.ExportAllExtras` 참고.
+    /// attrs 는 string literal 쌍이라 visit 불필요 — 원본 리스트 그대로 전달.
+    fn visitExportAllDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
+        const x = module_parser.readExportAllExtras(self.ast, node.data.extra);
+        const new_name = try self.visitNode(x.exported_name);
+        const new_source = try self.visitNode(x.source);
+        return self.addExtraNode(.export_all_declaration, node.span, &.{
+            @intFromEnum(new_name),
+            @intFromEnum(new_source),
+            x.attrs_start,
+            x.attrs_len,
+        });
     }
 
     /// export_named_declaration: `module_parser.ExportNamedExtras` 참고.


### PR DESCRIPTION
## Summary
#1836 의 follow-up. \`export * from \"x\" with {...}\` / \`export * as ns from \"x\" with {...}\` 의 attributes 가 파싱만 되고 AST 에 담기지 않아 codegen 에서 소실되던 경로를 라운드트립 완성.

## AST 변경
- \`export_all_declaration\` layout 을 **.binary → .extra** 로 이동. 슬롯 \`[exported_name, source, attrs_start, attrs_len]\` 4 필드.
- \`module_parser\` 에 \`ExportAllExtras\` + \`readExportAllExtras\` 헬퍼 추가 (\`ExportNamedExtras\` / \`ImportDeclExtras\` 와 동일 패턴).

## 사용처 동기화
- parser — .extra 생성, attrs 저장
- codegen \`emitExportAll\` — reader 경유 + \`with { ... }\` 출력
- semantic \`visitExportAllDeclaration\` — reader 경유
- transformer — 기존 범용 \`visitBinaryNode\` 경로를 전용 \`visitExportAllDeclaration\` 함수로 분리 (extras layout 이라 공용 visitor 불가)
- bundler — \`import_scanner.tryExtractExportAll\`, \`binding_scanner\` 모두 reader 경유

## Test plan
- [x] \`zig build test\` 전체 통과
- [x] 신규 라운드트립 테스트 2개:
  - \`export * from \"./x\" with { type: \"json\" }\` 보존
  - \`export * as ns from \"./x\" with { type: \"json\" }\` 보존
- [x] 기존 baseline 테스트 2개 (with clause 없는 경로) 회귀 없음
- [x] CLI 실측 라운드트립 확인

## CLI 실측
\`\`\`
$ zts /tmp/ea1.ts
export * from \"./a.json\" with {type: \"json\"};

$ zts /tmp/ea2.ts
export * as ns from \"./a.json\" with {type: \"json\"};
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)