### PR TITLE
feat(bundler): manualChunks Phase 1 — 사용자 정의 청크 분할 (#1027)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -72,6 +72,10 @@ pub const BundleOptions = struct {
     /// code splitting 활성화. true이면 dynamic import 경계에서 청크를 분리하고
     /// 공유 모듈을 공통 청크로 추출한다. 결과는 BundleResult.outputs에 다중 파일로 반환.
     code_splitting: bool = false,
+    /// 사용자 정의 청크 분할 (Rollup `manualChunks` 호환 Phase 1 / #1027).
+    /// code_splitting=true 일 때만 동작. 매칭된 모듈은 pseudo-entry 로 BFS 에 참여
+    /// → transitive dependency 도 같은 청크로, dynamic import target 도 manual 우선.
+    manual_chunks: []const types.ManualChunkEntry = &.{},
     /// dev mode: 각 모듈을 __zts_register() 팩토리로 래핑하고
     /// HMR 런타임을 주입한다. import.meta.hot API 지원.
     dev_mode: bool = false,
@@ -975,6 +979,7 @@ pub const Bundler = struct {
                     &graph,
                     self.options.entry_points,
                     if (shaker) |*s| s else null,
+                    self.options.manual_chunks,
                 );
             defer chunk_graph.deinit();
 

--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -35,5 +35,6 @@ comptime {
     _ = @import("bundler_test/ns_member_shadow.zig");
     _ = @import("bundler_test/exports_name_dedup.zig");
     _ = @import("bundler_test/lowering_rename_leak.zig");
+    _ = @import("bundler_test/manual_chunks.zig");
     _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/bundler_test/manual_chunks.zig
+++ b/src/bundler/bundler_test/manual_chunks.zig
@@ -1,0 +1,280 @@
+//! manualChunks 테스트 — 사용자 정의 청크 분할 (#1027).
+//!
+//! 최초 구현 범위 (Phase 1):
+//!   - `ManualChunkEntry { name, patterns }` 으로 모듈 경로 substring 매칭
+//!   - 매칭된 모듈을 지정 청크 이름으로 묶음
+//!   - code_splitting=true 전제 (단일 파일 모드에서는 의미 없음)
+//!
+//! 향후 (Phase 2+):
+//!   - regex 패턴, function callback (Rollup `manualChunks(id)` 시그니처)
+//!   - async chunk 와의 우선순위 / 순환 의존 diagnostic
+
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const types = @import("../types.zig");
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+const hasChunk = test_helpers.hasChunk;
+const chunkContaining = test_helpers.chunkContaining;
+
+// ============================================================
+// Baseline: manual_chunks 비어있으면 기존 자동 분할 동작
+// ============================================================
+
+test "manualChunks: empty list → 기존 code splitting 동작" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./lib";
+        \\console.log(a);
+    );
+    try writeFile(tmp.dir, "lib.ts", "export const a = 1;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks = &.{},
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    // 동적 import 없으므로 단일 청크
+    try std.testing.expectEqual(@as(usize, 1), outs.len);
+}
+
+// ============================================================
+// Phase 1: substring 매칭 — 지정 모듈을 전용 청크로 분리
+// ============================================================
+
+test "manualChunks: substring match → 지정 청크에 모듈 할당" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./vendor-lib";
+        \\import { b } from "./app-lib";
+        \\console.log(a, b);
+    );
+    try writeFile(tmp.dir, "vendor-lib.ts", "export const a = \"VENDOR_MARKER\";");
+    try writeFile(tmp.dir, "app-lib.ts", "export const b = \"APP_MARKER\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks = &.{
+            .{ .name = "vendor", .patterns = &.{"vendor-lib"} },
+        },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    // vendor 청크 존재
+    try std.testing.expect(hasChunk(outs, "vendor"));
+    // vendor 모듈 코드는 vendor 청크에
+    const vendor_chunk = chunkContaining(outs, "VENDOR_MARKER") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, vendor_chunk, "vendor") != null);
+    // 매칭 안 된 app-lib 은 entry 청크에 (vendor 에 안 들어감)
+    const app_chunk = chunkContaining(outs, "APP_MARKER") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, app_chunk, "vendor") == null);
+}
+
+test "manualChunks: multi-pattern → 여러 모듈을 한 청크로" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./alpha";
+        \\import { b } from "./beta";
+        \\console.log(a, b);
+    );
+    try writeFile(tmp.dir, "alpha.ts", "export const a = \"ALPHA\";");
+    try writeFile(tmp.dir, "beta.ts", "export const b = \"BETA\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks = &.{
+            .{ .name = "shared", .patterns = &.{ "alpha", "beta" } },
+        },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    // shared 청크에 두 마커가 모두 있어야 함
+    const alpha_chunk = chunkContaining(outs, "ALPHA") orelse return error.TestUnexpectedResult;
+    const beta_chunk = chunkContaining(outs, "BETA") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, alpha_chunk, "shared") != null);
+    try std.testing.expect(std.mem.indexOf(u8, beta_chunk, "shared") != null);
+    try std.testing.expectEqualStrings(alpha_chunk, beta_chunk);
+}
+
+test "manualChunks: multiple groups → 서로 다른 청크로 분리" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./ui-lib";
+        \\import { b } from "./data-lib";
+        \\console.log(a, b);
+    );
+    try writeFile(tmp.dir, "ui-lib.ts", "export const a = \"UI\";");
+    try writeFile(tmp.dir, "data-lib.ts", "export const b = \"DATA\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks = &.{
+            .{ .name = "ui", .patterns = &.{"ui-lib"} },
+            .{ .name = "data", .patterns = &.{"data-lib"} },
+        },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    const ui_chunk = chunkContaining(outs, "UI") orelse return error.TestUnexpectedResult;
+    const data_chunk = chunkContaining(outs, "DATA") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, ui_chunk, "ui") != null);
+    try std.testing.expect(std.mem.indexOf(u8, data_chunk, "data") != null);
+    try std.testing.expect(!std.mem.eql(u8, ui_chunk, data_chunk));
+}
+
+// ============================================================
+// rolldown parity 개념 (검증 개념만 이식, ZTS Phase 1 API 기준)
+// ============================================================
+
+test "manualChunks: transitive dependency follows matched module (rolldown include_dependencies_recursively)" {
+    // 출처 개념: rolldown `advanced_chunks/include_dependencies_recursively`.
+    // test regex 가 `foo.js` 만 매칭해도 snapshot 에서 `bar.js` (foo 의 dep) 가
+    // 같은 vendor 청크에 들어감. 이유: dep 을 다른 청크로 두면 순서 보장/순환 이슈.
+    // ZTS Phase 1 정책도 동일 — 매칭 모듈의 단독 dep 은 같은 청크로.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { foo } from "./foo";
+        \\console.log(foo);
+    );
+    try writeFile(tmp.dir, "foo.ts",
+        \\import { bar } from "./bar";
+        \\export const foo = "FOO_MARKER " + bar;
+    );
+    try writeFile(tmp.dir, "bar.ts", "export const bar = \"BAR_MARKER\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks = &.{
+            .{ .name = "vendor", .patterns = &.{"foo"} },
+        },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    // foo 와 bar 가 모두 vendor 청크에
+    const foo_chunk = chunkContaining(outs, "FOO_MARKER") orelse return error.TestUnexpectedResult;
+    const bar_chunk = chunkContaining(outs, "BAR_MARKER") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, foo_chunk, "vendor") != null);
+    try std.testing.expectEqualStrings(foo_chunk, bar_chunk);
+}
+
+test "manualChunks: dynamic import target hoisted into manual chunk" {
+    // 출처 개념: rolldown `dynamic_entry_shared_module_not_merged` 를 단순화.
+    // dynamic import 로만 참조되는 모듈이 manualChunks 패턴에 매칭되면,
+    // 기본 async chunk 대신 지정된 manual 청크에 포함. Rollup/rolldown 모두 동일.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const lazy = import("./lazy");
+        \\console.log(lazy);
+    );
+    try writeFile(tmp.dir, "lazy.ts", "export const v = \"LAZY_MARKER\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks = &.{
+            .{ .name = "vendor", .patterns = &.{"lazy"} },
+        },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    // lazy 가 vendor 청크로 (async chunk 가 아니라 manual chunk 우선)
+    const lazy_chunk = chunkContaining(outs, "LAZY_MARKER") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, lazy_chunk, "vendor") != null);
+}
+
+test "manualChunks: no match → 엔트리 청크에 머묾 (기존 동작)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./lib";
+        \\console.log(a);
+    );
+    try writeFile(tmp.dir, "lib.ts", "export const a = \"ONLY\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks = &.{
+            .{ .name = "vendor", .patterns = &.{"nonexistent-pattern"} },
+        },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    // 매칭 없음 → vendor 청크 생성 안 됨, 단일 entry 청크만
+    try std.testing.expectEqual(@as(usize, 1), outs.len);
+    try std.testing.expect(std.mem.indexOf(u8, outs[0].contents, "ONLY") != null);
+}

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -75,6 +75,23 @@ pub const BitSet = struct {
         self.entries[byte_idx] &= ~(@as(u8, 1) << @intCast(bit % 8));
     }
 
+    /// [start, start+count) 범위에 설정된 비트가 하나라도 있는지.
+    pub fn hasAnyBitInRange(self: BitSet, start: u32, count: u32) bool {
+        var i: u32 = 0;
+        while (i < count) : (i += 1) {
+            if (self.hasBit(start + i)) return true;
+        }
+        return false;
+    }
+
+    /// [start, start+count) 범위의 모든 비트를 해제한다.
+    pub fn clearBitRange(self: *BitSet, start: u32, count: u32) void {
+        var i: u32 = 0;
+        while (i < count) : (i += 1) {
+            self.clearBit(start + i);
+        }
+    }
+
     /// 설정된 비트의 개수를 반환한다.
     pub fn bitCount(self: BitSet) u32 {
         var count: u32 = 0;
@@ -125,7 +142,7 @@ pub const BitSetContext = struct {
 // ChunkKind — 청크 종류
 // ============================================================
 
-/// 청크의 종류: 진입점(entry_point) 또는 공통 모듈(common).
+/// 청크의 종류: 진입점(entry_point) / 공통(common) / 사용자 정의(manual).
 pub const ChunkKind = union(enum) {
     /// 진입점에서 생성된 청크
     entry_point: struct {
@@ -138,6 +155,12 @@ pub const ChunkKind = union(enum) {
     },
     /// 여러 진입점이 공유하는 공통 청크
     common,
+    /// `manual_chunks` 옵션이 지정한 사용자 정의 청크 (#1027).
+    /// 이 청크에 해당하는 BitSet bit 를 소유하며, 매칭된 모듈은 항상 이 청크로 간다.
+    manual: struct {
+        bit: u32,
+        name: []const u8,
+    },
 };
 
 // ============================================================
@@ -319,6 +342,7 @@ pub fn generateChunks(
     graph: *const ModuleGraph,
     entry_points: []const []const u8,
     shaker: ?*const TreeShaker,
+    manual_chunks: []const types.ManualChunkEntry,
 ) !ChunkGraph {
     const module_count = graph.moduleCount();
 
@@ -381,12 +405,19 @@ pub fn generateChunks(
         return ChunkGraph.init(allocator, module_count);
     }
 
+    // manual chunks 는 entry 뒤에 bit 를 할당 — splitting_info 총 비트폭 = entry + manual.
+    // BFS 단계에서 매칭 모듈의 transitive deps 에 manual bit 가 전파되어
+    // `rolldown advanced_chunks/include_dependencies_recursively` 와 동일한
+    // 정책 (dep 도 같은 manual 청크로) 을 자동으로 얻는다.
+    const manual_count = manual_chunks.len;
+    const total_bits = entry_count + manual_count;
+
     // ChunkGraph 생성 — 모듈→청크 매핑 배열을 module_count 크기로 할당.
     var chunk_graph = try ChunkGraph.init(allocator, module_count);
     errdefer chunk_graph.deinit();
 
     // 모듈별 도달 가능성 BitSet — splitting_info[module_index]는
-    // 그 모듈이 어떤 엔트리들에서 도달 가능한지를 나타낸다.
+    // 그 모듈이 어떤 엔트리/manual 청크에서 도달 가능한지를 나타낸다.
     var splitting_info = try allocator.alloc(BitSet, module_count);
     // 안전한 초기값 — init 실패 시 defer에서 deinit 호출해도 안전
     @memset(splitting_info, .{ .entries = &.{} });
@@ -395,7 +426,7 @@ pub fn generateChunks(
         allocator.free(splitting_info);
     }
     for (splitting_info) |*bs| {
-        bs.* = try BitSet.init(allocator, @intCast(entry_count));
+        bs.* = try BitSet.init(allocator, @intCast(total_bits));
     }
 
     // BitSet → ChunkIndex HashMap (Phase 3에서 O(1) 청크 lookup에 사용).
@@ -407,7 +438,7 @@ pub fn generateChunks(
 
     // Phase 1c: 엔트리별 Chunk 생성
     for (entries.items, 0..) |entry, bit_idx| {
-        var bits = try BitSet.init(allocator, @intCast(entry_count));
+        var bits = try BitSet.init(allocator, @intCast(total_bits));
         errdefer bits.deinit(allocator);
         bits.setBit(@intCast(bit_idx));
 
@@ -421,6 +452,39 @@ pub fn generateChunks(
             .is_dynamic = entry.is_dynamic,
         } }, bits);
         chunk.name = name;
+
+        const ci = try chunk_graph.addChunk(chunk);
+        try bits_to_chunk.put(allocator, bits, ci);
+    }
+
+    // Phase 1d: manual chunks — 실제 매칭 모듈 seed 수집 + 비어있지 않으면 Chunk 등록.
+    // 매칭 없는 manual chunk 는 빈 출력 파일을 만들지 않도록 skip. 실제 BFS 전파는 Phase 2.5.
+    // `manual_seeds[i].items.len > 0` 이 곧 "이 청크 등록됨" 의 signal — 별도 flag 불필요.
+    const manual_seeds = try allocator.alloc(std.ArrayList(ModuleIndex), manual_count);
+    defer {
+        for (manual_seeds) |*s| s.deinit(allocator);
+        allocator.free(manual_seeds);
+    }
+    for (manual_seeds) |*s| s.* = .empty;
+
+    if (manual_count > 0) {
+        var it = graph.modulesIterator();
+        var mi: usize = 0;
+        while (it.next()) |m| : (mi += 1) {
+            const idx = types.ManualChunkEntry.lookup(manual_chunks, m.path) orelse continue;
+            try manual_seeds[idx].append(allocator, ModuleIndex.fromUsize(mi));
+        }
+    }
+
+    for (manual_chunks, 0..) |mc, i| {
+        if (manual_seeds[i].items.len == 0) continue;
+        const manual_bit: u32 = @intCast(entry_count + i);
+        var bits = try BitSet.init(allocator, @intCast(total_bits));
+        errdefer bits.deinit(allocator);
+        bits.setBit(manual_bit);
+
+        var chunk = Chunk.init(.none, .{ .manual = .{ .bit = manual_bit, .name = mc.name } }, bits);
+        chunk.name = mc.name;
 
         const ci = try chunk_graph.addChunk(chunk);
         try bits_to_chunk.put(allocator, bits, ci);
@@ -453,6 +517,40 @@ pub fn generateChunks(
                     try queue.append(allocator, dep_idx);
                 }
             }
+        }
+    }
+
+    // ── Phase 2.5: manual chunks — 매칭 모듈 + transitive dep 에 manual bit 전파 ──
+    // rolldown advanced_chunks/include_dependencies_recursively 와 동일 정책:
+    // 매칭 모듈만이 아니라 그 의존성까지 같은 청크로 내려야 cross-chunk 순환을 피할 수 있음.
+    if (manual_count > 0) {
+        for (0..manual_count) |i| {
+            if (manual_seeds[i].items.len == 0) continue;
+            const manual_bit: u32 = @intCast(entry_count + i);
+            queue.clearRetainingCapacity();
+            for (manual_seeds[i].items) |seed| try queue.append(allocator, seed);
+
+            while (queue.items.len > 0) {
+                const mod_idx = queue.pop() orelse break;
+                const m = graph.getModule(mod_idx) orelse continue;
+                const mi = @intFromEnum(mod_idx);
+                if (splitting_info[mi].hasBit(manual_bit)) continue;
+                splitting_info[mi].setBit(manual_bit);
+                for (m.dependencies.items) |dep_idx| {
+                    const dep_i = @intFromEnum(dep_idx);
+                    if (dep_i < module_count and !splitting_info[dep_i].hasBit(manual_bit)) {
+                        try queue.append(allocator, dep_idx);
+                    }
+                }
+            }
+        }
+
+        // manual bit 가 켜진 모듈은 entry bit 를 모두 제거 — Phase 3 BitSet lookup 이
+        // `{entry=n, manual=1}` 이 아닌 정확히 `{manual=1}` 패턴으로 manual 청크에 귀속.
+        // dynamic import target 도 여기서 async chunk 에서 빠져나와 manual 청크로 합류.
+        for (splitting_info) |*bs| {
+            if (!bs.hasAnyBitInRange(@intCast(entry_count), @intCast(manual_count))) continue;
+            bs.clearBitRange(0, @intCast(entry_count));
         }
     }
 
@@ -510,6 +608,7 @@ pub fn generateChunks(
 
     // 엔트리 모듈은 반드시 자신의 엔트리 청크에 할당되어야 함.
     // Phase 3에서 공통 청크에 배정되었을 수 있으므로, 강제로 엔트리 청크로 이동.
+    // 단, manual chunk 에 배정된 경우는 manual 우선 정책이라 그대로 유지.
     for (entries.items, 0..) |entry, ci| {
         const chunk_idx: ChunkIndex = @enumFromInt(@as(u32, @intCast(ci)));
         const current = chunk_graph.getModuleChunk(entry.module_idx);
@@ -518,6 +617,7 @@ pub fn generateChunks(
             chunk_graph.assignModuleToChunk(entry.module_idx, chunk_idx);
             try chunk_graph.getChunkMut(chunk_idx).addModule(allocator, entry.module_idx);
         } else if (current != chunk_idx) {
+            if (chunk_graph.getChunk(current).kind == .manual) continue;
             // 공통 청크에 잘못 배정됨 → 이전 청크에서 제거 후 엔트리 청크로 이동
             const old_chunk = chunk_graph.getChunkMut(current);
             removeModuleFromList(&old_chunk.modules, entry.module_idx);

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -406,7 +406,7 @@ test "ChunkKind: entry_point vs common" {
             try std.testing.expectEqual(mod0, info.module);
             try std.testing.expect(info.is_dynamic);
         },
-        .common => unreachable,
+        .common, .manual => unreachable,
     }
 
     const cm: ChunkKind = .common;
@@ -445,7 +445,7 @@ test "generateChunks: single entry, no dynamic imports" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{});
     defer cg.deinit();
 
     // 엔트리 청크 1개
@@ -482,7 +482,7 @@ test "generateChunks: dynamic import creates separate chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null, &.{});
     defer cg.deinit();
 
     // 엔트리 청크 1개 + dynamic 청크 1개 = 2개
@@ -501,7 +501,7 @@ test "generateChunks: dynamic import creates separate chunk" {
     const lazy_chunk = cg.getChunk(chunk1);
     switch (lazy_chunk.kind) {
         .entry_point => |info| try std.testing.expect(info.is_dynamic),
-        .common => return error.TestUnexpectedResult,
+        .common, .manual => return error.TestUnexpectedResult,
     }
 }
 
@@ -523,7 +523,7 @@ test "generateChunks: shared module creates common chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{});
     defer cg.deinit();
 
     // 엔트리 2개 + 공통 1개 = 3개
@@ -564,7 +564,7 @@ test "generateChunks: diamond dependency" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{});
     defer cg.deinit();
 
     // D가 양쪽 엔트리에서 도달 가능 → 공통 청크 생성
@@ -592,7 +592,7 @@ test "generateChunks: no modules" {
     var tg = try TestGraph.init(alloc, &empty_modules);
     defer tg.deinit(alloc);
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{});
     defer cg.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), cg.chunkCount());
@@ -617,7 +617,7 @@ test "generateChunks: circular dependency stays in same chunk" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{});
     defer cg.deinit();
 
     // 1 엔트리 청크, 모든 모듈 포함
@@ -643,7 +643,7 @@ test "generateChunks: static + dynamic import same module" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
     try tg.graph.modules.at(0).addDynamicImport(alloc, @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{});
     defer cg.deinit();
 
     // b.ts는 엔트리 청크에 포함 (static이 우선)
@@ -672,7 +672,7 @@ test "generateChunks: three entries sharing a module" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(3));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null, &.{});
     defer cg.deinit();
 
     // 3 엔트리 + 1 공통 = 4 청크
@@ -702,7 +702,7 @@ test "generateChunks: entry imports another entry statically" {
 
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{});
     defer cg.deinit();
 
     // 2개 엔트리 청크 생성
@@ -731,7 +731,7 @@ test "generateChunks: deep chain with dynamic import at middle" {
     try tg.graph.modules.at(1).addDynamicImport(alloc, @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{});
     defer cg.deinit();
 
     // 2개 청크: a엔트리(a,b), c엔트리(c,d)
@@ -982,7 +982,7 @@ test "generateChunks: entry module reassignment removes from old chunk" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{});
     defer cg.deinit();
 
     // c.ts는 엔트리 청크에 있어야 함 (공통 청크 아님)

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -236,10 +236,10 @@ pub fn emitChunks(
             try l.computeRenamesForModules(sorted_mods, occupied.items);
         }
 
-        // 엔트리 모듈 인덱스 (final exports용)
+        // 엔트리 모듈 인덱스 (final exports용). manual/common 은 엔트리 모듈 없음.
         const entry_mod_idx: ?u32 = switch (chunk.kind) {
             .entry_point => |info| @intFromEnum(info.module),
-            .common => null,
+            .common, .manual => null,
         };
 
         for (sorted_mods) |mod_idx| {

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -370,7 +370,7 @@ test "inline (bundle): shared module 내부 inline — emitChunks 경로" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -430,7 +430,7 @@ test "emitChunks: single chunk produces one OutputFile" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -465,7 +465,7 @@ test "emitChunks: two entries with shared module — 3 OutputFiles" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -514,7 +514,7 @@ test "CodeSplitting: dynamic import path rewritten to chunk filename" {
     const lazy_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "lazy.ts" });
     defer std.testing.allocator.free(lazy_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null, &.{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -573,7 +573,7 @@ test "CodeSplitting: multiple dynamic imports rewritten" {
     const pageB_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "pageB.ts" });
     defer std.testing.allocator.free(pageB_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null, &.{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -619,7 +619,7 @@ test "chunkStem: common chunk uses hex hash, not index" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -669,7 +669,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null);
+    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null, &.{});
     defer cg1.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg1, &result1.graph, std.testing.allocator, null);
 
@@ -687,7 +687,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     defer result2.graph.deinit();
     defer result2.cache.deinit();
 
-    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null);
+    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null, &.{});
     defer cg2.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg2, &result2.graph, std.testing.allocator, null);
 
@@ -791,7 +791,7 @@ test "naming pattern: entry-names with hash" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{
@@ -832,7 +832,7 @@ test "naming pattern: chunk-names with directory" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -879,7 +879,7 @@ test "content hash: cross-chunk import uses content hash" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -946,7 +946,7 @@ test "CJS runtime: __commonJS only in chunks containing CJS modules" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -981,7 +981,7 @@ test "CodeSplitting: static import not rewritten" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);

--- a/src/bundler/test_helpers.zig
+++ b/src/bundler/test_helpers.zig
@@ -3,6 +3,7 @@ const Bundler = @import("bundler.zig").Bundler;
 const BundleResult = @import("bundler.zig").BundleResult;
 const BundleOptions = @import("bundler.zig").BundleOptions;
 const resolve_cache_mod = @import("resolve_cache.zig");
+const OutputFile = @import("emitter.zig").OutputFile;
 
 /// 테스트용 번들 결과 wrapper: arena 가 linker 관련 로컬 할당의 수명을 보장.
 pub const Bundled = struct {
@@ -65,6 +66,22 @@ pub fn absPath(tmp: *std.testing.TmpDir, rel: []const u8) ![]const u8 {
     const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
     defer std.testing.allocator.free(dp);
     return try std.fs.path.resolve(std.testing.allocator, &.{ dp, rel });
+}
+
+/// code_splitting=true 번들 결과에서 이름이 포함된 청크 존재 확인.
+pub fn hasChunk(outs: []const OutputFile, name: []const u8) bool {
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.path, name) != null) return true;
+    }
+    return false;
+}
+
+/// 특정 marker 문자열이 포함된 청크의 path 반환 (없으면 null).
+pub fn chunkContaining(outs: []const OutputFile, marker: []const u8) ?[]const u8 {
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.contents, marker) != null) return o.path;
+    }
+    return null;
 }
 
 /// 테스트용 헬퍼: ArenaAllocator 를 ThreadSafeAllocator 로 감싸 worker 동시 alloc 보호.

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -105,6 +105,29 @@ pub const GlobalEntry = struct {
     }
 };
 
+/// 사용자 정의 청크 분할 (#1027 / Rollup `manualChunks` 호환 Phase 1).
+/// Rollup record form `{ "vendor": ["lodash", "react"] }` 를 네이티브 슬라이스로 1:1 매핑.
+/// 모듈 절대경로에 `patterns` 중 하나가 substring 으로 포함되면 `name` 청크에 할당.
+///
+/// 매칭된 모듈은 pseudo-entry 로 BFS 에 참여 → transitive dependency 도 자동으로
+/// 같은 청크에 따라가고, dynamic import target 도 async chunk 대신 manual 청크에 포함.
+/// regex/function 지원 및 순환 의존 diagnostic 은 Phase 2 에서.
+pub const ManualChunkEntry = struct {
+    name: []const u8,
+    patterns: []const []const u8,
+
+    /// 모듈 경로가 어느 entry 에 매칭되는지 찾는다. 없으면 null.
+    /// 다중 매칭 시 **먼저 선언된 엔트리** 우선 (사용자 의도 반영).
+    pub fn lookup(entries: []const ManualChunkEntry, module_path: []const u8) ?usize {
+        for (entries, 0..) |e, i| {
+            for (e.patterns) |p| {
+                if (std.mem.indexOf(u8, module_path, p) != null) return i;
+            }
+        }
+        return null;
+    }
+};
+
 // ============================================================
 // Import 종류
 // ============================================================


### PR DESCRIPTION
## Summary
rolldown \`advanced_chunks.groups\` / Rollup \`manualChunks\` 호환 Phase 1 구현. Vite/rolldown 에서 가장 자주 쓰이는 "vendor/ui/data 청크로 쪼개기" 시나리오를 커버.

## API
\`\`\`zig
manual_chunks: []const types.ManualChunkEntry = &.{},

pub const ManualChunkEntry = struct {
    name: []const u8,
    patterns: []const []const u8, // 모듈 경로 substring 매칭
};
\`\`\`

Rollup record form \`{ "vendor": ["lodash", "react"] }\` 을 네이티브 슬라이스로 1:1 매핑.

## 동작 정책 (rolldown 과 동일)

| 상황 | 동작 |
|---|---|
| 매칭 모듈 | 지정 manual 청크로 |
| 매칭 모듈의 transitive dep | 같은 manual 청크로 (cross-chunk 순환 회피, rolldown \`include_dependencies_recursively\`) |
| dynamic import target 가 매칭됨 | async chunk 대신 manual 청크 우선 |
| 매칭 없는 manual chunk | 출력 skip (빈 파일 방지) |
| 엔트리 모듈 강제 이동 | manual 청크에 있으면 유지 |

## 구현 (chunk.zig)
- \`ChunkKind\` 에 \`.manual { bit, name }\` variant 추가
- Phase 1d: manual 매칭 모듈 seed 수집 + 비어있지 않을 때만 Chunk 등록
- Phase 2.5: manual BFS — seed 부터 dep 재귀로 manual bit 전파
- 후처리: manual bit 있는 모듈의 entry bit 제거 → Phase 3 BitSet lookup 이 manual 청크로 귀속
- BitSet 에 \`hasAnyBitInRange\`, \`clearBitRange\` 유틸 추가

## Test plan (bundler_test/manual_chunks.zig — 7개)
- [x] empty list → 기존 동작 유지
- [x] substring match → 지정 청크 분리
- [x] multi-pattern → 여러 모듈을 한 청크로
- [x] multiple groups → 서로 다른 청크
- [x] **transitive dependency follows** (rolldown \`include_dependencies_recursively\` 개념)
- [x] **dynamic import hoisted into manual chunk** (rolldown \`dynamic_entry_shared_module_not_merged\` 단순화)
- [x] no match → 단일 엔트리 청크

\`zig build test\` 전체 통과.

## Out of scope (Phase 2+)
- regex / function callback 매칭 (Rollup \`manualChunks(id, meta)\` 전체 시그니처)
- 순환 의존 diagnostic
- rolldown \`entries_aware_*\` / \`min/max_size\` 사이즈 기반 merge

Refs #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)