### PR TITLE
fix(chunk): external phantom 이 chunk 배정 받지 못하도록 가드

### DIFF
--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -386,10 +386,12 @@ pub fn generateChunks(
     defer entries.deinit(allocator);
 
     // Phase 1a: 유저 엔트리 — entry_points 경로와 일치하는 모듈을 찾는다.
+    // External phantom 은 chunk 배정 대상이 아니므로 모든 phase 에서 skip.
     {
         var it = graph.modulesIterator();
         var i: usize = 0;
         while (it.next()) |m| : (i += 1) {
+            if (m.is_external) continue;
             for (entry_points) |ep| {
                 if (std.mem.eql(u8, m.path, ep)) {
                     try entries.append(allocator, .{
@@ -414,6 +416,10 @@ pub fn generateChunks(
         while (it.next()) |m| {
             for (m.dynamic_imports.items) |dyn_idx| {
                 const di = @intFromEnum(dyn_idx);
+                // External phantom 이 dyn-imported 면 async chunk 만들 필요 없음 (번들 외부)
+                if (graph.getModule(dyn_idx)) |dyn_mod| {
+                    if (dyn_mod.is_external) continue;
+                }
                 const gop = try dynamic_seen.getOrPut(di);
                 if (!gop.found_existing) {
                     // 이미 유저 엔트리로 등록된 모듈인지 확인
@@ -475,6 +481,7 @@ pub fn generateChunks(
         var it = graph.modulesIterator();
         var mi: usize = 0;
         while (it.next()) |m| : (mi += 1) {
+            if (m.is_external) continue;
             if (dynamic_entry_modules.contains(@intCast(mi))) continue;
             if (fn_ptr(manual_resolver_ctx, m.path, @ptrCast(graph))) |chunk_name| {
                 ra[mi] = try ensureNameSlot(&name_to_slot, &effective_names, allocator, chunk_name);
@@ -544,6 +551,7 @@ pub fn generateChunks(
         var it = graph.modulesIterator();
         var mi: usize = 0;
         while (it.next()) |m| : (mi += 1) {
+            if (m.is_external) continue;
             // dynamic import target 은 정책상 manual 청크 제외 (#1848/#1849, 근본수정 #1850)
             if (dynamic_entry_modules.contains(@intCast(mi))) continue;
             if (resolver_assignments) |ra| {
@@ -587,6 +595,8 @@ pub fn generateChunks(
             const mod_idx = queue.pop() orelse break;
             const m = graph.getModule(mod_idx) orelse continue;
             const mi = @intFromEnum(mod_idx);
+            // External phantom 은 chunk 에 안 들어감 — 비트 설정 / 큐 추가 모두 skip.
+            if (m.is_external) continue;
 
             // 이미 이 비트가 설정되어 있으면 스킵 (순환 참조 방지)
             if (splitting_info[mi].hasBit(@intCast(bit_idx))) continue;
@@ -640,6 +650,7 @@ pub fn generateChunks(
                 const mod_idx = queue.pop() orelse break;
                 const m = graph.getModule(mod_idx) orelse continue;
                 const mi = @intFromEnum(mod_idx);
+                if (m.is_external) continue;
                 if (splitting_info[mi].hasBit(manual_bit)) continue;
                 // 다른 slot 의 seed 면 skip — 그쪽에서 처리됨
                 if (module_primary_slot[mi]) |other| {

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -1093,3 +1093,51 @@ test "generateChunks: inline_dynamic_imports — dynamic target 의 transitive s
     try std.testing.expect(cg.getModuleChunk(@enumFromInt(1)) == entry_chunk);
     try std.testing.expect(cg.getModuleChunk(@enumFromInt(2)) == entry_chunk);
 }
+
+test "generateChunks: external phantom 은 chunk 배정 받지 않음" {
+    const alloc = std.testing.allocator;
+
+    var modules: [2]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "react"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    // module 1 을 external 로 표시 + entry → react static link
+    tg.graph.modules.at(1).is_external = true;
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
+
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{});
+    defer cg.deinit();
+
+    // entry chunk 1개. external phantom 은 어느 chunk 에도 안 들어감.
+    try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);
+    const entry_chunk = cg.getModuleChunk(@enumFromInt(0));
+    try std.testing.expect(!entry_chunk.isNone());
+    const react_chunk = cg.getModuleChunk(@enumFromInt(1));
+    try std.testing.expect(react_chunk.isNone());
+}
+
+test "generateChunks: external 가 manual pattern 매칭돼도 manual chunk 안 만들어짐" {
+    // Phase 1d 에서 phantom 의 path = "vendor-react" 가 manual pattern "vendor-" 매칭해도
+    // is_external 가드로 seeds 에 안 들어가야. 빈 manual chunk 회피.
+    const alloc = std.testing.allocator;
+
+    var modules: [2]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "vendor-react"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    tg.graph.modules.at(1).is_external = true;
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
+
+    const manual_entries = [_]types.ManualChunkEntry{.{ .name = "vendor", .patterns = &.{"vendor-"} }};
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{ .manual_chunks = &manual_entries });
+    defer cg.deinit();
+
+    // entry chunk 만. vendor manual chunk 는 매칭 모듈 0 이라 생성 안 됨.
+    try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);
+}

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -539,14 +539,153 @@ describe("manualChunks NAPI bridge", () => {
       },
     });
 
-    // external phantom 은 resolver 에 직접 안 옴 (modulesIterator 가 외부도 보지만
-    // 정책상 chunk 배정 받지 않으므로 manual_chunks resolver loop 는 외부 가드 추가 가능 —
-    // 일단 entry resolver 안에서 external-pkg 를 lookup 해 검증).
+    // external phantom 은 resolver 에 직접 안 옴 (chunk.zig 의 is_external 가드).
+    // entry resolver 안에서 external-pkg 를 lookup 해 검증.
     const ext = observed.find((o) => o.id === "external-pkg");
     expect(ext).toBeDefined();
     expect(ext!.isExternal).toBe(true);
 
     // entry 의 importedIds 에 external-pkg 가 포함됨 (Rollup parity)
     expect(entryImportedIds.some((i) => i === "external-pkg")).toBe(true);
+  });
+
+  test("meta.getModuleInfo: external 은 manualChunks resolver 에 직접 호출되지 않음", async () => {
+    // 회귀 가드 — chunk.zig 의 is_external 가드가 빠지면 resolver 가 phantom external 도
+    // 호출하게 되어 사용자 콜백이 bare specifier 를 받아 혼란.
+    const fixture = await createFixture({
+      "entry.ts": `import { x } from "external-pkg"; console.log(x);`,
+    });
+    cleanup = fixture.cleanup;
+
+    const seenIds: string[] = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["external-pkg"],
+      splitting: true,
+      manualChunks: (id) => {
+        seenIds.push(id);
+        return null;
+      },
+    });
+
+    expect(seenIds.length).toBeGreaterThan(0);
+    // external phantom 의 path = "external-pkg" 가 resolver 에 안 옴
+    expect(seenIds).not.toContain("external-pkg");
+  });
+
+  test("meta.getModuleInfo: external 패턴이 manualChunks 매칭돼도 빈 청크 안 만듦", async () => {
+    // 회귀 가드 — phantom 의 path 가 manual chunk pattern 과 매칭하면 빈 청크 생성 위험.
+    // is_external 가드로 phantom 은 manual seeds 에 안 들어가야.
+    const fixture = await createFixture({
+      "entry.ts": `import { x } from "external-pkg"; console.log(x);`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["external-pkg"],
+      splitting: true,
+      manualChunks: (id) => {
+        if (id.includes("external-pkg")) return "vendor"; // 의도적 매칭 시도
+        return null;
+      },
+    });
+
+    // vendor 청크가 만들어지지 않아야 (in-graph 모듈이 매칭되지 않음)
+    const vendorChunk = result.outputFiles!.find((o) => o.path.includes("vendor"));
+    expect(vendorChunk).toBeUndefined();
+    // 모든 chunk 가 비지 않음
+    for (const f of result.outputFiles!) {
+      expect(f.text.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("meta.getModuleInfo: 같은 external 을 여러 모듈이 import 해도 phantom 1개 공유", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { x } from "shared-ext";
+        import { y } from "./b";
+        console.log(x, y);
+      `,
+      "b.ts": `import { z } from "shared-ext"; export const y = z;`,
+    });
+    cleanup = fixture.cleanup;
+
+    let extImporters: string[] = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["shared-ext"],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          const ext = meta.getModuleInfo("shared-ext");
+          if (ext) extImporters = ext.importers;
+        }
+        return null;
+      },
+    });
+
+    // 두 모듈이 모두 importer 로 등록되어야 함
+    expect(extImporters.length).toBe(2);
+    expect(extImporters.some((p) => p.endsWith("entry.ts"))).toBe(true);
+    expect(extImporters.some((p) => p.endsWith("b.ts"))).toBe(true);
+  });
+
+  test("meta.getModuleInfo: dynamic external — dynamicImporters 에만 포함", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() { const m = await import("dyn-ext"); console.log(m.x); }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    let extInfo:
+      | { importers: string[]; dynamicImporters: string[]; isExternal: boolean }
+      | undefined;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["dyn-ext"],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          const ext = meta.getModuleInfo("dyn-ext");
+          if (ext)
+            extInfo = {
+              importers: ext.importers,
+              dynamicImporters: ext.dynamicImporters,
+              isExternal: ext.isExternal,
+            };
+        }
+        return null;
+      },
+    });
+
+    expect(extInfo).toBeDefined();
+    expect(extInfo!.isExternal).toBe(true);
+    expect(extInfo!.importers.length).toBe(0);
+    expect(extInfo!.dynamicImporters.length).toBe(1);
+    expect(extInfo!.dynamicImporters[0].endsWith("entry.ts")).toBe(true);
+  });
+
+  test("meta.getModuleInfo: 존재하지 않는 external specifier → null", async () => {
+    const fixture = await createFixture({
+      "entry.ts": "console.log(1);",
+    });
+    cleanup = fixture.cleanup;
+
+    let probed: unknown = "untouched";
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          probed = meta.getModuleInfo("never-imported-ext");
+        }
+        return null;
+      },
+    });
+
+    expect(probed).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
/simplify (PR #1863 머지 후) P1 이슈. external phantom Module 이 chunk gen 5곳에서 정상 모듈처럼 처리되어 다음 부작용 가능했음:

1. resolver 에 bare specifier 호출 — 사용자 혼란
2. external 이 manual pattern 매칭 시 빈 vendor chunk 생성
3. dynamic external 이 async chunk 생성 시도

## Fix
chunk.zig 5곳에 `if (m.is_external) continue;` 가드.

## 회귀 가드 (총 7개 신규)
- Zig 유닛 +2
- integration +5

🤖 Generated with [Claude Code](https://claude.com/claude-code)