### PR TITLE
[codex] Minify guard helper name

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2597,7 +2597,9 @@ test "entry_error_guard #13: minify_whitespace — minified helper 형태 정상
 
     try std.testing.expect(!result.hasErrors());
     // minified 형태도 helper 정의 + console.warn swallow 보존
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zts_guarded") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function $zg") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$zg(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zts_guarded") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "console.warn") != null);
 }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1020,8 +1020,9 @@ pub fn appendGuardedModuleCall(
     else
         try mod.allocInitName(allocator);
     defer allocator.free(call_name);
-    // `__zts_guarded(callName)` — fn 인자로 함수 식별자만 전달. helper 가 fn() 호출.
-    try output.appendSlice(allocator, "__zts_guarded(");
+    // guard helper 에 함수 식별자만 전달. helper 가 fn() 호출.
+    try output.appendSlice(allocator, if (options.minify_whitespace) rt.GUARD_FN_NAME_MIN else rt.GUARD_FN_NAME);
+    try output.append(allocator, '(');
     try output.appendSlice(allocator, call_name);
     try output.appendSlice(allocator, ");\n");
 }

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -962,7 +962,7 @@ fn appendWrappedInitCall(
     switch (src_mod.wrap_kind) {
         .esm => {
             if (is_tla) try buf.appendSlice(allocator, "await ");
-            if (guard) try buf.appendSlice(allocator, rt.GUARD_LAMBDA_OPEN);
+            if (guard) try buf.appendSlice(allocator, if (options.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
             if (options.dev_mode) {
                 try buf.appendSlice(allocator, "__zts_modules[\"");
                 try buf.appendSlice(allocator, src_mod.dev_id);
@@ -978,7 +978,7 @@ fn appendWrappedInitCall(
         .cjs => {
             const rv = try types.makeRequireVarName(allocator, src_mod.path);
             defer allocator.free(rv);
-            if (guard) try buf.appendSlice(allocator, rt.GUARD_LAMBDA_OPEN);
+            if (guard) try buf.appendSlice(allocator, if (options.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
             try buf.appendSlice(allocator, rv);
             try buf.appendSlice(allocator, "()");
             try buf.appendSlice(allocator, if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -416,7 +416,7 @@ pub fn buildMetadataForAst(
                     const is_tla = target_mod.uses_top_level_await;
                     const guard = target_mod.shouldGuard(self.entry_error_guard);
                     if (is_tla) try preamble.write("await ");
-                    if (guard) try preamble.write(rt.GUARD_LAMBDA_OPEN);
+                    if (guard) try preamble.write(if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
                     if (self.dev_mode) {
                         try preamble.write("__zts_modules[\"");
                         try preamble.write(target_mod.dev_id);

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -931,7 +931,7 @@ pub const GUARDED_RUNTIME =
 ;
 
 pub const GUARDED_RUNTIME_MIN =
-    "function __zts_guarded(fn){try{return fn()}catch(e){if(typeof globalThis!==\"undefined\"&&globalThis.__ZTS_DEBUG_GUARD&&typeof console!==\"undefined\"&&console.warn)console.warn(\"[zts:guard] caught:\",e)}}\n";
+    "function $zg(fn){try{return fn()}catch(e){if(typeof globalThis!==\"undefined\"&&globalThis.__ZTS_DEBUG_GUARD&&typeof console!==\"undefined\"&&console.warn)console.warn(\"[zts:guard] caught:\",e)}}\n";
 
 /// `silent_console_error_patterns` 가 비어있지 않을 때 prologue 에 주입.
 /// `Object.defineProperty(console, "error", { set })` setter intercept — RN
@@ -1007,7 +1007,10 @@ pub fn emitConsoleErrorInterceptInto(
 /// `__zts_guarded(function(){return <expr>;})` wrap 매크로 — esm_wrap / linker preamble /
 /// emitter 의 entry chain unroll 모두 같은 형식이라 한 곳에서 정의. 패턴 변경 시 여기만.
 pub const GUARD_LAMBDA_OPEN = "__zts_guarded(function(){return ";
+pub const GUARD_LAMBDA_OPEN_MIN = "$zg(function(){return ";
 pub const GUARD_LAMBDA_CLOSE = ";});\n";
+pub const GUARD_FN_NAME = "__zts_guarded";
+pub const GUARD_FN_NAME_MIN = "$zg";
 pub const INIT_CALL_END = ";\n";
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Shorten the React Native entry guard helper from `__zts_guarded` to `$zg` in minified output.
- Route all minified guard call sites through the shortened helper name.
- Update the entry error guard regression test to assert that minified output no longer emits the long helper name.

## Root Cause

Release/minified React Native bundles still emitted the internal guard helper name `__zts_guarded` at every guarded module init call site. In the ExampleApp iOS release bundle this appeared 3,135 times, adding avoidable raw bytes even though the helper is internal runtime glue.

## Validation

- `zig build test -- entry_error_guard`
- Rebuilt NAPI and measured ExampleApp iOS release output:
  - before: `2,547,120 bytes`
  - after: `2,515,698 bytes`
  - raw delta: `-31,422 bytes`
