### PR TITLE
docs: import attributes 라운드트립 + class expression anonymize 반영

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -106,7 +106,9 @@
   - **BOM 처리**: UTF-8 BOM(0xEF 0xBB 0xBF)을 파일 시작에서 스킵, 출력에는 넣지 않음
   - **줄 끝 문자**: `\n`, `\r\n`, `\r`, U+2028, U+2029 전부 줄바꿈으로 인식
   - **유니코드 식별자**: `\uXXXX`, `\u{XXXX}` 이스케이프 시퀀스 지원 + 정규화
-  - **import attributes**: `with { type: "json" }` + deprecated `assert { type: "json" }` 둘 다 파싱
+  - **import attributes**: ES2024 `with { type: "json" }` + deprecated `assert { ... }` 둘 다 파싱. 네 경로 모두 AST 보존 + codegen 라운드트립:
+    - static `import x from "./y" with { ... }` · dynamic `import("./y", { with: {...} })` · `export { x } from "./y" with { ... }` · `export * / export * as ns from "./y" with { ... }`
+    - `assert` 는 static 에서 `with` 로 자동 마이그레이션 (ES2024 표준 통일)
   - **direct eval 감지**: `eval()` 직접 호출 감지 → 해당 스코프 변수 최적화 비활성화
 
 ### D020: define (전역 치환)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,6 +49,8 @@
 | 36. import.meta.glob | Vite 호환 `import.meta.glob()`, eager/import 옵션 | ✅ |
 | 37. Stage 3 decorators | TC39 Stage 3 데코레이터 (method/getter/setter/field/accessor/class, MobX 6 호환). ES5 타겟 lowering 포함 완료 — 단 `accessor #x` / `accessor [k]` 는 미구현 (실사용 라이브러리 없음, 필요 시 추가) | ✅ |
 | 38. CSS 번들링 | @import 인라이닝, 별도 .css 파일 emit, Lightning CSS minify 연동 | ✅ |
+| 39. Minify 확장 | 미참조 class expression name 익명화 — fast/non-fast path 통합 (#1587 + #1596) | ✅ |
+| 40. Import attributes | ES2024 `with {...}` 라운드트립: static / dynamic / export named / export * 네 경로 전부 AST 보존. `assert` → `with` 자동 마이그레이션 | ✅ |
 
 ## 번들러 성능 현황 (2026-04-10 실측)
 

--- a/documents/src/content/docs/en/guides/transpile.md
+++ b/documents/src/content/docs/en/guides/transpile.md
@@ -55,6 +55,26 @@ zts --use-define-for-class-fields=false app.ts
 zts --flow app.js
 ```
 
+### Import attributes (ES2024)
+
+`with { type: "json" }` is preserved as a round-trip across every import/export form.
+Legacy `assert` on static imports is auto-migrated to `with` (Node 20+ deprecates `assert`).
+
+```ts
+// static
+import data from "./data.json" with { type: "json" };
+
+// dynamic — the second argument is preserved too
+const mod = await import("./data.json", { with: { type: "json" } });
+
+// re-export
+export { default as data } from "./data.json" with { type: "json" };
+export * from "./data.json" with { type: "json" };
+export * as ns from "./data.json" with { type: "json" };
+```
+
+> Local JSON imports are already inlined during bundling based on extension. `with { type }` matters when the bundle output runs on Node as ESM, or when emitting sources that require spec-compliant JSON module syntax.
+
 ## Output Options
 
 ### Module Format
@@ -88,7 +108,7 @@ zts --minify app.ts  # All three
 
 # Granular (esbuild-compatible)
 zts --minify-whitespace app.ts    # Whitespace/semicolons/newlines (debuggable)
-zts --minify-syntax app.ts        # true→!0, paren removal, constant folding
+zts --minify-syntax app.ts        # true→!0, paren removal, constant folding, drop unreferenced class expression names
 zts --minify-identifiers app.ts   # Shorten local identifiers
 ```
 

--- a/documents/src/content/docs/guides/transpile.md
+++ b/documents/src/content/docs/guides/transpile.md
@@ -55,6 +55,26 @@ zts --use-define-for-class-fields=false app.ts
 zts --flow app.js
 ```
 
+### Import attributes (ES2024)
+
+`with { type: "json" }` 구문을 모든 import/export 경로에서 라운드트립으로 보존합니다.
+구버전 `assert` 는 static import 에 한해 `with` 로 자동 변환 (Node 20+ 가 `assert` 를 deprecate).
+
+```ts
+// static
+import data from "./data.json" with { type: "json" };
+
+// dynamic — 두 번째 인자도 그대로 보존
+const mod = await import("./data.json", { with: { type: "json" } });
+
+// re-export
+export { default as data } from "./data.json" with { type: "json" };
+export * from "./data.json" with { type: "json" };
+export * as ns from "./data.json" with { type: "json" };
+```
+
+> 로컬 JSON import 는 확장자 기반으로 이미 번들에 인라인됩니다. `with { type }` 은 번들 산출물을 ESM 으로 Node 런타임에 흘려보낼 때, 또는 JSON 모듈 스펙에 호환되는 소스 생성이 필요할 때 유용합니다.
+
 ## 출력 옵션
 
 ### 모듈 포맷
@@ -88,7 +108,7 @@ zts --minify app.ts  # 세 가지 모두
 
 # 세분화 (esbuild 호환)
 zts --minify-whitespace app.ts    # 공백·세미콜론·줄바꿈 (디버깅 가능)
-zts --minify-syntax app.ts        # true→!0, 괄호 제거, constant folding
+zts --minify-syntax app.ts        # true→!0, 괄호 제거, constant folding, 미참조 class expression name 제거
 zts --minify-identifiers app.ts   # 지역 변수명 단축
 ```
 


### PR DESCRIPTION
## Summary
최근 머지된 PR 4개의 기능/결정 사항을 문서에 동기화합니다.

- #1833 — migration 가이드 (이미 반영)
- #1834 — non-fast-path class expression name 익명화
- #1836 — import attributes 라운드트립 (static/dynamic/export named)
- #1838 — export * 라운드트립 (layout 전환)

## 변경 파일
- \`docs/ROADMAP.md\` — Phase 39/40 추가
- \`docs/DECISIONS.md\` — D019 import attributes 를 "파싱만 지원" → "네 경로 전부 AST 보존 + codegen 라운드트립 / \`assert\` → \`with\` 자동 마이그레이션" 으로 보강
- \`documents/src/content/docs/guides/transpile.md\` (ko/en) — "Import attributes (ES2024)" 섹션 신설 (static/dynamic/export named/export */export as ns 예시 + 사용 시점 가이드). \`--minify-syntax\` 설명에 class expression name 제거 추가

## Test plan
- [x] \`bun run build\` (340 pages, link validator 통과)
- [ ] 배포 후 \`/guides/transpile\` 의 "Import attributes (ES2024)" 섹션 육안 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)