### PR TITLE
feat(bundler): inlineDynamicImports — chunk 구조 부분 구현 (A 범위)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -232,6 +232,13 @@ interface BuildOptionsCommon {
   minifyIdentifiers?: boolean;
   minifySyntax?: boolean;
   splitting?: boolean;
+  /** Rollup `output.inlineDynamicImports` — dynamic import target 을 별도 async chunk 로
+   * 분리하지 않고 importer 의 chunk 에 포함. `splitting: true` 와 조합해야 의미 있음.
+   *
+   * 주의: 이 플래그의 구조 부분만 구현 — async chunk 는 사라지지만 런타임 `import()`
+   * 호출은 원본 specifier 를 유지. 완전한 런타임 re-entry 는 후속 작업.
+   */
+  inlineDynamicImports?: boolean;
   sourcemap?: boolean;
   sourcemapDebugIds?: boolean;
   sourcesContent?: boolean;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -203,8 +203,14 @@ export type { OutputFile, Diagnostic };
 export interface ManualChunksModuleInfo {
   id: string;
   isEntry: boolean;
+  /** 이 모듈을 static import 하는 모듈들. */
   importers: string[];
+  /** 이 모듈을 dynamic import (`import()`) 하는 모듈들. */
+  dynamicImporters: string[];
+  /** 이 모듈이 static import 하는 모듈들. */
   importedIds: string[];
+  /** 이 모듈이 dynamic import (`import()`) 하는 모듈들. */
+  dynamicallyImportedIds: string[];
 }
 
 /** `manualChunks` 콜백의 두 번째 인자 — 모듈 그래프 토폴로지 조회. */

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -199,6 +199,20 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
 
 export type { OutputFile, Diagnostic };
 
+/** Rollup `manualChunks(id, meta)` 의 `meta.getModuleInfo(id)` 반환. */
+export interface ManualChunksModuleInfo {
+  id: string;
+  isEntry: boolean;
+  importers: string[];
+  importedIds: string[];
+}
+
+/** `manualChunks` 콜백의 두 번째 인자 — 모듈 그래프 토폴로지 조회. */
+export interface ManualChunksMeta {
+  /** `id` 로 모듈 정보 조회. 없으면 null. */
+  getModuleInfo(id: string): ManualChunksModuleInfo | null;
+}
+
 /**
  * Common build options shared by all platforms.
  * `platform` + `target` 조합은 `BuildOptions` 에서 discriminated union으로 제한됨.
@@ -273,16 +287,19 @@ interface BuildOptionsCommon {
    * null/undefined 반환 시 기존 자동 분배. transitive dependency 도 같은 청크로 따라감
    * (cross-chunk 순환 회피). dynamic import target 은 async chunk 대신 manual 우선.
    *
+   * 두 번째 인자 `meta.getModuleInfo(id)` 는 그래프 토폴로지 조회 — Rollup 호환.
+   *
    * 예:
    * ```ts
-   * manualChunks: (id) => {
+   * manualChunks: (id, meta) => {
+   *   const info = meta.getModuleInfo(id);
+   *   if (info && info.importers.length >= 2) return 'shared';
    *   if (/node_modules\/react/.test(id)) return 'react';
-   *   if (id.includes('/src/components/')) return 'ui';
    *   return null;
    * }
    * ```
    */
-  manualChunks?: (id: string) => string | null | undefined;
+  manualChunks?: (id: string, meta: ManualChunksMeta) => string | null | undefined;
   /** 확장자별 로더 오버라이드 (예: { ".png": "file", ".svg": "text" }) */
   loader?: Record<string, string>;
   /** package.json exports 커스텀 조건 */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1049,7 +1049,9 @@ const NapiManualChunksResolver = struct {
         _ = c.napi_set_named_property(env, js_obj, "isEntry", js_is_entry);
 
         _ = c.napi_set_named_property(env, js_obj, "importers", pathArrayFromIndices(env, graph, mod_info.importers));
+        _ = c.napi_set_named_property(env, js_obj, "dynamicImporters", pathArrayFromIndices(env, graph, mod_info.dynamic_importers));
         _ = c.napi_set_named_property(env, js_obj, "importedIds", pathArrayFromIndices(env, graph, mod_info.imported_ids));
+        _ = c.napi_set_named_property(env, js_obj, "dynamicallyImportedIds", pathArrayFromIndices(env, graph, mod_info.dynamically_imported_ids));
 
         return js_obj;
     }

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3124,6 +3124,7 @@ fn parseBuildOptions(
         .minify_identifiers = if (minify) true else getObjectBool(env, opts_obj, "minifyIdentifiers", false),
         .minify_syntax = if (minify) true else getObjectBool(env, opts_obj, "minifySyntax", false),
         .code_splitting = getObjectBool(env, opts_obj, "splitting", false),
+        .inline_dynamic_imports = getObjectBool(env, opts_obj, "inlineDynamicImports", false),
         .sourcemap = .{
             .enable = getObjectBool(env, opts_obj, "sourcemap", false),
             .debug_ids = getObjectBool(env, opts_obj, "sourcemapDebugIds", false),

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1054,7 +1054,8 @@ const NapiManualChunksResolver = struct {
 
     /// Zig resolver 인터페이스 — `ManualChunksResolveFn` 과 동일 시그니처.
     /// worker thread 에서 호출됨. JS 호출 후 동기 대기.
-    fn resolve(ctx_ptr: ?*anyopaque, id: []const u8) ?[]const u8 {
+    fn resolve(ctx_ptr: ?*anyopaque, id: []const u8, graph: ?*const anyopaque) ?[]const u8 {
+        _ = graph;
         const self: *NapiManualChunksResolver = @ptrCast(@alignCast(ctx_ptr.?));
         var call_ctx = CallContext{ .id = id };
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -993,11 +993,66 @@ const NapiManualChunksResolver = struct {
 
     const CallContext = struct {
         id: []const u8,
+        graph: ?*const anyopaque,
         result: ?[]const u8 = null,
         ready: bool = false,
         mutex: std.Thread.Mutex = .{},
         cond: std.Thread.Condition = .{},
     };
+
+    /// ModuleIndex 배열 → JS string[]. invalid index 는 skip 해서 compact 한 배열 반환.
+    fn pathArrayFromIndices(
+        env: c.napi_env,
+        graph: ?*const anyopaque,
+        indices: []const types_mod.ModuleIndex,
+    ) c.napi_value {
+        var js_arr: c.napi_value = undefined;
+        _ = c.napi_create_array(env, &js_arr);
+        var write_idx: u32 = 0;
+        for (indices) |idx| {
+            const p = types_mod.getModulePathByIndex(graph, idx) orelse continue;
+            var js_p: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, p.ptr, p.len, &js_p);
+            _ = c.napi_set_element(env, js_arr, write_idx, js_p);
+            write_idx += 1;
+        }
+        return js_arr;
+    }
+
+    /// JS `meta.getModuleInfo(id)` 구현. napi function 의 data 슬롯에 graph 포인터를
+    /// 담아 전달받는다. 동일 bundle() 안에서 모든 resolver 호출이 같은 graph 를 공유.
+    fn getModuleInfoCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var js_null: c.napi_value = undefined;
+        _ = c.napi_get_null(env, &js_null);
+
+        var argc: usize = 1;
+        var argv: [1]c.napi_value = undefined;
+        var data: ?*anyopaque = null;
+        if (c.napi_get_cb_info(env, info, &argc, &argv, null, &data) != c.napi_ok) return js_null;
+        if (argc < 1) return js_null;
+
+        const id = getStringArg(env, argv[0], native_alloc) orelse return js_null;
+        defer native_alloc.free(id);
+
+        const graph: ?*const anyopaque = @ptrCast(data);
+        const mod_info = types_mod.getModuleInfo(graph, id) orelse return js_null;
+
+        var js_obj: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_obj);
+
+        var js_id_str: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, mod_info.id.ptr, mod_info.id.len, &js_id_str);
+        _ = c.napi_set_named_property(env, js_obj, "id", js_id_str);
+
+        var js_is_entry: c.napi_value = undefined;
+        _ = c.napi_get_boolean(env, mod_info.is_entry, &js_is_entry);
+        _ = c.napi_set_named_property(env, js_obj, "isEntry", js_is_entry);
+
+        _ = c.napi_set_named_property(env, js_obj, "importers", pathArrayFromIndices(env, graph, mod_info.importers));
+        _ = c.napi_set_named_property(env, js_obj, "importedIds", pathArrayFromIndices(env, graph, mod_info.imported_ids));
+
+        return js_obj;
+    }
 
     /// threadsafe function 의 call_js 콜백 (main thread).
     fn callJsCallback(env: c.napi_env, js_callback: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
@@ -1006,12 +1061,28 @@ const NapiManualChunksResolver = struct {
         var js_id: c.napi_value = undefined;
         _ = c.napi_create_string_utf8(env, ctx.id.ptr, ctx.id.len, &js_id);
 
+        // meta 객체 — graph 가 있을 때만 `getModuleInfo` 노출.
+        var js_meta: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_meta);
+        if (ctx.graph) |g| {
+            var js_get_mod_info: c.napi_value = undefined;
+            _ = c.napi_create_function(
+                env,
+                "getModuleInfo",
+                "getModuleInfo".len,
+                getModuleInfoCallback,
+                @constCast(g),
+                &js_get_mod_info,
+            );
+            _ = c.napi_set_named_property(env, js_meta, "getModuleInfo", js_get_mod_info);
+        }
+
         var js_undefined: c.napi_value = undefined;
         _ = c.napi_get_undefined(env, &js_undefined);
 
         var js_result: c.napi_value = undefined;
-        const args = [_]c.napi_value{js_id};
-        if (c.napi_call_function(env, js_undefined, js_callback, 1, &args, &js_result) != c.napi_ok) {
+        const args = [_]c.napi_value{ js_id, js_meta };
+        if (c.napi_call_function(env, js_undefined, js_callback, 2, &args, &js_result) != c.napi_ok) {
             // JS exception 은 uncaught 로 전파되기 전에 clear — 번들 중단 방지.
             // manualChunks 가 throw 하면 해당 모듈은 null (auto 분배) 로 취급.
             var is_pending: bool = false;
@@ -1055,9 +1126,8 @@ const NapiManualChunksResolver = struct {
     /// Zig resolver 인터페이스 — `ManualChunksResolveFn` 과 동일 시그니처.
     /// worker thread 에서 호출됨. JS 호출 후 동기 대기.
     fn resolve(ctx_ptr: ?*anyopaque, id: []const u8, graph: ?*const anyopaque) ?[]const u8 {
-        _ = graph;
         const self: *NapiManualChunksResolver = @ptrCast(@alignCast(ctx_ptr.?));
-        var call_ctx = CallContext{ .id = id };
+        var call_ctx = CallContext{ .id = id, .graph = graph };
 
         if (c.napi_call_threadsafe_function(self.tsfn, &call_ctx, c.napi_tsfn_blocking) != c.napi_ok) {
             return null;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1061,7 +1061,6 @@ const NapiManualChunksResolver = struct {
         var js_id: c.napi_value = undefined;
         _ = c.napi_create_string_utf8(env, ctx.id.ptr, ctx.id.len, &js_id);
 
-        // meta 객체 — graph 가 있을 때만 `getModuleInfo` 노출.
         var js_meta: c.napi_value = undefined;
         _ = c.napi_create_object(env, &js_meta);
         if (ctx.graph) |g| {

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -72,6 +72,12 @@ pub const BundleOptions = struct {
     /// code splitting 활성화. true이면 dynamic import 경계에서 청크를 분리하고
     /// 공유 모듈을 공통 청크로 추출한다. 결과는 BundleResult.outputs에 다중 파일로 반환.
     code_splitting: bool = false,
+    /// Rollup `output.inlineDynamicImports` — **chunk 구조만 구현**.
+    /// true 이면 dynamic import target 이 별도 async chunk 로 분리되지 않고 importer 의
+    /// chunk (entry 또는 manual) 에 흡수된다. `code_splitting=true` 와 조합해야 의미 있음.
+    /// 런타임 `import()` 호출은 same-chunk 여도 원본 specifier 를 유지하며, 모듈 registry
+    /// 기반 re-entry 는 아직 미구현 — 번들 출력을 Node/브라우저로 바로 실행하려면 후속 PR 필요.
+    inline_dynamic_imports: bool = false,
     /// 사용자 정의 청크 분할 (Rollup `manualChunks` 호환 Phase 1 / #1027).
     /// code_splitting=true 일 때만 동작. 매칭된 모듈은 pseudo-entry 로 BFS 에 참여
     /// → transitive dependency 도 같은 청크로, dynamic import target 도 manual 우선.
@@ -985,6 +991,7 @@ pub const Bundler = struct {
                     self.options.manual_chunks,
                     self.options.manual_chunks_resolver,
                     self.options.manual_chunks_ctx,
+                    self.options.inline_dynamic_imports,
                 );
             defer chunk_graph.deinit();
 

--- a/src/bundler/bundler_test/manual_chunks.zig
+++ b/src/bundler/bundler_test/manual_chunks.zig
@@ -315,7 +315,7 @@ test "manualChunks resolver: dynamic entry 반환 이름 무시" {
         .entry_points = &.{entry},
         .code_splitting = true,
         .manual_chunks_resolver = struct {
-            fn r(_: ?*anyopaque, _: []const u8) ?[]const u8 {
+            fn r(_: ?*anyopaque, _: []const u8, _: ?*const anyopaque) ?[]const u8 {
                 return "bucket";
             }
         }.r,
@@ -340,23 +340,23 @@ test "manualChunks resolver: dynamic entry 반환 이름 무시" {
 // ============================================================
 // resolver 반환 이름은 동적으로 manual 청크를 생성. record 와 공존 시 resolver 우선.
 
-fn resolverVendorSubstring(_: ?*anyopaque, id: []const u8) ?[]const u8 {
+fn resolverVendorSubstring(_: ?*anyopaque, id: []const u8, _: ?*const anyopaque) ?[]const u8 {
     if (std.mem.indexOf(u8, id, "vendor-lib") != null) return "vendor";
     return null;
 }
 
-fn resolverAlwaysNull(_: ?*anyopaque, _: []const u8) ?[]const u8 {
+fn resolverAlwaysNull(_: ?*anyopaque, _: []const u8, _: ?*const anyopaque) ?[]const u8 {
     return null;
 }
 
-fn resolverTwoGroups(_: ?*anyopaque, id: []const u8) ?[]const u8 {
+fn resolverTwoGroups(_: ?*anyopaque, id: []const u8, _: ?*const anyopaque) ?[]const u8 {
     if (std.mem.indexOf(u8, id, "ui-") != null) return "ui";
     if (std.mem.indexOf(u8, id, "data-") != null) return "data";
     return null;
 }
 
 /// ctx 로 호출 카운터 전달 — 호출 검증용.
-fn resolverCountingSink(ctx: ?*anyopaque, id: []const u8) ?[]const u8 {
+fn resolverCountingSink(ctx: ?*anyopaque, id: []const u8, _: ?*const anyopaque) ?[]const u8 {
     const counter: *usize = @ptrCast(@alignCast(ctx.?));
     counter.* += 1;
     if (std.mem.indexOf(u8, id, "match") != null) return "sink";
@@ -554,4 +554,194 @@ test "manualChunks: no match → 엔트리 청크에 머묾 (기존 동작)" {
     // 매칭 없음 → vendor 청크 생성 안 됨, 단일 entry 청크만
     try std.testing.expectEqual(@as(usize, 1), outs.len);
     try std.testing.expect(std.mem.indexOf(u8, outs[0].contents, "ONLY") != null);
+}
+
+// ============================================================
+// Phase 3: meta.getModuleInfo — Rollup `manualChunks(id, meta)` 호환
+// ============================================================
+
+const MetaSeen = struct {
+    entries: std.ArrayList(struct {
+        id: []const u8,
+        is_entry: bool,
+        importer_count: usize,
+        imported_count: usize,
+    }) = .empty,
+    allocator: std.mem.Allocator,
+
+    // ModuleInfo.id / importers / imported_ids 는 graph 수명 동안 borrowed.
+    // bundle() 리턴 시 graph 가 deinit 되므로, 테스트에서는 record 시점에 dupe 해서 보관.
+    fn record(self: *MetaSeen, info: types.ModuleInfo) !void {
+        const owned_id = try self.allocator.dupe(u8, info.id);
+        errdefer self.allocator.free(owned_id);
+        try self.entries.append(self.allocator, .{
+            .id = owned_id,
+            .is_entry = info.is_entry,
+            .importer_count = info.importers.len,
+            .imported_count = info.imported_ids.len,
+        });
+    }
+
+    fn deinit(self: *MetaSeen) void {
+        for (self.entries.items) |e| self.allocator.free(e.id);
+        self.entries.deinit(self.allocator);
+    }
+};
+
+fn resolverMeta(ctx: ?*anyopaque, id: []const u8, graph: ?*const anyopaque) ?[]const u8 {
+    const seen: *MetaSeen = @ptrCast(@alignCast(ctx.?));
+    const info = types.getModuleInfo(graph, id) orelse return null;
+    seen.record(info) catch return null;
+    return null;
+}
+
+test "manualChunks meta.getModuleInfo: isEntry / importers / imported_ids 수집" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./lib";
+        \\console.log(a);
+    );
+    try writeFile(tmp.dir, "lib.ts", "export const a = 1;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var seen = MetaSeen{ .allocator = std.testing.allocator };
+    defer seen.deinit();
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverMeta,
+        .manual_chunks_ctx = &seen,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    var entry_seen = false;
+    var lib_seen = false;
+    for (seen.entries.items) |e| {
+        if (std.mem.endsWith(u8, e.id, "entry.ts")) {
+            try std.testing.expect(e.is_entry);
+            try std.testing.expectEqual(@as(usize, 0), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 1), e.imported_count);
+            entry_seen = true;
+        } else if (std.mem.endsWith(u8, e.id, "lib.ts")) {
+            try std.testing.expect(!e.is_entry);
+            try std.testing.expectEqual(@as(usize, 1), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 0), e.imported_count);
+            lib_seen = true;
+        }
+    }
+    try std.testing.expect(entry_seen);
+    try std.testing.expect(lib_seen);
+}
+
+test "getModuleInfo / getModulePathByIndex: null graph / invalid id 안전하게 null" {
+    try std.testing.expect(types.getModuleInfo(null, "anything") == null);
+    try std.testing.expect(types.getModulePathByIndex(null, @enumFromInt(0)) == null);
+}
+
+// resolver 안에서 graph 가 valid 한 동안 missing path / invalid idx 조회 테스트.
+// bundle 종료 후엔 graph 해제되므로 resolver 콜백 타이밍에만 할 수 있다.
+const NullChecks = struct {
+    missing_id_null: bool = false,
+    invalid_idx_null: bool = false,
+};
+
+fn resolverNullChecks(ctx: ?*anyopaque, _: []const u8, graph: ?*const anyopaque) ?[]const u8 {
+    const checks: *NullChecks = @ptrCast(@alignCast(ctx.?));
+    if (types.getModuleInfo(graph, "/totally/does-not-exist.ts") == null) {
+        checks.missing_id_null = true;
+    }
+    if (types.getModulePathByIndex(graph, @enumFromInt(999_999)) == null) {
+        checks.invalid_idx_null = true;
+    }
+    return null;
+}
+
+test "getModuleInfo / getModulePathByIndex: graph valid 상태에서 missing / OOB 조회" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "console.log(1);");
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var checks = NullChecks{};
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverNullChecks,
+        .manual_chunks_ctx = &checks,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(checks.missing_id_null);
+    try std.testing.expect(checks.invalid_idx_null);
+}
+
+test "manualChunks meta.getModuleInfo: 다중 엔트리 + shared 모듈 토폴로지" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "pageA.ts",
+        \\import { s } from "./shared";
+        \\console.log(s);
+    );
+    try writeFile(tmp.dir, "pageB.ts",
+        \\import { s } from "./shared";
+        \\console.log(s);
+    );
+    try writeFile(tmp.dir, "shared.ts", "export const s = 1;");
+
+    const page_a = try absPath(&tmp, "pageA.ts");
+    defer std.testing.allocator.free(page_a);
+    const page_b = try absPath(&tmp, "pageB.ts");
+    defer std.testing.allocator.free(page_b);
+
+    var seen = MetaSeen{ .allocator = std.testing.allocator };
+    defer seen.deinit();
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{ page_a, page_b },
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverMeta,
+        .manual_chunks_ctx = &seen,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    var a_seen = false;
+    var b_seen = false;
+    var shared_seen = false;
+    for (seen.entries.items) |e| {
+        if (std.mem.endsWith(u8, e.id, "pageA.ts")) {
+            try std.testing.expect(e.is_entry);
+            try std.testing.expectEqual(@as(usize, 0), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 1), e.imported_count);
+            a_seen = true;
+        } else if (std.mem.endsWith(u8, e.id, "pageB.ts")) {
+            try std.testing.expect(e.is_entry);
+            try std.testing.expectEqual(@as(usize, 0), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 1), e.imported_count);
+            b_seen = true;
+        } else if (std.mem.endsWith(u8, e.id, "shared.ts")) {
+            try std.testing.expect(!e.is_entry);
+            try std.testing.expectEqual(@as(usize, 2), e.importer_count);
+            try std.testing.expectEqual(@as(usize, 0), e.imported_count);
+            shared_seen = true;
+        }
+    }
+    try std.testing.expect(a_seen);
+    try std.testing.expect(b_seen);
+    try std.testing.expect(shared_seen);
 }

--- a/src/bundler/bundler_test/manual_chunks.zig
+++ b/src/bundler/bundler_test/manual_chunks.zig
@@ -566,10 +566,12 @@ const MetaSeen = struct {
         is_entry: bool,
         importer_count: usize,
         imported_count: usize,
+        dynamic_importer_count: usize,
+        dynamically_imported_count: usize,
     }) = .empty,
     allocator: std.mem.Allocator,
 
-    // ModuleInfo.id / importers / imported_ids 는 graph 수명 동안 borrowed.
+    // ModuleInfo slice 들은 graph 수명 동안 borrowed.
     // bundle() 리턴 시 graph 가 deinit 되므로, 테스트에서는 record 시점에 dupe 해서 보관.
     fn record(self: *MetaSeen, info: types.ModuleInfo) !void {
         const owned_id = try self.allocator.dupe(u8, info.id);
@@ -579,6 +581,8 @@ const MetaSeen = struct {
             .is_entry = info.is_entry,
             .importer_count = info.importers.len,
             .imported_count = info.imported_ids.len,
+            .dynamic_importer_count = info.dynamic_importers.len,
+            .dynamically_imported_count = info.dynamically_imported_ids.len,
         });
     }
 
@@ -744,4 +748,68 @@ test "manualChunks meta.getModuleInfo: 다중 엔트리 + shared 모듈 토폴�
     try std.testing.expect(a_seen);
     try std.testing.expect(b_seen);
     try std.testing.expect(shared_seen);
+}
+
+// dynamic entry 모듈은 resolver 가 건너뛰므로 (chunk.zig policy),
+// dyn-dep 의 역방향 정보는 entry resolver 안에서 직접 graph 조회로 검증.
+const DynamicMetaProbe = struct {
+    // entry 에서 직접 조회할 dyn-dep 경로
+    dyn_dep_path: []const u8,
+    // entry resolver 호출 시점에 dyn-dep 의 dynamic_importers 길이 기록
+    dyn_dep_dynamic_importer_count: ?usize = null,
+    dyn_dep_static_importer_count: ?usize = null,
+};
+
+fn resolverDynamicProbe(ctx: ?*anyopaque, id: []const u8, graph: ?*const anyopaque) ?[]const u8 {
+    const probe: *DynamicMetaProbe = @ptrCast(@alignCast(ctx.?));
+    if (std.mem.endsWith(u8, id, "entry.ts")) {
+        if (types.getModuleInfo(graph, probe.dyn_dep_path)) |info| {
+            probe.dyn_dep_dynamic_importer_count = info.dynamic_importers.len;
+            probe.dyn_dep_static_importer_count = info.importers.len;
+        }
+    }
+    return null;
+}
+
+test "manualChunks meta.getModuleInfo: dynamic import 는 static importers/importedIds 에 안 잡히고 dynamic 쪽으로" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { s } from "./static-dep";
+        \\export async function load() { return (await import("./dyn-dep")).default; }
+        \\console.log(s);
+    );
+    try writeFile(tmp.dir, "static-dep.ts", "export const s = 1;");
+    try writeFile(tmp.dir, "dyn-dep.ts", "export default 42;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const dyn_dep = try absPath(&tmp, "dyn-dep.ts");
+    defer std.testing.allocator.free(dyn_dep);
+
+    // 1차 — MetaSeen 으로 entry / static-dep 측 assertion.
+    var seen = MetaSeen{ .allocator = std.testing.allocator };
+    defer seen.deinit();
+
+    // 같은 resolver 가 MetaSeen 과 DynamicMetaProbe 둘 다 만질 순 없으니
+    // ctx 에 probe 만 넘기고 MetaSeen 기록은 여기서 포기. 정적 쪽은
+    // 기존 "isEntry / importers" 테스트가 이미 커버.
+    var probe = DynamicMetaProbe{ .dyn_dep_path = dyn_dep };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverDynamicProbe,
+        .manual_chunks_ctx = &probe,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    // entry resolver 가 호출됐고 dyn-dep 를 찾을 수 있었다면 각 값 set.
+    try std.testing.expect(probe.dyn_dep_dynamic_importer_count != null);
+    try std.testing.expectEqual(@as(usize, 1), probe.dyn_dep_dynamic_importer_count.?);
+    try std.testing.expectEqual(@as(usize, 0), probe.dyn_dep_static_importer_count.?);
 }

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -459,7 +459,7 @@ pub fn generateChunks(
         var mi: usize = 0;
         while (it.next()) |m| : (mi += 1) {
             if (dynamic_entry_modules.contains(@intCast(mi))) continue;
-            if (fn_ptr(manual_resolver_ctx, m.path)) |chunk_name| {
+            if (fn_ptr(manual_resolver_ctx, m.path, @ptrCast(graph))) |chunk_name| {
                 ra[mi] = try ensureNameSlot(&name_to_slot, &effective_names, allocator, chunk_name);
             }
         }

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -361,6 +361,10 @@ pub fn generateChunks(
     manual_chunks: []const types.ManualChunkEntry,
     manual_resolver: ?types.ManualChunksResolveFn,
     manual_resolver_ctx: ?*anyopaque,
+    /// true 이면 dynamic import target 을 별도 chunk 로 분리하지 않고 importer 와 같은
+    /// chunk 에 포함. Rollup `output.inlineDynamicImports` 의 구조 부분만 구현 (A 범위).
+    /// 런타임 `import()` rewriting 은 후속 PR.
+    inline_dynamic_imports: bool,
 ) !ChunkGraph {
     const module_count = graph.moduleCount();
 
@@ -389,10 +393,12 @@ pub fn generateChunks(
 
     // Phase 1b: dynamic import 대상 — 이미 유저 엔트리인 모듈은 스킵.
     // dynamic import 대상은 별도의 청크 경계를 형성한다 (code splitting의 핵심).
+    // `inline_dynamic_imports` 가 true 면 이 단계 전체를 skip → dynamic target 이
+    // 별도 chunk 로 나뉘지 않고 Phase 2 BFS 에서 importer 와 같은 chunk 로 흡수.
     var dynamic_seen: std.AutoHashMap(u32, void) = .init(allocator);
     defer dynamic_seen.deinit();
 
-    {
+    if (!inline_dynamic_imports) {
         var it = graph.modulesIterator();
         while (it.next()) |m| {
             for (m.dynamic_imports.items) |dyn_idx| {
@@ -575,11 +581,21 @@ pub fn generateChunks(
             if (splitting_info[mi].hasBit(@intCast(bit_idx))) continue;
             splitting_info[mi].setBit(@intCast(bit_idx));
 
-            // 정적 의존성만 따라감 — dynamic import는 별도 엔트리이므로 BFS 경계
+            // 정적 의존성 + (inline_dynamic_imports 일 때) dynamic edge 도 따라감.
+            // 후자는 dynamic target 이 별도 entry 가 아니기 때문에 importer 경로로
+            // 흡수시키기 위함.
             for (m.dependencies.items) |dep_idx| {
                 const dep_i = @intFromEnum(dep_idx);
                 if (dep_i < module_count and !splitting_info[dep_i].hasBit(@intCast(bit_idx))) {
                     try queue.append(allocator, dep_idx);
+                }
+            }
+            if (inline_dynamic_imports) {
+                for (m.dynamic_imports.items) |dep_idx| {
+                    const dep_i = @intFromEnum(dep_idx);
+                    if (dep_i < module_count and !splitting_info[dep_i].hasBit(@intCast(bit_idx))) {
+                        try queue.append(allocator, dep_idx);
+                    }
                 }
             }
         }
@@ -623,6 +639,14 @@ pub fn generateChunks(
                     const dep_i = @intFromEnum(dep_idx);
                     if (dep_i < module_count and !splitting_info[dep_i].hasBit(manual_bit)) {
                         try queue.append(allocator, dep_idx);
+                    }
+                }
+                if (inline_dynamic_imports) {
+                    for (m.dynamic_imports.items) |dep_idx| {
+                        const dep_i = @intFromEnum(dep_idx);
+                        if (dep_i < module_count and !splitting_info[dep_i].hasBit(manual_bit)) {
+                            try queue.append(allocator, dep_idx);
+                        }
                     }
                 }
             }

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -445,7 +445,7 @@ test "generateChunks: single entry, no dynamic imports" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 엔트리 청크 1개
@@ -482,7 +482,7 @@ test "generateChunks: dynamic import creates separate chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 엔트리 청크 1개 + dynamic 청크 1개 = 2개
@@ -523,7 +523,7 @@ test "generateChunks: shared module creates common chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 엔트리 2개 + 공통 1개 = 3개
@@ -564,7 +564,7 @@ test "generateChunks: diamond dependency" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // D가 양쪽 엔트리에서 도달 가능 → 공통 청크 생성
@@ -592,7 +592,7 @@ test "generateChunks: no modules" {
     var tg = try TestGraph.init(alloc, &empty_modules);
     defer tg.deinit(alloc);
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), cg.chunkCount());
@@ -617,7 +617,7 @@ test "generateChunks: circular dependency stays in same chunk" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 1 엔트리 청크, 모든 모듈 포함
@@ -643,7 +643,7 @@ test "generateChunks: static + dynamic import same module" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
     try tg.graph.modules.at(0).addDynamicImport(alloc, @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // b.ts는 엔트리 청크에 포함 (static이 우선)
@@ -672,7 +672,7 @@ test "generateChunks: three entries sharing a module" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(3));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 3 엔트리 + 1 공통 = 4 청크
@@ -702,7 +702,7 @@ test "generateChunks: entry imports another entry statically" {
 
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 2개 엔트리 청크 생성
@@ -731,7 +731,7 @@ test "generateChunks: deep chain with dynamic import at middle" {
     try tg.graph.modules.at(1).addDynamicImport(alloc, @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 2개 청크: a엔트리(a,b), c엔트리(c,d)
@@ -982,7 +982,7 @@ test "generateChunks: entry module reassignment removes from old chunk" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // c.ts는 엔트리 청크에 있어야 함 (공통 청크 아님)
@@ -997,4 +997,96 @@ test "generateChunks: entry module reassignment removes from old chunk" {
         }
     }
     try std.testing.expectEqual(@as(u32, 1), count);
+}
+
+test "generateChunks: inline_dynamic_imports=false — dynamic target 은 별도 chunk" {
+    const alloc = std.testing.allocator;
+    var modules: [2]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "lazy.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
+
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, false);
+    defer cg.deinit();
+
+    // 기본 정책 — lazy 는 entry 와 다른 chunk 에 배정
+    const entry_chunk = cg.getModuleChunk(@enumFromInt(0));
+    const lazy_chunk = cg.getModuleChunk(@enumFromInt(1));
+    try std.testing.expect(!entry_chunk.isNone());
+    try std.testing.expect(!lazy_chunk.isNone());
+    try std.testing.expect(entry_chunk != lazy_chunk);
+}
+
+test "generateChunks: inline_dynamic_imports=true — dynamic target 이 entry chunk 에 흡수" {
+    const alloc = std.testing.allocator;
+    var modules: [2]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "lazy.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
+
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, true);
+    defer cg.deinit();
+
+    // inline 정책 — lazy 가 entry chunk 로 흡수. 전체 청크 1개.
+    try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);
+    const entry_chunk = cg.getModuleChunk(@enumFromInt(0));
+    const lazy_chunk = cg.getModuleChunk(@enumFromInt(1));
+    try std.testing.expect(entry_chunk == lazy_chunk);
+}
+
+test "generateChunks: inline_dynamic_imports + manual_chunks — manual seed 의 dynamic dep 도 manual chunk 로" {
+    // Phase 2.5 manual BFS 가 inline 모드에서 dynamic edge 를 따라가야 한다 (/simplify 후속).
+    const alloc = std.testing.allocator;
+    var modules: [3]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "vendor-root.ts"),
+        makeTestModule(alloc, 2, "vendor-lazy.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    // entry → vendor-root (static), vendor-root → vendor-lazy (dynamic)
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
+    try tg.graph.linkDynamicImport(@enumFromInt(1), @enumFromInt(2));
+
+    const manual_entries = [_]types.ManualChunkEntry{.{ .name = "vendor", .patterns = &.{"vendor-"} }};
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &manual_entries, null, null, true);
+    defer cg.deinit();
+
+    // vendor-root 은 manual 매칭, vendor-lazy 는 vendor-root 의 dynamic dep.
+    // inline + manual BFS 확장으로 vendor-lazy 도 vendor chunk 로.
+    const vendor_chunk = cg.getModuleChunk(@enumFromInt(1));
+    try std.testing.expect(!vendor_chunk.isNone());
+    try std.testing.expect(cg.getModuleChunk(@enumFromInt(2)) == vendor_chunk);
+}
+
+test "generateChunks: inline_dynamic_imports — dynamic target 의 transitive static dep 도 흡수" {
+    const alloc = std.testing.allocator;
+    var modules: [3]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "lazy.ts"),
+        makeTestModule(alloc, 2, "util.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    // entry → lazy (dynamic) → util (static)
+    try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
+    try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(2));
+
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, true);
+    defer cg.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);
+    const entry_chunk = cg.getModuleChunk(@enumFromInt(0));
+    try std.testing.expect(cg.getModuleChunk(@enumFromInt(1)) == entry_chunk);
+    try std.testing.expect(cg.getModuleChunk(@enumFromInt(2)) == entry_chunk);
 }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -610,12 +610,18 @@ fn rewriteDynamicImports(
     var result = try allocator.dupe(u8, code);
     errdefer allocator.free(result);
 
+    const source_chunk_idx = chunk_graph.getModuleChunk(module.index);
+
     for (module.import_records) |rec| {
         if (rec.kind != .dynamic_import) continue;
         if (rec.resolved == .none) continue;
 
         const target_chunk_idx = chunk_graph.getModuleChunk(rec.resolved);
         if (target_chunk_idx == .none) continue;
+
+        // target 이 같은 chunk 에 있으면 specifier 그대로 둔다 (inline_dynamic_imports
+        // 또는 우연한 same-chunk 케이스). 런타임에서 original path 로 해석되도록 위임.
+        if (source_chunk_idx != .none and target_chunk_idx == source_chunk_idx) continue;
 
         const target_chunk = chunk_graph.getChunk(target_chunk_idx);
 

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -370,7 +370,7 @@ test "inline (bundle): shared module 내부 inline — emitChunks 경로" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -429,7 +429,7 @@ test "emitChunks: single chunk produces one OutputFile" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -463,7 +463,7 @@ test "emitChunks: two entries with shared module — 3 OutputFiles" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -511,7 +511,7 @@ test "CodeSplitting: dynamic import path rewritten to chunk filename" {
     const lazy_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "lazy.ts" });
     defer std.testing.allocator.free(lazy_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -569,7 +569,7 @@ test "CodeSplitting: multiple dynamic imports rewritten" {
     const pageB_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "pageB.ts" });
     defer std.testing.allocator.free(pageB_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -614,7 +614,7 @@ test "chunkStem: common chunk uses hex hash, not index" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -663,7 +663,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg1.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg1, &result1.graph, std.testing.allocator, null);
 
@@ -680,7 +680,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     defer result2.graph.deinit();
     defer result2.cache.deinit();
 
-    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg2.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg2, &result2.graph, std.testing.allocator, null);
 
@@ -783,7 +783,7 @@ test "naming pattern: entry-names with hash" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{
@@ -823,7 +823,7 @@ test "naming pattern: chunk-names with directory" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -869,7 +869,7 @@ test "content hash: cross-chunk import uses content hash" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -935,7 +935,7 @@ test "CJS runtime: __commonJS only in chunks containing CJS modules" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -969,7 +969,7 @@ test "CodeSplitting: static import not rewritten" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -673,6 +673,15 @@ pub const ModuleGraph = struct {
         try to_mod.importers.append(self.allocator, from);
     }
 
+    /// 양방향 dynamic import 등록. `linkDependency` 의 dynamic 버전.
+    pub fn linkDynamicImport(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
+        if (to.isNone()) return;
+        const from_mod = self.moduleAtMut(from) orelse return;
+        const to_mod = self.moduleAtMut(to) orelse return;
+        try from_mod.dynamic_imports.append(self.allocator, to);
+        try to_mod.dynamic_importers.append(self.allocator, from);
+    }
+
     /// context_expansion_deps 를 resolve 하고 graph 에 module + dependency 로 등록 (#1579 Phase 4).
     /// scanModules receiver / resolveModuleImports 양쪽 경로에서 호출. SegmentedList 로
     /// append 해도 기존 *Module 포인터는 유효 (#1779 INVARIANTS.md).
@@ -733,7 +742,7 @@ pub const ModuleGraph = struct {
                 const src_mod = self.modules.at(mod_idx);
                 src_mod.import_records[rec_i].resolved = dep_idx;
                 if (record.kind == .dynamic_import) {
-                    try src_mod.addDynamicImport(self.allocator, dep_idx);
+                    try self.linkDynamicImport(mod_index, dep_idx);
                 } else {
                     try self.linkDependency(mod_index, dep_idx);
                 }
@@ -763,7 +772,7 @@ pub const ModuleGraph = struct {
                 const src_mod = self.modules.at(mod_idx);
                 src_mod.import_records[rec_i].resolved = dep_idx;
                 if (record.kind == .dynamic_import) {
-                    try src_mod.addDynamicImport(self.allocator, dep_idx);
+                    try self.linkDynamicImport(mod_index, dep_idx);
                 } else {
                     try self.linkDependency(mod_index, dep_idx);
                 }
@@ -780,7 +789,7 @@ pub const ModuleGraph = struct {
             src_mod.import_records[rec_i].resolved = dep_idx;
 
             if (record.kind == .dynamic_import) {
-                try src_mod.addDynamicImport(self.allocator, dep_idx);
+                try self.linkDynamicImport(mod_index, dep_idx);
             } else {
                 try self.linkDependency(mod_index, dep_idx);
             }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -117,6 +117,8 @@ pub const Module = struct {
     importers: std.ArrayList(ModuleIndex),
     /// 동적 import (별도 관리, code splitting용)
     dynamic_imports: std.ArrayList(ModuleIndex),
+    /// 나를 dynamic import 하는 모듈들 (역방향). `ModuleGraph.linkDynamicImport` 가 채움.
+    dynamic_importers: std.ArrayList(ModuleIndex),
 
     module_type: ModuleType,
     /// 모듈의 로딩 방식 (file/dataurl/text/binary/copy 등).
@@ -321,6 +323,7 @@ pub const Module = struct {
             .dependencies = .empty,
             .importers = .empty,
             .dynamic_imports = .empty,
+            .dynamic_importers = .empty,
             .module_type = .unknown,
             .side_effects = true,
             .exec_index = std.math.maxInt(u32),
@@ -347,6 +350,7 @@ pub const Module = struct {
         self.dependencies.deinit(allocator);
         self.importers.deinit(allocator);
         self.dynamic_imports.deinit(allocator);
+        self.dynamic_importers.deinit(allocator);
         if (self.alias_table) |*t| t.deinit();
         // require.context: plugin 이 채운 outer slice + 각 inner string free (#1579 Phase 2).
         // contract: plugin 이 allocator 로 dupe 한 상태로 반환 → graph 가 일괄 해제.

--- a/src/bundler/phase.zig
+++ b/src/bundler/phase.zig
@@ -225,8 +225,7 @@ pub const ResolveAccessor = struct {
     }
 
     pub fn appendDynamicImport(self: ResolveAccessor, idx: ModuleIndex, dep: ModuleIndex) !void {
-        const m = self.graph.moduleAtMut(idx) orelse return;
-        try m.addDynamicImport(self.graph.allocator, dep);
+        try self.graph.linkDynamicImport(idx, dep);
     }
 
     /// alias_table lazy 초기화 (existing Module.ensureAliasTable wrapper).

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -105,13 +105,49 @@ pub const GlobalEntry = struct {
     }
 };
 
-/// Rollup `manualChunks(id)` 호환 콜백 (#1027 Phase 2).
+/// Rollup `manualChunks(id, meta)` 호환 콜백.
 /// 모듈 절대경로 `id` 를 받아 청크 이름을 반환하면 그 이름의 manual 청크로 묶인다.
 /// null 반환이면 기존 auto 분배. resolver 로 동적 생성된 청크는 `ManualChunkEntry`
 /// record 와 동일 파이프라인 (bit 할당 / BFS / transitive dep 포함) 을 탄다.
 ///
-/// `ctx` 는 caller 가 원하는 상태 (TSFN 핸들, 카운터 등) 를 전달하는 슬롯.
-pub const ManualChunksResolveFn = *const fn (ctx: ?*anyopaque, id: []const u8) ?[]const u8;
+/// `ctx` 는 caller 가 원하는 상태 (TSFN 핸들, 카운터 등) 를 전달.
+/// `graph` 는 ModuleGraph opaque — `getModuleInfo` 로 meta 조회용. null 이면 meta 미지원.
+pub const ManualChunksResolveFn = *const fn (
+    ctx: ?*anyopaque,
+    id: []const u8,
+    graph: ?*const anyopaque,
+) ?[]const u8;
+
+/// Rollup `manualChunks(id, meta)` 의 `meta.getModuleInfo(id)` 반환 타입.
+/// 모든 slice 는 graph 수명 동안 borrowed — 추가 alloc/free 없음.
+/// NAPI 레이어는 `importers` / `imported_ids` 의 ModuleIndex 를
+/// `getModulePathByIndex` 로 순회해 JS string 배열을 직접 만든다.
+pub const ModuleInfo = struct {
+    id: []const u8,
+    importers: []const ModuleIndex,
+    imported_ids: []const ModuleIndex,
+    is_entry: bool,
+};
+
+/// `id` 로 모듈 메타를 조회. 없으면 null. Zero allocation — graph 내부 slice borrow.
+pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInfo {
+    const graph = @as(?*const @import("graph.zig").ModuleGraph, @ptrCast(@alignCast(graph_opaque))) orelse return null;
+    const idx = graph.path_to_module.get(id) orelse return null;
+    const m = graph.getModule(idx) orelse return null;
+    return .{
+        .id = m.path,
+        .importers = m.importers.items,
+        .imported_ids = m.dependencies.items,
+        .is_entry = m.is_entry_point,
+    };
+}
+
+/// ModuleIndex 로 모듈 경로 조회. importers/imported_ids 배열 순회용.
+pub fn getModulePathByIndex(graph_opaque: ?*const anyopaque, idx: ModuleIndex) ?[]const u8 {
+    const graph = @as(?*const @import("graph.zig").ModuleGraph, @ptrCast(@alignCast(graph_opaque))) orelse return null;
+    const m = graph.getModule(idx) orelse return null;
+    return m.path;
+}
 
 /// 사용자 정의 청크 분할 (#1027 / Rollup `manualChunks` 호환 Phase 1).
 /// Rollup record form `{ "vendor": ["lodash", "react"] }` 를 네이티브 슬라이스로 1:1 매핑.

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -120,12 +120,13 @@ pub const ManualChunksResolveFn = *const fn (
 
 /// Rollup `manualChunks(id, meta)` 의 `meta.getModuleInfo(id)` 반환 타입.
 /// 모든 slice 는 graph 수명 동안 borrowed — 추가 alloc/free 없음.
-/// NAPI 레이어는 `importers` / `imported_ids` 의 ModuleIndex 를
-/// `getModulePathByIndex` 로 순회해 JS string 배열을 직접 만든다.
+/// NAPI 레이어는 ModuleIndex 배열을 `getModulePathByIndex` 로 순회해 JS string 배열을 만든다.
 pub const ModuleInfo = struct {
     id: []const u8,
     importers: []const ModuleIndex,
+    dynamic_importers: []const ModuleIndex,
     imported_ids: []const ModuleIndex,
+    dynamically_imported_ids: []const ModuleIndex,
     is_entry: bool,
 };
 
@@ -137,7 +138,9 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
     return .{
         .id = m.path,
         .importers = m.importers.items,
+        .dynamic_importers = m.dynamic_importers.items,
         .imported_ids = m.dependencies.items,
+        .dynamically_imported_ids = m.dynamic_imports.items,
         .is_entry = m.is_entry_point,
     };
 }

--- a/tests/integration/tests/inline-dynamic-imports-smoke.test.ts
+++ b/tests/integration/tests/inline-dynamic-imports-smoke.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { join, resolve } from "node:path";
+import { createFixture, hasPackage } from "./helpers";
+import { init, close, build } from "../../../packages/core/index";
+
+const PROJECT_ROOT = resolve(import.meta.dir, "../../..");
+const ROOT_NODE_MODULES = join(PROJECT_ROOT, "node_modules");
+
+// `inlineDynamicImports` 스모크 — 실전 크기의 fixture + 라이브러리로 구조 검증.
+// 런타임 실행은 A 범위 밖 (후속 PR).
+
+describe("inlineDynamicImports smoke", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("SPA 라우팅 패턴: 여러 route 가 lazy + 공용 util → 단일 chunk 로 압축", async () => {
+    const fixture = await createFixture({
+      "util/logger.ts": `export const log = (t: string) => console.log("[log]", t);`,
+      "util/format.ts": `
+        import { log } from "./logger";
+        export const fmt = (s: string) => { log("fmt"); return s.toUpperCase(); };
+      `,
+      "routes/home.ts": `
+        import { fmt } from "../util/format";
+        export default () => fmt("home");
+      `,
+      "routes/about.ts": `
+        import { fmt } from "../util/format";
+        export default () => fmt("about");
+      `,
+      "routes/contact.ts": `
+        import { fmt } from "../util/format";
+        export default () => fmt("contact");
+      `,
+      "entry.ts": `
+        import { log } from "./util/logger";
+        async function nav(r: string) {
+          if (r === "home") return (await import("./routes/home")).default;
+          if (r === "about") return (await import("./routes/about")).default;
+          return (await import("./routes/contact")).default;
+        }
+        log("boot");
+        nav("home").then((f) => console.log((f as () => string)()));
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    // 모든 라우트 + 공용 util 이 단일 chunk 안에
+    expect(outs.length).toBe(1);
+    const mods = outs[0].moduleIds!;
+    for (const p of ["entry.ts", "home.ts", "about.ts", "contact.ts", "format.ts", "logger.ts"]) {
+      expect(mods.some((m) => m.endsWith(p))).toBe(true);
+    }
+  });
+
+  test("manualChunks + inline: vendor seed 의 dynamic dep 도 vendor chunk 로 (Phase 2.5 확장)", async () => {
+    const fixture = await createFixture({
+      "vendor/root.ts": `
+        export async function loadExtra() {
+          const m = await import("./extra");
+          return m.heavy();
+        }
+      `,
+      "vendor/extra.ts": `
+        export const heavy = () => "HEAVY_MARK";
+      `,
+      "entry.ts": `
+        import { loadExtra } from "./vendor/root";
+        loadExtra().then(console.log);
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      manualChunks: (id) => {
+        if (id.includes("/vendor/")) return "vendor";
+        return null;
+      },
+    });
+
+    const outs = result.outputFiles!;
+    const vendorChunk = outs.find((o) => o.path.includes("vendor"));
+    expect(vendorChunk).toBeDefined();
+    const vendorMods = vendorChunk!.moduleIds!;
+    // vendor/root + vendor/extra 모두 vendor chunk 에 (extra 가 dynamic 이어도)
+    expect(vendorMods.some((m) => m.endsWith("root.ts"))).toBe(true);
+    expect(vendorMods.some((m) => m.endsWith("extra.ts"))).toBe(true);
+    // entry chunk 에는 vendor 모듈 없음
+    const entryChunk = outs.find((o) => o.moduleIds?.some((m) => m.endsWith("entry.ts")))!;
+    expect(entryChunk.moduleIds!.some((m) => m.includes("/vendor/"))).toBe(false);
+  });
+
+  test("동일 모듈을 static + dynamic 둘 다로 import — inline 에서 중복 없이 entry chunk 에 한 번만", async () => {
+    const fixture = await createFixture({
+      "shared.ts": 'export const v = "SHARED_MARK";',
+      "entry.ts": `
+        import { v as staticV } from "./shared";
+        async function boot() {
+          const m = await import("./shared");
+          console.log(staticV + "|" + m.v);
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(1);
+    const mods = outs[0].moduleIds!;
+    // shared 가 moduleIds 에 단 한 번
+    const sharedCount = mods.filter((m) => m.endsWith("shared.ts")).length;
+    expect(sharedCount).toBe(1);
+    // SHARED_MARK 는 한 번만 emit
+    const occurrences = outs[0].text.split("SHARED_MARK").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test("중첩 dynamic import (A dyn→ B dyn→ C) 도 하나의 chunk 로 평탄화", async () => {
+    const fixture = await createFixture({
+      "c.ts": 'export const c = "C_MARK";',
+      "b.ts": `
+        export async function run() {
+          const m = await import("./c");
+          return "B:" + m.c;
+        }
+      `,
+      "entry.ts": `
+        async function boot() {
+          const m = await import("./b");
+          console.log(await m.run());
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(1);
+    const mods = outs[0].moduleIds!;
+    expect(mods.some((m) => m.endsWith("entry.ts"))).toBe(true);
+    expect(mods.some((m) => m.endsWith("b.ts"))).toBe(true);
+    expect(mods.some((m) => m.endsWith("c.ts"))).toBe(true);
+    expect(outs[0].text).toContain("C_MARK");
+  });
+
+  test("splitting=false 에서 플래그는 무시 — 단일 파일 기본 동작 유지", async () => {
+    // splitting 없으면 어차피 단일 파일. 플래그 자체가 no-op.
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("./lazy"); console.log(m.v); }
+        boot();
+      `,
+      "lazy.ts": 'export const v = "LAZY_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: false,
+      inlineDynamicImports: true,
+    });
+
+    // splitting 없을 땐 outputFiles 가 undefined 이거나 단일
+    const outs = result.outputFiles ?? [];
+    // 크래시 없고 결과가 나오면 성공 — 실제 출력 형태는 splitting=false 경로에 종속
+    expect(outs.length >= 0).toBe(true);
+  });
+
+  test.skipIf(!hasPackage("clsx"))(
+    "실 라이브러리: clsx 를 dynamic 으로만 import 해도 inline 모드에서 entry chunk 에",
+    async () => {
+      const fixture = await createFixture({
+        "entry.ts": `
+          async function boot() {
+            const { clsx } = await import("clsx");
+            console.log(clsx("a", { b: true }));
+          }
+          boot();
+        `,
+      });
+      cleanup = fixture.cleanup;
+
+      const result = await build({
+        entryPoints: [join(fixture.dir, "entry.ts")],
+        splitting: true,
+        inlineDynamicImports: true,
+        nodePaths: [ROOT_NODE_MODULES],
+      });
+
+      const outs = result.outputFiles!;
+      expect(outs.length).toBe(1);
+      // clsx 구현이 entry chunk 안에 인라인
+      expect(outs[0].moduleIds!.some((m) => m.includes("clsx"))).toBe(true);
+    },
+  );
+});

--- a/tests/integration/tests/inline-dynamic-imports.test.ts
+++ b/tests/integration/tests/inline-dynamic-imports.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { join } from "node:path";
+import { createFixture } from "./helpers";
+import { init, close, build } from "../../../packages/core/index";
+
+// `inlineDynamicImports` 구조 검증 — dynamic import target 이 별도 async chunk 로
+// 분리되지 않고 importer 의 chunk 에 포함되는지. 런타임 실행은 후속 PR 에서 다룸.
+
+describe("inlineDynamicImports (structural)", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("기본 (false): dynamic target 이 별도 async chunk 로", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("./lazy"); console.log(m.v); }
+        boot();
+      `,
+      "lazy.ts": 'export const v = "LAZY_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+    });
+
+    // 2개 chunk: entry + lazy
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(2);
+    const lazyChunk = outs.find((o) => o.text.includes("LAZY_MARK"))!;
+    const entryChunk = outs.find((o) => o.moduleIds?.some((m) => m.endsWith("entry.ts")))!;
+    expect(lazyChunk.path).not.toBe(entryChunk.path);
+    expect(entryChunk.moduleIds!.some((m) => m.endsWith("lazy.ts"))).toBe(false);
+  });
+
+  test("true: dynamic target 이 entry chunk 에 흡수 — 단일 chunk", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("./lazy"); console.log(m.v); }
+        boot();
+      `,
+      "lazy.ts": 'export const v = "LAZY_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(1);
+    expect(outs[0].moduleIds!.some((m) => m.endsWith("entry.ts"))).toBe(true);
+    expect(outs[0].moduleIds!.some((m) => m.endsWith("lazy.ts"))).toBe(true);
+    // LAZY_MARK 가 entry chunk 안에 직접 들어있어야 함
+    expect(outs[0].text).toContain("LAZY_MARK");
+  });
+
+  test("true: transitive static dep 도 entry chunk 로 흡수", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() {
+          const m = await import("./lazy");
+          console.log(m.run());
+        }
+        boot();
+      `,
+      "lazy.ts": `
+        import { util } from "./util";
+        export const run = () => util() + "_LAZY";
+      `,
+      "util.ts": 'export const util = () => "UTIL_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(1);
+    const mods = outs[0].moduleIds!;
+    expect(mods.some((m) => m.endsWith("entry.ts"))).toBe(true);
+    expect(mods.some((m) => m.endsWith("lazy.ts"))).toBe(true);
+    expect(mods.some((m) => m.endsWith("util.ts"))).toBe(true);
+    expect(outs[0].text).toContain("UTIL_MARK");
+  });
+
+  test("true: same-chunk dynamic import 는 specifier 그대로 유지 (런타임 위임)", async () => {
+    // inline 모드에서도 `import("./lazy")` 호출 텍스트는 남아있어야 한다 (A 범위 스펙).
+    // 런타임 registry 를 통한 해석은 후속 PR.
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("./lazy"); console.log(m.v); }
+        boot();
+      `,
+      "lazy.ts": 'export const v = "MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    // 청크 파일명으로 specifier 가 재작성되지 않고 원본 유지되는지
+    // (재작성됐으면 "./lazy.js" 같은 .js 확장자가 따라붙는다)
+    expect(result.outputFiles![0].text).toMatch(/import\s*\(\s*["']\.\/lazy["']\s*\)/);
+  });
+
+  test("meta.getModuleInfo 는 dynamic 관계를 그대로 관찰", async () => {
+    // 청크 구조만 바뀌고 그래프 토폴로지 자체는 불변 — dynamicallyImportedIds 유지.
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { await import("./lazy"); }
+        boot();
+      `,
+      "lazy.ts": "export const v = 1;",
+    });
+    cleanup = fixture.cleanup;
+
+    let observedDyn: string[] | undefined;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          observedDyn = meta.getModuleInfo(id)?.dynamicallyImportedIds;
+        }
+        return null;
+      },
+    });
+
+    expect(observedDyn).toBeDefined();
+    expect(observedDyn!.some((p) => p.endsWith("lazy.ts"))).toBe(true);
+  });
+});

--- a/tests/integration/tests/manual-chunks-smoke.test.ts
+++ b/tests/integration/tests/manual-chunks-smoke.test.ts
@@ -989,4 +989,155 @@ describe("manualChunks smoke (실제 번들 실행)", () => {
     // 실행 가능한 번들이어야 함 (빈 entry chunk 문제 없음)
     expect(entryChunk!.text).toContain("ENTRY_MARKER");
   });
+
+  // ============================================================
+  // meta.getModuleInfo dynamic fields 스모크 — 실전 lazy-load 패턴
+  // ============================================================
+
+  test("lazy-route 패턴: entry.dynamicallyImportedIds 가 route 모듈들 정확히 추적", async () => {
+    // React.lazy 스타일 — 각 라우트를 lazy load
+    const fixture = await createFixture({
+      "shared/logger.ts": `export const log = (m: string) => console.log("[log]", m);`,
+      "routes/home.ts": `
+        import { log } from "../shared/logger";
+        export default function Home() { log("home"); }
+      `,
+      "routes/about.ts": `
+        import { log } from "../shared/logger";
+        export default function About() { log("about"); }
+      `,
+      "entry.ts": `
+        import { log } from "./shared/logger";
+        async function route(name: string) {
+          if (name === "home") return (await import("./routes/home")).default;
+          if (name === "about") return (await import("./routes/about")).default;
+          throw new Error("unknown");
+        }
+        log("boot");
+        route("home").then((f) => (f as () => void)());
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const routeIds: string[] = [];
+    const staticIds: string[] = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+      manualChunks: (id, meta) => {
+        if (!id.endsWith("entry.ts")) return null;
+        const info = meta.getModuleInfo(id);
+        if (info) {
+          routeIds.push(...info.dynamicallyImportedIds);
+          staticIds.push(...info.importedIds);
+        }
+        return null;
+      },
+    });
+
+    // dynamicallyImportedIds 에는 두 라우트가 들어가고, importedIds 에는 안 들어감
+    expect(routeIds.some((p) => p.endsWith("home.ts"))).toBe(true);
+    expect(routeIds.some((p) => p.endsWith("about.ts"))).toBe(true);
+    expect(staticIds.some((p) => p.endsWith("home.ts"))).toBe(false);
+    expect(staticIds.some((p) => p.endsWith("about.ts"))).toBe(false);
+    // 반대로 logger 는 static 에만
+    expect(staticIds.some((p) => p.endsWith("logger.ts"))).toBe(true);
+    expect(routeIds.some((p) => p.endsWith("logger.ts"))).toBe(false);
+  });
+
+  test("같은 모듈을 한쪽은 static 다른쪽은 dynamic 으로 import — importers 와 dynamicImporters 분리", async () => {
+    // pageA 는 static, pageB 는 dynamic 으로 shared 를 참조
+    const fixture = await createFixture({
+      "shared.ts": `export const v = "SHARED";`,
+      "pageA.ts": `import { v } from "./shared"; console.log("A:" + v);`,
+      "pageB.ts": `
+        async function boot() {
+          const m = await import("./shared");
+          console.log("B:" + m.v);
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    // shared 는 pageB 에서 dynamic 이기도 해서 dynamic-entry 로 분류 → resolver skip.
+    // 그래서 pageA resolver 안에서 shared 경로를 정확히 얻어 직접 lookup.
+    const diag: Array<{ staticImporters: string[]; dynamicImporters: string[] }> = [];
+    await build({
+      entryPoints: [join(fixture.dir, "pageA.ts"), join(fixture.dir, "pageB.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+      manualChunks: (id, meta) => {
+        if (!id.endsWith("pageA.ts")) return null;
+        const pageInfo = meta.getModuleInfo(id);
+        if (!pageInfo) return null;
+        const sharedPath = pageInfo.importedIds.find((p) => p.endsWith("shared.ts"));
+        if (!sharedPath) return null;
+        const info = meta.getModuleInfo(sharedPath);
+        if (info) {
+          diag.push({ staticImporters: info.importers, dynamicImporters: info.dynamicImporters });
+        }
+        return null;
+      },
+    });
+
+    expect(diag.length).toBe(1);
+    const seen = diag[0];
+    expect(seen.staticImporters.some((p) => p.endsWith("pageA.ts"))).toBe(true);
+    expect(seen.dynamicImporters.some((p) => p.endsWith("pageB.ts"))).toBe(true);
+    // cross-pollution 없어야 함
+    expect(seen.staticImporters.some((p) => p.endsWith("pageB.ts"))).toBe(false);
+    expect(seen.dynamicImporters.some((p) => p.endsWith("pageA.ts"))).toBe(false);
+  });
+
+  test("실전 분류: dynamicImporters 기반 분류 규칙으로 shared-lazy chunk 분리", async () => {
+    // 두 라우트가 공통으로 lazy load 하는 util → "shared-lazy" 청크로 추출
+    const fixture = await createFixture({
+      "util/common.ts": `export const commonOp = () => "COMMON_OP";`,
+      "routes/a.ts": `
+        import { commonOp } from "../util/common";
+        export default () => console.log("A:" + commonOp());
+      `,
+      "routes/b.ts": `
+        import { commonOp } from "../util/common";
+        export default () => console.log("B:" + commonOp());
+      `,
+      "entry.ts": `
+        async function pick(n: "a" | "b") {
+          if (n === "a") return (await import("./routes/a")).default;
+          return (await import("./routes/b")).default;
+        }
+        pick("a").then((f) => f());
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+      // util/common 은 dynamic 루트에서만 접근되므로 importers = 0 but dynamic 후손으로 연결됨.
+      // 명시적 manual 분류로 shared-lazy 청크 분리.
+      manualChunks: (id) => {
+        if (id.includes("/util/")) return "shared-lazy";
+        return null;
+      },
+    });
+
+    const sharedLazyChunk = result.outputFiles.find((o) => o.path.includes("shared-lazy"));
+    expect(sharedLazyChunk).toBeDefined();
+    expect(sharedLazyChunk!.text).toContain("COMMON_OP");
+    // 라우트 청크들에는 COMMON_OP 구현 자체가 들어가지 않고 shared-lazy 를 import
+    const routeAChunk = result.outputFiles.find(
+      (o) =>
+        o.path.includes("a.ts") || (o.moduleIds && o.moduleIds.some((m) => m.endsWith("a.ts"))),
+    );
+    if (routeAChunk) {
+      expect(routeAChunk.moduleIds!.some((m) => m.endsWith("common.ts"))).toBe(false);
+    }
+  });
 });

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test
 import { join } from "node:path";
 import { createFixture } from "./helpers";
 import { init, close, build } from "../../../packages/core/index";
+import type { ManualChunksModuleInfo } from "../../../packages/core/index";
 
 // Phase 2 NAPI 브리지 integration 테스트 — JS manualChunks 함수가 Zig resolver 로
 // 연결되는지 실제 번들 결과로 검증. Zig 유닛테스트 (bundler_test/manual_chunks.zig)
@@ -161,7 +162,6 @@ describe("manualChunks NAPI bridge", () => {
     });
     cleanup = fixture.cleanup;
 
-    let call = 0;
     const result = await build({
       entryPoints: [join(fixture.dir, "entry.ts")],
       splitting: true,
@@ -174,7 +174,6 @@ describe("manualChunks NAPI bridge", () => {
       }) as (id: string) => string | null | undefined,
     });
 
-    void call;
     // 모든 모듈이 null 취급되어 단일 청크
     const outs = result.outputFiles!;
     expect(outs.length).toBe(1);
@@ -187,6 +186,25 @@ describe("manualChunks NAPI bridge", () => {
   // manualChunks(id, meta) — Rollup/rolldown 호환 meta 파라미터
   // ============================================================
 
+  // meta.getModuleInfo 를 각 모듈에 대해 호출해 pick 결과를 Map 으로 수집.
+  async function collectMeta<T>(
+    dir: string,
+    entries: string[],
+    pick: (info: ManualChunksModuleInfo) => T,
+  ): Promise<Map<string, T>> {
+    const seen = new Map<string, T>();
+    await build({
+      entryPoints: entries.map((e) => join(dir, e)),
+      splitting: true,
+      manualChunks: (id, meta) => {
+        const info = meta.getModuleInfo(id);
+        if (info) seen.set(id, pick(info));
+        return null;
+      },
+    });
+    return seen;
+  }
+
   test("meta.getModuleInfo: 엔트리 모듈 isEntry=true, 일반 모듈 isEntry=false", async () => {
     const fixture = await createFixture({
       "entry.ts": `import { a } from "./lib"; console.log(a);`,
@@ -194,25 +212,13 @@ describe("manualChunks NAPI bridge", () => {
     });
     cleanup = fixture.cleanup;
 
-    const entryPath = join(fixture.dir, "entry.ts");
-    const seen = new Map<string, { isEntry: boolean }>();
-    await build({
-      entryPoints: [entryPath],
-      splitting: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      manualChunks: ((id: string, meta: any) => {
-        const info = meta?.getModuleInfo?.(id);
-        if (info) seen.set(id, { isEntry: info.isEntry });
-        return null;
-      }) as (id: string) => string | null,
-    });
-
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.isEntry);
     const entryInfo = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"));
     const libInfo = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"));
     expect(entryInfo).toBeDefined();
     expect(libInfo).toBeDefined();
-    expect(entryInfo![1].isEntry).toBe(true);
-    expect(libInfo![1].isEntry).toBe(false);
+    expect(entryInfo![1]).toBe(true);
+    expect(libInfo![1]).toBe(false);
   });
 
   test("meta.getModuleInfo: importers — 누가 이 모듈을 import 하는가", async () => {
@@ -223,19 +229,7 @@ describe("manualChunks NAPI bridge", () => {
     });
     cleanup = fixture.cleanup;
 
-    // 두 엔트리 — shared 는 양쪽에서 import
-    const seen = new Map<string, string[]>();
-    await build({
-      entryPoints: [join(fixture.dir, "entry.ts"), join(fixture.dir, "other.ts")],
-      splitting: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      manualChunks: ((id: string, meta: any) => {
-        const info = meta?.getModuleInfo?.(id);
-        if (info) seen.set(id, info.importers ?? []);
-        return null;
-      }) as (id: string) => string | null,
-    });
-
+    const seen = await collectMeta(fixture.dir, ["entry.ts", "other.ts"], (info) => info.importers);
     const sharedEntry = [...seen.entries()].find(([k]) => k.endsWith("shared.ts"));
     expect(sharedEntry).toBeDefined();
     const importers = sharedEntry![1];
@@ -256,18 +250,7 @@ describe("manualChunks NAPI bridge", () => {
     });
     cleanup = fixture.cleanup;
 
-    const seen = new Map<string, string[]>();
-    await build({
-      entryPoints: [join(fixture.dir, "entry.ts")],
-      splitting: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      manualChunks: ((id: string, meta: any) => {
-        const info = meta?.getModuleInfo?.(id);
-        if (info) seen.set(id, info.importedIds ?? []);
-        return null;
-      }) as (id: string) => string | null,
-    });
-
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.importedIds);
     const entryIds = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
     expect(entryIds.length).toBe(2);
     expect(entryIds.some((p) => p.endsWith("foo.ts"))).toBe(true);
@@ -288,12 +271,11 @@ describe("manualChunks NAPI bridge", () => {
     const result = await build({
       entryPoints: [join(fixture.dir, "pageA.ts"), join(fixture.dir, "pageB.ts")],
       splitting: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      manualChunks: ((id: string, meta: any) => {
-        const info = meta?.getModuleInfo?.(id);
-        if (info && info.importers && info.importers.length >= 2) return "shared-chunk";
+      manualChunks: (id, meta) => {
+        const info = meta.getModuleInfo(id);
+        if (info && info.importers.length >= 2) return "shared-chunk";
         return null;
-      }) as (id: string) => string | null,
+      },
     });
 
     const sharedChunk = result.outputFiles!.find((o) => o.path.includes("shared-chunk"));

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -452,4 +452,67 @@ describe("manualChunks NAPI bridge", () => {
     expect(all).toContain("B_MARK");
     expect(all).toContain("C_MARK");
   });
+
+  test("meta.getModuleInfo: entry.dynamicallyImportedIds — entry 가 dynamic 으로 import 하는 것", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { s } from "./static-dep";
+        export async function load() { return (await import("./dyn-dep")).default; }
+        console.log(s);
+      `,
+      "static-dep.ts": "export const s = 1;",
+      "dyn-dep.ts": "export default 42;",
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => ({
+      imported: info.importedIds,
+      dyn: info.dynamicallyImportedIds,
+    }));
+    const entry = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
+    expect(entry.imported.some((p) => p.endsWith("static-dep.ts"))).toBe(true);
+    expect(entry.imported.some((p) => p.endsWith("dyn-dep.ts"))).toBe(false);
+    expect(entry.dyn.some((p) => p.endsWith("dyn-dep.ts"))).toBe(true);
+    expect(entry.dyn.some((p) => p.endsWith("static-dep.ts"))).toBe(false);
+  });
+
+  test("meta.getModuleInfo: dynamic-dep.dynamicImporters — 누가 dynamic 으로 import 하는가", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function main() {
+          const m = await import("./dyn-dep");
+          console.log(m.default);
+        }
+        main();
+      `,
+      "dyn-dep.ts": 'export default "DYN_VALUE";',
+    });
+    cleanup = fixture.cleanup;
+
+    // dyn-dep 은 resolver 호출에서 제외되는 dynamic entry 라 직접 조회가 안 된다.
+    // 대신 entry resolver 안에서 entry.dynamicallyImportedIds 로 dyn-dep 의 실제 저장 경로를
+    // 받아 그대로 조회 (macOS /private prefix 같은 경로 정규화 이슈 회피).
+    const results: Array<{ importers: string[]; dynamicImporters: string[] }> = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (!id.endsWith("entry.ts")) return null;
+        const entryInfo = meta.getModuleInfo(id);
+        if (!entryInfo) return null;
+        const dynPath = entryInfo.dynamicallyImportedIds.find((p) => p.endsWith("dyn-dep.ts"));
+        if (!dynPath) return null;
+        const info = meta.getModuleInfo(dynPath);
+        if (info) {
+          results.push({ importers: info.importers, dynamicImporters: info.dynamicImporters });
+        }
+        return null;
+      },
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0].importers.length).toBe(0);
+    expect(results[0].dynamicImporters.length).toBe(1);
+    expect(results[0].dynamicImporters[0].endsWith("entry.ts")).toBe(true);
+  });
 });

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -284,4 +284,172 @@ describe("manualChunks NAPI bridge", () => {
     // only-a, only-b 는 shared-chunk 에 안 들어감 (importers=1)
     expect(sharedChunk!.moduleIds!.every((id) => !id.includes("only-"))).toBe(true);
   });
+
+  // ============================================================
+  // meta API 경계값 / 토폴로지 / 실사용 패턴
+  // ============================================================
+
+  test("meta.getModuleInfo: 빈 문자열 / 존재하지 않는 경로 → null", async () => {
+    const fixture = await createFixture({
+      "entry.ts": "console.log(1);",
+    });
+    cleanup = fixture.cleanup;
+
+    const results: Array<{ empty: unknown; missing: unknown }> = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        results.push({
+          empty: meta.getModuleInfo(""),
+          missing: meta.getModuleInfo("/does-not-exist.ts"),
+        });
+        return null;
+      },
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      expect(r.empty).toBeNull();
+      expect(r.missing).toBeNull();
+    }
+  });
+
+  test("meta.getModuleInfo: resolver 안 다회 호출 안전 (NAPI reentrance)", async () => {
+    const fixture = await createFixture({
+      "entry.ts": 'import { a } from "./lib"; console.log(a);',
+      "lib.ts": "export const a = 1;",
+    });
+    cleanup = fixture.cleanup;
+
+    let callCount = 0;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        // 동일 id 로 여러 번 + 서로 다른 id 로도 섞어서
+        meta.getModuleInfo(id);
+        meta.getModuleInfo(id);
+        meta.getModuleInfo(id);
+        callCount++;
+        return null;
+      },
+    });
+    expect(callCount).toBeGreaterThan(0);
+  });
+
+  test("meta.getModuleInfo: deep chain (A → B → C) 토폴로지", async () => {
+    const fixture = await createFixture({
+      "a.ts": 'import { b } from "./b"; console.log(b);',
+      "b.ts": 'export { c as b } from "./c";',
+      "c.ts": "export const c = 1;",
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["a.ts"], (info) => ({
+      importers: info.importers,
+      imported: info.importedIds,
+    }));
+
+    const a = [...seen.entries()].find(([k]) => k.endsWith("a.ts"))![1];
+    const b = [...seen.entries()].find(([k]) => k.endsWith("b.ts"))![1];
+    const c = [...seen.entries()].find(([k]) => k.endsWith("c.ts"))![1];
+
+    expect(a.importers.length).toBe(0);
+    expect(a.imported.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(b.importers.some((p) => p.endsWith("a.ts"))).toBe(true);
+    expect(b.imported.some((p) => p.endsWith("c.ts"))).toBe(true);
+    expect(c.importers.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(c.imported.length).toBe(0);
+  });
+
+  test("meta.getModuleInfo: 순환 의존 (A ↔ B) 양방향", async () => {
+    const fixture = await createFixture({
+      "a.ts": 'import { b } from "./b"; export const a = b + 1;',
+      "b.ts": 'import { a } from "./a"; export const b = 1; export const ab = a;',
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["a.ts"], (info) => ({
+      importers: info.importers,
+      imported: info.importedIds,
+    }));
+
+    const a = [...seen.entries()].find(([k]) => k.endsWith("a.ts"))![1];
+    const b = [...seen.entries()].find(([k]) => k.endsWith("b.ts"))![1];
+    expect(a.imported.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(a.importers.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(b.imported.some((p) => p.endsWith("a.ts"))).toBe(true);
+    expect(b.importers.some((p) => p.endsWith("a.ts"))).toBe(true);
+  });
+
+  test("meta.getModuleInfo: dynamic import 는 importedIds 에 포함 안 됨 (Rollup 스펙)", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { s } from "./static-dep";
+        export async function load() { return (await import("./dynamic-dep")).default; }
+        console.log(s);
+      `,
+      "static-dep.ts": "export const s = 1;",
+      "dynamic-dep.ts": 'export default "DYNAMIC";',
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.importedIds);
+    const entryIds = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
+    expect(entryIds.some((p) => p.endsWith("static-dep.ts"))).toBe(true);
+    expect(entryIds.some((p) => p.endsWith("dynamic-dep.ts"))).toBe(false);
+  });
+
+  test("meta.getModuleInfo: 엔트리가 자기 자신 조회 시 isEntry=true", async () => {
+    const fixture = await createFixture({
+      "entry.ts": "console.log(1);",
+    });
+    cleanup = fixture.cleanup;
+
+    let entryIsEntry: boolean | undefined;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          entryIsEntry = meta.getModuleInfo(id)?.isEntry;
+        }
+        return null;
+      },
+    });
+    expect(entryIsEntry).toBe(true);
+  });
+
+  test("meta.getModuleInfo: 일부 모듈에서만 조회해도 나머지 정상 번들 (lazy 패턴)", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { a } from "./a";
+        import { b } from "./b";
+        import { c } from "./c";
+        console.log(a, b, c);
+      `,
+      "a.ts": 'export const a = "A_MARK";',
+      "b.ts": 'export const b = "B_MARK";',
+      "c.ts": 'export const c = "C_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    // b.ts 에서만 meta.getModuleInfo 호출. 나머지는 touch 안 함.
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("b.ts")) {
+          void meta.getModuleInfo(id);
+        }
+        return null;
+      },
+    });
+
+    const all = result.outputFiles!.map((o) => o.text).join("\n");
+    expect(all).toContain("A_MARK");
+    expect(all).toContain("B_MARK");
+    expect(all).toContain("C_MARK");
+  });
 });

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -182,4 +182,124 @@ describe("manualChunks NAPI bridge", () => {
     expect(outs[0].text).toContain("B_MARKER");
     expect(outs[0].text).toContain("C_MARKER");
   });
+
+  // ============================================================
+  // manualChunks(id, meta) — Rollup/rolldown 호환 meta 파라미터
+  // ============================================================
+
+  test("meta.getModuleInfo: 엔트리 모듈 isEntry=true, 일반 모듈 isEntry=false", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `import { a } from "./lib"; console.log(a);`,
+      "lib.ts": 'export const a = "LIB";',
+    });
+    cleanup = fixture.cleanup;
+
+    const entryPath = join(fixture.dir, "entry.ts");
+    const seen = new Map<string, { isEntry: boolean }>();
+    await build({
+      entryPoints: [entryPath],
+      splitting: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manualChunks: ((id: string, meta: any) => {
+        const info = meta?.getModuleInfo?.(id);
+        if (info) seen.set(id, { isEntry: info.isEntry });
+        return null;
+      }) as (id: string) => string | null,
+    });
+
+    const entryInfo = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"));
+    const libInfo = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"));
+    expect(entryInfo).toBeDefined();
+    expect(libInfo).toBeDefined();
+    expect(entryInfo![1].isEntry).toBe(true);
+    expect(libInfo![1].isEntry).toBe(false);
+  });
+
+  test("meta.getModuleInfo: importers — 누가 이 모듈을 import 하는가", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `import { a } from "./shared"; console.log(a);`,
+      "other.ts": `import { a } from "./shared"; export const x = a;`,
+      "shared.ts": 'export const a = "S";',
+    });
+    cleanup = fixture.cleanup;
+
+    // 두 엔트리 — shared 는 양쪽에서 import
+    const seen = new Map<string, string[]>();
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts"), join(fixture.dir, "other.ts")],
+      splitting: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manualChunks: ((id: string, meta: any) => {
+        const info = meta?.getModuleInfo?.(id);
+        if (info) seen.set(id, info.importers ?? []);
+        return null;
+      }) as (id: string) => string | null,
+    });
+
+    const sharedEntry = [...seen.entries()].find(([k]) => k.endsWith("shared.ts"));
+    expect(sharedEntry).toBeDefined();
+    const importers = sharedEntry![1];
+    expect(importers.length).toBe(2);
+    expect(importers.some((p) => p.endsWith("entry.ts"))).toBe(true);
+    expect(importers.some((p) => p.endsWith("other.ts"))).toBe(true);
+  });
+
+  test("meta.getModuleInfo: importedIds — 이 모듈이 import 하는 것", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { a } from "./foo";
+        import { b } from "./bar";
+        console.log(a, b);
+      `,
+      "foo.ts": 'export const a = "FOO";',
+      "bar.ts": 'export const b = "BAR";',
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = new Map<string, string[]>();
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manualChunks: ((id: string, meta: any) => {
+        const info = meta?.getModuleInfo?.(id);
+        if (info) seen.set(id, info.importedIds ?? []);
+        return null;
+      }) as (id: string) => string | null,
+    });
+
+    const entryIds = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
+    expect(entryIds.length).toBe(2);
+    expect(entryIds.some((p) => p.endsWith("foo.ts"))).toBe(true);
+    expect(entryIds.some((p) => p.endsWith("bar.ts"))).toBe(true);
+  });
+
+  test("meta 기반 실용 패턴: shared 모듈만 vendor 로", async () => {
+    // 실전 "importers 수 >= 2 면 shared 로" 패턴 — 자동 청크 분할 규칙 커스터마이즈
+    const fixture = await createFixture({
+      "pageA.ts": `import { s } from "./shared"; import { a } from "./only-a"; console.log(s, a);`,
+      "pageB.ts": `import { s } from "./shared"; import { b } from "./only-b"; console.log(s, b);`,
+      "shared.ts": 'export const s = "SHARED";',
+      "only-a.ts": 'export const a = "A";',
+      "only-b.ts": 'export const b = "B";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "pageA.ts"), join(fixture.dir, "pageB.ts")],
+      splitting: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manualChunks: ((id: string, meta: any) => {
+        const info = meta?.getModuleInfo?.(id);
+        if (info && info.importers && info.importers.length >= 2) return "shared-chunk";
+        return null;
+      }) as (id: string) => string | null,
+    });
+
+    const sharedChunk = result.outputFiles!.find((o) => o.path.includes("shared-chunk"));
+    expect(sharedChunk).toBeDefined();
+    expect(sharedChunk!.moduleIds!.some((id) => id.endsWith("shared.ts"))).toBe(true);
+    // only-a, only-b 는 shared-chunk 에 안 들어감 (importers=1)
+    expect(sharedChunk!.moduleIds!.every((id) => !id.includes("only-"))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Rollup `output.inlineDynamicImports` 의 chunk 분할 구조만 구현 — C 분할 전략의 앞쪽 (A 범위)
- `true` 이면 dynamic import target 이 별도 async chunk 로 분리되지 않고 importer chunk (entry 또는 manual) 에 흡수
- 런타임 `import()` 는 same-chunk 여도 원본 specifier 유지 — 모듈 registry 기반 re-entry 는 후속 PR

## 구현
- `BundleOptions.inline_dynamic_imports` + NAPI `inlineDynamicImports` + TS `BuildOptionsCommon.inlineDynamicImports`
- `chunk.generateChunks`:
  - Phase 1b (dynamic entry 생성) skip
  - Phase 2 BFS 가 `dynamic_imports` edge 도 따라감
  - Phase 2.5 manual BFS 도 동일 확장 (/simplify 후속) — manual seed 의 dynamic dep 이 manual chunk 로
- `rewriteDynamicImports` — target 이 source 와 같은 chunk 면 specifier 재작성 skip
- 모든 generateChunks 테스트 call site 업데이트 (22+개)

## 테스트 (+14)
- Zig 유닛 4개
- integration 5개 (구조 / specifier 유지 / meta 관찰)
- smoke 6개 (SPA 라우팅 / manual × inline / 중복 shared / 중첩 dynamic / splitting=false / 실 라이브러리)

## 스택
- PR #1855 (dynamicImporters/dynamicallyImportedIds) 위에

## 후속
- 런타임 helper — `import()` 을 module registry 로 해석. Node/브라우저 실행 가능성 확보. 별도 PR

## Test plan
- [x] `zig build test` green
- [x] `bun test tests/{manual-chunks,inline-dynamic-imports}*.test.ts` 58/58 green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)