### PR TITLE
feat(bundler): manualChunks Phase 2 — function resolver 콜백 (#1027)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -76,6 +76,12 @@ pub const BundleOptions = struct {
     /// code_splitting=true 일 때만 동작. 매칭된 모듈은 pseudo-entry 로 BFS 에 참여
     /// → transitive dependency 도 같은 청크로, dynamic import target 도 manual 우선.
     manual_chunks: []const types.ManualChunkEntry = &.{},
+    /// Rollup `manualChunks(id)` 함수 시그니처 호환 (#1027 Phase 2).
+    /// 모듈 경로마다 호출해 반환한 이름으로 동적 manual 청크 생성. null 반환이면 auto.
+    /// resolver + record 공존 시 **resolver 결과 우선**.
+    manual_chunks_resolver: ?types.ManualChunksResolveFn = null,
+    /// resolver 에 전달할 user context (TSFN 핸들, 상태 포인터 등).
+    manual_chunks_ctx: ?*anyopaque = null,
     /// dev mode: 각 모듈을 __zts_register() 팩토리로 래핑하고
     /// HMR 런타임을 주입한다. import.meta.hot API 지원.
     dev_mode: bool = false,
@@ -980,6 +986,8 @@ pub const Bundler = struct {
                     self.options.entry_points,
                     if (shaker) |*s| s else null,
                     self.options.manual_chunks,
+                    self.options.manual_chunks_resolver,
+                    self.options.manual_chunks_ctx,
                 );
             defer chunk_graph.deinit();
 

--- a/src/bundler/bundler_test/manual_chunks.zig
+++ b/src/bundler/bundler_test/manual_chunks.zig
@@ -248,6 +248,196 @@ test "manualChunks: dynamic import target hoisted into manual chunk" {
     try std.testing.expect(std.mem.indexOf(u8, lazy_chunk, "vendor") != null);
 }
 
+// ============================================================
+// Phase 2: function resolver (Rollup `manualChunks(id)` 호환)
+// ============================================================
+// resolver 반환 이름은 동적으로 manual 청크를 생성. record 와 공존 시 resolver 우선.
+
+fn resolverVendorSubstring(_: ?*anyopaque, id: []const u8) ?[]const u8 {
+    if (std.mem.indexOf(u8, id, "vendor-lib") != null) return "vendor";
+    return null;
+}
+
+fn resolverAlwaysNull(_: ?*anyopaque, _: []const u8) ?[]const u8 {
+    return null;
+}
+
+fn resolverTwoGroups(_: ?*anyopaque, id: []const u8) ?[]const u8 {
+    if (std.mem.indexOf(u8, id, "ui-") != null) return "ui";
+    if (std.mem.indexOf(u8, id, "data-") != null) return "data";
+    return null;
+}
+
+/// ctx 로 호출 카운터 전달 — 호출 검증용.
+fn resolverCountingSink(ctx: ?*anyopaque, id: []const u8) ?[]const u8 {
+    const counter: *usize = @ptrCast(@alignCast(ctx.?));
+    counter.* += 1;
+    if (std.mem.indexOf(u8, id, "match") != null) return "sink";
+    return null;
+}
+
+test "manualChunks resolver: returns chunk name → 해당 청크로 할당" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./vendor-lib";
+        \\console.log(a);
+    );
+    try writeFile(tmp.dir, "vendor-lib.ts", "export const a = \"VENDOR_MARKER\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverVendorSubstring,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    const vendor_chunk = chunkContaining(outs, "VENDOR_MARKER") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, vendor_chunk, "vendor") != null);
+}
+
+test "manualChunks resolver: returning null → 기존 자동 분배" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./lib";
+        \\console.log(a);
+    );
+    try writeFile(tmp.dir, "lib.ts", "export const a = \"ONLY\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverAlwaysNull,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(usize, 1), outs.len);
+    try std.testing.expect(std.mem.indexOf(u8, outs[0].contents, "ONLY") != null);
+}
+
+test "manualChunks resolver: multiple names → 각자 다른 청크로 동적 생성" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./ui-lib";
+        \\import { b } from "./data-lib";
+        \\console.log(a, b);
+    );
+    try writeFile(tmp.dir, "ui-lib.ts", "export const a = \"UI\";");
+    try writeFile(tmp.dir, "data-lib.ts", "export const b = \"DATA\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverTwoGroups,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    const ui_chunk = chunkContaining(outs, "UI") orelse return error.TestUnexpectedResult;
+    const data_chunk = chunkContaining(outs, "DATA") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, ui_chunk, "ui") != null);
+    try std.testing.expect(std.mem.indexOf(u8, data_chunk, "data") != null);
+    try std.testing.expect(!std.mem.eql(u8, ui_chunk, data_chunk));
+}
+
+test "manualChunks resolver: ctx 로 호출 카운터 전달" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./match-a";
+        \\import { b } from "./lib-b";
+        \\console.log(a, b);
+    );
+    try writeFile(tmp.dir, "match-a.ts", "export const a = \"A_MATCH\";");
+    try writeFile(tmp.dir, "lib-b.ts", "export const b = \"B\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var counter: usize = 0;
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverCountingSink,
+        .manual_chunks_ctx = &counter,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // resolver 는 최소 3 모듈 (entry + 2 dep) 에 대해 호출됨
+    try std.testing.expect(counter >= 3);
+    // "match-a" 는 sink 청크, "lib-b" 는 auto
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    const a_chunk = chunkContaining(outs, "A_MATCH") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, a_chunk, "sink") != null);
+}
+
+test "manualChunks resolver + record 공존: resolver 우선" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./vendor-lib";
+        \\console.log(a);
+    );
+    try writeFile(tmp.dir, "vendor-lib.ts", "export const a = \"MIX\";");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    // record 는 "record-chunk", resolver 는 "vendor" — 모듈이 둘 다 매칭
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks = &.{
+            .{ .name = "record-chunk", .patterns = &.{"vendor-lib"} },
+        },
+        .manual_chunks_resolver = resolverVendorSubstring,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    // resolver 결과 ("vendor") 가 우선. "record-chunk" 는 생성되지 않음.
+    const chunk = chunkContaining(outs, "MIX") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, chunk, "vendor") != null);
+    try std.testing.expect(!hasChunk(outs, "record-chunk"));
+}
+
 test "manualChunks: no match → 엔트리 청크에 머묾 (기존 동작)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -337,12 +337,30 @@ const EntryInfo = struct {
 ///          여러 엔트리에서 도달 가능한 모듈은 공통 청크(common chunk)로 분리.
 ///
 /// shaker가 null이 아니면 tree-shaking 결과를 반영하여 미포함 모듈을 스킵한다.
+/// manual chunk 이름을 slot index 로 매핑. 이미 있으면 기존 slot 반환, 없으면 새 slot 생성.
+/// record entries + resolver 동적 결과의 dedup 통합 지점.
+fn ensureNameSlot(
+    name_to_slot: *std.StringHashMap(usize),
+    effective_names: *std.ArrayList([]const u8),
+    allocator: std.mem.Allocator,
+    name: []const u8,
+) !usize {
+    const gop = try name_to_slot.getOrPut(name);
+    if (!gop.found_existing) {
+        gop.value_ptr.* = effective_names.items.len;
+        try effective_names.append(allocator, name);
+    }
+    return gop.value_ptr.*;
+}
+
 pub fn generateChunks(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
     entry_points: []const []const u8,
     shaker: ?*const TreeShaker,
     manual_chunks: []const types.ManualChunkEntry,
+    manual_resolver: ?types.ManualChunksResolveFn,
+    manual_resolver_ctx: ?*anyopaque,
 ) !ChunkGraph {
     const module_count = graph.moduleCount();
 
@@ -409,7 +427,35 @@ pub fn generateChunks(
     // BFS 단계에서 매칭 모듈의 transitive deps 에 manual bit 가 전파되어
     // `rolldown advanced_chunks/include_dependencies_recursively` 와 동일한
     // 정책 (dep 도 같은 manual 청크로) 을 자동으로 얻는다.
-    const manual_count = manual_chunks.len;
+    //
+    // effective_names[i] = i 번째 manual slot 의 청크 이름. record + resolver 동적
+    // 결과를 순서대로 병합. resolver 가 반환한 name 이 record 와 겹치면 동일 slot.
+    var effective_names: std.ArrayList([]const u8) = .empty;
+    defer effective_names.deinit(allocator);
+    var name_to_slot = std.StringHashMap(usize).init(allocator);
+    defer name_to_slot.deinit();
+    for (manual_chunks) |mc| {
+        _ = try ensureNameSlot(&name_to_slot, &effective_names, allocator, mc.name);
+    }
+
+    // Resolver 결과 미리 수집 — 모듈당 1회 호출. NAPI TSFN 경로에서도 재호출 없음.
+    // resolver 없으면 배열 할당 자체 skip (빌드당 module_count × 16B 절약).
+    var resolver_assignments: ?[]?usize = null;
+    defer if (resolver_assignments) |ra| allocator.free(ra);
+    if (manual_resolver) |fn_ptr| {
+        const ra = try allocator.alloc(?usize, module_count);
+        resolver_assignments = ra;
+        @memset(ra, null);
+        var it = graph.modulesIterator();
+        var mi: usize = 0;
+        while (it.next()) |m| : (mi += 1) {
+            if (fn_ptr(manual_resolver_ctx, m.path)) |chunk_name| {
+                ra[mi] = try ensureNameSlot(&name_to_slot, &effective_names, allocator, chunk_name);
+            }
+        }
+    }
+
+    const manual_count = effective_names.items.len;
     const total_bits = entry_count + manual_count;
 
     // ChunkGraph 생성 — 모듈→청크 매핑 배열을 module_count 크기로 할당.
@@ -459,7 +505,7 @@ pub fn generateChunks(
 
     // Phase 1d: manual chunks — 실제 매칭 모듈 seed 수집 + 비어있지 않으면 Chunk 등록.
     // 매칭 없는 manual chunk 는 빈 출력 파일을 만들지 않도록 skip. 실제 BFS 전파는 Phase 2.5.
-    // `manual_seeds[i].items.len > 0` 이 곧 "이 청크 등록됨" 의 signal — 별도 flag 불필요.
+    // Resolver 결과 우선, 없으면 record substring 매칭으로 fallback.
     const manual_seeds = try allocator.alloc(std.ArrayList(ModuleIndex), manual_count);
     defer {
         for (manual_seeds) |*s| s.deinit(allocator);
@@ -471,20 +517,27 @@ pub fn generateChunks(
         var it = graph.modulesIterator();
         var mi: usize = 0;
         while (it.next()) |m| : (mi += 1) {
+            if (resolver_assignments) |ra| {
+                if (ra[mi]) |slot| {
+                    try manual_seeds[slot].append(allocator, ModuleIndex.fromUsize(mi));
+                    continue;
+                }
+            }
             const idx = types.ManualChunkEntry.lookup(manual_chunks, m.path) orelse continue;
+            // record name 의 slot index (effective_names 병합으로 record 가 먼저 등록됨).
             try manual_seeds[idx].append(allocator, ModuleIndex.fromUsize(mi));
         }
     }
 
-    for (manual_chunks, 0..) |mc, i| {
+    for (effective_names.items, 0..) |name, i| {
         if (manual_seeds[i].items.len == 0) continue;
         const manual_bit: u32 = @intCast(entry_count + i);
         var bits = try BitSet.init(allocator, @intCast(total_bits));
         errdefer bits.deinit(allocator);
         bits.setBit(manual_bit);
 
-        var chunk = Chunk.init(.none, .{ .manual = .{ .bit = manual_bit, .name = mc.name } }, bits);
-        chunk.name = mc.name;
+        var chunk = Chunk.init(.none, .{ .manual = .{ .bit = manual_bit, .name = name } }, bits);
+        chunk.name = name;
 
         const ci = try chunk_graph.addChunk(chunk);
         try bits_to_chunk.put(allocator, bits, ci);

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -445,7 +445,7 @@ test "generateChunks: single entry, no dynamic imports" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
     defer cg.deinit();
 
     // 엔트리 청크 1개
@@ -482,7 +482,7 @@ test "generateChunks: dynamic import creates separate chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null, &.{}, null, null);
     defer cg.deinit();
 
     // 엔트리 청크 1개 + dynamic 청크 1개 = 2개
@@ -523,7 +523,7 @@ test "generateChunks: shared module creates common chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null);
     defer cg.deinit();
 
     // 엔트리 2개 + 공통 1개 = 3개
@@ -564,7 +564,7 @@ test "generateChunks: diamond dependency" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null);
     defer cg.deinit();
 
     // D가 양쪽 엔트리에서 도달 가능 → 공통 청크 생성
@@ -592,7 +592,7 @@ test "generateChunks: no modules" {
     var tg = try TestGraph.init(alloc, &empty_modules);
     defer tg.deinit(alloc);
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null);
     defer cg.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), cg.chunkCount());
@@ -617,7 +617,7 @@ test "generateChunks: circular dependency stays in same chunk" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
     defer cg.deinit();
 
     // 1 엔트리 청크, 모든 모듈 포함
@@ -643,7 +643,7 @@ test "generateChunks: static + dynamic import same module" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
     try tg.graph.modules.at(0).addDynamicImport(alloc, @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
     defer cg.deinit();
 
     // b.ts는 엔트리 청크에 포함 (static이 우선)
@@ -672,7 +672,7 @@ test "generateChunks: three entries sharing a module" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(3));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null, &.{}, null, null);
     defer cg.deinit();
 
     // 3 엔트리 + 1 공통 = 4 청크
@@ -702,7 +702,7 @@ test "generateChunks: entry imports another entry statically" {
 
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null);
     defer cg.deinit();
 
     // 2개 엔트리 청크 생성
@@ -731,7 +731,7 @@ test "generateChunks: deep chain with dynamic import at middle" {
     try tg.graph.modules.at(1).addDynamicImport(alloc, @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
     defer cg.deinit();
 
     // 2개 청크: a엔트리(a,b), c엔트리(c,d)
@@ -982,7 +982,7 @@ test "generateChunks: entry module reassignment removes from old chunk" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{});
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null);
     defer cg.deinit();
 
     // c.ts는 엔트리 청크에 있어야 함 (공통 청크 아님)

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -370,7 +370,7 @@ test "inline (bundle): shared module 내부 inline — emitChunks 경로" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -430,7 +430,7 @@ test "emitChunks: single chunk produces one OutputFile" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -465,7 +465,7 @@ test "emitChunks: two entries with shared module — 3 OutputFiles" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -514,7 +514,7 @@ test "CodeSplitting: dynamic import path rewritten to chunk filename" {
     const lazy_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "lazy.ts" });
     defer std.testing.allocator.free(lazy_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null, &.{}, null, null);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -573,7 +573,7 @@ test "CodeSplitting: multiple dynamic imports rewritten" {
     const pageB_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "pageB.ts" });
     defer std.testing.allocator.free(pageB_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null, &.{}, null, null);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -619,7 +619,7 @@ test "chunkStem: common chunk uses hex hash, not index" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -669,7 +669,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null, &.{});
+    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
     defer cg1.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg1, &result1.graph, std.testing.allocator, null);
 
@@ -687,7 +687,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     defer result2.graph.deinit();
     defer result2.cache.deinit();
 
-    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null, &.{});
+    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
     defer cg2.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg2, &result2.graph, std.testing.allocator, null);
 
@@ -791,7 +791,7 @@ test "naming pattern: entry-names with hash" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{
@@ -832,7 +832,7 @@ test "naming pattern: chunk-names with directory" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -879,7 +879,7 @@ test "content hash: cross-chunk import uses content hash" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -946,7 +946,7 @@ test "CJS runtime: __commonJS only in chunks containing CJS modules" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -981,7 +981,7 @@ test "CodeSplitting: static import not rewritten" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{});
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -105,6 +105,14 @@ pub const GlobalEntry = struct {
     }
 };
 
+/// Rollup `manualChunks(id)` 호환 콜백 (#1027 Phase 2).
+/// 모듈 절대경로 `id` 를 받아 청크 이름을 반환하면 그 이름의 manual 청크로 묶인다.
+/// null 반환이면 기존 auto 분배. resolver 로 동적 생성된 청크는 `ManualChunkEntry`
+/// record 와 동일 파이프라인 (bit 할당 / BFS / transitive dep 포함) 을 탄다.
+///
+/// `ctx` 는 caller 가 원하는 상태 (TSFN 핸들, 카운터 등) 를 전달하는 슬롯.
+pub const ManualChunksResolveFn = *const fn (ctx: ?*anyopaque, id: []const u8) ?[]const u8;
+
 /// 사용자 정의 청크 분할 (#1027 / Rollup `manualChunks` 호환 Phase 1).
 /// Rollup record form `{ "vendor": ["lodash", "react"] }` 를 네이티브 슬라이스로 1:1 매핑.
 /// 모듈 절대경로에 `patterns` 중 하나가 substring 으로 포함되면 `name` 청크에 할당.


### PR DESCRIPTION
## Summary
Rollup \`manualChunks(id)\` 함수 시그니처 호환 Phase 2. Zig 레벨 resolver API 완성.

## API
\`\`\`zig
pub const ManualChunksResolveFn = *const fn (ctx: ?*anyopaque, id: []const u8) ?[]const u8;

// BundleOptions
manual_chunks_resolver: ?types.ManualChunksResolveFn = null,
manual_chunks_ctx: ?*anyopaque = null,
\`\`\`

## 동작
- resolver 반환 이름으로 **동적 manual 청크 생성** (record 선언 불필요)
- **resolver + record 공존 시 resolver 우선**
- transitive dep / dynamic import hoist / Phase 4 entry 보호 정책 Phase 1 그대로

## 구현 (chunk.zig)
- \`effective_names\` + \`name_to_slot\` 로 record + resolver 동적 이름 통합
- \`ensureNameSlot\` helper 로 dedup 로직 단일화
- \`resolver_assignments: ?[]?usize\` — pre-pass 에서 모듈당 1회 resolver 호출, Phase 1d 에서 lookup 재활용 (NAPI TSFN 경로에서도 재호출 없음)
- resolver 없으면 \`resolver_assignments\` 할당 skip

## Test plan
Phase 2 테스트 5개 추가 (Phase 1 의 7개와 함께 총 12개 통과):
- [x] returns chunk name → 해당 청크 할당
- [x] returning null → 기존 자동 분배
- [x] multiple names → 각자 다른 청크 동적 생성
- [x] ctx 로 호출 카운터 전달 — opaque ctx pointer 검증
- [x] resolver + record 공존: resolver 우선

\`zig build test\` 전체 통과.

## Out of scope (PR 2)
- NAPI 브리지 — JS \`manualChunks\` 함수를 TSFN 으로 Zig resolver 에 연결
- Integration 테스트 (실제 Node/Bun 에서 JS 함수 호출)

Refs #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)