### PR TITLE
feat(wasm): bundler ABI 옵션 JSON 확장 — format/platform/external/minify (#1885 PR 9-1)

### DIFF
--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -280,8 +280,8 @@ describe("Bundler (minimal)", () => {
     await initBundler(vfs, wasmBytes);
   });
 
-  test("bundlerVersion = ABI v1", () => {
-    expect(bundlerVersion()).toBe(1);
+  test("bundlerVersion = ABI v2 (옵션 JSON 인자 추가)", () => {
+    expect(bundlerVersion()).toBe(2);
   });
 
   test("build: 단일 entry → bundle 코드 (TS 어노테이션 strip + 모듈 wrap)", () => {
@@ -304,5 +304,43 @@ describe("Bundler (minimal)", () => {
   test("build: 존재하지 않는 entry → null", () => {
     const result = build("/nonexistent.ts");
     expect(result).toBeNull();
+  });
+
+  test("build: format=cjs 옵션 → CJS prologue (`use strict`) 추가", () => {
+    const esmOut = build("/index.ts", { format: "esm" });
+    const cjsOut = build("/index.ts", { format: "cjs" });
+    expect(cjsOut).not.toBeNull();
+    // CJS 모드는 `"use strict"` prologue 를 자동 추가 (esm 은 미추가).
+    expect(cjsOut?.code).toContain('"use strict"');
+    expect(esmOut?.code).not.toContain('"use strict"');
+  });
+
+  test("build: minifyWhitespace 옵션 → 공백 압축", () => {
+    const baseline = build("/utils.ts");
+    const minified = build("/utils.ts", { minifyWhitespace: true });
+    expect(baseline).not.toBeNull();
+    expect(minified).not.toBeNull();
+    // 압축 시 baseline 보다 작거나 같음 (보통 작음).
+    expect(minified!.code.length).toBeLessThan(baseline!.code.length);
+  });
+
+  test("build: minify shorthand → whitespace + identifiers + syntax 모두 활성", () => {
+    const baseline = build("/utils.ts");
+    const minified = build("/utils.ts", { minify: true });
+    expect(minified).not.toBeNull();
+    expect(minified!.code.length).toBeLessThan(baseline!.code.length);
+  });
+
+  test("build: 잘못된 옵션 값 (unknown format) → 무시 + 기본값 사용", () => {
+    // Zig 측 parseFormat 가 unknown 이면 default (.esm) 유지.
+    const result = build("/index.ts", { format: "made-up" as any });
+    expect(result).not.toBeNull();
+    expect(result?.code).toContain("export { x }");
+  });
+
+  test("build: 미지원 옵션 필드 → ignore (forward compat)", () => {
+    // ignore_unknown_fields=true 이라 신규 필드는 silent skip.
+    const result = build("/index.ts", { someFutureOption: 42 } as any);
+    expect(result).not.toBeNull();
   });
 });

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -321,9 +321,15 @@ interface BundlerExports {
   alloc(len: number): number;
   dealloc(ptr: number, len: number): void;
   bundler_version(): number;
-  /// PR 6-2c-2c — entry path 로 실제 bundler.Bundler.init + bundle() 호출 후
+  /// entry path + 옵션 JSON 으로 bundler.Bundler.init + bundle() 호출 후
   /// result.output (단일 파일 모드 번들 코드) 반환. 0 = error 또는 빈 출력.
-  build(entryPathPtr: number, entryPathLen: number): bigint;
+  /// options_json_ptr=0 이면 기본 옵션 (esm/browser).
+  build(
+    entryPathPtr: number,
+    entryPathLen: number,
+    optionsJsonPtr: number,
+    optionsJsonLen: number,
+  ): bigint;
 }
 
 let bundler: BundlerExports | null = null;
@@ -331,7 +337,11 @@ let bundlerMemory: WebAssembly.Memory | null = null;
 let bundlerVfs: VirtualFileSystem | null = null;
 
 function readBundlerString(ptr: number, len: number): string {
-  return decoder.decode(new Uint8Array(bundlerMemory!.buffer, ptr, len));
+  // bundlerMemory 는 SharedArrayBuffer (threads features 로 shared:true). 해당 view 를
+  // 그대로 TextDecoder.decode 에 전달하면 브라우저가 거부 ("must not be shared") —
+  // .slice() 로 새 ArrayBuffer 복사 후 decode.
+  const view = new Uint8Array(bundlerMemory!.buffer, ptr, len);
+  return decoder.decode(view.slice());
 }
 
 /// host 가 wasm 메모리에 buffer 확보 + 데이터 복사 → packed (ptr<<32 | len) 반환.
@@ -441,11 +451,26 @@ export interface BundleResult {
   code: string;
 }
 
-/// PR 6-2c-2c minimal build — VFS entry path 로 bundler.Bundler.init + bundle() 호출 후
-/// 단일 파일 번들 코드 (`result.output`) 반환. esm/browser 고정. multi-entry / chunk /
-/// manualChunks / sourcemap 옵션은 후속 PR.
-/// 빈 출력 또는 실패 시 null.
-export function build(entryPath: string): BundleResult | null {
+/// build() 가 받는 옵션. ZTS bundler 의 BundleOptions 의 minimal subset —
+/// 후속 PR 에서 sourcemap / target / jsx 등 추가.
+export interface BundleOptionsInput {
+  /// 출력 모듈 형식. 기본 "esm".
+  format?: "esm" | "cjs" | "iife";
+  /// 타겟 플랫폼. 기본 "browser". import.meta polyfill / Node 빌트인 처리 등 영향.
+  platform?: "browser" | "node" | "neutral" | "react-native";
+  /// 외부 처리할 모듈 specifier 목록 (와일드카드 `*` 지원).
+  external?: string[];
+  /// minify shorthand — true 면 whitespace/identifiers/syntax 모두 활성화.
+  /// 개별 옵션이 명시되면 그게 우선.
+  minify?: boolean;
+  minifyWhitespace?: boolean;
+  minifyIdentifiers?: boolean;
+  minifySyntax?: boolean;
+}
+
+/// VFS entry path + 옵션으로 bundler 호출 후 단일 파일 번들 코드 반환.
+/// 옵션 미전달 시 esm/browser 기본. 빈 출력 또는 실패 시 null.
+export function build(entryPath: string, options?: BundleOptionsInput): BundleResult | null {
   if (!bundler || !bundlerMemory) {
     throw new Error("zts-wasm: bundler not initialized. Call initBundler() first.");
   }
@@ -455,16 +480,41 @@ export function build(entryPath: string): BundleResult | null {
   if (entryPtr === 0) throw new Error("zts-wasm: bundler alloc failed");
   new Uint8Array(bundlerMemory.buffer, entryPtr, entryBytes.length).set(entryBytes);
 
+  let optsPtr = 0;
+  let optsLen = 0;
+  if (options) {
+    // minify shorthand 펼치기 — 개별 옵션이 명시되어 있으면 그게 우선.
+    const expanded = { ...options };
+    if (expanded.minify) {
+      expanded.minifyWhitespace = expanded.minifyWhitespace ?? true;
+      expanded.minifyIdentifiers = expanded.minifyIdentifiers ?? true;
+      expanded.minifySyntax = expanded.minifySyntax ?? true;
+    }
+    delete expanded.minify;
+    const json = JSON.stringify(expanded);
+    const optsBytes = encoder.encode(json);
+    optsPtr = bundler.alloc(optsBytes.length);
+    if (optsPtr === 0) {
+      bundler.dealloc(entryPtr, entryBytes.length);
+      throw new Error("zts-wasm: bundler alloc failed");
+    }
+    new Uint8Array(bundlerMemory.buffer, optsPtr, optsBytes.length).set(optsBytes);
+    optsLen = optsBytes.length;
+  }
+
   try {
-    const packed = bundler.build(entryPtr, entryBytes.length);
+    const packed = bundler.build(entryPtr, entryBytes.length, optsPtr, optsLen);
     if (packed === 0n) return null;
 
     const outPtr = Number(packed >> 32n);
     const outLen = Number(packed & 0xffffffffn);
-    const code = decoder.decode(new Uint8Array(bundlerMemory.buffer, outPtr, outLen));
+    // SharedArrayBuffer view 는 TextDecoder.decode 가 거부 — .slice() 로 복사.
+    const view = new Uint8Array(bundlerMemory.buffer, outPtr, outLen);
+    const code = decoder.decode(view.slice());
     bundler.dealloc(outPtr, outLen);
     return { code };
   } finally {
     bundler.dealloc(entryPtr, entryBytes.length);
+    if (optsPtr) bundler.dealloc(optsPtr, optsLen);
   }
 }

--- a/packages/wasm/src/wasm_bundler_entry.zig
+++ b/packages/wasm/src/wasm_bundler_entry.zig
@@ -2,14 +2,14 @@
 //!
 //! wasm32-wasip1-threads 타겟용 — bundler 전용. transpile-only 빌드 (wasm_entry.zig)
 //! 와 분리해서 brower 호환성/번들 사이즈 트레이드오프 분리.
-//!
-//! PR 6-2c-2c: build() 가 bundler.Bundler.init + bundle() 진짜 호출.
 
 const std = @import("std");
 const zts_lib = @import("zts_lib");
 const bundler_mod = zts_lib.bundler;
 const Bundler = bundler_mod.Bundler;
 const BundleOptions = bundler_mod.BundleOptions;
+const Format = bundler_mod.types.Format;
+const Platform = bundler_mod.Platform;
 
 pub const panic = zts_lib.crash_handler.panic;
 
@@ -23,8 +23,9 @@ const wasm_alloc = std.heap.c_allocator;
 pub fn main() void {}
 
 /// Bundler ABI version. host 가 호환성 체크용.
+/// v2 — build() 가 options_json (ptr/len) 인자 추가.
 export fn bundler_version() u32 {
-    return 1;
+    return 2;
 }
 
 /// JS 측이 entry path 등 입력 메모리 확보용.
@@ -40,13 +41,45 @@ export fn dealloc(ptr: u32, len: u32) void {
     wasm_alloc.free(slice[0..len]);
 }
 
-/// PR 6-2c-2c build() — VFS entry path 로 bundler.Bundler.init + bundle() 실 호출.
-/// Phase 2 minimal: 단일 entry, 기본 옵션 (esm/browser). 옵션 JSON / multi-entry /
-/// chunk 출력은 후속 PR.
+/// JSON 옵션 스키마 — JS bridge 의 BundleOptions 와 동기. 모든 필드 optional —
+/// 누락 시 BundleOptions 기본값 적용. 미지원 필드는 ignore_unknown_fields 로 무시.
+const BuildOptionsJson = struct {
+    format: ?[]const u8 = null,
+    platform: ?[]const u8 = null,
+    external: ?[]const []const u8 = null,
+    minifyWhitespace: ?bool = null,
+    minifyIdentifiers: ?bool = null,
+    minifySyntax: ?bool = null,
+};
+
+fn parseFormat(s: []const u8) ?Format {
+    if (std.mem.eql(u8, s, "esm")) return .esm;
+    if (std.mem.eql(u8, s, "cjs")) return .cjs;
+    if (std.mem.eql(u8, s, "iife")) return .iife;
+    if (std.mem.eql(u8, s, "umd")) return .umd;
+    if (std.mem.eql(u8, s, "amd")) return .amd;
+    return null;
+}
+
+fn parsePlatform(s: []const u8) ?Platform {
+    if (std.mem.eql(u8, s, "browser")) return .browser;
+    if (std.mem.eql(u8, s, "node")) return .node;
+    if (std.mem.eql(u8, s, "neutral")) return .neutral;
+    if (std.mem.eql(u8, s, "react_native") or std.mem.eql(u8, s, "react-native")) return .react_native;
+    return null;
+}
+
+/// build() — VFS entry path + 옵션 JSON 으로 bundler.bundle() 호출.
+/// options_json_ptr=0 이면 기본 옵션 (esm/browser).
 ///
-/// ABI: 반환 packed u64 (ptr<<32 | len), 0 = error 또는 빈 출력. caller (JS) 가 dealloc 책임.
-/// 결과 = single bundle code string (result.output — 단일 파일 모드).
-export fn build(entry_path_ptr: u32, entry_path_len: u32) u64 {
+/// ABI: 반환 packed u64 (ptr<<32 | len), 0 = error 또는 빈 출력. caller (JS) 가
+/// 결과 dealloc 책임. 옵션 JSON 파싱 실패는 silent — 기본 옵션으로 진행 (best effort).
+export fn build(
+    entry_path_ptr: u32,
+    entry_path_len: u32,
+    options_json_ptr: u32,
+    options_json_len: u32,
+) u64 {
     if (entry_path_ptr == 0 or entry_path_len == 0) return 0;
     const entry_path: []const u8 = @as([*]const u8, @ptrFromInt(entry_path_ptr))[0..entry_path_len];
 
@@ -59,11 +92,34 @@ export fn build(entry_path_ptr: u32, entry_path_len: u32) u64 {
     const entry_dupe = arena_alloc.dupe(u8, entry_path) catch return 0;
     const entry_points: []const []const u8 = &.{entry_dupe};
 
-    const options: BundleOptions = .{
+    var options: BundleOptions = .{
         .entry_points = entry_points,
         .format = .esm,
         .platform = .browser,
     };
+
+    if (options_json_ptr != 0 and options_json_len != 0) {
+        const json_bytes: []const u8 = @as([*]const u8, @ptrFromInt(options_json_ptr))[0..options_json_len];
+        const parsed = std.json.parseFromSlice(
+            BuildOptionsJson,
+            arena_alloc,
+            json_bytes,
+            .{ .ignore_unknown_fields = true },
+        ) catch null;
+        if (parsed) |p| {
+            const o = p.value;
+            if (o.format) |s| if (parseFormat(s)) |f| {
+                options.format = f;
+            };
+            if (o.platform) |s| if (parsePlatform(s)) |pf| {
+                options.platform = pf;
+            };
+            if (o.external) |list| options.external = list;
+            if (o.minifyWhitespace) |b| options.minify_whitespace = b;
+            if (o.minifyIdentifiers) |b| options.minify_identifiers = b;
+            if (o.minifySyntax) |b| options.minify_syntax = b;
+        }
+    }
 
     var bundler = Bundler.init(arena_alloc, options);
     const result = bundler.bundle() catch return 0;


### PR DESCRIPTION
## Summary
- `wasm_bundler_entry.build()` 시그니처 확장: `(entry_path, options_json)` (옵션 누락 시 esm/browser 기본)
- `bundler_version()` 1 → 2
- JS bridge: `build(entry, options?)` 시그니처 + `BundleOptionsInput` 타입 export
- minimal 옵션 노출: `format` (esm/cjs/iife), `platform` (browser/node/neutral/react-native), `external`, `minify` shorthand + 개별 minify*

## ABI 호환성
- ABI v2 — JS bridge 가 `optionsJsonPtr=0`, `optionsJsonLen=0` 항상 전달 (옵션 미사용 시 0). 기존 `build(entry)` 호출처는 JS bridge 통해 그대로 동작
- `bundler_version()` 으로 host 가 호환성 체크

## 옵션 처리
- Zig 측 `std.json.parseFromSlice` (`ignore_unknown_fields=true`) — forward-compat. 신규 옵션 필드 추가 시 기존 wasm binary 가 silent skip
- 잘못된 enum 값 (`format: "made-up"`) → silent ignore + 기본값 유지 (best-effort)
- `minify: true` shorthand 는 JS 측에서 whitespace/identifiers/syntax 펼침 — 개별 옵션 명시되면 그게 우선

## 부수 변경
- SharedArrayBuffer + TextDecoder fix — `view.slice()` 로 복사 후 decode. PR #1949 와 중복 (main rebase 시 자동 정리). 두 PR 독립 진행 가능하도록 둘 다 같이 fix

## Test plan
- [x] `zig build wasm-bundler` 통과
- [x] `bun test packages/wasm/index.test.ts` 43/43 pass
  - ABI v2 검증
  - format=cjs → "use strict" prologue 추가 (esm 과 비교)
  - minifyWhitespace / minify shorthand → 출력 길이 감소
  - 잘못된 옵션 값 → 기본값 fallback
  - 미지원 옵션 필드 → silent skip

## Follow-up
- PR 9-2: `result.outputs` (multi-chunk) 노출 + UI 업데이트
- PR 9-3: PlaygroundBundler 옵션 패널 (이 PR 머지 후)

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)