### PR TITLE
chore(simplify): /simplify followup — super wrapper-unwrap helper 공용화 (#2030/#2034)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -522,29 +522,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
         // super() / super.method() 변환
         // ================================================================
 
-        /// `super` 검사 시 transparent wrapper(괄호, TS type assertion, Flow cast 등)을 통과한다.
-        /// `(super)`, `(super as any)`, `<any>super`, `super!` 등은 의미상 noop 이므로 안쪽 super 도
-        /// super lowering 대상으로 봐야 한다 — 그렇지 않으면 raw `(super)[k]` / `super[k]` 가 그대로
-        /// emit 돼 syntax error (#2030). 모든 wrapper 는 `data.unary.operand` 로 안쪽 노드를 갖는다.
+        /// transparent wrapper(괄호, TS as 등) 안쪽이 super_expression 인지 검사 (#2030).
+        /// wrapper-unwrap 자체는 `es_helpers.unwrapTransparentWrappers` 가 담당.
         fn isSuperUnwrapped(self: *Transformer, idx: NodeIndex) bool {
-            var cur = idx;
-            while (true) {
-                if (cur.isNone()) return false;
-                const node = self.ast.getNode(cur);
-                switch (node.tag) {
-                    .super_expression => return true,
-                    .parenthesized_expression,
-                    .ts_as_expression,
-                    .ts_satisfies_expression,
-                    .ts_type_assertion,
-                    .ts_instantiation_expression,
-                    .ts_non_null_expression,
-                    .flow_as_expression,
-                    .flow_type_cast_expression,
-                    => cur = node.data.unary.operand,
-                    else => return false,
-                }
-            }
+            const inner = es_helpers.unwrapTransparentWrappers(self, idx);
+            if (inner.isNone()) return false;
+            return self.ast.getNode(inner).tag == .super_expression;
         }
 
         /// call_expression의 callee가 super_expression인지 확인.

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -412,29 +412,12 @@ pub fn ES2020(comptime Transformer: type) type {
             }
         }
 
-        /// transparent wrapper(괄호, TS as/satisfies/type-assertion/!/instantiation, Flow as/cast)
-        /// 통과 후 super_expression 인지 검사. wrapped super 도 super 전용 lowering 분기 (#2034) 를
-        /// 타야 raw `super` 가 temp 대입 RHS 로 흘러나오지 않는다 (es2015_class.zig 의 isSuperUnwrapped
-        /// 와 동일 의도).
+        /// transparent wrapper(괄호, TS as 등) 안쪽이 super_expression 인지 검사 (#2034).
+        /// wrapper-unwrap 자체는 `helpers.unwrapTransparentWrappers` 가 담당.
         fn isSuperExpression(self: *const Transformer, idx: NodeIndex) bool {
-            var cur = idx;
-            while (true) {
-                if (cur.isNone()) return false;
-                const node = self.ast.getNode(cur);
-                switch (node.tag) {
-                    .super_expression => return true,
-                    .parenthesized_expression,
-                    .ts_as_expression,
-                    .ts_satisfies_expression,
-                    .ts_type_assertion,
-                    .ts_instantiation_expression,
-                    .ts_non_null_expression,
-                    .flow_as_expression,
-                    .flow_type_cast_expression,
-                    => cur = node.data.unary.operand,
-                    else => return false,
-                }
-            }
+            const inner = helpers.unwrapTransparentWrappers(self, idx);
+            if (inner.isNone()) return false;
+            return self.ast.getNode(inner).tag == .super_expression;
         }
 
         fn makeSuperMethodMember(

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -110,6 +110,31 @@ pub fn isSimpleIdentifier(self: anytype, left_idx: NodeIndex) bool {
     return left_node.tag == .identifier_reference;
 }
 
+/// transparent wrapper(괄호, TS as/satisfies/type_assertion/non_null/instantiation, Flow as/cast)
+/// 를 재귀적으로 통과해서 안쪽 실제 노드 인덱스를 반환. 이 wrapper 들은 모두 의미상 noop 이라
+/// `(super as any)` 처럼 super tag check 가 wrapper 에 막혀 raw super 가 emit 되는 패턴을 막기
+/// 위함 (#2030, #2034). 모든 wrapper 는 `data.unary.operand` 로 안쪽 노드를 가짐.
+/// idx 가 wrapper 가 아니면 그대로 반환. NodeIndex.none 도 그대로 반환.
+pub fn unwrapTransparentWrappers(self: anytype, idx: NodeIndex) NodeIndex {
+    var cur = idx;
+    while (true) {
+        if (cur.isNone()) return cur;
+        const node = self.ast.getNode(cur);
+        switch (node.tag) {
+            .parenthesized_expression,
+            .ts_as_expression,
+            .ts_satisfies_expression,
+            .ts_type_assertion,
+            .ts_instantiation_expression,
+            .ts_non_null_expression,
+            .flow_as_expression,
+            .flow_type_cast_expression,
+            => cur = node.data.unary.operand,
+            else => return cur,
+        }
+    }
+}
+
 /// `void 0` 노드를 새 AST에 생성.
 pub fn makeVoidZero(self: anytype, span: Span) !NodeIndex {
     const zero_span = try self.ast.addString("0");


### PR DESCRIPTION
## Summary

#2030 (PR #2032), #2034 (PR #2035) 머지 후 cross-cutting `/simplify` 에서 식별된 중복 제거 — 8 transparent wrapper tag 통과 로직이 두 파일에 1:1 동일 복사돼 있어 단일 helper 로 공용화.

## Why

`/simplify` reuse review 결론:
- `src/transformer/es2015_class.zig:isSuperUnwrapped` (#2030 에서 추가)
- `src/transformer/es2020.zig:isSuperExpression` (#2034 에서 수정)

두 함수가 8 wrapper kind (parens, `ts_as_expression`, `ts_satisfies_expression`, `ts_type_assertion`, `ts_instantiation_expression`, `ts_non_null_expression`, `flow_as_expression`, `flow_type_cast_expression`) 를 unwrap 하는 while-loop 가 100% 동일 (function 이름, `*Transformer` vs `*const Transformer` 시그니처만 다름). 향후 새 wrapper kind 가 parser 에 추가될 때 두 곳을 동시에 수정해야 하는 동기화 부담.

## Changes

`src/transformer/es_helpers.zig`:
- 신규 `unwrapTransparentWrappers(self: anytype, idx: NodeIndex) NodeIndex` — 8 wrapper 통과 후 안쪽 노드 인덱스 반환 (super 와 무관, 일반 unwrap 유틸로 작성). 모든 wrapper 는 `data.unary.operand` 로 안쪽 노드를 가짐.

`src/transformer/es2015_class.zig`:
- `isSuperUnwrapped` 가 helper 호출 + tag 검사 분리 (3줄)

`src/transformer/es2020.zig`:
- `isSuperExpression` 가 helper 호출 + tag 검사 분리 (3줄)

Net: -44 / +35 lines, 로직 변화 없음.

## Test plan

- [x] `zig build test` (debug) 통과
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] `tests/integration/tests/downlevel.test.ts` 249/249 (회귀 없음)
- [x] #2030 / #2034 의 모든 wrapped super 케이스 native runtime 일치 재확인

## Note

`unwrapParens` (`src/transformer/minify.zig:136`) 는 별개 helper 로 유지 — parens-only context (minify peephole) 라 8-wrapper 와 다른 contract. /simplify reuse agent 도 consolidation 비권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)