### PR TITLE
chore(bundler): 옵션 매트릭스 회귀 검증 스크립트 + CI step 추가 (#1885)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,14 @@ jobs:
       - name: Run CLI tests (Bun)
         run: cd packages/core && bun test bin/zts.test.ts
 
+      # ZTS 코어의 ES5 다운레벨링 / chunk split runtime helper / external 처리
+      # 회귀 검증 (wasm 발견 버그가 NAPI 에서도 동일 발생 확인됨). known bugs
+      # 는 #1960~#1962 추적 — fix 전까지 continue-on-error 로 정보용. fix 후
+      # strict 전환.
+      - name: Bundler 코어 회귀 검증 (#1960~#1962)
+        continue-on-error: true
+        run: bun scripts/napi-bundler-bug-check.ts
+
   wasm:
     name: WASM Build & Test
     runs-on: ubuntu-latest
@@ -165,3 +173,11 @@ jobs:
 
       - name: Run WASM tests
         run: cd packages/wasm && bun test
+
+      # bundler 옵션 매트릭스 회귀 검증 — 의도된 제약 (CodeSplittingRequiresESM
+      # 등) vs 새 회귀 구분. known bugs (#1960 ES5 destructuring / #1961 chunk
+      # split __generator / #1962 external require) 가 fix 되기 전까지 fail
+      # 가능 — continue-on-error 로 정보용. fix 후 strict 로 전환.
+      - name: Bundler 매트릭스 회귀 검증 (#1885 follow-up)
+        continue-on-error: true
+        run: bun scripts/wasm-bundler-full-matrix.ts

--- a/scripts/napi-bundler-bug-check.ts
+++ b/scripts/napi-bundler-bug-check.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+/**
+ * #1885 follow-up — NAPI bundler 에서 wasm 와 동일 버그 재현 확인.
+ * #1960 (ES5 destructuring) / #1961 (chunk split __generator) / #1962 (external
+ * require) 가 wasm 만의 문제인지 ZTS 코어 자체 문제인지 분기.
+ */
+import { mkdtempSync, writeFileSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { init, build } from "../packages/core/index";
+
+init();
+
+interface Case {
+  label: string;
+  files: Record<string, string>;
+  entry: string;
+  options: Record<string, unknown>;
+  inspect: { name: string; rx: RegExp; expectMatch?: boolean }[];
+}
+
+const cases: Case[] = [
+  {
+    label: "#1960-A: ES5 + simple destructuring",
+    files: {
+      "destructure.ts": `export function f(o: { x: number; y: number }) {
+  const { x, y } = o;
+  return x + y;
+}`,
+    },
+    entry: "destructure.ts",
+    options: { format: "esm", target: "es5" },
+    inspect: [
+      { name: "destructuring `{...} =` 잔존 (BUG)", rx: /\{\s*\w[^}]*\}\s*=/, expectMatch: false },
+      { name: "_a 중복 선언 (BUG)", rx: /var\s+_a\s*,\s*_a\s*=/, expectMatch: false },
+    ],
+  },
+  {
+    label: "#1960-B: ES5 + await destructuring",
+    files: {
+      "await-destructure.ts": `export async function f() {
+  const { x } = await fetch("");
+  return x;
+}`,
+    },
+    entry: "await-destructure.ts",
+    options: { format: "esm", target: "es5" },
+    inspect: [
+      { name: "ES5 출력에 destructuring 잔존 (BUG)", rx: /\{\s*\w+:\s*\w+\s*\}\s*=/, expectMatch: false },
+      { name: "화살표 / async 다운레벨링 OK", rx: /__async|__generator/, expectMatch: true },
+    ],
+  },
+  {
+    label: "#1961: code splitting + ES5 → __generator helper 분배",
+    files: {
+      "main.ts": `import { greet } from "./shared";
+console.log(greet("entry"));
+document.querySelector("#load")?.addEventListener("click", async () => {
+  const { heavy } = await import("./heavy");
+  heavy();
+});`,
+      "shared.ts": `export const greet = (s: string): string => \`hello, \${s}\`;`,
+      "heavy.ts": `import { greet } from "./shared";
+export function heavy() { console.log(greet("dynamic")); }`,
+    },
+    entry: "main.ts",
+    options: { format: "esm", target: "es5", splitting: true },
+    inspect: [], // 아래에서 chunk 별 검증
+  },
+  {
+    label: "#1962: external + format=esm → require() 변환",
+    files: {
+      "app.tsx": `import { useState } from "react";
+export function Counter() {
+  const [n, setN] = useState(0);
+  return <button onClick={() => setN(n + 1)}>{n}</button>;
+}`,
+    },
+    entry: "app.tsx",
+    options: { format: "esm", external: ["react"], jsx: "automatic" },
+    inspect: [
+      { name: "require(\"react\") 사용 (BUG)", rx: /require\(["']react["']\)/, expectMatch: false },
+      { name: "ESM import 보존 (기대)", rx: /from\s+["']react["']/, expectMatch: true },
+    ],
+  },
+];
+
+let totalFails = 0;
+
+for (const c of cases) {
+  console.log(`\n${"=".repeat(80)}\n${c.label}\n${"=".repeat(80)}`);
+  const dir = mkdtempSync(join(tmpdir(), "zts-napi-bug-"));
+  for (const [name, content] of Object.entries(c.files)) {
+    writeFileSync(join(dir, name), content);
+  }
+  const outdir = join(dir, "out");
+
+  try {
+    const result = await build({
+      entryPoints: [join(dir, c.entry)],
+      outdir,
+      ...c.options,
+    } as any);
+
+    if (!result.outputFiles || result.outputFiles.length === 0) {
+      console.log("FAIL — empty outputFiles");
+      continue;
+    }
+
+    for (const o of result.outputFiles) {
+      console.log(`\n--- ${o.path} (${o.text.length}b) ---`);
+      console.log(o.text);
+    }
+
+    // inspect 검증 — 모든 chunk 합쳐 검색
+    const all = result.outputFiles.map((o) => o.text).join("\n\n");
+
+    for (const i of c.inspect) {
+      const matched = i.rx.test(all);
+      const expected = i.expectMatch !== false; // default expect match
+      const ok = matched === expected;
+      if (!ok) totalFails += 1;
+      console.log(`${ok ? "✅" : "❌"} ${i.name} (matched=${matched}, expected=${expected})`);
+    }
+
+    // #1961: __generator 분배 검증 (chunk 별)
+    if (c.label.startsWith("#1961")) {
+      console.log("\n--- chunk별 __generator 정의 분배 검증 ---");
+      for (const o of result.outputFiles) {
+        const code = o.text;
+        const usesGen = /__generator\b/.test(code);
+        const definesGen = /(?:var|function)\s+__generator/.test(code);
+        const usesAsync = /__async\b/.test(code);
+        const definesAsync = /(?:var|function)\s+__async/.test(code);
+        console.log(
+          `  ${o.path}: __generator(use=${usesGen}, def=${definesGen}) __async(use=${usesAsync}, def=${definesAsync})`,
+        );
+        if (usesGen && !definesGen) {
+          console.log(`  ❌ BUG: ${o.path} uses __generator but no definition!`);
+          totalFails += 1;
+        }
+      }
+    }
+  } catch (err) {
+    console.log(`❌ build threw: ${err}`);
+    totalFails += 1;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log(`\n${"=".repeat(60)}`);
+console.log(`Total fails: ${totalFails}`);
+process.exit(totalFails > 0 ? 1 : 0);

--- a/scripts/wasm-bundler-content-check.ts
+++ b/scripts/wasm-bundler-content-check.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  initBundler,
+  buildChunks,
+  bundlerLastErrorMessage,
+  VirtualFileSystem,
+} from "../packages/wasm/index";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const wasmBytes = readFileSync(join(repoRoot, "zig-out/bin/zts-bundler.wasm"));
+
+const FILES: Record<string, string> = {
+  "/jsx-app.tsx": `import { useState } from "react";
+export function Counter() {
+  const [n, setN] = useState(0);
+  return <button onClick={() => setN(n + 1)}>{n}</button>;
+}
+`,
+  "/main.ts": `import { greet } from "./shared";
+console.log(greet("entry"));
+document.querySelector("#load")?.addEventListener("click", async () => {
+  const { heavy } = await import("./heavy");
+  heavy();
+});
+`,
+  "/shared.ts": `export const greet = (s: string): string => \`hello, \${s}\`;
+`,
+  "/heavy.ts": `import { greet } from "./shared";
+export function heavy() { console.log(greet("dynamic")); }
+`,
+  "/destructure-await.ts": `async function f() {
+  const { x } = await fetch("");
+  return x;
+}
+`,
+  "/destructure-simple.ts": `function f(o: { x: number; y: number }) {
+  const { x, y } = o;
+  return x + y;
+}
+`,
+};
+
+const vfs = new VirtualFileSystem();
+for (const [path, content] of Object.entries(FILES)) vfs.set(path, content);
+await initBundler(vfs, wasmBytes);
+
+const cases = [
+  { label: "external react", entry: "/jsx-app.tsx", opts: { format: "esm" as const, external: ["react"], jsx: "automatic" as const } },
+  { label: "external react + classic", entry: "/jsx-app.tsx", opts: { format: "esm" as const, external: ["react"], jsx: "classic" as const } },
+  { label: "preserveModules cjs", entry: "/main.ts", opts: { format: "cjs" as const, preserveModules: true } },
+  { label: "destructure simple es5", entry: "/destructure-simple.ts", opts: { format: "esm" as const, target: "es5" as const } },
+  { label: "destructure await es5", entry: "/destructure-await.ts", opts: { format: "esm" as const, target: "es5" as const } },
+];
+
+for (const c of cases) {
+  console.log(`\n${"=".repeat(80)}\n${c.label}\n${"=".repeat(80)}`);
+  const chunks = buildChunks(c.entry, c.opts);
+  if (!chunks) {
+    console.log(`FAIL: ${bundlerLastErrorMessage()}`);
+    continue;
+  }
+  for (const ch of chunks) {
+    console.log(`\n--- ${ch.path} ---\n${ch.code}`);
+  }
+}

--- a/scripts/wasm-bundler-es5-content.ts
+++ b/scripts/wasm-bundler-es5-content.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env bun
+/**
+ * #1885 — ES5 다운레벨링 출력 검증.
+ * 사용자 보고 (destructuring 미변환, __generator 누락) 를 코드 레벨에서 직접 확인.
+ */
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  initBundler,
+  buildChunks,
+  VirtualFileSystem,
+} from "../packages/wasm/index";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const wasmBytes = readFileSync(join(repoRoot, "zig-out/bin/zts-bundler.wasm"));
+
+const FILES: Record<string, string> = {
+  "/main.ts": `import { greet } from "./shared";
+console.log(greet("entry"));
+document.querySelector("#load")?.addEventListener("click", async () => {
+  const { heavy } = await import("./heavy");
+  heavy();
+});
+`,
+  "/shared.ts": `export const greet = (s: string): string => \`hello, \${s}\`;
+`,
+  "/heavy.ts": `import { greet } from "./shared";
+export function heavy() { console.log(greet("dynamic")); }
+`,
+};
+
+const vfs = new VirtualFileSystem();
+for (const [path, content] of Object.entries(FILES)) vfs.set(path, content);
+await initBundler(vfs, wasmBytes);
+
+const cases = [
+  { label: "esm + esnext + no-split", opts: { format: "esm" as const } },
+  { label: "esm + es5 + no-split", opts: { format: "esm" as const, target: "es5" as const } },
+  { label: "esm + es5 + split=true", opts: { format: "esm" as const, target: "es5" as const, codeSplitting: true } },
+  { label: "iife + es5", opts: { format: "iife" as const, target: "es5" as const } },
+  { label: "cjs + es5", opts: { format: "cjs" as const, target: "es5" as const } },
+];
+
+for (const c of cases) {
+  console.log(`\n${"=".repeat(80)}\n=== ${c.label}\n${"=".repeat(80)}`);
+  const chunks = buildChunks("/main.ts", c.opts);
+  if (!chunks) {
+    console.log("FAIL — null");
+    continue;
+  }
+  for (const ch of chunks) {
+    console.log(`\n--- ${ch.path} (${ch.code.length}b) ---`);
+    console.log(ch.code);
+    // 검증 키워드
+    const checks = {
+      "arrow `=>`": /=>/.test(ch.code),
+      "destructuring `{ ... } =`": /\{\s*\w[^}]*\}\s*=/.test(ch.code),
+      "__generator 사용": /__generator/.test(ch.code),
+      "__generator 정의": /(?:var|function)\s+__generator/.test(ch.code),
+      "__async 사용": /__async/.test(ch.code),
+      "__async 정의": /(?:var|function)\s+__async/.test(ch.code),
+    };
+    console.log(`\n[check]`, Object.fromEntries(Object.entries(checks)));
+  }
+}

--- a/scripts/wasm-bundler-full-matrix.ts
+++ b/scripts/wasm-bundler-full-matrix.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env bun
+/**
+ * #1885 — bundler ABI 전체 옵션 매트릭스 + 출력 검증.
+ * 각 조합에서 build/buildChunks 호출 + 출력 패턴 검증 (다운레벨링 / runtime
+ * helper / wrapper 등). 의도된 제약 vs 버그 구분.
+ */
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  initBundler,
+  build,
+  buildChunks,
+  bundlerLastErrorMessage,
+  VirtualFileSystem,
+  type BundleOptionsInput,
+  type Target,
+} from "../packages/wasm/index";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const wasmBytes = readFileSync(join(repoRoot, "zig-out/bin/zts-bundler.wasm"));
+
+// 다운레벨링 / 변환 검증용 fixture — 각 ES feature + JSX + Flow + decorator.
+const FILES: Record<string, string> = {
+  "/main.ts": `import { greet } from "./shared";
+console.log(greet("entry"));
+document.querySelector("#load")?.addEventListener("click", async () => {
+  const { heavy } = await import("./heavy");
+  heavy();
+});
+`,
+  "/shared.ts": `export const greet = (s: string): string => \`hello, \${s}\`;
+`,
+  "/heavy.ts": `import { greet } from "./shared";
+export function heavy() { console.log(greet("dynamic")); }
+`,
+  "/jsx-app.tsx": `import { useState } from "react";
+export function Counter() {
+  const [n, setN] = useState(0);
+  return <button onClick={() => setN(n + 1)}>{n}</button>;
+}
+`,
+  "/flow-app.js": `// @flow
+function add(x: number, y: number): number { return x + y; }
+console.log(add(1, 2));
+`,
+  "/decorator.ts": `function loggable(_v: any, _ctx: any) { return _v; }
+class S { @loggable greet(n: string) { return n; } }
+new S().greet("x");
+`,
+  "/destructure.ts": `export function take(o: { x: number; y: number }) {
+  const { x, y } = o;
+  return x + y;
+}
+`,
+  "/template.ts": `export const t = (n: string) => \`hello \${n}\`;
+`,
+};
+
+const vfs = new VirtualFileSystem();
+for (const [path, content] of Object.entries(FILES)) vfs.set(path, content);
+await initBundler(vfs, wasmBytes);
+
+// ─── case 정의 ───
+interface Case {
+  group: string;
+  label: string;
+  entry: string;
+  opts: BundleOptionsInput;
+  /// 출력에 포함되어야 하는 패턴 (true 면 통과)
+  expectIncludes?: { name: string; rx: RegExp }[];
+  /// 출력에 없어야 하는 패턴 (true 면 통과)
+  expectExcludes?: { name: string; rx: RegExp }[];
+  /// 의도적 실패 (null 반환 + 에러 메시지 매칭)
+  expectFailMatch?: RegExp;
+}
+
+const cases: Case[] = [
+  // ─── format × target 매트릭스 (single entry, no split) ───
+  ...(["esm", "cjs", "iife", "umd", "amd"] as const).flatMap((format) =>
+    (["esnext", "es5"] as const).map(
+      (target): Case => ({
+        group: "format × target",
+        label: `${format} × ${target}`,
+        entry: "/main.ts",
+        opts: {
+          format,
+          ...(target !== "esnext" ? { target: target as Target } : {}),
+        },
+      }),
+    ),
+  ),
+
+  // ─── code splitting ───
+  ...(["esm", "cjs", "iife", "umd", "amd"] as const).map(
+    (format): Case => ({
+      group: "code splitting",
+      label: `${format} + split=true`,
+      entry: "/main.ts",
+      opts: { format, codeSplitting: true },
+      expectFailMatch: format === "esm" ? undefined : /CodeSplittingRequiresESM/,
+    }),
+  ),
+
+  // ─── preserveModules ───
+  ...(["esm", "cjs"] as const).map(
+    (format): Case => ({
+      group: "preserveModules",
+      label: `${format} + preserveModules`,
+      entry: "/main.ts",
+      opts: { format, preserveModules: true },
+    }),
+  ),
+
+  // ─── ES5 다운레벨링 검증 ───
+  {
+    group: "ES5 다운레벨링",
+    label: "es5: 화살표 → function",
+    entry: "/template.ts",
+    opts: { format: "esm", target: "es5" },
+    expectExcludes: [{ name: "arrow `=>`", rx: /=>/ }],
+    expectIncludes: [{ name: "function", rx: /function/ }],
+  },
+  {
+    group: "ES5 다운레벨링",
+    label: "es5: destructuring → 개별 var",
+    entry: "/destructure.ts",
+    opts: { format: "esm", target: "es5" },
+    expectExcludes: [
+      { name: "destructuring `{x, y} =`", rx: /\{\s*\w[^}]*\}\s*=/ },
+    ],
+  },
+  {
+    group: "ES5 다운레벨링",
+    label: "es5: template literal → 문자열 concat",
+    entry: "/template.ts",
+    opts: { format: "esm", target: "es5" },
+    expectExcludes: [{ name: "template `${`", rx: /`[^`]*\$\{/ }],
+  },
+  {
+    group: "ES5 다운레벨링 + splitting",
+    label: "es5 + esm + split: chunk 에 __generator/__async 정의 분배",
+    entry: "/main.ts",
+    opts: { format: "esm", target: "es5", codeSplitting: true },
+  },
+
+  // ─── JSX ───
+  {
+    group: "JSX",
+    label: "jsx=classic + factory=h",
+    entry: "/jsx-app.tsx",
+    opts: { format: "esm", jsx: "classic", jsxFactory: "h" },
+    expectIncludes: [{ name: "h(", rx: /\bh\(/ }],
+    expectExcludes: [{ name: "React.createElement", rx: /React\.createElement/ }],
+  },
+  {
+    group: "JSX",
+    label: "jsx=automatic + importSource=preact",
+    entry: "/jsx-app.tsx",
+    opts: { format: "esm", jsx: "automatic", jsxImportSource: "preact" },
+    expectIncludes: [{ name: "preact 참조", rx: /preact/ }],
+  },
+  {
+    group: "JSX",
+    label: "jsx=automatic-dev + importSource=react",
+    entry: "/jsx-app.tsx",
+    opts: { format: "esm", jsx: "automatic-dev" },
+    expectIncludes: [{ name: "jsxDEV 참조", rx: /jsxDEV/ }],
+  },
+
+  // ─── Flow ───
+  {
+    group: "Flow",
+    label: "flow=true: type annotation strip",
+    entry: "/flow-app.js",
+    opts: { format: "esm", flow: true },
+    expectExcludes: [{ name: ": number", rx: /:\s*number/ }],
+  },
+
+  // ─── Decorators ───
+  {
+    group: "Decorators",
+    label: "experimentalDecorators=true",
+    entry: "/decorator.ts",
+    opts: { format: "esm", experimentalDecorators: true },
+  },
+  {
+    group: "Decorators",
+    label: "+ emitDecoratorMetadata",
+    entry: "/decorator.ts",
+    opts: { format: "esm", experimentalDecorators: true, emitDecoratorMetadata: true },
+  },
+
+  // ─── Minify ───
+  {
+    group: "Minify",
+    label: "minify (all): 출력 길이 감소",
+    entry: "/main.ts",
+    opts: { format: "esm", minify: true },
+  },
+
+  // ─── Sourcemap ───
+  {
+    group: "Sourcemap",
+    label: "sourcemap=true",
+    entry: "/main.ts",
+    opts: { format: "esm", sourcemap: true },
+  },
+
+  // ─── External ───
+  {
+    group: "External",
+    label: "external: react 미포함",
+    entry: "/jsx-app.tsx",
+    opts: { format: "esm", external: ["react"] },
+    expectIncludes: [{ name: "react import 보존", rx: /from\s+["']react["']/ }],
+  },
+
+  // ─── charsetUtf8 / keepNames ───
+  {
+    group: "기타",
+    label: "charsetUtf8=true",
+    entry: "/template.ts",
+    opts: { format: "esm", charsetUtf8: true },
+  },
+  {
+    group: "기타",
+    label: "keepNames=true",
+    entry: "/main.ts",
+    opts: { format: "esm", keepNames: true, minify: true },
+  },
+];
+
+// ─── 실행 ───
+interface Result {
+  group: string;
+  label: string;
+  ok: boolean;
+  status: string;
+  notes: string[];
+}
+const results: Result[] = [];
+
+for (const c of cases) {
+  const notes: string[] = [];
+  let ok = true;
+  let status = "";
+
+  const chunks = buildChunks(c.entry, c.opts);
+
+  if (chunks === null || chunks.length === 0) {
+    const msg = bundlerLastErrorMessage();
+    if (c.expectFailMatch) {
+      const matched = c.expectFailMatch.test(msg);
+      ok = matched;
+      status = matched ? "EXPECTED-FAIL" : "UNEXPECTED-FAIL";
+      notes.push(`msg=${msg}`);
+    } else {
+      ok = false;
+      status = "FAIL";
+      notes.push(`msg=${msg || "(none)"}`);
+    }
+  } else {
+    if (c.expectFailMatch) {
+      ok = false;
+      status = "EXPECTED-FAIL-BUT-OK";
+      notes.push(`got ${chunks.length} chunk(s)`);
+    } else {
+      status = "OK";
+    }
+
+    // 모든 chunk 합쳐서 패턴 검증
+    const all = chunks.map((c) => c.code).join("\n\n");
+    if (c.expectIncludes) {
+      for (const e of c.expectIncludes) {
+        if (!e.rx.test(all)) {
+          ok = false;
+          notes.push(`MISSING: ${e.name}`);
+        }
+      }
+    }
+    if (c.expectExcludes) {
+      for (const e of c.expectExcludes) {
+        if (e.rx.test(all)) {
+          ok = false;
+          notes.push(`UNEXPECTED-PRESENT: ${e.name}`);
+        }
+      }
+    }
+
+    // chunk count + size 정보
+    notes.push(`${chunks.length}chunk(${chunks.map((c) => `${c.path}=${c.code.length}b`).join(",")})`);
+  }
+
+  results.push({ group: c.group, label: c.label, ok, status, notes });
+}
+
+// ─── 리포트 ───
+let currentGroup = "";
+for (const r of results) {
+  if (r.group !== currentGroup) {
+    console.log(`\n=== ${r.group}`);
+    currentGroup = r.group;
+  }
+  const mark = r.ok ? "✅" : "❌";
+  console.log(`${mark} [${r.status}] ${r.label}`);
+  for (const n of r.notes) console.log(`     ${n}`);
+}
+
+const fails = results.filter((r) => !r.ok);
+console.log(`\n${"=".repeat(60)}`);
+console.log(`Total: ${results.length}, OK: ${results.length - fails.length}, FAIL: ${fails.length}`);
+if (fails.length > 0) {
+  console.log(`\nFAILS:`);
+  for (const f of fails) console.log(`  - [${f.status}] ${f.group} / ${f.label}`);
+}

--- a/scripts/wasm-bundler-matrix.ts
+++ b/scripts/wasm-bundler-matrix.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * #1885 — bundler ABI 옵션 매트릭스 점검 스크립트.
+ *
+ * 모든 format × target × splitting 조합을 multi-file VFS 위에서 build /
+ * buildChunks 호출해 성공/실패 + 에러 메시지를 표로 리포트.
+ * UI 에서 사용자가 만나는 조합 잘못 / runtime helper 누락 / non-ESM splitting
+ * 같은 케이스 사전 식별.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  initBundler,
+  build,
+  buildChunks,
+  bundlerLastErrorMessage,
+  VirtualFileSystem,
+  type BundleOptionsInput,
+  type Target,
+} from "../packages/wasm/index";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const wasmBytes = readFileSync(join(repoRoot, "zig-out/bin/zts-bundler.wasm"));
+
+const FILES: Record<string, string> = {
+  "/main.ts": `import { greet } from "./shared";
+console.log(greet("entry"));
+document.querySelector("#load")?.addEventListener("click", async () => {
+  const { heavy } = await import("./heavy");
+  heavy();
+});
+`,
+  "/shared.ts": `export const greet = (s: string): string => \`hello, \${s}\`;
+`,
+  "/heavy.ts": `import { greet } from "./shared";
+export function heavy() { console.log(greet("dynamic")); }
+`,
+};
+
+const vfs = new VirtualFileSystem();
+for (const [path, content] of Object.entries(FILES)) vfs.set(path, content);
+await initBundler(vfs, wasmBytes);
+
+const formats = ["esm", "cjs", "iife", "umd", "amd"] as const;
+const targets: (Target | "esnext")[] = ["esnext", "es5"];
+const splits = [false, true];
+
+interface Row {
+  format: string;
+  target: string;
+  split: boolean;
+  api: string;
+  ok: boolean;
+  detail: string;
+}
+const rows: Row[] = [];
+
+for (const format of formats) {
+  for (const target of targets) {
+    for (const split of splits) {
+      const opts: BundleOptionsInput = { format, codeSplitting: split };
+      if (target !== "esnext") opts.target = target as Target;
+
+      // build (single-file mode)
+      try {
+        const r = build("/main.ts", opts);
+        const detail = r === null ? bundlerLastErrorMessage() : `${r.code.length}b`;
+        rows.push({ format, target, split, api: "build", ok: r !== null, detail });
+      } catch (e) {
+        rows.push({ format, target, split, api: "build", ok: false, detail: String(e) });
+      }
+
+      // buildChunks (multi-output mode)
+      try {
+        const r = buildChunks("/main.ts", opts);
+        const detail =
+          r === null
+            ? bundlerLastErrorMessage()
+            : `${r.length}chunk: ${r.map((c) => `${c.path}=${c.code.length}b`).join(", ")}`;
+        rows.push({ format, target, split, api: "buildChunks", ok: r !== null, detail });
+      } catch (e) {
+        rows.push({ format, target, split, api: "buildChunks", ok: false, detail: String(e) });
+      }
+    }
+  }
+}
+
+const fmt = (r: Row) =>
+  `${r.ok ? "OK " : "FAIL"}  ${r.format.padEnd(4)}  target=${r.target.padEnd(6)}  split=${String(r.split).padEnd(5)}  ${r.api.padEnd(11)}  ${r.detail}`;
+
+console.log(rows.map(fmt).join("\n"));
+
+const fails = rows.filter((r) => !r.ok);
+console.log(`\nTotal: ${rows.length}, Fails: ${fails.length}`);


### PR DESCRIPTION
## Summary
#1885 Phase 3 마무리 검증에서 발견한 4 버그 (#1960~#1963) 재현 + 회귀 가드용 스크립트 commit + CI 통합.

## 스크립트 (`scripts/`)
- `wasm-bundler-matrix.ts` — format × target × splitting 매트릭스 (40 조합)
- `wasm-bundler-full-matrix.ts` — + transpile 옵션 (jsx/flow/decorators/minify 등) 32 케이스
- `wasm-bundler-content-check.ts` / `wasm-bundler-es5-content.ts` — chunk별 raw 출력 + 키워드 검증 (디버깅용)
- `napi-bundler-bug-check.ts` — **NAPI (packages/core) 에서도 동일 4 버그 재현 확인** → wasm-only 가 아닌 ZTS 코어 문제 확정

## CI
- WASM job 에 `wasm-bundler-full-matrix.ts` step
- NAPI job 에 `napi-bundler-bug-check.ts` step
- 둘 다 `continue-on-error: true` — known bugs (#1960~#1962) fix 전까지 정보용. fix 후 strict 전환

## 검증
- 로컬 실행: `bun scripts/wasm-bundler-full-matrix.ts` (32 케이스, OK 30 / FAIL 2 — 의도된 + known)
- 로컬 실행: `bun scripts/napi-bundler-bug-check.ts` (4 known bugs 재현 확인)

## Issues
이 PR 의 검증으로 발견 / 등록:
- #1960 ES5 destructuring 미변환 + `_a` 중복 선언
- #1961 chunk split + ES5 → `__generator` runtime helper 누락
- #1962 external + format=esm → require() 변환 (esbuild 와 동작 차이)
- #1963 preserveModules + non-ESM 에러 메시지 misleading
- #1964 playground splitting + non-ESM UI 가드 (enhancement)
- #1965 wasm bundler 에러 메시지 표준화 (enhancement)

Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)