### PR TITLE
chore(tools): NAPI callback hot-path bench (#1891)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -236,6 +236,32 @@ pub fn build(b: *std.Build) void {
         napi_step.dependOn(&napi_install.step);
     }
 
+    // ─── NAPI callback bench (#1891 PoC) ───
+    // `zig build bench-callback` — 격리 마이크로 벤치 .node 빌드.
+    // ZTS 본체와 무관, throw-away. 결과 측정 종료 후 step/디렉토리 제거 가능.
+    {
+        const bench_mod_napi = b.createModule(.{
+            .root_source_file = b.path("tools/napi-callback-bench/src/bench.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+        });
+        bench_mod_napi.addIncludePath(b.path("vendor/node-api-headers"));
+
+        const bench_lib = b.addLibrary(.{
+            .linkage = .dynamic,
+            .name = "bench-callback",
+            .root_module = bench_mod_napi,
+        });
+        bench_lib.linkLibC();
+        bench_lib.linker_allow_shlib_undefined = true;
+
+        const bench_install = b.addInstallArtifact(bench_lib, .{
+            .dest_sub_path = "bench-callback.node",
+        });
+        const bench_step = b.step("bench-callback", "Build NAPI callback hot-path bench (#1891)");
+        bench_step.dependOn(&bench_install.step);
+    }
+
     // Test262 러너 테스트 (유닛 테스트)
     // lib_mod에 이미 test262가 포함되어 있으므로 같은 모듈로 테스트.
     const test262_step = b.step("test262", "Run Test262 runner unit tests");

--- a/tools/napi-callback-bench/bench.mjs
+++ b/tools/napi-callback-bench/bench.mjs
@@ -1,0 +1,73 @@
+import { createRequire } from "module";
+import { existsSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const addonPath = resolve(__dirname, "../../zig-out/lib/bench-callback.node");
+
+if (!existsSync(addonPath)) {
+  console.error(`addon not found at ${addonPath}`);
+  console.error(`run: zig build bench-callback`);
+  process.exit(1);
+}
+
+const require = createRequire(import.meta.url);
+const native = require(addonPath);
+
+function noop() {
+  return;
+}
+
+native.register(noop);
+
+const sizes = [10_000, 100_000, 1_000_000];
+const WARMUP = 10_000;
+
+console.log("=== NAPI callback hot-path bench (#1891) ===\n");
+
+console.log("Mode 1: napi_call_function (main thread, sync)");
+const syncResults = {};
+for (const N of sizes) {
+  native.benchSync(WARMUP);
+  const ms = native.benchSync(N);
+  const nsPerCall = (ms * 1e6) / N;
+  syncResults[N] = nsPerCall;
+  console.log(
+    `  ${N.toString().padStart(9)} iter: ${ms.toFixed(2).padStart(9)}ms  ${nsPerCall.toFixed(0).padStart(7)} ns/call`,
+  );
+}
+
+console.log("\nMode 2: napi_call_threadsafe_function (worker → main, blocking)");
+const tsfResults = {};
+for (const N of sizes) {
+  await native.benchTsf(WARMUP);
+  const ms = await native.benchTsf(N);
+  const nsPerCall = (ms * 1e6) / N;
+  tsfResults[N] = nsPerCall;
+  console.log(
+    `  ${N.toString().padStart(9)} iter: ${ms.toFixed(2).padStart(9)}ms  ${nsPerCall.toFixed(0).padStart(7)} ns/call`,
+  );
+}
+
+const ratio = tsfResults[1_000_000] / syncResults[1_000_000];
+console.log(`\nTSF / Sync overhead ratio: ${ratio.toFixed(1)}x`);
+
+console.log("\n=== 회귀 추정 (모듈당 평균 빌드 시간 가정) ===");
+const tsfNs = tsfResults[1_000_000];
+const overheadMs = tsfNs / 1e6;
+console.log(
+  `  TSF 호출 1회 비용: ${overheadMs.toFixed(4)}ms (${tsfNs.toFixed(0)} ns/call)\n`,
+);
+const scenarios = [
+  { name: "트랜스파일 핫패스 (1ms)", buildMs: 1 },
+  { name: "평균 모듈 (5ms)", buildMs: 5 },
+  { name: "복잡 TSX (15ms)", buildMs: 15 },
+];
+for (const s of scenarios) {
+  const pct = (overheadMs / s.buildMs) * 100;
+  const verdict = pct < 5 ? "✅" : pct < 15 ? "⚠️" : "❌";
+  console.log(
+    `  ${s.name.padEnd(28)} → 회귀 ${pct.toFixed(1).padStart(5)}% ${verdict}`,
+  );
+}

--- a/tools/napi-callback-bench/package.json
+++ b/tools/napi-callback-bench/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "napi-callback-bench",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "NAPI callback hot-path micro-bench for #1891"
+}

--- a/tools/napi-callback-bench/src/bench.zig
+++ b/tools/napi-callback-bench/src/bench.zig
@@ -1,0 +1,213 @@
+//! NAPI callback hot-path 마이크로 벤치 (#1891).
+//!
+//! 두 dispatch 모드의 raw cost 를 측정해 ZTS plugin layer 도입 시 회귀를 추정한다.
+//!   1. benchSync(N)  — main thread 에서 napi_call_function N 회 (sync, no worker)
+//!   2. benchTsf(N)   — worker 1개에서 napi_call_threadsafe_function N 회 (worker → main, blocking)
+//!
+//! 등록된 callback 은 no-op 권장 — overhead 격리 측정 목적.
+
+const std = @import("std");
+const c = @cImport({
+    @cInclude("node_api.h");
+});
+
+// 글로벌 callback 상태. register() 호출 시 갱신.
+var g_tsfn: c.napi_threadsafe_function = null;
+var g_callback_ref: c.napi_ref = null;
+
+// per-call worker stack — tsf 모드에서 worker 가 main thread JS 실행을 기다림.
+const CallCtx = struct {
+    done: bool = false,
+    mutex: std.Thread.Mutex = .{},
+    cond: std.Thread.Condition = .{},
+};
+
+fn callJsCb(env: c.napi_env, js_callback: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
+    const ctx: *CallCtx = @ptrCast(@alignCast(data.?));
+    var js_undefined: c.napi_value = undefined;
+    _ = c.napi_get_undefined(env, &js_undefined);
+    var result: c.napi_value = undefined;
+    _ = c.napi_call_function(env, js_undefined, js_callback, 0, null, &result);
+    ctx.mutex.lock();
+    ctx.done = true;
+    ctx.cond.signal();
+    ctx.mutex.unlock();
+}
+
+fn throwError(env: c.napi_env, msg: [*:0]const u8) c.napi_value {
+    _ = c.napi_throw_error(env, null, msg);
+    var undef: c.napi_value = undefined;
+    _ = c.napi_get_undefined(env, &undef);
+    return undef;
+}
+
+fn cleanupGlobals(env: c.napi_env) void {
+    if (g_tsfn != null) {
+        _ = c.napi_release_threadsafe_function(g_tsfn, c.napi_tsfn_release);
+        g_tsfn = null;
+    }
+    if (g_callback_ref != null) {
+        _ = c.napi_delete_reference(env, g_callback_ref);
+        g_callback_ref = null;
+    }
+}
+
+fn registerCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "register: cannot get args");
+    }
+    if (argc < 1) return throwError(env, "register: callback required");
+
+    cleanupGlobals(env);
+
+    if (c.napi_create_reference(env, argv[0], 1, &g_callback_ref) != c.napi_ok) {
+        return throwError(env, "register: cannot create ref");
+    }
+
+    var work_name: c.napi_value = undefined;
+    _ = c.napi_create_string_utf8(env, "bench_tsfn", "bench_tsfn".len, &work_name);
+    if (c.napi_create_threadsafe_function(
+        env,
+        argv[0],
+        null,
+        work_name,
+        0,
+        1,
+        null,
+        null,
+        null,
+        callJsCb,
+        &g_tsfn,
+    ) != c.napi_ok) {
+        return throwError(env, "register: cannot create tsfn");
+    }
+
+    var undef: c.napi_value = undefined;
+    _ = c.napi_get_undefined(env, &undef);
+    return undef;
+}
+
+fn benchSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "benchSync: cannot get args");
+    }
+    if (argc < 1) return throwError(env, "benchSync: iterations required");
+
+    var n: u32 = 0;
+    if (c.napi_get_value_uint32(env, argv[0], &n) != c.napi_ok) {
+        return throwError(env, "benchSync: invalid iterations");
+    }
+    if (g_callback_ref == null) return throwError(env, "benchSync: no callback registered");
+
+    var js_cb: c.napi_value = undefined;
+    if (c.napi_get_reference_value(env, g_callback_ref, &js_cb) != c.napi_ok) {
+        return throwError(env, "benchSync: cannot get callback");
+    }
+
+    var js_undefined: c.napi_value = undefined;
+    _ = c.napi_get_undefined(env, &js_undefined);
+
+    const start_ns = std.time.nanoTimestamp();
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        var result: c.napi_value = undefined;
+        _ = c.napi_call_function(env, js_undefined, js_cb, 0, null, &result);
+    }
+    const elapsed_ns: f64 = @floatFromInt(std.time.nanoTimestamp() - start_ns);
+
+    var ms: c.napi_value = undefined;
+    _ = c.napi_create_double(env, elapsed_ns / 1e6, &ms);
+    return ms;
+}
+
+const AsyncBenchCtx = struct {
+    iterations: u32,
+    elapsed_ns: i128 = 0,
+    deferred: c.napi_deferred = null,
+    work: c.napi_async_work = null,
+};
+
+fn doWorkBench(_: c.napi_env, data: ?*anyopaque) callconv(.c) void {
+    const ctx: *AsyncBenchCtx = @ptrCast(@alignCast(data.?));
+    // CallCtx 를 loop 밖에서 1회 init — mutex/cond init 비용을 hot path 에서 제외해
+    // napi_call_threadsafe_function 자체 비용만 측정.
+    var call_ctx = CallCtx{};
+    const start_ns = std.time.nanoTimestamp();
+    var i: u32 = 0;
+    while (i < ctx.iterations) : (i += 1) {
+        call_ctx.done = false;
+        const status = c.napi_call_threadsafe_function(g_tsfn, @ptrCast(&call_ctx), c.napi_tsfn_blocking);
+        if (status != c.napi_ok) break;
+        call_ctx.mutex.lock();
+        while (!call_ctx.done) call_ctx.cond.wait(&call_ctx.mutex);
+        call_ctx.mutex.unlock();
+    }
+    ctx.elapsed_ns = std.time.nanoTimestamp() - start_ns;
+}
+
+fn completeWorkBench(env: c.napi_env, _: c.napi_status, data: ?*anyopaque) callconv(.c) void {
+    const ctx: *AsyncBenchCtx = @ptrCast(@alignCast(data.?));
+    const ms_val: f64 = @as(f64, @floatFromInt(ctx.elapsed_ns)) / 1e6;
+    var ms: c.napi_value = undefined;
+    _ = c.napi_create_double(env, ms_val, &ms);
+    _ = c.napi_resolve_deferred(env, ctx.deferred, ms);
+    _ = c.napi_delete_async_work(env, ctx.work);
+    std.heap.c_allocator.destroy(ctx);
+}
+
+fn benchTsf(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "benchTsf: cannot get args");
+    }
+    if (argc < 1) return throwError(env, "benchTsf: iterations required");
+
+    var n: u32 = 0;
+    if (c.napi_get_value_uint32(env, argv[0], &n) != c.napi_ok) {
+        return throwError(env, "benchTsf: invalid iterations");
+    }
+    if (g_tsfn == null) return throwError(env, "benchTsf: no callback registered");
+
+    const ctx = std.heap.c_allocator.create(AsyncBenchCtx) catch {
+        return throwError(env, "benchTsf: OOM");
+    };
+    ctx.* = .{ .iterations = n };
+
+    var promise: c.napi_value = undefined;
+    if (c.napi_create_promise(env, &ctx.deferred, &promise) != c.napi_ok) {
+        std.heap.c_allocator.destroy(ctx);
+        return throwError(env, "benchTsf: cannot create promise");
+    }
+
+    var work_name: c.napi_value = undefined;
+    _ = c.napi_create_string_utf8(env, "bench_tsf_work", "bench_tsf_work".len, &work_name);
+
+    if (c.napi_create_async_work(env, null, work_name, doWorkBench, completeWorkBench, ctx, &ctx.work) != c.napi_ok) {
+        std.heap.c_allocator.destroy(ctx);
+        return throwError(env, "benchTsf: cannot create async work");
+    }
+    if (c.napi_queue_async_work(env, ctx.work) != c.napi_ok) {
+        _ = c.napi_delete_async_work(env, ctx.work);
+        std.heap.c_allocator.destroy(ctx);
+        return throwError(env, "benchTsf: cannot queue async work");
+    }
+    return promise;
+}
+
+fn defineFn(env: c.napi_env, exports: c.napi_value, name: [:0]const u8, cb: c.napi_callback) void {
+    var fn_value: c.napi_value = undefined;
+    _ = c.napi_create_function(env, name.ptr, name.len, cb, null, &fn_value);
+    _ = c.napi_set_named_property(env, exports, name.ptr, fn_value);
+}
+
+export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi_value {
+    defineFn(env, exports, "register", registerCallback);
+    defineFn(env, exports, "benchSync", benchSync);
+    defineFn(env, exports, "benchTsf", benchTsf);
+    return exports;
+}


### PR DESCRIPTION
## Summary

- ZTS plugin layer 도입 시 NAPI callback dispatch 비용 회귀 측정용 격리 마이크로 벤치 추가
- 두 모드 측정: `napi_call_function` (main thread sync) vs `napi_call_threadsafe_function` (worker → main blocking)
- ZTS 본체와 격리, throw-away 가능. 향후 plugin/Zig 업그레이드 회귀 모니터링에 재사용

## 측정 결과 ([#1891 코멘트](https://github.com/ohah/zts/issues/1891#issuecomment-4318453048))

| 모드 | 1M iter | ns/call |
|---|---|---|
| Sync (`napi_call_function`) | 15.32 ms | **15 ns** |
| TSF (`napi_call_threadsafe_function`, worker→main blocking) | 4369.48 ms | **4,369 ns (4.4µs)** |

**TSF / Sync 비율 285x** — 그러나 절대값이 작아 실 환경 회귀 < 1%:

| 시나리오 | 모듈당 빌드 | 회귀 |
|---|---|---|
| 트랜스파일 핫패스 (1ms) | 1 ms | 0.4% ✅ |
| 평균 모듈 (5ms) | 5 ms | 0.1% ✅ |
| 복잡 TSX (15ms) | 15 ms | 0.0% ✅ |

→ **A 풀세트 plugin 도입 안전** (#1885 epic 의 핵심 unknown 해소)

## 변경

- `tools/napi-callback-bench/src/bench.zig` (신규) — NAPI shared lib, register/benchSync/benchTsf 3개 export
- `tools/napi-callback-bench/bench.mjs` (신규) — 측정 스크립트 (warmup 분리, 회귀 추정 출력)
- `tools/napi-callback-bench/package.json` (신규)
- `build.zig` — `bench-callback` step 추가 (NAPI 빌드 패턴 그대로)

## /simplify 검토 반영

- doWorkBench 의 CallCtx 를 loop 밖 1회 init (mutex/cond init 비용을 hot path 에서 제거)
- bench.mjs warmup 을 측정 N 과 분리 (별도 WARMUP 상수)
- defineFn 에 `[:0]const u8` 활용해 name_len 인자 제거
- registerCallback 의 cleanup 을 `cleanupGlobals` helper 로 통합

## Test plan

- [x] `zig build bench-callback` 빌드 성공
- [x] `bun tools/napi-callback-bench/bench.mjs` 실행 성공
- [x] /simplify 3-agent 검토 적용 후 재측정 — 결과 변동 < 2% (4450 → 4369 ns/call, 노이즈 범위)

Closes #1891

🤖 Generated with [Claude Code](https://claude.com/claude-code)