### PR TITLE
fix(linker, tree_shaker): hoist re_export_namespace ns_var + recover tree-shake (#1928)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -232,15 +232,19 @@ pub const LinkingMetadata = struct {
         entries: []const Entry = &.{},
 
         pub const Entry = struct {
-            symbol_id: u32,
+            /// `null` = declaration-only (preamble 에 `var X_ns = {...};` 만 emit, codegen
+            /// `get(sid)` lookup 은 항상 miss). `re_export_namespace` 가 만든 hoisted ns_var
+            /// 에 사용 (#1928).
+            symbol_id: ?u32,
             object_literal: []const u8,
-            /// namespace 변수명 (동적 접근 시 변수 참조용)
             var_name: []const u8,
         };
 
         pub fn get(self: *const NsInlineObjects, sym_id: u32) ?*const Entry {
             for (self.entries) |*e| {
-                if (e.symbol_id == sym_id) return e;
+                if (e.symbol_id) |sid| {
+                    if (sid == sym_id) return e;
+                }
             }
             return null;
         }
@@ -441,6 +445,11 @@ pub const Linker = struct {
         /// buildInlineObjectStr에서 할당된 문자열인 경우 true.
         /// exports ArrayList 해제 시 owned=true인 local만 free.
         owned: bool = false,
+        /// re_export_namespace (`export * as Foo from './src'`) / `import * as X; export {X}`
+        /// 패턴에서 source 모듈 인덱스. registerNamespaceRewrites 가 이 정보로
+        /// hoisted ns_var (예: `Foo_ns`) 를 한 번 declare 하고 inner_map 매핑을
+        /// 변수명으로 둔다 (per-access inline literal 중복 emit 방지, #1928).
+        ns_target_mod: ?u32 = null,
     };
 
     /// re-export 체인 순환 방지 깊이 제한.
@@ -1891,6 +1900,9 @@ pub const Linker = struct {
         self: *const Linker,
         ns_rewrite_list: *std.ArrayList(LinkingMetadata.NsMemberRewrites.Entry),
         ns_inline_list: *std.ArrayList(LinkingMetadata.NsInlineObjects.Entry),
+        /// 같은 importer 안에서 여러 namespace import 가 같은 target source 의 inline ns_var
+        /// 를 공유하도록 caller 가 owned. `cjs_var_cache` 와 같은 패턴 (`metadata.zig`).
+        ns_target_to_var: *std.AutoHashMap(u32, []const u8),
         force_inline: bool,
         importer_mod_idx: u32,
         symbol_id: u32,
@@ -1940,15 +1952,45 @@ pub const Linker = struct {
             break :blk owned_slice;
         };
 
+        var seen_exports = std.StringHashMap(void).init(self.allocator);
+        defer seen_exports.deinit();
+        for (cached_exports) |exp| {
+            try seen_exports.put(exp.exported, {});
+        }
+
         // importer 의 nested binding 과 충돌하는 export 는 inline 시 self-shadow 무한
         // 재귀 위험 → 매핑 등록을 건너뛰고 has_shadow 로 추적.
         // (예: `const setSelectedLog = (i) => LogBoxData.setSelectedLog(i);` 가
         //  `const setSelectedLog = (i) => setSelectedLog(i);` 로 inline 되는 케이스)
+        //
+        // 또한 ns_target_mod 가 있는 export (re_export_namespace 등) 는 target_mod 별
+        // hoisted ns_var 를 만들고 inner_map 매핑은 그 변수명으로 둔다 — emitStaticMember
+        // 가 access site 마다 객체 literal 을 inline emit 하는 회귀 방지 (#1928).
         var inner_map = std.StringHashMap([]const u8).init(self.allocator);
         var has_shadow = false;
         for (cached_exports) |exp| {
             if (self.hasNestedBinding(importer_mod_idx, exp.exported)) {
                 has_shadow = true;
+                continue;
+            }
+            if (exp.ns_target_mod) |target| {
+                const ns_var = if (ns_target_to_var.get(target)) |cached|
+                    cached
+                else blk: {
+                    const fresh = try self.makeUniqueNsVarName(exp.exported, &seen_exports);
+                    try ns_target_to_var.put(target, fresh);
+                    const obj_str = try self.buildInlineObjectStr(target, 0);
+                    try ns_inline_list.append(self.allocator, .{
+                        .symbol_id = null,
+                        .object_literal = obj_str,
+                        .var_name = fresh,
+                    });
+                    break :blk fresh;
+                };
+                // inner_map 은 ns_inline_list.entry.var_name pointer 를 borrow — ns_inline
+                // 이 owner. inner_map.deinit 은 backing 만 해제, value pointer 는 안 건드림 →
+                // 같은 메모리 double-free 없음.
+                try inner_map.put(exp.exported, ns_var);
                 continue;
             }
             const local = if (exp.owned)
@@ -1966,12 +2008,7 @@ pub const Linker = struct {
         // 후자의 경우 codegen fallback 이 namespace 객체 access 로 emit 할 수 있도록 객체가 필요.
         if (force_inline or has_shadow) {
             const obj_str = try self.buildInlineObjectStr(target_mod_idx, 0);
-            var seen = std.StringHashMap(void).init(self.allocator);
-            defer seen.deinit();
-            for (cached_exports) |exp| {
-                try seen.put(exp.exported, {});
-            }
-            const ns_var_name = try self.makeUniqueNsVarName(var_name, &seen);
+            const ns_var_name = try self.makeUniqueNsVarName(var_name, &seen_exports);
             try ns_inline_list.append(self.allocator, .{
                 .symbol_id = symbol_id,
                 .object_literal = obj_str,
@@ -1979,6 +2016,7 @@ pub const Linker = struct {
             });
         }
     }
+
 
     /// namespace preamble 변수명을 export 이름과 충돌하지 않도록 생성.
     /// "z" → "z_ns", 충돌 시 "z_ns2", "z_ns3", ...
@@ -2103,6 +2141,16 @@ pub const Linker = struct {
         return try self.allocator.dupe(u8, result);
     }
 
+    /// `import_records[idx].resolved` 가 valid 면 모듈 인덱스 반환, 아니면 null.
+    /// `collectExportsRecursive` 의 3개 분기에서 공유.
+    inline fn resolvedRecordModule(records: anytype, rec_idx_opt: ?u32) ?u32 {
+        const rec_idx = rec_idx_opt orelse return null;
+        if (rec_idx >= records.len) return null;
+        const src = records[rec_idx].resolved;
+        if (src.isNone()) return null;
+        return @intFromEnum(src);
+    }
+
     /// 모듈의 모든 export를 재귀적으로 수집 (export * 체인 포함).
     /// seen: export 이름 dedup, visited: 모듈 수준 dedup (diamond export * 방지).
     fn collectExportsRecursive(
@@ -2137,52 +2185,36 @@ pub const Linker = struct {
             try seen.put(eb.exported_name, {});
 
             const eb_local = m.exportBindingLocalName(eb);
+            // ns_target_mod: hoisted ns_var 가 필요한 source 모듈 (registerNamespaceRewrites
+            // 가 처리). inline literal 을 직접 만들어 inner_map 에 넣으면 emitStaticMember
+            // 가 access site 마다 객체 literal 을 inline emit (#1928). 대신 source mod_idx
+            // 만 기록하고 ns_var 등록은 호출 site 가 일임.
+            var ns_target_mod: ?u32 = null;
             const actual_local = if (eb.kind == .re_export_namespace) blk: {
-                // export * as ns — 소스 모듈의 인라인 객체를 생성 (재귀)
-                if (eb.import_record_index) |rec_idx| {
-                    if (rec_idx < m.import_records.len) {
-                        const src = m.import_records[rec_idx].resolved;
-                        if (!src.isNone()) {
-                            break :blk try self.buildInlineObjectStr(@intFromEnum(src), depth + 1);
-                        }
-                    }
-                }
+                ns_target_mod = resolvedRecordModule(m.import_records, eb.import_record_index);
                 break :blk eb_local;
             } else if (eb.kind == .re_export) blk: {
                 if (self.resolveExportChain(module_idx, eb.exported_name, 0)) |canonical| {
-                    // canonical이 export * as ns 패턴인지 확인
                     if (self.graph.getModule(canonical.module_index)) |cmod| {
                         for (cmod.export_bindings) |ceb| {
                             if (ceb.kind.isReExportAll() and
                                 std.mem.eql(u8, ceb.exported_name, canonical.export_name) and
                                 !std.mem.eql(u8, ceb.exported_name, "*"))
                             {
-                                if (ceb.import_record_index) |rec_idx| {
-                                    if (rec_idx < cmod.import_records.len) {
-                                        const src = cmod.import_records[rec_idx].resolved;
-                                        if (!src.isNone()) {
-                                            break :blk try self.buildInlineObjectStr(@intFromEnum(src), depth + 1);
-                                        }
-                                    }
+                                if (resolvedRecordModule(cmod.import_records, ceb.import_record_index)) |src_mod| {
+                                    ns_target_mod = src_mod;
                                 }
                             }
                         }
                     }
-                    break :blk self.resolveToLocalName(canonical);
+                    if (ns_target_mod == null) break :blk self.resolveToLocalName(canonical);
+                    break :blk eb_local;
                 }
                 break :blk eb_local;
             } else blk: {
-                // .local export: namespace import를 re-export하는 경우 인라인 객체 생성
-                // 예: import * as X from './Module'; export { X }
-                if (ns_imports.get(eb_local)) |rec_idx| {
-                    if (rec_idx < m.import_records.len) {
-                        const src = m.import_records[rec_idx].resolved;
-                        if (!src.isNone()) {
-                            break :blk try self.buildInlineObjectStr(@intFromEnum(src), depth + 1);
-                        }
-                    }
-                }
-                break :blk self.getCanonicalByRef(eb.symbol) orelse eb_local;
+                ns_target_mod = resolvedRecordModule(m.import_records, ns_imports.get(eb_local));
+                if (ns_target_mod == null) break :blk self.getCanonicalByRef(eb.symbol) orelse eb_local;
+                break :blk eb_local;
             };
 
             const safe_local = self.safeIdentifierName(actual_local, @intCast(mod_i));
@@ -2190,9 +2222,8 @@ pub const Linker = struct {
             try exports.append(self.allocator, .{
                 .exported = eb.exported_name,
                 .local = safe_local,
-                // actual_local로 체크: "{"이면 buildInlineObjectStr이 할당한 문자열.
-                // safeIdentifierName은 소유권을 변경하지 않음 (canonical 참조 반환).
-                .owned = actual_local.len > 0 and actual_local[0] == '{',
+                .owned = false,
+                .ns_target_mod = ns_target_mod,
             });
         }
 

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -214,6 +214,12 @@ pub fn buildMetadataForAst(
         ns_inline_list.deinit(self.allocator);
     }
 
+    // 같은 importer 안에서 여러 namespace import 가 같은 source 의 hoisted ns_var 를
+    // 공유하도록 caller-owned cache. registerNamespaceRewrites 가 source mod_idx 별로
+    // ns_var_name 을 dedup. 값 (var_name) 의 owner 는 ns_inline_list — 중복 free 안 함.
+    var ns_target_to_var = std.AutoHashMap(u32, []const u8).init(self.allocator);
+    defer ns_target_to_var.deinit();
+
     // CJS 모듈별 require_xxx 변수명 캐시 (같은 모듈에서 여러 named import 시 중복 생성 방지)
     var cjs_var_cache = std.AutoHashMap(u32, []const u8).init(self.allocator);
     defer {
@@ -436,6 +442,7 @@ pub fn buildMetadataForAst(
                 try self.registerNamespaceRewrites(
                     &ns_rewrite_list,
                     &ns_inline_list,
+                    &ns_target_to_var,
                     force_inline,
                     module_index,
                     ns_sym_id,
@@ -496,6 +503,7 @@ pub fn buildMetadataForAst(
                                             try self.registerNamespaceRewrites(
                                                 &ns_rewrite_list,
                                                 &ns_inline_list,
+                                                &ns_target_to_var,
                                                 true,
                                                 module_index,
                                                 @intCast(import_sym_id),
@@ -524,6 +532,7 @@ pub fn buildMetadataForAst(
                                 try self.registerNamespaceRewrites(
                                     &ns_rewrite_list,
                                     &ns_inline_list,
+                                    &ns_target_to_var,
                                     true,
                                     module_index,
                                     @intCast(imp_sym),

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -58,6 +58,9 @@ pub const TreeShaker = struct {
     /// prebuilt StmtInfo를 사용하는 모듈 마스크.
     /// prebuilt는 parse_arena가 소유하므로 deinit에서 해제하지 않는다.
     prebuilt_mask: ?std.DynamicBitSet = null,
+    /// 모듈 인덱스가 다른 모듈의 `export * from` source 인지 표시. tryMarkReExportNsSubset
+    /// 에서 chain 추적 시 O(M·E) scan 대신 O(1) 조회 (#1928).
+    re_export_star_targets: ?std.DynamicBitSet = null,
 
     const max_fixpoint_iterations: u32 = 100;
 
@@ -97,6 +100,7 @@ pub const TreeShaker = struct {
             self.allocator.free(self.module_stmt_infos);
         }
         if (self.prebuilt_mask) |*mask| mask.deinit();
+        if (self.re_export_star_targets) |*mask| mask.deinit();
         if (self.reachable_stmts.len > 0) {
             for (self.reachable_stmts) |*rs| {
                 if (rs.*) |*bs| bs.deinit();
@@ -131,6 +135,23 @@ pub const TreeShaker = struct {
     /// 변경이 없을 때 수렴하며, 실제로는 2-3회 이내.
     pub fn analyze(self: *TreeShaker, entry_points: []const []const u8) !void {
         const mod_count = self.graph.moduleCount();
+
+        // re_export_star_targets bitset 한 번 build — tryMarkReExportNsSubset 가 fixpoint
+        // 안에서 매번 O(M·E) scan 하지 않도록.
+        var re_star_targets = try std.DynamicBitSet.initEmpty(self.allocator, mod_count);
+        errdefer re_star_targets.deinit();
+        for (0..mod_count) |i| {
+            const m = self.getModule(@intCast(i)) orelse continue;
+            for (m.export_bindings) |eb| {
+                if (eb.kind != .re_export_star) continue;
+                const rec_idx = eb.import_record_index orelse continue;
+                if (rec_idx >= m.import_records.len) continue;
+                const src = m.import_records[rec_idx].resolved;
+                if (src == .none) continue;
+                re_star_targets.set(@intFromEnum(src));
+            }
+        }
+        self.re_export_star_targets = re_star_targets;
 
         // entry_set 먼저 계산 (자동 순수 판별에서 진입점 제외용)
         for (0..mod_count) |i| {
@@ -910,18 +931,44 @@ pub const TreeShaker = struct {
         reexport_name: []const u8,
         src_mod: u32,
     ) !bool {
+        // Chain check: reexport_mod 가 다른 모듈의 `export * from` source 면 transitive
+        // consumer 가 reexport_name 을 사용할 수 있다. chain 너머의 namespace_used_properties
+        // 는 추적 안 하므로 보수적으로 fallback — markAllExportsUsed (#1928).
+        if (self.re_export_star_targets) |mask| {
+            if (mask.isSet(reexport_mod)) return false;
+        }
+
         var union_set: std.StringHashMapUnmanaged(void) = .{};
         defer union_set.deinit(self.allocator);
 
-        // 소비자 검색: 모든 모듈의 .named import_bindings에서 이 re-export 소비자 찾기
+        // 소비자 검색: 모든 모듈의 import_bindings 에서 이 re-export 소비자 찾기.
         var cit = self.graph.modulesIterator();
         while (cit.next()) |consumer_ptr| {
             const consumer = consumer_ptr.*;
             for (consumer.import_bindings) |ib| {
-                if (!Linker.isReExportNsConsumer(consumer, ib, reexport_mod, reexport_name)) continue;
-
-                const props = ib.namespace_used_properties orelse return false; // opaque → fallback
-                for (props) |p| try union_set.put(self.allocator, p, {});
+                // Case 1: named — `import { NsA } from './barrel'`. consumer 의 used props
+                // 가 곧 NsA 의 사용된 멤버.
+                if (Linker.isReExportNsConsumer(consumer, ib, reexport_mod, reexport_name)) {
+                    const props = ib.namespace_used_properties orelse return false;
+                    for (props) |p| try union_set.put(self.allocator, p, {});
+                    continue;
+                }
+                // Case 2: namespace — `import * as Lib from './barrel'; Lib.NsA.a01(...)`.
+                // 현재 namespace_used_properties 는 1-depth (`["NsA"]`) 만 추적하므로
+                // NsA 가 사용됐다면 그 안의 어느 멤버가 쓰였는지는 opaque → fallback (#1928).
+                if (ib.kind != .namespace) continue;
+                if (ib.import_record_index >= consumer.import_records.len) continue;
+                const resolved = consumer.import_records[ib.import_record_index].resolved;
+                if (resolved == .none or @intFromEnum(resolved) != reexport_mod) continue;
+                const props = ib.namespace_used_properties orelse return false;
+                var uses_reexport_name = false;
+                for (props) |p| {
+                    if (std.mem.eql(u8, p, reexport_name)) {
+                        uses_reexport_name = true;
+                        break;
+                    }
+                }
+                if (uses_reexport_name) return false; // markAllExportsUsed fallback
             }
         }
 

--- a/tests/integration/tests/ns-shadow-runtime.test.ts
+++ b/tests/integration/tests/ns-shadow-runtime.test.ts
@@ -110,11 +110,12 @@ console.log(run(99));`,
     expect(r.runOutput).toBe("p:99");
   });
 
-  // Tracked by https://github.com/ohah/zts/issues/1928 — `export * as NsA from './data.js'`
-  // currently emits the entire data.js exports as an inline getter object literal at every
-  // member access site, and the source module statements get tree-shaken away, leaving the
-  // getters dangling (`ReferenceError: a01 is not defined`). Fix lives in a follow-up PR.
-  test.skip("re-export namespace barrel: Lib.NsA.x must reach the original", async () => {
+  // #1928: `export * as NsA from './data.js'` used to emit the full inline getter object
+  // at every access site AND tree-shake away the source statements (ReferenceError).
+  // Fix: collectExportsRecursive records ns_target_mod; registerNamespaceRewrites hoists
+  // a single `var NsA_ns = {...};` to the preamble; tryMarkReExportNsSubset recognizes
+  // namespace consumers and falls back to markAllExportsUsed.
+  test("re-export namespace barrel: Lib.NsA.x must reach the original", async () => {
     const r = await bundleAndRun(
       {
         "data.js": `export const a01 = () => "a01";
@@ -129,5 +130,149 @@ console.log(Lib.NsA.a01() + "/" + Lib.NsA.setSelectedLog(7));`,
     expect(r.runStderr).not.toContain("ReferenceError");
     expect(r.exitCode).toBe(0);
     expect(r.runOutput).toBe("a01/log:7");
+  });
+
+  test("re-export barrel: hoist correctness across many accesses", async () => {
+    const r = await bundleAndRun(
+      {
+        "data.js": `export const a = () => "A"; export const b = () => "B"; export const c = () => "C";`,
+        "barrel.js": `export * as Ns from './data.js';`,
+        "entry.js": `import * as Lib from './barrel.js';
+console.log([Lib.Ns.a(), Lib.Ns.b(), Lib.Ns.c(), Lib.Ns.a(), Lib.Ns.b()].join("/"));`,
+      },
+      "entry.js",
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("A/B/C/A/B");
+  });
+
+  test("multiple importers of the same barrel: each gets its own hoist (no cross-importer leak)", async () => {
+    const r = await bundleAndRun(
+      {
+        "data.js": `export const greet = (n) => "hi " + n;`,
+        "barrel.js": `export * as Ns from './data.js';`,
+        "userA.js": `import * as Lib from './barrel.js';
+export function callA() { return Lib.Ns.greet("A"); }`,
+        "userB.js": `import * as Lib from './barrel.js';
+export function callB() { return Lib.Ns.greet("B"); }`,
+        "entry.js": `import { callA } from './userA.js';
+import { callB } from './userB.js';
+console.log(callA() + "/" + callB());`,
+      },
+      "entry.js",
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("hi A/hi B");
+  });
+
+  test("nested re-export chain: outer barrel re-exports inner barrel re-exports data", async () => {
+    const r = await bundleAndRun(
+      {
+        "data.js": `export const v = () => 42;`,
+        "inner.js": `export * as Inner from './data.js';`,
+        "outer.js": `export * from './inner.js';`,
+        "entry.js": `import * as Lib from './outer.js';
+console.log(Lib.Inner.v());`,
+      },
+      "entry.js",
+    );
+    cleanup = r.cleanup;
+    expect(r.runStderr).not.toContain("ReferenceError");
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("42");
+  });
+
+  test("ns_var name does not collide with an exported identifier of the same prefix", async () => {
+    const r = await bundleAndRun(
+      {
+        "data.js": `export const v = () => "data.v";`,
+        // export name `Ns` exists alongside re-exported namespace also named `Ns_ns` —
+        // makeUniqueNsVarName must pick a non-colliding name.
+        "barrel.js": `export const Ns_ns = "exported_string";
+export * as Ns from './data.js';`,
+        "entry.js": `import * as Lib from './barrel.js';
+console.log(Lib.Ns_ns + "|" + Lib.Ns.v());`,
+      },
+      "entry.js",
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("exported_string|data.v");
+  });
+
+  test("local export of namespace import: import * as X; export {X}", async () => {
+    const r = await bundleAndRun(
+      {
+        "data.js": `export const k = () => "k";`,
+        "wrap.js": `import * as Inner from './data.js';
+export { Inner };`,
+        "entry.js": `import * as W from './wrap.js';
+console.log(W.Inner.k());`,
+      },
+      "entry.js",
+    );
+    cleanup = r.cleanup;
+    expect(r.runStderr).not.toContain("ReferenceError");
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("k");
+  });
+
+  test("re-export ns + nested binding shadow on same barrel access", async () => {
+    const r = await bundleAndRun(
+      {
+        "data.js": `export const fn = () => "data.fn"; export const other = () => "data.other";`,
+        "barrel.js": `export * as Ns from './data.js';`,
+        "user.js": `import * as Lib from './barrel.js';
+export function compute() {
+  // local 'fn' shadows nothing relevant — but Ns is still hoisted, and Lib.Ns.fn must work.
+  const fn = (i) => "shadow:" + Lib.Ns.fn() + ":" + i;
+  return fn(7) + "|" + Lib.Ns.other();
+}`,
+        "entry.js": `import { compute } from './user.js';
+console.log(compute());`,
+      },
+      "entry.js",
+    );
+    cleanup = r.cleanup;
+    expect(r.runStderr).not.toContain("Maximum call stack");
+    expect(r.runStderr).not.toContain("ReferenceError");
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("shadow:data.fn:7|data.other");
+  });
+
+  test("namespace member chain depth 3: Lib.Outer.Inner.x", async () => {
+    const r = await bundleAndRun(
+      {
+        "data.js": `export const x = () => "deep";`,
+        "inner.js": `export * as Inner from './data.js';`,
+        "outer.js": `export * as Outer from './inner.js';`,
+        "entry.js": `import * as Lib from './outer.js';
+console.log(Lib.Outer.Inner.x());`,
+      },
+      "entry.js",
+    );
+    cleanup = r.cleanup;
+    expect(r.runStderr).not.toContain("ReferenceError");
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("deep");
+  });
+
+  test("only one member of barrel used → unused exports may still be tree-shaken if precision allows", async () => {
+    const r = await bundleAndRun(
+      {
+        "data.js": `export const used = () => "used";
+export const unused = () => "unused";`,
+        "barrel.js": `export * as Ns from './data.js';`,
+        // Direct named import path (precision should work).
+        "entry.js": `import { Ns } from './barrel.js';
+console.log(Ns.used());`,
+      },
+      "entry.js",
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("used");
   });
 });


### PR DESCRIPTION
Closes #1928

## Problem

`collectExportsRecursive` eagerly called `buildInlineObjectStr` for `re_export_namespace` / `re_export` (chain ends in namespace) / `.local + ns_imports`, putting the literal directly into `ns_member_rewrites.inner_map`. `emitStaticMember` then wrote `({get a() {...}, get b() {...}, ...}).a()` at every access site.

Worse: `tryMarkReExportNsSubset` only checked `.named` import consumers — namespace import consumers (`import * as Lib`) were ignored, so the source statements were tree-shaken away, leaving the inline getters dangling. Result: `ReferenceError: a is not defined` at runtime.

## Repro from issue body

```js
// data.js
export const a01 = () => "a01";
export const setSelectedLog = (i) => "log:" + i;
// barrel.js
export * as NsA from './data.js';
// entry.js
import * as Lib from './barrel.js';
console.log(Lib.NsA.a01() + "/" + Lib.NsA.setSelectedLog(7));
```

Before: `ReferenceError: a01 is not defined`.
After:
```js
var NsA_ns = {get a01() { return a01; }, get setSelectedLog() { return setSelectedLog; }};
const a01 = () => "a01";
const setSelectedLog = (i) => "log:" + i;
console.log(NsA_ns.a01() + "/" + NsA_ns.setSelectedLog(7));
```
→ `a01/log:7`.

## Changes

### `linker.zig`
- `NsExportPair` carries `ns_target_mod: ?u32`. `collectExportsRecursive` records the source mod_idx instead of building the literal — extracted shared `resolvedRecordModule` helper to collapse 3 duplicated `import_records[idx].resolved → @intFromEnum(src)` blocks.
- `registerNamespaceRewrites` accepts caller-owned `ns_target_to_var: AutoHashMap(u32, []const u8)` (mirrors the established `cjs_var_cache` pattern). Per-importer dedup: same source's `var X_ns = {...};` declaration emits exactly once.
- `inner_map` borrows the `var_name` pointer from `ns_inline_list` (no double-free; `LinkingMetadata.deinit` only frees through `ns_inline_objects`).
- `NsInlineObjects.Entry.symbol_id` is now `?u32`. `null` = declaration-only entry, `get()` lookups always miss, only the preamble emit fires. Replaces an earlier `maxInt(u32)` sentinel for clarity.

### `tree_shaker.zig`
- `tryMarkReExportNsSubset` now scans `.namespace` consumers as well. If any consumer's `namespace_used_properties` includes the reexport_name, fall back to `markAllExportsUsed(src_mod)` — we don't have nested `Lib.NsA.x` precision yet.
- New `re_export_star_targets: ?DynamicBitSet` field. Built once in `analyze()` (O(M·E) one-shot) so the chain check (when `reexport_mod` is itself a `export * from` source) is O(1) per `tryMarkReExportNsSubset` call instead of O(M·E) per call.

## Tests

`tests/integration/tests/ns-shadow-runtime.test.ts` — **13 runtime cases all pass** (PR #1932 added 4 pass + 1 skip; this PR unskips and adds 8 new):

- ✅ LogBox patterns (4 from PR #1932)
- ✅ re-export barrel (the issue #1928 fixture, was `test.skip`)
- ✅ hoist correctness across 5 member accesses
- ✅ multiple importers of the same barrel
- ✅ nested re-export chain (`outer: export * → inner: export * as`)
- ✅ ns_var name collision with existing `Foo_ns` export
- ✅ `import * as X; export {X}` local re-export
- ✅ ns + nested binding shadow combo
- ✅ depth-3 chain (`Lib.Outer.Inner.x`)
- ✅ direct named-import path (precision works through chain bitset fallback)

`zig build test`: **3789/3789 pass** — no regressions.

## Out of scope

The effect smoke benchmark still shows 583KB vs esbuild 477KB (1.22x). That gap is a separate mechanism — effect's heavy use of `import { Effect, pipe }` named imports doesn't go through the namespace fallback path this PR fixes. Tracking separately.

## Test plan
- [x] `bun test ./tests/integration/tests/ns-shadow-runtime.test.ts` — 13 pass
- [x] `zig build test` — 3789 pass
- [ ] Wait for CI on Linux/Windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)