### PR TITLE
feat(bundler): split silentConsoleErrorPatterns from entryErrorGuard

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -426,6 +426,14 @@ interface BuildOptionsCommon {
    * `defineProperty` 시도 throw 였지만, mechanism 은 OS/엔진 무관 — 모든 module factory throw 케이스
    * 커버. React Native 플랫폼에서 자동 활성화. */
   entryErrorGuard?: boolean;
+  /** Prologue 에 `console.error` setter intercept 주입 — RegExp source string 배열의 어느 하나라도
+   * match 하는 console.error 호출은 silent swallow. `entryErrorGuard` 와 직교. consumer 가 환경
+   * (e.g. expo) 감지 후 패턴 주입. 비어있거나 미지정 시 wrap 자체 emit 안 됨 → vanilla RN CLI 빌드는
+   * dead code 0. RN preset 에서도 자동 활성화 안 함 (trigger 가 environment-specific 이므로).
+   *
+   * 예: `["^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$"]`
+   * (expo `installGlobal.ts` + RN `polyfillObjectProperty` 의 native immutable global 충돌 메시지) */
+  silentConsoleErrorPatterns?: string[];
   /** scope hoisting 활성화 (기본 true). 단일 chunk에서 모듈 경계를 제거하고 심볼을 평탄화. */
   scopeHoist?: boolean;
   /** Reanimated worklet 변환 — "worklet" 디렉티브 함수에 __workletHash/__closure/__initData 주입.

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3091,6 +3091,13 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
+    // silentConsoleErrorPatterns: string[] (RegExp source strings)
+    const silent_console_error_patterns = getObjectStringArray(env, opts_obj, "silentConsoleErrorPatterns", native_alloc);
+    if (silent_console_error_patterns) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
     // dropLabels: string[]
     const drop_labels = getObjectStringArray(env, opts_obj, "dropLabels", native_alloc);
     if (drop_labels) |arr| {
@@ -3214,6 +3221,7 @@ fn parseBuildOptions(
         .global_identifiers = global_identifiers orelse &.{},
         .polyfills = polyfills orelse &.{},
         .run_before_main = run_before_main orelse &.{},
+        .silent_console_error_patterns = silent_console_error_patterns orelse &.{},
     };
 }
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -218,6 +218,10 @@ pub const BundleOptions = struct {
     /// `ErrorUtils.reportFatalError(e)` 로 wrap. 자세한 설명은
     /// `EmitOptions.entry_error_guard`. RN preset 자동 활성.
     entry_error_guard: bool = false,
+    /// Prologue 에 `console.error` setter intercept 주입 — RegExp source string 배열 의
+    /// 어느 하나라도 match 하면 silent swallow. `entry_error_guard` 와 직교. consumer 가
+    /// 환경 (e.g. expo) 감지 후 패턴 주입. 비어있으면 wrap 자체 emit X.
+    silent_console_error_patterns: []const []const u8 = &.{},
     /// Reanimated worklet 네이티브 변환. --platform=react-native에서 자동 활성화.
     worklet_transform: bool = false,
     /// worklet의 `__pluginVersion` 값. null이면 ZTS 기본 상수 사용.
@@ -509,6 +513,7 @@ pub const Bundler = struct {
             .configurable_exports = self.options.configurable_exports,
             .strict_execution_order = self.options.strict_execution_order,
             .entry_error_guard = self.options.entry_error_guard,
+            .silent_console_error_patterns = self.options.silent_console_error_patterns,
             .worklet_transform = self.options.worklet_transform,
             .worklet_plugin_version = self.options.worklet_plugin_version,
             .compiled_cache = self.options.compiled_cache,

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2261,6 +2261,18 @@ fn buildRnGuarded(allocator: std.mem.Allocator, entry: []const u8) !Bundler {
     });
 }
 
+const expo_polyfill_pattern = "^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$";
+
+fn buildRnGuardedWithSilentPatterns(allocator: std.mem.Allocator, entry: []const u8, patterns: []const []const u8) !Bundler {
+    return Bundler.init(allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .entry_error_guard = true,
+        .silent_console_error_patterns = patterns,
+    });
+}
+
 test "entry_error_guard #1: 옵션 활성 시 prologue 에 helper + inGuard pattern 보존" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -2644,9 +2656,9 @@ test "entry_error_guard #16: GUARD_LAMBDA 매크로 형식 — esm_wrap / metada
     try std.testing.expect(close_count >= open_count);
 }
 
-test "entry_error_guard #17: prologue 에 console.error setter intercept + IGNORE regex emit" {
-    // expo `installGlobal.ts:96` 의 `console.error('Failed to set polyfill. X is not configurable.')` 를
-    // setter intercept 로 swallow. RN `setUpDeveloperTools` 가 console.error 를 다시 wrap 해도
+test "entry_error_guard #17: silent_console_error_patterns 주입 시 setter intercept emit" {
+    // 패턴 배열 주입 시 prologue 에 `Object.defineProperty(console, "error", { set })` 등장 +
+    // IGNORE regex literal 포함. RN `setUpDeveloperTools` 가 console.error 를 다시 wrap 해도
     // 우리 setter 가 그 위에 wrap 을 다시 씌워 outermost 유지.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -2654,13 +2666,14 @@ test "entry_error_guard #17: prologue 에 console.error setter intercept + IGNOR
     const entry = try absPath(&tmp, "entry.js");
     defer std.testing.allocator.free(entry);
 
-    var b = try buildRnGuarded(std.testing.allocator, entry);
+    const patterns = [_][]const u8{expo_polyfill_pattern};
+    var b = try buildRnGuardedWithSilentPatterns(std.testing.allocator, entry, &patterns);
     defer b.deinit();
     const result = try b.bundle();
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // IGNORE regex literal — expo `installGlobal.ts:96` 의 정확한 메시지 패턴.
+    // IGNORE regex literal — 주입한 패턴 그대로 emit.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "Failed to set polyfill") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "is not configurable") != null);
     // setter intercept — Object.defineProperty(console, "error", { set ... })
@@ -2670,6 +2683,27 @@ test "entry_error_guard #17: prologue 에 console.error setter intercept + IGNOR
     try std.testing.expect(std.mem.indexOf(u8, result.output, "set: function(fn)") != null);
     // configurable: true — RN 등 후속 코드가 다시 set 할 수 있게.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "configurable: true") != null);
+}
+
+test "entry_error_guard #17b: silent_console_error_patterns 비어있으면 setter intercept emit X" {
+    // 패턴 비어있으면 vanilla RN 빌드처럼 console wrap 자체 emit 안 됨 → dead code 0.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "export const x = 1;\n");
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = try buildRnGuarded(std.testing.allocator, entry); // patterns 비어있음
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // setter intercept 없음.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Object.defineProperty(console, \"error\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Failed to set polyfill") == null);
+    // 단 __zts_guarded helper 는 entry_error_guard 활성이라 emit.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function __zts_guarded") != null);
 }
 
 test "entry_error_guard #18: __ZTS_DEBUG_GUARD toggle — 기본 silent, toggle on 시 console.warn" {
@@ -2726,26 +2760,61 @@ test "entry_error_guard #19: dev_mode + entry_chain — __zts_modules[\"...\"].f
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__zts_guarded(function(){return __zts_modules[") != null);
 }
 
-test "entry_error_guard #20: regex 패턴 정확도 — 실제 expo 메시지 형식과 매치" {
-    // GUARDED_RUNTIME 안 IGNORE 정규식이 expo `installGlobal.ts:96` 의 출력을 정확히
-    // 매치하는지 정적 검증. 패턴 변경이 expo 메시지를 더 이상 못 잡는 회귀 방지.
-    const rt = @import("../runtime_helpers.zig");
-    // expo 가 emit 하는 실제 메시지 형식 (Location, TextEncoderStream, TextDecoderStream)
+test "entry_error_guard #20: silent_console_error_patterns 정확도 — 실제 expo 메시지 형식과 매치" {
+    // 주입한 expo polyfill 패턴이 console intercept emit 결과에 정확한 regex literal 로 들어있어야 함.
+    // expo 메시지 형식 (Location, TextEncoderStream, TextDecoderStream) 의 name 부분이 `\w+` 매칭.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "export const x = 1;\n");
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    const patterns = [_][]const u8{expo_polyfill_pattern};
+    var b = try buildRnGuardedWithSilentPatterns(std.testing.allocator, entry, &patterns);
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 주입한 패턴이 정확히 regex literal 로 emit (escape 보존).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "/^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$/") != null);
+
+    // 의미 검증 — sample 메시지 들의 name 부분이 모두 ASCII letter (`\w+` 매치 가능).
     const samples = [_][]const u8{
         "Failed to set polyfill. Location is not configurable.",
         "Failed to set polyfill. TextEncoderStream is not configurable.",
         "Failed to set polyfill. TextDecoderStream is not configurable.",
     };
-    // GUARDED_RUNTIME 안에 정규식 literal 이 그대로 들어있어야 함.
     for (samples) |sample| {
         const name_start = std.mem.indexOf(u8, sample, "polyfill. ").? + "polyfill. ".len;
         const name_end = std.mem.indexOf(u8, sample[name_start..], " is").? + name_start;
         const name = sample[name_start..name_end];
-        // 모든 sample 의 name (Location, TextEncoderStream, TextDecoderStream) 이 \w+ 매치.
         for (name) |c| {
             try std.testing.expect((c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z'));
         }
     }
-    // pattern literal 자체가 GUARDED_RUNTIME 에 포함.
-    try std.testing.expect(std.mem.indexOf(u8, rt.GUARDED_RUNTIME, "/^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$/") != null);
+}
+
+test "entry_error_guard #21: silent_console_error_patterns 다중 패턴 — 모두 IGNORE array 에 emit" {
+    // 사용자가 여러 RegExp 주입 시 [...,...] 배열로 emit. 각 패턴 독립 test.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "export const x = 1;\n");
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    const patterns = [_][]const u8{
+        expo_polyfill_pattern,
+        "^Some other warning$",
+    };
+    var b = try buildRnGuardedWithSilentPatterns(std.testing.allocator, entry, &patterns);
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "/^Failed to set polyfill") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "/^Some other warning$/") != null);
+    // 배열 loop 으로 검사 (단일 regex .test 가 아니라 IGNORE.length loop).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "for (var i = 0; i < IGNORE.length") != null);
 }

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -89,7 +89,7 @@ pub const InputHasher = struct {
 /// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
 /// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
 /// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
-const expected_emit_options_field_count: usize = 45;
+const expected_emit_options_field_count: usize = 46;
 
 comptime {
     const actual = @typeInfo(EmitOptions).@"struct".fields.len;
@@ -183,6 +183,7 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addBool(options.configurable_exports);
     h.addBool(options.strict_execution_order);
     h.addBool(options.entry_error_guard);
+    h.addStrList(options.silent_console_error_patterns);
     h.addBool(options.preserve_modules);
     h.addOptStr(options.preserve_modules_root);
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -155,6 +155,11 @@ pub const EmitOptions = struct {
     /// 가드 없이 `defineProperty` 호출 → throw → 부팅 실패. mechanism 은 OS/엔진
     /// 무관이라 모든 module factory throw 케이스 커버. RN 플랫폼 default 활성 권장.
     entry_error_guard: bool = false,
+    /// Prologue 에 `console.error` setter intercept 주입 — 각 RegExp source string 이
+    /// match 하는 console.error 호출을 silent swallow. 비어있으면 intercept 자체 emit X.
+    /// `entry_error_guard` 와 직교 — consumer 가 환경 (e.g. expo) 감지 후 패턴 주입.
+    /// vanilla RN CLI 빌드는 비어있어 dead code 0.
+    silent_console_error_patterns: []const []const u8 = &.{},
     /// preserve-modules: 모듈 1개 = 출력 파일 1개
     preserve_modules: bool = false,
     /// preserve-modules-root: 출력 디렉토리 구조의 기준 경로
@@ -1665,6 +1670,9 @@ fn emitBundleRuntimeHelpers(
     if (options.entry_error_guard) {
         try output.appendSlice(allocator, if (options.minify_whitespace) rt.GUARDED_RUNTIME_MIN else rt.GUARDED_RUNTIME);
     }
+    // silent_console_error_patterns: 패턴 비어있으면 emit X — vanilla RN 등 trigger 없는
+    // 환경에서 dead code 0. consumer 가 환경 (e.g. expo) 감지 후 패턴 주입.
+    try rt.emitConsoleErrorInterceptInto(output, allocator, options.silent_console_error_patterns, options.minify_whitespace);
 }
 
 /// 청크별 런타임 헬퍼 주입.

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -740,32 +740,25 @@ pub const REFRESH_STUB =
     "var $RefreshReg$ = function() {};\n" ++
     "var $RefreshSig$ = function() { return function(type) { return type; }; };\n";
 
-/// `entry_error_guard` 활성 시 prologue 에 주입. 두 부분으로 구성:
+/// `entry_error_guard` 활성 시 prologue 에 주입. `__zts_guarded(fn)` helper —
+/// 각 module init 호출 site (entry trigger / linker preamble / re-export / side-effect
+/// init) 가 통과. throw 를 silent swallow 해서 부팅 진행. Metro 의 `metro-runtime/src/
+/// polyfills/require.js:178` `guardedLoadModule` 와 등가 mechanism — Metro 도 module
+/// 평가는 eager 이지만 top-level `__r(N)` 호출이 try/catch wrap 되어 있어 throw 가
+/// LogBox 로 흘러가고 RN runtime 자체는 살아있음. ZTS 는 자체 module 시스템
+/// (`__esm`/`__commonJS`) 사용해 metro require.js 를 안 써서 이 invariant 가 빠져있었음.
 ///
-/// 1. `__zts_guarded(fn)` — 각 module init 호출 site (entry trigger / linker preamble /
-///    re-export / side-effect init) 가 통과. throw 를 silent swallow 해서 부팅 진행.
-///    Metro 의 `guardedLoadModule` 와 동등 mechanism — Metro 도 module 평가는 eager
-///    이지만 top-level `__r(N)` 호출이 try/catch wrap 되어 있어 throw 가 LogBox 로
-///    흘러가고 RN runtime 자체는 살아있음. ZTS 는 entry trigger 를 raw 로 emit 했었기
-///    때문에 동일 throw 가 Hermes 까지 propagate → 부팅 정지. 이 wrapper 부재가 부팅
-///    실패의 결정 요인.
+/// Metro 의 `inGuard` flag (nested 호출 무력화) 는 채택하지 않음 — 그건 native
+/// `ErrorUtils.reportFatalError` → `RN$handleException` 와 짝인데, iOS native immutable
+/// global 이 trigger 한 상황 (관측: iPad iOS 26.4 + Expo SDK 55) 에서는 그 handler 가
+/// "runtime not ready" 로 부팅 정지시킴. ZTS 는 silent swallow + 디버그 toggle:
+/// `globalThis.__ZTS_DEBUG_GUARD = true`.
 ///
-///    Metro 의 `inGuard` flag (nested 호출 무력화) 는 채택하지 않음 — 그건 native
-///    `ErrorUtils.reportFatalError` → `RN$handleException` 와 짝인데, iOS 26.4+
-///    환경에서는 그 handler 가 "runtime not ready" 로 부팅 정지시킴. ZTS 는 silent
-///    swallow + 디버그 toggle: `globalThis.__ZTS_DEBUG_GUARD = true`.
-///
-/// 2. `console.error` setter intercept — iOS 26.x 에서 host platform 이 spec global
-///    (`Location` / `TextEncoderStream` / `TextDecoderStream`) 을 placeholder
-///    (`configurable: false`) 로 사전 등록. expo `installGlobal.ts:96` 이 가드 거치고
-///    `console.error('Failed to set polyfill. X is not configurable.')` 출력 + return
-///    (throw 안 함 — 부팅에는 영향 없음). 단지 dev 콘솔 노이즈.
-///
-///    Metro 도 동일 메시지 출력하지만 LogBox 만 표시되고 콘솔 자체는 안 보이게 처리됨
-///    (RN `setUpDeveloperTools` 가 console.error 를 LogBox 로 redirect). ZTS 도 같은
-///    redirect 가 적용되지만 dev 환경에서 DevTools 가 backend.js 로 console 을
-///    추가로 hook 하면서 노이즈가 노출됨. setter intercept 로 RN wrap 위에 우리 wrap
-///    을 덧씌워 영구 outermost 필터 유지 → LogBox + DevTools 콘솔 양쪽 모두 깨끗.
+/// 별도 `console.error` setter intercept (`emitConsoleErrorIntercept`) 는 RN preset 자동
+/// 활성 안 함 — `silent_console_error_patterns` 옵션이 비어있으면 emit X. trigger 가
+/// expo winter polyfill (TextEncoderStream/TextDecoderStream/Location) ↔ iOS native
+/// immutable 충돌처럼 specific 환경에서만 발생하므로, consumer (bungae 등) 가 환경 감지
+/// 후 패턴 주입. vanilla RN CLI 빌드는 dead code 0.
 pub const GUARDED_RUNTIME =
     \\function __zts_guarded(fn) {
     \\  try { return fn(); }
@@ -776,31 +769,82 @@ pub const GUARDED_RUNTIME =
     \\    }
     \\  }
     \\}
-    \\(function() {
-    \\  if (typeof console === "undefined" || typeof console.error !== "function") return;
-    \\  var IGNORE = /^Failed to set polyfill\.\s+\w+\s+is not configurable\.?$/;
-    \\  function wrap(fn) {
-    \\    return function() {
-    \\      var first = arguments[0];
-    \\      if (typeof first === "string" && IGNORE.test(first)) return;
-    \\      return fn.apply(this, arguments);
-    \\    };
-    \\  }
-    \\  var current = wrap(console.error);
-    \\  try {
-    \\    Object.defineProperty(console, "error", {
-    \\      configurable: true,
-    \\      get: function() { return current; },
-    \\      set: function(fn) { current = wrap(fn); }
-    \\    });
-    \\  } catch (e) {}
-    \\})();
     \\
 ;
 
 pub const GUARDED_RUNTIME_MIN =
-    "function __zts_guarded(fn){try{return fn()}catch(e){if(typeof globalThis!==\"undefined\"&&globalThis.__ZTS_DEBUG_GUARD&&typeof console!==\"undefined\"&&console.warn)console.warn(\"[zts:guard] caught:\",e)}}" ++
-    "(function(){if(typeof console===\"undefined\"||typeof console.error!==\"function\")return;var I=/^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$/;function w(fn){return function(){var f=arguments[0];if(typeof f===\"string\"&&I.test(f))return;return fn.apply(this,arguments)}}var c=w(console.error);try{Object.defineProperty(console,\"error\",{configurable:true,get:function(){return c},set:function(fn){c=w(fn)}})}catch(e){}})();\n";
+    "function __zts_guarded(fn){try{return fn()}catch(e){if(typeof globalThis!==\"undefined\"&&globalThis.__ZTS_DEBUG_GUARD&&typeof console!==\"undefined\"&&console.warn)console.warn(\"[zts:guard] caught:\",e)}}\n";
+
+/// `silent_console_error_patterns` 가 비어있지 않을 때 prologue 에 주입.
+/// `Object.defineProperty(console, "error", { set })` setter intercept — RN
+/// `setUpDeveloperTools` 가 console.error 를 LogBox/ExceptionsManager 로 wrap 하지만
+/// 우리 setter 가 그 위에 한 번 더 wrap 을 덧씌워 영구 outermost 필터 유지.
+///
+/// 현재 알려진 trigger:
+/// - expo `installGlobal.ts:96` — winter polyfill (TextEncoderStream/TextDecoderStream/
+///   Location) 이 iOS native immutable global 위에 redefine 시도 → console.error (throw 안 함)
+/// - vanilla RN `Libraries/Utilities/PolyfillFunctions.js:41` — 동일 메시지 형식이지만
+///   RN core 가 polyfill 하는 globals (Promise/setTimeout/URL 등) 가 iOS native immutable
+///   대상과 안 겹쳐 실측에선 trigger 안 됨. 미래 OS 가 RN core polyfill 영역도 immutable 로
+///   깔면 그때 trigger 가능.
+///
+/// 패턴은 사용자가 RegExp source string 으로 주입. ZTS 는 expo 모름.
+pub fn emitConsoleErrorInterceptInto(
+    buf: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    patterns: []const []const u8,
+    minify: bool,
+) !void {
+    if (patterns.len == 0) return;
+    if (minify) {
+        try buf.appendSlice(allocator, "(function(){if(typeof console===\"undefined\"||typeof console.error!==\"function\")return;var I=[");
+        for (patterns, 0..) |p, i| {
+            if (i > 0) try buf.append(allocator, ',');
+            try buf.append(allocator, '/');
+            try buf.appendSlice(allocator, p);
+            try buf.append(allocator, '/');
+        }
+        try buf.appendSlice(allocator, "];function w(fn){return function(){var f=arguments[0];if(typeof f===\"string\"){for(var i=0;i<I.length;i++){if(I[i].test(f))return}}return fn.apply(this,arguments)}}var c=w(console.error);try{Object.defineProperty(console,\"error\",{configurable:true,get:function(){return c},set:function(fn){c=w(fn)}})}catch(e){}})();\n");
+        return;
+    }
+    try buf.appendSlice(allocator,
+        \\(function() {
+        \\  if (typeof console === "undefined" || typeof console.error !== "function") return;
+        \\  var IGNORE = [
+    );
+    try buf.append(allocator, '\n');
+    for (patterns, 0..) |p, i| {
+        try buf.appendSlice(allocator, "    /");
+        try buf.appendSlice(allocator, p);
+        try buf.append(allocator, '/');
+        if (i + 1 < patterns.len) try buf.append(allocator, ',');
+        try buf.append(allocator, '\n');
+    }
+    try buf.appendSlice(allocator,
+        \\  ];
+        \\  function wrap(fn) {
+        \\    return function() {
+        \\      var first = arguments[0];
+        \\      if (typeof first === "string") {
+        \\        for (var i = 0; i < IGNORE.length; i++) {
+        \\          if (IGNORE[i].test(first)) return;
+        \\        }
+        \\      }
+        \\      return fn.apply(this, arguments);
+        \\    };
+        \\  }
+        \\  var current = wrap(console.error);
+        \\  try {
+        \\    Object.defineProperty(console, "error", {
+        \\      configurable: true,
+        \\      get: function() { return current; },
+        \\      set: function(fn) { current = wrap(fn); }
+        \\    });
+        \\  } catch (e) {}
+        \\})();
+        \\
+    );
+}
 
 /// `__zts_guarded(function(){return <expr>;})` wrap 매크로 — esm_wrap / linker preamble /
 /// emitter 의 entry chain unroll 모두 같은 형식이라 한 곳에서 정의. 패턴 변경 시 여기만.


### PR DESCRIPTION
## Summary

Splits the `entry_error_guard` mode (#1864) into two orthogonal options to remove the expo-specific regex baked into the generic bundler.

| Option | Scope | RN preset auto |
| --- | --- | --- |
| `entryErrorGuard: boolean` | `__zts_guarded(fn)` wrapper — Metro `guardedLoadModule` equivalent (RN-wide invariant, decisive for boot) | ✅ yes |
| **`silentConsoleErrorPatterns: string[]` (NEW)** | `Object.defineProperty(console, "error", { set })` setter intercept — RegExp source array | ❌ no (consumer-injected) |

## Motivation

Real-world testing showed the previous bundling was wrong:
- `__zts_guarded` is universally needed for any RN preset (Metro invariant).
- console.error setter intercept **only triggers when expo winter polyfills collide with iOS native immutable globals** — vanilla RN CLI never hits the regex (RN core polyfill targets like Promise/setTimeout don't overlap with iOS-immutable globals like Location/TextEncoderStream).

So hard-coding the expo regex inside the generic bundler made:
- vanilla RN CLI builds carry dead code (regex test fails for every console.error)
- ZTS know about expo-specific message formats

## After

ZTS has **zero expo-specific code**. Patterns are pure data, injected by consumer:

```ts
// In bungae (or any RN consumer) — detect environment and inject
if (hasExpo) {
  opts.silentConsoleErrorPatterns = [
    '^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$'
  ];
}
```

Empty/missing array → setter intercept emit skipped entirely (zero overhead in vanilla RN).

## Implementation

- `EmitOptions.silent_console_error_patterns: []const []const u8`
- `BundleOptions.silent_console_error_patterns: []const []const u8`
- NAPI: `silentConsoleErrorPatterns?: string[]`
- `runtime_helpers.zig` — extracted `emitConsoleErrorInterceptInto(buf, allocator, patterns, minify)` from `GUARDED_RUNTIME`. Static IGNORE regex literal → dynamic `IGNORE = [/p1/, /p2/, ...]` array. Each console.error call iterates IGNORE and short-circuits on match.
- `compiled_cache.zig` — `expected_emit_options_field_count` 45 → 46. Cache hash includes new patterns.
- Doc correction in `runtime_helpers.zig` GUARDED_RUNTIME — "iOS 26.4+" was sloppy without an official source. Now reads "iOS native immutable global (관측: iPad iOS 26.4 + Expo SDK 55)".

## Tests

3743/3743 passed. New cases:
- **#17** — patterns 주입 시 setter intercept + IGNORE regex literal emit
- **#17b** — patterns 비어있으면 wrap 자체 emit X (vanilla RN dead-code-0 검증)
- **#20** — 주입 패턴이 정확한 regex literal 로 emit + escape 보존 + sample 메시지 의미 검증
- **#21** — 다중 패턴 시 `IGNORE = [/p1/, /p2/]` 배열 + loop iteration emit

## Follow-up

bungae monorepo PR — `napi-build.ts` 에서 expo 감지 시 `silentConsoleErrorPatterns` 주입 추가. ZTS 머지 + submodule sync 후 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)