### PR TITLE
fix(transformer): async this binding (#1909) + yield* iterable wrap (#1910)

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -388,17 +388,17 @@ pub const EXTENDS_RUNTIME = "var __extends = function(d, b) {\n  for (var p in b
 pub const EXTENDS_RUNTIME_MIN = "var " ++ NAMES.EXTENDS_MIN ++ "=function(d,b){for(var p in b)if(Object.prototype.hasOwnProperty.call(b,p))d[p]=b[p];function __(){this.constructor=d}d.prototype=b===null?Object.create(b):(__.prototype=b.prototype,new __())};";
 
 /// __generator: generator 상태 머신 (ES2015). TypeScript __generator 호환.
-/// yield/return/throw를 label 기반 switch로 처리.
-/// 두 번째 인자 genFn을 받아 프로토타입 체인을 설정:
+/// signature: `__generator(thisArg, body, genFn)` — body 안 `this` 가 enclosing function 의
+/// this 가 되도록 thisArg 첫 인자로 받음 (#1909). `body.call(thisArg, _)`.
+/// genFn 은 프로토타입 체인 설정용 (compat-table generator prototype 호환):
 ///   g -> genFn.prototype -> __GeneratorPrototype -> IteratorPrototype (Symbol.iterator)
-/// compat-table "%GeneratorPrototype% prototype chain" 테스트 통과를 위해 필요.
 pub const GENERATOR_RUNTIME =
     \\var __generator = function() {
     \\  var __iterProto = {};
     \\  __iterProto[Symbol.iterator] = function() { return this; };
     \\  var __genProto = Object.create(__iterProto);
     \\  var __protoSet = typeof Symbol !== "undefined" ? Symbol("__protoSet") : "__gen_proto_set__";
-    \\  return function(body, genFn) {
+    \\  return function(thisArg, body, genFn) {
     \\    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
     \\    if (genFn) {
     \\      if (!genFn[__protoSet]) {
@@ -431,7 +431,7 @@ pub const GENERATOR_RUNTIME =
     \\            if (t[2]) _.ops.pop();
     \\            _.trys.pop(); continue;
     \\        }
-    \\        op = body.call(null, _);
+    \\        op = body.call(thisArg, _);
     \\      } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
     \\      if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     \\    }
@@ -439,7 +439,27 @@ pub const GENERATOR_RUNTIME =
     \\}();
     \\
 ;
-pub const GENERATOR_RUNTIME_MIN = "var " ++ NAMES.GENERATOR_MIN ++ "=function(){var __iterProto={};__iterProto[Symbol.iterator]=function(){return this};var __genProto=Object.create(__iterProto);return function(body,genFn){var _={label:0,sent:function(){if(t[0]&1)throw t[1];return t[1]},trys:[],ops:[]},f,y,t,g;if(genFn){if(!genFn.__proto_set){Object.setPrototypeOf(genFn.prototype,__genProto);genFn.__proto_set=true}g=Object.create(genFn.prototype)}else{g={};g[Symbol.iterator]=function(){return this}}g.next=verb(0);g[\"throw\"]=verb(1);g[\"return\"]=verb(2);return g;function verb(n){return function(v){return step([n,v])}}function step(op){if(f)throw new TypeError(\"Generator is already executing.\");while(g&&(g=0,op[0]&&(_=0)),_)try{if(f=1,y&&(t=op[0]&2?y[\"return\"]:op[0]?y[\"throw\"]||((t=y[\"return\"])&&t.call(y),0):y.next)&&!(t=t.call(y,op[1])).done)return t;if(y=0,t)op=[op[0]&2,t.value];switch(op[0]){case 0:case 1:t=op;break;case 4:_.label++;return{value:op[1],done:false};case 5:_.label++;y=op[1];op=[0];continue;case 7:op=_.ops.pop();_.trys.pop();continue;default:if(!(t=_.trys,t=t.length>0&&t[t.length-1])&&(op[0]===6||op[0]===2)){_=0;continue}if(op[0]===3&&(!t||(op[1]>t[0]&&op[1]<t[3]))){_.label=op[1];break}if(op[0]===6&&_.label<t[1]){_.label=t[1];t=op;break}if(t&&_.label<t[2]){_.label=t[2];_.ops.push(op);break}if(t[2])_.ops.pop();_.trys.pop();continue}op=body.call(null,_)}catch(e){op=[6,e];y=0}finally{f=t=0}if(op[0]&5)throw op[1];return{value:op[0]?op[1]:void 0,done:true}}}}();";
+pub const GENERATOR_RUNTIME_MIN = "var " ++ NAMES.GENERATOR_MIN ++ "=function(){var __iterProto={};__iterProto[Symbol.iterator]=function(){return this};var __genProto=Object.create(__iterProto);return function(thisArg,body,genFn){var _={label:0,sent:function(){if(t[0]&1)throw t[1];return t[1]},trys:[],ops:[]},f,y,t,g;if(genFn){if(!genFn.__proto_set){Object.setPrototypeOf(genFn.prototype,__genProto);genFn.__proto_set=true}g=Object.create(genFn.prototype)}else{g={};g[Symbol.iterator]=function(){return this}}g.next=verb(0);g[\"throw\"]=verb(1);g[\"return\"]=verb(2);return g;function verb(n){return function(v){return step([n,v])}}function step(op){if(f)throw new TypeError(\"Generator is already executing.\");while(g&&(g=0,op[0]&&(_=0)),_)try{if(f=1,y&&(t=op[0]&2?y[\"return\"]:op[0]?y[\"throw\"]||((t=y[\"return\"])&&t.call(y),0):y.next)&&!(t=t.call(y,op[1])).done)return t;if(y=0,t)op=[op[0]&2,t.value];switch(op[0]){case 0:case 1:t=op;break;case 4:_.label++;return{value:op[1],done:false};case 5:_.label++;y=op[1];op=[0];continue;case 7:op=_.ops.pop();_.trys.pop();continue;default:if(!(t=_.trys,t=t.length>0&&t[t.length-1])&&(op[0]===6||op[0]===2)){_=0;continue}if(op[0]===3&&(!t||(op[1]>t[0]&&op[1]<t[3]))){_.label=op[1];break}if(op[0]===6&&_.label<t[1]){_.label=t[1];t=op;break}if(t&&_.label<t[2]){_.label=t[2];_.ops.push(op);break}if(t[2])_.ops.pop();_.trys.pop();continue}op=body.call(thisArg,_)}catch(e){op=[6,e];y=0}finally{f=t=0}if(op[0]&5)throw op[1];return{value:op[0]?op[1]:void 0,done:true}}}}();";
+
+/// __values: iterable → iterator 변환 (ES2015 yield* / for-of helper). tslib 호환.
+/// `Symbol.iterator` 호출 가능하면 그 결과 반환. 없으면 `length` 기반 array-like fallback.
+/// (#1910) `yield* 'abc'` 같이 raw iterable 을 generator state machine 의 op[5] 가 받을 때
+/// `.next` 호출 가능한 iterator 로 wrap 필요.
+pub const VALUES_RUNTIME =
+    \\var __values = function(o) {
+    \\  var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
+    \\  if (m) return m.call(o);
+    \\  if (o && typeof o.length === "number") return {
+    \\    next: function() {
+    \\      if (o && i >= o.length) o = void 0;
+    \\      return { value: o && o[i++], done: !o };
+    \\    }
+    \\  };
+    \\  throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
+    \\};
+    \\
+;
+pub const VALUES_RUNTIME_MIN = "var __values=function(o){var s=typeof Symbol===\"function\"&&Symbol.iterator,m=s&&o[s],i=0;if(m)return m.call(o);if(o&&typeof o.length===\"number\")return{next:function(){if(o&&i>=o.length)o=void 0;return{value:o&&o[i++],done:!o}}};throw new TypeError(s?\"Object is not iterable.\":\"Symbol.iterator is not defined.\")};";
 
 /// __taggedTemplateLiteral: tagged template literal의 template 객체 생성 (ES2015).
 /// cooked 배열에 raw 프로퍼티를 추가하여 Object.freeze로 불변 처리.
@@ -999,6 +1019,11 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
     if (helpers.async_values) {
         try buf.appendSlice(allocator, if (minify) ASYNC_VALUES_RUNTIME_MIN else ASYNC_VALUES_RUNTIME);
+    }
+    // __values 는 yield* / for-of / __asyncValues fallback 모두 사용 — async_values 가 켜져 있으면
+    // 그 안에서 typeof __values 체크하므로 함께 emit 필요.
+    if (helpers.values or helpers.async_values) {
+        try buf.appendSlice(allocator, if (minify) VALUES_RUNTIME_MIN else VALUES_RUNTIME);
     }
     if (helpers.to_binary) {
         try buf.appendSlice(allocator, if (minify) TO_BINARY_RUNTIME_MIN else TO_BINARY_RUNTIME);

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -354,6 +354,38 @@ test "ES5: async state-machine edge cases (#1887 + control-flow self-loop)" {
     }
 }
 
+// === #1909: async function this binding via __generator(thisArg, ...) ===
+
+test "ES5: async function emits __generator(this, ...) for body this access (#1909)" {
+    // async method 안 `this.x` 가 generator state machine callback 의 null this 가 아닌
+    // enclosing function 의 this 로 binding 되도록 __generator 첫 인자에 `this` 전달.
+    var r = try e2eTarget(std.testing.allocator, "var obj = { x: 10, async f() { return this.x * 2; } }; obj.f();", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+    // signature: __generator(this, function(...) {...}) — old signature `__generator(function...)` 면 fail.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__generator(this,function") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__generator(this, function") != null or
+        std.mem.indexOf(u8, r.output, "__generator(this,function") != null);
+}
+
+// === #1910: yield* iterable — __values() wrap ===
+
+test "ES5: yield* string wraps with __values (#1910)" {
+    var r = try e2eTarget(std.testing.allocator, "function* g() { yield* 'abc'; }", .es5);
+    defer r.deinit();
+    // raw value 직접 op[5] 로 가는 게 아니라 __values() 거쳐야 string/Map/Set 도 처리.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__values(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return [5,\"abc\"]") == null);
+}
+
+test "ES5: yield* nested generator still works (#1910 regression)" {
+    var r = try e2eTarget(std.testing.allocator, "function* a() { yield 1; } function* b() { yield* a(); yield 2; }", .es5);
+    defer r.deinit();
+    // 일반 generator (async X) 라 __async 없음 — __generator 만 확인.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__generator") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__values(") != null);
+}
+
 test "ES5: if-await edge — empty then block (no statements)" {
     // 빈 then — await 없으니 e2eES5Async 의 self-loop assertion N/A. emit 깨지지 않는지만.
     var r = try e2eTarget(std.testing.allocator, "async function f(x) { if (x) {} await a(); }", .es5);
@@ -1475,7 +1507,8 @@ test "ES2015: generator var hoisting without yield" {
 test "ES2015: generator yield*" {
     var r = try e2eTarget(std.testing.allocator, "function* gen(){yield* [1,2];}", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "return [5,[1,2]]") != null);
+    // (#1910) yield* 가 raw iterable 을 __values() 로 wrap — `return [5, __values([1,2])]`
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return [5,__values([1,2])]") != null);
 }
 
 test "ES2015: generator do-while with yield" {

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1902,8 +1902,16 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                         }
                     },
                     .yield_star => {
-                        // return [5, iter]
-                        const ret = try buildInstructionReturn(self, 5, if (op.arg == .node) op.arg.node else .none, span);
+                        // return [5, __values(iter)] — (#1910) raw iterable 을 iterator 로 wrap.
+                        // __generator 의 op[5] 가 .next 직접 호출해서 string/Map/Set 같이
+                        // [Symbol.iterator] 만 가진 iterable 은 그대로 못 씀.
+                        const inner_iter = if (op.arg == .node) op.arg.node else .none;
+                        const wrapped_iter = if (!inner_iter.isNone()) blk: {
+                            self.runtime_helpers.values = true;
+                            const values_ref = try es_helpers.makeRuntimeHelperRef(self, "__values");
+                            break :blk try es_helpers.makeCallExpr(self, values_ref, &.{inner_iter}, span);
+                        } else inner_iter;
+                        const ret = try buildInstructionReturn(self, 5, wrapped_iter, span);
                         try current_case_stmts.append(self.allocator, ret);
                     },
                 }
@@ -2082,12 +2090,14 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 .data = .{ .extra = func_extra },
             });
 
-            // __generator(func) 또는 __generator(func, genFn)
+            // __generator(this, func) 또는 __generator(this, func, genFn) — (#1909)
+            // body 안 `this` 가 enclosing function 의 this 가 되도록 thisArg 첫 인자 전달.
             const gen_ref = try es_helpers.makeRuntimeHelperRef(self, "__generator");
+            const this_arg = try es_helpers.makeThisExpr(self, span);
             if (!genFn_idx.isNone()) {
-                return es_helpers.makeCallExpr(self, gen_ref, &.{ func_expr, genFn_idx }, span);
+                return es_helpers.makeCallExpr(self, gen_ref, &.{ this_arg, func_expr, genFn_idx }, span);
             }
-            return es_helpers.makeCallExpr(self, gen_ref, &.{func_expr}, span);
+            return es_helpers.makeCallExpr(self, gen_ref, &.{ this_arg, func_expr }, span);
         }
     };
 }

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -394,6 +394,15 @@ pub fn makeExprStmt(self: anytype, expr: NodeIndex, span: Span) !NodeIndex {
     });
 }
 
+/// `this` keyword expression 노드 생성.
+pub fn makeThisExpr(self: anytype, span: Span) !NodeIndex {
+    return self.ast.addNode(.{
+        .tag = .this_expression,
+        .span = span,
+        .data = .{ .none = 0 },
+    });
+}
+
 /// `left <op>= right` assignment expression 노드 생성. `flags` 는 op kind
 /// (`Kind.eq` = `=`, `Kind.plus_eq` = `+=`, ...). 0 = transformer-synthesized plain `=`.
 pub fn makeAssignExpr(self: anytype, left: NodeIndex, right: NodeIndex, span: Span, flags: u16) !NodeIndex {


### PR DESCRIPTION
Closes #1909, #1910.

Two more bugs surfaced via the ES5 downlevel **runtime probe** (Bun eval) — beyond the static `__generator` emit checks.

## #1909 — async `this` is null in generator state machine

```js
var obj = { x: 10, async f() { return this.x * 2; } };
obj.f();
// Expected: 20
// Actual:   TypeError: null is not an object (evaluating 'this.x')
```

ZTS emits:
```js
f: function() {
    return __async(function() {
        return __generator(function(_state) {   // ← body
            return [2, this.x * 2];              // `this` = null inside callback
        });
    }).call(this);
}
```

`__async` correctly forwards `self = this` to the generator function — but `__generator(body)` invoked `body.call(null, _)` internally, dropping `this`.

**Root cause**: ZTS `__generator` runtime signature was `(body, genFn)` — no `thisArg`. tslib/Babel `__generator(thisArg, body)` invokes `body.call(thisArg, _)`.

**Fix**:
- `runtime_helpers.zig:__generator` signature: `function(thisArg, body, genFn)` + `body.call(thisArg, _)`
- `buildGeneratorHelperCallWithProto` emits `__generator(this, function(_state){...})`
- New `es_helpers.makeThisExpr` for the `this` argument

## #1910 — `yield*` iterable (string/Map/Set) drops to `[]`

```js
function* g() { yield* 'abc'; }
[...g()];
// Expected: ['a','b','c']
// Actual:   []
```

`__generator` op[5] reads `y = op[1]; ... y.next` — string has `[Symbol.iterator]()` but no `.next`. tslib pattern is `[5, __values(value)]` where `__values` wraps with the iterator.

**Fix**:
- New `__values` runtime helper (tslib pattern — returns iterator if `Symbol.iterator`, array-like fallback)
- `yield_star` emit wraps `iter` with `__values(...)`
- `appendRuntimeHelpers` emits `__values` when `helpers.values` (also auto-emits when `async_values` is on, since `__asyncValues` falls back to `__values`)

## Verification

- `zig build test` — **3755/3755 passed**
- ES5 downlevel runtime probe (Bun eval) — **33/37** passed
  - 4 remaining: 2× async generator (#1911), 2× decorator (#1912) — separate fixes
- New regression tests in `es_downlevel.zig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)