### PR TITLE
refactor(chunk): generateChunks 8 positional → GenerateOptions struct

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -984,16 +984,13 @@ pub const Bundler = struct {
                     if (shaker) |*s| s else null,
                 )
             else
-                try chunk_mod.generateChunks(
-                    self.allocator,
-                    &graph,
-                    self.options.entry_points,
-                    if (shaker) |*s| s else null,
-                    self.options.manual_chunks,
-                    self.options.manual_chunks_resolver,
-                    self.options.manual_chunks_ctx,
-                    self.options.inline_dynamic_imports,
-                );
+                try chunk_mod.generateChunks(self.allocator, &graph, self.options.entry_points, .{
+                    .shaker = if (shaker) |*s| s else null,
+                    .manual_chunks = self.options.manual_chunks,
+                    .manual_resolver = self.options.manual_chunks_resolver,
+                    .manual_resolver_ctx = self.options.manual_chunks_ctx,
+                    .inline_dynamic_imports = self.options.inline_dynamic_imports,
+                });
             defer chunk_graph.deinit();
 
             try chunk_mod.computeCrossChunkLinks(&chunk_graph, &graph, self.allocator, if (linker) |*l| l else null);

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -353,19 +353,30 @@ fn ensureNameSlot(
     return gop.value_ptr.*;
 }
 
+pub const GenerateOptions = struct {
+    /// Tree-shaker — 제공되면 unreachable export/모듈을 chunk 에서 제외.
+    shaker: ?*const TreeShaker = null,
+    /// Rollup record-form `manualChunks` (#1027). substring pattern → chunk name.
+    manual_chunks: []const types.ManualChunkEntry = &.{},
+    /// Rollup function-form `manualChunks(id, meta)` resolver. resolver 결과가 record 보다 우선.
+    manual_resolver: ?types.ManualChunksResolveFn = null,
+    /// resolver 에 전달할 user context (TSFN 핸들 등).
+    manual_resolver_ctx: ?*anyopaque = null,
+    /// Rollup `output.inlineDynamicImports` — dynamic import target 을 importer 의 chunk 로 흡수.
+    inline_dynamic_imports: bool = false,
+};
+
 pub fn generateChunks(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
     entry_points: []const []const u8,
-    shaker: ?*const TreeShaker,
-    manual_chunks: []const types.ManualChunkEntry,
-    manual_resolver: ?types.ManualChunksResolveFn,
-    manual_resolver_ctx: ?*anyopaque,
-    /// true 이면 dynamic import target 을 별도 chunk 로 분리하지 않고 importer 와 같은
-    /// chunk 에 포함. Rollup `output.inlineDynamicImports` 의 구조 부분만 구현 (A 범위).
-    /// 런타임 `import()` rewriting 은 후속 PR.
-    inline_dynamic_imports: bool,
+    options: GenerateOptions,
 ) !ChunkGraph {
+    const shaker = options.shaker;
+    const manual_chunks = options.manual_chunks;
+    const manual_resolver = options.manual_resolver;
+    const manual_resolver_ctx = options.manual_resolver_ctx;
+    const inline_dynamic_imports = options.inline_dynamic_imports;
     const module_count = graph.moduleCount();
 
     // ── Phase 1: 엔트리 수집 ──

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -445,7 +445,7 @@ test "generateChunks: single entry, no dynamic imports" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, .{});
     defer cg.deinit();
 
     // 엔트리 청크 1개
@@ -482,7 +482,7 @@ test "generateChunks: dynamic import creates separate chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"index.ts"}, .{});
     defer cg.deinit();
 
     // 엔트리 청크 1개 + dynamic 청크 1개 = 2개
@@ -523,7 +523,7 @@ test "generateChunks: shared module creates common chunk" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, .{});
     defer cg.deinit();
 
     // 엔트리 2개 + 공통 1개 = 3개
@@ -564,7 +564,7 @@ test "generateChunks: diamond dependency" {
 
     var tg = try TestGraph.init(alloc, &modules);
     defer tg.deinit(alloc);
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, .{});
     defer cg.deinit();
 
     // D가 양쪽 엔트리에서 도달 가능 → 공통 청크 생성
@@ -592,7 +592,7 @@ test "generateChunks: no modules" {
     var tg = try TestGraph.init(alloc, &empty_modules);
     defer tg.deinit(alloc);
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{});
     defer cg.deinit();
 
     try std.testing.expectEqual(@as(usize, 0), cg.chunkCount());
@@ -617,7 +617,7 @@ test "generateChunks: circular dependency stays in same chunk" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, .{});
     defer cg.deinit();
 
     // 1 엔트리 청크, 모든 모듈 포함
@@ -643,7 +643,7 @@ test "generateChunks: static + dynamic import same module" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
     try tg.graph.modules.at(0).addDynamicImport(alloc, @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, .{});
     defer cg.deinit();
 
     // b.ts는 엔트리 청크에 포함 (static이 우선)
@@ -672,7 +672,7 @@ test "generateChunks: three entries sharing a module" {
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(3));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts", "c.ts" }, .{});
     defer cg.deinit();
 
     // 3 엔트리 + 1 공통 = 4 청크
@@ -702,7 +702,7 @@ test "generateChunks: entry imports another entry statically" {
 
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "b.ts" }, .{});
     defer cg.deinit();
 
     // 2개 엔트리 청크 생성
@@ -731,7 +731,7 @@ test "generateChunks: deep chain with dynamic import at middle" {
     try tg.graph.modules.at(1).addDynamicImport(alloc, @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(3));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"a.ts"}, .{});
     defer cg.deinit();
 
     // 2개 청크: a엔트리(a,b), c엔트리(c,d)
@@ -982,7 +982,7 @@ test "generateChunks: entry module reassignment removes from old chunk" {
     try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(2));
     try tg.graph.linkDependency(@enumFromInt(2), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{ "a.ts", "c.ts" }, .{});
     defer cg.deinit();
 
     // c.ts는 엔트리 청크에 있어야 함 (공통 청크 아님)
@@ -1010,7 +1010,7 @@ test "generateChunks: inline_dynamic_imports=false — dynamic target 은 별도
 
     try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{});
     defer cg.deinit();
 
     // 기본 정책 — lazy 는 entry 와 다른 chunk 에 배정
@@ -1032,7 +1032,7 @@ test "generateChunks: inline_dynamic_imports=true — dynamic target 이 entry c
 
     try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, true);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{ .inline_dynamic_imports = true });
     defer cg.deinit();
 
     // inline 정책 — lazy 가 entry chunk 로 흡수. 전체 청크 1개.
@@ -1058,7 +1058,10 @@ test "generateChunks: inline_dynamic_imports + manual_chunks — manual seed 의
     try tg.graph.linkDynamicImport(@enumFromInt(1), @enumFromInt(2));
 
     const manual_entries = [_]types.ManualChunkEntry{.{ .name = "vendor", .patterns = &.{"vendor-"} }};
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &manual_entries, null, null, true);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{
+        .manual_chunks = &manual_entries,
+        .inline_dynamic_imports = true,
+    });
     defer cg.deinit();
 
     // vendor-root 은 manual 매칭, vendor-lazy 는 vendor-root 의 dynamic dep.
@@ -1082,7 +1085,7 @@ test "generateChunks: inline_dynamic_imports — dynamic target 의 transitive s
     try tg.graph.linkDynamicImport(@enumFromInt(0), @enumFromInt(1));
     try tg.graph.linkDependency(@enumFromInt(1), @enumFromInt(2));
 
-    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, null, &.{}, null, null, true);
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{ .inline_dynamic_imports = true });
     defer cg.deinit();
 
     try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -370,7 +370,7 @@ test "inline (bundle): shared module 내부 inline — emitChunks 경로" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, .{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -429,7 +429,7 @@ test "emitChunks: single chunk produces one OutputFile" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -463,7 +463,7 @@ test "emitChunks: two entries with shared module — 3 OutputFiles" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, .{});
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -511,7 +511,7 @@ test "CodeSplitting: dynamic import path rewritten to chunk filename" {
     const lazy_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "lazy.ts" });
     defer std.testing.allocator.free(lazy_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, .{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -569,7 +569,7 @@ test "CodeSplitting: multiple dynamic imports rewritten" {
     const pageB_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "pageB.ts" });
     defer std.testing.allocator.free(pageB_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, .{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -614,7 +614,7 @@ test "chunkStem: common chunk uses hex hash, not index" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, .{});
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -663,7 +663,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
+    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{ ep_a, ep_b }, .{});
     defer cg1.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg1, &result1.graph, std.testing.allocator, null);
 
@@ -680,7 +680,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     defer result2.graph.deinit();
     defer result2.cache.deinit();
 
-    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
+    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{ ep_a, ep_b }, .{});
     defer cg2.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg2, &result2.graph, std.testing.allocator, null);
 
@@ -783,7 +783,7 @@ test "naming pattern: entry-names with hash" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{
@@ -823,7 +823,7 @@ test "naming pattern: chunk-names with directory" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, .{});
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -869,7 +869,7 @@ test "content hash: cross-chunk import uses content hash" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, .{});
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
@@ -935,7 +935,7 @@ test "CJS runtime: __commonJS only in chunks containing CJS modules" {
     const ep_b = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "b.ts" });
     defer std.testing.allocator.free(ep_b);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, .{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
@@ -969,7 +969,7 @@ test "CodeSplitting: static import not rewritten" {
     const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
     defer std.testing.allocator.free(entry_path);
 
-    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, null, &.{}, null, null, false);
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
     defer cg.deinit();
 
     const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);


### PR DESCRIPTION
## Summary
- `generateChunks` 의 5개 후방 positional → `GenerateOptions` struct
- 호출지 30 곳에서 `null, &.{}, null, null, false` 트레일러 제거

## Before/After
\`\`\`zig
// before
generateChunks(alloc, &graph, eps, null, &.{}, null, null, false)
// after
generateChunks(alloc, &graph, eps, .{})
\`\`\`

## 영향
- 동작 변화 0
- Zig 테스트 + integration 62/62 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)