### PR TITLE
refactor(transformer): async generator cleanup — simplify findings

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1034,6 +1034,13 @@ pub const Ast = struct {
         self.nodes.items[@intFromEnum(index)].tag = new_tag;
     }
 
+    /// 노드 in-place 교체. 주로 transformer 의 cover-grammar / await→yield rewrite 같이
+    /// 하위 트리는 보존하면서 같은 인덱스의 tag/data 만 새 형태로 바꿀 때. span 은 caller 가
+    /// 보존하든 변경하든 자유 — 일반적으로는 source 위치 유지를 위해 기존 span 유지.
+    pub fn replaceNode(self: *Ast, index: NodeIndex, new_node: Node) void {
+        self.nodes.items[@intFromEnum(index)] = new_node;
+    }
+
     /// variable_declaration 노드의 kind를 typed enum으로 반환.
     /// node.tag == .variable_declaration 가정. extra[0]에 저장된 u32를 디코드.
     pub inline fn variableDeclarationKind(self: *const Ast, node: Node) VariableDeclarationKind {

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -37,14 +37,24 @@ pub fn ES2017(comptime Transformer: type) type {
                     self.runtime_helpers.await_helper = true;
                     const await_ref = try es_helpers.makeRuntimeHelperRef(self, "__await");
                     const await_call = try es_helpers.makeCallExpr(self, await_ref, &.{node.data.unary.operand}, node.span);
-                    // node 자체를 in-place 로 yield_expression 으로 교체 (operand = __await(value)).
-                    var n = self.ast.nodes.items[@intFromEnum(node_idx)];
-                    n.tag = .yield_expression;
-                    n.data = .{ .unary = .{ .operand = await_call, .flags = 0 } };
-                    self.ast.nodes.items[@intFromEnum(node_idx)] = n;
+                    // span 보존하면서 await_expression → yield __await(value).
+                    self.ast.replaceNode(node_idx, .{
+                        .tag = .yield_expression,
+                        .span = node.span,
+                        .data = .{ .unary = .{ .operand = await_call, .flags = 0 } },
+                    });
                 },
-                // 자체 async/await context 를 가진 nested scope — skip.
-                .function_declaration, .function_expression, .arrow_function_expression, .method_definition => {},
+                // 자체 async/await context 를 가진 nested scope — skip. `es2022_tla.hasTopLevelAwait`
+                // 의 boundary set 과 동일 (function/method/class 모두). class body 안 method
+                // 도 자체 컨텍스트라 await rewrite 에서 제외.
+                .function_declaration,
+                .function_expression,
+                .function,
+                .arrow_function_expression,
+                .method_definition,
+                .class_declaration,
+                .class_expression,
+                => {},
                 else => {
                     // 일반 노드 — child iterator 로 모든 자식 traversal.
                     const ast_walk = @import("../parser/ast_walk.zig");
@@ -71,11 +81,9 @@ pub fn ES2017(comptime Transformer: type) type {
             const new_name = try self.visitNode(name_idx);
             const new_params = try self.visitExtraList(.{ .start = params_list.start, .len = params_list.len });
 
-            // body 안 await → yield __await(value) 변환 (in-place AST 편집).
             try rewriteAwaitToYieldAwait(self, body_idx);
 
-            // inner function*(): 일반 generator (async flag 제거). visitNode 거치면 ES5 target 시
-            // 자동으로 generator state machine 으로 lower.
+            // inner function*(): visitNode 거치면 ES5 target 시 자동으로 generator state machine 으로 lower.
             const inner_flags = (flags & ~@as(u32, ast_mod.FunctionFlags.is_async)) | @as(u32, ast_mod.FunctionFlags.is_generator);
             const inner_params_node = try self.ast.addFormalParameters(new_params, span);
             const none = @intFromEnum(NodeIndex.none);
@@ -115,7 +123,7 @@ pub fn ES2017(comptime Transformer: type) type {
                 .data = .{ .list = outer_body_list },
             });
             const outer_params_node = try self.ast.addFormalParameters(new_params, span);
-            const outer_flags = flags & ~(ast_mod.FunctionFlags.is_async | @as(u32, ast_mod.FunctionFlags.is_generator));
+            const outer_flags = flags & ~(@as(u32, ast_mod.FunctionFlags.is_async) | @as(u32, ast_mod.FunctionFlags.is_generator));
             const outer_extra = try self.ast.addExtras(&.{
                 @intFromEnum(new_name),
                 @intFromEnum(outer_params_node),


### PR DESCRIPTION
Follow-up to #1919 — applied review findings from \`/simplify\`. Same behavior, cleaner.

## Reproduction first — false positive ruled out

The reuse review flagged "skip-list missing class_declaration → nested class method's await would be incorrectly rewritten." Verified locally — \`method_definition\` already protects class methods (no actual user-visible bug):

\`\`\`ts
async function* outer() {
  class Inner {
    async method() { return await Promise.resolve(42); }
  }
  yield await new Inner().method();
}
\`\`\`

Hermes runtime output before and after the boundary expansion: \`RES:42\` (both pass). Kept the expansion anyway — aligns with \`es2022_tla.hasTopLevelAwait\` boundary set, prevents future drift.

## Changes

| Item | File:line |
| --- | --- |
| New \`Ast.replaceNode(idx, node)\` helper — encapsulates the only in-place mutation outside minify.zig | parser/ast.zig:1037 |
| \`rewriteAwaitToYieldAwait\` skip-list extended to match \`es2022_tla.hasTopLevelAwait\` (adds function/class_declaration/class_expression) | transformer/es2017.zig:46-54 |
| \`outer_flags\` cast asymmetry fixed (both operands cast) | transformer/es2017.zig:126 |
| Narrative comment trimmed | transformer/es2017.zig:84 |

## Verification

- \`zig build test\` — **3777/3777 passed**
- Reproduction case (nested class async method inside async generator) — Hermes runtime \`RES:42\` ✓ (both before/after)

## Not applied (deferred)

- Extracting \`buildAsyncWrapperShell\` from the two parallel \`lowerAsync*ToStateMachine\` functions — meaningful but larger refactor, separate PR if desired.
- Promoting boundary skip-list into \`ast_walk.walkSkippingFunctionScopes\` helper — same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)