### PR TITLE
fix(transformer): derived constructor return 평가 순서 보존

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -362,7 +362,7 @@ pub const DERIVED_CONSTRUCTOR_RUNTIME =
     \\var __assertThisUninitialized = function(self) {
     \\  if (self !== void 0) throw new ReferenceError("Super constructor may only be called once");
     \\};
-    \\var __possibleConstructorReturn = function(self, call) {
+    \\var __possibleConstructorReturn = function(call, self) {
     \\  if (call && (typeof call === "object" || typeof call === "function")) return call;
     \\  if (call !== void 0) throw new TypeError("Derived constructors may only return object or undefined");
     \\  return __assertThisInitialized(self);
@@ -372,7 +372,7 @@ pub const DERIVED_CONSTRUCTOR_RUNTIME =
 pub const DERIVED_CONSTRUCTOR_RUNTIME_MIN =
     "var " ++ NAMES.ASSERT_THIS_INITIALIZED_MIN ++ "=function(self){if(self===void 0)throw new ReferenceError(\"this hasn't been initialised - super() hasn't been called\");return self};" ++
     "var " ++ NAMES.ASSERT_THIS_UNINITIALIZED_MIN ++ "=function(self){if(self!==void 0)throw new ReferenceError(\"Super constructor may only be called once\")};" ++
-    "var " ++ NAMES.POSSIBLE_CONSTRUCTOR_RETURN_MIN ++ "=function(self,call){if(call&&(typeof call===\"object\"||typeof call===\"function\"))return call;if(call!==void 0)throw new TypeError(\"Derived constructors may only return object or undefined\");return " ++ NAMES.ASSERT_THIS_INITIALIZED_MIN ++ "(self)};";
+    "var " ++ NAMES.POSSIBLE_CONSTRUCTOR_RETURN_MIN ++ "=function(call,self){if(call&&(typeof call===\"object\"||typeof call===\"function\"))return call;if(call!==void 0)throw new TypeError(\"Derived constructors may only return object or undefined\");return " ++ NAMES.ASSERT_THIS_INITIALIZED_MIN ++ "(self)};";
 
 /// __async: async/await → generator 변환 시 주입 (esbuild 호환).
 /// generator-to-Promise wrapper. this/arguments를 fn.apply로 보존.

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1742,6 +1742,22 @@ test "ES2015: derived constructor return 값이 super를 먼저 평가" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(_this,value(") == null);
 }
 
+test "ES2015: derived constructor return comma expression super 평가 순서" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(){return (super(),undefined);}}", .es5);
+    defer r.deinit();
+    const helper_pos = std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(((__assertThisUninitialized") orelse return error.TestExpectedEqual;
+    const this_pos = std.mem.indexOfPos(u8, r.output, helper_pos, "),_this)") orelse return error.TestExpectedEqual;
+    try std.testing.expect(helper_pos < this_pos);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(_this,((__assertThisUninitialized") == null);
+}
+
+test "ES2015: derived constructor return primitive도 super 후 검사" {
+    var r = try e2eTarget(std.testing.allocator, "function value(x){return 1;}class C extends P{constructor(){return value(super());}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(value(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(_this,value(") == null);
+}
+
 test "ES2015: derived constructor super 중복 호출은 할당 전 검사" {
     var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(){super();super();}}", .es5);
     defer r.deinit();

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1733,6 +1733,15 @@ test "ES2015: derived constructor return 검사" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__possibleConstructorReturn") != null);
 }
 
+test "ES2015: derived constructor return 값이 super를 먼저 평가" {
+    var r = try e2eTarget(std.testing.allocator, "function value(x){return undefined;}class C extends P{constructor(){return value(super());}}", .es5);
+    defer r.deinit();
+    const helper_pos = std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(value(") orelse return error.TestExpectedEqual;
+    const this_pos = std.mem.indexOfPos(u8, r.output, helper_pos, "),_this)") orelse return error.TestExpectedEqual;
+    try std.testing.expect(helper_pos < this_pos);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(_this,value(") == null);
+}
+
 test "ES2015: derived constructor super 중복 호출은 할당 전 검사" {
     var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(){super();super();}}", .es5);
     defer r.deinit();

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2275,10 +2275,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const helper = try es_helpers.makeRuntimeHelperRef(self, "__possibleConstructorReturn");
             const this_ref = try es_helpers.makeIdentifierRef(self, "_this");
             self.runtime_helpers.derived_constructor = true;
-            return es_helpers.makeCallExpr(self, helper, &.{ this_ref, value }, span);
+            return es_helpers.makeCallExpr(self, helper, &.{ value, this_ref }, span);
         }
 
-        /// derived constructor의 직접 return을 `__possibleConstructorReturn(_this, value)`로 감싼다.
+        /// derived constructor의 직접 return을 `__possibleConstructorReturn(value, _this)`로 감싼다.
         /// 중첩 함수/클래스의 return은 별도 this 바인딩이므로 건드리지 않는다.
         fn transformDerivedConstructorReturns(self: *Transformer, idx: NodeIndex) Transformer.Error!void {
             if (idx.isNone()) return;

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1643,6 +1643,66 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("true true");
     });
 
+    test("derived constructor return super 포함 복합 표현식", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function asUndefined(x: unknown) {
+              return undefined;
+            }
+            function asPrimitive(x: unknown) {
+              return 1;
+            }
+            function asObject(x: unknown) {
+              return { ok: 1 };
+            }
+            class Base {}
+            class FromComma extends Base {
+              constructor() {
+                return (super(), undefined);
+              }
+            }
+            class FromCallObject extends Base {
+              constructor() {
+                return asObject(super()) as any;
+              }
+            }
+            class FromCallPrimitive extends Base {
+              constructor() {
+                return asPrimitive(super()) as any;
+              }
+            }
+            class FromConditional extends Base {
+              constructor(flag: boolean) {
+                return flag ? asUndefined(super()) : undefined;
+              }
+            }
+
+            const comma = new FromComma();
+            const objectResult = new FromCallObject() as any;
+            console.log(comma instanceof FromComma, objectResult.ok);
+            try {
+              new FromCallPrimitive();
+            } catch (e) {
+              console.log((e as Error).constructor.name);
+            }
+            try {
+              const conditional = new FromConditional(true);
+              console.log(conditional instanceof FromConditional);
+              new FromConditional(false);
+            } catch (e) {
+              console.log((e as Error).constructor.name);
+            }
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("true 1\nTypeError\ntrue\nReferenceError");
+    });
+
     test("derived constructor super 두 번 호출 검사", async () => {
       const result = await bundleAndRun(
         {

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1618,6 +1618,31 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("TypeError");
     });
 
+    test("derived constructor return 표현식의 super 평가 순서 보존", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function value(x: unknown) {
+              return undefined;
+            }
+            class Base {}
+            class Child extends Base {
+              constructor() {
+                return value(super());
+              }
+            }
+            const child = new Child();
+            console.log(child instanceof Child, child instanceof Base);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("true true");
+    });
+
     test("derived constructor super 두 번 호출 검사", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## 변경 내용
- derived constructor의 `return value(super())` 변환에서 반환식이 `_this` 읽기보다 먼저 평가되도록 `__possibleConstructorReturn(value, _this)` 순서로 변경했습니다.
- 런타임 헬퍼 시그니처도 `call, self` 순서로 맞췄습니다.
- 코드 생성 테스트와 실제 ES5 번들 실행 회귀 테스트를 추가했습니다.

## 확인
- `zig build test -Dtest-filter="ES2015: derived constructor return 값이 super를 먼저 평가"`
- `zig build test -Dtest-filter="derived constructor"`
- `zig build test`
- `zig build -Doptimize=Debug`
- `bun test --cwd tests/integration downlevel.test.ts --test-name-pattern "derived constructor"`

## 참고
- `bun run fmt -- tests/integration/tests/downlevel.test.ts`는 기존 `oxlintrc`의 `sortImports` 설정에서 `ts-equals-import` 그룹을 현재 oxfmt가 인식하지 못해 설정 파싱 단계에서 실패했습니다. Zig 파일은 `zig fmt`로 정리했고, 변경된 TS는 포맷 변경이 필요 없는 형태입니다.