### PR TITLE
fix: define class methods with descriptors

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -681,7 +681,7 @@ test "ES5: class with async method + non-async method" {
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__generator") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "yield") == null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "prototype.sync") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(Foo.prototype,\"sync\"") != null);
 }
 
 test "ES5: async with while(true) + await + break" {
@@ -1506,14 +1506,14 @@ test "ES2015: class with constructor and methods" {
     var r = try e2eTarget(std.testing.allocator, "class Foo{constructor(x){this.x=x;}method(){return this.x;}}", .es5);
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "function Foo(x)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Foo.prototype.method=function()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(Foo.prototype,\"method\"") != null);
 }
 
 test "ES2015: class with static method" {
     var r = try e2eTarget(std.testing.allocator, "class Foo{static create(){return 1;}}", .es5);
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "function Foo()") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Foo.create=function()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(Foo,\"create\"") != null);
 }
 
 test "ES2015: empty class" {
@@ -1752,6 +1752,16 @@ test "ES2015: class getter/setter paired" {
     // "get:" 와 "set:" 가 같은 호출 안에 있어야 함
     try std.testing.expect(std.mem.indexOf(u8, r.output, "get:function()") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "set:function(x)") != null);
+}
+
+test "ES2015: class method descriptor는 enumerable false" {
+    var r = try e2eTarget(std.testing.allocator, "class F{m(){return 1;}static s(){return 2;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(F.prototype,\"m\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(F,\"s\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "configurable:true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "writable:true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "F.prototype.m=function") == null);
 }
 
 test "ES2015: class static getter" {
@@ -2056,10 +2066,10 @@ test "ES2015: class with computed method" {
 }
 
 test "ES2015: class with computed method uses bracket notation" {
-    // [Symbol.iterator]() → prototype[Symbol.iterator] = function() (dot 없이)
+    // [Symbol.iterator]() → Object.defineProperty(prototype, Symbol.iterator, ...) (dot 없이)
     var r = try e2eTarget(std.testing.allocator, "class F{[Symbol.iterator](){return this;}}", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "prototype[Symbol.iterator]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(F.prototype,Symbol.iterator") != null);
     // prototype.[Symbol.iterator] (잘못된 dot notation) 금지
     try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "prototype.["), null);
 }

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -50,8 +50,8 @@ test "private method: es5 → WeakSet + function + prototype" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "function Foo()") != null);
     // WeakSet
     try std.testing.expect(std.mem.indexOf(u8, r.output, "var _bar=new WeakSet") != null);
-    // prototype method
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Foo.prototype.method=function()") != null);
+    // prototype method descriptor
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(Foo.prototype,\"method\"") != null);
     // brand check
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodInit(this,_bar)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodGet(this,_bar,_bar_fn).call(this)") != null);

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2927,22 +2927,56 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
         }
 
-        /// target.methodName = func_expr (expression_statement)
+        fn buildBooleanProp(self: *Transformer, name: []const u8, value: bool, span: Span) Transformer.Error!NodeIndex {
+            const key = try es_helpers.makeIdentifierRef(self, name);
+            const value_span = try self.ast.addString(if (value) "true" else "false");
+            const val = try self.ast.addNode(.{
+                .tag = .boolean_literal,
+                .span = value_span,
+                .data = .{ .none = if (value) 0 else 1 },
+            });
+            return self.ast.addNode(.{
+                .tag = .object_property,
+                .span = span,
+                .data = .{ .binary = .{ .left = key, .right = val, .flags = 0 } },
+            });
+        }
+
+        fn buildValueProp(self: *Transformer, value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            const key = try es_helpers.makeIdentifierRef(self, "value");
+            return self.ast.addNode(.{
+                .tag = .object_property,
+                .span = span,
+                .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
+            });
+        }
+
+        /// method → Object.defineProperty(ClassName.prototype, "method", { configurable: true, writable: true, value: function() {} })
+        /// static method → Object.defineProperty(ClassName, "method", { configurable: true, writable: true, value: function() {} })
         fn buildMethodAssignment(self: *Transformer, info: MethodInfo, class_name_span: Span, key_idx: NodeIndex, func_expr: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const target = if (info.is_static)
                 try es_helpers.makeIdentifierRefFromSpan(self, class_name_span)
             else
                 try buildFreshPrototypeRef(self, class_name_span, span);
-            const member_access = try es_helpers.makeMemberFromKeyIdx(self, target, key_idx, span);
-            const assign = try self.ast.addNode(.{
-                .tag = .assignment_expression,
+
+            const config_prop = try buildBooleanProp(self, "configurable", true, span);
+            const writable_prop = try buildBooleanProp(self, "writable", true, span);
+            const value_prop = try buildValueProp(self, func_expr, span);
+            const desc_list = try self.ast.addNodeList(&.{ config_prop, writable_prop, value_prop });
+            const desc_obj = try self.ast.addNode(.{
+                .tag = .object_expression,
                 .span = span,
-                .data = .{ .binary = .{ .left = member_access, .right = func_expr, .flags = 0 } },
+                .data = .{ .list = desc_list },
             });
+
+            const obj_str_span = try self.ast.addString("Object");
+            const dp_str_span = try self.ast.addString("defineProperty");
+            const key_arg = try es_helpers.buildDefinePropertyKeyArg(self, key_idx);
+            const call = try es_helpers.buildObjectDefinePropertyCall(self, obj_str_span, dp_str_span, target, key_arg, desc_obj, span);
             return self.ast.addNode(.{
                 .tag = .expression_statement,
                 .span = info.member_span,
-                .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+                .data = .{ .unary = .{ .operand = call, .flags = 0 } },
             });
         }
 

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1718,6 +1718,65 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("1\nReferenceError");
     });
 
+    test("class prototype method는 enumerable이 아님", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              m() {}
+              n() {}
+            }
+            console.log(JSON.stringify(Object.keys(C.prototype)));
+            console.log(Object.prototype.propertyIsEnumerable.call(C.prototype, "m"));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("[]\nfalse");
+    });
+
+    test("class static method는 enumerable이 아님", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              static m() {}
+              static n() {}
+            }
+            console.log(JSON.stringify(Object.keys(C)));
+            console.log(Object.prototype.propertyIsEnumerable.call(C, "m"));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("[]\nfalse");
+    });
+
+    test("class method descriptor 속성 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              m() {}
+            }
+            const d = Object.getOwnPropertyDescriptor(C.prototype, "m")!;
+            console.log([d.enumerable, d.configurable, d.writable].join(":"));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("false:true:true");
+    });
+
     // --- SWC 대비 추가 테스트: Destructuring ---
 
     test("sparse array destructuring", async () => {


### PR DESCRIPTION
## 요약
- ES5 class method lowering을 assignment에서 Object.defineProperty descriptor 기반으로 변경했습니다.
- prototype/static/computed method가 enumerable: false, configurable: true, writable: true를 보존합니다.
- 기존 getter/setter와 같은 descriptor 기반 경로에 맞췄습니다.

## 테스트
- zig build test
- cd tests/integration && bun test tests/downlevel.test.ts
- bun run fmt:check
- bun run lint (기존 warning 61개, error 0)

Closes #1997