### PR TITLE
feat(bundler): manualChunks(id, meta) Zig 인프라

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1054,7 +1054,8 @@ const NapiManualChunksResolver = struct {
 
     /// Zig resolver 인터페이스 — `ManualChunksResolveFn` 과 동일 시그니처.
     /// worker thread 에서 호출됨. JS 호출 후 동기 대기.
-    fn resolve(ctx_ptr: ?*anyopaque, id: []const u8) ?[]const u8 {
+    fn resolve(ctx_ptr: ?*anyopaque, id: []const u8, graph: ?*const anyopaque) ?[]const u8 {
+        _ = graph;
         const self: *NapiManualChunksResolver = @ptrCast(@alignCast(ctx_ptr.?));
         var call_ctx = CallContext{ .id = id };
 

--- a/src/bundler/bundler_test/manual_chunks.zig
+++ b/src/bundler/bundler_test/manual_chunks.zig
@@ -315,7 +315,7 @@ test "manualChunks resolver: dynamic entry 반환 이름 무시" {
         .entry_points = &.{entry},
         .code_splitting = true,
         .manual_chunks_resolver = struct {
-            fn r(_: ?*anyopaque, _: []const u8) ?[]const u8 {
+            fn r(_: ?*anyopaque, _: []const u8, _: ?*const anyopaque) ?[]const u8 {
                 return "bucket";
             }
         }.r,
@@ -340,23 +340,23 @@ test "manualChunks resolver: dynamic entry 반환 이름 무시" {
 // ============================================================
 // resolver 반환 이름은 동적으로 manual 청크를 생성. record 와 공존 시 resolver 우선.
 
-fn resolverVendorSubstring(_: ?*anyopaque, id: []const u8) ?[]const u8 {
+fn resolverVendorSubstring(_: ?*anyopaque, id: []const u8, _: ?*const anyopaque) ?[]const u8 {
     if (std.mem.indexOf(u8, id, "vendor-lib") != null) return "vendor";
     return null;
 }
 
-fn resolverAlwaysNull(_: ?*anyopaque, _: []const u8) ?[]const u8 {
+fn resolverAlwaysNull(_: ?*anyopaque, _: []const u8, _: ?*const anyopaque) ?[]const u8 {
     return null;
 }
 
-fn resolverTwoGroups(_: ?*anyopaque, id: []const u8) ?[]const u8 {
+fn resolverTwoGroups(_: ?*anyopaque, id: []const u8, _: ?*const anyopaque) ?[]const u8 {
     if (std.mem.indexOf(u8, id, "ui-") != null) return "ui";
     if (std.mem.indexOf(u8, id, "data-") != null) return "data";
     return null;
 }
 
 /// ctx 로 호출 카운터 전달 — 호출 검증용.
-fn resolverCountingSink(ctx: ?*anyopaque, id: []const u8) ?[]const u8 {
+fn resolverCountingSink(ctx: ?*anyopaque, id: []const u8, _: ?*const anyopaque) ?[]const u8 {
     const counter: *usize = @ptrCast(@alignCast(ctx.?));
     counter.* += 1;
     if (std.mem.indexOf(u8, id, "match") != null) return "sink";
@@ -554,4 +554,194 @@ test "manualChunks: no match → 엔트리 청크에 머묾 (기존 동작)" {
     // 매칭 없음 → vendor 청크 생성 안 됨, 단일 entry 청크만
     try std.testing.expectEqual(@as(usize, 1), outs.len);
     try std.testing.expect(std.mem.indexOf(u8, outs[0].contents, "ONLY") != null);
+}
+
+// ============================================================
+// Phase 3: meta.getModuleInfo — Rollup `manualChunks(id, meta)` 호환
+// ============================================================
+
+const MetaSeen = struct {
+    entries: std.ArrayList(struct {
+        id: []const u8,
+        is_entry: bool,
+        importer_count: usize,
+        imported_count: usize,
+    }) = .empty,
+    allocator: std.mem.Allocator,
+
+    // ModuleInfo.id / importers / imported_ids 는 graph 수명 동안 borrowed.
+    // bundle() 리턴 시 graph 가 deinit 되므로, 테스트에서는 record 시점에 dupe 해서 보관.
+    fn record(self: *MetaSeen, info: types.ModuleInfo) !void {
+        const owned_id = try self.allocator.dupe(u8, info.id);
+        errdefer self.allocator.free(owned_id);
+        try self.entries.append(self.allocator, .{
+            .id = owned_id,
+            .is_entry = info.is_entry,
+            .importer_count = info.importers.len,
+            .imported_count = info.imported_ids.len,
+        });
+    }
+
+    fn deinit(self: *MetaSeen) void {
+        for (self.entries.items) |e| self.allocator.free(e.id);
+        self.entries.deinit(self.allocator);
+    }
+};
+
+fn resolverMeta(ctx: ?*anyopaque, id: []const u8, graph: ?*const anyopaque) ?[]const u8 {
+    const seen: *MetaSeen = @ptrCast(@alignCast(ctx.?));
+    const info = types.getModuleInfo(graph, id) orelse return null;
+    seen.record(info) catch return null;
+    return null;
+}
+
+test "manualChunks meta.getModuleInfo: isEntry / importers / imported_ids 수집" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./lib";
+        \\console.log(a);
+    );
+    try writeFile(tmp.dir, "lib.ts", "export const a = 1;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var seen = MetaSeen{ .allocator = std.testing.allocator };
+    defer seen.deinit();
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverMeta,
+        .manual_chunks_ctx = &seen,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    var entry_seen = false;
+    var lib_seen = false;
+    for (seen.entries.items) |e| {
+        if (std.mem.endsWith(u8, e.id, "entry.ts")) {
+            try std.testing.expect(e.is_entry);
+            try std.testing.expectEqual(@as(usize, 0), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 1), e.imported_count);
+            entry_seen = true;
+        } else if (std.mem.endsWith(u8, e.id, "lib.ts")) {
+            try std.testing.expect(!e.is_entry);
+            try std.testing.expectEqual(@as(usize, 1), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 0), e.imported_count);
+            lib_seen = true;
+        }
+    }
+    try std.testing.expect(entry_seen);
+    try std.testing.expect(lib_seen);
+}
+
+test "getModuleInfo / getModulePathByIndex: null graph / invalid id 안전하게 null" {
+    try std.testing.expect(types.getModuleInfo(null, "anything") == null);
+    try std.testing.expect(types.getModulePathByIndex(null, @enumFromInt(0)) == null);
+}
+
+// resolver 안에서 graph 가 valid 한 동안 missing path / invalid idx 조회 테스트.
+// bundle 종료 후엔 graph 해제되므로 resolver 콜백 타이밍에만 할 수 있다.
+const NullChecks = struct {
+    missing_id_null: bool = false,
+    invalid_idx_null: bool = false,
+};
+
+fn resolverNullChecks(ctx: ?*anyopaque, _: []const u8, graph: ?*const anyopaque) ?[]const u8 {
+    const checks: *NullChecks = @ptrCast(@alignCast(ctx.?));
+    if (types.getModuleInfo(graph, "/totally/does-not-exist.ts") == null) {
+        checks.missing_id_null = true;
+    }
+    if (types.getModulePathByIndex(graph, @enumFromInt(999_999)) == null) {
+        checks.invalid_idx_null = true;
+    }
+    return null;
+}
+
+test "getModuleInfo / getModulePathByIndex: graph valid 상태에서 missing / OOB 조회" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "console.log(1);");
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var checks = NullChecks{};
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverNullChecks,
+        .manual_chunks_ctx = &checks,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(checks.missing_id_null);
+    try std.testing.expect(checks.invalid_idx_null);
+}
+
+test "manualChunks meta.getModuleInfo: 다중 엔트리 + shared 모듈 토폴로지" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "pageA.ts",
+        \\import { s } from "./shared";
+        \\console.log(s);
+    );
+    try writeFile(tmp.dir, "pageB.ts",
+        \\import { s } from "./shared";
+        \\console.log(s);
+    );
+    try writeFile(tmp.dir, "shared.ts", "export const s = 1;");
+
+    const page_a = try absPath(&tmp, "pageA.ts");
+    defer std.testing.allocator.free(page_a);
+    const page_b = try absPath(&tmp, "pageB.ts");
+    defer std.testing.allocator.free(page_b);
+
+    var seen = MetaSeen{ .allocator = std.testing.allocator };
+    defer seen.deinit();
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{ page_a, page_b },
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverMeta,
+        .manual_chunks_ctx = &seen,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    var a_seen = false;
+    var b_seen = false;
+    var shared_seen = false;
+    for (seen.entries.items) |e| {
+        if (std.mem.endsWith(u8, e.id, "pageA.ts")) {
+            try std.testing.expect(e.is_entry);
+            try std.testing.expectEqual(@as(usize, 0), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 1), e.imported_count);
+            a_seen = true;
+        } else if (std.mem.endsWith(u8, e.id, "pageB.ts")) {
+            try std.testing.expect(e.is_entry);
+            try std.testing.expectEqual(@as(usize, 0), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 1), e.imported_count);
+            b_seen = true;
+        } else if (std.mem.endsWith(u8, e.id, "shared.ts")) {
+            try std.testing.expect(!e.is_entry);
+            try std.testing.expectEqual(@as(usize, 2), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 0), e.imported_count);
+            shared_seen = true;
+        }
+    }
+    try std.testing.expect(a_seen);
+    try std.testing.expect(b_seen);
+    try std.testing.expect(shared_seen);
 }

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -459,7 +459,7 @@ pub fn generateChunks(
         var mi: usize = 0;
         while (it.next()) |m| : (mi += 1) {
             if (dynamic_entry_modules.contains(@intCast(mi))) continue;
-            if (fn_ptr(manual_resolver_ctx, m.path)) |chunk_name| {
+            if (fn_ptr(manual_resolver_ctx, m.path, @ptrCast(graph))) |chunk_name| {
                 ra[mi] = try ensureNameSlot(&name_to_slot, &effective_names, allocator, chunk_name);
             }
         }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -105,13 +105,49 @@ pub const GlobalEntry = struct {
     }
 };
 
-/// Rollup `manualChunks(id)` 호환 콜백 (#1027 Phase 2).
+/// Rollup `manualChunks(id, meta)` 호환 콜백.
 /// 모듈 절대경로 `id` 를 받아 청크 이름을 반환하면 그 이름의 manual 청크로 묶인다.
 /// null 반환이면 기존 auto 분배. resolver 로 동적 생성된 청크는 `ManualChunkEntry`
 /// record 와 동일 파이프라인 (bit 할당 / BFS / transitive dep 포함) 을 탄다.
 ///
-/// `ctx` 는 caller 가 원하는 상태 (TSFN 핸들, 카운터 등) 를 전달하는 슬롯.
-pub const ManualChunksResolveFn = *const fn (ctx: ?*anyopaque, id: []const u8) ?[]const u8;
+/// `ctx` 는 caller 가 원하는 상태 (TSFN 핸들, 카운터 등) 를 전달.
+/// `graph` 는 ModuleGraph opaque — `getModuleInfo` 로 meta 조회용. null 이면 meta 미지원.
+pub const ManualChunksResolveFn = *const fn (
+    ctx: ?*anyopaque,
+    id: []const u8,
+    graph: ?*const anyopaque,
+) ?[]const u8;
+
+/// Rollup `manualChunks(id, meta)` 의 `meta.getModuleInfo(id)` 반환 타입.
+/// 모든 slice 는 graph 수명 동안 borrowed — 추가 alloc/free 없음.
+/// NAPI 레이어는 `importers` / `imported_ids` 의 ModuleIndex 를
+/// `getModulePathByIndex` 로 순회해 JS string 배열을 직접 만든다.
+pub const ModuleInfo = struct {
+    id: []const u8,
+    importers: []const ModuleIndex,
+    imported_ids: []const ModuleIndex,
+    is_entry: bool,
+};
+
+/// `id` 로 모듈 메타를 조회. 없으면 null. Zero allocation — graph 내부 slice borrow.
+pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInfo {
+    const graph = @as(?*const @import("graph.zig").ModuleGraph, @ptrCast(@alignCast(graph_opaque))) orelse return null;
+    const idx = graph.path_to_module.get(id) orelse return null;
+    const m = graph.getModule(idx) orelse return null;
+    return .{
+        .id = m.path,
+        .importers = m.importers.items,
+        .imported_ids = m.dependencies.items,
+        .is_entry = m.is_entry_point,
+    };
+}
+
+/// ModuleIndex 로 모듈 경로 조회. importers/imported_ids 배열 순회용.
+pub fn getModulePathByIndex(graph_opaque: ?*const anyopaque, idx: ModuleIndex) ?[]const u8 {
+    const graph = @as(?*const @import("graph.zig").ModuleGraph, @ptrCast(@alignCast(graph_opaque))) orelse return null;
+    const m = graph.getModule(idx) orelse return null;
+    return m.path;
+}
 
 /// 사용자 정의 청크 분할 (#1027 / Rollup `manualChunks` 호환 Phase 1).
 /// Rollup record form `{ "vendor": ["lodash", "react"] }` 를 네이티브 슬라이스로 1:1 매핑.


### PR DESCRIPTION
## Summary
- Rollup `manualChunks(id, meta)` 호환을 위한 Zig 레이어 인프라 (Part 1)
- `ManualChunksResolveFn` 시그니처에 `graph: ?*const anyopaque` 추가
- `types.ModuleInfo` + `getModuleInfo` / `getModulePathByIndex` 두 헬퍼 — O(1) path_to_module 조회, zero allocation (slice borrow)
- NAPI 브리지 (JS 에서 `meta.getModuleInfo(id)` 호출 가능) 는 **Part 2 후속 PR**에서

## 설계 포인트
- `ModuleInfo.importers` / `imported_ids` 는 `[]const ModuleIndex` 로 노출 — NAPI 레이어가 인덱스 순회하며 JS string 배열을 직접 만들게 한다 (중간 Zig 할당 없음)
- `graph` 는 opaque 포인터 — types.zig ↔ graph.zig cycle 방지

## 테스트 (3개 신규)
- [x] 기본 topology (entry + lib) — `is_entry` / `importers` / `imported_ids` 검증
- [x] null graph / missing id / OOB idx 안전성
- [x] 다중 엔트리 + shared 모듈 — shared 의 `importers.len == 2`

## Test plan
- [x] `zig build test` 로컬 통과 (3711/3711)
- [ ] CI green 대기

## 후속
- Part 2: `napi_entry.zig` 에 JS `meta` 객체 + `getModuleInfo(id)` TSFN 콜백 구현, 통합 테스트 4개 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)