### PR TITLE
feat(napi): manualChunks meta 에 hasModuleSideEffects 추가 (Rollup parity)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -206,6 +206,10 @@ export interface ManualChunksModuleInfo {
   /** `external` 패턴 매칭으로 번들에 포함되지 않는 모듈. AST/source 없음 — graph
    * traversal 1급 노드로만 노출됨. */
   isExternal: boolean;
+  /** 모듈이 side effect 를 가질 수 있는지 (Rollup `hasModuleSideEffects` 호환).
+   * `package.json` `sideEffects` 필드 또는 `treeShaking.moduleSideEffects` 옵션으로 결정.
+   * `false` 면 unused 시 tree-shaker 가 제거 가능. */
+  hasModuleSideEffects: boolean;
   /** 이 모듈을 static import 하는 모듈들. external 도 importer 목록에 포함됨
    * (자기 자신은 external 일 때 in-graph 모듈이 importer). */
   importers: string[];

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1052,6 +1052,10 @@ const NapiManualChunksResolver = struct {
         _ = c.napi_get_boolean(env, mod_info.is_external, &js_is_external);
         _ = c.napi_set_named_property(env, js_obj, "isExternal", js_is_external);
 
+        var js_has_side_effects: c.napi_value = undefined;
+        _ = c.napi_get_boolean(env, mod_info.has_module_side_effects, &js_has_side_effects);
+        _ = c.napi_set_named_property(env, js_obj, "hasModuleSideEffects", js_has_side_effects);
+
         _ = c.napi_set_named_property(env, js_obj, "importers", pathArrayFromIndices(env, graph, mod_info.importers));
         _ = c.napi_set_named_property(env, js_obj, "dynamicImporters", pathArrayFromIndices(env, graph, mod_info.dynamic_importers));
         _ = c.napi_set_named_property(env, js_obj, "importedIds", pathArrayFromIndices(env, graph, mod_info.imported_ids));

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -130,6 +130,10 @@ pub const ModuleInfo = struct {
     is_entry: bool,
     /// `external` 패턴 매칭으로 번들에 포함되지 않는 모듈인지 여부 (Rollup `isExternal` 호환).
     is_external: bool,
+    /// 모듈이 side effect 를 가질 수 있는지 (Rollup `hasModuleSideEffects` 호환).
+    /// `package.json` `sideEffects` 필드 또는 `treeShaking.moduleSideEffects` 옵션으로 결정.
+    /// false 면 unused 시 tree-shaker 가 제거 가능.
+    has_module_side_effects: bool,
 };
 
 /// `id` 로 모듈 메타를 조회. 없으면 null. Zero allocation — graph 내부 slice borrow.
@@ -145,6 +149,7 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
         .dynamically_imported_ids = m.dynamic_imports.items,
         .is_entry = m.is_entry_point,
         .is_external = m.is_external,
+        .has_module_side_effects = m.side_effects,
     };
 }
 

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -688,4 +688,20 @@ describe("manualChunks NAPI bridge", () => {
 
     expect(probed).toBeNull();
   });
+
+  test("meta.getModuleInfo: hasModuleSideEffects — package.json sideEffects=false 반영", async () => {
+    // 패키지가 sideEffects: false 선언하면 그 패키지 모듈들은 hasModuleSideEffects=false.
+    // tree-shaker 가 자동 순수 분석으로 일부 모듈을 false 로 만들 수도 있어 (라이브러리 모듈)
+    // 여기선 명시적 sideEffects=false 선언이 lib.ts 에 반영되는지 lock.
+    const fixture = await createFixture({
+      "package.json": '{"name":"app","sideEffects":false}',
+      "entry.ts": `import { a } from "./lib"; console.log(a);`,
+      "lib.ts": 'export const a = "LIB";',
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.hasModuleSideEffects);
+    const libFlag = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"))![1];
+    expect(libFlag).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Rollup `info.hasModuleSideEffects` 호환. `Module.side_effects` 그대로 노출.

## 활용 예
\`\`\`ts
manualChunks: (id, meta) => {
  const info = meta.getModuleInfo(id);
  if (info && !info.hasModuleSideEffects) return "pure-lib";
  return null;
}
\`\`\`

## 동작
- \`package.json sideEffects: false\` → hasModuleSideEffects=false
- 글롭 패턴 → 매칭만 true
- 미선언 → tree-shaker auto-purity 결과 반영

## 테스트
integration +1: package.json sideEffects=false 가 hasModuleSideEffects 에 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)