### PR TITLE
fix(ci): zig fmt — lowering_rename_leak.zig

### DIFF
--- a/src/bundler/bundler_test/lowering_rename_leak.zig
+++ b/src/bundler/bundler_test/lowering_rename_leak.zig
@@ -23,7 +23,7 @@ const writeFile = helpers.writeFile;
 fn fnBody(code: []const u8, sig: []const u8, ret_marker: []const u8) ?[]const u8 {
     const start = std.mem.indexOf(u8, code, sig) orelse return null;
     const ret_idx = std.mem.indexOfPos(u8, code, start, ret_marker) orelse return null;
-    return code[start..ret_idx + ret_marker.len];
+    return code[start .. ret_idx + ret_marker.len];
 }
 
 fn bundleEntry(backing: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !helpers.Bundled {


### PR DESCRIPTION
## Summary
main 브랜치의 CI Lint job 이 \`zig fmt --check\` 에서 실패 중. \`src/bundler/bundler_test/lowering_rename_leak.zig\` 파일에 포맷 안 된 slice 표현식 한 줄이 남아있음.

## 수정
\`\`\`diff
-    return code[start..ret_idx + ret_marker.len];
+    return code[start .. ret_idx + ret_marker.len];
\`\`\`
Zig 표준 포맷 — 우측이 복합 표현식(덧셈)이면 \`..\` 앞뒤 공백.

## Test plan
- [x] \`zig fmt --check src/\` 통과
- [ ] CI Lint job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)