### PR TITLE
feat(napi): manualChunks meta Phase A — 5 필드 추가 (Rollup 64% → 93%)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -211,9 +211,23 @@ export interface ManualChunksModuleInfo {
    * `false` 면 unused 시 tree-shaker 가 제거 가능. */
   hasModuleSideEffects: boolean;
   /** 모듈 source 코드 (Rollup `code` 호환).
-   * external / asset / 미파싱 모듈은 null. UTF-8 디코딩 실패 시도 null.
-   * `meta.getModuleInfo` 호출 시점에 graph 의 source 를 JS 문자열로 복사 — 큰 모듈은 비용 있음. */
+   * external / asset / 미파싱 모듈은 null. UTF-8 디코딩 실패 시도 null. */
   code: string | null;
+  /** tree-shake 후 번들에 포함된 모듈인지 (Rollup `isIncluded` 호환).
+   * `treeShaking: false` 일 땐 모든 모듈이 false 처럼 보일 수 있음 — Module 의 mirror flag 라
+   * tree-shaker 가 안 돌면 기본값 그대로. */
+  isIncluded: boolean;
+  /** 이 모듈이 export 하는 이름 목록 (Rollup `exports` 호환). default / re-export 별표 모두 포함.
+   * external 은 빈 배열 (graph 가 export 정보 없음). */
+  exports: string[];
+  /** Plugin 이 정의한 synthetic named exports (Rollup `syntheticNamedExports` 호환).
+   * ZTS 는 plugin context API 확장 (Phase B) 까지 항상 false. */
+  syntheticNamedExports: boolean;
+  /** `this.emitFile` 의 `implicitlyLoadedAfterOneOf` 옵션 결과 (Rollup 호환).
+   * ZTS plugin context API (Phase B) 까지 항상 빈 배열. */
+  implicitlyLoadedAfterOneOf: string[];
+  /** 위와 반대 방향 — 이 모듈을 implicitly 로드 후에 로드돼야 하는 모듈들. */
+  implicitlyLoadedBefore: string[];
   /** 이 모듈을 static import 하는 모듈들. external 도 importer 목록에 포함됨
    * (자기 자신은 external 일 때 in-graph 모듈이 importer). */
   importers: string[];

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1067,6 +1067,27 @@ const NapiManualChunksResolver = struct {
         }
         _ = c.napi_set_named_property(env, js_obj, "code", js_code);
 
+        var js_is_included: c.napi_value = undefined;
+        _ = c.napi_get_boolean(env, mod_info.is_included, &js_is_included);
+        _ = c.napi_set_named_property(env, js_obj, "isIncluded", js_is_included);
+
+        var js_synthetic: c.napi_value = undefined;
+        _ = c.napi_get_boolean(env, mod_info.synthetic_named_exports, &js_synthetic);
+        _ = c.napi_set_named_property(env, js_obj, "syntheticNamedExports", js_synthetic);
+
+        // exports — ExportBinding[] → exported_name string array.
+        var js_exports: c.napi_value = undefined;
+        _ = c.napi_create_array(env, &js_exports);
+        for (mod_info.export_bindings, 0..) |eb, i| {
+            var js_name: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, eb.exported_name.ptr, eb.exported_name.len, &js_name);
+            _ = c.napi_set_element(env, js_exports, @intCast(i), js_name);
+        }
+        _ = c.napi_set_named_property(env, js_obj, "exports", js_exports);
+
+        _ = c.napi_set_named_property(env, js_obj, "implicitlyLoadedAfterOneOf", pathArrayFromIndices(env, graph, mod_info.implicitly_loaded_after_one_of));
+        _ = c.napi_set_named_property(env, js_obj, "implicitlyLoadedBefore", pathArrayFromIndices(env, graph, mod_info.implicitly_loaded_before));
+
         _ = c.napi_set_named_property(env, js_obj, "importers", pathArrayFromIndices(env, graph, mod_info.importers));
         _ = c.napi_set_named_property(env, js_obj, "dynamicImporters", pathArrayFromIndices(env, graph, mod_info.dynamic_importers));
         _ = c.napi_set_named_property(env, js_obj, "importedIds", pathArrayFromIndices(env, graph, mod_info.imported_ids));

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -144,6 +144,10 @@ pub const Module = struct {
     /// `meta.getModuleInfo` / `info.importedIds` 등 graph traversal API 의 1급 노드로 보이지만
     /// chunk 배정 / emit / tree-shake 에선 제외. AST 없음, source 없음, path = original specifier.
     is_external: bool = false,
+    /// tree-shake 결과 — 번들에 포함된 모듈인지 (Rollup `info.isIncluded` 호환).
+    /// `TreeShaker.analyze` 가 finalize 후 set. 기본 false 라 tree-shaking 비활성 시
+    /// 의미 없음 — chunk gen 단계에서도 `m.side_effects or entry_set.isSet` 으로 항상 alive 처리.
+    is_included: bool = false,
     /// package.json "module" 필드를 통해 resolve된 파일.
     /// .js 확장자라도 ESM으로 파싱해야 함.
     is_module_field: bool = false,

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -296,6 +296,13 @@ pub const TreeShaker = struct {
                 self.included.unset(i);
             }
         }
+
+        // ModuleInfo `isIncluded` 노출용 — 최종 included BitSet 을 Module 에 mirror.
+        // chunk gen / NAPI 가 BitSet 직접 보유 안 해도 `m.is_included` 로 조회 가능.
+        for (0..mod_count) |i| {
+            const m = self.moduleAtMut(@intCast(i)) orelse continue;
+            m.is_included = self.included.isSet(i);
+        }
     }
 
     pub fn isStmtReachable(self: *const TreeShaker, module_index: u32, stmt_idx: u32) bool {

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -131,15 +131,26 @@ pub const ModuleInfo = struct {
     /// `external` 패턴 매칭으로 번들에 포함되지 않는 모듈인지 여부 (Rollup `isExternal` 호환).
     is_external: bool,
     /// 모듈이 side effect 를 가질 수 있는지 (Rollup `hasModuleSideEffects` 호환).
-    /// `package.json` `sideEffects` 필드 또는 `treeShaking.moduleSideEffects` 옵션으로 결정.
-    /// false 면 unused 시 tree-shaker 가 제거 가능.
     has_module_side_effects: bool,
     /// 모듈 source 코드 (Rollup `code` 호환). external / asset / 미파싱 모듈은 null.
-    /// graph 수명 동안 borrowed (parse_arena 소유). NAPI 가 JS string 으로 복사.
     code: ?[]const u8,
+    /// tree-shake 후 번들에 포함된 모듈인지 (Rollup `isIncluded` 호환).
+    is_included: bool,
+    /// 모듈의 export binding 목록 (Rollup `exports` 호환). NAPI 가 `.exported_name` 으로 투영.
+    /// external 모듈은 빈 슬라이스. `m.export_bindings` 의 borrow.
+    export_bindings: []const @import("binding_scanner.zig").ExportBinding,
+    /// Plugin 이 정의한 synthetic named exports (Rollup `syntheticNamedExports` 호환).
+    /// ZTS 는 plugin 시스템 확장 (Phase B) 까지 항상 false. 노출 시그니처만 맞춤.
+    synthetic_named_exports: bool,
+    /// `this.emitFile` 의 `implicitlyLoadedAfterOneOf` 옵션 결과 (Rollup 호환).
+    /// ZTS 는 plugin context API (Phase B) 까지 항상 빈 배열.
+    implicitly_loaded_after_one_of: []const ModuleIndex,
+    /// 위와 반대 방향 — 이 모듈을 implicitly 로드 후에 로드돼야 하는 모듈들.
+    implicitly_loaded_before: []const ModuleIndex,
 };
 
-/// `id` 로 모듈 메타를 조회. 없으면 null. Zero allocation — graph 내부 slice borrow.
+/// `id` 로 모듈 메타를 조회. 없으면 null. Zero allocation — 모든 slice 가 graph borrow.
+/// `exports` 는 ExportBinding 슬라이스를 그대로 노출 — caller 가 `.exported_name` 으로 투영.
 pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInfo {
     const graph = @as(?*const @import("graph.zig").ModuleGraph, @ptrCast(@alignCast(graph_opaque))) orelse return null;
     const idx = graph.path_to_module.get(id) orelse return null;
@@ -155,6 +166,12 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
         .has_module_side_effects = m.side_effects,
         // External phantom 은 source 없음, asset/binary 모듈은 source 비어있을 수 있음.
         .code = if (m.is_external or m.source.len == 0) null else m.source,
+        .is_included = m.is_included,
+        .export_bindings = if (m.is_external) &.{} else m.export_bindings,
+        // Phase B (plugin context API) 까지 placeholder 값.
+        .synthetic_named_exports = false,
+        .implicitly_loaded_after_one_of = &.{},
+        .implicitly_loaded_before = &.{},
     };
 }
 

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -1011,4 +1011,91 @@ describe("manualChunks NAPI bridge", () => {
     expect(vendorChunk!.moduleIds!.some((m) => m.endsWith("annotated.ts"))).toBe(true);
     expect(vendorChunk!.moduleIds!.some((m) => m.endsWith("plain.ts"))).toBe(false);
   });
+
+  // ============================================================
+  // Phase A — Rollup ModuleInfo 추가 필드 (exports / isIncluded / 기타 placeholder)
+  // ============================================================
+
+  test("meta.getModuleInfo: exports — 모듈이 export 하는 이름 목록", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `import { a, b } from "./lib"; console.log(a, b);`,
+      "lib.ts": `
+        export const a = 1;
+        export const b = 2;
+        export default "DEF";
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.exports);
+    const libExports = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"))![1];
+    expect(libExports).toContain("a");
+    expect(libExports).toContain("b");
+    expect(libExports).toContain("default");
+  });
+
+  test("meta.getModuleInfo: external 의 exports 는 빈 배열", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `import { x } from "ext"; console.log(x);`,
+    });
+    cleanup = fixture.cleanup;
+
+    let extExports: string[] | undefined;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      external: ["ext"],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) extExports = meta.getModuleInfo("ext")?.exports;
+        return null;
+      },
+    });
+    expect(extExports).toEqual([]);
+  });
+
+  test("meta.getModuleInfo: isIncluded — tree-shake 후 사용된 모듈만 true", async () => {
+    // entry 가 used 모듈만 import. unused 모듈은 사용자 코드라서 fixture 에 안 만들고
+    // 모든 모듈이 included=true 인지 확인 (모두 reachable).
+    const fixture = await createFixture({
+      "entry.ts": `import { a } from "./lib"; console.log(a);`,
+      "lib.ts": "export const a = 1;",
+    });
+    cleanup = fixture.cleanup;
+
+    const seen = await collectMeta(fixture.dir, ["entry.ts"], (info) => info.isIncluded);
+    const libIncluded = [...seen.entries()].find(([k]) => k.endsWith("lib.ts"))![1];
+    const entryIncluded = [...seen.entries()].find(([k]) => k.endsWith("entry.ts"))![1];
+    expect(entryIncluded).toBe(true);
+    expect(libIncluded).toBe(true);
+  });
+
+  test("meta.getModuleInfo: Phase B placeholder 필드들 — 시그니처만 맞춤", async () => {
+    // syntheticNamedExports / implicitlyLoaded* 는 plugin context API (후속) 까지 default.
+    const fixture = await createFixture({
+      "entry.ts": "console.log(1);",
+    });
+    cleanup = fixture.cleanup;
+
+    let entryInfo: { syn: boolean; before: string[]; after: string[] } | undefined;
+    await build({
+      entryPoints: [join(fixture.dir, "entry.ts")],
+      splitting: true,
+      manualChunks: (id, meta) => {
+        if (id.endsWith("entry.ts")) {
+          const info = meta.getModuleInfo(id)!;
+          entryInfo = {
+            syn: info.syntheticNamedExports,
+            before: info.implicitlyLoadedBefore,
+            after: info.implicitlyLoadedAfterOneOf,
+          };
+        }
+        return null;
+      },
+    });
+
+    expect(entryInfo).toBeDefined();
+    expect(entryInfo!.syn).toBe(false);
+    expect(entryInfo!.before).toEqual([]);
+    expect(entryInfo!.after).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
Rollup `ModuleInfo` 의 cheap 필드 5개 추가.

## 필드
- `exports: string[]` — module exports
- `isIncluded: boolean` — tree-shake 후 포함 여부
- `syntheticNamedExports: false` — Phase B placeholder
- `implicitlyLoadedAfterOneOf: []` — Phase B placeholder
- `implicitlyLoadedBefore: []` — Phase B placeholder

## 호환률
- 9/14 → **13/14 표면적** 노출 (`ast` 만 미노출 → 후속 #1881)
- 의미적 호환은 `syntheticNamedExports` / `implicitlyLoaded*` placeholder 라 plugin context API (#1880) 와야 완전

## 구현
- `Module.is_included: bool` 필드 + TreeShaker mirror
- `ModuleInfo.export_bindings` zero-alloc (이전 alloc 시도 leak 발견)

## 테스트
- integration +4

## 후속
- #1880: plugin context API + ModuleInfo.meta (Phase B)
- #1881: ESTree adapter — ModuleInfo.ast (Phase C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)