### PR TITLE
fix(minify): CJS require 래퍼 이름도 망글링

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -132,6 +132,7 @@ test "Bundler: minify가 래퍼 합성 심볼을 짧은 이름으로 바꿈" {
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "init_") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "exports_") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log") != null);
 }
 
@@ -169,6 +170,7 @@ test "Bundler: minify가 require 래퍼 합성 심볼도 짧은 이름으로 바
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "init_") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "exports_") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log") != null);
 }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -990,7 +990,7 @@ pub fn appendIndented(wrapped: *std.ArrayList(u8), allocator: std.mem.Allocator,
 /// run-before-main, 엔트리 자동 호출, star export init 등에서 공용.
 pub fn appendModuleCall(output: *std.ArrayList(u8), allocator: std.mem.Allocator, mod: anytype) !void {
     const call_name = if (mod.wrap_kind == .cjs)
-        try types.makeRequireVarName(allocator, mod.path)
+        try mod.allocRequireName(allocator)
     else
         try mod.allocInitName(allocator);
     defer allocator.free(call_name);
@@ -1016,7 +1016,7 @@ pub fn appendGuardedModuleCall(
         return;
     }
     const call_name = if (mod.wrap_kind == .cjs)
-        try types.makeRequireVarName(allocator, mod.path)
+        try mod.allocRequireName(allocator)
     else
         try mod.allocInitName(allocator);
     defer allocator.free(call_name);
@@ -1475,7 +1475,7 @@ pub fn emitModule(
         const basename = module.wrapperId();
         const preamble_code = if (metadata) |md| md.cjs_import_preamble else null;
 
-        const var_name = try types.makeRequireVarName(allocator, module.path);
+        const var_name = try module.allocRequireName(allocator);
         defer allocator.free(var_name);
 
         var wrapped: std.ArrayList(u8) = .empty;

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -654,7 +654,7 @@ fn rewriteDynamicImports(
                     break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>({s}(),{s}))", .{ init_name, exports_name });
                 },
                 .cjs => blk: {
-                    const require_name = try types.makeRequireVarName(allocator, target_mod.path);
+                    const require_name = try target_mod.allocRequireName(allocator);
                     defer allocator.free(require_name);
                     break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>{s}())", .{require_name});
                 },

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -5,7 +5,6 @@
 //! 케이스를 담당: asset (file/copy 로더) + disabled (browser 빌드의 Node 빌트인).
 
 const std = @import("std");
-const types = @import("../types.zig");
 const rt = @import("../runtime_helpers.zig");
 const Module = @import("../module.zig").Module;
 const EmitOptions = @import("../emitter.zig").EmitOptions;
@@ -13,7 +12,7 @@ const EmitOptions = @import("../emitter.zig").EmitOptions;
 /// Disabled 모듈: platform=browser에서 Node 빌트인 모듈을 빈 __commonJS wrapper로 출력.
 /// esbuild 호환 형식: `var require_util = __commonJS({ "(disabled)"(exports, module) {} });`
 pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, minify: bool) !?[]const u8 {
-    const var_name = try types.makeRequireVarName(allocator, module.path);
+    const var_name = try module.allocRequireName(allocator);
     defer allocator.free(var_name);
 
     var buf: std.ArrayList(u8) = .empty;
@@ -34,13 +33,13 @@ pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, m
 /// linker가 `require_X()` 호출을 생성하므로, 모든 포맷에서 CJS 패턴을 사용.
 pub fn emitAssetModule(allocator: std.mem.Allocator, module: *const Module, options: *const EmitOptions) !?[]const u8 {
     if (module.source.len == 0) return null;
-    return emitCjsWrapper(allocator, module.path, module.source, options.minify_whitespace);
+    return emitCjsWrapper(allocator, module, module.source, options.minify_whitespace);
 }
 
 /// `var require_X = __commonJS({ "filename"(exports, module) { module.exports = <source>; } });`
 /// 형태의 __commonJS wrapper를 생성.
-pub fn emitCjsWrapper(allocator: std.mem.Allocator, path: []const u8, source: []const u8, minify: bool) !?[]const u8 {
-    const var_name = try types.makeRequireVarName(allocator, path);
+pub fn emitCjsWrapper(allocator: std.mem.Allocator, module: *const Module, source: []const u8, minify: bool) !?[]const u8 {
+    const var_name = try module.allocRequireName(allocator);
     defer allocator.free(var_name);
 
     var buf: std.ArrayList(u8) = .empty;
@@ -49,7 +48,7 @@ pub fn emitCjsWrapper(allocator: std.mem.Allocator, path: []const u8, source: []
         try buf.appendSlice(allocator, var_name);
         // #1621: minify 시 __commonJS → $cj 축약 (#1618 follow-up).
         try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "({\"");
-        try buf.appendSlice(allocator, std.fs.path.basename(path));
+        try buf.appendSlice(allocator, std.fs.path.basename(module.path));
         try buf.appendSlice(allocator, "\"(exports,module){module.exports=");
         try buf.appendSlice(allocator, source);
         try buf.appendSlice(allocator, "}});");
@@ -57,7 +56,7 @@ pub fn emitCjsWrapper(allocator: std.mem.Allocator, path: []const u8, source: []
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
         try buf.appendSlice(allocator, " = __commonJS({\n\t\"");
-        try buf.appendSlice(allocator, std.fs.path.basename(path));
+        try buf.appendSlice(allocator, std.fs.path.basename(module.path));
         try buf.appendSlice(allocator, "\"(exports, module) {\nmodule.exports=");
         try buf.appendSlice(allocator, source);
         try buf.appendSlice(allocator, ";\n\t}\n});\n");

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -421,7 +421,7 @@ pub fn emitEsmWrappedModule(
                     const getter_val = switch (src_mod.wrap_kind) {
                         .esm, .none => try src_mod.allocExportsName(allocator),
                         .cjs => blk: {
-                            const rv = try types.makeRequireVarName(allocator, src_mod.path);
+                            const rv = try src_mod.allocRequireName(allocator);
                             defer allocator.free(rv);
                             break :blk try std.fmt.allocPrint(allocator, "{s}()", .{rv});
                         },
@@ -662,7 +662,7 @@ pub fn emitEsmWrappedModule(
                         if (found_preamble_var) |pv| {
                             try reexport_buf.appendSlice(allocator, pv);
                         } else {
-                            const rv = try types.makeRequireVarName(allocator, source_mod.path);
+                            const rv = try source_mod.allocRequireName(allocator);
                             defer allocator.free(rv);
                             const interop_mode: types.Interop = if (module.def_format.isEsm()) .node else .babel;
                             // #1621: minify 시 __toESM → $tE 축약.
@@ -976,7 +976,7 @@ fn appendWrappedInitCall(
             try buf.appendSlice(allocator, if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);
         },
         .cjs => {
-            const rv = try types.makeRequireVarName(allocator, src_mod.path);
+            const rv = try src_mod.allocRequireName(allocator);
             defer allocator.free(rv);
             if (guard) try buf.appendSlice(allocator, if (options.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
             try buf.appendSlice(allocator, rv);
@@ -1080,7 +1080,7 @@ fn makeStarGetterValue(
                     return try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, name });
                 }
                 if (canonical_mod.wrap_kind == .cjs) {
-                    const rv = try types.makeRequireVarName(allocator, canonical_mod.path);
+                    const rv = try canonical_mod.allocRequireName(allocator);
                     defer allocator.free(rv);
                     return try std.fmt.allocPrint(allocator, "{s}().{s}", .{ rv, name });
                 }
@@ -1101,7 +1101,7 @@ fn makeStarGetterValue(
             return try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, name });
         },
         .cjs => {
-            const rv = try types.makeRequireVarName(allocator, src_mod.path);
+            const rv = try src_mod.allocRequireName(allocator);
             defer allocator.free(rv);
             return try std.fmt.allocPrint(allocator, "{s}().{s}", .{ rv, name });
         },

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1983,37 +1983,57 @@ pub const ModuleGraph = struct {
             if (m.wrap_kind == .none) continue;
             if (m.getInitName()) |n| _ = used_names.put(n, 1) catch {};
             if (m.getExportsName()) |n| _ = used_names.put(n, 1) catch {};
+            if (m.getRequireName()) |n| _ = used_names.put(n, 1) catch {};
         }
 
         var it = self.modules.iterator(0);
         while (it.next()) |m| {
             if (m.wrap_kind == .none) continue;
-            if (m.init_symbol != null or m.exports_symbol != null) continue;
+            const needs_init = m.init_symbol == null;
+            const needs_exports = m.exports_symbol == null;
+            const needs_require = m.wrap_kind == .cjs and m.require_symbol == null;
+            if (!needs_init and !needs_exports and !needs_require) continue;
             const sem_ptr = if (m.semantic) |*s| s else continue;
             const arena = if (m.parse_arena) |*a| a.allocator() else continue;
 
-            const init_base = types.makeInitVarName(arena, m.path) catch continue;
-            const exports_base = types.makeExportsVarName(arena, m.path) catch continue;
-            const init_name = uniqueName(arena, init_base, &used_names) catch continue;
-            const exports_name = uniqueName(arena, exports_base, &used_names) catch continue;
+            if (needs_init) {
+                const init_base = types.makeInitVarName(arena, m.path) catch continue;
+                const init_name = uniqueName(arena, init_base, &used_names) catch continue;
+                m.init_symbol = semantic_symbol.extendSymbol(
+                    arena,
+                    &sem_ptr.symbols,
+                    .function_decl,
+                    .esm_init,
+                    init_name,
+                    Span.EMPTY,
+                ) catch null;
+            }
 
-            m.init_symbol = semantic_symbol.extendSymbol(
-                arena,
-                &sem_ptr.symbols,
-                .function_decl,
-                .esm_init,
-                init_name,
-                Span.EMPTY,
-            ) catch null;
+            if (needs_exports) {
+                const exports_base = types.makeExportsVarName(arena, m.path) catch continue;
+                const exports_name = uniqueName(arena, exports_base, &used_names) catch continue;
+                m.exports_symbol = semantic_symbol.extendSymbol(
+                    arena,
+                    &sem_ptr.symbols,
+                    .variable_var,
+                    .cjs_exports,
+                    exports_name,
+                    Span.EMPTY,
+                ) catch null;
+            }
 
-            m.exports_symbol = semantic_symbol.extendSymbol(
-                arena,
-                &sem_ptr.symbols,
-                .variable_var,
-                .cjs_exports,
-                exports_name,
-                Span.EMPTY,
-            ) catch null;
+            if (needs_require) {
+                const require_base = types.makeRequireVarName(arena, m.path) catch continue;
+                const require_name = uniqueName(arena, require_base, &used_names) catch continue;
+                m.require_symbol = semantic_symbol.extendSymbol(
+                    arena,
+                    &sem_ptr.symbols,
+                    .function_decl,
+                    .cjs_require,
+                    require_name,
+                    Span.EMPTY,
+                ) catch null;
+            }
         }
     }
 

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -907,6 +907,26 @@ pub const Linker = struct {
             // helper module 은 후보 / Phase B 양쪽 skip — modules[mi] 는 빈 entry 로 init.
             const is_helper_module = helper_modules.isVirtualId(m.path);
             if (is_helper_module) {
+                if (sem_opt) |sem| {
+                    if (sem.scopes.len == 0 or !sem.scopes[0].blocksMangling()) {
+                        for (sem.symbols.items, 0..) |*sym, si| {
+                            const sk = sym.synthetic_kind orelse continue;
+                            switch (sk) {
+                                .cjs_exports, .cjs_require, .esm_init => {},
+                                else => continue,
+                            }
+                            const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym.synthetic_name;
+                            if (key.len <= 1) continue;
+                            if (exported.contains(key)) continue;
+                            try candidates.append(self.allocator, .{
+                                .module_index = @intCast(mi),
+                                .symbol_id = @intCast(si),
+                                .name = key,
+                                .ref_count = if (sym.reference_count == 0) 1 else sym.reference_count,
+                            });
+                        }
+                    }
+                }
                 modules[mi] = .{
                     .scopes = &.{},
                     .symbols = &.{},
@@ -961,7 +981,7 @@ pub const Linker = struct {
                     for (sem.symbols.items, 0..) |*sym, si| {
                         const sk = sym.synthetic_kind orelse continue;
                         switch (sk) {
-                            .default_export, .cjs_exports, .esm_init => {},
+                            .default_export, .cjs_exports, .cjs_require, .esm_init => {},
                         }
                         const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym.synthetic_name;
                         if (key.len <= 1) continue;
@@ -971,7 +991,7 @@ pub const Linker = struct {
                         // 번들러가 직접 emit하므로 semantic reference_count가 보통 0이다.
                         // 그래도 선언과 cross-module 호출에 실제로 등장하고 RN 번들에서는
                         // 매우 길어지므로, 작은 0이 아닌 가중치로 최상위 망글 후보에 남긴다.
-                        const ref_count: u32 = if ((sk == .cjs_exports or sk == .esm_init) and sym.reference_count == 0)
+                        const ref_count: u32 = if ((sk == .cjs_exports or sk == .cjs_require or sk == .esm_init) and sym.reference_count == 0)
                             1
                         else
                             sym.reference_count;
@@ -2808,8 +2828,8 @@ pub fn getOrCreateRequireVar(
     mod_idx: u32,
 ) ![]const u8 {
     if (cache.get(mod_idx)) |cached| return cached;
-    const target_path = self.getModule(mod_idx).?.path;
-    const name = try types.makeRequireVarName(self.allocator, target_path);
+    const target_mod = self.getModule(mod_idx).?;
+    const name = try target_mod.allocRequireName(self.allocator);
     try cache.put(mod_idx, name);
     return name;
 }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -752,7 +752,7 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
             if (require_rewrites.get(rec.specifier)) |old| {
                 self.allocator.free(old);
             }
-            const var_name = try types.makeRequireVarName(self.allocator, target_mod.path);
+            const var_name = try target_mod.allocRequireName(self.allocator);
             try require_rewrites.put(self.allocator, rec.specifier, var_name);
         } else if (target_mod.wrap_kind == .esm) {
             // ESM 타겟: require("spec") → (init_xxx(), __toCommonJS(exports_xxx))

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -134,6 +134,8 @@ pub const Module = struct {
     init_symbol: ?SemanticSymbolId = null,
     /// wrap_kind != .none 모듈의 `exports_<path>` 객체 심볼 id.
     exports_symbol: ?SemanticSymbolId = null,
+    /// wrap_kind == .cjs 모듈의 `require_<path>` 함수 심볼 id.
+    require_symbol: ?SemanticSymbolId = null,
 
     /// 내가 import하는 모듈들 (순방향)
     dependencies: std.ArrayList(ModuleIndex),
@@ -273,6 +275,10 @@ pub const Module = struct {
         return self.syntheticName(self.exports_symbol);
     }
 
+    pub fn getRequireName(self: *const Module) ?[]const u8 {
+        return self.syntheticName(self.require_symbol);
+    }
+
     /// `getInitName()`의 할당 버전 — 등록된 경우 dupe, 아니면 fresh 생성.
     /// 기존 `types.makeInitVarName(alloc, path)` 호출지의 drop-in 대체.
     pub fn allocInitName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
@@ -283,6 +289,11 @@ pub const Module = struct {
     pub fn allocExportsName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
         if (self.getExportsName()) |n| return allocator.dupe(u8, n);
         return types.makeExportsVarName(allocator, self.path);
+    }
+
+    pub fn allocRequireName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
+        if (self.getRequireName()) |n| return allocator.dupe(u8, n);
+        return types.makeRequireVarName(allocator, self.path);
     }
 
     /// Semantic 심볼 배열 slice. semantic이 없으면 빈 slice.

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -204,6 +204,8 @@ pub const SyntheticKind = enum(u8) {
     default_export,
     /// CJS 래퍼의 `exports_<module>` 객체
     cjs_exports,
+    /// CJS 래퍼의 `require_<module>` 함수
+    cjs_require,
     /// ESM 래퍼의 `init_<module>` 함수
     esm_init,
 };

--- a/src/transformer/es2015_template.zig
+++ b/src/transformer/es2015_template.zig
@@ -224,7 +224,7 @@ pub fn templateCookedHasInvalidEscape(text: []const u8) bool {
                     while (j < text.len and text[j] != '}') : (j += 1) {
                         const d = text[j];
                         if (!std.ascii.isHex(d)) return true;
-                        code = (code << 4) | std.fmt.charToDigit(d, 16) catch return true;
+                        code = (code << 4) | @as(u32, std.fmt.charToDigit(d, 16) catch return true);
                         n += 1;
                         if (n > 6) return true;
                     }


### PR DESCRIPTION
## 요약
- CJS 래퍼의 `require_<module>` 이름을 `init_`/`exports_`와 같은 합성 심볼로 등록해 minify identifier 경로에 태웠습니다.
- emitter/linker의 CJS 래퍼 호출부가 `types.makeRequireVarName()` 대신 `Module.allocRequireName()`을 사용하도록 바꿨습니다.
- Zig 0.15.2에서 깨지던 tagged template invalid escape 처리의 `charToDigit` 타입 불일치도 함께 보정했습니다.

## 실측
ExampleApp iOS release bundle 기준:
- 이전 helper-wrapper mangle: raw `2,508,221`, gzip `551,715`, brotli `414,486`
- 이번 require-wrapper mangle: raw `2,493,617`, gzip `550,212`, brotli `414,120`
- 차이: raw `-14,604`, gzip `-1,503`, brotli `-366`

긴 CJS 래퍼 이름 카운트:
- `require_react_index`: `243` -> `0`
- `require_react_native_index`: `63` -> `0`
- `require_invariant_browser`: `56` -> `0`

## 검증
- `zig build napi` 통과
- `packages/core` bun build 통과
- ExampleApp iOS release bundle 생성 통과
- `zig build test --summary all`은 기존 `semantic.analyzer_test.test.#1669: 함수 body 내부 선언도 declare ref 로 기록` 1개 실패가 남아 있습니다. 이번 변경과 별개로 보이며, 중복 declare ref 쪽은 별도 수정 범위로 분리하는 게 안전합니다.