### PR TITLE
fix(bundler): resolve_cache 가 fallback disabled 결과 무시 (#1885)

### DIFF
--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -397,6 +397,18 @@ pub const ResolveCache = struct {
             if (thread_safe) self.cache_mutex.lock();
             defer if (thread_safe) self.cache_mutex.unlock();
 
+            // resolver 가 `--fallback:NAME=false` (또는 다른 disabled 경로) 로 빈 모듈을
+            // 반환한 경우 — disabled variant 로 캐싱 + 반환. 이 분기 없이는 `.file` 로
+            // cache 되어 graph 단계에서 일반 파싱 시도 → "No loader configured" 에러.
+            if (result.disabled) {
+                const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
+                self.putCache(cache_key, .{ .resolved = .{ .disabled = .{
+                    .path = cache_path,
+                    .module_type = result.module_type,
+                } } }) catch {};
+                return disabledResult(result.path, result.module_type);
+            }
+
             if (self.platform.isBrowserLike()) {
                 const override = self.getBrowserOverride(result.path);
                 switch (override) {


### PR DESCRIPTION
## Summary
- `--fallback:NAME=false` 가 ReleaseFast 빌드에서 깨지던 회귀 fix
- main CI (`Integration & E2E`) 의 `tests/resolve-fallback.test.ts > --fallback:NAME=false` 실패 원인
- `resolve_cache.resolveInner` 가 `result.disabled = true` 를 무시하고 항상 `.file` variant 로 cache → graph 가 일반 모듈로 파싱 시도 → "No loader is configured" 에러
- `result.disabled` 분기를 추가해서 `.disabled` variant 로 cache + 반환

## Background
이 회귀는 release-only 라서 debug 빌드 (`zig build test`) 와 로컬 통합 테스트 (debug) 에선 통과. CI 가 `-Doptimize=ReleaseFast` 로 빌드해서 노출됨. #1885 시리즈와 무관 — 이전부터 존재했지만 최근 PR (#1885 PR 6-2c-2a, 6-2c-2b) 머지 후 CI 가 이 테스트를 실행하면서 발견.

## Test plan
- [x] `tests/integration/tests/resolve-fallback.test.ts` (ReleaseFast) 6/6 통과
- [x] `zig build test` 전체 통과
- [x] `bun test --cwd tests/integration` 3317/3323 통과 (4 skip / 2 todo / 0 fail)
- [x] `zig build wasm-bundler` + wasm 테스트 38/38 통과

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)