### PR TITLE
fix: preserve default initializer TDZ

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -374,6 +374,15 @@ pub const DERIVED_CONSTRUCTOR_RUNTIME_MIN =
     "var " ++ NAMES.ASSERT_THIS_UNINITIALIZED_MIN ++ "=function(self){if(self!==void 0)throw new ReferenceError(\"Super constructor may only be called once\")};" ++
     "var " ++ NAMES.POSSIBLE_CONSTRUCTOR_RETURN_MIN ++ "=function(self,call){if(call&&(typeof call===\"object\"||typeof call===\"function\"))return call;if(call!==void 0)throw new TypeError(\"Derived constructors may only return object or undefined\");return " ++ NAMES.ASSERT_THIS_INITIALIZED_MIN ++ "(self)};";
 
+/// ES2015 TDZ read helper. Babel/OXC runtime의 tdz helper와 같은 역할이다.
+pub const TDZ_RUNTIME =
+    \\var __tdz = function(name) {
+    \\  throw new ReferenceError(name + " is not defined - temporal dead zone");
+    \\};
+    \\
+;
+pub const TDZ_RUNTIME_MIN = "var " ++ NAMES.TDZ_MIN ++ "=function(name){throw new ReferenceError(name+\" is not defined - temporal dead zone\")};";
+
 /// __async: async/await → generator 변환 시 주입 (esbuild 호환).
 /// generator-to-Promise wrapper. this/arguments를 fn.apply로 보존.
 ///
@@ -1170,6 +1179,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
     if (helpers.derived_constructor) {
         try buf.appendSlice(allocator, if (minify) DERIVED_CONSTRUCTOR_RUNTIME_MIN else DERIVED_CONSTRUCTOR_RUNTIME);
+    }
+    if (helpers.tdz) {
+        try buf.appendSlice(allocator, if (minify) TDZ_RUNTIME_MIN else TDZ_RUNTIME);
     }
     if (helpers.tagged_template_literal) {
         try buf.appendSlice(allocator, if (minify) TAGGED_TEMPLATE_RUNTIME_MIN else TAGGED_TEMPLATE_RUNTIME);

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1031,6 +1031,19 @@ test "ES2015: default + rest combined" {
     try std.testing.expectEqualStrings("function f(x){x=x===void 0?1:x;var rest=[].slice.call(arguments,1);}", r.output);
 }
 
+test "ES2015: default parameter self TDZ 보존" {
+    var r = try e2eTarget(std.testing.allocator, "function f(a=a){return a;}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__tdz(\"a\")") != null);
+}
+
+test "ES2015: default parameter later binding TDZ 보존" {
+    var r = try e2eTarget(std.testing.allocator, "function f(a=b,b=2){return a+b;}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__tdz(\"b\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "b=b===void 0?2:b") != null);
+}
+
 test "ES2015: params no transform on esnext" {
     var r = try e2eTarget(std.testing.allocator, "function f(x=1,...rest){}", .esnext);
     defer r.deinit();
@@ -1378,6 +1391,19 @@ test "ES2015: destructuring default" {
     var r = try e2eTarget(std.testing.allocator, "var {a=1}=obj;", .es5);
     defer r.deinit();
     try std.testing.expectEqualStrings("var _a=obj,a=_a.a===void 0?1:_a.a;", r.output);
+}
+
+test "ES2015: destructuring default self TDZ 보존" {
+    var r = try e2eTarget(std.testing.allocator, "var {a=a}=obj;", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__tdz(\"a\")") != null);
+}
+
+test "ES2015: destructuring default later binding TDZ 보존" {
+    var r = try e2eTarget(std.testing.allocator, "var {a=b,b=1}=obj;", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__tdz(\"b\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "b=_a.b===void 0?1:_a.b") != null);
 }
 
 test "ES2015: destructuring no transform on esnext" {

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -147,6 +147,11 @@ const MODULES = [_]HelperModule{
         .body = .{ .plain = rt.DERIVED_CONSTRUCTOR_RUNTIME, .min = rt.DERIVED_CONSTRUCTOR_RUNTIME_MIN },
     },
     .{
+        .short = "tdz",
+        .helpers = &.{"__tdz"},
+        .body = .{ .plain = rt.TDZ_RUNTIME, .min = rt.TDZ_RUNTIME_MIN },
+    },
+    .{
         .short = "rest",
         .helpers = &.{"__rest"},
         .body = .{ .plain = rt.REST_RUNTIME, .min = rt.REST_RUNTIME_MIN },

--- a/src/runtime_helper_names.zig
+++ b/src/runtime_helper_names.zig
@@ -39,6 +39,7 @@ pub const NAMES = struct {
     pub const ASSERT_THIS_INITIALIZED_MIN = "$aT"; // __assertThisInitialized
     pub const ASSERT_THIS_UNINITIALIZED_MIN = "$aU"; // __assertThisUninitialized
     pub const POSSIBLE_CONSTRUCTOR_RETURN_MIN = "$pR"; // __possibleConstructorReturn
+    pub const TDZ_MIN = "$td"; // __tdz
     pub const ASYNC_MIN = "$aS"; // __async (async/await → generator)
     pub const ASYNC_VALUES_MIN = "$aV"; // __asyncValues (for-await-of)
     pub const GENERATOR_MIN = "$gn"; // __generator
@@ -97,6 +98,7 @@ pub const PAIRS = [_]struct { base: []const u8, short: []const u8 }{
     .{ .base = "__assertThisInitialized", .short = NAMES.ASSERT_THIS_INITIALIZED_MIN },
     .{ .base = "__assertThisUninitialized", .short = NAMES.ASSERT_THIS_UNINITIALIZED_MIN },
     .{ .base = "__possibleConstructorReturn", .short = NAMES.POSSIBLE_CONSTRUCTOR_RETURN_MIN },
+    .{ .base = "__tdz", .short = NAMES.TDZ_MIN },
     .{ .base = "__async", .short = NAMES.ASYNC_MIN },
     .{ .base = "__asyncValues", .short = NAMES.ASYNC_VALUES_MIN },
     .{ .base = "__generator", .short = NAMES.GENERATOR_MIN },

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -575,6 +575,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         // default: { a = 1 } → var a = _ref.a === void 0 ? 1 : _ref.a
                         const binding = try self.visitNode(value_node.data.binary.left);
                         const default_val = try self.visitNode(value_node.data.binary.right);
+                        try rewritePatternDefaultTDZ(self, default_val, pattern, i_loop);
                         const defaulted = try buildDefaulted(self, member_access, default_val, ref_span, key_idx, key_node.tag, span);
                         const decl = try es_helpers.makeDeclarator(self, binding, defaulted, span);
                         try self.scratch.append(self.allocator, decl);
@@ -624,6 +625,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     // default: [x = 1] → var x = _ref[0] === void 0 ? 1 : _ref[0]
                     const binding = try self.visitNode(elem.data.binary.left);
                     const default_val = try self.visitNode(elem.data.binary.right);
+                    try rewritePatternDefaultTDZ(self, default_val, pattern, idx);
                     const void_zero = try es_helpers.makeVoidZero(self, span);
                     const elem_access2 = try makeArrayAccess(self, ref_span, idx, span);
                     const eq_check = try self.ast.addNode(.{
@@ -698,6 +700,49 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             // slice(N)
             const idx_node = try es_helpers.makeNumericLiteral(self, @intCast(start_idx));
             return es_helpers.makeCallExpr(self, callee, &.{idx_node}, span);
+        }
+
+        fn rewritePatternDefaultTDZ(self: *Transformer, default_val: NodeIndex, pattern: Node, start_idx: u32) Transformer.Error!void {
+            var names: std.ArrayList(Span) = .empty;
+            defer names.deinit(self.allocator);
+            try collectPatternBindingNamesFrom(self, pattern, start_idx, &names);
+            try es_helpers.rewriteTDZReferences(self, default_val, names.items);
+        }
+
+        fn collectPatternBindingNamesFrom(self: *Transformer, pattern: Node, start_idx: u32, out: *std.ArrayList(Span)) Transformer.Error!void {
+            const split = self.ast.nodeListSplitRest(pattern.data.list);
+            const non_rest_len: u32 = @intCast(split.elements.len);
+            var i: u32 = start_idx;
+            while (i < non_rest_len) : (i += 1) {
+                const raw = self.ast.extra_data.items[pattern.data.list.start + i];
+                try collectBindingNames(self, @enumFromInt(raw), out);
+            }
+            if (split.rest_operand) |rest| try collectBindingNames(self, rest, out);
+        }
+
+        fn collectBindingNames(self: *Transformer, idx: NodeIndex, out: *std.ArrayList(Span)) Transformer.Error!void {
+            if (idx.isNone()) return;
+            const node = self.ast.getNode(idx);
+            switch (node.tag) {
+                .binding_identifier, .identifier_reference, .assignment_target_identifier => {
+                    try out.append(self.allocator, node.data.string_ref);
+                },
+                .assignment_pattern, .assignment_target_with_default => {
+                    try collectBindingNames(self, node.data.binary.left, out);
+                },
+                .rest_element, .binding_rest_element, .assignment_target_rest => {
+                    try collectBindingNames(self, node.data.unary.operand, out);
+                },
+                .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
+                    const value = node.data.binary.right;
+                    try collectBindingNames(self, if (value.isNone()) node.data.binary.left else value, out);
+                },
+                .object_pattern, .array_pattern, .object_assignment_target, .array_assignment_target => {
+                    const items = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
+                    for (items) |raw| try collectBindingNames(self, @enumFromInt(raw), out);
+                },
+                else => {},
+            }
         }
 
         /// rest = __rest(_ref, ["key1", "key2"]) declarator 생성.

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -88,6 +88,17 @@ pub fn ES2015Params(comptime Transformer: type) type {
             var body_stmts: std.ArrayList(NodeIndex) = .empty;
 
             var param_index: usize = 0; // arguments index tracking
+            var param_tdz_names: std.ArrayList(Span) = .empty;
+            defer param_tdz_names.deinit(self.allocator);
+            const name_starts = try self.allocator.alloc(usize, params.len);
+            defer self.allocator.free(name_starts);
+
+            var name_i: u32 = 0;
+            while (name_i < params.len) : (name_i += 1) {
+                name_starts[name_i] = param_tdz_names.items.len;
+                const raw_idx = self.ast.extra_data.items[params.start + name_i];
+                try collectBindingNames(self, @enumFromInt(raw_idx), &param_tdz_names);
+            }
 
             // pass2에서는 노드가 이미 visited 상태이므로 인덱스를 그대로 사용
             const maybeVisit = struct {
@@ -121,12 +132,14 @@ pub fn ES2015Params(comptime Transformer: type) type {
                         if (pat_node.tag == .object_pattern or pat_node.tag == .array_pattern) {
                             const vp = try maybeVisit(self, pattern_idx);
                             const vd = try maybeVisit(self, default_idx);
+                            try es_helpers.rewriteTDZReferences(self, vd, param_tdz_names.items[name_starts[i_loop]..]);
                             const result = try buildDestructuringDefault(self, vp, vd, &body_stmts, span);
                             try self.scratch.append(self.allocator, result);
                         } else {
                             const new_pattern = try maybeVisit(self, pattern_idx);
                             try self.scratch.append(self.allocator, new_pattern);
                             const new_default = try maybeVisit(self, default_idx);
+                            try es_helpers.rewriteTDZReferences(self, new_default, param_tdz_names.items[name_starts[i_loop]..]);
                             const default_stmt = try buildDefaultCheck(self, new_pattern, new_default, span);
                             try body_stmts.append(self.allocator, default_stmt);
                         }
@@ -141,12 +154,14 @@ pub fn ES2015Params(comptime Transformer: type) type {
                     if (pattern_node.tag == .object_pattern or pattern_node.tag == .array_pattern) {
                         const vp = try maybeVisit(self, param.data.binary.left);
                         const vd = try maybeVisit(self, param.data.binary.right);
+                        try es_helpers.rewriteTDZReferences(self, vd, param_tdz_names.items[name_starts[i_loop]..]);
                         const result = try buildDestructuringDefault(self, vp, vd, &body_stmts, span);
                         try self.scratch.append(self.allocator, result);
                     } else {
                         const new_pattern = try maybeVisit(self, param.data.binary.left);
                         try self.scratch.append(self.allocator, new_pattern);
                         const new_default = try maybeVisit(self, param.data.binary.right);
+                        try es_helpers.rewriteTDZReferences(self, new_default, param_tdz_names.items[name_starts[i_loop]..]);
                         const default_stmt = try buildDefaultCheck(self, new_pattern, new_default, span);
                         try body_stmts.append(self.allocator, default_stmt);
                     }
@@ -333,6 +348,34 @@ pub fn ES2015Params(comptime Transformer: type) type {
                 .span = node.span,
                 .data = .{ .string_ref = node.data.string_ref },
             });
+        }
+
+        fn collectBindingNames(self: *Transformer, idx: NodeIndex, out: *std.ArrayList(Span)) Transformer.Error!void {
+            if (idx.isNone()) return;
+            const node = self.ast.getNode(idx);
+            switch (node.tag) {
+                .binding_identifier, .identifier_reference, .assignment_target_identifier => {
+                    try out.append(self.allocator, node.data.string_ref);
+                },
+                .formal_parameter => {
+                    try collectBindingNames(self, self.readNodeIdx(node.data.extra, ast_mod.FormalParameterExtra.pattern), out);
+                },
+                .assignment_pattern, .assignment_target_with_default => {
+                    try collectBindingNames(self, node.data.binary.left, out);
+                },
+                .rest_element, .binding_rest_element, .assignment_target_rest => {
+                    try collectBindingNames(self, node.data.unary.operand, out);
+                },
+                .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
+                    const value = node.data.binary.right;
+                    try collectBindingNames(self, if (value.isNone()) node.data.binary.left else value, out);
+                },
+                .object_pattern, .array_pattern, .object_assignment_target, .array_assignment_target => {
+                    const items = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
+                    for (items) |raw| try collectBindingNames(self, @enumFromInt(raw), out);
+                },
+                else => {},
+            }
         }
     };
 }

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -165,6 +165,95 @@ pub fn makeRuntimeHelperRef(self: anytype, base_name: []const u8) !NodeIndex {
     return makeIdentifierRef(self, resolved);
 }
 
+/// default initializer가 함수 body로 내려간 뒤에도 parameter/destructuring
+/// binding의 TDZ read를 보존한다. `tdz_names`에 들어 있는 이름의
+/// identifier_reference를 `__tdz("name")` 호출로 치환한다.
+pub fn rewriteTDZReferences(self: anytype, root: NodeIndex, tdz_names: []const Span) !void {
+    if (root.isNone() or tdz_names.len == 0) return;
+    try rewriteTDZReferencesInner(self, root, tdz_names);
+}
+
+fn rewriteTDZReferencesInner(self: anytype, idx: NodeIndex, tdz_names: []const Span) !void {
+    if (idx.isNone()) return;
+    const raw_i = @intFromEnum(idx);
+    if (raw_i >= self.ast.nodes.items.len) return;
+
+    const node = self.ast.nodes.items[raw_i];
+    switch (node.tag) {
+        .identifier_reference => {
+            if (tdzNameMatch(self, node.data.string_ref, tdz_names)) |name_span| {
+                const call = try makeTDZCall(self, name_span, node.span);
+                self.ast.nodes.items[raw_i] = self.ast.getNode(call);
+            }
+            return;
+        },
+        // default initializer 평가 중에는 nested function/class body가 실행되지 않는다.
+        .function_expression,
+        .function_declaration,
+        .function,
+        .arrow_function_expression,
+        .class_expression,
+        .class_declaration,
+        => return,
+        else => {},
+    }
+
+    switch (Node.Tag.dataKind(node.tag)) {
+        .leaf => {},
+        .unary => try rewriteTDZReferencesInner(self, node.data.unary.operand, tdz_names),
+        .binary => {
+            try rewriteTDZReferencesInner(self, node.data.binary.left, tdz_names);
+            try rewriteTDZReferencesInner(self, node.data.binary.right, tdz_names);
+        },
+        .ternary => {
+            try rewriteTDZReferencesInner(self, node.data.ternary.a, tdz_names);
+            try rewriteTDZReferencesInner(self, node.data.ternary.b, tdz_names);
+            try rewriteTDZReferencesInner(self, node.data.ternary.c, tdz_names);
+        },
+        .list => {
+            const items = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
+            for (items) |child_raw| try rewriteTDZReferencesInner(self, @enumFromInt(child_raw), tdz_names);
+        },
+        .extra => {
+            const e = node.data.extra;
+            for (Node.Tag.extraChildOffsets(node.tag)) |offset| {
+                try rewriteTDZReferencesInner(self, @enumFromInt(self.ast.extra_data.items[e + offset]), tdz_names);
+            }
+            for (Node.Tag.extraListOffsets(node.tag)) |pair| {
+                const start = self.ast.extra_data.items[e + pair[0]];
+                const len = self.ast.extra_data.items[e + pair[1]];
+                const items = self.ast.extra_data.items[start .. start + len];
+                for (items) |child_raw| try rewriteTDZReferencesInner(self, @enumFromInt(child_raw), tdz_names);
+            }
+        },
+    }
+}
+
+fn tdzNameMatch(self: anytype, ref_span: Span, tdz_names: []const Span) ?Span {
+    const ref_text = self.ast.getText(ref_span);
+    for (tdz_names) |name_span| {
+        if (std.mem.eql(u8, ref_text, self.ast.getText(name_span))) return name_span;
+    }
+    return null;
+}
+
+fn makeTDZCall(self: anytype, name_span: Span, span: Span) !NodeIndex {
+    self.runtime_helpers.tdz = true;
+
+    const name = self.ast.getText(name_span);
+    const quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{name});
+    defer self.allocator.free(quoted);
+    const str_span = try self.ast.addString(quoted);
+    const str = try self.ast.addNode(.{
+        .tag = .string_literal,
+        .span = str_span,
+        .data = .{ .string_ref = str_span },
+    });
+
+    const callee = try makeRuntimeHelperRef(self, "__tdz");
+    return makeCallExpr(self, callee, &.{str}, span);
+}
+
 /// Span으로 identifier_reference 노드 생성 (이미 addString된 span 사용).
 pub fn makeIdentifierRefFromSpan(self: anytype, name_span: Span) !NodeIndex {
     return self.ast.addNode(.{

--- a/src/transformer/runtime_helper_imports.zig
+++ b/src/transformer/runtime_helper_imports.zig
@@ -60,6 +60,7 @@ const HelperBit = enum {
     class_private_field_set,
     async_generator,
     await_helper,
+    tdz,
 };
 
 const BitDef = struct {
@@ -105,6 +106,7 @@ const BIT_DEFS = [_]BitDef{
     .{ .bit = .class_private_field_set, .bases = &.{"__classPrivateFieldSet"} },
     .{ .bit = .async_generator, .bases = &.{"__asyncGenerator"} },
     .{ .bit = .await_helper, .bases = &.{"__await"} },
+    .{ .bit = .tdz, .bases = &.{"__tdz"} },
 };
 
 comptime {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -235,7 +235,9 @@ pub const RuntimeHelpers = packed struct(u32) {
     async_generator: bool = false,
     /// __await: async generator body 안 await 표현 wrapper (ES2018, #1911)
     await_helper: bool = false,
-    _padding: u9 = 0,
+    /// __tdz: default initializer / block scope TDZ read
+    tdz: bool = false,
+    _padding: u8 = 0,
 };
 
 /// 단일 AST append-only 변환기.

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -81,6 +81,50 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("hello world");
     });
 
+    test("default parameter self TDZ는 ReferenceError", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function f(a = a) {
+              console.log(a);
+            }
+            try {
+              f();
+            } catch (e) {
+              console.log(e.constructor.name);
+            }
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("ReferenceError");
+    });
+
+    test("default parameter later binding TDZ는 ReferenceError", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function f(a = b, b = 2) {
+              console.log(a, b);
+            }
+            try {
+              f();
+            } catch (e) {
+              console.log(e.constructor.name);
+            }
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("ReferenceError");
+    });
+
     test("rest params", async () => {
       const result = await bundleAndRun(
         {
@@ -126,6 +170,46 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       cleanup = result.cleanup;
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("3");
+    });
+
+    test("destructuring default self TDZ는 ReferenceError", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            try {
+              let { a = a } = {};
+              console.log(a);
+            } catch (e) {
+              console.log(e.constructor.name);
+            }
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("ReferenceError");
+    });
+
+    test("destructuring default later binding TDZ는 ReferenceError", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            try {
+              let { a = b, b = 2 } = {};
+              console.log(a, b);
+            } catch (e) {
+              console.log(e.constructor.name);
+            }
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("ReferenceError");
     });
 
     test("destructuring array", async () => {


### PR DESCRIPTION
## 요약
- default parameter lowering에서 현재/뒤쪽 parameter binding 참조를 TDZ read로 보존했습니다.
- destructuring binding default initializer도 현재 요소 이후 binding 참조가 ReferenceError를 내도록 lowering했습니다.
- Babel/OXC 계열과 같은 역할의 __tdz 런타임 헬퍼를 runtime helper registry에 연결했습니다.

## 루트 원인
기존 변환은 default initializer를 함수 body의 일반 대입/선언 initializer로 옮기면서, initializer 평가 시점에 현재 binding과 뒤쪽 binding이 아직 초기화 전이라는 parameter/destructuring TDZ 환경을 잃었습니다. 이번 수정은 initializer lowering 지점에서 그 평가 환경을 반영해 TDZ read를 직접 보존합니다.

## 테스트
- zig build test -Dtest-filter="TDZ 보존"
- zig build test -Dtest-filter="ES2015:"
- zig build test
- cd tests/integration && bun test tests/downlevel.test.ts --test-name-pattern "TDZ"
- cd tests/integration && bun test tests/downlevel.test.ts
- bunx oxfmt format --check packages/ tests/integration tests/e2e
- zig fmt --check src/transformer/es2015_params.zig src/transformer/es2015_destructuring.zig src/transformer/es_helpers.zig src/transformer/transformer.zig src/runtime_helper_names.zig src/bundler/runtime_helpers.zig src/runtime_helper_modules.zig src/transformer/runtime_helper_imports.zig src/codegen/codegen_test/es_downlevel.zig
- bun run lint (기존/generated warning, error 0)

참고: bun run fmt:check는 기존 untracked tests/benchmark/_inproc-multi-tmp 생성물이 포함되어 실패했습니다. 변경 파일 포맷은 위 명령으로 별도 확인했습니다.

Closes #1998