### PR TITLE
fix(transformer): ES5 string-keyed method 의 defineProperty key 이중 quote

### DIFF
--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -435,6 +435,15 @@ pub fn buildDefinePropertyKeyArg(self: anytype, key_idx: NodeIndex) !NodeIndex {
     if (key_node.tag == .computed_property_key) {
         return self.visitNode(key_node.data.unary.operand);
     }
+    if (key_node.tag == .string_literal) {
+        // string literal key (예: `class C { "foo bar"() {} }`) 는 이미 quote 포함된 raw 라
+        // buildQuotedKeyLiteral 로 감싸면 ``""foo bar""`` 같은 이중 quote 발생. 새 노드로 복제만.
+        return self.ast.addNode(.{
+            .tag = .string_literal,
+            .span = key_node.span,
+            .data = key_node.data,
+        });
+    }
     return buildQuotedKeyLiteral(self, key_node.span);
 }
 

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -4388,4 +4388,28 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("false");
     });
   });
+
+  describe("ES5 string-keyed method", () => {
+    // class C { "foo bar"() {} } 가 ES5 다운레벨 시
+    // Object.defineProperty(C.prototype, ""foo bar"", ...) 같이 이중 quote
+    // 되어 syntax error 가 나던 회귀 (compat-table es5 string-keyed methods).
+    test("string literal key 메서드가 ES5 다운레벨 후 정상 호출", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class C {
+              "foo bar"() { return 2; }
+            }
+            const v = new C()["foo bar"]();
+            console.log(v, typeof (C as any).prototype["foo bar"]);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("2 function");
+    });
+  });
 });


### PR DESCRIPTION
## 요약
- `class C { "foo bar"() {} }` 같이 string literal key 메서드를 ES5 다운레벨링하면 `Object.defineProperty(C.prototype, ""foo bar"", ...)` 처럼 큰따옴표가 두 번 들어가 JS parser 가 syntax error.
- compat-table es5 의 `class > string-keyed methods` 케이스 회복.

## 루트 원인
`buildDefinePropertyKeyArg` 가 string_literal key 도 일반 identifier/numeric key 와 똑같이 `buildQuotedKeyLiteral` 로 감쌌는데, string literal 의 span 텍스트는 이미 quote 포함이라 한 번 더 감싸면 이중 quote 가 됐다.

## 수정
- `src/transformer/es_helpers.zig:buildDefinePropertyKeyArg` — string_literal tag 의 경우 span/data 를 그대로 복제해 새 노드만 만들어 반환. computed_property_key 와 같은 방식의 special case.
- 회귀 가드용 통합 테스트 1건 추가.

## 테스트 계획
- [ ] `zig build -Doptimize=ReleaseFast`
- [ ] `bun run --cwd tests/integration test:compat` (ES5 의 `class > string-keyed methods` PASS)
- [ ] `cd tests/integration && bun test tests/downlevel.test.ts -t "string-keyed"`