### PR TITLE
fix(bundler): 미사용 Svelte custom-element fanout 제거

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1635,8 +1635,6 @@ test "TreeShaking: unused direct re-export Svelte custom-element fanout is prune
     var b = Bundler.init(std.testing.allocator, .{
         .entry_points = &.{entry},
         .tree_shaking = true,
-        .minify_whitespace = true,
-        .minify_syntax = true,
     });
     defer b.deinit();
     const result = try b.bundle();

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1588,6 +1588,67 @@ test "TreeShaking: unused direct re-export source with local init is pruned" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "DIRECT_REEXPORT_LEGACY_MARKER") == null);
 }
 
+test "TreeShaking: unused direct re-export Svelte custom-element fanout is pruned" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { mount } from './runtime';
+        \\console.log(mount());
+    );
+    try writeFile(tmp.dir, "runtime.ts",
+        \\export { mount } from './client';
+        \\export { create_custom_element } from './custom-element';
+    );
+    try writeFile(tmp.dir, "client.ts",
+        \\export function mount() { return 'SVELTE_FANOUT_USED_MOUNT'; }
+    );
+    try writeFile(tmp.dir, "props.ts",
+        \\export function heavyProps() {
+        \\  return 'SVELTE_FANOUT_PROPS_HEAVY';
+        \\}
+    );
+    try writeFile(tmp.dir, "legacy-client.ts",
+        \\import { heavyProps } from './props';
+        \\export function createClassComponent() {
+        \\  return 'SVELTE_FANOUT_LEGACY_CLIENT' + heavyProps();
+        \\}
+    );
+    try writeFile(tmp.dir, "custom-element.ts",
+        \\import { createClassComponent } from './legacy-client';
+        \\let SvelteElement;
+        \\if (typeof HTMLElement === 'function') {
+        \\  SvelteElement = class extends HTMLElement {
+        \\    connectedCallback() {
+        \\      createClassComponent();
+        \\    }
+        \\  };
+        \\}
+        \\export function create_custom_element() {
+        \\  return 'SVELTE_FANOUT_CUSTOM_ELEMENT' + SvelteElement;
+        \\}
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SVELTE_FANOUT_USED_MOUNT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SVELTE_FANOUT_CUSTOM_ELEMENT") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SVELTE_FANOUT_LEGACY_CLIENT") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SVELTE_FANOUT_PROPS_HEAVY") == null);
+}
+
 test "TreeShaking: unused direct re-export source preserves eval side effect only" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -418,7 +418,7 @@ fn assignmentHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*c
     // A top-level assignment to an unresolved global can mutate global state. A bare
     // identifier that is not unresolved is a module-local binding, so the statement
     // can be dropped when no live export observes that binding.
-    if (left.tag != .identifier_reference) return true;
+    if (left.tag != .identifier_reference and left.tag != .assignment_target_identifier) return true;
     if (unresolved_globals) |globals| {
         if (globals.contains(ast.getText(left.span))) return true;
     }

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -416,8 +416,8 @@ fn assignmentHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*c
     const left = ast.nodes.items[@intFromEnum(left_idx)];
 
     // A top-level assignment to an unresolved global can mutate global state. A bare
-    // identifier that is not unresolved is a module-local binding, so the statement
-    // can be dropped when no live export observes that binding.
+    // identifier (read or assignment-target form) that is not unresolved is a module-local
+    // binding, so the statement can be dropped when no live export observes that binding.
     if (left.tag != .identifier_reference and left.tag != .assignment_target_identifier) return true;
     if (unresolved_globals) |globals| {
         if (globals.contains(ast.getText(left.span))) return true;

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -10,6 +10,7 @@
 const std = @import("std");
 const purity = @import("purity.zig");
 const Ast = @import("../parser/ast.zig").Ast;
+const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
@@ -64,6 +65,14 @@ fn initOfDecl(ctx: *const TestCtx, stmt_idx: usize) NodeIndex {
     const decl = ctx.ast.nodes.items[raw_decl];
     // variable_declarator extra: [pattern(0), type_ann(1), init(2)]
     return @enumFromInt(ctx.ast.extra_data.items[decl.data.extra + 2]);
+}
+
+fn topLevelStmt(ctx: *const TestCtx, stmt_idx: usize) Node {
+    const root_ni = @intFromEnum(ctx.root);
+    const root_node = ctx.ast.nodes.items[root_ni];
+    const stmts = root_node.data.list;
+    const raw_stmt: u32 = ctx.ast.extra_data.items[stmts.start + stmt_idx];
+    return ctx.ast.nodes.items[raw_stmt];
 }
 
 test "pure builtin: new Set() with unresolved globals is pure" {
@@ -186,6 +195,40 @@ test "pure builtin: stmt-level classification for `const s = new Set();`" {
     try std.testing.expect(purity.stmtHasSideEffects(&ctx.ast, stmt_node, null));
     // 컨텍스트 전달 시 순수 statement로 판정
     try std.testing.expect(!purity.stmtHasSideEffects(&ctx.ast, stmt_node, &ctx.analyzer.unresolved_references));
+}
+
+test "assignment statement: module-local assignment target identifier is removable when RHS is pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\let Local;
+        \\Local = 1;
+        \\if (typeof HTMLElement === 'function') {
+        \\  Local = class extends HTMLElement {};
+        \\}
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    const globals = &ctx.analyzer.unresolved_references;
+    try std.testing.expect(!purity.stmtHasSideEffects(&ctx.ast, topLevelStmt(&ctx, 1), globals));
+    try std.testing.expect(!purity.stmtHasSideEffects(&ctx.ast, topLevelStmt(&ctx, 2), globals));
+}
+
+test "assignment statement: global, member, computed, and destructuring LHS stay side-effectful" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\x = 1;
+        \\obj.x = 1;
+        \\obj[key] = 1;
+        \\[x] = [1];
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    const globals = &ctx.analyzer.unresolved_references;
+    for (0..4) |i| {
+        try std.testing.expect(purity.stmtHasSideEffects(&ctx.ast, topLevelStmt(&ctx, i), globals));
+    }
 }
 
 test "pure builtin: call without `new` also pure (Symbol(), Array(3))" {

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -50,29 +50,24 @@ fn setup(allocator: std.mem.Allocator, source: []const u8) !TestCtx {
     };
 }
 
-/// program의 `stmt_idx`번째 top-level statement가 불러지는 variable_declaration일 때
-/// 그 첫 declarator의 initializer NodeIndex를 반환한다.
-fn initOfDecl(ctx: *const TestCtx, stmt_idx: usize) NodeIndex {
-    const root_ni = @intFromEnum(ctx.root);
-    const root_node = ctx.ast.nodes.items[root_ni];
-    const stmts = root_node.data.list;
-    const raw_stmt: u32 = ctx.ast.extra_data.items[stmts.start + stmt_idx];
-    const stmt = ctx.ast.nodes.items[raw_stmt];
-    // variable_declaration: [kind(0), list_start(1), list_len(2)]
-    const de = stmt.data.extra;
-    const list_start = ctx.ast.extra_data.items[de + 1];
-    const raw_decl: u32 = ctx.ast.extra_data.items[list_start];
-    const decl = ctx.ast.nodes.items[raw_decl];
-    // variable_declarator extra: [pattern(0), type_ann(1), init(2)]
-    return @enumFromInt(ctx.ast.extra_data.items[decl.data.extra + 2]);
-}
-
 fn topLevelStmt(ctx: *const TestCtx, stmt_idx: usize) Node {
     const root_ni = @intFromEnum(ctx.root);
     const root_node = ctx.ast.nodes.items[root_ni];
     const stmts = root_node.data.list;
     const raw_stmt: u32 = ctx.ast.extra_data.items[stmts.start + stmt_idx];
     return ctx.ast.nodes.items[raw_stmt];
+}
+
+/// program의 `stmt_idx`번째 top-level statement가 variable_declaration일 때
+/// 그 첫 declarator의 initializer NodeIndex를 반환한다.
+fn initOfDecl(ctx: *const TestCtx, stmt_idx: usize) NodeIndex {
+    const stmt = topLevelStmt(ctx, stmt_idx);
+    // variable_declaration: [kind(0), list_start(1), list_len(2)]
+    const list_start = ctx.ast.extra_data.items[stmt.data.extra + 1];
+    const raw_decl: u32 = ctx.ast.extra_data.items[list_start];
+    const decl = ctx.ast.nodes.items[raw_decl];
+    // variable_declarator extra: [pattern(0), type_ann(1), init(2)]
+    return @enumFromInt(ctx.ast.extra_data.items[decl.data.extra + 2]);
 }
 
 test "pure builtin: new Set() with unresolved globals is pure" {


### PR DESCRIPTION
## 요약

- top-level module-local assignment LHS에서 parser가 생성하는 `.assignment_target_identifier`를 순수 assignment 후보로 허용했습니다.
- `if (typeof HTMLElement === 'function') { Local = class extends HTMLElement { ... } }` 형태의 미사용 local init이 side-effect root로 seed되지 않도록 했습니다.
- direct re-export barrel에서 미사용 `create_custom_element`가 `legacy-client -> props` fanout을 살리는 회귀를 방지하는 번들 출력 테스트를 추가했습니다.

## 검증

- `zig build test -Dtest-filter="TreeShaking"`
- `zig build test -Dtest-filter="re-export"`
- `zig build test`
- `zig build`
- `cd tests/integration && bun test tests/tree-shake-precision.test.ts`
- `cd tests/benchmark && bun run smoke.ts --filter=svelte`

## Svelte smoke 결과

- `svelte-mount-min`: 35KB
- `svelte-full`: 100KB -> 91KB
- `svelte-full-min`: 47KB -> 42KB

추가로 rebuilt `svelte-full-min` 출력에서 `createClassComponent`, `SvelteElement`, `HTMLElement`가 사라진 것을 확인했습니다.