### PR TITLE
fix(emitter): runtime helper virtual module 의 used_export_names 강제 (#1961 PR 1g)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -746,8 +746,9 @@ pub fn emitWithTreeShaking(
     // ES2015 런타임 헬퍼 주입: transformer가 실제 사용한 헬퍼만 주입.
     // #1961 부터 code splitting 모드에선 transformer 가 helper module 의 named import
     // 으로 emit 하여 graph 가 분배 → chunk-level appendAsyncRuntime 등은 제거.
-    // single-bundle 모드는 helper module 의 declaration 이 statement-level shake 로
-    // elide 되는 회귀가 있어 후속 fix 까지 기존 preamble 모델 유지 (중복 시 dead code).
+    // single-bundle 모드는 minify_identifiers 가 helper module 안 식별자를 rename 하면서
+    // cross-module binding 이 깨지는 회귀가 있어 후속 fix 까지 기존 preamble 모델 유지
+    // (중복 시 dead code).
     try rt.appendRuntimeHelpers(&output, allocator, collected_helpers, options.minify_whitespace, options.unsupported.arrow);
 
     // prologue(banner/polyfill/runtime helper) 줄 수 → 소스맵 오프셋에 반영

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -1077,8 +1077,17 @@ pub fn computeAllUsedNames(
         }
     }
 
+    const helper_modules = @import("../../runtime_helper_modules.zig");
     for (sorted, 0..) |m, idx| {
         const mod_idx: u32 = m.index.toU32();
+        // #1961: ZTS runtime helper virtual module 은 모든 export 가 항상 used.
+        // tree_shaker 의 export-use 추적이 transformer 가 추가한 import_binding 을
+        // 인식 못 하면 helper 정의가 statement_shaker 에 의해 dead 로 elide → 런타임
+        // ReferenceError. helper module 은 작아서 over-include 안전.
+        if (helper_modules.isVirtualId(m.path)) {
+            list[idx] = .{ .names = &.{}, .all_used = true };
+            continue;
+        }
         // ALL_EXPORTS_SENTINEL 마킹이 있고 BFS reachable_stmts가 없으면 모든 export 사용
         if (s.isExportUsed(mod_idx, ALL_EXPORTS_SENTINEL) and s.getModuleStmtInfos(mod_idx) == null) {
             list[idx] = .{ .names = &.{}, .all_used = true };


### PR DESCRIPTION
## Summary

splitting 모드 single-bundle reachability 디버깅 도중 발견 — `computeAllUsedNames`
가 helper module (virtual ID) 의 export 를 used 로 마킹하지 않아 statement_shaker 가
helper 정의를 dead 로 elide 할 수 있는 잠재 회귀를 차단.

helper module 은 작아서 over-include 안전 — virtual ID prefix (`\x00zts:runtime/`) 검사
한 줄로 강제 `all_used=true`.

## 단계 D 의 본격 활성화는 후속

single-bundle 모드 helper module 활성화는 minify_identifiers 가 helper module 안
식별자를 rename 하면서 cross-module binding 이 깨지는 회귀 (mangler 가 helper module
의 internal name 을 reserved 로 인식 못 함) 가 있어 후속 PR (1h) 으로 분리.

## Test plan

- [x] `zig build test` 통과
- [x] `bun test runtime-helper-virtual-module.test.ts` (2/2 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)