### PR TITLE
fix(playground): bundler preset 변경 시 사용자 옵션 보존 (#1885)

### DIFF
--- a/documents/src/components/PlaygroundBundler.tsx
+++ b/documents/src/components/PlaygroundBundler.tsx
@@ -505,9 +505,10 @@ export default function PlaygroundBundler() {
   function handlePreset(label: string) {
     const preset = PRESETS.find((p) => p.label === label);
     if (!preset) return;
-    // preset 의 권장 옵션은 default 위에 merge — 이전 preset 의 옵션이 새 preset 에
-    // 새어들어가지 않도록 default reset 후 적용.
-    const nextOpts: BundleOpts = { ...DEFAULT_OPTS, ...preset.opts };
+    // preset 의 권장 옵션을 현재 opts 위에 merge — 사용자가 토글한 옵션 (target=es5
+    // 등) 은 보존, preset 이 명시한 키만 덮어씀. (이전 preset 의 자동-적용된 권장
+    // 옵션은 그대로 남는데, 사용자가 직접 토글로 끄면 됨.)
+    const nextOpts: BundleOpts = { ...opts, ...preset.opts };
     setFiles(preset.files);
     setActivePath(preset.entry);
     setEntryPath(preset.entry);


### PR DESCRIPTION
## Summary
사용자 보고 — bundler 에서 ES5 등 옵션 토글 후 다른 preset 변경 시 옵션 reset.

## Fix
`handlePreset` 가 `DEFAULT_OPTS` reset 대신 현재 `opts` 위에 `preset.opts` merge:
- 사용자가 직접 토글한 옵션 보존
- preset 이 명시한 키만 덮어씀

## Tradeoff
이전 preset 의 자동 적용된 권장 옵션 (예: Dynamic import → codeSplitting=true) 이 새 preset 으로 따라가는 부작용 있지만, 사용자가 토글로 끌 수 있고 옵션 reset 보다 UX 일관성 좋음.

## Test plan
- [x] `bun run build` 통과
- [ ] dev/배포 후: ES5 토글 → 다른 preset 변경 → ES5 유지 확인

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)