### PR TITLE
refactor(bundler): pkg_json path-based 시그니처 — fs 추상화 완성 (#1921)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1408,19 +1408,13 @@ pub const ModuleGraph = struct {
         if (cached) |c| return c;
 
         var info: PkgInfo = .{ .is_module = false, .side_effects = .unknown };
-        // pkg_json.parsePackageJson 이 std.fs.Dir 핸들 직접 요구 — fs.zig 추상화 보류
-        // (#1885 Phase 1 후속). path 기반 리팩터링 또는 fs.zig 에 openDir 추가 필요.
-        if (std.fs.cwd().openDir(pkg_dir_path, .{})) |dir_val| {
-            var pkg_dir = dir_val;
-            defer pkg_dir.close();
-            if (pkg_json.parsePackageJson(self.allocator, pkg_dir)) |parsed_val| {
-                var parsed = parsed_val;
-                info.is_module = parsed.pkg.isModule();
-                info.side_effects = parsed.pkg.side_effects;
-                // 소유권을 info 로 이전 — parsed.deinit() 에서 이중 free 방지.
-                parsed.pkg.side_effects = .unknown;
-                parsed.deinit();
-            } else |_| {}
+        if (pkg_json.parsePackageJson(self.allocator, pkg_dir_path)) |parsed_val| {
+            var parsed = parsed_val;
+            info.is_module = parsed.pkg.isModule();
+            info.side_effects = parsed.pkg.side_effects;
+            // 소유권을 info 로 이전 — parsed.deinit() 에서 이중 free 방지.
+            parsed.pkg.side_effects = .unknown;
+            parsed.deinit();
         } else |_| {}
 
         self.pkg_info_cache_mutex.lock();

--- a/src/bundler/package_json.zig
+++ b/src/bundler/package_json.zig
@@ -24,6 +24,7 @@
 //!   - references/rolldown/crates/rolldown_resolver/src/resolver_config.rs
 
 const std = @import("std");
+const fs = @import("fs.zig");
 
 /// package.json 필드명 / exports conditions 문자열 상수.
 /// main_fields 순서 지정과 conditional exports 해석 양쪽에서 재사용된다.
@@ -103,13 +104,23 @@ pub const ParsedPackageJson = struct {
     }
 };
 
-/// package.json 파일을 읽고 파싱한다.
-pub fn parsePackageJson(allocator: std.mem.Allocator, dir: std.fs.Dir) !ParsedPackageJson {
-    const source = dir.readFileAlloc(allocator, "package.json", 1024 * 1024) catch
-        return error.FileNotFound;
-    defer allocator.free(source);
+/// `pkg_dir_path` 디렉토리의 package.json 을 읽고 파싱한다. path 기반 시그니처로
+/// fs.zig 추상화 통과 — std.fs.Dir 핸들 의존 제거 (#1921, #1885 Phase 1 완성).
+pub fn parsePackageJson(allocator: std.mem.Allocator, pkg_dir_path: []const u8) !ParsedPackageJson {
+    const json_path = try std.fs.path.join(allocator, &.{ pkg_dir_path, "package.json" });
+    defer allocator.free(json_path);
 
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, source, .{}) catch
+    const loaded = fs.readFile(allocator, json_path, 1024 * 1024) catch |err| switch (err) {
+        fs.FsError.NotFound => return error.FileNotFound,
+        fs.FsError.OutOfMemory => return error.OutOfMemory,
+        // PermissionDenied / IoError / NotDirectory / IsDirectory 모두 IoError 로 통합 —
+        // caller (resolver/graph) 는 이미 catch 후 null 반환 패턴이라 silent fallback. 단
+        // OutOfMemory 만은 분리해 silent swallow 방지.
+        else => return error.IoError,
+    };
+    defer allocator.free(loaded.contents);
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, loaded.contents, .{}) catch
         return error.JsonParseError;
 
     const root = parsed.value;

--- a/src/bundler/package_json_test.zig
+++ b/src/bundler/package_json_test.zig
@@ -118,6 +118,64 @@ test "parsePackageJson: missing file" {
     try std.testing.expectError(error.FileNotFound, result);
 }
 
+// path-based 시그니처의 회귀 방지 — std.fs.Dir 핸들 우회 후 새로 노출되는 경로:
+
+test "parsePackageJson: symlink-to-directory 안의 package.json (bun/.bun 패턴)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // 실제 패키지 디렉토리
+    try tmp.dir.makeDir("real_pkg");
+    var real_dir = try tmp.dir.openDir("real_pkg", .{});
+    defer real_dir.close();
+    try real_dir.writeFile(.{
+        .sub_path = "package.json",
+        .data =
+        \\{"name":"linked-pkg","main":"./index.js"}
+        ,
+    });
+
+    // bun/.bun 같은 symlink-to-directory
+    tmp.dir.symLink("real_pkg", "linked_pkg", .{ .is_directory = true }) catch |err| switch (err) {
+        // Windows / 권한 부족 환경 skip
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_path = try tmp.dir.realpath(".", &buf);
+
+    // symlink 경로로 parsePackageJson 호출 — std.fs.path.join 후 readFile 가
+    // symlink 를 따라가 target 의 package.json 읽음
+    var join_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const linked_path = try std.fmt.bufPrint(&join_buf, "{s}/linked_pkg", .{tmp_path});
+
+    var result = try parsePackageJson(std.testing.allocator, linked_path);
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("linked-pkg", result.pkg.name.?);
+}
+
+test "parsePackageJson: OutOfMemory 는 별도로 throw (silent swallow 방지)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{
+        .sub_path = "package.json",
+        .data =
+        \\{"name":"oom-test"}
+        ,
+    });
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmpDirPath(&tmp, &buf);
+
+    // failingAllocator 0 byte 허용 — std.fs.path.join 의 첫 alloc 부터 실패
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const result = parsePackageJson(failing.allocator(), dir_path);
+    try std.testing.expectError(error.OutOfMemory, result);
+}
+
 test "resolveExports: string shorthand" {
     const source =
         \\{"exports":"./index.js"}

--- a/src/bundler/package_json_test.zig
+++ b/src/bundler/package_json_test.zig
@@ -156,6 +156,43 @@ test "parsePackageJson: symlink-to-directory 안의 package.json (bun/.bun 패�
     try std.testing.expectEqualStrings("linked-pkg", result.pkg.name.?);
 }
 
+test "parsePackageJson: pnpm/bun farm symlink — node_modules/foo → .pnpm/foo@x/node_modules/foo" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // pnpm/bun 의 farm 구조 모방 — content-addressable store + flat symlink farm
+    try tmp.dir.makePath(".pnpm/foo@1.0.0/node_modules/foo");
+    var farm_dir = try tmp.dir.openDir(".pnpm/foo@1.0.0/node_modules/foo", .{});
+    defer farm_dir.close();
+    try farm_dir.writeFile(.{
+        .sub_path = "package.json",
+        .data =
+        \\{"name":"foo","version":"1.0.0","main":"./index.js","module":"./esm/index.js"}
+        ,
+    });
+
+    // node_modules/foo 가 farm 으로 symlink — bun install 과 pnpm install 양쪽 동일 패턴
+    try tmp.dir.makeDir("node_modules");
+    tmp.dir.symLink("../.pnpm/foo@1.0.0/node_modules/foo", "node_modules/foo", .{ .is_directory = true }) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp_path = try tmp.dir.realpath(".", &buf);
+
+    var join_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const farm_path = try std.fmt.bufPrint(&join_buf, "{s}/node_modules/foo", .{tmp_path});
+
+    // path-based 호출이 farm symlink 를 따라가 farm 의 package.json 읽음
+    var result = try parsePackageJson(std.testing.allocator, farm_path);
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("foo", result.pkg.name.?);
+    try std.testing.expectEqualStrings("./index.js", result.pkg.main.?);
+    try std.testing.expectEqualStrings("./esm/index.js", result.pkg.module.?);
+}
+
 test "parsePackageJson: OutOfMemory 는 별도로 throw (silent swallow 방지)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/package_json_test.zig
+++ b/src/bundler/package_json_test.zig
@@ -9,6 +9,12 @@ const isSubpathMap = pkg_json.isSubpathMap;
 // Tests
 // ============================================================
 
+// path-based parsePackageJson 호출용 helper — tmp dir 의 절대경로 반환.
+// caller 는 buf 를 자체 stack 에 보유.
+fn tmpDirPath(tmp: *std.testing.TmpDir, buf: *[std.fs.max_path_bytes]u8) ![]const u8 {
+    return try tmp.dir.realpath(".", buf);
+}
+
 test "parsePackageJson: basic fields" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -20,7 +26,9 @@ test "parsePackageJson: basic fields" {
         ,
     });
 
-    var result = try parsePackageJson(std.testing.allocator, tmp.dir);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmpDirPath(&tmp, &buf);
+    var result = try parsePackageJson(std.testing.allocator, dir_path);
     defer result.deinit();
 
     try std.testing.expectEqualStrings("test-pkg", result.pkg.name.?);
@@ -40,7 +48,9 @@ test "parsePackageJson: sideEffects false" {
         ,
     });
 
-    var result = try parsePackageJson(std.testing.allocator, tmp.dir);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmpDirPath(&tmp, &buf);
+    var result = try parsePackageJson(std.testing.allocator, dir_path);
     defer result.deinit();
 
     switch (result.pkg.side_effects) {
@@ -60,7 +70,9 @@ test "parsePackageJson: sideEffects array" {
         ,
     });
 
-    var result = try parsePackageJson(std.testing.allocator, tmp.dir);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmpDirPath(&tmp, &buf);
+    var result = try parsePackageJson(std.testing.allocator, dir_path);
     defer result.deinit();
 
     switch (result.pkg.side_effects) {
@@ -84,7 +96,9 @@ test "parsePackageJson: sideEffects empty array" {
         ,
     });
 
-    var result = try parsePackageJson(std.testing.allocator, tmp.dir);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmpDirPath(&tmp, &buf);
+    var result = try parsePackageJson(std.testing.allocator, dir_path);
     defer result.deinit();
 
     // 빈 배열은 sideEffects: false와 동일
@@ -98,7 +112,9 @@ test "parsePackageJson: missing file" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    const result = parsePackageJson(std.testing.allocator, tmp.dir);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmpDirPath(&tmp, &buf);
+    const result = parsePackageJson(std.testing.allocator, dir_path);
     try std.testing.expectError(error.FileNotFound, result);
 }
 
@@ -280,7 +296,9 @@ test "parsePackageJson: imports field" {
         ,
     });
 
-    var result = try parsePackageJson(std.testing.allocator, tmp.dir);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmpDirPath(&tmp, &buf);
+    var result = try parsePackageJson(std.testing.allocator, dir_path);
     defer result.deinit();
 
     try std.testing.expect(result.pkg.imports != null);

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -553,10 +553,7 @@ pub const ResolveCache = struct {
     /// package.json 의 browser 필드를 4 축 (path/module × disabled/remap) 으로 수집.
     /// 키 prefix 로 분류: "./foo" → path-key, 나머지는 bare module key (#1530).
     fn buildBrowserOverrides(self: *ResolveCache, pkg_dir_path: []const u8) ?BrowserOverrides {
-        var pkg_dir = std.fs.cwd().openDir(pkg_dir_path, .{}) catch return null;
-        defer pkg_dir.close();
-
-        var parsed = pkg_json.parsePackageJson(std.heap.page_allocator, pkg_dir) catch return null;
+        var parsed = pkg_json.parsePackageJson(std.heap.page_allocator, pkg_dir_path) catch return null;
         defer parsed.deinit();
 
         const browser_map = parsed.pkg.browser_map orelse return null;

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -449,12 +449,7 @@ pub const Resolver = struct {
     /// 디렉토리 내 package.json에서 module/main 필드를 읽어 resolve 시도.
     /// fp-ts 등에서 사용하는 서브패스 package.json 패턴 지원.
     fn tryDirectoryPackageJson(self: *Resolver, dir_path: []const u8) ResolveError!?ResolveResult {
-        // pkg_json.parsePackageJson 이 std.fs.Dir 핸들 직접 요구 — fs.zig 추상화 보류
-        // (#1885 Phase 1 후속). path 기반 시그니처 또는 fs.openDir 추가 필요.
-        var dir = std.fs.cwd().openDir(dir_path, .{}) catch return null;
-        defer dir.close();
-
-        var parsed = pkg_json.parsePackageJson(self.allocator, dir) catch return null;
+        var parsed = pkg_json.parsePackageJson(self.allocator, dir_path) catch return null;
         defer parsed.deinit();
 
         return self.resolveByMainFields(&parsed, dir_path);
@@ -549,12 +544,8 @@ pub const Resolver = struct {
     /// 패키지 디렉토리에서 엔트리포인트를 해석한다.
     /// 우선순위: exports → module → main → index 파일
     fn resolvePackage(self: *Resolver, pkg_dir_path: []const u8, subpath: []const u8) ResolveError!?ResolveResult {
-        // pkg_json.parsePackageJson 이 std.fs.Dir 핸들 직접 요구 — fs.zig 추상화 보류 (#1885).
-        var pkg_dir = std.fs.cwd().openDir(pkg_dir_path, .{}) catch return null;
-        defer pkg_dir.close();
-
         // package.json 파싱 시도
-        var parsed = pkg_json.parsePackageJson(self.allocator, pkg_dir) catch |err| switch (err) {
+        var parsed = pkg_json.parsePackageJson(self.allocator, pkg_dir_path) catch |err| switch (err) {
             error.FileNotFound => {
                 // package.json 없으면 index 파일 탐색
                 return self.tryDirectoryIndex(pkg_dir_path);
@@ -619,11 +610,7 @@ pub const Resolver = struct {
     fn resolveSubpathImports(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
         var current_dir = source_dir;
         while (true) {
-            // pkg_json.parsePackageJson 이 std.fs.Dir 핸들 직접 요구 — fs.zig 추상화 보류 (#1885).
-            var dir = std.fs.cwd().openDir(current_dir, .{}) catch break;
-            defer dir.close();
-
-            if (pkg_json.parsePackageJson(self.allocator, dir)) |*parsed_result| {
+            if (pkg_json.parsePackageJson(self.allocator, current_dir)) |*parsed_result| {
                 var parsed = parsed_result.*;
                 defer parsed.deinit();
 


### PR DESCRIPTION
## Summary

PR #1915/#1917/#1918 의 fs 추상화를 완성. \`pkg_json.parsePackageJson\` 가 \`std.fs.Dir\` 핸들 직접 요구하던 디자인을 path-based 로 변경. **PR 2/3 의 보류 4곳** (graph.zig:1416 + resolver.zig:452/550/620) **통합 해결**.

bundler 영역에서 \`std.fs.cwd()\` 직접 호출이 fs.zig 내부만 남음 — Phase 1 의 fs 추상화 카테고리 마무리.

## 변경

### pkg_json.zig 시그니처 변경
\`\`\`zig
// before
pub fn parsePackageJson(allocator: Allocator, dir: std.fs.Dir) !ParsedPackageJson

// after
pub fn parsePackageJson(allocator: Allocator, pkg_dir_path: []const u8) !ParsedPackageJson
\`\`\`

내부: \`std.fs.path.join + fs.readFile\` — fs 추상화 통과.

### Caller 마이그레이션 (5곳)
| 파일 | 라인 | 함수 |
|---|---|---|
| graph.zig | 1411 | \`parsePkgInfo\` |
| resolver.zig | 452 | \`tryDirectoryPackageJson\` |
| resolver.zig | 548 | \`resolvePackage\` |
| resolver.zig | 613 | \`resolveSubpathImports\` |
| resolve_cache.zig | 556 | \`buildBrowserOverrides\` |

모두 \`openDir + close\` 패턴 제거. 보류 주석도 정리.

### 테스트
- \`package_json_test.zig\`: 6 테스트의 \`tmp.dir\` → \`tmpDirPath\` helper 패턴 (realpath + buf)

## 부가 효과

### Syscall 절감
이전 패턴 (\`openDir + close + readFileAlloc\`) → 이후 (\`readFile\` 1회)
- 특히 \`resolveSubpathImports\` 의 parent 디렉토리 탐색 루프에서 **1-10 syscall 절감**
- node_modules 트리 탐색 시 누적 효과

### bundler 의 fs 직접 호출
- 이전: \`std.fs.cwd()\` 가 graph/resolver/resolve_cache 5곳
- 이후: \`fs.zig\` 내부만 (\`fs.RealFS.listDir\` 등 implementation 안)
- → Phase 2 (WASM VirtualFS) 도입 시 자동 swap

## /simplify 검토 반영

- \`fs.readFile\` 의 에러 매핑에 \`OutOfMemory\` 분리 추가 (silent swallow 방지)
- 다른 fs 에러 (PermissionDenied/IoError) 는 \`IoError\` 로 통합 — caller 의 \`catch ... return null\` 패턴과 호환

## Test plan

- [x] \`zig build test\` 통과 — 기존 + 6 갱신된 pkg_json 테스트
- [x] \`zig build napi\` 통과 — NAPI hot path 영향 없음 (오히려 syscall 절감)
- [x] /simplify 3-agent 검토 반영
- [x] 보류 코드 4곳 (PR 2/3 의 주석) 모두 정리

## 다음 단계

#1885 epic 의 Phase 1 fs 인프라 카테고리 완료. 이제 PR 4 (plugin layer + \`union(enum) ResolveResult\`) 진행 가능.

Closes #1921
Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)