### PR TITLE
test(manualChunks): 회귀 가드 + 스모크 테스트 13개 추가

### DIFF
--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -189,6 +189,42 @@ test "graph: external module — phantom 으로 graph 에 등록 (Rollup parity)
     // record 의 is_external 도 그대로 set (emit/linker 호환)
     const a_mod = graph.getModule(@enumFromInt(0)) orelse return error.TestUnexpectedResult;
     try std.testing.expect(a_mod.import_records[0].is_external);
+
+    // 양방향 link 도 등록되어야 — a 의 dependencies 에 react, react 의 importers 에 a
+    try std.testing.expect(a_mod.dependencies.items.len == 1);
+    try std.testing.expect(a_mod.dependencies.items[0] == react_idx);
+    try std.testing.expect(react_mod.importers.items.len == 1);
+    try std.testing.expect(@intFromEnum(react_mod.importers.items[0]) == 0);
+}
+
+test "graph: 같은 external 을 여러 모듈이 import → phantom 1개 공유" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import 'shared-ext';");
+    try writeFile(tmp.dir, "b.ts", "import 'shared-ext';");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import './a';
+        \\import './b';
+    );
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "entry.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"shared-ext"} });
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    // entry + a + b + 1 phantom shared-ext = 4
+    try std.testing.expectEqual(@as(usize, 4), graph.moduleCount());
+    const ext_idx = graph.path_to_module.get("shared-ext") orelse return error.TestUnexpectedResult;
+    const ext_mod = graph.getModule(ext_idx) orelse return error.TestUnexpectedResult;
+    // a, b 둘 다 importer 로 등록
+    try std.testing.expectEqual(@as(usize, 2), ext_mod.importers.items.len);
 }
 
 test "graph: unresolved import — error diagnostic" {

--- a/tests/integration/tests/inline-dynamic-imports-smoke.test.ts
+++ b/tests/integration/tests/inline-dynamic-imports-smoke.test.ts
@@ -369,6 +369,87 @@ describe("inlineDynamicImports smoke", () => {
     expect(stdout).toContain("AFTER:2");
   });
 
+  test("런타임: 다중 lazy 모듈이 같은 shared 의존성 — shared 도 1회만 init", async () => {
+    // route-a, route-b 둘 다 shared util 정적 import. inline 모드에서 shared 가
+    // entry chunk 로 흡수되고, 두 라우트 lazy 호출에서 shared 의 side-effect 는 1회만.
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "shared.ts": `
+        console.log("SHARED_INIT");
+        export const greet = (n: string) => "hi " + n;
+      `,
+      "route-a.ts": `
+        import { greet } from "./shared";
+        export default () => console.log("A:" + greet("a"));
+      `,
+      "route-b.ts": `
+        import { greet } from "./shared";
+        export default () => console.log("B:" + greet("b"));
+      `,
+      "entry.ts": `
+        async function boot() {
+          const a = await import("./route-a");
+          const b = await import("./route-b");
+          a.default();
+          b.default();
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      outdir: outDir,
+      write: true,
+    });
+
+    const stdout = runBundleInNode(outDir, "entry.js");
+    // shared 의 init log 정확히 1회
+    const sharedInitCount = stdout.split("SHARED_INIT").length - 1;
+    expect(sharedInitCount).toBe(1);
+    // 두 라우트 모두 실행 결과 확인
+    expect(stdout).toContain("A:hi a");
+    expect(stdout).toContain("B:hi b");
+  });
+
+  test("런타임: throw 하는 lazy 모듈의 1회차 실패 + 재호출 시 같은 에러 던짐", async () => {
+    // __esm 헬퍼는 첫 호출에서 throw 시 fn 을 복원해서 재시도 가능. 같은 에러여도 throw 함.
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "broken.ts": `
+        if (true) throw new Error("BOOM");
+        export const x = 1;
+      `,
+      "entry.ts": `
+        async function boot() {
+          try { await import("./broken"); } catch(e) { console.log("FIRST:" + (e as Error).message); }
+          try { await import("./broken"); } catch(e) { console.log("SECOND:" + (e as Error).message); }
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      inlineDynamicImports: true,
+      outdir: outDir,
+      write: true,
+    });
+
+    const stdout = runBundleInNode(outDir, "entry.js");
+    expect(stdout).toContain("FIRST:BOOM");
+    expect(stdout).toContain("SECOND:BOOM");
+  });
+
   // 미사용 import 회피
   void writeFileSync;
 });

--- a/tests/integration/tests/manual-chunks-smoke.test.ts
+++ b/tests/integration/tests/manual-chunks-smoke.test.ts
@@ -1140,4 +1140,159 @@ describe("manualChunks smoke (실제 번들 실행)", () => {
       expect(routeAChunk.moduleIds!.some((m) => m.endsWith("common.ts"))).toBe(false);
     }
   });
+
+  // ============================================================
+  // 회귀 가드 — external + 실전 시나리오
+  // ============================================================
+
+  test("external 실전: react/react-dom 모두 external — 둘 다 phantom 으로 graph 에 + 분리 보존", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { createElement } from "react";
+        import { render } from "react-dom";
+        const el = createElement("div", null, "hi");
+        render(el, document.body);
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    let metaSeen: { react?: boolean; reactDom?: boolean; importedIds?: string[] } = {};
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["react", "react-dom"],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          metaSeen.react = meta.getModuleInfo("react")?.isExternal === true;
+          metaSeen.reactDom = meta.getModuleInfo("react-dom")?.isExternal === true;
+          metaSeen.importedIds = meta.getModuleInfo(id)?.importedIds;
+        }
+        return null;
+      },
+    });
+
+    expect(metaSeen.react).toBe(true);
+    expect(metaSeen.reactDom).toBe(true);
+    expect(metaSeen.importedIds).toContain("react");
+    expect(metaSeen.importedIds).toContain("react-dom");
+
+    // 출력 chunk 1개 (entry). 두 external 은 chunk 에 안 들어감.
+    expect(result.outputFiles!.length).toBe(1);
+    const text = result.outputFiles![0].text;
+    // 외부 의존성 호출 흔적 — require 또는 import 형태 보존
+    const reactRef = /react/.test(text);
+    const reactDomRef = /react-dom/.test(text);
+    expect(reactRef).toBe(true);
+    expect(reactDomRef).toBe(true);
+  });
+
+  test("external + manualChunks: in-graph 만 vendor 로, external 은 영향 없음", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { x } from "ext-pkg";
+        import { y } from "./local-vendor";
+        console.log(x, y);
+      `,
+      "local-vendor.ts": 'export const y = "LV";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["ext-pkg"],
+      splitting: true,
+      manualChunks: (id) => {
+        if (id.includes("local-vendor")) return "vendor";
+        return null;
+      },
+    });
+
+    // vendor chunk 는 local-vendor 만, external 은 entry chunk 에서 직접 require/import
+    const vendorChunk = result.outputFiles.find((o) => o.path.includes("vendor"));
+    expect(vendorChunk).toBeDefined();
+    expect(vendorChunk!.moduleIds!.every((m) => !m.includes("ext-pkg"))).toBe(true);
+    expect(vendorChunk!.moduleIds!.some((m) => m.endsWith("local-vendor.ts"))).toBe(true);
+  });
+
+  test("external dynamic import: native import() 로 emit, 다른 dynamic 은 lazy chunk", async () => {
+    // mixed: external dynamic + internal dynamic 동시 사용. external 은 native, internal 은
+    // lazy chunk (또는 inlineDynamicImports off 면 별도 chunk).
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() {
+          const r = await import("react-pkg");
+          const local = await import("./internal");
+          console.log(r, local);
+        }
+        boot();
+      `,
+      "internal.ts": 'export const v = "INT_MARK";',
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["react-pkg"],
+      splitting: true,
+    });
+
+    // external dynamic — entry chunk 텍스트에 import("react-pkg") 그대로
+    const entryChunk = result.outputFiles.find((o) =>
+      o.moduleIds!.some((m) => m.endsWith("entry.ts")),
+    );
+    expect(entryChunk).toBeDefined();
+    expect(entryChunk!.text).toMatch(/import\s*\(\s*["']react-pkg["']\s*\)/);
+
+    // internal dynamic — 별도 async chunk 생성 + INT_MARK 그쪽에
+    const lazyChunk = result.outputFiles.find((o) => o.text.includes("INT_MARK"));
+    expect(lazyChunk).toBeDefined();
+    expect(lazyChunk!.moduleIds!.some((m) => m.endsWith("internal.ts"))).toBe(true);
+  });
+
+  test("external 다수: 10개 external 동시 import — 모두 phantom + importedIds 등장", async () => {
+    const externals = [
+      "mod-a",
+      "mod-b",
+      "mod-c",
+      "mod-d",
+      "mod-e",
+      "mod-f",
+      "mod-g",
+      "mod-h",
+      "mod-i",
+      "mod-j",
+    ];
+    const importLines = externals.map((e, i) => `import { v${i} } from "${e}";`).join("\n");
+    const useLines = externals.map((_, i) => `v${i}`).join(", ");
+    const fixture = await createFixture({
+      "entry.ts": `${importLines}\nconsole.log(${useLines});`,
+    });
+    cleanup = fixture.cleanup;
+
+    let entryImported: string[] = [];
+    const flagsPerExternal: Record<string, boolean> = {};
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: externals,
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          entryImported = meta.getModuleInfo(id)?.importedIds ?? [];
+          for (const e of externals) {
+            flagsPerExternal[e] = meta.getModuleInfo(e)?.isExternal === true;
+          }
+        }
+        return null;
+      },
+    });
+
+    // 모든 external 이 phantom 으로 등록되어 isExternal=true
+    for (const e of externals) {
+      expect(flagsPerExternal[e]).toBe(true);
+    }
+    // 모두 entry.importedIds 에 포함
+    for (const e of externals) {
+      expect(entryImported).toContain(e);
+    }
+  });
 });

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -704,4 +704,186 @@ describe("manualChunks NAPI bridge", () => {
     const libFlag = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"))![1];
     expect(libFlag).toBe(false);
   });
+
+  // ============================================================
+  // 회귀 가드 추가 — external + 다른 기능 조합
+  // ============================================================
+
+  test("external 여러 specifier 가 한 모듈에 동시 import — 모두 phantom 등록", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { x } from "ext-a";
+        import { y } from "ext-b";
+        import { z } from "ext-c";
+        console.log(x, y, z);
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    let entryImportedIds: string[] = [];
+    let extAFound = false;
+    let extBFound = false;
+    let extCFound = false;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["ext-a", "ext-b", "ext-c"],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          entryImportedIds = meta.getModuleInfo(id)?.importedIds ?? [];
+          extAFound = meta.getModuleInfo("ext-a")?.isExternal === true;
+          extBFound = meta.getModuleInfo("ext-b")?.isExternal === true;
+          extCFound = meta.getModuleInfo("ext-c")?.isExternal === true;
+        }
+        return null;
+      },
+    });
+
+    expect(extAFound).toBe(true);
+    expect(extBFound).toBe(true);
+    expect(extCFound).toBe(true);
+    // 3개 external 모두 entry.importedIds 에 포함
+    expect(entryImportedIds).toContain("ext-a");
+    expect(entryImportedIds).toContain("ext-b");
+    expect(entryImportedIds).toContain("ext-c");
+  });
+
+  test("external 의 importedIds / dynamicallyImportedIds 는 빈 배열", async () => {
+    // Rollup 스펙 — external 은 graph traversal 끝점, 자체 import 정보 없음.
+    const fixture = await createFixture({
+      "entry.ts": `import { x } from "lib-x"; console.log(x);`,
+    });
+    cleanup = fixture.cleanup;
+
+    let extInfo: { importedIds: string[]; dynamicallyImportedIds: string[] } | undefined;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["lib-x"],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          const info = meta.getModuleInfo("lib-x");
+          if (info)
+            extInfo = {
+              importedIds: info.importedIds,
+              dynamicallyImportedIds: info.dynamicallyImportedIds,
+            };
+        }
+        return null;
+      },
+    });
+
+    expect(extInfo).toBeDefined();
+    expect(extInfo!.importedIds).toEqual([]);
+    expect(extInfo!.dynamicallyImportedIds).toEqual([]);
+  });
+
+  test("external + inlineDynamicImports — dynamic external 은 inline 안 됨 (런타임 import 유지)", async () => {
+    // external 은 번들 외부라 inlineDynamicImports 의 wrap 변환 대상 아님.
+    // 출력에 `Promise.resolve().then(...)` 변환 패턴 등장 안 함, 원본 import() 유지.
+    const fixture = await createFixture({
+      "entry.ts": `
+        async function boot() {
+          const m = await import("ext-dyn");
+          console.log(m);
+        }
+        boot();
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["ext-dyn"],
+      splitting: true,
+      inlineDynamicImports: true,
+    });
+
+    const text = result.outputFiles![0].text;
+    // external dynamic import 는 그대로 남아야 (런타임에 native ESM 동적 import)
+    expect(text).toMatch(/import\s*\(\s*["']ext-dyn["']\s*\)/);
+    // wrap 변환 패턴은 안 들어가야
+    expect(text).not.toContain("init_ext-dyn");
+  });
+
+  test("external 이 manualChunks resolver 로부터 chunk 이름 받아도 무시 (graph 가드)", async () => {
+    // resolver 가 external 에 대해 호출되지 않음을 이미 다른 테스트가 lock — 추가로 만약
+    // 사용자가 명시적으로 lookup 후 분류 시도해도 graph 측 가드로 빈 chunk 안 만들어지는지.
+    const fixture = await createFixture({
+      "entry.ts": `import { x } from "react-mock"; console.log(x);`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["react-mock"],
+      splitting: true,
+      manualChunks: (id) => {
+        // bare "react-mock" 가 들어왔다면 vendor 로 가게 시도. 실제로는 external 가드로
+        // resolver 에 호출 안 옴.
+        if (id === "react-mock") return "vendor-react";
+        return null;
+      },
+    });
+
+    // vendor-react chunk 가 만들어지지 않아야 (resolver 가 external 에 호출 안 됐기에)
+    const vendorChunk = result.outputFiles!.find((o) => o.path.includes("vendor-react"));
+    expect(vendorChunk).toBeUndefined();
+  });
+
+  test("external + tree-shaking — external import 는 tree-shake 되지 않음", async () => {
+    // external 은 런타임에 외부 의존성이라 사용 표면적이 모르므로 항상 보존.
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { used } from "ext-side";
+        console.log(used);
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["ext-side"],
+      splitting: true,
+    });
+
+    const text = result.outputFiles![0].text;
+    // external 은 보존 — `require("ext-side")` 또는 `import "ext-side"` 흔적이 남아야
+    const hasExternalRef =
+      /require\(["']ext-side["']\)/.test(text) ||
+      /from\s*["']ext-side["']/.test(text) ||
+      /import\s*["']ext-side["']/.test(text);
+    expect(hasExternalRef).toBe(true);
+  });
+
+  test("manualChunks meta 다회 호출 안전 — 같은 id 여러번 lookup", async () => {
+    // 사용자 코드가 같은 id 여러 번 lookup 해도 zero-alloc 경로라 leak 없음 + 같은 결과 반환.
+    const fixture = await createFixture({
+      "entry.ts": `import { a } from "./lib"; console.log(a);`,
+      "lib.ts": 'export const a = "L";',
+    });
+    cleanup = fixture.cleanup;
+
+    const results: { iter: number; importers: number; isEntry: boolean }[] = [];
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (!id.endsWith("lib.ts")) return null;
+        for (let i = 0; i < 5; i++) {
+          const info = meta.getModuleInfo(id);
+          if (info)
+            results.push({ iter: i, importers: info.importers.length, isEntry: info.isEntry });
+        }
+        return null;
+      },
+    });
+
+    expect(results.length).toBe(5);
+    // 모든 호출 결과 동일
+    for (const r of results) {
+      expect(r.importers).toBe(1);
+      expect(r.isEntry).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
external phantom + inlineDynamicImports 런타임 + meta multi-call 등 코너 케이스 테스트 추가.

## 신규 (13)
**Integration (6)**:
- 다중 external 동시 import — 모두 phantom 등록
- external 의 importedIds / dynamicallyImportedIds 빈 배열 보장
- external + inlineDynamicImports — dynamic external native import() 보존
- external 분류 시도해도 빈 chunk 안 만듦
- external + tree-shaking 보존
- meta 다회 호출 안전 (zero-alloc 일관성)

**Smoke (4)**:
- react/react-dom 둘 다 external 실전
- in-graph vendor + external 혼합
- mixed dynamic: external native + internal lazy
- 10개 external 동시 (확장성)

**Runtime (2)**:
- inlineDynamicImports + 두 lazy 라우트가 공유 모듈 — shared 정확히 1회 init
- throw 하는 lazy 모듈 재호출 — 같은 에러 재던짐 (__esm 헬퍼 동작 lock)

**Zig 그래프 (+1)**:
- 같은 external specifier 여러 모듈 import 시 phantom 1개 공유 + importers 양방향

## 영향
- 동작 변화 0
- Integration 69 → 81, Zig 그래프 +1
- 회귀 가드 강화 — 향후 phantom/external 관련 변경 시 안전망

🤖 Generated with [Claude Code](https://claude.com/claude-code)