### PR TITLE
fix(test262): test262 repo root 입력 시 toolchain self-fixture 자동 제외

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1431,8 +1431,26 @@ pub fn main() !void {
         };
         const abs_path = try std.fs.cwd().realpathAlloc(allocator, dir_path);
         defer allocator.free(abs_path);
-        try stdout.print("Running Test262: {s}\n", .{abs_path});
-        const summary = try runner.runDirectory(allocator, abs_path, false);
+
+        // test262 repo root 자동 감지: `test/` 와 `tools/` 가 둘 다 있으면 conformance `test/` 만 측정.
+        // tools/lint·generation 의 self-fixture (의도적으로 invalid 한 frontmatter 를 갖는 .js)
+        // 가 함께 walk 되어 fake fail 로 카운트되는 것을 막는다.
+        const test_sub = try std.fs.path.join(allocator, &.{ abs_path, "test" });
+        defer allocator.free(test_sub);
+        const tools_sub = try std.fs.path.join(allocator, &.{ abs_path, "tools" });
+        defer allocator.free(tools_sub);
+        const is_repo_root = blk: {
+            std.fs.accessAbsolute(test_sub, .{}) catch break :blk false;
+            std.fs.accessAbsolute(tools_sub, .{}) catch break :blk false;
+            break :blk true;
+        };
+
+        const walk_path = if (is_repo_root) test_sub else abs_path;
+        if (is_repo_root) {
+            try stdout.print("Detected test262 repo root — restricting walk to '{s}'\n", .{walk_path});
+        }
+        try stdout.print("Running Test262: {s}\n", .{walk_path});
+        const summary = try runner.runDirectory(allocator, walk_path, false);
         try summary.print(stdout);
         return;
     }


### PR DESCRIPTION
## 요약
- `zts --test262 tests/test262` 처럼 repo root 를 주면 walker 가 `tools/lint/test/fixtures` · `tools/generation/test/expected` 안의 의도적으로 invalid 한 frontmatter 를 갖는 .js 파일까지 같이 파싱해 fake fail 약 70건이 측정에 포함되던 문제 수정.
- `test/` 와 `tools/` 가 둘 다 있으면 test262 repo root 로 판단하고 conformance `test/` 하위로 walk 경로를 자동 제한. CLI 에 안내 메시지도 함께 출력.

## 루트 원인
`runDirectory(allocator, abs_path, ...)` 가 `abs_path` 의 모든 `.js` 를 재귀 탐색. test262 repo root 를 그대로 받으면 toolchain self-fixture (test262 의 lint/generation 도구가 검증 대상으로 두는 의도적으로 깨진 frontmatter 파일) 까지 잡혀 진짜 ECMAScript conformance 와 무관한 fail 이 합산된다.

## 수정
src/main.zig 의 `--test262` 처리부에서 dir_path 가 test262 repo root 인지 (`test/` + `tools/` 동시 존재) 감지 → conformance `test/` 만 walk. `Detected test262 repo root — restricting walk to '<path>'` stdout 메시지.

## 효과
- 측정 노이즈 69 fake fail 제거 → 실제 6 known fail 만 남음 (annexB B.3.3.1 sloppy hoisting; 별도 PR 에서 fix).

## 테스트 계획
- [ ] `zig build -Doptimize=ReleaseFast`
- [ ] `zts --test262 tests/test262` → "Detected test262 repo root" 메시지 + Total 50,504 (이전 50,650)
- [ ] `zts --test262 tests/test262/test` → 그대로 walk (정상 경로)
- [ ] `zts --test262 tests/test262/test/expressions` → 그대로 walk (하위 디렉토리)