### PR TITLE
fix(transformer): super logical assignment receiver 보존

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2315,6 +2315,34 @@ test "ES2021: ??= with member expression" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "obj.x") != null);
 }
 
+test "ES2021: logical assignment super member receiver 보존" {
+    var r1 = try e2eTarget(std.testing.allocator, "class C extends B{m(){super.x ||= 1;}}", .es2020);
+    defer r1.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "=super") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "super.x||") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "super.x=1") != null);
+
+    var r2 = try e2eTarget(std.testing.allocator, "class C extends B{m(){super.x &&= 2;}}", .es2020);
+    defer r2.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "=super") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "super.x&&") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "super.x=2") != null);
+
+    var r3 = try e2eTarget(std.testing.allocator, "class C extends B{m(){super.x ??= 3;}}", .es2020);
+    defer r3.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r3.output, "=super") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r3.output, "super.x??") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r3.output, "super.x=3") != null);
+}
+
+test "ES2021: logical assignment computed super member key 1회 평가" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends B{m(){super[getKey()] ||= 1;}}", .es2020);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=super") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super[(_a=getKey())]||") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super[_a]=1") != null);
+}
+
 test "ES2021: ||= with member expression" {
     var r = try e2eTarget(std.testing.allocator, "obj.x ||= 5;", .es2020);
     defer r.deinit();

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -297,6 +297,15 @@ fn makeSingleEvalExpr(
     simple_identifier_is_reusable: bool,
 ) !SingleEvalExpr {
     const old = self.ast.getNode(old_idx);
+    if (old.tag == .super_expression) {
+        const visited = try self.visitNode(old_idx);
+        return .{
+            .read = visited,
+            .value = try cloneNode(self, visited),
+            .write = try cloneNode(self, visited),
+        };
+    }
+
     if (simple_identifier_is_reusable and old.tag == .identifier_reference) {
         const visited = try self.visitNode(old_idx);
         return .{

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -3130,6 +3130,71 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("10 0");
     });
 
+    test("logical assignment super member this 바인딩 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base {
+              v: any = 0;
+              get x() {
+                return this.v;
+              }
+              set x(value: any) {
+                this.v = value;
+              }
+            }
+            class Child extends Base {
+              run() {
+                super.x ||= 2;
+                return this.v;
+              }
+            }
+            console.log(new Child().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("2");
+    });
+
+    test("logical assignment computed super member key 1회 평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let keyCalls = 0;
+            function key() {
+              keyCalls++;
+              return "x";
+            }
+            class Base {
+              v: any = 0;
+              get x() {
+                return this.v;
+              }
+              set x(value: any) {
+                this.v = value;
+              }
+            }
+            class Child extends Base {
+              run() {
+                super[key()] ||= 3;
+                return [this.v, keyCalls].join(" ");
+              }
+            }
+            console.log(new Child().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es2020"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("3 1");
+    });
+
     test("logical assignment member receiver 1회 평가", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary
- reproduce `super.x ||= value` downleveling into invalid `(_a = super).x`
- treat `super` as a reusable Reference receiver in member assignment target preparation
- keep computed super keys single-evaluated while avoiding assigning `super` itself to a temp

## Tests
- `zig build test -Dtest-filter="logical assignment super member"`
- `zig build test -Dtest-filter="ES2021:"`
- `zig build test`
- `bun run fmt:check`
- `bun run lint`
- direct runtime smoke through `bun -e` for static/computed super logical assignment

Note: ES5 class lowering for general `super.x` property get/set is a broader pre-existing class transform limitation; this PR fixes the ES2021 logical assignment root cause where `super` was incorrectly temp-assigned.