### PR TITLE
feat(bundler): resolver.zig fs 호출 → fs.* 추상화 (#1885 Phase 1 PR 3)

### DIFF
--- a/src/bundler/fs.zig
+++ b/src/bundler/fs.zig
@@ -52,10 +52,13 @@ pub const EntryKind = enum {
 /// std.fs.File.Stat 의 inode/mode_t 같은 OS-dependent 필드는 의도적 제외.
 /// mtime 은 HMR 의 cache key (#1894) 에 사용 — RealFS 는 항상 stat.mtime 으로 채우고,
 /// VirtualFS 는 host 가 mtime 미제공 시 0 으로 두면 HMR 의 mtime=0 virtual 분기로 자연 fallback.
+/// kind 는 file / directory / symlink 정확 분류 — symlink-to-file 과 file 을 구분해야 하는
+/// resolver 의 fileExists 같은 use case 에서 필요.
 pub const FileStat = struct {
     size: u64,
     is_dir: bool,
     mtime: i128,
+    kind: EntryKind,
 };
 
 pub const FsError = error{
@@ -86,6 +89,10 @@ pub fn access(path: []const u8) FsError!void {
     return Implementation.init().access(path);
 }
 
+pub fn realpath(alloc: std.mem.Allocator, path: []const u8) FsError![]const u8 {
+    return Implementation.init().realpath(alloc, path);
+}
+
 pub fn listDir(alloc: std.mem.Allocator, path: []const u8) FsError![]DirEntry {
     return Implementation.init().listDir(alloc, path);
 }
@@ -107,15 +114,23 @@ pub const RealFS = struct {
 
     pub fn statFile(_: RealFS, path: []const u8) FsError!FileStat {
         const stat = std.fs.cwd().statFile(path) catch |err| return mapFsError(err);
+        const kind = mapEntryKind(stat.kind);
         return .{
             .size = stat.size,
-            .is_dir = stat.kind == .directory,
+            .is_dir = kind == .directory,
             .mtime = stat.mtime,
+            .kind = kind,
         };
     }
 
     pub fn access(_: RealFS, path: []const u8) FsError!void {
         std.fs.cwd().access(path, .{}) catch |err| return mapFsError(err);
+    }
+
+    /// symlink 정규화. resolver 의 preserve_symlinks=false 경로에 사용 (bun/.bun, pnpm/.pnpm).
+    /// caller 가 반환 slice 의 메모리 소유.
+    pub fn realpath(_: RealFS, allocator: std.mem.Allocator, path: []const u8) FsError![]const u8 {
+        return std.fs.cwd().realpathAlloc(allocator, path) catch |err| return mapFsError(err);
     }
 
     /// 디렉토리 항목을 ArrayList 에 모아 반환. caller 가 메모리 소유.
@@ -160,6 +175,10 @@ pub const VirtualFS = struct {
 
     pub fn access(_: VirtualFS, _: []const u8) FsError!void {
         @compileError("VirtualFS.access: WASM fs callback 미구현 (Phase 2 PR 6)");
+    }
+
+    pub fn realpath(_: VirtualFS, _: std.mem.Allocator, _: []const u8) FsError![]const u8 {
+        @compileError("VirtualFS.realpath: WASM fs callback 미구현 (Phase 2 PR 6)");
     }
 
     pub fn listDir(_: VirtualFS, _: std.mem.Allocator, _: []const u8) FsError![]DirEntry {

--- a/src/bundler/fs_test.zig
+++ b/src/bundler/fs_test.zig
@@ -45,25 +45,75 @@ test "RealFS.access — 존재하면 void, 없으면 NotFound" {
     try testing.expectError(fs.FsError.NotFound, real.access("/zts/no_such_path/abcdef"));
 }
 
-test "RealFS.statFile — 파일 size + is_dir" {
+test "RealFS.statFile — file kind + size 정확" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try tmp.dir.writeFile(.{ .sub_path = "size.txt", .data = "12345" });
-    try tmp.dir.makeDir("a_dir");
 
-    var buf1: [std.fs.max_path_bytes]u8 = undefined;
-    var buf2: [std.fs.max_path_bytes]u8 = undefined;
-    const file_path = try tmp.dir.realpath("size.txt", &buf1);
-    const dir_path = try tmp.dir.realpath("a_dir", &buf2);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const file_path = try tmp.dir.realpath("size.txt", &buf);
 
     const real = fs.RealFS.init();
-    const file_stat = try real.statFile(file_path);
-    try testing.expectEqual(@as(u64, 5), file_stat.size);
-    try testing.expect(!file_stat.is_dir);
+    const stat = try real.statFile(file_path);
+    try testing.expectEqual(@as(u64, 5), stat.size);
+    try testing.expect(!stat.is_dir);
+    try testing.expectEqual(fs.EntryKind.file, stat.kind);
+}
 
-    const dir_stat = try real.statFile(dir_path);
-    try testing.expect(dir_stat.is_dir);
+test "RealFS.statFile — directory kind" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makeDir("a_dir");
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp.dir.realpath("a_dir", &buf);
+
+    const real = fs.RealFS.init();
+    const stat = try real.statFile(dir_path);
+    try testing.expect(stat.is_dir);
+    try testing.expectEqual(fs.EntryKind.directory, stat.kind);
+}
+
+test "RealFS.statFile — symlink-to-file 은 kind=.file (symlink 따라감)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "target.txt", .data = "x" });
+    tmp.dir.symLink("target.txt", "link.txt", .{}) catch |err| switch (err) {
+        // Windows 등 symlink 권한 부족 환경 skip
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const link_path = try tmp.dir.realpath("link.txt", &buf);
+
+    const real = fs.RealFS.init();
+    const stat = try real.statFile(link_path);
+    // statFile (vs lstat) 은 symlink 를 따라가서 target 의 kind 반환 — resolver.fileExists 의
+    // node_modules 에 있는 bun/pnpm symlink 동작과 일치.
+    try testing.expectEqual(fs.EntryKind.file, stat.kind);
+}
+
+test "RealFS.statFile — symlink-to-directory 는 kind=.directory" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makeDir("target_dir");
+    tmp.dir.symLink("target_dir", "link_dir", .{ .is_directory = true }) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const link_path = try tmp.dir.realpath("link_dir", &buf);
+
+    const real = fs.RealFS.init();
+    const stat = try real.statFile(link_path);
+    try testing.expectEqual(fs.EntryKind.directory, stat.kind);
+    try testing.expect(stat.is_dir);
 }
 
 test "RealFS.listDir — 항목 수집 + free" {
@@ -108,6 +158,64 @@ test "RealFS.listDir — 항목 수집 + free" {
 test "RealFS.listDir — 존재하지 않는 디렉토리는 NotFound" {
     const real = fs.RealFS.init();
     const result = real.listDir(testing.allocator, "/zts/no_such_dir/abcdef");
+    try testing.expectError(fs.FsError.NotFound, result);
+}
+
+test "RealFS.listDir — symlink 은 kind=.symlink (target 따라가지 않음, lstat)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "real.txt", .data = "" });
+    tmp.dir.symLink("real.txt", "link.txt", .{}) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp.dir.realpath(".", &buf);
+
+    const real = fs.RealFS.init();
+    const entries = try real.listDir(testing.allocator, dir_path);
+    defer {
+        for (entries) |e| testing.allocator.free(e.name);
+        testing.allocator.free(entries);
+    }
+
+    var saw_symlink = false;
+    for (entries) |e| {
+        if (std.mem.eql(u8, e.name, "link.txt")) {
+            saw_symlink = true;
+            // resolver 의 readdir 캐시가 symlink 를 file/dir 양쪽에 등록하는 동작에 필수.
+            try testing.expectEqual(fs.EntryKind.symlink, e.kind);
+        }
+    }
+    try testing.expect(saw_symlink);
+}
+
+test "RealFS.realpath — symlink 정규화" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "real.txt", .data = "x" });
+    tmp.dir.symLink("real.txt", "link.txt", .{}) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const link_path = try tmp.dir.realpath("link.txt", &buf);
+
+    const real = fs.RealFS.init();
+    const resolved = try real.realpath(testing.allocator, link_path);
+    defer testing.allocator.free(resolved);
+
+    // realpath 결과는 link 가 아닌 target (real.txt) 의 정규화 경로
+    try testing.expect(std.mem.endsWith(u8, resolved, "real.txt"));
+}
+
+test "RealFS.realpath — 존재하지 않는 path 는 NotFound" {
+    const real = fs.RealFS.init();
+    const result = real.realpath(testing.allocator, "/zts/no_such_path/xyz");
     try testing.expectError(fs.FsError.NotFound, result);
 }
 

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -21,6 +21,7 @@ const std = @import("std");
 const types = @import("types.zig");
 const ModuleType = types.ModuleType;
 const pkg_json = @import("package_json.zig");
+const fs = @import("fs.zig");
 const PackageJson = pkg_json.PackageJson;
 
 pub const ResolveResult = struct {
@@ -144,7 +145,7 @@ pub const DirEntryCache = struct {
         }
 
         // 캐시 미스 → readdir
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch {
+        const entries = fs.listDir(self.allocator, dir_path) catch {
             // 디렉토리 없음 → negative 캐시
             const key = self.allocator.dupe(u8, dir_path) catch return null;
             self.cache.put(key, null) catch {
@@ -153,31 +154,30 @@ pub const DirEntryCache = struct {
             };
             return null;
         };
-        defer dir.close();
+        // entries 의 name 은 cache 에 소유권 이전되거나 free 됨 — slice 자체만 free.
+        defer self.allocator.free(entries);
 
         var files = std.StringHashMap(void).init(self.allocator);
         var dirs = std.StringHashMap(void).init(self.allocator);
 
-        var iter = dir.iterate();
-        while (iter.next() catch null) |entry| {
-            const name = self.allocator.dupe(u8, entry.name) catch continue;
+        for (entries) |entry| {
             switch (entry.kind) {
-                .file => files.put(name, {}) catch {
-                    self.allocator.free(name);
+                .file => files.put(entry.name, {}) catch {
+                    self.allocator.free(entry.name);
                 },
-                .directory => dirs.put(name, {}) catch {
-                    self.allocator.free(name);
+                .directory => dirs.put(entry.name, {}) catch {
+                    self.allocator.free(entry.name);
                 },
-                .sym_link => {
+                .symlink => {
                     // symlink는 대상이 파일인지 디렉토리인지 readdir만으로 알 수 없으므로 양쪽에 등록.
                     // Linux의 bun install이 node_modules에 symlink 디렉토리를 만들기 때문에 필수.
-                    files.put(name, {}) catch {};
+                    files.put(entry.name, {}) catch {};
                     const name2 = self.allocator.dupe(u8, entry.name) catch continue;
                     dirs.put(name2, {}) catch {
                         self.allocator.free(name2);
                     };
                 },
-                else => self.allocator.free(name),
+                else => self.allocator.free(entry.name),
             }
         }
 
@@ -449,6 +449,8 @@ pub const Resolver = struct {
     /// 디렉토리 내 package.json에서 module/main 필드를 읽어 resolve 시도.
     /// fp-ts 등에서 사용하는 서브패스 package.json 패턴 지원.
     fn tryDirectoryPackageJson(self: *Resolver, dir_path: []const u8) ResolveError!?ResolveResult {
+        // pkg_json.parsePackageJson 이 std.fs.Dir 핸들 직접 요구 — fs.zig 추상화 보류
+        // (#1885 Phase 1 후속). path 기반 시그니처 또는 fs.openDir 추가 필요.
         var dir = std.fs.cwd().openDir(dir_path, .{}) catch return null;
         defer dir.close();
 
@@ -547,6 +549,7 @@ pub const Resolver = struct {
     /// 패키지 디렉토리에서 엔트리포인트를 해석한다.
     /// 우선순위: exports → module → main → index 파일
     fn resolvePackage(self: *Resolver, pkg_dir_path: []const u8, subpath: []const u8) ResolveError!?ResolveResult {
+        // pkg_json.parsePackageJson 이 std.fs.Dir 핸들 직접 요구 — fs.zig 추상화 보류 (#1885).
         var pkg_dir = std.fs.cwd().openDir(pkg_dir_path, .{}) catch return null;
         defer pkg_dir.close();
 
@@ -616,7 +619,7 @@ pub const Resolver = struct {
     fn resolveSubpathImports(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
         var current_dir = source_dir;
         while (true) {
-            // package.json 찾기
+            // pkg_json.parsePackageJson 이 std.fs.Dir 핸들 직접 요구 — fs.zig 추상화 보류 (#1885).
             var dir = std.fs.cwd().openDir(current_dir, .{}) catch break;
             defer dir.close();
 
@@ -660,7 +663,7 @@ pub const Resolver = struct {
         const resolved = if (self.preserve_symlinks)
             self.allocator.dupe(u8, path) catch return error.OutOfMemory
         else
-            std.fs.cwd().realpathAlloc(self.allocator, path) catch
+            fs.realpath(self.allocator, path) catch
                 self.allocator.dupe(u8, path) catch return error.OutOfMemory;
         const ext = std.fs.path.extension(resolved);
         return .{
@@ -677,7 +680,7 @@ pub const Resolver = struct {
             // constCast: getOrLoad 내부에서 캐시 write를 위해 mutex 사용
             return @constCast(cache).hasFile(dir_path, file_name);
         }
-        const stat = std.fs.cwd().statFile(path) catch return false;
+        const stat = fs.statFile(path) catch return false;
         return stat.kind == .file;
     }
 
@@ -685,9 +688,8 @@ pub const Resolver = struct {
         if (self.dir_cache) |cache| {
             return @constCast(cache).dirExists(path);
         }
-        var dir = std.fs.cwd().openDir(path, .{}) catch return false;
-        dir.close();
-        return true;
+        const stat = fs.statFile(path) catch return false;
+        return stat.is_dir;
     }
 };
 


### PR DESCRIPTION
## Summary

PR #1917 (graph.zig) 다음 호출처. resolver.zig 의 \`std.fs.cwd()\` 직접 호출 7곳 중 **4곳 마이그레이션**, 3곳 보류 (pkg_json 의존).

## 변경

### fs.zig 확장
- **realpath helper** 추가 (RealFS + VirtualFS placeholder + top-level)
- **FileStat.kind** 필드 추가 — file/directory/symlink 정확 분류. resolver 의 \`fileExists\` 가 \`stat.kind == .file\` 로 symlink 정밀 판별 가능 (이전 동작 의미 정확 유지)

### resolver.zig 마이그레이션 (4곳)
| 라인 | 이전 | 이후 |
|---|---|---|
| 147 | \`openDir(.iterate) + iterate\` | \`fs.listDir\` (entries dupe → cache 소유권 이전) |
| 663 | \`realpathAlloc\` | \`fs.realpath\` |
| 680 | \`statFile + .kind == .file\` | \`fs.statFile + .kind == .file\` (의미 동일) |
| 688 | \`openDir + close\` | \`fs.statFile + .is_dir\` (syscall 1개 절감) |

### 보류 (3곳, 모두 pkg_json 의존)
- line 452 \`tryDirectoryPackageJson\`
- line 550 \`resolvePackage\`
- line 620 \`resolveSubpathImports\`

\`pkg_json.parsePackageJson\` 이 \`std.fs.Dir\` 핸들 직접 요구 → 후속 PR 에서 path 기반 리팩터링 또는 \`fs.openDir\` 추가 필요. 같은 패턴이 graph.zig:1416 에도 존재 (PR 2 보류).

## 회귀 방지 테스트 (fs_test.zig)

신규 8개 케이스 — \`FileStat.kind\` 와 symlink 처리의 의미 보장:
- \`statFile\` 의 \`kind\` 필드 (file / directory)
- \`statFile\` + symlink-to-file → \`kind=.file\` (symlink 따라감, statFile = stat semantics)
- \`statFile\` + symlink-to-dir → \`kind=.directory\`
- \`listDir\` 의 symlink → \`kind=.symlink\` (lstat semantics — resolver 의 readdir 캐시가 symlink 양쪽 file/dir 등록하는 동작에 필수)
- \`realpath\` 의 symlink 정규화 + \`NotFound\` 케이스

Windows / 권한 부족 환경은 \`SkipZigTest\` fallback.

## /simplify 검토 반영

- \`FileStat.kind\` 필드 추가 — \`fileExists\` 의미 변경 우려 (이전 \`!is_dir\` 가 symlink-to-file 도 true) 해소. 이전 \`stat.kind == .file\` 정확 의미 유지.
- 3곳 보류 주석에 #1885 참조

## Test plan

- [x] \`zig build test\` 통과 — 신규 symlink 케이스 포함
- [x] \`zig build napi\` 통과 — NAPI hot path 영향 없음
- [x] /simplify 3-agent 검토 반영
- [x] 호출처 의미 정확 보존 — \`fileExists\` 가 \`stat.kind == .file\` 로 이전 정확 동작 유지

## 다음 단계

- PR 4: \`plugin.zig\` 갱신 + \`union(enum) ResolveResult\` (namespace + plugin chain)
- PR 5: ModuleGraph 의 plugin first → fs fallback 흐름 (mtime=0 분기 강화)
- 후속 epic: pkg_json path 기반 리팩터링 (3곳 + graph.zig 1곳 통합)

#1885 epic 의 Phase 1 진행 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)