### PR TITLE
fix(bundler): transformer 이후 분석 산출물 재생성

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -15,6 +15,7 @@ const std = @import("std");
 const Ast = @import("../parser/ast.zig").Ast;
 const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const ast_walk = @import("../parser/ast_walk.zig");
 const Span = @import("../lexer/token.zig").Span;
 const types = @import("types.zig");
 const module_parser = @import("../parser/module.zig");
@@ -148,7 +149,11 @@ pub fn extractImportBindings(
         try source_to_record.put(key, @intCast(i));
     }
 
-    for (ast.nodes.items) |node| {
+    const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
+    defer allocator.free(reachable);
+
+    for (reachable) |ni| {
+        const node = ast.nodes.items[ni];
         if (node.tag != .import_declaration) continue;
 
         const e = node.data.extra;
@@ -254,7 +259,11 @@ pub fn extractExportBindings(
         try import_by_name.put(allocator, ib.local_name, ib);
     }
 
-    for (ast.nodes.items) |node| {
+    const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
+    defer allocator.free(reachable);
+
+    for (reachable) |ni| {
+        const node = ast.nodes.items[ni];
         switch (node.tag) {
             .export_named_declaration => {
                 const e = node.data.extra;
@@ -571,7 +580,11 @@ pub fn collectNamespaceAccesses(
     defer escaped_refs.deinit(allocator);
 
     // 단일 패스: member access 수집 + 탈출 후보 기록
-    for (ast.nodes.items, 0..) |node, ni| {
+    const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
+    defer allocator.free(reachable);
+
+    for (reachable) |ni| {
+        const node = ast.nodes.items[ni];
         switch (node.tag) {
             .static_member_expression => {
                 const me = node.data.extra;
@@ -600,7 +613,7 @@ pub fn collectNamespaceAccesses(
             .identifier_reference => {
                 const name = ast.getText(node.span);
                 if (ns_map.get(name)) |binding_idx| {
-                    try escaped_refs.append(allocator, .{ .ni = @intCast(ni), .binding_idx = binding_idx });
+                    try escaped_refs.append(allocator, .{ .ni = ni, .binding_idx = binding_idx });
                 }
             },
             .computed_member_expression => {

--- a/src/bundler/emitter/external_imports.zig
+++ b/src/bundler/emitter/external_imports.zig
@@ -76,6 +76,7 @@ pub fn emitChunkExternalImports(
             const rec = m.import_records[ib.import_record_index];
             if (!rec.is_external) continue;
             if (rec.kind != .static_import and rec.kind != .re_export) continue;
+            if (!ib.isSynthetic() and !ib.local_symbol.isValid()) continue;
 
             // verbatim_module_syntax=true 면 모두 보존, 아니면 type-only 는 drop.
             if (!verbatim) {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -40,6 +40,7 @@ const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
 const profile = @import("../profile.zig");
 const semantic_symbol = @import("../semantic/symbol.zig");
 const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
+const AliasTable = @import("module.zig").AliasTable;
 const stmt_info_mod = @import("stmt_info.zig");
 const Span = @import("../lexer/token.zig").Span;
 const pkg_json = @import("package_json.zig");
@@ -52,8 +53,6 @@ const TransformOptions = transformer_mod.TransformOptions;
 const TransformCache = @import("module.zig").TransformCache;
 const builtin_plugins = @import("../transformer/plugins/builtin.zig");
 const Ast = @import("../parser/ast.zig").Ast;
-const NodeIndex = @import("../parser/ast.zig").NodeIndex;
-const module_parser = @import("../parser/module.zig");
 const runtime_helper_modules = @import("../runtime_helper_modules.zig");
 pub const module_store = @import("module_store.zig");
 const phase_mod = @import("phase.zig");
@@ -1496,20 +1495,21 @@ pub const ModuleGraph = struct {
             }
         }
 
-        // #1961: transformer pre-pass. helper module 을 graph 의 1급 모듈로 분배하려면
-        // helper import 가 link 단계 전에 import_records 에 등록되어야 한다. transformer 를
-        // 여기서 1회 실행해 transformed AST 를 module.ast 에 in-place 저장 + helper import
-        // 노드를 records 에 append. emitter 는 module.transform_cache hit 시 transform skip.
+        // #1961/#1913: transformer pre-pass. helper module 을 graph 의 1급 모듈로
+        // 분배하려면 helper import 가 link 단계 전에 import_records 에 등록되어야 한다.
+        // transformer 를 여기서 1회 실행해 final AST 를 module.ast 에 저장하고, 그 AST
+        // 기준으로 semantic/import/export/StmtInfo 를 다시 만든다. emitter 는
+        // module.transform_cache hit 시 transform skip.
         self.runTransformerPrePass(module, arena_alloc);
 
         module.state = .parsed;
     }
 
     /// transformer pre-pass — graph 단계에서 1회 실행.
-    /// 결과: `module.ast` 에 transformer 노드 in-place append, `module.transform_cache` set,
-    /// helper module import 들이 `module.import_records` 에 append.
-    /// 실패는 silent — 기존 import_records 와 `transform_cache=null` 로 emitter 가 legacy
-    /// 경로로 fallback (out-of-memory 등에 대한 부분 진행 회피).
+    /// 결과: `module.ast` 를 transformer 결과 AST 로 교체, `module.transform_cache` set,
+    /// final AST 기준 분석 데이터 refresh.
+    /// 실패 시 error diagnostic 을 남기고 모듈 파싱을 중단한다. stale semantic/binding
+    /// 데이터로 tree-shaker/linker 가 진행하는 silent bug 를 막기 위한 정책 (#1913).
     fn runTransformerPrePass(self: *ModuleGraph, module: *Module, arena_alloc: std.mem.Allocator) void {
         if (module.ast == null) return;
         const ast_ptr = &(module.ast.?);
@@ -1559,140 +1559,228 @@ pub const ModuleGraph = struct {
             .symbol_ids = owned_symbol_ids,
         };
 
-        // transformer 가 추가한 helper module import 들을 records 에 append.
-        // [parser_node_count..) 영역만 walk — parser 영역은 이미 records 에 등록됨.
-        appendTransformerHelperImports(self, module, &(module.ast.?), parser_node_count, arena_alloc);
+        _ = parser_node_count;
 
-        if (self.minify_identifiers) {
-            self.refreshSemanticAfterTransform(module, arena_alloc);
-        }
+        self.refreshAnalysisAfterAstMutation(module, arena_alloc) catch {
+            self.addDiag(
+                .parse_error,
+                .@"error",
+                module.path,
+                Span.EMPTY,
+                .parse,
+                "Post-transform analysis refresh failed",
+                "The transformed AST could not be re-analyzed safely.",
+            );
+            module.state = .ready;
+            return;
+        };
     }
 
-    fn refreshSemanticAfterTransform(_: *ModuleGraph, module: *Module, arena_alloc: std.mem.Allocator) void {
-        if (module.ast == null) return;
-        var analyzer = SemanticAnalyzer.init(arena_alloc, &(module.ast.?));
+    /// AST mutation 이후 module 의 분석 산출물을 final AST 기준으로 재생성한다.
+    /// 이 함수가 성공한 뒤에는 `module.ast`, semantic, import/export bindings,
+    /// prebuilt_stmt_info, alias_table 이 같은 AST 기준이어야 한다 (#1913).
+    fn refreshAnalysisAfterAstMutation(
+        self: *ModuleGraph,
+        module: *Module,
+        arena_alloc: std.mem.Allocator,
+    ) !void {
+        const ast = &(module.ast orelse return);
+        const previous_import_records = module.import_records;
+        const previous_import_bindings = module.import_bindings;
+
+        var analyzer = SemanticAnalyzer.init(arena_alloc, ast);
         analyzer.is_strict_mode = true;
         analyzer.is_module = true;
+        analyzer.is_ts = isTypeScriptPath(module.path);
+        analyzer.is_flow = self.flow or isFlowPath(module.path);
         analyzer.enable_stmt_info = true;
+        try analyzer.analyze();
 
-        if (analyzer.analyze()) |_| {
-            module.semantic = .{
-                .symbols = analyzer.symbols,
-                .scopes = analyzer.scopes.items,
-                .scope_maps = analyzer.scope_maps.items,
-                .exported_names = analyzer.exported_names,
-                .symbol_ids = analyzer.symbol_ids.items,
-                .unresolved_references = analyzer.unresolved_references,
-                .references = analyzer.references.items,
-            };
-            refreshLocalExportSymbols(module);
-            if (module.transform_cache) |*cache| {
-                cache.symbol_ids = analyzer.symbol_ids.items;
-            }
+        module.semantic = .{
+            .symbols = analyzer.symbols,
+            .scopes = analyzer.scopes.items,
+            .scope_maps = analyzer.scope_maps.items,
+            .exported_names = analyzer.exported_names,
+            .symbol_ids = analyzer.symbol_ids.items,
+            .unresolved_references = analyzer.unresolved_references,
+            .references = analyzer.references.items,
+        };
+        suppressRuntimeHelperInternalUnresolved(module);
+        module.uses_top_level_await = analyzer.has_top_level_await;
+        if (module.transform_cache) |*cache| {
+            cache.symbol_ids = analyzer.symbol_ids.items;
+        }
 
-            if (analyzer.stmt_info_count > 0) {
-                module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
-                    arena_alloc,
-                    &(module.ast.?),
-                    analyzer.symbols.items,
-                    analyzer.references.items,
-                    if (module.semantic) |*s| &s.unresolved_references else null,
-                ) catch module.prebuilt_stmt_info;
-            }
-        } else |_| {}
-    }
+        module.prebuilt_stmt_info = null;
+        if (analyzer.stmt_info_count > 0) {
+            module.prebuilt_stmt_info = try stmt_info_mod.buildFromSemantic(
+                arena_alloc,
+                ast,
+                analyzer.symbols.items,
+                analyzer.references.items,
+                if (module.semantic) |*s| &s.unresolved_references else null,
+            );
+        }
 
-    fn refreshLocalExportSymbols(module: *Module) void {
-        const sem = if (module.semantic) |*s| s else return;
-        if (sem.scope_maps.len == 0) return;
-        const scope0 = sem.scope_maps[0];
-        const mod_idx = module.index;
+        const scan_result = try import_scanner.extractImportsWithCjsDetectionAndDefines(arena_alloc, ast, self.defines);
+        module.import_records = try mergeImportRecords(arena_alloc, previous_import_records, scan_result.records);
+        try import_scanner.markOptionalRequiresInTryBlocks(arena_alloc, ast, module.import_records);
 
-        for (module.export_bindings) |*eb| {
-            if (eb.kind != .local) continue;
+        const transformed_import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records);
+        module.import_bindings = try mergeImportBindings(arena_alloc, previous_import_bindings, transformed_import_bindings);
 
-            const lookup_name = if (std.mem.eql(u8, eb.exported_name, "default") and
-                (std.mem.eql(u8, eb.local_name, "_default") or std.mem.eql(u8, eb.local_name, "default")))
-                "_default"
-            else
-                eb.local_name;
+        try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
+        module.export_bindings = try binding_scanner_mod.extractExportBindings(
+            arena_alloc,
+            ast,
+            module.import_records,
+            module.import_bindings,
+        );
+        module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
 
-            const sym_idx = scope0.get(lookup_name) orelse continue;
-            if (sym_idx >= sem.symbols.items.len) continue;
-            if (std.mem.eql(u8, eb.exported_name, "default") and std.mem.eql(u8, lookup_name, "_default")) {
-                sem.symbols.items[sym_idx].synthetic_kind = .default_export;
-                sem.symbols.items[sym_idx].synthetic_name = "_default";
-            }
-            eb.symbol = bundler_symbol.SymbolRef.makeSemantic(mod_idx, sym_idx);
+        const refreshed_scan_result = import_scanner.ScanResult{
+            .records = module.import_records,
+            .has_esm_syntax = scan_result.has_esm_syntax,
+            .has_cjs_require = scan_result.has_cjs_require,
+            .has_module_exports = scan_result.has_module_exports,
+            .has_exports_dot = scan_result.has_exports_dot,
+        };
+
+        try self.injectJsxSyntheticImportsForModule(module, arena_alloc, ast);
+
+        module.exports_kind = determineExportsKind(refreshed_scan_result, module.path);
+        module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
+
+        if (module.alias_table) |*table| table.deinit();
+        module.alias_table = AliasTable.init(self.allocator);
+        if (module.semantic) |*sem| {
+            const scope0: ?std.StringHashMap(usize) =
+                if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
+            try binding_scanner_mod.populateSyntheticSymbols(
+                &module.alias_table.?,
+                module.index,
+                module.export_bindings,
+                &sem.symbols,
+                arena_alloc,
+                scope0,
+            );
         }
     }
 
-    /// transformer 영역 ([parser_node_count..)) 에서 import_declaration 노드만 골라
-    /// `\x00zts:runtime/...` specifier 를 가지면 module.import_records 와 module.import_bindings
-    /// 에 binding 정보까지 등록 — link 단계의 cross-chunk symbol resolution 에 필요.
-    fn appendTransformerHelperImports(
-        _: *ModuleGraph,
+    fn suppressRuntimeHelperInternalUnresolved(module: *Module) void {
+        if (!runtime_helper_modules.isVirtualId(module.path)) return;
+        var semantic = &(module.semantic orelse return);
+        runtime_helper_modules.removeRegisteredHelperBaseNames(&semantic.unresolved_references);
+    }
+
+    fn injectJsxSyntheticImportsForModule(
+        self: *ModuleGraph,
         module: *Module,
-        ast_ptr: *const Ast,
-        parser_node_count: u32,
         arena_alloc: std.mem.Allocator,
-    ) void {
-        var added_records: std.ArrayList(ImportRecord) = .empty;
-        defer added_records.deinit(arena_alloc);
-        var added_bindings: std.ArrayList(binding_scanner_mod.ImportBinding) = .empty;
-        defer added_bindings.deinit(arena_alloc);
+        ast: *const Ast,
+    ) !void {
+        if (self.jsx_runtime == .classic or !ast.has_jsx) return;
+        if (self.jsx_specifier_cache == null) {
+            const is_dev = self.jsx_runtime == .automatic_dev;
+            self.jsx_specifier_cache = try std.fmt.allocPrint(
+                self.allocator,
+                "{s}/{s}",
+                .{ self.jsx_import_source, if (is_dev) "jsx-dev-runtime" else "jsx-runtime" },
+            );
+        }
+        const specifier = self.jsx_specifier_cache orelse return;
+        for (module.import_records) |rec| {
+            if (rec.kind == .static_import and std.mem.eql(u8, rec.specifier, specifier)) return;
+        }
+        const base_record_count: u32 = @intCast(module.import_records.len);
+        var specs_buf: [2][]const u8 = undefined;
+        specs_buf[0] = specifier;
+        var n: usize = 1;
+        const react_injected = ast.has_jsx_key_after_spread;
+        if (react_injected) {
+            specs_buf[n] = self.jsx_import_source;
+            n += 1;
+        }
+        module.import_records = try injectJsxRuntimeImports(
+            specs_buf[0..n],
+            arena_alloc,
+            module.import_records,
+        );
+        module.import_bindings = try createJsxImportBindings(
+            self.jsx_runtime,
+            arena_alloc,
+            module.import_bindings,
+            base_record_count,
+            if (react_injected) base_record_count + 1 else null,
+        );
+    }
 
-        const initial_record_count: u32 = @intCast(module.import_records.len);
+    fn isTypeScriptPath(path: []const u8) bool {
+        const ext = std.fs.path.extension(path);
+        return std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx") or
+            std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".cts");
+    }
 
-        for (ast_ptr.nodes.items[parser_node_count..]) |node| {
-            if (node.tag != .import_declaration) continue;
-            if (!ast_ptr.hasExtra(node.data.extra, 5)) continue;
-            const xs = module_parser.readImportDeclExtras(ast_ptr, node.data.extra);
-            if (xs.source.isNone()) continue;
-            const source_node = ast_ptr.getNode(xs.source);
-            if (source_node.tag != .string_literal) continue;
-            const spec = Ast.stripStringQuotes(ast_ptr.getText(source_node.span));
-            if (!runtime_helper_modules.isVirtualId(spec)) continue;
+    fn isFlowPath(path: []const u8) bool {
+        return std.mem.endsWith(u8, path, ".js.flow") or std.mem.endsWith(u8, path, ".jsx.flow");
+    }
 
-            const record_idx_for_bindings: u32 = initial_record_count + @as(u32, @intCast(added_records.items.len));
-            added_records.append(arena_alloc, .{
-                .specifier = spec,
-                .kind = .static_import,
-                .span = source_node.span,
-            }) catch return;
+    fn mergeImportRecords(
+        arena_alloc: std.mem.Allocator,
+        previous: []const ImportRecord,
+        transformed: []const ImportRecord,
+    ) ![]ImportRecord {
+        var records: std.ArrayList(ImportRecord) = .empty;
+        errdefer records.deinit(arena_alloc);
+        try records.appendSlice(arena_alloc, previous);
+        for (transformed) |rec| {
+            if (hasImportRecord(records.items, rec)) continue;
+            try records.append(arena_alloc, rec);
+        }
+        return records.toOwnedSlice(arena_alloc);
+    }
 
-            for (0..xs.specs_len) |i| {
-                const spec_idx: NodeIndex = @enumFromInt(ast_ptr.extra_data.items[xs.specs_start + i]);
-                if (spec_idx.isNone()) continue;
-                const spec_node = ast_ptr.getNode(spec_idx);
-                if (spec_node.tag != .import_specifier) continue;
-                const imported_idx = spec_node.data.binary.left;
-                const local_idx = spec_node.data.binary.right;
-                if (imported_idx.isNone() or local_idx.isNone()) continue;
-                added_bindings.append(arena_alloc, .{
-                    .kind = .named,
-                    .local_name = ast_ptr.getText(ast_ptr.getNode(local_idx).span),
-                    .imported_name = ast_ptr.getText(ast_ptr.getNode(imported_idx).span),
-                    .local_span = ast_ptr.getNode(local_idx).span,
-                    .import_record_index = record_idx_for_bindings,
-                }) catch return;
+    fn hasImportRecord(records: []const ImportRecord, needle: ImportRecord) bool {
+        for (records) |rec| {
+            if (rec.kind == needle.kind and
+                rec.span.start == needle.span.start and
+                rec.span.end == needle.span.end and
+                std.mem.eql(u8, rec.specifier, needle.specifier))
+            {
+                return true;
             }
         }
+        return false;
+    }
 
-        if (added_records.items.len > 0) {
-            const old = module.import_records;
-            const merged = arena_alloc.alloc(ImportRecord, old.len + added_records.items.len) catch return;
-            @memcpy(merged[0..old.len], old);
-            @memcpy(merged[old.len..], added_records.items);
-            module.import_records = merged;
+    fn mergeImportBindings(
+        arena_alloc: std.mem.Allocator,
+        previous: []const binding_scanner_mod.ImportBinding,
+        transformed: []const binding_scanner_mod.ImportBinding,
+    ) ![]binding_scanner_mod.ImportBinding {
+        var bindings: std.ArrayList(binding_scanner_mod.ImportBinding) = .empty;
+        errdefer bindings.deinit(arena_alloc);
+        try bindings.appendSlice(arena_alloc, previous);
+        for (transformed) |binding| {
+            if (hasImportBinding(bindings.items, binding)) continue;
+            try bindings.append(arena_alloc, binding);
         }
-        if (added_bindings.items.len > 0) {
-            const old = module.import_bindings;
-            const merged = arena_alloc.alloc(binding_scanner_mod.ImportBinding, old.len + added_bindings.items.len) catch return;
-            @memcpy(merged[0..old.len], old);
-            @memcpy(merged[old.len..], added_bindings.items);
-            module.import_bindings = merged;
+        return bindings.toOwnedSlice(arena_alloc);
+    }
+
+    fn hasImportBinding(bindings: []const binding_scanner_mod.ImportBinding, needle: binding_scanner_mod.ImportBinding) bool {
+        for (bindings) |binding| {
+            if (binding.kind == needle.kind and
+                binding.import_record_index == needle.import_record_index and
+                binding.local_span.start == needle.local_span.start and
+                binding.local_span.end == needle.local_span.end and
+                std.mem.eql(u8, binding.local_name, needle.local_name) and
+                std.mem.eql(u8, binding.imported_name, needle.imported_name))
+            {
+                return true;
+            }
         }
+        return false;
     }
 
     const findPackageDirPath = resolve_cache_mod.findPackageDirPath;

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -28,6 +28,7 @@ const std = @import("std");
 const Ast = @import("../parser/ast.zig").Ast;
 const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const ast_walk = @import("../parser/ast_walk.zig");
 const CallFlags = @import("../parser/ast.zig").CallFlags;
 const MemberFlags = @import("../parser/ast.zig").MemberFlags;
 const TokenKind = @import("../lexer/token.zig").Kind;
@@ -76,7 +77,11 @@ pub fn extractImportsWithCjsDetectionAndDefines(
     defer dead_ranges.deinit(allocator);
     if (defines.len > 0) try collectDeadIfRanges(allocator, ast, defines, &dead_ranges);
 
-    for (ast.nodes.items) |node| {
+    const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
+    defer allocator.free(reachable);
+
+    for (reachable) |ni| {
+        const node = ast.nodes.items[ni];
         if (isInsideAnySpan(node.span, dead_ranges.items)) continue;
         switch (node.tag) {
             .import_declaration => {
@@ -150,7 +155,11 @@ fn collectDeadIfRanges(
     defines: []const DefineEntry,
     dead_ranges: *std.ArrayList(Span),
 ) !void {
-    for (ast.nodes.items) |node| {
+    const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
+    defer allocator.free(reachable);
+
+    for (reachable) |ni| {
+        const node = ast.nodes.items[ni];
         if (node.tag != .if_statement) continue;
         const parts = node.data.ternary;
         const known = evalToBoolean(ast, parts.a, defines) orelse continue;
@@ -771,7 +780,11 @@ fn isImportMetaUrl(ast: *const Ast, idx: NodeIndex) bool {
 /// new Worker(new URL('./worker.ts', import.meta.url)) 패턴만 감지.
 pub fn extractWorkerRecords(allocator: std.mem.Allocator, ast: *const Ast) ![]ImportRecord {
     var records = std.ArrayListUnmanaged(ImportRecord).empty;
-    for (ast.nodes.items) |node| {
+    const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
+    defer allocator.free(reachable);
+
+    for (reachable) |ni| {
+        const node = ast.nodes.items[ni];
         if (node.tag == .new_expression) {
             if (tryExtractWorkerNew(ast, node)) |record| {
                 try records.append(allocator, record);

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -11,6 +11,7 @@ const ImportKind = types.ImportKind;
 const RequireContextMode = types.RequireContextMode;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
+const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 
 // ============================================================
 // Tests
@@ -166,6 +167,40 @@ test "multiple imports" {
     try std.testing.expectEqualStrings("./c", records[2].specifier);
     try std.testing.expectEqualStrings("./d", records[3].specifier);
     try std.testing.expectEqualStrings("./e", records[4].specifier);
+}
+
+test "transformed_root: orphan import declaration is ignored" {
+    const alloc = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var scanner = try Scanner.init(arena_alloc,
+        \\import { unused } from './dead';
+        \\console.log('entry');
+    );
+    var parser = Parser.init(arena_alloc, &scanner);
+    parser.is_module = true;
+    scanner.is_module = true;
+    _ = try parser.parse();
+
+    const old_root_idx: NodeIndex = @enumFromInt(@as(u32, @intCast(parser.ast.nodes.items.len - 1)));
+    const old_root = parser.ast.getNode(old_root_idx);
+    const old_body = old_root.data.list;
+    try std.testing.expectEqual(@as(u32, 2), old_body.len);
+
+    const expr_idx: NodeIndex = @enumFromInt(parser.ast.extra_data.items[old_body.start + 1]);
+    const new_body = try parser.ast.addNodeList(&.{expr_idx});
+    const new_root = try parser.ast.addNode(.{
+        .tag = .program,
+        .span = old_root.span,
+        .data = .{ .list = new_body },
+    });
+    parser.ast.transformed_root = new_root;
+
+    const records = try extractImports(alloc, &parser.ast);
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), records.len);
 }
 
 test "no imports" {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -319,7 +319,7 @@ pub const Module = struct {
         const sem = self.semantic orelse return null;
         const idx: u32 = @intFromEnum(id);
         if (idx >= sem.symbols.items.len) return null;
-        return sem.symbols.items[idx].nameText(self.source);
+        return self.symbolText(&sem.symbols.items[idx]);
     }
 
     /// SymbolRef가 semantic을 가리키면 Symbol.nameText, 아니면 null.
@@ -327,7 +327,15 @@ pub const Module = struct {
         const idx = ref.semanticIndex() orelse return null;
         const sem = self.semantic orelse return null;
         if (idx >= sem.symbols.items.len) return null;
-        return sem.symbols.items[idx].nameText(self.source);
+        return self.symbolText(&sem.symbols.items[idx]);
+    }
+
+    /// Semantic symbol 이름을 모듈 AST 기준으로 읽는다.
+    /// transformer/generated symbol 이름은 source span이 아니라 AST string_table span일 수 있다.
+    fn symbolText(self: *const Module, sym: *const Symbol) ?[]const u8 {
+        if (sym.synthetic_name.len > 0) return sym.synthetic_name;
+        if (self.ast) |*ast| return ast.getText(sym.name);
+        @panic("Module semantic symbol name requires AST text storage");
     }
 
     /// ImportBinding의 현재 모듈 로컬 이름. local_symbol에서 derive 가능하면

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -360,7 +360,7 @@ pub const TreeShaker = struct {
         const m = self.getModule(module_index) orelse return true;
         const sem = m.semantic orelse return true;
         if (sem.scope_maps.len == 0) return true;
-        const sym_idx = sem.scope_maps[0].get(local_name) orelse return true;
+        const sym_idx = sem.scope_maps[0].get(local_name) orelse return false;
 
         // 역인덱스로 이 심볼을 참조하는 statement 중 reachable한 것이 있는지 확인
         if (sym_idx < infos.sym_to_referencing_stmts.len) {

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -286,6 +286,19 @@ test "esbuild: sideEffects=false removes module when import unused" {
     try std.testing.expect(!r.shaker.isIncluded(r.findModule("pkg.ts").?));
 }
 
+test "#1913: unused import elision still keeps side-effectful module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { foo } from './pkg'; console.log('entry');");
+    try writeFile(tmp.dir, "pkg.ts", "console.log('pkg side effect'); export const foo = 123;");
+
+    var r = try buildAndShake(std.testing.allocator, &tmp, "entry.ts");
+    defer r.deinit();
+
+    try std.testing.expect(r.shaker.isIncluded(r.findModule("pkg.ts").?));
+    try std.testing.expect(!r.shaker.isExportUsed(r.findModule("pkg.ts").?, "foo"));
+}
+
 test "esbuild: sideEffects=false removes side-effect-only import" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -664,9 +664,9 @@ pub const Node = struct {
                 // export_default: unary = { operand: decl, flags: 0 }
                 .export_default_declaration => .{ .kind = .unary },
                 // jsx_element: extra = [tag(0), attrs_start, attrs_len, children_start, children_len]
-                .jsx_element => .{ .kind = .extra, .child_offsets = &.{0} },
+                .jsx_element => .{ .kind = .extra, .child_offsets = &.{0}, .list_offsets = &.{ .{ 1, 2 }, .{ 3, 4 } } },
                 // jsx_opening_element: extra = [tag(0), attrs_start, attrs_len]
-                .jsx_opening_element => .{ .kind = .extra, .child_offsets = &.{0} },
+                .jsx_opening_element => .{ .kind = .extra, .child_offsets = &.{0}, .list_offsets = &.{.{ 1, 2 }} },
                 // jsx_fragment: list = children (파서에서 .list로 저장)
                 .jsx_fragment => .{ .kind = .list },
                 // flow_component_wrapper: extra = [func_decl(0), const_decl(1)]

--- a/src/parser/ast_walk.zig
+++ b/src/parser/ast_walk.zig
@@ -144,3 +144,52 @@ pub fn children(ast: *const Ast, node: Node) ChildIterator {
         .data = node.data,
     };
 }
+
+/// AST 루트(마지막 program 노드)에서 도달 가능한 노드 인덱스를 pre-order로 수집한다.
+/// transformer는 새 노드를 append하면서 이전 노드를 orphan으로 남길 수 있으므로,
+/// post-transform 분석은 `ast.nodes.items` 전체 순회 대신 이 결과를 사용해야 한다.
+pub fn collectReachableNodeIndices(allocator: std.mem.Allocator, ast: *const Ast) ![]u32 {
+    if (ast.nodes.items.len == 0) return &.{};
+
+    var visited = try allocator.alloc(bool, ast.nodes.items.len);
+    defer allocator.free(visited);
+    @memset(visited, false);
+
+    var result: std.ArrayList(u32) = .empty;
+    errdefer result.deinit(allocator);
+
+    var stack: std.ArrayList(NodeIndex) = .empty;
+    defer stack.deinit(allocator);
+    const root_idx = ast.transformed_root orelse
+        @as(NodeIndex, @enumFromInt(@as(u32, @intCast(ast.nodes.items.len - 1))));
+    try stack.append(allocator, root_idx);
+
+    var child_buf: std.ArrayList(NodeIndex) = .empty;
+    defer child_buf.deinit(allocator);
+
+    while (stack.pop()) |idx| {
+        if (idx.isNone()) continue;
+        const ni: u32 = @intFromEnum(idx);
+        if (ni >= ast.nodes.items.len) continue;
+        if (visited[ni]) continue;
+        visited[ni] = true;
+
+        try result.append(allocator, ni);
+
+        child_buf.clearRetainingCapacity();
+        var it = children(ast, ast.nodes.items[ni]);
+        while (it.next()) |child_idx| {
+            if (child_idx.isNone()) continue;
+            if (@intFromEnum(child_idx) >= ast.nodes.items.len) continue;
+            try child_buf.append(allocator, child_idx);
+        }
+
+        var i = child_buf.items.len;
+        while (i > 0) {
+            i -= 1;
+            try stack.append(allocator, child_buf.items[i]);
+        }
+    }
+
+    return result.toOwnedSlice(allocator);
+}

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -324,6 +324,22 @@ pub fn moduleShortFor(base_name: []const u8) ?[]const u8 {
     return null;
 }
 
+/// 이 런타임 helper 시스템이 export 하는 helper base name 인지 검사.
+/// helper virtual module 내부의 helper-to-helper 참조는 같은 helper namespace 안에서
+/// 해석되므로 브라우저/global 예약명으로 취급하면 안 된다.
+pub fn isRegisteredHelperBaseName(base_name: []const u8) bool {
+    return moduleShortFor(base_name) != null;
+}
+
+/// map 에 들어있는 등록 helper base name 을 제거한다.
+pub fn removeRegisteredHelperBaseNames(map: *std.StringHashMap(void)) void {
+    for (MODULES) |m| {
+        for (m.helpers) |h| {
+            _ = map.remove(h);
+        }
+    }
+}
+
 /// helper base name → virtual module 의 internal ID 생성.
 /// 예: `__generator` → `\x00zts:runtime/generator`. caller 가 소유.
 /// 미등록 helper 는 null.

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -268,7 +268,8 @@ pub const SemanticAnalyzer = struct {
         // 하한을 미리 확보해 growth realloc 횟수를 줄인다 (measured ~11회 → ~2회).
         try self.references.ensureTotalCapacity(self.allocator, self.ast.nodes.items.len / 4);
 
-        const root_idx: NodeIndex = @enumFromInt(@as(u32, @intCast(self.ast.nodes.items.len - 1)));
+        const root_idx: NodeIndex = self.ast.transformed_root orelse
+            @as(NodeIndex, @enumFromInt(@as(u32, @intCast(self.ast.nodes.items.len - 1))));
         try self.visitNode(root_idx);
     }
 

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -168,6 +168,41 @@ describe("번들 스모크 테스트", () => {
     expect(output).not.toContain("unused.ts");
   });
 
+  test("#1913: unused import elision 뒤에도 side-effectful package 실행", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import { unused } from "pkg"; console.log("entry");`,
+      "node_modules/pkg/package.json": `{"name":"pkg","main":"index.js"}`,
+      "node_modules/pkg/index.js": `console.log("pkg-side-marker-1913"); export const unused = 1;`,
+    });
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("pkg-side-marker-1913\nentry");
+    expect(result.bundleOutput).toContain("pkg-side-marker-1913");
+  });
+
+  test("#1913: sideEffects=false package의 unused import는 실행하지 않음", async () => {
+    const result = await bundleAndRun({
+      "index.ts": `import { unused } from "pkg"; console.log("entry");`,
+      "node_modules/pkg/package.json": `{"name":"pkg","main":"index.js","sideEffects":false}`,
+      "node_modules/pkg/index.js": `console.log("pkg-side-marker-1913"); export const unused = 1;`,
+    });
+    const sideEffectful = await bundleAndRun({
+      "index.ts": `import { unused } from "pkg"; console.log("entry");`,
+      "node_modules/pkg/package.json": `{"name":"pkg","main":"index.js"}`,
+      "node_modules/pkg/index.js": `console.log("pkg-side-marker-1913"); export const unused = 1;`,
+    });
+    cleanup = async () => {
+      await result.cleanup();
+      await sideEffectful.cleanup();
+    };
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("entry");
+    expect(result.bundleOutput).not.toContain("pkg-side-marker-1913");
+    expect(result.bundleOutput.length).toBeLessThan(sideEffectful.bundleOutput.length);
+  });
+
   test("서브패스 package.json resolve (디렉토리 내 main/module 필드)", async () => {
     // fp-ts 패턴: fp-ts/function → fp-ts/function/package.json → { "module": "../es6/function.js" }
     const result = await bundleAndRun({

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -264,7 +264,7 @@ export async function bundleAndRun(
     const run = await runCmd(["bun", "run", outFile]);
 
     return {
-      bundleOutput: bundle.stdout,
+      bundleOutput: readFileSync(outFile, "utf-8"),
       runOutput: run.stdout.trim(),
       runStderr: run.stderr,
       exitCode: run.exitCode,


### PR DESCRIPTION
## 요약

- transformer pre-pass 이후 `module.ast` 기준으로 semantic / import-export binding / StmtInfo / alias table을 다시 생성합니다.
- transformed AST의 실제 root에서 도달 가능한 노드만 재스캔하도록 공용 `ast_walk.collectReachableNodeIndices`를 추가했습니다.
- transformer가 남긴 orphan import/export 노드가 tree-shaker/linker에 다시 살아나는 문제를 막았습니다.
- generated symbol 이름은 source slice fallback 없이 AST string_table을 통해 해석하고, AST가 없으면 invariant violation으로 실패하게 했습니다.

## 테스트

- `zig build test`
- `zig build`
- `cd tests/integration && bun test tests/bundle-smoke.test.ts -t "#1913"`

## 관련

- #1913