### PR TITLE
test(transformer): #2014 의 tagged template invalid escape 회귀 가드 복원

### DIFF
--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -4680,6 +4680,45 @@ describe("ES 다운레벨링 런타임 테스트", () => {
     });
   });
 
+  describe("Tagged template + invalid escape (ES2018 lifting)", () => {
+    // raw 그대로 cooked array 에 박으면 JS engine 이 \\x can only be followed by
+    // a hex character sequence 같은 SyntaxError 를 낸다. ES2018 spec 은 invalid
+    // escape 가 있으면 cooked element 가 undefined 여야 한다.
+    test("invalid escape 가 있는 cooked element 가 undefined", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function strings(arr: TemplateStringsArray) { return arr; }
+            const str = strings\`\\1\\xz\\uz\\u{110000}\\u{z}\`;
+            console.log(str.length === 1, str[0] === undefined, str.raw[0] === "\\\\1\\\\xz\\\\uz\\\\u{110000}\\\\u{z}");
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("true true true");
+    });
+
+    test("valid escape 는 그대로 cooked 에 박힌다", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            function strings(arr: TemplateStringsArray) { return arr; }
+            const str = strings\`a\\nb\\tc\`;
+            console.log(str[0] === "a\\nb\\tc");
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("true");
+    });
+  });
+
   describe("Annex B B.3.3.1 sloppy hoist skip", () => {
     // outer scope 의 lexical (let/const) 와 같은 이름의 function declaration 이
     // 안쪽 block 에 있을 때, var-scope hoist 를 시도하면 redeclaration 으로 막혀


### PR DESCRIPTION
## 요약
- #2014 (64582dfa) 가 추가한 회귀 가드 두 테스트가 #2015 (d2a393ee) 의 rebase conflict resolve 과정에서 통째로 삭제됨.
- fix 코드 자체는 main 에 그대로 살아 있음 (`src/transformer/es2015_template.zig:templateCookedHasInvalidEscape`, `src/transformer/transformer.zig:visitTaggedTemplate`).
- 단지 통합 테스트가 비어 있어 향후 누군가 invalid escape 처리를 건드려도 잡지 못함.

## 루트 원인
#2014 와 #2015 가 같은 줄 (`tests/integration/tests/downlevel.test.ts` 끝부분) 에 새 describe 블록을 추가. #2015 머지 시 rebase conflict 해결 과정에서 #2014 두 테스트 (\`Tagged template + invalid escape (ES2018 lifting)\` describe 의 `invalid escape 가 있는 cooked element 가 undefined`, `valid escape 는 그대로 cooked 에 박힌다`) 가 사라짐.

## 수정
- `Annex B B.3.3.1 sloppy hoist skip` describe 바로 위에 #2014 의 describe 와 두 test 를 그대로 복원.

## 테스트 계획
- [ ] `cd tests/integration && bun test tests/downlevel.test.ts -t "Tagged template + invalid escape"`