### PR TITLE
fix(playground): bundler SharedArrayBuffer decode + Transpile→Bundler 진입 링크 (#1885)

### DIFF
--- a/documents/src/components/Playground.tsx
+++ b/documents/src/components/Playground.tsx
@@ -411,6 +411,9 @@ export default function Playground() {
             ))}
           </select>
           <button type="button" onClick={handleShare} className={BTN_CLASS}>Share</button>
+          <a href={`${(import.meta.env.BASE_URL ?? "/").replace(/\/?$/, "/")}playground/bundler/`} className={BTN_CLASS}>
+            Bundler 모드
+          </a>
           <a href="https://github.com/ohah/zts" target="_blank" rel="noreferrer" className={BTN_CLASS}>
             GitHub
           </a>

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -331,7 +331,11 @@ let bundlerMemory: WebAssembly.Memory | null = null;
 let bundlerVfs: VirtualFileSystem | null = null;
 
 function readBundlerString(ptr: number, len: number): string {
-  return decoder.decode(new Uint8Array(bundlerMemory!.buffer, ptr, len));
+  // bundlerMemory 는 SharedArrayBuffer (threads features 로 shared:true). 해당 view 를
+  // 그대로 TextDecoder.decode 에 전달하면 브라우저가 거부 ("must not be shared") —
+  // .slice() 로 새 ArrayBuffer 복사 후 decode.
+  const view = new Uint8Array(bundlerMemory!.buffer, ptr, len);
+  return decoder.decode(view.slice());
 }
 
 /// host 가 wasm 메모리에 buffer 확보 + 데이터 복사 → packed (ptr<<32 | len) 반환.
@@ -461,7 +465,9 @@ export function build(entryPath: string): BundleResult | null {
 
     const outPtr = Number(packed >> 32n);
     const outLen = Number(packed & 0xffffffffn);
-    const code = decoder.decode(new Uint8Array(bundlerMemory.buffer, outPtr, outLen));
+    // SharedArrayBuffer view 는 TextDecoder.decode 가 거부 — .slice() 로 복사.
+    const view = new Uint8Array(bundlerMemory.buffer, outPtr, outLen);
+    const code = decoder.decode(view.slice());
     bundler.dealloc(outPtr, outLen);
     return { code };
   } finally {


### PR DESCRIPTION
## Summary
PR #1948 (PR 8) 머지 후 follow-up 두 건:

### 1. SharedArrayBuffer + TextDecoder 호환성 (CRITICAL — 페이지 깨짐)
- bundler WASM 메모리는 `shared: true` 라 buffer 가 `SharedArrayBuffer`. view 를 그대로 `TextDecoder.decode()` 에 전달하면 브라우저가 `TypeError: ... must not be shared` 로 거부.
- 사용자 보고: \`TypeError: Failed to execute 'decode' on 'TextDecoder': The provided ArrayBufferView value must not be shared.\`
- 두 곳 fix: `packages/wasm/index.ts` 의 `readBundlerString` + `build()` output decode → `view.slice()` 로 새 ArrayBuffer 복사 후 decode

### 2. Transpile → Bundler 진입 링크 누락
- 기존엔 URL 직접 쳐야 bundler playground 진입 가능
- `Playground.tsx` 상단 toolbar 에 "Bundler 모드" 링크 추가

## Test plan
- [x] `bun test packages/wasm/index.test.ts` 38/38 pass (Bun TextDecoder 는 shared 도 받음 → 회귀 없음)
- [ ] 브라우저: `https://ohah.github.io/zts/playground/bundler/` 에서 preset 로드 후 bundle 코드 emit 확인
- [ ] 브라우저: `/playground` 의 "Bundler 모드" 버튼 → `/playground/bundler` 이동 확인

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)