### PR TITLE
feat(playground): bundler 에 transpile 옵션 전체 노출 (target/jsx/decorators/sourcemap) (#1885)

### DIFF
--- a/documents/src/components/PlaygroundBundler.tsx
+++ b/documents/src/components/PlaygroundBundler.tsx
@@ -6,7 +6,7 @@
  */
 import { useEffect, useRef, useState } from "react";
 import Editor from "@monaco-editor/react";
-import type { BundleOptionsInput, OutputChunk } from "../../../packages/wasm/index.ts";
+import type { BundleOptionsInput, OutputChunk, Target } from "../../../packages/wasm/index.ts";
 import {
   BTN_CLASS,
   Badge,
@@ -15,6 +15,7 @@ import {
   SELECT_BTN_CLASS,
   Section,
   Sel,
+  Txt,
   editorOpts,
   inferLanguage,
 } from "./playground-shared";
@@ -245,6 +246,20 @@ interface BundleOpts {
   preserveModules: boolean;
   /// 한 줄에 specifier 하나 (`react`, `react-dom/*` 등 와일드카드 지원).
   externalText: string;
+  // ─── transpile 계열 (각 모듈 transform 단계) ───
+  target: Target | "esnext";
+  jsx: "classic" | "automatic" | "automatic-dev";
+  jsxFactory: string;
+  jsxFragment: string;
+  jsxImportSource: string;
+  flow: boolean;
+  jsxInJs: boolean;
+  experimentalDecorators: boolean;
+  emitDecoratorMetadata: boolean;
+  useDefineForClassFields: boolean;
+  charsetUtf8: boolean;
+  keepNames: boolean;
+  sourcemap: boolean;
 }
 
 const DEFAULT_OPTS: BundleOpts = {
@@ -257,6 +272,19 @@ const DEFAULT_OPTS: BundleOpts = {
   codeSplitting: false,
   preserveModules: false,
   externalText: "",
+  target: "esnext",
+  jsx: "classic",
+  jsxFactory: "",
+  jsxFragment: "",
+  jsxImportSource: "",
+  flow: false,
+  jsxInJs: false,
+  experimentalDecorators: false,
+  emitDecoratorMetadata: false,
+  useDefineForClassFields: true,
+  charsetUtf8: false,
+  keepNames: false,
+  sourcemap: false,
 };
 
 function parseExternal(text: string): string[] {
@@ -278,6 +306,20 @@ function toApiOptions(opts: BundleOpts): BundleOptionsInput {
     codeSplitting: opts.codeSplitting,
     preserveModules: opts.preserveModules,
     ...(external.length > 0 ? { external } : {}),
+    // transpile 계열 — 빈 문자열 / esnext / 기본값은 전송 생략 (URL/payload 짧게).
+    ...(opts.target !== "esnext" ? { target: opts.target as Target } : {}),
+    jsx: opts.jsx,
+    ...(opts.jsxFactory ? { jsxFactory: opts.jsxFactory } : {}),
+    ...(opts.jsxFragment ? { jsxFragment: opts.jsxFragment } : {}),
+    ...(opts.jsxImportSource ? { jsxImportSource: opts.jsxImportSource } : {}),
+    flow: opts.flow,
+    jsxInJs: opts.jsxInJs,
+    experimentalDecorators: opts.experimentalDecorators,
+    emitDecoratorMetadata: opts.emitDecoratorMetadata,
+    useDefineForClassFields: opts.useDefineForClassFields,
+    charsetUtf8: opts.charsetUtf8,
+    keepNames: opts.keepNames,
+    sourcemap: opts.sourcemap,
   };
 }
 
@@ -688,6 +730,99 @@ export default function PlaygroundBundler() {
                   rows={3}
                   spellCheck={false}
                   className="w-full resize-y rounded border border-surface-800 bg-surface-950 px-1.5 py-1 text-[12px] text-neutral-200 placeholder:text-neutral-600"
+                />
+              </Section>
+              <Section title="Parser">
+                <Chk label="Flow" checked={opts.flow} onChange={(v) => updateOpt("flow", v)} />
+                <Chk
+                  label="JSX in .js"
+                  checked={opts.jsxInJs}
+                  onChange={(v) => updateOpt("jsxInJs", v)}
+                />
+                <Chk
+                  label="Experimental Decorators"
+                  checked={opts.experimentalDecorators}
+                  onChange={(v) => updateOpt("experimentalDecorators", v)}
+                />
+                <Chk
+                  label="Emit Decorator Metadata"
+                  checked={opts.emitDecoratorMetadata}
+                  onChange={(v) => updateOpt("emitDecoratorMetadata", v)}
+                />
+              </Section>
+              <Section title="Target">
+                <Sel
+                  label="Target"
+                  value={opts.target}
+                  onChange={(v) => updateOpt("target", v as BundleOpts["target"])}
+                  options={[
+                    ["esnext", "ESNext"],
+                    ["es2025", "ES2025"],
+                    ["es2024", "ES2024"],
+                    ["es2022", "ES2022"],
+                    ["es2021", "ES2021"],
+                    ["es2020", "ES2020"],
+                    ["es2019", "ES2019"],
+                    ["es2018", "ES2018"],
+                    ["es2017", "ES2017"],
+                    ["es2016", "ES2016"],
+                    ["es2015", "ES2015"],
+                    ["es5", "ES5"],
+                  ]}
+                />
+              </Section>
+              <Section title="JSX">
+                <Sel
+                  label="JSX"
+                  value={opts.jsx}
+                  onChange={(v) => updateOpt("jsx", v as BundleOpts["jsx"])}
+                  options={[
+                    ["classic", "Classic"],
+                    ["automatic", "Automatic"],
+                    ["automatic-dev", "Automatic (Dev)"],
+                  ]}
+                />
+                <Txt
+                  label="JSX Factory"
+                  value={opts.jsxFactory}
+                  placeholder="React.createElement"
+                  onChange={(v) => updateOpt("jsxFactory", v)}
+                />
+                <Txt
+                  label="JSX Fragment"
+                  value={opts.jsxFragment}
+                  placeholder="React.Fragment"
+                  onChange={(v) => updateOpt("jsxFragment", v)}
+                />
+                <Txt
+                  label="JSX Import Source"
+                  value={opts.jsxImportSource}
+                  placeholder="react"
+                  onChange={(v) => updateOpt("jsxImportSource", v)}
+                />
+              </Section>
+              <Section title="Transform">
+                <Chk
+                  label="useDefineForClassFields"
+                  checked={opts.useDefineForClassFields}
+                  onChange={(v) => updateOpt("useDefineForClassFields", v)}
+                />
+                <Chk
+                  label="Charset UTF-8"
+                  checked={opts.charsetUtf8}
+                  onChange={(v) => updateOpt("charsetUtf8", v)}
+                />
+                <Chk
+                  label="Keep Names (.name 보존)"
+                  checked={opts.keepNames}
+                  onChange={(v) => updateOpt("keepNames", v)}
+                />
+              </Section>
+              <Section title="Sourcemap">
+                <Chk
+                  label="Generate"
+                  checked={opts.sourcemap}
+                  onChange={(v) => updateOpt("sourcemap", v)}
                 />
               </Section>
             </div>

--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -282,8 +282,8 @@ describe("Bundler (minimal)", () => {
     await initBundler(vfs, wasmBytes);
   });
 
-  test("bundlerVersion = ABI v4 (last_error_message_get 추가)", () => {
-    expect(bundlerVersion()).toBe(4);
+  test("bundlerVersion = ABI v5 (transpile 옵션 노출)", () => {
+    expect(bundlerVersion()).toBe(5);
   });
 
   test("build: 단일 entry → bundle 코드 (TS 어노테이션 strip + 모듈 wrap)", () => {
@@ -383,5 +383,29 @@ describe("Bundler (minimal)", () => {
     expect(chunks![0].code).toContain("`hi ${n}`");
     // newline 도 escape 안 깨지고 round-trip
     expect(chunks![0].code.split("\n").length).toBeGreaterThan(1);
+  });
+
+  test("build: target=es5 옵션 → 화살표 함수가 function 으로 다운레벨링", () => {
+    // utils.ts 의 `(n) => ...` arrow 가 baseline (esnext) 에는 그대로,
+    // es5 에선 function expression 으로 변환되어야 함.
+    const baseline = build("/utils.ts");
+    const downleveled = build("/utils.ts", { target: "es5" });
+    expect(baseline).not.toBeNull();
+    expect(downleveled).not.toBeNull();
+    expect(baseline?.code).toContain("=>");
+    expect(downleveled?.code).not.toContain("=>");
+    expect(downleveled?.code).toContain("function");
+  });
+
+  test("build: jsxFactory 커스텀 옵션 적용", () => {
+    // 임시로 JSX 파일 추가 — 그러나 globalVfs 가 모듈-수준이라 직접 set 안 됨.
+    // utils.ts 에 JSX 가 없으니 jsx 옵션 효과 없음. 그래서 ABI smoke test 만 — 옵션
+    // 전달이 에러 없이 처리되는지 확인.
+    const result = build("/index.ts", {
+      jsx: "classic",
+      jsxFactory: "h",
+      jsxFragment: "Frag",
+    });
+    expect(result).not.toBeNull();
   });
 });

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -461,7 +461,7 @@ export interface BundleResult {
   code: string;
 }
 
-/// build() / buildChunks() 가 받는 옵션. ZTS bundler 의 BundleOptions minimal subset.
+/// build() / buildChunks() 가 받는 옵션. ZTS bundler 의 BundleOptions subset.
 export interface BundleOptionsInput {
   /// 출력 모듈 형식. 기본 "esm". umd/amd 는 IIFE 계열 (함수 래퍼).
   format?: "esm" | "cjs" | "iife" | "umd" | "amd";
@@ -479,10 +479,28 @@ export interface BundleOptionsInput {
   codeSplitting?: boolean;
   /// `buildChunks` 에서만 의미. true 면 모듈 1개 = 출력 1개 (rollup preserveModules).
   preserveModules?: boolean;
+  // ─── transpile 계열 옵션 (각 모듈 transform 단계) ───
+  /// ES 다운레벨링 타겟. JS 측에서 targetToUnsupported 로 unsupported bitmask 변환.
+  target?: Target;
+  /// 또는 직접 unsupported bitmask 지정 (target 보다 우선).
+  unsupported?: number;
+  jsx?: "classic" | "automatic" | "automatic-dev";
+  jsxFactory?: string;
+  jsxFragment?: string;
+  jsxImportSource?: string;
+  flow?: boolean;
+  jsxInJs?: boolean;
+  experimentalDecorators?: boolean;
+  emitDecoratorMetadata?: boolean;
+  useDefineForClassFields?: boolean;
+  charsetUtf8?: boolean;
+  keepNames?: boolean;
+  sourcemap?: boolean;
 }
 
 /// 옵션을 wasm 메모리에 JSON 으로 인코딩 + 복사. ptr=0/len=0 이면 옵션 미전달 의미.
 /// caller 가 dealloc 책임. minify shorthand 는 여기서 펼쳐 wasm 측은 항상 개별 키만 봄.
+/// target 은 unsupported bitmask 로 변환 (JS 측에서 처리해 wasm 의 매핑 부담 제거).
 function encodeBundleOptions(options?: BundleOptionsInput): { ptr: number; len: number } {
   if (!options) return { ptr: 0, len: 0 };
   const expanded: BundleOptionsInput = { ...options };
@@ -492,6 +510,12 @@ function encodeBundleOptions(options?: BundleOptionsInput): { ptr: number; len: 
     expanded.minifySyntax = expanded.minifySyntax ?? true;
   }
   delete expanded.minify;
+  // target → unsupported bitmask. 명시적 unsupported 가 우선.
+  if (expanded.target && expanded.unsupported == null) {
+    const bits = targetToUnsupported(expanded.target);
+    if (bits !== 0) expanded.unsupported = bits;
+  }
+  delete expanded.target;
   const optsBytes = encoder.encode(JSON.stringify(expanded));
   const ptr = bundler!.alloc(optsBytes.length);
   if (ptr === 0) throw new Error("zts-wasm: bundler alloc failed");

--- a/packages/wasm/src/wasm_bundler_entry.zig
+++ b/packages/wasm/src/wasm_bundler_entry.zig
@@ -24,9 +24,11 @@ const wasm_alloc = std.heap.c_allocator;
 pub fn main() void {}
 
 /// Bundler ABI version. host 가 호환성 체크용.
-/// v4 — last_error_message_get export 추가, build() 가 실패 시 의미 있는 메시지 노출.
+/// v5 — BuildOptionsJson 에 transpile 계열 옵션 추가 (target unsupported bitmask,
+/// jsx runtime / factory / fragment / importSource, flow, jsxInJs, decorators,
+/// useDefineForClassFields, charsetUtf8, keepNames, sourcemap).
 export fn bundler_version() u32 {
-    return 4;
+    return 5;
 }
 
 /// JS 측이 entry path 등 입력 메모리 확보용.
@@ -90,7 +92,30 @@ const BuildOptionsJson = struct {
     codeSplitting: ?bool = null,
     /// build_chunks 에서만 의미 있음. true 면 모듈 1개 = 출력 1개 (rollup preserveModules).
     preserveModules: ?bool = null,
+    /// transpile 계열 옵션 — 각 모듈 transform 단계에 적용 (Phase 3 PR D).
+    /// target → unsupported bitmask. JS 측에서 packages/shared 의 targetToUnsupported() 로 변환 후 전달.
+    unsupported: ?u32 = null,
+    /// "classic" | "automatic" | "automatic-dev"
+    jsx: ?[]const u8 = null,
+    jsxFactory: ?[]const u8 = null,
+    jsxFragment: ?[]const u8 = null,
+    jsxImportSource: ?[]const u8 = null,
+    flow: ?bool = null,
+    jsxInJs: ?bool = null,
+    experimentalDecorators: ?bool = null,
+    emitDecoratorMetadata: ?bool = null,
+    useDefineForClassFields: ?bool = null,
+    charsetUtf8: ?bool = null,
+    keepNames: ?bool = null,
+    sourcemap: ?bool = null,
 };
+
+fn parseJsxRuntime(s: []const u8) ?@import("zts_lib").codegen.codegen.JsxRuntime {
+    if (std.mem.eql(u8, s, "classic")) return .classic;
+    if (std.mem.eql(u8, s, "automatic")) return .automatic;
+    if (std.mem.eql(u8, s, "automatic-dev") or std.mem.eql(u8, s, "automatic_dev")) return .automatic_dev;
+    return null;
+}
 
 fn parseFormat(s: []const u8) ?Format {
     if (std.mem.eql(u8, s, "esm")) return .esm;
@@ -161,6 +186,23 @@ fn applyOptionsJson(
     if (o.minifySyntax) |b| base.minify_syntax = b;
     if (o.codeSplitting) |b| base.code_splitting = b;
     if (o.preserveModules) |b| base.preserve_modules = b;
+
+    // transpile 계열 옵션 — 각 모듈 transform 단계 적용.
+    if (o.unsupported) |bits| base.unsupported = @bitCast(bits);
+    if (o.jsx) |s| if (parseJsxRuntime(s)) |r| {
+        base.jsx_runtime = r;
+    };
+    if (o.jsxFactory) |s| base.jsx_factory = s;
+    if (o.jsxFragment) |s| base.jsx_fragment = s;
+    if (o.jsxImportSource) |s| base.jsx_import_source = s;
+    if (o.flow) |b| base.flow = b;
+    if (o.jsxInJs) |b| base.jsx_in_js = b;
+    if (o.experimentalDecorators) |b| base.experimental_decorators = b;
+    if (o.emitDecoratorMetadata) |b| base.emit_decorator_metadata = b;
+    if (o.useDefineForClassFields) |b| base.use_define_for_class_fields = b;
+    if (o.charsetUtf8) |b| base.charset_utf8 = b;
+    if (o.keepNames) |b| base.keep_names = b;
+    if (o.sourcemap) |b| base.sourcemap.enable = b;
 }
 
 /// bundle() 결과의 fatal diagnostic 첫 번째를 last_error_msg 로 캡처 (있으면).


### PR DESCRIPTION
## Summary
사용자 보고 — bundler 모드에 ES5 등 transpile 옵션 누락. ABI + UI 둘 다 확장.

## ABI v4 → v5
- `unsupported: u32` (JS 측에서 targetToUnsupported 로 변환 후 전달)
- `jsx`, `jsxFactory`, `jsxFragment`, `jsxImportSource`
- `flow`, `jsxInJs`, `experimentalDecorators`, `emitDecoratorMetadata`, `useDefineForClassFields`
- `charsetUtf8`, `keepNames`
- `sourcemap` (boolean → BundleOptions.sourcemap.enable)
- `parseJsxRuntime` 헬퍼

## JS
- `BundleOptionsInput` 확장 + `target: Target`
- `encodeBundleOptions`: target → unsupported bitmask 변환 (명시적 unsupported 우선)

## UI
- 좌측 사이드바 신규 섹션: Parser / Target / JSX / Transform / Sourcemap
- transpile playground 와 동일 helper (Sel/Chk/Txt) 재사용

## Test plan
- [x] `zig build wasm-bundler` 통과
- [x] `bun test packages/wasm/index.test.ts` 50/50 pass — target=es5 화살표 다운레벨링 검증
- [x] `cd documents && bun run build` 347 페이지 통과

## 미지원 (BundleOptions 미보유 — 코어 확장 필요)
- `dropConsole` / `dropDebugger` / `quotes` / `asciiOnly` — bundler 가 emit 옵션으로 못 받음

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)