### PR TITLE
feat(wasm): JS VirtualFileSystem + zts_fs imports + Astro COOP/COEP (#1885 Phase 2 PR 6-2b)

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -146,5 +146,14 @@ export default defineConfig({
     ssr: {
       noExternal: ["@monaco-editor/react", "echarts-for-react"],
     },
+    // SharedArrayBuffer 사용 (#1885 Phase 2 — bundler WASM 의 wasm32-wasi+threads).
+    // dev 서버에서 COOP/COEP 헤더 set 으로 cross-origin isolation 활성. prod 환경
+    // (GitHub Pages) 은 헤더 set 불가 — coi-serviceworker 로 우회 (별도 PR).
+    server: {
+      headers: {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp",
+      },
+    },
   },
 });

--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeAll } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
-import { initSync, transpile } from "./index";
+import { initSync, transpile, VirtualFileSystem } from "./index";
 
 beforeAll(() => {
   const wasmPath = join(import.meta.dir, "../../zig-out/bin/zts.wasm");
@@ -206,5 +206,57 @@ describe("@zts/wasm", () => {
       const result = transpile(`const x${i}: number = ${i};`);
       expect(result.code).toContain(`const x${i} = ${i};`);
     }
+  });
+});
+
+// VirtualFileSystem (#1885 Phase 2 PR 6-2b) — bundler 의 host fs 추상화.
+// 단위 테스트는 pure JS (wasm 무관). bundler instance + zts_fs callback 통합은 PR 6-2c.
+describe("VirtualFileSystem", () => {
+  test("set / get string content (utf-8 encoded)", () => {
+    const vfs = new VirtualFileSystem();
+    vfs.set("/index.ts", "export const x = 1;");
+    const data = vfs.get("/index.ts");
+    expect(data).toBeDefined();
+    expect(new TextDecoder().decode(data!)).toBe("export const x = 1;");
+  });
+
+  test("set / get Uint8Array content (binary 보존)", () => {
+    const vfs = new VirtualFileSystem();
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG header
+    vfs.set("/image.png", bytes);
+    expect(vfs.get("/image.png")).toEqual(bytes);
+  });
+
+  test("has / delete / clear", () => {
+    const vfs = new VirtualFileSystem();
+    vfs.set("/a", "1");
+    vfs.set("/b", "2");
+    expect(vfs.has("/a")).toBe(true);
+    expect(vfs.has("/c")).toBe(false);
+    expect(vfs.size()).toBe(2);
+
+    expect(vfs.delete("/a")).toBe(true);
+    expect(vfs.delete("/a")).toBe(false);
+    expect(vfs.size()).toBe(1);
+
+    vfs.clear();
+    expect(vfs.size()).toBe(0);
+  });
+
+  test("paths iterator", () => {
+    const vfs = new VirtualFileSystem();
+    vfs.set("/a.ts", "");
+    vfs.set("/b.ts", "");
+    vfs.set("/c.ts", "");
+    const collected = [...vfs.paths()].sort();
+    expect(collected).toEqual(["/a.ts", "/b.ts", "/c.ts"]);
+  });
+
+  test("재set 시 덮어쓰기", () => {
+    const vfs = new VirtualFileSystem();
+    vfs.set("/x", "first");
+    vfs.set("/x", "second");
+    expect(new TextDecoder().decode(vfs.get("/x")!)).toBe("second");
+    expect(vfs.size()).toBe(1);
   });
 });

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -113,42 +113,52 @@ function writeOptionalString(s?: string): [number, number] {
 
 // ─── Public API ───
 
-export async function init(
-  input?: URL | string | Request | Response | BufferSource | WebAssembly.Module,
-): Promise<void> {
-  if (wasm) return;
-
-  let source: BufferSource | WebAssembly.Module | Response;
-
+/// 입력을 WebAssembly instantiate 가능한 source 로 정규화. undefined 면 default
+/// .wasm 파일 (Node.js 환경) 을 동적으로 읽음.
+async function resolveWasmSource(
+  input: URL | string | Request | Response | BufferSource | WebAssembly.Module | undefined,
+  defaultFile: string,
+): Promise<BufferSource | WebAssembly.Module | Response> {
   if (input === undefined) {
     const fs = await import("fs");
     const path = await import("path");
     const url = await import("url");
     const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-    source = fs.readFileSync(path.join(__dirname, "zts.wasm"));
-  } else if (input instanceof WebAssembly.Module) {
-    source = input;
-  } else if (input instanceof Response) {
-    source = input;
-  } else if (input instanceof ArrayBuffer || ArrayBuffer.isView(input)) {
-    source = input as BufferSource;
-  } else {
-    source = await fetch(input as string | URL | Request);
+    return fs.readFileSync(path.join(__dirname, defaultFile));
   }
+  if (input instanceof WebAssembly.Module) return input;
+  if (input instanceof Response) return input;
+  if (input instanceof ArrayBuffer || ArrayBuffer.isView(input)) {
+    return input as BufferSource;
+  }
+  return await fetch(input as string | URL | Request);
+}
 
-  let instance: WebAssembly.Instance;
+/// source + imports 로 WebAssembly instance 생성. Module/Response/BufferSource 분기 처리.
+async function instantiateWasm(
+  source: BufferSource | WebAssembly.Module | Response,
+  imports: WebAssembly.Imports,
+): Promise<WebAssembly.Instance> {
+  if (source instanceof WebAssembly.Module) {
+    return new WebAssembly.Instance(source, imports);
+  }
+  if (source instanceof Response) {
+    const result = await WebAssembly.instantiateStreaming(source, imports);
+    return result.instance;
+  }
+  const result = await WebAssembly.instantiate(source, imports);
+  return result.instance;
+}
+
+export async function init(
+  input?: URL | string | Request | Response | BufferSource | WebAssembly.Module,
+): Promise<void> {
+  if (wasm) return;
+  const source = await resolveWasmSource(input, "zts.wasm");
+
   let memory: WebAssembly.Memory;
   const imports = createWasiImports(() => memory);
-
-  if (source instanceof WebAssembly.Module) {
-    instance = new WebAssembly.Instance(source, imports);
-  } else if (source instanceof Response) {
-    const result = await WebAssembly.instantiateStreaming(source, imports);
-    instance = result.instance;
-  } else {
-    const result = await WebAssembly.instantiate(source, imports);
-    instance = result.instance;
-  }
+  const instance = await instantiateWasm(source, imports);
 
   memory = instance.exports.memory as WebAssembly.Memory;
   wasm = instance.exports as unknown as WasmExports;
@@ -216,4 +226,150 @@ export function transpile(source: string, options: TranspileOptions = {}): Trans
     if (filePtr) wasm.dealloc(filePtr, fileLen);
     wasm.dealloc(optsPtr, optsLen);
   }
+}
+
+// ─── Bundler (#1885 Phase 2) ───
+//
+// 별도 wasm instance (zts-bundler.wasm, wasm32-wasi + threads). transpile-only
+// (zts.wasm) 와 격리 — bundler 는 SharedArrayBuffer 필요 (COOP/COEP 헤더).
+
+/// Host 가 제공하는 in-memory file system. bundler 가 fs syscall 시 host JS callback
+/// 으로 위임 (zts_fs imports). path → bytes 매핑.
+export class VirtualFileSystem {
+  private files = new Map<string, Uint8Array>();
+
+  set(path: string, content: string | Uint8Array): void {
+    const bytes = typeof content === "string" ? encoder.encode(content) : content;
+    this.files.set(path, bytes);
+  }
+
+  get(path: string): Uint8Array | undefined {
+    return this.files.get(path);
+  }
+
+  has(path: string): boolean {
+    return this.files.has(path);
+  }
+
+  delete(path: string): boolean {
+    return this.files.delete(path);
+  }
+
+  paths(): IterableIterator<string> {
+    return this.files.keys();
+  }
+
+  size(): number {
+    return this.files.size;
+  }
+
+  clear(): void {
+    this.files.clear();
+  }
+}
+
+interface BundlerExports {
+  memory: WebAssembly.Memory;
+  alloc(len: number): number;
+  dealloc(ptr: number, len: number): void;
+  bundler_version(): number;
+  // build() export 는 PR 6-2c
+}
+
+let bundler: BundlerExports | null = null;
+let bundlerVfs: VirtualFileSystem | null = null;
+
+function readBundlerString(ptr: number, len: number): string {
+  return decoder.decode(new Uint8Array(bundler!.memory.buffer, ptr, len));
+}
+
+/// host 가 wasm 메모리에 buffer 확보 + 데이터 복사 → packed (ptr<<32 | len) 반환.
+/// 0 = error sentinel (alloc 실패 또는 미존재).
+function packBytes(data: Uint8Array): bigint {
+  if (!bundler) return 0n;
+  const ptr = bundler.alloc(data.length);
+  if (ptr === 0) return 0n;
+  new Uint8Array(bundler.memory.buffer, ptr, data.length).set(data);
+  return (BigInt(ptr) << 32n) | BigInt(data.length);
+}
+
+function createBundlerImports(memory: () => WebAssembly.Memory) {
+  const wasi = createWasiImports(memory);
+  return {
+    ...wasi,
+    zts_fs: {
+      readFile(pathPtr: number, pathLen: number, _maxBytes: number): bigint {
+        const path = readBundlerString(pathPtr, pathLen);
+        const data = bundlerVfs?.get(path);
+        if (!data) return 0n;
+        return packBytes(data);
+      },
+
+      statFile(
+        pathPtr: number,
+        pathLen: number,
+        outSize: number,
+        outKind: number,
+        outMtimeLo: number,
+        outMtimeHi: number,
+      ): number {
+        const path = readBundlerString(pathPtr, pathLen);
+        const data = bundlerVfs?.get(path);
+        if (!data) return 1; // NotFound
+        const view = new DataView(bundler!.memory.buffer);
+        view.setBigUint64(outSize, BigInt(data.length), true);
+        new Uint8Array(bundler!.memory.buffer, outKind, 1)[0] = 0; // file
+        view.setBigUint64(outMtimeLo, 0n, true);
+        view.setBigUint64(outMtimeHi, 0n, true);
+        return 0; // ok
+      },
+
+      access(pathPtr: number, pathLen: number): number {
+        const path = readBundlerString(pathPtr, pathLen);
+        return bundlerVfs?.has(path) ? 0 : 1;
+      },
+
+      realpath(pathPtr: number, pathLen: number): bigint {
+        const path = readBundlerString(pathPtr, pathLen);
+        if (!bundlerVfs?.has(path)) return 0n;
+        // VFS 는 symlink 없음 — identity.
+        return packBytes(encoder.encode(path));
+      },
+
+      listDir(_pathPtr: number, _pathLen: number): bigint {
+        // PR 6-2c 후속 — Phase 2 minimal use case 에선 미사용.
+        return 0n;
+      },
+
+      hostFreeBytes(ptr: number, len: number): void {
+        bundler?.dealloc(ptr, len);
+      },
+    },
+  };
+}
+
+/// Bundler WASM (zts-bundler.wasm) 초기화. transpile init 와 별도 instance.
+/// vfs = host 가 제공하는 in-memory file system. bundler 가 fs syscall 시 위임.
+export async function initBundler(
+  vfs: VirtualFileSystem,
+  input?: URL | string | Request | Response | BufferSource | WebAssembly.Module,
+): Promise<void> {
+  if (bundler) return;
+  const source = await resolveWasmSource(input, "zts-bundler.wasm");
+
+  let memory: WebAssembly.Memory;
+  const imports = createBundlerImports(() => memory);
+  const instance = await instantiateWasm(source, imports);
+
+  memory = instance.exports.memory as WebAssembly.Memory;
+  bundler = instance.exports as unknown as BundlerExports;
+  bundlerVfs = vfs;
+}
+
+/// Bundler ABI version. host 가 호환성 체크용.
+export function bundlerVersion(): number {
+  if (!bundler) {
+    throw new Error("zts-wasm: bundler not initialized. Call initBundler() first.");
+  }
+  return bundler.bundler_version();
 }

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "files": [
     "dist/",
-    "zts.wasm"
+    "zts.wasm",
+    "zts-bundler.wasm"
   ],
   "type": "module",
   "main": "dist/index.js",
@@ -15,12 +16,13 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./zts.wasm": "./zts.wasm"
+    "./zts.wasm": "./zts.wasm",
+    "./zts-bundler.wasm": "./zts-bundler.wasm"
   },
   "scripts": {
-    "build:wasm": "cd ../.. && zig build wasm",
+    "build:wasm": "cd ../.. && zig build wasm && zig build wasm-bundler",
     "build:js": "bun build index.ts --outdir dist --format esm --target browser",
-    "build": "bun run build:wasm && cp ../../zig-out/bin/zts.wasm . && bun run build:js",
+    "build": "bun run build:wasm && cp ../../zig-out/bin/zts.wasm . && cp ../../zig-out/bin/zts-bundler.wasm . && bun run build:js",
     "test": "bun test"
   }
 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2017,7 +2017,6 @@ pub const Linker = struct {
         }
     }
 
-
     /// namespace preamble 변수명을 export 이름과 충돌하지 않도록 생성.
     /// "z" → "z_ns", 충돌 시 "z_ns2", "z_ns3", ...
     fn makeUniqueNsVarName(self: *const Linker, base: []const u8, exports: *const std.StringHashMap(void)) std.mem.Allocator.Error![]const u8 {


### PR DESCRIPTION
## Summary

#1885 Phase 2 의 JS bridge 인프라. PR 6-2c 의 \`build()\` 호출 + 통합 검증 전 단계.

PR 6-1 (Zig \`VirtualFS\` + \`zts_fs\` extern) 와 매칭되는 JS 측 구현.

## 변경

### \`packages/wasm/index.ts\`
- **\`VirtualFileSystem\` class** — \`Map<string, Uint8Array>\` wrapper. set/get/has/delete/clear/paths
- **\`createBundlerImports\`** — \`zts_fs\` namespace (readFile/statFile/access/realpath/listDir/hostFreeBytes), \`createWasiImports\` 확장
- **\`initBundler\`** — \`zts-bundler.wasm\` 별도 instance 로드 + VFS 주입
- **\`bundlerVersion\`** — ABI version stub (PR 6-2a 의 \`bundler_version\` export)
- **\`resolveWasmSource\` / \`instantiateWasm\` helper** 추출 — \`init\` / \`initBundler\` 공통 (/simplify)

### \`packages/wasm/index.test.ts\`
\`VirtualFileSystem\` 단위 테스트 5개 (set/get/has/delete/clear/paths/덮어쓰기).

### \`packages/wasm/package.json\`
\`exports\` + \`scripts\` 에 \`zts-bundler.wasm\` 추가. build 스크립트 = `wasm + wasm-bundler` 동시 빌드.

### \`documents/astro.config.mjs\`
\`vite.server.headers\` 에 COOP/COEP — dev 환경 SharedArrayBuffer. **prod (GitHub Pages) 는 헤더 set 불가** → \`coi-serviceworker\` 별도 PR.

## ABI 매칭 (PR 6-1 의 \`wasm_imports\`)

| API | JS 측 | 비고 |
|---|---|---|
| readFile | VFS lookup → \`packBytes\` (alloc + copy) | host 가 wasm 메모리에 buffer 만들어 packed u64 반환 |
| statFile | VFS lookup → 4 out param (size/kind=0/mtime=0) | VFS 는 file 만 (kind=0) |
| access | \`VFS.has\` → 0/1 | |
| realpath | \`VFS.has\` → identity (symlink 없음) | VFS = flat |
| listDir | \`0n\` | PR 6-2c 후속, minimal use case 미사용 |
| hostFreeBytes | \`bundler.dealloc\` | host alloc 한 buffer 해제 |

## /simplify 검토 반영

- \`resolveWasmSource\` / \`instantiateWasm\` helper 추출 (init/initBundler 14줄 중복 제거)
- \`TextEncoder\` 매 호출 → module-level encoder 재사용 (2곳)
- bundle size: 39.57 → **38.76 KB** (helper 추출 효과)

## Test plan

- [x] \`bun test\` 34 통과 (transpile 29 + VirtualFileSystem 5)
- [x] \`bun build index.ts --target browser\` 통과 (38.76 KB)

## 다음 단계

- **PR 6-2c**: \`wasm_bundler_entry.zig\` 의 \`build()\` export + \`bundler.bundle()\` 통합 + 실 동작 검증
- **별도**: \`coi-serviceworker\` (prod GitHub Pages 환경 SharedArrayBuffer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)