### PR TITLE
refactor(types): ModuleInfo ExportBinding 타입 leak 제거

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1075,12 +1075,11 @@ const NapiManualChunksResolver = struct {
         _ = c.napi_get_boolean(env, mod_info.synthetic_named_exports, &js_synthetic);
         _ = c.napi_set_named_property(env, js_obj, "syntheticNamedExports", js_synthetic);
 
-        // exports — ExportBinding[] → exported_name string array.
         var js_exports: c.napi_value = undefined;
         _ = c.napi_create_array(env, &js_exports);
-        for (mod_info.export_bindings, 0..) |eb, i| {
+        for (mod_info.exports, 0..) |name, i| {
             var js_name: c.napi_value = undefined;
-            _ = c.napi_create_string_utf8(env, eb.exported_name.ptr, eb.exported_name.len, &js_name);
+            _ = c.napi_create_string_utf8(env, name.ptr, name.len, &js_name);
             _ = c.napi_set_element(env, js_exports, @intCast(i), js_name);
         }
         _ = c.napi_set_named_property(env, js_obj, "exports", js_exports);

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1022,6 +1022,7 @@ pub const ModuleGraph = struct {
             module.import_bindings = binding_scanner_mod.extractImportBindings(arena_alloc, &(module.ast.?), scan_result.records) catch &.{};
             binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &(module.ast.?), module.import_bindings) catch {};
             module.export_bindings = binding_scanner_mod.extractExportBindings(arena_alloc, &(module.ast.?), scan_result.records, module.import_bindings) catch &.{};
+            module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
 
             // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
             module.ensureAliasTable(self.allocator);
@@ -1302,6 +1303,7 @@ pub const ModuleGraph = struct {
                     };
                 }
                 module.export_bindings = ebindings;
+                module.exported_names = projectExportedNames(arena_alloc, ebindings);
             } else |_| {}
 
             // Worker 패턴 보완: new Worker(new URL(...)) 는 inline scan에서 감지하지 않으므로
@@ -1460,6 +1462,16 @@ pub const ModuleGraph = struct {
             },
             .unknown => {},
         }
+    }
+
+    /// `ExportBinding[]` → `[]const []const u8` 평탄 이름 슬라이스 (#1883).
+    /// `ModuleInfo` 가 binding_scanner internal struct 를 노출 안 하도록 사전 투영.
+    /// 실패 시 빈 슬라이스 — caller 가 fallback 가능하게.
+    fn projectExportedNames(allocator: std.mem.Allocator, bindings: []const binding_scanner_mod.ExportBinding) []const []const u8 {
+        if (bindings.len == 0) return &.{};
+        const out = allocator.alloc([]const u8, bindings.len) catch return &.{};
+        for (bindings, 0..) |b, i| out[i] = b.exported_name;
+        return out;
     }
 
     /// sideEffects 글롭 패턴 매칭.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -101,6 +101,9 @@ pub const Module = struct {
     import_bindings: []ImportBinding = &.{},
     /// export 바인딩 상세. graph allocator 소유 (소스 텍스트 참조).
     export_bindings: []ExportBinding = &.{},
+    /// `export_bindings.exported_name` 의 평탄 slice 프리컴퓨트 (ModuleInfo 노출용 #1883).
+    /// graph allocator 소유. 이름 자체는 source/AST text 의 borrow 라 별도 free 불필요.
+    exported_names: []const []const u8 = &.{},
     /// Bundler-local 합성 심볼 테이블 (cross-module linking용). #1328 Phase 1.
     /// graph allocator 소유. null = 미초기화 (asset/disabled 모듈 등).
     alias_table: ?AliasTable = null,

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -136,9 +136,10 @@ pub const ModuleInfo = struct {
     code: ?[]const u8,
     /// tree-shake 후 번들에 포함된 모듈인지 (Rollup `isIncluded` 호환).
     is_included: bool,
-    /// 모듈의 export binding 목록 (Rollup `exports` 호환). NAPI 가 `.exported_name` 으로 투영.
-    /// external 모듈은 빈 슬라이스. `m.export_bindings` 의 borrow.
-    export_bindings: []const @import("binding_scanner.zig").ExportBinding,
+    /// 모듈이 export 하는 이름 목록 (Rollup `exports` 호환). default / re-export 별표 모두 포함.
+    /// `Module.exported_names` 의 borrow — graph 에서 이미 평탄 투영됨 (#1883).
+    /// external 모듈은 빈 슬라이스.
+    exports: []const []const u8,
     /// Plugin 이 정의한 synthetic named exports (Rollup `syntheticNamedExports` 호환).
     /// ZTS 는 plugin 시스템 확장 (#1880) 까지 항상 false. 노출 시그니처만 맞춤.
     synthetic_named_exports: bool,
@@ -150,7 +151,6 @@ pub const ModuleInfo = struct {
 };
 
 /// `id` 로 모듈 메타를 조회. 없으면 null. Zero allocation — 모든 slice 가 graph borrow.
-/// `exports` 는 ExportBinding 슬라이스를 그대로 노출 — caller 가 `.exported_name` 으로 투영.
 pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInfo {
     const graph = @as(?*const @import("graph.zig").ModuleGraph, @ptrCast(@alignCast(graph_opaque))) orelse return null;
     const idx = graph.path_to_module.get(id) orelse return null;
@@ -167,7 +167,7 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
         // External phantom 은 source 없음, asset/binary 모듈은 source 비어있을 수 있음.
         .code = if (m.is_external or m.source.len == 0) null else m.source,
         .is_included = m.is_included,
-        .export_bindings = if (m.is_external) &.{} else m.export_bindings,
+        .exports = if (m.is_external) &.{} else m.exported_names,
         // Phase B (plugin context API) 까지 placeholder 값.
         .synthetic_named_exports = false,
         .implicitly_loaded_after_one_of = &.{},


### PR DESCRIPTION
## Closes #1883

## Summary
ModuleInfo 가 binding_scanner internal struct (\`ExportBinding\`) 를 노출하던 leak 제거.

## 변경
- \`Module.exported_names: []const []const u8\` 추가 — binding scan 직후 graph allocator 로 평탄 투영 (1회)
- \`ModuleInfo.export_bindings\` → \`ModuleInfo.exports: []const []const u8\`
- \`graph.projectExportedNames\` 헬퍼 — 두 export_bindings set 사이트 모두 동일하게 처리

## 동작 변화 0
- integration 91/91 그대로
- 추가 메모리 negligible (모듈당 ~80B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)