### PR TITLE
feat(wasm): bundler ABI build_chunks — multi-output 노출 (#1885 PR 9-2)

### DIFF
--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -8,6 +8,7 @@ import {
   initBundler,
   bundlerVersion,
   build,
+  buildChunks,
 } from "./index";
 
 beforeAll(() => {
@@ -280,8 +281,8 @@ describe("Bundler (minimal)", () => {
     await initBundler(vfs, wasmBytes);
   });
 
-  test("bundlerVersion = ABI v2 (옵션 JSON 인자 추가)", () => {
-    expect(bundlerVersion()).toBe(2);
+  test("bundlerVersion = ABI v3 (build_chunks 추가)", () => {
+    expect(bundlerVersion()).toBe(3);
   });
 
   test("build: 단일 entry → bundle 코드 (TS 어노테이션 strip + 모듈 wrap)", () => {
@@ -342,5 +343,35 @@ describe("Bundler (minimal)", () => {
     // ignore_unknown_fields=true 이라 신규 필드는 silent skip.
     const result = build("/index.ts", { someFutureOption: 42 } as any);
     expect(result).not.toBeNull();
+  });
+
+  test("buildChunks: 단일 entry → 한 개 chunk wrap", () => {
+    const chunks = buildChunks("/index.ts");
+    expect(chunks).not.toBeNull();
+    expect(chunks!.length).toBe(1);
+    expect(chunks![0].path).toBe("bundle.js");
+    expect(chunks![0].code).toContain("const x = 42;");
+  });
+
+  test("buildChunks: 옵션 (format=cjs) 적용", () => {
+    const chunks = buildChunks("/index.ts", { format: "cjs" });
+    expect(chunks).not.toBeNull();
+    expect(chunks!.length).toBe(1);
+    expect(chunks![0].code).toContain('"use strict"');
+  });
+
+  test("buildChunks: 존재하지 않는 entry → null", () => {
+    const chunks = buildChunks("/nonexistent.ts");
+    expect(chunks).toBeNull();
+  });
+
+  test("buildChunks: JSON escape — code 안의 특수 문자 round-trip", () => {
+    // 출력에 quote / newline / backslash 가 들어가니 JSON escape 검증.
+    const chunks = buildChunks("/utils.ts");
+    expect(chunks).not.toBeNull();
+    // utils.ts 의 template literal `hi ${n}` 가 그대로 출력에 — backtick / dollar / brace
+    expect(chunks![0].code).toContain("`hi ${n}`");
+    // newline 도 escape 안 깨지고 round-trip
+    expect(chunks![0].code.split("\n").length).toBeGreaterThan(1);
   });
 });

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -321,10 +321,17 @@ interface BundlerExports {
   alloc(len: number): number;
   dealloc(ptr: number, len: number): void;
   bundler_version(): number;
-  /// entry path + 옵션 JSON 으로 bundler.Bundler.init + bundle() 호출 후
-  /// result.output (단일 파일 모드 번들 코드) 반환. 0 = error 또는 빈 출력.
-  /// options_json_ptr=0 이면 기본 옵션 (esm/browser).
+  /// 단일 파일 번들 코드 반환. 0 = error 또는 빈 출력.
+  /// optionsJsonPtr=0 이면 기본 옵션 (esm/browser).
   build(
+    entryPathPtr: number,
+    entryPathLen: number,
+    optionsJsonPtr: number,
+    optionsJsonLen: number,
+  ): bigint;
+  /// multi-output 번들 결과를 JSON 배열 (`[{"path","code"}, ...]`) 로 반환.
+  /// code splitting / preserve modules 시 multi-chunk, 그 외엔 단일 chunk wrap.
+  build_chunks(
     entryPathPtr: number,
     entryPathLen: number,
     optionsJsonPtr: number,
@@ -451,8 +458,7 @@ export interface BundleResult {
   code: string;
 }
 
-/// build() 가 받는 옵션. ZTS bundler 의 BundleOptions 의 minimal subset —
-/// 후속 PR 에서 sourcemap / target / jsx 등 추가.
+/// build() / buildChunks() 가 받는 옵션. ZTS bundler 의 BundleOptions minimal subset.
 export interface BundleOptionsInput {
   /// 출력 모듈 형식. 기본 "esm".
   format?: "esm" | "cjs" | "iife";
@@ -466,6 +472,28 @@ export interface BundleOptionsInput {
   minifyWhitespace?: boolean;
   minifyIdentifiers?: boolean;
   minifySyntax?: boolean;
+  /// `buildChunks` 에서만 의미. true 면 dynamic import / 공유 모듈을 별도 chunk 로 분리.
+  codeSplitting?: boolean;
+  /// `buildChunks` 에서만 의미. true 면 모듈 1개 = 출력 1개 (rollup preserveModules).
+  preserveModules?: boolean;
+}
+
+/// 옵션을 wasm 메모리에 JSON 으로 인코딩 + 복사. ptr=0/len=0 이면 옵션 미전달 의미.
+/// caller 가 dealloc 책임. minify shorthand 는 여기서 펼쳐 wasm 측은 항상 개별 키만 봄.
+function encodeBundleOptions(options?: BundleOptionsInput): { ptr: number; len: number } {
+  if (!options) return { ptr: 0, len: 0 };
+  const expanded: BundleOptionsInput = { ...options };
+  if (expanded.minify) {
+    expanded.minifyWhitespace = expanded.minifyWhitespace ?? true;
+    expanded.minifyIdentifiers = expanded.minifyIdentifiers ?? true;
+    expanded.minifySyntax = expanded.minifySyntax ?? true;
+  }
+  delete expanded.minify;
+  const optsBytes = encoder.encode(JSON.stringify(expanded));
+  const ptr = bundler!.alloc(optsBytes.length);
+  if (ptr === 0) throw new Error("zts-wasm: bundler alloc failed");
+  new Uint8Array(bundlerMemory!.buffer, ptr, optsBytes.length).set(optsBytes);
+  return { ptr, len: optsBytes.length };
 }
 
 /// VFS entry path + 옵션으로 bundler 호출 후 단일 파일 번들 코드 반환.
@@ -480,27 +508,7 @@ export function build(entryPath: string, options?: BundleOptionsInput): BundleRe
   if (entryPtr === 0) throw new Error("zts-wasm: bundler alloc failed");
   new Uint8Array(bundlerMemory.buffer, entryPtr, entryBytes.length).set(entryBytes);
 
-  let optsPtr = 0;
-  let optsLen = 0;
-  if (options) {
-    // minify shorthand 펼치기 — 개별 옵션이 명시되어 있으면 그게 우선.
-    const expanded = { ...options };
-    if (expanded.minify) {
-      expanded.minifyWhitespace = expanded.minifyWhitespace ?? true;
-      expanded.minifyIdentifiers = expanded.minifyIdentifiers ?? true;
-      expanded.minifySyntax = expanded.minifySyntax ?? true;
-    }
-    delete expanded.minify;
-    const json = JSON.stringify(expanded);
-    const optsBytes = encoder.encode(json);
-    optsPtr = bundler.alloc(optsBytes.length);
-    if (optsPtr === 0) {
-      bundler.dealloc(entryPtr, entryBytes.length);
-      throw new Error("zts-wasm: bundler alloc failed");
-    }
-    new Uint8Array(bundlerMemory.buffer, optsPtr, optsBytes.length).set(optsBytes);
-    optsLen = optsBytes.length;
-  }
+  const { ptr: optsPtr, len: optsLen } = encodeBundleOptions(options);
 
   try {
     const packed = bundler.build(entryPtr, entryBytes.length, optsPtr, optsLen);
@@ -513,6 +521,44 @@ export function build(entryPath: string, options?: BundleOptionsInput): BundleRe
     const code = decoder.decode(view.slice());
     bundler.dealloc(outPtr, outLen);
     return { code };
+  } finally {
+    bundler.dealloc(entryPtr, entryBytes.length);
+    if (optsPtr) bundler.dealloc(optsPtr, optsLen);
+  }
+}
+
+/// 번들 결과의 단일 chunk. multi-output (code splitting / preserve modules) 시 여러 개,
+/// 단일 파일 모드 시 한 개 (path="bundle.js" 로 wrap).
+export interface OutputChunk {
+  path: string;
+  code: string;
+}
+
+/// VFS entry path + 옵션으로 bundler 호출 후 multi-output 결과 반환.
+/// `codeSplitting=true` 또는 `preserveModules=true` 시 multi-chunk, 그 외엔 단일 chunk.
+/// 실패 시 null. 빈 array 는 정상 (entry 가 빈 출력).
+export function buildChunks(entryPath: string, options?: BundleOptionsInput): OutputChunk[] | null {
+  if (!bundler || !bundlerMemory) {
+    throw new Error("zts-wasm: bundler not initialized. Call initBundler() first.");
+  }
+
+  const entryBytes = encoder.encode(entryPath);
+  const entryPtr = bundler.alloc(entryBytes.length);
+  if (entryPtr === 0) throw new Error("zts-wasm: bundler alloc failed");
+  new Uint8Array(bundlerMemory.buffer, entryPtr, entryBytes.length).set(entryBytes);
+
+  const { ptr: optsPtr, len: optsLen } = encodeBundleOptions(options);
+
+  try {
+    const packed = bundler.build_chunks(entryPtr, entryBytes.length, optsPtr, optsLen);
+    if (packed === 0n) return null;
+
+    const outPtr = Number(packed >> 32n);
+    const outLen = Number(packed & 0xffffffffn);
+    const view = new Uint8Array(bundlerMemory.buffer, outPtr, outLen);
+    const json = decoder.decode(view.slice());
+    bundler.dealloc(outPtr, outLen);
+    return JSON.parse(json) as OutputChunk[];
   } finally {
     bundler.dealloc(entryPtr, entryBytes.length);
     if (optsPtr) bundler.dealloc(optsPtr, optsLen);

--- a/packages/wasm/src/wasm_bundler_entry.zig
+++ b/packages/wasm/src/wasm_bundler_entry.zig
@@ -1,4 +1,4 @@
-//! ZTS WASM bundler 진입점 (#1885 Phase 2).
+//! ZTS WASM bundler 진입점 (#1885 Phase 2/3).
 //!
 //! wasm32-wasip1-threads 타겟용 — bundler 전용. transpile-only 빌드 (wasm_entry.zig)
 //! 와 분리해서 brower 호환성/번들 사이즈 트레이드오프 분리.
@@ -23,9 +23,9 @@ const wasm_alloc = std.heap.c_allocator;
 pub fn main() void {}
 
 /// Bundler ABI version. host 가 호환성 체크용.
-/// v2 — build() 가 options_json (ptr/len) 인자 추가.
+/// v3 — build_chunks export 추가, BuildOptionsJson 에 codeSplitting/preserveModules.
 export fn bundler_version() u32 {
-    return 2;
+    return 3;
 }
 
 /// JS 측이 entry path 등 입력 메모리 확보용.
@@ -41,7 +41,7 @@ export fn dealloc(ptr: u32, len: u32) void {
     wasm_alloc.free(slice[0..len]);
 }
 
-/// JSON 옵션 스키마 — JS bridge 의 BundleOptions 와 동기. 모든 필드 optional —
+/// JSON 옵션 스키마 — JS bridge 의 BundleOptionsInput 와 동기. 모든 필드 optional —
 /// 누락 시 BundleOptions 기본값 적용. 미지원 필드는 ignore_unknown_fields 로 무시.
 const BuildOptionsJson = struct {
     format: ?[]const u8 = null,
@@ -50,6 +50,10 @@ const BuildOptionsJson = struct {
     minifyWhitespace: ?bool = null,
     minifyIdentifiers: ?bool = null,
     minifySyntax: ?bool = null,
+    /// build_chunks 에서만 의미 있음. true 면 dynamic import / 공유 모듈을 별도 chunk 로 분리.
+    codeSplitting: ?bool = null,
+    /// build_chunks 에서만 의미 있음. true 면 모듈 1개 = 출력 1개 (rollup preserveModules).
+    preserveModules: ?bool = null,
 };
 
 fn parseFormat(s: []const u8) ?Format {
@@ -69,11 +73,67 @@ fn parsePlatform(s: []const u8) ?Platform {
     return null;
 }
 
+/// JSON string literal 을 buf 에 직접 escape 처리해 추가 ("\"" 포함). RFC8259 §7
+/// 의 control char + quote + backslash escape. 외부 std.json.Stringify 의 *Io.Writer
+/// 요구가 ArrayList 와 호환 안 돼 작은 schema 직접 처리.
+fn appendJsonString(a: std.mem.Allocator, buf: *std.ArrayList(u8), s: []const u8) !void {
+    try buf.append(a, '"');
+    for (s) |c| switch (c) {
+        '"' => try buf.appendSlice(a, "\\\""),
+        '\\' => try buf.appendSlice(a, "\\\\"),
+        '\n' => try buf.appendSlice(a, "\\n"),
+        '\r' => try buf.appendSlice(a, "\\r"),
+        '\t' => try buf.appendSlice(a, "\\t"),
+        0x08 => try buf.appendSlice(a, "\\b"),
+        0x0c => try buf.appendSlice(a, "\\f"),
+        0x00...0x07, 0x0b, 0x0e...0x1f => {
+            var hex: [6]u8 = undefined;
+            const slice = std.fmt.bufPrint(&hex, "\\u{x:0>4}", .{c}) catch unreachable;
+            try buf.appendSlice(a, slice);
+        },
+        else => try buf.append(a, c),
+    };
+    try buf.append(a, '"');
+}
+
+/// options_json 을 파싱해 BundleOptions 의 일부 필드를 채운다. base 는 entry_points
+/// 설정된 기본값 (esm/browser). caller 가 entry_points 등 비-옵션 필드 미리 세팅.
+fn applyOptionsJson(
+    arena_alloc: std.mem.Allocator,
+    base: *BundleOptions,
+    options_json_ptr: u32,
+    options_json_len: u32,
+) void {
+    if (options_json_ptr == 0 or options_json_len == 0) return;
+    const json_bytes: []const u8 = @as([*]const u8, @ptrFromInt(options_json_ptr))[0..options_json_len];
+    const parsed = std.json.parseFromSlice(
+        BuildOptionsJson,
+        arena_alloc,
+        json_bytes,
+        .{ .ignore_unknown_fields = true },
+    ) catch return;
+    const o = parsed.value;
+    if (o.format) |s| if (parseFormat(s)) |f| {
+        base.format = f;
+    };
+    if (o.platform) |s| if (parsePlatform(s)) |p| {
+        base.platform = p;
+    };
+    if (o.external) |list| base.external = list;
+    if (o.minifyWhitespace) |b| base.minify_whitespace = b;
+    if (o.minifyIdentifiers) |b| base.minify_identifiers = b;
+    if (o.minifySyntax) |b| base.minify_syntax = b;
+    if (o.codeSplitting) |b| base.code_splitting = b;
+    if (o.preserveModules) |b| base.preserve_modules = b;
+}
+
 /// build() — VFS entry path + 옵션 JSON 으로 bundler.bundle() 호출.
 /// options_json_ptr=0 이면 기본 옵션 (esm/browser).
 ///
 /// ABI: 반환 packed u64 (ptr<<32 | len), 0 = error 또는 빈 출력. caller (JS) 가
 /// 결과 dealloc 책임. 옵션 JSON 파싱 실패는 silent — 기본 옵션으로 진행 (best effort).
+///
+/// 단일 파일 모드 전용 — code splitting / preserve modules 는 build_chunks 사용.
 export fn build(
     entry_path_ptr: u32,
     entry_path_len: u32,
@@ -97,29 +157,7 @@ export fn build(
         .format = .esm,
         .platform = .browser,
     };
-
-    if (options_json_ptr != 0 and options_json_len != 0) {
-        const json_bytes: []const u8 = @as([*]const u8, @ptrFromInt(options_json_ptr))[0..options_json_len];
-        const parsed = std.json.parseFromSlice(
-            BuildOptionsJson,
-            arena_alloc,
-            json_bytes,
-            .{ .ignore_unknown_fields = true },
-        ) catch null;
-        if (parsed) |p| {
-            const o = p.value;
-            if (o.format) |s| if (parseFormat(s)) |f| {
-                options.format = f;
-            };
-            if (o.platform) |s| if (parsePlatform(s)) |pf| {
-                options.platform = pf;
-            };
-            if (o.external) |list| options.external = list;
-            if (o.minifyWhitespace) |b| options.minify_whitespace = b;
-            if (o.minifyIdentifiers) |b| options.minify_identifiers = b;
-            if (o.minifySyntax) |b| options.minify_syntax = b;
-        }
-    }
+    applyOptionsJson(arena_alloc, &options, options_json_ptr, options_json_len);
 
     var bundler = Bundler.init(arena_alloc, options);
     const result = bundler.bundle() catch return 0;
@@ -130,6 +168,74 @@ export fn build(
 
     // arena.deinit() 후에도 caller (JS) 가 읽도록 wasm_alloc 으로 별도 dupe.
     const out = wasm_alloc.dupe(u8, code) catch return 0;
+    const out_ptr: u32 = @intCast(@intFromPtr(out.ptr));
+    const out_len: u32 = @intCast(out.len);
+    return (@as(u64, out_ptr) << 32) | @as(u64, out_len);
+}
+
+/// build_chunks() — multi-output 번들 결과를 JSON 배열로 반환.
+/// 형식: `[{"path":"<chunk-path>","code":"<chunk-content>"}, ...]`
+///
+/// `code_splitting=true` 또는 `preserve_modules=true` 옵션 시 result.outputs 의
+/// 모든 chunk 를 직렬화. 단일 파일 모드일 땐 result.output 한 개를 path="bundle.js"
+/// 로 wrap — caller (JS) 가 시그니처 분기 없이 항상 array 받도록.
+///
+/// ABI: 반환 packed u64 (ptr<<32 | len), 0 = error. caller dealloc 책임.
+export fn build_chunks(
+    entry_path_ptr: u32,
+    entry_path_len: u32,
+    options_json_ptr: u32,
+    options_json_len: u32,
+) u64 {
+    if (entry_path_ptr == 0 or entry_path_len == 0) return 0;
+    const entry_path: []const u8 = @as([*]const u8, @ptrFromInt(entry_path_ptr))[0..entry_path_len];
+
+    var arena = std.heap.ArenaAllocator.init(wasm_alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const entry_dupe = arena_alloc.dupe(u8, entry_path) catch return 0;
+    const entry_points: []const []const u8 = &.{entry_dupe};
+
+    var options: BundleOptions = .{
+        .entry_points = entry_points,
+        .format = .esm,
+        .platform = .browser,
+    };
+    applyOptionsJson(arena_alloc, &options, options_json_ptr, options_json_len);
+
+    var bundler = Bundler.init(arena_alloc, options);
+    const result = bundler.bundle() catch return 0;
+
+    // 단일 파일 모드 / 비-splitting 시엔 result.output 한 개를 wrap. code splitting /
+    // preserve modules 시엔 result.outputs 의 모든 chunk.
+    const Pair = struct { path: []const u8, code: []const u8 };
+    var chunks: []Pair = undefined;
+    if (result.outputs) |outs| {
+        chunks = arena_alloc.alloc(Pair, outs.len) catch return 0;
+        for (outs, 0..) |o, i| chunks[i] = .{ .path = o.path, .code = o.contents };
+    } else {
+        if (result.output.len == 0) return 0;
+        chunks = arena_alloc.alloc(Pair, 1) catch return 0;
+        chunks[0] = .{ .path = "bundle.js", .code = result.output };
+    }
+
+    // JSON 직렬화 — std.json.Stringify 의 *Io.Writer 요구가 ArrayList writer 와 호환
+    // 안 돼 직접 escape 처리 (간단한 schema라 외부 의존 회피).
+    var buf: std.ArrayList(u8) = .empty;
+    buf.append(arena_alloc, '[') catch return 0;
+    for (chunks, 0..) |c, i| {
+        if (i != 0) buf.append(arena_alloc, ',') catch return 0;
+        buf.appendSlice(arena_alloc, "{\"path\":") catch return 0;
+        appendJsonString(arena_alloc, &buf, c.path) catch return 0;
+        buf.appendSlice(arena_alloc, ",\"code\":") catch return 0;
+        appendJsonString(arena_alloc, &buf, c.code) catch return 0;
+        buf.append(arena_alloc, '}') catch return 0;
+    }
+    buf.append(arena_alloc, ']') catch return 0;
+
+    // arena.deinit() 후에도 caller 가 읽도록 wasm_alloc 으로 dupe.
+    const out = wasm_alloc.dupe(u8, buf.items) catch return 0;
     const out_ptr: u32 = @intCast(@intFromPtr(out.ptr));
     const out_len: u32 = @intCast(out.len);
     return (@as(u64, out_ptr) << 32) | @as(u64, out_len);


### PR DESCRIPTION
## Summary
- `buildChunks(entry, options?)` 추가 — `OutputChunk[]` 반환
- code splitting / preserve modules 시 multi-chunk, 그 외엔 단일 chunk wrap (path="bundle.js")
- 시그니처가 항상 array 라 호스트 분기 불필요
- `BundleOptionsInput` 에 `codeSplitting` / `preserveModules` 추가
- `bundler_version()` 2 → 3

## Zig
- `build_chunks` export — `(entry, options_json)` → `[{path, code}]` JSON
- `applyOptionsJson` 헬퍼로 옵션 파싱 로직 공유 (`build` / `build_chunks`)
- `appendJsonString` — RFC8259 §7 escape (직접 처리. `std.json.Stringify` 의 `*Io.Writer` 가 ArrayList writer 와 호환 안 됨)

## JS
- `OutputChunk` interface (`path` + `code`)
- `encodeBundleOptions` 헬퍼 — `build` / `buildChunks` 옵션 인코딩 공유
- `buildChunks` 가 `JSON.parse(decoded)` 후 array 반환

## Test plan
- [x] `zig build wasm-bundler` 통과
- [x] `bun test packages/wasm/index.test.ts` 47/47 pass
  - ABI v3 검증
  - 단일 entry → "bundle.js" 1 chunk wrap
  - format=cjs → "use strict" prologue chunks 경로 검증
  - JSON escape round-trip — backtick / dollar / brace / newline 보존

## Follow-up
- PR 9-4: PlaygroundBundler chunk viewer UI (탭 + chunk별 Monaco)
- PR 10: external + manualChunks UI + 데모 시나리오 (multi-entry / dynamic import)

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)