### PR TITLE
fix(bundler): inject react synthetic import for JSX key-after-spread

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2191,3 +2191,39 @@ test "JSX automatic: _createElement import injected when key-after-spread used" 
     // `react` package 에서 createElement 를 가져오는 require 가 번들에 주입되어야.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"react\")") != null);
 }
+
+// Regression: expo-router 의 `useScreens.js` 처럼 .js 확장자 + JSX 인 케이스.
+// 실제 expo-router 빌드 산출물의 routeToScreen() 형태를 그대로 재현.
+// .tsx 가 아닌 .js 에서도 동일 fix 가 동작해야 함 (JSX 활성은 확장자가 아니라 ast.has_jsx).
+test "JSX automatic: _createElement injected for .js source (expo-router useScreens shape)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\const primitives = { Screen: function() { return null; } };
+        \\export function routeToScreen(route, opts = {}) {
+        \\  const { options, getId, ...props } = opts;
+        \\  return (<primitives.Screen {...props} name={route.route} key={route.route} getId={getId} options={options}/>);
+        \\}
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .jsx_runtime = .automatic_dev,
+        // RN 프리셋과 동일하게 .js 에서 JSX 파싱 활성화 — bungae 가 react-native platform 으로
+        // 호출 시 자동으로 true. 이게 없으면 .js 의 JSX 가 syntax error.
+        .jsx_in_js = true,
+        .external = &.{ "react/jsx-dev-runtime", "react" },
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_createElement(") != null);
+    const has_def = std.mem.indexOf(u8, result.output, "_createElement = ") != null or
+        std.mem.indexOf(u8, result.output, "var _createElement") != null;
+    try std.testing.expect(has_def);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"react\")") != null);
+}

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2153,3 +2153,41 @@ test "RN preset: async/await도 ES5 매트릭스로 다운레벨 (보수적 정�
     // async function이 더 이상 native 형태로 남지 않음 (state machine으로 변환)
     try std.testing.expect(std.mem.indexOf(u8, result.output, "async function f") == null);
 }
+
+// Regression: JSX automatic runtime 의 `<Comp {...props} key={x} />` 패턴은 jsxDEV/jsx
+// 의 signature 로 표현할 수 없어 jsx_lowering 이 `_createElement(tag, {...props, key: x})`
+// fallback 을 emit. single-file transpile 은 `import { createElement as _createElement } from "react";`
+// 를 prepend 하지만 bundle mode 는 jsx_import_info 를 무시해 `_createElement` 가 free variable
+// 로 남는다. expo-router 의 `useScreens.js` 등 컴파일된 패키지에서 이 패턴이 흔해 RN 부팅 시
+// ReferenceError.
+test "JSX automatic: _createElement import injected when key-after-spread used" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.tsx",
+        \\export function App(props) {
+        \\  return <div {...props} key={props.id} />;
+        \\}
+    );
+    const entry = try absPath(&tmp, "entry.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .jsx_runtime = .automatic_dev,
+        .external = &.{ "react/jsx-dev-runtime", "react" },
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // key-after-spread fallback 이 실제로 트리거되어야 — `_createElement(` 호출 존재.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_createElement(") != null);
+    // `_createElement` 는 `react` 의 createElement 로 정의되어야 — free variable 이면 안 됨.
+    // bundle mode 에서는 var 선언 or 할당 형태로 emit.
+    const has_def = std.mem.indexOf(u8, result.output, "_createElement = ") != null or
+        std.mem.indexOf(u8, result.output, "var _createElement") != null;
+    try std.testing.expect(has_def);
+    // `react` package 에서 createElement 를 가져오는 require 가 번들에 주입되어야.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"react\")") != null);
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1300,26 +1300,35 @@ pub const ModuleGraph = struct {
                 .has_exports_dot = parser.scan_result.has_exports_dot,
             };
 
-            // JSX automatic: AST에 JSX가 있으면 synthetic import를 추가한다.
+            // JSX automatic synthetic imports. `react` 는 key-after-spread 일 때만 주입 —
+            // 모든 JSX 모듈에 일괄 주입하면 `createElement` 문자열이 노출되어
+            // `createElement 미노출` 회귀 테스트를 깬다.
             var jsx_injected = false;
-            if (self.jsx_runtime != .classic) {
-                if (parser.ast.has_jsx) {
-                    if (self.jsx_specifier_cache == null) {
-                        const is_dev = self.jsx_runtime == .automatic_dev;
-                        self.jsx_specifier_cache = std.fmt.allocPrint(
-                            self.allocator,
-                            "{s}/{s}",
-                            .{ self.jsx_import_source, if (is_dev) "jsx-dev-runtime" else "jsx-runtime" },
-                        ) catch null;
+            var react_injected = false;
+            if (self.jsx_runtime != .classic and parser.ast.has_jsx) {
+                if (self.jsx_specifier_cache == null) {
+                    const is_dev = self.jsx_runtime == .automatic_dev;
+                    self.jsx_specifier_cache = std.fmt.allocPrint(
+                        self.allocator,
+                        "{s}/{s}",
+                        .{ self.jsx_import_source, if (is_dev) "jsx-dev-runtime" else "jsx-runtime" },
+                    ) catch null;
+                }
+                if (self.jsx_specifier_cache) |specifier| {
+                    var specs_buf: [2][]const u8 = undefined;
+                    specs_buf[0] = specifier;
+                    var n: usize = 1;
+                    if (parser.ast.has_jsx_key_after_spread) {
+                        specs_buf[n] = self.jsx_import_source;
+                        n += 1;
                     }
-                    if (self.jsx_specifier_cache) |specifier| {
-                        module.import_records = injectJsxRuntimeImport(
-                            specifier,
-                            arena_alloc,
-                            records,
-                        ) catch records;
-                        jsx_injected = (module.import_records.len > records.len);
-                    }
+                    module.import_records = injectJsxRuntimeImports(
+                        specs_buf[0..n],
+                        arena_alloc,
+                        records,
+                    ) catch records;
+                    jsx_injected = (module.import_records.len > records.len);
+                    react_injected = (n == 2) and jsx_injected;
                 }
             }
 
@@ -1329,11 +1338,13 @@ pub const ModuleGraph = struct {
             // JSX synthetic import bindings 추가
             if (jsx_injected) {
                 const jsx_record_idx: u32 = @intCast(records.len);
+                const react_record_idx: ?u32 = if (react_injected) jsx_record_idx + 1 else null;
                 module.import_bindings = createJsxImportBindings(
                     self.jsx_runtime,
                     arena_alloc,
                     module.import_bindings,
                     jsx_record_idx,
+                    react_record_idx,
                 ) catch module.import_bindings;
             }
         }
@@ -2380,59 +2391,70 @@ const JsxRuntime = @import("../codegen/codegen.zig").JsxRuntime;
 const ImportBinding = binding_scanner_mod.ImportBinding;
 
 /// JSX automatic import를 synthetic하게 추가한다.
-/// 기존 import_records 배열 끝에 jsx-runtime import record를 1개 추가.
-fn injectJsxRuntimeImport(
-    specifier: []const u8,
+/// 기존 import_records 배열 끝에 각 specifier 를 static_import record 로 append.
+/// 한 번의 alloc + memcpy 로 처리해 중간 버퍼 낭비를 피한다.
+fn injectJsxRuntimeImports(
+    specifiers: []const []const u8,
     arena_alloc: std.mem.Allocator,
     existing_records: []ImportRecord,
 ) ![]ImportRecord {
-    const new_record = ImportRecord{
-        .specifier = specifier,
-        .kind = .static_import,
-        .span = Span.EMPTY,
-    };
-
-    // 기존 records + 새 record를 합친 새 슬라이스 생성
-    const new_records = try arena_alloc.alloc(ImportRecord, existing_records.len + 1);
+    const new_records = try arena_alloc.alloc(ImportRecord, existing_records.len + specifiers.len);
     @memcpy(new_records[0..existing_records.len], existing_records);
-    new_records[existing_records.len] = new_record;
+    for (specifiers, 0..) |specifier, i| {
+        new_records[existing_records.len + i] = .{
+            .specifier = specifier,
+            .kind = .static_import,
+            .span = Span.EMPTY,
+        };
+    }
     return new_records;
 }
 
-/// JSX automatic import에 대한 synthetic import bindings를 생성한다.
+/// JSX automatic import 의 synthetic bindings. `react_record_index` 가 있으면
+/// key-after-spread fallback 용 `_createElement` 도 포함.
 fn createJsxImportBindings(
     jsx_runtime: JsxRuntime,
     arena_alloc: std.mem.Allocator,
     existing_bindings: []ImportBinding,
     jsx_record_index: u32,
+    react_record_index: ?u32,
 ) ![]ImportBinding {
     const is_dev = jsx_runtime == .automatic_dev;
 
-    // dev: jsxDEV, Fragment | prod: jsx, jsxs, Fragment
-    const jsx_bindings: []const struct { local: []const u8, imported: []const u8 } = if (is_dev)
-        &.{
-            .{ .local = "_jsxDEV", .imported = "jsxDEV" },
-            .{ .local = "_Fragment", .imported = "Fragment" },
-        }
-    else
-        &.{
-            .{ .local = "_jsx", .imported = "jsx" },
-            .{ .local = "_jsxs", .imported = "jsxs" },
-            .{ .local = "_Fragment", .imported = "Fragment" },
-        };
+    const Entry = struct { local: []const u8, imported: []const u8, record: u32 };
+    var buf: [4]Entry = undefined;
+    var len: usize = 0;
+    if (is_dev) {
+        buf[len] = .{ .local = "_jsxDEV", .imported = "jsxDEV", .record = jsx_record_index };
+        len += 1;
+        buf[len] = .{ .local = "_Fragment", .imported = "Fragment", .record = jsx_record_index };
+        len += 1;
+    } else {
+        buf[len] = .{ .local = "_jsx", .imported = "jsx", .record = jsx_record_index };
+        len += 1;
+        buf[len] = .{ .local = "_jsxs", .imported = "jsxs", .record = jsx_record_index };
+        len += 1;
+        buf[len] = .{ .local = "_Fragment", .imported = "Fragment", .record = jsx_record_index };
+        len += 1;
+    }
+    if (react_record_index) |rr| {
+        buf[len] = .{ .local = "_createElement", .imported = "createElement", .record = rr };
+        len += 1;
+    }
 
-    const new_bindings = try arena_alloc.alloc(ImportBinding, existing_bindings.len + jsx_bindings.len);
+    const entries = buf[0..len];
+    const new_bindings = try arena_alloc.alloc(ImportBinding, existing_bindings.len + entries.len);
     @memcpy(new_bindings[0..existing_bindings.len], existing_bindings);
-    for (jsx_bindings, 0..) |jb, i| {
+    for (entries, 0..) |e, i| {
         // 각 synthetic binding에 고유 sentinel span 부여.
         // Span.EMPTY(0,0)를 공유하면 linker의 spanKey 기반 HashMap에서 덮어쓰기 발생.
         const sentinel_start: u32 = ImportBinding.SYNTHETIC_SPAN_BASE + @as(u32, @intCast(i));
         new_bindings[existing_bindings.len + i] = .{
             .kind = .named,
-            .local_name = jb.local,
-            .imported_name = jb.imported,
+            .local_name = e.local,
+            .imported_name = e.imported,
             .local_span = .{ .start = sentinel_start, .end = sentinel_start },
-            .import_record_index = jsx_record_index,
+            .import_record_index = e.record,
         };
     }
     return new_bindings;

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -834,6 +834,11 @@ pub const Ast = struct {
     /// 파싱 중 JSX element/fragment가 발견되었는지 (automatic JSX import 주입용)
     has_jsx: bool = false,
 
+    /// `<Tag {...props} key={k} />` 가 있는가. jsx_lowering 이 이 패턴에 대해
+    /// `_createElement` fallback 을 emit 하므로 bundler 가 `react` synthetic import
+    /// 주입 여부를 이 플래그로 결정.
+    has_jsx_key_after_spread: bool = false,
+
     /// D1 (RFC #1672) 디버그 인프라. Transformer.init 시점의 `nodes.items.len` snapshot.
     /// null = 미변환. boundary 이상의 노드는 transformer 가 append 한 것.
     /// D1a 부터 clone 경로 (Transformer.init → cloneForTransformer) 에서 활성.
@@ -881,6 +886,7 @@ pub const Ast = struct {
             .string_table = .empty,
             .source = source_ast.source,
             .has_jsx = source_ast.has_jsx,
+            .has_jsx_key_after_spread = source_ast.has_jsx_key_after_spread,
             .allocator = allocator,
         };
         // 세 appendSlice 중 하나라도 실패하면 이미 할당된 ArrayList 버퍼를 정리해야 한다.

--- a/src/parser/jsx.zig
+++ b/src/parser/jsx.zig
@@ -139,11 +139,13 @@ fn parseJSXElementImpl(self: *Parser, as_child: bool) ParseError2!NodeIndex {
 
     // Attributes
     const scratch_top = self.saveScratch();
+    // `{...p} key={k}` 패턴에서 parseJSXAttribute 가 Ast.has_jsx_key_after_spread 를 세팅.
+    // (jsx_lowering 의 `_createElement` fallback → bundler 의 react import 주입 신호).
+    var saw_spread = false;
     while (self.current() != .r_angle and self.current() != .slash and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
-        const attr = try parseJSXAttribute(self);
+        const attr = try parseJSXAttribute(self, &saw_spread);
         try self.scratch.append(self.allocator, attr);
-
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
     }
     const attrs = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
@@ -253,7 +255,7 @@ fn parseJSXTagName(self: *Parser) ParseError2!NodeIndex {
     return NodeIndex.none;
 }
 
-fn parseJSXAttribute(self: *Parser) ParseError2!NodeIndex {
+fn parseJSXAttribute(self: *Parser, saw_spread: *bool) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
 
     // spread attribute: {...expr}
@@ -271,6 +273,7 @@ fn parseJSXAttribute(self: *Parser) ParseError2!NodeIndex {
                 });
             }
             try self.scanner.nextInsideJSXElement();
+            saw_spread.* = true;
             return try self.ast.addNode(.{
                 .tag = .jsx_spread_attribute,
                 .span = .{ .start = start, .end = self.currentSpan().start },
@@ -284,6 +287,10 @@ fn parseJSXAttribute(self: *Parser) ParseError2!NodeIndex {
     // name="value" or name={expr}
     const name_span = self.currentSpan();
     try self.scanner.nextInsideJSXElement(); // skip attribute name
+
+    if (saw_spread.* and std.mem.eql(u8, self.ast.getText(name_span), "key")) {
+        self.ast.has_jsx_key_after_spread = true;
+    }
 
     const name = try self.ast.addNode(.{
         .tag = .jsx_identifier,


### PR DESCRIPTION
## Summary

- `<Tag {...props} key={k}/>` 패턴은 `_jsx` signature 로 표현 불가하여 jsx_lowering 이 `_createElement(tag, {...props, key: k})` fallback 을 emit
- single-file transpile 은 `import { createElement as _createElement } from "react"` 를 prepend 하지만, **bundle mode 는 synthetic import 주입 시점에 `has_jsx` 만 보고 `react/jsx-runtime` 만 넣어 `_createElement` 가 free variable 로 남음**
- expo-router 의 `useScreens.js` 등 컴파일된 패키지에서 이 패턴이 흔해 RN 부팅 시 `Property '_createElement' doesn't exist` ReferenceError

## 증상 (실측)

번개 dev server 로 Expo 55 / RN 0.83 / iPad iOS 26.4 simulator 부팅 시:

```
ReferenceError: Property '_createElement' doesn't exist
  at RootLayout (node_modules/expo-router/build/useScreens.js:...)
```

같은 소스를 Metro 로 번들하면 정상 — Metro 는 Babel 변환 시 `@babel/plugin-transform-react-jsx` 가 해당 fallback 에 대해 `react` import 를 source transformation 단계에서 추가하기 때문.

## 해결

### Parser 변경 (`src/parser/jsx.zig`, `src/parser/ast.zig`)

`parseJSXAttribute` 에 `saw_spread: *bool` 파라미터 추가. spread attribute 파싱 시 `*saw_spread = true`, 이후 일반 attribute 이름이 `"key"` 이면 `Ast.has_jsx_key_after_spread = true` 세팅.

- 감지 로직이 `parseJSXAttribute` 내부 (`name_span` 로컬) 에 있어서 호출 측의 AST 재탐색 불필요
- `has_jsx` 처럼 `cloneForTransformer` 에 propagate

### Bundler 변경 (`src/bundler/graph.zig`)

- `has_jsx_key_after_spread` 가 true 인 모듈에만 `react` (정확히는 `self.jsx_import_source`) synthetic import 추가 주입
- `_createElement` synthetic binding 을 `createJsxImportBindings` 에 4번째 엔트리로 추가
- **일괄 주입 안 하는 이유**: `JSX automatic: multiple modules sharing same jsx-runtime` 테스트가 `createElement` 문자열 미노출을 요구 — 모든 JSX 모듈에 `createElement` import 를 넣으면 회귀
- `injectJsxRuntimeImport` → `injectJsxRuntimeImports(specifiers: []const []const u8, ...)` 로 일반화해 jsx-runtime + react 2개 specifier 를 한 번의 alloc + memcpy 로 처리 (arena 중간 버퍼 낭비 제거)

### jsx_import_source 호환

`--jsx-import-source=preact` 인 경우 preact 의 `createElement` 를 사용 — `jsx_import_source` 값을 그대로 재사용하므로 자동 대응.

## Test plan

- [x] `zig build test` 전체 3694/3694 통과
- [x] 회귀 테스트 추가: `JSX automatic: _createElement import injected when key-after-spread used` (`bundler_test/plugin_misc.zig`)
  - `<div {...props} key={props.id} />` 번들 출력에 `_createElement(`, `_createElement` 정의, `require("react")` 모두 존재하는지 검증
- [x] 기존 `JSX automatic: custom import source` / `multiple modules sharing same jsx-runtime` 회귀 없음
- [x] 번개 iPad iOS 26.4 simulator 부팅 확인 예정 (NAPI rebuild 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)