### PR TITLE
fix(bundler): skip dead conditional requires

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -172,6 +172,45 @@ test "Bundler: minify가 require 래퍼 합성 심볼도 짧은 이름으로 바
     try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log") != null);
 }
 
+test "Bundler: define으로 죽은 require 분기는 그래프에 포함하지 않음" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\if (process.env.NODE_ENV === 'production') {
+        \\  module.exports = require('./prod.js');
+        \\} else {
+        \\  module.exports = require('./dev.js');
+        \\}
+    );
+    try writeFile(tmp.dir, "prod.js", "module.exports = 'prod-only';");
+    try writeFile(tmp.dir, "dev.js", "module.exports = 'dev-only';");
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    const defines = [_]@import("../../parser/scan_results.zig").DefineEntry{
+        .{ .key = "process.env.NODE_ENV", .value = "\"production\"" },
+    };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+        .define = &defines,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "prod-only") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "dev-only") == null);
+}
+
 test "Bundler: unresolved import produces error diagnostic" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1096,7 +1096,7 @@ pub const ModuleGraph = struct {
             } else |_| {}
 
             // import/export 스캔 — JSON에는 import가 없지만 export default가 있음
-            const scan_result = import_scanner.extractImportsWithCjsDetection(arena_alloc, &(module.ast.?)) catch {
+            const scan_result = import_scanner.extractImportsWithCjsDetectionAndDefines(arena_alloc, &(module.ast.?), self.defines) catch {
                 module.state = .ready;
                 return;
             };

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -30,6 +30,7 @@ const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const CallFlags = @import("../parser/ast.zig").CallFlags;
 const MemberFlags = @import("../parser/ast.zig").MemberFlags;
+const TokenKind = @import("../lexer/token.zig").Kind;
 const scan_results = @import("../parser/scan_results.zig");
 const module_parser = @import("../parser/module.zig");
 const DefineEntry = scan_results.DefineEntry;
@@ -71,7 +72,12 @@ pub fn extractImportsWithCjsDetectionAndDefines(
     var has_module_exports = false;
     var has_exports_dot = false;
 
+    var dead_ranges: std.ArrayList(Span) = .empty;
+    defer dead_ranges.deinit(allocator);
+    if (defines.len > 0) try collectDeadIfRanges(allocator, ast, defines, &dead_ranges);
+
     for (ast.nodes.items) |node| {
+        if (isInsideDeadRange(node.span, dead_ranges.items)) continue;
         switch (node.tag) {
             .import_declaration => {
                 has_esm_syntax = true;
@@ -136,6 +142,89 @@ pub fn extractImportsWithCjsDetectionAndDefines(
         .has_module_exports = has_module_exports,
         .has_exports_dot = has_exports_dot,
     };
+}
+
+fn collectDeadIfRanges(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    defines: []const DefineEntry,
+    dead_ranges: *std.ArrayList(Span),
+) !void {
+    for (ast.nodes.items) |node| {
+        if (node.tag != .if_statement) continue;
+        const parts = node.data.ternary;
+        const known = evalToBoolean(ast, parts.a, defines) orelse continue;
+        const dead_idx = if (known) parts.c else parts.b;
+        if (dead_idx.isNone()) continue;
+        if (@intFromEnum(dead_idx) >= ast.nodes.items.len) continue;
+        try dead_ranges.append(allocator, ast.getNode(dead_idx).span);
+    }
+}
+
+fn isInsideDeadRange(span: Span, ranges: []const Span) bool {
+    for (ranges) |range| {
+        if (span.start >= range.start and span.end <= range.end) return true;
+    }
+    return false;
+}
+
+pub fn evalToBoolean(ast: *const Ast, idx: NodeIndex, defines: []const DefineEntry) ?bool {
+    return evalToBooleanDepth(ast, idx, defines, 0);
+}
+
+fn evalToBooleanDepth(ast: *const Ast, idx: NodeIndex, defines: []const DefineEntry, depth: u8) ?bool {
+    if (depth >= 8 or idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const node = ast.getNode(idx);
+    return switch (node.tag) {
+        .boolean_literal => std.mem.eql(u8, ast.getText(node.span), "true"),
+        .identifier_reference, .static_member_expression => evalDefinedBoolean(ast.getText(node.span), defines),
+        .unary_expression => blk: {
+            const e = node.data.extra;
+            if (e + 1 >= ast.extra_data.items.len) break :blk null;
+            const operand_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
+            const op: TokenKind = @enumFromInt(@as(u8, @truncate(ast.extra_data.items[e + 1])));
+            if (op != .bang) break :blk null;
+            const value = evalToBooleanDepth(ast, operand_idx, defines, depth + 1) orelse break :blk null;
+            break :blk !value;
+        },
+        .logical_expression => blk: {
+            const left = evalToBooleanDepth(ast, node.data.binary.left, defines, depth + 1) orelse break :blk null;
+            const op: TokenKind = @enumFromInt(node.data.binary.flags);
+            if (op == .amp2 and !left) break :blk false;
+            if (op == .pipe2 and left) break :blk true;
+            const right = evalToBooleanDepth(ast, node.data.binary.right, defines, depth + 1) orelse break :blk null;
+            if (op == .amp2) break :blk left and right;
+            if (op == .pipe2) break :blk left or right;
+            break :blk null;
+        },
+        .binary_expression => evalBinaryBoolean(ast, node, defines, depth),
+        else => null,
+    };
+}
+
+fn evalBinaryBoolean(ast: *const Ast, node: Node, defines: []const DefineEntry, depth: u8) ?bool {
+    const op: TokenKind = @enumFromInt(node.data.binary.flags);
+    if (op != .eq2 and op != .eq3 and op != .neq and op != .neq2) return null;
+
+    const left = evalToString(ast, node.data.binary.left, defines) orelse return null;
+    const right = evalToString(ast, node.data.binary.right, defines) orelse return null;
+    const is_equal = std.mem.eql(u8, left, right);
+    _ = depth;
+    return switch (op) {
+        .eq2, .eq3 => is_equal,
+        .neq, .neq2 => !is_equal,
+        else => null,
+    };
+}
+
+fn evalDefinedBoolean(text: []const u8, defines: []const DefineEntry) ?bool {
+    for (defines) |def| {
+        if (!std.mem.eql(u8, def.key, text)) continue;
+        if (std.mem.eql(u8, def.value, "true")) return true;
+        if (std.mem.eql(u8, def.value, "false")) return false;
+        return null;
+    }
+    return null;
 }
 
 /// AST를 순회하여 모든 import/export 소스 경로를 추출한다.

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const import_scanner = @import("import_scanner.zig");
 const extractImports = import_scanner.extractImports;
 const extractImportsWithCjsDetection = import_scanner.extractImportsWithCjsDetection;
+const extractImportsWithCjsDetectionAndDefines = import_scanner.extractImportsWithCjsDetectionAndDefines;
 const ScanResult = import_scanner.ScanResult;
 const stripQuotes = import_scanner.stripQuotes;
 const types = @import("types.zig");
@@ -47,6 +48,22 @@ fn parseAndExtractFull(allocator: std.mem.Allocator, source: []const u8) !ScanRe
     _ = try parser.parse();
 
     return extractImportsWithCjsDetection(allocator, &parser.ast);
+}
+
+fn parseAndExtractFullWithDefines(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    defines: []const DefineEntry,
+) !ScanResult {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var scanner = try Scanner.init(arena_alloc, source);
+    var parser = Parser.init(arena_alloc, &scanner);
+    _ = try parser.parse();
+
+    return extractImportsWithCjsDetectionAndDefines(allocator, &parser.ast, defines);
 }
 
 test "side-effect import" {
@@ -205,6 +222,44 @@ test "CJS: require() call detected" {
     try std.testing.expectEqual(ImportKind.require, result.records[0].kind);
     try std.testing.expect(result.has_cjs_require);
     try std.testing.expect(!result.has_esm_syntax);
+}
+
+test "CJS: define으로 죽은 if 분기의 require는 스캔하지 않음" {
+    const alloc = std.testing.allocator;
+    const result = try parseAndExtractFullWithDefines(
+        alloc,
+        \\if (process.env.NODE_ENV === 'production') {
+        \\  module.exports = require('./prod');
+        \\} else {
+        \\  module.exports = require('./dev');
+        \\}
+    ,
+        &.{.{ .key = "process.env.NODE_ENV", .value = "\"production\"" }},
+    );
+    defer alloc.free(result.records);
+
+    try std.testing.expectEqual(@as(usize, 1), result.records.len);
+    try std.testing.expectEqualStrings("./prod", result.records[0].specifier);
+    try std.testing.expect(result.has_cjs_require);
+    try std.testing.expect(result.has_module_exports);
+}
+
+test "CJS: define boolean으로 죽은 if 분기의 require는 스캔하지 않음" {
+    const alloc = std.testing.allocator;
+    const result = try parseAndExtractFullWithDefines(
+        alloc,
+        \\if (__DEV__) {
+        \\  require('./dev-only');
+        \\} else {
+        \\  require('./prod-only');
+        \\}
+    ,
+        &.{.{ .key = "__DEV__", .value = "false" }},
+    );
+    defer alloc.free(result.records);
+
+    try std.testing.expectEqual(@as(usize, 1), result.records.len);
+    try std.testing.expectEqualStrings("./prod-only", result.records[0].specifier);
 }
 
 test "CJS: require with non-string argument ignored" {

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -464,7 +464,7 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
         const right = try parseAssignmentExpression(self);
 
         // Inline scan: CJS pattern detection (module.exports = ..., exports.x = ...)
-        if (self.enable_scan) {
+        if (self.enable_scan and self.scan_dead_depth == 0) {
             scanAssignmentCjs(self, left);
         }
 
@@ -878,7 +878,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
 
                 // Inline scan: require("specifier") → CJS import record
                 const call_span = Span{ .start = expr_start, .end = self.currentSpan().start };
-                if (self.enable_scan) {
+                if (self.enable_scan and self.scan_dead_depth == 0) {
                     scanRequireCall(self, expr, arg_list);
                     scanGlobCall(self, expr, arg_list);
                     scanRequireContextCall(self, expr, arg_list, call_span);

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -78,6 +78,8 @@ pub const Parser = struct {
     /// require.context 인자 평가 (Phase 2.6) 와 미래 build-time 정적 평가에 활용.
     /// bundler 가 parse 전 설정. 비어있으면 evaluator 가 define lookup 안 함. (#1579)
     scan_defines: []const scan_results_mod.DefineEntry = &.{},
+    /// define으로 죽은 분기를 파싱 중일 때 inline require 스캔을 막는 깊이.
+    scan_dead_depth: u32 = 0,
 
     /// arrow 파라미터 중복 검사용 임시 이름 수집 버퍼.
     param_name_spans: std.ArrayList(Span),

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -18,6 +18,7 @@ const Kind = token_mod.Kind;
 const Span = token_mod.Span;
 const Parser = @import("parser.zig").Parser;
 const ParseError2 = @import("parser.zig").ParseError2;
+const import_scanner = @import("../bundler/import_scanner.zig");
 
 /// 소스 전체를 파싱하여 AST를 반환한다.
 pub fn parse(self: *Parser) !NodeIndex {
@@ -631,14 +632,22 @@ fn parseIfStatement(self: *Parser) ParseError2!NodeIndex {
     try self.expect(.l_paren);
     const test_expr = try self.parseExpression();
     try self.expect(.r_paren);
+    const known_scan_condition = if (self.enable_scan and self.scan_defines.len > 0)
+        import_scanner.evalToBoolean(&self.ast, test_expr, self.scan_defines)
+    else
+        null;
     // ECMAScript 13.6.1: IsLabelledFunction(Statement) → SyntaxError
     const saved_labelled = self.in_labelled_fn_check;
     self.in_labelled_fn_check = true;
+    if (known_scan_condition == false) self.scan_dead_depth += 1;
     const consequent = try parseStatementChecked(self, false);
+    if (known_scan_condition == false) self.scan_dead_depth -= 1;
 
     var alternate = NodeIndex.none;
     if (try self.eat(.kw_else)) {
+        if (known_scan_condition == true) self.scan_dead_depth += 1;
         alternate = try parseStatementChecked(self, false);
+        if (known_scan_condition == true) self.scan_dead_depth -= 1;
     }
     self.in_labelled_fn_check = saved_labelled;
 


### PR DESCRIPTION
## 요약
- define으로 결과가 확정되는 `if` 분기 안의 죽은 `require()`를 그래프에 포함하지 않도록 수정했습니다.
- 파서 inline scan 경로와 AST import scanner 경로를 모두 보강했습니다.
- `process.env.NODE_ENV === "production"` 패턴과 `__DEV__` boolean 패턴 회귀 테스트를 추가했습니다.
- 실제 번들러 테스트에서 죽은 `require('./dev')` 모듈이 출력에 포함되지 않는지 검증합니다.

## 근본 원인
- zts는 transform 단계에서 죽은 분기 코드는 제거했지만, 의존성 그래프는 그보다 앞선 scan 단계에서 만들어졌습니다.
- 기존 inline scanner가 조건 결과와 상관없이 AST를 파싱하면서 만나는 모든 `require()`를 import record로 등록했습니다.
- 그래서 React/RN 패키지의 `NODE_ENV` 분기에서 production 파일과 development 파일이 동시에 그래프에 들어갔습니다.

## 검증
- `zig build test -Doptimize=Debug`
- `zig build napi -Doptimize=ReleaseFast`
- 번개 `bun run build`
- ExampleApp iOS/Android release bundle 재생성 및 용량 비교

## 실측
| Target | Raw | Gzip | Brotli | react.dev | refresh.dev | assets |
|---|---:|---:|---:|---:|---:|---:|
| zts iOS before | 3.10 MiB (3248138) | 749.2 KiB (767207) | 518.6 KiB (531088) | 2 | 2 | 6 |
| zts iOS after | 2.35 MiB (2464909) | 536.3 KiB (549123) | 402.7 KiB (412413) | 0 | 0 | 2 |
| zts Android before | 3.11 MiB (3256814) | 751.3 KiB (769349) | 520.1 KiB (532574) | 2 | 2 | 6 |
| zts Android after | 2.36 MiB (2473338) | 538.7 KiB (551671) | 404.7 KiB (414439) | 0 | 0 | 2 |

## 메모
- Metro 대비 남은 차이는 이제 raw 기준 약 338KB, gzip 기준 약 79KB 수준입니다.
