### PR TITLE
fix(transformer): exponentiation assignment member reference 보존

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -141,6 +141,18 @@ test "ES2016: **= to Math.pow assignment" {
     try std.testing.expectEqualStrings("a=Math.pow(a,b);", r.output);
 }
 
+test "ES2016: **= member receiver 1회 평가" {
+    var r = try e2eTarget(std.testing.allocator, "getObj().x **= 3;", .es2015);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=getObj()).x=Math.pow(_a.x,3)") != null);
+}
+
+test "ES2016: **= computed member key 1회 평가" {
+    var r = try e2eTarget(std.testing.allocator, "obj[getKey()] **= 3;", .es2015);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "obj[(_a=getKey())]=Math.pow(obj[_a],3)") != null);
+}
+
 test "ES2016: ** no transform on es2016" {
     var r = try e2eTarget(std.testing.allocator, "const x = a ** b;", .es2016);
     defer r.deinit();

--- a/src/transformer/es2016.zig
+++ b/src/transformer/es2016.zig
@@ -31,6 +31,21 @@ pub fn ES2016(comptime Transformer: type) type {
 
         /// `a **= b` → `a = Math.pow(a, b)`
         pub fn lowerExponentiationAssignment(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+            if (try es_helpers.prepareMemberAssignmentTargetRef(self, node.data.binary.left, node.span)) |target| {
+                const new_right = try self.visitNode(node.data.binary.right);
+                const pow_call = try es_helpers.makeMathPowCall(self, target.value, new_right, node.span);
+
+                return self.ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = node.span,
+                    .data = .{ .binary = .{
+                        .left = target.read,
+                        .right = pow_call,
+                        .flags = @intFromEnum(token_mod.Kind.eq),
+                    } },
+                });
+            }
+
             const new_left = try self.visitNode(node.data.binary.left);
             const new_right = try self.visitNode(node.data.binary.right);
 

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -2419,6 +2419,50 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("9");
     });
+
+    test("exponentiation assignment member receiver 1회 평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let calls = 0;
+            const target: any = { x: 2 };
+            function getObj(): any {
+              calls++;
+              return target;
+            }
+            getObj().x **= 3;
+            console.log(calls, target.x);
+          `,
+        },
+        "index.ts",
+        ["--target=es2015"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 8");
+    });
+
+    test("exponentiation assignment computed member key 1회 평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let keyCalls = 0;
+            const obj: any = { x: 2 };
+            function getKey() {
+              keyCalls++;
+              return "x";
+            }
+            obj[getKey()] **= 3;
+            console.log(keyCalls, obj.x);
+          `,
+        },
+        "index.ts",
+        ["--target=es2015"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 8");
+    });
   });
 
   // ===== ES2017 (target=es2016) =====


### PR DESCRIPTION
## 요약
- ES2016 `**=` 다운레벨링에서 member 좌변의 receiver/key가 두 번 평가되던 문제를 수정했습니다.
- `getObj().x **= 3`, `obj[getKey()] **= 3`가 좌변 Reference(receiver + key)를 한 번만 준비하도록 했습니다.
- 기존 logical assignment에서 만든 공통 `prepareMemberAssignmentTargetRef`를 재사용해 compound assignment의 Reference 보존 계층에서 처리했습니다.

## 재현
```ts
let calls = 0;
const target = { x: 2 };
function getObj() { calls++; return target; }
getObj().x **= 3;
console.log(calls, target.x);
```
- 네이티브: `1 8`
- 수정 전 zts 다운레벨: `2 8` (`getObj().x = Math.pow(getObj().x, 3)`)
- 수정 후 zts 다운레벨: `1 8` (`(_a = getObj()).x = Math.pow(_a.x, 3)`)

## 테스트
- `zig build test -Dtest-filter="**= member receiver 1회 평가"`
- `zig build test -Dtest-filter="**= computed member key 1회 평가"`
- `zig build test -Dtest-filter="ES2016:"`
- `zig build test`
- `zig build`
- `bun run fmt:check`
- `bun run lint` (기존 경고, 에러 0개)
- TS 번들/실행 수동 검증: receiver/key side effect 케이스
- pre-push hook 통과: zig fmt --check, zig build test, oxlint, oxfmt --check