### PR TITLE
fix(transformer): optional eval call indirect eval 보존

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -63,6 +63,12 @@ test "ES2020: ?. call" {
     try std.testing.expectEqualStrings("(a==null?void 0:a());", r.output);
 }
 
+test "ES2020: optional eval call indirect eval 보존" {
+    var r = try e2eTarget(std.testing.allocator, "eval?.('x=1');", .es2019);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(0,eval)(") != null);
+}
+
 test "ES2020: ?. side effect (temp var)" {
     var r = try e2eTarget(std.testing.allocator, "foo()?.bar;", .es2019);
     defer r.deinit();

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -464,7 +464,10 @@ pub fn ES2020(comptime Transformer: type) type {
                     const args_len = self.readU32(e, 2);
                     const flags = self.readU32(e, 3);
                     const is_optional = (flags & ast_mod.CallFlags.optional_chain) != 0;
-                    const new_callee = if (is_optional) chain_base else try rebuildChainNode(self, self.ast.getNode(old_callee), chain_base);
+                    const new_callee = if (is_optional)
+                        try makeOptionalCallCallee(self, old_callee, chain_base, old_node.span)
+                    else
+                        try rebuildChainNode(self, self.ast.getNode(old_callee), chain_base);
                     const new_args = try self.visitExtraList(.{ .start = args_start, .len = args_len });
                     const new_flags = flags & ~ast_mod.CallFlags.optional_chain;
                     const new_extra = try self.ast.addExtras(&.{ @intFromEnum(new_callee), new_args.start, new_args.len, new_flags });
@@ -520,7 +523,7 @@ pub fn ES2020(comptime Transformer: type) type {
                     }
 
                     const new_callee = if (is_optional)
-                        chain_base
+                        try makeOptionalCallCallee(self, old_callee, chain_base, old_node.span)
                     else
                         try rebuildChainNodeWithOptionalMemberCallThis(self, self.ast.getNode(old_callee), chain_base, optional_call_callee_idx, receiver);
                     const new_flags = flags & ~ast_mod.CallFlags.optional_chain;
@@ -529,6 +532,33 @@ pub fn ES2020(comptime Transformer: type) type {
                 },
                 else => unreachable,
             }
+        }
+
+        fn makeOptionalCallCallee(
+            self: *Transformer,
+            old_callee: NodeIndex,
+            chain_base: NodeIndex,
+            span: Span,
+        ) Transformer.Error!NodeIndex {
+            if (!isEvalIdentifier(self, old_callee)) return chain_base;
+
+            // `eval?.()`은 spec상 indirect eval이다. `eval()`로 재구성하면 direct eval이 되어
+            // local scope를 건드리므로 Babel/OXC처럼 `(0, eval)()` 형태로 callee Reference를 끊는다.
+            const zero = try helpers.makeNumericLiteral(self, 0);
+            const seq_list = try self.ast.addNodeList(&.{ zero, chain_base });
+            const seq = try self.ast.addNode(.{
+                .tag = .sequence_expression,
+                .span = span,
+                .data = .{ .list = seq_list },
+            });
+            return helpers.makeParenExpr(self, seq, span);
+        }
+
+        fn isEvalIdentifier(self: *Transformer, idx: NodeIndex) bool {
+            if (idx.isNone()) return false;
+            const node = self.ast.getNode(idx);
+            if (node.tag != .identifier_reference) return false;
+            return std.mem.eql(u8, self.ast.getText(node.data.string_ref), "eval");
         }
     };
 }

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -289,6 +289,10 @@ fn clearBitSet(b: *std.DynamicBitSet) void {
 /// 새로 append 된 노드는 `items.len` 증가로 자동 순회됨.
 fn runOnce(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.DynamicBitSet, live_nodes: ?*const std.DynamicBitSet, scratch: std.mem.Allocator) bool {
     var changed = false;
+    var protected_sequences = std.DynamicBitSet.initEmpty(scratch, ast.nodes.items.len) catch null;
+    defer if (protected_sequences) |*set| set.deinit();
+    if (protected_sequences) |*set| markCallCalleeSequences(ast, set);
+
     var i: u32 = 0;
     while (i < ast.nodes.items.len) : (i += 1) {
         const node = ast.nodes.items[i];
@@ -299,7 +303,10 @@ fn runOnce(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.DynamicBitSe
             .conditional_expression => foldConditional(ast, i, node, &changed),
             .if_statement => foldIf(ast, i, node, &changed),
             .while_statement => foldWhile(ast, i, node, &changed),
-            .sequence_expression => simplifySequence(ast, ctx, i, node, &changed),
+            .sequence_expression => {
+                const is_protected = if (protected_sequences) |set| i < set.capacity() and set.isSet(i) else true;
+                if (!is_protected) simplifySequence(ast, ctx, i, node, &changed);
+            },
             // PR1.5 (a): unused expression statement 축약 — semantic 정보 있을 때만
             // (symbol_ids 가 없으면 identifier local binding 판정 불가)
             .expression_statement => if (ctx.hasSemantic()) simplifyUnusedExprStmt(ast, ctx, i, node, &changed),
@@ -315,6 +322,27 @@ fn runOnce(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.DynamicBitSe
         removeDeadStores(ast, ctx, skip_for_binding, live_nodes, &changed);
     }
     return changed;
+}
+
+fn markCallCalleeSequences(ast: *const Ast, protected_sequences: *std.DynamicBitSet) void {
+    for (ast.nodes.items) |node| {
+        if (node.tag != .call_expression and node.tag != .new_expression) continue;
+        const e = node.data.extra;
+        if (!ast.hasExtra(e, 0)) continue;
+        markSequenceInCallee(ast, @enumFromInt(ast.readExtra(e, 0)), protected_sequences);
+    }
+}
+
+fn markSequenceInCallee(ast: *const Ast, idx: NodeIndex, protected_sequences: *std.DynamicBitSet) void {
+    if (idx.isNone()) return;
+    const ni = @intFromEnum(idx);
+    if (ni >= ast.nodes.items.len or ni >= protected_sequences.capacity()) return;
+    const node = ast.nodes.items[ni];
+    switch (node.tag) {
+        .sequence_expression => protected_sequences.set(ni),
+        .parenthesized_expression => markSequenceInCallee(ast, node.data.unary.operand, protected_sequences),
+        else => {},
+    }
 }
 
 /// root 에서 BFS 로 도달 가능한 노드 인덱스를 `live` 에 표시. `queue` 는 호출자가 재사용.

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -1607,6 +1607,13 @@ test "unused: (foo.bar)(); — call callee 자리 paren 은 minify 범위 밖" {
     );
 }
 
+test "unused: (0, eval)(); — indirect eval sequence callee 보존" {
+    try expectMinifyDead(
+        "(0, eval)(\"x=1\");",
+        "function run() {\n\t(0,eval)(\"x=1\");\n}\nrun();",
+    );
+}
+
 test "unused: ({v} = o); — object destructuring assignment 은 paren 유지 ({ block 모호)" {
     // LHS 가 object_assignment_target 이면 unwrap 시 `{v} = o;` — `{` 가 block 시작으로 파싱.
     try expectMinifyDead(

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -2859,6 +2859,26 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("ok undefined");
     });
 
+    test("optional eval call indirect eval 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function run() {
+              let x = 1;
+              eval?.("x = 2");
+              console.log(x, globalThis.x);
+            }
+            run();
+          `,
+        },
+        "index.ts",
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 2");
+    });
+
     test("optional method call this 바인딩 보존", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## 요약
- `eval?.()` 다운레벨링이 direct eval로 바뀌던 문제를 수정했습니다.
- ES2020 optional call 재구성 시 callee가 `eval`이면 Babel/OXC와 같이 `(0, eval)()` 형태로 Reference를 끊습니다.
- 번들 경로에서 minify가 call callee의 `(0, eval)` sequence를 다시 `(eval)`로 줄이지 않도록 callee sequence를 보호했습니다.

## 재현
```ts
function run() {
  let x = 1;
  eval?.("x = 2");
  console.log(x, globalThis.x);
}
run();
```
- 네이티브: `1 2`
- 수정 전 zts 다운레벨: `2 undefined` (`eval(...)` direct eval로 변환)
- 수정 후 zts 다운레벨: `1 2`, 출력은 `eval == null || (0,eval)(...)`

## 참고
- Babel optional chaining transform: `eval?.()`은 indirect eval이라 `(0, eval)()`로 변환
- OXC optional chaining transform도 동일한 처리 주석과 구현 확인

## 테스트
- `zig build test -Dtest-filter="optional eval call indirect eval 보존"`
- `zig build test -Dtest-filter="indirect eval sequence callee 보존"`
- `zig build test -Dtest-filter="ES2020:"`
- `zig build test`
- `zig build`
- `bun run fmt:check`
- `bun run lint` (기존 경고 61개, 에러 0개)
- TS 번들/실행 수동 검증: optional eval call runtime `1 2`
- pre-push hook 통과: zig fmt --check, zig build test, oxlint, oxfmt --check