### PR TITLE
feat(playground): bundler 페이지 + multi-file 입력 UI (#1885 Phase 3 PR 8)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,15 +40,14 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Build WASM
-        run: zig build wasm
+      - name: Build WASM (transpile + bundler)
+        run: zig build wasm wasm-bundler
 
       - name: Install dependencies
         run: bun install
 
-      - name: Copy WASM to public
-        run: cp zig-out/bin/zts.wasm documents/public/zts-core.wasm
-
+      # documents/package.json 의 prebuild 가 zig-out/bin/zts.wasm + zts-bundler.wasm 을
+      # public/ 으로 복사 — playground (transpile) + playground/bundler 둘 다 동작.
       - name: Build docs
         run: cd documents && bun run build
 

--- a/documents/.gitignore
+++ b/documents/.gitignore
@@ -19,6 +19,8 @@ pnpm-debug.log*
 
 # WASM (빌드 시 복사됨)
 public/zts-core.wasm
+public/zts.wasm
+public/zts-bundler.wasm
 
 # macOS-specific files
 .DS_Store

--- a/documents/package.json
+++ b/documents/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "prebuild": "cp ../zig-out/bin/zts-core.wasm public/zts-core.wasm 2>/dev/null || true",
-    "predev": "cp ../zig-out/bin/zts-core.wasm public/zts-core.wasm 2>/dev/null || true",
+    "prebuild": "cp ../zig-out/bin/zts.wasm public/zts.wasm 2>/dev/null && cp ../zig-out/bin/zts-bundler.wasm public/zts-bundler.wasm 2>/dev/null; true",
+    "predev": "cp ../zig-out/bin/zts.wasm public/zts.wasm 2>/dev/null && cp ../zig-out/bin/zts-bundler.wasm public/zts-bundler.wasm 2>/dev/null; true",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/documents/src/components/Playground.tsx
+++ b/documents/src/components/Playground.tsx
@@ -1,6 +1,14 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import Editor from "@monaco-editor/react";
 import type { TranspileResult } from "../../../packages/shared/index";
+import {
+  BTN_CLASS,
+  Badge,
+  EditorPanel,
+  SELECT_BTN_CLASS,
+  editorOpts as sharedEditorOpts,
+  inferLanguage,
+} from "./playground-shared";
 
 const EXAMPLES: { label: string; code: string }[] = [
   {
@@ -280,7 +288,7 @@ export default function Playground() {
       try {
         const mod = await import("../../../packages/wasm/index.ts");
         const base = "/zts/";
-        const wasmUrl = new URL(`${base}zts-core.wasm`, window.location.origin);
+        const wasmUrl = new URL(`${base}zts.wasm`, window.location.origin);
         await mod.init(wasmUrl);
         transpileFnRef.current = mod.transpile;
         setLoading(false);
@@ -367,27 +375,8 @@ export default function Playground() {
     }, 100);
   }
 
-  const inputLang =
-    options.filename.endsWith(".ts") || options.filename.endsWith(".tsx")
-      ? "typescript"
-      : "javascript";
-
-  const editorOpts = {
-    minimap: { enabled: false },
-    fontSize: 13,
-    fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
-    fontLigatures: false,
-    lineNumbers: "on" as const,
-    scrollBeyondLastLine: false,
-    wordWrap: "on" as const,
-    tabSize: 2,
-    automaticLayout: true,
-    padding: { top: 8, bottom: 8 },
-    renderLineHighlight: "none" as const,
-    overviewRulerLanes: 0,
-    hideCursorInOverviewRuler: true,
-    scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
-  };
+  const inputLang = inferLanguage(options.filename);
+  const editorOpts = sharedEditorOpts;
 
   return (
     <div
@@ -402,7 +391,7 @@ export default function Playground() {
           <a href="/zts/" className="text-sm font-bold text-neutral-200 no-underline">
             ZTS Playground
           </a>
-          {loading && <Badge variant="loading" />}
+          {loading && <Badge variant="loading" text="Loading WASM..." />}
           {!loading && !error && <Badge variant="ready" />}
         </div>
         <div className="flex items-center gap-2">
@@ -509,23 +498,6 @@ export default function Playground() {
   );
 }
 
-const BTN_BASE =
-  "cursor-pointer rounded border border-surface-800 bg-transparent text-[13px] text-neutral-200 no-underline transition-colors hover:border-zig-500 hover:text-zig-400";
-const BTN_CLASS = `${BTN_BASE} px-3 py-1`;
-const SELECT_BTN_CLASS = `${BTN_BASE} px-2 py-1`;
-
-function Badge({ variant }: { variant: "loading" | "ready" }) {
-  const { tone, text } =
-    variant === "loading"
-      ? { tone: "bg-sky-950 text-sky-300", text: "Loading WASM..." }
-      : { tone: "bg-emerald-950 text-emerald-300", text: "Ready" };
-  return (
-    <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${tone}`}>
-      {text}
-    </span>
-  );
-}
-
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="mb-3">
@@ -573,17 +545,6 @@ function Txt({ label, value, placeholder, onChange }: { label: string; value: st
         onChange={(e) => onChange(e.target.value)}
         className={`${FIELD_CLASS} w-[130px]`}
       />
-    </div>
-  );
-}
-
-function EditorPanel({ header, children }: { header: React.ReactNode; children: React.ReactNode }) {
-  return (
-    <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center border-b border-surface-800 bg-surface-900 px-3 py-1.5 text-[12px] font-semibold text-neutral-400">
-        {header}
-      </div>
-      <div className="flex-1">{children}</div>
     </div>
   );
 }

--- a/documents/src/components/PlaygroundBundler.tsx
+++ b/documents/src/components/PlaygroundBundler.tsx
@@ -1,0 +1,374 @@
+/**
+ * PlaygroundBundler — `/playground/bundler` 라우트 메인 컴포넌트.
+ *
+ * transpile playground 와 분리: 별도 wasm binary (`zts-bundler.wasm`) lazy 로드,
+ * 멀티파일 입력 (좌측 사이드바 + Monaco model swap), 단일 output editor.
+ *
+ * `bundler.build(entry)` 호출은 esm/browser 고정 — 옵션 패널은 ABI 가 옵션 JSON
+ * 받도록 확장된 후 활성화.
+ */
+import { useEffect, useRef, useState } from "react";
+import Editor from "@monaco-editor/react";
+import {
+  BTN_CLASS,
+  Badge,
+  EditorPanel,
+  SELECT_BTN_CLASS,
+  editorOpts,
+  inferLanguage,
+} from "./playground-shared";
+
+interface VfsFile {
+  path: string;
+  content: string;
+  language: "typescript" | "javascript";
+}
+
+const PRESETS: { label: string; entry: string; files: VfsFile[] }[] = [
+  {
+    label: "기본 — entry + utils",
+    entry: "/index.ts",
+    files: [
+      {
+        path: "/index.ts",
+        language: "typescript",
+        content: `import { greet } from "./utils";
+
+const user = { name: "ZTS" };
+console.log(greet(user.name));
+`,
+      },
+      {
+        path: "/utils.ts",
+        language: "typescript",
+        content: `export const greet = (name: string): string => \`Hello, \${name}!\`;
+`,
+      },
+    ],
+  },
+  {
+    label: "TypeScript 단일 파일",
+    entry: "/main.ts",
+    files: [
+      {
+        path: "/main.ts",
+        language: "typescript",
+        content: `interface Counter {
+  value: number;
+  increment(): void;
+}
+
+export const counter: Counter = {
+  value: 0,
+  increment() {
+    this.value += 1;
+  },
+};
+`,
+      },
+    ],
+  },
+];
+
+type WasmModule = typeof import("../../../packages/wasm/index.ts");
+
+// 매 키스트로크 = 번들 호출. 큰 파일에서 input lag 방지 (transpile 보다 비싸).
+const BUNDLE_DEBOUNCE_MS = 200;
+
+const BASE_URL = (import.meta.env.BASE_URL ?? "/").replace(/\/?$/, "/");
+
+export default function PlaygroundBundler() {
+  const [files, setFiles] = useState<VfsFile[]>(PRESETS[0].files);
+  const [activePath, setActivePath] = useState<string>(PRESETS[0].entry);
+  const [entryPath, setEntryPath] = useState<string>(PRESETS[0].entry);
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [showSidebar, setShowSidebar] = useState(true);
+  const wasmRef = useRef<WasmModule | null>(null);
+  const vfsRef = useRef<InstanceType<WasmModule["VirtualFileSystem"]> | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function runBundle(nextFiles: VfsFile[], entry: string) {
+    const wasm = wasmRef.current;
+    const vfs = vfsRef.current;
+    if (!wasm || !vfs) return;
+
+    vfs.clear();
+    for (const f of nextFiles) vfs.set(f.path, f.content);
+
+    try {
+      const result = wasm.build(entry);
+      if (result === null) {
+        setOutput("");
+        setError(`Bundle failed — entry "${entry}" 가 빈 출력을 반환했거나 해석 실패`);
+        return;
+      }
+      setOutput(result.code);
+      setError("");
+    } catch (err) {
+      setOutput("");
+      setError(String(err));
+    }
+  }
+
+  function scheduleBundle(nextFiles: VfsFile[], entry: string) {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => runBundle(nextFiles, entry), BUNDLE_DEBOUNCE_MS);
+  }
+
+  useEffect(() => {
+    // Init 한 번만 — files/entryPath 변경은 핸들러에서 직접 scheduleBundle 호출.
+    (async () => {
+      try {
+        const mod = await import("../../../packages/wasm/index.ts");
+        const wasmUrl = new URL(`${BASE_URL}zts-bundler.wasm`, window.location.origin);
+        const vfs = new mod.VirtualFileSystem();
+        for (const f of files) vfs.set(f.path, f.content);
+        await mod.initBundler(vfs, wasmUrl);
+        wasmRef.current = mod;
+        vfsRef.current = vfs;
+        setLoading(false);
+        runBundle(files, entryPath);
+      } catch (err) {
+        setError(`WASM bundler load failed: ${err}`);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const activeFile = files.find((f) => f.path === activePath) ?? files[0];
+
+  function handleEditorChange(value: string | undefined) {
+    const code = value ?? "";
+    const next = files.map((f) => (f.path === activePath ? { ...f, content: code } : f));
+    setFiles(next);
+    scheduleBundle(next, entryPath);
+  }
+
+  function handleAddFile() {
+    let i = 1;
+    while (files.some((f) => f.path === `/file${i}.ts`)) i += 1;
+    const path = `/file${i}.ts`;
+    const next = [...files, { path, content: "", language: inferLanguage(path) }];
+    setFiles(next);
+    setActivePath(path);
+    runBundle(next, entryPath);
+  }
+
+  function handleRenameFile(oldPath: string) {
+    if (typeof window === "undefined") return;
+    const newPath = window.prompt("새 파일 경로", oldPath)?.trim();
+    if (!newPath || newPath === oldPath) return;
+    if (files.some((f) => f.path === newPath)) return;
+    const next = files.map((f) =>
+      f.path === oldPath ? { ...f, path: newPath, language: inferLanguage(newPath) } : f,
+    );
+    const nextEntry = entryPath === oldPath ? newPath : entryPath;
+    setFiles(next);
+    setActivePath(newPath);
+    if (nextEntry !== entryPath) setEntryPath(nextEntry);
+    runBundle(next, nextEntry);
+  }
+
+  function handleDeleteFile(path: string) {
+    if (files.length <= 1) return;
+    const next = files.filter((f) => f.path !== path);
+    const nextActive = activePath === path ? next[0].path : activePath;
+    const nextEntry = entryPath === path ? next[0].path : entryPath;
+    setFiles(next);
+    if (nextActive !== activePath) setActivePath(nextActive);
+    if (nextEntry !== entryPath) setEntryPath(nextEntry);
+    runBundle(next, nextEntry);
+  }
+
+  function handleSetEntry(path: string) {
+    setEntryPath(path);
+    runBundle(files, path);
+  }
+
+  function handlePreset(label: string) {
+    const preset = PRESETS.find((p) => p.label === label);
+    if (!preset) return;
+    setFiles(preset.files);
+    setActivePath(preset.entry);
+    setEntryPath(preset.entry);
+    runBundle(preset.files, preset.entry);
+  }
+
+  return (
+    <div
+      className="not-content playground-root flex flex-col overflow-hidden bg-surface-950"
+      style={{ height: "calc(100vh - 64px)" }}
+    >
+      <div className="flex shrink-0 items-center justify-between border-b border-surface-800 bg-surface-900 px-4 py-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setShowSidebar(!showSidebar)}
+            className={BTN_CLASS}
+            aria-label="Toggle file panel"
+          >
+            {showSidebar ? "◀" : "▶"}
+          </button>
+          <a href={`${BASE_URL}playground/`} className="text-sm font-bold text-neutral-200 no-underline">
+            ZTS Bundler Playground
+          </a>
+          {loading && <Badge variant="loading" text="Loading bundler..." />}
+          {!loading && !error && <Badge variant="ready" />}
+          {!loading && error && <Badge variant="error" />}
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            aria-label="Preset"
+            onChange={(e) => {
+              if (e.target.value) handlePreset(e.target.value);
+              e.target.value = "";
+            }}
+            defaultValue=""
+            className={SELECT_BTN_CLASS}
+          >
+            <option value="" disabled>
+              예제 선택…
+            </option>
+            {PRESETS.map((p) => (
+              <option key={p.label} value={p.label}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+          <a href={`${BASE_URL}playground/`} className={BTN_CLASS}>
+            Transpile 모드
+          </a>
+          <a
+            href="https://github.com/ohah/zts"
+            target="_blank"
+            rel="noreferrer"
+            className={BTN_CLASS}
+          >
+            GitHub
+          </a>
+        </div>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {showSidebar && (
+          <div className="w-56 min-w-[14rem] shrink-0 overflow-y-auto border-r border-surface-800 bg-surface-900 p-2 text-[13px]">
+            <div className="mb-2 flex items-center justify-between border-b border-surface-800 pb-1">
+              <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-neutral-400">
+                Files
+              </span>
+              <button type="button" onClick={handleAddFile} className={`${BTN_CLASS} px-2`}>
+                + Add
+              </button>
+            </div>
+            <ul className="flex flex-col gap-0.5">
+              {files.map((f) => {
+                const isActive = f.path === activePath;
+                const isEntry = f.path === entryPath;
+                return (
+                  <li key={f.path}>
+                    <div
+                      className={`flex items-center justify-between rounded px-2 py-1 ${
+                        isActive
+                          ? "bg-surface-800 text-neutral-100"
+                          : "text-neutral-300 hover:bg-surface-800/50"
+                      }`}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => setActivePath(f.path)}
+                        className="flex-1 cursor-pointer truncate bg-transparent text-left"
+                        title={f.path}
+                      >
+                        {isEntry && <span className="mr-1 text-zig-400">●</span>}
+                        {f.path}
+                      </button>
+                      <div className="ml-2 flex shrink-0 items-center gap-1 opacity-60 hover:opacity-100">
+                        {!isEntry && (
+                          <button
+                            type="button"
+                            onClick={() => handleSetEntry(f.path)}
+                            className="cursor-pointer bg-transparent text-[11px] text-neutral-400 hover:text-zig-400"
+                            title="Set as entry"
+                          >
+                            entry
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => handleRenameFile(f.path)}
+                          className="cursor-pointer bg-transparent text-[11px] text-neutral-400 hover:text-neutral-200"
+                          title="Rename"
+                        >
+                          ✎
+                        </button>
+                        {files.length > 1 && (
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteFile(f.path)}
+                            className="cursor-pointer bg-transparent text-[11px] text-neutral-400 hover:text-red-400"
+                            title="Delete"
+                          >
+                            ✕
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="mt-3 border-t border-surface-800 pt-2 text-[11px] text-neutral-500">
+              <p className="mb-1">
+                <span className="text-zig-400">●</span> = entry point
+              </p>
+              <p>esm / browser 고정 (Phase 2)</p>
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-1 overflow-hidden">
+          <EditorPanel
+            header={
+              <span>
+                Input <span className="text-[11px] opacity-50">{activeFile.path}</span>
+              </span>
+            }
+          >
+            <Editor
+              height="100%"
+              path={activeFile.path}
+              language={activeFile.language}
+              theme="vs-dark"
+              value={activeFile.content}
+              onChange={handleEditorChange}
+              options={editorOpts}
+            />
+          </EditorPanel>
+          <div className="w-[2px] shrink-0 bg-surface-800" />
+          <EditorPanel
+            header={
+              <div className="flex w-full items-center justify-between">
+                <span>Bundle Output</span>
+                {error && <span className="text-[11px] text-red-400">Error</span>}
+              </div>
+            }
+          >
+            <Editor
+              height="100%"
+              language={error ? "plaintext" : "javascript"}
+              theme="vs-dark"
+              value={error || output}
+              options={{ ...editorOpts, readOnly: true }}
+            />
+          </EditorPanel>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/documents/src/components/playground-bundler-mount.ts
+++ b/documents/src/components/playground-bundler-mount.ts
@@ -1,0 +1,10 @@
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import PlaygroundBundler from "./PlaygroundBundler";
+
+const root =
+  document.getElementById("playground-bundler-mount") ||
+  document.getElementById("playground-mount");
+if (root) {
+  createRoot(root).render(createElement(PlaygroundBundler));
+}

--- a/documents/src/components/playground-shared.tsx
+++ b/documents/src/components/playground-shared.tsx
@@ -1,0 +1,59 @@
+/**
+ * Playground 컴포넌트 공유 헬퍼 — transpile + bundler 두 페이지에서 사용.
+ */
+import type { ReactNode } from "react";
+
+export const BTN_BASE =
+  "cursor-pointer rounded border border-surface-800 bg-transparent text-[13px] text-neutral-200 no-underline transition-colors hover:border-zig-500 hover:text-zig-400";
+export const BTN_CLASS = `${BTN_BASE} px-3 py-1`;
+export const SELECT_BTN_CLASS = `${BTN_BASE} px-2 py-1`;
+
+export const editorOpts = {
+  minimap: { enabled: false },
+  fontSize: 13,
+  fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
+  fontLigatures: false,
+  lineNumbers: "on" as const,
+  scrollBeyondLastLine: false,
+  wordWrap: "on" as const,
+  tabSize: 2,
+  automaticLayout: true,
+  padding: { top: 8, bottom: 8 },
+  renderLineHighlight: "none" as const,
+  overviewRulerLanes: 0,
+  hideCursorInOverviewRuler: true,
+  scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
+};
+
+export type BadgeVariant = "loading" | "ready" | "error";
+
+const BADGE_TONES: Record<BadgeVariant, { tone: string; defaultText: string }> = {
+  loading: { tone: "bg-sky-950 text-sky-300", defaultText: "Loading..." },
+  ready: { tone: "bg-emerald-950 text-emerald-300", defaultText: "Ready" },
+  error: { tone: "bg-red-950 text-red-300", defaultText: "Error" },
+};
+
+export function Badge({ variant, text }: { variant: BadgeVariant; text?: string }) {
+  const { tone, defaultText } = BADGE_TONES[variant];
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${tone}`}>
+      {text ?? defaultText}
+    </span>
+  );
+}
+
+export function EditorPanel({ header, children }: { header: ReactNode; children: ReactNode }) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center border-b border-surface-800 bg-surface-900 px-3 py-1.5 text-[12px] font-semibold text-neutral-400">
+        {header}
+      </div>
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}
+
+/// 파일 확장자로 Monaco language ID 추론.
+export function inferLanguage(path: string): "typescript" | "javascript" {
+  return /\.(ts|tsx|mts|cts)$/.test(path) ? "typescript" : "javascript";
+}

--- a/documents/src/pages/playground/bundler.astro
+++ b/documents/src/pages/playground/bundler.astro
@@ -1,0 +1,38 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+---
+<StarlightPage
+  frontmatter={{
+    title: "Bundler Playground",
+    description: "브라우저에서 ZTS 번들러를 직접 사용해보세요. 멀티파일 입력, 모듈 wrap 출력 시연.",
+    tableOfContents: false,
+    pagefind: false,
+    template: "splash",
+  }}
+>
+  <div id="playground-bundler-mount" class="not-content" style="min-height: calc(100vh - 200px);"></div>
+  <script>
+    import('../../components/playground-bundler-mount.ts');
+  </script>
+</StarlightPage>
+
+<style>
+  /* Bundler Playground: content 패딩/타이틀 제거 — Playground.astro 와 동일 */
+  :global(.playground-page .content-panel) {
+    padding: 0 !important;
+  }
+  :global(.playground-page h1) {
+    display: none !important;
+  }
+  :global(.playground-page .sl-markdown-content) {
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+  :global(.playground-page .pagination-links) {
+    display: none !important;
+  }
+</style>
+
+<script is:inline>
+  document.documentElement.classList.add('playground-page');
+</script>


### PR DESCRIPTION
## Summary
- `/playground/bundler` 신규 — transpile playground (`/playground`) 와 분리된 페이지
- 멀티파일 입력 UI (좌측 VSCode 스타일 사이드바 + Monaco model swap) + 단일 bundle output editor
- `zts-bundler.wasm` (513 KiB gzip) 페이지 진입 시 lazy 로드
- preset 2 개: 멀티파일 (entry + utils), 단일 파일
- 매 키스트로크 후 200ms debounce → bundler 호출

## 신규 파일
- `documents/src/components/PlaygroundBundler.tsx` — 메인 컴포넌트
- `documents/src/components/playground-bundler-mount.ts` — createRoot
- `documents/src/components/playground-shared.tsx` — `BTN_*`, `Badge`, `EditorPanel`, `editorOpts`, `inferLanguage` 공통 헬퍼 (기존 `Playground.tsx` 도 사용 — ~60 줄 중복 제거)
- `documents/src/pages/playground/bundler.astro` — 라우트

## CI / 빌드 변경
- `.github/workflows/docs.yml`: `zig build wasm` → `zig build wasm wasm-bundler`. 기존 `Copy WASM to public` step 제거 — `documents/package.json prebuild` 로 통합
- `documents/package.json`: prebuild/predev 가 `zts.wasm` + `zts-bundler.wasm` 복사 (기존엔 `zts-core.wasm` 만 silent fail)
- `documents/.gitignore`: 신규 wasm 항목 추가
- `Playground.tsx` wasmUrl: `zts-core.wasm` → `zts.wasm` (prebuild 동기화)

## 후속
- PR 9: chunk output viewer + manualChunks UI (ABI 확장 후)
- PR 10: external + 데모 시나리오 fixture

## Test plan
- [x] `cd documents && bun run build` 347 페이지 통과 (`/playground` + `/playground/bundler` 둘 다 생성)
- [x] prebuild 가 `zts.wasm` + `zts-bundler.wasm` 복사 확인 (md5 매칭)
- [ ] dev 서버 브라우저 동작 확인 — 사용자 검증 권장 (헤드리스 한계)
  - `/playground/bundler` 접속, "Loading bundler..." → "Ready"
  - preset 변경 시 multi-file → bundle output 갱신
  - editor 입력 시 200ms 후 bundle 갱신
  - file add/rename/delete/set-entry 동작
  - "Transpile 모드" 링크 → `/playground` 정상 작동

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)