### PR TITLE
feat(wasm): bundler build() 가 bundler.bundle() 실 호출 (#1885 PR 6-2c-2c)

### DIFF
--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -268,8 +268,8 @@ describe("VirtualFileSystem", () => {
   });
 });
 
-// PR 6-2c-1 minimal build() — VFS readFile echo 검증 (zts_fs callback round-trip).
-// 실 bundler 호출은 PR 6-2c-2.
+// PR 6-2c-2c — bundler.Bundler.init + bundle() 실 호출 + VFS round-trip.
+// esm/browser 단일 entry. 출력은 단일 파일 모드 (result.output) — 모듈 wrap + TS strip.
 describe("Bundler (minimal)", () => {
   beforeAll(async () => {
     const wasmPath = join(import.meta.dir, "../../zig-out/bin/zts-bundler.wasm");
@@ -284,15 +284,21 @@ describe("Bundler (minimal)", () => {
     expect(bundlerVersion()).toBe(1);
   });
 
-  test("build: VFS entry → readFile echo (PR 6-2c-1)", () => {
+  test("build: 단일 entry → bundle 코드 (TS 어노테이션 strip + 모듈 wrap)", () => {
     const result = build("/index.ts");
     expect(result).not.toBeNull();
-    expect(result?.code).toBe("export const x = 42;");
+    // 번들러는 entry 모듈을 wrap 해서 single bundle 로 emit.
+    // 정확한 wrap 형식은 bundler 구현에 종속 — 핵심 시맨틱만 검증.
+    expect(result?.code).toContain("const x = 42;");
+    expect(result?.code).toContain("export { x }");
   });
 
-  test("build: 다른 entry 도 동일 동작", () => {
+  test("build: TS 어노테이션 (`: string`) 이 strip 됨", () => {
     const result = build("/utils.ts");
-    expect(result?.code).toBe("export const greet = (n: string) => `hi ${n}`;");
+    expect(result).not.toBeNull();
+    expect(result?.code).not.toContain(": string");
+    expect(result?.code).toContain("greet");
+    expect(result?.code).toContain("`hi ${n}`");
   });
 
   test("build: 존재하지 않는 entry → null", () => {

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -132,6 +132,12 @@ function createWasiImports(memory: () => WebAssembly.Memory) {
       path_symlink: ok,
       path_readlink: () => 8,
     },
+    // wasi-libc 의 pthread_create 가 dispatch — single-thread 환경 (Node/Bun) 에선
+    // -1 (ENOSYS) 반환 → bundler 의 std.Thread.spawn 이 single-thread fallback.
+    // Worker 활용은 Phase 3 (#1885).
+    wasi: {
+      "thread-spawn": () => -1,
+    },
   };
 }
 
@@ -315,8 +321,8 @@ interface BundlerExports {
   alloc(len: number): number;
   dealloc(ptr: number, len: number): void;
   bundler_version(): number;
-  /// minimal build (PR 6-2c-1) — entry path → VFS readFile echo. 실제 bundler.bundle()
-  /// 호출은 PR 6-2c-2.
+  /// PR 6-2c-2c — entry path 로 실제 bundler.Bundler.init + bundle() 호출 후
+  /// result.output (단일 파일 모드 번들 코드) 반환. 0 = error 또는 빈 출력.
   build(entryPathPtr: number, entryPathLen: number): bigint;
 }
 
@@ -435,8 +441,10 @@ export interface BundleResult {
   code: string;
 }
 
-/// PR 6-2c-1 minimal build — VFS 의 entry path 읽어 contents 그대로 반환 (echo).
-/// 실제 bundler.bundle() 호출은 PR 6-2c-2 — 그때 multi-file + chunk + manualChunks 지원.
+/// PR 6-2c-2c minimal build — VFS entry path 로 bundler.Bundler.init + bundle() 호출 후
+/// 단일 파일 번들 코드 (`result.output`) 반환. esm/browser 고정. multi-entry / chunk /
+/// manualChunks / sourcemap 옵션은 후속 PR.
+/// 빈 출력 또는 실패 시 null.
 export function build(entryPath: string): BundleResult | null {
   if (!bundler || !bundlerMemory) {
     throw new Error("zts-wasm: bundler not initialized. Call initBundler() first.");

--- a/packages/wasm/src/wasm_bundler_entry.zig
+++ b/packages/wasm/src/wasm_bundler_entry.zig
@@ -3,12 +3,13 @@
 //! wasm32-wasip1-threads 타겟용 — bundler 전용. transpile-only 빌드 (wasm_entry.zig)
 //! 와 분리해서 brower 호환성/번들 사이즈 트레이드오프 분리.
 //!
-//! PR 6-2c-1: minimal build() — JS bridge (zts_fs callback round-trip) 검증.
-//! 실제 bundler.bundle() 호출은 PR 6-2c-2.
+//! PR 6-2c-2c: build() 가 bundler.Bundler.init + bundle() 진짜 호출.
 
 const std = @import("std");
 const zts_lib = @import("zts_lib");
-const fs = zts_lib.bundler.fs;
+const bundler_mod = zts_lib.bundler;
+const Bundler = bundler_mod.Bundler;
+const BundleOptions = bundler_mod.BundleOptions;
 
 pub const panic = zts_lib.crash_handler.panic;
 
@@ -39,16 +40,41 @@ export fn dealloc(ptr: u32, len: u32) void {
     wasm_alloc.free(slice[0..len]);
 }
 
-/// PR 6-2c-1 minimal build() — VFS entry path 받아 fs.readFile 통과 (zts_fs callback)
-/// → contents 직접 반환 (echo). bundler.bundle() 호출은 PR 6-2c-2.
+/// PR 6-2c-2c build() — VFS entry path 로 bundler.Bundler.init + bundle() 실 호출.
+/// Phase 2 minimal: 단일 entry, 기본 옵션 (esm/browser). 옵션 JSON / multi-entry /
+/// chunk 출력은 후속 PR.
 ///
-/// ABI: 반환 packed u64 (ptr<<32 | len), 0 = error. caller (JS) 가 dealloc 책임.
+/// ABI: 반환 packed u64 (ptr<<32 | len), 0 = error 또는 빈 출력. caller (JS) 가 dealloc 책임.
+/// 결과 = single bundle code string (result.output — 단일 파일 모드).
 export fn build(entry_path_ptr: u32, entry_path_len: u32) u64 {
     if (entry_path_ptr == 0 or entry_path_len == 0) return 0;
     const entry_path: []const u8 = @as([*]const u8, @ptrFromInt(entry_path_ptr))[0..entry_path_len];
 
-    const loaded = fs.readFile(wasm_alloc, entry_path, 100 * 1024 * 1024) catch return 0;
-    const out_ptr: u32 = @intCast(@intFromPtr(loaded.contents.ptr));
-    const out_len: u32 = @intCast(loaded.contents.len);
+    // arena 일괄 해제 — Bundler/BundleResult 내부 자료구조 모두 arena_alloc 소유.
+    // CLAUDE.md "Arena 안 리소스 개별 deinit 금지" 패턴.
+    var arena = std.heap.ArenaAllocator.init(wasm_alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const entry_dupe = arena_alloc.dupe(u8, entry_path) catch return 0;
+    const entry_points: []const []const u8 = &.{entry_dupe};
+
+    const options: BundleOptions = .{
+        .entry_points = entry_points,
+        .format = .esm,
+        .platform = .browser,
+    };
+
+    var bundler = Bundler.init(arena_alloc, options);
+    const result = bundler.bundle() catch return 0;
+
+    // 단일 entry / 비-splitting 경로: result.output 사용 (outputs 는 code-splitting 시).
+    const code = result.output;
+    if (code.len == 0) return 0;
+
+    // arena.deinit() 후에도 caller (JS) 가 읽도록 wasm_alloc 으로 별도 dupe.
+    const out = wasm_alloc.dupe(u8, code) catch return 0;
+    const out_ptr: u32 = @intCast(@intFromPtr(out.ptr));
+    const out_len: u32 = @intCast(out.len);
     return (@as(u64, out_ptr) << 32) | @as(u64, out_len);
 }


### PR DESCRIPTION
## Summary
- PR 6-2c-1 의 minimal echo 구현을 실제 `bundler.Bundler.bundle()` 호출로 교체
- `wasm-bundler` 가 JS 측 `VirtualFileSystem` 위에서 단일 entry → single-file 번들 코드 emit
- esm/browser 고정. multi-entry / chunk / manualChunks / sourcemap 옵션은 후속 PR

## 주요 변경
- `wasm_bundler_entry.zig`: `build()` 가 ArenaAllocator + Bundler.init + bundle() 호출. result.output (단일 파일 모드) 반환
- `index.ts`: `wasi.thread-spawn` stub 을 `createWasiImports()` 안으로 이동. bundler 의 `std.Thread.spawn` 이 단일 스레드 환경에서 -1 (ENOSYS) 받아 single-thread fallback
- `index.test.ts`: echo 검증 → 실제 번들 출력 검증 (TS strip + 모듈 wrap)
- CLAUDE.md "Arena 안 리소스 개별 deinit 금지" 패턴 준수

## Dependencies
- 머지 순서: #1945 (resolve_cache fallback fix) → 본 PR. 본 PR 자체는 #1945 변경 사용 안 하지만, main CI 가 #1945 머지 전에는 항상 빨간 상태라 본 PR CI 도 빨강.

## Test plan
- [x] `zig build wasm-bundler` 통과
- [x] `bun test packages/wasm/index.test.ts` 38/38 pass
  - 단일 entry → bundle 코드 (TS 어노테이션 strip + 모듈 wrap) ✓
  - TS 어노테이션 (`: string`) 이 strip 됨 ✓
  - 존재하지 않는 entry → null ✓

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)