### PR TITLE
ci: bundle-perf.ts 통합 + --no-fail/--output 플래그

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,11 +65,21 @@ jobs:
           cd tests/benchmark
           bun run napi-bench.ts 2>&1 | tee -a bench-output.txt
 
+      - name: Run bundle perf regression check
+        # baseline 은 dev 머신 절대값 — CI 머신과 다르므로 회귀 비교는 informational.
+        # `--no-fail` 로 회귀 시도 CI 통과, JSON 결과는 artifact 로 트렌드 추적.
+        shell: bash
+        run: |
+          cd tests/benchmark
+          bun run bundle-perf.ts --no-fail --output bundle-perf-${{ matrix.os }}.json 2>&1 | tee -a bench-output.txt
+
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-${{ matrix.os }}
-          path: tests/benchmark/bench-output.txt
+          path: |
+            tests/benchmark/bench-output.txt
+            tests/benchmark/bundle-perf-${{ matrix.os }}.json
 
   comment:
     name: Post Results

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -58,4 +58,5 @@ bun run tests/benchmark/bundle-perf.ts --write
 - fixture 3종 (small 10 / medium 100 / large 200 모듈, externals 포함)
 - 워밍업 5회 + 측정 20회 → median 비교
 - baseline 은 `tests/benchmark/baselines/bundle-perf.json` 에 commit
-- 머신 의존 — CI 통합 시 동일 머신에서 baseline 갱신 + 거기서만 회귀 체크
+- 머신 의존 — 절대값은 머신마다 다름. dev 머신 비교는 의미 있고, CI 절대값은 다름
+- CI: `benchmark.yml` 가 PR 마다 `--no-fail --output` 로 실행 → JSON artifact 업로드 (트렌드 추적용, 회귀 fail 안 함)

--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -7,8 +7,10 @@
  * "보이지 않는 perf 회귀" 가 누적되는 것 방지.
  *
  * 실행:
- *   bun run tests/benchmark/bundle-perf.ts          # baseline 과 비교
- *   bun run tests/benchmark/bundle-perf.ts --write  # baseline 갱신
+ *   bun run tests/benchmark/bundle-perf.ts                    # baseline 과 비교
+ *   bun run tests/benchmark/bundle-perf.ts --write            # baseline 갱신
+ *   bun run tests/benchmark/bundle-perf.ts --output <path>    # 결과 JSON 덤프
+ *   bun run tests/benchmark/bundle-perf.ts --no-fail          # 회귀 시도 exit 0
  *
  * 측정 방법론:
  *   - 워밍업 5회 (mtime/dentry 캐시 워밍)
@@ -17,7 +19,8 @@
  *
  * 머신 의존성:
  *   - 절대값은 머신마다 다름 — 같은 머신에서 PR 전후 비교 의미 있음
- *   - CI 통합 시엔 baseline 을 CI 머신에서 갱신 + 거기서만 회귀 체크
+ *   - CI 에선 absolute 비교 무의미 → `--no-fail --output` 으로 결과만 수집,
+ *     artifact 업로드해 PR 코멘트 / 트렌드 추적용으로 활용.
  */
 
 import { spawnSync } from "node:child_process";
@@ -208,7 +211,24 @@ function fmtMs(n: number): string {
   return n.toFixed(2) + "ms";
 }
 
-async function main(writeMode: boolean) {
+interface CliArgs {
+  write: boolean;
+  noFail: boolean;
+  output: string | null;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { write: false, noFail: false, output: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--write") args.write = true;
+    else if (a === "--no-fail") args.noFail = true;
+    else if (a === "--output") args.output = argv[++i] ?? null;
+  }
+  return args;
+}
+
+async function main(cli: CliArgs) {
   buildBin();
   console.log(`[bundle-perf] zts ${getCommit()} | warmup=${WARMUP} iter=${ITERATIONS}`);
   console.log();
@@ -223,14 +243,20 @@ async function main(writeMode: boolean) {
     results.push(r);
   }
 
-  if (writeMode) {
-    const baseline: BaselineFile = {
-      version: 1,
-      generated_at: new Date().toISOString(),
-      zts_commit: getCommit(),
-      fixtures: results,
-    };
-    writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + "\n");
+  const runReport: BaselineFile = {
+    version: 1,
+    generated_at: new Date().toISOString(),
+    zts_commit: getCommit(),
+    fixtures: results,
+  };
+
+  if (cli.output) {
+    writeFileSync(cli.output, JSON.stringify(runReport, null, 2) + "\n");
+    console.log(`\n[bundle-perf] run report written: ${cli.output}`);
+  }
+
+  if (cli.write) {
+    writeFileSync(BASELINE_PATH, JSON.stringify(runReport, null, 2) + "\n");
     console.log(`\n[bundle-perf] baseline written: ${BASELINE_PATH}`);
     return;
   }
@@ -238,7 +264,8 @@ async function main(writeMode: boolean) {
   if (!existsSync(BASELINE_PATH)) {
     console.log(`\n[bundle-perf] no baseline at ${BASELINE_PATH}`);
     console.log("Run with --write to create baseline.");
-    process.exit(1);
+    if (!cli.noFail) process.exit(1);
+    return;
   }
 
   const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as BaselineFile;
@@ -265,10 +292,11 @@ async function main(writeMode: boolean) {
   }
 
   if (regressed > 0) {
-    console.log(`\n[bundle-perf] ${regressed} regression(s) — fail`);
-    process.exit(1);
+    console.log(`\n[bundle-perf] ${regressed} regression(s)`);
+    if (!cli.noFail) process.exit(1);
+    return;
   }
   console.log("\n[bundle-perf] no regression");
 }
 
-await main(process.argv.slice(2).includes("--write"));
+await main(parseArgs(process.argv.slice(2)));


### PR DESCRIPTION
## Summary
PR #1873 에서 추가한 bundle perf 회귀 가드를 CI benchmark workflow 에 통합.

## CLI 보강
- \`--no-fail\`: 회귀 발견해도 exit 0 (CI 용)
- \`--output <path>\`: 결과 JSON 덤프 (artifact 업로드용)

## CI (benchmark.yml)
- ubuntu/macos/windows 3 머신에서 매 PR 마다 측정
- \`--no-fail\` — baseline 절대값 머신 의존이라 fail 무의미, 트렌드 추적 목적
- JSON artifact 업로드 → 향후 PR 코멘트 / 트렌드 비교 가능

## 한계 + 향후
- baseline 비교 fail 은 dev 머신에서 직접 \`bun run\` 으로 사용
- CI 자체의 회귀 가드 하려면 main 브랜치 결과 캐시 + PR delta 비교 필요 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)