### PR TITLE
perf(bundler): pass *const EmitOptions throughout (sweep)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -618,7 +618,7 @@ pub const Bundler = struct {
         const worker_result = try emitter.emitWithTreeShaking(
             arena_alloc,
             &worker_graph,
-            emit_opts,
+            &emit_opts,
             &worker_linker,
             null,
         );
@@ -973,7 +973,7 @@ pub const Bundler = struct {
             const emit_result = try emitter.emitWithTreeShaking(
                 self.allocator,
                 &graph,
-                dev_emit_opts,
+                &dev_emit_opts,
                 if (linker) |*l| l else null,
                 null, // dev mode: tree-shaking 비활성
             );
@@ -1009,7 +1009,7 @@ pub const Bundler = struct {
                 self.allocator,
                 &graph,
                 &chunk_graph,
-                emit_opts,
+                &emit_opts,
                 if (linker) |*l| l else null,
             );
             errdefer if (outputs) |outs| {
@@ -1030,7 +1030,7 @@ pub const Bundler = struct {
             const emit_result = try emitter.emitWithTreeShaking(
                 self.allocator,
                 &graph,
-                emit_opts,
+                &emit_opts,
                 if (linker) |*l| l else null,
                 if (shaker) |*s| s else null,
             );

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -103,7 +103,7 @@ comptime {
 }
 
 /// EmitOptions 의 emit 결과에 영향을 주는 모든 필드를 순차 hash.
-pub fn hashEmitOptions(h: *InputHasher, options: EmitOptions) void {
+pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addU32(@intFromEnum(options.format));
     h.addBool(options.minify_whitespace);
     h.addBool(options.minify_syntax);
@@ -188,7 +188,7 @@ pub fn hashEmitOptions(h: *InputHasher, options: EmitOptions) void {
 }
 
 /// 전체 emit 에 1회만 계산하면 되는 options_hash 를 캐싱용으로 반환.
-pub fn computeOptionsHash(options: EmitOptions) u64 {
+pub fn computeOptionsHash(options: *const EmitOptions) u64 {
     var h = InputHasher.init(0);
     hashEmitOptions(&h, options);
     return h.final();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -231,7 +231,7 @@ pub const EmitResult = struct {
 pub fn emit(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
-    options: EmitOptions,
+    options: *const EmitOptions,
     linker: ?*const Linker,
 ) !EmitResult {
     return emitWithTreeShaking(allocator, graph, options, linker, null);
@@ -241,7 +241,7 @@ pub fn emit(
 pub fn emitWithTreeShaking(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
-    options: EmitOptions,
+    options: *const EmitOptions,
     linker: ?*const Linker,
     shaker: ?*const TreeShaker,
 ) !EmitResult {
@@ -613,7 +613,7 @@ pub fn emitWithTreeShaking(
         const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
         if (is_entry and options.run_before_main.len > 0 and m.wrap_kind != .esm) {
             const before_len = module_output.items.len;
-            try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, &options);
+            try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options);
             module_line += @intCast(std.mem.count(u8, module_output.items[before_len..], "\n"));
         }
 
@@ -769,7 +769,7 @@ pub fn emitWithTreeShaking(
                 if (results[ei_idx].entry_chain) |chain| {
                     try output.appendSlice(allocator, chain);
                 }
-                try appendGuardedModuleCall(&output, allocator, em, &options);
+                try appendGuardedModuleCall(&output, allocator, em, options);
                 break;
             }
         }
@@ -907,7 +907,7 @@ pub const makeModuleId = dev.makeModuleId;
 
 /// 소스맵 sources 배열에 사용할 경로를 반환.
 /// RN 플랫폼은 Metro 호환 절대 경로, 다른 플랫폼은 root_dir 기준 상대 경로.
-pub fn sourcemapSourcePath(path: []const u8, options: EmitOptions) []const u8 {
+pub fn sourcemapSourcePath(path: []const u8, options: *const EmitOptions) []const u8 {
     if (options.platform == .react_native) return path;
     return makeModuleId(path, options.root_dir);
 }
@@ -1007,7 +1007,7 @@ pub fn appendRunBeforeMainCalls(output: *std.ArrayList(u8), allocator: std.mem.A
 fn emitModuleThread(
     allocator: std.mem.Allocator,
     module: *const Module,
-    options: EmitOptions,
+    options: *const EmitOptions,
     linker: ?*const Linker,
     is_entry: bool,
     used_names: ?[]const []const u8,
@@ -1023,7 +1023,7 @@ fn emitModuleThread(
 pub fn emitModule(
     allocator: std.mem.Allocator,
     module: *const Module,
-    options: EmitOptions,
+    options: *const EmitOptions,
     linker: ?*const Linker,
     is_entry: bool,
     used_export_names: ?[]const []const u8,
@@ -1626,7 +1626,7 @@ fn emitBundleRuntimeHelpers(
     output: *std.ArrayList(u8),
     allocator: std.mem.Allocator,
     sorted_modules: []const *const Module,
-    options: EmitOptions,
+    options: *const EmitOptions,
 ) !void {
     // 런타임 헬퍼 주입: 래핑 모듈 유형에 따라 필요한 헬퍼 결정.
     var needs_cjs_runtime = false;
@@ -1674,7 +1674,7 @@ pub fn emitChunkRuntimeHelpers(
     allocator: std.mem.Allocator,
     chunk: *const Chunk,
     graph: *const ModuleGraph,
-    options: EmitOptions,
+    options: *const EmitOptions,
     collected_helpers: ?RuntimeHelpers,
 ) !void {
     var needs_cjs_runtime = false;

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -38,7 +38,7 @@ pub fn emitChunks(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
     chunk_graph: *const ChunkGraph,
-    options: EmitOptions,
+    options: *const EmitOptions,
     linker: ?*Linker,
 ) ![]OutputFile {
     const module_count = graph.moduleCount();
@@ -583,7 +583,7 @@ fn rewriteDynamicImports(
     chunk_graph: *const ChunkGraph,
     public_path: []const u8,
     out_ext: []const u8,
-    emit_options: EmitOptions,
+    emit_options: *const EmitOptions,
 ) ![]const u8 {
     // dynamic import가 없으면 그대로 복사해서 반환
     if (module.import_records.len == 0) {
@@ -798,7 +798,7 @@ fn buildPlaceholder(chunk: *const Chunk, ph: *[HASH_PLACEHOLDER_PREFIX.len + HAS
 /// 청크의 placeholder stem을 반환한다 (확장자 없음).
 /// cross-chunk import 등 content가 아직 없는 시점에서 사용.
 /// 최종 출력 시 placeholder를 content hash로 치환한다.
-fn chunkPlaceholderStem(chunk: *const Chunk, buf: []u8, options: EmitOptions) []const u8 {
+fn chunkPlaceholderStem(chunk: *const Chunk, buf: []u8, options: *const EmitOptions) []const u8 {
     const is_entry = chunk.name != null;
     const base_name = chunk.name orelse "chunk";
     const pattern = if (is_entry) options.entry_names else options.chunk_names;

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -32,7 +32,7 @@ pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, m
 
 /// Asset 모듈(file/copy 로더)을 CJS wrap 패턴으로 출력. source엔 값 표현식이 저장됨.
 /// linker가 `require_X()` 호출을 생성하므로, 모든 포맷에서 CJS 패턴을 사용.
-pub fn emitAssetModule(allocator: std.mem.Allocator, module: *const Module, options: EmitOptions) !?[]const u8 {
+pub fn emitAssetModule(allocator: std.mem.Allocator, module: *const Module, options: *const EmitOptions) !?[]const u8 {
     if (module.source.len == 0) return null;
     return emitCjsWrapper(allocator, module.path, module.source, options.minify_whitespace);
 }

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -738,7 +738,7 @@ pub fn emitEsmWrappedModule(
     defer rbm_code.deinit(allocator);
     if (module.is_entry_point and options.run_before_main.len > 0) {
         if (linker) |l| {
-            try appendRunBeforeMainCalls(&rbm_code, allocator, l.graph, options.run_before_main, &options);
+            try appendRunBeforeMainCalls(&rbm_code, allocator, l.graph, options.run_before_main, options);
         }
     }
 
@@ -955,7 +955,7 @@ fn appendWrappedInitCall(
     buf: *std.ArrayList(u8),
     allocator: std.mem.Allocator,
     src_mod: *const Module,
-    options: EmitOptions,
+    options: *const EmitOptions,
 ) !void {
     const is_tla = src_mod.wrap_kind == .esm and src_mod.uses_top_level_await;
     const guard = src_mod.shouldGuard(options.entry_error_guard);

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -32,7 +32,7 @@ test "emitter: single module" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -50,7 +50,7 @@ test "emitter: two modules exec order" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -69,7 +69,7 @@ test "emitter: minified output" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .minify_whitespace = true }, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{ .minify_whitespace = true }, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -87,7 +87,7 @@ test "emitter: IIFE format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .format = .iife }, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{ .format = .iife }, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -106,7 +106,7 @@ test "emitter: IIFE format — ES5 target uses `function` wrapper" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .format = .iife,
         .unsupported = compat.fromESTarget(.es5),
     }, null);
@@ -126,7 +126,7 @@ test "emitter: CJS format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .format = .cjs }, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{ .format = .cjs }, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -139,7 +139,7 @@ test "emitter: empty graph" {
     var graph = ModuleGraph.init(std.testing.allocator, &cache);
     defer graph.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -157,7 +157,7 @@ test "emitter: chain A → B → C order" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -182,7 +182,7 @@ test "emitter: TS enum and interface stripping" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -216,7 +216,7 @@ test "inline (bundle): 함수 body 안 literal — inline" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -239,7 +239,7 @@ test "inline (bundle): top-level const — 보존 (scope=0)" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -269,7 +269,7 @@ test "inline (bundle): 크로스 모듈 — 각 모듈 함수 내부 별개로 i
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -303,7 +303,7 @@ test "inline (bundle): container literal 여러 모듈에 걸쳐" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -331,7 +331,7 @@ test "inline (bundle): minify_syntax 플래그 없어도 inline 실행 (#1552)" 
     defer result.cache.deinit();
 
     // minify_syntax=false (기본) — 그래도 inline 돌아야 함.
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .minify_syntax = false }, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{ .minify_syntax = false }, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -373,7 +373,7 @@ test "inline (bundle): shared module 내부 inline — emitChunks 경로" {
     var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, .{});
     defer cg.deinit();
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -432,7 +432,7 @@ test "emitChunks: single chunk produces one OutputFile" {
     var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
     defer cg.deinit();
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -467,7 +467,7 @@ test "emitChunks: two entries with shared module — 3 OutputFiles" {
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -514,7 +514,7 @@ test "CodeSplitting: dynamic import path rewritten to chunk filename" {
     var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, lazy_path }, .{});
     defer cg.deinit();
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -572,7 +572,7 @@ test "CodeSplitting: multiple dynamic imports rewritten" {
     var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ entry_path, pageA_path, pageB_path }, .{});
     defer cg.deinit();
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -618,7 +618,7 @@ test "chunkStem: common chunk uses hex hash, not index" {
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -667,7 +667,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     defer cg1.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg1, &result1.graph, std.testing.allocator, null);
 
-    const outputs1 = try emitter.emitChunks(std.testing.allocator, &result1.graph, &cg1, .{}, null);
+    const outputs1 = try emitter.emitChunks(std.testing.allocator, &result1.graph, &cg1, &.{}, null);
     defer {
         for (outputs1) |o| {
             o.deinit(std.testing.allocator);
@@ -684,7 +684,7 @@ test "chunkStem: same modules produce same hash (deterministic)" {
     defer cg2.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg2, &result2.graph, std.testing.allocator, null);
 
-    const outputs2 = try emitter.emitChunks(std.testing.allocator, &result2.graph, &cg2, .{}, null);
+    const outputs2 = try emitter.emitChunks(std.testing.allocator, &result2.graph, &cg2, &.{}, null);
     defer {
         for (outputs2) |o| {
             o.deinit(std.testing.allocator);
@@ -786,7 +786,7 @@ test "naming pattern: entry-names with hash" {
     var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
     defer cg.deinit();
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{
         .entry_names = "[name]-[hash]",
     }, null);
     defer {
@@ -827,7 +827,7 @@ test "naming pattern: chunk-names with directory" {
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{
         .chunk_names = "chunks/[name]-[hash]",
     }, null);
     defer {
@@ -873,7 +873,7 @@ test "content hash: cross-chunk import uses content hash" {
     defer cg.deinit();
     try chunk_mod.computeCrossChunkLinks(&cg, &result.graph, std.testing.allocator, null);
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -938,7 +938,7 @@ test "CJS runtime: __commonJS only in chunks containing CJS modules" {
     var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{ ep_a, ep_b }, .{});
     defer cg.deinit();
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -972,7 +972,7 @@ test "CodeSplitting: static import not rewritten" {
     var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
     defer cg.deinit();
 
-    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, .{}, null);
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{}, null);
     defer {
         for (outputs) |o| {
             o.deinit(std.testing.allocator);
@@ -1094,7 +1094,7 @@ test "banner/footer — basic ESM" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .banner_js = "/* banner */",
         .footer_js = "/* footer */",
     }, null);
@@ -1116,7 +1116,7 @@ test "banner/footer — IIFE format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .format = .iife,
         .banner_js = "// license header",
         .footer_js = "// end",
@@ -1138,7 +1138,7 @@ test "banner/footer — CJS format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .format = .cjs,
         .banner_js = "/* CJS banner */",
     }, null);
@@ -1166,7 +1166,7 @@ test "IIFE + globals: epilogue emits factory call args (#1824)" {
     defer result.cache.deinit();
 
     // globals 비어있음 → 기존 IIFE 경로
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .format = .iife,
         .globals = &.{},
     }, null);
@@ -1186,7 +1186,7 @@ test "globalName — IIFE wrapping" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .format = .iife,
         .global_name = "MyLib",
     }, null);
@@ -1208,7 +1208,7 @@ test "globalName — dotted name warning" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .format = .iife,
         .global_name = "MyApp.Utils",
     }, null);
@@ -1230,7 +1230,7 @@ test "globalName — ignored for non-IIFE" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .format = .esm,
         .global_name = "MyLib",
     }, null);
@@ -1250,7 +1250,7 @@ test "globalName — with banner/footer" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{
         .format = .iife,
         .global_name = "MyLib",
         .banner_js = "/* license */",
@@ -1281,7 +1281,7 @@ test "JSON module — ESM format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .format = .esm }, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{ .format = .esm }, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -1307,7 +1307,7 @@ test "JSON module — CJS format" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const emit_result = try emit(std.testing.allocator, &result.graph, .{ .format = .cjs }, null);
+    const emit_result = try emit(std.testing.allocator, &result.graph, &.{ .format = .cjs }, null);
     defer emit_result.deinit(std.testing.allocator);
     const output = emit_result.output;
 
@@ -1337,7 +1337,7 @@ test "emitter: lazy_sourcemap 은 eager 경로와 바이트 동등한 JSON 을 �
     // Eager: emit 단계에서 JSON 생성, sourcemap_builder 는 null.
     var eager_opts = base_opts;
     eager_opts.sourcemap.lazy = false;
-    const eager_res = try emit(std.testing.allocator, &result.graph, eager_opts, null);
+    const eager_res = try emit(std.testing.allocator, &result.graph, &eager_opts, null);
     defer eager_res.deinit(std.testing.allocator);
     try std.testing.expect(eager_res.sourcemap != null);
     try std.testing.expect(eager_res.sourcemap_builder == null);
@@ -1345,7 +1345,7 @@ test "emitter: lazy_sourcemap 은 eager 경로와 바이트 동등한 JSON 을 �
     // Lazy: emit 단계에서 builder 이관, sourcemap 은 null.
     var lazy_opts = base_opts;
     lazy_opts.sourcemap.lazy = true;
-    const lazy_res = try emit(std.testing.allocator, &result.graph, lazy_opts, null);
+    const lazy_res = try emit(std.testing.allocator, &result.graph, &lazy_opts, null);
     defer lazy_res.deinit(std.testing.allocator);
     try std.testing.expect(lazy_res.sourcemap == null);
     try std.testing.expect(lazy_res.sourcemap_builder != null);
@@ -1368,7 +1368,7 @@ test "emitter: lazy_sourcemap 은 sourcemap=false 일 때 builder 도 null" {
     defer result.cache.deinit();
 
     // sourcemap.enable=false 면 lazy 플래그는 무시된다 — builder/json 모두 null.
-    const res = try emit(std.testing.allocator, &result.graph, .{ .sourcemap = .{ .lazy = true } }, null);
+    const res = try emit(std.testing.allocator, &result.graph, &.{ .sourcemap = .{ .lazy = true } }, null);
     defer res.deinit(std.testing.allocator);
     try std.testing.expect(res.sourcemap == null);
     try std.testing.expect(res.sourcemap_builder == null);
@@ -1393,12 +1393,12 @@ test "emitter: lazy_sourcemap multi-module 바이트 동등성 (eager vs lazy)" 
 
     var eager = base;
     eager.sourcemap.lazy = false;
-    const eager_res = try emit(std.testing.allocator, &result.graph, eager, null);
+    const eager_res = try emit(std.testing.allocator, &result.graph, &eager, null);
     defer eager_res.deinit(std.testing.allocator);
 
     var lazy = base;
     lazy.sourcemap.lazy = true;
-    const lazy_res = try emit(std.testing.allocator, &result.graph, lazy, null);
+    const lazy_res = try emit(std.testing.allocator, &result.graph, &lazy, null);
     defer lazy_res.deinit(std.testing.allocator);
 
     const lazy_json = try lazy_res.sourcemap_builder.?.generateJSON("bundle.js");
@@ -1416,7 +1416,7 @@ test "emitter: lazy_sourcemap 에서 sourceMappingURL 주석은 항상 붙는다
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true, .lazy = true },
         .output_filename = "bundle.js",
     }, null);
@@ -1436,7 +1436,7 @@ test "emitter: lazy_sourcemap + debug_ids 는 builder 에 UUID 를 보관한다"
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true, .lazy = true, .debug_ids = true },
         .output_filename = "bundle.js",
     }, null);
@@ -1465,7 +1465,7 @@ test "emitter: lazy_sourcemap 은 source_root 를 builder 에 전파" {
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true, .lazy = true, .source_root = "/src" },
         .output_filename = "bundle.js",
     }, null);
@@ -1484,7 +1484,7 @@ test "emitter: lazy_sourcemap 은 sources_content=false 를 반영해 배열 제
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true, .lazy = true, .sources_content = false },
         .output_filename = "bundle.js",
     }, null);
@@ -1515,7 +1515,7 @@ test "emitter: lazy_sourcemap dev mode — ModuleDevCode.sm_builder 채워지고
         m.dev_id = "";
     };
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true, .lazy = true },
         .output_filename = "bundle.js",
         .dev_mode = true,
@@ -1560,12 +1560,12 @@ test "emitter: per-module sm_builder lazy/eager JSON 바이트 동등" {
 
     var eager = base;
     eager.sourcemap.lazy = false;
-    const eager_res = try emit(std.testing.allocator, &result.graph, eager, null);
+    const eager_res = try emit(std.testing.allocator, &result.graph, &eager, null);
     defer eager_res.deinit(std.testing.allocator);
 
     var lazy = base;
     lazy.sourcemap.lazy = true;
-    const lazy_res = try emit(std.testing.allocator, &result.graph, lazy, null);
+    const lazy_res = try emit(std.testing.allocator, &result.graph, &lazy, null);
     defer lazy_res.deinit(std.testing.allocator);
 
     const eager_codes = eager_res.module_codes orelse return error.TestUnexpectedResult;
@@ -1590,7 +1590,7 @@ test "emitter: lazy_sourcemap builder.generateJSON 은 두 번 호출 가능 (�
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true, .lazy = true },
         .output_filename = "bundle.js",
     }, null);
@@ -1613,7 +1613,7 @@ test "emitter: SourceMapOptions 기본값 — 모든 sourcemap 기능 비활성"
     defer result.cache.deinit();
 
     // EmitOptions.{} 기본값에서 sourcemap 은 완전 비활성. output 에 sourceMappingURL 없어야.
-    const res = try emit(std.testing.allocator, &result.graph, .{}, null);
+    const res = try emit(std.testing.allocator, &result.graph, &.{}, null);
     defer res.deinit(std.testing.allocator);
     try std.testing.expect(res.sourcemap == null);
     try std.testing.expect(res.sourcemap_builder == null);
@@ -1643,7 +1643,7 @@ test "emitter: dev_mode + sourcemap 활성 시 per-module code 끝에 sourceURL 
         m.dev_id = "";
     };
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true },
         .dev_mode = true,
         .collect_module_codes = true,
@@ -1679,7 +1679,7 @@ test "emitter: dev_mode + sourcemap 비활성 시 sourceURL 주석 없음" {
         m.dev_id = "";
     };
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .dev_mode = true,
         .collect_module_codes = true,
     }, null);
@@ -1712,7 +1712,7 @@ test "emitter: multi-module 각각에 고유 sourceURL 포함" {
         m.dev_id = "";
     };
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true },
         .dev_mode = true,
         .collect_module_codes = true,
@@ -1763,7 +1763,7 @@ test "emitter: root_dir 설정 시 sourceURL 이 상대경로" {
         m.dev_id = "";
     };
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true },
         .dev_mode = true,
         .collect_module_codes = true,
@@ -1791,7 +1791,7 @@ test "emitter: collect_module_codes=false — per-module code 자체 미수집 (
     defer result.graph.deinit();
     defer result.cache.deinit();
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true },
         .dev_mode = true,
         // collect_module_codes 의도적으로 false.
@@ -1825,7 +1825,7 @@ test "emitter: sourceURL 은 IIFE 뒤에 위치 — HMR_PREAMBLE_LINES 오프셋
         m.dev_id = "";
     };
 
-    const res = try emit(std.testing.allocator, &result.graph, .{
+    const res = try emit(std.testing.allocator, &result.graph, &.{
         .sourcemap = .{ .enable = true },
         .dev_mode = true,
         .collect_module_codes = true,


### PR DESCRIPTION
## Summary

Completes the `*const EmitOptions` migration started in #1871. All 14 remaining `options: EmitOptions` (by-value) sites across `emitter.zig`, `chunks.zig`, `cjs_wrap.zig`, `esm_wrap.zig`, and `compiled_cache.zig` now take `*const EmitOptions`.

Bundle output is **bit-identical** — pure cosmetic + ABI consistency refactor. Avoids potentially copying ~50 fields (slices, optionals, sub-structs) at every call boundary; matches the convention used for `*const ModuleGraph` etc.

## Touches

- **5 source files** — signature swap + 4 call sites in `bundler.zig` updated to pass `&emit_opts` / `&dev_emit_opts`
- **`emitter_test.zig`** — 53 inline `.{...}` literals + 4 variable passes → `&.{...}` / `&var`

## Test plan

- [x] `zig build test` — 3740/3740 passed
- [x] `zig build napi` — clean

## Co-relation

- #1864 (entry_error_guard feature)
- #1866 (refactor cleanup)
- #1871 (`*const EmitOptions` for guard helpers — narrow first step)
- **This PR** — sweep the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)