### PR TITLE
refactor(bundler): resolveAsModule → resolve rename cleanup (#1885)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -718,7 +718,7 @@ pub const ModuleGraph = struct {
         const module_path = mod_ptr.path;
         const source_dir = std.fs.path.dirname(module_path) orelse ".";
         for (context_deps) |dep| {
-            const resolved = self.resolve_cache.resolveAsModuleThreadSafe(source_dir, dep.specifier, dep.kind) catch |err| switch (err) {
+            const resolved = self.resolve_cache.resolveThreadSafe(source_dir, dep.specifier, dep.kind) catch |err| switch (err) {
                 error.ModuleNotFound => {
                     self.addDiag(
                         .unresolved_import,
@@ -913,7 +913,7 @@ pub const ModuleGraph = struct {
                 }
             }
 
-            const resolved = self.resolve_cache.resolveAsModuleThreadSafe(
+            const resolved = self.resolve_cache.resolveThreadSafe(
                 source_dir,
                 record.specifier,
                 record.kind,
@@ -1560,7 +1560,7 @@ pub const ModuleGraph = struct {
                 // null이면 기본 resolver로 fall through
             }
 
-            const resolved = self.resolve_cache.resolveAsModule(
+            const resolved = self.resolve_cache.resolve(
                 source_dir,
                 record.specifier,
                 record.kind,
@@ -2702,7 +2702,7 @@ fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
                     if (resolved_paths_opt) |paths| {
                         // default null — file variant 만 dupe 성공 시 덮어씀.
                         paths[i] = null;
-                        if (self.resolve_cache.resolveAsModuleThreadSafe(source_dir, joined, .require) catch null) |res| switch (res) {
+                        if (self.resolve_cache.resolveThreadSafe(source_dir, joined, .require) catch null) |res| switch (res) {
                             // resolve_cache 가 self.allocator 로 path 할당 → arena 로 dupe 후 free.
                             .file => |f| {
                                 paths[i] = arena_alloc.dupe(u8, f.path) catch null;

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -263,7 +263,7 @@ pub const ResolveCache = struct {
     /// specifier를 해석한다. 캐시 히트 시 캐시에서 반환.
     /// 결과는 `ResolvedModule` (union(enum)) — caller 가 variant 분기 처리.
     /// Phase 1 단계에선 file/disabled variant 만 반환.
-    pub fn resolveAsModule(
+    pub fn resolve(
         self: *ResolveCache,
         source_dir: []const u8,
         specifier: []const u8,
@@ -272,8 +272,8 @@ pub const ResolveCache = struct {
         return self.resolveInner(false, source_dir, specifier, kind);
     }
 
-    /// 스레드 안전 resolveAsModule. 병렬 resolve 의 union 직접 사용.
-    pub fn resolveAsModuleThreadSafe(
+    /// 스레드 안전 resolve. 병렬 resolve 의 union 직접 사용.
+    pub fn resolveThreadSafe(
         self: *ResolveCache,
         source_dir: []const u8,
         specifier: []const u8,

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -81,7 +81,7 @@ test "resolve: external returns null" {
     var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
     defer cache.deinit();
 
-    const result = try cache.resolveAsModule("/some/dir", "react", .static_import);
+    const result = try cache.resolve("/some/dir", "react", .static_import);
     try std.testing.expect(result == null);
 }
 
@@ -100,7 +100,7 @@ test "resolve: cache hit" {
     defer cache.deinit();
 
     // 첫 번째 호출 (캐시 미스) — caller 소유
-    const result1 = (try cache.resolveAsModule(dir_path, "./foo", .static_import)).?;
+    const result1 = (try cache.resolve(dir_path, "./foo", .static_import)).?;
     defer freeResolvedPath(result1);
     const path1 = switch (result1) {
         .file => |f| f.path,
@@ -109,7 +109,7 @@ test "resolve: cache hit" {
     try std.testing.expect(std.mem.endsWith(u8, path1, "foo.ts"));
 
     // 두 번째 호출 (캐시 히트) — 별도 할당, caller 소유
-    const result2 = (try cache.resolveAsModule(dir_path, "./foo", .static_import)).?;
+    const result2 = (try cache.resolve(dir_path, "./foo", .static_import)).?;
     defer freeResolvedPath(result2);
     const path2 = switch (result2) {
         .file => |f| f.path,
@@ -133,11 +133,11 @@ test "resolve: not found cached" {
     defer cache.deinit();
 
     // 존재하지 않는 파일
-    const r1 = cache.resolveAsModule(dir_path, "./nonexistent", .static_import);
+    const r1 = cache.resolve(dir_path, "./nonexistent", .static_import);
     try std.testing.expectError(error.ModuleNotFound, r1);
 
     // 두 번째 호출도 ModuleNotFound (캐시에서)
-    const r2 = cache.resolveAsModule(dir_path, "./nonexistent", .static_import);
+    const r2 = cache.resolve(dir_path, "./nonexistent", .static_import);
     try std.testing.expectError(error.ModuleNotFound, r2);
 }
 
@@ -150,7 +150,7 @@ test "resolve: profile .resolve 활성 시 누적" {
     defer cache.deinit();
 
     // external 경로로 호출 — filesystem 접근 없이 resolveInner 진입 확인.
-    _ = try cache.resolveAsModule("/some/dir", "react", .static_import);
+    _ = try cache.resolve("/some/dir", "react", .static_import);
 
     try std.testing.expect(profile.count(.resolve) > 0);
     try std.testing.expect(profile.totalNs(.resolve) > 0);
@@ -163,13 +163,13 @@ test "resolve: profile .resolve 비활성 시 누적 없음" {
     var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
     defer cache.deinit();
 
-    _ = try cache.resolveAsModule("/some/dir", "react", .static_import);
+    _ = try cache.resolve("/some/dir", "react", .static_import);
 
     try std.testing.expectEqual(@as(u32, 0), profile.count(.resolve));
     try std.testing.expectEqual(@as(u64, 0), profile.totalNs(.resolve));
 }
 
-// resolveAsModule API (#1885 PR 4c-1) — ResolvedModule 직접 반환
+// resolve API (#1885 PR 4c-1) — ResolvedModule 직접 반환
 
 fn freeResolvedPath(m: ResolvedModule) void {
     switch (m) {
@@ -182,7 +182,7 @@ fn freeResolvedPath(m: ResolvedModule) void {
     }
 }
 
-test "resolveAsModule: 일반 파일 → .file variant" {
+test "resolve: 일반 파일 → .file variant" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -193,7 +193,7 @@ test "resolveAsModule: 일반 파일 → .file variant" {
     var cache = ResolveCache.init(std.testing.allocator, .{});
     defer cache.deinit();
 
-    const result = (try cache.resolveAsModule(dir_path, "./foo", .static_import)).?;
+    const result = (try cache.resolve(dir_path, "./foo", .static_import)).?;
     defer freeResolvedPath(result);
 
     switch (result) {
@@ -202,15 +202,15 @@ test "resolveAsModule: 일반 파일 → .file variant" {
     }
 }
 
-test "resolveAsModule: external pattern → null (resolve 와 동일 의미)" {
+test "resolve: external pattern → null (resolve 와 동일 의미)" {
     var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
     defer cache.deinit();
 
-    const result = try cache.resolveAsModule("/some/dir", "react", .static_import);
+    const result = try cache.resolve("/some/dir", "react", .static_import);
     try std.testing.expect(result == null);
 }
 
-test "resolveAsModule: not found → ModuleNotFound" {
+test "resolve: not found → ModuleNotFound" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -220,11 +220,11 @@ test "resolveAsModule: not found → ModuleNotFound" {
     var cache = ResolveCache.init(std.testing.allocator, .{});
     defer cache.deinit();
 
-    const result = cache.resolveAsModule(dir_path, "./nonexistent", .static_import);
+    const result = cache.resolve(dir_path, "./nonexistent", .static_import);
     try std.testing.expectError(error.ModuleNotFound, result);
 }
 
-test "resolveAsModuleThreadSafe: 동작 검증" {
+test "resolveThreadSafe: 동작 검증" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -235,7 +235,7 @@ test "resolveAsModuleThreadSafe: 동작 검증" {
     var cache = ResolveCache.init(std.testing.allocator, .{});
     defer cache.deinit();
 
-    const result = (try cache.resolveAsModuleThreadSafe(dir_path, "./bar", .static_import)).?;
+    const result = (try cache.resolveThreadSafe(dir_path, "./bar", .static_import)).?;
     defer freeResolvedPath(result);
 
     switch (result) {


### PR DESCRIPTION
## Summary

PR #1931 (PR 4d) 에서 옛 \`resolve\` / \`resolveThreadSafe\` API 제거 후 \`resolveAsModule\` 이 사실상 main API. 원래 이름 회복.

## 변경

| 파일 | 변경 |
|---|---|
| \`resolve_cache.zig\` | \`resolveAsModule\` → \`resolve\`, \`resolveAsModuleThreadSafe\` → \`resolveThreadSafe\` |
| \`graph.zig\` | 4곳 호출처 갱신 |
| \`resolve_cache_test.zig\` | 9곳 (테스트 본문 + 이름) 갱신 |

호환성 무관 — 외부 caller 0 (PR 4c-2 에서 graph 가 모두 마이그레이션 완료).

## Test plan
- [x] \`zig build test\` 통과
- [x] \`zig build napi\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)