### PR TITLE
fix(bundler): mangle wrapper synthetic symbols

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -102,6 +102,76 @@ test "Bundler: minified output" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "// ---") == null);
 }
 
+test "Bundler: minify가 래퍼 합성 심볼을 짧은 이름으로 바꿈" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\import { value } from './feature.js';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "feature.js",
+        \\export const value = 42;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "init_") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports_") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log") != null);
+}
+
+test "Bundler: minify가 require 래퍼 합성 심볼도 짧은 이름으로 바꿈" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\const esm = require('./esm.js');
+        \\const cjs = require('./cjs.cjs');
+        \\console.log(esm.value + cjs.value);
+    );
+    try writeFile(tmp.dir, "esm.js",
+        \\export const value = 40;
+    );
+    try writeFile(tmp.dir, "cjs.cjs",
+        \\exports.value = 2;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "init_") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports_") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log") != null);
+}
+
 test "Bundler: unresolved import produces error diagnostic" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -960,15 +960,27 @@ pub const Linker = struct {
                 if (!blocks) {
                     for (sem.symbols.items, 0..) |*sym, si| {
                         const sk = sym.synthetic_kind orelse continue;
-                        if (sk != .default_export) continue;
+                        switch (sk) {
+                            .default_export, .cjs_exports, .esm_init => {},
+                        }
                         const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym.synthetic_name;
                         if (key.len <= 1) continue;
                         if (exported.contains(key)) continue;
+
+                        // 래퍼 심볼(`init_<path>`, `exports_<path>`)은 소스 AST가 아니라
+                        // 번들러가 직접 emit하므로 semantic reference_count가 보통 0이다.
+                        // 그래도 선언과 cross-module 호출에 실제로 등장하고 RN 번들에서는
+                        // 매우 길어지므로, 작은 0이 아닌 가중치로 최상위 망글 후보에 남긴다.
+                        const ref_count: u32 = if ((sk == .cjs_exports or sk == .esm_init) and sym.reference_count == 0)
+                            1
+                        else
+                            sym.reference_count;
+
                         try candidates.append(self.allocator, .{
                             .module_index = @intCast(mi),
                             .symbol_id = @intCast(si),
                             .name = key,
-                            .ref_count = sym.reference_count,
+                            .ref_count = ref_count,
                         });
                     }
                 }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -240,14 +240,18 @@ pub const Module = struct {
         ready,
     };
 
-    /// 등록된 합성 심볼의 이름(synthetic_name)을 반환. 미등록이면 null.
+    /// 등록된 합성 심볼의 출력 이름을 반환. 링커/망글러가 canonical_name 을
+    /// 주입한 경우 릴리즈/압축 출력에서는 그 이름을 우선 사용한다.
+    /// 미등록이면 null.
     /// 반환 slice는 parse_arena가 소유 — 모듈 수명 내 유효.
     fn syntheticName(self: *const Module, maybe_id: ?SemanticSymbolId) ?[]const u8 {
         const id = maybe_id orelse return null;
         const sem = self.semantic orelse return null;
         const idx: u32 = @intFromEnum(id);
         if (idx >= sem.symbols.items.len) return null;
-        const name = sem.symbols.items[idx].synthetic_name;
+        const sym = sem.symbols.items[idx];
+        if (sym.canonical_name.len > 0) return sym.canonical_name;
+        const name = sym.synthetic_name;
         return if (name.len > 0) name else null;
     }
 


### PR DESCRIPTION
## 요약
- RN 릴리즈 번들에서 `init_<path>`, `exports_<path>` 래퍼 합성 심볼이 minify 대상에서 빠지던 문제를 수정했습니다.
- 링커가 `default_export`뿐 아니라 `esm_init`, `cjs_exports` 합성 심볼도 최상위 망글 후보에 포함합니다.
- emitter가 합성 심볼 출력 이름을 가져올 때 `canonical_name`을 우선 사용하도록 바꿨습니다.
- 정적 ESM import와 `require()` 래퍼 경로 회귀 테스트를 추가했습니다.

## 검증
- `zig fmt src/bundler/module.zig src/bundler/linker.zig src/bundler/bundler_test/basic.zig`
- `zig build test -Doptimize=Debug`
- `zig build napi -Doptimize=ReleaseFast`
- 번개 `bun run build`
- ExampleApp iOS/Android release bundle 재생성 및 용량 비교

## 실측
- iOS raw: 3,702,438 -> 3,248,138 bytes, 약 454KB 감소
- Android raw: 3,714,721 -> 3,256,814 bytes, 약 458KB 감소
- iOS gzip: 788,171 -> 767,207 bytes
- Android gzip: 790,411 -> 769,349 bytes
- 래퍼 이름 문자 합: iOS 491,208 -> 12,830, Android 495,026 -> 12,857

## 메모
- 압축 후 감소 폭이 raw보다 작은 이유는 긴 경로 기반 이름이 반복되어 gzip/brotli에서 이미 잘 압축되기 때문입니다.
- Metro 대비 남은 차이는 dev-only 모듈 포함, RN 래퍼 구조, 추가 helper/preamble, minifier 고도화 차이를 별도 이슈로 계속 추적해야 합니다.
