### PR TITLE
fix(bundler): ESM external import을 require()로 변환하지 않고 보존 (#1962)

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1499,8 +1499,9 @@ test "JSX automatic: ESM-wrapped with multiple JSX functions (_jsx, _jsxs, _Frag
     try std.testing.expect(std.mem.indexOf(u8, result.output, "_jsxs(_Fragment") != null);
 }
 
-test "JSX automatic: non-ESM-wrapped module still uses var declaration" {
-    // ESM-wrapped가 아닌 일반 모듈에서는 preamble에 var _jsx = ... 형태 유지.
+test "JSX automatic: non-ESM-wrapped module emits ESM external import" {
+    // #1962: scope-hoisted 모듈은 chunk top 의 ESM `import { jsx as _jsx } from "react/jsx-runtime"`
+    // 형태로 jsx-runtime binding 을 받는다 (esbuild/rolldown 동등). __esm 래퍼 없음.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.tsx",
@@ -1520,10 +1521,11 @@ test "JSX automatic: non-ESM-wrapped module still uses var declaration" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // __esm이 아님 (일반 scope-hoisted)
+    // __esm 이 아님 (일반 scope-hoisted)
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__esm(") == null);
-    // var _jsx = require(...) 형태 (var 포함)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var _jsx") != null);
+    // ESM external import 구문이 chunk top 에 prepend.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react/jsx-runtime\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_jsx") != null);
 }
 
 // ============================================================
@@ -2183,13 +2185,10 @@ test "JSX automatic: _createElement import injected when key-after-spread used" 
     try std.testing.expect(!result.hasErrors());
     // key-after-spread fallback 이 실제로 트리거되어야 — `_createElement(` 호출 존재.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "_createElement(") != null);
-    // `_createElement` 는 `react` 의 createElement 로 정의되어야 — free variable 이면 안 됨.
-    // bundle mode 에서는 var 선언 or 할당 형태로 emit.
-    const has_def = std.mem.indexOf(u8, result.output, "_createElement = ") != null or
-        std.mem.indexOf(u8, result.output, "var _createElement") != null;
-    try std.testing.expect(has_def);
-    // `react` package 에서 createElement 를 가져오는 require 가 번들에 주입되어야.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"react\")") != null);
+    // #1962 ESM external: `import { createElement as _createElement } from "react";` 형태로 주입.
+    // free variable 이면 안 되므로 react import 와 _createElement 식별자가 모두 출력에 존재.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "createElement as _createElement") != null);
 }
 
 // Regression: expo-router 의 `useScreens.js` 처럼 .js 확장자 + JSX 인 케이스.
@@ -2222,10 +2221,9 @@ test "JSX automatic: _createElement injected for .js source (expo-router useScre
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "_createElement(") != null);
-    const has_def = std.mem.indexOf(u8, result.output, "_createElement = ") != null or
-        std.mem.indexOf(u8, result.output, "var _createElement") != null;
-    try std.testing.expect(has_def);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"react\")") != null);
+    // #1962 ESM external: `import { createElement as _createElement } from "react";` 형태.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "createElement as _createElement") != null);
 }
 
 // ============================================================================

--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -805,8 +805,9 @@ test "TypeScript: external + type-only usage → preamble require skip" {
     // 회귀 시 `var HeaderBarButtonItem = require("external-types").HeaderBarButtonItem;`
     // 가 factory 스코프에서 ReferenceError 를 냄 — bungae RN 0.83 crash.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "HeaderBarButtonItem") == null);
-    // 값으로 쓰인 Used 의 preamble 은 남아있어야 함.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var Used = require(\"external-types\").Used") != null);
+    // 값으로 쓰인 Used 는 ESM external import 로 보존 (#1962). type-only elision 후 남은 binding.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Used") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"external-types\"") != null);
 }
 
 test "TypeScript: verbatimModuleSyntax=true preserves external type-only preamble" {
@@ -829,9 +830,10 @@ test "TypeScript: verbatimModuleSyntax=true preserves external type-only preambl
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // 사용자가 명시적으로 보존을 요청 → 두 binding 모두 preamble require 로 남아야 함.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var TypeAlpha = require(\"external-lib\").TypeAlpha") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var useValue = require(\"external-lib\").useValue") != null);
+    // 사용자가 명시적으로 보존을 요청 → 두 binding 모두 ESM import 로 남아야 함 (#1962).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TypeAlpha") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useValue") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"external-lib\"") != null);
 }
 
 test "TypeScript: external + export re-export → preamble require 유지 (#1793 revert 원인)" {
@@ -855,7 +857,9 @@ test "TypeScript: external + export re-export → preamble require 유지 (#1793
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var ExportMe = require(\"external-pkg\").ExportMe") != null);
+    // ESM external (#1962): import 구문 보존 + re-export 가 ExportMe 식별자를 통해 동작.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ExportMe") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"external-pkg\"") != null);
 }
 
 test "TypeScript: external + namespace member access → preamble 유지 (namespace 는 elision 제외)" {
@@ -905,7 +909,9 @@ test "TypeScript: external + default import → Phase D 는 default 를 elide �
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"external-mod\")") != null);
+    // ESM external (#1962): default import 도 보존 — `import DefaultX from "external-mod"`.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DefaultX") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"external-mod\"") != null);
 }
 
 test "TypeScript: external + named mixed → type-only 만 elide, value-used 유지" {
@@ -929,9 +935,10 @@ test "TypeScript: external + named mixed → type-only 만 elide, value-used 유
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // value-used 만 preamble 에 남음.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var UtilY = require(\"external-kit\").UtilY") != null);
-    // type-only 는 preamble 에 없음.
+    // value-used 만 ESM external import 에 남음 (#1962). Phase D type-only elision 결과.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UtilY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"external-kit\"") != null);
+    // type-only 는 elide 되어 출력에 없음.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "TypeX") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "TypeZ") == null);
 }

--- a/src/bundler/bundler_test/typescript_format.zig
+++ b/src/bundler/bundler_test/typescript_format.zig
@@ -676,7 +676,7 @@ test "Edge: multiple external packages" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"yes\"") != null);
 }
 
-test "ESM external: require preamble (esbuild compatible, no import)" {
+test "ESM external: import 구문 보존 (#1962 esbuild/rolldown 호환)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",
@@ -699,10 +699,14 @@ test "ESM external: require preamble (esbuild compatible, no import)" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // esbuild 호환: require() preamble 사용 (import 구문 없음 → Node CJS 파싱)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(") != null);
-    // import 구문이 없어야 함 (있으면 Node가 ESM으로 파싱하여 var 재선언 에러)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "import ") == null);
+    // ESM external: chunk top 에 ESM `import` 구문 prepend (esbuild/rolldown 동등).
+    // require() 는 emit 되지 않아야 — Node ESM 파서에서 ReferenceError 발생.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(") == null);
+    // default + named 는 같은 specifier 라 한 줄로 묶임.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react\"") != null);
+    // namespace 는 별도 라인 (ESM spec: `import * as ns, { x }` 불가).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import * as ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"lodash\"") != null);
 }
 
 test "CJS external: require preamble generated" {

--- a/src/bundler/bundler_test/typescript_format.zig
+++ b/src/bundler/bundler_test/typescript_format.zig
@@ -965,3 +965,340 @@ test "Complex: destructuring imports used in complex expressions" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "width * height") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "width + height") != null);
 }
+
+// ============================================================
+// #1962 ESM external import 보존 — 엣지케이스
+// rolldown / esbuild 동등성 검증. chunk top dedup + namespace 별도 라인.
+// ============================================================
+
+test "#1962 ESM external: side-effect import (specifier 만)" {
+    // `import "polyfill"` — binding 없음. side-effect 만.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import "side-fx-only";
+        \\console.log("entry");
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"side-fx-only"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import\"side-fx-only\"") != null or
+        std.mem.indexOf(u8, result.output, "import \"side-fx-only\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(") == null);
+}
+
+test "#1962 ESM external: import { default as X } 가 default slot 으로 정규화" {
+    // `import { default as Foo }` 와 `import Foo` 는 의미적으로 동일 → 단일 default 로 emit.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { default as React, useState } from "react";
+        \\console.log(React, useState);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // default + named 는 한 라인. `default as React` 가 아닌 default specifier 로 정규화 emit.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "React") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useState") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(") == null);
+}
+
+test "#1962 ESM external: namespace 와 named 는 별도 라인 (ESM syntax)" {
+    // `import * as ns, { x } from "spec"` 는 ESM syntax error — namespace 전용 라인 분리.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import * as React from "react";
+        \\import { useState } from "react";
+        \\console.log(React, useState);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import * as React from \"react\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "{ useState }") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(") == null);
+}
+
+test "#1962 ESM external: 여러 모듈 같은 specifier dedup" {
+    // 두 모듈이 같은 binding 을 import → chunk top 에 import 한 번만 등장.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./mod-a";
+        \\import { b } from "./mod-b";
+        \\console.log(a, b);
+    );
+    try writeFile(tmp.dir, "mod-a.ts",
+        \\import { useState } from "react";
+        \\export const a = useState(1);
+    );
+    try writeFile(tmp.dir, "mod-b.ts",
+        \\import { useState } from "react";
+        \\export const b = useState(2);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 핵심: `import ... from "react"` 라인이 chunk 당 한 번만 등장 — dedup 검증.
+    const first = std.mem.indexOf(u8, result.output, "from \"react\"") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOfPos(u8, result.output, first + 1, "from \"react\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(") == null);
+}
+
+test "#1962 ESM external: 같은 binding 여러 모듈에서 import 시 한 라인으로 통합" {
+    // 두 모듈이 `useState` 동일 binding 사용 → import { useState } 하나만 emit.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a } from "./mod-a";
+        \\import { b } from "./mod-b";
+        \\console.log(a, b);
+    );
+    try writeFile(tmp.dir, "mod-a.ts",
+        \\import { useState, useEffect } from "react";
+        \\export const a = useState(1);
+        \\useEffect(() => {});
+    );
+    try writeFile(tmp.dir, "mod-b.ts",
+        \\import { useEffect, useMemo } from "react";
+        \\export const b = useMemo(() => 1, []);
+        \\useEffect(() => {});
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 세 binding 이 한 import 라인에 합쳐짐.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useState") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useEffect") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useMemo") != null);
+    // react import 는 하나의 라인만.
+    const first = std.mem.indexOf(u8, result.output, "from \"react\"") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOfPos(u8, result.output, first + 1, "from \"react\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(") == null);
+}
+
+test "#1962 ESM external: 패키지 sub-path 자동 external" {
+    // `external: ["react"]` → "react/jsx-runtime" 도 자동 external (esbuild/rolldown 동등).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.tsx",
+        \\export function App() { return <div>hi</div>; }
+    );
+    const entry = try absPath(&tmp, "entry.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+        .jsx_runtime = .automatic,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // react/jsx-runtime 도 ESM import 로 보존 (require() 변환 없음).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react/jsx-runtime\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"react/jsx-runtime\")") == null);
+}
+
+test "#1962 ESM external: wildcard 패턴은 sub-path 자동 확장 안 함" {
+    // `external: ["react/*"]` 는 사용자가 sub-path 매칭 직접 작성한 것 — 자동 확장 안 함.
+    // "react" 자체는 매칭 안 되어야 (`react/*` 은 "react/foo" 만 매칭).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { jsx } from "react/jsx-runtime";
+        \\console.log(jsx);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react/*"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react/jsx-runtime\"") != null);
+}
+
+test "#1962 ESM external: import alias rename 보존" {
+    // `import { useState as US }` 는 alias 그대로 보존되어야 — `useState as US` emit.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { useState as US } from "react";
+        \\console.log(US(0));
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useState as US") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react\"") != null);
+}
+
+test "#1962 ESM external: CJS 출력 시 require() preamble 그대로 (regression 가드)" {
+    // ESM external 처리는 format=esm 한정. CJS 출력은 기존 require() 경로 유지.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { useState } from "react";
+        \\console.log(useState);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+        .format = .cjs,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // CJS 출력: require() preamble 유지.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"react\")") != null);
+    // import 구문은 emit 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import {") == null);
+}
+
+test "#1962 ESM external: minify_whitespace 출력 형식" {
+    // minify=true 시 import 구문도 압축 형식으로 emit.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { useState } from "react";
+        \\console.log(useState);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // minify: `import{useState}from"react";` (공백 없음).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import{useState}from\"react\";") != null);
+}
+
+test "#1962 ESM external: type-only mixed — value 만 import 라인에 남음" {
+    // type-only binding 은 elide, value-used 만 ESM external import 에 남음.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { ReactNode, useState } from "react";
+        \\export function Wrap(_node: ReactNode) { return useState(0); }
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // useState 는 보존, ReactNode 는 elide.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useState") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ReactNode") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react\"") != null);
+}
+
+test "#1962 ESM external: re-export 가 import 보존 + canonical 식별자로 동작" {
+    // `import { X } from "ext"; export { X };` — X 가 import 라인에 살아있고
+    // export 가 같은 식별자로 re-export.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { useState } from "react";
+        \\export { useState };
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .external = &.{"react"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from \"react\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "export") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useState") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(") == null);
+}

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -49,6 +49,7 @@ const statement_shaker = @import("statement_shaker.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const ExportBinding = @import("binding_scanner.zig").ExportBinding;
 const plugin_mod = @import("plugin.zig");
+const external_imports = @import("emitter/external_imports.zig");
 
 pub const EmitOptions = struct {
     /// transformer pre-pass / emit 단계 transformer.init 양쪽에서 사용하는 옵션 base.
@@ -436,9 +437,18 @@ pub fn emitWithTreeShaking(
         }
     }
 
-    // ESM 출력 + external: esbuild와 동일하게 require() preamble만 사용.
-    // import 구문이 없으면 Node가 CJS로 파싱하여 require()가 동작한다.
-    // (createRequire shim은 ESM 파싱을 유발하여 var 재선언 에러를 일으킴)
+    // ESM 출력 + external (#1962): esbuild/rolldown 동등하게 chunk top 에 ESM `import`
+    // 구문 그대로 보존. specifier 별로 dedup + canonical rename 적용.
+    // CJS/IIFE/UMD/AMD 는 위쪽 prologue/factory-param 경로에서 처리됨.
+    if (options.format == .esm) {
+        try external_imports.emitChunkExternalImports(
+            &output,
+            allocator,
+            sorted.items,
+            linker,
+            options.minify_whitespace,
+        );
+    }
 
     // 런타임 헬퍼 수집: 모듈별 transform에서 실제 사용된 헬퍼만 추적
     var collected_helpers: RuntimeHelpers = .{};

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -29,6 +29,7 @@ const statement_shaker = @import("../statement_shaker.zig");
 const ExportBinding = @import("../binding_scanner.zig").ExportBinding;
 const parent = @import("../emitter.zig");
 const plugin_mod = @import("../plugin.zig");
+const external_imports = @import("external_imports.zig");
 const EmitOptions = parent.EmitOptions;
 const OutputFile = parent.OutputFile;
 const emitChunkRuntimeHelpers = parent.emitChunkRuntimeHelpers;
@@ -96,6 +97,24 @@ pub fn emitChunks(
 
         // 청크별 런타임 헬퍼 주입
         try emitChunkRuntimeHelpers(&chunk_output, allocator, chunk, graph, options, null);
+
+        // ESM external imports (#1962): chunk 모듈들이 보유한 external import 를
+        // dedup 후 chunk top 에 단일 `import` 구문으로 prepend. emitChunks 는 ESM 전용 (line 46).
+        {
+            var chunk_mods: std.ArrayListUnmanaged(*const Module) = .empty;
+            defer chunk_mods.deinit(allocator);
+            try chunk_mods.ensureTotalCapacity(allocator, chunk.modules.items.len);
+            for (chunk.modules.items) |mod_idx| {
+                if (graph.getModule(mod_idx)) |m| chunk_mods.appendAssumeCapacity(m);
+            }
+            try external_imports.emitChunkExternalImports(
+                &chunk_output,
+                allocator,
+                chunk_mods.items,
+                linker,
+                options.minify_whitespace,
+            );
+        }
 
         // 크로스 청크 import deconfliction:
         // 여러 청크에서 같은 이름의 심볼을 import할 때 충돌 방지.

--- a/src/bundler/emitter/external_imports.zig
+++ b/src/bundler/emitter/external_imports.zig
@@ -1,0 +1,206 @@
+//! ESM external imports — chunk top 에 dedup 된 `import` 구문 emit.
+//!
+//! `format=esm` 출력에서 external 모듈의 import 는 require() 로 변환하면 안 되고
+//! 그대로 `import { x } from "spec"` 형태로 보존되어야 한다 (esbuild/rolldown 동등).
+//!
+//! 흐름:
+//!   1. chunk 에 포함된 모듈들의 import_bindings 중 is_external 인 것 수집
+//!   2. specifier 별로 묶고 (default / namespace / named) dedup
+//!   3. canonical rename 적용된 local 이름으로 import 구문 한 번 emit
+//!
+//! linker 의 metadata 단계에서는 ESM external 분기에서 require() preamble 생성을
+//! skip 하므로, codegen 이 import_declaration 노드를 skip 한 결과와 함께 chunk top
+//! 의 ESM import 가 유일한 진입점이 된다.
+
+const std = @import("std");
+const types = @import("../types.zig");
+const Module = @import("../module.zig").Module;
+const ImportBinding = @import("../binding_scanner.zig").ImportBinding;
+const Linker = @import("../linker.zig").Linker;
+const isImportBindingTypeOnly = @import("../linker/metadata.zig").isImportBindingTypeOnly;
+
+const NamedBinding = struct {
+    imported: []const u8,
+    local: []const u8,
+};
+
+const SpecifierGroup = struct {
+    default_local: ?[]const u8 = null,
+    namespace_local: ?[]const u8 = null,
+    named: std.ArrayListUnmanaged(NamedBinding) = .empty,
+    side_effect_only: bool = false,
+
+    fn deinit(self: *SpecifierGroup, allocator: std.mem.Allocator) void {
+        self.named.deinit(allocator);
+    }
+};
+
+/// chunk 단위 ESM external import 구문 emit. format == .esm 이 아니면 no-op.
+/// modules 는 chunk 가 포함하는 모듈 슬라이스 (단일 bundle 모드는 sorted 전체).
+pub fn emitChunkExternalImports(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    modules: []const *const Module,
+    linker: ?*const Linker,
+    minify_whitespace: bool,
+) !void {
+    // specifier → group. ArrayHashMap 으로 첫 등장 순서 유지 → 결정론적 출력.
+    var per_spec: std.StringArrayHashMapUnmanaged(SpecifierGroup) = .empty;
+    defer {
+        var it = per_spec.iterator();
+        while (it.next()) |e| e.value_ptr.deinit(allocator);
+        per_spec.deinit(allocator);
+    }
+
+    for (modules) |m| {
+        // ESM-wrapped (init 함수로 둘러싼) 모듈은 require()/init 패턴이 필요.
+        // 일반 scope-hoisted 모듈만 chunk-level ESM import 로 끌어올린다.
+        if (m.wrap_kind.isWrapped()) continue;
+
+        // (1) named/default/namespace bindings — import_bindings 에서 추출.
+        // type-only binding 은 elide (linker 의 metadata 경로와 대칭, #1791 Phase D).
+        const verbatim = if (linker) |l| l.verbatim_module_syntax else false;
+        for (m.import_bindings) |ib| {
+            if (ib.import_record_index >= m.import_records.len) continue;
+            const rec = m.import_records[ib.import_record_index];
+            if (!rec.is_external) continue;
+            if (rec.kind != .static_import and rec.kind != .re_export) continue;
+
+            // verbatim_module_syntax=true 면 모두 보존, 아니면 type-only 는 drop.
+            if (!verbatim) {
+                if (m.semantic) |sem| {
+                    if (isImportBindingTypeOnly(&sem, ib)) continue;
+                }
+            }
+
+            const local_name = if (linker) |l|
+                (l.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib))
+            else
+                m.importBindingLocalName(ib);
+
+            const gop = try per_spec.getOrPut(allocator, rec.specifier);
+            if (!gop.found_existing) gop.value_ptr.* = .{};
+            try addBinding(gop.value_ptr, allocator, ib.kind, ib.imported_name, local_name);
+        }
+
+        // (2) side-effect import (specs 0개) — import_records 에서 직접 감지.
+        for (m.import_records) |rec| {
+            if (!rec.is_external) continue;
+            if (rec.kind != .side_effect) continue;
+            const gop = try per_spec.getOrPut(allocator, rec.specifier);
+            if (!gop.found_existing) {
+                gop.value_ptr.* = .{ .side_effect_only = true };
+            }
+            // bindings 가 이미 있는 specifier 는 side_effect 만 별도로 표시할 필요 없음
+            // (어차피 import 구문 한 줄로 동시 표현되므로).
+        }
+    }
+
+    // emit
+    var spec_it = per_spec.iterator();
+    while (spec_it.next()) |e| {
+        try emitOneImport(output, allocator, e.key_ptr.*, e.value_ptr, minify_whitespace);
+    }
+}
+
+fn addBinding(
+    group: *SpecifierGroup,
+    allocator: std.mem.Allocator,
+    kind: ImportBinding.Kind,
+    imported: []const u8,
+    local: []const u8,
+) !void {
+    switch (kind) {
+        .default => {
+            if (group.default_local == null) group.default_local = local;
+        },
+        .namespace => {
+            if (group.namespace_local == null) group.namespace_local = local;
+        },
+        .named => {
+            // `import { default as X }` 도 default slot 으로 흡수 — esbuild 와 동일하게
+            // 단일 default specifier 로 emit.
+            if (std.mem.eql(u8, imported, "default")) {
+                if (group.default_local == null) group.default_local = local;
+                return;
+            }
+            // dedup: 여러 모듈이 같은 specifier 의 같은 binding 을 import 하면 SyntaxError
+            // (`import { x, x } from ...`) — 사전 차단. n 은 specifier 당 보통 < 50 이라
+            // linear scan 비용 무시 가능.
+            for (group.named.items) |nb| {
+                if (std.mem.eql(u8, nb.imported, imported) and std.mem.eql(u8, nb.local, local)) {
+                    return;
+                }
+            }
+            try group.named.append(allocator, .{ .imported = imported, .local = local });
+        },
+    }
+}
+
+fn emitOneImport(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    spec: []const u8,
+    group: *const SpecifierGroup,
+    minify_whitespace: bool,
+) !void {
+    const list_sep: []const u8 = if (minify_whitespace) "," else ", ";
+    const brace_open: []const u8 = if (minify_whitespace) "{" else "{ ";
+    const brace_close: []const u8 = if (minify_whitespace) "}" else " }";
+    const from_open: []const u8 = if (minify_whitespace) "from\"" else " from \"";
+    const eol: []const u8 = if (minify_whitespace) "" else "\n";
+
+    const has_default_or_named = group.default_local != null or group.named.items.len > 0;
+    const has_any = has_default_or_named or group.namespace_local != null;
+
+    // side-effect only: `import "spec";`
+    if (!has_any and group.side_effect_only) {
+        try output.appendSlice(allocator, "import\"");
+        try output.appendSlice(allocator, spec);
+        try output.appendSlice(allocator, "\";");
+        try output.appendSlice(allocator, eol);
+        return;
+    }
+    if (!has_any) return;
+
+    // (1) default + named — 한 줄. rolldown 의 `create_import_declaration` 동일.
+    //     ESM spec 상 `import D, { x } from "spec"` 합법. namespace 는 같이 못 묶음.
+    if (has_default_or_named) {
+        try output.appendSlice(allocator, if (minify_whitespace) "import" else "import ");
+        var has_pre = false;
+        if (group.default_local) |d| {
+            try output.appendSlice(allocator, d);
+            has_pre = true;
+        }
+        if (group.named.items.len > 0) {
+            if (has_pre) try output.appendSlice(allocator, list_sep);
+            try output.appendSlice(allocator, brace_open);
+            for (group.named.items, 0..) |nb, i| {
+                if (i > 0) try output.appendSlice(allocator, list_sep);
+                if (std.mem.eql(u8, nb.imported, nb.local)) {
+                    try output.appendSlice(allocator, nb.local);
+                } else {
+                    try output.appendSlice(allocator, nb.imported);
+                    try output.appendSlice(allocator, " as ");
+                    try output.appendSlice(allocator, nb.local);
+                }
+            }
+            try output.appendSlice(allocator, brace_close);
+        }
+        try output.appendSlice(allocator, from_open);
+        try output.appendSlice(allocator, spec);
+        try output.appendSlice(allocator, "\";");
+        try output.appendSlice(allocator, eol);
+    }
+
+    // (2) namespace — 별도 라인. rolldown `Specifier::Star` 분리 정책.
+    //     `import * as ns, { x }` 는 ESM syntax error 라 묶을 수 없음.
+    if (group.namespace_local) |n| {
+        try output.appendSlice(allocator, if (minify_whitespace) "import*as " else "import * as ");
+        try output.appendSlice(allocator, n);
+        try output.appendSlice(allocator, from_open);
+        try output.appendSlice(allocator, spec);
+        try output.appendSlice(allocator, "\";");
+        try output.appendSlice(allocator, eol);
+    }
+}

--- a/src/bundler/emitter/external_imports.zig
+++ b/src/bundler/emitter/external_imports.zig
@@ -118,8 +118,9 @@ fn addBinding(
             if (group.namespace_local == null) group.namespace_local = local;
         },
         .named => {
-            // `import { default as X }` 도 default slot 으로 흡수 — esbuild 와 동일하게
-            // 단일 default specifier 로 emit.
+            // `import { default as X }` 는 의미상 default import 와 동일 → default slot 으로 정규화.
+            // 같은 specifier 의 `import D from ...` 와 `import { default as D } from ...` 가
+            // 한 라인에서 중복 specifier 로 emit 되는 것을 막음 (esbuild/rolldown 동등).
             if (std.mem.eql(u8, imported, "default")) {
                 if (group.default_local == null) group.default_local = local;
                 return;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -51,7 +51,7 @@ inline fn isIifeMappedExternal(
         types.GlobalEntry.lookup(globals, rec.specifier) != null;
 }
 
-inline fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
+pub fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
     if (ib.isSynthetic()) return false;
     // named 한정 — default / namespace 는 JSX pragma 등 implicit value use 위험이
     // 큼 (#1793 revert 원인). transformer 와 동일 제한.
@@ -333,10 +333,16 @@ pub fn buildMetadataForAst(
                                 .suggestion = null,
                             });
                         }
+                    } else if (self.format == .esm and rec.is_external and !is_synthetic_esm) {
+                        // #1962 ESM external: chunk top 의 ESM `import` 구문이 binding 을
+                        // 제공하므로 모듈 preamble 에 require() 를 두지 않는다.
+                        // - emitter 의 `external_imports.emitChunkExternalImports` 가 dedup 후 emit.
+                        // - codegen 은 import_declaration 노드를 skip (skip_imports=true).
+                        // - canonical rename 은 emitter 측에서 동일 ImportBinding 을 보고 적용.
+                        // synthetic_esm (JSX runtime 합성 binding + ESM-wrapped 모듈) 은 init
+                        // 함수 본문에서 var 할당이 필요해 require() 경로를 유지한다.
                     } else {
-                        // ESM/CJS: require() preamble 생성. ESM 출력에서도 esbuild 호환으로
-                        // require() 를 유지 — Node.js 가 `import` 없는 출력을 CJS 로 파싱하여
-                        // `var X; var X;` 재선언을 허용하게 한다 (`emitter.zig` 상단 주석 참조).
+                        // CJS / ESM-wrapped + synthetic / 그 외: require() preamble 생성.
                         if (is_synthetic_esm) {
                             try preamble.writeUnresolvedRequireAssignOnly(preamble_name, rec.specifier, ib.imported_name, ib.kind == .namespace);
                         } else {

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -660,16 +660,7 @@ pub const ResolveCache = struct {
         // 사용자 지정 external 패턴
         for (self.external_patterns) |pattern| {
             if (matchGlob(pattern, specifier)) return true;
-            // #1962 esbuild/rolldown 동등: external 패키지의 sub-path 도 자동 external.
-            // 예) `external: ["react"]` → "react/jsx-runtime", "react/jsx-dev-runtime" 도 external.
-            // `*` 보유 패턴은 사용자가 sub-path 매칭을 직접 작성한 것이므로 자동 확장 안 함
-            // — `react/*` 처럼 명시한 의도와 충돌하지 않게.
-            const has_wildcard = std.mem.indexOf(u8, pattern, "*") != null;
-            const is_sub_path = !has_wildcard and
-                specifier.len > pattern.len and
-                std.mem.startsWith(u8, specifier, pattern) and
-                specifier[pattern.len] == '/';
-            if (is_sub_path) return true;
+            if (matchPackageSubPath(pattern, specifier)) return true;
         }
 
         return false;
@@ -723,6 +714,17 @@ pub fn isNodeBuiltin(specifier: []const u8) bool {
 /// "react" matches "react"
 /// "@mui/*" matches "@mui/material" but not "@mui/icons/filled"
 /// "node:*" matches "node:fs", "node:path"
+/// #1962 esbuild/rolldown 동등 — external 패키지의 sub-path 자동 매칭.
+/// 예) `external: ["react"]` → "react/jsx-runtime", "react/jsx-dev-runtime" 도 external.
+/// `*` 보유 패턴 (e.g. `react/*`) 은 사용자가 sub-path 매칭을 직접 작성한 것이므로
+/// 자동 확장 안 함 — 명시 의도와 충돌하지 않게.
+pub fn matchPackageSubPath(pattern: []const u8, specifier: []const u8) bool {
+    if (std.mem.indexOf(u8, pattern, "*") != null) return false;
+    if (specifier.len <= pattern.len) return false;
+    if (!std.mem.startsWith(u8, specifier, pattern)) return false;
+    return specifier[pattern.len] == '/';
+}
+
 pub fn matchGlob(pattern: []const u8, text: []const u8) bool {
     if (std.mem.indexOf(u8, pattern, "*")) |star_pos| {
         const prefix = pattern[0..star_pos];

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -660,6 +660,16 @@ pub const ResolveCache = struct {
         // 사용자 지정 external 패턴
         for (self.external_patterns) |pattern| {
             if (matchGlob(pattern, specifier)) return true;
+            // #1962 esbuild/rolldown 동등: external 패키지의 sub-path 도 자동 external.
+            // 예) `external: ["react"]` → "react/jsx-runtime", "react/jsx-dev-runtime" 도 external.
+            // `*` 보유 패턴은 사용자가 sub-path 매칭을 직접 작성한 것이므로 자동 확장 안 함
+            // — `react/*` 처럼 명시한 의도와 충돌하지 않게.
+            const has_wildcard = std.mem.indexOf(u8, pattern, "*") != null;
+            const is_sub_path = !has_wildcard and
+                specifier.len > pattern.len and
+                std.mem.startsWith(u8, specifier, pattern) and
+                specifier[pattern.len] == '/';
+            if (is_sub_path) return true;
         }
 
         return false;

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const resolve_cache = @import("resolve_cache.zig");
 const ResolveCache = resolve_cache.ResolveCache;
 const matchGlob = resolve_cache.matchGlob;
+const matchPackageSubPath = resolve_cache.matchPackageSubPath;
 const isNodeBuiltin = resolve_cache.isNodeBuiltin;
 const profile = @import("../profile.zig");
 const ResolvedModule = @import("plugin.zig").ResolvedModule;
@@ -75,6 +76,64 @@ test "isExternal: user patterns" {
     try std.testing.expect(cache.isExternal("react"));
     try std.testing.expect(cache.isExternal("@mui/material"));
     try std.testing.expect(!cache.isExternal("vue"));
+}
+
+// ============================================================
+// #1962 — external 패키지 sub-path 자동 매칭 (esbuild/rolldown 동등)
+// ============================================================
+
+test "matchPackageSubPath: exact 매칭은 false (matchGlob 책임)" {
+    try std.testing.expect(!matchPackageSubPath("react", "react"));
+}
+
+test "matchPackageSubPath: sub-path 자동 external" {
+    try std.testing.expect(matchPackageSubPath("react", "react/jsx-runtime"));
+    try std.testing.expect(matchPackageSubPath("react", "react/jsx-dev-runtime"));
+    try std.testing.expect(matchPackageSubPath("@mui/material", "@mui/material/Button"));
+    // 깊은 sub-path 도 매칭 (esbuild/rolldown 동등)
+    try std.testing.expect(matchPackageSubPath("react", "react/some/deep/path"));
+}
+
+test "matchPackageSubPath: prefix-only 비매칭 (false-positive 차단)" {
+    // pattern="react" specifier="react-dom" — prefix 지만 sub-path 아님
+    try std.testing.expect(!matchPackageSubPath("react", "react-dom"));
+    try std.testing.expect(!matchPackageSubPath("react", "react-native"));
+    // pattern="react" specifier="reactstrap" — 우연한 prefix
+    try std.testing.expect(!matchPackageSubPath("react", "reactstrap"));
+}
+
+test "matchPackageSubPath: wildcard 보유 패턴은 자동 확장 안 함" {
+    // 사용자가 명시적으로 sub-path 매칭을 작성한 경우 (`react/*`) 매칭은 matchGlob 가 담당
+    try std.testing.expect(!matchPackageSubPath("react/*", "react/jsx-runtime"));
+    try std.testing.expect(!matchPackageSubPath("@mui/*", "@mui/material/Button"));
+}
+
+test "matchPackageSubPath: 빈 specifier / pattern 안전성" {
+    try std.testing.expect(!matchPackageSubPath("", ""));
+    try std.testing.expect(!matchPackageSubPath("", "react"));
+    try std.testing.expect(!matchPackageSubPath("react", ""));
+}
+
+test "isExternal: sub-path 가 자동 external (#1962)" {
+    var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"react"} });
+    defer cache.deinit();
+
+    try std.testing.expect(cache.isExternal("react"));
+    try std.testing.expect(cache.isExternal("react/jsx-runtime"));
+    try std.testing.expect(cache.isExternal("react/jsx-dev-runtime"));
+    // 우연한 prefix 는 external 아님
+    try std.testing.expect(!cache.isExternal("react-dom"));
+    try std.testing.expect(!cache.isExternal("reactstrap"));
+}
+
+test "isExternal: scoped 패키지 sub-path 도 자동 external (#1962)" {
+    var cache = ResolveCache.init(std.testing.allocator, .{ .external_patterns = &.{"@babel/runtime"} });
+    defer cache.deinit();
+
+    try std.testing.expect(cache.isExternal("@babel/runtime"));
+    try std.testing.expect(cache.isExternal("@babel/runtime/helpers/extends"));
+    // 다른 scope 는 external 아님
+    try std.testing.expect(!cache.isExternal("@babel/core"));
 }
 
 test "resolve: external returns null" {


### PR DESCRIPTION
## Summary
- `format=esm + external=[\"react\"]` 시 chunk top 에 `import { useState } from \"react\";` 형태로 보존 (esbuild/rolldown 동등). 이전엔 `var useState = require(\"react\").useState;` 로 emit 되어 Node ESM 파서에서 ReferenceError.
- external 패키지의 sub-path 도 자동 external — `external: [\"react\"]` → `react/jsx-runtime` 도 external (esbuild 동등). `*` 보유 패턴은 자동 확장 안 함.
- type-only binding elision (#1791 Phase D) 을 새 ESM external 경로에서도 적용.

## 설계 — rolldown / oxc 방식 채택
- chunk 단위로 importee → importer specifier 맵 수집 (모듈별 → chunk 별 합침).
- specifier 별로 default + named 한 라인, namespace 는 별도 라인 (`import * as ns, { x }` 는 ESM syntax error).
- 모듈 인라인 위치의 import 는 codegen 이 그대로 skip (이미 동작), preamble 도 require() 안 만들고 chunk top 의 ESM import 가 유일한 진입점.
- 참조: `rolldown/crates/rolldown/src/ecmascript/format/esm.rs` (\`render_esm_chunk_imports\`, \`render_named_imports\`), \`rollup/src/finalisers/es.ts\`, \`esbuild/internal/linker/linker.go\` \`generateCodeForFileInChunkJS\`.

## 변경 범위
- 신규 `src/bundler/emitter/external_imports.zig` — chunk 단위 external import 수집·dedup·emit
- `linker/metadata.zig` — `format=.esm and is_external and !is_synthetic_esm` 분기 신설하여 require() preamble 생성 skip. `isImportBindingTypeOnly` 를 pub 으로 전환해 emitter 에서 재사용
- `emitter.zig` / `emitter/chunks.zig` — 단일 bundle / multi-chunk 모두 hook 추가
- `resolve_cache.zig` — external 패키지 sub-path 자동 external

## Test plan
- [x] `scripts/napi-bundler-bug-check.ts` 의 #1962 case 통과 — react/jsx-runtime 의 require → import 전환 검증
- [x] `zig build test` (Debug + ReleaseFast) 모두 통과
- [x] 기존 테스트 7개 esbuild 호환 동작에 맞게 업데이트 (require → import 검증으로 이전)
  - `ESM external: require preamble (esbuild compatible, no import)` → `ESM external: import 구문 보존 (#1962 esbuild/rolldown 호환)`
  - `JSX automatic: non-ESM-wrapped module still uses var declaration` → `... emits ESM external import`
  - `TypeScript: external + type-only usage`, `verbatimModuleSyntax`, `re-export`, `default import`, `named mixed` 5건 — 검증 패턴 import 형태로 업데이트
- [x] `JSX automatic: _createElement injected ...` 2건 — `import { createElement as _createElement } from \"react\"` 형태 검증
- [x] CJS / IIFE / UMD / AMD 출력은 동작 변화 없음 (기존 분기 그대로 진입)

## 미수행
- 통합 테스트 `RN 번들: ... 미변환 require() 호출 검출` 13건 — main baseline 에서도 동일 13개 발생 확인. 본 PR 의 회귀 아니라 RN runtime helper virtual specifier 의 별개 이슈.

Closes #1962

🤖 Generated with [Claude Code](https://claude.com/claude-code)