### PR TITLE
feat(wasm): WASM 빌드 사이즈 측정 + 분리 전략 문서화 (#1885 PR 7, Closes #1899)

### DIFF
--- a/docs/BUNDLER.md
+++ b/docs/BUNDLER.md
@@ -263,3 +263,19 @@ Zig 코어 (parser + transformer + codegen)
 - **도입 시점**: Phase 6 초반에 C ABI 노출 → N-API 바인딩 → npm 패키지 → 플러그인 래퍼
 - **핵심**: N-API 바인딩 하나만 만들면 Vite/Webpack/Rollup 플러그인은 JS 래퍼 수십 줄
 - esbuild, SWC가 동일한 구조로 생태계 확장에 성공한 검증된 패턴
+
+## WASM 빌드 사이즈 (#1885 / #1899)
+
+WASM 모듈은 **transpile-only** 와 **bundler** 두 binary 로 분리해서 빌드한다 — bundler 는 graph/resolver/linker + wasi-libc (thread support) 가 포함되어 ~1.7배 크기.
+playground 가 trans pile-only 모드에선 작은 binary 만 다운로드, bundler 모드 진입 시 lazy 로드 (`initBundler()`) — 두 함수가 별도 entry point 라 자연 lazy.
+
+`zig build wasm wasm-bundler` (둘 다 `.optimize = .ReleaseSmall`) 후 `bun scripts/measure-wasm-size.ts` 로 측정한 사이즈:
+
+| Target | Role | Raw | Gzip (-9) | Brotli (q=11) |
+|---|---|---:|---:|---:|
+| `zts.wasm` | transpile-only | 908.5 KiB | 321.0 KiB | 250.0 KiB |
+| `zts-bundler.wasm` | bundler | 1.57 MiB | 512.6 KiB | 393.7 KiB |
+
+- 분리 결정: 단일 binary (1.57 MiB) 면 transpile-only playground 도 풀 bundler 다운로드 강제 → 분리 우위. 후속 wasm-opt (binaryen) 적용 시 추가 10-30% 절감 가능 (별도 follow-up).
+- `playground/bundler` 페이지에서만 `initBundler()` 호출 → bundler binary 가 lazy 로드.
+- 회귀 추적: `bun scripts/measure-wasm-size.ts` 를 빌드 후 실행. CI 통합은 후속 PR.

--- a/scripts/measure-wasm-size.ts
+++ b/scripts/measure-wasm-size.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+/**
+ * #1899 — WASM bundle size 측정 + 분리 빌드 결과 보고.
+ *
+ * `zig-out/bin/zts.wasm` (transpile-only) 와 `zts-bundler.wasm` (bundler) 의
+ * raw / gzip / brotli 사이즈를 측정해서 마크다운 표로 출력. CI 또는 로컬에서
+ * 사이즈 회귀 추적용.
+ *
+ * 사용법:
+ *   zig build wasm wasm-bundler -Doptimize=ReleaseSmall
+ *   bun scripts/measure-wasm-size.ts
+ */
+
+import { readFileSync, statSync, existsSync } from "node:fs";
+import { gzipSync, brotliCompressSync, constants as zlibConst } from "node:zlib";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const targets = [
+  { name: "zts.wasm", role: "transpile-only", path: "zig-out/bin/zts.wasm" },
+  { name: "zts-bundler.wasm", role: "bundler", path: "zig-out/bin/zts-bundler.wasm" },
+];
+
+const fmt = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+};
+
+let missingAny = false;
+const rows = targets.map((t) => {
+  const abs = join(repoRoot, t.path);
+  if (!existsSync(abs)) {
+    missingAny = true;
+    return { ...t, raw: 0, gzip: 0, brotli: 0, missing: true };
+  }
+  const buf = readFileSync(abs);
+  const raw = statSync(abs).size;
+  const gzip = gzipSync(buf, { level: 9 }).length;
+  const brotli = brotliCompressSync(buf, {
+    params: { [zlibConst.BROTLI_PARAM_QUALITY]: 11 },
+  }).length;
+  return { ...t, raw, gzip, brotli, missing: false };
+});
+
+console.log("| Target | Role | Raw | Gzip (-9) | Brotli (q=11) |");
+console.log("|---|---|---:|---:|---:|");
+for (const r of rows) {
+  if (r.missing) {
+    console.log(`| \`${r.name}\` | ${r.role} | _missing — run \`zig build wasm wasm-bundler\`_ | | |`);
+    continue;
+  }
+  console.log(`| \`${r.name}\` | ${r.role} | ${fmt(r.raw)} | ${fmt(r.gzip)} | ${fmt(r.brotli)} |`);
+}
+
+if (missingAny) {
+  console.error("\n[error] one or more wasm artifacts missing — build with `zig build wasm wasm-bundler`");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- `#1899` 결론 정리 — transpile/bundler 두 binary 분리 + lazy 로드 (이미 PR 6-2a 부터 구현)
- 사이즈 회귀 추적 스크립트 추가 (`bun scripts/measure-wasm-size.ts`)
- `docs/BUNDLER.md` 에 WASM 빌드 사이즈 섹션 + 측정 결과 + 분리 결정 배경 명시

## 측정 결과 (ReleaseSmall)
| Target | Role | Raw | Gzip (-9) | Brotli (q=11) |
|---|---|---:|---:|---:|
| `zts.wasm` | transpile-only | 908.5 KiB | 321.0 KiB | 250.0 KiB |
| `zts-bundler.wasm` | bundler | 1.57 MiB | 512.6 KiB | 393.7 KiB |

## 분리 결정 근거
- 단일 binary 면 transpile-only playground 도 풀 bundler 다운로드 강제 → 분리 우위
- `init()` (transpile) / `initBundler()` (bundler) 가 별도 entry 라 자연 lazy
- bundler binary 가 1.7배 큰 이유: graph/resolver/linker + wasi-libc (thread support)

## Follow-up (별도)
- wasm-opt (binaryen) post-processing — 추가 10-30% 절감 추정
- CI 사이즈 회귀 가드

## Test plan
- [x] `zig build wasm wasm-bundler -Doptimize=ReleaseSmall` 통과
- [x] `bun scripts/measure-wasm-size.ts` 표 출력 확인
- [x] missing artifact 케이스에서 exit 1 + stderr 안내

Closes #1899
Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)