### PR TITLE
fix(bundler): 순수 class expression 트리쉐이킹 적용

### DIFF
--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -65,8 +65,8 @@ fn isNodePureDepth(ast: *const Ast, node: Node, unresolved_globals: ?*const Glob
         .arrow_function_expression,
         => true,
 
-        // class expression — extends/static 초기화에 side effect 가능
-        .class_expression => false,
+        // class expression — class declaration 과 같은 side-effect 규칙을 적용.
+        .class_expression => !classHasSideEffects(ast, node, unresolved_globals),
 
         .object_expression => isObjectPure(ast, node, unresolved_globals, d),
         .array_expression => isArrayPure(ast, node, unresolved_globals, d),

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -78,6 +78,33 @@ test "pure builtin: new Set() with unresolved globals is pure" {
     try std.testing.expect(purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
 }
 
+test "class expression: pure body is removable (#1665)" {
+    const alloc = std.testing.allocator;
+    var ctx = try setup(alloc,
+        \\const C = class {
+        \\  value() { return 1; }
+        \\  static tag = "pure";
+        \\};
+    );
+    defer ctx.deinit();
+
+    const init = initOfDecl(&ctx, 0);
+    try std.testing.expect(purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
+test "class expression: impure static members are preserved (#1665)" {
+    const alloc = std.testing.allocator;
+    var ctx = try setup(alloc,
+        \\const C = class {
+        \\  static tag = init();
+        \\};
+    );
+    defer ctx.deinit();
+
+    const init = initOfDecl(&ctx, 0);
+    try std.testing.expect(!purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
+}
+
 test "pure builtin: whitelist covers Map/WeakMap/WeakSet/Array/Object/Date/Error" {
     // `new Symbol()` 은 ECMAScript 명세상 TypeError throw → pure 아님 (아래 별도 테스트).
     const alloc = std.testing.allocator;

--- a/src/bundler/statement_shaker_test.zig
+++ b/src/bundler/statement_shaker_test.zig
@@ -677,6 +677,45 @@ test "statement shaker: class with pure static field is removable" {
     try std.testing.expectEqual(@as(u32, 2), skipped);
 }
 
+test "statement shaker: unused class expression variable is removable (#1665)" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\const Used = class { value() { return 1; } };
+        \\const Unused = class { value() { return 2; } static tag = "pure"; };
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    const names: [1][]const u8 = .{"Used"};
+    try markUnusedStatements(alloc, &r.ast, r.root, &names, &skip, no_globals);
+
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
+test "statement shaker: class expression with impure static field is preserved (#1665)" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndGetRoot(alloc,
+        \\const X = class { static value = init(); };
+        \\function unused() { return 1; }
+    );
+    defer r.arena.deinit();
+
+    var skip = try std.DynamicBitSet.initEmpty(alloc, r.ast.nodes.items.len);
+    defer skip.deinit();
+
+    try markUnusedStatements(alloc, &r.ast, r.root, &.{}, &skip, no_globals);
+
+    var skipped: u32 = 0;
+    var it = skip.iterator(.{});
+    while (it.next()) |_| skipped += 1;
+    try std.testing.expectEqual(@as(u32, 1), skipped);
+}
+
 test "statement shaker module compiles" {
     _ = @import("statement_shaker.zig");
 }

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect, afterAll } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, unlinkSync, rmSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -34,6 +34,26 @@ function bundleIn(benchmarkDir: string, entryContent: string, name: string): str
     try {
       unlinkSync(entryFile);
     } catch {}
+  }
+}
+
+function bundleFiles(files: Record<string, string>, entry: string, name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `zts-tsprec-${name}-`));
+  const outFile = join(dir, "out.js");
+  for (const [file, content] of Object.entries(files)) {
+    writeFileSync(join(dir, file), content);
+  }
+  try {
+    const r = spawnSync(ZTS_BIN, ["--bundle", join(dir, entry), "-o", outFile, "--platform=node"], {
+      stdio: "pipe",
+      timeout: 30000,
+    });
+    if (r.status !== 0) {
+      throw new Error(`ZTS bundle failed (${name}): ${r.stderr?.toString().slice(0, 400)}`);
+    }
+    return readFileSync(outFile, "utf-8");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 
@@ -127,5 +147,39 @@ describe("#1558 Phase 5 tree-shake 정밀도", () => {
       const re = new RegExp(`(^|\\n)(function|const|var|let)\\s+${name}\\b`, "m");
       expect(re.test(bundle), `dead identifier "${name}" leaked to bundle`).toBe(false);
     }
+  });
+});
+
+describe("#1665 class-level tree-shake 정밀도", () => {
+  test("unused class expression with pure static field is dropped", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { Used } from "./lib";\nconsole.log(new Used().value());\n`,
+        "lib.ts":
+          `export const Used = class { value() { return "used"; } };\n` +
+          `const Unused = class { value() { return "unused-class-marker-1665"; } static tag = "pure"; };\n` +
+          `export { Unused };\n`,
+      },
+      "index.ts",
+      "class-expression",
+    );
+
+    expect(bundle).toContain("used");
+    expect(bundle).not.toContain("unused-class-marker-1665");
+  });
+
+  test("class expression with impure static field is preserved", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import "./lib";\nconsole.log("entry");\n`,
+        "lib.ts":
+          `function init() { console.log("class-static-effect-1665"); return 1; }\n` +
+          `const X = class { static value = init(); };\n`,
+      },
+      "index.ts",
+      "class-expression-impure",
+    );
+
+    expect(bundle).toContain("class-static-effect-1665");
   });
 });


### PR DESCRIPTION
## 요약

- `class expression`도 `class declaration`과 같은 side-effect 판정을 사용하도록 수정했습니다.
- 순수한 class expression 변수 선언이 미사용이면 제거되도록 했습니다.
- static field initializer처럼 side-effect가 있는 class expression은 보존합니다.
- 실제 번들 스모크에서 imported module 내부의 unused class expression이 제거되는지 검증했습니다.

## 테스트

- 테스트 먼저 추가 후 실패 확인
- `zig build test -Dtest-filter="#1665"`
- `zig build test`
- `zig build`
- `cd tests/integration && bun test tests/tree-shake-precision.test.ts -t "#1665"`
- `cd tests/integration && bun test tests/tree-shake-precision.test.ts`
- `cd tests/integration && bunx oxfmt format --check tests/tree-shake-precision.test.ts`
- pre-push hook 통과 (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`)

Closes #1665