### PR TITLE
feat(bundler): inlineDynamicImports B 범위 — 런타임 registry (__esm/CJS)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -232,11 +232,14 @@ interface BuildOptionsCommon {
   minifyIdentifiers?: boolean;
   minifySyntax?: boolean;
   splitting?: boolean;
-  /** Rollup `output.inlineDynamicImports` — dynamic import target 을 별도 async chunk 로
-   * 분리하지 않고 importer 의 chunk 에 포함. `splitting: true` 와 조합해야 의미 있음.
+  /** Rollup `output.inlineDynamicImports` — dynamic import target 을 importer 의 chunk 에
+   * 흡수하고 `import("./x")` 호출을 `__esm` 래퍼 init/exports 호출로 재작성.
+   * `splitting: true` 와 조합. 결과 번들은 단일 파일로 실행 가능.
    *
-   * 주의: 이 플래그의 구조 부분만 구현 — async chunk 는 사라지지만 런타임 `import()`
-   * 호출은 원본 specifier 를 유지. 완전한 런타임 re-entry 는 후속 작업.
+   * 보존 보장:
+   * - namespace identity: `(await import("./x")) === (await import("./x"))`
+   * - top-level side effect 1회 실행 (캐싱)
+   * - live binding (모듈이 `export let` 을 mutate 하면 caller 측에서도 반영)
    */
   inlineDynamicImports?: boolean;
   sourcemap?: boolean;

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -72,11 +72,11 @@ pub const BundleOptions = struct {
     /// code splitting 활성화. true이면 dynamic import 경계에서 청크를 분리하고
     /// 공유 모듈을 공통 청크로 추출한다. 결과는 BundleResult.outputs에 다중 파일로 반환.
     code_splitting: bool = false,
-    /// Rollup `output.inlineDynamicImports` — **chunk 구조만 구현**.
-    /// true 이면 dynamic import target 이 별도 async chunk 로 분리되지 않고 importer 의
-    /// chunk (entry 또는 manual) 에 흡수된다. `code_splitting=true` 와 조합해야 의미 있음.
-    /// 런타임 `import()` 호출은 same-chunk 여도 원본 specifier 를 유지하며, 모듈 registry
-    /// 기반 re-entry 는 아직 미구현 — 번들 출력을 Node/브라우저로 바로 실행하려면 후속 PR 필요.
+    /// Rollup `output.inlineDynamicImports` — dynamic import target 을 importer 와 같은
+    /// chunk 로 흡수하고 `import("./x")` 호출을 `__esm` 래퍼 init/exports 호출로 재작성.
+    /// `code_splitting=true` 와 조합해야 의미 있음. 결과 번들은 단일 파일로 실행 가능.
+    /// 보존 보장: namespace identity (`(await import(x)) === (await import(x))`),
+    /// top-level side effect 1회 실행, live binding.
     inline_dynamic_imports: bool = false,
     /// 사용자 정의 청크 분할 (Rollup `manualChunks` 호환 Phase 1 / #1027).
     /// code_splitting=true 일 때만 동작. 매칭된 모듈은 pseudo-entry 로 BFS 에 참여
@@ -700,6 +700,7 @@ pub const Bundler = struct {
         var graph_scope = profile.begin(.graph);
         var graph = ModuleGraph.init(self.allocator, self.getResolveCache());
         graph.dev_mode = self.options.dev_mode;
+        graph.inline_dynamic_imports = self.options.inline_dynamic_imports;
         // require.context 등 parser inline scan 의 build-time 정적 평가에 사용 (#1579 Phase 2.6)
         graph.defines = self.options.define;
         // #1621: binary loader 의 `$tb(...)` 축약 활성화.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -252,7 +252,7 @@ pub fn emitChunks(
             defer allocator.free(raw_code);
 
             // 동적 import 경로 리라이트: import('./page') → import('./page.js')
-            const code = try rewriteDynamicImports(allocator, raw_code, m, chunk_graph, options.public_path, ext, options);
+            const code = try rewriteDynamicImports(allocator, raw_code, m, graph, chunk_graph, options.public_path, ext, options);
             defer allocator.free(code);
 
             // entry 모듈(또는 preserve-modules의 단일 모듈)의 directive prologue 추출.
@@ -579,6 +579,7 @@ fn rewriteDynamicImports(
     allocator: std.mem.Allocator,
     code: []const u8,
     module: *const Module,
+    graph: *const ModuleGraph,
     chunk_graph: *const ChunkGraph,
     public_path: []const u8,
     out_ext: []const u8,
@@ -619,9 +620,39 @@ fn rewriteDynamicImports(
         const target_chunk_idx = chunk_graph.getModuleChunk(rec.resolved);
         if (target_chunk_idx == .none) continue;
 
-        // target 이 같은 chunk 에 있으면 specifier 그대로 둔다 (inline_dynamic_imports
-        // 또는 우연한 same-chunk 케이스). 런타임에서 original path 로 해석되도록 위임.
-        if (source_chunk_idx != .none and target_chunk_idx == source_chunk_idx) continue;
+        const same_chunk = source_chunk_idx != .none and target_chunk_idx == source_chunk_idx;
+
+        // inlineDynamicImports + same-chunk: `import("./x")` 호출을 wrap factory 호출로
+        // 재작성. ESM 래핑은 `(init_x(), exports_x)`, CJS 는 `require_x()` 패턴.
+        if (same_chunk and graph.inline_dynamic_imports) {
+            const target_mod = graph.getModule(rec.resolved) orelse continue;
+            const replacement_expr = switch (target_mod.wrap_kind) {
+                .esm => blk: {
+                    const init_name = try target_mod.allocInitName(allocator);
+                    defer allocator.free(init_name);
+                    const exports_name = try target_mod.allocExportsName(allocator);
+                    defer allocator.free(exports_name);
+                    break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>({s}(),{s}))", .{ init_name, exports_name });
+                },
+                .cjs => blk: {
+                    const require_name = try types.makeRequireVarName(allocator, target_mod.path);
+                    defer allocator.free(require_name);
+                    break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>{s}())", .{require_name});
+                },
+                .none => continue,
+            };
+            defer allocator.free(replacement_expr);
+
+            const new_result_opt = try rewriteImportCallToWrapper(allocator, result, rec.specifier, replacement_expr);
+            if (new_result_opt) |new_result| {
+                allocator.free(result);
+                result = new_result;
+            }
+            continue;
+        }
+
+        // 그 외 same-chunk 는 specifier 그대로 (런타임 위임 — A 범위 잔여 동작)
+        if (same_chunk) continue;
 
         const target_chunk = chunk_graph.getChunk(target_chunk_idx);
 
@@ -647,6 +678,33 @@ fn rewriteDynamicImports(
     }
 
     return result;
+}
+
+/// `import("specifier")` 호출 전체를 미리 만들어진 expression 으로 교체.
+/// 매칭 실패 시 null. codegen 출력 형태 (`import("./x")`) 만 처리 — import attributes
+/// 같은 second-arg 폼은 미지원 (현재 codegen 이 emit 하지 않음).
+fn rewriteImportCallToWrapper(
+    allocator: std.mem.Allocator,
+    code: []const u8,
+    specifier: []const u8,
+    replacement: []const u8,
+) !?[]u8 {
+    const spec_pos = std.mem.indexOf(u8, code, specifier) orelse return null;
+    // `import("` 또는 `import('` 가 specifier 앞에 와야 함.
+    if (spec_pos < "import(\"".len) return null;
+    const opener = code[spec_pos - "import(\"".len .. spec_pos];
+    if (!std.mem.eql(u8, opener, "import(\"") and !std.mem.eql(u8, opener, "import('")) return null;
+    const quote = code[spec_pos - 1];
+
+    const after_spec = spec_pos + specifier.len;
+    if (after_spec + 1 >= code.len) return null;
+    if (code[after_spec] != quote) return null;
+    if (code[after_spec + 1] != ')') return null;
+
+    const call_start = spec_pos - "import(\"".len;
+    const call_end = after_spec + 2; // include ')'
+
+    return try std.mem.concat(allocator, u8, &.{ code[0..call_start], replacement, code[call_end..] });
 }
 
 const PlaceholderInfo = struct {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -77,6 +77,10 @@ pub const ModuleGraph = struct {
 
     /// dev mode: HMR을 위해 모든 모듈을 강제 래핑 (__esm).
     dev_mode: bool = false,
+    /// `output.inlineDynamicImports` 런타임 부분. true 면 dynamic-import target 모듈을
+    /// `__esm` 래핑해서 lazy 평가 + 모듈 namespace 동일성 보존. emitter 가 `import("./x")`
+    /// 호출을 래퍼 init/exports 호출로 재작성한다.
+    inline_dynamic_imports: bool = false,
     /// build-time 정적 평가 entries. parser inline scan (require.context 등 #1579 Phase 2.6) 활용.
     /// bundler 가 BundleOptions.define 으로 설정. transformer 의 define 치환과 동일 entries.
     defines: []const @import("../parser/scan_results.zig").DefineEntry = &.{},
@@ -1690,6 +1694,19 @@ pub const ModuleGraph = struct {
                 if (m.wrap_kind == .none and (m.exports_kind == .esm or m.exports_kind == .esm_with_dynamic_fallback)) {
                     m.wrap_kind = .esm;
                 }
+            }
+        }
+
+        // Pass 4: inlineDynamicImports — dynamic-import target 만 __esm 래핑.
+        // 일반 모듈은 scope-hoisting 그대로, dynamic target 만 lazy factory 로
+        // 묶어서 emitter 가 `import("./x")` 호출을 init/exports 호출로 재작성.
+        if (self.inline_dynamic_imports) {
+            var it = self.modules.iterator(0);
+            while (it.next()) |m| {
+                if (m.dynamic_importers.items.len == 0) continue;
+                if (m.wrap_kind != .none) continue;
+                if (m.exports_kind != .esm and m.exports_kind != .esm_with_dynamic_fallback) continue;
+                m.wrap_kind = .esm;
             }
         }
     }

--- a/tests/integration/tests/inline-dynamic-imports-smoke.test.ts
+++ b/tests/integration/tests/inline-dynamic-imports-smoke.test.ts
@@ -1,4 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createFixture, hasPackage } from "./helpers";
 import { init, close, build } from "../../../packages/core/index";
@@ -6,8 +8,16 @@ import { init, close, build } from "../../../packages/core/index";
 const PROJECT_ROOT = resolve(import.meta.dir, "../../..");
 const ROOT_NODE_MODULES = join(PROJECT_ROOT, "node_modules");
 
+// 빌드 결과를 Node 로 실행해 stdout 캡처. B 범위 런타임 정합성 검증용.
+function runBundleInNode(outDir: string, entryFile: string): string {
+  const r = spawnSync("node", [entryFile], { stdio: "pipe", timeout: 15000, cwd: outDir });
+  if (r.status !== 0) {
+    throw new Error(`node failed (${r.status}): ${r.stderr?.toString().slice(0, 1000)}`);
+  }
+  return r.stdout.toString();
+}
+
 // `inlineDynamicImports` 스모크 — 실전 크기의 fixture + 라이브러리로 구조 검증.
-// 런타임 실행은 A 범위 밖 (후속 PR).
 
 describe("inlineDynamicImports smoke", () => {
   let cleanup: (() => Promise<void>) | undefined;
@@ -223,4 +233,142 @@ describe("inlineDynamicImports smoke", () => {
       expect(outs[0].moduleIds!.some((m) => m.includes("clsx"))).toBe(true);
     },
   );
+
+  // ============================================================
+  // 런타임 정합성 — Node 실행 + stdout 검증
+  // ============================================================
+
+  test("런타임: import() 결과 가 정상 namespace 객체 (exports 접근 가능)", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "lazy.ts": `
+        export const greeting = "HELLO_FROM_LAZY";
+        export function answer() { return 42; }
+      `,
+      "entry.ts": `
+        async function boot() {
+          const m = await import("./lazy");
+          console.log("OUT:" + m.greeting + "|" + m.answer());
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      outdir: outDir,
+      write: true,
+    });
+
+    const stdout = runBundleInNode(outDir, "entry.js");
+    expect(stdout).toContain("OUT:HELLO_FROM_LAZY|42");
+  });
+
+  test("런타임: 같은 모듈 두 번 import() 시 namespace identity 보존 (===)", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "lazy.ts": "export const v = 1;",
+      "entry.ts": `
+        async function boot() {
+          const a = await import("./lazy");
+          const b = await import("./lazy");
+          console.log("IDENTITY:" + (a === b));
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      outdir: outDir,
+      write: true,
+    });
+
+    const stdout = runBundleInNode(outDir, "entry.js");
+    expect(stdout).toContain("IDENTITY:true");
+  });
+
+  test("런타임: top-level side effect 가 정확히 1회 실행 (캐싱)", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "lazy.ts": `
+        console.log("SIDE_EFFECT");
+        export const v = 1;
+      `,
+      "entry.ts": `
+        async function boot() {
+          await import("./lazy");
+          await import("./lazy");
+          await import("./lazy");
+          console.log("DONE");
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      outdir: outDir,
+      write: true,
+    });
+
+    const stdout = runBundleInNode(outDir, "entry.js");
+    // SIDE_EFFECT 가 정확히 1번
+    const sideEffectCount = stdout.split("SIDE_EFFECT").length - 1;
+    expect(sideEffectCount).toBe(1);
+    expect(stdout).toContain("DONE");
+  });
+
+  test("런타임: live binding — exports 가 모듈 함수 호출 후 변경 사항 반영", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "lazy.ts": `
+        export let counter = 0;
+        export function inc() { counter++; }
+      `,
+      "entry.ts": `
+        async function boot() {
+          const m = await import("./lazy");
+          console.log("BEFORE:" + m.counter);
+          m.inc();
+          m.inc();
+          console.log("AFTER:" + m.counter);
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      outdir: outDir,
+      write: true,
+    });
+
+    const stdout = runBundleInNode(outDir, "entry.js");
+    expect(stdout).toContain("BEFORE:0");
+    expect(stdout).toContain("AFTER:2");
+  });
+
+  // 미사용 import 회피
+  void writeFileSync;
 });

--- a/tests/integration/tests/inline-dynamic-imports.test.ts
+++ b/tests/integration/tests/inline-dynamic-imports.test.ts
@@ -98,9 +98,10 @@ describe("inlineDynamicImports (structural)", () => {
     expect(outs[0].text).toContain("UTIL_MARK");
   });
 
-  test("true: same-chunk dynamic import 는 specifier 그대로 유지 (런타임 위임)", async () => {
-    // inline 모드에서도 `import("./lazy")` 호출 텍스트는 남아있어야 한다 (A 범위 스펙).
-    // 런타임 registry 를 통한 해석은 후속 PR.
+  test("true: same-chunk dynamic import 가 __esm wrapper 호출로 재작성", async () => {
+    // B 범위 — `import("./x")` 가 `Promise.resolve().then(()=>(init_x(),exports_x))` 로
+    // 재작성. 결과적으로 (1) 원본 import() 텍스트는 사라지고 (2) __esm + exports 객체
+    // 패턴이 들어간다.
     const fixture = await createFixture({
       "entry.ts": `
         async function boot() { const m = await import("./lazy"); console.log(m.v); }
@@ -116,9 +117,14 @@ describe("inlineDynamicImports (structural)", () => {
       inlineDynamicImports: true,
     });
 
-    // 청크 파일명으로 specifier 가 재작성되지 않고 원본 유지되는지
-    // (재작성됐으면 "./lazy.js" 같은 .js 확장자가 따라붙는다)
-    expect(result.outputFiles![0].text).toMatch(/import\s*\(\s*["']\.\/lazy["']\s*\)/);
+    const text = result.outputFiles![0].text;
+    // import("./lazy") 가 재작성되어 사라짐
+    expect(text).not.toMatch(/import\s*\(\s*["']\.\/lazy["']\s*\)/);
+    // wrapper 호출 패턴 등장
+    expect(text).toMatch(/Promise\.resolve\(\)\.then/);
+    expect(text).toMatch(/__esm\(\{/);
+    expect(text).toMatch(/exports_lazy/);
+    expect(text).toMatch(/init_lazy/);
   });
 
   test("meta.getModuleInfo 는 dynamic 관계를 그대로 관찰", async () => {


### PR DESCRIPTION
## Summary
- Rollup `output.inlineDynamicImports` B 범위 — A (chunk 구조) 위에 런타임 의미 완성
- dynamic-import target 모듈을 `__esm` 래퍼로 강제 변환하고 `import("./x")` 호출을 wrap factory 호출로 재작성
- 결과 번들 단일 파일로 Node/브라우저 실행 가능

## 동작
- ESM target: `import("./x")` → `Promise.resolve().then(()=>(init_x(),exports_x))`
- CJS target: `import("./x")` → `Promise.resolve().then(()=>require_x())`

## 보장 (런타임 검증 테스트로 lock)
- namespace identity: `(await import(x)) === (await import(x))`
- top-level side effect 1회 실행 (`__esm` 캐싱)
- live binding (`export let` mutation 반영)

## 구현
- `ModuleGraph.inline_dynamic_imports` 필드 + bundler propagate
- graph Pass 4 — `dynamic_importers > 0` 모듈을 `wrap_kind = .esm` (already .cjs 면 skip)
- `rewriteDynamicImports` 가 graph + wrap_kind 분기로 ESM/CJS 다른 패턴 emit
- `rewriteImportCallToWrapper` 가 `import("./x")` 호출 전체를 미리 만든 expression 으로 교체

## 테스트
- integration 1 갱신 (옛 "specifier 유지" → 새 wrapper 호출 검증)
- smoke +4 — Node 로 실제 실행해 4가지 보장 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)