### PR TITLE
feat(bundler): FileSystem 추상화 + RealFS (#1885 Phase 1 PR 1)

### DIFF
--- a/src/bundler/fs.zig
+++ b/src/bundler/fs.zig
@@ -1,0 +1,167 @@
+//! ZTS Bundler FileSystem 추상화 (#1885 epic — Phase 1 PR 1).
+//!
+//! comptime polymorphism 으로 빌드 타겟별 fs 구현 선택. NAPI/CLI 빌드는
+//! `RealFS` (호스트 std.fs.cwd() wrapping), WASM 빌드는 `VirtualFS`
+//! (host JS callback 위임 — Phase 2 PR 6 에서 구현).
+//!
+//! Plugin layer (PR 4) 도입 시 `ModuleLoadResult` union(enum) 을 위에 얹어
+//! "plugin first → fs fallback" 흐름 구성.
+//!
+//! 호출처는 PR 2/3 (graph.zig, resolver.zig) 에서 std.fs.cwd() 직접 호출을
+//! `Implementation.readFile/iterDir/...` 로 점진 마이그레이션.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const types = @import("types.zig");
+
+const is_wasm_build = builtin.target.cpu.arch == .wasm32;
+
+/// 모듈의 namespace 분류. `union(enum) ResolveResult` (PR 4 plugin.zig) 의
+/// tag 로도 사용 — `file` 만 fs 통과, 나머지는 plugin 책임.
+pub const Namespace = enum {
+    file,
+    virtual,
+    dataurl,
+    external,
+    custom,
+};
+
+/// fs.readFile 또는 plugin.load 의 결과.
+pub const LoadedModule = struct {
+    contents: []const u8,
+    path: []const u8,
+    namespace: Namespace = .file,
+    /// caller 가 확장자 / shebang / 내용으로 결정.
+    /// fs 계층은 `unknown` 으로 반환 — graph 가 `ModuleType.fromExtension` 호출.
+    module_type: types.ModuleType = .unknown,
+};
+
+pub const DirEntry = struct {
+    name: []const u8,
+    kind: EntryKind,
+};
+
+pub const EntryKind = enum {
+    file,
+    directory,
+    symlink,
+    other,
+};
+
+/// VirtualFS (WASM) 가 호스트로부터 받을 수 있는 최소 정보만 노출.
+/// std.fs.File.Stat 의 inode/mode_t 같은 OS-dependent 필드는 의도적 제외.
+pub const FileStat = struct {
+    size: u64,
+    is_dir: bool,
+};
+
+pub const FsError = error{
+    NotFound,
+    PermissionDenied,
+    NotDirectory,
+    IsDirectory,
+    OutOfMemory,
+    IoError,
+};
+
+/// 빌드 타겟별 fs 구현 (comptime 선택, vtable 비용 0).
+/// bun 의 `pub const Implementation = RealFS;` 패턴 — `references/bun/src/fs.zig:1475`.
+pub const Implementation = if (is_wasm_build) VirtualFS else RealFS;
+
+/// 호스트 OS 의 std.fs.cwd() 를 wrapping. NAPI / CLI 빌드의 default 구현.
+pub const RealFS = struct {
+    pub fn init() RealFS {
+        return .{};
+    }
+
+    pub fn readFile(_: RealFS, allocator: std.mem.Allocator, path: []const u8, max_bytes: usize) FsError!LoadedModule {
+        const bytes = std.fs.cwd().readFileAlloc(allocator, path, max_bytes) catch |err| return mapFsError(err);
+        return .{
+            .contents = bytes,
+            .path = path,
+            .namespace = .file,
+        };
+    }
+
+    pub fn statFile(_: RealFS, path: []const u8) FsError!FileStat {
+        const stat = std.fs.cwd().statFile(path) catch |err| return mapFsError(err);
+        return .{
+            .size = stat.size,
+            .is_dir = stat.kind == .directory,
+        };
+    }
+
+    pub fn access(_: RealFS, path: []const u8) FsError!void {
+        std.fs.cwd().access(path, .{}) catch |err| return mapFsError(err);
+    }
+
+    /// 디렉토리 항목을 ArrayList 에 모아 반환. caller 가 메모리 소유.
+    /// resolver 의 typical use case = 전체 항목 한 번에 보고 매칭.
+    pub fn listDir(_: RealFS, allocator: std.mem.Allocator, path: []const u8) FsError![]DirEntry {
+        var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch |err| return mapFsError(err);
+        defer dir.close();
+
+        var list: std.ArrayList(DirEntry) = .empty;
+        errdefer {
+            for (list.items) |item| allocator.free(item.name);
+            list.deinit(allocator);
+        }
+
+        var it = dir.iterate();
+        while (it.next() catch return FsError.IoError) |entry| {
+            const name_copy = allocator.dupe(u8, entry.name) catch return FsError.OutOfMemory;
+            errdefer allocator.free(name_copy);
+            list.append(allocator, .{
+                .name = name_copy,
+                .kind = mapEntryKind(entry.kind),
+            }) catch return FsError.OutOfMemory;
+        }
+        return list.toOwnedSlice(allocator) catch FsError.OutOfMemory;
+    }
+};
+
+/// WASM 빌드용 placeholder. Phase 2 PR 6 에서 host JS callback (zts_plugins
+/// import) 으로 실제 구현. 현재는 wasm 빌드 시 호출하면 컴파일 에러.
+pub const VirtualFS = struct {
+    pub fn init() VirtualFS {
+        return .{};
+    }
+
+    pub fn readFile(_: VirtualFS, _: std.mem.Allocator, _: []const u8, _: usize) FsError!LoadedModule {
+        @compileError("VirtualFS.readFile: WASM fs callback 미구현 (Phase 2 PR 6)");
+    }
+
+    pub fn statFile(_: VirtualFS, _: []const u8) FsError!FileStat {
+        @compileError("VirtualFS.statFile: WASM fs callback 미구현 (Phase 2 PR 6)");
+    }
+
+    pub fn access(_: VirtualFS, _: []const u8) FsError!void {
+        @compileError("VirtualFS.access: WASM fs callback 미구현 (Phase 2 PR 6)");
+    }
+
+    pub fn listDir(_: VirtualFS, _: std.mem.Allocator, _: []const u8) FsError![]DirEntry {
+        @compileError("VirtualFS.listDir: WASM fs callback 미구현 (Phase 2 PR 6)");
+    }
+};
+
+/// std.fs 의 OS error 를 fs 도메인 error 로 통일 매핑.
+/// readFile/statFile/access/openDir 공통.
+fn mapFsError(err: anyerror) FsError {
+    return switch (err) {
+        error.FileNotFound => FsError.NotFound,
+        error.AccessDenied, error.PermissionDenied => FsError.PermissionDenied,
+        error.NotDir => FsError.NotDirectory,
+        error.IsDir => FsError.IsDirectory,
+        error.OutOfMemory => FsError.OutOfMemory,
+        else => FsError.IoError,
+    };
+}
+
+fn mapEntryKind(kind: std.fs.Dir.Entry.Kind) EntryKind {
+    return switch (kind) {
+        .file => .file,
+        .directory => .directory,
+        .sym_link => .symlink,
+        else => .other,
+    };
+}

--- a/src/bundler/fs_test.zig
+++ b/src/bundler/fs_test.zig
@@ -1,0 +1,126 @@
+//! src/bundler/fs.zig 단위 테스트.
+//!
+//! RealFS 의 호스트 fs 통합만 검증 (VirtualFS 는 Phase 2 PR 6 에서).
+//! 임시 디렉토리 (std.testing.tmpDir) 를 사용해 격리.
+
+const std = @import("std");
+const testing = std.testing;
+const fs = @import("fs.zig");
+
+test "RealFS.readFile — 정상 케이스" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "hello.txt", .data = "hello world" });
+
+    var sub_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const abs_path = try tmp.dir.realpath("hello.txt", &sub_path_buf);
+
+    const real = fs.RealFS.init();
+    const loaded = try real.readFile(testing.allocator, abs_path, 1024);
+    defer testing.allocator.free(loaded.contents);
+
+    try testing.expectEqualStrings("hello world", loaded.contents);
+    try testing.expectEqual(fs.Namespace.file, loaded.namespace);
+    try testing.expectEqual(@import("types.zig").ModuleType.unknown, loaded.module_type);
+}
+
+test "RealFS.readFile — 존재하지 않는 파일은 NotFound" {
+    const real = fs.RealFS.init();
+    const result = real.readFile(testing.allocator, "/zts/no_such_path/abcdef", 1024);
+    try testing.expectError(fs.FsError.NotFound, result);
+}
+
+test "RealFS.access — 존재하면 void, 없으면 NotFound" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "exists.txt", .data = "" });
+
+    var sub_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const abs_path = try tmp.dir.realpath("exists.txt", &sub_path_buf);
+
+    const real = fs.RealFS.init();
+    try real.access(abs_path);
+    try testing.expectError(fs.FsError.NotFound, real.access("/zts/no_such_path/abcdef"));
+}
+
+test "RealFS.statFile — 파일 size + is_dir" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "size.txt", .data = "12345" });
+    try tmp.dir.makeDir("a_dir");
+
+    var buf1: [std.fs.max_path_bytes]u8 = undefined;
+    var buf2: [std.fs.max_path_bytes]u8 = undefined;
+    const file_path = try tmp.dir.realpath("size.txt", &buf1);
+    const dir_path = try tmp.dir.realpath("a_dir", &buf2);
+
+    const real = fs.RealFS.init();
+    const file_stat = try real.statFile(file_path);
+    try testing.expectEqual(@as(u64, 5), file_stat.size);
+    try testing.expect(!file_stat.is_dir);
+
+    const dir_stat = try real.statFile(dir_path);
+    try testing.expect(dir_stat.is_dir);
+}
+
+test "RealFS.listDir — 항목 수집 + free" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "a.txt", .data = "" });
+    try tmp.dir.writeFile(.{ .sub_path = "b.txt", .data = "" });
+    try tmp.dir.makeDir("subdir");
+
+    var sub_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp.dir.realpath(".", &sub_path_buf);
+
+    const real = fs.RealFS.init();
+    const entries = try real.listDir(testing.allocator, dir_path);
+    defer {
+        for (entries) |e| testing.allocator.free(e.name);
+        testing.allocator.free(entries);
+    }
+
+    try testing.expectEqual(@as(usize, 3), entries.len);
+
+    var saw_a = false;
+    var saw_b = false;
+    var saw_subdir = false;
+    for (entries) |e| {
+        if (std.mem.eql(u8, e.name, "a.txt")) {
+            saw_a = true;
+            try testing.expectEqual(fs.EntryKind.file, e.kind);
+        } else if (std.mem.eql(u8, e.name, "b.txt")) {
+            saw_b = true;
+        } else if (std.mem.eql(u8, e.name, "subdir")) {
+            saw_subdir = true;
+            try testing.expectEqual(fs.EntryKind.directory, e.kind);
+        }
+    }
+    try testing.expect(saw_a);
+    try testing.expect(saw_b);
+    try testing.expect(saw_subdir);
+}
+
+test "RealFS.listDir — 존재하지 않는 디렉토리는 NotFound" {
+    const real = fs.RealFS.init();
+    const result = real.listDir(testing.allocator, "/zts/no_such_dir/abcdef");
+    try testing.expectError(fs.FsError.NotFound, result);
+}
+
+test "Implementation 은 native 빌드에서 RealFS" {
+    if (@import("builtin").target.cpu.arch == .wasm32) return error.SkipZigTest;
+    try testing.expect(fs.Implementation == fs.RealFS);
+}
+
+test "LoadedModule default 값" {
+    const m: fs.LoadedModule = .{
+        .contents = "x",
+        .path = "y",
+    };
+    try testing.expectEqual(fs.Namespace.file, m.namespace);
+    try testing.expectEqual(@import("types.zig").ModuleType.unknown, m.module_type);
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -40,6 +40,7 @@ pub const css_emitter = @import("css_emitter.zig");
 pub const symbol = @import("symbol.zig");
 pub const asset_meta = @import("asset_meta.zig");
 pub const block_list = @import("block_list.zig");
+pub const fs = @import("fs.zig");
 
 // 공개 타입 re-export
 pub const ModuleIndex = types.ModuleIndex;
@@ -123,5 +124,7 @@ test {
     _ = asset_meta;
     _ = block_list;
     _ = incremental;
+    _ = fs;
     _ = @import("incremental_test.zig");
+    _ = @import("fs_test.zig");
 }


### PR DESCRIPTION
## Summary

#1885 epic 의 Phase 1 첫 PR. ZTS bundler 가 \`std.fs.cwd()\` 를 직접 호출하던 패턴을 추상화 layer 뒤로 이동시킬 수 있는 인터페이스 도입.

**호출처 변경 0** — PR 2 (graph.zig) / PR 3 (resolver.zig) 에서 점진 마이그레이션.

## 디자인 (#1892 결정)

- **comptime polymorphism** (bun 패턴) — \`Implementation = if(wasm) VirtualFS else RealFS\`
- vtable 비용 0, 빌드 타겟 고정 가정 활용 (\`references/bun/src/fs.zig:1475\` 참조)
- **\`LoadedModule\`** struct: \`namespace\` + \`module_type\` 필드 미리 포함 → plugin layer (PR 4) 도입 시 fs 인터페이스 재작성 없이 \`union(enum) ResolveResult\` 와 자연스럽게 통합
- **\`FileStat\`** 은 \`size\` / \`is_dir\` 만 — \`std.fs.File.Stat\` 의 OS-dependent 필드 (inode, mode_t) 격리해서 VirtualFS (WASM) 가 호스트 JS 로부터 동일 타입 줄 수 있게
- **\`mapFsError\`** 통합 — std.fs OS error 를 fs 도메인 error 로 단일 매핑
- **VirtualFS** 는 placeholder (\`@compileError\`) — Phase 2 PR 6 에서 host JS callback 구현

## API

\`\`\`zig
pub const Implementation = if (is_wasm_build) VirtualFS else RealFS;

pub const LoadedModule = struct {
    contents: []const u8,
    path: []const u8,
    namespace: Namespace = .file,
    module_type: types.ModuleType = .unknown,
};

pub const Namespace = enum { file, virtual, dataurl, external, custom };
pub const FileStat = struct { size: u64, is_dir: bool };

pub const RealFS = struct {
    pub fn readFile(_: RealFS, allocator, path, max_bytes) !LoadedModule
    pub fn statFile(_: RealFS, path) !FileStat
    pub fn access(_: RealFS, path) !void
    pub fn listDir(_: RealFS, allocator, path) ![]DirEntry
};
\`\`\`

## 변경

- \`src/bundler/fs.zig\` (신규, ~150 LoC) — 추상화 인터페이스 + RealFS
- \`src/bundler/fs_test.zig\` (신규, ~115 LoC) — 단위 테스트 (RealFS 의 호스트 fs 통합)
- \`src/bundler/mod.zig\` — fs export + test 등록

## /simplify 검토 반영

- \`errdefer\` 강화 — \`listDir\` 의 dupe 된 name 들이 append/toOwnedSlice 실패 시 leak 없도록
- \`std.fs.File.Stat\` 노출 → \`FileStat\` wrapping (VirtualFS 와 인터페이스 호환)
- \`mapReadError/mapStatError/mapAccessError/mapOpenDirError\` 4개 → 단일 \`mapFsError\` 통합 (60+줄 → ~10줄)

## Test plan

- [x] \`zig build test\` 통과 — fs_test 8 케이스 (readFile/access/statFile/listDir 정상+에러 + Namespace/Implementation 검증)
- [x] /simplify 3-agent 검토 적용
- [x] 호출처 변경 0 — 기존 모든 테스트 영향 없음

## 다음 단계

- PR 2: \`graph.zig\` 의 \`std.fs.cwd().readFileAlloc\` 8곳 → \`Implementation.readFile\` 마이그레이션
- PR 3: \`resolver.zig\` 의 \`openDir/access/statFile\` 6곳 → \`Implementation.*\` 마이그레이션
- PR 4: \`plugin.zig\` 갱신 + \`union(enum) ResolveResult\`
- PR 5: ModuleGraph 의 plugin first → fs fallback 흐름

#1885 epic 의 Phase 1 진행 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)