### PR TITLE
fix(bundler): 플러그인 transform 결과를 캐시 키에 반영

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -11,9 +11,19 @@ import {
   type RollupPlugin,
 } from "./index";
 import { resolve } from "node:path";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+  symlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+
+const ROOT_NODE_MODULES = resolve(__dirname, "../../node_modules");
 
 beforeAll(() => {
   init();
@@ -457,6 +467,90 @@ describe("@zts/core build + plugins", () => {
     expect(result.outputFiles[0].text).not.toContain("console.log");
     rmSync(entryDir, { recursive: true, force: true });
   });
+
+  test("#2038: onTransform이 추가한 sideEffects:false 패키지 import도 tree-shaking 입력이 됨", async () => {
+    const entryDir = mkdtempSync(join(tmpdir(), "zts-2038-plugin-pkg-"));
+    writeFileSync(join(entryDir, "main.ts"), "console.log('__ORIGINAL_2038__');");
+    mkdirSync(join(entryDir, "node_modules", "pure-lib-2038"), { recursive: true });
+    writeFileSync(
+      join(entryDir, "node_modules", "pure-lib-2038", "package.json"),
+      '{"name":"pure-lib-2038","main":"index.js","sideEffects":false}',
+    );
+    writeFileSync(
+      join(entryDir, "node_modules", "pure-lib-2038", "index.js"),
+      [
+        'export const used = "core-plugin-used-2038";',
+        'export const unused = "core-plugin-unused-2038";',
+      ].join("\n"),
+    );
+
+    const transformPlugin: ZtsPlugin = {
+      name: "transform-adds-package-import",
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, () => ({
+          code: 'import { used } from "pure-lib-2038";\nconsole.log(used);',
+        }));
+      },
+    };
+
+    try {
+      const result = await build({
+        entryPoints: [join(entryDir, "main.ts")],
+        treeShaking: true,
+        plugins: [transformPlugin],
+      });
+      expect(result.errors.length).toBe(0);
+      const text = result.outputFiles[0].text;
+      expect(text).toContain("core-plugin-used-2038");
+      expect(text).not.toContain("core-plugin-unused-2038");
+      expect(text).not.toContain("__ORIGINAL_2038__");
+    } finally {
+      rmSync(entryDir, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(!existsSync(join(ROOT_NODE_MODULES, "lodash-es", "package.json")))(
+    "#2038: 실제 lodash-es import를 onTransform으로 주입해도 dead export가 새지 않음",
+    async () => {
+      const entryDir = mkdtempSync(join(tmpdir(), "zts-2038-lodash-plugin-"));
+      writeFileSync(join(entryDir, "main.ts"), "console.log('__ORIGINAL_LODASH_2038__');");
+      mkdirSync(join(entryDir, "node_modules"), { recursive: true });
+      symlinkSync(
+        join(ROOT_NODE_MODULES, "lodash-es"),
+        join(entryDir, "node_modules", "lodash-es"),
+      );
+
+      const transformPlugin: ZtsPlugin = {
+        name: "transform-adds-lodash-import",
+        setup(build) {
+          build.onTransform({ filter: /main\.ts$/ }, () => ({
+            code: 'import { uniq } from "lodash-es";\nconsole.log(uniq([1,2,2,3]).join(","));',
+          }));
+        },
+      };
+
+      try {
+        const result = await build({
+          entryPoints: [join(entryDir, "main.ts")],
+          platform: "node",
+          treeShaking: true,
+          plugins: [transformPlugin],
+        });
+        expect(result.errors.length).toBe(0);
+        const text = result.outputFiles[0].text;
+        expect(text).toContain("uniq");
+        expect(text).not.toContain("__ORIGINAL_LODASH_2038__");
+        for (const dead of ["groupBy", "orderBy", "mapValues", "debounce", "throttle"]) {
+          expect(
+            new RegExp(`(^|\\n)(function|const|var|let)\\s+${dead}\\b`, "m").test(text),
+            `dead lodash-es identifier "${dead}" leaked to transform-added bundle`,
+          ).toBe(false);
+        }
+      } finally {
+        rmSync(entryDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   // ============================================================
   // require.context — onResolveContext hook (#1579 Phase 2.5)

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -421,6 +421,26 @@ test "computeInputHash: transformed source participates in cache key (#2038)" {
     try std.testing.expect(hash_a != hash_b);
 }
 
+test "computeInputHash: unchanged transformed source keeps cache key stable (#2038)" {
+    const alloc = std.testing.allocator;
+
+    var resolve_cache = ResolveCache.init(alloc, .{});
+    defer resolve_cache.deinit();
+    var graph = ModuleGraph.init(alloc, &resolve_cache);
+    defer graph.deinit();
+
+    var a = Module.init(@enumFromInt(0), "/entry.ts");
+    var b = Module.init(@enumFromInt(0), "/entry.ts");
+    a.mtime = 123;
+    b.mtime = 123;
+    a.source = "console.log('same plugin output');";
+    b.source = "console.log('same plugin output');";
+
+    const hash_a = computeInputHash(&a, 0xCAFE, null, &graph);
+    const hash_b = computeInputHash(&b, 0xCAFE, null, &graph);
+    try std.testing.expectEqual(hash_a, hash_b);
+}
+
 test "CompiledOutputCache: put → tryHit 성공" {
     const alloc = std.testing.allocator;
     var cache = CompiledOutputCache.init(alloc);

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -4,7 +4,7 @@
 //! HMR/watch rebuild 시 변경되지 않은 모듈의 emit 을 스킵한다.
 //!
 //! ### input_hash 구성 (in-memory cache 한정)
-//! `mtime_ns + options_hash(수동) + used_names_hash + import_records_hash`.
+//! `mtime_ns + source_hash + options_hash(수동) + used_names_hash + import_records_hash`.
 //! `options_hash` 는 emit 영향 필드만 수동 집계 — slice 필드 (`plugins` /
 //! `define` / `drop_labels` / `polyfills` / `run_before_main`) 때문에 comptime
 //! reflection (`autoHash`) 은 부적합.
@@ -26,6 +26,7 @@
 const std = @import("std");
 const Module = @import("module.zig").Module;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
+const ResolveCache = @import("resolve_cache.zig").ResolveCache;
 const emitter = @import("emitter.zig");
 const EmitOptions = emitter.EmitOptions;
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
@@ -223,6 +224,9 @@ pub fn computeInputHash(
 ) u64 {
     var h = InputHasher.init(0);
     h.addI128(module.mtime);
+    // 플러그인 load/transform 이후 실제 파싱·분석·emit 입력. 같은 파일 mtime 과
+    // 같은 플러그인 identity 에서 transform 결과만 바뀌어도 stale emit 재사용 금지.
+    h.addStr(module.source);
     h.addU64(options_hash);
 
     if (used_export_names) |names| {
@@ -395,6 +399,26 @@ test "InputHasher: 동일 입력은 동일 해시" {
     b.addStrList(&.{ "x", "yy" });
 
     try std.testing.expectEqual(a.final(), b.final());
+}
+
+test "computeInputHash: transformed source participates in cache key (#2038)" {
+    const alloc = std.testing.allocator;
+
+    var resolve_cache = ResolveCache.init(alloc, .{});
+    defer resolve_cache.deinit();
+    var graph = ModuleGraph.init(alloc, &resolve_cache);
+    defer graph.deinit();
+
+    var a = Module.init(@enumFromInt(0), "/entry.ts");
+    var b = Module.init(@enumFromInt(0), "/entry.ts");
+    a.mtime = 123;
+    b.mtime = 123;
+    a.source = "console.log('plugin output A');";
+    b.source = "console.log('plugin output B');";
+
+    const hash_a = computeInputHash(&a, 0xCAFE, null, &graph);
+    const hash_b = computeInputHash(&b, 0xCAFE, null, &graph);
+    try std.testing.expect(hash_a != hash_b);
 }
 
 test "CompiledOutputCache: put → tryHit 성공" {

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -226,6 +226,51 @@ test "Plugin integration: transform-added imports are scanned from final source 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "entry-2038") != null);
 }
 
+fn transformAddsPurePackageImportHook(_: ?*anyopaque, _: []const u8, id: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    if (!std.mem.endsWith(u8, id, "index.ts")) return null;
+    return allocator.dupe(u8,
+        \\import { used } from "pure-lib-2038";
+        \\console.log(used);
+        \\
+    ) catch return error.OutOfMemory;
+}
+
+test "Plugin integration: transform-added package import feeds tree-shaking (#2038)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('original source replaced by plugin');");
+    try writeFile(tmp.dir, "node_modules/pure-lib-2038/package.json",
+        \\{"name":"pure-lib-2038","main":"index.js","sideEffects":false}
+    );
+    try writeFile(tmp.dir, "node_modules/pure-lib-2038/index.js",
+        \\export const used = "plugin-pure-used-2038";
+        \\export const unused = "plugin-pure-unused-2038";
+        \\
+    );
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{
+        .{ .name = "add-pure-package-import-transform", .transform = transformAddsPurePackageImportHook },
+    };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .plugins = &plugins,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-pure-used-2038") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-pure-unused-2038") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "original source replaced") == null);
+}
+
 var compiled_cache_transform_marker: []const u8 = "A";
 
 fn cacheSensitiveTransformHook(_: ?*anyopaque, _: []const u8, id: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
@@ -284,6 +329,85 @@ test "Plugin integration: transform output invalidates compiled cache (#2038)" {
         try std.testing.expect(!result.hasErrors());
         try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-cache-B-2038") != null);
         try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-cache-A-2038") == null);
+    }
+
+    _ = cache.takeStats();
+    {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .plugins = &plugins,
+            .compiled_cache = &cache,
+        });
+        defer b.deinit();
+
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+        const stats = cache.takeStats();
+
+        try std.testing.expect(!result.hasErrors());
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-cache-B-2038") != null);
+        try std.testing.expect(stats.hits > 0);
+    }
+}
+
+var compiled_cache_load_marker: []const u8 = "A";
+
+fn cacheSensitiveLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    if (!std.mem.endsWith(u8, path, "index.ts")) return null;
+    return std.fmt.allocPrint(
+        allocator,
+        "const marker = \"plugin-load-cache-{s}-2038\";\nconsole.log(marker);\n",
+        .{compiled_cache_load_marker},
+    ) catch return error.OutOfMemory;
+}
+
+test "Plugin integration: load output invalidates compiled cache (#2038)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('filesystem source is stable');");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var cache = CompiledOutputCache.init(std.testing.allocator);
+    defer cache.deinit();
+
+    const plugins = [_]Plugin{
+        .{ .name = "cache-sensitive-load", .load = cacheSensitiveLoadHook },
+    };
+
+    compiled_cache_load_marker = "A";
+    {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .plugins = &plugins,
+            .compiled_cache = &cache,
+        });
+        defer b.deinit();
+
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.hasErrors());
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-load-cache-A-2038") != null);
+    }
+
+    _ = cache.takeStats();
+    compiled_cache_load_marker = "B";
+    {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .plugins = &plugins,
+            .compiled_cache = &cache,
+        });
+        defer b.deinit();
+
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.hasErrors());
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-load-cache-B-2038") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-load-cache-A-2038") == null);
     }
 }
 

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -10,6 +10,7 @@ const Plugin = plugin_mod.Plugin;
 const PluginRunner = plugin_mod.PluginRunner;
 const ResolveResult = @import("resolver.zig").ResolveResult;
 const OutputFile = @import("emitter.zig").OutputFile;
+const CompiledOutputCache = @import("compiled_cache.zig").CompiledOutputCache;
 const test_helpers = @import("test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
@@ -191,6 +192,99 @@ test "Plugin integration: transform hook modifies output" {
     // transform 훅이 삽입한 변수 선언이 출력에 포함되어야 함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__PLUGIN_TRANSFORM__") != null);
     try std.testing.expect(!result.hasErrors());
+}
+
+fn transformAddsImportHook(_: ?*anyopaque, code: []const u8, id: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    if (!std.mem.endsWith(u8, id, "index.ts")) return null;
+    return std.mem.concat(allocator, u8, &.{ "import './side';\n", code }) catch return error.OutOfMemory;
+}
+
+test "Plugin integration: transform-added imports are scanned from final source (#2038)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('entry-2038');");
+    try writeFile(tmp.dir, "side.ts", "console.log('plugin-added-side-effect-2038');");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{
+        .{ .name = "add-import-transform", .transform = transformAddsImportHook },
+    };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .plugins = &plugins,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-added-side-effect-2038") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "entry-2038") != null);
+}
+
+var compiled_cache_transform_marker: []const u8 = "A";
+
+fn cacheSensitiveTransformHook(_: ?*anyopaque, _: []const u8, id: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+    if (!std.mem.endsWith(u8, id, "index.ts")) return null;
+    return std.fmt.allocPrint(
+        allocator,
+        "const marker = \"plugin-cache-{s}-2038\";\nconsole.log(marker);\n",
+        .{compiled_cache_transform_marker},
+    ) catch return error.OutOfMemory;
+}
+
+test "Plugin integration: transform output invalidates compiled cache (#2038)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('original source is stable');");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var cache = CompiledOutputCache.init(std.testing.allocator);
+    defer cache.deinit();
+
+    const plugins = [_]Plugin{
+        .{ .name = "cache-sensitive-transform", .transform = cacheSensitiveTransformHook },
+    };
+
+    compiled_cache_transform_marker = "A";
+    {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .plugins = &plugins,
+            .compiled_cache = &cache,
+        });
+        defer b.deinit();
+
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.hasErrors());
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-cache-A-2038") != null);
+    }
+
+    _ = cache.takeStats();
+    compiled_cache_transform_marker = "B";
+    {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .plugins = &plugins,
+            .compiled_cache = &cache,
+        });
+        defer b.deinit();
+
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.hasErrors());
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-cache-B-2038") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "plugin-cache-A-2038") == null);
+    }
 }
 
 // --- generateBundle 훅 통합 테스트 ---


### PR DESCRIPTION
## 요약

- compiled output cache 입력 해시에 플러그인 load/transform 이후의 최종 `module.source`를 포함했습니다.
- transform이 추가한 import가 최종 소스 기준으로 스캔되는지 회귀 테스트를 추가했습니다.
- 같은 파일 mtime과 같은 플러그인 identity에서 transform 출력만 바뀌어도 stale compiled output을 재사용하지 않는 회귀 테스트를 추가했습니다.
- transform 결과가 동일하면 compiled cache hit가 유지되는지 확인해 불필요한 invalidation도 방지했습니다.
- load hook 결과도 compiled cache key에 반영되는지 검증했습니다.
- JS API 레벨에서 transform이 `sideEffects:false` 패키지 import를 추가하는 경우 tree-shaking 입력이 갱신되는지 확인했습니다.
- 실제 라이브러리 스모크로 `lodash-es` import를 transform에서 주입한 뒤 dead export가 번들에 새지 않는지 확인했습니다.

## 검증

- `zig build test -Dtest-filter="#2038"`
- `bun test packages/core/index.test.ts -t "#2038"`
- `zig build test`
- `zig build`
- `bun test packages/core/index.test.ts`
- `bunx oxfmt format --check packages/core/index.test.ts`
- pre-push hook 통과 (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`)

Closes #2038