### PR TITLE
feat(bundler): ResolvedModule union(enum) 도입 (#1885 Phase 1 PR 4a)

### DIFF
--- a/src/bundler/fs.zig
+++ b/src/bundler/fs.zig
@@ -16,13 +16,24 @@ const types = @import("types.zig");
 
 const is_wasm_build = builtin.target.cpu.arch == .wasm32;
 
-/// 모듈의 namespace 분류. `union(enum) ResolveResult` (PR 4 plugin.zig) 의
-/// tag 로도 사용 — `file` 만 fs 통과, 나머지는 plugin 책임.
+/// `plugin.ResolvedModule` (union(enum)) 의 tag 로 사용되는 namespace 분류.
+///
+/// **위치 주의**: 진짜 fs layer 책임은 `file` 뿐. `virtual / dataurl / external /
+/// disabled / custom` 은 모두 plugin/resolver layer 의 분류이며, 단일 enum 동기화
+/// 부담을 피하기 위해 통합 정의. PR 4d (ResolveResult 제거) 시점에 plugin.zig 로
+/// 이동 검토 — 그때 fs.LoadedModule 의 namespace 필드도 함께 결정.
 pub const Namespace = enum {
+    /// fs 가 직접 읽음 (RealFS) 또는 host VirtualFS (WASM)
     file,
+    /// plugin 의 메모리 모듈
     virtual,
+    /// data: URL — 인라인 base64 asset
     dataurl,
+    /// 번들 미포함 — 런타임 import 유지
     external,
+    /// browser 필드 false 매핑 — 빈 CJS 로 대체 (esbuild "(disabled)" 호환)
+    disabled,
+    /// 사용자 plugin 의 자유 namespace
     custom,
 };
 

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -13,6 +13,9 @@ const std = @import("std");
 const resolver_mod = @import("resolver.zig");
 const ResolveResult = resolver_mod.ResolveResult;
 const OutputFile = @import("emitter.zig").OutputFile;
+const fs = @import("fs.zig");
+const types = @import("types.zig");
+const ModuleType = types.ModuleType;
 const ast_plugin_mod = @import("../transformer/ast_plugin.zig");
 pub const AstTransformCtx = ast_plugin_mod.AstTransformCtx;
 pub const FunctionInfo = ast_plugin_mod.FunctionInfo;
@@ -24,6 +27,80 @@ pub const PluginError = error{
     PluginFailed,
     OutOfMemory,
 };
+
+/// Plugin resolveId 응답의 통합 모델 (#1885 Phase 1 PR 4 — 옵션 B).
+///
+/// origin 별 type-safe 분기 — esbuild 의 string namespace 보다 컴파일 타임 안전.
+/// rolldown 의 풍부한 ResolvedId 와 비슷하지만 tag 가 fs.Namespace 와 통일.
+///
+/// PR 4a 단계: 타입 정의 + 변환 helper 만. 호출처 (graph/resolver/cache) 의
+/// `ResolveResult` 직접 사용은 PR 4b/4c 에서 점진 마이그레이션.
+pub const ResolvedModule = union(fs.Namespace) {
+    /// fs 또는 plugin 이 제공한 실제 파일. 절대 경로 + module_type + ESM hint.
+    file: struct {
+        path: []const u8,
+        module_type: ModuleType = .unknown,
+        is_module_field: bool = false,
+    },
+    /// 메모리 모듈 (plugin only). plugin_data 로 plugin context 전달.
+    virtual: struct {
+        path: []const u8,
+        plugin_data: ?*anyopaque = null,
+    },
+    /// data: URL — 인라인 base64 asset.
+    dataurl: struct {
+        mime: []const u8,
+        data: []const u8,
+    },
+    /// 번들 미포함 — 런타임 import 유지.
+    external: struct {
+        path: []const u8,
+    },
+    /// browser 필드 false 매핑 — 빈 CJS 로 대체 (esbuild "(disabled)" 방식).
+    /// `resolver.ResolveResult.disabled = true` 와 동등 semantic — 변환 helper
+    /// fromLegacy/toLegacy 가 정확 매핑. PR 4d 에서 단일 표현으로 통합.
+    disabled: struct {
+        path: []const u8,
+    },
+    /// 사용자 plugin 의 자유 namespace.
+    custom: struct {
+        name: []const u8,
+        path: []const u8,
+        plugin_data: ?*anyopaque = null,
+    },
+};
+
+/// 기존 `ResolveResult` (struct) → `ResolvedModule` (union) 변환.
+/// PR 4b/4c 마이그레이션 중간 호환 layer. 모든 마이그레이션 완료 시 제거 (PR 4d).
+pub fn fromLegacy(r: ResolveResult) ResolvedModule {
+    if (r.disabled) return .{ .disabled = .{ .path = r.path } };
+    return .{ .file = .{
+        .path = r.path,
+        .module_type = r.module_type,
+        .is_module_field = r.is_module_field,
+    } };
+}
+
+/// `ResolvedModule` (union) → 기존 `ResolveResult` (struct) 변환.
+/// `file` / `disabled` 만 변환 가능 — virtual/dataurl/external/custom 은 legacy
+/// 모델에 표현 불가 → null 반환. caller (graph/resolver) 가 별도 분기 필요.
+pub fn toLegacy(m: ResolvedModule) ?ResolveResult {
+    return switch (m) {
+        .file => |f| .{
+            .path = f.path,
+            .module_type = f.module_type,
+            .disabled = false,
+            .is_module_field = f.is_module_field,
+        },
+        .disabled => |d| .{
+            .path = d.path,
+            .module_type = .unknown,
+            .disabled = true,
+            .is_module_field = false,
+        },
+        .virtual, .dataurl, .external, .custom => null,
+    };
+}
 
 /// `Plugin.resolveContext` hook signature. (#1579 Phase 2)
 pub const ResolveContextFn = ?*const fn (

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -394,3 +394,135 @@ test "Plugin integration: transform hook is called for user source files (#964)"
     // 유저 소스 파일(non-node_modules)에 대해 호출되어야 함
     try std.testing.expect(transform_all_user_file_seen);
 }
+
+// ============================================================
+// 단위 테스트: ResolvedModule union(enum) (#1885 Phase 1 PR 4a)
+// ============================================================
+
+const ResolvedModule = plugin_mod.ResolvedModule;
+const fromLegacy = plugin_mod.fromLegacy;
+const toLegacy = plugin_mod.toLegacy;
+const ModuleType = @import("types.zig").ModuleType;
+
+test "ResolvedModule: file variant 보존" {
+    const m: ResolvedModule = .{ .file = .{
+        .path = "/abs/foo.ts",
+        .module_type = .javascript,
+        .is_module_field = true,
+    } };
+    switch (m) {
+        .file => |f| {
+            try std.testing.expectEqualStrings("/abs/foo.ts", f.path);
+            try std.testing.expectEqual(ModuleType.javascript, f.module_type);
+            try std.testing.expect(f.is_module_field);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" {
+    const v: ResolvedModule = .{ .virtual = .{ .path = "virtual:foo" } };
+    switch (v) {
+        .virtual => |x| try std.testing.expectEqualStrings("virtual:foo", x.path),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const d: ResolvedModule = .{ .dataurl = .{ .mime = "image/png", .data = "AAAA" } };
+    switch (d) {
+        .dataurl => |x| {
+            try std.testing.expectEqualStrings("image/png", x.mime);
+            try std.testing.expectEqualStrings("AAAA", x.data);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    const e: ResolvedModule = .{ .external = .{ .path = "react" } };
+    switch (e) {
+        .external => |x| try std.testing.expectEqualStrings("react", x.path),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const dis: ResolvedModule = .{ .disabled = .{ .path = "/abs/disabled.js" } };
+    switch (dis) {
+        .disabled => |x| try std.testing.expectEqualStrings("/abs/disabled.js", x.path),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const c: ResolvedModule = .{ .custom = .{ .name = "my-plugin", .path = "/x" } };
+    switch (c) {
+        .custom => |x| {
+            try std.testing.expectEqualStrings("my-plugin", x.name);
+            try std.testing.expectEqualStrings("/x", x.path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "fromLegacy: ResolveResult { disabled=true } → .disabled variant" {
+    const legacy: ResolveResult = .{
+        .path = "/abs/x.js",
+        .module_type = .javascript,
+        .disabled = true,
+    };
+    const m = fromLegacy(legacy);
+    switch (m) {
+        .disabled => |d| try std.testing.expectEqualStrings("/abs/x.js", d.path),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "fromLegacy: ResolveResult { disabled=false } → .file variant + flags 보존" {
+    const legacy: ResolveResult = .{
+        .path = "/abs/y.ts",
+        .module_type = .javascript,
+        .is_module_field = true,
+    };
+    const m = fromLegacy(legacy);
+    switch (m) {
+        .file => |f| {
+            try std.testing.expectEqualStrings("/abs/y.ts", f.path);
+            try std.testing.expectEqual(ModuleType.javascript, f.module_type);
+            try std.testing.expect(f.is_module_field);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "toLegacy: .file → ResolveResult, .disabled → ResolveResult, 그 외 null" {
+    const f: ResolvedModule = .{ .file = .{
+        .path = "/a",
+        .module_type = .javascript,
+        .is_module_field = true,
+    } };
+    const f_legacy = toLegacy(f).?;
+    try std.testing.expectEqualStrings("/a", f_legacy.path);
+    try std.testing.expect(!f_legacy.disabled);
+    try std.testing.expect(f_legacy.is_module_field);
+
+    const d: ResolvedModule = .{ .disabled = .{ .path = "/b" } };
+    const d_legacy = toLegacy(d).?;
+    try std.testing.expect(d_legacy.disabled);
+    try std.testing.expectEqualStrings("/b", d_legacy.path);
+
+    // virtual/dataurl/external/custom 은 legacy 모델에 표현 불가
+    try std.testing.expect(toLegacy(.{ .virtual = .{ .path = "v" } }) == null);
+    try std.testing.expect(toLegacy(.{ .external = .{ .path = "react" } }) == null);
+    try std.testing.expect(toLegacy(.{ .custom = .{ .name = "p", .path = "/x" } }) == null);
+}
+
+test "ResolvedModule: roundtrip (legacy → union → legacy) 동등성" {
+    const original: ResolveResult = .{
+        .path = "/abs/round.ts",
+        .module_type = .javascript,
+        .disabled = false,
+        .is_module_field = true,
+    };
+    const restored = toLegacy(fromLegacy(original)).?;
+    try std.testing.expectEqualStrings(original.path, restored.path);
+    try std.testing.expectEqual(original.module_type, restored.module_type);
+    try std.testing.expectEqual(original.disabled, restored.disabled);
+    try std.testing.expectEqual(original.is_module_field, restored.is_module_field);
+}
+
+// Note: ResolvedModule = union(fs.Namespace) 자체가 컴파일 타임에 모든 Namespace
+// variant 의 payload 정의 강제 — 별도 exhaustive 검증 테스트 불필요.


### PR DESCRIPTION
## Summary

#1885 Phase 1 의 plugin layer 시작. **옵션 B (통합 union(enum)) 의 단계 분해 첫 PR** — 타입 정의 + 변환 helper 만, **호출처 영향 0**. 후속 PR 4b/4c 가 graph/resolver/cache 의 \`ResolveResult\` 직접 사용을 점진 마이그레이션, PR 4d 에서 변환 helper 제거.

#1895 (I2) 결정의 \`union(enum)\` 독자 모델 — esbuild string namespace 보다 컴파일 타임 type-safe.

## 변경

### fs.zig
- \`Namespace\` enum 에 \`disabled\` variant 추가 (browser 필드 false 매핑, esbuild 호환)
- 6 variant (file / virtual / dataurl / external / disabled / custom) 의 layer 명시 주석 — 진짜 fs 책임은 \`file\` 뿐, 나머지는 plugin/resolver 분류 (PR 4d 에서 plugin.zig 이동 검토)

### plugin.zig 신규
\`\`\`zig
pub const ResolvedModule = union(fs.Namespace) {
    file: struct { path, module_type, is_module_field },
    virtual: struct { path, plugin_data },
    dataurl: struct { mime, data },
    external: struct { path },
    disabled: struct { path },
    custom: struct { name, path, plugin_data },
};
\`\`\`

\`fromLegacy(ResolveResult) → ResolvedModule\` + \`toLegacy(ResolvedModule) → ?ResolveResult\` 변환 helper.

**비대칭성** (의도): \`fromLegacy\` 는 모든 ResolveResult 처리, \`toLegacy\` 는 file/disabled 만 변환 (virtual/dataurl/external/custom 은 null — legacy 모델 표현 불가).

### plugin_test.zig
신규 단위 테스트 7개:
- 각 variant init + switch 검증 (file / virtual / dataurl / external / disabled / custom)
- \`fromLegacy\` 의 disabled true/false 분기
- \`toLegacy\` 의 file/disabled → ResolveResult, 그 외 → null
- roundtrip (legacy → union → legacy) 동등성

## /simplify 검토 반영

- \`fs.Namespace\` 6 variant 의 layer 명시 주석 (fs 책임 vs plugin/resolver 분류)
- \`ResolvedModule.disabled\` 의 ResolveResult.disabled 동등 semantic 명시
- 의미 없는 exhaustive switch test 제거 (union(fs.Namespace) 자체가 컴파일 타임 강제)

## Skip (의도된 패턴)

- \`Namespace\` 에 disabled 가 fs layer 에 약간 부적절 — 단 두 enum 분리 시 동기화 부담. PR 4d 에서 plugin.zig 이동 검토 (주석 명시)
- ResolveResult ↔ ResolvedModule 공존 — 단계 분해의 핵심. PR 4d 에서 ResolveResult 제거
- 변환 helper 비대칭 — legacy 모델의 표현 한계, caller 명시 분기 의도

## Test plan

- [x] \`zig build test\` 통과 — 신규 7 단위 테스트
- [x] \`zig build napi\` 통과 — 호출처 변경 0
- [x] 통합 테스트 147 통과 (bundle-smoke + browser-field) — 회귀 없음
- [x] /simplify 3-agent 검토 반영

## 다음 단계 (단계 분해)

- **PR 4b**: \`resolve_cache\` 마이그레이션 — union 직접 저장
- **PR 4c**: \`graph.zig\` + \`resolver\` 호출처 마이그레이션 (variant 분기 처리)
- **PR 4d**: 변환 helper + \`ResolveResult\` 제거 (전부 union 동작 확인 후)

#1885 epic 의 Phase 1 plugin layer 카테고리 시작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)