### PR TITLE
feat(bundler): plugin runner resolveId union 직접 반환 (#1885 Phase 1 PR 5-1)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -562,7 +562,6 @@ fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult) c.n
 const plugin_mod = bundler_mod.plugin;
 const Plugin = plugin_mod.Plugin;
 const PluginError = plugin_mod.PluginError;
-const ResolveResult = bundler_mod.ResolveResult;
 
 const NapiPlugin = struct {
     name: []const u8,
@@ -796,7 +795,7 @@ const NapiPlugin = struct {
         return null;
     }
 
-    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator) PluginError!?ResolveResult {
+    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator) PluginError!?bundler_mod.plugin.ResolvedModule {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.resolveId, specifier, importer) orelse return null;
         defer {
@@ -808,18 +807,17 @@ const NapiPlugin = struct {
         // Metro `{ type: 'empty' }` 매핑, webpack `resolve.fallback: false`와 동등.
         if (resp.is_disabled) {
             const id_path = resp.resolved_path orelse specifier;
-            return .{
+            return .{ .disabled = .{
                 .path = alloc.dupe(u8, id_path) catch return error.OutOfMemory,
                 .module_type = .javascript,
-                .disabled = true,
-            };
+            } };
         }
 
         if (resp.resolved_path) |path| {
-            return .{
+            return .{ .file = .{
                 .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
                 .module_type = .javascript,
-            };
+            } };
         }
         return null;
     }

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -795,7 +795,7 @@ const NapiPlugin = struct {
         return null;
     }
 
-    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator) PluginError!?bundler_mod.plugin.ResolvedModule {
+    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.ResolvedModule {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.resolveId, specifier, importer) orelse return null;
         defer {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -908,7 +908,7 @@ pub const ModuleGraph = struct {
                     },
                 };
                 if (resolve_result) |plugin_result| {
-                    results[rec_i] = .{ .resolved = plugin_mod.fromLegacy(plugin_result), .is_error = false };
+                    results[rec_i] = .{ .resolved = plugin_result, .is_error = false };
                     continue;
                 }
             }
@@ -1554,7 +1554,7 @@ pub const ModuleGraph = struct {
                 };
                 // non-null이면 플러그인이 resolve 완료 → 기본 resolver 건너뜀
                 if (resolve_result) |plugin_result| {
-                    try self.applyResolveResult(mod_idx, rec_i, record, plugin_mod.fromLegacy(plugin_result), false);
+                    try self.applyResolveResult(mod_idx, rec_i, record, plugin_result, false);
                     continue;
                 }
                 // null이면 기본 resolver로 fall through

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -68,21 +68,6 @@ pub const ResolvedModule = union(fs.Namespace) {
     },
 };
 
-/// 기존 `ResolveResult` (struct) → `ResolvedModule` (union) 변환.
-/// 현재 graph 의 plugin runner 응답 변환에 사용 — plugin runner 가 union 직접
-/// 반환으로 마이그레이션되면 제거 가능 (TODO).
-pub fn fromLegacy(r: ResolveResult) ResolvedModule {
-    if (r.disabled) return .{ .disabled = .{
-        .path = r.path,
-        .module_type = r.module_type,
-    } };
-    return .{ .file = .{
-        .path = r.path,
-        .module_type = r.module_type,
-        .is_module_field = r.is_module_field,
-    } };
-}
-
 /// `Plugin.resolveContext` hook signature. (#1579 Phase 2)
 pub const ResolveContextFn = ?*const fn (
     ctx: ?*anyopaque,
@@ -103,7 +88,7 @@ pub const Plugin = struct {
 
     /// 모듈 경로 해석 커스텀 (alias, virtual module).
     /// non-null 반환 시 기본 resolver를 건너뜀.
-    resolveId: ?*const fn (ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, allocator: std.mem.Allocator) PluginError!?ResolveResult = null,
+    resolveId: ?*const fn (ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, allocator: std.mem.Allocator) PluginError!?ResolvedModule = null,
 
     /// 모듈 내용 로딩 (virtual module, 커스텀 로더).
     /// non-null 반환 시 파일 시스템 읽기를 건너뜀.
@@ -219,7 +204,7 @@ pub const PluginRunner = struct {
         specifier: []const u8,
         importer: ?[]const u8,
         allocator: std.mem.Allocator,
-    ) PluginError!?ResolveResult {
+    ) PluginError!?ResolvedModule {
         for (self.plugins) |p| {
             if (p.resolveId) |hook| {
                 if (try hook(p.context, specifier, importer, allocator)) |result| {

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -10,8 +10,6 @@
 //!   - generateBundle: 모두 실행
 
 const std = @import("std");
-const resolver_mod = @import("resolver.zig");
-const ResolveResult = resolver_mod.ResolveResult;
 const OutputFile = @import("emitter.zig").OutputFile;
 const fs = @import("fs.zig");
 const types = @import("types.zig");
@@ -54,7 +52,6 @@ pub const ResolvedModule = union(fs.Namespace) {
         path: []const u8,
     },
     /// browser 필드 false 매핑 — 빈 CJS 로 대체 (esbuild "(disabled)" 방식).
-    /// `resolver.ResolveResult.disabled = true` 와 동등 semantic.
     /// module_type 보존 — resolve_cache 의 cache lookup 정보 손실 방지.
     disabled: struct {
         path: []const u8,

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -39,12 +39,12 @@ test "PluginRunner: empty plugins is no-op" {
 
 // --- resolveId 훅 테스트 ---
 
-fn testResolveIdHook(_: ?*anyopaque, specifier: []const u8, _: ?[]const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?ResolveResult {
+fn testResolveIdHook(_: ?*anyopaque, specifier: []const u8, _: ?[]const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
     if (std.mem.eql(u8, specifier, "virtual:config")) {
-        return .{
+        return .{ .file = .{
             .path = try allocator.dupe(u8, "/virtual/config.js"),
             .module_type = .javascript,
-        };
+        } };
     }
     return null;
 }
@@ -58,8 +58,12 @@ test "PluginRunner: resolveId first mode" {
     // 매칭되는 specifier → non-null
     const result = try runner.runResolveId("virtual:config", null, std.testing.allocator);
     try std.testing.expect(result != null);
-    try std.testing.expectEqualStrings("/virtual/config.js", result.?.path);
-    std.testing.allocator.free(result.?.path);
+    const path = switch (result.?) {
+        .file => |f| f.path,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqualStrings("/virtual/config.js", path);
+    std.testing.allocator.free(path);
 
     // 매칭 안 되는 specifier → null (기본 resolver 사용)
     const result2 = try runner.runResolveId("./normal", null, std.testing.allocator);
@@ -289,7 +293,7 @@ test "Plugin integration: multiple plugins chain transforms" {
 
 // --- resolveId가 null 반환 시 기본 resolver fall through ---
 
-fn nullResolveHook(_: ?*anyopaque, _: []const u8, _: ?[]const u8, _: std.mem.Allocator) plugin_mod.PluginError!?ResolveResult {
+fn nullResolveHook(_: ?*anyopaque, _: []const u8, _: ?[]const u8, _: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
     return null;
 }
 
@@ -400,7 +404,6 @@ test "Plugin integration: transform hook is called for user source files (#964)"
 // ============================================================
 
 const ResolvedModule = plugin_mod.ResolvedModule;
-const fromLegacy = plugin_mod.fromLegacy;
 const ModuleType = @import("types.zig").ModuleType;
 
 test "ResolvedModule: file variant 보존" {
@@ -460,41 +463,5 @@ test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" 
     }
 }
 
-test "fromLegacy: ResolveResult { disabled=true } → .disabled variant + module_type 보존" {
-    const legacy: ResolveResult = .{
-        .path = "/abs/x.js",
-        .module_type = .javascript,
-        .disabled = true,
-    };
-    const m = fromLegacy(legacy);
-    switch (m) {
-        .disabled => |d| {
-            try std.testing.expectEqualStrings("/abs/x.js", d.path);
-            try std.testing.expectEqual(ModuleType.javascript, d.module_type);
-        },
-        else => return error.TestUnexpectedResult,
-    }
-}
-
-test "fromLegacy: ResolveResult { disabled=false } → .file variant + flags 보존" {
-    const legacy: ResolveResult = .{
-        .path = "/abs/y.ts",
-        .module_type = .javascript,
-        .is_module_field = true,
-    };
-    const m = fromLegacy(legacy);
-    switch (m) {
-        .file => |f| {
-            try std.testing.expectEqualStrings("/abs/y.ts", f.path);
-            try std.testing.expectEqual(ModuleType.javascript, f.module_type);
-            try std.testing.expect(f.is_module_field);
-        },
-        else => return error.TestUnexpectedResult,
-    }
-}
-
 // Note: ResolvedModule = union(fs.Namespace) 자체가 컴파일 타임에 모든 Namespace
 // variant 의 payload 정의 강제 — 별도 exhaustive 검증 테스트 불필요.
-// toLegacy 는 PR 4d 에서 제거 (resolve_cache 가 union 직접 반환). fromLegacy 만
-// plugin runner 응답 변환 (ResolveResult → ResolvedModule) 용도로 유지 — PR 5 의
-// plugin runner 마이그레이션 시 함께 제거.


### PR DESCRIPTION
## Summary

\`Plugin.resolveId\` 시그니처 \`?ResolveResult\` → \`?ResolvedModule\`. 마지막 변환 layer (\`plugin.fromLegacy\`) 제거 — Phase 1 의 resolve 경로가 모두 union 일관 사용.

PR 4d 완료 후 남았던 fromLegacy 의 유일한 사용처 정리.

## 변경

- \`plugin.zig\`: \`Plugin.resolveId\` / \`PluginRunner.runResolveId\` 시그니처 갱신
- \`plugin.zig\`: \`fromLegacy\` 제거 (사용처 0)
- \`graph.zig\`: 2곳의 plugin runner 응답 \`fromLegacy\` 호출 제거 (직접 union 전달)
- \`napi_entry.zig\`: \`NapiPlugin.pluginResolveId\` 가 union 직접 반환 (file/disabled variant 명시)
- \`plugin_test.zig\`: \`testResolveIdHook\` / \`nullResolveHook\` 시그니처 갱신 + fromLegacy 단위 테스트 제거 (사용처 0)

## Test plan

- [x] \`zig build test\` 통과
- [x] \`zig build napi\` 통과 — JS plugin 호환성 보존
- [x] 통합 162 통과 (bundle-smoke + browser-field + resolve-fallback + asset-registry)

## Phase 1 결산

PR 5-1 머지 시 #1885 Phase 1 fs+plugin 인프라 카테고리 완전 마무리:
- fs 추상화 (PR 1/2/3 + #1923)
- ResolvedModule union (PR 4a-d)
- plugin runner 마이그레이션 (PR 5-1)

다음:
- PR 5-2: load/transform hook 시그니처 정리 (현재 ResolveResult 미사용, 검토만)
- PR 5-3: mtime=0 분기 강화 (#1894)
- 또는 Phase 2 시작 (WASM build())

🤖 Generated with [Claude Code](https://claude.com/claude-code)