### PR TITLE
fix(transformer): preserve NewTarget for lowered super calls

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -295,17 +295,18 @@ pub const CLASS_CALL_CHECK_RUNTIME_MIN = "var " ++ NAMES.CLASS_CALL_CHECK_MIN ++
 /// Reflect.construct를 사용하여 올바른 내부 슬롯을 가진 인스턴스를 생성.
 /// 트랜스파일된 클래스에는 fallback으로 .apply()를 사용.
 pub const CALL_SUPER_RUNTIME =
-    \\var __callSuper = function(_this, Parent, args) {
+    \\var __callSuper = function(Parent, args, NewTarget) {
     \\  if (typeof Reflect !== "undefined" && typeof Reflect.construct === "function") {
-    \\    return Reflect.construct(Parent, args || [], _this.constructor);
+    \\    return Reflect.construct(Parent, args || [], NewTarget);
     \\  }
+    \\  var _this = Object.create(NewTarget.prototype);
     \\  var result = Parent.apply(_this, args);
     \\  if (result && (typeof result === "object" || typeof result === "function")) return result;
     \\  return _this;
     \\};
     \\
 ;
-pub const CALL_SUPER_RUNTIME_MIN = "var " ++ NAMES.CALL_SUPER_MIN ++ "=function(_this,Parent,args){if(typeof Reflect!==\"undefined\"&&typeof Reflect.construct===\"function\")return Reflect.construct(Parent,args||[],_this.constructor);var result=Parent.apply(_this,args);if(result&&(typeof result===\"object\"||typeof result===\"function\"))return result;return _this};";
+pub const CALL_SUPER_RUNTIME_MIN = "var " ++ NAMES.CALL_SUPER_MIN ++ "=function(Parent,args,NewTarget){if(typeof Reflect!==\"undefined\"&&typeof Reflect.construct===\"function\")return Reflect.construct(Parent,args||[],NewTarget);var _this=Object.create(NewTarget.prototype);var result=Parent.apply(_this,args);if(result&&(typeof result===\"object\"||typeof result===\"function\"))return result;return _this};";
 
 /// __superGet/__superSet: super property 접근 시 receiver(this)를 보존한다.
 /// `Parent.prototype.x` 직접 접근은 getter/setter의 this를 Parent.prototype으로 바꾸므로

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1681,8 +1681,8 @@ test "ES2015: generator try/catch/finally with yield" {
 test "ES2015: class extends with super()" {
     var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(x){super(x);this.x=x;}}", .es5);
     defer r.deinit();
-    // super(x) → _this=__callSuper(this,_super,[x]) 뒤 this 접근/반환은 초기화 검사
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super,[x])") != null);
+    // super(x) → _this=__callSuper(_super,[x],C) 뒤 this 접근/반환은 초기화 검사
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(_super,[x],C)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__assertThisInitialized(_this).x=x") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "return __assertThisInitialized(_this)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__extends(C,_super)") != null);
@@ -1691,8 +1691,8 @@ test "ES2015: class extends with super()" {
 test "ES2015: class extends default constructor" {
     var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){}}", .es5);
     defer r.deinit();
-    // 기본 생성자 → return __callSuper(this,_super,arguments) — implicit forwarding
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super,arguments)") != null);
+    // 기본 생성자 → return __callSuper(_super,arguments,C) — implicit forwarding
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(_super,arguments,C)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__extends(C,_super)") != null);
 }
 
@@ -1797,6 +1797,13 @@ test "ES2015: derived constructor super 중복 호출은 할당 전 검사" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__assertThisUninitialized(_this,_this=") == null);
 }
 
+test "ES2015: derived constructor arrow super uses lexical NewTarget" {
+    var r = try e2eTarget(std.testing.allocator, "class B{constructor(arg){this.x=arg;}}class C extends B{constructor(){var callSuper=()=>super('foo');callSuper();}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(_super,[\"foo\"],C)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super") == null);
+}
+
 // --- class getter/setter ---
 
 test "ES2015: class getter/setter paired" {
@@ -1850,8 +1857,8 @@ test "ES2015: class extends member expression (e.g. React.Component)" {
     // _super 매개변수 + __extends 호출
     try std.testing.expect(std.mem.indexOf(u8, r.output, "(function(_super)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__extends(Foo,_super)") != null);
-    // super() → __callSuper(this,_super,arguments) 변환
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super,[])") != null);
+    // super() → __callSuper(_super,[],Foo) 변환
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(_super,[],Foo)") != null);
     // 원본 super 키워드가 남아있으면 안 됨
     try std.testing.expect(std.mem.indexOf(u8, r.output, "super(") == null);
 }
@@ -1883,7 +1890,7 @@ test "ES2015: class expression extends member expression" {
     var r = try e2eTarget(std.testing.allocator, "const F=class extends a.B{constructor(){super();}};", .es5);
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, ")(a.B)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(this,_super,[])") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__callSuper(_super,[],_Class)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "super(") == null);
 }
 

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -532,13 +532,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
             return self.ast.getNode(callee).tag == .super_expression;
         }
 
-        /// super(args) → __callSuper(this, _super, [args])
+        /// super(args) → __callSuper(_super, [args], Derived)
         /// Reflect.construct를 사용하여 네이티브 클래스 extends도 지원.
         /// super() 호출 후 this → _this 별칭을 활성화하여
         /// __callSuper가 반환하는 새 객체를 올바르게 참조.
         /// call_expression: extra = [callee, args_start, args_len, flags]
         pub fn lowerSuperCall(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const super_class_span = self.current_super_class orelse return self.visitCallExpression(node);
+            const new_target_span = self.current_derived_constructor_name orelse return self.visitCallExpression(node);
             const e = node.data.extra;
             const args_start = self.readU32(e, 1);
             const args_len = self.readU32(e, 2);
@@ -546,13 +547,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             const callee = try es_helpers.makeRuntimeHelperRef(self, "__callSuper");
 
-            const this_node = try self.ast.addNode(.{
-                .tag = .this_expression,
-                .span = span,
-                .data = .{ .none = 0 },
-            });
-
             const parent_ref = try es_helpers.makeIdentifierRefFromSpan(self, super_class_span);
+            const new_target_ref = try es_helpers.makeIdentifierRefFromSpan(self, new_target_span);
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
@@ -574,9 +570,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .data = .{ .list = elems },
             });
 
-            const call = try es_helpers.makeCallExpr(self, callee, &.{ this_node, parent_ref, args_array }, span);
+            const call = try es_helpers.makeCallExpr(self, callee, &.{ parent_ref, args_array, new_target_ref }, span);
 
-            // _this = __callSuper(this, _super, [args])
+            // _this = __callSuper(_super, [args], Derived)
             // 대입식으로 반환하여 super()가 if/else 등 어디에 있든 동작.
             // var _this 선언과 return 검사는 postProcessDerivedConstructorBody에서 추가.
             const this_ref = try es_helpers.makeIdentifierRef(self, "_this");
@@ -2222,8 +2218,13 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             // derived constructor 안의 this는 super() 전 접근을 런타임에서 검사해야 한다.
             const saved_super_alias = self.super_call_this_alias;
+            const saved_derived_name = self.current_derived_constructor_name;
             self.super_call_this_alias = is_derived;
-            defer self.super_call_this_alias = saved_super_alias;
+            self.current_derived_constructor_name = if (is_derived) self.ast.getNode(name).data.string_ref else null;
+            defer {
+                self.super_call_this_alias = saved_super_alias;
+                self.current_derived_constructor_name = saved_derived_name;
+            }
 
             // TS parameter property(`constructor(public x)`)는 modifier 만 strip 되어 일반 형태로 visit 되지만,
             // 이 경로는 visitMethodDefinition 을 거치지 않으므로 `this.x = x` 삽입을 직접 수행해야 함 (#1471).
@@ -2561,18 +2562,15 @@ pub fn ES2015Class(comptime Transformer: type) type {
         }
 
         /// extends가 있고 constructor가 없을 때 기본 constructor 생성:
-        /// instance_fields가 없으면: function Child() { return __callSuper(this, _super, arguments); }
-        /// instance_fields가 있으면: function Child() { var _this = __callSuper(this, _super, arguments); <fields on _this>; return _this; }
+        /// instance_fields가 없으면: function Child() { return __callSuper(_super, arguments, Child); }
+        /// instance_fields가 있으면: function Child() { var _this = __callSuper(_super, arguments, Child); <fields on _this>; return _this; }
         fn buildDefaultSuperConstructor(self: *Transformer, name: NodeIndex, super_class_span: Span, instance_fields: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const call_super_ref = try es_helpers.makeRuntimeHelperRef(self, "__callSuper");
-            const this_node = try self.ast.addNode(.{
-                .tag = .this_expression,
-                .span = span,
-                .data = .{ .none = 0 },
-            });
             const parent_ref = try es_helpers.makeIdentifierRefFromSpan(self, super_class_span);
             const args_ref = try es_helpers.makeIdentifierRef(self, "arguments");
-            const call_super = try es_helpers.makeCallExpr(self, call_super_ref, &.{ this_node, parent_ref, args_ref }, span);
+            const name_span = self.ast.getNode(name).data.string_ref;
+            const new_target_ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
+            const call_super = try es_helpers.makeCallExpr(self, call_super_ref, &.{ parent_ref, args_ref, new_target_ref }, span);
 
             self.runtime_helpers.call_super = true;
 
@@ -2580,7 +2578,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
             if (instance_fields.len > 0) {
-                // var _this = __callSuper(this, _super, arguments);
+                // var _this = __callSuper(_super, arguments, Child);
                 try self.scratch.append(self.allocator, try self.buildVarDecl("_this", call_super, span));
 
                 // instance fields: this → _this 치환된 버전 사용
@@ -2600,7 +2598,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     .data = .{ .unary = .{ .operand = this_ref, .flags = 0 } },
                 }));
             } else {
-                // return __callSuper(this, _super, arguments);
+                // return __callSuper(_super, arguments, Child);
                 try self.scratch.append(self.allocator, try self.ast.addNode(.{
                     .tag = .return_statement,
                     .span = span,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -364,6 +364,12 @@ pub const Transformer = struct {
     /// super() 이후의 this 참조를 _this로 교체해야 한다.
     super_call_this_alias: bool = false,
 
+    /// ES2015 class extends: 현재 derived constructor의 NewTarget.
+    /// super() lowering은 호출 위치의 `this.constructor`에 의존하지 않고 이 이름을
+    /// __callSuper에 명시 전달한다. arrow로 낮아진 함수 안의 super()도 동일 NewTarget을
+    /// 써야 하므로 constructor body 방문 중 유지한다.
+    current_derived_constructor_name: ?Span = null,
+
     /// for-in/for-of/for-await-of 헤더의 left(variable_declaration)를 방문 중인지.
     /// true면 let/const → var 다운레벨 시 `= void 0` init 주입을 생략.
     /// 헤더에선 루프가 매 반복 바인딩에 쓰므로 TDZ 흉내가 불필요하고,

--- a/tests/integration/tests/es5-call-super.test.ts
+++ b/tests/integration/tests/es5-call-super.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { bundleAndRun } from "./helpers";
+
+describe("ES5 __callSuper", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("derived constructor arrow 안의 super()도 lexical NewTarget을 사용한다", async () => {
+    const result = await bundleAndRun(
+      {
+        "index.ts": `class Base { x: string; constructor(arg: string) { this.x = arg; } }
+class Child extends Base {
+  constructor() {
+    const callSuper = () => super("foo");
+    callSuper();
+  }
+}
+const c = new Child();
+console.log(c.x + ":" + (c instanceof Child) + ":" + (c instanceof Base));`,
+      },
+      "index.ts",
+      ["--target=es5"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("foo:true:true");
+  });
+});


### PR DESCRIPTION
## Summary
- Change `__callSuper` to take an explicit `NewTarget` instead of deriving it from call-site `this.constructor`
- Pass the lowered derived constructor name into `super()` calls, including default derived constructors
- Add codegen and integration coverage for `super()` inside an arrow in a derived constructor

Fixes #2010.

## Tests
- `zig build test -Dtest-filter="ES2015: class extends" --summary all`
- `zig build test -Dtest-filter="derived constructor" --summary all`
- `cd tests/integration && bun test tests/es5-call-super.test.ts`
- `zig build install` + manual ES5 bundle/runtime repro: `foo:true:true`

## Notes
- `git push` pre-push hook ran full `zig build test` and failed on existing unrelated `semantic.analyzer_test.test.#1669: 함수 body 내부 선언도 declare ref 로 기록` (`expected 1, found 2`). The targeted tests above pass.