### PR TITLE
test(infra): e2eFull errors on parser diagnostics

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2361,7 +2361,7 @@ test "unicode_escape: es2015 no-op" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "\\u{1F600}") != null);
 }
 
-// === ES5 async transform regression suite (zts/issues 1896, 1901, 1903) ===
+// === ES5 async transform regression suite (zts/issues 1896, 1901) ===
 
 test "ES5: compound assignment with await RHS preserves operator (#1896)" {
     // `sum += await x()` 가 `sum = _state.sent()` 으로 변환되어 += 누락 → 누적 안 됨.
@@ -2398,14 +2398,4 @@ test "ES5: for-await-of hoists loop var to function top (#1901)" {
         std.mem.indexOf(u8, r.output, ",v=") != null or
         std.mem.indexOf(u8, r.output, ",v,") != null;
     try std.testing.expect(has_v_decl);
-}
-
-test "ES5: await in default param of nested async function (#1903)" {
-    // `async function inner(x = await ...)` 가 ES spec 상 허용 (default param 은 async
-    // function body 의 일부, await 가능). 현재 ZTS parser 가 `await not allowed` 로 reject.
-    // 단순 transform 후 parser 가 통과해야 (정확한 emit 검증은 fix 후 별도).
-    var r = try e2eTarget(std.testing.allocator, "async function f() { async function inner(x = await Promise.resolve(7)) { return x; } return await inner(); }", .es5);
-    defer r.deinit();
-    // 통과만 확인 (parser reject 면 위 line 에서 errdefer/error 로 fail).
-    try std.testing.expect(r.output.len > 0);
 }

--- a/src/codegen/codegen_test/helpers.zig
+++ b/src/codegen/codegen_test/helpers.zig
@@ -130,6 +130,15 @@ pub fn e2eFull(backing_allocator: std.mem.Allocator, source: []const u8, t_optio
     var parser = Parser.init(allocator, &scanner);
     parser.configureFromExtension(ext);
     _ = try parser.parse();
+    // Parser diagnostics 가 누적되어 있는데 silent ignore 하면 spec-violation source 가
+    // codegen 까지 흘러들어 test 가 false-pass — silent regression 위험 (#1906). errors
+    // 가 있으면 첫 메시지를 stderr 에 dump 하고 test fail 처리. 의도된 negative test 는
+    // `e2eFullExpectingErrors` 사용.
+    if (parser.errors.items.len > 0) {
+        const first = parser.errors.items[0];
+        std.debug.print("\nparser error in e2eFull: {s}\n  source: {s}\n", .{ first.message, source });
+        return error.ParserDiagnosticsPresent;
+    }
 
     var t = try Transformer.init(allocator, &parser.ast, t_options);
     t.line_offsets = scanner.line_offsets.items;


### PR DESCRIPTION
Closes #1906. Note: original branch name is `fix/await-in-default-param` (was for #1903), but #1903 turned out to be a spec-compliant rejection — see issue close comment.

## Summary

`e2eFull` (and downstream `e2e`/`e2eTarget`/`e2eES5Async`/etc.) was calling `_ = try parser.parse()` and discarding the parser's accumulated `errors` slice. Spec-violation source — input the CLI rejects with `zts####` codes — would silently pass through to the codegen path, leaving tests false-passing.

## Discovery

While verifying #1903 (await in default param of nested async function), the test passed unexpectedly. CLI behavior on the same source:

```
$ zig build run -- --target=es5 repro.js
async function f() { async function inner(x = await Promise.resolve(7)) { return x; } }
                                              ^^^^^
error: zts0901
exit 1
```

But `e2eTarget(...)` returned a non-empty output. Confirmed in `node` and `bun` that the source itself is a Syntax Error (ECMAScript 14.7 — "AsyncFunctionDeclaration: It is a Syntax Error if FormalParameters Contains AwaitExpression"). #1903 closed as won't-fix; the test infrastructure leak became #1906.

## Fix

After `parser.parse()`:

```zig
if (parser.errors.items.len > 0) {
    const first = parser.errors.items[0];
    std.debug.print("\nparser error in e2eFull: {s}\n  source: {s}\n", .{ first.message, source });
    return error.ParserDiagnosticsPresent;
}
```

Tests that intentionally exercise parser diagnostics should not use this helper (today there are none — `parser_test.zig` uses the parser API directly).

## Verification

- `zig build test` — **3753/3753 passed** (no existing test was relying on silent-ignore behavior)
- The dead #1903 reproduction test (which only passed via this silent-ignore bug) was deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)