### PR TITLE
fix(transformer): preserve this for optional method calls

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2232,6 +2232,18 @@ test "ES2020: ?. with method call" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "==null?void 0") != null);
 }
 
+test "ES2020: optional method call this 바인딩 보존" {
+    var r = try e2eTarget(std.testing.allocator, "obj.method?.(1,2);", .es2019);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var _a;((_a=obj.method)==null?void 0:_a.call(obj,1,2));", r.output);
+}
+
+test "ES2020: optional method call 복잡 receiver 1회 평가" {
+    var r = try e2eTarget(std.testing.allocator, "getObj().method?.();", .es2019);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var _a,_b;((_b=(_a=getObj()).method)==null?void 0:_b.call(_a));", r.output);
+}
+
 test "ES2020: ?? with ?. combined" {
     var r = try e2eTarget(std.testing.allocator, "const x = a?.b ?? 'default';", .es2019);
     defer r.deinit();

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -126,13 +126,21 @@ pub fn ES2020(comptime Transformer: type) type {
             base_idx: NodeIndex,
             ctx: LowerCtx,
         ) Transformer.Error!NodeIndex {
-            const simple = helpers.isSimpleIdentifier(self, base_idx);
-            const visited_base = try self.visitNode(base_idx);
+            const optional_member_call = if (ctx == .normal)
+                try prepareOptionalMemberCall(self, node, base_idx)
+            else
+                null;
+
+            const simple = optional_member_call == null and helpers.isSimpleIdentifier(self, base_idx);
+            const visited_base = if (optional_member_call) |mc| mc.null_check_base else try self.visitNode(base_idx);
 
             var null_check_base: NodeIndex = undefined;
             var chain_base: NodeIndex = undefined;
 
-            if (simple) {
+            if (optional_member_call) |mc| {
+                null_check_base = mc.null_check_base;
+                chain_base = mc.chain_base;
+            } else if (simple) {
                 null_check_base = visited_base;
                 chain_base = try self.ast.addNode(self.ast.getNode(visited_base));
                 // symbol_id 전파: 복제된 노드에도 rename이 적용되도록
@@ -153,7 +161,10 @@ pub fn ES2020(comptime Transformer: type) type {
                 chain_base = try helpers.makeTempVarRef(self, temp_span, node.span);
             }
 
-            const rebuilt_chain = try rebuildChainNode(self, node, chain_base);
+            const rebuilt_chain = if (optional_member_call) |mc|
+                try rebuildChainNodeWithOptionalMemberCallThis(self, node, chain_base, base_idx, mc.receiver)
+            else
+                try rebuildChainNode(self, node, chain_base);
             const eq_null = try helpers.makeEqNull(self, null_check_base, node.span);
 
             const b_branch: NodeIndex, const c_branch: NodeIndex = switch (ctx) {
@@ -169,6 +180,99 @@ pub fn ES2020(comptime Transformer: type) type {
             // 괄호로 감싸서 binary expression 안에서 우선순위 보장
             // 예: a?.b !== c?.d → (a == null ? void 0 : a.b) !== (c == null ? void 0 : c.d)
             return helpers.makeParenExpr(self, cond, node.span);
+        }
+
+        const OptionalMemberCall = struct {
+            null_check_base: NodeIndex,
+            chain_base: NodeIndex,
+            receiver: NodeIndex,
+        };
+
+        fn prepareOptionalMemberCall(self: *Transformer, root: Node, base_idx: NodeIndex) Transformer.Error!?OptionalMemberCall {
+            if (!isOptionalCallBase(self, root, base_idx)) return null;
+
+            const base = self.ast.getNode(base_idx);
+            switch (base.tag) {
+                .static_member_expression, .computed_member_expression => {},
+                else => return null,
+            }
+
+            const e = base.data.extra;
+            const old_obj = self.readNodeIdx(e, 0);
+            const old_prop = self.readNodeIdx(e, 1);
+            const flags = self.readU32(e, 2);
+            const obj_simple = helpers.isSimpleIdentifier(self, old_obj);
+            const visited_obj = try self.visitNode(old_obj);
+
+            var member_obj: NodeIndex = undefined;
+            var receiver: NodeIndex = undefined;
+            if (obj_simple) {
+                member_obj = visited_obj;
+                receiver = try self.ast.addNode(self.ast.getNode(visited_obj));
+                self.copySymbolId(visited_obj, receiver);
+            } else {
+                const obj_temp_span = try helpers.makeTempVarSpan(self);
+                const obj_temp_lhs = try helpers.makeTempVarRef(self, obj_temp_span, root.span);
+                const obj_assign = try self.ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = root.span,
+                    .data = .{ .binary = .{
+                        .left = obj_temp_lhs,
+                        .right = visited_obj,
+                        .flags = @intFromEnum(token_mod.Kind.eq),
+                    } },
+                });
+                member_obj = try helpers.makeParenExpr(self, obj_assign, root.span);
+                receiver = try helpers.makeTempVarRef(self, obj_temp_span, root.span);
+            }
+
+            const new_prop = try self.visitNode(old_prop);
+            const member_flags = flags & ~ast_mod.MemberFlags.optional_chain;
+            const member_extra = try self.ast.addExtras(&.{ @intFromEnum(member_obj), @intFromEnum(new_prop), member_flags });
+            const member = try self.ast.addNode(.{ .tag = base.tag, .span = base.span, .data = .{ .extra = member_extra } });
+
+            const fn_temp_span = try helpers.makeTempVarSpan(self);
+            const fn_temp_lhs = try helpers.makeTempVarRef(self, fn_temp_span, root.span);
+            const fn_assign = try self.ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = root.span,
+                .data = .{ .binary = .{
+                    .left = fn_temp_lhs,
+                    .right = member,
+                    .flags = @intFromEnum(token_mod.Kind.eq),
+                } },
+            });
+
+            return .{
+                .null_check_base = try helpers.makeParenExpr(self, fn_assign, root.span),
+                .chain_base = try helpers.makeTempVarRef(self, fn_temp_span, root.span),
+                .receiver = receiver,
+            };
+        }
+
+        fn isOptionalCallBase(self: *const Transformer, node: Node, base_idx: NodeIndex) bool {
+            switch (node.tag) {
+                .call_expression => {
+                    const e = node.data.extra;
+                    const old_callee = self.readNodeIdx(e, 0);
+                    const flags = self.readU32(e, 3);
+                    if ((flags & ast_mod.CallFlags.optional_chain) != 0 and sameNodeIndex(old_callee, base_idx)) {
+                        return true;
+                    }
+                    if (old_callee.isNone()) return false;
+                    return isOptionalCallBase(self, self.ast.getNode(old_callee), base_idx);
+                },
+                .static_member_expression, .computed_member_expression, .private_field_expression => {
+                    const obj = getChainObject(self, node);
+                    if (obj.isNone()) return false;
+                    return isOptionalCallBase(self, self.ast.getNode(obj), base_idx);
+                },
+                else => return false,
+            }
+        }
+
+        fn sameNodeIndex(a: NodeIndex, b: NodeIndex) bool {
+            return @intFromEnum(a) == @intFromEnum(b);
         }
 
         fn makeTrueLiteral(self: *Transformer, _: Span) Transformer.Error!NodeIndex {
@@ -247,6 +351,63 @@ pub fn ES2020(comptime Transformer: type) type {
                     const is_optional = (flags & ast_mod.CallFlags.optional_chain) != 0;
                     const new_callee = if (is_optional) chain_base else try rebuildChainNode(self, self.ast.getNode(old_callee), chain_base);
                     const new_args = try self.visitExtraList(.{ .start = args_start, .len = args_len });
+                    const new_flags = flags & ~ast_mod.CallFlags.optional_chain;
+                    const new_extra = try self.ast.addExtras(&.{ @intFromEnum(new_callee), new_args.start, new_args.len, new_flags });
+                    return self.ast.addNode(.{ .tag = .call_expression, .span = old_node.span, .data = .{ .extra = new_extra } });
+                },
+                else => unreachable,
+            }
+        }
+
+        fn rebuildChainNodeWithOptionalMemberCallThis(
+            self: *Transformer,
+            old_node: Node,
+            chain_base: NodeIndex,
+            optional_call_callee_idx: NodeIndex,
+            receiver: NodeIndex,
+        ) Transformer.Error!NodeIndex {
+            switch (old_node.tag) {
+                .static_member_expression, .computed_member_expression, .private_field_expression => {
+                    const e = old_node.data.extra;
+                    const old_obj: NodeIndex = self.readNodeIdx(e, 0);
+                    const old_prop: NodeIndex = self.readNodeIdx(e, 1);
+                    const flags = self.readU32(e, 2);
+                    const is_optional = (flags & ast_mod.MemberFlags.optional_chain) != 0;
+                    const new_obj = if (is_optional)
+                        chain_base
+                    else
+                        try rebuildChainNodeWithOptionalMemberCallThis(self, self.ast.getNode(old_obj), chain_base, optional_call_callee_idx, receiver);
+                    const new_prop = try self.visitNode(old_prop);
+                    const new_flags = flags & ~ast_mod.MemberFlags.optional_chain;
+                    const new_extra = try self.ast.addExtras(&.{ @intFromEnum(new_obj), @intFromEnum(new_prop), new_flags });
+                    return self.ast.addNode(.{ .tag = old_node.tag, .span = old_node.span, .data = .{ .extra = new_extra } });
+                },
+                .call_expression => {
+                    const e = old_node.data.extra;
+                    const old_callee: NodeIndex = self.readNodeIdx(e, 0);
+                    const args_start = self.readU32(e, 1);
+                    const args_len = self.readU32(e, 2);
+                    const flags = self.readU32(e, 3);
+                    const is_optional = (flags & ast_mod.CallFlags.optional_chain) != 0;
+                    const new_args = try self.visitExtraList(.{ .start = args_start, .len = args_len });
+
+                    if (is_optional and sameNodeIndex(old_callee, optional_call_callee_idx)) {
+                        const call_prop = try helpers.makeIdentifierRef(self, "call");
+                        const call_member = try helpers.makeStaticMember(self, chain_base, call_prop, old_node.span);
+                        var args = std.ArrayList(NodeIndex).empty;
+                        try args.ensureTotalCapacity(self.allocator, new_args.len + 1);
+                        args.appendAssumeCapacity(receiver);
+                        var i: u32 = 0;
+                        while (i < new_args.len) : (i += 1) {
+                            args.appendAssumeCapacity(@enumFromInt(self.ast.extra_data.items[new_args.start + i]));
+                        }
+                        return helpers.makeCallExpr(self, call_member, args.items, old_node.span);
+                    }
+
+                    const new_callee = if (is_optional)
+                        chain_base
+                    else
+                        try rebuildChainNodeWithOptionalMemberCallThis(self, self.ast.getNode(old_callee), chain_base, optional_call_callee_idx, receiver);
                     const new_flags = flags & ~ast_mod.CallFlags.optional_chain;
                     const new_extra = try self.ast.addExtras(&.{ @intFromEnum(new_callee), new_args.start, new_args.len, new_flags });
                     return self.ast.addNode(.{ .tag = .call_expression, .span = old_node.span, .data = .{ .extra = new_extra } });

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -2858,6 +2858,52 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("ok undefined");
     });
+
+    test("optional method call this 바인딩 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const obj: any = {
+              value: 41,
+              inc(n: number) {
+                return this.value + n;
+              },
+            };
+            console.log(obj.inc?.(1));
+          `,
+        },
+        "index.ts",
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("42");
+    });
+
+    test("optional method call 복잡 receiver 1회 평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let calls = 0;
+            function getObj(): any {
+              calls++;
+              return {
+                value: 5,
+                inc() {
+                  return this.value + calls;
+                },
+              };
+            }
+            console.log(getObj().inc?.(), calls);
+          `,
+        },
+        "index.ts",
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("6 1");
+    });
   });
 
   // ===== ES2021 (target=es2020) =====


### PR DESCRIPTION
## 요약
- ES2020 optional method call 다운레벨링에서 receiver this 바인딩을 보존하도록 수정했습니다.
- 복잡한 receiver는 한 번만 평가한 뒤 Function.prototype.call 로 호출합니다.
- obj.method?.() / getObj().method?.() 재현 케이스를 Zig codegen 테스트와 TS 통합 런타임 테스트에 추가했습니다.

## 테스트
- zig build test -Dtest-filter="optional method call"
- obj.inc?.(1), getObj().inc?.() TS 번들/실행 수동 검증
- pre-push hook 통과: zig fmt --check, zig build test, oxlint, oxfmt --check