### PR TITLE
refactor(bundler): emitter transformer.init 도 transform_options_base 통합 (#1961 PR 1f)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -474,9 +474,34 @@ pub const Bundler = struct {
         }
     }
 
+    /// BundleOptions → TransformOptions base 변환 (#1961 PR 1f). graph 와 emitter
+    /// 양쪽이 동일 base 를 시작점으로 transformer.init 호출 — drift hot spot 단일화.
+    /// per-module override (react_refresh / plugins / jsx_transform / jsx_filename /
+    /// emit_runtime_helper_imports / borrow_source_ast) 만 caller 가 추가.
+    fn buildTransformOptionsBase(self: *const Bundler) @import("../transformer/transformer.zig").TransformOptions {
+        return .{
+            .define = self.options.define,
+            .experimental_decorators = self.options.experimental_decorators,
+            .emit_decorator_metadata = self.options.emit_decorator_metadata,
+            .use_define_for_class_fields = self.options.use_define_for_class_fields,
+            .verbatim_module_syntax = self.options.verbatim_module_syntax,
+            .unsupported = self.options.unsupported,
+            .drop_labels = self.options.drop_labels,
+            .jsx_runtime = self.options.jsx_runtime,
+            .jsx_factory = self.options.jsx_factory,
+            .jsx_fragment = self.options.jsx_fragment,
+            .jsx_import_source = self.options.jsx_import_source,
+            .worklet_plugin_version = self.options.worklet_plugin_version,
+            .minify_syntax = self.options.minify_syntax,
+            .minify_whitespace = self.options.minify_whitespace,
+            .keep_names = self.options.keep_names,
+        };
+    }
+
     /// BundleOptions → EmitOptions 변환. 3개 경로(단일/splitting/dev)에서 공용.
     fn makeEmitOptions(self: *const Bundler) EmitOptions {
         return .{
+            .transform_options_base = self.buildTransformOptionsBase(),
             .format = self.options.format,
             .minify_whitespace = self.options.minify_whitespace,
             .minify_syntax = self.options.minify_syntax,
@@ -597,6 +622,11 @@ pub const Bundler = struct {
         worker_graph.jsx_in_js = self.options.jsx_in_js;
         worker_graph.jsx_runtime = self.options.jsx_runtime;
         worker_graph.jsx_import_source = self.options.jsx_import_source;
+        // #1961: worker 모듈도 transformer pre-pass 가 동일 옵션 사용 — drift 방지.
+        worker_graph.worklet_transform = self.options.worklet_transform;
+        worker_graph.react_refresh = self.options.react_refresh;
+        worker_graph.code_splitting = self.options.code_splitting;
+        worker_graph.transform_options_base = self.buildTransformOptionsBase();
         defer worker_graph.deinit();
 
         const entry_path = try arena_alloc.dupe(u8, worker_path);
@@ -715,8 +745,8 @@ pub const Bundler = struct {
         graph.inline_dynamic_imports = self.options.inline_dynamic_imports;
         // require.context 등 parser inline scan 의 build-time 정적 평가에 사용 (#1579 Phase 2.6)
         graph.defines = self.options.define;
-        // #1621: binary loader 의 `$tb(...)` 축약 활성화.
-        graph.minify_whitespace = self.options.minify_whitespace;
+        // #1961 PR 1f: minify_whitespace 는 graph.transform_options_base 에서 단일 source.
+        // (#1621: binary loader 의 `$tb(...)` 축약 등 graph 자체 사용처도 base 에서 read)
         graph.loader_overrides = self.options.loader_overrides;
         graph.public_path = self.options.public_path;
         graph.project_root = self.options.project_root;
@@ -736,31 +766,13 @@ pub const Bundler = struct {
         graph.jsx_runtime = self.options.jsx_runtime;
         graph.jsx_import_source = self.options.jsx_import_source;
 
-        // #1961: transformer pre-pass 옵션 — graph 가 module 마다 transformer 실행 시 사용.
-        // emitter 의 동일 옵션 set 과 1:1 매칭되어야 cache 일관성 보장.
+        // #1961: transformer pre-pass 옵션 — graph 와 emitter 가 동일한 base 사용
+        // (drift hot spot 단일화). graph 가 직접 사용하는 일부 (worklet_transform /
+        // react_refresh / code_splitting) 만 별도 mirror.
         graph.worklet_transform = self.options.worklet_transform;
         graph.react_refresh = self.options.react_refresh;
         graph.code_splitting = self.options.code_splitting;
-        // 14 mirror 필드 → transform_options_base 1 필드로 통합 (drift hot spot 제거).
-        // graph 가 직접 사용하는 옵션 (worklet_transform / react_refresh / code_splitting /
-        // jsx_runtime / jsx_in_js / jsx_import_source 등) 만 별도 mirror.
-        graph.transform_options_base = .{
-            .define = self.options.define,
-            .experimental_decorators = self.options.experimental_decorators,
-            .emit_decorator_metadata = self.options.emit_decorator_metadata,
-            .use_define_for_class_fields = self.options.use_define_for_class_fields,
-            .verbatim_module_syntax = self.options.verbatim_module_syntax,
-            .unsupported = self.options.unsupported,
-            .drop_labels = self.options.drop_labels,
-            .jsx_runtime = self.options.jsx_runtime,
-            .jsx_factory = self.options.jsx_factory,
-            .jsx_fragment = self.options.jsx_fragment,
-            .jsx_import_source = self.options.jsx_import_source,
-            .worklet_plugin_version = self.options.worklet_plugin_version,
-            .minify_syntax = self.options.minify_syntax,
-            .minify_whitespace = self.options.minify_whitespace,
-            .keep_names = self.options.keep_names,
-        };
+        graph.transform_options_base = self.buildTransformOptionsBase();
         defer graph.deinit();
 
         // graph.build() 또는 buildIncremental() 호출.

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -89,7 +89,7 @@ pub const InputHasher = struct {
 /// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
 /// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
 /// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
-const expected_emit_options_field_count: usize = 46;
+const expected_emit_options_field_count: usize = 47;
 
 comptime {
     const actual = @typeInfo(EmitOptions).@"struct".fields.len;
@@ -186,6 +186,17 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addStrList(options.silent_console_error_patterns);
     h.addBool(options.preserve_modules);
     h.addOptStr(options.preserve_modules_root);
+    // #1961 PR 1f: transform_options_base — emit 시점에는 EmitOptions 의 다른 필드 (정의된
+    // experimental_decorators 등) 와 동일 값이라 redundant 지만, fingerprint 의 단일 source
+    // 로 base 가 변할 때 cache invalidation 보장.
+    h.addBool(options.transform_options_base.minify_whitespace);
+    h.addBool(options.transform_options_base.minify_syntax);
+    h.addBool(options.transform_options_base.experimental_decorators);
+    h.addBool(options.transform_options_base.emit_decorator_metadata);
+    h.addBool(options.transform_options_base.use_define_for_class_fields);
+    h.addBool(options.transform_options_base.verbatim_module_syntax);
+    h.addBool(options.transform_options_base.keep_names);
+    h.addU32(@bitCast(options.transform_options_base.unsupported));
 }
 
 /// 전체 emit 에 1회만 계산하면 되는 options_hash 를 캐싱용으로 반환.

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -51,6 +51,11 @@ const ExportBinding = @import("binding_scanner.zig").ExportBinding;
 const plugin_mod = @import("plugin.zig");
 
 pub const EmitOptions = struct {
+    /// transformer pre-pass / emit 단계 transformer.init 양쪽에서 사용하는 옵션 base.
+    /// bundler 가 init 시 1회 채움 — graph 와 emitter 가 동일한 매핑 사용 (drift 방지).
+    /// per-module override (`react_refresh` / `plugins` / `jsx_transform` /
+    /// `jsx_filename` / `emit_runtime_helper_imports` / `borrow_source_ast`) 만 추가.
+    transform_options_base: @import("../transformer/transformer.zig").TransformOptions = .{},
     format: Format = .esm,
     minify_whitespace: bool = false,
     /// AST 레벨 최적화 (constant folding, DCE 등)
@@ -1082,32 +1087,23 @@ pub fn emitModule(
         .worklet = options.worklet_transform and !exclude_worklet,
     }, options.plugins, arena_alloc) catch return error.OutOfMemory;
 
-    var transformer = try Transformer.init(arena_alloc, ast, .{
-        .react_refresh = apply_refresh,
-        .plugins = merged_plugins,
-        .define = options.define,
-        .experimental_decorators = options.experimental_decorators,
-        .emit_decorator_metadata = options.emit_decorator_metadata,
-        .use_define_for_class_fields = options.use_define_for_class_fields,
-        .verbatim_module_syntax = options.verbatim_module_syntax,
-        .unsupported = options.unsupported,
-        .drop_labels = options.drop_labels,
-        .jsx_transform = jsx_active,
-        .jsx_runtime = options.jsx_runtime,
-        .jsx_factory = options.jsx_factory,
-        .jsx_fragment = options.jsx_fragment,
-        .jsx_import_source = options.jsx_import_source,
-        .jsx_filename = module.path,
-        .worklet_plugin_version = options.worklet_plugin_version,
-        .minify_syntax = options.minify_syntax,
-        .minify_whitespace = options.minify_whitespace,
-        .keep_names = options.keep_names,
-        // emit 단계 transformer 는 helper import emit 안 함 — graph pre-pass 가 이미 처리.
-        .emit_runtime_helper_imports = false,
-        // graph pre-pass 가 이미 transform 한 ast 면 clone 회피 (#1961 PR 1d).
-        // transform_cache 가 set 일 때만 borrow — legacy 경로는 기존처럼 clone.
-        .borrow_source_ast = (module.transform_cache != null),
-    });
+    // #1961 PR 1f: bundler 가 채운 transform_options_base 를 시작점으로 per-module
+    // override 만 추가. graph.runTransformerPrePass 와 동일 매핑 — drift 자동 방지.
+    var transform_opts = options.transform_options_base;
+    transform_opts.react_refresh = apply_refresh;
+    transform_opts.plugins = merged_plugins;
+    transform_opts.jsx_transform = jsx_active;
+    transform_opts.jsx_filename = module.path;
+    // emit 단계 transformer 는 helper import emit 안 함 — graph pre-pass 가 이미 처리.
+    transform_opts.emit_runtime_helper_imports = false;
+    // graph pre-pass 가 이미 transform 한 ast 면 clone 회피 (#1961 PR 1d).
+    // transform_cache 가 set 이면 ast.transformed_root 도 set 인 invariant 가정.
+    transform_opts.borrow_source_ast = (module.transform_cache != null);
+    if (transform_opts.borrow_source_ast) {
+        std.debug.assert(ast.transformed_root != null);
+    }
+
+    var transformer = try Transformer.init(arena_alloc, ast, transform_opts);
     // #1961: graph parse 단계의 transformer pre-pass 결과가 있으면 hydrate.
     // transformer.transform() 은 ast.transformed_root 가 set 이면 즉시 cached root 반환 →
     // emit 단계에서 동일 transform 재실행 없이 graph 단계의 결과를 그대로 사용.

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -94,9 +94,6 @@ pub const ModuleGraph = struct {
     /// build-time 정적 평가 entries. parser inline scan (require.context 등 #1579 Phase 2.6) 활용.
     /// bundler 가 BundleOptions.define 으로 설정. transformer 의 define 치환과 동일 entries.
     defines: []const @import("../parser/scan_results.zig").DefineEntry = &.{},
-    /// #1621: binary loader 가 생성하는 `__toBinary(...)` 소스에서 축약 이름 사용.
-    /// bundler 에서 self.options.minify_whitespace 를 주입.
-    minify_whitespace: bool = false,
     /// 확장자별 로더 오버라이드 (--loader:.png=file). bundler에서 전달.
     loader_overrides: []const types.LoaderOverride = &.{},
     /// 에셋/청크 URL prefix (--public-path). asset 로더에서 사용.
@@ -216,7 +213,7 @@ pub const ModuleGraph = struct {
         // SourceOptions 는 빌드 옵션 기반으로 1회 결정.
         const u = self.transform_options_base.unsupported;
         self.helper_plugin_opts = .{
-            .minify = self.minify_whitespace,
+            .minify = self.transform_options_base.minify_whitespace,
             .es5 = u.async_await or u.arrow,
             // configurable_exports 는 RN 같은 환경 — 현재 graph 에 직접 필드 없으므로 false.
             // 후속 PR 에서 BundleOptions.configurable_exports 또는 platform=react-native 기반 결정.
@@ -2251,7 +2248,7 @@ pub const ModuleGraph = struct {
                     return;
                 };
                 // #1621: minify 시 $tb 축약.
-                const to_bin_name = runtime_helpers.helperName("__toBinary", self.minify_whitespace);
+                const to_bin_name = runtime_helpers.helperName("__toBinary", self.transform_options_base.minify_whitespace);
                 module.source = std.fmt.allocPrint(arena_alloc, "{s}(\"{s}\")", .{ to_bin_name, encoded }) catch {
                     module.state = .ready;
                     return;


### PR DESCRIPTION
## Summary

PR 1b 의 /simplify 사후 review 후속. PR 1e 가 graph 만 정리한 drift hot spot 의
나머지 절반 (emitter 의 21 필드 manual mirror) 까지 통합.

## 변경

- `EmitOptions.transform_options_base: TransformOptions` 추가. bundler 가
  `buildTransformOptionsBase()` 로 단일 source 채움.
- `emitter.emitModule`: 21 필드 manual list → base 시작 + per-module override (5 필드).
- `bundler.buildTransformOptionsBase`: BundleOptions → TransformOptions base 단일
  helper. graph + EmitOptions 양쪽 동일 source.
- `graph.minify_whitespace` 필드 제거 — base 의 minify_whitespace 단일 source.
- `borrow_source_ast` 가 set 일 때 `ast.transformed_root != null` invariant assertion.
- `compiled_cache.hashEmitOptions`: 새 base 필드를 cache key 에 반영.

옵션 추가 site 가 BundleOptions struct + buildTransformOptionsBase 2 곳으로 좁혀짐.

## Test plan

- [x] `zig build test` 통과
- [x] `bun test runtime-helper-virtual-module.test.ts` (2/2 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)