### PR TITLE
fix(codegen): require.context ctx(req) returns module exports

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -874,6 +874,10 @@ test "Bundler: require.context emits webpackContext IIFE (sync)" {
     // 매치 파일들이 번들에 실제로 포함되어야 — graph dep 등록 확인.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "// --- a.tsx ---") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "// --- b.tsx ---") != null);
+    // `ctx(req)` 가 module exports 를 반환해야 — Metro/webpack require.context semantic.
+    // `fn()` 만 호출하면 init 만 실행되고 exports 가 undefined 로 떨어져서 expo-router 등이
+    // 빈 route module 을 보고 "Unmatched Route" 로 fallback.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toCommonJS(__zts_modules[") != null);
 }
 
 test "Bundler: require.context emits empty map when no matches" {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2025,9 +2025,16 @@ pub const Codegen = struct {
                 else
                     null;
                 if (resolved_abs) |abs| {
-                    try self.write("__zts_modules[\"");
+                    // `ctx(req)` 는 Metro/webpack 의 require.context semantic 대로 module
+                    // exports 를 반환해야 한다. `fn()` 만 호출하면 init 은 실행되지만 exports
+                    // 는 undefined — expo-router 가 `ctx(req)` 반환값을 route module 로 사용해
+                    // tree 구성이 실패하고 "Unmatched Route" 로 fallback.
+                    // 다른 require 호출과 동일한 `(fn(), __toCommonJS(.exports))` 패턴으로 emit.
+                    try self.write("(__zts_modules[\"");
                     try self.writeJsStringContent(abs);
-                    try self.write("\"].fn()");
+                    try self.write("\"].fn(),__toCommonJS(__zts_modules[\"");
+                    try self.writeJsStringContent(abs);
+                    try self.write("\"].exports))");
                 } else {
                     try self.write("(function(){throw new Error(\"require.context match unresolved: \"+");
                     try self.writeByte('"');


### PR DESCRIPTION
## Summary

\`require.context\` IIFE 의 \`ctx(req)\` 가 module exports 를 반환해야 하는데 init 만 실행하고 undefined 반환. Metro/webpack semantic 불일치로 expo-router 가 routes 를 인식하지 못해 \"Unmatched Route\" fallback.

## 증상 (실측)

bungae + iOS sim 부팅 시 "Welcome to Expo" Tutorial 또는 "Unmatched Route" 화면. 사용자의 \`app/(tabs)/index.tsx\` 가 load 되지 않음.

## Root cause

\`codegen.zig:2030\` 가 map value 를 이렇게 emit:

\`\`\`js
var map = {
  \"./(tabs)/_layout.tsx\": function(){ return __zts_modules[...].fn(); },
  ...
};
function ctx(req){
  var fn = map[req];
  return fn();  // ← undefined (fn = init, void 반환)
}
\`\`\`

하지만 Metro/webpack 의 \`require.context\` 는 \`ctx(req)\` 가 require(req) 와 동등하게 module exports 를 반환하는 것이 표준. expo-router 의 \`loadRoute\` 가 \`ctx(req)\` 결과를 route module 로 사용해 route tree 구성.

## Fix

다른 모든 require 호출과 동일한 \`(fn(), __toCommonJS(.exports))\` 패턴으로 emit:

\`\`\`js
var map = {
  \"./(tabs)/_layout.tsx\": function(){ return (__zts_modules[...].fn(), __toCommonJS(__zts_modules[...].exports)); },
  ...
};
\`\`\`

## Test plan

- [x] \`bundler_test/basic.zig\` 의 \`Bundler: require.context emits webpackContext IIFE (sync)\` 테스트에 \`__toCommonJS(__zts_modules[\` assertion 추가
- [x] 전체 unit/regression suite (\`zig build test\`) **3677 passed**
- [x] bungae monorepo + iOS 26.4 시뮬레이터에서 routes 인식 확인 (\"Unmatched Route\" 사라짐, 그 다음 단계 에러는 별도 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)