### PR TITLE
feat(build): wasm-bundler 빌드 target 추가 (#1885 Phase 2 PR 6-2a)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -167,6 +167,49 @@ pub fn build(b: *std.Build) void {
         wasm_step.dependOn(&wasm_install.step);
     }
 
+    // ─── WASM bundler 빌드 (#1885 Phase 2) ───
+    // `zig build wasm-bundler` — wasm32-wasip1-threads 타겟. 별도 binary 로 transpile
+    // (wasm32-wasi) 와 분리. threads 가 필요 (bundler 가 worker pool 사용)하지만
+    // SharedArrayBuffer + COOP/COEP 헤더가 필요하므로 transpile 빌드와 호환성 분리.
+    {
+        const wasm_bundler_target = b.resolveTargetQuery(.{
+            .cpu_arch = .wasm32,
+            .os_tag = .wasi,
+            .abi = .musl,
+            .cpu_features_add = std.Target.wasm.featureSet(&.{ .atomics, .bulk_memory, .mutable_globals }),
+        });
+
+        const wasm_bundler_lib_mod = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = wasm_bundler_target,
+            .optimize = .ReleaseSmall,
+            .single_threaded = false,
+        });
+
+        const wasm_bundler_mod = b.createModule(.{
+            .root_source_file = b.path("packages/wasm/src/wasm_bundler_entry.zig"),
+            .target = wasm_bundler_target,
+            .optimize = .ReleaseSmall,
+            .single_threaded = false,
+        });
+        wasm_bundler_mod.addImport("zts_lib", wasm_bundler_lib_mod);
+
+        const wasm_bundler_exe = b.addExecutable(.{
+            .name = "zts-bundler",
+            .root_module = wasm_bundler_mod,
+        });
+        wasm_bundler_exe.rdynamic = true;
+        wasm_bundler_exe.entry = .disabled;
+        // Threading 활성: wasi-libc 의 pthread 활용 (wasm32-wasip1-threads 패턴).
+        wasm_bundler_exe.import_memory = true;
+        wasm_bundler_exe.shared_memory = true;
+        wasm_bundler_exe.max_memory = 4 * 1024 * 1024 * 1024; // 4 GiB
+
+        const wasm_bundler_install = b.addInstallArtifact(wasm_bundler_exe, .{});
+        const wasm_bundler_step = b.step("wasm-bundler", "Build WASM bundler module (wasm32-wasi + threads)");
+        wasm_bundler_step.dependOn(&wasm_bundler_install.step);
+    }
+
     // ─── NAPI 네이티브 모듈 빌드 ───
     // `zig build napi` — .node 파일(공유 라이브러리)을 빌드한다.
     // Node.js/Bun/Deno에서 require()로 로드하여 in-process 트랜스파일을 수행한다.

--- a/packages/wasm/src/wasm_bundler_entry.zig
+++ b/packages/wasm/src/wasm_bundler_entry.zig
@@ -1,0 +1,20 @@
+//! ZTS WASM bundler 진입점 (#1885 Phase 2).
+//!
+//! wasm32-wasip1-threads 타겟용 — bundler 전용. transpile-only 빌드 (wasm_entry.zig)
+//! 와 분리해서 brower 호환성/번들 사이즈 트레이드오프 분리.
+//!
+//! Phase 2 PR 6-2a 단계: 컴파일 검증만. build() export 는 PR 6-2c.
+
+const std = @import("std");
+const zts_lib = @import("zts_lib");
+
+pub const panic = zts_lib.crash_handler.panic;
+
+const wasm_alloc = std.heap.wasm_allocator;
+
+// 컴파일 검증용 — bundler 가 wasm32-wasip1-threads 환경에서 link 가능한지 확인.
+// PR 6-2c 에서 진짜 build() 호출 + 인자/결과 ABI 구현.
+export fn bundler_version() u32 {
+    // Phase 2 의 ABI version stub — 호스트 측 호환성 체크용.
+    return 1;
+}


### PR DESCRIPTION
## Summary

#1885 Phase 2 — bundler WASM 빌드 가능 환경 마련. 옵션 3 (분리 빌드) 의 첫 단계.

bundler 가 \`std.Thread.Pool\` 광범위 사용 — wasm32-wasi (no threads) 에서 컴파일 안 됨. 새 build target \`wasm-bundler\` (wasm32-wasi + threads features) 추가, transpile-only WASM (wasm32-wasi) 와 분리.

**기존 빌드 영향 없음** (transpile WASM/NAPI/test 그대로).

## 분리 빌드 정당성

| 빌드 | 환경 | Threads | 호환성 |
|---|---|---|---|
| **transpile** (\`wasm\`) | CDN / StackBlitz / 일반 browser | ❌ | 광범위 |
| **bundler** (\`wasm-bundler\`) | self-hosted (COOP/COEP) | ✅ | 성능 우선 |

rolldown 동일 패턴 (wasm32-wasip1-threads). esbuild-wasm 도 사실상 분리.

## 변경

### \`build.zig\` — 새 step
\`\`\`zig
const wasm_bundler_target = b.resolveTargetQuery(.{
    .cpu_arch = .wasm32,
    .os_tag = .wasi,
    .abi = .musl,
    .cpu_features_add = std.Target.wasm.featureSet(&.{ .atomics, .bulk_memory, .mutable_globals }),
});
// + shared_memory + import_memory + single_threaded=false
\`\`\`

### \`packages/wasm/src/wasm_bundler_entry.zig\` 신규
- minimal stub (\`bundler_version\` export 만)
- bundler 호출 + JS bridge + ABI 는 PR 6-2b/6-2c

## Test plan

- [x] \`zig build wasm-bundler\` 통과 (zts-bundler.wasm 80 byte stub)
- [x] \`zig build test / napi / wasm\` 통과 — 기존 빌드 영향 0

## 다음 단계

- **PR 6-2b**: JS 측 \`VirtualFileSystem\` + \`zts_fs\` imports + Astro COOP/COEP 헤더
- **PR 6-2c**: \`wasm_bundler_entry.zig\` 의 \`build()\` export + 통합 검증
- 실제 zts-bundler.wasm size 측정은 PR 6-2c 이후 (#1899 와 결합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)