### PR TITLE
fix(bundler): metafile JSON 의 control character escape (NUL byte)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1368,6 +1368,16 @@ fn appendJsonString(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, s: []
             '\n' => try buf.appendSlice(allocator, "\\n"),
             '\r' => try buf.appendSlice(allocator, "\\r"),
             '\t' => try buf.appendSlice(allocator, "\\t"),
+            // JSON spec: 0x00–0x1F 모든 control char 는 반드시 escape.
+            // ZTS virtual specifier (NUL+"zts:runtime/...") 등이 raw NUL 그대로
+            // 들어가면 JSON.parse 가 "Bad control character" 로 reject.
+            0x00...0x07, 0x0B, 0x0E...0x1F => {
+                var tmp: [6]u8 = .{ '\\', 'u', '0', '0', 0, 0 };
+                const hex = "0123456789abcdef";
+                tmp[4] = hex[(c >> 4) & 0xF];
+                tmp[5] = hex[c & 0xF];
+                try buf.appendSlice(allocator, &tmp);
+            },
             else => try buf.append(allocator, c),
         }
     }

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -47,6 +47,38 @@ test "Batch D: metafile — JSON with inputs and outputs" {
     try std.testing.expect(std.mem.indexOf(u8, mf, "\"bytes\"") != null);
 }
 
+test "Batch D: metafile — virtual specifier (NUL byte) JSON-escape" {
+    // Regression: ZTS runtime helper virtual specifier (NUL + "zts:runtime/...") 가
+    // raw NUL 그대로 metafile JSON 에 들어가 JSON.parse 가 "Bad control character" 로 reject.
+    // RN 통합 테스트 (`Metro 모듈 수 기준선`) 가 meta.json 파싱 실패로 깨짐.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export function f({ a, ...rest }: any) { return rest; }
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        // ES5 → object rest spread 가 `__rest` runtime helper 로 다운레벨링되어
+        // ZTS virtual specifier "zts:runtime/rest" 가 graph 에 등록됨.
+        .unsupported = @import("../../transformer/compat.zig").fromESTarget(.es5),
+        .metafile = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const mf = result.metafile_json orelse return error.TestUnexpectedResult;
+    // raw NUL 절대 포함되면 안 됨 — JSON.parse 에서 reject.
+    try std.testing.expect(std.mem.indexOfScalar(u8, mf, 0x00) == null);
+    // 어떤 형태로든 NUL escape 되어야 — `zts:runtime/rest` 형태로 emit.
+    try std.testing.expect(std.mem.indexOf(u8, mf, "\\u0000zts:runtime") != null);
+}
+
 test "Batch D: metafile — disabled when not requested" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## Summary
- \`generateMetafileJson\` 의 \`appendJsonString\` 이 0x00–0x1F control char 를 escape 하지 않아 JSON spec 위반.
- ZTS runtime helper virtual specifier (NUL byte + \"zts:runtime/...\") 가 raw 그대로 meta.json 에 emit → \`JSON.parse\` 가 \"Bad control character in string literal\" 로 reject.
- RN 통합 테스트 \`Metro vs ZTS 모듈 수 비교 > Metro 번들 모듈 수 기준선\` 깨짐 (Metro 모듈수 = 512, ZTS = 602, ratio = 117.6% 정상이지만 meta.json 파싱 실패로 fail).

## 변경
- \`src/bundler/bundler.zig\` \`appendJsonString\`: \`\\n\` / \`\\r\` / \`\\t\` 외 나머지 control char (0x00–0x07, 0x0B, 0x0E–0x1F) 를 \`\\\\uXXXX\` 형태로 escape (codegen 의 \`emitString\` 동등).
- 회귀 가드 테스트 \`Batch D: metafile — virtual specifier (NUL byte) JSON-escape\` 추가 — ES5 + object rest spread fixture 로 \`__rest\` runtime helper 가 graph 에 등록되는 케이스에서 raw NUL 부재 + \`\\\\u0000zts:runtime\` 형태 emit 검증.

## Test plan
- [x] \`zig build test\` 통과 (Debug + ReleaseFast)
- [x] \`tests/integration\` \`Metro 번들 모듈 수 기준선\` 통과 — Metro 512 / ZTS 602 / ratio 117.6%
- [x] 신규 \`Batch D: metafile — virtual specifier ... JSON-escape\` 테스트 통과

## 미해결 (별개 이슈)
- \`Metro vs ZTS 모듈 수 비교 > 번들 내 미변환 require() 호출 검출\` 13 fail — ZTS runtime helper virtual module 의 raw \`require()\` 가 \`require_xxx()\` 로 치환 안 되는 별개 문제. #1961 helper virtual module 작업 진행 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)