### PR TITLE
feat(bundler): runtime helper virtual module loader 인프라 (#1961 PR 1a)

### DIFF
--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -30,6 +30,7 @@ pub const purity = @import("purity.zig");
 pub const stmt_info = @import("stmt_info.zig");
 pub const chunk = @import("chunk.zig");
 pub const runtime_helpers = @import("runtime_helpers.zig");
+pub const runtime_helper_modules = @import("runtime_helper_modules.zig");
 pub const bundler_core = @import("bundler.zig");
 pub const mpsc_channel = @import("mpsc_channel.zig");
 pub const json_to_esm = @import("json_to_esm.zig");
@@ -97,6 +98,7 @@ test {
     _ = stmt_info;
     _ = chunk;
     _ = runtime_helpers;
+    _ = runtime_helper_modules;
     _ = bundler_core;
     _ = plugin;
     _ = module_store;

--- a/src/bundler/runtime_helper_modules.zig
+++ b/src/bundler/runtime_helper_modules.zig
@@ -1,0 +1,553 @@
+//! ZTS runtime helper virtual module loader (#1961).
+//!
+//! ## 배경
+//!
+//! ES5 다운레벨링 등에서 사용되는 runtime helper (`__generator`, `__async` 등) 는
+//! 기존엔 `bundler/runtime_helpers.zig` 의 string 상수가 entry chunk preamble 에
+//! prepend 되는 모델이었다. 단일 번들에선 helper 가 entry 한 곳에만 emit 되어 모든
+//! 모듈이 free identifier 로 참조 가능했지만, code splitting + dynamic import 시
+//! dynamic chunk 에 helper 정의가 없어 ReferenceError 발생 (#1961 의 `__generator`).
+//!
+//! 새 모델: helper 를 graph 의 1급 모듈로 만들면 chunk 간 helper 분배 == 일반 모듈의
+//! chunk 분배. transformer 가 helper 사용 모듈 상단에 named import 를 emit 하면
+//! plugin 이 resolveId/load 훅으로 source 를 반환 → graph 의 표준 module dedup
+//! 메커니즘이 chunk 간 helper 공유를 자동 처리.
+//!
+//! ## 식별자 규약
+//!
+//! - **Internal ID** (graph 안): `\x00zts:runtime/<short>` (oxc 식 NULL prefix).
+//!   NULL byte 가 다른 plugin/resolver 가 건드리지 못하게 하는 sentinel.
+//! - **External ID** (chunk 파일명/import specifier/sourcemap source URL):
+//!   `sanitizeId` 가 NULL prefix 제거 + `runtime-` prefix 부여. e.g. `runtime-generator`.
+//! - **Module short name**: kebab-case (`generator`, `async`, `to-esm`, `es-decorator`).
+//!
+//! ## 묶음 모듈
+//!
+//! 일부 helper 정의 string 은 여러 helper 를 한 묶음으로 정의한다 (e.g.
+//! DECORATOR_RUNTIME 의 `__decorateClass` + `__decorateParam` + `__defProp2`).
+//! 묶음 단위 = 한 virtual module + 묶음 멤버 모두 named export. transformer 의
+//! helper-base → module-short lookup 은 `moduleShortFor` 가 처리.
+//!
+//! ## 미등록 helper
+//!
+//! 다음 helper 들은 정의 string 상수 매핑이 아직 검증되지 않아 등록되지 않았다 —
+//! `__spreadArray`, `__arrayLikeToArray`, `__toConsumableArray`, `__toBinary`,
+//! `__name`, `__using`, `__callDispose`, `__classPrivateMethodInit`,
+//! `__classPrivateMethodGet`, `__classPrivateFieldSet`,
+//! `__classCheckPrivateStaticAccess`, `__classCheckPrivateStaticFieldDescriptor`,
+//! `__classStaticPrivateFieldSpecGet`, `__classStaticPrivateFieldSpecSet`.
+//! 미등록 helper 가 import 되면 plugin 이 null 반환 → 호출자가 기존 preamble 경로로
+//! fallback. transformer 통합 PR 에서 이 helper 들의 매핑이 추가되며 fallback 도 제거된다.
+
+const std = @import("std");
+const rt = @import("runtime_helpers.zig");
+const plugin_mod = @import("plugin.zig");
+const names = @import("../runtime_helper_names.zig");
+
+/// Internal virtual module ID prefix. NULL byte sentinel.
+pub const ID_PREFIX = "\x00zts:runtime/";
+
+/// 외부 노출 prefix. sanitize 결과 chunk 파일명/import specifier/sourcemap 에서 사용.
+pub const EXTERNAL_PREFIX = "runtime-";
+
+/// helper module 의 source 빌드 옵션. plugin context 로 전달.
+pub const SourceOptions = struct {
+    minify: bool = false,
+    es5: bool = false,
+    /// `__toESM`, `__toCommonJS`, `__export` 등 RN/Hermes 호환 configurable variant.
+    configurable_exports: bool = false,
+};
+
+/// Helper 정의 변형. plain/min 은 필수, es5/configurable 은 해당 helper 가 그 variant
+/// 를 제공할 때만 채워진다. `pickBody` 가 옵션 조합에 따라 적절한 variant 를 선택.
+const BodyVariants = struct {
+    plain: []const u8,
+    min: []const u8,
+    es5: ?[]const u8 = null,
+    es5_min: ?[]const u8 = null,
+    configurable: ?[]const u8 = null,
+    configurable_min: ?[]const u8 = null,
+};
+
+/// Helper 정의 묶음. 한 묶음 = 한 virtual module.
+const HelperModule = struct {
+    /// virtual module 의 short name (URL 마지막 segment, kebab-case).
+    short: []const u8,
+    /// 이 module 에 정의된 helper base name 들 (named export 대상).
+    helpers: []const []const u8,
+    /// helper 정의 string 의 variant 모음.
+    body: BodyVariants,
+};
+
+const MODULES = [_]HelperModule{
+    // ES2015+ 다운레벨링 (transformer 가 emit)
+    .{
+        .short = "generator",
+        .helpers = &.{"__generator"},
+        .body = .{ .plain = rt.GENERATOR_RUNTIME, .min = rt.GENERATOR_RUNTIME_MIN },
+    },
+    .{
+        .short = "async",
+        .helpers = &.{"__async"},
+        .body = .{
+            .plain = rt.ASYNC_RUNTIME,
+            .min = rt.ASYNC_RUNTIME_MIN,
+            .es5 = rt.ASYNC_RUNTIME_ES5,
+            .es5_min = rt.ASYNC_RUNTIME_ES5_MIN,
+        },
+    },
+    .{
+        .short = "await",
+        .helpers = &.{"__await"},
+        .body = .{ .plain = rt.AWAIT_RUNTIME, .min = rt.AWAIT_RUNTIME_MIN },
+    },
+    .{
+        .short = "async-values",
+        .helpers = &.{"__asyncValues"},
+        .body = .{ .plain = rt.ASYNC_VALUES_RUNTIME, .min = rt.ASYNC_VALUES_RUNTIME_MIN },
+    },
+    .{
+        .short = "async-generator",
+        .helpers = &.{"__asyncGenerator"},
+        .body = .{ .plain = rt.ASYNC_GENERATOR_RUNTIME, .min = rt.ASYNC_GENERATOR_RUNTIME_MIN },
+    },
+    .{
+        .short = "values",
+        .helpers = &.{"__values"},
+        .body = .{ .plain = rt.VALUES_RUNTIME, .min = rt.VALUES_RUNTIME_MIN },
+    },
+    .{
+        .short = "extends",
+        .helpers = &.{"__extends"},
+        .body = .{ .plain = rt.EXTENDS_RUNTIME, .min = rt.EXTENDS_RUNTIME_MIN },
+    },
+    .{
+        .short = "class-call-check",
+        .helpers = &.{"__classCallCheck"},
+        .body = .{ .plain = rt.CLASS_CALL_CHECK_RUNTIME, .min = rt.CLASS_CALL_CHECK_RUNTIME_MIN },
+    },
+    .{
+        .short = "call-super",
+        .helpers = &.{"__callSuper"},
+        .body = .{ .plain = rt.CALL_SUPER_RUNTIME, .min = rt.CALL_SUPER_RUNTIME_MIN },
+    },
+    .{
+        .short = "rest",
+        .helpers = &.{"__rest"},
+        .body = .{ .plain = rt.REST_RUNTIME, .min = rt.REST_RUNTIME_MIN },
+    },
+    .{
+        .short = "tagged-template",
+        .helpers = &.{"__taggedTemplateLiteral"},
+        .body = .{ .plain = rt.TAGGED_TEMPLATE_RUNTIME, .min = rt.TAGGED_TEMPLATE_RUNTIME_MIN },
+    },
+
+    // Decorator (TypeScript experimental — `experimentalDecorators`)
+    .{
+        .short = "decorator",
+        .helpers = &.{ "__decorateClass", "__decorateParam", "__defProp2" },
+        .body = .{ .plain = rt.DECORATOR_RUNTIME, .min = rt.DECORATOR_RUNTIME_MIN },
+    },
+    .{
+        .short = "metadata",
+        .helpers = &.{"__metadata"},
+        .body = .{ .plain = rt.METADATA_RUNTIME, .min = rt.METADATA_RUNTIME_MIN },
+    },
+
+    // TC39 Stage 3 decorator (TypeScript 5.0+)
+    .{
+        .short = "es-decorator",
+        .helpers = &.{ "__esDecorate", "__runInitializers", "__setFunctionName", "__propKey" },
+        .body = .{ .plain = rt.ES_DECORATOR_RUNTIME, .min = rt.ES_DECORATOR_RUNTIME_MIN },
+    },
+
+    // Bundler interop — 현재는 emitter wrap 단계에서 직접 사용. transformer/emitter
+    // 통합 시점에 graph 경로로 전환 결정.
+    .{
+        .short = "to-esm",
+        .helpers = &.{
+            "__create",
+            "__getProtoOf",
+            "__defProp",
+            "__getOwnPropNames",
+            "__getOwnPropDesc",
+            "__hasOwn",
+            "__copyProps",
+            "__toESM",
+        },
+        .body = .{
+            .plain = rt.TOESM_RUNTIME,
+            .min = rt.TOESM_RUNTIME_MIN,
+            .configurable = rt.TOESM_RUNTIME_CONFIGURABLE,
+            .configurable_min = rt.TOESM_RUNTIME_CONFIGURABLE_MIN,
+        },
+    },
+    .{
+        .short = "to-commonjs",
+        .helpers = &.{"__toCommonJS"},
+        .body = .{
+            .plain = rt.TOCOMMONJS_RUNTIME,
+            .min = rt.TOCOMMONJS_RUNTIME_MIN,
+            .configurable = rt.TOCOMMONJS_RUNTIME_CONFIGURABLE,
+            .configurable_min = rt.TOCOMMONJS_RUNTIME_CONFIGURABLE_MIN,
+        },
+    },
+    .{
+        .short = "esm-init",
+        .helpers = &.{"__esm"},
+        .body = .{
+            .plain = rt.ESM_RUNTIME,
+            .min = rt.ESM_RUNTIME_MIN,
+            .es5 = rt.ESM_RUNTIME_ES5,
+            .es5_min = rt.ESM_RUNTIME_ES5_MIN,
+        },
+    },
+    .{
+        .short = "export",
+        .helpers = &.{"__export"},
+        .body = .{
+            .plain = rt.EXPORT_RUNTIME,
+            .min = rt.EXPORT_RUNTIME_MIN,
+            .configurable = rt.EXPORT_RUNTIME_CONFIGURABLE,
+            .configurable_min = rt.EXPORT_RUNTIME_CONFIGURABLE_MIN,
+        },
+    },
+    .{
+        .short = "commonjs",
+        .helpers = &.{ "__commonJS", "__require" },
+        .body = .{
+            .plain = rt.CJS_RUNTIME,
+            .min = rt.CJS_RUNTIME_MIN,
+            .es5 = rt.CJS_RUNTIME_ES5,
+            .es5_min = rt.CJS_RUNTIME_ES5_MIN,
+        },
+    },
+};
+
+// ============================================================
+// Public API
+// ============================================================
+
+/// helper base name → 묶음 module 의 short name lookup.
+/// transformer 가 import statement 의 specifier 결정에 사용.
+/// 미등록 helper 는 null 반환 — caller 가 기존 preamble 경로로 fallback.
+pub fn moduleShortFor(base_name: []const u8) ?[]const u8 {
+    for (MODULES) |m| {
+        for (m.helpers) |h| {
+            if (std.mem.eql(u8, h, base_name)) return m.short;
+        }
+    }
+    return null;
+}
+
+/// helper base name → virtual module 의 internal ID 생성.
+/// 예: `__generator` → `\x00zts:runtime/generator`. caller 가 소유.
+/// 미등록 helper 는 null.
+pub fn idForBase(allocator: std.mem.Allocator, base_name: []const u8) !?[]const u8 {
+    const short = moduleShortFor(base_name) orelse return null;
+    return try std.fmt.allocPrint(allocator, "{s}{s}", .{ ID_PREFIX, short });
+}
+
+/// virtual module specifier 를 외부 노출용 안전 ID 로 변환.
+/// chunk 파일명 / import specifier (chunk 간) / sourcemap source URL 에서 NULL byte 가
+/// 새지 않도록 sanitize. caller 가 소유.
+/// `\x00zts:runtime/generator` → `runtime-generator`
+/// virtual prefix 가 아니면 입력 그대로 dupe.
+pub fn sanitizeId(allocator: std.mem.Allocator, id: []const u8) ![]const u8 {
+    if (!isVirtualId(id)) return try allocator.dupe(u8, id);
+    const short = id[ID_PREFIX.len..];
+    return try std.fmt.allocPrint(allocator, "{s}{s}", .{ EXTERNAL_PREFIX, short });
+}
+
+/// internal ID 인지 검사.
+pub fn isVirtualId(id: []const u8) bool {
+    return std.mem.startsWith(u8, id, ID_PREFIX);
+}
+
+/// builtin runtime helper plugin 을 생성. graph 가 plugin slice 에 prepend.
+/// `opts` 는 caller 소유 — bundler 가 빌드 옵션 기반으로 만들어 lifetime 동안 유지.
+pub fn makePlugin(opts: *const SourceOptions) plugin_mod.Plugin {
+    return .{
+        .name = "zts:runtime-helpers",
+        .context = @ptrCast(@constCast(opts)),
+        .resolveId = resolveIdHook,
+        .load = loadHook,
+    };
+}
+
+// ============================================================
+// Plugin hooks
+// ============================================================
+
+fn resolveIdHook(
+    _: ?*anyopaque,
+    specifier: []const u8,
+    _: ?[]const u8,
+    _: std.mem.Allocator,
+) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
+    if (!isVirtualId(specifier)) return null;
+    const short = specifier[ID_PREFIX.len..];
+    if (findModule(short) == null) return null;
+    return .{ .virtual = .{ .path = specifier } };
+}
+
+fn loadHook(
+    ctx: ?*anyopaque,
+    path: []const u8,
+    allocator: std.mem.Allocator,
+) plugin_mod.PluginError!?[]const u8 {
+    if (!isVirtualId(path)) return null;
+    const short = path[ID_PREFIX.len..];
+    const m = findModule(short) orelse return null;
+    const default_opts = SourceOptions{};
+    const opts: *const SourceOptions = if (ctx) |c|
+        @ptrCast(@alignCast(c))
+    else
+        &default_opts;
+    return try buildSource(allocator, m, opts.*);
+}
+
+fn findModule(short: []const u8) ?*const HelperModule {
+    for (&MODULES) |*m| {
+        if (std.mem.eql(u8, m.short, short)) return m;
+    }
+    return null;
+}
+
+// ============================================================
+// Source builder
+// ============================================================
+
+/// 옵션 조합에 따른 body variant 선택. variant 가 정의되지 않은 옵션은 plain/min 으로
+/// fallback — 호출자가 module 의 helper 종류와 무관하게 같은 옵션 set 을 사용 가능.
+fn pickBody(body: BodyVariants, opts: SourceOptions) []const u8 {
+    if (opts.configurable_exports) {
+        if (opts.minify) {
+            if (body.configurable_min) |b| return b;
+        } else {
+            if (body.configurable) |b| return b;
+        }
+    }
+    if (opts.es5) {
+        if (opts.minify) {
+            if (body.es5_min) |b| return b;
+        } else {
+            if (body.es5) |b| return b;
+        }
+    }
+    return if (opts.minify) body.min else body.plain;
+}
+
+fn buildSource(allocator: std.mem.Allocator, m: *const HelperModule, opts: SourceOptions) ![]const u8 {
+    return buildExports(allocator, pickBody(m.body, opts), m.helpers, opts.minify);
+}
+
+/// helper 정의 + named export suffix 결합.
+/// minify 시 정의 안 식별자가 short name (e.g. `$gn`) 이라 export alias 로 base name
+/// 노출 — consumer 는 항상 base name 으로 import 가능.
+///   `var $gn=...; export { $gn as __generator };`
+fn buildExports(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+    bases: []const []const u8,
+    minify: bool,
+) ![]const u8 {
+    var list: std.ArrayList(u8) = .empty;
+    errdefer list.deinit(allocator);
+    try list.appendSlice(allocator, body);
+    try list.appendSlice(allocator, "\nexport { ");
+    for (bases, 0..) |base, i| {
+        if (i > 0) try list.appendSlice(allocator, ", ");
+        const local = names.helperName(base, minify);
+        if (std.mem.eql(u8, local, base)) {
+            try list.appendSlice(allocator, base);
+        } else {
+            try list.appendSlice(allocator, local);
+            try list.appendSlice(allocator, " as ");
+            try list.appendSlice(allocator, base);
+        }
+    }
+    try list.appendSlice(allocator, " };\n");
+    return try list.toOwnedSlice(allocator);
+}
+
+// ============================================================
+// 단위 테스트
+// ============================================================
+
+test "moduleShortFor: 등록된 helper 매핑" {
+    try std.testing.expectEqualStrings("generator", moduleShortFor("__generator").?);
+    try std.testing.expectEqualStrings("async", moduleShortFor("__async").?);
+    try std.testing.expectEqualStrings("await", moduleShortFor("__await").?);
+    try std.testing.expectEqualStrings("decorator", moduleShortFor("__decorateClass").?);
+    try std.testing.expectEqualStrings("decorator", moduleShortFor("__decorateParam").?);
+    try std.testing.expectEqualStrings("decorator", moduleShortFor("__defProp2").?);
+    try std.testing.expectEqualStrings("es-decorator", moduleShortFor("__esDecorate").?);
+    try std.testing.expectEqualStrings("to-esm", moduleShortFor("__toESM").?);
+    try std.testing.expectEqualStrings("to-esm", moduleShortFor("__create").?);
+    try std.testing.expectEqualStrings("commonjs", moduleShortFor("__commonJS").?);
+    try std.testing.expectEqualStrings("rest", moduleShortFor("__rest").?);
+}
+
+test "moduleShortFor: 미등록 helper 는 null" {
+    try std.testing.expect(moduleShortFor("__spreadArray") == null);
+    try std.testing.expect(moduleShortFor("__toBinary") == null);
+    try std.testing.expect(moduleShortFor("__name") == null);
+    try std.testing.expect(moduleShortFor("__using") == null);
+    try std.testing.expect(moduleShortFor("__classPrivateMethodInit") == null);
+    try std.testing.expect(moduleShortFor("not_a_helper") == null);
+}
+
+test "idForBase: helper base → virtual ID" {
+    const allocator = std.testing.allocator;
+    const id = (try idForBase(allocator, "__generator")).?;
+    defer allocator.free(id);
+    try std.testing.expectEqualStrings("\x00zts:runtime/generator", id);
+}
+
+test "idForBase: 미등록 helper 는 null" {
+    const allocator = std.testing.allocator;
+    const id = try idForBase(allocator, "__spreadArray");
+    try std.testing.expect(id == null);
+}
+
+test "sanitizeId: NULL prefix 제거 + runtime- prefix" {
+    const allocator = std.testing.allocator;
+    const safe = try sanitizeId(allocator, "\x00zts:runtime/generator");
+    defer allocator.free(safe);
+    try std.testing.expectEqualStrings("runtime-generator", safe);
+}
+
+test "sanitizeId: 비 virtual ID 는 그대로 (dupe)" {
+    const allocator = std.testing.allocator;
+    const safe = try sanitizeId(allocator, "/path/to/file.ts");
+    defer allocator.free(safe);
+    try std.testing.expectEqualStrings("/path/to/file.ts", safe);
+}
+
+test "isVirtualId" {
+    try std.testing.expect(isVirtualId("\x00zts:runtime/generator"));
+    try std.testing.expect(!isVirtualId("/local/path.ts"));
+    try std.testing.expect(!isVirtualId(""));
+}
+
+test "buildSource: 정의 + named export 포함 (generator)" {
+    const allocator = std.testing.allocator;
+    const m = findModule("generator").?;
+    const src = try buildSource(allocator, m, .{});
+    defer allocator.free(src);
+    try std.testing.expect(std.mem.indexOf(u8, src, "__generator") != null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "export { __generator };") != null);
+}
+
+test "buildSource: minify 시 short name 정의 + alias export" {
+    const allocator = std.testing.allocator;
+    const m = findModule("generator").?;
+    const src = try buildSource(allocator, m, .{ .minify = true });
+    defer allocator.free(src);
+    try std.testing.expect(std.mem.indexOf(u8, src, "$gn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "$gn as __generator") != null);
+}
+
+test "buildSource: ES5 variant 는 arrow function 없음 (async)" {
+    const allocator = std.testing.allocator;
+    const m = findModule("async").?;
+    const src = try buildSource(allocator, m, .{ .es5 = true });
+    defer allocator.free(src);
+    try std.testing.expect(std.mem.indexOf(u8, src, "=>") == null);
+    try std.testing.expect(std.mem.indexOf(u8, src, "function") != null);
+}
+
+test "buildSource: configurable variant 가 없으면 plain 으로 fallback (extends)" {
+    // extends 는 configurable variant 미정의 — opts.configurable_exports=true 라도
+    // plain 반환되어야 (옵션 set 은 모듈 무관 단일 set 이라 fallback 필요).
+    const allocator = std.testing.allocator;
+    const m = findModule("extends").?;
+    const src = try buildSource(allocator, m, .{ .configurable_exports = true });
+    defer allocator.free(src);
+    try std.testing.expect(std.mem.indexOf(u8, src, "__extends") != null);
+}
+
+test "buildSource: 묶음 module — 모든 helper named export (decorator)" {
+    const allocator = std.testing.allocator;
+    const m = findModule("decorator").?;
+    const src = try buildSource(allocator, m, .{});
+    defer allocator.free(src);
+    const last_export_pos = std.mem.lastIndexOf(u8, src, "export {").?;
+    const export_tail = src[last_export_pos..];
+    try std.testing.expect(std.mem.indexOf(u8, export_tail, "__decorateClass") != null);
+    try std.testing.expect(std.mem.indexOf(u8, export_tail, "__decorateParam") != null);
+    try std.testing.expect(std.mem.indexOf(u8, export_tail, "__defProp2") != null);
+}
+
+test "smoke: 모든 MODULES 의 helper 가 source 에 export 됨" {
+    const allocator = std.testing.allocator;
+    inline for (MODULES) |m| {
+        const src = try buildSource(allocator, &m, .{});
+        defer allocator.free(src);
+        for (m.helpers) |base| {
+            // base name 이 정의 부분 또는 export alias 로 등장
+            try std.testing.expect(std.mem.indexOf(u8, src, base) != null);
+        }
+        // 정확히 하나의 export 문
+        try std.testing.expect(std.mem.indexOf(u8, src, "\nexport { ") != null);
+    }
+}
+
+test "loadHook: virtual ID → source 반환" {
+    const allocator = std.testing.allocator;
+    const opts = SourceOptions{};
+    const src = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/generator", allocator)).?;
+    defer allocator.free(src);
+    try std.testing.expect(std.mem.indexOf(u8, src, "__generator") != null);
+}
+
+test "loadHook: 비 virtual ID 는 null" {
+    const allocator = std.testing.allocator;
+    const result = try loadHook(null, "/some/path.ts", allocator);
+    try std.testing.expect(result == null);
+}
+
+test "loadHook: 미등록 short 는 null" {
+    const allocator = std.testing.allocator;
+    const opts = SourceOptions{};
+    const result = try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/spread-array", allocator);
+    try std.testing.expect(result == null);
+}
+
+test "loadHook: ctx 의 minify 옵션이 source 에 반영 (alias export)" {
+    // ctx 캐스트 회귀 방지 — ctx 가 무시되면 default_opts 사용해서 alias 가 없을 것.
+    const allocator = std.testing.allocator;
+    const opts = SourceOptions{ .minify = true };
+    const src = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/generator", allocator)).?;
+    defer allocator.free(src);
+    try std.testing.expect(std.mem.indexOf(u8, src, "$gn as __generator") != null);
+}
+
+test "resolveIdHook: virtual specifier 만 가로챔" {
+    const allocator = std.testing.allocator;
+    const r1 = try resolveIdHook(null, "\x00zts:runtime/generator", null, allocator);
+    try std.testing.expect(r1 != null);
+    try std.testing.expect(r1.? == .virtual);
+
+    const r2 = try resolveIdHook(null, "./local.ts", null, allocator);
+    try std.testing.expect(r2 == null);
+
+    const r3 = try resolveIdHook(null, "\x00zts:runtime/spread-array", null, allocator);
+    try std.testing.expect(r3 == null);
+}
+
+test "makePlugin: hook 호출이 ctx 통해 동작" {
+    // makePlugin 결과의 hook 호출까지 검증 — 단순 non-null 어설션이 아니라 e2e.
+    const allocator = std.testing.allocator;
+    const opts = SourceOptions{};
+    const p = makePlugin(&opts);
+    try std.testing.expectEqualStrings("zts:runtime-helpers", p.name);
+
+    const resolved = (try p.resolveId.?(p.context, "\x00zts:runtime/generator", null, allocator)).?;
+    try std.testing.expect(resolved == .virtual);
+
+    const loaded = (try p.load.?(p.context, "\x00zts:runtime/generator", allocator)).?;
+    defer allocator.free(loaded);
+    try std.testing.expect(std.mem.indexOf(u8, loaded, "__generator") != null);
+}


### PR DESCRIPTION
## Summary
- ES5 다운레벨링용 runtime helper (`__generator`, `__async` 등) 를 module graph 의 1급 virtual module 로 노출하는 인프라
- ID 규약 (`\x00zts:runtime/<short>`, oxc 식 NULL prefix sentinel) + helper 14종 매핑 + builtin Plugin
- 단위 테스트 18개

## 배경

기존 helper 모델은 `bundler/runtime_helpers.zig` 의 string 상수를 entry chunk preamble 에 prepend. 단일 번들에선 helper 가 entry 한 곳에만 emit 되어 모든 모듈이 free identifier 로 참조 가능했지만, code splitting + dynamic import 시 dynamic chunk 에 helper 정의가 없어 ReferenceError 발생 (#1961 의 `__generator`).

새 모델: helper 를 graph 의 1급 모듈로 만들면 chunk 간 helper 분배 == 일반 모듈의 chunk 분배. transformer 가 helper 사용 모듈 상단에 named import 를 emit 하면 plugin 의 resolveId/load 훅이 source 를 반환 → graph 표준 module dedup 으로 chunk 간 helper 공유가 자동 처리. oxc/`rolldown_plugin_oxc_runtime` 와 동일 패턴.

## PR 분할 (1a / 1b)

이 PR (1a) — **인프라 only**:
- 새 파일 `src/bundler/runtime_helper_modules.zig`
- helper 14종 매핑 (generator, async, await, async-values, async-generator, values, extends, class-call-check, call-super, rest, tagged-template, decorator(3), metadata, es-decorator(4), to-esm(8), to-commonjs, esm-init, export, commonjs(2))
- public API: `moduleShortFor`, `idForBase`, `sanitizeId`, `isVirtualId`, `makePlugin`
- builtin `Plugin` factory + resolveId/load 훅 + body variant (plain/min/es5/configurable) 데이터 테이블
- 단위 테스트 18개 (lookup + ID 변환 + sanitize + plugin hooks + ctx flow + smoke)
- **외부 호출자 0, 동작 변경 0** — 머지 후에도 기존 preamble 모델이 그대로 동작

PR 1b (별도, follow-up):
1. 미등록 helper 14종 매핑 추가 (`__spreadArray`, `__toBinary`, `__name`, `__using`/`__callDispose`, `__classPrivate*`, `__classStaticPrivate*`)
2. transformer finalize 경로에서 helper import statement emit
3. graph 가 builtin plugin 자동 등록
4. `bundler/emitter.zig` 의 `appendRuntimeHelpers` / `appendAsyncRuntime` / chunk fallback 코드 완전 제거
5. chunk 파일명 / chunk 간 import specifier / sourcemap source URL 노출 시 `sanitizeId` 호출
6. #1961 회귀 fixture (codeSplitting + target=es5 + dynamic import + async/await)
7. 이 시점에 #1961 close

## 식별자 규약

- **Internal ID** (graph 안): `\x00zts:runtime/<short>` (oxc 식 NULL prefix). NULL byte 가 다른 plugin/resolver 가 건드리지 못하게 하는 sentinel.
- **External ID** (chunk 파일명/import specifier/sourcemap source URL): `sanitizeId` 가 NULL prefix 제거 + `runtime-` prefix 부여 → `runtime-generator`. PR 1b 에서 emitter/sourcemap 통합 시 호출.

## /simplify 결과

- 초기 `buildXxx` 19 함수 패턴 → `BodyVariants` 데이터 테이블 + 단일 `buildSource` 로 통합 (drift 위험 제거, ~150줄 감소)
- `mem.startsWith` 3곳 → `isVirtualId` 호출로 통일
- 테스트 강화: tautological 삭제, 모든 MODULES iterate smoke test 추가, `loadHook` ctx flow (minify ctx 가 source 에 반영되는지 — `@ptrCast`/`@alignCast` 회귀 방지), `makePlugin` hook 실제 호출까지 검증
- skip 결정: `SourceOptions` struct 분해 / shorts enum 화 (false positive 또는 과도)

## Refs

- #1961 (root cause; PR 1a 단독으로는 close 안 함, PR 1b 가 close)
- #1969 (helper 소스 .ts 분리 + codegen 마이그레이션 — 별도 backlog)

## Test plan

- [x] `zig build` 통과
- [x] `zig build test` 통과 (단위 테스트 18개 포함)
- [x] `zig build -Doptimize=ReleaseFast` 통과
- [x] `zig fmt --check src/` 통과 (pre-push hook)
- [x] `oxfmt --check` 통과 (pre-push hook)
- [ ] 검토자 — 인프라가 PR 1b 의 transformer/emitter 통합 요구사항을 만족하는지 확인 (특히 `Plugin` context lifetime, ID 규약의 sourcemap 호환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)