### PR TITLE
refactor(bundler): entry_error_guard cleanup (3 commits)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -613,7 +613,7 @@ pub fn emitWithTreeShaking(
         const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
         if (is_entry and options.run_before_main.len > 0 and m.wrap_kind != .esm) {
             const before_len = module_output.items.len;
-            try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options.entry_error_guard);
+            try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options);
             module_line += @intCast(std.mem.count(u8, module_output.items[before_len..], "\n"));
         }
 
@@ -769,7 +769,7 @@ pub fn emitWithTreeShaking(
                 if (results[ei_idx].entry_chain) |chain| {
                     try output.appendSlice(allocator, chain);
                 }
-                try appendGuardedModuleCall(&output, allocator, em, options.entry_error_guard);
+                try appendGuardedModuleCall(&output, allocator, em, options);
                 break;
             }
         }
@@ -971,9 +971,9 @@ pub fn appendGuardedModuleCall(
     output: *std.ArrayList(u8),
     allocator: std.mem.Allocator,
     mod: anytype,
-    error_guard: bool,
+    options: EmitOptions,
 ) !void {
-    if (!mod.shouldGuard(error_guard)) {
+    if (!mod.shouldGuard(options.entry_error_guard)) {
         try appendModuleCall(output, allocator, mod);
         return;
     }
@@ -992,12 +992,12 @@ pub fn appendGuardedModuleCall(
 /// `entry_error_guard` 활성 시 각 rbm 호출도 `__zts_guarded(...)` 로 wrap —
 /// Metro `getAppendScripts` 가 `runBeforeMainModule` 의 각 path 마다 별도
 /// `__r(N);` (= guardedLoadModule outer 호출) 을 emit 하는 것과 동등.
-pub fn appendRunBeforeMainCalls(output: *std.ArrayList(u8), allocator: std.mem.Allocator, graph: *const @import("graph.zig").ModuleGraph, run_before_main: []const []const u8, error_guard: bool) !void {
+pub fn appendRunBeforeMainCalls(output: *std.ArrayList(u8), allocator: std.mem.Allocator, graph: *const @import("graph.zig").ModuleGraph, run_before_main: []const []const u8, options: EmitOptions) !void {
     for (run_before_main) |rbm_path| {
         var it = graph.modulesIterator();
         while (it.next()) |rbm| {
             if (std.mem.eql(u8, rbm.path, rbm_path)) {
-                try appendGuardedModuleCall(output, allocator, rbm, error_guard);
+                try appendGuardedModuleCall(output, allocator, rbm, options);
                 break;
             }
         }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -952,9 +952,9 @@ pub fn appendIndented(wrapped: *std.ArrayList(u8), allocator: std.mem.Allocator,
 /// run-before-main, 엔트리 자동 호출, star export init 등에서 공용.
 pub fn appendModuleCall(output: *std.ArrayList(u8), allocator: std.mem.Allocator, mod: anytype) !void {
     const call_name = if (mod.wrap_kind == .cjs)
-        types.makeRequireVarName(allocator, mod.path) catch return
+        try types.makeRequireVarName(allocator, mod.path)
     else
-        mod.allocInitName(allocator) catch return;
+        try mod.allocInitName(allocator);
     defer allocator.free(call_name);
     if (mod.wrap_kind != .cjs and mod.uses_top_level_await) {
         try output.appendSlice(allocator, "await ");
@@ -973,15 +973,14 @@ pub fn appendGuardedModuleCall(
     mod: anytype,
     error_guard: bool,
 ) !void {
-    const tla = mod.wrap_kind != .cjs and mod.uses_top_level_await;
-    if (!error_guard or tla) {
+    if (!mod.shouldGuard(error_guard)) {
         try appendModuleCall(output, allocator, mod);
         return;
     }
     const call_name = if (mod.wrap_kind == .cjs)
-        types.makeRequireVarName(allocator, mod.path) catch return
+        try types.makeRequireVarName(allocator, mod.path)
     else
-        mod.allocInitName(allocator) catch return;
+        try mod.allocInitName(allocator);
     defer allocator.free(call_name);
     // `__zts_guarded(callName)` — fn 인자로 함수 식별자만 전달. helper 가 fn() 호출.
     try output.appendSlice(allocator, "__zts_guarded(");

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -964,7 +964,7 @@ fn appendWrappedInitCall(
     options: EmitOptions,
 ) !void {
     const is_tla = src_mod.wrap_kind == .esm and src_mod.uses_top_level_await;
-    const guard = options.entry_error_guard and !is_tla and src_mod.wrap_kind != .none;
+    const guard = src_mod.shouldGuard(options.entry_error_guard);
     switch (src_mod.wrap_kind) {
         .esm => {
             if (is_tla) try buf.appendSlice(allocator, "await ");

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -738,7 +738,7 @@ pub fn emitEsmWrappedModule(
     defer rbm_code.deinit(allocator);
     if (module.is_entry_point and options.run_before_main.len > 0) {
         if (linker) |l| {
-            try appendRunBeforeMainCalls(&rbm_code, allocator, l.graph, options.run_before_main, options.entry_error_guard);
+            try appendRunBeforeMainCalls(&rbm_code, allocator, l.graph, options.run_before_main, options);
         }
     }
 

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -778,25 +778,15 @@ pub fn emitEsmWrappedModule(
             try wrapped.appendSlice(allocator, " \"+id)};");
             try wrapped.appendSlice(allocator, "__zts_g.$RefreshSig$=function(){var rt=__zts_g.__ReactRefresh||__zts_resolveRefresh();if(rt)return rt.createSignatureFunctionForTransform();return function(t){return t}};");
         }
-        if (rbm_code.items.len > 0) {
-            if (unroll_entry_chain) {
-                try entry_chain_buf.appendSlice(allocator, rbm_code.items);
-            } else try wrapped.appendSlice(allocator, rbm_code.items);
-        }
+        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, rbm_code.items, unroll_entry_chain, false);
         if (func_code.len > 0) {
             func_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
             try wrapped.appendSlice(allocator, func_code);
         }
         if (preamble_code) |p| {
-            if (unroll_entry_chain) {
-                try entry_chain_buf.appendSlice(allocator, p);
-            } else try wrapped.appendSlice(allocator, p);
+            try writeChainPiece(&entry_chain_buf, &wrapped, allocator, p, unroll_entry_chain, false);
         }
-        if (star_init_buf.items.len > 0) {
-            if (unroll_entry_chain) {
-                try entry_chain_buf.appendSlice(allocator, star_init_buf.items);
-            } else try wrapped.appendSlice(allocator, star_init_buf.items);
-        }
+        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, star_init_buf.items, unroll_entry_chain, false);
         try wrapped.appendSlice(allocator, body_code);
         if (reexport_buf.items.len > 0) try wrapped.appendSlice(allocator, reexport_buf.items);
         if (has_refresh) {
@@ -834,14 +824,7 @@ pub fn emitEsmWrappedModule(
             try wrapped.appendSlice(allocator, "\t\treturn function(t) { return t; };\n");
             try wrapped.appendSlice(allocator, "\t};\n");
         }
-        if (rbm_code.items.len > 0) {
-            if (unroll_entry_chain) {
-                try entry_chain_buf.appendSlice(allocator, rbm_code.items);
-            } else {
-                try wrapped.append(allocator, '\t');
-                try appendIndented(&wrapped, allocator, rbm_code.items);
-            }
-        }
+        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, rbm_code.items, unroll_entry_chain, true);
         // func_code를 preamble 앞에 배치: 순환 참조에서 preamble이 의존 모듈을 init할 때
         // 이 모듈의 함수가 이미 할당된 상태여야 한다. (#1092)
         if (func_code.len > 0) {
@@ -850,21 +833,9 @@ pub fn emitEsmWrappedModule(
             try appendIndented(&wrapped, allocator, func_code);
         }
         if (preamble_code) |p| {
-            if (unroll_entry_chain) {
-                try entry_chain_buf.appendSlice(allocator, p);
-            } else {
-                try wrapped.append(allocator, '\t');
-                try appendIndented(&wrapped, allocator, p);
-            }
+            try writeChainPiece(&entry_chain_buf, &wrapped, allocator, p, unroll_entry_chain, true);
         }
-        if (star_init_buf.items.len > 0) {
-            if (unroll_entry_chain) {
-                try entry_chain_buf.appendSlice(allocator, star_init_buf.items);
-            } else {
-                try wrapped.append(allocator, '\t');
-                try appendIndented(&wrapped, allocator, star_init_buf.items);
-            }
-        }
+        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, star_init_buf.items, unroll_entry_chain, true);
         body_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
         if (body_code.len > 0) {
             try wrapped.append(allocator, '\t');
@@ -948,6 +919,29 @@ pub fn emitEsmWrappedModule(
         .mappings = mappings,
         .entry_chain = entry_chain_owned,
     };
+}
+
+/// rbm / preamble / star_init chunk 를 entry chain unroll 모드면 chain_buf 에, 아니면
+/// wrapped factory body 에 emit. `indent=true` 면 factory body 안에서 한 칸 들여쓰기.
+fn writeChainPiece(
+    chain_buf: *std.ArrayList(u8),
+    wrapped: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    src: []const u8,
+    unroll: bool,
+    indent: bool,
+) !void {
+    if (src.len == 0) return;
+    if (unroll) {
+        try chain_buf.appendSlice(allocator, src);
+        return;
+    }
+    if (indent) {
+        try wrapped.append(allocator, '\t');
+        try appendIndented(wrapped, allocator, src);
+    } else {
+        try wrapped.appendSlice(allocator, src);
+    }
 }
 
 /// 래핑된 소스 모듈의 init/require 호출을 buffer에 추가한다.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -402,7 +402,7 @@ pub fn buildMetadataForAst(
                     try esm_init_set.put(@intCast(canonical_mod), {});
                     const target_mod = canonical_m_opt.?;
                     const is_tla = target_mod.uses_top_level_await;
-                    const guard = self.entry_error_guard and !is_tla;
+                    const guard = target_mod.shouldGuard(self.entry_error_guard);
                     if (is_tla) try preamble.write("await ");
                     if (guard) try preamble.write(rt.GUARD_LAMBDA_OPEN);
                     if (self.dev_mode) {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -227,6 +227,16 @@ pub const Module = struct {
         return self.syntheticName(self.init_symbol);
     }
 
+    /// `entry_error_guard` 활성 시 이 모듈의 init 호출을 `__zts_guarded(...)` 로 wrap 할지 결정.
+    /// TLA (`uses_top_level_await`) 인 ESM 모듈은 await 가 lambda 안에 못 들어가므로 wrap 안 함.
+    /// `wrap_kind == .none` (래핑 없음) 도 호출할 init 함수 자체가 없어 wrap 무의미.
+    pub fn shouldGuard(self: *const Module, error_guard: bool) bool {
+        if (!error_guard) return false;
+        if (self.wrap_kind == .none) return false;
+        if (self.wrap_kind == .esm and self.uses_top_level_await) return false;
+        return true;
+    }
+
     pub fn getExportsName(self: *const Module) ?[]const u8 {
         return self.syntheticName(self.exports_symbol);
     }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -232,7 +232,7 @@ pub const Module = struct {
     /// `wrap_kind == .none` (래핑 없음) 도 호출할 init 함수 자체가 없어 wrap 무의미.
     pub fn shouldGuard(self: *const Module, error_guard: bool) bool {
         if (!error_guard) return false;
-        if (self.wrap_kind == .none) return false;
+        if (!self.wrap_kind.isWrapped()) return false;
         if (self.wrap_kind == .esm and self.uses_top_level_await) return false;
         return true;
     }


### PR DESCRIPTION
## Summary

Follow-up to #1864. Address the deferred items from `/simplify` review without changing emitted output. Each commit is an independent, self-contained refactor.

## Commits

### 1. `refactor(bundler): unify TLA gate via Module.shouldGuard() + propagate OOM`

- Adds `Module.shouldGuard(error_guard)` covering the three TLA gate variants previously duplicated in `esm_wrap`, `linker/metadata`, and `emitter`. Single source of truth for "ESM-wrapped, non-TLA, error_guard on".
- Replaces the silent `catch return` on allocator failures in `appendModuleCall` and `appendGuardedModuleCall` with `try`. OOM now propagates instead of producing a syntactically broken bundle (open `__zts_guarded(` with no body).

### 2. `refactor(bundler): pass EmitOptions instead of bool to guard helpers`

- `appendGuardedModuleCall` and `appendRunBeforeMainCalls` now take `options: EmitOptions` instead of `error_guard: bool`. Future emit-time flags can be added to EmitOptions without touching every helper signature, matching `appendWrappedInitCall`.

### 3. `refactor(bundler): extract writeChainPiece helper for esm_wrap`

- Collapses 6 mirrored if/else blocks (`rbm_code` / `preamble_code` / `star_init_buf` × dev branch + prod branch) in `emitEsmWrappedModule` into single-line calls of a new `writeChainPiece(chain_buf, wrapped, allocator, src, unroll, indent)` helper.
- Behavior unchanged: dev branch uses `indent=false`, prod branch uses `indent=true` (`appendIndented`).
- Net `-6 lines` in `esm_wrap.zig` (29 insertions / 35 deletions).

## Test plan

- [x] `zig build test` — 3738/3738 passed (incl. 32 entry_error_guard cases) after each commit
- [x] `zig build napi` — clean build
- [x] No bundle output diff vs PR #1864 (emit logic preserved)

## Not in this PR

- `inlineRequires` implementation (true root-cause parity with Metro for "Failed to set polyfill" warnings — tracked in memory as deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)