### PR TITLE
fix(transformer): static super downlevel receiver

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1707,6 +1707,19 @@ test "ES2015: super property update expression receiver 보존" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"x\",this)++") == null);
 }
 
+test "ES2015: static super access는 parent constructor 참조" {
+    var r1 = try e2eTarget(std.testing.allocator, "class C extends P{static m(){return super.x+super.m();}}", .es5);
+    defer r1.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "__superGet(_super,\"x\",this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "_super.m.call(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "_super.prototype") == null);
+
+    var r2 = try e2eTarget(std.testing.allocator, "class C extends P{static x=super.y;}", .es5);
+    defer r2.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "__superGet(_super,\"y\",C)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "_super.prototype") == null);
+}
+
 // --- class getter/setter ---
 
 test "ES2015: class getter/setter paired" {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -98,10 +98,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // super class context 설정 (constructor/method body 방문 시 사용)
             const saved_super = self.current_super_class;
             const saved_super_old_idx = self.current_super_class_old_idx;
+            const saved_super_static = self.current_super_is_static;
+            const saved_super_static_receiver = self.current_super_static_receiver;
             self.current_super_class = super_span;
             self.current_super_class_old_idx = super_idx;
+            self.current_super_is_static = false;
+            self.current_super_static_receiver = null;
             defer self.current_super_class = saved_super;
             defer self.current_super_class_old_idx = saved_super_old_idx;
+            defer self.current_super_is_static = saved_super_static;
+            defer self.current_super_static_receiver = saved_super_static_receiver;
 
             // 클래스 바디 멤버 분류
             var cm = try classifyMembers(self, body_idx, span, name_span);
@@ -214,6 +220,18 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             self.pending_nodes.shrinkRetainingCapacity(pending_top);
 
+            // static fields/blocks 는 class evaluation 중 실행된다. extends class 의 경우 IIFE
+            // 밖으로 내보내면 super lowering 이 참조하는 _super scope가 사라지므로 IIFE 내부에서
+            // __extends 이후, return 이전에 실행한다.
+            for (cm.static_fields.items) |field| {
+                const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, fresh_name_span);
+                const static_assign = try buildStaticFieldAssignWithCtx(self, class_ref, field.key, field.init, fresh_name_span, span);
+                try self.scratch.append(self.allocator, static_assign);
+            }
+            for (cm.static_block_stmts.items) |sb_stmt| {
+                try self.scratch.append(self.allocator, sb_stmt);
+            }
+
             // return ClassName;
             try self.scratch.append(self.allocator, try self.ast.addNode(.{
                 .tag = .return_statement,
@@ -254,16 +272,6 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const declarator = try es_helpers.makeDeclarator(self, new_name, iife_call, span);
             const var_decl = try es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", span);
             try self.pending_nodes.append(self.allocator, var_decl);
-
-            // static fields → IIFE 밖 (init에서 ClassName 자기참조 시 이미 할당된 상태)
-            for (cm.static_fields.items) |field| {
-                const class_ref = try self.makeIdentifierRefWithSymbol(name_span, name_idx);
-                const static_assign = try buildFieldAssign(self, class_ref, field.key, field.init, span);
-                try self.pending_nodes.append(self.allocator, static_assign);
-            }
-            for (cm.static_block_stmts.items) |sb_stmt| {
-                try self.pending_nodes.append(self.allocator, sb_stmt);
-            }
 
             // experimentalDecorators
             if (self.options.experimental_decorators) {
@@ -323,10 +331,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             const saved_super = self.current_super_class;
             const saved_super_old_idx = self.current_super_class_old_idx;
+            const saved_super_static = self.current_super_is_static;
+            const saved_super_static_receiver = self.current_super_static_receiver;
             self.current_super_class = super_span;
             self.current_super_class_old_idx = super_idx;
+            self.current_super_is_static = false;
+            self.current_super_static_receiver = null;
             defer self.current_super_class = saved_super;
             defer self.current_super_class_old_idx = saved_super_old_idx;
+            defer self.current_super_is_static = saved_super_static;
+            defer self.current_super_static_receiver = saved_super_static_receiver;
 
             // 바디 멤버 분류
             var cm = try classifyMembers(self, body_idx, span, name_span);
@@ -467,7 +481,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             try self.scratch.appendSlice(self.allocator, self.pending_nodes.items[pending_top..]);
 
             for (cm.static_fields.items) |field| {
-                try self.scratch.append(self.allocator, try buildFieldAssign(self, try es_helpers.makeIdentifierRefFromSpan(self, name_span), field.key, field.init, span));
+                try self.scratch.append(self.allocator, try buildStaticFieldAssignWithCtx(self, try es_helpers.makeIdentifierRefFromSpan(self, name_span), field.key, field.init, name_span, span));
             }
             for (cm.static_block_stmts.items) |sb_stmt| {
                 try self.scratch.append(self.allocator, sb_stmt);
@@ -591,8 +605,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
         }
 
         /// super.method(args) → Parent.prototype.method.call(this, args)
+        /// static method 안에서는 Parent.method.call(this, args)
         pub fn lowerSuperMethodCall(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
-            const super_class_span = self.current_super_class orelse return self.visitCallExpression(node);
+            _ = self.current_super_class orelse return self.visitCallExpression(node);
             const e = node.data.extra;
             const callee_idx: NodeIndex = self.readNodeIdx(e, 0);
             const args_start = self.readU32(e, 1);
@@ -604,18 +619,17 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const ce = callee_node.data.extra;
             const method_prop_idx: NodeIndex = self.readNodeIdx(ce, 1);
 
-            // Parent.prototype.method
-            const proto_member = try buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
-
+            // Parent.prototype.method 또는 static Parent.method
+            const super_base = try buildSuperBaseRef(self, span);
             const new_method_prop = try self.visitNode(method_prop_idx);
-            const method_member = try es_helpers.makeStaticMember(self, proto_member, new_method_prop, span);
+            const method_member = try es_helpers.makeStaticMember(self, super_base, new_method_prop, span);
 
             // Parent.prototype.method.call
             const call_prop = try es_helpers.makeIdentifierRef(self, "call");
             const call_callee = try es_helpers.makeStaticMember(self, method_member, call_prop, span);
 
             // args: [this, ...original_args]
-            const this_node = try makeThisOrAlias(self, span);
+            const this_node = try buildSuperReceiver(self, span);
 
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
@@ -743,22 +757,37 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return es_helpers.makeParenExpr(self, seq, span);
         }
 
+        fn buildSuperBaseRef(self: *Transformer, span: Span) Transformer.Error!NodeIndex {
+            const super_class_span = self.current_super_class orelse return NodeIndex.none;
+            if (self.current_super_is_static) {
+                return self.makeIdentifierRefWithSymbol(super_class_span, self.current_super_class_old_idx);
+            }
+            return buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
+        }
+
+        fn buildSuperReceiver(self: *Transformer, span: Span) Transformer.Error!NodeIndex {
+            if (self.current_super_static_receiver) |receiver_span| {
+                return es_helpers.makeIdentifierRefFromSpan(self, receiver_span);
+            }
+            return makeThisOrAlias(self, span);
+        }
+
         fn buildSuperPropGet(self: *Transformer, prop_arg: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const super_class_span = self.current_super_class orelse return prop_arg;
+            _ = self.current_super_class orelse return prop_arg;
             const helper = try es_helpers.makeRuntimeHelperRef(self, "__superGet");
-            const proto = try buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
-            const receiver = try makeThisOrAlias(self, span);
+            const base = try buildSuperBaseRef(self, span);
+            const receiver = try buildSuperReceiver(self, span);
             self.runtime_helpers.super_get = true;
-            return es_helpers.makeCallExpr(self, helper, &.{ proto, prop_arg, receiver }, span);
+            return es_helpers.makeCallExpr(self, helper, &.{ base, prop_arg, receiver }, span);
         }
 
         fn buildSuperPropSet(self: *Transformer, prop_arg: NodeIndex, value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const super_class_span = self.current_super_class orelse return value;
+            _ = self.current_super_class orelse return value;
             const helper = try es_helpers.makeRuntimeHelperRef(self, "__superSet");
-            const proto = try buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
-            const receiver = try makeThisOrAlias(self, span);
+            const base = try buildSuperBaseRef(self, span);
+            const receiver = try buildSuperReceiver(self, span);
             self.runtime_helpers.super_set = true;
-            return es_helpers.makeCallExpr(self, helper, &.{ proto, prop_arg, value, receiver }, span);
+            return es_helpers.makeCallExpr(self, helper, &.{ base, prop_arg, value, receiver }, span);
         }
 
         /// super.method → __superGet(Parent.prototype, "method", this)
@@ -951,8 +980,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
         }
 
         /// super["method"](args) → Parent.prototype["method"].call(this, args)
+        /// static method 안에서는 Parent["method"].call(this, args)
         pub fn lowerSuperComputedMethodCall(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
-            const super_class_span = self.current_super_class orelse return self.visitCallExpression(node);
+            _ = self.current_super_class orelse return self.visitCallExpression(node);
             const e = node.data.extra;
             const callee_idx: NodeIndex = self.readNodeIdx(e, 0);
             const args_start = self.readU32(e, 1);
@@ -963,14 +993,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const ce = callee_node.data.extra;
             const method_prop_idx: NodeIndex = self.readNodeIdx(ce, 1);
 
-            const proto_member = try buildPrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
+            const super_base = try buildSuperBaseRef(self, span);
             const new_method_prop = try self.visitNode(method_prop_idx);
-            const method_member = try es_helpers.makeComputedMember(self, proto_member, new_method_prop, span);
+            const method_member = try es_helpers.makeComputedMember(self, super_base, new_method_prop, span);
 
             const call_prop = try es_helpers.makeIdentifierRef(self, "call");
             const call_callee = try es_helpers.makeStaticMember(self, method_member, call_prop, span);
 
-            const this_node = try makeThisOrAlias(self, span);
+            const this_node = try buildSuperReceiver(self, span);
 
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
@@ -1786,11 +1816,17 @@ pub fn ES2015Class(comptime Transformer: type) type {
                             // this_depth > 0이므로 영향받지 않음.
                             const saved_sb_name = self.static_block_class_name;
                             const saved_sb_depth = self.this_depth;
+                            const saved_super_static = self.current_super_is_static;
+                            const saved_super_static_receiver = self.current_super_static_receiver;
                             self.static_block_class_name = class_name_span;
                             self.this_depth = 0;
+                            self.current_super_is_static = true;
+                            self.current_super_static_receiver = class_name_span;
                             defer {
                                 self.static_block_class_name = saved_sb_name;
                                 self.this_depth = saved_sb_depth;
+                                self.current_super_is_static = saved_super_static;
+                                self.current_super_static_receiver = saved_super_static_receiver;
                             }
                             const sb_stmts_start = sb_body.data.list.start;
                             const sb_stmts_len = sb_body.data.list.len;
@@ -2125,6 +2161,18 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
             });
+        }
+
+        fn buildStaticFieldAssignWithCtx(self: *Transformer, obj: NodeIndex, key_idx: NodeIndex, init_idx: NodeIndex, class_name_span: Span, span: Span) Transformer.Error!NodeIndex {
+            const saved_static = self.current_super_is_static;
+            const saved_receiver = self.current_super_static_receiver;
+            self.current_super_is_static = true;
+            self.current_super_static_receiver = class_name_span;
+            defer {
+                self.current_super_is_static = saved_static;
+                self.current_super_static_receiver = saved_receiver;
+            }
+            return buildFieldAssign(self, obj, key_idx, init_idx, span);
         }
 
         /// function_declaration의 body 앞에 문들을 삽입 (in-place).
@@ -2596,6 +2644,15 @@ pub fn ES2015Class(comptime Transformer: type) type {
         /// method → ClassName.prototype.method = function() {} (expression_statement)
         /// static method → ClassName.method = function() {}
         fn buildPrototypeAssignment(self: *Transformer, info: MethodInfo, class_name_span: Span, span: Span) Transformer.Error!NodeIndex {
+            const saved_static = self.current_super_is_static;
+            const saved_receiver = self.current_super_static_receiver;
+            self.current_super_is_static = info.is_static;
+            self.current_super_static_receiver = null;
+            defer {
+                self.current_super_is_static = saved_static;
+                self.current_super_static_receiver = saved_receiver;
+            }
+
             const member = self.ast.getNode(info.member_idx);
             const me = member.data.extra;
             // 모든 읽기가 mutation(visitExtraList) 이전이므로 캐시 안전.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -321,6 +321,11 @@ pub const Transformer = struct {
     /// super.method() → Parent.prototype.method.call(this) 변환에 사용.
     current_super_class: ?Span = null,
     current_super_class_old_idx: NodeIndex = .none,
+    /// 현재 super member 접근이 static class element 안에서 발생하는지 여부.
+    /// static method/field/block 에서는 super base가 Parent.prototype이 아니라 Parent constructor다.
+    current_super_is_static: bool = false,
+    /// static field/block 처럼 `this` 표현식이 사라지는 위치에서 super receiver로 사용할 class 이름.
+    current_super_static_receiver: ?Span = null,
 
     /// ES2015 generator: labeled break/continue를 위한 label 스택.
     /// labeled_statement 진입 시 push, 퇴장 시 pop.

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1450,6 +1450,94 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("2:3");
     });
 
+    test("static super property/method receiver 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base {
+              static v = 1;
+              static get x() {
+                return this.v;
+              }
+              static m() {
+                return this.v;
+              }
+            }
+            class Child extends Base {
+              static v = 2;
+              static run() {
+                return super.x + ":" + super.m();
+              }
+            }
+            console.log(Child.run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("2:2");
+    });
+
+    test("static super compound assignment receiver 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base {
+              static v = 1;
+              static get x() {
+                return this.v;
+              }
+              static set x(value: number) {
+                this.v = value;
+              }
+            }
+            class Child extends Base {
+              static v = 2;
+              static run() {
+                super.x += 3;
+                return this.v;
+              }
+            }
+            console.log(Child.run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("5");
+    });
+
+    test("static field와 static block super receiver 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class Base {
+              static v = 3;
+              static get x() {
+                return this.v;
+              }
+            }
+            class Child extends Base {
+              static v = 4;
+              static y = super.x;
+              static {
+                console.log(super.x + ":" + this.y);
+              }
+            }
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("4:4");
+    });
+
     // --- SWC 대비 추가 테스트: Destructuring ---
 
     test("sparse array destructuring", async () => {


### PR DESCRIPTION
## Summary
- Fixes #1995.
- Preserve static `super` base/receiver when lowering ES2015 classes to ES5.
- Keep static fields and static blocks inside the class IIFE so `_super` remains in scope during static `super` lowering.
- Add Zig codegen and TS runtime regression tests for static method calls, static property get/set, compound assignment, static fields, and static blocks.

## Root cause
The ES2015 class transform always treated `super` member access as instance access, building `Parent.prototype` as the base and `this` as the receiver. That is only valid for instance methods. Static methods/fields/blocks need the parent constructor as the base and the current class constructor as the receiver when there is no runtime `this` expression.

## Verification
- `zig build test -Dtest-filter="static super"`
- `zig build test -Dtest-filter="super property"`
- `zig build test -Dtest-filter="ES2015:"`
- `zig build test`
- direct `bundleAndRun` smoke for static super method/property, compound assignment, static field/static block
- `bun run fmt:check`
- `bun run lint` (warnings only, existing unrelated warnings)
- pre-push hook passed (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`)