### PR TITLE
feat(napi): manualChunks meta 에 code 필드 추가 (Rollup parity)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -210,6 +210,10 @@ export interface ManualChunksModuleInfo {
    * `package.json` `sideEffects` 필드 또는 `treeShaking.moduleSideEffects` 옵션으로 결정.
    * `false` 면 unused 시 tree-shaker 가 제거 가능. */
   hasModuleSideEffects: boolean;
+  /** 모듈 source 코드 (Rollup `code` 호환).
+   * external / asset / 미파싱 모듈은 null. UTF-8 디코딩 실패 시도 null.
+   * `meta.getModuleInfo` 호출 시점에 graph 의 source 를 JS 문자열로 복사 — 큰 모듈은 비용 있음. */
+  code: string | null;
   /** 이 모듈을 static import 하는 모듈들. external 도 importer 목록에 포함됨
    * (자기 자신은 external 일 때 in-graph 모듈이 importer). */
   importers: string[];

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1056,6 +1056,17 @@ const NapiManualChunksResolver = struct {
         _ = c.napi_get_boolean(env, mod_info.has_module_side_effects, &js_has_side_effects);
         _ = c.napi_set_named_property(env, js_obj, "hasModuleSideEffects", js_has_side_effects);
 
+        var js_code: c.napi_value = undefined;
+        if (mod_info.code) |src| {
+            // UTF-8 검증 실패 시 null 로 fallback (binary loader 등 비-UTF8 source 대응)
+            if (c.napi_create_string_utf8(env, src.ptr, src.len, &js_code) != c.napi_ok) {
+                _ = c.napi_get_null(env, &js_code);
+            }
+        } else {
+            _ = c.napi_get_null(env, &js_code);
+        }
+        _ = c.napi_set_named_property(env, js_obj, "code", js_code);
+
         _ = c.napi_set_named_property(env, js_obj, "importers", pathArrayFromIndices(env, graph, mod_info.importers));
         _ = c.napi_set_named_property(env, js_obj, "dynamicImporters", pathArrayFromIndices(env, graph, mod_info.dynamic_importers));
         _ = c.napi_set_named_property(env, js_obj, "importedIds", pathArrayFromIndices(env, graph, mod_info.imported_ids));

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -134,6 +134,9 @@ pub const ModuleInfo = struct {
     /// `package.json` `sideEffects` 필드 또는 `treeShaking.moduleSideEffects` 옵션으로 결정.
     /// false 면 unused 시 tree-shaker 가 제거 가능.
     has_module_side_effects: bool,
+    /// 모듈 source 코드 (Rollup `code` 호환). external / asset / 미파싱 모듈은 null.
+    /// graph 수명 동안 borrowed (parse_arena 소유). NAPI 가 JS string 으로 복사.
+    code: ?[]const u8,
 };
 
 /// `id` 로 모듈 메타를 조회. 없으면 null. Zero allocation — graph 내부 slice borrow.
@@ -150,6 +153,8 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
         .is_entry = m.is_entry_point,
         .is_external = m.is_external,
         .has_module_side_effects = m.side_effects,
+        // External phantom 은 source 없음, asset/binary 모듈은 source 비어있을 수 있음.
+        .code = if (m.is_external or m.source.len == 0) null else m.source,
     };
 }
 

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -939,4 +939,76 @@ describe("manualChunks NAPI bridge", () => {
     // 사용자 코드 `pure-lib.ts` — package.json sideEffects=true 무시되고 auto-purity 가 false 로.
     expect(libFlag).toBe(false);
   });
+
+  // ============================================================
+  // info.code — Rollup 호환 source 노출
+  // ============================================================
+
+  test("meta.getModuleInfo: code — 모듈 source 그대로 노출", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `import { a } from "./lib"; console.log(a);`,
+      "lib.ts": 'export const a = "UNIQUE_LIB_MARKER_42";',
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.code);
+    const libCode = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"))![1];
+    const entryCode = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
+
+    expect(typeof libCode).toBe("string");
+    expect(libCode).toContain("UNIQUE_LIB_MARKER_42");
+    expect(typeof entryCode).toBe("string");
+    expect(entryCode).toContain('from "./lib"');
+  });
+
+  test("meta.getModuleInfo: code — external 모듈은 null", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `import { x } from "ext-pkg"; console.log(x);`,
+    });
+    cleanup = fixture.cleanup;
+
+    let extCode: unknown = "untouched";
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["ext-pkg"],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          extCode = meta.getModuleInfo("ext-pkg")?.code;
+        }
+        return null;
+      },
+    });
+
+    expect(extCode).toBeNull();
+  });
+
+  test("meta.getModuleInfo: code 기반 manualChunks 분류 — content 패턴 매칭", async () => {
+    // 실전 패턴: source 안에 특정 marker 가 있는 모듈만 별도 청크로.
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { a } from "./annotated";
+        import { b } from "./plain";
+        console.log(a, b);
+      `,
+      "annotated.ts": `// @vendor\nexport const a = 1;`,
+      "plain.ts": "export const b = 2;",
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        const info = meta.getModuleInfo(id);
+        if (info?.code?.includes("@vendor")) return "vendor";
+        return null;
+      },
+    });
+
+    const vendorChunk = result.outputFiles!.find((o) => o.path.includes("vendor"));
+    expect(vendorChunk).toBeDefined();
+    expect(vendorChunk!.moduleIds!.some((m) => m.endsWith("annotated.ts"))).toBe(true);
+    expect(vendorChunk!.moduleIds!.some((m) => m.endsWith("plain.ts"))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Rollup \`info.code\` 호환. 모듈 source 코드를 JS 문자열로 노출.

## 활용 예
\`\`\`ts
manualChunks: (id, meta) => {
  const info = meta.getModuleInfo(id);
  if (info?.code?.includes(\"@vendor\")) return \"vendor\";
  return null;
}
\`\`\`

## 동작
- 일반 모듈: source 그대로
- external phantom / asset / 미파싱: null
- UTF-8 디코딩 실패: null

## 비용
- \`meta.getModuleInfo(id)\` 호출 시점에 source 1회 복사 (lazy 아님 — Rollup 동일)
- 큰 모듈 많을 시 비용 누적 → 후속 PR 에서 lazy getter 검토 가능

## 테스트
- integration +3 (string 노출 / external null / content 기반 분류)

🤖 Generated with [Claude Code](https://claude.com/claude-code)