### PR TITLE
feat(bundler): manualChunks meta 에 dynamicImporters / dynamicallyImportedIds 추가

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -203,8 +203,14 @@ export type { OutputFile, Diagnostic };
 export interface ManualChunksModuleInfo {
   id: string;
   isEntry: boolean;
+  /** 이 모듈을 static import 하는 모듈들. */
   importers: string[];
+  /** 이 모듈을 dynamic import (`import()`) 하는 모듈들. */
+  dynamicImporters: string[];
+  /** 이 모듈이 static import 하는 모듈들. */
   importedIds: string[];
+  /** 이 모듈이 dynamic import (`import()`) 하는 모듈들. */
+  dynamicallyImportedIds: string[];
 }
 
 /** `manualChunks` 콜백의 두 번째 인자 — 모듈 그래프 토폴로지 조회. */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1049,7 +1049,9 @@ const NapiManualChunksResolver = struct {
         _ = c.napi_set_named_property(env, js_obj, "isEntry", js_is_entry);
 
         _ = c.napi_set_named_property(env, js_obj, "importers", pathArrayFromIndices(env, graph, mod_info.importers));
+        _ = c.napi_set_named_property(env, js_obj, "dynamicImporters", pathArrayFromIndices(env, graph, mod_info.dynamic_importers));
         _ = c.napi_set_named_property(env, js_obj, "importedIds", pathArrayFromIndices(env, graph, mod_info.imported_ids));
+        _ = c.napi_set_named_property(env, js_obj, "dynamicallyImportedIds", pathArrayFromIndices(env, graph, mod_info.dynamically_imported_ids));
 
         return js_obj;
     }

--- a/src/bundler/bundler_test/manual_chunks.zig
+++ b/src/bundler/bundler_test/manual_chunks.zig
@@ -566,10 +566,12 @@ const MetaSeen = struct {
         is_entry: bool,
         importer_count: usize,
         imported_count: usize,
+        dynamic_importer_count: usize,
+        dynamically_imported_count: usize,
     }) = .empty,
     allocator: std.mem.Allocator,
 
-    // ModuleInfo.id / importers / imported_ids 는 graph 수명 동안 borrowed.
+    // ModuleInfo slice 들은 graph 수명 동안 borrowed.
     // bundle() 리턴 시 graph 가 deinit 되므로, 테스트에서는 record 시점에 dupe 해서 보관.
     fn record(self: *MetaSeen, info: types.ModuleInfo) !void {
         const owned_id = try self.allocator.dupe(u8, info.id);
@@ -579,6 +581,8 @@ const MetaSeen = struct {
             .is_entry = info.is_entry,
             .importer_count = info.importers.len,
             .imported_count = info.imported_ids.len,
+            .dynamic_importer_count = info.dynamic_importers.len,
+            .dynamically_imported_count = info.dynamically_imported_ids.len,
         });
     }
 
@@ -744,4 +748,68 @@ test "manualChunks meta.getModuleInfo: 다중 엔트리 + shared 모듈 토폴�
     try std.testing.expect(a_seen);
     try std.testing.expect(b_seen);
     try std.testing.expect(shared_seen);
+}
+
+// dynamic entry 모듈은 resolver 가 건너뛰므로 (chunk.zig policy),
+// dyn-dep 의 역방향 정보는 entry resolver 안에서 직접 graph 조회로 검증.
+const DynamicMetaProbe = struct {
+    // entry 에서 직접 조회할 dyn-dep 경로
+    dyn_dep_path: []const u8,
+    // entry resolver 호출 시점에 dyn-dep 의 dynamic_importers 길이 기록
+    dyn_dep_dynamic_importer_count: ?usize = null,
+    dyn_dep_static_importer_count: ?usize = null,
+};
+
+fn resolverDynamicProbe(ctx: ?*anyopaque, id: []const u8, graph: ?*const anyopaque) ?[]const u8 {
+    const probe: *DynamicMetaProbe = @ptrCast(@alignCast(ctx.?));
+    if (std.mem.endsWith(u8, id, "entry.ts")) {
+        if (types.getModuleInfo(graph, probe.dyn_dep_path)) |info| {
+            probe.dyn_dep_dynamic_importer_count = info.dynamic_importers.len;
+            probe.dyn_dep_static_importer_count = info.importers.len;
+        }
+    }
+    return null;
+}
+
+test "manualChunks meta.getModuleInfo: dynamic import 는 static importers/importedIds 에 안 잡히고 dynamic 쪽으로" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { s } from "./static-dep";
+        \\export async function load() { return (await import("./dyn-dep")).default; }
+        \\console.log(s);
+    );
+    try writeFile(tmp.dir, "static-dep.ts", "export const s = 1;");
+    try writeFile(tmp.dir, "dyn-dep.ts", "export default 42;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const dyn_dep = try absPath(&tmp, "dyn-dep.ts");
+    defer std.testing.allocator.free(dyn_dep);
+
+    // 1차 — MetaSeen 으로 entry / static-dep 측 assertion.
+    var seen = MetaSeen{ .allocator = std.testing.allocator };
+    defer seen.deinit();
+
+    // 같은 resolver 가 MetaSeen 과 DynamicMetaProbe 둘 다 만질 순 없으니
+    // ctx 에 probe 만 넘기고 MetaSeen 기록은 여기서 포기. 정적 쪽은
+    // 기존 "isEntry / importers" 테스트가 이미 커버.
+    var probe = DynamicMetaProbe{ .dyn_dep_path = dyn_dep };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .manual_chunks_resolver = resolverDynamicProbe,
+        .manual_chunks_ctx = &probe,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    // entry resolver 가 호출됐고 dyn-dep 를 찾을 수 있었다면 각 값 set.
+    try std.testing.expect(probe.dyn_dep_dynamic_importer_count != null);
+    try std.testing.expectEqual(@as(usize, 1), probe.dyn_dep_dynamic_importer_count.?);
+    try std.testing.expectEqual(@as(usize, 0), probe.dyn_dep_static_importer_count.?);
 }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -673,6 +673,15 @@ pub const ModuleGraph = struct {
         try to_mod.importers.append(self.allocator, from);
     }
 
+    /// 양방향 dynamic import 등록. `linkDependency` 의 dynamic 버전.
+    pub fn linkDynamicImport(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
+        if (to.isNone()) return;
+        const from_mod = self.moduleAtMut(from) orelse return;
+        const to_mod = self.moduleAtMut(to) orelse return;
+        try from_mod.dynamic_imports.append(self.allocator, to);
+        try to_mod.dynamic_importers.append(self.allocator, from);
+    }
+
     /// context_expansion_deps 를 resolve 하고 graph 에 module + dependency 로 등록 (#1579 Phase 4).
     /// scanModules receiver / resolveModuleImports 양쪽 경로에서 호출. SegmentedList 로
     /// append 해도 기존 *Module 포인터는 유효 (#1779 INVARIANTS.md).
@@ -733,7 +742,7 @@ pub const ModuleGraph = struct {
                 const src_mod = self.modules.at(mod_idx);
                 src_mod.import_records[rec_i].resolved = dep_idx;
                 if (record.kind == .dynamic_import) {
-                    try src_mod.addDynamicImport(self.allocator, dep_idx);
+                    try self.linkDynamicImport(mod_index, dep_idx);
                 } else {
                     try self.linkDependency(mod_index, dep_idx);
                 }
@@ -763,7 +772,7 @@ pub const ModuleGraph = struct {
                 const src_mod = self.modules.at(mod_idx);
                 src_mod.import_records[rec_i].resolved = dep_idx;
                 if (record.kind == .dynamic_import) {
-                    try src_mod.addDynamicImport(self.allocator, dep_idx);
+                    try self.linkDynamicImport(mod_index, dep_idx);
                 } else {
                     try self.linkDependency(mod_index, dep_idx);
                 }
@@ -780,7 +789,7 @@ pub const ModuleGraph = struct {
             src_mod.import_records[rec_i].resolved = dep_idx;
 
             if (record.kind == .dynamic_import) {
-                try src_mod.addDynamicImport(self.allocator, dep_idx);
+                try self.linkDynamicImport(mod_index, dep_idx);
             } else {
                 try self.linkDependency(mod_index, dep_idx);
             }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -117,6 +117,8 @@ pub const Module = struct {
     importers: std.ArrayList(ModuleIndex),
     /// 동적 import (별도 관리, code splitting용)
     dynamic_imports: std.ArrayList(ModuleIndex),
+    /// 나를 dynamic import 하는 모듈들 (역방향). `ModuleGraph.linkDynamicImport` 가 채움.
+    dynamic_importers: std.ArrayList(ModuleIndex),
 
     module_type: ModuleType,
     /// 모듈의 로딩 방식 (file/dataurl/text/binary/copy 등).
@@ -321,6 +323,7 @@ pub const Module = struct {
             .dependencies = .empty,
             .importers = .empty,
             .dynamic_imports = .empty,
+            .dynamic_importers = .empty,
             .module_type = .unknown,
             .side_effects = true,
             .exec_index = std.math.maxInt(u32),
@@ -347,6 +350,7 @@ pub const Module = struct {
         self.dependencies.deinit(allocator);
         self.importers.deinit(allocator);
         self.dynamic_imports.deinit(allocator);
+        self.dynamic_importers.deinit(allocator);
         if (self.alias_table) |*t| t.deinit();
         // require.context: plugin 이 채운 outer slice + 각 inner string free (#1579 Phase 2).
         // contract: plugin 이 allocator 로 dupe 한 상태로 반환 → graph 가 일괄 해제.

--- a/src/bundler/phase.zig
+++ b/src/bundler/phase.zig
@@ -225,8 +225,7 @@ pub const ResolveAccessor = struct {
     }
 
     pub fn appendDynamicImport(self: ResolveAccessor, idx: ModuleIndex, dep: ModuleIndex) !void {
-        const m = self.graph.moduleAtMut(idx) orelse return;
-        try m.addDynamicImport(self.graph.allocator, dep);
+        try self.graph.linkDynamicImport(idx, dep);
     }
 
     /// alias_table lazy 초기화 (existing Module.ensureAliasTable wrapper).

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -120,12 +120,13 @@ pub const ManualChunksResolveFn = *const fn (
 
 /// Rollup `manualChunks(id, meta)` 의 `meta.getModuleInfo(id)` 반환 타입.
 /// 모든 slice 는 graph 수명 동안 borrowed — 추가 alloc/free 없음.
-/// NAPI 레이어는 `importers` / `imported_ids` 의 ModuleIndex 를
-/// `getModulePathByIndex` 로 순회해 JS string 배열을 직접 만든다.
+/// NAPI 레이어는 ModuleIndex 배열을 `getModulePathByIndex` 로 순회해 JS string 배열을 만든다.
 pub const ModuleInfo = struct {
     id: []const u8,
     importers: []const ModuleIndex,
+    dynamic_importers: []const ModuleIndex,
     imported_ids: []const ModuleIndex,
+    dynamically_imported_ids: []const ModuleIndex,
     is_entry: bool,
 };
 
@@ -137,7 +138,9 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
     return .{
         .id = m.path,
         .importers = m.importers.items,
+        .dynamic_importers = m.dynamic_importers.items,
         .imported_ids = m.dependencies.items,
+        .dynamically_imported_ids = m.dynamic_imports.items,
         .is_entry = m.is_entry_point,
     };
 }

--- a/tests/integration/tests/manual-chunks-smoke.test.ts
+++ b/tests/integration/tests/manual-chunks-smoke.test.ts
@@ -989,4 +989,155 @@ describe("manualChunks smoke (실제 번들 실행)", () => {
     // 실행 가능한 번들이어야 함 (빈 entry chunk 문제 없음)
     expect(entryChunk!.text).toContain("ENTRY_MARKER");
   });
+
+  // ============================================================
+  // meta.getModuleInfo dynamic fields 스모크 — 실전 lazy-load 패턴
+  // ============================================================
+
+  test("lazy-route 패턴: entry.dynamicallyImportedIds 가 route 모듈들 정확히 추적", async () => {
+    // React.lazy 스타일 — 각 라우트를 lazy load
+    const fixture = await createFixture({
+      "shared/logger.ts": `export const log = (m: string) => console.log("[log]", m);`,
+      "routes/home.ts": `
+        import { log } from "../shared/logger";
+        export default function Home() { log("home"); }
+      `,
+      "routes/about.ts": `
+        import { log } from "../shared/logger";
+        export default function About() { log("about"); }
+      `,
+      "entry.ts": `
+        import { log } from "./shared/logger";
+        async function route(name: string) {
+          if (name === "home") return (await import("./routes/home")).default;
+          if (name === "about") return (await import("./routes/about")).default;
+          throw new Error("unknown");
+        }
+        log("boot");
+        route("home").then((f) => (f as () => void)());
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const routeIds: string[] = [];
+    const staticIds: string[] = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+      manualChunks: (id, meta) => {
+        if (!id.endsWith("entry.ts")) return null;
+        const info = meta.getModuleInfo(id);
+        if (info) {
+          routeIds.push(...info.dynamicallyImportedIds);
+          staticIds.push(...info.importedIds);
+        }
+        return null;
+      },
+    });
+
+    // dynamicallyImportedIds 에는 두 라우트가 들어가고, importedIds 에는 안 들어감
+    expect(routeIds.some((p) => p.endsWith("home.ts"))).toBe(true);
+    expect(routeIds.some((p) => p.endsWith("about.ts"))).toBe(true);
+    expect(staticIds.some((p) => p.endsWith("home.ts"))).toBe(false);
+    expect(staticIds.some((p) => p.endsWith("about.ts"))).toBe(false);
+    // 반대로 logger 는 static 에만
+    expect(staticIds.some((p) => p.endsWith("logger.ts"))).toBe(true);
+    expect(routeIds.some((p) => p.endsWith("logger.ts"))).toBe(false);
+  });
+
+  test("같은 모듈을 한쪽은 static 다른쪽은 dynamic 으로 import — importers 와 dynamicImporters 분리", async () => {
+    // pageA 는 static, pageB 는 dynamic 으로 shared 를 참조
+    const fixture = await createFixture({
+      "shared.ts": `export const v = "SHARED";`,
+      "pageA.ts": `import { v } from "./shared"; console.log("A:" + v);`,
+      "pageB.ts": `
+        async function boot() {
+          const m = await import("./shared");
+          console.log("B:" + m.v);
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    // shared 는 pageB 에서 dynamic 이기도 해서 dynamic-entry 로 분류 → resolver skip.
+    // 그래서 pageA resolver 안에서 shared 경로를 정확히 얻어 직접 lookup.
+    const diag: Array<{ staticImporters: string[]; dynamicImporters: string[] }> = [];
+    await build({
+      entryPoints: [join(fixture.dir, "pageA.ts"), join(fixture.dir, "pageB.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+      manualChunks: (id, meta) => {
+        if (!id.endsWith("pageA.ts")) return null;
+        const pageInfo = meta.getModuleInfo(id);
+        if (!pageInfo) return null;
+        const sharedPath = pageInfo.importedIds.find((p) => p.endsWith("shared.ts"));
+        if (!sharedPath) return null;
+        const info = meta.getModuleInfo(sharedPath);
+        if (info) {
+          diag.push({ staticImporters: info.importers, dynamicImporters: info.dynamicImporters });
+        }
+        return null;
+      },
+    });
+
+    expect(diag.length).toBe(1);
+    const seen = diag[0];
+    expect(seen.staticImporters.some((p) => p.endsWith("pageA.ts"))).toBe(true);
+    expect(seen.dynamicImporters.some((p) => p.endsWith("pageB.ts"))).toBe(true);
+    // cross-pollution 없어야 함
+    expect(seen.staticImporters.some((p) => p.endsWith("pageB.ts"))).toBe(false);
+    expect(seen.dynamicImporters.some((p) => p.endsWith("pageA.ts"))).toBe(false);
+  });
+
+  test("실전 분류: dynamicImporters 기반 분류 규칙으로 shared-lazy chunk 분리", async () => {
+    // 두 라우트가 공통으로 lazy load 하는 util → "shared-lazy" 청크로 추출
+    const fixture = await createFixture({
+      "util/common.ts": `export const commonOp = () => "COMMON_OP";`,
+      "routes/a.ts": `
+        import { commonOp } from "../util/common";
+        export default () => console.log("A:" + commonOp());
+      `,
+      "routes/b.ts": `
+        import { commonOp } from "../util/common";
+        export default () => console.log("B:" + commonOp());
+      `,
+      "entry.ts": `
+        async function pick(n: "a" | "b") {
+          if (n === "a") return (await import("./routes/a")).default;
+          return (await import("./routes/b")).default;
+        }
+        pick("a").then((f) => f());
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      outdir: join(fixture.dir, "dist"),
+      write: false,
+      // util/common 은 dynamic 루트에서만 접근되므로 importers = 0 but dynamic 후손으로 연결됨.
+      // 명시적 manual 분류로 shared-lazy 청크 분리.
+      manualChunks: (id) => {
+        if (id.includes("/util/")) return "shared-lazy";
+        return null;
+      },
+    });
+
+    const sharedLazyChunk = result.outputFiles.find((o) => o.path.includes("shared-lazy"));
+    expect(sharedLazyChunk).toBeDefined();
+    expect(sharedLazyChunk!.text).toContain("COMMON_OP");
+    // 라우트 청크들에는 COMMON_OP 구현 자체가 들어가지 않고 shared-lazy 를 import
+    const routeAChunk = result.outputFiles.find(
+      (o) =>
+        o.path.includes("a.ts") || (o.moduleIds && o.moduleIds.some((m) => m.endsWith("a.ts"))),
+    );
+    if (routeAChunk) {
+      expect(routeAChunk.moduleIds!.some((m) => m.endsWith("common.ts"))).toBe(false);
+    }
+  });
 });

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -452,4 +452,67 @@ describe("manualChunks NAPI bridge", () => {
     expect(all).toContain("B_MARK");
     expect(all).toContain("C_MARK");
   });
+
+  test("meta.getModuleInfo: entry.dynamicallyImportedIds — entry 가 dynamic 으로 import 하는 것", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { s } from "./static-dep";
+        export async function load() { return (await import("./dyn-dep")).default; }
+        console.log(s);
+      `,
+      "static-dep.ts": "export const s = 1;",
+      "dyn-dep.ts": "export default 42;",
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => ({
+      imported: info.importedIds,
+      dyn: info.dynamicallyImportedIds,
+    }));
+    const entry = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
+    expect(entry.imported.some((p) => p.endsWith("static-dep.ts"))).toBe(true);
+    expect(entry.imported.some((p) => p.endsWith("dyn-dep.ts"))).toBe(false);
+    expect(entry.dyn.some((p) => p.endsWith("dyn-dep.ts"))).toBe(true);
+    expect(entry.dyn.some((p) => p.endsWith("static-dep.ts"))).toBe(false);
+  });
+
+  test("meta.getModuleInfo: dynamic-dep.dynamicImporters — 누가 dynamic 으로 import 하는가", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function main() {
+          const m = await import("./dyn-dep");
+          console.log(m.default);
+        }
+        main();
+      `,
+      "dyn-dep.ts": 'export default "DYN_VALUE";',
+    });
+    cleanup = fixture.cleanup;
+
+    // dyn-dep 은 resolver 호출에서 제외되는 dynamic entry 라 직접 조회가 안 된다.
+    // 대신 entry resolver 안에서 entry.dynamicallyImportedIds 로 dyn-dep 의 실제 저장 경로를
+    // 받아 그대로 조회 (macOS /private prefix 같은 경로 정규화 이슈 회피).
+    const results: Array<{ importers: string[]; dynamicImporters: string[] }> = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (!id.endsWith("entry.ts")) return null;
+        const entryInfo = meta.getModuleInfo(id);
+        if (!entryInfo) return null;
+        const dynPath = entryInfo.dynamicallyImportedIds.find((p) => p.endsWith("dyn-dep.ts"));
+        if (!dynPath) return null;
+        const info = meta.getModuleInfo(dynPath);
+        if (info) {
+          results.push({ importers: info.importers, dynamicImporters: info.dynamicImporters });
+        }
+        return null;
+      },
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0].importers.length).toBe(0);
+    expect(results[0].dynamicImporters.length).toBe(1);
+    expect(results[0].dynamicImporters[0].endsWith("entry.ts")).toBe(true);
+  });
 });


### PR DESCRIPTION
(재생성 — 원본 #1855 는 base branch 자동 삭제로 close)

## Summary
- Rollup `ModuleInfo` 호환 — `meta.getModuleInfo(id)` 반환에 dynamic import 양방향 필드 추가
- `dynamicImporters` / `dynamicallyImportedIds` 2필드
- `ModuleGraph.linkDynamicImport` — `linkDependency` 대칭형 양방향 등록
- zero-alloc slice borrow 유지

## 테스트
- Zig 유닛 +1 / integration +2 / smoke +3

🤖 Generated with [Claude Code](https://claude.com/claude-code)