### PR TITLE
fix: read array destructuring from iterables

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -383,6 +383,30 @@ pub const TDZ_RUNTIME =
 ;
 pub const TDZ_RUNTIME_MIN = "var " ++ NAMES.TDZ_MIN ++ "=function(name){throw new ReferenceError(name+\" is not defined - temporal dead zone\")};";
 
+/// array destructuring의 iterable protocol read helper. TypeScript __read와 같은
+/// 구조로 limit 개수만 읽고 iterator.return()으로 close한다.
+pub const READ_RUNTIME =
+    \\var __read = function(o, n) {
+    \\  var m = typeof Symbol === "function" && o[Symbol.iterator];
+    \\  if (!m) return o;
+    \\  var i = m.call(o), r, ar = [], e;
+    \\  try {
+    \\    while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    \\  } catch (error) {
+    \\    e = { error: error };
+    \\  } finally {
+    \\    try {
+    \\      if (r && !r.done && (m = i.return)) m.call(i);
+    \\    } finally {
+    \\      if (e) throw e.error;
+    \\    }
+    \\  }
+    \\  return ar;
+    \\};
+    \\
+;
+pub const READ_RUNTIME_MIN = "var " ++ NAMES.READ_MIN ++ "=function(o,n){var m=typeof Symbol===\"function\"&&o[Symbol.iterator];if(!m)return o;var i=m.call(o),r,ar=[],e;try{while((n===void 0||n-- >0)&&!(r=i.next()).done)ar.push(r.value)}catch(error){e={error:error}}finally{try{if(r&&!r.done&&(m=i.return))m.call(i)}finally{if(e)throw e.error}}return ar};";
+
 /// __async: async/await → generator 변환 시 주입 (esbuild 호환).
 /// generator-to-Promise wrapper. this/arguments를 fn.apply로 보존.
 ///
@@ -1182,6 +1206,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
     if (helpers.tdz) {
         try buf.appendSlice(allocator, if (minify) TDZ_RUNTIME_MIN else TDZ_RUNTIME);
+    }
+    if (helpers.read) {
+        try buf.appendSlice(allocator, if (minify) READ_RUNTIME_MIN else READ_RUNTIME);
     }
     if (helpers.tagged_template_literal) {
         try buf.appendSlice(allocator, if (minify) TAGGED_TEMPLATE_RUNTIME_MIN else TAGGED_TEMPLATE_RUNTIME);

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1378,7 +1378,13 @@ test "ES2015: object destructuring" {
 test "ES2015: array destructuring" {
     var r = try e2eTarget(std.testing.allocator, "var [x,y]=arr;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var _a=arr,x=_a[0],y=_a[1];", r.output);
+    try std.testing.expectEqualStrings("var _a=__read(arr,2),x=_a[0],y=_a[1];", r.output);
+}
+
+test "ES2015: array destructuring iterable read helper" {
+    var r = try e2eTarget(std.testing.allocator, "var [x]=iter;", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__read(iter,1)") != null);
 }
 
 test "ES2015: destructuring rename" {
@@ -1423,7 +1429,7 @@ test "ES2015: assignment object destructuring" {
 test "ES2015: assignment array destructuring" {
     var r = try e2eTarget(std.testing.allocator, "([x,y]=arr);", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "_a=arr") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_a=__read(arr,2)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "x=_a[0]") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "y=_a[1]") != null);
 }

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -152,6 +152,11 @@ const MODULES = [_]HelperModule{
         .body = .{ .plain = rt.TDZ_RUNTIME, .min = rt.TDZ_RUNTIME_MIN },
     },
     .{
+        .short = "read",
+        .helpers = &.{"__read"},
+        .body = .{ .plain = rt.READ_RUNTIME, .min = rt.READ_RUNTIME_MIN },
+    },
+    .{
         .short = "rest",
         .helpers = &.{"__rest"},
         .body = .{ .plain = rt.REST_RUNTIME, .min = rt.REST_RUNTIME_MIN },

--- a/src/runtime_helper_names.zig
+++ b/src/runtime_helper_names.zig
@@ -40,6 +40,7 @@ pub const NAMES = struct {
     pub const ASSERT_THIS_UNINITIALIZED_MIN = "$aU"; // __assertThisUninitialized
     pub const POSSIBLE_CONSTRUCTOR_RETURN_MIN = "$pR"; // __possibleConstructorReturn
     pub const TDZ_MIN = "$td"; // __tdz
+    pub const READ_MIN = "$rd"; // __read
     pub const ASYNC_MIN = "$aS"; // __async (async/await → generator)
     pub const ASYNC_VALUES_MIN = "$aV"; // __asyncValues (for-await-of)
     pub const GENERATOR_MIN = "$gn"; // __generator
@@ -99,6 +100,7 @@ pub const PAIRS = [_]struct { base: []const u8, short: []const u8 }{
     .{ .base = "__assertThisUninitialized", .short = NAMES.ASSERT_THIS_UNINITIALIZED_MIN },
     .{ .base = "__possibleConstructorReturn", .short = NAMES.POSSIBLE_CONSTRUCTOR_RETURN_MIN },
     .{ .base = "__tdz", .short = NAMES.TDZ_MIN },
+    .{ .base = "__read", .short = NAMES.READ_MIN },
     .{ .base = "__async", .short = NAMES.ASYNC_MIN },
     .{ .base = "__asyncValues", .short = NAMES.ASYNC_VALUES_MIN },
     .{ .base = "__generator", .short = NAMES.GENERATOR_MIN },

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -106,11 +106,15 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     // destructuring → 분해
                     // 먼저 init을 임시 변수에 저장
                     const new_init = try self.visitNode(init_idx);
+                    const pattern_init = if (name_node.tag == .array_pattern)
+                        try buildArrayRead(self, new_init, name_node, span)
+                    else
+                        new_init;
                     const temp_span = try es_helpers.makeTempVarSpan(self);
                     const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
 
                     // var _ref = init
-                    const ref_decl = try es_helpers.makeDeclarator(self, temp_binding, new_init, span);
+                    const ref_decl = try es_helpers.makeDeclarator(self, temp_binding, pattern_init, span);
                     try self.scratch.append(self.allocator, ref_decl);
 
                     // 패턴을 개별 declarator로 분해
@@ -310,6 +314,10 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
             const left_node = self.ast.getNode(left_idx);
             const new_right = try self.visitNode(right_idx);
+            const assignment_right = if (left_node.tag == .array_assignment_target or left_node.tag == .array_pattern)
+                try buildArrayRead(self, new_right, left_node, span)
+            else
+                new_right;
             const temp_span = try es_helpers.makeTempVarSpan(self);
 
             const scratch_top = self.scratch.items.len;
@@ -320,7 +328,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             const init_assign = try self.ast.addNode(.{
                 .tag = .assignment_expression,
                 .span = span,
-                .data = .{ .binary = .{ .left = temp_ref, .right = new_right, .flags = 0 } },
+                .data = .{ .binary = .{ .left = temp_ref, .right = assignment_right, .flags = 0 } },
             });
             try self.scratch.append(self.allocator, init_assign);
 
@@ -454,17 +462,21 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 return;
             }
             const target_node = self.ast.getNode(target_old_idx);
-            if (target_node.tag == .object_assignment_target or target_node.tag == .array_assignment_target) {
+            if (target_node.tag == .object_assignment_target or target_node.tag == .array_assignment_target or target_node.tag == .object_pattern or target_node.tag == .array_pattern) {
                 // nested: _inner = value; 각 element 재귀 emit.
                 const inner_span = try es_helpers.makeTempVarSpan(self);
                 const inner_lhs = try es_helpers.makeTempVarRef(self, inner_span, inner_span);
+                const inner_value = if (target_node.tag == .array_assignment_target or target_node.tag == .array_pattern)
+                    try buildArrayRead(self, value, target_node, span)
+                else
+                    value;
                 const init = try self.ast.addNode(.{
                     .tag = .assignment_expression,
                     .span = span,
-                    .data = .{ .binary = .{ .left = inner_lhs, .right = value, .flags = 0 } },
+                    .data = .{ .binary = .{ .left = inner_lhs, .right = inner_value, .flags = 0 } },
                 });
                 try self.scratch.append(self.allocator, init);
-                if (target_node.tag == .object_assignment_target) {
+                if (target_node.tag == .object_assignment_target or target_node.tag == .object_pattern) {
                     try emitObjectAssignments(self, target_node, inner_span, span);
                 } else {
                     try emitArrayAssignments(self, target_node, inner_span, span);
@@ -583,7 +595,11 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         // nested: { a: { b } } → var _ref2 = _ref.a; var b = _ref2.b
                         const nested_span = try es_helpers.makeTempVarSpan(self);
                         const nested_binding = try es_helpers.makeBindingIdentifier(self, nested_span);
-                        const nested_decl = try es_helpers.makeDeclarator(self, nested_binding, member_access, span);
+                        const nested_init = if (value_node.tag == .array_pattern)
+                            try buildArrayRead(self, member_access, value_node, span)
+                        else
+                            member_access;
+                        const nested_decl = try es_helpers.makeDeclarator(self, nested_binding, nested_init, span);
                         try self.scratch.append(self.allocator, nested_decl);
                         try emitPatternDeclarators(self, value_node, nested_span, span);
                     } else {
@@ -644,7 +660,11 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     // nested: [[a, b]] → var _ref2 = _ref[0]; var a = _ref2[0]; ...
                     const nested_span = try es_helpers.makeTempVarSpan(self);
                     const nested_binding = try es_helpers.makeBindingIdentifier(self, nested_span);
-                    const nested_decl = try es_helpers.makeDeclarator(self, nested_binding, elem_access, span);
+                    const nested_init = if (elem.tag == .array_pattern)
+                        try buildArrayRead(self, elem_access, elem, span)
+                    else
+                        elem_access;
+                    const nested_decl = try es_helpers.makeDeclarator(self, nested_binding, nested_init, span);
                     try self.scratch.append(self.allocator, nested_decl);
                     try emitPatternDeclarators(self, elem, nested_span, span);
                 } else {
@@ -700,6 +720,23 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             // slice(N)
             const idx_node = try es_helpers.makeNumericLiteral(self, @intCast(start_idx));
             return es_helpers.makeCallExpr(self, callee, &.{idx_node}, span);
+        }
+
+        pub fn buildArrayRead(self: *Transformer, value: NodeIndex, pattern: Node, span: Span) Transformer.Error!NodeIndex {
+            self.runtime_helpers.read = true;
+            const callee = try es_helpers.makeRuntimeHelperRef(self, "__read");
+            const read_len = arrayPatternReadLimit(self, pattern);
+            if (read_len) |len| {
+                const len_node = try es_helpers.makeNumericLiteral(self, len);
+                return es_helpers.makeCallExpr(self, callee, &.{ value, len_node }, span);
+            }
+            return es_helpers.makeCallExpr(self, callee, &.{value}, span);
+        }
+
+        fn arrayPatternReadLimit(self: *Transformer, pattern: Node) ?u32 {
+            const split = self.ast.nodeListSplitRest(pattern.data.list);
+            if (split.rest_operand != null) return null;
+            return @intCast(split.elements.len);
         }
 
         fn rewritePatternDefaultTDZ(self: *Transformer, default_val: NodeIndex, pattern: Node, start_idx: u32) Transformer.Error!void {

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -224,13 +224,30 @@ pub fn ES2015Params(comptime Transformer: type) type {
             try body_stmts.append(self.allocator, default_stmt);
 
             const temp_ref2 = try es_helpers.makeTempVarRef(self, temp_span, span);
-            const destruct_decl = try es_helpers.makeVarDeclaration(
-                self,
-                &.{try es_helpers.makeDeclarator(self, visited_pattern, temp_ref2, span)},
-                .@"var",
-                span,
-            );
-            try body_stmts.append(self.allocator, destruct_decl);
+            const pattern_node = self.ast.getNode(visited_pattern);
+            const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(Transformer);
+            const read_span = if (pattern_node.tag == .array_pattern) blk: {
+                const read_span = try es_helpers.makeTempVarSpan(self);
+                const read_binding = try es_helpers.makeBindingIdentifier(self, read_span);
+                const read_init = try es2015_destruct.buildArrayRead(self, temp_ref2, pattern_node, span);
+                const read_decl = try es_helpers.makeVarDeclaration(
+                    self,
+                    &.{try es_helpers.makeDeclarator(self, read_binding, read_init, span)},
+                    .@"var",
+                    span,
+                );
+                try body_stmts.append(self.allocator, read_decl);
+                break :blk read_span;
+            } else temp_span;
+
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+            try es2015_destruct.emitPatternDeclarators(self, pattern_node, read_span, span);
+            const declarators = self.scratch.items[scratch_top..];
+            if (declarators.len > 0) {
+                const destruct_decl = try es_helpers.makeVarDeclaration(self, declarators, .@"var", span);
+                try body_stmts.append(self.allocator, destruct_decl);
+            }
 
             return temp_binding;
         }
@@ -251,7 +268,16 @@ pub fn ES2015Params(comptime Transformer: type) type {
 
             const pattern = self.ast.getNode(pattern_idx);
             const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(Transformer);
-            try es2015_destruct.emitPatternDeclarators(self, pattern, temp_span, span);
+            const read_span = if (pattern.tag == .array_pattern) blk: {
+                const read_span = try es_helpers.makeTempVarSpan(self);
+                const read_binding = try es_helpers.makeBindingIdentifier(self, read_span);
+                const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, span);
+                const read_init = try es2015_destruct.buildArrayRead(self, temp_ref, pattern, span);
+                const read_decl = try es_helpers.makeDeclarator(self, read_binding, read_init, span);
+                try self.scratch.append(self.allocator, read_decl);
+                break :blk read_span;
+            } else temp_span;
+            try es2015_destruct.emitPatternDeclarators(self, pattern, read_span, span);
 
             const declarators = self.scratch.items[scratch_top..];
             if (declarators.len > 0) {

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -198,6 +198,38 @@ fn rewriteTDZReferencesInner(self: anytype, idx: NodeIndex, tdz_names: []const S
         else => {},
     }
 
+    switch (node.tag) {
+        .object_property => {
+            const left = node.data.binary.left;
+            const right = node.data.binary.right;
+            if (!left.isNone()) {
+                const left_node = self.ast.getNode(left);
+                if (left_node.tag == .computed_property_key) {
+                    try rewriteTDZReferencesInner(self, left, tdz_names);
+                }
+            }
+            if (!right.isNone()) {
+                if (@intFromEnum(right) == @intFromEnum(left)) {
+                    const right_node = self.ast.getNode(right);
+                    if (right_node.tag == .identifier_reference) {
+                        if (tdzNameMatch(self, right_node.data.string_ref, tdz_names)) |name_span| {
+                            const call = try makeTDZCall(self, name_span, right_node.span);
+                            self.ast.nodes.items[raw_i].data.binary.right = call;
+                        }
+                    }
+                } else {
+                    try rewriteTDZReferencesInner(self, right, tdz_names);
+                }
+            }
+            return;
+        },
+        .static_member_expression, .private_field_expression => {
+            try rewriteTDZReferencesInner(self, @enumFromInt(self.ast.extra_data.items[node.data.extra]), tdz_names);
+            return;
+        },
+        else => {},
+    }
+
     switch (Node.Tag.dataKind(node.tag)) {
         .leaf => {},
         .unary => try rewriteTDZReferencesInner(self, node.data.unary.operand, tdz_names),
@@ -730,13 +762,17 @@ pub fn buildForOfLoopVarAssign(self: anytype, left: NodeIndex, elem: NodeIndex, 
             // Destructuring pattern — 임시 변수 _t 도입 후 패턴을 declarator 로 전개
             const temp_span = try makeTempVarSpan(self);
             const temp_binding = try makeBindingIdentifier(self, temp_span);
-            const temp_decl = try makeDeclarator(self, temp_binding, elem, span);
+            const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(@TypeOf(self.*));
+            const temp_init = if (binding_node.tag == .array_pattern)
+                try es2015_destruct.buildArrayRead(self, elem, binding_node, span)
+            else
+                elem;
+            const temp_decl = try makeDeclarator(self, temp_binding, temp_init, span);
 
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
             try self.scratch.append(self.allocator, temp_decl);
 
-            const es2015_destruct = @import("es2015_destructuring.zig").ES2015Destructuring(@TypeOf(self.*));
             try es2015_destruct.emitPatternDeclarators(self, binding_node, temp_span, span);
 
             return makeVarDeclaration(self, self.scratch.items[scratch_top..], .@"var", span);

--- a/src/transformer/runtime_helper_imports.zig
+++ b/src/transformer/runtime_helper_imports.zig
@@ -61,6 +61,7 @@ const HelperBit = enum {
     async_generator,
     await_helper,
     tdz,
+    read,
 };
 
 const BitDef = struct {
@@ -107,6 +108,7 @@ const BIT_DEFS = [_]BitDef{
     .{ .bit = .async_generator, .bases = &.{"__asyncGenerator"} },
     .{ .bit = .await_helper, .bases = &.{"__await"} },
     .{ .bit = .tdz, .bases = &.{"__tdz"} },
+    .{ .bit = .read, .bases = &.{"__read"} },
 };
 
 comptime {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -237,7 +237,9 @@ pub const RuntimeHelpers = packed struct(u32) {
     await_helper: bool = false,
     /// __tdz: default initializer / block scope TDZ read
     tdz: bool = false,
-    _padding: u8 = 0,
+    /// __read: array destructuring iterable protocol read
+    read: bool = false,
+    _padding: u7 = 0,
 };
 
 /// 단일 AST append-only 변환기.

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -223,6 +223,69 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("30");
     });
 
+    test("array destructuring은 iterable protocol과 close를 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            let closed = 0;
+            const it = {
+              [Symbol.iterator]() {
+                let i = 0;
+                return {
+                  next() {
+                    i++;
+                    return i === 1 ? { value: 1, done: false } : { value: 2, done: false };
+                  },
+                  return() {
+                    closed++;
+                    return { done: true };
+                  },
+                };
+              },
+            };
+            const [a] = it;
+            console.log(a + ":" + closed);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1:1");
+    });
+
+    test("array destructuring assignment도 iterable protocol을 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const it = {
+              [Symbol.iterator]() {
+                let i = 0;
+                return {
+                  next() {
+                    i++;
+                    return { value: i, done: false };
+                  },
+                  return() {
+                    return { done: true };
+                  },
+                };
+              },
+            };
+            let a = 0;
+            [a] = it;
+            console.log(a);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1");
+    });
+
     test("destructuring rest (object)", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## 요약
- ES5 array destructuring lowering에서 RHS를 __read(iterable, limit)로 먼저 읽도록 변경했습니다.
- declaration, assignment, parameter, nested pattern, for-of destructuring head가 같은 iterable read 경로를 사용합니다.
- __read helper는 필요한 개수만 읽은 뒤 iterator.return()을 호출해 iterator close semantics를 보존합니다.

## 루트 원인
기존 array pattern lowering은 RHS를 array-like 값으로 가정하고 `_ref[0]` 같은 index access만 생성했습니다. 네이티브 array destructuring은 iterable protocol을 통해 값을 읽고 조기 종료 시 iterator close를 수행하므로, array pattern lowering의 입력 temp 생성 지점에서 iterable read를 수행하도록 수정했습니다.

## 테스트
- zig build test -Dtest-filter="array destructuring"
- zig build test -Dtest-filter="ES2015:"
- zig build test
- cd tests/integration && bun test tests/downlevel.test.ts --test-name-pattern "array destructuring.*iterable|destructuring array"
- cd tests/integration && bun test tests/downlevel.test.ts
- bunx oxfmt format --check packages/ tests/integration tests/e2e
- zig fmt --check src/transformer/es2015_destructuring.zig src/transformer/es2015_params.zig src/transformer/es_helpers.zig src/transformer/transformer.zig src/runtime_helper_names.zig src/bundler/runtime_helpers.zig src/runtime_helper_modules.zig src/transformer/runtime_helper_imports.zig src/codegen/codegen_test/es_downlevel.zig
- bun run lint (기존/generated warning, error 0)

참고: bun run fmt:check는 기존 untracked tests/benchmark/_inproc-multi-tmp 생성물이 포함되어 실패할 수 있어 변경 범위 포맷을 별도 확인했습니다.

Closes #1999