### PR TITLE
chore(simplify): /simplify followup — 최근 머지된 10 PR 정리

### DIFF
--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -197,19 +197,18 @@ fn evalToBooleanDepth(ast: *const Ast, idx: NodeIndex, defines: []const DefineEn
             if (op == .pipe2) break :blk left or right;
             break :blk null;
         },
-        .binary_expression => evalBinaryBoolean(ast, node, defines, depth),
+        .binary_expression => evalBinaryBoolean(ast, node, defines),
         else => null,
     };
 }
 
-fn evalBinaryBoolean(ast: *const Ast, node: Node, defines: []const DefineEntry, depth: u8) ?bool {
+fn evalBinaryBoolean(ast: *const Ast, node: Node, defines: []const DefineEntry) ?bool {
     const op: TokenKind = @enumFromInt(node.data.binary.flags);
     if (op != .eq2 and op != .eq3 and op != .neq and op != .neq2) return null;
 
     const left = evalToString(ast, node.data.binary.left, defines) orelse return null;
     const right = evalToString(ast, node.data.binary.right, defines) orelse return null;
     const is_equal = std.mem.eql(u8, left, right);
-    _ = depth;
     return switch (op) {
         .eq2, .eq3 => is_equal,
         .neq, .neq2 => !is_equal,

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -3275,15 +3275,10 @@ pub const SemanticAnalyzer = struct {
         if (body_idx.isNone()) return;
         const body_node = self.ast.getNode(body_idx);
         if (body_node.tag == .block_statement) {
-            // ECMAScript Annex B B.3.3.1 을 위해 함수 body 의 직속 lexical (let/const/class)
-            // 도 var pre-pass 보다 먼저 등록한다. 그래야 nested block 안의 function
-            // declaration 이 var-scope hoist 를 시도할 때 outer lexical 과의 충돌을 감지하고
-            // hoist 를 skip 할 수 있다 (annexB function-code/*-func-skip-early-err 케이스).
+            // lexical 을 var pre-pass 보다 먼저 등록 — `predeclareVarDeclsRecursive` 의
+            // function_declaration 분기가 outer lexical 충돌을 감지해 Annex B B.3.3.1
+            // 의 hoist-skip 을 수행하기 위해 필요.
             try self.predeclareLexicalDecls(body_node.data.list);
-
-            // var hoisting: 함수 body 내부의 모든 var 선언을 함수 스코프에 미리 등록.
-            // ECMAScript var는 함수 진입 시 hoisting되므로 사용 위치가 선언보다 앞이어도 유효.
-            // predeclared_scope는 설정하지 않음 — isVarPredeclared가 var 전용으로 처리.
             try self.predeclareVarDecls(body_node.data.list);
             try self.visitStmtList(body_node.data.list);
         } else {
@@ -3314,9 +3309,8 @@ pub const SemanticAnalyzer = struct {
                 try self.predeclareVarDecl(node);
             },
             // 함수 선언도 hoisting 대상 (var scope에 등록).
-            // ECMAScript Annex B B.3.3.1: outer var scope 에 같은 이름의 lexical
-            // (let/const/class) 가 이미 있으면 hoist 를 skip 한다 — 그 경우 var 바인딩이
-            // early error 를 만들 상황이라 extension 이 적용되지 않는다.
+            // Annex B B.3.3.1: outer var scope 에 같은 이름의 lexical 이 있으면
+            // hoist skip (var binding 이 early error 를 만들 상황엔 extension 미적용).
             .function_declaration => {
                 const extra_start = node.data.extra;
                 const extras = self.ast.extra_data.items;
@@ -3327,10 +3321,7 @@ pub const SemanticAnalyzer = struct {
                     const var_scope = self.findVarScope();
                     const name_text = self.ast.getText(name_node.span);
                     if (self.findSymbolInScope(var_scope, name_text)) |existing| {
-                        if (existing.kind.isBlockScoped()) {
-                            // outer lexical 충돌 — hoist skip (Annex B B.3.3.1).
-                            return;
-                        }
+                        if (existing.kind.isBlockScoped()) return;
                     }
                     try self.declareSymbolWithNode(name_node.span, .function_decl, name_node.span, null);
                 }

--- a/src/transformer/es2015_template.zig
+++ b/src/transformer/es2015_template.zig
@@ -198,7 +198,8 @@ pub fn buildRawStringLiteral(self: anytype, text: []const u8) !NodeIndex {
 /// - `\\1` ~ `\\9` legacy octal escape (template literal 컨텍스트에선 항상 invalid)
 /// - `\\0` 뒤가 decimal digit (즉 `\\01`, `\\09` 등) 도 legacy octal 로 해석 → invalid
 pub fn templateCookedHasInvalidEscape(text: []const u8) bool {
-    var i: usize = 0;
+    // backslash 가 없으면 escape 도 없다 — 가장 흔한 경우 short-circuit (SIMD-accelerated).
+    var i: usize = std.mem.indexOfScalar(u8, text, '\\') orelse return false;
     while (i < text.len) {
         if (text[i] != '\\') {
             i += 1;
@@ -249,6 +250,16 @@ pub fn templateCookedHasInvalidEscape(text: []const u8) bool {
         }
     }
     return false;
+}
+
+/// Tagged template 의 cooked element 노드 생성: invalid escape 면 `void 0`, 아니면 string literal.
+/// ES2018 "Lifting Template Literal Restriction" 적용 — visitTaggedTemplate 의 두 분기 공통.
+pub fn buildCookedElement(self: anytype, text: []const u8, span: Span) !NodeIndex {
+    const es_helpers = @import("es_helpers.zig");
+    if (templateCookedHasInvalidEscape(text)) {
+        return es_helpers.makeVoidZero(self, span);
+    }
+    return buildStringLiteral(self, text);
 }
 
 /// template 텍스트를 string_literal 노드로 변환한다.

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -557,13 +557,9 @@ pub fn buildDefinePropertyKeyArg(self: anytype, key_idx: NodeIndex) !NodeIndex {
         return self.visitNode(key_node.data.unary.operand);
     }
     if (key_node.tag == .string_literal) {
-        // string literal key (예: `class C { "foo bar"() {} }`) 는 이미 quote 포함된 raw 라
-        // buildQuotedKeyLiteral 로 감싸면 ``""foo bar""`` 같은 이중 quote 발생. 새 노드로 복제만.
-        return self.ast.addNode(.{
-            .tag = .string_literal,
-            .span = key_node.span,
-            .data = key_node.data,
-        });
+        // string literal key 는 이미 quote 포함이라 buildQuotedKeyLiteral 로 감싸면 이중 quote.
+        // visitNode 경로가 quote 보존 + unicode_brace_escape 같은 ES5 lower 까지 동시 처리.
+        return self.visitNode(key_idx);
     }
     return buildQuotedKeyLiteral(self, key_node.span);
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3314,18 +3314,11 @@ pub const Transformer = struct {
         var raw_count: u32 = 0;
         var has_escape = false;
 
-        // ES2018 "Lifting Template Literal Restriction": tagged template 의 cooked
-        // element 가 invalid escape sequence 를 포함하면 `undefined` 로 emit 해야 한다.
-        // raw 그대로 string literal 로 박으면 JS engine 의 parse 단계에서 "\\x can only
-        // be followed by a hex character sequence" 류 SyntaxError.
-        const cooked_span = tmpl.span;
+        // ES2018 "Lifting Template Literal Restriction" — invalid escape 면 cooked element 를
+        // `undefined` 로. buildCookedElement 가 검사 + dispatch 양쪽을 담당.
         if (!is_substitution) {
             const text = es2015_template.getTemplateElementText(source, tmpl.span);
-            const cooked_node = if (es2015_template.templateCookedHasInvalidEscape(text))
-                try es_helpers.makeVoidZero(self, cooked_span)
-            else
-                try es2015_template.buildStringLiteral(self, text);
-            try self.scratch.append(self.allocator, cooked_node);
+            try self.scratch.append(self.allocator, try es2015_template.buildCookedElement(self, text, tmpl.span));
             cooked_count = 1;
         } else {
             const tl_start = tmpl.data.list.start;
@@ -3336,11 +3329,7 @@ pub const Transformer = struct {
                 const member = self.ast.getNode(@enumFromInt(raw_idx));
                 if (member.tag == .template_element) {
                     const text = es2015_template.getTemplateElementText(source, member.span);
-                    const cooked_node = if (es2015_template.templateCookedHasInvalidEscape(text))
-                        try es_helpers.makeVoidZero(self, member.span)
-                    else
-                        try es2015_template.buildStringLiteral(self, text);
-                    try self.scratch.append(self.allocator, cooked_node);
+                    try self.scratch.append(self.allocator, try es2015_template.buildCookedElement(self, text, member.span));
                     cooked_count += 1;
                 }
             }


### PR DESCRIPTION
## 요약
3-agent simplify 리뷰 (reuse / quality / efficiency) 결과 중 deterministic + 작은 위험인 항목만 한 PR 에 묶음. 큰 리팩토링은 효과 측정 후 별도 PR.

## 적용 항목

### 1. `buildDefinePropertyKeyArg` — string_literal 분기를 visitNode 로 (#2013 후속)
- 기존 새 노드 복제 방식은 transformer.zig 의 string_literal visit 가 수행하는 `unicode_brace_escape` (`\u{XX}` lower) 같은 ES5 lower 를 우회.
- `visitNode` 가 quote 보존 + 추가 lower 를 동시 처리. 이중 quote 회귀 가드 유지하면서 ES5 호환성 확보.

### 2. tagged template cooked 분기 통합 + early return (#2014 후속)
- `visitTaggedTemplate` 의 sub/non-sub 분기에 동일한 invalid escape 검사 + dispatch inline copy → `buildCookedElement` helper 한 줄로.
- `templateCookedHasInvalidEscape` 시작에 `indexOfScalar(text, '\\\\')` SIMD short-circuit. backslash 없는 cooked 는 스캔 0회.

### 3. `evalBinaryBoolean` dead `_ = depth;` 제거 (#2006 후속)
- 함수가 재귀 안 함 (left/right 가 `evalToString`) 이라 depth 인자 무용. 시그니처에서 제거.

### 4. analyzer 주석 narrate 정리 (#2015 후속)
- 같은 Annex B B.3.3.1 spec 인용이 두 곳에 4줄씩 중복. 한 줄로 압축.
- 즉시 위 코드 narrate 하는 inline 주석 제거.

## 통계
순감 14줄 (5 files, +27 / -41).

## 보류 (별도 PR)
- `collectBindingNames` 두 카피 통합 (es2015_destructuring + es2015_params)
- `buildArrayRead` 5+ inline 패턴 → wrapper helper
- `templateCookedHasInvalidEscape` 폐기 + lexer flag 사용 (parser 변경 필요)
- `predeclareLexicalDecls` lazy 화 — `--timing` 측정 후
- `__possibleConstructorReturn` 인자 swap ABI 위험 — helper 이름 bump

## 테스트 계획
- [ ] `zig build -Doptimize=ReleaseFast`
- [ ] `zig build test`
- [ ] `cd tests/integration && bun test tests/downlevel.test.ts -t "Tagged template|string-keyed|Annex B"`