### PR TITLE
fix(mangler): include generated temp bindings

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -631,6 +631,7 @@ pub const Bundler = struct {
         worker_graph.worklet_transform = self.options.worklet_transform;
         worker_graph.react_refresh = self.options.react_refresh;
         worker_graph.code_splitting = self.options.code_splitting;
+        worker_graph.minify_identifiers = self.options.minify_identifiers;
         worker_graph.transform_options_base = self.buildTransformOptionsBase();
         defer worker_graph.deinit();
 
@@ -777,6 +778,7 @@ pub const Bundler = struct {
         graph.worklet_transform = self.options.worklet_transform;
         graph.react_refresh = self.options.react_refresh;
         graph.code_splitting = self.options.code_splitting;
+        graph.minify_identifiers = self.options.minify_identifiers;
         graph.transform_options_base = self.buildTransformOptionsBase();
         defer graph.deinit();
 

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -2073,8 +2073,9 @@ test "Bundler: AMD external dependencies in wrapper" {
 // Parser (flow.zig) 가 `const Name = React.forwardRef(Name_withRef)` 의 binding
 // identifier span 을 `addString(name_text)` 로 재래핑하면서 bit-31 tagged (string_table)
 // span 을 만들었고, 이게 semantic 에서 const 선언의 Symbol.name 으로 전파되어
-// mangler 가 `source[span.start..]` 슬라이싱 시 OOB. root cause 는 원본 name 노드
-// span 을 재사용하도록 fix. 이 테스트는 crash-free + 정상 실행 검증.
+// mangler 가 `source[span.start..]` 슬라이싱 시 OOB. string_table 이름은 semantic 이
+// synthetic_name 에 보존하고 일반 심볼처럼 mangle 한다. 이 테스트는 crash-free +
+// forwardRef 호출 보존을 검증.
 test "Bundler: #1751 Flow component with ref + minify regression" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -2107,7 +2108,7 @@ test "Bundler: #1751 Flow component with ref + minify regression" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "React.forwardRef") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "_withRef") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_withRef") == null);
 }
 
 // #1751: ESM wrap 의 function_declaration → `foo = function(){...}` 변환형에

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -31,6 +31,7 @@ const ResolveCache = resolve_cache_mod.ResolveCache;
 const resolver_mod = @import("resolver.zig");
 const import_scanner = @import("import_scanner.zig");
 const binding_scanner_mod = @import("binding_scanner.zig");
+const bundler_symbol = @import("symbol.zig");
 const json_to_esm = @import("json_to_esm.zig");
 const fs = @import("fs.zig");
 const Scanner = @import("../lexer/scanner.zig").Scanner;
@@ -139,6 +140,9 @@ pub const ModuleGraph = struct {
     /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
     /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
     code_splitting: bool = false,
+    /// identifier mangling 활성화. transformer pre-pass 이후 생성된 임시 binding도
+    /// mangler 입력에 포함하려고 transformed AST semantic을 재구축할 때 사용.
+    minify_identifiers: bool = false,
 
     /// transformer pre-pass 의 옵션 base (#1961). bundler 가 init 시 BundleOptions →
     /// TransformOptions 매핑을 1회 채움. parseModule 이 base 를 복사 후 per-module
@@ -1558,6 +1562,69 @@ pub const ModuleGraph = struct {
         // transformer 가 추가한 helper module import 들을 records 에 append.
         // [parser_node_count..) 영역만 walk — parser 영역은 이미 records 에 등록됨.
         appendTransformerHelperImports(self, module, &(module.ast.?), parser_node_count, arena_alloc);
+
+        if (self.minify_identifiers) {
+            self.refreshSemanticAfterTransform(module, arena_alloc);
+        }
+    }
+
+    fn refreshSemanticAfterTransform(_: *ModuleGraph, module: *Module, arena_alloc: std.mem.Allocator) void {
+        if (module.ast == null) return;
+        var analyzer = SemanticAnalyzer.init(arena_alloc, &(module.ast.?));
+        analyzer.is_strict_mode = true;
+        analyzer.is_module = true;
+        analyzer.enable_stmt_info = true;
+
+        if (analyzer.analyze()) |_| {
+            module.semantic = .{
+                .symbols = analyzer.symbols,
+                .scopes = analyzer.scopes.items,
+                .scope_maps = analyzer.scope_maps.items,
+                .exported_names = analyzer.exported_names,
+                .symbol_ids = analyzer.symbol_ids.items,
+                .unresolved_references = analyzer.unresolved_references,
+                .references = analyzer.references.items,
+            };
+            refreshLocalExportSymbols(module);
+            if (module.transform_cache) |*cache| {
+                cache.symbol_ids = analyzer.symbol_ids.items;
+            }
+
+            if (analyzer.stmt_info_count > 0) {
+                module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
+                    arena_alloc,
+                    &(module.ast.?),
+                    analyzer.symbols.items,
+                    analyzer.references.items,
+                    if (module.semantic) |*s| &s.unresolved_references else null,
+                ) catch module.prebuilt_stmt_info;
+            }
+        } else |_| {}
+    }
+
+    fn refreshLocalExportSymbols(module: *Module) void {
+        const sem = if (module.semantic) |*s| s else return;
+        if (sem.scope_maps.len == 0) return;
+        const scope0 = sem.scope_maps[0];
+        const mod_idx = module.index;
+
+        for (module.export_bindings) |*eb| {
+            if (eb.kind != .local) continue;
+
+            const lookup_name = if (std.mem.eql(u8, eb.exported_name, "default") and
+                (std.mem.eql(u8, eb.local_name, "_default") or std.mem.eql(u8, eb.local_name, "default")))
+                "_default"
+            else
+                eb.local_name;
+
+            const sym_idx = scope0.get(lookup_name) orelse continue;
+            if (sym_idx >= sem.symbols.items.len) continue;
+            if (std.mem.eql(u8, eb.exported_name, "default") and std.mem.eql(u8, lookup_name, "_default")) {
+                sem.symbols.items[sym_idx].synthetic_kind = .default_export;
+                sem.symbols.items[sym_idx].synthetic_name = "_default";
+            }
+            eb.symbol = bundler_symbol.SymbolRef.makeSemantic(mod_idx, sym_idx);
+        }
     }
 
     /// transformer 영역 ([parser_node_count..)) 에서 import_declaration 노드만 골라

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -188,7 +188,6 @@ pub const Codegen = struct {
     /// 모든 call expression 에 대해 호출되므로, 해당 종류의 record 가 없으면 O(1) 로 빠짐.
     has_glob_records: bool = false,
     has_require_context_records: bool = false,
-
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
     }
@@ -264,7 +263,6 @@ pub const Codegen = struct {
 
         // namespace var 중복 제거: top-level 선언 이름 사전 수집
         self.collectTopLevelDeclNames(root);
-
         // function map: program 진입 시 <global> frame
         if (self.fn_map_builder != null) try self.fnMapEnter("<global>");
         try self.emitNode(root);

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -23,7 +23,9 @@ const std = @import("std");
 const Scope = @import("../semantic/scope.zig").Scope;
 const ScopeId = @import("../semantic/scope.zig").ScopeId;
 const Symbol = @import("../semantic/symbol.zig").Symbol;
+const SymbolKind = @import("../semantic/symbol.zig").SymbolKind;
 const Reference = @import("../semantic/symbol.zig").Reference;
+const Span = @import("../lexer/token.zig").Span;
 
 pub const ManglerResult = struct {
     /// symbol_id -> 새 이름. codegen의 linking_metadata.renames에 주입.
@@ -350,15 +352,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
         // Bundler 합성 심볼(#1338)은 source AST에 식별자 참조가 없고 span이 (0,0).
         // rename은 parser AST의 identifier 노드를 바꾸는 것이라 무의미 — skip.
         if (sym.isSynthetic()) continue;
-        // string_table-backed span (Ast.STRING_TABLE_BIT). parser/transformer 가
-        // `addString` 으로 합성한 identifier 가 semantic 에서 const/let declaration
-        // 으로 재분석될 때 발생 (#1751). 이런 심볼의 이름은 source 에 존재하지 않고
-        // string_table 에만 있으므로 원본 텍스트 비교가 의미 없고 slice 는 OOB.
-        // 현재 mangler 는 `source: []const u8` 만 받아서 string_table 접근 불가 —
-        // 합성 이름은 rename 대상에서 제외한다 (mangle 해도 renames 맵이 span-offset
-        // 기반 codegen 과 맞물리지 않아 효과도 없음).
-        if (sym.name.start & 0x80000000 != 0) continue;
-        const orig_name = source[sym.name.start..sym.name.end];
+        const orig_name = sym.nameText(source);
 
         if (std.mem.eql(u8, orig_name, new_name)) continue;
 
@@ -593,4 +587,54 @@ pub fn nextBase54Name(counter: *u32, buf: *[8]u8) []const u8 {
         counter.* += 1;
     }
     return name;
+}
+
+test "mangle: string_table 기반 생성 심볼도 rename 결과에 포함" {
+    const allocator = std.testing.allocator;
+
+    const scopes = [_]Scope{
+        .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 0 },
+        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 1 },
+    };
+
+    const string_table_bit: u32 = 0x80000000;
+    const symbols = [_]Symbol{
+        .{
+            .name = .{ .start = string_table_bit, .end = string_table_bit + 5 },
+            .scope_id = @enumFromInt(1),
+            .origin_scope = @enumFromInt(1),
+            .kind = .variable_var,
+            .decl_flags = SymbolKind.variable_var.declFlags(),
+            .declaration_span = Span{ .start = string_table_bit, .end = string_table_bit + 5 },
+            .reference_count = 2,
+            .synthetic_name = "_this",
+        },
+    };
+
+    var empty_scope = std.StringHashMap(usize).init(allocator);
+    defer empty_scope.deinit();
+    var function_scope = std.StringHashMap(usize).init(allocator);
+    defer function_scope.deinit();
+    try function_scope.put("_this", 0);
+
+    const scope_maps = [_]std.StringHashMap(usize){ empty_scope, function_scope };
+    const refs = [_]Reference{
+        .{
+            .node_index = @enumFromInt(0),
+            .scope_id = @enumFromInt(1),
+            .symbol_id = @enumFromInt(0),
+            .flags = .{ .read = true },
+        },
+    };
+
+    var result = try mangle(allocator, .{
+        .scopes = &scopes,
+        .symbols = &symbols,
+        .scope_maps = &scope_maps,
+        .references = &refs,
+        .source = "",
+    });
+    defer result.deinit();
+
+    try std.testing.expectEqualStrings("e", result.renames.get(0).?);
 }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -603,6 +603,7 @@ pub const SemanticAnalyzer = struct {
             .decl_flags = decl_flags,
             .declaration_span = decl_span,
             .origin_scope = self.current_scope,
+            .synthetic_name = if (name_span.start & ast_mod.Ast.STRING_TABLE_BIT != 0) name_text else "",
         });
 
         // symbol_ids에 선언 노드 기록

--- a/tests/integration/tests/mangler-minify.test.ts
+++ b/tests/integration/tests/mangler-minify.test.ts
@@ -144,4 +144,80 @@ describe("mangler --minify 회귀", () => {
     // RUNTIME_FLAG는 dep.js 평가 시점에 undefined → falsy → 양쪽 null
     expect(result.runOutput).toBe("null null");
   });
+
+  // post-transform semantic refresh가 module.semantic을 교체하면 기존 ExportBinding.symbol이
+  // 이전 symbol table을 가리킬 수 있다. named local export alias가 새 semantic symbol로
+  // 다시 연결되지 않으면 importer의 참조와 declaration 이름이 어긋난다.
+  test("post-transform semantic refresh 후 named export alias가 새 심볼을 가리킨다", async () => {
+    const result = await bundleAndRun(
+      {
+        "dep.js": `
+          const localValue = globalThis.RUNTIME_FLAG ? "bad" : "ok";
+          export { localValue as value };
+        `,
+        "index.js": `
+          import { value } from './dep.js';
+          globalThis.RUNTIME_FLAG = true;
+          console.log(value);
+        `,
+      },
+      "index.js",
+      ["--minify", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    // dep.js 평가 시점에는 RUNTIME_FLAG가 undefined라 falsy.
+    expect(result.runOutput).toBe("ok");
+  });
+
+  // source 모듈의 default export 심볼이 post-transform semantic 기준으로 갱신되지 않으면
+  // barrel re-export가 stale SymbolRef를 따라가며 default 값 연결을 잃는다.
+  test("post-transform semantic refresh 후 default re-export chain이 stale 심볼을 쓰지 않는다", async () => {
+    const result = await bundleAndRun(
+      {
+        "dep.js": `export default globalThis.RUNTIME_FLAG ? "bad" : "ok";`,
+        "barrel.js": `export { default as value } from './dep.js';`,
+        "index.js": `
+          import { value } from './barrel.js';
+          globalThis.RUNTIME_FLAG = true;
+          console.log(value);
+        `,
+      },
+      "index.js",
+      ["--minify", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("ok");
+  });
+
+  // namespace import는 current-side local_symbol과 local export symbol 양쪽을 모두 사용한다.
+  // semantic refresh 후 ExportBinding.symbol만 낡으면 `export { ns }` 경로에서 namespace 객체가
+  // 잘못된 mangled 이름으로 노출될 수 있다.
+  test("post-transform semantic refresh 후 namespace import local export가 유지된다", async () => {
+    const result = await bundleAndRun(
+      {
+        "dep.js": `
+          export const left = "L";
+          export const right = "R";
+        `,
+        "barrel.js": `
+          import * as ns from './dep.js';
+          export { ns };
+        `,
+        "index.js": `
+          import { ns } from './barrel.js';
+          console.log(ns.left + ns.right);
+        `,
+      },
+      "index.js",
+      ["--minify", "--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("LR");
+  });
 });


### PR DESCRIPTION
## 요약
- codegen 전용 alias 치환 방식을 제거하고, 생성 임시 binding을 실제 mangler 경로에 포함하도록 근본 수정했습니다.
- semantic이 string_table 기반 선언 이름을 `Symbol.synthetic_name`에 보존하고, mangler가 `Symbol.nameText()`로 원래 이름을 비교해 rename 결과를 생성합니다.
- minify-identifiers 번들 경로에서는 transformer pre-pass 이후 transformed AST를 다시 semantic 분석하고, 그 `symbol_ids`를 transform cache에 연결해 codegen이 mangler rename을 실제 출력에 적용합니다.
- post-transform semantic 교체 후 기존 import/export binding이 stale symbol id를 들고 있던 CI 회귀를 수정했습니다. `.local` export의 `eb.symbol`을 새 semantic scope 기준으로 다시 연결하고 default export `_default` 합성 표식도 다시 붙입니다.
- 기존 #1751 Flow component 회귀 테스트는 string_table 이름이 이제 mangling되는 기대값으로 갱신했습니다.

## 실측
ExampleApp iOS release bundle 기준:
- main current: raw 2,477,743 / gzip 543,378 / br 408,789
- root mangler fix + CI fix: raw 2,403,618 / gzip 533,551 / br 403,143
- 감소: raw -74,125 bytes, gzip -9,827 bytes, br -5,646 bytes
- `_this`: 2620 -> 7, `_super`: 722 -> 0, `_newTarget`: 480 -> 0

Metro 대비 현재 차이:
- Metro: raw 2,126,501 / gzip 469,962 / br 345,064
- zts: raw 2,403,618 / gzip 533,551 / br 403,143
- zts가 더 큼: raw +277,117 bytes / gzip +63,589 bytes / br +58,079 bytes

## 검증
- `zig build -Doptimize=ReleaseFast`
- `zig build napi`
- `bun test tests/integration/tests/mangler-minify.test.ts --test-name-pattern "cross-module default import"`
- `bun test tests/integration/tests/mangler-minify.test.ts`
- `zig build test`
- `cd packages/core && bun build index.ts --outdir dist --format esm --target bun`
- `examples/ExampleApp` iOS release bundle 생성 및 크기 측정