### PR TITLE
feat(bundler): wasm-bundler 빌드 호환성 (#1885 Phase 2 PR 6-2c-2a)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -14,6 +14,7 @@
 const std = @import("std");
 const plugin_mod = @import("plugin.zig");
 const types = @import("types.zig");
+const fs = @import("fs.zig");
 const BundlerDiagnostic = types.BundlerDiagnostic;
 const ModuleIndex = types.ModuleIndex;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
@@ -675,12 +676,12 @@ pub const Bundler = struct {
             const init_core_rel = "node_modules/react-native/Libraries/Core/InitializeCore.js";
 
             auto_init_core_path = blk: {
-                // entry_dir 기준 탐색
+                // entry_dir 기준 탐색 → fs.realpath 통과 (#1885: VirtualFS 호환)
                 const full = std.fs.path.join(self.allocator, &.{ entry_dir, init_core_rel }) catch break :blk null;
                 defer self.allocator.free(full);
-                if (std.fs.cwd().realpathAlloc(self.allocator, full)) |real| break :blk real else |_| {}
+                if (fs.realpath(self.allocator, full)) |real| break :blk real else |_| {}
                 // CWD 기준 탐색
-                break :blk std.fs.cwd().realpathAlloc(self.allocator, init_core_rel) catch null;
+                break :blk fs.realpath(self.allocator, init_core_rel) catch null;
             };
 
             if (auto_init_core_path) |init_path| {
@@ -913,13 +914,14 @@ pub const Bundler = struct {
             const raw = blk2: {
                 const full_path = std.fs.path.join(self.allocator, &.{ entry_dir, dev_path }) catch break :blk;
                 defer self.allocator.free(full_path);
-                if (std.fs.cwd().realpathAlloc(self.allocator, full_path)) |real| {
+                // fs.realpath / fs.readFile 통과 → wasm VirtualFS 호환 (#1885 Phase 2).
+                if (fs.realpath(self.allocator, full_path)) |real| {
                     defer self.allocator.free(real);
-                    if (std.fs.cwd().readFileAlloc(self.allocator, real, 1024 * 1024)) |r| break :blk2 r else |_| {}
+                    if (fs.readFile(self.allocator, real, 1024 * 1024)) |r| break :blk2 r.contents else |_| {}
                 } else |_| {}
-                if (std.fs.cwd().realpathAlloc(self.allocator, dev_path)) |real| {
+                if (fs.realpath(self.allocator, dev_path)) |real| {
                     defer self.allocator.free(real);
-                    if (std.fs.cwd().readFileAlloc(self.allocator, real, 1024 * 1024)) |r| break :blk2 r else |_| {}
+                    if (fs.readFile(self.allocator, real, 1024 * 1024)) |r| break :blk2 r.contents else |_| {}
                 } else |_| {}
                 std.log.warn("zts: react-refresh not found — install react-refresh for HMR", .{});
                 break :blk;

--- a/src/bundler/fs.zig
+++ b/src/bundler/fs.zig
@@ -252,9 +252,10 @@ pub const VirtualFS = struct {
     }
 
     pub fn listDir(_: VirtualFS, _: std.mem.Allocator, _: []const u8) FsError![]DirEntry {
-        // Phase 2 후속 — JSON 파싱 비용 회피 위해 minimal use case 에선 제외.
-        // require.context / glob import 사용 시 channel 통과.
-        @compileError("VirtualFS.listDir: Phase 2 후속 — host JSON ABI 미구현");
+        // Phase 2 minimal — require.context / glob import 미사용 가정. 빈 slice 반환으로
+        // 호출처 (graph.expandRequireContextRecords 등) 가 silent fallback.
+        // 후속 PR 에서 host JSON ABI 추가 시 실 구현.
+        return &.{};
     }
 };
 

--- a/src/bundler/module_list.zig
+++ b/src/bundler/module_list.zig
@@ -70,7 +70,8 @@ pub fn StableSegmentedList(comptime T: type) type {
 
             // Lazy shelf alloc (shelf 당 최대 1회). len 증가 전에 write 완료 → race-free.
             if (self.shelves[shelf_idx] == null) {
-                const shelf_size = @as(usize, 1) << shelf_idx;
+                // wasm32 (32-bit usize) 에서 shift amount type 이 u5 — @intCast 로 truncate.
+                const shelf_size = @as(usize, 1) << @intCast(shelf_idx);
                 const buf = try allocator.alloc(T, shelf_size);
                 self.shelves[shelf_idx] = buf.ptr;
             }
@@ -137,7 +138,7 @@ pub fn StableSegmentedList(comptime T: type) type {
 
         inline fn boxInShelf(list_index: usize, shelf_idx: ShelfIndex) usize {
             // inner = list_index - (2^shelf_idx - 1)
-            return list_index + 1 - (@as(usize, 1) << shelf_idx);
+            return list_index + 1 - (@as(usize, 1) << @intCast(shelf_idx));
         }
     };
 }


### PR DESCRIPTION
## Summary

Phase 2 의 wasm-bundler 빌드 차단 호환성 fix. PR 6-2c-2c 에서 \`build()\` 가 \`bundler.bundle()\` 진짜 호출하기 위한 prerequisite.

bundler 가 wasm-bundler (wasm32-wasi-musl + threads) 환경에서 컴파일 가능하도록.

## 변경

### \`bundler.zig\`
- react-refresh 자동 주입 경로 (line 917, 921) 의 \`std.fs.cwd().realpathAlloc + readFileAlloc\` → \`fs.realpath + fs.readFile\` (VirtualFS 호환)

### \`fs.zig\`
- \`VirtualFS.listDir\` 의 \`@compileError\` → 빈 slice placeholder
- require.context / glob import 미사용 가정 (Phase 2 minimal). 후속 PR 에서 host JSON ABI 추가 시 실 구현

### \`module_list.zig\`
- shift amount 가 wasm32 (u5) 와 native (u6) 다름 → \`@intCast\` 추가 (line 73, 141)

## Test plan
- [x] \`zig build test / napi / wasm / wasm-bundler\` 모두 통과

## 다음 단계 (남은 호환성)

- **PR 6-2c-2b**: \`wasm_allocator\` 호출처 fix (\`bundler.bundle()\` 호출 시 발견 — std lib 어딘가)
- **PR 6-2c-2c**: \`wasm_bundler_entry build()\` 가 \`bundler.bundle()\` 진짜 호출 + 통합 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)