### PR TITLE
feat(bundler): inlineDynamicImports — chunk 구조 부분 구현 (A 범위)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -232,6 +232,13 @@ interface BuildOptionsCommon {
   minifyIdentifiers?: boolean;
   minifySyntax?: boolean;
   splitting?: boolean;
+  /** Rollup `output.inlineDynamicImports` — dynamic import target 을 별도 async chunk 로
+   * 분리하지 않고 importer 의 chunk 에 포함. `splitting: true` 와 조합해야 의미 있음.
+   *
+   * 주의: 이 플래그의 구조 부분만 구현 — async chunk 는 사라지지만 런타임 `import()`
+   * 호출은 원본 specifier 를 유지. 완전한 런타임 re-entry 는 후속 작업.
+   */
+  inlineDynamicImports?: boolean;
   sourcemap?: boolean;
   sourcemapDebugIds?: boolean;
   sourcesContent?: boolean;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3124,6 +3124,7 @@ fn parseBuildOptions(
         .minify_identifiers = if (minify) true else getObjectBool(env, opts_obj, "minifyIdentifiers", false),
         .minify_syntax = if (minify) true else getObjectBool(env, opts_obj, "minifySyntax", false),
         .code_splitting = getObjectBool(env, opts_obj, "splitting", false),
+        .inline_dynamic_imports = getObjectBool(env, opts_obj, "inlineDynamicImports", false),
         .sourcemap = .{
             .enable = getObjectBool(env, opts_obj, "sourcemap", false),
             .debug_ids = getObjectBool(env, opts_obj, "sourcemapDebugIds", false),

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -72,6 +72,12 @@ pub const BundleOptions = struct {
     /// code splitting 활성화. true이면 dynamic import 경계에서 청크를 분리하고
     /// 공유 모듈을 공통 청크로 추출한다. 결과는 BundleResult.outputs에 다중 파일로 반환.
     code_splitting: bool = false,
+    /// Rollup `output.inlineDynamicImports` — **chunk 구조만 구현**.
+    /// true 이면 dynamic import target 이 별도 async chunk 로 분리되지 않고 importer 의
+    /// chunk (entry 또는 manual) 에 흡수된다. `code_splitting=true` 와 조합해야 의미 있음.
+    /// 런타임 `import()` 호출은 same-chunk 여도 원본 specifier 를 유지하며, 모듈 registry
+    /// 기반 re-entry 는 아직 미구현 — 번들 출력을 Node/브라우저로 바로 실행하려면 후속 PR 필요.
+    inline_dynamic_imports: bool = false,
     /// 사용자 정의 청크 분할 (Rollup `manualChunks` 호환 Phase 1 / #1027).
     /// code_splitting=true 일 때만 동작. 매칭된 모듈은 pseudo-entry 로 BFS 에 참여
     /// → transitive dependency 도 같은 청크로, dynamic import target 도 manual 우선.
@@ -985,6 +991,7 @@ pub const Bundler = struct {
                     self.options.manual_chunks,
                     self.options.manual_chunks_resolver,
                     self.options.manual_chunks_ctx,
+                    self.options.inline_dynamic_imports,
                 );
             defer chunk_graph.deinit();
 

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -361,6 +361,10 @@ pub fn generateChunks(
     manual_chunks: []const types.ManualChunkEntry,
     manual_resolver: ?types.ManualChunksResolveFn,
     manual_resolver_ctx: ?*anyopaque,
+    /// true 이면 dynamic import target 을 별도 chunk 로 분리하지 않고 importer 와 같은
+    /// chunk 에 포함. Rollup `output.inlineDynamicImports` 의 구조 부분만 구현 (A 범위).
+    /// 런타임 `import()` rewriting 은 후속 PR.
+    inline_dynamic_imports: bool,
 ) !ChunkGraph {
     const module_count = graph.moduleCount();
 
@@ -389,10 +393,12 @@ pub fn generateChunks(
 
     // Phase 1b: dynamic import 대상 — 이미 유저 엔트리인 모듈은 스킵.
     // dynamic import 대상은 별도의 청크 경계를 형성한다 (code splitting의 핵심).
+    // `inline_dynamic_imports` 가 true 면 이 단계 전체를 skip → dynamic target 이
+    // 별도 chunk 로 나뉘지 않고 Phase 2 BFS 에서 importer 와 같은 chunk 로 흡수.
     var dynamic_seen: std.AutoHashMap(u32, void) = .init(allocator);
     defer dynamic_seen.deinit();
 
-    {
+    if (!inline_dynamic_imports) {
         var it = graph.modulesIterator();
         while (it.next()) |m| {
             for (m.dynamic_imports.items) |dyn_idx| {
@@ -575,11 +581,21 @@ pub fn generateChunks(
             if (splitting_info[mi].hasBit(@intCast(bit_idx))) continue;
             splitting_info[mi].setBit(@intCast(bit_idx));
 
-            // 정적 의존성만 따라감 — dynamic import는 별도 엔트리이므로 BFS 경계
+            // 정적 의존성 + (inline_dynamic_imports 일 때) dynamic edge 도 따라감.
+            // 후자는 dynamic target 이 별도 entry 가 아니기 때문에 importer 경로로
+            // 흡수시키기 위함.
             for (m.dependencies.items) |dep_idx| {
                 const dep_i = @intFromEnum(dep_idx);
                 if (dep_i < module_count and !splitting_info[dep_i].hasBit(@intCast(bit_idx))) {
                     try queue.append(allocator, dep_idx);
+                }
+            }
+            if (inline_dynamic_imports) {
+                for (m.dynamic_imports.items) |dep_idx| {
+                    const dep_i = @intFromEnum(dep_idx);
+                    if (dep_i < module_count and !splitting_info[dep_i].hasBit(@intCast(bit_idx))) {
+                        try queue.append(allocator, dep_idx);
+                    }
                 }
             }
         }
@@ -623,6 +639,14 @@ pub fn generateChunks(
                     const dep_i = @intFromEnum(dep_idx);
                     if (dep_i < module_count and !splitting_info[dep_i].hasBit(manual_bit)) {
                         try queue.append(allocator, dep_idx);
+                    }
+                }
+                if (inline_dynamic_imports) {
+                    for (m.dynamic_imports.items) |dep_idx| {
+                        const dep_i = @intFromEnum(dep_idx);
+                        if (dep_i < module_count and !splitting_info[dep_i].hasBit(manual_bit)) {
+                            try queue.append(allocator, dep_idx);
+                        }
                     }
                 }
             }

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -445,7 +445,7 @@ test "generateChunks: single entry, no dynamic imports" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 엔트리 청크 1개
@@ -482,7 +482,7 @@ test "generateChunks: dynamic import creates separate chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 엔트리 청크 1개 + dynamic 청크 1개 = 2개
@@ -523,7 +523,7 @@ test "generateChunks: shared module creates common chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 엔트리 2개 + 공통 1개 = 3개
@@ -564,7 +564,7 @@ test "generateChunks: diamond dependency" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // D가 양쪽 엔트리에서 도달 가능 → 공통 청크 생성
@@ -592,7 +592,7 @@ test "generateChunks: no modules" {
     var tg = try TestGraph.init(alloc, &empty_modules);
     defer tg.deinit(alloc);
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), cg.chunkCount());
@@ -617,7 +617,7 @@ test "generateChunks: circular dependency stays in same chunk" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 1 엔트리 청크, 모든 모듈 포함
@@ -643,7 +643,7 @@ test "generateChunks: static + dynamic import same module" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
     try tg.graph.modules.at(0).addDynamicImport(alloc, @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // b.ts는 엔트리 청크에 포함 (static이 우선)
@@ -672,7 +672,7 @@ test "generateChunks: three entries sharing a module" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(3));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 3 엔트리 + 1 공통 = 4 청크
@@ -702,7 +702,7 @@ test "generateChunks: entry imports another entry statically" {
 
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 2개 엔트리 청크 생성
@@ -731,7 +731,7 @@ test "generateChunks: deep chain with dynamic import at middle" {
     try tg.graph.modules.at(1).addDynamicImport(alloc, @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // 2개 청크: a엔트리(a,b), c엔트리(c,d)
@@ -982,7 +982,7 @@ test "generateChunks: entry module reassignment removes from old chunk" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     // c.ts는 엔트리 청크에 있어야 함 (공통 청크 아님)
@@ -997,4 +997,96 @@ test "generateChunks: entry module reassignment removes from old chunk" {
         }
     }
     try std.testing.expectEqual(@as(u32, 1), count);
+}
+
+test "generateChunks: inline_dynamic_imports=false — dynamic target 은 별도 chunk" {
+    const alloc = std.testing.allocator;
+    var modules: [2]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "lazy.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
+
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, false);
+    defer cg.deinit();
+
+    // 기본 정책 — lazy 는 entry 와 다른 chunk 에 배정
+    const entry_chunk = cg.getModuleChunk(@enumFromInt(0));
+    const lazy_chunk = cg.getModuleChunk(@enumFromInt(1));
+    try std.testing.expect(!entry_chunk.isNone());
+    try std.testing.expect(!lazy_chunk.isNone());
+    try std.testing.expect(entry_chunk != lazy_chunk);
+}
+
+test "generateChunks: inline_dynamic_imports=true — dynamic target 이 entry chunk 에 흡수" {
+    const alloc = std.testing.allocator;
+    var modules: [2]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "lazy.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
+
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, true);
+    defer cg.deinit();
+
+    // inline 정책 — lazy 가 entry chunk 로 흡수. 전체 청크 1개.
+    try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);
+    const entry_chunk = cg.getModuleChunk(@enumFromInt(0));
+    const lazy_chunk = cg.getModuleChunk(@enumFromInt(1));
+    try std.testing.expect(entry_chunk == lazy_chunk);
+}
+
+test "generateChunks: inline_dynamic_imports + manual_chunks — manual seed 의 dynamic dep 도 manual chunk 로" {
+    // Phase 2.5 manual BFS 가 inline 모드에서 dynamic edge 를 따라가야 한다 (/simplify 후속).
+    const alloc = std.testing.allocator;
+    var modules: [3]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "vendor-root.ts"),
+        makeTestModule(alloc, 2, "vendor-lazy.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    // entry → vendor-root (static), vendor-root → vendor-lazy (dynamic)
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
+    try tg.graph.linkDynamicImport(@enumFromInt(1), @enumFromInt(2));
+
+    const manual_entries = [_]types.ManualChunkEntry{.{ .name = "vendor", .patterns = &.{"vendor-"} }};
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &manual_entries, null, null, true);
+    defer cg.deinit();
+
+    // vendor-root 은 manual 매칭, vendor-lazy 는 vendor-root 의 dynamic dep.
+    // inline + manual BFS 확장으로 vendor-lazy 도 vendor chunk 로.
+    const vendor_chunk = cg.getModuleChunk(@enumFromInt(1));
+    try std.testing.expect(!vendor_chunk.isNone());
+    try std.testing.expect(cg.getModuleChunk(@enumFromInt(2)) == vendor_chunk);
+}
+
+test "generateChunks: inline_dynamic_imports — dynamic target 의 transitive static dep 도 흡수" {
+    const alloc = std.testing.allocator;
+    var modules: [3]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "lazy.ts"),
+        makeTestModule(alloc, 2, "util.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    // entry → lazy (dynamic) → util (static)
+    try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
+    try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(2));
+
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, true);
+    defer cg.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);
+    const entry_chunk = cg.getModuleChunk(@enumFromInt(0));
+    try std.testing.expect(cg.getModuleChunk(@enumFromInt(1)) == entry_chunk);
+    try std.testing.expect(cg.getModuleChunk(@enumFromInt(2)) == entry_chunk);
 }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -610,12 +610,18 @@ fn rewriteDynamicImports(
     var result = try allocator.dupe(u8, code);
     errdefer allocator.free(result);
 
+    const source_chunk_idx = chunk_graph.getModuleChunk(module.index);
+
     for (module.import_records) |rec| {
         if (rec.kind != .dynamic_import) continue;
         if (rec.resolved == .none) continue;
 
         const target_chunk_idx = chunk_graph.getModuleChunk(rec.resolved);
         if (target_chunk_idx == .none) continue;
+
+        // target 이 같은 chunk 에 있으면 specifier 그대로 둔다 (inline_dynamic_imports
+        // 또는 우연한 same-chunk 케이스). 런타임에서 original path 로 해석되도록 위임.
+        if (source_chunk_idx != .none and target_chunk_idx == source_chunk_idx) continue;
 
         const target_chunk = chunk_graph.getChunk(target_chunk_idx);
 

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -370,7 +370,7 @@ test "inline (bundle): shared module 내부 inline — emitChunks 경로" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -429,7 +429,7 @@ test "emitChunks: single chunk produces one OutputFile" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -463,7 +463,7 @@ test "emitChunks: two entries with shared module — 3 OutputFiles" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -511,7 +511,7 @@ test "CodeSplitting: dynamic import path rewritten to chunk filename" {
     const lazy_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "lazy.ts" });
     defer std.testing.allocator.free(lazy_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -569,7 +569,7 @@ test "CodeSplitting: multiple dynamic imports rewritten" {
     const pageB_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "pageB.ts" });
     defer std.testing.allocator.free(pageB_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -614,7 +614,7 @@ test "chunkStem: common chunk uses hex hash, not index" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -663,7 +663,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg1.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg1, &result1.graph, std.testing.allocator, null);
 
@@ -680,7 +680,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     defer result2.graph.deinit();
     defer result2.cache.deinit();
 
-    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg2.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg2, &result2.graph, std.testing.allocator, null);
 
@@ -783,7 +783,7 @@ test "naming pattern: entry-names with hash" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{
@@ -823,7 +823,7 @@ test "naming pattern: chunk-names with directory" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -869,7 +869,7 @@ test "content hash: cross-chunk import uses content hash" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -935,7 +935,7 @@ test "CJS runtime: __commonJS only in chunks containing CJS modules" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -969,7 +969,7 @@ test "CodeSplitting: static import not rewritten" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);

--- a/tests/integration/tests/inline-dynamic-imports-smoke.test.ts
+++ b/tests/integration/tests/inline-dynamic-imports-smoke.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { join, resolve } from "node:path";
+import { createFixture, hasPackage } from "./helpers";
+import { init, close, build } from "../../../packages/core/index";
+
+const PROJECT_ROOT = resolve(import.meta.dir, "../../..");
+const ROOT_NODE_MODULES = join(PROJECT_ROOT, "node_modules");
+
+// `inlineDynamicImports` 스모크 — 실전 크기의 fixture + 라이브러리로 구조 검증.
+// 런타임 실행은 A 범위 밖 (후속 PR).
+
+describe("inlineDynamicImports smoke", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("SPA 라우팅 패턴: 여러 route 가 lazy + 공용 util → 단일 chunk 로 압축", async () => {
+    const fixture = await createFixture({
+      "util/logger.ts": `export const log = (t: string) => console.log("[log]", t);`,
+      "util/format.ts": `
+        import { log } from "./logger";
+        export const fmt = (s: string) => { log("fmt"); return s.toUpperCase(); };
+      `,
+      "routes/home.ts": `
+        import { fmt } from "../util/format";
+        export default () => fmt("home");
+      `,
+      "routes/about.ts": `
+        import { fmt } from "../util/format";
+        export default () => fmt("about");
+      `,
+      "routes/contact.ts": `
+        import { fmt } from "../util/format";
+        export default () => fmt("contact");
+      `,
+      "entry.ts": `
+        import { log } from "./util/logger";
+        async function nav(r: string) {
+          if (r === "home") return (await import("./routes/home")).default;
+          if (r === "about") return (await import("./routes/about")).default;
+          return (await import("./routes/contact")).default;
+        }
+        log("boot");
+        nav("home").then((f) => console.log((f as () => string)()));
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    // 모든 라우트 + 공용 util 이 단일 chunk 안에
+    expect(outs.length).toBe(1);
+    const mods = outs[0].moduleIds!;
+    for (const p of ["entry.ts", "home.ts", "about.ts", "contact.ts", "format.ts", "logger.ts"]) {
+      expect(mods.some((m) => m.endsWith(p))).toBe(true);
+    }
+  });
+
+  test("manualChunks + inline: vendor seed 의 dynamic dep 도 vendor chunk 로 (Phase 2.5 확장)", async () => {
+    const fixture = await createFixture({
+      "vendor/root.ts": `
+        export async function loadExtra() {
+          const m = await import("./extra");
+          return m.heavy();
+        }
+      `,
+      "vendor/extra.ts": `
+        export const heavy = () => "HEAVY_MARK";
+      `,
+      "entry.ts": `
+        import { loadExtra } from "./vendor/root";
+        loadExtra().then(console.log);
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      manualChunks: (id) => {
+        if (id.includes("/vendor/")) return "vendor";
+        return null;
+      },
+    });
+
+    const outs = result.outputFiles!;
+    const vendorChunk = outs.find((o) => o.path.includes("vendor"));
+    expect(vendorChunk).toBeDefined();
+    const vendorMods = vendorChunk!.moduleIds!;
+    // vendor/root + vendor/extra 모두 vendor chunk 에 (extra 가 dynamic 이어도)
+    expect(vendorMods.some((m) => m.endsWith("root.ts"))).toBe(true);
+    expect(vendorMods.some((m) => m.endsWith("extra.ts"))).toBe(true);
+    // entry chunk 에는 vendor 모듈 없음
+    const entryChunk = outs.find((o) => o.moduleIds?.some((m) => m.endsWith("entry.ts")))!;
+    expect(entryChunk.moduleIds!.some((m) => m.includes("/vendor/"))).toBe(false);
+  });
+
+  test("동일 모듈을 static + dynamic 둘 다로 import — inline 에서 중복 없이 entry chunk 에 한 번만", async () => {
+    const fixture = await createFixture({
+      "shared.ts": 'export const v = "SHARED_MARK";',
+      "entry.ts": `
+        import { v as staticV } from "./shared";
+        async function boot() {
+          const m = await import("./shared");
+          console.log(staticV + "|" + m.v);
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(1);
+    const mods = outs[0].moduleIds!;
+    // shared 가 moduleIds 에 단 한 번
+    const sharedCount = mods.filter((m) => m.endsWith("shared.ts")).length;
+    expect(sharedCount).toBe(1);
+    // SHARED_MARK 는 한 번만 emit
+    const occurrences = outs[0].text.split("SHARED_MARK").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  test("중첩 dynamic import (A dyn→ B dyn→ C) 도 하나의 chunk 로 평탄화", async () => {
+    const fixture = await createFixture({
+      "c.ts": 'export const c = "C_MARK";',
+      "b.ts": `
+        export async function run() {
+          const m = await import("./c");
+          return "B:" + m.c;
+        }
+      `,
+      "entry.ts": `
+        async function boot() {
+          const m = await import("./b");
+          console.log(await m.run());
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(1);
+    const mods = outs[0].moduleIds!;
+    expect(mods.some((m) => m.endsWith("entry.ts"))).toBe(true);
+    expect(mods.some((m) => m.endsWith("b.ts"))).toBe(true);
+    expect(mods.some((m) => m.endsWith("c.ts"))).toBe(true);
+    expect(outs[0].text).toContain("C_MARK");
+  });
+
+  test("splitting=false 에서 플래그는 무시 — 단일 파일 기본 동작 유지", async () => {
+    // splitting 없으면 어차피 단일 파일. 플래그 자체가 no-op.
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("./lazy"); console.log(m.v); }
+        boot();
+      `,
+      "lazy.ts": 'export const v = "LAZY_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: false,
+      inlineDynamicImports: true,
+    });
+
+    // splitting 없을 땐 outputFiles 가 undefined 이거나 단일
+    const outs = result.outputFiles ?? [];
+    // 크래시 없고 결과가 나오면 성공 — 실제 출력 형태는 splitting=false 경로에 종속
+    expect(outs.length >= 0).toBe(true);
+  });
+
+  test.skipIf(!hasPackage("clsx"))(
+    "실 라이브러리: clsx 를 dynamic 으로만 import 해도 inline 모드에서 entry chunk 에",
+    async () => {
+      const fixture = await createFixture({
+        "entry.ts": `
+          async function boot() {
+            const { clsx } = await import("clsx");
+            console.log(clsx("a", { b: true }));
+          }
+          boot();
+        `,
+      });
+      cleanup = fixture.cleanup;
+
+      const result = await build({
+        entryPoints: [join(fixture.dir, "entry.ts")],
+        splitting: true,
+        inlineDynamicImports: true,
+        nodePaths: [ROOT_NODE_MODULES],
+      });
+
+      const outs = result.outputFiles!;
+      expect(outs.length).toBe(1);
+      // clsx 구현이 entry chunk 안에 인라인
+      expect(outs[0].moduleIds!.some((m) => m.includes("clsx"))).toBe(true);
+    },
+  );
+});

--- a/tests/integration/tests/inline-dynamic-imports.test.ts
+++ b/tests/integration/tests/inline-dynamic-imports.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { join } from "node:path";
+import { createFixture } from "./helpers";
+import { init, close, build } from "../../../packages/core/index";
+
+// `inlineDynamicImports` 구조 검증 — dynamic import target 이 별도 async chunk 로
+// 분리되지 않고 importer 의 chunk 에 포함되는지. 런타임 실행은 후속 PR 에서 다룸.
+
+describe("inlineDynamicImports (structural)", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("기본 (false): dynamic target 이 별도 async chunk 로", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("./lazy"); console.log(m.v); }
+        boot();
+      `,
+      "lazy.ts": 'export const v = "LAZY_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+    });
+
+    // 2개 chunk: entry + lazy
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(2);
+    const lazyChunk = outs.find((o) => o.text.includes("LAZY_MARK"))!;
+    const entryChunk = outs.find((o) => o.moduleIds?.some((m) => m.endsWith("entry.ts")))!;
+    expect(lazyChunk.path).not.toBe(entryChunk.path);
+    expect(entryChunk.moduleIds!.some((m) => m.endsWith("lazy.ts"))).toBe(false);
+  });
+
+  test("true: dynamic target 이 entry chunk 에 흡수 — 단일 chunk", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("./lazy"); console.log(m.v); }
+        boot();
+      `,
+      "lazy.ts": 'export const v = "LAZY_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(1);
+    expect(outs[0].moduleIds!.some((m) => m.endsWith("entry.ts"))).toBe(true);
+    expect(outs[0].moduleIds!.some((m) => m.endsWith("lazy.ts"))).toBe(true);
+    // LAZY_MARK 가 entry chunk 안에 직접 들어있어야 함
+    expect(outs[0].text).toContain("LAZY_MARK");
+  });
+
+  test("true: transitive static dep 도 entry chunk 로 흡수", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() {
+          const m = await import("./lazy");
+          console.log(m.run());
+        }
+        boot();
+      `,
+      "lazy.ts": `
+        import { util } from "./util";
+        export const run = () => util() + "_LAZY";
+      `,
+      "util.ts": 'export const util = () => "UTIL_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const outs = result.outputFiles!;
+    expect(outs.length).toBe(1);
+    const mods = outs[0].moduleIds!;
+    expect(mods.some((m) => m.endsWith("entry.ts"))).toBe(true);
+    expect(mods.some((m) => m.endsWith("lazy.ts"))).toBe(true);
+    expect(mods.some((m) => m.endsWith("util.ts"))).toBe(true);
+    expect(outs[0].text).toContain("UTIL_MARK");
+  });
+
+  test("true: same-chunk dynamic import 는 specifier 그대로 유지 (런타임 위임)", async () => {
+    // inline 모드에서도 `import("./lazy")` 호출 텍스트는 남아있어야 한다 (A 범위 스펙).
+    // 런타임 registry 를 통한 해석은 후속 PR.
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("./lazy"); console.log(m.v); }
+        boot();
+      `,
+      "lazy.ts": 'export const v = "MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    // 청크 파일명으로 specifier 가 재작성되지 않고 원본 유지되는지
+    // (재작성됐으면 "./lazy.js" 같은 .js 확장자가 따라붙는다)
+    expect(result.outputFiles![0].text).toMatch(/import\s*\(\s*["']\.\/lazy["']\s*\)/);
+  });
+
+  test("meta.getModuleInfo 는 dynamic 관계를 그대로 관찰", async () => {
+    // 청크 구조만 바뀌고 그래프 토폴로지 자체는 불변 — dynamicallyImportedIds 유지.
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { await import("./lazy"); }
+        boot();
+      `,
+      "lazy.ts": "export const v = 1;",
+    });
+    cleanup = fixture.cleanup;
+
+    let observedDyn: string[] | undefined;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          observedDyn = meta.getModuleInfo(id)?.dynamicallyImportedIds;
+        }
+        return null;
+      },
+    });
+
+    expect(observedDyn).toBeDefined();
+    expect(observedDyn!.some((p) => p.endsWith("lazy.ts"))).toBe(true);
+  });
+});


### PR DESCRIPTION
(재생성 — 원본 #1856 는 base branch 자동 삭제로 close)

## Summary
- Rollup `output.inlineDynamicImports` chunk 분할 구조만 구현 (A 범위)
- true 일 때 dynamic target 이 별도 async chunk 로 분리되지 않고 importer chunk 로 흡수
- 런타임 `import()` 은 same-chunk 여도 원본 specifier 유지 — registry 기반 re-entry 는 후속

## 테스트
- Zig 유닛 +4 / integration +5 / smoke +6

🤖 Generated with [Claude Code](https://claude.com/claude-code)