### PR TITLE
feat(bundler): resolve_cache 직접 union + 변환 layer 제거 (#1885 Phase 1 PR 4d)

### DIFF
--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -28,13 +28,10 @@ pub const PluginError = error{
     OutOfMemory,
 };
 
-/// Plugin resolveId 응답의 통합 모델 (#1885 Phase 1 PR 4 — 옵션 B).
+/// Plugin resolveId 응답의 통합 모델 (#1885).
 ///
 /// origin 별 type-safe 분기 — esbuild 의 string namespace 보다 컴파일 타임 안전.
 /// rolldown 의 풍부한 ResolvedId 와 비슷하지만 tag 가 fs.Namespace 와 통일.
-///
-/// PR 4a 단계: 타입 정의 + 변환 helper 만. 호출처 (graph/resolver/cache) 의
-/// `ResolveResult` 직접 사용은 PR 4b/4c 에서 점진 마이그레이션.
 pub const ResolvedModule = union(fs.Namespace) {
     /// fs 또는 plugin 이 제공한 실제 파일. 절대 경로 + module_type + ESM hint.
     file: struct {
@@ -57,8 +54,7 @@ pub const ResolvedModule = union(fs.Namespace) {
         path: []const u8,
     },
     /// browser 필드 false 매핑 — 빈 CJS 로 대체 (esbuild "(disabled)" 방식).
-    /// `resolver.ResolveResult.disabled = true` 와 동등 semantic — 변환 helper
-    /// fromLegacy/toLegacy 가 정확 매핑. PR 4d 에서 단일 표현으로 통합.
+    /// `resolver.ResolveResult.disabled = true` 와 동등 semantic.
     /// module_type 보존 — resolve_cache 의 cache lookup 정보 손실 방지.
     disabled: struct {
         path: []const u8,
@@ -73,7 +69,8 @@ pub const ResolvedModule = union(fs.Namespace) {
 };
 
 /// 기존 `ResolveResult` (struct) → `ResolvedModule` (union) 변환.
-/// PR 4b/4c 마이그레이션 중간 호환 layer. 모든 마이그레이션 완료 시 제거 (PR 4d).
+/// 현재 graph 의 plugin runner 응답 변환에 사용 — plugin runner 가 union 직접
+/// 반환으로 마이그레이션되면 제거 가능 (TODO).
 pub fn fromLegacy(r: ResolveResult) ResolvedModule {
     if (r.disabled) return .{ .disabled = .{
         .path = r.path,

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -86,27 +86,6 @@ pub fn fromLegacy(r: ResolveResult) ResolvedModule {
     } };
 }
 
-/// `ResolvedModule` (union) → 기존 `ResolveResult` (struct) 변환.
-/// `file` / `disabled` 만 변환 가능 — virtual/dataurl/external/custom 은 legacy
-/// 모델에 표현 불가 → null 반환. caller (graph/resolver) 가 별도 분기 필요.
-pub fn toLegacy(m: ResolvedModule) ?ResolveResult {
-    return switch (m) {
-        .file => |f| .{
-            .path = f.path,
-            .module_type = f.module_type,
-            .disabled = false,
-            .is_module_field = f.is_module_field,
-        },
-        .disabled => |d| .{
-            .path = d.path,
-            .module_type = d.module_type,
-            .disabled = true,
-            .is_module_field = false,
-        },
-        .virtual, .dataurl, .external, .custom => null,
-    };
-}
-
 /// `Plugin.resolveContext` hook signature. (#1579 Phase 2)
 pub const ResolveContextFn = ?*const fn (
     ctx: ?*anyopaque,

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -401,7 +401,6 @@ test "Plugin integration: transform hook is called for user source files (#964)"
 
 const ResolvedModule = plugin_mod.ResolvedModule;
 const fromLegacy = plugin_mod.fromLegacy;
-const toLegacy = plugin_mod.toLegacy;
 const ModuleType = @import("types.zig").ModuleType;
 
 test "ResolvedModule: file variant 보존" {
@@ -494,41 +493,8 @@ test "fromLegacy: ResolveResult { disabled=false } → .file variant + flags 보
     }
 }
 
-test "toLegacy: .file → ResolveResult, .disabled → ResolveResult, 그 외 null" {
-    const f: ResolvedModule = .{ .file = .{
-        .path = "/a",
-        .module_type = .javascript,
-        .is_module_field = true,
-    } };
-    const f_legacy = toLegacy(f).?;
-    try std.testing.expectEqualStrings("/a", f_legacy.path);
-    try std.testing.expect(!f_legacy.disabled);
-    try std.testing.expect(f_legacy.is_module_field);
-
-    const d: ResolvedModule = .{ .disabled = .{ .path = "/b" } };
-    const d_legacy = toLegacy(d).?;
-    try std.testing.expect(d_legacy.disabled);
-    try std.testing.expectEqualStrings("/b", d_legacy.path);
-
-    // virtual/dataurl/external/custom 은 legacy 모델에 표현 불가
-    try std.testing.expect(toLegacy(.{ .virtual = .{ .path = "v" } }) == null);
-    try std.testing.expect(toLegacy(.{ .external = .{ .path = "react" } }) == null);
-    try std.testing.expect(toLegacy(.{ .custom = .{ .name = "p", .path = "/x" } }) == null);
-}
-
-test "ResolvedModule: roundtrip (legacy → union → legacy) 동등성" {
-    const original: ResolveResult = .{
-        .path = "/abs/round.ts",
-        .module_type = .javascript,
-        .disabled = false,
-        .is_module_field = true,
-    };
-    const restored = toLegacy(fromLegacy(original)).?;
-    try std.testing.expectEqualStrings(original.path, restored.path);
-    try std.testing.expectEqual(original.module_type, restored.module_type);
-    try std.testing.expectEqual(original.disabled, restored.disabled);
-    try std.testing.expectEqual(original.is_module_field, restored.is_module_field);
-}
-
 // Note: ResolvedModule = union(fs.Namespace) 자체가 컴파일 타임에 모든 Namespace
 // variant 의 payload 정의 강제 — 별도 exhaustive 검증 테스트 불필요.
+// toLegacy 는 PR 4d 에서 제거 (resolve_cache 가 union 직접 반환). fromLegacy 만
+// plugin runner 응답 변환 (ResolveResult → ResolvedModule) 용도로 유지 — PR 5 의
+// plugin runner 마이그레이션 시 함께 제거.

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -19,6 +19,7 @@ const plugin_mod = @import("plugin.zig");
 const ResolvedModule = plugin_mod.ResolvedModule;
 const ResolveError = resolver_mod.ResolveError;
 const types = @import("types.zig");
+const ModuleType = types.ModuleType;
 const ImportKind = types.ImportKind;
 const pkg_json = @import("package_json.zig");
 const profile = @import("../profile.zig");
@@ -262,36 +263,15 @@ pub const ResolveCache = struct {
     }
 
     /// specifier를 해석한다. 캐시 히트 시 캐시에서 반환.
-    pub fn resolve(
-        self: *ResolveCache,
-        source_dir: []const u8,
-        specifier: []const u8,
-        kind: ImportKind,
-    ) ResolveError!?ResolveResult {
-        return self.resolveInner(false, source_dir, specifier, kind);
-    }
-
-    /// 스레드 안전 resolve. 병렬 resolve에서 사용.
-    pub fn resolveThreadSafe(
-        self: *ResolveCache,
-        source_dir: []const u8,
-        specifier: []const u8,
-        kind: ImportKind,
-    ) ResolveError!?ResolveResult {
-        return self.resolveInner(true, source_dir, specifier, kind);
-    }
-
-    /// `resolve` 와 동일하지만 결과를 `ResolvedModule` (union(enum)) 으로 반환 (#1885 PR 4c).
-    /// caller 가 union variant 분기 처리 — virtual/dataurl/external/custom variant 도 향후
-    /// plugin layer 도입 시 표현 가능. Phase 1 단계에선 file/disabled 만 반환.
+    /// 결과는 `ResolvedModule` (union(enum)) — caller 가 variant 분기 처리.
+    /// Phase 1 단계에선 file/disabled variant 만 반환.
     pub fn resolveAsModule(
         self: *ResolveCache,
         source_dir: []const u8,
         specifier: []const u8,
         kind: ImportKind,
     ) ResolveError!?ResolvedModule {
-        const legacy = (try self.resolveInner(false, source_dir, specifier, kind)) orelse return null;
-        return plugin_mod.fromLegacy(legacy);
+        return self.resolveInner(false, source_dir, specifier, kind);
     }
 
     /// 스레드 안전 resolveAsModule. 병렬 resolve 의 union 직접 사용.
@@ -301,8 +281,7 @@ pub const ResolveCache = struct {
         specifier: []const u8,
         kind: ImportKind,
     ) ResolveError!?ResolvedModule {
-        const legacy = (try self.resolveInner(true, source_dir, specifier, kind)) orelse return null;
-        return plugin_mod.fromLegacy(legacy);
+        return self.resolveInner(true, source_dir, specifier, kind);
     }
 
     /// resolve 공통 구현. thread_safe=true이면 mutex로 캐시 접근 보호 + resolver 스택 복사.
@@ -312,7 +291,7 @@ pub const ResolveCache = struct {
         source_dir: []const u8,
         specifier: []const u8,
         kind: ImportKind,
-    ) ResolveError!?ResolveResult {
+    ) ResolveError!?ResolvedModule {
         var scope = profile.begin(.resolve);
         defer scope.end();
 
@@ -346,18 +325,17 @@ pub const ResolveCache = struct {
             if (self.cache.get(cache_key)) |cached| {
                 return switch (cached) {
                     // Phase 1 의 cache 는 file/disabled 만 저장 (putCache 호출처 검증).
-                    // 명시적 unreachable — 새 variant 추가 시 컴파일러가 dispatch 강제.
+                    // path 만 caller 소유로 dupe — 다른 필드는 by-value copy.
                     .resolved => |m| switch (m) {
-                        .file => |f| ResolveResult{
-                            .path = self.allocator.dupe(u8, f.path) catch return error.OutOfMemory,
-                            .module_type = f.module_type,
-                            .is_module_field = f.is_module_field,
-                        },
-                        .disabled => |d| ResolveResult{
-                            .path = self.allocator.dupe(u8, d.path) catch return error.OutOfMemory,
-                            .module_type = d.module_type,
-                            .disabled = true,
-                        },
+                        .file => |f| fileResult(
+                            self.allocator.dupe(u8, f.path) catch return error.OutOfMemory,
+                            f.module_type,
+                            f.is_module_field,
+                        ),
+                        .disabled => |d| disabledResult(
+                            self.allocator.dupe(u8, d.path) catch return error.OutOfMemory,
+                            d.module_type,
+                        ),
                         .virtual, .dataurl, .external, .custom => unreachable,
                     },
                     .not_found => error.ModuleNotFound,
@@ -384,11 +362,7 @@ pub const ResolveCache = struct {
                             .path = self.allocator.dupe(u8, disabled_path) catch return error.OutOfMemory,
                             .module_type = .javascript,
                         } } }) catch {};
-                        return ResolveResult{
-                            .path = disabled_path,
-                            .module_type = .javascript,
-                            .disabled = true,
-                        };
+                        return disabledResult(disabled_path, .javascript);
                     },
                     .remap => |rep| {
                         remap_buf[remap_depth] = effective_spec;
@@ -434,11 +408,7 @@ pub const ResolveCache = struct {
                             .path = cache_path,
                             .module_type = result.module_type,
                         } } }) catch {};
-                        return ResolveResult{
-                            .path = result.path,
-                            .module_type = result.module_type,
-                            .disabled = true,
-                        };
+                        return disabledResult(result.path, result.module_type);
                     },
                     .remap => |rep| {
                         // rep 는 package-root 상대. Resolver.resolve(pkg_root, "./rep") 로
@@ -451,7 +421,7 @@ pub const ResolveCache = struct {
                                     .path = cache_path,
                                     .module_type = result.module_type,
                                 } } }) catch {};
-                                return result;
+                                return fileResult(result.path, result.module_type, result.is_module_field);
                             };
                             defer self.allocator.free(spec_buf);
                             if (thread_safe) self.cache_mutex.unlock();
@@ -463,7 +433,7 @@ pub const ResolveCache = struct {
                                     .path = cache_path,
                                     .module_type = replaced.module_type,
                                 } } }) catch {};
-                                return replaced;
+                                return fileResult(replaced.path, replaced.module_type, replaced.is_module_field);
                             } else |_| {
                                 // fallthrough — replacement 해결 실패 시 원본 사용.
                             }
@@ -480,7 +450,17 @@ pub const ResolveCache = struct {
             } } }) catch {};
         }
 
-        return result;
+        return fileResult(result.path, result.module_type, result.is_module_field);
+    }
+
+    /// 7곳에서 반복하던 ResolvedModule.file/disabled 생성 통일 (#1885 PR 4d /simplify).
+    /// path 는 caller 가 이미 dupe 한 것을 전달 — caller 가 메모리 owner.
+    fn fileResult(path: []const u8, module_type: ModuleType, is_module_field: bool) ResolvedModule {
+        return .{ .file = .{ .path = path, .module_type = module_type, .is_module_field = is_module_field } };
+    }
+
+    fn disabledResult(path: []const u8, module_type: ModuleType) ResolvedModule {
+        return .{ .disabled = .{ .path = path, .module_type = module_type } };
     }
 
     /// CachedResult.resolved (ResolvedModule) 의 path 추출.

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -108,10 +108,8 @@ pub const ResolveCache = struct {
     /// Remap chain cycle 방어 — depth 3 이상이면 원본 경로로 fallback (#1530).
     const MAX_REMAP_DEPTH: u8 = 3;
 
-    /// Cache 의 internal storage. ResolvedModule 직접 보유 (#1885 PR 4b).
-    /// 외부 API (resolve) 는 toLegacy 변환 후 ResolveResult 반환 — caller 영향 0.
-    /// `.external` variant 는 dead code (cache 저장 경로 없음, isExternal 즉시 null 반환)
-    /// 제거 — PR 4b cleanup.
+    /// Cache 의 internal storage. external 모듈은 isExternal 이 즉시 null 반환하므로
+    /// 별도 variant 불필요.
     const CachedResult = union(enum) {
         resolved: ResolvedModule,
         not_found,
@@ -453,7 +451,6 @@ pub const ResolveCache = struct {
         return fileResult(result.path, result.module_type, result.is_module_field);
     }
 
-    /// 7곳에서 반복하던 ResolvedModule.file/disabled 생성 통일 (#1885 PR 4d /simplify).
     /// path 는 caller 가 이미 dupe 한 것을 전달 — caller 가 메모리 owner.
     fn fileResult(path: []const u8, module_type: ModuleType, is_module_field: bool) ResolvedModule {
         return .{ .file = .{ .path = path, .module_type = module_type, .is_module_field = is_module_field } };

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -81,7 +81,7 @@ test "resolve: external returns null" {
     var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
     defer cache.deinit();
 
-    const result = try cache.resolve("/some/dir", "react", .static_import);
+    const result = try cache.resolveAsModule("/some/dir", "react", .static_import);
     try std.testing.expect(result == null);
 }
 
@@ -100,20 +100,26 @@ test "resolve: cache hit" {
     defer cache.deinit();
 
     // 첫 번째 호출 (캐시 미스) — caller 소유
-    const result1 = try cache.resolve(dir_path, "./foo", .static_import);
-    try std.testing.expect(result1 != null);
-    defer std.testing.allocator.free(result1.?.path);
-    try std.testing.expect(std.mem.endsWith(u8, result1.?.path, "foo.ts"));
+    const result1 = (try cache.resolveAsModule(dir_path, "./foo", .static_import)).?;
+    defer freeResolvedPath(result1);
+    const path1 = switch (result1) {
+        .file => |f| f.path,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expect(std.mem.endsWith(u8, path1, "foo.ts"));
 
     // 두 번째 호출 (캐시 히트) — 별도 할당, caller 소유
-    const result2 = try cache.resolve(dir_path, "./foo", .static_import);
-    try std.testing.expect(result2 != null);
-    defer std.testing.allocator.free(result2.?.path);
-    try std.testing.expect(std.mem.endsWith(u8, result2.?.path, "foo.ts"));
+    const result2 = (try cache.resolveAsModule(dir_path, "./foo", .static_import)).?;
+    defer freeResolvedPath(result2);
+    const path2 = switch (result2) {
+        .file => |f| f.path,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expect(std.mem.endsWith(u8, path2, "foo.ts"));
 
     // 내용은 같지만 포인터는 다름 (각각 독립 할당)
-    try std.testing.expectEqualStrings(result1.?.path, result2.?.path);
-    try std.testing.expect(result1.?.path.ptr != result2.?.path.ptr);
+    try std.testing.expectEqualStrings(path1, path2);
+    try std.testing.expect(path1.ptr != path2.ptr);
 }
 
 test "resolve: not found cached" {
@@ -127,11 +133,11 @@ test "resolve: not found cached" {
     defer cache.deinit();
 
     // 존재하지 않는 파일
-    const r1 = cache.resolve(dir_path, "./nonexistent", .static_import);
+    const r1 = cache.resolveAsModule(dir_path, "./nonexistent", .static_import);
     try std.testing.expectError(error.ModuleNotFound, r1);
 
     // 두 번째 호출도 ModuleNotFound (캐시에서)
-    const r2 = cache.resolve(dir_path, "./nonexistent", .static_import);
+    const r2 = cache.resolveAsModule(dir_path, "./nonexistent", .static_import);
     try std.testing.expectError(error.ModuleNotFound, r2);
 }
 
@@ -144,7 +150,7 @@ test "resolve: profile .resolve 활성 시 누적" {
     defer cache.deinit();
 
     // external 경로로 호출 — filesystem 접근 없이 resolveInner 진입 확인.
-    _ = try cache.resolve("/some/dir", "react", .static_import);
+    _ = try cache.resolveAsModule("/some/dir", "react", .static_import);
 
     try std.testing.expect(profile.count(.resolve) > 0);
     try std.testing.expect(profile.totalNs(.resolve) > 0);
@@ -157,7 +163,7 @@ test "resolve: profile .resolve 비활성 시 누적 없음" {
     var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
     defer cache.deinit();
 
-    _ = try cache.resolve("/some/dir", "react", .static_import);
+    _ = try cache.resolveAsModule("/some/dir", "react", .static_import);
 
     try std.testing.expectEqual(@as(u32, 0), profile.count(.resolve));
     try std.testing.expectEqual(@as(u64, 0), profile.totalNs(.resolve));


### PR DESCRIPTION
## Summary

옵션 B 단계 분해 마지막 PR. \`resolveInner\` 시그니처 \`ResolveResult\` → \`ResolvedModule\` 직접 반환. **변환 layer 완전 제거**.

## 변경

### resolve_cache.zig
- \`resolveInner\` 시그니처: \`?ResolveResult\` → \`?ResolvedModule\`
- 모든 ResolvedModule 생성 지점 (cache lookup / browser disabled / remap fallthrough/success / normal end) 직접 union
- \`resolve\` / \`resolveThreadSafe\` public API 제거 — graph 가 모두 \`resolveAsModule\` 사용
- \`resolveAsModule / resolveAsModuleThreadSafe\` = \`resolveInner\` 단순 wrapper (이름 유지)

### plugin.zig
- \`toLegacy\` 제거 (사용처 0)

### Test
- \`plugin_test.zig\` 의 \`toLegacy\` / roundtrip 테스트 제거
- \`resolve_cache_test.zig\` 의 5 테스트 \`cache.resolve\` → \`resolveAsModule\` + variant switch

### Helper 추출 (/simplify 검토)
- \`fileResult\` / \`disabledResult\` — 7곳 반복하던 \`ResolvedModule.file/disabled\` 생성 통일

## 남은 변환 layer

- \`plugin.fromLegacy\` — graph 의 plugin runner 응답 변환용 (\`ResolveResult\` → \`ResolvedModule\`). PR 5 (plugin runner union 직접 반환) 까지 유지.

## /simplify 검토 반영

- \`fileResult / disabledResult\` helper 추출 (7곳 반복 → top-level helper)

Skip:
- Cache lookup inline switch (PR 4c 일관성)
- Test helper 반복 (테스트 명확성)
- Narration 주석 (ROADMAP 추적 가치)

## Test plan

- [x] \`zig build test\` 통과
- [x] \`zig build napi\` 통과
- [x] 통합 162 통과 (bundle-smoke + browser-field + resolve-fallback + asset-registry)
- [x] /simplify 3-agent 검토 반영

## PR 4 시리즈 완료

- PR 4a (#1925): ResolvedModule union(enum) 도입
- PR 4b (#1927): resolve_cache internal storage 마이그레이션
- PR 4c-1 (#1929): resolveAsModule API 추가
- PR 4c-2 (#1930): graph.zig 9곳 마이그레이션
- **PR 4d (this)**: 변환 layer 완전 제거

#1885 epic Phase 1 plugin layer 카테고리 마무리. 다음은 PR 5 (plugin layer 본격 도입).

🤖 Generated with [Claude Code](https://claude.com/claude-code)