### PR TITLE
fix(transformer): logical assignment member reference 보존

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2279,6 +2279,27 @@ test "ES2021: ||= with member expression" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "obj.x") != null);
 }
 
+test "ES2021: ||= member receiver 1회 평가" {
+    var r = try e2eTarget(std.testing.allocator, "getObj().x ||= 5;", .es2020);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=getObj()).x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_a.x=5") != null);
+}
+
+test "ES2021: &&= member receiver 1회 평가" {
+    var r = try e2eTarget(std.testing.allocator, "getObj().x &&= 5;", .es2020);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=getObj()).x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_a.x=5") != null);
+}
+
+test "ES2021: ??= computed member key 1회 평가" {
+    var r = try e2eTarget(std.testing.allocator, "obj[getKey()] ??= 5;", .es2019);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=getKey())") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "obj[_a]=5") != null);
+}
+
 // --- ES2022 edge cases ---
 
 test "ES2022: static block with side effects" {

--- a/src/transformer/es2021.zig
+++ b/src/transformer/es2021.zig
@@ -13,12 +13,10 @@
 //! - esbuild: internal/js_parser/js_parser_lower.go (lowerAssign)
 //! - oxc: crates/oxc_transformer/src/es2021/
 
-const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const token_mod = @import("../lexer/token.zig");
-const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
 
 pub fn ES2021(comptime Transformer: type) type {
@@ -28,6 +26,39 @@ pub fn ES2021(comptime Transformer: type) type {
         /// 주의: private field 좌변은 caller(transformer.zig)에서 es2015_class로 먼저 라우팅됨 —
         /// private get/set이 함수 호출이라 여기서 만드는 `(a = b)` 패턴의 assignment target이 될 수 없음.
         pub fn lowerNullishAssignment(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            if (try es_helpers.prepareMemberAssignmentTargetRef(self, node.data.binary.left, node.span)) |target| {
+                const new_right = try self.visitNode(node.data.binary.right);
+                const assign = try self.ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = node.span,
+                    .data = .{ .binary = .{
+                        .left = target.write,
+                        .right = new_right,
+                        .flags = @intFromEnum(token_mod.Kind.eq),
+                    } },
+                });
+                const paren_assign = try es_helpers.makeParenExpr(self, assign, node.span);
+
+                if (self.options.unsupported.nullish_coalescing) {
+                    const neq_null = try es_helpers.makeNeqNull(self, target.read, node.span);
+                    return self.ast.addNode(.{
+                        .tag = .conditional_expression,
+                        .span = node.span,
+                        .data = .{ .ternary = .{ .a = neq_null, .b = target.value, .c = paren_assign } },
+                    });
+                }
+
+                return self.ast.addNode(.{
+                    .tag = .logical_expression,
+                    .span = node.span,
+                    .data = .{ .binary = .{
+                        .left = target.read,
+                        .right = paren_assign,
+                        .flags = @intFromEnum(token_mod.Kind.question2),
+                    } },
+                });
+            }
+
             const new_left = try self.visitNode(node.data.binary.left);
             const new_right = try self.visitNode(node.data.binary.right);
             const left_copy1 = try self.ast.addNode(self.ast.getNode(new_left));
@@ -69,6 +100,29 @@ pub fn ES2021(comptime Transformer: type) type {
         /// `a ||= b` → `a || (a = b)`, `a &&= b` → `a && (a = b)`
         /// 주의: private field 좌변은 caller(transformer.zig)에서 es2015_class로 먼저 라우팅됨.
         pub fn lowerLogicalAssignment(self: *Transformer, node: Node, logical_op: token_mod.Kind) Transformer.Error!NodeIndex {
+            if (try es_helpers.prepareMemberAssignmentTargetRef(self, node.data.binary.left, node.span)) |target| {
+                const new_right = try self.visitNode(node.data.binary.right);
+                const assign = try self.ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = node.span,
+                    .data = .{ .binary = .{
+                        .left = target.write,
+                        .right = new_right,
+                        .flags = @intFromEnum(token_mod.Kind.eq),
+                    } },
+                });
+                const paren_assign = try es_helpers.makeParenExpr(self, assign, node.span);
+                return self.ast.addNode(.{
+                    .tag = .logical_expression,
+                    .span = node.span,
+                    .data = .{ .binary = .{
+                        .left = target.read,
+                        .right = paren_assign,
+                        .flags = @intFromEnum(logical_op),
+                    } },
+                });
+            }
+
             const new_left = try self.visitNode(node.data.binary.left);
             const new_right = try self.visitNode(node.data.binary.right);
             const left_copy = try self.ast.addNode(self.ast.getNode(new_left));

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -239,6 +239,119 @@ pub fn makeCallExpr(self: anytype, callee: NodeIndex, args: []const NodeIndex, s
     });
 }
 
+/// assignment target reference 보존용 구성 요소.
+///
+/// `obj[key] ||= rhs` 같은 compound/logical assignment는 좌변이 단순 값이 아니라
+/// JS Reference(receiver + key)다. receiver/key를 read/write 양쪽에서 새로 평가하면
+/// `getObj().x ||= y`가 `getObj()`를 두 번 호출한다. 이 구조체는 read/value/write가
+/// 같은 receiver/key 평가 결과를 공유하도록 미리 준비한 member expression 묶음이다.
+pub const AssignmentTargetRef = struct {
+    read: NodeIndex,
+    value: NodeIndex,
+    write: NodeIndex,
+};
+
+/// static/computed member assignment target의 Reference를 1회 평가 형태로 준비.
+/// 지원 대상: `obj.x`, `obj[key]`.
+/// 비-member target이면 null을 반환해 caller가 기존 단순 경로를 사용할 수 있게 한다.
+pub fn prepareMemberAssignmentTargetRef(
+    self: anytype,
+    left_idx: NodeIndex,
+    span: Span,
+) !?AssignmentTargetRef {
+    if (left_idx.isNone()) return null;
+    const left = self.ast.getNode(left_idx);
+    switch (left.tag) {
+        .static_member_expression, .computed_member_expression => {},
+        else => return null,
+    }
+
+    const e = left.data.extra;
+    const old_obj = self.readNodeIdx(e, 0);
+    const old_prop = self.readNodeIdx(e, 1);
+    const flags = self.readU32(e, 2);
+
+    const obj = try makeSingleEvalExpr(self, old_obj, span, true);
+    const prop = if (left.tag == .computed_member_expression)
+        try makeSingleEvalExpr(self, old_prop, span, false)
+    else
+        try makeStaticPropRef(self, old_prop);
+
+    return .{
+        .read = try makeMemberWithFlags(self, left.tag, obj.read, prop.read, flags, left.span),
+        .value = try makeMemberWithFlags(self, left.tag, obj.value, prop.value, flags, left.span),
+        .write = try makeMemberWithFlags(self, left.tag, obj.write, prop.write, flags, left.span),
+    };
+}
+
+const SingleEvalExpr = struct {
+    read: NodeIndex,
+    value: NodeIndex,
+    write: NodeIndex,
+};
+
+fn makeSingleEvalExpr(
+    self: anytype,
+    old_idx: NodeIndex,
+    span: Span,
+    simple_identifier_is_reusable: bool,
+) !SingleEvalExpr {
+    const old = self.ast.getNode(old_idx);
+    if (simple_identifier_is_reusable and old.tag == .identifier_reference) {
+        const visited = try self.visitNode(old_idx);
+        return .{
+            .read = visited,
+            .value = try cloneNode(self, visited),
+            .write = try cloneNode(self, visited),
+        };
+    }
+
+    const visited = try self.visitNode(old_idx);
+    const temp_span = try makeTempVarSpan(self);
+    const temp_lhs = try makeTempVarRef(self, temp_span, span);
+    const assign = try self.ast.addNode(.{
+        .tag = .assignment_expression,
+        .span = span,
+        .data = .{ .binary = .{
+            .left = temp_lhs,
+            .right = visited,
+            .flags = @intFromEnum(token_mod.Kind.eq),
+        } },
+    });
+    return .{
+        .read = try makeParenExpr(self, assign, span),
+        .value = try makeTempVarRef(self, temp_span, span),
+        .write = try makeTempVarRef(self, temp_span, span),
+    };
+}
+
+fn makeStaticPropRef(self: anytype, old_prop: NodeIndex) !SingleEvalExpr {
+    const prop = try self.visitNode(old_prop);
+    return .{
+        .read = prop,
+        .value = try cloneNode(self, prop),
+        .write = try cloneNode(self, prop),
+    };
+}
+
+fn cloneNode(self: anytype, idx: NodeIndex) !NodeIndex {
+    const cloned = try self.ast.addNode(self.ast.getNode(idx));
+    self.copySymbolId(idx, cloned);
+    return cloned;
+}
+
+fn makeMemberWithFlags(
+    self: anytype,
+    tag: ast_mod.Node.Tag,
+    obj: NodeIndex,
+    prop: NodeIndex,
+    flags: u32,
+    span: Span,
+) !NodeIndex {
+    const extra = try self.ast.addExtras(&.{ @intFromEnum(obj), @intFromEnum(prop), flags });
+    return self.ast.addNode(.{ .tag = tag, .span = span, .data = .{ .extra = extra } });
+}
+
 /// u32 값으로 numeric_literal 노드 생성.
 pub fn makeNumericLiteral(self: anytype, value: u32) !NodeIndex {
     var buf: [16]u8 = undefined;

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -2987,6 +2987,114 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("10 0");
     });
+
+    test("logical assignment member receiver 1회 평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let receiverCalls = 0;
+            let rhsCalls = 0;
+            const target: any = { x: 0 };
+            function getObj(): any {
+              receiverCalls++;
+              return target;
+            }
+            function rhs() {
+              rhsCalls++;
+              return 5;
+            }
+            getObj().x ||= rhs();
+            console.log(receiverCalls, rhsCalls, target.x);
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 1 5");
+    });
+
+    test("logical assignment member 단락 시 RHS 미평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let receiverCalls = 0;
+            let rhsCalls = 0;
+            const target: any = { x: 7 };
+            function getObj(): any {
+              receiverCalls++;
+              return target;
+            }
+            function rhs() {
+              rhsCalls++;
+              return 5;
+            }
+            getObj().x ||= rhs();
+            console.log(receiverCalls, rhsCalls, target.x);
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 0 7");
+    });
+
+    test("logical assignment &&= member 단락 시 RHS 미평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let receiverCalls = 0;
+            let rhsCalls = 0;
+            const target: any = { x: 0 };
+            function getObj(): any {
+              receiverCalls++;
+              return target;
+            }
+            function rhs() {
+              rhsCalls++;
+              return 5;
+            }
+            getObj().x &&= rhs();
+            console.log(receiverCalls, rhsCalls, target.x);
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 0 0");
+    });
+
+    test("nullish assignment computed member key 1회 평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let keyCalls = 0;
+            let rhsCalls = 0;
+            const obj: any = {};
+            function getKey() {
+              keyCalls++;
+              return "x";
+            }
+            function rhs() {
+              rhsCalls++;
+              return 9;
+            }
+            obj[getKey()] ??= rhs();
+            console.log(keyCalls, rhsCalls, obj.x);
+          `,
+        },
+        "index.ts",
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 1 9");
+    });
   });
 
   // ===== ES2022 (target=es2021) =====


### PR DESCRIPTION
## 요약
- ES2021 logical assignment 다운레벨링에서 member 좌변의 receiver/key를 한 번만 평가하도록 수정했습니다.
- `getObj().x ||= rhs()`, `getObj().x &&= rhs()`, `obj[getKey()] ??= rhs()`가 read/write에서 같은 Reference를 공유합니다.
- receiver/key/RHS side effect 회귀 테스트를 Zig codegen과 TS 런타임에 추가했습니다.

## 재현
- 수정 전 `getObj().x ||= 1` 이 `getObj().x || (getObj().x = 1)` 로 내려가 `getObj()`를 두 번 호출했습니다.
- 수정 전 `obj[getKey()] ??= 5` 는 read/write에서 computed key를 다시 평가할 수 있었습니다.
- 수정 후 lowering 전에 member target Reference(receiver + key)를 준비해 같은 평가 결과로 read/value/write를 만듭니다.
- TypeScript transformer의 `isAccessExpression(left)` 처리처럼 receiver와 element key를 temp로 분리해 assignment target을 구성하는 방식과 같은 방향입니다.

## 테스트
- `zig build test -Dtest-filter="member receiver 1회 평가"`
- `zig build test -Dtest-filter="computed member key 1회 평가"`
- `zig build test -Dtest-filter="ES2021:"`
- `zig build test`
- `zig fmt --check src/transformer/es_helpers.zig src/transformer/es2021.zig src/codegen/codegen_test/es_downlevel.zig`
- `bun run fmt:check`
- `bun run lint` (기존 경고 61개, 에러 0개)
- TS 번들/실행 수동 검증: receiver/key/RHS side effect 4개 케이스
- pre-push hook 통과: zig fmt --check, zig build test, oxlint, oxfmt --check