### PR TITLE
fix(wasm bundler): 에러 메시지를 ZTS 표준 진단 형식으로 통일 (Closes #1965)

### DIFF
--- a/documents/src/content/docs/reference/errors/zts0002.md
+++ b/documents/src/content/docs/reference/errors/zts0002.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0002: Top-level await requires ESM output format'
+description: 'Top-level await requires ESM output format'
+---
+
+## ZTS0002
+
+> Top-level await requires ESM output format
+
+**카테고리**: 타겟/호환성
+
+### 해결 방법
+
+이 에러의 원인과 해결 방법은 에러 메시지를 참고하세요.

--- a/documents/src/content/docs/reference/errors/zts0003.md
+++ b/documents/src/content/docs/reference/errors/zts0003.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0003: Code splitting / preserveModules requires ESM output format'
+description: 'Code splitting / preserveModules requires ESM output format'
+---
+
+## ZTS0003
+
+> Code splitting / preserveModules requires ESM output format
+
+**카테고리**: 타겟/호환성
+
+### 해결 방법
+
+이 에러의 원인과 해결 방법은 에러 메시지를 참고하세요.

--- a/documents/src/content/docs/reference/errors/zts0004.md
+++ b/documents/src/content/docs/reference/errors/zts0004.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0004: Entry path is empty or not found'
+description: 'Entry path is empty or not found'
+---
+
+## ZTS0004
+
+> Entry path is empty or not found
+
+**카테고리**: 타겟/호환성
+
+### 해결 방법
+
+이 에러의 원인과 해결 방법은 에러 메시지를 참고하세요.

--- a/documents/src/content/docs/reference/errors/zts0915.md
+++ b/documents/src/content/docs/reference/errors/zts0915.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0915: Modifiers cannot appear on index signature parameters'
+description: 'Modifiers cannot appear on index signature parameters'
+---
+
+## ZTS0915
+
+> Modifiers cannot appear on index signature parameters
+
+**카테고리**: 파서: await/yield/JSX/TS
+
+### 해결 방법
+
+이 에러의 원인과 해결 방법은 에러 메시지를 참고하세요.

--- a/documents/src/content/docs/reference/errors/zts0916.md
+++ b/documents/src/content/docs/reference/errors/zts0916.md
@@ -1,0 +1,14 @@
+---
+title: 'ZTS0916: An index signature parameter cannot have a question mark'
+description: 'An index signature parameter cannot have a question mark'
+---
+
+## ZTS0916
+
+> An index signature parameter cannot have a question mark
+
+**카테고리**: 파서: await/yield/JSX/TS
+
+### 해결 방법
+
+이 에러의 원인과 해결 방법은 에러 메시지를 참고하세요.

--- a/packages/wasm/index.test.ts
+++ b/packages/wasm/index.test.ts
@@ -282,8 +282,8 @@ describe("Bundler (minimal)", () => {
     await initBundler(vfs, wasmBytes);
   });
 
-  test("bundlerVersion = ABI v5 (transpile 옵션 노출)", () => {
-    expect(bundlerVersion()).toBe(5);
+  test("bundlerVersion = ABI v6 (ZTS 표준 진단 형식)", () => {
+    expect(bundlerVersion()).toBe(6);
   });
 
   test("build: 단일 entry → bundle 코드 (TS 어노테이션 strip + 모듈 wrap)", () => {
@@ -361,13 +361,15 @@ describe("Bundler (minimal)", () => {
     expect(chunks![0].code).toContain('"use strict"');
   });
 
-  test("buildChunks: 존재하지 않는 entry → null + 에러 메시지", () => {
+  test("buildChunks: 존재하지 않는 entry → null + ZTS 표준 진단 형식 에러", () => {
     const chunks = buildChunks("/nonexistent.ts");
     expect(chunks).toBeNull();
     const msg = bundlerLastErrorMessage();
     expect(msg.length).toBeGreaterThan(0);
-    // bundle 단계 실패 또는 빈 출력 — 둘 중 하나로 분류되며 메시지에 표시.
-    expect(msg).toMatch(/bundle|nonexistent|빈 출력/);
+    // 표준 형식: `× <message> [<tag>]` (+ optional `\n  hint: ...`)
+    expect(msg.startsWith("×")).toBe(true);
+    // 에러 종류: bundle 단계 실패 / 빈 출력 / unresolved import 중 하나.
+    expect(msg).toMatch(/번들링 실패|nonexistent|빈 출력|ZTS\d{4}/);
   });
 
   test("bundlerLastErrorMessage: 성공 호출 후엔 비어있음", () => {

--- a/packages/wasm/src/wasm_bundler_entry.zig
+++ b/packages/wasm/src/wasm_bundler_entry.zig
@@ -24,11 +24,10 @@ const wasm_alloc = std.heap.c_allocator;
 pub fn main() void {}
 
 /// Bundler ABI version. host 가 호환성 체크용.
-/// v5 — BuildOptionsJson 에 transpile 계열 옵션 추가 (target unsupported bitmask,
-/// jsx runtime / factory / fragment / importSource, flow, jsxInJs, decorators,
-/// useDefineForClassFields, charsetUtf8, keepNames, sourcemap).
+/// v6 — last_error_message_get 출력이 ZTS 표준 진단 형식 (`× <message> [ZTS####]
+/// + hint`). 새 ZTS 에러 코드: splitting_requires_esm_format, invalid_entry_path.
 export fn bundler_version() u32 {
-    return 5;
+    return 6;
 }
 
 /// JS 측이 entry path 등 입력 메모리 확보용.
@@ -48,6 +47,8 @@ export fn dealloc(ptr: u32, len: u32) void {
 
 /// 마지막 에러 메시지 — wasm_alloc 소유. 새 메시지 setLastError 시 이전 free.
 /// single-threaded JS bridge 가정 (wasm instance per page).
+/// 형식: ZTS 표준 진단 (`× <message> [<tag>]\n  hint: <suggestion>`).
+/// 사용자 친화 (영문 error name 직접 노출 X). #1965.
 var last_error_msg: ?[]u8 = null;
 
 fn clearLastError() void {
@@ -57,14 +58,62 @@ fn clearLastError() void {
     }
 }
 
-fn setLastError(msg: []const u8) void {
+/// 형식화된 에러 메시지 작성. `× <message> [<tag>]` (+ optional `\n  hint: <hint>`).
+/// tag 는 ZTS error code (`ZTS####`) 또는 internal Zig error name (fallback).
+fn setLastErrorDiag(message: []const u8, tag: []const u8, hint: ?[]const u8) void {
     clearLastError();
-    last_error_msg = wasm_alloc.dupe(u8, msg) catch null;
+    if (hint) |h| {
+        last_error_msg = std.fmt.allocPrint(
+            wasm_alloc,
+            "× {s} [{s}]\n  hint: {s}",
+            .{ message, tag, h },
+        ) catch null;
+    } else {
+        last_error_msg = std.fmt.allocPrint(
+            wasm_alloc,
+            "× {s} [{s}]",
+            .{ message, tag },
+        ) catch null;
+    }
 }
 
-fn setLastErrorFmt(comptime fmt: []const u8, args: anytype) void {
+/// 단순 메시지 — tag 없는 경우 (alloc 실패 등 internal).
+fn setLastError(msg: []const u8) void {
     clearLastError();
-    last_error_msg = std.fmt.allocPrint(wasm_alloc, fmt, args) catch null;
+    last_error_msg = std.fmt.allocPrint(wasm_alloc, "× {s}", .{msg}) catch null;
+}
+
+const error_codes = zts_lib.error_codes;
+const ErrorCode = error_codes.Code;
+
+/// Zig error → ZTS error code 매핑. 알려진 케이스는 ZTS#### 코드 + message + help
+/// 노출. unknown 은 Zig error name fallback.
+fn setLastErrorFromZigError(err: anyerror) void {
+    const name = @errorName(err);
+    const mapped: ?ErrorCode = if (std.mem.eql(u8, name, "CodeSplittingRequiresESM"))
+        .splitting_requires_esm_format
+    else if (std.mem.eql(u8, name, "InvalidEntryModule") or std.mem.eql(u8, name, "InvalidPath"))
+        .invalid_entry_path
+    else if (std.mem.eql(u8, name, "ModuleNotFound"))
+        .unresolved_import
+    else if (std.mem.eql(u8, name, "JsonParseError"))
+        .json_parse_error
+    else
+        null;
+
+    if (mapped) |code| {
+        setLastErrorDiag(code.message(), code.format(), code.help());
+        return;
+    }
+
+    // ZTS 코드 미매핑 — Zig error name 직접 노출 (디버깅 fallback).
+    if (std.mem.eql(u8, name, "OutOfMemory")) {
+        setLastErrorDiag("메모리 부족", name, null);
+    } else if (std.mem.eql(u8, name, "NameTooLong")) {
+        setLastErrorDiag("경로가 너무 깁니다", name, null);
+    } else {
+        setLastErrorDiag("번들링 실패", name, null);
+    }
 }
 
 /// 최근 build/build_chunks 실패 시 에러 메시지 조회. 반환 packed u64 (ptr<<32 | len).
@@ -206,16 +255,22 @@ fn applyOptionsJson(
 }
 
 /// bundle() 결과의 fatal diagnostic 첫 번째를 last_error_msg 로 캡처 (있으면).
-/// caller 가 직후 dealloc(arena) 해도 메시지는 wasm_alloc 으로 dupe 되어 안전.
+/// ZTS 표준 형식: `× [path: ]<message> [<code>][\n  hint: <suggestion>]`.
+/// caller 가 직후 arena.deinit 해도 메시지는 wasm_alloc 으로 dupe 되어 안전.
 fn captureDiagnostic(result: *const BundleResult) void {
     const diags = result.diagnostics orelse return;
     for (diags) |d| {
         if (d.severity != .@"error") continue;
-        if (d.file_path.len > 0) {
-            setLastErrorFmt("{s}: {s}", .{ d.file_path, d.message });
-        } else {
-            setLastError(d.message);
-        }
+        clearLastError();
+        const tag_name = @tagName(d.code);
+        last_error_msg = if (d.file_path.len > 0 and d.suggestion != null)
+            std.fmt.allocPrint(wasm_alloc, "× {s}: {s} [{s}]\n  hint: {s}", .{ d.file_path, d.message, tag_name, d.suggestion.? }) catch null
+        else if (d.file_path.len > 0)
+            std.fmt.allocPrint(wasm_alloc, "× {s}: {s} [{s}]", .{ d.file_path, d.message, tag_name }) catch null
+        else if (d.suggestion) |s|
+            std.fmt.allocPrint(wasm_alloc, "× {s} [{s}]\n  hint: {s}", .{ d.message, tag_name, s }) catch null
+        else
+            std.fmt.allocPrint(wasm_alloc, "× {s} [{s}]", .{ d.message, tag_name }) catch null;
         return;
     }
 }
@@ -236,7 +291,8 @@ export fn build(
 ) u64 {
     clearLastError();
     if (entry_path_ptr == 0 or entry_path_len == 0) {
-        setLastError("entry path 가 비어있습니다");
+        const code = ErrorCode.invalid_entry_path;
+        setLastErrorDiag(code.message(), code.format(), code.help());
         return 0;
     }
     const entry_path: []const u8 = @as([*]const u8, @ptrFromInt(entry_path_ptr))[0..entry_path_len];
@@ -262,7 +318,7 @@ export fn build(
 
     var bundler = Bundler.init(arena_alloc, options);
     const result = bundler.bundle() catch |err| {
-        setLastErrorFmt("bundle() 실패: {s}", .{@errorName(err)});
+        setLastErrorFromZigError(err);
         return 0;
     };
 
@@ -272,7 +328,14 @@ export fn build(
     // 단일 entry / 비-splitting 경로: result.output 사용 (outputs 는 code-splitting 시).
     const code = result.output;
     if (code.len == 0) {
-        if (last_error_msg == null) setLastErrorFmt("entry \"{s}\" 가 빈 출력을 반환했습니다", .{entry_path});
+        if (last_error_msg == null) {
+            clearLastError();
+            last_error_msg = std.fmt.allocPrint(
+                wasm_alloc,
+                "× entry \"{s}\" 가 빈 출력을 반환했습니다",
+                .{entry_path},
+            ) catch null;
+        }
         return 0;
     }
 
@@ -302,7 +365,8 @@ export fn build_chunks(
 ) u64 {
     clearLastError();
     if (entry_path_ptr == 0 or entry_path_len == 0) {
-        setLastError("entry path 가 비어있습니다");
+        const code = ErrorCode.invalid_entry_path;
+        setLastErrorDiag(code.message(), code.format(), code.help());
         return 0;
     }
     const entry_path: []const u8 = @as([*]const u8, @ptrFromInt(entry_path_ptr))[0..entry_path_len];
@@ -326,7 +390,7 @@ export fn build_chunks(
 
     var bundler = Bundler.init(arena_alloc, options);
     const result = bundler.bundle() catch |err| {
-        setLastErrorFmt("bundle() 실패: {s}", .{@errorName(err)});
+        setLastErrorFromZigError(err);
         return 0;
     };
 
@@ -344,7 +408,14 @@ export fn build_chunks(
         for (outs, 0..) |o, i| chunks[i] = .{ .path = o.path, .code = o.contents };
     } else {
         if (result.output.len == 0) {
-            if (last_error_msg == null) setLastErrorFmt("entry \"{s}\" 가 빈 출력을 반환했습니다", .{entry_path});
+            if (last_error_msg == null) {
+            clearLastError();
+            last_error_msg = std.fmt.allocPrint(
+                wasm_alloc,
+                "× entry \"{s}\" 가 빈 출력을 반환했습니다",
+                .{entry_path},
+            ) catch null;
+        }
             return 0;
         }
         chunks = arena_alloc.alloc(Pair, 1) catch {

--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -31,6 +31,11 @@ pub const Code = enum(u16) {
     /// Top-level await는 ESM 포맷 전용 — CJS/IIFE/UMD/AMD 에서는 런타임 동작 불가.
     /// bundler emitter 에서 non-ESM 포맷 + TLA 조합 감지 시 경고로 emit.
     tla_requires_esm_format = 2,
+    /// Code splitting / preserveModules 는 dynamic import 활용한 multi-chunk 시나리오 —
+    /// ESM 만 지원 (cjs/iife/umd/amd 의 require/wrapper 시스템과 호환 X). esbuild/rollup 동일.
+    splitting_requires_esm_format = 3,
+    /// build / build_chunks 의 entry path 가 비어있거나 VFS 에 미등록.
+    invalid_entry_path = 4,
 
     // ═══════════════════════════════════════════════════════
     // 0100-0199: 번들러 — import/export/resolve
@@ -244,6 +249,8 @@ pub const Code = enum(u16) {
             // 타겟
             .top_level_await_target => "Set --target=es2022 or later, or wrap the code in an 'async' function.",
             .tla_requires_esm_format => "Use --format=esm, or wrap the top-level await in an async IIFE.",
+            .splitting_requires_esm_format => "Use --format=esm, or disable codeSplitting/preserveModules.",
+            .invalid_entry_path => "Provide a non-empty entry path that exists in the VFS / file system.",
             // 번들러
             .unresolved_import => "Check the import path spelling and confirm the file exists.",
             .missing_export => "Verify the exported name. Use 'export * from' or named re-exports if needed.",
@@ -270,6 +277,8 @@ pub const Code = enum(u16) {
             // 타겟
             .top_level_await_target => "Top-level await is not available in the configured target environment",
             .tla_requires_esm_format => "Top-level await requires ESM output format",
+            .splitting_requires_esm_format => "Code splitting / preserveModules requires ESM output format",
+            .invalid_entry_path => "Entry path is empty or not found",
             // 번들러
             .unresolved_import => "Could not resolve import",
             .missing_export => "Export not found in module",


### PR DESCRIPTION
## Summary
사용자 보고 — wasm bundler 에러가 internal Zig error name 그대로 노출 (`bundle() 실패: CodeSplittingRequiresESM`). ZTS 표준 진단 형식 (`× <message> [ZTS####]` + hint) 으로 통일.

ABI v5 → v6.

## Before / After

### Before
```
bundle() 실패: CodeSplittingRequiresESM
```

### After
```
× Code splitting / preserveModules requires ESM output format [ZTS0003]
  hint: Use --format=esm, or disable codeSplitting/preserveModules.
```

## 변경
- `src/error_codes.zig`: ZTS 코드 2개 신규
  - `splitting_requires_esm_format = 3`
  - `invalid_entry_path = 4`
- `packages/wasm/src/wasm_bundler_entry.zig`:
  - `setLastErrorDiag(message, tag, hint)` 헬퍼
  - `setLastErrorFromZigError(err)` — Zig error name → ZTS Code 매핑
  - `captureDiagnostic` 가 path/code/suggestion 모두 포함
- `documents/src/content/docs/reference/errors/zts0003.md`, `zts0004.md` 자동 생성

## Test plan
- [x] `zig build wasm-bundler` + `zig build test` 통과
- [x] `bun test packages/wasm/index.test.ts` 50/50 pass (메시지 형식 검증 포함)
- [x] `cd documents && bun run build` 357 페이지 통과 — `/reference/errors/zts0003/`, `/zts0004/` 라우트 신규

## 부수
- 기존 누락된 ZTS0002, 0915, 0916 docs 도 generator 가 같이 생성

Closes #1965
Refs #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)