### PR TITLE
fix(semantic): predeclare double declare-ref 회귀 해소

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@
 | 6a-si | StmtInfo 기반 statement DCE (rolldown 방식, pathe ESM 77% 감소) | ✅ |
 | 6a-ex | exports 조건 해석 Node.js 스펙 준수 (tslib CJS→ESM 해결) | ✅ |
 | 6b. Dev server | HTTP+WS, Live Reload, HMR, React Fast Refresh, CSS 핫 리로드 | ✅ |
-| Test262 | 50,504건 / 50,498 통과 / **6 known fail** (annexB B.3.3.1 sloppy hoisting) | 🟡 |
+| Test262 | 50,504건 / 50,504 통과 / **0 fail** (100%) | ✅ |
 | Smoke | **136 케이스** (엔진 타겟 변형 포함), avg **0.82x**, ❌ 0개 | ✅ |
 | 7-2. emit 병렬화 | 모듈별 transform+codegen 스레드 풀 실행 | ✅ |
 | 7-3. resolve 병렬화 | 배치 내 resolve 스레드 풀 + ResolveCache Mutex | ✅ |
@@ -348,15 +348,15 @@ SWC 비교 테스트: 29 cases × 9 targets 전부 통과.
 
 | 카테고리 | Total | Pass | Fail |
 |---|---|---|---|
-| annexB | 1,079 | 1,073 | **6** (B.3.3.1 sloppy hoisting) |
+| annexB | 1,079 | 1,079 | 0 |
 | built-ins | 22,729 | 22,729 | 0 |
 | harness | 116 | 116 | 0 |
 | intl402 | 1,566 | 1,566 | 0 |
 | language | 23,384 | 23,384 | 0 |
 | staging | 1,630 | 1,630 | 0 |
-| **TOTAL** | **50,504** | **50,498** | **6** (99.99%) |
+| **TOTAL** | **50,504** | **50,504** | **0** (100%) |
 
-annexB 6 fail 은 모두 `language/function-code/*-func-skip-early-err.js` — outer scope `let f` 가 있을 때 `if/else`/block 안의 `function f(){}` 가 var-bound 호이스팅을 건너뛰어야 하는 sloppy-mode 예외 (B.3.3.1) 미구현. ZTS 가 redeclaration error 로 막아 fail.
+이전 annexB 6 fail (`language/function-code/*-func-skip-early-err.js`, B.3.3.1 sloppy function hoisting — outer `let f` 충돌 시 var-bound 호이스팅 skip) 은 d2a393ee 에서 semantic analyzer 가 outer lexical 충돌 감지 시 hoist 를 건너뛰도록 수정해 해소.
 
 ## 성능 최적화 현황
 | 최적화 | 상태 | 효과 |

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1962,7 +1962,13 @@ pub const SemanticAnalyzer = struct {
         // ECMAScript 스펙상 lexical binding 은 block 진입 시 스코프에 존재한다 (TDZ 는
         // 런타임 개념). 정적 분석에서 선언 위치보다 앞선 중첩 함수가 해당 심볼을 참조할
         // 수 있으므로, statement 순회 전에 선언을 scope map 에만 등록해 둔다.
+        // predeclare 동안에는 current_stmt_idx 를 NO_STMT 로 강제 — top-level
+        // predeclareTopLevelBindings 와 동일한 규약. declare ref 기록은 2nd pass 의
+        // setSymbolIdForPredeclared 단일 책임으로 두어 중복을 차단 (#2023 이 단일화 epic).
+        const saved_stmt = self.current_stmt_idx;
+        self.current_stmt_idx = symbol_mod.Reference.NO_STMT;
         try self.predeclareLexicalDecls(node.data.list);
+        self.current_stmt_idx = saved_stmt;
         try self.visitStmtList(node.data.list);
         self.exitScope(saved);
     }
@@ -3285,8 +3291,12 @@ pub const SemanticAnalyzer = struct {
             // lexical 을 var pre-pass 보다 먼저 등록 — `predeclareVarDeclsRecursive` 의
             // function_declaration 분기가 outer lexical 충돌을 감지해 Annex B B.3.3.1
             // 의 hoist-skip 을 수행하기 위해 필요.
+            // predeclare 동안 current_stmt_idx 는 NO_STMT (declare ref 는 2nd pass 만 기록 — #2023).
+            const saved_stmt = self.current_stmt_idx;
+            self.current_stmt_idx = symbol_mod.Reference.NO_STMT;
             try self.predeclareLexicalDecls(body_node.data.list);
             try self.predeclareVarDecls(body_node.data.list);
+            self.current_stmt_idx = saved_stmt;
             try self.visitStmtList(body_node.data.list);
         } else {
             try self.visitNode(body_idx);


### PR DESCRIPTION
## Summary

- d2a393ee (Annex B B.3.3.1 sloppy hoist) 가 `visitFunctionBodyInner` 에 lexical predeclare 를 추가하면서 #1669 declare-ref 단위 테스트가 expected 1, found 2 로 깨짐 (CI Test262 Conformance / Run Test262 runner unit tests 실패).
- 모든 predeclare path 가 동일 invariant — "predeclare 는 등록만, declare ref 는 2nd pass `setSymbolIdForPredeclared` 단일 책임" — 을 따르도록 통일.

## Root cause

| Path | 1st pass `current_stmt_idx` | 1st 호출 record | 2nd pass record | 결과 |
|---|---|---|---|---|
| top-level (`predeclareTopLevelBindings`) | NO_STMT (visitProgram 1st pass) | no-op | ✓ | 1 |
| block (`visitBlockStatement`) | 외부에서 set | ✓ | ✓ | **2 (silent, 테스트 부재)** |
| function body (`visitFunctionBodyInner`, d2a393ee 후) | 외부에서 set | ✓ | ✓ | **2 (#1669 테스트가 캐치)** |

`recordDeclareRef` 가 `current_stmt_idx == NO_STMT` 일 때 no-op 인 점을 활용해 모든 predeclare 호출 직전에 `current_stmt_idx` 를 NO_STMT 로 강제 → top-level 의 검증된 패턴을 확장.

## Fix

`visitBlockStatement` / `visitFunctionBodyInner` 에서 predeclare 호출 직전에 `current_stmt_idx` 를 NO_STMT 로 set, 복원 후 `visitStmtList` 호출. 14줄 추가.

선택한 방향 (책임 분리 — visit 만 record):
- 변경 범위 최소, 회귀 위험 낮음
- top-level 의 기존 invariant 와 일관
- 장기적인 책임 통합 (predeclare 가 ref 까지 직접 기록) 은 #2023 으로 분리

## ROADMAP 업데이트

d2a393ee + 본 fix 후 Test262 50,504/50,504 통과 (100%) 반영. 이전에 추가했던 docs 변경분이 본 PR 에 포함됨 (CI 가 깨진 상태에서 100% 라고 적혀있던 것을 바로잡음).

## Test plan

- [x] `zig build test` — 3879/3879 통과 (이전: 3878/3879, #1669 declare-ref 테스트 fail)
- [ ] CI Test262 Conformance 통과
- [ ] CI Integration & E2E 통과

## Refs

- d2a393ee fix(semantic): Annex B B.3.3.1 sloppy function hoist 의 outer lexical 충돌 시 skip
- #1669 scope-wide declare ref + per-scope stmt index + Symbol 확장
- #2023 refactor(semantic): predeclare pass 를 단일 책임 구조로 통합 (방향 B, 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)