### PR TITLE
feat(napi): OutputFile.imports — rolldown chunk.imports 완전 호환

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -32,6 +32,9 @@ interface OutputFile {
   moduleIds?: string[];
   /** 이 chunk 가 export 하는 심볼 이름 목록 (cross-chunk 검증용). */
   exports?: string[];
+  /** 이 chunk 가 import 하는 다른 chunk 의 최종 filename 배열 (rolldown `chunk.imports` 호환).
+   * content-hash 까지 확정된 경로. */
+  imports?: string[];
 }
 
 interface Diagnostic {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -430,6 +430,16 @@ fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult) c.n
             }
             _ = c.napi_set_named_property(env, js_file, "exports", js_exports);
 
+            // imports — cross-chunk 로 참조하는 다른 chunk 들의 최종 filename
+            var js_imports: c.napi_value = undefined;
+            _ = c.napi_create_array(env, &js_imports);
+            for (out.imports, 0..) |im, k| {
+                var s: c.napi_value = undefined;
+                _ = c.napi_create_string_utf8(env, im.ptr, im.len, &s);
+                _ = c.napi_set_element(env, js_imports, @intCast(k), s);
+            }
+            _ = c.napi_set_named_property(env, js_file, "imports", js_imports);
+
             _ = c.napi_set_element(env, js_outputs, @intCast(i), js_file);
         }
     } else {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -687,6 +687,34 @@ fn resolveContentHashes(
         allocator.free(out.path);
         out.path = new_path;
     }
+
+    // 3단계: imports 메타 채우기 (rolldown `chunk.imports` 호환).
+    // path 가 content-hash 까지 확정된 이후에 각 chunk 의 cross_chunk_imports 를
+    // 최종 filename 배열로 변환. chunk idx → output idx 역매핑으로 O(N) lookup.
+    var chunk_to_out = try allocator.alloc(?usize, chunk_graph.chunks.items.len);
+    defer allocator.free(chunk_to_out);
+    @memset(chunk_to_out, null);
+    for (sorted_indices, 0..) |ci, out_idx| {
+        if (out_idx >= outputs.len) break;
+        chunk_to_out[ci] = out_idx;
+    }
+
+    for (sorted_indices, 0..) |ci, out_idx| {
+        if (out_idx >= outputs.len) break;
+        const chunk = &chunk_graph.chunks.items[ci];
+        if (chunk.cross_chunk_imports.items.len == 0) continue;
+
+        var imps: std.ArrayList([]const u8) = .empty;
+        errdefer {
+            for (imps.items) |p| allocator.free(p);
+            imps.deinit(allocator);
+        }
+        for (chunk.cross_chunk_imports.items) |dep_ci| {
+            const dep_out = chunk_to_out[@intFromEnum(dep_ci)] orelse continue;
+            try imps.append(allocator, try allocator.dupe(u8, outputs[dep_out].path));
+        }
+        outputs[out_idx].imports = try imps.toOwnedSlice(allocator);
+    }
 }
 
 /// placeholder 해시 길이 (8자리 hex).

--- a/tests/integration/tests/manual-chunks-smoke.test.ts
+++ b/tests/integration/tests/manual-chunks-smoke.test.ts
@@ -82,6 +82,13 @@ describe("manualChunks smoke (실제 번들 실행)", () => {
     expect(entry!.moduleIds).toEqual(expect.arrayContaining([expect.stringMatching(/entry\.ts$/)]));
     expect(entry!.moduleIds!.find((id) => id.includes("/vendor/"))).toBeUndefined();
 
+    // rolldown `chunk.imports` 호환: entry 는 vendor.js 를 import
+    expect(entry!.imports).toEqual(
+      expect.arrayContaining([expect.stringMatching(/vendor.*\.js$/)]),
+    );
+    // vendor 는 leaf chunk — 아무 것도 import 안 함
+    expect(vendor!.imports).toEqual([]);
+
     // entry 청크엔 ui/formatter 만, vendor 구현 없음
     expect(entry!.text).toMatch(/function\s+format\s*\(/);
     expect(entry!.text).not.toMatch(/function\s+add\s*\(/);

--- a/tests/integration/tests/manual-chunks-smoke.test.ts
+++ b/tests/integration/tests/manual-chunks-smoke.test.ts
@@ -839,6 +839,133 @@ describe("manualChunks smoke (실제 번들 실행)", () => {
     expect(entry!.text).toMatch(/from\s*["'][^"']*date-utils[^"']*["']/);
   });
 
+  test("imports 메타: multi-group — entry 가 vendor + ui 둘 다 import", async () => {
+    // manualChunks 로 vendor, ui 각각 분리 시 entry 의 imports 가 양쪽 모두 포함.
+    const fixture = await createFixture({
+      "vendor/math.ts": `export function add(a: number, b: number) { return a + b; }`,
+      "ui/button.ts": `export function renderBtn() { return "<btn>"; }`,
+      "entry.ts": `
+        import { add } from "./vendor/math";
+        import { renderBtn } from "./ui/button";
+        console.log(add(1, 2) + renderBtn());
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+      manualChunks: (id) => {
+        if (id.includes("/vendor/")) return "vendor";
+        if (id.includes("/ui/")) return "ui";
+        return null;
+      },
+    });
+
+    const entry = result.outputFiles.find((o) => o.path.endsWith("entry.js"))!;
+    expect(entry.imports).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/vendor.*\.js$/),
+        expect.stringMatching(/ui.*\.js$/),
+      ]),
+    );
+    expect(entry.imports!.length).toBe(2);
+  });
+
+  test("imports 메타: shared vendor — 두 엔트리가 같은 chunk 를 import", async () => {
+    // pageA + pageB 가 shared vendor 를 각각 import. rolldown 에서도 동일 결과.
+    const fixture = await createFixture({
+      "vendor/shared.ts": `export const VALUE = "SHARED";`,
+      "pageA.ts": `
+        import { VALUE } from "./vendor/shared";
+        console.log("A:" + VALUE);
+      `,
+      "pageB.ts": `
+        import { VALUE } from "./vendor/shared";
+        console.log("B:" + VALUE);
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "pageA.ts"), join(fixture.dir, "pageB.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+      manualChunks: (id) => (id.includes("/vendor/") ? "vendor" : null),
+    });
+
+    const pageA = result.outputFiles.find((o) => o.path.includes("pageA"))!;
+    const pageB = result.outputFiles.find((o) => o.path.includes("pageB"))!;
+    const vendor = result.outputFiles.find((o) => o.path.includes("vendor"))!;
+
+    // 두 엔트리 모두 vendor 를 import
+    expect(pageA.imports).toEqual(expect.arrayContaining([expect.stringMatching(/vendor.*\.js$/)]));
+    expect(pageB.imports).toEqual(expect.arrayContaining([expect.stringMatching(/vendor.*\.js$/)]));
+    // 두 엔트리의 imports 에서 vendor path 는 동일해야 (같은 실제 파일 가리킴)
+    const aVendorRef = pageA.imports!.find((p) => p.includes("vendor"));
+    const bVendorRef = pageB.imports!.find((p) => p.includes("vendor"));
+    expect(aVendorRef).toBe(bVendorRef);
+    // vendor 는 leaf
+    expect(vendor.imports).toEqual([]);
+  });
+
+  test("imports 메타: 단일 청크는 imports 비어있음", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `console.log("SINGLE");`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+    });
+
+    expect(result.outputFiles.length).toBe(1);
+    expect(result.outputFiles[0].imports).toEqual([]);
+  });
+
+  test.skipIf(!hasPackage("react") || !hasPackage("immer"))(
+    "imports 메타 실 라이브러리: react-vendor + vendor 둘 다 import",
+    async () => {
+      const fixture = await createFixture({
+        "entry.tsx": `
+          import { createElement } from "react";
+          import { produce } from "immer";
+          const state = produce({ n: 0 }, (d: any) => { d.n = 1; });
+          console.log(createElement("div", null, state.n));
+        `,
+      });
+      cleanup = fixture.cleanup;
+
+      const result = await build({
+        entryPoints: [join(fixture.dir, "entry.tsx")],
+        splitting: true,
+        outdir: join(fixture.dir, "dist"),
+        write: false,
+        nodePaths: [ROOT_NODE_MODULES],
+        manualChunks: (id) => {
+          if (id.includes("/react/") || id.includes("/scheduler/")) return "react-vendor";
+          if (id.includes("node_modules")) return "vendor";
+          return null;
+        },
+      });
+
+      const entry = result.outputFiles.find((o) => o.path.endsWith("entry.js"))!;
+      // entry 가 두 chunk 를 모두 import
+      expect(entry.imports).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/react-vendor.*\.js$/),
+          expect.stringMatching(/vendor.*\.js$/),
+        ]),
+      );
+    },
+  );
+
   test("엔트리 모듈이 manualChunks 매칭: 엔트리 청크로 유지 (정책)", async () => {
     // 엔트리 모듈 자체가 manualChunks 패턴에 매칭되면 어떻게?
     // Phase 4 가드로 엔트리는 manual 로 강제 이동하지 않음 — entry chunk 유지.


### PR DESCRIPTION
## Summary
PR #1851 에서 stub 으로 남긴 \`OutputFile.imports\` 필드를 실제로 채움. rolldown 의 \`chunk.imports\` / \`moduleIds\` / \`exports\` 3종 메타를 ZTS 가 모두 제공.

## 구현 (emitter/chunks.zig)

\`resolveContentHashes\` 의 기존 2패스 (placeholder 치환 → content hash) 끝에 3단계 추가:
- chunk idx → output idx 역매핑 구축
- 각 chunk 의 \`cross_chunk_imports\` 순회 → 최종 filename 배열로 변환
- 각 \`OutputFile.imports\` 에 dupe 로 저장

**content-hash 까지 확정된 시점**에 수집해야 올바른 filename. deinit 은 기존 \`OutputFile.deinit()\` 헬퍼 경유로 표준화.

## NAPI + TS

- \`napi_entry.zig\` 에 \`imports\` 배열 JS 전달 추가
- \`packages/core/index.ts\` OutputFile 인터페이스에 \`imports?: string[]\` 추가

## Test plan

스모크 테스트에 구조적 검증 추가:
\`\`\`ts
// entry 는 vendor.js 를 import
expect(entry!.imports).toEqual(
  expect.arrayContaining([expect.stringMatching(/vendor.*\\.js$/)])
);
// vendor 는 leaf chunk — 아무 것도 import 안 함
expect(vendor!.imports).toEqual([]);
\`\`\`

27 tests, 142 assertions 전부 통과.

## rolldown 갭 현황

| 기능 | ZTS |
|---|---|
| \`chunk.moduleIds\` | ✅ #1851 |
| \`chunk.exports\` | ✅ #1851 |
| \`chunk.imports\` | ✅ **이 PR** |
| \`chunk.type\` | ✅ #1851 |

Refs #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)