### PR TITLE
fix(transformer): wrapped super 도 super lowering — (super)/(super as any) 등 (#2030)

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1775,6 +1775,52 @@ test "ES2015: derived constructor 안 computed super[k]= receiver = _this (#2022
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,k,1,this)") == null);
 }
 
+// #2030: transparent wrapper(괄호, TS as/satisfies/type-assertion/!, Flow cast) 로 감싸진 super 도
+// super lowering 의 obj 검사가 통과해야 한다 — 그렇지 않으면 raw `(super)[k]` / `super.x` 가 emit 돼
+// 런타임 syntax error.
+test "ES2015: 괄호 super 도 lowering — (super)[k] (#2030)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){const k=\"x\";(super)[k]=1;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(super)") == null);
+}
+
+test "ES2015: TS as-cast super 도 lowering — (super as any).x (#2030)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){(super as any).x=1;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,\"x\"") != null);
+    // type assertion 이 strip 된 후 raw `super.x = 1` 로 떨어지면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.x=1") == null);
+}
+
+test "ES2015: TS as-cast computed super 도 lowering — (super as any)[k] (#2030)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){const k=\"x\";(super as any)[k]=1;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,k") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super[k]=1") == null);
+}
+
+test "ES2015: TS legacy <T>cast super 도 lowering — (<any>super)[k] (#2030)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){const k=\"x\";(<any>super)[k]=1;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(_super.prototype,k") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super[k]=1") == null);
+}
+
+test "ES2015: TS non-null assertion super 도 lowering — super!.x (#2030)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){return (super!).x;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"x\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.x") == null);
+}
+
+test "ES2015: wrapped super method call 도 lowering — (super as any).m() (#2030)" {
+    var r = try e2eTarget(std.testing.allocator, "class C extends P{m(){return (super as any).m();}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.prototype.m.call(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.m") == null);
+}
+
 test "ES2015: static super access는 parent constructor 참조" {
     var r1 = try e2eTarget(std.testing.allocator, "class C extends P{static m(){return super.x+super.m();}}", .es5);
     defer r1.deinit();

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -522,14 +522,38 @@ pub fn ES2015Class(comptime Transformer: type) type {
         // super() / super.method() 변환
         // ================================================================
 
+        /// `super` 검사 시 transparent wrapper(괄호, TS type assertion, Flow cast 등)을 통과한다.
+        /// `(super)`, `(super as any)`, `<any>super`, `super!` 등은 의미상 noop 이므로 안쪽 super 도
+        /// super lowering 대상으로 봐야 한다 — 그렇지 않으면 raw `(super)[k]` / `super[k]` 가 그대로
+        /// emit 돼 syntax error (#2030). 모든 wrapper 는 `data.unary.operand` 로 안쪽 노드를 갖는다.
+        fn isSuperUnwrapped(self: *Transformer, idx: NodeIndex) bool {
+            var cur = idx;
+            while (true) {
+                if (cur.isNone()) return false;
+                const node = self.ast.getNode(cur);
+                switch (node.tag) {
+                    .super_expression => return true,
+                    .parenthesized_expression,
+                    .ts_as_expression,
+                    .ts_satisfies_expression,
+                    .ts_type_assertion,
+                    .ts_instantiation_expression,
+                    .ts_non_null_expression,
+                    .flow_as_expression,
+                    .flow_type_cast_expression,
+                    => cur = node.data.unary.operand,
+                    else => return false,
+                }
+            }
+        }
+
         /// call_expression의 callee가 super_expression인지 확인.
         pub fn isSuperCall(self: *Transformer, node: Node) bool {
             const extras = self.ast.extra_data.items;
             const e = node.data.extra;
             if (e >= extras.len) return false;
             const callee: NodeIndex = @enumFromInt(extras[e]);
-            if (callee.isNone()) return false;
-            return self.ast.getNode(callee).tag == .super_expression;
+            return isSuperUnwrapped(self, callee);
         }
 
         /// super(args) → __callSuper(_super, [args], _newTarget)
@@ -613,8 +637,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const me = callee_node.data.extra;
             if (me >= extras.len) return false;
             const obj: NodeIndex = @enumFromInt(extras[me]);
-            if (obj.isNone()) return false;
-            return self.ast.getNode(obj).tag == .super_expression;
+            return isSuperUnwrapped(self, obj);
         }
 
         /// super.method(args) → Parent.prototype.method.call(this, args)
@@ -676,8 +699,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const e = node.data.extra;
             if (e >= extras.len) return false;
             const obj: NodeIndex = @enumFromInt(extras[e]);
-            if (obj.isNone()) return false;
-            return self.ast.getNode(obj).tag == .super_expression;
+            return isSuperUnwrapped(self, obj);
         }
 
         const SuperPropRef = struct {
@@ -824,8 +846,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const e = node.data.extra;
             if (e >= extras.len) return false;
             const obj: NodeIndex = @enumFromInt(extras[e]);
-            if (obj.isNone()) return false;
-            return self.ast.getNode(obj).tag == .super_expression;
+            return isSuperUnwrapped(self, obj);
         }
 
         /// super["prop"] → __superGet(Parent.prototype, "prop", this)
@@ -849,7 +870,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const le = left.data.extra;
             if (le >= self.ast.extra_data.items.len) return null;
             const obj_idx: NodeIndex = self.readNodeIdx(le, 0);
-            if (obj_idx.isNone() or self.ast.getNode(obj_idx).tag != .super_expression) return null;
+            if (!isSuperUnwrapped(self, obj_idx)) return null;
 
             const prop_idx: NodeIndex = self.readNodeIdx(le, 1);
             const op_kind: token_mod.Kind = @enumFromInt(node.data.binary.flags);
@@ -927,7 +948,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const e = node.data.extra;
             if (e >= self.ast.extra_data.items.len) return null;
             const obj_idx: NodeIndex = self.readNodeIdx(e, 0);
-            if (obj_idx.isNone() or self.ast.getNode(obj_idx).tag != .super_expression) return null;
+            if (!isSuperUnwrapped(self, obj_idx)) return null;
 
             const op_kind = op_flags & 0xff;
             const is_increment = (op_kind == @intFromEnum(token_mod.Kind.plus2));
@@ -993,8 +1014,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const me = callee_node.data.extra;
             if (me >= extras.len) return false;
             const obj: NodeIndex = @enumFromInt(extras[me]);
-            if (obj.isNone()) return false;
-            return self.ast.getNode(obj).tag == .super_expression;
+            return isSuperUnwrapped(self, obj);
         }
 
         /// super["method"](args) → Parent.prototype["method"].call(this, args)

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1795,6 +1795,137 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("c:1");
     });
 
+    // #2030: transparent wrapper(괄호, TS as/satisfies/non-null/legacy <T>) 로 감싸진 super 도
+    // super lowering 의 obj 검사가 통과해야 한다. 그렇지 않으면 raw `super[k]` / `super.x` 가 emit 돼
+    // 런타임 syntax error.
+    test("괄호 super 도 lowering — (super)[k] (#2030)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              v: number = 0;
+              set x(n: number) { this.v = n; }
+            }
+            class C extends B {
+              run() {
+                const k = "x";
+                (super)[k] = 7;
+                return this.v;
+              }
+            }
+            console.log(new C().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("7");
+    });
+
+    test("TS as-cast super 도 lowering — (super as any).x (#2030)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              v: number = 0;
+              set x(n: number) { this.v = n; }
+            }
+            class C extends B {
+              run() {
+                (super as any).x = 9;
+                return this.v;
+              }
+            }
+            console.log(new C().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("9");
+    });
+
+    test("TS as-cast computed super 도 lowering — (super as any)[k] (#2030)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              v: number = 0;
+              set x(n: number) { this.v = n; }
+            }
+            class C extends B {
+              run() {
+                const k = "x";
+                (super as any)[k] = 11;
+                return this.v;
+              }
+            }
+            console.log(new C().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("11");
+    });
+
+    test("TS legacy <T>cast super 도 lowering — (<any>super)[k] (#2030)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              v: number = 0;
+              set x(n: number) { this.v = n; }
+            }
+            class C extends B {
+              run() {
+                const k = "x";
+                (<any>super)[k] = 13;
+                return this.v;
+              }
+            }
+            console.log(new C().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("13");
+    });
+
+    test("wrapped super method call 도 lowering — (super as any).m() (#2030)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B {
+              greet(): string { return "hi:" + this.tag; }
+              tag: string = "B";
+            }
+            class C extends B {
+              tag: string = "C";
+              run() {
+                return (super as any).greet();
+              }
+            }
+            console.log(new C().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("hi:C");
+    });
+
     test("derived constructor super 전 this 접근 검사", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary

- `src/transformer/es2015_class.zig` 의 7개 super tag check site 가 obj 의 직접 tag 만 비교해서 transparent wrapper(괄호, TS as/satisfies/type-assertion/non-null/instantiation, Flow as/cast) 로 감싸진 super 의 lowering 이 스킵되던 버그를 root-fix.
- `isSuperUnwrapped` helper 한 개 신설, 7 site 모두 helper 호출로 교체 (단일 chokepoint).

## Stacked on top of #2029 (#2022 fix)

이 PR 은 `fix/issue-2022-super-receiver-derived-ctor` 브랜치 위에 stack 돼 있습니다 — base 도 그쪽으로 설정. #2029 머지 후 main 으로 자동 rebase 되어야 합니다.

## Why

이슈 #2030 에 정리한 그대로:

```ts
class C extends B {
  m() { (super as any).x = 1; }   // ← raw `super.x = 1` emit, syntax error
}
```

`getNode(obj).tag == .super_expression` 검사가 wrapper 노드 (e.g., `ts_as_expression(super_expression, type)`) 를 인식 못해 super lowering 이 스킵됨. wrapper 가 strip 된 후엔 raw `super.x = 1` 이 남고, 이는 spec 상 method body 가 아니면 invalid → 런타임 syntax error.

8 wrapper tag 모두 `data.unary.operand` 로 안쪽 expression 을 갖는 unary kind 라서 단일 helper 로 일괄 unwrap 가능.

## Affected wrapper kinds

- `parenthesized_expression` — JS `(super)[k]`
- `ts_as_expression` — `(super as any).x`
- `ts_satisfies_expression` — `(super satisfies X).x`
- `ts_type_assertion` — legacy `(<any>super)[k]`
- `ts_instantiation_expression` — `super<T>` (rare)
- `ts_non_null_expression` — `(super!).x`
- `flow_as_expression` — Flow `(super: any).x`
- `flow_type_cast_expression` — Flow `(super: any)[k]`

## Affected check sites (7)

`src/transformer/es2015_class.zig` :
- `isSuperCall` — `super(args)` callee
- `isSuperMethodCall` — `super.method()` callee
- `isSuperMember` — `super.x`
- `isSuperComputedMember` — `super[k]`
- `lowerSuperPropertyAssignment` LHS
- `lowerSuperPropertyUpdate` operand
- `isSuperComputedMethodCall` — `super[k](args)` callee

## Test plan

- [x] 유닛 테스트 6개 추가 (`src/codegen/codegen_test/es_downlevel.zig`):
  - 괄호 `(super)[k]` set
  - TS as-cast `(super as any).x` set
  - TS as-cast computed `(super as any)[k]` set
  - TS legacy `(<any>super)[k]` set
  - TS non-null `(super!).x` get
  - wrapped `(super as any).m()` method call
- [x] 통합 런타임 테스트 5개 추가 (`tests/integration/tests/downlevel.test.ts`): 위 케이스의 native runtime 동작 일치 확인 (실제 bun 실행)
- [x] `zig build test` 통과 (debug)
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] `tests/integration/tests/downlevel.test.ts` 전체 244/244 통과 (회귀 없음)

## Out of scope (별도 검토 필요)

다른 5개 super tag check site 가 codebase 에 존재하지만 본 PR scope 밖:
- `src/transformer/es2020.zig:368` `isSuperExpression` — optional chain (e.g., `super?.x`) 경로. wrapped optional chain super 는 더 edge case 라 별개로 평가.
- `src/transformer/transformer.zig:3159` — derived ctor super-call statement scan (parameter property 삽입 위치). statement-level scan 이라 wrap 영향 적음.
- `src/transformer/es_helpers.zig:429` `makeSingleEvalExpr` — 임시변수 처리.
- `src/transformer/minify.zig:1748` — minifier const-fold 회피.
- `src/transformer/transformer/class_decorator.zig:1023` — decorator init.

이들은 wrapped super 가 실제 문제를 일으키는지 별도 재현 후 필요 시 후속 PR 로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)