### PR TITLE
Refine re-export star reachability

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1444,6 +1444,150 @@ test "TreeShaking: size regression — deep re-export chain only used exports (#
     }
 }
 
+test "TreeShaking: export star named import prunes unused source exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './barrel';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "barrel.ts", "export * from './source';");
+    try writeFile(tmp.dir, "source.ts",
+        \\export function used() { return "USED_STAR_MARKER"; }
+        \\export function unused() { return "UNUSED_STAR_MARKER"; }
+        \\export function alsoUnused() { return "ALSO_UNUSED_STAR_MARKER"; }
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_STAR_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_STAR_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ALSO_UNUSED_STAR_MARKER") == null);
+}
+
+test "TreeShaking: chained export star named import prunes unrelated sources" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { leaf } from './top';
+        \\console.log(leaf());
+    );
+    try writeFile(tmp.dir, "top.ts", "export * from './mid'; export * from './other';");
+    try writeFile(tmp.dir, "mid.ts", "export * from './leaf';");
+    try writeFile(tmp.dir, "leaf.ts",
+        \\export function leaf() { return "LIVE_LEAF_MARKER"; }
+        \\export function deadLeaf() { return "DEAD_LEAF_MARKER"; }
+    );
+    try writeFile(tmp.dir, "other.ts",
+        \\export function unrelated() { return "UNRELATED_SOURCE_MARKER"; }
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LIVE_LEAF_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DEAD_LEAF_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNRELATED_SOURCE_MARKER") == null);
+}
+
+test "TreeShaking: export star from CJS keeps wrapped source for named import" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './barrel';
+        \\console.log(used);
+    );
+    try writeFile(tmp.dir, "barrel.ts", "export * from './source.cjs';");
+    try writeFile(tmp.dir, "source.cjs",
+        \\exports.used = "CJS_STAR_USED_MARKER";
+        \\exports.unused = "CJS_STAR_UNUSED_MARKER";
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_STAR_USED_MARKER") != null);
+    // CJS wrappers do not have statement-level export precision yet, so this is the remaining
+    // conservative fallback that prevents dropping the wrapped source.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_STAR_UNUSED_MARKER") != null);
+}
+
+test "TreeShaking: unused direct re-export source with local init is pruned" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './barrel';
+        \\console.log(used);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\export { used } from './live';
+        \\export { createCustomElement } from './custom-element';
+    );
+    try writeFile(tmp.dir, "live.ts", "export const used = 'DIRECT_REEXPORT_USED_MARKER';");
+    try writeFile(tmp.dir, "legacy.ts",
+        \\export function createClassComponent() {
+        \\  console.log('DIRECT_REEXPORT_LEGACY_MARKER');
+        \\}
+    );
+    try writeFile(tmp.dir, "custom-element.ts",
+        \\import { createClassComponent } from './legacy';
+        \\let CustomElement;
+        \\if (typeof HTMLElement === 'function') {
+        \\  CustomElement = class extends HTMLElement {};
+        \\}
+        \\export function createCustomElement() {
+        \\  console.log('DIRECT_REEXPORT_CUSTOM_MARKER', CustomElement, createClassComponent);
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DIRECT_REEXPORT_USED_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DIRECT_REEXPORT_CUSTOM_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DIRECT_REEXPORT_LEGACY_MARKER") == null);
+}
+
 test "TreeShaking: class extends call expression preserved (#1261 edge)" {
     // class Foo extends getBase() — extends call은 side-effect이므로 보존.
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -371,6 +371,8 @@ pub fn stmtHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*con
         .function_declaration => false,
         .class_declaration => classHasSideEffects(ast, node, unresolved_globals),
         .variable_declaration => !isVarDeclPure(ast, node, unresolved_globals),
+        .expression_statement => exprStmtHasSideEffects(ast, node.data.unary.operand, unresolved_globals),
+        .if_statement => ifStmtHasSideEffects(ast, node, unresolved_globals),
         .export_named_declaration => {
             const e = node.data.extra;
             if (e + 3 < ast.extra_data.items.len) {
@@ -396,6 +398,53 @@ pub fn stmtHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*con
         .export_all_declaration => true,
         else => true,
     };
+}
+
+fn exprStmtHasSideEffects(ast: *const Ast, expr_idx: NodeIndex, unresolved_globals: ?*const GlobalRefSet) bool {
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag == .assignment_expression) {
+        return assignmentHasSideEffects(ast, expr, unresolved_globals);
+    }
+    return !isExprPureDepth(ast, expr_idx, unresolved_globals, 0);
+}
+
+fn assignmentHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet) bool {
+    const left_idx = node.data.binary.left;
+    const right_idx = node.data.binary.right;
+    if (left_idx.isNone() or @intFromEnum(left_idx) >= ast.nodes.items.len) return true;
+    const left = ast.nodes.items[@intFromEnum(left_idx)];
+
+    // A top-level assignment to an unresolved global can mutate global state. A bare
+    // identifier that is not unresolved is a module-local binding, so the statement
+    // can be dropped when no live export observes that binding.
+    if (left.tag != .identifier_reference) return true;
+    if (unresolved_globals) |globals| {
+        if (globals.contains(ast.getText(left.span))) return true;
+    }
+    return !isExprPureDepth(ast, right_idx, unresolved_globals, 0);
+}
+
+fn ifStmtHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet) bool {
+    const data = node.data.ternary;
+    if (!isExprPureDepth(ast, data.a, unresolved_globals, 0)) return true;
+    return childStmtHasSideEffects(ast, data.b, unresolved_globals) or
+        childStmtHasSideEffects(ast, data.c, unresolved_globals);
+}
+
+fn childStmtHasSideEffects(ast: *const Ast, idx: NodeIndex, unresolved_globals: ?*const GlobalRefSet) bool {
+    if (idx.isNone()) return false;
+    if (@intFromEnum(idx) >= ast.nodes.items.len) return true;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag == .block_statement) {
+        const list = node.data.list;
+        if (list.start + list.len > ast.extra_data.items.len) return true;
+        for (ast.extra_data.items[list.start .. list.start + list.len]) |raw| {
+            if (childStmtHasSideEffects(ast, @enumFromInt(raw), unresolved_globals)) return true;
+        }
+        return false;
+    }
+    return stmtHasSideEffects(ast, node, unresolved_globals);
 }
 
 /// class declaration/expression의 side effect 판정.

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -431,7 +431,9 @@ pub const TreeShaker = struct {
             => false,
 
             .variable_declaration => purity.isVarDeclPure(ast, stmt, unresolved_globals),
-            .expression_statement => purity.isExprPure(ast, stmt.data.unary.operand, unresolved_globals),
+            .expression_statement,
+            .if_statement,
+            => !purity.stmtHasSideEffects(ast, stmt, unresolved_globals),
 
             .empty_statement => true,
 
@@ -821,10 +823,16 @@ pub const TreeShaker = struct {
                     const src_idx = m.import_records[rec_idx].resolved;
                     if (self.graph.getModule(src_idx) == null) continue;
                     const src = @intFromEnum(src_idx);
-                    if (eb.kind.isReExportAll()) {
-                        try self.markAllExportsUsed(@intCast(src));
-                        self.included.set(src);
-                        try self.seedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
+                    if (eb.kind == .re_export_star) {
+                        if (self.isExportUsed(mod_idx, ALL_EXPORTS_SENTINEL)) {
+                            try self.markAndSeedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
+                        } else {
+                            try self.seedUsedReExportStarNames(mod_idx, @intCast(src), queue, module_stmt_infos, reachable_stmts);
+                        }
+                    } else if (eb.kind.isReExportAll()) {
+                        // `export * as ns from` (re_export_namespace): namespace 객체 자체가 named export
+                        // 라 소비자가 `ns.foo` 로 escape 가능 → 정밀화 불가, 보수적으로 markAll.
+                        try self.markAndSeedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
                     } else {
                         try self.seedExport(src, m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);
                     }
@@ -868,7 +876,16 @@ pub const TreeShaker = struct {
             const src_idx = m.import_records[rec_idx].resolved;
             if (self.graph.getModule(src_idx) == null) continue;
             const src = @intFromEnum(src_idx);
-            if (eb.kind.isReExportAll()) {
+            if (eb.kind == .re_export_star) {
+                if (self.isExportUsed(mod_idx, ALL_EXPORTS_SENTINEL)) {
+                    self.included.set(src);
+                    try self.seedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
+                } else {
+                    try self.seedUsedReExportStarNames(mod_idx, @intCast(src), queue, module_stmt_infos, reachable_stmts);
+                }
+            } else if (eb.kind.isReExportAll()) {
+                // re_export_namespace: namespace 객체 escape 가능 — 정밀화 불가.
+                // 호출자(seedAllStmts 진입자)가 markAll 처리했다고 가정하므로 여기선 included+seed 만.
                 self.included.set(src);
                 try self.seedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
             } else {
@@ -885,6 +902,69 @@ pub const TreeShaker = struct {
             if (self.graph.getModule(rec.resolved) == null) continue;
             self.included.set(target);
             try self.seedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
+        }
+    }
+
+    fn markAndSeedAllStmts(
+        self: *TreeShaker,
+        mod_idx: u32,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        module_stmt_infos: []?StmtInfos,
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        try self.markAllExportsUsed(mod_idx);
+        self.included.set(mod_idx);
+        try self.seedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
+    }
+
+    fn collectDirectUsedExportNames(self: *TreeShaker, module_index: u32) !std.ArrayListUnmanaged([]const u8) {
+        var names: std.ArrayListUnmanaged([]const u8) = .{};
+        errdefer names.deinit(self.allocator);
+
+        // used_exports 키 형식 (types.makeModuleKey, types.zig:716): [u32 module_idx][0x00][name]
+        var it = self.used_exports.keyIterator();
+        while (it.next()) |key_ptr| {
+            const key = key_ptr.*;
+            if (key.len < 5 or key[4] != 0) continue;
+            var key_module: u32 = undefined;
+            @memcpy(std.mem.asBytes(&key_module), key[0..4]);
+            if (key_module != module_index) continue;
+
+            const name = key[5..];
+            if (std.mem.eql(u8, name, ALL_EXPORTS_SENTINEL)) continue;
+            try names.append(self.allocator, name);
+        }
+        return names;
+    }
+
+    fn seedUsedReExportStarNames(
+        self: *TreeShaker,
+        reexport_mod: u32,
+        src_mod: u32,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        module_stmt_infos: []?StmtInfos,
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        var names = try self.collectDirectUsedExportNames(reexport_mod);
+        defer names.deinit(self.allocator);
+        if (names.items.len == 0) return;
+
+        const reexport_idx: ModuleIndex = @enumFromInt(reexport_mod);
+        const src_idx: ModuleIndex = @enumFromInt(src_mod);
+        for (names.items) |name| {
+            const from_reexport = self.linker.resolveExportChain(reexport_idx, name, 0) orelse continue;
+            const from_src = self.linker.resolveExportChain(src_idx, name, 0) orelse {
+                const src_module = self.getModule(src_mod) orelse continue;
+                if (from_reexport.module_index.toU32() == src_mod and
+                    (src_module.wrap_kind.isWrapped() or src_module.exports_kind == .esm_with_dynamic_fallback))
+                {
+                    try self.markAndSeedAllStmts(src_mod, queue, module_stmt_infos, reachable_stmts);
+                }
+                continue;
+            };
+            if (from_reexport.module_index != from_src.module_index) continue;
+            if (!std.mem.eql(u8, from_reexport.export_name, from_src.export_name)) continue;
+            try self.seedExport(src_mod, name, queue, module_stmt_infos, reachable_stmts);
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid whole-module seeding for plain `export * from` when only named exports are live
- follow live export names to the canonical source before seeding source statements
- remove the previous ambiguous-star whole-source fallback; unresolved static names now stay unresolved instead of forcing every star source live
- keep whole-source fallback for genuinely opaque paths: `*` sentinel/full namespace, `export * as ns`, dynamic fallback, and wrapped/CJS sources
- add output-level regressions for single/deep `export *`, CJS fallback, and an unused direct re-export source with Svelte-like local init

## Reference Notes
- Rolldown precomputes resolved exports and records ambiguity instead of broad-seeding every `export *` source; dynamic/CJS fallback remains explicit.
- Webpack narrows star reexports to known used/provided exports and only uses unknown-way usage for opaque namespace-like cases.
- Rollup includes specific namespace members for static member access and includes all exports only for unknown namespace/full export paths.

## Svelte Smoke Impact
Compared current branch (`cf86851f`) against `origin/main` (`731879f5`) with the CI Svelte smoke series. Build/output status is OK/MATCH for all five cases, but ZTS byte sizes are unchanged:

| Project | main bytes | PR bytes | Delta |
| --- | ---: | ---: | ---: |
| svelte | 1,864 | 1,864 | 0 |
| svelte-mount | 95,940 | 95,940 | 0 |
| svelte-mount-min | 44,625 | 44,625 | 0 |
| svelte-full | 102,566 | 102,566 | 0 |
| svelte-full-min | 48,112 | 48,112 | 0 |

Conclusion: this PR improves the targeted synthetic `export *` reachability cases, but it does **not** reduce the current Svelte CI smoke bundles. The remaining Svelte size appears to come from direct re-export fanout plus side-effect/purity classification rather than the plain `export *` path handled here.

## Verification
- `zig build test -Dtest-filter="export star named import"`
- `zig build test -Dtest-filter="chained export star"`
- `zig build test -Dtest-filter="export star from CJS"`
- `zig build test -Dtest-filter="unused direct re-export source"`
- `zig build test -Dtest-filter="re-export"`
- `zig build test -Dtest-filter="TreeShaking"`
- `zig build test`
- `cd tests/integration && bun test tests/tree-shake-precision.test.ts`
- `cd tests/benchmark && bun run smoke.ts --filter=svelte` (5/5 OK, 5/5 MATCH)

Note: pre-push also ran `zig fmt --check src/...`, `zig build test`, `oxlint`, and `oxfmt --check`; oxlint reported existing warnings but 0 errors.