### PR TITLE
feat(bundler): resolve_cache.resolveAsModule API (#1885 Phase 1 PR 4c-1)

### DIFF
--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -281,6 +281,30 @@ pub const ResolveCache = struct {
         return self.resolveInner(true, source_dir, specifier, kind);
     }
 
+    /// `resolve` 와 동일하지만 결과를 `ResolvedModule` (union(enum)) 으로 반환 (#1885 PR 4c).
+    /// caller 가 union variant 분기 처리 — virtual/dataurl/external/custom variant 도 향후
+    /// plugin layer 도입 시 표현 가능. Phase 1 단계에선 file/disabled 만 반환.
+    pub fn resolveAsModule(
+        self: *ResolveCache,
+        source_dir: []const u8,
+        specifier: []const u8,
+        kind: ImportKind,
+    ) ResolveError!?ResolvedModule {
+        const legacy = (try self.resolveInner(false, source_dir, specifier, kind)) orelse return null;
+        return plugin_mod.fromLegacy(legacy);
+    }
+
+    /// 스레드 안전 resolveAsModule. 병렬 resolve 의 union 직접 사용.
+    pub fn resolveAsModuleThreadSafe(
+        self: *ResolveCache,
+        source_dir: []const u8,
+        specifier: []const u8,
+        kind: ImportKind,
+    ) ResolveError!?ResolvedModule {
+        const legacy = (try self.resolveInner(true, source_dir, specifier, kind)) orelse return null;
+        return plugin_mod.fromLegacy(legacy);
+    }
+
     /// resolve 공통 구현. thread_safe=true이면 mutex로 캐시 접근 보호 + resolver 스택 복사.
     fn resolveInner(
         self: *ResolveCache,

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -4,6 +4,7 @@ const ResolveCache = resolve_cache.ResolveCache;
 const matchGlob = resolve_cache.matchGlob;
 const isNodeBuiltin = resolve_cache.isNodeBuiltin;
 const profile = @import("../profile.zig");
+const ResolvedModule = @import("plugin.zig").ResolvedModule;
 
 // ============================================================
 // Tests
@@ -160,4 +161,76 @@ test "resolve: profile .resolve 비활성 시 누적 없음" {
 
     try std.testing.expectEqual(@as(u32, 0), profile.count(.resolve));
     try std.testing.expectEqual(@as(u64, 0), profile.totalNs(.resolve));
+}
+
+// resolveAsModule API (#1885 PR 4c-1) — ResolvedModule 직접 반환
+
+fn freeResolvedPath(m: ResolvedModule) void {
+    switch (m) {
+        .file => |f| std.testing.allocator.free(f.path),
+        .disabled => |d| std.testing.allocator.free(d.path),
+        else => {},
+    }
+}
+
+test "resolveAsModule: 일반 파일 → .file variant" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "foo.ts", .data = "" });
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var cache = ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+
+    const result = (try cache.resolveAsModule(dir_path, "./foo", .static_import)).?;
+    defer freeResolvedPath(result);
+
+    switch (result) {
+        .file => |f| try std.testing.expect(std.mem.endsWith(u8, f.path, "foo.ts")),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "resolveAsModule: external pattern → null (resolve 와 동일 의미)" {
+    var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
+    defer cache.deinit();
+
+    const result = try cache.resolveAsModule("/some/dir", "react", .static_import);
+    try std.testing.expect(result == null);
+}
+
+test "resolveAsModule: not found → ModuleNotFound" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var cache = ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+
+    const result = cache.resolveAsModule(dir_path, "./nonexistent", .static_import);
+    try std.testing.expectError(error.ModuleNotFound, result);
+}
+
+test "resolveAsModuleThreadSafe: 동작 검증" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "bar.ts", .data = "" });
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var cache = ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+
+    const result = (try cache.resolveAsModuleThreadSafe(dir_path, "./bar", .static_import)).?;
+    defer freeResolvedPath(result);
+
+    switch (result) {
+        .file => |f| try std.testing.expect(std.mem.endsWith(u8, f.path, "bar.ts")),
+        else => return error.TestUnexpectedResult,
+    }
 }

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -169,6 +169,9 @@ fn freeResolvedPath(m: ResolvedModule) void {
     switch (m) {
         .file => |f| std.testing.allocator.free(f.path),
         .disabled => |d| std.testing.allocator.free(d.path),
+        // Phase 1 cache 는 file/disabled 만 저장 — virtual/dataurl/external/custom variant
+        // 가 cache 에서 반환되지 않음. 향후 그 variant 검증 테스트 추가 시 plugin_data
+        // 등 payload 별 cleanup 을 helper 에 추가.
         else => {},
     }
 }


### PR DESCRIPTION
## Summary

옵션 B 단계 분해 — PR 4c-1. \`ResolveCache\` 에 \`ResolvedModule\` 직접 반환 API 추가. **호출처 영향 0**. PR 4c-2 에서 graph.zig 가 점진 마이그레이션.

## 변경

\`resolve_cache.zig\` 에 두 신규 public API:
\`\`\`zig
pub fn resolveAsModule(...) ResolveError!?ResolvedModule
pub fn resolveAsModuleThreadSafe(...) ResolveError!?ResolvedModule
\`\`\`

내부: \`resolve* + plugin.fromLegacy\` 단순 wrapper. PR 4d 에서 \`resolveInner\` 자체를 ResolvedModule 반환으로 변경하면 wrapper 제거 가능.

\`resolve_cache_test.zig\` 에 단위 테스트 4개:
- file variant (일반 파일)
- external pattern → null
- not found → ModuleNotFound
- threadsafe 변형 동작

## Test plan
- [x] zig build test 통과 (4 신규 단위 테스트 포함)
- [x] 호출처 영향 0 — 기존 resolve* API 그대로

## 다음 단계
- PR 4c-2: graph.zig 의 9곳 \`resolve\` 호출 → \`resolveAsModule\` (variant 분기 처리)
- PR 4d: 변환 helper 제거 + resolveInner 직접 union 반환

#1885 epic Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)