### PR TITLE
docs: manualChunks epic 동기화 (ROADMAP + Astro guide)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,6 +51,9 @@
 | 38. CSS 번들링 | @import 인라이닝, 별도 .css 파일 emit, Lightning CSS minify 연동 | ✅ |
 | 39. Minify 확장 | 미참조 class expression name 익명화 — fast/non-fast path 통합 (#1587 + #1596) | ✅ |
 | 40. Import attributes | ES2024 `with {...}` 라운드트립: static / dynamic / export named / export * 네 경로 전부 AST 보존. `assert` → `with` 자동 마이그레이션 | ✅ |
+| 41. manualChunks | Rollup `manualChunks(id, meta)` 호환. record + function 형, NAPI TSFN, 동적 그룹화, dynamic import 정책, manualChunks meta API (id/isEntry/isExternal/code/isIncluded/exports/importers/dynamicImporters/importedIds/dynamicallyImportedIds/hasModuleSideEffects/syntheticNamedExports/implicitlyLoaded\*) | ✅ |
+| 42. external phantom | external 모듈을 phantom Module 로 graph 등록 — Rollup parity (`getModuleInfo("react").isExternal === true`, `info.importedIds` 에 external 포함) | ✅ |
+| 43. inlineDynamicImports | Rollup `output.inlineDynamicImports` — chunk 구조 (A) + 런타임 registry (B). `import("./x")` → `__esm` / `__commonJS` 래퍼로 재작성. namespace identity / single-execution / live binding 보장 | ✅ |
 
 ## 번들러 성능 현황 (2026-04-10 실측)
 
@@ -185,8 +188,8 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 
 - ~~**jsx-dev**~~ — ✅ 완료. `--jsx=automatic-dev` / `--jsx-dev` React 개발 모드 `jsxDEV` + `__source`/`__self`
 - ~~**UMD/AMD 포맷**~~ — ✅ 완료. `--format=umd` / `--format=amd` + external dependency array + factory params
-- **manualChunks** — `L` | 사용자 정의 청크 분할 규칙 (rolldown advancedChunks, rspack splitChunks)
-  프로덕션 청크 최적화 시 벤더/공통 코드 분리 필수. rolldown은 `advancedChunks`, rspack은 webpack의 `splitChunks` 호환.
+- ~~**manualChunks**~~ — ✅ 완료. Rollup `manualChunks(id, meta)` 호환. record + function 형, manualChunks meta API (`getModuleInfo`) 13/14 필드 노출, external phantom Module 처리, `inlineDynamicImports` (chunk 구조 + 런타임 registry).
+  남은 1필드 (`info.ast`) 는 ESTree adapter epic (#1881) — Phase C 로 분리.
 - ~~**preserveModules**~~ — ✅ 완료. `--preserve-modules` + `--preserve-modules-root` (Rollup/Rolldown 호환)
 - ~~**using 다운레벨링**~~ — ✅ 완료. `using`/`await using` → try-finally + `__using`/`__callDispose` (esbuild 호환)
 - ~~**설정 파일 (zts.config.js)**~~ — ✅ 완료. `packages/core`에서 `defineConfig()` 내보냄.
@@ -211,7 +214,9 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 | 항목 | 난이도 | esbuild | rolldown | rspack | ZTS | 설명 |
 |------|--------|---------|----------|--------|-----|------|
 | ~~**CSS 번들링**~~ | ✅ | ✅ | ✅ | ✅ | ✅ | @import 인라이닝 + Lightning CSS minify (CSS Modules 후순위) |
-| **manualChunks** | L | ❌ | ✅ advancedChunks | ✅ splitChunks | ❌ | 사용자 정의 청크 분할 규칙 |
+| ~~**manualChunks**~~ | ✅ | ❌ | ✅ advancedChunks | ✅ splitChunks | ✅ | Rollup `manualChunks(id, meta)` 호환 + meta API 13/14 필드 |
+| ~~**inlineDynamicImports**~~ | ✅ | ❌ | ✅ | ❌ | ✅ | Rollup `output.inlineDynamicImports` — `__esm`/`__commonJS` 래핑으로 런타임 처리 |
+| ~~**external phantom**~~ | ✅ | ❌ | ✅ | ❌ | ✅ | external 도 graph 1급 노드 — Rollup `getModuleInfo("react").isExternal` 동작 |
 | **innerGraph** | L | ❌ | ✅ | ✅ | ❌ | 변수 할당 추적으로 정밀 DCE |
 | **Persistent caching** | XL | ❌ | ❌ | ✅ | ❌ | 디스크 캐시, 콜드 리빌드 250%↑ |
 | **Module Federation** | XL | ❌ | ❌ | ✅ | ❌ | 마이크로프론트엔드 코드/리소스 공유 |
@@ -253,8 +258,10 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
   mangleProps (1주+) — cross-module 프로퍼티 추적
   Stage 3 decorators ✅ 완료 — TC39 Stage 3 데코레이터 (legacy + Stage 3, MobX 6 호환)
   Module Concatenation 고도화 — rspack/rolldown 수준 scope hoisting
-  manualChunks (3~5일) — 사용자 정의 청크 분할
+  manualChunks ✅ 완료 — Rollup 호환 (record + function + meta API 13/14 필드)
   innerGraph (3~5일) — 변수 할당 추적 정밀 DCE
+  Rollup ModuleInfo Phase B (#1880) — plugin context API + meta 필드 (1.5~2주)
+  Rollup ModuleInfo Phase C (#1881) — ESTree adapter (info.ast, 2~4주)
 ```
 
 ### 기술부채 & 구조적 제약

--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
           translations: { en: "Bundler" },
           items: [
             { label: "개요", slug: "guides/bundling", translations: { en: "Overview" } },
+            { label: "manualChunks", slug: "guides/manual-chunks", translations: { en: "manualChunks" } },
           ],
         },
         {

--- a/documents/src/content/docs/guides/manual-chunks.md
+++ b/documents/src/content/docs/guides/manual-chunks.md
@@ -1,0 +1,188 @@
+---
+title: manualChunks
+description: 사용자 정의 청크 분할 — Rollup `manualChunks(id, meta)` 호환 API.
+---
+
+ZTS 는 Rollup 의 `manualChunks(id, meta)` 시그니처를 호환합니다. 벤더/공통 코드 분리, content 기반 분류, 그래프 토폴로지 기반 분류 등 프로덕션 청크 최적화에 자주 쓰는 패턴을 모두 지원합니다.
+
+## 기본 사용
+
+```ts
+import { build } from "@zts/core";
+
+await build({
+  entryPoints: ["./src/main.ts"],
+  splitting: true,
+  outdir: "./dist",
+  manualChunks: (id) => {
+    if (id.includes("node_modules")) return "vendor";
+    return null;
+  },
+});
+```
+
+`manualChunks` 가 반환한 이름의 청크에 모듈이 묶입니다. `null`/`undefined` 를 반환하면 자동 분배.
+
+## meta API — 그래프 토폴로지 기반 분류
+
+두 번째 인자 `meta` 의 `getModuleInfo(id)` 로 모듈 정보를 조회합니다.
+
+```ts
+manualChunks: (id, meta) => {
+  const info = meta.getModuleInfo(id);
+  if (!info) return null;
+
+  // 2개 이상 모듈에서 import 되는 것만 shared 로
+  if (info.importers.length >= 2) return "shared";
+
+  // 외부 의존성은 항상 분리
+  if (info.isExternal) return "vendor";
+
+  // tree-shake 후 포함되지 않으면 분류 안 함
+  if (!info.isIncluded) return null;
+
+  return null;
+},
+```
+
+### `ManualChunksModuleInfo` 필드
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `id` | `string` | 모듈 절대 경로 |
+| `isEntry` | `boolean` | 엔트리 모듈 여부 |
+| `isExternal` | `boolean` | `external` 패턴 매칭으로 번들 제외된 모듈 |
+| `hasModuleSideEffects` | `boolean` | `package.json sideEffects` / 글롭 매칭 결과 |
+| `code` | `string \| null` | 모듈 source. external/asset 은 null |
+| `isIncluded` | `boolean` | tree-shake 후 번들에 포함됐는지 |
+| `exports` | `string[]` | export 된 이름 목록 (default 포함) |
+| `importers` | `string[]` | static import 한 모듈들의 절대 경로 |
+| `dynamicImporters` | `string[]` | `import()` 한 모듈들 |
+| `importedIds` | `string[]` | 이 모듈이 static import 한 것들 (external 포함) |
+| `dynamicallyImportedIds` | `string[]` | 이 모듈이 dynamic import 한 것들 |
+| `syntheticNamedExports` | `boolean` | plugin 정의 — 현재 항상 false (Phase B 대기) |
+| `implicitlyLoadedAfterOneOf` | `string[]` | plugin emitFile 옵션 — 현재 항상 [] |
+| `implicitlyLoadedBefore` | `string[]` | 같음 |
+
+`info.ast` 만 미노출 — ESTree adapter (별도 epic) 후 추가 예정.
+
+## inlineDynamicImports
+
+dynamic import target 도 importer 와 같은 chunk 로 흡수해 단일 파일 출력에 가까워집니다.
+
+```ts
+await build({
+  entryPoints: ["./src/main.ts"],
+  splitting: true,
+  inlineDynamicImports: true,  // dynamic import 도 inline
+  outdir: "./dist",
+});
+```
+
+내부적으로 dynamic-import target 모듈을 `__esm` 래퍼로 묶고 `import("./x")` 호출을 `Promise.resolve().then(() => (init_x(), exports_x))` 로 재작성합니다.
+
+### 보장
+- **namespace identity**: `(await import("./x")) === (await import("./x"))`
+- **single-execution**: top-level side effect 정확히 1회 실행 (`__esm` 캐싱)
+- **live binding**: `export let counter; counter++` 같은 변경이 caller 에 반영됨
+
+## external 처리
+
+`external` 패턴 매칭된 모듈은 번들에 들어가지 않지만 graph 에는 phantom Module 로 등록됩니다 — Rollup parity.
+
+```ts
+await build({
+  entryPoints: ["./src/main.ts"],
+  external: ["react", "react-dom"],
+  manualChunks: (id, meta) => {
+    // external 도 직접 조회 가능
+    const reactInfo = meta.getModuleInfo("react");
+    console.log(reactInfo?.isExternal); // true
+
+    // entry 의 importedIds 에 external 포함
+    const entry = meta.getModuleInfo(id);
+    console.log(entry?.importedIds.includes("react")); // true if entry imports react
+
+    return null;
+  },
+});
+```
+
+## 패턴별 예제
+
+### 벤더/공통 분리
+
+```ts
+manualChunks: (id) => {
+  if (id.includes("/node_modules/")) return "vendor";
+  if (id.includes("/src/components/")) return "components";
+  return null;
+}
+```
+
+### content 기반 분류
+
+`@vendor` 같은 마커가 source 에 있는 모듈만 별도로:
+
+```ts
+manualChunks: (id, meta) => {
+  const info = meta.getModuleInfo(id);
+  if (info?.code?.includes("@vendor")) return "vendor";
+  return null;
+}
+```
+
+### shared chunk (2개 이상 entry 가 공유)
+
+```ts
+manualChunks: (id, meta) => {
+  const info = meta.getModuleInfo(id);
+  if (!info) return null;
+  if (info.isEntry) return null;
+  if (info.importers.length >= 2) return "shared";
+  return null;
+}
+```
+
+### tree-shake 가능한 라이브러리만 별도 청크
+
+```ts
+manualChunks: (id, meta) => {
+  const info = meta.getModuleInfo(id);
+  if (info && !info.hasModuleSideEffects) return "pure";
+  return null;
+}
+```
+
+## 정책 / 제한
+
+- `manualChunks` resolver 는 모듈당 정확히 1회 호출 (NAPI TSFN — JS 호출 비용 최소화)
+- resolver 가 throw 하면 해당 모듈은 `null` 처리 (auto 분배), 번들 중단되지 않음
+- string 외 반환 (number, boolean) 은 `null` 동일 취급 (Rollup 스펙)
+- `external` 모듈은 resolver 에 직접 호출되지 않음 — phantom 이라 chunk 배정 대상 아님
+- dynamic-import target 도 manual 청크에서 제외 (lazy load 의미 보존). `inlineDynamicImports: true` 시 importer 청크로 흡수
+
+## CLI
+
+`manualChunks` 는 함수라 CLI 직접 노출 X — JS API (`@zts/core`) 또는 `zts.config.{js,ts}` 사용.
+
+```ts
+// zts.config.ts
+import { defineConfig } from "@zts/core";
+
+export default defineConfig({
+  entryPoints: ["./src/main.ts"],
+  splitting: true,
+  inlineDynamicImports: true,
+  manualChunks: (id, meta) => {
+    if (meta.getModuleInfo(id)?.isExternal) return "vendor";
+    return null;
+  },
+});
+```
+
+## 향후
+
+현재 13/14 Rollup `ModuleInfo` 필드 노출. 진행 중:
+- **Phase B** (issue #1880): plugin context API (`this.getModuleInfo`/`emitFile`/`resolve`) + `info.meta` 필드
+- **Phase C** (issue #1881): ESTree adapter — `info.ast` 노출

--- a/documents/src/content/docs/reference/options.md
+++ b/documents/src/content/docs/reference/options.md
@@ -57,6 +57,16 @@ ZTS의 트랜스파일 옵션은 **Zig `TranspileOptionsDto` struct에서 compti
 | `asciiOnly` | `boolean` | `false` | 비-ASCII 문자를 hex 이스케이프로 치환 |
 | `charsetUtf8` | `boolean` | `false` | 비-ASCII 문자 그대로 유지 |
 
+### Code Splitting / Chunks
+
+| 옵션 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `splitting` | `boolean` | `false` | dynamic import 경계에서 청크 분리 + 공유 모듈 추출 |
+| `manualChunks` | `(id, meta) => string \| null` | — | Rollup 호환 사용자 정의 분할. [상세 가이드](/zts/guides/manual-chunks/) |
+| `inlineDynamicImports` | `boolean` | `false` | dynamic import target 을 importer chunk 로 흡수 + `__esm` 래핑 (단일 파일 출력) |
+| `external` | `string[]` | `[]` | 번들에서 제외할 specifier 목록. graph 에는 phantom Module 로 등록 |
+| `preserveModules` | `boolean` | `false` | 번들 대신 원본 디렉토리 구조 유지 (Rollup 호환) |
+
 ### Minify
 
 | 옵션 | 타입 | 기본값 | 설명 |


### PR DESCRIPTION
## Summary
manualChunks 에픽 (Rollup parity Phase A 까지) 문서 동기화. ROADMAP 에 ❌ 로 남아있던 항목들을 ✅ 로 갱신, Astro 사이트에 가이드 페이지 신설.

## 변경
- \`docs/ROADMAP.md\` — 항목 41/42/43 추가, 비교 테이블 갱신
- \`documents/src/content/docs/guides/manual-chunks.md\` — 신규 가이드 (필드 표 / 패턴 예제)
- \`documents/src/content/docs/reference/options.md\` — Code Splitting 섹션
- \`documents/astro.config.mjs\` — sidebar 갱신

## 검증
\`bun run astro build\` 346 pages OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)