### PR TITLE
fix(bundler): binding local name invariant 정리

### DIFF
--- a/src/bundler/bundler_test/default_deconflict.zig
+++ b/src/bundler/bundler_test/default_deconflict.zig
@@ -461,6 +461,10 @@ test "TypeScript: namespace with export" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "Colors") != null);
+    // namespace 내부 export는 top-level semantic symbol이 없어도 scanner local_name으로
+    // export getter를 구성해야 한다 (#2039).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Red") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "#ff0000") != null);
 }
 
 test "TypeScript: abstract class bundling" {

--- a/src/bundler/bundler_test/typescript_format.zig
+++ b/src/bundler/bundler_test/typescript_format.zig
@@ -385,6 +385,9 @@ test "Real-world: re-export from node_modules (external)" {
     try std.testing.expect(!result.hasErrors());
     // 로컬 모듈은 번들에 포함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "function render") != null);
+    // unused external named import는 semantic local symbol이 없으므로 preamble/output에
+    // 다시 살아나면 안 된다 (#2039).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useState") == null);
 }
 
 // ============================================================

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -888,7 +888,11 @@ pub const Linker = struct {
             for (m.import_bindings) |ib| {
                 if (ib.import_record_index >= m.import_records.len) continue;
                 if (!m.import_records[ib.import_record_index].is_external) continue;
-                try exported.put(m.importBindingLocalName(ib), {});
+                // External import bindings may not have a semantic local symbol when the
+                // import is only preserved for output syntax. In that case the scanner
+                // local name is the external contract we must not mangle.
+                const local_name = if (ib.local_symbol.isValid()) m.importBindingLocalName(ib) else ib.local_name;
+                try exported.put(local_name, {});
             }
         }
 

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -277,6 +277,7 @@ pub fn buildMetadataForAst(
             // resolve 미완료: external 또는 resolve 실패.
             if (rec.resolved.isNone()) {
                 if (rec.kind == .static_import or rec.kind == .side_effect or rec.kind == .re_export) {
+                    if (!ib.isSynthetic() and !ib.local_symbol.isValid()) continue;
                     const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                     // synthetic binding(JSX runtime 등) + ESM-wrapped 모듈 조합에서는
                     // top-level에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨.

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -260,6 +260,7 @@ const TestResult = struct {
 fn buildLinkAndRename(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !TestResult {
     var r = try buildAndLink(allocator, tmp, entry_name);
     try r.linker.computeRenames();
+    r.linker.populateImportSymbols();
     return .{ .linker = r.linker, .graph = r.graph, .cache = r.cache };
 }
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -338,14 +338,25 @@ pub const Module = struct {
         @panic("Module semantic symbol name requires AST text storage");
     }
 
-    /// ImportBinding의 현재 모듈 로컬 이름. local_symbol에서 derive 가능하면
-    /// Symbol.nameText, 아니면 ib.local_name 필드 fallback.
+    /// ImportBinding의 현재 모듈 로컬 이름.
+    /// 일반 import 는 semantic ref 에서 이름을 가져와야 한다. synthetic import
+    /// binding(JSX runtime 등)은 semantic scope 에 실제 로컬 선언이 없으므로 scanner 가
+    /// 저장한 `local_name` 이 canonical source of truth 다.
     pub fn importBindingLocalName(self: *const Module, ib: ImportBinding) []const u8 {
-        return self.refName(ib.local_symbol) orelse ib.local_name;
+        if (self.refName(ib.local_symbol)) |name| return name;
+        if (ib.isSynthetic()) return ib.local_name;
+        std.debug.panic(
+            "non-synthetic import binding '{s}' in module '{s}' has no semantic local symbol",
+            .{ ib.local_name, self.path },
+        );
     }
 
-    /// ExportBinding의 로컬 이름. `.local` + semantic ref면 Symbol.nameText에서
-    /// derive, 그 외엔 eb.local_name 필드 그대로 반환.
+    /// ExportBinding의 로컬 이름.
+    /// `.local` export 는 semantic ref 가 있으면 canonical name 을 사용한다. semantic
+    /// ref 가 없는 `.local` export 도 합법이다. 예: TypeScript namespace 내부 export 는
+    /// scanner 가 저장한 `local_name` 이 emit 대상 이름이고 top-level semantic symbol 이
+    /// 없을 수 있다. re-export 계열은 `local_name` 이 source module 의 exported name 을
+    /// 의미하므로 semantic local ref 가 없는 것이 정상이다.
     pub fn exportBindingLocalName(self: *const Module, eb: ExportBinding) []const u8 {
         if (eb.kind != .local) return eb.local_name;
         return self.refName(eb.symbol) orelse eb.local_name;
@@ -440,3 +451,35 @@ pub const Module = struct {
         }
     }
 };
+
+test "Module.importBindingLocalName allows synthetic binding local_name" {
+    var module = Module.init(@enumFromInt(0), "synthetic.tsx");
+    defer module.deinit(std.testing.allocator);
+
+    const ib = ImportBinding{
+        .kind = .named,
+        .local_name = "_jsx",
+        .imported_name = "jsx",
+        .local_span = .{
+            .start = ImportBinding.SYNTHETIC_SPAN_BASE,
+            .end = ImportBinding.SYNTHETIC_SPAN_BASE + 1,
+        },
+        .import_record_index = 0,
+    };
+
+    try std.testing.expectEqualStrings("_jsx", module.importBindingLocalName(ib));
+}
+
+test "Module.exportBindingLocalName keeps scanner local_name without semantic ref" {
+    var module = Module.init(@enumFromInt(0), "namespace.ts");
+    defer module.deinit(std.testing.allocator);
+
+    const eb = ExportBinding{
+        .exported_name = "Red",
+        .local_name = "Red",
+        .local_span = Span.EMPTY,
+        .kind = .local,
+    };
+
+    try std.testing.expectEqualStrings("Red", module.exportBindingLocalName(eb));
+}

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1687,6 +1687,7 @@ pub const SemanticAnalyzer = struct {
         //       const bar = () => "hello"; // 여기서 선언된 bar를 1st pass에서 미리 등록
         // 2nd pass — 기존 visitNodeList로 전체 순회 (initializer 포함).
         try self.predeclareTopLevelBindings(node.data.list);
+        try self.predeclareNestedTopLevelVarDecls(node.data.list);
         self.predeclared_scope = self.current_scope;
 
         // StmtInfo 사전 수집: statement 개수만 기록. declared/referenced 둘 다 references 배열에서
@@ -1806,6 +1807,59 @@ pub const SemanticAnalyzer = struct {
                     }
                 },
                 else => {},
+            }
+        }
+    }
+
+    /// Program/module scope 에서 nested statement 안의 `var` 선언을 미리 등록한다.
+    /// transformer 이후 block-scoped `let`/`const` 가 `var` 로 낮아질 수 있으므로
+    /// top-level `{ var x; }` / `if (...) var x` 도 module/global var scope 에 hoist 되어야
+    /// 한다. Direct top-level declarations 는 `predeclareTopLevelBindings` 가 이미 처리하므로
+    /// 여기서는 중복 등록하지 않는다.
+    fn predeclareNestedTopLevelVarDecls(self: *SemanticAnalyzer, list: NodeList) AllocError!void {
+        if (list.len == 0) return;
+        if (list.start + list.len > self.ast.extra_data.items.len) return;
+
+        const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
+        const saved_scope_idx = self.current_stmt_idx;
+        const saved_top_idx = self.current_top_stmt_idx;
+        defer {
+            self.current_stmt_idx = saved_scope_idx;
+            self.current_top_stmt_idx = saved_top_idx;
+        }
+
+        for (indices, 0..) |raw_idx, i| {
+            if (self.enable_stmt_info) {
+                self.current_top_stmt_idx = @intCast(i);
+                self.current_stmt_idx = @intCast(i);
+            }
+            const idx: NodeIndex = @enumFromInt(raw_idx);
+            if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) continue;
+            const node = self.ast.getNode(idx);
+            switch (node.tag) {
+                .variable_declaration,
+                .function_declaration,
+                .class_declaration,
+                .ts_enum_declaration,
+                => continue,
+                .export_named_declaration => {
+                    const extra_start = node.data.extra;
+                    const extras = self.ast.extra_data.items;
+                    if (extra_start >= extras.len) continue;
+                    const decl_idx: NodeIndex = @enumFromInt(extras[extra_start]);
+                    if (decl_idx.isNone() or @intFromEnum(decl_idx) >= self.ast.nodes.items.len) continue;
+                    const decl_node = self.ast.getNode(decl_idx);
+                    switch (decl_node.tag) {
+                        .variable_declaration,
+                        .function_declaration,
+                        .class_declaration,
+                        .ts_enum_declaration,
+                        => continue,
+                        else => try self.predeclareVarDeclsRecursive(decl_idx),
+                    }
+                },
+                .export_default_declaration => continue,
+                else => try self.predeclareVarDeclsRecursive(idx),
             }
         }
     }

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1589,6 +1589,38 @@ test "#2023: predeclared lexical bindings record declare ref once" {
     try std.testing.expectEqual(@as(u32, 1), y_scope_stmt_idx);
 }
 
+test "#2037 regression: top-level nested var is predeclared for forward nested function refs" {
+    const source =
+        \\{
+        \\  var api = function() { return helper(); };
+        \\  var helper = function() { return 42; };
+        \\}
+    ;
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    ana.is_module = true;
+    ana.enable_stmt_info = true;
+    try ana.analyze();
+
+    try std.testing.expect(!ana.unresolved_references.contains("helper"));
+
+    var helper_ref_count: ?u32 = null;
+    for (ana.symbols.items) |sym| {
+        if (std.mem.eql(u8, sym.nameText(parser.ast.source), "helper")) {
+            helper_ref_count = sym.reference_count;
+            break;
+        }
+    }
+    try std.testing.expect(helper_ref_count != null);
+    try std.testing.expect(helper_ref_count.? > 0);
+}
+
 // ============================================================
 // #1660: block / switch / module / nested-block 에서 var 와 lexical 이름 충돌
 // (ECMA §sec-block-static-semantics-early-errors / §sec-switch-statement-static-semantics-early-errors


### PR DESCRIPTION
## 요약

- 일반 `ImportBinding`은 semantic `local_symbol` 없이 `local_name`으로 조용히 fallback하지 않도록 invariant를 명확히 했습니다.
- synthetic import binding(JSX runtime 등), external output contract, TypeScript namespace export처럼 `local_name`이 합법적인 source of truth인 경로는 호출부와 주석으로 분리했습니다.
- #2037 이후 CI에서 드러난 lexical hoist 회귀를 함께 수정했습니다. transformer 이후 `let`/`const`가 top-level block 내부 `var`로 낮아진 경우에도 module/global var scope에 사전 등록되도록 했습니다.

## 회귀 테스트

- synthetic import binding local name 허용
- TS namespace 내부 export local name 보존
- unused external named import가 preamble/output에 다시 살아나지 않는지 확인
- external import local binding minify 보존 기존 테스트 유지
- top-level nested `var` forward reference semantic 분석 테스트 추가
- CI 실패 케이스였던 `semantic-lexical-hoist.test.ts` 통과 확인

## 테스트

- `zig build test`
- `zig build`
- `cd tests/integration && bun test tests/semantic-lexical-hoist.test.ts`
- `cd tests/integration && bun test tests/bundle-smoke.test.ts -t "#1913"`

## 관련

- #2039
- #2037