### PR TITLE
fix(transformer): super property receiver downlevel

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -307,6 +307,50 @@ pub const CALL_SUPER_RUNTIME =
 ;
 pub const CALL_SUPER_RUNTIME_MIN = "var " ++ NAMES.CALL_SUPER_MIN ++ "=function(_this,Parent,args){if(typeof Reflect!==\"undefined\"&&typeof Reflect.construct===\"function\")return Reflect.construct(Parent,args||[],_this.constructor);var result=Parent.apply(_this,args);if(result&&(typeof result===\"object\"||typeof result===\"function\"))return result;return _this};";
 
+/// __superGet/__superSet: super property 접근 시 receiver(this)를 보존한다.
+/// `Parent.prototype.x` 직접 접근은 getter/setter의 this를 Parent.prototype으로 바꾸므로
+/// ES2015 [[Get]]/[[Set]]의 receiver 인자를 helper에서 명시적으로 전달한다.
+pub const SUPER_GET_RUNTIME =
+    \\var __superGet = function(parent, prop, receiver) {
+    \\  var desc;
+    \\  while (parent) {
+    \\    desc = Object.getOwnPropertyDescriptor(parent, prop);
+    \\    if (desc) {
+    \\      if (desc.get) return desc.get.call(receiver);
+    \\      return desc.value;
+    \\    }
+    \\    parent = Object.getPrototypeOf(parent);
+    \\  }
+    \\};
+    \\
+;
+pub const SUPER_GET_RUNTIME_MIN = "var " ++ NAMES.SUPER_GET_MIN ++ "=function(parent,prop,receiver){var desc;while(parent){desc=Object.getOwnPropertyDescriptor(parent,prop);if(desc){if(desc.get)return desc.get.call(receiver);return desc.value}parent=Object.getPrototypeOf(parent)}};";
+
+pub const SUPER_SET_RUNTIME =
+    \\var __superSet = function(parent, prop, value, receiver) {
+    \\  var desc;
+    \\  while (parent) {
+    \\    desc = Object.getOwnPropertyDescriptor(parent, prop);
+    \\    if (desc) {
+    \\      if (desc.set) {
+    \\        desc.set.call(receiver, value);
+    \\        return value;
+    \\      }
+    \\      if (desc.writable) {
+    \\        receiver[prop] = value;
+    \\        return value;
+    \\      }
+    \\      throw new TypeError("Cannot set property");
+    \\    }
+    \\    parent = Object.getPrototypeOf(parent);
+    \\  }
+    \\  receiver[prop] = value;
+    \\  return value;
+    \\};
+    \\
+;
+pub const SUPER_SET_RUNTIME_MIN = "var " ++ NAMES.SUPER_SET_MIN ++ "=function(parent,prop,value,receiver){var desc;while(parent){desc=Object.getOwnPropertyDescriptor(parent,prop);if(desc){if(desc.set){desc.set.call(receiver,value);return value}if(desc.writable){receiver[prop]=value;return value}throw new TypeError(\"Cannot set property\")}parent=Object.getPrototypeOf(parent)}receiver[prop]=value;return value};";
+
 /// __async: async/await → generator 변환 시 주입 (esbuild 호환).
 /// generator-to-Promise wrapper. this/arguments를 fn.apply로 보존.
 ///
@@ -1094,6 +1138,12 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
     if (helpers.call_super) {
         try buf.appendSlice(allocator, if (minify) CALL_SUPER_RUNTIME_MIN else CALL_SUPER_RUNTIME);
+    }
+    if (helpers.super_get) {
+        try buf.appendSlice(allocator, if (minify) SUPER_GET_RUNTIME_MIN else SUPER_GET_RUNTIME);
+    }
+    if (helpers.super_set) {
+        try buf.appendSlice(allocator, if (minify) SUPER_SET_RUNTIME_MIN else SUPER_SET_RUNTIME);
     }
     if (helpers.tagged_template_literal) {
         try buf.appendSlice(allocator, if (minify) TAGGED_TEMPLATE_RUNTIME_MIN else TAGGED_TEMPLATE_RUNTIME);

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1671,6 +1671,42 @@ test "ES2015: super.method() call" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.prototype.m.call(this)") != null);
 }
 
+test "ES2015: super property get/set receiver 보존" {
+    var r1 = try e2eTarget(std.testing.allocator, "class C extends P{m(){return super.x;}}", .es5);
+    defer r1.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "__superGet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "_super.prototype.x") == null);
+
+    var r2 = try e2eTarget(std.testing.allocator, "class C extends P{m(){super.x=1;}}", .es5);
+    defer r2.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "__superSet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "_super.prototype.x=1") == null);
+}
+
+test "ES2015: super property compound assignment receiver 보존" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){super.x += 2;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.prototype.x+2") == null);
+}
+
+test "ES2015: computed super property assignment key 단일 평가" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){super[key()] += 2;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_a=key()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,_a,this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,_a") != null);
+}
+
+test "ES2015: super property update expression receiver 보존" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){return super.x++;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"x\",this)++") == null);
+}
+
 // --- class getter/setter ---
 
 test "ES2015: class getter/setter paired" {

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -132,6 +132,16 @@ const MODULES = [_]HelperModule{
         .body = .{ .plain = rt.CALL_SUPER_RUNTIME, .min = rt.CALL_SUPER_RUNTIME_MIN },
     },
     .{
+        .short = "super-get",
+        .helpers = &.{"__superGet"},
+        .body = .{ .plain = rt.SUPER_GET_RUNTIME, .min = rt.SUPER_GET_RUNTIME_MIN },
+    },
+    .{
+        .short = "super-set",
+        .helpers = &.{"__superSet"},
+        .body = .{ .plain = rt.SUPER_SET_RUNTIME, .min = rt.SUPER_SET_RUNTIME_MIN },
+    },
+    .{
         .short = "rest",
         .helpers = &.{"__rest"},
         .body = .{ .plain = rt.REST_RUNTIME, .min = rt.REST_RUNTIME_MIN },

--- a/src/runtime_helper_names.zig
+++ b/src/runtime_helper_names.zig
@@ -34,6 +34,8 @@ pub const NAMES = struct {
     pub const EXTENDS_MIN = "$eX"; // __extends (ES2015 class)
     pub const CLASS_CALL_CHECK_MIN = "$cC"; // __classCallCheck
     pub const CALL_SUPER_MIN = "$cS"; // __callSuper
+    pub const SUPER_GET_MIN = "$sPg"; // __superGet
+    pub const SUPER_SET_MIN = "$sPs"; // __superSet
     pub const ASYNC_MIN = "$aS"; // __async (async/await → generator)
     pub const ASYNC_VALUES_MIN = "$aV"; // __asyncValues (for-await-of)
     pub const GENERATOR_MIN = "$gn"; // __generator
@@ -87,6 +89,8 @@ pub const PAIRS = [_]struct { base: []const u8, short: []const u8 }{
     .{ .base = "__extends", .short = NAMES.EXTENDS_MIN },
     .{ .base = "__classCallCheck", .short = NAMES.CLASS_CALL_CHECK_MIN },
     .{ .base = "__callSuper", .short = NAMES.CALL_SUPER_MIN },
+    .{ .base = "__superGet", .short = NAMES.SUPER_GET_MIN },
+    .{ .base = "__superSet", .short = NAMES.SUPER_SET_MIN },
     .{ .base = "__async", .short = NAMES.ASYNC_MIN },
     .{ .base = "__asyncValues", .short = NAMES.ASYNC_VALUES_MIN },
     .{ .base = "__generator", .short = NAMES.GENERATOR_MIN },

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -653,20 +653,121 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return self.ast.getNode(obj).tag == .super_expression;
         }
 
-        /// super.method → Parent.prototype.method
+        const SuperPropRef = struct {
+            init: NodeIndex,
+            read: NodeIndex,
+            value: NodeIndex,
+            write: NodeIndex,
+        };
+
+        fn cloneNewNode(self: *Transformer, idx: NodeIndex) Transformer.Error!NodeIndex {
+            const cloned = try self.ast.addNode(self.ast.getNode(idx));
+            self.copySymbolId(idx, cloned);
+            return cloned;
+        }
+
+        fn makeStringLiteralFromText(self: *Transformer, text: []const u8) Transformer.Error!NodeIndex {
+            var escaped = std.ArrayList(u8).empty;
+            defer escaped.deinit(self.allocator);
+            try escaped.append(self.allocator, '"');
+            for (text) |c| {
+                switch (c) {
+                    '\\', '"' => {
+                        try escaped.append(self.allocator, '\\');
+                        try escaped.append(self.allocator, c);
+                    },
+                    else => try escaped.append(self.allocator, c),
+                }
+            }
+            try escaped.append(self.allocator, '"');
+            const lit_span = try self.ast.addString(escaped.items);
+            return self.ast.addNode(.{
+                .tag = .string_literal,
+                .span = lit_span,
+                .data = .{ .string_ref = lit_span },
+            });
+        }
+
+        fn makeStaticSuperPropArg(self: *Transformer, prop_idx: NodeIndex) Transformer.Error!NodeIndex {
+            const prop = self.ast.getNode(prop_idx);
+            const text = if (prop.tag == .identifier_reference or prop.tag == .binding_identifier)
+                self.ast.getText(prop.data.string_ref)
+            else
+                self.ast.getText(prop.span);
+            return makeStringLiteralFromText(self, text);
+        }
+
+        fn makeSuperPropRefForAssignment(self: *Transformer, prop_idx: NodeIndex, is_computed: bool, span: Span) Transformer.Error!SuperPropRef {
+            if (!is_computed) {
+                const read = try makeStaticSuperPropArg(self, prop_idx);
+                return .{
+                    .init = .none,
+                    .read = read,
+                    .value = try cloneNewNode(self, read),
+                    .write = try cloneNewNode(self, read),
+                };
+            }
+
+            const visited = try self.visitNode(prop_idx);
+            const temp_span = try es_helpers.makeTempVarSpan(self);
+            const temp_lhs = try es_helpers.makeTempVarRef(self, temp_span, span);
+            const assign = try self.ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = span,
+                .data = .{ .binary = .{
+                    .left = temp_lhs,
+                    .right = visited,
+                    .flags = @intFromEnum(token_mod.Kind.eq),
+                } },
+            });
+            return .{
+                .init = assign,
+                .read = try es_helpers.makeTempVarRef(self, temp_span, span),
+                .value = try es_helpers.makeTempVarRef(self, temp_span, span),
+                .write = try es_helpers.makeTempVarRef(self, temp_span, span),
+            };
+        }
+
+        fn wrapSuperPropInit(self: *Transformer, prop_ref: SuperPropRef, expr: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            if (prop_ref.init.isNone()) return expr;
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+            try self.scratch.append(self.allocator, prop_ref.init);
+            try self.scratch.append(self.allocator, expr);
+            const seq_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+            const seq = try self.ast.addNode(.{
+                .tag = .sequence_expression,
+                .span = span,
+                .data = .{ .list = seq_list },
+            });
+            return es_helpers.makeParenExpr(self, seq, span);
+        }
+
+        fn buildSuperPropGet(self: *Transformer, prop_arg: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            const super_class_span = self.current_super_class orelse return prop_arg;
+            const helper = try es_helpers.makeRuntimeHelperRef(self, "__superGet");
+            const proto = try buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
+            const receiver = try makeThisOrAlias(self, span);
+            self.runtime_helpers.super_get = true;
+            return es_helpers.makeCallExpr(self, helper, &.{ proto, prop_arg, receiver }, span);
+        }
+
+        fn buildSuperPropSet(self: *Transformer, prop_arg: NodeIndex, value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            const super_class_span = self.current_super_class orelse return value;
+            const helper = try es_helpers.makeRuntimeHelperRef(self, "__superSet");
+            const proto = try buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
+            const receiver = try makeThisOrAlias(self, span);
+            self.runtime_helpers.super_set = true;
+            return es_helpers.makeCallExpr(self, helper, &.{ proto, prop_arg, value, receiver }, span);
+        }
+
+        /// super.method → __superGet(Parent.prototype, "method", this)
         /// static_member_expression: extra = [object, property, flags]
         pub fn lowerSuperMember(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
-            const super_class_span = self.current_super_class orelse return self.visitMemberExpression(node);
             const e = node.data.extra;
             const prop_idx: NodeIndex = self.readNodeIdx(e, 1);
             const span = node.span;
-
-            // Parent.prototype
-            const proto_member = try buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
-
-            // Parent.prototype.method
-            const new_prop = try self.visitNode(prop_idx);
-            return es_helpers.makeStaticMember(self, proto_member, new_prop, span);
+            return buildSuperPropGet(self, try makeStaticSuperPropArg(self, prop_idx), span);
         }
 
         /// computed_member_expression의 object가 super_expression인지 확인.
@@ -680,15 +781,157 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return self.ast.getNode(obj).tag == .super_expression;
         }
 
-        /// super["prop"] → Parent.prototype["prop"]
+        /// super["prop"] → __superGet(Parent.prototype, "prop", this)
         pub fn lowerSuperComputedMember(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
-            const super_class_span = self.current_super_class orelse return self.visitMemberExpression(node);
             const e = node.data.extra;
             const prop_idx: NodeIndex = self.readNodeIdx(e, 1);
             const span = node.span;
-            const proto_member = try buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
-            const new_prop = try self.visitNode(prop_idx);
-            return es_helpers.makeComputedMember(self, proto_member, new_prop, span);
+            return buildSuperPropGet(self, try self.visitNode(prop_idx), span);
+        }
+
+        /// super.x = v / super.x += v / super.x ||= v 를 receiver 보존 helper로 낮춘다.
+        pub fn lowerSuperPropertyAssignment(self: *Transformer, node: Node) ?Transformer.Error!NodeIndex {
+            const left_idx = node.data.binary.left;
+            if (left_idx.isNone()) return null;
+            const left = self.ast.getNode(left_idx);
+            const is_computed = switch (left.tag) {
+                .static_member_expression => false,
+                .computed_member_expression => true,
+                else => return null,
+            };
+            const le = left.data.extra;
+            if (le >= self.ast.extra_data.items.len) return null;
+            const obj_idx: NodeIndex = self.readNodeIdx(le, 0);
+            if (obj_idx.isNone() or self.ast.getNode(obj_idx).tag != .super_expression) return null;
+
+            const prop_idx: NodeIndex = self.readNodeIdx(le, 1);
+            const op_kind: token_mod.Kind = @enumFromInt(node.data.binary.flags);
+            const span = node.span;
+
+            if (op_kind == .eq) {
+                const prop_arg = if (is_computed)
+                    try self.visitNode(prop_idx)
+                else
+                    try makeStaticSuperPropArg(self, prop_idx);
+                const new_rhs = try self.visitNode(node.data.binary.right);
+                return buildSuperPropSet(self, prop_arg, new_rhs, span);
+            }
+
+            const prop_ref = try makeSuperPropRefForAssignment(self, prop_idx, is_computed, span);
+
+            if (op_kind == .question2_eq or op_kind == .pipe2_eq or op_kind == .amp2_eq) {
+                const get_read = try buildSuperPropGet(self, prop_ref.read, span);
+                const new_rhs = try self.visitNode(node.data.binary.right);
+                const set_call = try buildSuperPropSet(self, prop_ref.write, new_rhs, span);
+
+                if (op_kind == .pipe2_eq or op_kind == .amp2_eq) {
+                    const logical_op: token_mod.Kind = if (op_kind == .pipe2_eq) .pipe2 else .amp2;
+                    const logical = try self.ast.addNode(.{
+                        .tag = .logical_expression,
+                        .span = span,
+                        .data = .{ .binary = .{ .left = get_read, .right = set_call, .flags = @intFromEnum(logical_op) } },
+                    });
+                    return wrapSuperPropInit(self, prop_ref, logical, span);
+                }
+
+                if (self.options.unsupported.nullish_coalescing) {
+                    const neq_null = try es_helpers.makeNeqNull(self, get_read, span);
+                    const get_value = try buildSuperPropGet(self, prop_ref.value, span);
+                    const cond = try self.ast.addNode(.{
+                        .tag = .conditional_expression,
+                        .span = span,
+                        .data = .{ .ternary = .{ .a = neq_null, .b = get_value, .c = set_call } },
+                    });
+                    return wrapSuperPropInit(self, prop_ref, cond, span);
+                }
+                const logical = try self.ast.addNode(.{
+                    .tag = .logical_expression,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = get_read, .right = set_call, .flags = @intFromEnum(token_mod.Kind.question2) } },
+                });
+                return wrapSuperPropInit(self, prop_ref, logical, span);
+            }
+
+            if (compoundAssignBaseOp(node.data.binary.flags)) |bin_op| {
+                const get_call = try buildSuperPropGet(self, prop_ref.read, span);
+                const new_rhs = try self.visitNode(node.data.binary.right);
+                const computed = if (bin_op == @intFromEnum(token_mod.Kind.star2) and self.options.unsupported.exponentiation)
+                    try es_helpers.makeMathPowCall(self, get_call, new_rhs, span)
+                else
+                    try self.ast.addNode(.{
+                        .tag = .binary_expression,
+                        .span = span,
+                        .data = .{ .binary = .{ .left = get_call, .right = new_rhs, .flags = bin_op } },
+                    });
+                const set_call = try buildSuperPropSet(self, prop_ref.write, computed, span);
+                return wrapSuperPropInit(self, prop_ref, set_call, span);
+            }
+
+            return null;
+        }
+
+        /// super.x++ / --super[x] 도 get/set helper로 낮춘다.
+        pub fn lowerSuperPropertyUpdate(self: *Transformer, node: Node, op_flags: u32, span: Span) ?Transformer.Error!NodeIndex {
+            const is_computed = switch (node.tag) {
+                .static_member_expression => false,
+                .computed_member_expression => true,
+                else => return null,
+            };
+            const e = node.data.extra;
+            if (e >= self.ast.extra_data.items.len) return null;
+            const obj_idx: NodeIndex = self.readNodeIdx(e, 0);
+            if (obj_idx.isNone() or self.ast.getNode(obj_idx).tag != .super_expression) return null;
+
+            const op_kind = op_flags & 0xff;
+            const is_increment = (op_kind == @intFromEnum(token_mod.Kind.plus2));
+            const is_postfix = (op_flags & ast_mod.UnaryFlags.postfix) != 0;
+            const bin_op: u16 = if (is_increment) @intFromEnum(token_mod.Kind.plus) else @intFromEnum(token_mod.Kind.minus);
+            const prop_ref = try makeSuperPropRefForAssignment(self, self.readNodeIdx(e, 1), is_computed, span);
+
+            if (is_postfix) {
+                const scratch_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+                const temp_span = try es_helpers.makeTempVarSpan(self);
+                const get_call = try buildSuperPropGet(self, prop_ref.read, span);
+                const tmp_lhs = try es_helpers.makeTempVarRef(self, temp_span, span);
+                const init_old = try self.ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = span,
+                    .data = .{ .binary = .{ .left = tmp_lhs, .right = get_call, .flags = @intFromEnum(token_mod.Kind.eq) } },
+                });
+                try self.scratch.append(self.allocator, init_old);
+
+                const computed = try self.ast.addNode(.{
+                    .tag = .binary_expression,
+                    .span = span,
+                    .data = .{ .binary = .{
+                        .left = try es_helpers.makeTempVarRef(self, temp_span, span),
+                        .right = try es_helpers.makeNumericLiteral(self, 1),
+                        .flags = bin_op,
+                    } },
+                });
+                try self.scratch.append(self.allocator, try buildSuperPropSet(self, prop_ref.write, computed, span));
+                try self.scratch.append(self.allocator, try es_helpers.makeTempVarRef(self, temp_span, span));
+
+                const seq_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+                const seq = try self.ast.addNode(.{
+                    .tag = .sequence_expression,
+                    .span = span,
+                    .data = .{ .list = seq_list },
+                });
+                const paren = try es_helpers.makeParenExpr(self, seq, span);
+                return wrapSuperPropInit(self, prop_ref, paren, span);
+            }
+
+            const get_call = try buildSuperPropGet(self, prop_ref.read, span);
+            const computed = try self.ast.addNode(.{
+                .tag = .binary_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = get_call, .right = try es_helpers.makeNumericLiteral(self, 1), .flags = bin_op } },
+            });
+            const set_call = try buildSuperPropSet(self, prop_ref.write, computed, span);
+            return wrapSuperPropInit(self, prop_ref, set_call, span);
         }
 
         /// call_expression의 callee가 super["method"] 인지 확인.

--- a/src/transformer/runtime_helper_imports.zig
+++ b/src/transformer/runtime_helper_imports.zig
@@ -49,6 +49,8 @@ const HelperBit = enum {
     class_private_method_get,
     class_call_check,
     call_super,
+    super_get,
+    super_set,
     tagged_template_literal,
     using_ctx,
     class_static_private_field,
@@ -77,6 +79,8 @@ const BIT_DEFS = [_]BitDef{
     .{ .bit = .class_private_method_get, .bases = &.{"__classPrivateMethodGet"} },
     .{ .bit = .class_call_check, .bases = &.{"__classCallCheck"} },
     .{ .bit = .call_super, .bases = &.{"__callSuper"} },
+    .{ .bit = .super_get, .bases = &.{"__superGet"} },
+    .{ .bit = .super_set, .bases = &.{"__superSet"} },
     .{ .bit = .tagged_template_literal, .bases = &.{"__taggedTemplateLiteral"} },
     .{ .bit = .using_ctx, .bases = &.{ "__using", "__callDispose" } },
     .{ .bit = .class_static_private_field, .bases = &.{

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -223,13 +223,17 @@ pub const RuntimeHelpers = packed struct(u32) {
     es_decorator: bool = false,
     /// __asyncValues: for-await-of → while 루프 변환 (ES2018)
     async_values: bool = false,
+    /// __superGet: super property get receiver 보존 (ES2015 class)
+    super_get: bool = false,
+    /// __superSet: super property set receiver 보존 (ES2015 class)
+    super_set: bool = false,
     /// __classPrivateFieldSet: instance private field set with return value (#1488).
     class_private_field_set: bool = false,
     /// __asyncGenerator: `async function*` → Symbol.asyncIterator 객체 (ES2018, #1911)
     async_generator: bool = false,
     /// __await: async generator body 안 await 표현 wrapper (ES2018, #1911)
     await_helper: bool = false,
-    _padding: u12 = 0,
+    _padding: u10 = 0,
 };
 
 /// 단일 AST append-only 변환기.
@@ -946,6 +950,15 @@ pub const Transformer = struct {
                 return self.visitBinaryNode(idx);
             },
             .assignment_expression => {
+                // ES2015: super.x = v / super.x += v / super.x ||= v 는
+                // Parent.prototype.x 직접 접근이 아니라 receiver(this)를 보존하는 get/set
+                // 헬퍼로 먼저 lowering한다. 이후 generic logical/compound lowering으로 넘기면
+                // helper call에 대입하는 잘못된 target이 생성된다.
+                if (self.options.unsupported.class and self.current_super_class != null) {
+                    if (es2015_class.ES2015Class(Transformer).lowerSuperPropertyAssignment(self, node)) |result| {
+                        return result;
+                    }
+                }
                 // Private field 좌변은 모든 assignment 연산자(=, +=, ??=, ||=, &&= ...)를
                 // lowerPrivateFieldSet 단일 경로에서 처리 — es2021/es2016 등은 좌변에
                 // `(a = b)` 패턴을 만들어 get()/helper call에 대입하게 되므로 먼저 가로챈다.
@@ -1641,6 +1654,11 @@ pub const Transformer = struct {
         // private field update: this.#x++ → _x.set(this, _x.get(this) + 1)
         if (node.tag == .update_expression and (self.options.unsupported.class or self.options.unsupported.class_private_field)) {
             const operand = self.ast.getNode(operand_idx);
+            if (self.options.unsupported.class and self.current_super_class != null) {
+                if (es2015_class.ES2015Class(Transformer).lowerSuperPropertyUpdate(self, operand, op_flags, node.span)) |result| {
+                    return try result;
+                }
+            }
             if (operand.tag == .private_field_expression) {
                 if (es2015_class.ES2015Class(Transformer).lowerPrivateFieldUpdate(self, operand, op_flags, node.span)) |result| {
                     return try result;

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1325,6 +1325,131 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("Hello WORLD!");
     });
 
+    test("super property get/set receiver 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base {
+              v = 2;
+              get x() {
+                return this.v;
+              }
+              set x(value: number) {
+                this.v = value;
+              }
+            }
+            class Child extends Base {
+              run() {
+                const before = super.x;
+                super.x = before + 3;
+                return this.v;
+              }
+            }
+            console.log(new Child().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("5");
+    });
+
+    test("super property compound assignment receiver 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base {
+              v = 2;
+              get x() {
+                return this.v;
+              }
+              set x(value: number) {
+                this.v = value;
+              }
+            }
+            class Child extends Base {
+              run() {
+                super.x += 3;
+                return this.v;
+              }
+            }
+            console.log(new Child().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("5");
+    });
+
+    test("computed super property compound assignment key 단일 평가", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let count = 0;
+            class Base {
+              v = 2;
+              get x() {
+                return this.v;
+              }
+              set x(value: number) {
+                this.v = value;
+              }
+            }
+            class Child extends Base {
+              key() {
+                count++;
+                return "x";
+              }
+              run() {
+                super[this.key()] += 3;
+                return this.v + ":" + count;
+              }
+            }
+            console.log(new Child().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("5:1");
+    });
+
+    test("super property update expression receiver 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base {
+              v = 2;
+              get x() {
+                return this.v;
+              }
+              set x(value: number) {
+                this.v = value;
+              }
+            }
+            class Child extends Base {
+              run() {
+                return super.x++ + ":" + this.v;
+              }
+            }
+            console.log(new Child().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("2:3");
+    });
+
     // --- SWC 대비 추가 테스트: Destructuring ---
 
     test("sparse array destructuring", async () => {


### PR DESCRIPTION
## Summary
- Reproduce and fix ES5 class downleveling for `super` property get/set so accessor receiver stays as the child instance.
- Add `__superGet` / `__superSet` runtime helpers and route super property assignment, compound/logical assignment, computed keys, and update expressions through them.
- Add Zig codegen and TS runtime regression cases, including computed key single-evaluation and postfix update.

## Root cause
`super.x` was lowered to `_super.prototype.x`. That reads/writes through the parent prototype object, so getters/setters run with the wrong receiver and writes do not update the child instance. Compound/update forms also inherited the same invalid target shape.

## Verification
- `zig build test -Dtest-filter="super property"`
- `zig build test -Dtest-filter="computed super"`
- `zig build test -Dtest-filter="update expression"`
- `zig build test -Dtest-filter="ES2015:"`
- `zig build test`
- direct `bundleAndRun` smoke for get/set, compound, computed compound, update, logical, computed logical, optional super
- `bun run fmt:check`
- `bun run lint` (warnings only, existing unrelated warnings)
- pre-push hook passed (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`)