### PR TITLE
fix(transformer): derived ctor 안 super property receiver 를 _this 로 emit (#2022)

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1743,6 +1743,38 @@ test "ES2015: super property update expression receiver 보존" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"x\",this)++") == null);
 }
 
+// #2022: derived constructor 안의 super.x receiver 는 외부 `this` 가 아니라 _this 여야 한다.
+// super() lowering 이 인스턴스를 `_this = __callSuper(...)` 에 저장하므로 base accessor 의 `this`
+// 가 인스턴스를 보려면 receiver 도 같은 _this 로 전달돼야 함.
+test "ES2015: derived constructor 안 super property set receiver = _this (#2022)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(){super();super.x=1;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,\"x\",1,__assertThisInitialized(_this))") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,\"x\",1,this)") == null);
+}
+
+test "ES2015: derived constructor 안 super property get receiver = _this (#2022)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(){super();return super.x;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"x\",__assertThisInitialized(_this))") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"x\",this)") == null);
+}
+
+test "ES2015: derived constructor 안 super property compound assign receiver = _this (#2022)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(){super();super.x+=3;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__assertThisInitialized(_this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,\"x\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,\"x\",__superGet(_super.prototype,\"x\",this)") == null);
+}
+
+test "ES2015: derived constructor 안 computed super[k]= receiver = _this (#2022)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(){super();const k=\"x\";super[k]=1;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,k,1,__assertThisInitialized(_this))") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,k,1,this)") == null);
+}
+
 test "ES2015: static super access는 parent constructor 참조" {
     var r1 = try e2eTarget(std.testing.allocator, "class C extends P{static m(){return super.x+super.m();}}", .es5);
     defer r1.deinit();

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -782,6 +782,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
             if (self.current_super_static_receiver) |receiver_span| {
                 return es_helpers.makeIdentifierRefFromSpan(self, receiver_span);
             }
+            // derived constructor body 안에서는 super() lowering 이 인스턴스를 _this 에 저장하므로
+            // super.x / super.x = v 의 receiver 도 외부 `this` 가 아닌 _this 여야 한다 (#2022).
+            if (self.super_call_this_alias) {
+                return buildAssertThisInitialized(self, span);
+            }
             return makeThisOrAlias(self, span);
         }
 

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1685,6 +1685,116 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("4:4");
     });
 
+    // #2022: derived constructor body 안의 super.x = / super.x / super.x += / super[k] = 의 receiver 가
+    // 외부 `this` 가 아니라 `_this` (= __callSuper 결과) 여야 base accessor 의 this 가 새 인스턴스로 들어감.
+    test("derived constructor 안 super property set receiver = _this (#2022)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              tag: string = "";
+              set x(v: number) { console.log(this.tag + ":" + v); }
+            }
+            class C extends B {
+              constructor() {
+                super();
+                this.tag = "c";
+                super.x = 1;
+              }
+            }
+            new C();
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("c:1");
+    });
+
+    test("derived constructor 안 super property get receiver = _this (#2022)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              tag: string = "";
+              get x() { return this.tag; }
+            }
+            class C extends B {
+              constructor() {
+                super();
+                this.tag = "c";
+                console.log(super.x);
+              }
+            }
+            new C();
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("c");
+    });
+
+    test("derived constructor 안 super.x += 의 receiver = _this (#2022)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              v: number = 0;
+              get x() { return this.v; }
+              set x(n: number) { this.v = n; }
+            }
+            class C extends B {
+              constructor() {
+                super();
+                this.v = 2;
+                super.x += 3;
+                console.log(this.v);
+              }
+            }
+            new C();
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("5");
+    });
+
+    test("derived constructor 안 computed super[k] = receiver = _this (#2022)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              tag: string = "";
+              set x(v: number) { console.log(this.tag + ":" + v); }
+              [key: string]: any;
+            }
+            class C extends B {
+              constructor() {
+                super();
+                this.tag = "c";
+                const k = "x";
+                super[k] = 1;
+              }
+            }
+            new C();
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("c:1");
+    });
+
     test("derived constructor super 전 this 접근 검사", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary

- `buildSuperReceiver` 가 사용하는 `makeThisOrAlias` 가 derived constructor 의 `super_call_this_alias` 플래그를 무시하고 있어, derived ctor body 안 `super.x` / `super.x = v` / `super.x += v` / `super[k] = v` 의 receiver 로 외부 `this` 가 raw emit 되던 버그를 root-fix.
- `buildSuperReceiver` 에서 `super_call_this_alias` 면 `__assertThisInitialized(_this)` 를 emit (기존 `this_expression` visit 의 derived-ctor 경로와 동일 형태).

## Why

derived ctor 에서 `super()` 는 `_this = __callSuper(_super, args, _newTarget)` 으로 lowering 되어 새 인스턴스가 `_this` 에 저장된다. 하지만 super property access 의 receiver 는 별개 경로 (`buildSuperReceiver`) 를 거쳐 외부 `this` 가 emit 됐고, 이 `this` 는 일반 함수 호출 binding 의 receiver 라 `__callSuper` 가 만든 인스턴스와 다른 객체다. 결과적으로 base accessor 의 `this.tag` 등이 새 인스턴스를 못 보고 `undefined`.

이슈 본문이 지목한 root fix 위치 그대로 — runtime helper fallback 이 아니라 transform 단계에서 receiver operand 를 올바른 `_this` 로 만들도록 수정.

## Test plan

- [x] 유닛 테스트 4개 추가 (`src/codegen/codegen_test/es_downlevel.zig`):
  - derived ctor 안 super.x = (set)
  - derived ctor 안 super.x (get)
  - derived ctor 안 super.x += (compound)
  - derived ctor 안 computed super[k] = (computed set)
  - 각 테스트는 emitted JS 에서 `__assertThisInitialized(_this)` 가 receiver 로 들어가고 raw `this` 가 안 들어가는지 확인
- [x] 통합 런타임 테스트 4개 추가 (`tests/integration/tests/downlevel.test.ts`): 위 4 케이스의 native semantic 일치 검증 (실제 bun 실행)
- [x] `zig build test` 통과 (debug)
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] `tests/integration/tests/downlevel.test.ts` 전체 239/239 통과 (회귀 없음)
- [x] 이슈 본문 4 재현 케이스 모두 native 와 일치
- [x] 회귀 검증: non-ctor method 의 `super.x` (receiver = `this`), static method 의 `super.x` (receiver = `this`/class), derived ctor 안 arrow 안의 `super.x` 모두 변함 없음

## Notes

- 통합 테스트 작성 중 별개 lowering 버그 발견: `(super as any)[k] = 1` 형태에서 TS type assertion strip 후 super lowering 의 obj 검사가 wrap 된 super 를 인식 못해 raw `super[k] = 1` 이 emit → 런타임 SyntaxError. 본 PR 의 수정과 root cause 가 다른 별개 이슈라 분리 — 후속 issue 로 작성 예정.

Closes #2022

🤖 Generated with [Claude Code](https://claude.com/claude-code)