### PR TITLE
fix(transformer): optional chain 안의 wrapped super 도 super lowering (#2034)

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2553,6 +2553,54 @@ test "ES2020: optional super method call ES5 클래스 다운레벨 보존" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, ".call(this)") != null);
 }
 
+// #2034: transparent wrapper(괄호, TS as/!/<T>) 로 감싸진 super 가 optional chain base 일 때
+// raw `super` 가 temp 대입 RHS 로 emit 되던 버그 — super 는 항상 정의되어 있으므로 optional 무의미.
+// optional flag 만 벗기고 정상 super lowering 으로 routing.
+test "ES2020: 괄호 super 의 optional chain — (super)?.x (#2034)" {
+    var r = try e2eTarget(std.testing.allocator, "class B{x=1}class C extends B{m(){return (super)?.x}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"x\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=super)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=(super)") == null);
+}
+
+test "ES2020: TS as-cast super 의 optional chain — (super as any)?.x (#2034)" {
+    var r = try e2eTarget(std.testing.allocator, "class B{x=1}class C extends B{m(){return (super as any)?.x}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"x\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=super)") == null);
+}
+
+test "ES2020: TS as-cast super 의 optional computed chain — (super as any)?.[k] (#2034)" {
+    var r = try e2eTarget(std.testing.allocator, "class B{x=1;[k:string]:any}class C extends B{m(){const k=\"x\";return (super as any)?.[k]}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,k") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=super)") == null);
+}
+
+test "ES2020: TS as-cast super 의 optional method call — (super as any)?.m() (#2034)" {
+    var r = try e2eTarget(std.testing.allocator, "class B{m(){return 1}}class C extends B{run(){return (super as any)?.m()}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.prototype.m.call(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=super)") == null);
+}
+
+test "ES2020: TS non-null assertion super 의 optional chain — (super!)?.m() (#2034)" {
+    var r = try e2eTarget(std.testing.allocator, "class B{m(){return 1}}class C extends B{run(){return (super!)?.m()}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_super.prototype.m.call(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=super)") == null);
+}
+
+test "ES2020: wrapped super + 후속 optional chain — (super as any)?.x?.y (#2034)" {
+    // ?.x 는 super-base 라 strip 되고 __superGet 으로 lowering, ?.y 는 일반 ternary 로 보존.
+    var r = try e2eTarget(std.testing.allocator, "class B{get nested(){return {y:1}}}class C extends B{m(){return (super as any)?.nested?.y}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(_super.prototype,\"nested\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "==null?void 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=super)") == null);
+}
+
 test "ES2020: optional receiver + optional method call receiver 단락 평가" {
     var r = try e2eTarget(std.testing.allocator, "obj?.method?.(arg());", .es2019);
     defer r.deinit();

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -126,6 +126,14 @@ pub fn ES2020(comptime Transformer: type) type {
             base_idx: NodeIndex,
             ctx: LowerCtx,
         ) Transformer.Error!NodeIndex {
+            // chain base 가 (wrapped) super 면 optional 검사 무의미 — super 는 항상 정의되어 있다.
+            // 일반 capture 경로는 base_idx 를 visit 해서 raw `super` 를 temp 에 대입 → syntax error.
+            // optional flag 만 벗겨내고 정상 super lowering 으로 우회 (#2034).
+            if (ctx == .normal and isSuperExpression(self, base_idx)) {
+                const stripped = try stripOptionalAtSuperBase(self, node, base_idx);
+                return self.visitNode(stripped);
+            }
+
             const optional_member_call = if (ctx == .normal)
                 try prepareOptionalMemberCall(self, node, base_idx)
             else
@@ -365,8 +373,68 @@ pub fn ES2020(comptime Transformer: type) type {
             }
         }
 
+        /// node 부터 base_idx 까지 chain 을 따라 내려가서, 그 segment 의 obj/callee 가 base_idx 인
+        /// 지점의 optional_chain flag 만 제거한 새 노드 트리를 반환. 다른 chain segment 의 optional 은
+        /// 그대로 유지 — `(super as any)?.x?.y` 라면 `?.x` (super-base) 만 strip, `?.y` 는 보존되어
+        /// recursive visit 에서 일반 ternary 로 lowering.
+        fn stripOptionalAtSuperBase(self: *Transformer, node: Node, base_idx: NodeIndex) Transformer.Error!NodeIndex {
+            switch (node.tag) {
+                .static_member_expression, .computed_member_expression, .private_field_expression => {
+                    const e = node.data.extra;
+                    const obj_idx = self.readNodeIdx(e, 0);
+                    const prop = self.readNodeIdx(e, 1);
+                    const flags = self.readU32(e, 2);
+                    if (obj_idx == base_idx and (flags & ast_mod.MemberFlags.optional_chain) != 0) {
+                        const new_flags = flags & ~ast_mod.MemberFlags.optional_chain;
+                        const new_extra = try self.ast.addExtras(&.{ @intFromEnum(obj_idx), @intFromEnum(prop), new_flags });
+                        return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .extra = new_extra } });
+                    }
+                    const new_obj = try stripOptionalAtSuperBase(self, self.ast.getNode(obj_idx), base_idx);
+                    const new_extra = try self.ast.addExtras(&.{ @intFromEnum(new_obj), @intFromEnum(prop), flags });
+                    return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .extra = new_extra } });
+                },
+                .call_expression => {
+                    const e = node.data.extra;
+                    const callee_idx = self.readNodeIdx(e, 0);
+                    const args_start = self.readU32(e, 1);
+                    const args_len = self.readU32(e, 2);
+                    const flags = self.readU32(e, 3);
+                    if (callee_idx == base_idx and (flags & ast_mod.CallFlags.optional_chain) != 0) {
+                        const new_flags = flags & ~ast_mod.CallFlags.optional_chain;
+                        const new_extra = try self.ast.addExtras(&.{ @intFromEnum(callee_idx), args_start, args_len, new_flags });
+                        return self.ast.addNode(.{ .tag = .call_expression, .span = node.span, .data = .{ .extra = new_extra } });
+                    }
+                    const new_callee = try stripOptionalAtSuperBase(self, self.ast.getNode(callee_idx), base_idx);
+                    const new_extra = try self.ast.addExtras(&.{ @intFromEnum(new_callee), args_start, args_len, flags });
+                    return self.ast.addNode(.{ .tag = .call_expression, .span = node.span, .data = .{ .extra = new_extra } });
+                },
+                else => unreachable,
+            }
+        }
+
+        /// transparent wrapper(괄호, TS as/satisfies/type-assertion/!/instantiation, Flow as/cast)
+        /// 통과 후 super_expression 인지 검사. wrapped super 도 super 전용 lowering 분기 (#2034) 를
+        /// 타야 raw `super` 가 temp 대입 RHS 로 흘러나오지 않는다 (es2015_class.zig 의 isSuperUnwrapped
+        /// 와 동일 의도).
         fn isSuperExpression(self: *const Transformer, idx: NodeIndex) bool {
-            return !idx.isNone() and self.ast.getNode(idx).tag == .super_expression;
+            var cur = idx;
+            while (true) {
+                if (cur.isNone()) return false;
+                const node = self.ast.getNode(cur);
+                switch (node.tag) {
+                    .super_expression => return true,
+                    .parenthesized_expression,
+                    .ts_as_expression,
+                    .ts_satisfies_expression,
+                    .ts_type_assertion,
+                    .ts_instantiation_expression,
+                    .ts_non_null_expression,
+                    .flow_as_expression,
+                    .flow_type_cast_expression,
+                    => cur = node.data.unary.operand,
+                    else => return false,
+                }
+            }
         }
 
         fn makeSuperMethodMember(

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -3972,6 +3972,97 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       expect(result.runOutput).toBe("5");
     });
 
+    // #2034: transparent wrapper(괄호, TS as/!/<T>) 로 감싸진 super 가 optional chain base 일 때
+    // raw super 가 emit 되어 syntax error 나던 버그. super 는 항상 정의되어 있으므로 optional 무의미.
+    test("괄호 super 의 optional chain — (super)?.x (#2034)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B { get x() { return 7; } }
+            class C extends B { m() { return (super)?.x; } }
+            console.log(new C().m());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("7");
+    });
+
+    test("TS as-cast super 의 optional chain — (super as any)?.x (#2034)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B { get x() { return 42; } }
+            class C extends B { m() { return (super as any)?.x; } }
+            console.log(new C().m());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("42");
+    });
+
+    test("TS as-cast super 의 optional method call — (super as any)?.m() (#2034)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B { greet() { return "hello:" + this.tag; } tag = "B"; }
+            class C extends B { tag = "C"; run() { return (super as any)?.greet(); } }
+            console.log(new C().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("hello:C");
+    });
+
+    test("TS non-null assertion super 의 optional method call — (super!)?.m() (#2034)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B { greet() { return "hi"; } }
+            class C extends B { run() { return (super!)?.greet(); } }
+            console.log(new C().run());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("hi");
+    });
+
+    test("wrapped super + 후속 optional chain — (super as any)?.nested?.y (#2034)", async () => {
+      // ?.nested 는 super-base 라 strip 후 __superGet, ?.y 는 일반 ternary 로 보존돼야 함.
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            class B { get nested(): { y: number } | null { return { y: 100 }; } }
+            class C extends B { m() { return (super as any)?.nested?.y; } }
+            class D extends B { get nested(): null { return null; } m() { return (super as any)?.nested?.y; } }
+            console.log(new C().m(), new D().m());
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      // C: super.nested = {y:100} → 100. D: D.nested = null, super.nested 는 B.prototype.nested getter → {y:100} → 100.
+      // (super 는 prototype 체인의 _바로 위_ 인 B.prototype 을 가리키므로 D 의 own getter 무시.)
+      expect(result.runOutput).toBe("100 100");
+    });
+
     test("optional receiver + optional method call receiver 단락 평가", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary

- `src/transformer/es2020.zig` 의 `lowerOptionalChainCtx` 가 wrapped super (`(super as any)?.x` 등) 를 generic capture 경로로 처리해 raw `super` 가 temp 대입 RHS 로 emit → 런타임 SyntaxError 발생.
- super 는 항상 정의되어 있어 optional check 가 무의미하므로, base 가 wrapped super 면 optional flag 만 strip 한 새 노드 트리를 만들어 정상 super lowering 으로 routing.

## Why

```ts
class B { get x() { return 42; } }
class C extends B { m() { return (super as any)?.x; } }
```

기존 emit (broken):
```js
return ((_a = super) == null ? void 0 : _a.x);  // SyntaxError: 'super' keyword unexpected here
```

수정 후 emit:
```js
return __superGet(_super.prototype, "x", this);  // optional 무의미 → 정상 super lowering
```

#2030 의 root cause 와 동일 (transparent wrapper 가 super tag check 를 우회) — 다만 다른 lowering pass (es2020 optional chain).

## Changes

`src/transformer/es2020.zig`:
1. `isSuperExpression` 을 8 wrapper tag (parens, ts_as/satisfies/type_assertion/non_null/instantiation, flow_as/cast) 통과하도록 수정 — `es2015_class.zig:isSuperUnwrapped` 와 동일 의도.
2. `lowerOptionalChainCtx` 진입부에 short-circuit 추가 — base 가 wrapped super 면 strip 후 visit.
3. `stripOptionalAtSuperBase` helper — chain 을 따라 base_idx 까지 walk 후 그 segment 의 optional flag 만 제거 (다른 segment 의 optional 은 보존).

## Test plan

- [x] 유닛 테스트 6개 (`src/codegen/codegen_test/es_downlevel.zig`):
  - `(super)?.x`, `(super as any)?.x`, `(super as any)?.[k]`
  - `(super as any)?.m()` (method call)
  - `(super!)?.m()` (non-null assertion)
  - `(super as any)?.nested?.y` (super-base optional + 후속 optional 혼합)
- [x] 통합 런타임 테스트 5개 (`tests/integration/tests/downlevel.test.ts`): 동일 케이스 native runtime 일치
- [x] `zig build test` 통과 (debug + ReleaseFast)
- [x] `tests/integration/tests/downlevel.test.ts` 249/249 (회귀 없음)

회귀 검증:
- `super.x?.y` — chain on super result, 기존 capture-to-temp 경로 보존
- `super.method?.()` — `prepareOptionalMemberCall` 의 super-method-call 분기 정상 동작

## Note

PR description #2032 에 "out of scope" 로 분리한 5개 사이트 중 1개 — 사용자 요청으로 추가 검증 후 실제 깨짐 확인하여 본 PR 로 fix. 나머지 4개는 wrapped super 가 해당 검사 시점에 이미 `__callSuper(...)` 로 lowering 되어 있어 영향 없음.

Closes #2034

🤖 Generated with [Claude Code](https://claude.com/claude-code)