### PR TITLE
feat(wasm): bundler build() minimal export + JS bridge round-trip 검증 (#1885 Phase 2 PR 6-2c-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,11 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Build WASM
+      - name: Build WASM (transpile)
         run: zig build wasm
+
+      - name: Build WASM (bundler — #1885 Phase 2)
+        run: zig build wasm-bundler
 
       - name: Run WASM tests
         run: cd packages/wasm && bun test

--- a/build.zig
+++ b/build.zig
@@ -200,7 +200,10 @@ pub fn build(b: *std.Build) void {
         });
         wasm_bundler_exe.rdynamic = true;
         wasm_bundler_exe.entry = .disabled;
-        // Threading 활성: wasi-libc 의 pthread 활용 (wasm32-wasip1-threads 패턴).
+        // wasi-libc — Zig 0.15 wasm_allocator 가 multi-threaded 미지원이라
+        // c_allocator (musl thread-safe malloc) 필요. JS 측은 wasi_snapshot_preview1
+        // 의 모든 fn 을 stub 으로 제공 (createWasiImports 확장).
+        wasm_bundler_exe.linkLibC();
         wasm_bundler_exe.import_memory = true;
         wasm_bundler_exe.shared_memory = true;
         wasm_bundler_exe.max_memory = 4 * 1024 * 1024 * 1024; // 4 GiB

--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -1,7 +1,14 @@
 import { describe, test, expect, beforeAll } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
-import { initSync, transpile, VirtualFileSystem } from "./index";
+import {
+  initSync,
+  transpile,
+  VirtualFileSystem,
+  initBundler,
+  bundlerVersion,
+  build,
+} from "./index";
 
 beforeAll(() => {
   const wasmPath = join(import.meta.dir, "../../zig-out/bin/zts.wasm");
@@ -258,5 +265,38 @@ describe("VirtualFileSystem", () => {
     vfs.set("/x", "second");
     expect(new TextDecoder().decode(vfs.get("/x")!)).toBe("second");
     expect(vfs.size()).toBe(1);
+  });
+});
+
+// PR 6-2c-1 minimal build() — VFS readFile echo 검증 (zts_fs callback round-trip).
+// 실 bundler 호출은 PR 6-2c-2.
+describe("Bundler (minimal)", () => {
+  beforeAll(async () => {
+    const wasmPath = join(import.meta.dir, "../../zig-out/bin/zts-bundler.wasm");
+    const wasmBytes = readFileSync(wasmPath);
+    const vfs = new VirtualFileSystem();
+    vfs.set("/index.ts", "export const x = 42;");
+    vfs.set("/utils.ts", "export const greet = (n: string) => `hi ${n}`;");
+    await initBundler(vfs, wasmBytes);
+  });
+
+  test("bundlerVersion = ABI v1", () => {
+    expect(bundlerVersion()).toBe(1);
+  });
+
+  test("build: VFS entry → readFile echo (PR 6-2c-1)", () => {
+    const result = build("/index.ts");
+    expect(result).not.toBeNull();
+    expect(result?.code).toBe("export const x = 42;");
+  });
+
+  test("build: 다른 entry 도 동일 동작", () => {
+    const result = build("/utils.ts");
+    expect(result?.code).toBe("export const greet = (n: string) => `hi ${n}`;");
+  });
+
+  test("build: 존재하지 않는 entry → null", () => {
+    const result = build("/nonexistent.ts");
+    expect(result).toBeNull();
   });
 });

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -39,6 +39,11 @@ const decoder = new TextDecoder();
 // ─── 최소 WASI shim ───
 
 function createWasiImports(memory: () => WebAssembly.Memory) {
+  // bundler 빌드 (wasi-musl) 가 dispatch 하는 모든 wasi_snapshot_preview1 fn stub 제공.
+  // transpile 빌드는 일부 fn 만 호출 — 미호출 stub 은 link 영향 0.
+  // 대부분 stub 은 0 (errno_success) 반환 — bundler 가 실제 OS 의존 호출 안 한다는 가정.
+  const ok = () => 0;
+
   return {
     wasi_snapshot_preview1: {
       fd_write(fd: number, iovs_ptr: number, iovs_len: number, nwritten_ptr: number): number {
@@ -55,18 +60,17 @@ function createWasiImports(memory: () => WebAssembly.Memory) {
         mem.setUint32(nwritten_ptr, written, true);
         return 0;
       },
-      fd_read(): number {
-        return 8;
-      },
-      fd_seek(): number {
-        return 8;
-      },
-      fd_pwrite(): number {
-        return 8;
-      },
-      fd_filestat_get(): number {
-        return 8;
-      },
+      fd_read: ok,
+      fd_seek: ok,
+      fd_pwrite: ok,
+      fd_pread: ok,
+      fd_close: ok,
+      fd_fdstat_get: ok,
+      fd_fdstat_set_flags: ok,
+      fd_filestat_get: ok,
+      fd_prestat_get: () => 8, // BADF — 더 이상 prestat 없음
+      fd_prestat_dir_name: ok,
+      fd_sync: ok,
       random_get(buf_ptr: number, buf_len: number): number {
         const bytes = new Uint8Array(memory().buffer, buf_ptr, buf_len);
         if (typeof globalThis.crypto !== "undefined") {
@@ -88,6 +92,42 @@ function createWasiImports(memory: () => WebAssembly.Memory) {
         mem.setBigUint64(ts_ptr, ns, true);
         return 0;
       },
+      clock_res_get(_clock_id: number, ts_ptr: number): number {
+        const mem = new DataView(memory().buffer);
+        mem.setBigUint64(ts_ptr, 1_000_000n, true); // 1 ms resolution
+        return 0;
+      },
+      // args/environ — bundler 는 명시적 옵션 전달, args/env 미사용.
+      args_sizes_get(argc_ptr: number, argv_buf_size_ptr: number): number {
+        const mem = new DataView(memory().buffer);
+        mem.setUint32(argc_ptr, 0, true);
+        mem.setUint32(argv_buf_size_ptr, 0, true);
+        return 0;
+      },
+      args_get: ok,
+      environ_sizes_get(envc_ptr: number, env_buf_size_ptr: number): number {
+        const mem = new DataView(memory().buffer);
+        mem.setUint32(envc_ptr, 0, true);
+        mem.setUint32(env_buf_size_ptr, 0, true);
+        return 0;
+      },
+      environ_get: ok,
+      proc_exit(code: number): void {
+        throw new Error(`zts-wasm: proc_exit(${code})`);
+      },
+      sched_yield: ok,
+      poll_oneoff: ok,
+      // path_* — bundler 는 fs.zig 의 zts_fs callback 통과, wasi path_* 미호출.
+      // 단 wasi-musl 의 일부 함수 (e.g. realpath) 가 path_filestat_get 호출 시도 가능.
+      path_open: () => 8,
+      path_filestat_get: () => 8,
+      path_unlink_file: ok,
+      path_create_directory: ok,
+      path_remove_directory: ok,
+      path_rename: ok,
+      path_link: ok,
+      path_symlink: ok,
+      path_readlink: () => 8,
     },
   };
 }
@@ -269,27 +309,29 @@ export class VirtualFileSystem {
 }
 
 interface BundlerExports {
-  memory: WebAssembly.Memory;
   alloc(len: number): number;
   dealloc(ptr: number, len: number): void;
   bundler_version(): number;
-  // build() export 는 PR 6-2c
+  /// minimal build (PR 6-2c-1) — entry path → VFS readFile echo. 실제 bundler.bundle()
+  /// 호출은 PR 6-2c-2.
+  build(entryPathPtr: number, entryPathLen: number): bigint;
 }
 
 let bundler: BundlerExports | null = null;
+let bundlerMemory: WebAssembly.Memory | null = null;
 let bundlerVfs: VirtualFileSystem | null = null;
 
 function readBundlerString(ptr: number, len: number): string {
-  return decoder.decode(new Uint8Array(bundler!.memory.buffer, ptr, len));
+  return decoder.decode(new Uint8Array(bundlerMemory!.buffer, ptr, len));
 }
 
 /// host 가 wasm 메모리에 buffer 확보 + 데이터 복사 → packed (ptr<<32 | len) 반환.
 /// 0 = error sentinel (alloc 실패 또는 미존재).
 function packBytes(data: Uint8Array): bigint {
-  if (!bundler) return 0n;
+  if (!bundler || !bundlerMemory) return 0n;
   const ptr = bundler.alloc(data.length);
   if (ptr === 0) return 0n;
-  new Uint8Array(bundler.memory.buffer, ptr, data.length).set(data);
+  new Uint8Array(bundlerMemory.buffer, ptr, data.length).set(data);
   return (BigInt(ptr) << 32n) | BigInt(data.length);
 }
 
@@ -316,9 +358,9 @@ function createBundlerImports(memory: () => WebAssembly.Memory) {
         const path = readBundlerString(pathPtr, pathLen);
         const data = bundlerVfs?.get(path);
         if (!data) return 1; // NotFound
-        const view = new DataView(bundler!.memory.buffer);
+        const view = new DataView(bundlerMemory!.buffer);
         view.setBigUint64(outSize, BigInt(data.length), true);
-        new Uint8Array(bundler!.memory.buffer, outKind, 1)[0] = 0; // file
+        new Uint8Array(bundlerMemory!.buffer, outKind, 1)[0] = 0; // file
         view.setBigUint64(outMtimeLo, 0n, true);
         view.setBigUint64(outMtimeHi, 0n, true);
         return 0; // ok
@@ -357,12 +399,24 @@ export async function initBundler(
   if (bundler) return;
   const source = await resolveWasmSource(input, "zts-bundler.wasm");
 
-  let memory: WebAssembly.Memory;
-  const imports = createBundlerImports(() => memory);
+  // wasm32-wasi + threads features → shared_memory 강제 → env.memory import 필요.
+  // wasi-musl libc 가 stack/heap 위해 ~257 page 요구 — 1024 (64 MiB) initial 로 여유.
+  // 65536 page = 4 GiB max (build.zig:max_memory 와 일치).
+  const memory = new WebAssembly.Memory({
+    initial: 1024,
+    maximum: 65536,
+    shared: true,
+  });
+
+  const bundlerImports = createBundlerImports(() => memory);
+  const imports: WebAssembly.Imports = {
+    ...bundlerImports,
+    env: { memory },
+  };
   const instance = await instantiateWasm(source, imports);
 
-  memory = instance.exports.memory as WebAssembly.Memory;
   bundler = instance.exports as unknown as BundlerExports;
+  bundlerMemory = memory;
   bundlerVfs = vfs;
 }
 
@@ -372,4 +426,34 @@ export function bundlerVersion(): number {
     throw new Error("zts-wasm: bundler not initialized. Call initBundler() first.");
   }
   return bundler.bundler_version();
+}
+
+export interface BundleResult {
+  code: string;
+}
+
+/// PR 6-2c-1 minimal build — VFS 의 entry path 읽어 contents 그대로 반환 (echo).
+/// 실제 bundler.bundle() 호출은 PR 6-2c-2 — 그때 multi-file + chunk + manualChunks 지원.
+export function build(entryPath: string): BundleResult | null {
+  if (!bundler || !bundlerMemory) {
+    throw new Error("zts-wasm: bundler not initialized. Call initBundler() first.");
+  }
+
+  const entryBytes = encoder.encode(entryPath);
+  const entryPtr = bundler.alloc(entryBytes.length);
+  if (entryPtr === 0) throw new Error("zts-wasm: bundler alloc failed");
+  new Uint8Array(bundlerMemory.buffer, entryPtr, entryBytes.length).set(entryBytes);
+
+  try {
+    const packed = bundler.build(entryPtr, entryBytes.length);
+    if (packed === 0n) return null;
+
+    const outPtr = Number(packed >> 32n);
+    const outLen = Number(packed & 0xffffffffn);
+    const code = decoder.decode(new Uint8Array(bundlerMemory.buffer, outPtr, outLen));
+    bundler.dealloc(outPtr, outLen);
+    return { code };
+  } finally {
+    bundler.dealloc(entryPtr, entryBytes.length);
+  }
 }

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -68,7 +68,9 @@ function createWasiImports(memory: () => WebAssembly.Memory) {
       fd_fdstat_get: ok,
       fd_fdstat_set_flags: ok,
       fd_filestat_get: ok,
-      fd_prestat_get: () => 8, // BADF — 더 이상 prestat 없음
+      // EBADF (8) 반환 — wasi-musl libc 가 "valid fd 없음" 으로 처리 후 fallback. 0 반환
+      // 시 musl 이 gibberish 메모리 read 시도 → panic. EBADF 가 안전.
+      fd_prestat_get: () => 8,
       fd_prestat_dir_name: ok,
       fd_sync: ok,
       random_get(buf_ptr: number, buf_len: number): number {
@@ -117,8 +119,9 @@ function createWasiImports(memory: () => WebAssembly.Memory) {
       },
       sched_yield: ok,
       poll_oneoff: ok,
-      // path_* — bundler 는 fs.zig 의 zts_fs callback 통과, wasi path_* 미호출.
-      // 단 wasi-musl 의 일부 함수 (e.g. realpath) 가 path_filestat_get 호출 시도 가능.
+      // path_* — bundler 는 fs.zig 의 zts_fs callback 통과, 정상 경로에선 wasi path_*
+      // 미호출. 단 wasi-musl 의 일부 함수 (e.g. realpath) 가 path_filestat_get 호출
+      // 시도 가능 → EBADF 로 fallback. ok 반환 (0) 하면 gibberish 메모리 read panic.
       path_open: () => 8,
       path_filestat_get: () => 8,
       path_unlink_file: ok,

--- a/packages/wasm/src/wasm_bundler_entry.zig
+++ b/packages/wasm/src/wasm_bundler_entry.zig
@@ -3,18 +3,52 @@
 //! wasm32-wasip1-threads 타겟용 — bundler 전용. transpile-only 빌드 (wasm_entry.zig)
 //! 와 분리해서 brower 호환성/번들 사이즈 트레이드오프 분리.
 //!
-//! Phase 2 PR 6-2a 단계: 컴파일 검증만. build() export 는 PR 6-2c.
+//! PR 6-2c-1: minimal build() — JS bridge (zts_fs callback round-trip) 검증.
+//! 실제 bundler.bundle() 호출은 PR 6-2c-2.
 
 const std = @import("std");
 const zts_lib = @import("zts_lib");
+const fs = zts_lib.bundler.fs;
 
 pub const panic = zts_lib.crash_handler.panic;
 
-const wasm_alloc = std.heap.wasm_allocator;
+// Zig 0.15 의 wasm_allocator 는 multi-threaded 미지원 (page_allocator 도 내부 wasm_allocator
+// 사용) — wasi-musl 의 c_allocator (thread-safe malloc) 사용. JS 측은 wasi_snapshot_preview1
+// 의 모든 fn 을 stub 으로 제공.
+const wasm_alloc = std.heap.c_allocator;
 
-// 컴파일 검증용 — bundler 가 wasm32-wasip1-threads 환경에서 link 가능한지 확인.
-// PR 6-2c 에서 진짜 build() 호출 + 인자/결과 ABI 구현.
+// wasi-musl libc 가 `main` 심볼 강제 — entry=.disabled (reactor 모드) 와 충돌.
+// 미호출 stub 으로 link 통과.
+pub fn main() void {}
+
+/// Bundler ABI version. host 가 호환성 체크용.
 export fn bundler_version() u32 {
-    // Phase 2 의 ABI version stub — 호스트 측 호환성 체크용.
     return 1;
+}
+
+/// JS 측이 entry path 등 입력 메모리 확보용.
+export fn alloc(len: u32) u32 {
+    if (len == 0) return 0;
+    const slice = wasm_alloc.alloc(u8, len) catch return 0;
+    return @intCast(@intFromPtr(slice.ptr));
+}
+
+export fn dealloc(ptr: u32, len: u32) void {
+    if (ptr == 0 or len == 0) return;
+    const slice: [*]u8 = @ptrFromInt(ptr);
+    wasm_alloc.free(slice[0..len]);
+}
+
+/// PR 6-2c-1 minimal build() — VFS entry path 받아 fs.readFile 통과 (zts_fs callback)
+/// → contents 직접 반환 (echo). bundler.bundle() 호출은 PR 6-2c-2.
+///
+/// ABI: 반환 packed u64 (ptr<<32 | len), 0 = error. caller (JS) 가 dealloc 책임.
+export fn build(entry_path_ptr: u32, entry_path_len: u32) u64 {
+    if (entry_path_ptr == 0 or entry_path_len == 0) return 0;
+    const entry_path: []const u8 = @as([*]const u8, @ptrFromInt(entry_path_ptr))[0..entry_path_len];
+
+    const loaded = fs.readFile(wasm_alloc, entry_path, 100 * 1024 * 1024) catch return 0;
+    const out_ptr: u32 = @intCast(@intFromPtr(loaded.contents.ptr));
+    const out_len: u32 = @intCast(loaded.contents.len);
+    return (@as(u64, out_ptr) << 32) | @as(u64, out_len);
 }


### PR DESCRIPTION
## Summary

Phase 2 핵심 — JS host ↔ WASM bundler 의 \`zts_fs\` callback round-trip 동작 검증. 실제 \`bundler.bundle()\` 호출은 PR 6-2c-2.

**핵심 검증**:
\`\`\`
VFS.set("/foo.ts", "...")
→ build("/foo.ts")
→ wasm bundler_entry.build()
→ fs.readFile (Zig)
→ zts_fs.readFile callback (JS)
→ VFS.get → packed result
→ wasm → JS decode
→ { code: "..." }
\`\`\`

## 변경

### \`packages/wasm/src/wasm_bundler_entry.zig\`
- \`c_allocator\` (wasi-musl malloc, thread-safe) — Zig 0.15 \`wasm_allocator\` 가 multi-threaded 미지원
- \`main()\` stub — wasi-musl libc 가 main 심볼 강제
- \`alloc\` / \`dealloc\` export — JS 측 메모리 관리
- \`build(entry_path_ptr, len)\` export — \`fs.readFile\` 통과 echo

### \`build.zig\`
- \`wasm-bundler\` 에 \`linkLibC()\` 추가 (wasi-musl)

### \`packages/wasm/index.ts\`
- **\`createWasiImports\` 확장** — wasi-musl 의존 fn 풀 stub (args/environ/proc_exit/fd_*/path_*/sched_yield/poll_oneoff)
- \`BundlerExports\` 갱신 + \`bundlerMemory\` 별도 보관 (\`import_memory\` 라 \`instance.exports.memory\` undefined)
- \`initBundler\` 가 SharedArrayBuffer 기반 \`WebAssembly.Memory\` 생성 + \`env.memory\` import
- \`build()\` API — entry path → packed result decode

### \`packages/wasm/index.test.ts\`
- 통합 테스트 4개: bundlerVersion / build (file 1, file 2) / null

## 검증

- [x] \`zig build wasm-bundler\` 통과 — zts-bundler.wasm 5.5 KB
- [x] \`bun test\` 38 통과 (transpile 29 + VFS 5 + **Bundler 4**)
- [x] JS bridge round-trip 동작
- [x] zts_fs.readFile callback 정확히 호출됨

## 디자인 노트

**wasi-musl 의존 이유**: Zig 0.15 의 \`wasm_allocator\` (page_allocator 도 동일) 가 multi-threaded wasm 미지원. \`wasm32-wasi-musl\` + \`linkLibC\` 로 thread-safe \`malloc\` 사용.

**WASI shim**: bundler 가 wasi-musl libc 의존 → wasi_snapshot_preview1 의 다수 fn 호출. JS 측 stub (대부분 \`return 0\`) 으로 link 통과. bundler 가 실제 OS 의존 호출 안 한다는 가정.

**SharedArrayBuffer**: \`shared_memory=true\` + \`import_memory=true\` → JS 측이 \`WebAssembly.Memory({ shared: true })\` 생성, \`env.memory\` 로 import.

## 다음 단계

- **PR 6-2c-2**: \`wasm_bundler_entry.build()\` 가 \`bundler.Bundler.init + bundle()\` 진짜 호출. 호환성 검증 — \`Thread.Pool\`, \`fs.zig\` 의존, 기타 bundler 코드 wasm-musl link
- **별도**: \`coi-serviceworker\` (prod GitHub Pages SharedArrayBuffer)
- **별도**: \`zts-bundler.wasm\` size 측정 (#1899 와 결합 — bundler 진짜 link 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)