### PR TITLE
feat(playground): bundler UMD/AMD + 에러 메시지 노출 (#1885 follow-up)

### DIFF
--- a/documents/src/components/PlaygroundBundler.tsx
+++ b/documents/src/components/PlaygroundBundler.tsx
@@ -123,6 +123,50 @@ function greet(name: string): string {
     ],
   },
   {
+    label: "UMD — 브라우저 + Node 양쪽 호환",
+    entry: "/lib.ts",
+    opts: { format: "umd", platform: "neutral" },
+    files: [
+      {
+        path: "/lib.ts",
+        language: "typescript",
+        content: `// format=umd — UMD wrapper: AMD (define) / CJS (exports) / global 자동 분기.
+// 브라우저 <script> 직접 로드 + Node require + RequireJS 모두 지원하는 라이브러리.
+export function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+
+export const VERSION = "1.0.0";
+`,
+      },
+    ],
+  },
+  {
+    label: "AMD — RequireJS 호환",
+    entry: "/module.ts",
+    opts: { format: "amd", platform: "browser" },
+    files: [
+      {
+        path: "/module.ts",
+        language: "typescript",
+        content: `// format=amd — \`define(["dep"], function (dep) { ... })\` 래퍼.
+// RequireJS / SystemJS 같은 AMD 로더 환경 (legacy 또는 dynamic 로딩).
+import { greet } from "./helpers";
+
+export function run(name: string): void {
+  console.log(greet(name));
+}
+`,
+      },
+      {
+        path: "/helpers.ts",
+        language: "typescript",
+        content: `export const greet = (name: string): string => \`Hi, \${name}\`;
+`,
+      },
+    ],
+  },
+  {
     label: "Dynamic import — 코드 스플리팅 시연",
     entry: "/main.ts",
     opts: { codeSplitting: true },
@@ -191,7 +235,7 @@ const BUNDLE_DEBOUNCE_MS = 200;
 const BASE_URL = (import.meta.env.BASE_URL ?? "/").replace(/\/?$/, "/");
 
 interface BundleOpts {
-  format: "esm" | "cjs" | "iife";
+  format: "esm" | "cjs" | "iife" | "umd" | "amd";
   platform: "browser" | "node" | "neutral" | "react-native";
   minify: boolean;
   minifyWhitespace: boolean;
@@ -263,7 +307,8 @@ export default function PlaygroundBundler() {
       const result = wasm.buildChunks(entry, toApiOptions(nextOpts));
       if (result === null || result.length === 0) {
         setChunks([]);
-        setError(`Bundle failed — entry "${entry}" 가 빈 출력을 반환했거나 해석 실패`);
+        const detail = wasm.bundlerLastErrorMessage();
+        setError(detail || `entry "${entry}" 번들 실패`);
         return;
       }
       setChunks(result);
@@ -525,6 +570,8 @@ export default function PlaygroundBundler() {
                     ["esm", "ESM"],
                     ["cjs", "CJS"],
                     ["iife", "IIFE"],
+                    ["umd", "UMD"],
+                    ["amd", "AMD"],
                   ]}
                 />
                 <Sel

--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -9,6 +9,7 @@ import {
   bundlerVersion,
   build,
   buildChunks,
+  bundlerLastErrorMessage,
 } from "./index";
 
 beforeAll(() => {
@@ -281,8 +282,8 @@ describe("Bundler (minimal)", () => {
     await initBundler(vfs, wasmBytes);
   });
 
-  test("bundlerVersion = ABI v3 (build_chunks 추가)", () => {
-    expect(bundlerVersion()).toBe(3);
+  test("bundlerVersion = ABI v4 (last_error_message_get 추가)", () => {
+    expect(bundlerVersion()).toBe(4);
   });
 
   test("build: 단일 entry → bundle 코드 (TS 어노테이션 strip + 모듈 wrap)", () => {
@@ -360,9 +361,18 @@ describe("Bundler (minimal)", () => {
     expect(chunks![0].code).toContain('"use strict"');
   });
 
-  test("buildChunks: 존재하지 않는 entry → null", () => {
+  test("buildChunks: 존재하지 않는 entry → null + 에러 메시지", () => {
     const chunks = buildChunks("/nonexistent.ts");
     expect(chunks).toBeNull();
+    const msg = bundlerLastErrorMessage();
+    expect(msg.length).toBeGreaterThan(0);
+    // bundle 단계 실패 또는 빈 출력 — 둘 중 하나로 분류되며 메시지에 표시.
+    expect(msg).toMatch(/bundle|nonexistent|빈 출력/);
+  });
+
+  test("bundlerLastErrorMessage: 성공 호출 후엔 비어있음", () => {
+    buildChunks("/index.ts"); // 성공
+    expect(bundlerLastErrorMessage()).toBe("");
   });
 
   test("buildChunks: JSON escape — code 안의 특수 문자 round-trip", () => {

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -337,6 +337,9 @@ interface BundlerExports {
     optionsJsonPtr: number,
     optionsJsonLen: number,
   ): bigint;
+  /// 직전 build/build_chunks 가 0 반환했을 때 호출 — 의미 있는 에러 메시지 반환.
+  /// 0 = no error. 결과 ptr/len 은 wasm 내부 buffer (caller 가 dealloc 호출 금지).
+  last_error_message_get(): bigint;
 }
 
 let bundler: BundlerExports | null = null;
@@ -460,8 +463,8 @@ export interface BundleResult {
 
 /// build() / buildChunks() 가 받는 옵션. ZTS bundler 의 BundleOptions minimal subset.
 export interface BundleOptionsInput {
-  /// 출력 모듈 형식. 기본 "esm".
-  format?: "esm" | "cjs" | "iife";
+  /// 출력 모듈 형식. 기본 "esm". umd/amd 는 IIFE 계열 (함수 래퍼).
+  format?: "esm" | "cjs" | "iife" | "umd" | "amd";
   /// 타겟 플랫폼. 기본 "browser". import.meta polyfill / Node 빌트인 처리 등 영향.
   platform?: "browser" | "node" | "neutral" | "react-native";
   /// 외부 처리할 모듈 specifier 목록 (와일드카드 `*` 지원).
@@ -496,8 +499,22 @@ function encodeBundleOptions(options?: BundleOptionsInput): { ptr: number; len: 
   return { ptr, len: optsBytes.length };
 }
 
+/// 직전 build / buildChunks 호출이 실패해 null 을 반환했을 때 의미 있는 에러
+/// 메시지를 가져온다. 호출이 성공했거나 메시지가 없으면 빈 문자열.
+export function bundlerLastErrorMessage(): string {
+  if (!bundler || !bundlerMemory) return "";
+  const packed = bundler.last_error_message_get();
+  if (packed === 0n) return "";
+  const ptr = Number(packed >> 32n);
+  const len = Number(packed & 0xffffffffn);
+  // 결과 buffer 는 wasm 내부 소유 — dealloc 안 함. SharedArrayBuffer 라 .slice() 복사.
+  const view = new Uint8Array(bundlerMemory.buffer, ptr, len);
+  return decoder.decode(view.slice());
+}
+
 /// VFS entry path + 옵션으로 bundler 호출 후 단일 파일 번들 코드 반환.
-/// 옵션 미전달 시 esm/browser 기본. 빈 출력 또는 실패 시 null.
+/// 옵션 미전달 시 esm/browser 기본. 빈 출력 또는 실패 시 null —
+/// 자세한 에러는 `bundlerLastErrorMessage()` 로 조회.
 export function build(entryPath: string, options?: BundleOptionsInput): BundleResult | null {
   if (!bundler || !bundlerMemory) {
     throw new Error("zts-wasm: bundler not initialized. Call initBundler() first.");

--- a/packages/wasm/src/wasm_bundler_entry.zig
+++ b/packages/wasm/src/wasm_bundler_entry.zig
@@ -8,6 +8,7 @@ const zts_lib = @import("zts_lib");
 const bundler_mod = zts_lib.bundler;
 const Bundler = bundler_mod.Bundler;
 const BundleOptions = bundler_mod.BundleOptions;
+const BundleResult = bundler_mod.bundler_core.BundleResult;
 const Format = bundler_mod.types.Format;
 const Platform = bundler_mod.Platform;
 
@@ -23,9 +24,9 @@ const wasm_alloc = std.heap.c_allocator;
 pub fn main() void {}
 
 /// Bundler ABI version. host 가 호환성 체크용.
-/// v3 — build_chunks export 추가, BuildOptionsJson 에 codeSplitting/preserveModules.
+/// v4 — last_error_message_get export 추가, build() 가 실패 시 의미 있는 메시지 노출.
 export fn bundler_version() u32 {
-    return 3;
+    return 4;
 }
 
 /// JS 측이 entry path 등 입력 메모리 확보용.
@@ -40,6 +41,41 @@ export fn dealloc(ptr: u32, len: u32) void {
     const slice: [*]u8 = @ptrFromInt(ptr);
     wasm_alloc.free(slice[0..len]);
 }
+
+// ─── 마지막 에러 메시지 (build / build_chunks 가 0 반환 시 host 가 조회) ───
+
+/// 마지막 에러 메시지 — wasm_alloc 소유. 새 메시지 setLastError 시 이전 free.
+/// single-threaded JS bridge 가정 (wasm instance per page).
+var last_error_msg: ?[]u8 = null;
+
+fn clearLastError() void {
+    if (last_error_msg) |m| {
+        wasm_alloc.free(m);
+        last_error_msg = null;
+    }
+}
+
+fn setLastError(msg: []const u8) void {
+    clearLastError();
+    last_error_msg = wasm_alloc.dupe(u8, msg) catch null;
+}
+
+fn setLastErrorFmt(comptime fmt: []const u8, args: anytype) void {
+    clearLastError();
+    last_error_msg = std.fmt.allocPrint(wasm_alloc, fmt, args) catch null;
+}
+
+/// 최근 build/build_chunks 실패 시 에러 메시지 조회. 반환 packed u64 (ptr<<32 | len).
+/// 0 = no error. caller 는 dealloc 호출 금지 (wasm 내부 buffer).
+export fn last_error_message_get() u64 {
+    const m = last_error_msg orelse return 0;
+    if (m.len == 0) return 0;
+    const out_ptr: u32 = @intCast(@intFromPtr(m.ptr));
+    const out_len: u32 = @intCast(m.len);
+    return (@as(u64, out_ptr) << 32) | @as(u64, out_len);
+}
+
+// ─── 옵션 JSON 파싱 ───
 
 /// JSON 옵션 스키마 — JS bridge 의 BundleOptionsInput 와 동기. 모든 필드 optional —
 /// 누락 시 BundleOptions 기본값 적용. 미지원 필드는 ignore_unknown_fields 로 무시.
@@ -127,11 +163,27 @@ fn applyOptionsJson(
     if (o.preserveModules) |b| base.preserve_modules = b;
 }
 
+/// bundle() 결과의 fatal diagnostic 첫 번째를 last_error_msg 로 캡처 (있으면).
+/// caller 가 직후 dealloc(arena) 해도 메시지는 wasm_alloc 으로 dupe 되어 안전.
+fn captureDiagnostic(result: *const BundleResult) void {
+    const diags = result.diagnostics orelse return;
+    for (diags) |d| {
+        if (d.severity != .@"error") continue;
+        if (d.file_path.len > 0) {
+            setLastErrorFmt("{s}: {s}", .{ d.file_path, d.message });
+        } else {
+            setLastError(d.message);
+        }
+        return;
+    }
+}
+
 /// build() — VFS entry path + 옵션 JSON 으로 bundler.bundle() 호출.
 /// options_json_ptr=0 이면 기본 옵션 (esm/browser).
 ///
 /// ABI: 반환 packed u64 (ptr<<32 | len), 0 = error 또는 빈 출력. caller (JS) 가
 /// 결과 dealloc 책임. 옵션 JSON 파싱 실패는 silent — 기본 옵션으로 진행 (best effort).
+/// 실패 시 last_error_message_get 으로 의미 있는 메시지 조회 가능.
 ///
 /// 단일 파일 모드 전용 — code splitting / preserve modules 는 build_chunks 사용.
 export fn build(
@@ -140,7 +192,11 @@ export fn build(
     options_json_ptr: u32,
     options_json_len: u32,
 ) u64 {
-    if (entry_path_ptr == 0 or entry_path_len == 0) return 0;
+    clearLastError();
+    if (entry_path_ptr == 0 or entry_path_len == 0) {
+        setLastError("entry path 가 비어있습니다");
+        return 0;
+    }
     const entry_path: []const u8 = @as([*]const u8, @ptrFromInt(entry_path_ptr))[0..entry_path_len];
 
     // arena 일괄 해제 — Bundler/BundleResult 내부 자료구조 모두 arena_alloc 소유.
@@ -149,7 +205,10 @@ export fn build(
     defer arena.deinit();
     const arena_alloc = arena.allocator();
 
-    const entry_dupe = arena_alloc.dupe(u8, entry_path) catch return 0;
+    const entry_dupe = arena_alloc.dupe(u8, entry_path) catch {
+        setLastError("alloc 실패 (entry path dupe)");
+        return 0;
+    };
     const entry_points: []const []const u8 = &.{entry_dupe};
 
     var options: BundleOptions = .{
@@ -160,14 +219,26 @@ export fn build(
     applyOptionsJson(arena_alloc, &options, options_json_ptr, options_json_len);
 
     var bundler = Bundler.init(arena_alloc, options);
-    const result = bundler.bundle() catch return 0;
+    const result = bundler.bundle() catch |err| {
+        setLastErrorFmt("bundle() 실패: {s}", .{@errorName(err)});
+        return 0;
+    };
+
+    // diagnostics 가 있으면 fatal 메시지 캡처 (출력은 있어도 의미 있는 에러 노출).
+    captureDiagnostic(&result);
 
     // 단일 entry / 비-splitting 경로: result.output 사용 (outputs 는 code-splitting 시).
     const code = result.output;
-    if (code.len == 0) return 0;
+    if (code.len == 0) {
+        if (last_error_msg == null) setLastErrorFmt("entry \"{s}\" 가 빈 출력을 반환했습니다", .{entry_path});
+        return 0;
+    }
 
     // arena.deinit() 후에도 caller (JS) 가 읽도록 wasm_alloc 으로 별도 dupe.
-    const out = wasm_alloc.dupe(u8, code) catch return 0;
+    const out = wasm_alloc.dupe(u8, code) catch {
+        setLastError("alloc 실패 (output dupe)");
+        return 0;
+    };
     const out_ptr: u32 = @intCast(@intFromPtr(out.ptr));
     const out_len: u32 = @intCast(out.len);
     return (@as(u64, out_ptr) << 32) | @as(u64, out_len);
@@ -187,14 +258,21 @@ export fn build_chunks(
     options_json_ptr: u32,
     options_json_len: u32,
 ) u64 {
-    if (entry_path_ptr == 0 or entry_path_len == 0) return 0;
+    clearLastError();
+    if (entry_path_ptr == 0 or entry_path_len == 0) {
+        setLastError("entry path 가 비어있습니다");
+        return 0;
+    }
     const entry_path: []const u8 = @as([*]const u8, @ptrFromInt(entry_path_ptr))[0..entry_path_len];
 
     var arena = std.heap.ArenaAllocator.init(wasm_alloc);
     defer arena.deinit();
     const arena_alloc = arena.allocator();
 
-    const entry_dupe = arena_alloc.dupe(u8, entry_path) catch return 0;
+    const entry_dupe = arena_alloc.dupe(u8, entry_path) catch {
+        setLastError("alloc 실패 (entry path dupe)");
+        return 0;
+    };
     const entry_points: []const []const u8 = &.{entry_dupe};
 
     var options: BundleOptions = .{
@@ -205,37 +283,78 @@ export fn build_chunks(
     applyOptionsJson(arena_alloc, &options, options_json_ptr, options_json_len);
 
     var bundler = Bundler.init(arena_alloc, options);
-    const result = bundler.bundle() catch return 0;
+    const result = bundler.bundle() catch |err| {
+        setLastErrorFmt("bundle() 실패: {s}", .{@errorName(err)});
+        return 0;
+    };
+
+    captureDiagnostic(&result);
 
     // 단일 파일 모드 / 비-splitting 시엔 result.output 한 개를 wrap. code splitting /
     // preserve modules 시엔 result.outputs 의 모든 chunk.
     const Pair = struct { path: []const u8, code: []const u8 };
     var chunks: []Pair = undefined;
     if (result.outputs) |outs| {
-        chunks = arena_alloc.alloc(Pair, outs.len) catch return 0;
+        chunks = arena_alloc.alloc(Pair, outs.len) catch {
+            setLastError("alloc 실패 (chunks array)");
+            return 0;
+        };
         for (outs, 0..) |o, i| chunks[i] = .{ .path = o.path, .code = o.contents };
     } else {
-        if (result.output.len == 0) return 0;
-        chunks = arena_alloc.alloc(Pair, 1) catch return 0;
+        if (result.output.len == 0) {
+            if (last_error_msg == null) setLastErrorFmt("entry \"{s}\" 가 빈 출력을 반환했습니다", .{entry_path});
+            return 0;
+        }
+        chunks = arena_alloc.alloc(Pair, 1) catch {
+            setLastError("alloc 실패 (chunks array)");
+            return 0;
+        };
         chunks[0] = .{ .path = "bundle.js", .code = result.output };
     }
 
     // JSON 직렬화 — std.json.Stringify 의 *Io.Writer 요구가 ArrayList writer 와 호환
     // 안 돼 직접 escape 처리 (간단한 schema라 외부 의존 회피).
     var buf: std.ArrayList(u8) = .empty;
-    buf.append(arena_alloc, '[') catch return 0;
+    buf.append(arena_alloc, '[') catch {
+        setLastError("alloc 실패 (json buf)");
+        return 0;
+    };
     for (chunks, 0..) |c, i| {
-        if (i != 0) buf.append(arena_alloc, ',') catch return 0;
-        buf.appendSlice(arena_alloc, "{\"path\":") catch return 0;
-        appendJsonString(arena_alloc, &buf, c.path) catch return 0;
-        buf.appendSlice(arena_alloc, ",\"code\":") catch return 0;
-        appendJsonString(arena_alloc, &buf, c.code) catch return 0;
-        buf.append(arena_alloc, '}') catch return 0;
+        if (i != 0) buf.append(arena_alloc, ',') catch {
+            setLastError("alloc 실패 (json buf)");
+            return 0;
+        };
+        buf.appendSlice(arena_alloc, "{\"path\":") catch {
+            setLastError("alloc 실패 (json buf)");
+            return 0;
+        };
+        appendJsonString(arena_alloc, &buf, c.path) catch {
+            setLastError("alloc 실패 (json buf)");
+            return 0;
+        };
+        buf.appendSlice(arena_alloc, ",\"code\":") catch {
+            setLastError("alloc 실패 (json buf)");
+            return 0;
+        };
+        appendJsonString(arena_alloc, &buf, c.code) catch {
+            setLastError("alloc 실패 (json buf)");
+            return 0;
+        };
+        buf.append(arena_alloc, '}') catch {
+            setLastError("alloc 실패 (json buf)");
+            return 0;
+        };
     }
-    buf.append(arena_alloc, ']') catch return 0;
+    buf.append(arena_alloc, ']') catch {
+        setLastError("alloc 실패 (json buf)");
+        return 0;
+    };
 
     // arena.deinit() 후에도 caller 가 읽도록 wasm_alloc 으로 dupe.
-    const out = wasm_alloc.dupe(u8, buf.items) catch return 0;
+    const out = wasm_alloc.dupe(u8, buf.items) catch {
+        setLastError("alloc 실패 (output dupe)");
+        return 0;
+    };
     const out_ptr: u32 = @intCast(@intFromPtr(out.ptr));
     const out_len: u32 = @intCast(out.len);
     return (@as(u64, out_ptr) << 32) | @as(u64, out_len);


### PR DESCRIPTION
## Summary
사용자 피드백 두 건 fix:

### 1. UMD / AMD format 부족
- `Format` enum 엔 있지만 JS bridge / UI 에 누락
- `BundleOptionsInput.format` + `BundleOpts.format` 에 `"umd" | "amd"` 추가
- 옵션 패널 Format Sel 에 UMD / AMD entry
- preset 신규: "UMD — 브라우저+Node 양쪽 호환", "AMD — RequireJS 호환"

### 2. 번들 실패 시 generic 에러 메시지
- ABI v3 → v4 — `last_error_message_get` export 추가
- `wasm_bundler_entry.zig`: `setLastError`/`setLastErrorFmt`/`captureDiagnostic` 헬퍼. build/build_chunks 의 모든 fail-path 에서 의미 있는 메시지 set. fatal diagnostic 가 있으면 path + message 캡처
- `bundlerLastErrorMessage()` JS 함수 export — wasm 내부 buffer 읽어 string. SharedArrayBuffer 안전 (.slice() 후 decode)
- `PlaygroundBundler` 가 buildChunks null 시 bundler 메시지 fallback

## Test plan
- [x] `zig build wasm-bundler` 통과
- [x] `bun test packages/wasm/index.test.ts` 48/48 pass (ABI v4, 에러 메시지 round-trip)
- [x] `cd documents && bun run build` 347 페이지 통과
- [ ] dev/배포 후: UMD / AMD preset 선택 → 출력 wrapper 확인. 잘못된 entry 입력 → 의미 있는 에러 메시지 표시

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)