### PR TITLE
feat(napi): manualChunks meta.getModuleInfo JS 브리지

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -199,6 +199,20 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
 
 export type { OutputFile, Diagnostic };
 
+/** Rollup `manualChunks(id, meta)` 의 `meta.getModuleInfo(id)` 반환. */
+export interface ManualChunksModuleInfo {
+  id: string;
+  isEntry: boolean;
+  importers: string[];
+  importedIds: string[];
+}
+
+/** `manualChunks` 콜백의 두 번째 인자 — 모듈 그래프 토폴로지 조회. */
+export interface ManualChunksMeta {
+  /** `id` 로 모듈 정보 조회. 없으면 null. */
+  getModuleInfo(id: string): ManualChunksModuleInfo | null;
+}
+
 /**
  * Common build options shared by all platforms.
  * `platform` + `target` 조합은 `BuildOptions` 에서 discriminated union으로 제한됨.
@@ -273,16 +287,19 @@ interface BuildOptionsCommon {
    * null/undefined 반환 시 기존 자동 분배. transitive dependency 도 같은 청크로 따라감
    * (cross-chunk 순환 회피). dynamic import target 은 async chunk 대신 manual 우선.
    *
+   * 두 번째 인자 `meta.getModuleInfo(id)` 는 그래프 토폴로지 조회 — Rollup 호환.
+   *
    * 예:
    * ```ts
-   * manualChunks: (id) => {
+   * manualChunks: (id, meta) => {
+   *   const info = meta.getModuleInfo(id);
+   *   if (info && info.importers.length >= 2) return 'shared';
    *   if (/node_modules\/react/.test(id)) return 'react';
-   *   if (id.includes('/src/components/')) return 'ui';
    *   return null;
    * }
    * ```
    */
-  manualChunks?: (id: string) => string | null | undefined;
+  manualChunks?: (id: string, meta: ManualChunksMeta) => string | null | undefined;
   /** 확장자별 로더 오버라이드 (예: { ".png": "file", ".svg": "text" }) */
   loader?: Record<string, string>;
   /** package.json exports 커스텀 조건 */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -993,11 +993,66 @@ const NapiManualChunksResolver = struct {
 
     const CallContext = struct {
         id: []const u8,
+        graph: ?*const anyopaque,
         result: ?[]const u8 = null,
         ready: bool = false,
         mutex: std.Thread.Mutex = .{},
         cond: std.Thread.Condition = .{},
     };
+
+    /// ModuleIndex 배열 → JS string[]. invalid index 는 skip 해서 compact 한 배열 반환.
+    fn pathArrayFromIndices(
+        env: c.napi_env,
+        graph: ?*const anyopaque,
+        indices: []const types_mod.ModuleIndex,
+    ) c.napi_value {
+        var js_arr: c.napi_value = undefined;
+        _ = c.napi_create_array(env, &js_arr);
+        var write_idx: u32 = 0;
+        for (indices) |idx| {
+            const p = types_mod.getModulePathByIndex(graph, idx) orelse continue;
+            var js_p: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, p.ptr, p.len, &js_p);
+            _ = c.napi_set_element(env, js_arr, write_idx, js_p);
+            write_idx += 1;
+        }
+        return js_arr;
+    }
+
+    /// JS `meta.getModuleInfo(id)` 구현. napi function 의 data 슬롯에 graph 포인터를
+    /// 담아 전달받는다. 동일 bundle() 안에서 모든 resolver 호출이 같은 graph 를 공유.
+    fn getModuleInfoCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var js_null: c.napi_value = undefined;
+        _ = c.napi_get_null(env, &js_null);
+
+        var argc: usize = 1;
+        var argv: [1]c.napi_value = undefined;
+        var data: ?*anyopaque = null;
+        if (c.napi_get_cb_info(env, info, &argc, &argv, null, &data) != c.napi_ok) return js_null;
+        if (argc < 1) return js_null;
+
+        const id = getStringArg(env, argv[0], native_alloc) orelse return js_null;
+        defer native_alloc.free(id);
+
+        const graph: ?*const anyopaque = @ptrCast(data);
+        const mod_info = types_mod.getModuleInfo(graph, id) orelse return js_null;
+
+        var js_obj: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_obj);
+
+        var js_id_str: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, mod_info.id.ptr, mod_info.id.len, &js_id_str);
+        _ = c.napi_set_named_property(env, js_obj, "id", js_id_str);
+
+        var js_is_entry: c.napi_value = undefined;
+        _ = c.napi_get_boolean(env, mod_info.is_entry, &js_is_entry);
+        _ = c.napi_set_named_property(env, js_obj, "isEntry", js_is_entry);
+
+        _ = c.napi_set_named_property(env, js_obj, "importers", pathArrayFromIndices(env, graph, mod_info.importers));
+        _ = c.napi_set_named_property(env, js_obj, "importedIds", pathArrayFromIndices(env, graph, mod_info.imported_ids));
+
+        return js_obj;
+    }
 
     /// threadsafe function 의 call_js 콜백 (main thread).
     fn callJsCallback(env: c.napi_env, js_callback: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
@@ -1006,12 +1061,28 @@ const NapiManualChunksResolver = struct {
         var js_id: c.napi_value = undefined;
         _ = c.napi_create_string_utf8(env, ctx.id.ptr, ctx.id.len, &js_id);
 
+        // meta 객체 — graph 가 있을 때만 `getModuleInfo` 노출.
+        var js_meta: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_meta);
+        if (ctx.graph) |g| {
+            var js_get_mod_info: c.napi_value = undefined;
+            _ = c.napi_create_function(
+                env,
+                "getModuleInfo",
+                "getModuleInfo".len,
+                getModuleInfoCallback,
+                @constCast(g),
+                &js_get_mod_info,
+            );
+            _ = c.napi_set_named_property(env, js_meta, "getModuleInfo", js_get_mod_info);
+        }
+
         var js_undefined: c.napi_value = undefined;
         _ = c.napi_get_undefined(env, &js_undefined);
 
         var js_result: c.napi_value = undefined;
-        const args = [_]c.napi_value{js_id};
-        if (c.napi_call_function(env, js_undefined, js_callback, 1, &args, &js_result) != c.napi_ok) {
+        const args = [_]c.napi_value{ js_id, js_meta };
+        if (c.napi_call_function(env, js_undefined, js_callback, 2, &args, &js_result) != c.napi_ok) {
             // JS exception 은 uncaught 로 전파되기 전에 clear — 번들 중단 방지.
             // manualChunks 가 throw 하면 해당 모듈은 null (auto 분배) 로 취급.
             var is_pending: bool = false;
@@ -1055,9 +1126,8 @@ const NapiManualChunksResolver = struct {
     /// Zig resolver 인터페이스 — `ManualChunksResolveFn` 과 동일 시그니처.
     /// worker thread 에서 호출됨. JS 호출 후 동기 대기.
     fn resolve(ctx_ptr: ?*anyopaque, id: []const u8, graph: ?*const anyopaque) ?[]const u8 {
-        _ = graph;
         const self: *NapiManualChunksResolver = @ptrCast(@alignCast(ctx_ptr.?));
-        var call_ctx = CallContext{ .id = id };
+        var call_ctx = CallContext{ .id = id, .graph = graph };
 
         if (c.napi_call_threadsafe_function(self.tsfn, &call_ctx, c.napi_tsfn_blocking) != c.napi_ok) {
             return null;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1061,7 +1061,6 @@ const NapiManualChunksResolver = struct {
         var js_id: c.napi_value = undefined;
         _ = c.napi_create_string_utf8(env, ctx.id.ptr, ctx.id.len, &js_id);
 
-        // meta 객체 — graph 가 있을 때만 `getModuleInfo` 노출.
         var js_meta: c.napi_value = undefined;
         _ = c.napi_create_object(env, &js_meta);
         if (ctx.graph) |g| {

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test
 import { join } from "node:path";
 import { createFixture } from "./helpers";
 import { init, close, build } from "../../../packages/core/index";
+import type { ManualChunksModuleInfo } from "../../../packages/core/index";
 
 // Phase 2 NAPI 브리지 integration 테스트 — JS manualChunks 함수가 Zig resolver 로
 // 연결되는지 실제 번들 결과로 검증. Zig 유닛테스트 (bundler_test/manual_chunks.zig)
@@ -161,7 +162,6 @@ describe("manualChunks NAPI bridge", () => {
     });
     cleanup = fixture.cleanup;
 
-    let call = 0;
     const result = await build({
       entryPoints: [join(fixture.dir, "entry.ts")],
       splitting: true,
@@ -174,7 +174,6 @@ describe("manualChunks NAPI bridge", () => {
       }) as (id: string) => string | null | undefined,
     });
 
-    void call;
     // 모든 모듈이 null 취급되어 단일 청크
     const outs = result.outputFiles!;
     expect(outs.length).toBe(1);
@@ -187,6 +186,25 @@ describe("manualChunks NAPI bridge", () => {
   // manualChunks(id, meta) — Rollup/rolldown 호환 meta 파라미터
   // ============================================================
 
+  // meta.getModuleInfo 를 각 모듈에 대해 호출해 pick 결과를 Map 으로 수집.
+  async function collectMeta<T>(
+    dir: string,
+    entries: string[],
+    pick: (info: ManualChunksModuleInfo) => T,
+  ): Promise<Map<string, T>> {
+    const seen = new Map<string, T>();
+    await build({
+      entryPoints: entries.map((e) => join(dir, e)),
+      splitting: true,
+      manualChunks: (id, meta) => {
+        const info = meta.getModuleInfo(id);
+        if (info) seen.set(id, pick(info));
+        return null;
+      },
+    });
+    return seen;
+  }
+
   test("meta.getModuleInfo: 엔트리 모듈 isEntry=true, 일반 모듈 isEntry=false", async () => {
     const fixture = await createFixture({
       "entry.ts": `import { a } from "./lib"; console.log(a);`,
@@ -194,25 +212,13 @@ describe("manualChunks NAPI bridge", () => {
     });
     cleanup = fixture.cleanup;
 
-    const entryPath = join(fixture.dir, "entry.ts");
-    const seen = new Map<string, { isEntry: boolean }>();
-    await build({
-      entryPoints: [entryPath],
-      splitting: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      manualChunks: ((id: string, meta: any) => {
-        const info = meta?.getModuleInfo?.(id);
-        if (info) seen.set(id, { isEntry: info.isEntry });
-        return null;
-      }) as (id: string) => string | null,
-    });
-
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.isEntry);
     const entryInfo = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"));
     const libInfo = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"));
     expect(entryInfo).toBeDefined();
     expect(libInfo).toBeDefined();
-    expect(entryInfo![1].isEntry).toBe(true);
-    expect(libInfo![1].isEntry).toBe(false);
+    expect(entryInfo![1]).toBe(true);
+    expect(libInfo![1]).toBe(false);
   });
 
   test("meta.getModuleInfo: importers — 누가 이 모듈을 import 하는가", async () => {
@@ -223,19 +229,7 @@ describe("manualChunks NAPI bridge", () => {
     });
     cleanup = fixture.cleanup;
 
-    // 두 엔트리 — shared 는 양쪽에서 import
-    const seen = new Map<string, string[]>();
-    await build({
-      entryPoints: [join(fixture.dir, "entry.ts"), join(fixture.dir, "other.ts")],
-      splitting: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      manualChunks: ((id: string, meta: any) => {
-        const info = meta?.getModuleInfo?.(id);
-        if (info) seen.set(id, info.importers ?? []);
-        return null;
-      }) as (id: string) => string | null,
-    });
-
+    const seen = await collectMeta(fixture.dir, ["entry.ts", "other.ts"], (info) => info.importers);
     const sharedEntry = [...seen.entries()].find(([k]) => k.endsWith("shared.ts"));
     expect(sharedEntry).toBeDefined();
     const importers = sharedEntry![1];
@@ -256,18 +250,7 @@ describe("manualChunks NAPI bridge", () => {
     });
     cleanup = fixture.cleanup;
 
-    const seen = new Map<string, string[]>();
-    await build({
-      entryPoints: [join(fixture.dir, "entry.ts")],
-      splitting: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      manualChunks: ((id: string, meta: any) => {
-        const info = meta?.getModuleInfo?.(id);
-        if (info) seen.set(id, info.importedIds ?? []);
-        return null;
-      }) as (id: string) => string | null,
-    });
-
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.importedIds);
     const entryIds = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
     expect(entryIds.length).toBe(2);
     expect(entryIds.some((p) => p.endsWith("foo.ts"))).toBe(true);
@@ -288,12 +271,11 @@ describe("manualChunks NAPI bridge", () => {
     const result = await build({
       entryPoints: [join(fixture.dir, "pageA.ts"), join(fixture.dir, "pageB.ts")],
       splitting: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      manualChunks: ((id: string, meta: any) => {
-        const info = meta?.getModuleInfo?.(id);
-        if (info && info.importers && info.importers.length >= 2) return "shared-chunk";
+      manualChunks: (id, meta) => {
+        const info = meta.getModuleInfo(id);
+        if (info && info.importers.length >= 2) return "shared-chunk";
         return null;
-      }) as (id: string) => string | null,
+      },
     });
 
     const sharedChunk = result.outputFiles!.find((o) => o.path.includes("shared-chunk"));

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -284,4 +284,172 @@ describe("manualChunks NAPI bridge", () => {
     // only-a, only-b 는 shared-chunk 에 안 들어감 (importers=1)
     expect(sharedChunk!.moduleIds!.every((id) => !id.includes("only-"))).toBe(true);
   });
+
+  // ============================================================
+  // meta API 경계값 / 토폴로지 / 실사용 패턴
+  // ============================================================
+
+  test("meta.getModuleInfo: 빈 문자열 / 존재하지 않는 경로 → null", async () => {
+    const fixture = await createFixture({
+      "entry.ts": "console.log(1);",
+    });
+    cleanup = fixture.cleanup;
+
+    const results: Array<{ empty: unknown; missing: unknown }> = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        results.push({
+          empty: meta.getModuleInfo(""),
+          missing: meta.getModuleInfo("/does-not-exist.ts"),
+        });
+        return null;
+      },
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      expect(r.empty).toBeNull();
+      expect(r.missing).toBeNull();
+    }
+  });
+
+  test("meta.getModuleInfo: resolver 안 다회 호출 안전 (NAPI reentrance)", async () => {
+    const fixture = await createFixture({
+      "entry.ts": 'import { a } from "./lib"; console.log(a);',
+      "lib.ts": "export const a = 1;",
+    });
+    cleanup = fixture.cleanup;
+
+    let callCount = 0;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        // 동일 id 로 여러 번 + 서로 다른 id 로도 섞어서
+        meta.getModuleInfo(id);
+        meta.getModuleInfo(id);
+        meta.getModuleInfo(id);
+        callCount++;
+        return null;
+      },
+    });
+    expect(callCount).toBeGreaterThan(0);
+  });
+
+  test("meta.getModuleInfo: deep chain (A → B → C) 토폴로지", async () => {
+    const fixture = await createFixture({
+      "a.ts": 'import { b } from "./b"; console.log(b);',
+      "b.ts": 'export { c as b } from "./c";',
+      "c.ts": "export const c = 1;",
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["a.ts"], (info) => ({
+      importers: info.importers,
+      imported: info.importedIds,
+    }));
+
+    const a = [...seen.entries()].find(([k]) => k.endsWith("a.ts"))![1];
+    const b = [...seen.entries()].find(([k]) => k.endsWith("b.ts"))![1];
+    const c = [...seen.entries()].find(([k]) => k.endsWith("c.ts"))![1];
+
+    expect(a.importers.length).toBe(0);
+    expect(a.imported.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(b.importers.some((p) => p.endsWith("a.ts"))).toBe(true);
+    expect(b.imported.some((p) => p.endsWith("c.ts"))).toBe(true);
+    expect(c.importers.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(c.imported.length).toBe(0);
+  });
+
+  test("meta.getModuleInfo: 순환 의존 (A ↔ B) 양방향", async () => {
+    const fixture = await createFixture({
+      "a.ts": 'import { b } from "./b"; export const a = b + 1;',
+      "b.ts": 'import { a } from "./a"; export const b = 1; export const ab = a;',
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["a.ts"], (info) => ({
+      importers: info.importers,
+      imported: info.importedIds,
+    }));
+
+    const a = [...seen.entries()].find(([k]) => k.endsWith("a.ts"))![1];
+    const b = [...seen.entries()].find(([k]) => k.endsWith("b.ts"))![1];
+    expect(a.imported.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(a.importers.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(b.imported.some((p) => p.endsWith("a.ts"))).toBe(true);
+    expect(b.importers.some((p) => p.endsWith("a.ts"))).toBe(true);
+  });
+
+  test("meta.getModuleInfo: dynamic import 는 importedIds 에 포함 안 됨 (Rollup 스펙)", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { s } from "./static-dep";
+        export async function load() { return (await import("./dynamic-dep")).default; }
+        console.log(s);
+      `,
+      "static-dep.ts": "export const s = 1;",
+      "dynamic-dep.ts": 'export default "DYNAMIC";',
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.importedIds);
+    const entryIds = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
+    expect(entryIds.some((p) => p.endsWith("static-dep.ts"))).toBe(true);
+    expect(entryIds.some((p) => p.endsWith("dynamic-dep.ts"))).toBe(false);
+  });
+
+  test("meta.getModuleInfo: 엔트리가 자기 자신 조회 시 isEntry=true", async () => {
+    const fixture = await createFixture({
+      "entry.ts": "console.log(1);",
+    });
+    cleanup = fixture.cleanup;
+
+    let entryIsEntry: boolean | undefined;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          entryIsEntry = meta.getModuleInfo(id)?.isEntry;
+        }
+        return null;
+      },
+    });
+    expect(entryIsEntry).toBe(true);
+  });
+
+  test("meta.getModuleInfo: 일부 모듈에서만 조회해도 나머지 정상 번들 (lazy 패턴)", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { a } from "./a";
+        import { b } from "./b";
+        import { c } from "./c";
+        console.log(a, b, c);
+      `,
+      "a.ts": 'export const a = "A_MARK";',
+      "b.ts": 'export const b = "B_MARK";',
+      "c.ts": 'export const c = "C_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    // b.ts 에서만 meta.getModuleInfo 호출. 나머지는 touch 안 함.
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("b.ts")) {
+          void meta.getModuleInfo(id);
+        }
+        return null;
+      },
+    });
+
+    const all = result.outputFiles!.map((o) => o.text).join("\n");
+    expect(all).toContain("A_MARK");
+    expect(all).toContain("B_MARK");
+    expect(all).toContain("C_MARK");
+  });
 });

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -182,4 +182,124 @@ describe("manualChunks NAPI bridge", () => {
     expect(outs[0].text).toContain("B_MARKER");
     expect(outs[0].text).toContain("C_MARKER");
   });
+
+  // ============================================================
+  // manualChunks(id, meta) — Rollup/rolldown 호환 meta 파라미터
+  // ============================================================
+
+  test("meta.getModuleInfo: 엔트리 모듈 isEntry=true, 일반 모듈 isEntry=false", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `import { a } from "./lib"; console.log(a);`,
+      "lib.ts": 'export const a = "LIB";',
+    });
+    cleanup = fixture.cleanup;
+
+    const entryPath = join(fixture.dir, "entry.ts");
+    const seen = new Map<string, { isEntry: boolean }>();
+    await build({
+      entryPoints: [entryPath],
+      splitting: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manualChunks: ((id: string, meta: any) => {
+        const info = meta?.getModuleInfo?.(id);
+        if (info) seen.set(id, { isEntry: info.isEntry });
+        return null;
+      }) as (id: string) => string | null,
+    });
+
+    const entryInfo = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"));
+    const libInfo = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"));
+    expect(entryInfo).toBeDefined();
+    expect(libInfo).toBeDefined();
+    expect(entryInfo![1].isEntry).toBe(true);
+    expect(libInfo![1].isEntry).toBe(false);
+  });
+
+  test("meta.getModuleInfo: importers — 누가 이 모듈을 import 하는가", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `import { a } from "./shared"; console.log(a);`,
+      "other.ts": `import { a } from "./shared"; export const x = a;`,
+      "shared.ts": 'export const a = "S";',
+    });
+    cleanup = fixture.cleanup;
+
+    // 두 엔트리 — shared 는 양쪽에서 import
+    const seen = new Map<string, string[]>();
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts"), join(fixture.dir, "other.ts")],
+      splitting: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manualChunks: ((id: string, meta: any) => {
+        const info = meta?.getModuleInfo?.(id);
+        if (info) seen.set(id, info.importers ?? []);
+        return null;
+      }) as (id: string) => string | null,
+    });
+
+    const sharedEntry = [...seen.entries()].find(([k]) => k.endsWith("shared.ts"));
+    expect(sharedEntry).toBeDefined();
+    const importers = sharedEntry![1];
+    expect(importers.length).toBe(2);
+    expect(importers.some((p) => p.endsWith("entry.ts"))).toBe(true);
+    expect(importers.some((p) => p.endsWith("other.ts"))).toBe(true);
+  });
+
+  test("meta.getModuleInfo: importedIds — 이 모듈이 import 하는 것", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { a } from "./foo";
+        import { b } from "./bar";
+        console.log(a, b);
+      `,
+      "foo.ts": 'export const a = "FOO";',
+      "bar.ts": 'export const b = "BAR";',
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = new Map<string, string[]>();
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manualChunks: ((id: string, meta: any) => {
+        const info = meta?.getModuleInfo?.(id);
+        if (info) seen.set(id, info.importedIds ?? []);
+        return null;
+      }) as (id: string) => string | null,
+    });
+
+    const entryIds = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
+    expect(entryIds.length).toBe(2);
+    expect(entryIds.some((p) => p.endsWith("foo.ts"))).toBe(true);
+    expect(entryIds.some((p) => p.endsWith("bar.ts"))).toBe(true);
+  });
+
+  test("meta 기반 실용 패턴: shared 모듈만 vendor 로", async () => {
+    // 실전 "importers 수 >= 2 면 shared 로" 패턴 — 자동 청크 분할 규칙 커스터마이즈
+    const fixture = await createFixture({
+      "pageA.ts": `import { s } from "./shared"; import { a } from "./only-a"; console.log(s, a);`,
+      "pageB.ts": `import { s } from "./shared"; import { b } from "./only-b"; console.log(s, b);`,
+      "shared.ts": 'export const s = "SHARED";',
+      "only-a.ts": 'export const a = "A";',
+      "only-b.ts": 'export const b = "B";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "pageA.ts"), join(fixture.dir, "pageB.ts")],
+      splitting: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manualChunks: ((id: string, meta: any) => {
+        const info = meta?.getModuleInfo?.(id);
+        if (info && info.importers && info.importers.length >= 2) return "shared-chunk";
+        return null;
+      }) as (id: string) => string | null,
+    });
+
+    const sharedChunk = result.outputFiles!.find((o) => o.path.includes("shared-chunk"));
+    expect(sharedChunk).toBeDefined();
+    expect(sharedChunk!.moduleIds!.some((id) => id.endsWith("shared.ts"))).toBe(true);
+    // only-a, only-b 는 shared-chunk 에 안 들어감 (importers=1)
+    expect(sharedChunk!.moduleIds!.every((id) => !id.includes("only-"))).toBe(true);
+  });
 });


### PR DESCRIPTION
(재생성 — 원본 #1854 는 base branch 자동 삭제로 close 됨)

## Summary
- Part 1 (#1853 머지됨) 의 Zig 인프라 위에 JS 바인딩
- Rollup `manualChunks(id, meta)` 2-arg 시그니처 완성 — JS 에서 `meta.getModuleInfo(id)` 호출 가능
- 통합 테스트 4개 red → green, 총 10/10

## 후속 (이 PR 포함된 스택)
- #1855 dynamic 양방향 필드
- #1856 inlineDynamicImports A 범위

🤖 Generated with [Claude Code](https://claude.com/claude-code)