### PR TITLE
feat(bundler): runtime helper virtual module (#1961 PR 1b)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -735,6 +735,21 @@ pub const Bundler = struct {
         graph.jsx_in_js = self.options.jsx_in_js;
         graph.jsx_runtime = self.options.jsx_runtime;
         graph.jsx_import_source = self.options.jsx_import_source;
+
+        // #1961: transformer pre-pass 옵션 — graph 가 module 마다 transformer 실행 시 사용.
+        // emitter 의 동일 옵션 set 과 1:1 매칭되어야 cache 일관성 보장.
+        graph.worklet_transform = self.options.worklet_transform;
+        graph.experimental_decorators = self.options.experimental_decorators;
+        graph.emit_decorator_metadata = self.options.emit_decorator_metadata;
+        graph.use_define_for_class_fields = self.options.use_define_for_class_fields;
+        graph.verbatim_module_syntax = self.options.verbatim_module_syntax;
+        graph.unsupported = self.options.unsupported;
+        graph.drop_labels = self.options.drop_labels;
+        graph.minify_syntax = self.options.minify_syntax;
+        graph.keep_names = self.options.keep_names;
+        graph.jsx_factory = self.options.jsx_factory;
+        graph.jsx_fragment = self.options.jsx_fragment;
+        graph.worklet_plugin_version = self.options.worklet_plugin_version;
         defer graph.deinit();
 
         // graph.build() 또는 buildIncremental() 호출.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -739,6 +739,8 @@ pub const Bundler = struct {
         // #1961: transformer pre-pass 옵션 — graph 가 module 마다 transformer 실행 시 사용.
         // emitter 의 동일 옵션 set 과 1:1 매칭되어야 cache 일관성 보장.
         graph.worklet_transform = self.options.worklet_transform;
+        graph.react_refresh = self.options.react_refresh;
+        graph.code_splitting = self.options.code_splitting;
         graph.experimental_decorators = self.options.experimental_decorators;
         graph.emit_decorator_metadata = self.options.emit_decorator_metadata;
         graph.use_define_for_class_fields = self.options.use_define_for_class_fields;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1832,8 +1832,15 @@ const esm_wrap = @import("emitter/esm_wrap.zig");
 const emitEsmWrappedModule = esm_wrap.emitEsmWrappedModule;
 
 /// source 등록 + (선택) sourcesContent 등록을 한 번에. source_index 반환.
+/// `\x00zts:runtime/...` 같은 virtual module ID 는 NULL byte 가 sourcemap JSON 으로
+/// 새지 않도록 `runtime-...` 형태로 sanitize (#1961).
 fn addIdentitySource(sm: *SourceMap.SourceMapBuilder, path: []const u8, content: []const u8, include_content: bool) !u32 {
-    const idx = try sm.addSource(path);
+    const helper_modules = @import("runtime_helper_modules.zig");
+    const idx = if (helper_modules.isVirtualId(path)) blk: {
+        const sanitized = try helper_modules.sanitizeId(sm.allocator, path);
+        defer sm.allocator.free(sanitized);
+        break :blk try sm.addSource(sanitized);
+    } else try sm.addSource(path);
     if (include_content) try sm.addSourceContent(content);
     return idx;
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -738,7 +738,11 @@ pub fn emitWithTreeShaking(
         }
     }
 
-    // ES2015 런타임 헬퍼 주입: transformer가 실제 사용한 헬퍼만 주입
+    // ES2015 런타임 헬퍼 주입: transformer가 실제 사용한 헬퍼만 주입.
+    // #1961 부터 code splitting 모드에선 transformer 가 helper module 의 named import
+    // 으로 emit 하여 graph 가 분배 → chunk-level appendAsyncRuntime 등은 제거.
+    // single-bundle 모드는 helper module 의 declaration 이 statement-level shake 로
+    // elide 되는 회귀가 있어 후속 fix 까지 기존 preamble 모델 유지 (중복 시 dead code).
     try rt.appendRuntimeHelpers(&output, allocator, collected_helpers, options.minify_whitespace, options.unsupported.arrow);
 
     // prologue(banner/polyfill/runtime helper) 줄 수 → 소스맵 오프셋에 반영
@@ -1719,17 +1723,10 @@ pub fn emitChunkRuntimeHelpers(
     if (options.experimental_decorators) {
         try rt.appendDecoratorRuntime(output, allocator, options.minify_whitespace);
     }
-    if (collected_helpers) |h| {
-        if (h.es_decorator) {
-            try output.appendSlice(allocator, if (options.minify_whitespace) rt.ES_DECORATOR_RUNTIME_MIN else rt.ES_DECORATOR_RUNTIME);
-        }
-    }
-    // splitting 모드에서는 collected_helpers가 null로 전달되므로 per-chunk 사용 여부를
-    // 알 수 없다 → target 기반으로 주입 (단일-번들 모드와 달리 이 경로에선 appendRuntimeHelpers
-    // 가 다시 호출되지 않으므로 중복 아님).
-    if (options.unsupported.async_await) {
-        try rt.appendAsyncRuntime(output, allocator, options.minify_whitespace, options.unsupported.arrow);
-    }
+    // #1961: RuntimeHelpers 비트맵 기반 helper (es_decorator / async_helper / generator
+    // 등) 는 transformer 가 graph parse 단계에서 named import 으로 emit → graph 가 chunk
+    // 분배. chunk-level prepend 는 중복 정의를 만들기 때문에 제거.
+    _ = collected_helpers;
     if (needs_to_binary) {
         try output.appendSlice(allocator, if (options.minify_whitespace) rt.TO_BINARY_RUNTIME_MIN else rt.TO_BINARY_RUNTIME);
     }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1098,11 +1098,23 @@ pub fn emitModule(
         .minify_syntax = options.minify_syntax,
         .minify_whitespace = options.minify_whitespace,
         .keep_names = options.keep_names,
+        // emit 단계 transformer 는 helper import emit 안 함 — graph pre-pass 가 이미 처리.
+        .emit_runtime_helper_imports = false,
     });
-    // symbol_ids 전파: semantic analyzer가 생성한 원본 AST의 symbol_ids를
-    // transformer가 ast 기준으로 재매핑. symbols slice도 함께 전달하여
-    // reference_count 기반 optimization(#1587 등)이 번들 경로에서도 동작하도록 함.
-    if (module.semantic) |sem| {
+    // #1961: graph parse 단계의 transformer pre-pass 결과가 있으면 hydrate.
+    // transformer.transform() 은 ast.transformed_root 가 set 이면 즉시 cached root 반환 →
+    // emit 단계에서 동일 transform 재실행 없이 graph 단계의 결과를 그대로 사용.
+    if (module.transform_cache) |cache| {
+        transformer.runtime_helpers = cache.runtime_helpers;
+        if (cache.symbol_ids.len > 0) {
+            transformer.symbol_ids.appendSlice(arena_alloc, cache.symbol_ids) catch return error.OutOfMemory;
+        }
+        if (module.semantic) |sem| {
+            transformer.symbols = sem.symbols.items;
+            transformer.references = sem.references;
+        }
+    } else if (module.semantic) |sem| {
+        // legacy 경로: graph pre-pass 미실행 (asset/disabled/JSON 등). semantic 만 hydrate.
         transformer.initSymbolIds(sem.symbol_ids) catch return error.OutOfMemory;
         transformer.symbols = sem.symbols.items;
         transformer.references = sem.references;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -50,7 +50,9 @@ const Transformer = transformer_mod.Transformer;
 const TransformOptions = transformer_mod.TransformOptions;
 const TransformCache = @import("module.zig").TransformCache;
 const builtin_plugins = @import("../transformer/plugins/builtin.zig");
+const Ast = @import("../parser/ast.zig").Ast;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const module_parser = @import("../parser/module.zig");
 const runtime_helper_modules = @import("runtime_helper_modules.zig");
 pub const module_store = @import("module_store.zig");
 const phase_mod = @import("phase.zig");
@@ -1546,7 +1548,7 @@ pub const ModuleGraph = struct {
         }
         transformer.line_offsets = module.line_offsets;
 
-        const new_root = transformer.transform() catch return;
+        _ = transformer.transform() catch return;
 
         // transformer 가 새 ast (clone) 에 transform 결과를 보유. module.ast 를 그 새 ast 로
         // swap. arena_alloc 가 owner 라 backing 은 안전. emit 단계 transformer 가 module.ast
@@ -1555,7 +1557,6 @@ pub const ModuleGraph = struct {
 
         const owned_symbol_ids = transformer.symbol_ids.toOwnedSlice(arena_alloc) catch &[_]?u32{};
         module.transform_cache = .{
-            .root = new_root,
             .runtime_helpers = transformer.runtime_helpers,
             .symbol_ids = owned_symbol_ids,
         };
@@ -1571,13 +1572,10 @@ pub const ModuleGraph = struct {
     fn appendTransformerHelperImports(
         _: *ModuleGraph,
         module: *Module,
-        ast_ptr: *const @import("../parser/ast.zig").Ast,
+        ast_ptr: *const Ast,
         parser_node_count: u32,
         arena_alloc: std.mem.Allocator,
     ) void {
-        const helper_modules = @import("runtime_helper_modules.zig");
-        const nodes = ast_ptr.nodes.items;
-
         var added_records: std.ArrayList(ImportRecord) = .empty;
         defer added_records.deinit(arena_alloc);
         var added_bindings: std.ArrayList(binding_scanner_mod.ImportBinding) = .empty;
@@ -1585,19 +1583,15 @@ pub const ModuleGraph = struct {
 
         const initial_record_count: u32 = @intCast(module.import_records.len);
 
-        for (nodes[parser_node_count..]) |node| {
+        for (ast_ptr.nodes.items[parser_node_count..]) |node| {
             if (node.tag != .import_declaration) continue;
-            const e = node.data.extra;
-            if (e + 5 >= ast_ptr.extra_data.items.len) continue;
-            const specs_start = ast_ptr.extra_data.items[e + 0];
-            const specs_len = ast_ptr.extra_data.items[e + 1];
-            const source_idx: NodeIndex = @enumFromInt(ast_ptr.extra_data.items[e + 2]);
-            if (source_idx.isNone()) continue;
-            const source_node = ast_ptr.getNode(source_idx);
+            if (!ast_ptr.hasExtra(node.data.extra, 5)) continue;
+            const xs = module_parser.readImportDeclExtras(ast_ptr, node.data.extra);
+            if (xs.source.isNone()) continue;
+            const source_node = ast_ptr.getNode(xs.source);
             if (source_node.tag != .string_literal) continue;
-            const raw = ast_ptr.getText(source_node.span);
-            const spec = stripImportQuotes(raw);
-            if (!helper_modules.isVirtualId(spec)) continue;
+            const spec = Ast.stripStringQuotes(ast_ptr.getText(source_node.span));
+            if (!runtime_helper_modules.isVirtualId(spec)) continue;
 
             const record_idx_for_bindings: u32 = initial_record_count + @as(u32, @intCast(added_records.items.len));
             added_records.append(arena_alloc, .{
@@ -1606,25 +1600,19 @@ pub const ModuleGraph = struct {
                 .span = source_node.span,
             }) catch return;
 
-            // import_specifier 마다 binding 등록. spec layout: binary { left=imported, right=local, flags }.
-            if (specs_len == 0) continue;
-            for (0..specs_len) |i| {
-                const spec_idx: NodeIndex = @enumFromInt(ast_ptr.extra_data.items[specs_start + i]);
+            for (0..xs.specs_len) |i| {
+                const spec_idx: NodeIndex = @enumFromInt(ast_ptr.extra_data.items[xs.specs_start + i]);
                 if (spec_idx.isNone()) continue;
                 const spec_node = ast_ptr.getNode(spec_idx);
                 if (spec_node.tag != .import_specifier) continue;
                 const imported_idx = spec_node.data.binary.left;
                 const local_idx = spec_node.data.binary.right;
                 if (imported_idx.isNone() or local_idx.isNone()) continue;
-                const imported_node = ast_ptr.getNode(imported_idx);
-                const local_node = ast_ptr.getNode(local_idx);
-                const imported_name = ast_ptr.getText(imported_node.span);
-                const local_name = ast_ptr.getText(local_node.span);
                 added_bindings.append(arena_alloc, .{
                     .kind = .named,
-                    .local_name = local_name,
-                    .imported_name = imported_name,
-                    .local_span = local_node.span,
+                    .local_name = ast_ptr.getText(ast_ptr.getNode(local_idx).span),
+                    .imported_name = ast_ptr.getText(ast_ptr.getNode(imported_idx).span),
+                    .local_span = ast_ptr.getNode(local_idx).span,
                     .import_record_index = record_idx_for_bindings,
                 }) catch return;
             }
@@ -1644,14 +1632,6 @@ pub const ModuleGraph = struct {
             @memcpy(merged[old.len..], added_bindings.items);
             module.import_bindings = merged;
         }
-    }
-
-    /// `import_scanner.stripQuotes` 와 동일 — 그러나 import_scanner 의 private fn 이라 inline.
-    fn stripImportQuotes(raw: []const u8) []const u8 {
-        if (raw.len >= 2 and (raw[0] == '"' or raw[0] == '\'') and raw[raw.len - 1] == raw[0]) {
-            return raw[1 .. raw.len - 1];
-        }
-        return raw;
     }
 
     const findPackageDirPath = resolve_cache_mod.findPackageDirPath;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -132,6 +132,12 @@ pub const ModuleGraph = struct {
 
     /// `worklet "directive"` plugin 활성 여부 — bundler 가 BundleOptions.worklet_transform 으로 set.
     worklet_transform: bool = false,
+    /// React Fast Refresh — dev_mode + user_code 에 transformer 가 등록 코드 주입.
+    react_refresh: bool = false,
+    /// code splitting 활성화. helper module virtual import (#1961) 는 splitting 모드에서만
+    /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
+    /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
+    code_splitting: bool = false,
     /// `experimentalDecorators` — TS legacy decorator 변환.
     experimental_decorators: bool = false,
     /// `emitDecoratorMetadata` — `__metadata` 호출 주입.
@@ -901,7 +907,15 @@ pub const ModuleGraph = struct {
                     const dep_idx = try self.addDisabledModule(record.specifier);
                     try self.recordResolvedDep(mod_index, mod_idx, rec_i, dep_idx, record.kind);
                 },
-                .virtual, .dataurl, .external, .custom => unreachable,
+                .virtual => |v| {
+                    // #1961: virtual module 은 plugin 의 load 훅이 source 채움. addModule 이
+                    // path 를 dupe 하므로 graph 가 owner. v.path 는 plugin 이 borrow 한
+                    // specifier (runtime_helper_modules) 일 수 있어 free 안 함 — plugin 이
+                    // alloc 했으면 plugin context lifetime 동안 살아있어야 한다는 규약.
+                    const dep_idx = try self.addModule(v.path);
+                    try self.recordResolvedDep(mod_index, mod_idx, rec_i, dep_idx, record.kind);
+                },
+                .dataurl, .external, .custom => unreachable,
             }
         } else {
             // external — phantom Module 로 graph 에 등록 + 양방향 link.
@@ -1501,7 +1515,7 @@ pub const ModuleGraph = struct {
         const parser_node_count: u32 = @intCast(ast_ptr.nodes.items.len);
 
         var transformer = Transformer.init(arena_alloc, ast_ptr, .{
-            .react_refresh = false, // graph 단계는 user code 도 react_refresh 비활성 — registration code 는 dev_mode 에서만 의미. emitter 가 별도 처리할 경우 cache 무효화 필요 (#1961 후속).
+            .react_refresh = self.react_refresh and is_user_code,
             .plugins = merged_plugins,
             .define = self.defines, // transformer.DefineEntry 는 scan_results.DefineEntry 의 alias
             .experimental_decorators = self.experimental_decorators,
@@ -1520,7 +1534,9 @@ pub const ModuleGraph = struct {
             .minify_syntax = self.minify_syntax,
             .minify_whitespace = self.minify_whitespace,
             .keep_names = self.keep_names,
-            .emit_runtime_helper_imports = true, // 핵심: helper module import 를 finalize 에 emit
+            // #1961 단계 4 의 single-bundle 회귀 (helper module declaration 이 statement
+            // shake 로 elide) 가 fix 되기 전까지 code splitting 모드에서만 활성.
+            .emit_runtime_helper_imports = self.code_splitting,
         }) catch return;
 
         if (module.semantic) |sem| {
@@ -1529,9 +1545,13 @@ pub const ModuleGraph = struct {
             transformer.references = sem.references;
         }
         transformer.line_offsets = module.line_offsets;
-        _ = is_user_code; // 향후 react_refresh dev_mode 분기에 사용
 
         const new_root = transformer.transform() catch return;
+
+        // transformer 가 새 ast (clone) 에 transform 결과를 보유. module.ast 를 그 새 ast 로
+        // swap. arena_alloc 가 owner 라 backing 은 안전. emit 단계 transformer 가 module.ast
+        // 를 clone 시 transformed_root 까지 복사되어 cache hit 분기 즉시 return.
+        module.ast = transformer.ast.*;
 
         const owned_symbol_ids = transformer.symbol_ids.toOwnedSlice(arena_alloc) catch &[_]?u32{};
         module.transform_cache = .{
@@ -1542,11 +1562,12 @@ pub const ModuleGraph = struct {
 
         // transformer 가 추가한 helper module import 들을 records 에 append.
         // [parser_node_count..) 영역만 walk — parser 영역은 이미 records 에 등록됨.
-        appendTransformerHelperImports(self, module, ast_ptr, parser_node_count, arena_alloc);
+        appendTransformerHelperImports(self, module, &(module.ast.?), parser_node_count, arena_alloc);
     }
 
     /// transformer 영역 ([parser_node_count..)) 에서 import_declaration 노드만 골라
-    /// `\x00zts:runtime/...` specifier 를 가지면 module.import_records 에 append.
+    /// `\x00zts:runtime/...` specifier 를 가지면 module.import_records 와 module.import_bindings
+    /// 에 binding 정보까지 등록 — link 단계의 cross-chunk symbol resolution 에 필요.
     fn appendTransformerHelperImports(
         _: *ModuleGraph,
         module: *Module,
@@ -1557,13 +1578,19 @@ pub const ModuleGraph = struct {
         const helper_modules = @import("runtime_helper_modules.zig");
         const nodes = ast_ptr.nodes.items;
 
-        var added: std.ArrayList(ImportRecord) = .empty;
-        defer added.deinit(arena_alloc);
+        var added_records: std.ArrayList(ImportRecord) = .empty;
+        defer added_records.deinit(arena_alloc);
+        var added_bindings: std.ArrayList(binding_scanner_mod.ImportBinding) = .empty;
+        defer added_bindings.deinit(arena_alloc);
+
+        const initial_record_count: u32 = @intCast(module.import_records.len);
 
         for (nodes[parser_node_count..]) |node| {
             if (node.tag != .import_declaration) continue;
             const e = node.data.extra;
-            if (e + 2 >= ast_ptr.extra_data.items.len) continue;
+            if (e + 5 >= ast_ptr.extra_data.items.len) continue;
+            const specs_start = ast_ptr.extra_data.items[e + 0];
+            const specs_len = ast_ptr.extra_data.items[e + 1];
             const source_idx: NodeIndex = @enumFromInt(ast_ptr.extra_data.items[e + 2]);
             if (source_idx.isNone()) continue;
             const source_node = ast_ptr.getNode(source_idx);
@@ -1572,20 +1599,51 @@ pub const ModuleGraph = struct {
             const spec = stripImportQuotes(raw);
             if (!helper_modules.isVirtualId(spec)) continue;
 
-            added.append(arena_alloc, .{
+            const record_idx_for_bindings: u32 = initial_record_count + @as(u32, @intCast(added_records.items.len));
+            added_records.append(arena_alloc, .{
                 .specifier = spec,
                 .kind = .static_import,
                 .span = source_node.span,
             }) catch return;
+
+            // import_specifier 마다 binding 등록. spec layout: binary { left=imported, right=local, flags }.
+            if (specs_len == 0) continue;
+            for (0..specs_len) |i| {
+                const spec_idx: NodeIndex = @enumFromInt(ast_ptr.extra_data.items[specs_start + i]);
+                if (spec_idx.isNone()) continue;
+                const spec_node = ast_ptr.getNode(spec_idx);
+                if (spec_node.tag != .import_specifier) continue;
+                const imported_idx = spec_node.data.binary.left;
+                const local_idx = spec_node.data.binary.right;
+                if (imported_idx.isNone() or local_idx.isNone()) continue;
+                const imported_node = ast_ptr.getNode(imported_idx);
+                const local_node = ast_ptr.getNode(local_idx);
+                const imported_name = ast_ptr.getText(imported_node.span);
+                const local_name = ast_ptr.getText(local_node.span);
+                added_bindings.append(arena_alloc, .{
+                    .kind = .named,
+                    .local_name = local_name,
+                    .imported_name = imported_name,
+                    .local_span = local_node.span,
+                    .import_record_index = record_idx_for_bindings,
+                }) catch return;
+            }
         }
 
-        if (added.items.len == 0) return;
-
-        const old = module.import_records;
-        const merged = arena_alloc.alloc(ImportRecord, old.len + added.items.len) catch return;
-        @memcpy(merged[0..old.len], old);
-        @memcpy(merged[old.len..], added.items);
-        module.import_records = merged;
+        if (added_records.items.len > 0) {
+            const old = module.import_records;
+            const merged = arena_alloc.alloc(ImportRecord, old.len + added_records.items.len) catch return;
+            @memcpy(merged[0..old.len], old);
+            @memcpy(merged[old.len..], added_records.items);
+            module.import_records = merged;
+        }
+        if (added_bindings.items.len > 0) {
+            const old = module.import_bindings;
+            const merged = arena_alloc.alloc(binding_scanner_mod.ImportBinding, old.len + added_bindings.items.len) catch return;
+            @memcpy(merged[0..old.len], old);
+            @memcpy(merged[old.len..], added_bindings.items);
+            module.import_bindings = merged;
+        }
     }
 
     /// `import_scanner.stripQuotes` 와 동일 — 그러나 import_scanner 의 private fn 이라 inline.

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -45,6 +45,13 @@ const pkg_json = @import("package_json.zig");
 const mime = @import("../server/mime.zig");
 const plugin_mod = @import("plugin.zig");
 const MpscChannel = @import("mpsc_channel.zig").MpscChannel;
+const transformer_mod = @import("../transformer/transformer.zig");
+const Transformer = transformer_mod.Transformer;
+const TransformOptions = transformer_mod.TransformOptions;
+const TransformCache = @import("module.zig").TransformCache;
+const builtin_plugins = @import("../transformer/plugins/builtin.zig");
+const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const runtime_helper_modules = @import("runtime_helper_modules.zig");
 pub const module_store = @import("module_store.zig");
 const phase_mod = @import("phase.zig");
 pub const ModulePhase = phase_mod.ModulePhase;
@@ -123,6 +130,39 @@ pub const ModuleGraph = struct {
     /// 메인 그래프에는 모듈로 추가하지 않고, bundler에서 별도 빌드한다.
     worker_entries: std.ArrayList(WorkerEntry) = .empty,
 
+    /// `worklet "directive"` plugin 활성 여부 — bundler 가 BundleOptions.worklet_transform 으로 set.
+    worklet_transform: bool = false,
+    /// `experimentalDecorators` — TS legacy decorator 변환.
+    experimental_decorators: bool = false,
+    /// `emitDecoratorMetadata` — `__metadata` 호출 주입.
+    emit_decorator_metadata: bool = false,
+    /// `useDefineForClassFields` 기본값. false=TS 4.x 이전 [[Set]] semantics.
+    use_define_for_class_fields: bool = true,
+    /// `verbatimModuleSyntax` — TS 5.0+ value import elision 비활성.
+    verbatim_module_syntax: bool = false,
+    /// 다운레벨 대상 비-지원 feature 비트맵.
+    unsupported: transformer_mod.TransformOptions.compat.UnsupportedFeatures = .{},
+    /// 드롭할 labeled statement 라벨 (`--drop-labels=DEV,TEST`).
+    drop_labels: []const []const u8 = &.{},
+    /// `--minify-syntax` — AST 레벨 의미 보존 축약.
+    minify_syntax: bool = false,
+    /// `--keep-names` — 함수/클래스 .name 보존.
+    keep_names: bool = false,
+    /// JSX classic mode factory (e.g. "React.createElement").
+    jsx_factory: []const u8 = "React.createElement",
+    /// JSX classic mode fragment (e.g. "React.Fragment").
+    jsx_fragment: []const u8 = "React.Fragment",
+    /// Reanimated worklet plugin 의 `__pluginVersion` 값.
+    worklet_plugin_version: ?[]const u8 = null,
+
+    /// Runtime helper virtual module plugin (#1961) 의 `SourceOptions`.
+    /// graph 가 build() 동안 owner — `Plugin.context` 에서 `*const SourceOptions` 로 참조.
+    helper_plugin_opts: runtime_helper_modules.SourceOptions = .{},
+    /// `self.plugins` 앞에 ZTS builtin runtime helper plugin 을 prepend 한 slice.
+    /// `graph.allocator` 소유. `ensureBuiltinPlugins` 에서 lazy 초기화 후 PluginRunner.init
+    /// 호출 site 들이 이걸 참조.
+    plugins_with_helpers: ?[]plugin_mod.Plugin = null,
+
     pub const PkgInfo = struct {
         is_module: bool,
         side_effects: pkg_json.PackageJson.SideEffects,
@@ -169,6 +209,37 @@ pub const ModuleGraph = struct {
         }
         self.worker_entries.deinit(self.allocator);
         if (self.jsx_specifier_cache) |s| self.allocator.free(s);
+        if (self.plugins_with_helpers) |p| self.allocator.free(p);
+    }
+
+    /// `plugins_with_helpers` lazy 초기화 — `self.plugins` 앞에 ZTS builtin runtime
+    /// helper plugin 을 prepend 한 slice 를 graph allocator 로 만든다 (#1961).
+    /// 빌드 옵션 (minify_whitespace 등) 은 이미 graph 에 set 됐다는 전제. `helper_plugin_opts`
+    /// 도 같이 hydrate. 단일 thread 진입점 (`build` 등) 에서만 호출.
+    fn ensureBuiltinPlugins(self: *ModuleGraph) void {
+        if (self.plugins_with_helpers != null) return;
+        // SourceOptions 는 빌드 옵션 기반으로 1회 결정.
+        self.helper_plugin_opts = .{
+            .minify = self.minify_whitespace,
+            .es5 = self.unsupported.async_await or self.unsupported.arrow,
+            // configurable_exports 는 RN 같은 환경 — 현재 graph 에 직접 필드 없으므로 false.
+            // 후속 PR 에서 BundleOptions.configurable_exports 또는 platform=react-native 기반 결정.
+            .configurable_exports = false,
+        };
+        const builtin = runtime_helper_modules.makePlugin(&self.helper_plugin_opts);
+        const merged = self.allocator.alloc(plugin_mod.Plugin, self.plugins.len + 1) catch return;
+        merged[0] = builtin;
+        @memcpy(merged[1..], self.plugins);
+        self.plugins_with_helpers = merged;
+    }
+
+    /// 모든 PluginRunner 호출 site 가 사용하는 통합 진입점. `ensureBuiltinPlugins` 가
+    /// `plugins_with_helpers` 를 하이드레이트한 후 그걸로 runner 만든다. fallback 으로
+    /// `self.plugins` 사용 (alloc 실패 시).
+    fn pluginRunnerWithBuiltins(self: *ModuleGraph) ?plugin_mod.PluginRunner {
+        const list = self.plugins_with_helpers orelse self.plugins;
+        if (list.len == 0) return null;
+        return plugin_mod.PluginRunner.init(list);
     }
 
     // ============================================================
@@ -252,6 +323,10 @@ pub const ModuleGraph = struct {
     /// Phase 1: 모든 모듈 등록 + 파싱 + import resolve (BFS)
     /// Phase 2: DFS로 exec_index + 순환 감지
     pub fn build(self: *ModuleGraph, entry_points: []const []const u8) !void {
+        // #1961: ZTS builtin runtime helper plugin 을 plugin slice 앞에 prepend.
+        // 워커 스레드에서 호출하기 전 단일 thread 진입점에서 1회만.
+        self.ensureBuiltinPlugins();
+
         // entry_dir 계산: entry point들의 공통 부모 디렉토리 ([dir] 패턴용)
         if (self.entry_dir.len == 0 and entry_points.len > 0) {
             self.entry_dir = std.fs.path.dirname(entry_points[0]) orelse "";
@@ -465,6 +540,9 @@ pub const ModuleGraph = struct {
         /// 새로 그래프에 추가된 모듈 (`store.modules.contains(path) == false`) 은 강제로 stat (Issue #1727 §3).
         changed_files: ?*const std.StringHashMap(void),
     ) !IncrementalBuildResult {
+        // #1961: builtin runtime helper plugin prepend (build() 와 동일).
+        self.ensureBuiltinPlugins();
+
         // entry_dir 계산: entry point들의 공통 부모 디렉토리 ([dir] 패턴용)
         if (self.entry_dir.len == 0 and entry_points.len > 0) {
             self.entry_dir = std.fs.path.dirname(entry_points[0]) orelse "";
@@ -876,10 +954,7 @@ pub const ModuleGraph = struct {
         const module_path = mod_ptr.path;
         const source_dir = std.fs.path.dirname(module_path) orelse ".";
 
-        const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
-            plugin_mod.PluginRunner.init(self.plugins)
-        else
-            null;
+        const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();
 
         // import.meta.glob: 워커에서 glob 확장 수행
         expandGlobRecords(self.allocator, mod_ptr.import_records, source_dir);
@@ -947,10 +1022,7 @@ pub const ModuleGraph = struct {
         if (module.mtime == 0) module.mtime = getMtime(module.path) catch 0;
 
         // Plugin runner: parseModule 내에서 load + transform 훅에 공용
-        const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
-            plugin_mod.PluginRunner.init(self.plugins)
-        else
-            null;
+        const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();
 
         // Plugin: load 훅 — 모든 module_type 분기 전에 플러그인에게 기회를 줌.
         // 플러그인이 내용을 반환하면 JS 모듈로 전환 (예: .css → JS export).
@@ -1398,7 +1470,130 @@ pub const ModuleGraph = struct {
             }
         }
 
+        // #1961: transformer pre-pass. helper module 을 graph 의 1급 모듈로 분배하려면
+        // helper import 가 link 단계 전에 import_records 에 등록되어야 한다. transformer 를
+        // 여기서 1회 실행해 transformed AST 를 module.ast 에 in-place 저장 + helper import
+        // 노드를 records 에 append. emitter 는 module.transform_cache hit 시 transform skip.
+        self.runTransformerPrePass(module, arena_alloc);
+
         module.state = .parsed;
+    }
+
+    /// transformer pre-pass — graph 단계에서 1회 실행.
+    /// 결과: `module.ast` 에 transformer 노드 in-place append, `module.transform_cache` set,
+    /// helper module import 들이 `module.import_records` 에 append.
+    /// 실패는 silent — 기존 import_records 와 `transform_cache=null` 로 emitter 가 legacy
+    /// 경로로 fallback (out-of-memory 등에 대한 부분 진행 회피).
+    fn runTransformerPrePass(self: *ModuleGraph, module: *Module, arena_alloc: std.mem.Allocator) void {
+        if (module.ast == null) return;
+        const ast_ptr = &(module.ast.?);
+
+        // emitter 와 동일한 옵션 결정 휴리스틱 — 결과 분기 시 cache mismatch.
+        const is_user_code = std.mem.indexOf(u8, module.path, "/node_modules/") == null;
+        // worklet 변환은 react-native/@react-native 코어 제외, 나머지 node_modules 포함.
+        const exclude_worklet = self.worklet_transform and
+            (std.mem.indexOf(u8, module.path, "/node_modules/react-native/") != null or
+                std.mem.indexOf(u8, module.path, "/node_modules/@react-native/") != null);
+        const merged_plugins = builtin_plugins.collect(.{
+            .worklet = self.worklet_transform and !exclude_worklet,
+        }, self.plugins, arena_alloc) catch return;
+
+        const parser_node_count: u32 = @intCast(ast_ptr.nodes.items.len);
+
+        var transformer = Transformer.init(arena_alloc, ast_ptr, .{
+            .react_refresh = false, // graph 단계는 user code 도 react_refresh 비활성 — registration code 는 dev_mode 에서만 의미. emitter 가 별도 처리할 경우 cache 무효화 필요 (#1961 후속).
+            .plugins = merged_plugins,
+            .define = self.defines, // transformer.DefineEntry 는 scan_results.DefineEntry 의 alias
+            .experimental_decorators = self.experimental_decorators,
+            .emit_decorator_metadata = self.emit_decorator_metadata,
+            .use_define_for_class_fields = self.use_define_for_class_fields,
+            .verbatim_module_syntax = self.verbatim_module_syntax,
+            .unsupported = self.unsupported,
+            .drop_labels = self.drop_labels,
+            .jsx_transform = ast_ptr.has_jsx,
+            .jsx_runtime = self.jsx_runtime,
+            .jsx_factory = self.jsx_factory,
+            .jsx_fragment = self.jsx_fragment,
+            .jsx_import_source = self.jsx_import_source,
+            .jsx_filename = module.path,
+            .worklet_plugin_version = self.worklet_plugin_version,
+            .minify_syntax = self.minify_syntax,
+            .minify_whitespace = self.minify_whitespace,
+            .keep_names = self.keep_names,
+            .emit_runtime_helper_imports = true, // 핵심: helper module import 를 finalize 에 emit
+        }) catch return;
+
+        if (module.semantic) |sem| {
+            transformer.initSymbolIds(sem.symbol_ids) catch return;
+            transformer.symbols = sem.symbols.items;
+            transformer.references = sem.references;
+        }
+        transformer.line_offsets = module.line_offsets;
+        _ = is_user_code; // 향후 react_refresh dev_mode 분기에 사용
+
+        const new_root = transformer.transform() catch return;
+
+        const owned_symbol_ids = transformer.symbol_ids.toOwnedSlice(arena_alloc) catch &[_]?u32{};
+        module.transform_cache = .{
+            .root = new_root,
+            .runtime_helpers = transformer.runtime_helpers,
+            .symbol_ids = owned_symbol_ids,
+        };
+
+        // transformer 가 추가한 helper module import 들을 records 에 append.
+        // [parser_node_count..) 영역만 walk — parser 영역은 이미 records 에 등록됨.
+        appendTransformerHelperImports(self, module, ast_ptr, parser_node_count, arena_alloc);
+    }
+
+    /// transformer 영역 ([parser_node_count..)) 에서 import_declaration 노드만 골라
+    /// `\x00zts:runtime/...` specifier 를 가지면 module.import_records 에 append.
+    fn appendTransformerHelperImports(
+        _: *ModuleGraph,
+        module: *Module,
+        ast_ptr: *const @import("../parser/ast.zig").Ast,
+        parser_node_count: u32,
+        arena_alloc: std.mem.Allocator,
+    ) void {
+        const helper_modules = @import("runtime_helper_modules.zig");
+        const nodes = ast_ptr.nodes.items;
+
+        var added: std.ArrayList(ImportRecord) = .empty;
+        defer added.deinit(arena_alloc);
+
+        for (nodes[parser_node_count..]) |node| {
+            if (node.tag != .import_declaration) continue;
+            const e = node.data.extra;
+            if (e + 2 >= ast_ptr.extra_data.items.len) continue;
+            const source_idx: NodeIndex = @enumFromInt(ast_ptr.extra_data.items[e + 2]);
+            if (source_idx.isNone()) continue;
+            const source_node = ast_ptr.getNode(source_idx);
+            if (source_node.tag != .string_literal) continue;
+            const raw = ast_ptr.getText(source_node.span);
+            const spec = stripImportQuotes(raw);
+            if (!helper_modules.isVirtualId(spec)) continue;
+
+            added.append(arena_alloc, .{
+                .specifier = spec,
+                .kind = .static_import,
+                .span = source_node.span,
+            }) catch return;
+        }
+
+        if (added.items.len == 0) return;
+
+        const old = module.import_records;
+        const merged = arena_alloc.alloc(ImportRecord, old.len + added.items.len) catch return;
+        @memcpy(merged[0..old.len], old);
+        @memcpy(merged[old.len..], added.items);
+        module.import_records = merged;
+    }
+
+    /// `import_scanner.stripQuotes` 와 동일 — 그러나 import_scanner 의 private fn 이라 inline.
+    fn stripImportQuotes(raw: []const u8) []const u8 {
+        if (raw.len >= 2 and (raw[0] == '"' or raw[0] == '\'') and raw[raw.len - 1] == raw[0]) {
+            return raw[1 .. raw.len - 1];
+        }
+        return raw;
     }
 
     const findPackageDirPath = resolve_cache_mod.findPackageDirPath;
@@ -1531,10 +1726,7 @@ pub const ModuleGraph = struct {
         const source_dir = std.fs.path.dirname(module_path) orelse ".";
 
         // Plugin: resolveId 훅용 runner를 루프 밖에서 한 번만 생성
-        const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
-            plugin_mod.PluginRunner.init(self.plugins)
-        else
-            null;
+        const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();
 
         // import.meta.glob: glob 레코드를 파일 시스템에서 확장
         expandGlobRecords(self.allocator, mod_ptr.import_records, source_dir);
@@ -2654,10 +2846,7 @@ fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
     if (!has_any) return;
 
     const module_path = module.path;
-    const plugin_runner: ?plugin_mod.PluginRunner = if (self.plugins.len > 0)
-        plugin_mod.PluginRunner.init(self.plugins)
-    else
-        null;
+    const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();
 
     // require.context 는 parse 산출물이라 arena 가 항상 존재. 없으면 (disabled/asset 등)
     // expand 자체가 의미 없고, graph allocator fallback 은 module.deinit 에서 free 누락 →

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -26,6 +26,8 @@ pub const ExportBinding = binding_scanner.ExportBinding;
 const stmt_info_mod = @import("stmt_info.zig");
 const symbol_mod = @import("symbol.zig");
 pub const AliasTable = symbol_mod.AliasTable;
+const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
+const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 
 /// Semantic analyzer 결과. parse_arena가 소유하는 데이터의 참조.
 /// linker가 import→export 연결 + 이름 충돌 해결에 사용.
@@ -53,6 +55,21 @@ pub const ModuleSemanticData = struct {
         if (id >= self.symbols.items.len) return "";
         return self.symbols.items[id].nameText(source);
     }
+};
+
+/// graph parseModule 의 transformer pre-pass 결과 캐시 (#1961).
+///
+/// emitter 가 transformer 를 같은 ast 에 다시 호출하지 않고 (transformer 의 invariants
+/// 위반) 이 캐시 값을 그대로 사용. parse_arena 가 backing — symbol_ids slice 도 그 안.
+pub const TransformCache = struct {
+    /// transformer.transform() 의 새 root NodeIndex (transformer 영역).
+    root: NodeIndex,
+    /// transformer 가 set 한 RuntimeHelpers 비트맵.
+    /// emitter 의 chunk-level helper preamble 결정에 사용.
+    runtime_helpers: RuntimeHelpers,
+    /// transformer 가 만든 symbol_ids slice. parser 영역 + transformer 영역 매핑 포함.
+    /// emitter 의 minify/linker buildMetadataForAst override_syms 에 사용.
+    symbol_ids: []const ?u32,
 };
 
 pub const Module = struct {
@@ -107,6 +124,11 @@ pub const Module = struct {
     /// Bundler-local 합성 심볼 테이블 (cross-module linking용). #1328 Phase 1.
     /// graph allocator 소유. null = 미초기화 (asset/disabled 모듈 등).
     alias_table: ?AliasTable = null,
+
+    /// graph parseModule 단계의 transformer pre-pass 결과 캐시 (#1961).
+    /// null = pre-pass 미실행 (legacy 경로 또는 비-JS 모듈). emitter 는 set 이면
+    /// transformer 재실행 안 하고 캐시된 root/helpers/symbol_ids 사용.
+    transform_cache: ?TransformCache = null,
 
     /// wrap_kind != .none 모듈의 `init_<path>` 함수 심볼 id (semantic 공간).
     /// null = 미래핑 또는 semantic 없음 (fallback: makeInitVarName 재할당).

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -27,7 +27,6 @@ const stmt_info_mod = @import("stmt_info.zig");
 const symbol_mod = @import("symbol.zig");
 pub const AliasTable = symbol_mod.AliasTable;
 const RuntimeHelpers = @import("../transformer/transformer.zig").RuntimeHelpers;
-const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 
 /// Semantic analyzer 결과. parse_arena가 소유하는 데이터의 참조.
 /// linker가 import→export 연결 + 이름 충돌 해결에 사용.
@@ -61,9 +60,9 @@ pub const ModuleSemanticData = struct {
 ///
 /// emitter 가 transformer 를 같은 ast 에 다시 호출하지 않고 (transformer 의 invariants
 /// 위반) 이 캐시 값을 그대로 사용. parse_arena 가 backing — symbol_ids slice 도 그 안.
+/// transformed root 는 `ast.transformed_root` 가 보유 — emitter 의 transformer.transform()
+/// 이 cache hit 분기로 그 root 를 그대로 반환하므로 별도 캐시 불필요.
 pub const TransformCache = struct {
-    /// transformer.transform() 의 새 root NodeIndex (transformer 영역).
-    root: NodeIndex,
     /// transformer 가 set 한 RuntimeHelpers 비트맵.
     /// emitter 의 chunk-level helper preamble 결정에 사용.
     runtime_helpers: RuntimeHelpers,

--- a/src/bundler/runtime_helper_modules.zig
+++ b/src/bundler/runtime_helper_modules.zig
@@ -222,6 +222,65 @@ const MODULES = [_]HelperModule{
             .es5_min = rt.CJS_RUNTIME_ES5_MIN,
         },
     },
+
+    // ES2015 spread 연산 — `__toConsumableArray` 만 외부 호출, `__arrayLikeToArray` 는
+    // 모듈 내 closure-internal (export 불필요, tree-shake 단순화 위해 미노출).
+    .{
+        .short = "spread-array",
+        .helpers = &.{"__toConsumableArray"},
+        .body = .{ .plain = rt.SPREAD_ARRAY_RUNTIME, .min = rt.SPREAD_ARRAY_RUNTIME_MIN },
+    },
+
+    // --keep-names + binary loader
+    .{
+        .short = "keep-names",
+        .helpers = &.{"__name"},
+        .body = .{ .plain = rt.KEEP_NAMES_RUNTIME, .min = rt.KEEP_NAMES_RUNTIME_MIN },
+    },
+    .{
+        .short = "to-binary",
+        .helpers = &.{"__toBinary"},
+        .body = .{ .plain = rt.TO_BINARY_RUNTIME, .min = rt.TO_BINARY_RUNTIME_MIN },
+    },
+
+    // ES2022 private field/method downlevel
+    .{
+        .short = "class-private-method-init",
+        .helpers = &.{"__classPrivateMethodInit"},
+        .body = .{ .plain = rt.PRIVATE_METHOD_INIT_RUNTIME, .min = rt.PRIVATE_METHOD_INIT_RUNTIME_MIN },
+    },
+    .{
+        .short = "class-private-method-get",
+        .helpers = &.{"__classPrivateMethodGet"},
+        .body = .{ .plain = rt.PRIVATE_METHOD_GET_RUNTIME, .min = rt.PRIVATE_METHOD_GET_RUNTIME_MIN },
+    },
+    .{
+        .short = "class-private-field-set",
+        .helpers = &.{"__classPrivateFieldSet"},
+        .body = .{ .plain = rt.PRIVATE_FIELD_SET_RUNTIME, .min = rt.PRIVATE_FIELD_SET_RUNTIME_MIN },
+    },
+    .{
+        .short = "class-static-private-field",
+        .helpers = &.{
+            "__classCheckPrivateStaticAccess",
+            "__classCheckPrivateStaticFieldDescriptor",
+            "__classStaticPrivateFieldSpecGet",
+            "__classStaticPrivateFieldSpecSet",
+        },
+        .body = .{ .plain = rt.STATIC_PRIVATE_FIELD_RUNTIME, .min = rt.STATIC_PRIVATE_FIELD_RUNTIME_MIN },
+    },
+
+    // ES2025 explicit resource management (`using` / `await using`)
+    .{
+        .short = "using",
+        .helpers = &.{ "__using", "__callDispose" },
+        .body = .{
+            .plain = rt.USING_RUNTIME,
+            .min = rt.USING_RUNTIME_MIN,
+            .es5 = rt.USING_RUNTIME_ES5,
+            .es5_min = rt.USING_RUNTIME_ES5_MIN,
+        },
+    },
 };
 
 // ============================================================
@@ -390,12 +449,22 @@ test "moduleShortFor: 등록된 helper 매핑" {
 }
 
 test "moduleShortFor: 미등록 helper 는 null" {
+    // `__spreadArray` 는 transformer 가 emit 하지 않음 (`__toConsumableArray` 가 대체).
+    // `__arrayLikeToArray` 는 spread-array 모듈 내 closure-internal — 외부 export 안 함.
     try std.testing.expect(moduleShortFor("__spreadArray") == null);
-    try std.testing.expect(moduleShortFor("__toBinary") == null);
-    try std.testing.expect(moduleShortFor("__name") == null);
-    try std.testing.expect(moduleShortFor("__using") == null);
-    try std.testing.expect(moduleShortFor("__classPrivateMethodInit") == null);
+    try std.testing.expect(moduleShortFor("__arrayLikeToArray") == null);
     try std.testing.expect(moduleShortFor("not_a_helper") == null);
+}
+
+test "moduleShortFor: PR 1b 신규 등록 helper" {
+    try std.testing.expectEqualStrings("spread-array", moduleShortFor("__toConsumableArray").?);
+    try std.testing.expectEqualStrings("keep-names", moduleShortFor("__name").?);
+    try std.testing.expectEqualStrings("to-binary", moduleShortFor("__toBinary").?);
+    try std.testing.expectEqualStrings("class-private-method-init", moduleShortFor("__classPrivateMethodInit").?);
+    try std.testing.expectEqualStrings("class-static-private-field", moduleShortFor("__classCheckPrivateStaticAccess").?);
+    try std.testing.expectEqualStrings("class-static-private-field", moduleShortFor("__classStaticPrivateFieldSpecSet").?);
+    try std.testing.expectEqualStrings("using", moduleShortFor("__using").?);
+    try std.testing.expectEqualStrings("using", moduleShortFor("__callDispose").?);
 }
 
 test "idForBase: helper base → virtual ID" {
@@ -511,7 +580,7 @@ test "loadHook: 비 virtual ID 는 null" {
 test "loadHook: 미등록 short 는 null" {
     const allocator = std.testing.allocator;
     const opts = SourceOptions{};
-    const result = try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/spread-array", allocator);
+    const result = try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/no-such-helper", allocator);
     try std.testing.expect(result == null);
 }
 
@@ -533,7 +602,7 @@ test "resolveIdHook: virtual specifier 만 가로챔" {
     const r2 = try resolveIdHook(null, "./local.ts", null, allocator);
     try std.testing.expect(r2 == null);
 
-    const r3 = try resolveIdHook(null, "\x00zts:runtime/spread-array", null, allocator);
+    const r3 = try resolveIdHook(null, "\x00zts:runtime/no-such-helper", null, allocator);
     try std.testing.expect(r3 == null);
 }
 

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -888,6 +888,11 @@ pub const Ast = struct {
             .has_jsx = source_ast.has_jsx,
             .has_jsx_key_after_spread = source_ast.has_jsx_key_after_spread,
             .allocator = allocator,
+            // #1961: source_ast 가 이미 transform 된 상태면 transformed_root + boundary 도
+            // 복사. 그렇지 않으면 emit 단계 transformer 가 graph pre-pass 결과를 무시하고
+            // 두 번째 transform 을 시작 → ast.transformed_root 의 cache hit 분기를 놓침.
+            .transformed_root = source_ast.transformed_root,
+            .transform_boundary = source_ast.transform_boundary,
         };
         // 세 appendSlice 중 하나라도 실패하면 이미 할당된 ArrayList 버퍼를 정리해야 한다.
         errdefer cloned.deinit();

--- a/src/transformer/runtime_helper_imports.zig
+++ b/src/transformer/runtime_helper_imports.zig
@@ -1,0 +1,182 @@
+//! Runtime helper virtual module 의 named import statement 를 transformer finalize 단계에 emit (#1961).
+//!
+//! Transformer 가 visit 도중 set 한 `RuntimeHelpers` 비트맵을 보고, 각 비트가 가리키는
+//! helper base 들을 묶어 `import { __generator } from "\x00zts:runtime/generator"`
+//! 형태의 import_declaration 노드를 program body 앞에 추가한다. graph parse 단계가
+//! 이 노드를 발견해 helper module 을 chunk 분배 대상으로 등록한다.
+//!
+//! ## 비트맵 → 모듈 매핑
+//!
+//! `bundler/runtime_helper_modules.zig::moduleShortFor` 가 helper base name → module
+//! short name 매핑의 단일 소스. 이 모듈은 RuntimeHelpers 의 packed 비트가 어떤 base
+//! 들을 import 해야 하는지만 정의 — 모듈 short name 자체는 lookup.
+//!
+//! 비트 하나가 여러 base 를 export 하는 모듈을 가리키는 경우 (decorator/es-decorator/
+//! using/class-static-private-field) 한 import statement 에 named specifier 를 모두 묶는다.
+//!
+//! ## 활성화 조건
+//!
+//! `TransformOptions.emit_runtime_helper_imports = true` 일 때만 동작. graph parse
+//! 단계의 transformer pre-pass 만 이 플래그를 set — emitter 의 in-place transformer
+//! 호출은 false 유지 (그래프 통합 없이 helper specifier 만 출력에 들어가는 사고 방지).
+
+const std = @import("std");
+const ast_mod = @import("../parser/ast.zig");
+const NodeIndex = ast_mod.NodeIndex;
+const Span = @import("../lexer/token.zig").Span;
+const ImportPhase = @import("../parser/module.zig").ImportPhase;
+const helper_modules = @import("../bundler/runtime_helper_modules.zig");
+const helper_names = @import("../runtime_helper_names.zig");
+const RuntimeHelpers = @import("transformer.zig").RuntimeHelpers;
+
+/// RuntimeHelpers 비트 ↔ helper base list 매핑.
+/// 비트 하나 = helper module 하나. `bases` 의 첫 항목은 module short 결정용 lookup key
+/// (같은 모듈 안의 helper 라 어느 것을 골라도 동일 short 반환). 나머지는 named export.
+const BitDef = struct {
+    field: []const u8,
+    bases: []const []const u8,
+};
+
+const BIT_DEFS = [_]BitDef{
+    .{ .field = "async_helper", .bases = &.{"__async"} },
+    .{ .field = "extends", .bases = &.{"__extends"} },
+    .{ .field = "spread_array", .bases = &.{"__toConsumableArray"} },
+    .{ .field = "generator", .bases = &.{"__generator"} },
+    .{ .field = "rest", .bases = &.{"__rest"} },
+    .{ .field = "values", .bases = &.{"__values"} },
+    .{ .field = "to_binary", .bases = &.{"__toBinary"} },
+    .{ .field = "keep_names", .bases = &.{"__name"} },
+    .{ .field = "class_private_method_init", .bases = &.{"__classPrivateMethodInit"} },
+    .{ .field = "class_private_method_get", .bases = &.{"__classPrivateMethodGet"} },
+    .{ .field = "class_call_check", .bases = &.{"__classCallCheck"} },
+    .{ .field = "call_super", .bases = &.{"__callSuper"} },
+    .{ .field = "tagged_template_literal", .bases = &.{"__taggedTemplateLiteral"} },
+    .{ .field = "using_ctx", .bases = &.{ "__using", "__callDispose" } },
+    .{ .field = "class_static_private_field", .bases = &.{
+        "__classCheckPrivateStaticAccess",
+        "__classCheckPrivateStaticFieldDescriptor",
+        "__classStaticPrivateFieldSpecGet",
+        "__classStaticPrivateFieldSpecSet",
+    } },
+    .{ .field = "es_decorator", .bases = &.{
+        "__esDecorate",
+        "__runInitializers",
+        "__setFunctionName",
+        "__propKey",
+    } },
+    .{ .field = "async_values", .bases = &.{"__asyncValues"} },
+    .{ .field = "class_private_field_set", .bases = &.{"__classPrivateFieldSet"} },
+    .{ .field = "async_generator", .bases = &.{"__asyncGenerator"} },
+    .{ .field = "await_helper", .bases = &.{"__await"} },
+};
+
+/// 비트맵에 set 된 비트마다 import_declaration 노드 1개씩 생성하여 `out` 에 append.
+/// `span` 은 새 노드의 위치 정보 (prepend 대상의 span 권장).
+/// `self` 는 transformer (allocator/ast/scratch/options 가짐).
+pub fn appendHelperImports(
+    self: anytype,
+    helpers: RuntimeHelpers,
+    span: Span,
+    out: *std.ArrayList(NodeIndex),
+) !void {
+    inline for (BIT_DEFS) |def| {
+        if (@field(helpers, def.field)) {
+            try emitOne(self, def.bases, span, out);
+        }
+    }
+}
+
+fn emitOne(
+    self: anytype,
+    bases: []const []const u8,
+    span: Span,
+    out: *std.ArrayList(NodeIndex),
+) !void {
+    // bases[0] 이 module 안의 한 helper. moduleShortFor 가 module short 를 반환.
+    const id = (try helper_modules.idForBase(self.allocator, bases[0])) orelse return;
+    defer self.allocator.free(id);
+
+    // source string_literal: codegen 이 raw span text 를 그대로 출력하므로 quote 포함.
+    const quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{id});
+    defer self.allocator.free(quoted);
+    const source_span = try self.ast.addString(quoted);
+    const source_node = try self.ast.addNode(.{
+        .tag = .string_literal,
+        .span = source_span,
+        .data = .{ .string_ref = source_span },
+    });
+
+    const scratch_top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    for (bases) |base| {
+        const local = helper_names.helperName(base, self.options.minify_whitespace);
+
+        const imported_span = try self.ast.addString(base);
+        const imported_node = try self.ast.addNode(.{
+            .tag = .identifier_reference,
+            .span = imported_span,
+            .data = .{ .string_ref = imported_span },
+        });
+
+        // local == base 면 같은 노드 재사용 (parser 패턴 — module.zig:516).
+        const local_node = if (std.mem.eql(u8, local, base)) imported_node else blk: {
+            const local_span = try self.ast.addString(local);
+            break :blk try self.ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = local_span,
+                .data = .{ .string_ref = local_span },
+            });
+        };
+
+        const spec = try self.ast.addNode(.{
+            .tag = .import_specifier,
+            .span = span,
+            .data = .{ .binary = .{ .left = imported_node, .right = local_node, .flags = 0 } },
+        });
+        try self.scratch.append(self.allocator, spec);
+    }
+
+    const specs = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    const extra_start = try self.ast.addExtras(&.{
+        specs.start,
+        specs.len,
+        @intFromEnum(source_node),
+        @intFromEnum(ImportPhase.none),
+        0, // attrs.start
+        0, // attrs.len
+    });
+    const decl = try self.ast.addNode(.{
+        .tag = .import_declaration,
+        .span = span,
+        .data = .{ .extra = extra_start },
+    });
+    try out.append(self.allocator, decl);
+}
+
+// ============================================================
+// 단위 테스트
+// ============================================================
+
+test "BIT_DEFS 의 모든 base 가 helper_modules 에 등록되어 있음" {
+    // 빌드 타임 drift 가드: BIT_DEFS 추가 후 helper_modules.MODULES 매핑 누락이 즉시 노출.
+    inline for (BIT_DEFS) |def| {
+        for (def.bases) |base| {
+            try std.testing.expect(helper_modules.moduleShortFor(base) != null);
+        }
+    }
+}
+
+test "BIT_DEFS 의 같은 비트 안 모든 base 가 동일 module short 로 매핑" {
+    // 묶음 모듈 (decorator/es-decorator/using/class-static-private-field) 의 base 가
+    // 같은 short 인지 검증. drift 시 한 비트가 두 모듈에 분산되어 import 출력 깨짐.
+    inline for (BIT_DEFS) |def| {
+        if (def.bases.len > 1) {
+            const first_short = helper_modules.moduleShortFor(def.bases[0]).?;
+            for (def.bases[1..]) |base| {
+                const s = helper_modules.moduleShortFor(base).?;
+                try std.testing.expectEqualStrings(first_short, s);
+            }
+        }
+    }
+}

--- a/src/transformer/runtime_helper_imports.zig
+++ b/src/transformer/runtime_helper_imports.zig
@@ -70,6 +70,16 @@ const BIT_DEFS = [_]BitDef{
     .{ .field = "await_helper", .bases = &.{"__await"} },
 };
 
+comptime {
+    // BIT_DEFS 의 field 이름이 RuntimeHelpers 의 실 필드와 매핑되는지 빌드 타임 검증.
+    // 이름 typo 를 하면 즉시 컴파일 에러로 노출.
+    for (BIT_DEFS) |def| {
+        if (!@hasField(RuntimeHelpers, def.field)) {
+            @compileError("BIT_DEFS field '" ++ def.field ++ "' not present on RuntimeHelpers");
+        }
+    }
+}
+
 /// 비트맵에 set 된 비트마다 import_declaration 노드 1개씩 생성하여 `out` 에 append.
 /// `span` 은 새 노드의 위치 정보 (prepend 대상의 span 권장).
 /// `self` 는 transformer (allocator/ast/scratch/options 가짐).

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -552,11 +552,14 @@ pub const Transformer = struct {
         var scope = @import("../profile.zig").begin(.transform);
         defer scope.end();
 
-        // D1 (RFC #1672): 재진입 가드 (D1b in-place 전환 시 shared module 이중 transform 을 조기 탐지).
-        self.ast.assertInvariants();
-        if (@import("builtin").mode == .Debug) {
-            std.debug.assert(self.ast.transformed_root == null);
+        // #1961: graph parse 단계의 pre-pass 가 이미 transform 한 ast 면 cached root 반환.
+        // emitter 가 같은 ast 로 transformer 를 새로 만들 때 transform 을 다시 돌지 않도록.
+        // caller 는 미리 transformer.runtime_helpers / .symbol_ids 를 module.transform_cache
+        // 에서 hydrate 해 두어야 emit 시점에 동일한 결과 사용.
+        if (self.ast.transformed_root) |cached| {
+            return cached;
         }
+        self.ast.assertInvariants();
 
         // define value를 미리 string_table에 저장하여 tryDefineReplace에서 중복 addString 방지
         if (self.options.define.len > 0) {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -175,6 +175,13 @@ pub const TransformOptions = struct {
     /// minify_syntax 기반 이름 제거 최적화를 비활성화.
     keep_names: bool = false,
 
+    /// #1961: transform() 끝에서 set 된 RuntimeHelpers 비트마다
+    /// `import { __helper } from "\x00zts:runtime/<short>"` 노드를 program 앞에 prepend.
+    /// graph parse 단계의 transformer pre-pass 만 true 로 set — emitter 의 in-place
+    /// transformer 호출은 false 유지 (grafh 통합 없이 helper specifier 가 출력에 새는
+    /// 사고 방지). 자세한 매핑은 `runtime_helper_imports.zig`.
+    emit_runtime_helper_imports: bool = false,
+
     pub const compat = @import("compat.zig");
 };
 
@@ -586,6 +593,20 @@ pub const Transformer = struct {
         // ES2015 tagged template: _templateObject 캐싱 함수를 program 맨 앞에 호이스팅
         if (self.tagged_template_fns.items.len > 0 and !root.isNone()) {
             root = try self.prependStatementsToBody(root, self.tagged_template_fns.items);
+        }
+
+        // #1961: 사용된 runtime helper 별 named import statement 를 program 앞에 prepend.
+        // graph parse 단계의 transformer pre-pass 가 set 하는 옵션으로만 활성 — emitter 의
+        // in-place transformer 호출은 false 유지하여 helper specifier 가 출력에 새는 사고 방지.
+        if (self.options.emit_runtime_helper_imports and !root.isNone()) {
+            const helper_imports = @import("runtime_helper_imports.zig");
+            const root_span = self.ast.getNode(root).span;
+            var imports: std.ArrayList(NodeIndex) = .empty;
+            defer imports.deinit(self.allocator);
+            try helper_imports.appendHelperImports(self, self.runtime_helpers, root_span, &imports);
+            if (imports.items.len > 0) {
+                root = try self.prependStatementsToBody(root, imports.items);
+            }
         }
 
         // React Fast Refresh: 컴포넌트 등록 코드를 프로그램 끝에 추가 ($RefreshReg$만, $RefreshSig$ 제거)

--- a/tests/integration/tests/runtime-helper-virtual-module.test.ts
+++ b/tests/integration/tests/runtime-helper-virtual-module.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { createFixture } from "./helpers";
+import { init, close, build } from "../../../packages/core/index";
+
+// #1961: code splitting + target=es5 시 dynamic chunk 의 helper (`__generator` 등)
+// 정의 누락 → ReferenceError. 새 모델은 helper 를 graph 의 1급 모듈로 분배 (oxc 식
+// virtual module + named import). 이 회귀 테스트는 모든 chunk 가 helper 를 named
+// import 으로 가져오는지 + Node 실행 시 ReferenceError 0 인지 검증.
+
+describe("runtime helper virtual module (#1961)", () => {
+  beforeAll(() => init());
+  afterAll(() => close());
+
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("dynamic chunk async/await + target=es5: __generator/__async 가 named import 으로 분배", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "main.ts": `
+        async function load() {
+          const { greet } = await import("./greet");
+          return greet("ZTS");
+        }
+        load().then((s) => console.log(s));
+      `,
+      "greet.ts": `
+        export async function greet(name: string): Promise<string> {
+          return "hello, " + name;
+        }
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      entryPoints: [join(fixture.dir, "main.ts")],
+      target: "es5",
+      splitting: true,
+      outdir: outDir,
+      write: true,
+    });
+
+    const fs = await import("node:fs");
+    const files = fs.readdirSync(outDir).filter((f) => f.endsWith(".js"));
+    const main = fs.readFileSync(join(outDir, "main.js"), "utf8");
+    const greet = fs.readFileSync(join(outDir, "greet.js"), "utf8");
+
+    const helperChunkName = files.find((f) => f.startsWith("chunk-"));
+    expect(helperChunkName).toBeDefined();
+    const helperChunk = fs.readFileSync(join(outDir, helperChunkName!), "utf8");
+
+    // 1) main / greet 가 named import 으로 helper 받음
+    expect(main).toMatch(/import\s*\{[^}]*__async[^}]*\}\s*from\s*["']\.\/chunk-/);
+    expect(main).toMatch(/import\s*\{[^}]*__generator[^}]*\}\s*from\s*["']\.\/chunk-/);
+    expect(greet).toMatch(/import\s*\{[^}]*__async[^}]*\}\s*from\s*["']\.\/chunk-/);
+
+    // 2) helper chunk 안에 두 helper 정의 + named export
+    expect(helperChunk).toMatch(/(var|function)\s+__async/);
+    expect(helperChunk).toMatch(/(var|function)\s+__generator/);
+    expect(helperChunk).toMatch(/export\s*\{[^}]*__async[^}]*\}/);
+    expect(helperChunk).toMatch(/export\s*\{[^}]*__generator[^}]*\}/);
+
+    // 3) main / greet 안에 helper 정의 자체는 없어야 (graph 분배 작동 증거)
+    expect(main).not.toMatch(/var\s+__async\s*=\s*function/);
+    expect(main).not.toMatch(/var\s+__generator\s*=\s*function/);
+
+    // 4) 실제 Node 실행 — ReferenceError 0 인지 확인
+    const proc = spawnSync("node", [join(outDir, "main.js")], { encoding: "utf8" });
+    expect(proc.status).toBe(0);
+    expect(proc.stderr).toBe("");
+    expect(proc.stdout.trim()).toBe("hello, ZTS");
+  });
+
+  test("출력에 NULL byte (\\x00) / 'zts:runtime/' raw prefix 가 새지 않음", async () => {
+    // sanitize 검증의 minimal 형태 — 모든 chunk 출력 텍스트를 검사.
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "main.ts": `
+        async function go() {
+          const m = await import("./helper");
+          return m.run();
+        }
+        go().then((v) => console.log(v));
+      `,
+      "helper.ts": `
+        export async function run() { return "ok"; }
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      entryPoints: [join(fixture.dir, "main.ts")],
+      target: "es5",
+      splitting: true,
+      outdir: outDir,
+      write: true,
+    });
+
+    const fs = await import("node:fs");
+    for (const f of fs.readdirSync(outDir)) {
+      const text = fs.readFileSync(join(outDir, f), "utf8");
+      expect(text).not.toContain("\x00");
+      expect(text).not.toContain("zts:runtime/");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

#1961 — code splitting + target=es5 시 dynamic chunk 에 `__generator` 정의가 빠져
ReferenceError 가 발생하던 버그의 graph-level fix. helper preamble-prepend 모델 대신
helper 를 graph 의 1급 모듈로 만들어 chunk 분배가 일반 모듈과 동일하게 동작하도록
한다 (oxc 의 `rolldown_plugin_oxc_runtime` 패턴).

PR 1a (#1970) 가 인프라(`runtime_helper_modules`) 를 머지했고, 이 PR 1b 가 다음을
연결:

- transformer 가 finalize 단계에서 `RuntimeHelpers` 비트마다 `import { __generator }
  from "\x00zts:runtime/generator"` 같은 named import 노드를 program 앞에 prepend.
  (`emit_runtime_helper_imports = true` 일 때만 활성)
- graph 가 parse 단계에 transformer pre-pass 를 1회 실행해 transformed AST 를
  module 에 in-place swap. helper module import 가 link 단계 전에 `import_records`
  에 등록되어 chunk 분배 대상이 된다. helper module 의 named export 는
  `import_bindings` 에도 등록 → cross-chunk symbol resolution 이 정확히 매핑.
- `Ast.cloneForTransformer` 가 `transformed_root` + `transform_boundary` 까지
  복사해, emit 단계 transformer 가 cache hit 분기로 즉시 cached root 반환 → 두 번째
  transform 0회.
- graph 의 PluginRunner.init 호출 4 site 가 `pluginRunnerWithBuiltins()` 통합
  진입점 사용. ZTS builtin runtime helper plugin 을 사용자 plugin slice 앞에
  prepend (build/buildIncremental 시작 시 1회).
- splitting 모드에서 emitter 의 chunk-level `appendAsyncRuntime` / es_decorator
  preamble 제거. transformer 가 named import 으로 분배하므로 중복.
- sourcemap sources 에 NULL byte 가 새지 않도록 `addIdentitySource` 가 virtual ID 를
  `runtime-<short>` 로 sanitize.

## 검증

`tests/integration/tests/runtime-helper-virtual-module.test.ts` 가 `--splitting
--target=es5` + dynamic import + async/await 시나리오를 빌드해서:

- main / dynamic chunk 가 `import { __async, __generator } from "./chunk-XXX.js"` 로
  helper 받음
- helper chunk 에 두 helper 정의 + named export
- 실제 Node 실행 시 ReferenceError 0, stdout 일치

이전엔 dynamic chunk 에 `__generator` 정의 누락 → ReferenceError.

## 적용 범위 / 후속

- 새 모델은 **code splitting 모드에서만 활성**. single-bundle 모드는 helper module
  declaration 이 statement-level shake 로 elide 되는 회귀가 있어 기존 preamble 모델
  유지 (`graph.code_splitting` 분기).
- `/simplify` 후 즉시 적용한 것: dead field 제거, 중복 stripQuotes/extra 인덱싱
  helper 위임, BIT_DEFS comptime 검증.
- 후속 PR 으로 분리:
  - `runtime_helper_modules` layer 역전 정리 (transformer → bundler import) →
    `src/` root 로 승격
  - graph 의 14 mirror 옵션 필드 → BundleOptions 분리 + ref 보관
  - emit 단계 `cloneForTransformer` fast path (이미 transform 된 ast 면 clone skip)
  - single-bundle 모드 helper module reachability fix (statement_shaker 인터랙션)

## Test plan

- [x] `zig build test` 전체 통과
- [x] `bun test runtime-helper-virtual-module.test.ts` (2/2 pass — Node 실행 검증
  포함)
- [x] 직접 `zts --bundle main.ts --target=es5 --splitting --format=esm --outdir
  dist` 실행 → main.js / greet.js / chunk-XXX.js 3 청크, helper named import 확인

Closes #1961

🤖 Generated with [Claude Code](https://claude.com/claude-code)