### PR TITLE
perf(codegen): trim minified block boundary semicolons

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -419,6 +419,15 @@ pub const Codegen = struct {
         }
     }
 
+    fn trimTrailingSemicolonBeforeMinifyBoundary(self: *Codegen) void {
+        if (!self.options.minify_whitespace) return;
+        if (!self.options.minify_syntax) return;
+        if (self.buf.items.len == 0) return;
+        if (self.buf.items[self.buf.items.len - 1] != ';') return;
+        _ = self.buf.pop();
+        if (self.gen_col > 0) self.gen_col -= 1;
+    }
+
     // ================================================================
     // Function Map 도우미
     // ================================================================
@@ -1117,6 +1126,7 @@ pub const Codegen = struct {
             }
             self.indent_level -= 1;
         }
+        self.trimTrailingSemicolonBeforeMinifyBoundary();
         try self.writeNewline();
         try self.writeIndent();
         try self.writeByte('}');
@@ -2458,12 +2468,12 @@ pub const Codegen = struct {
     // 파서 노드는 writeNodeSpan으로 처리하지만,
     // transformer가 생성한 합성 노드(span={0,0})는 AST 기반으로 출력한다.
     fn emitStaticBlock(self: *Codegen, node: Node) !void {
-        if (node.span.start != 0 or node.span.end != 0) {
+        if (!(self.options.minify_whitespace and self.options.minify_syntax) and (node.span.start != 0 or node.span.end != 0)) {
             // 파서 원본 노드 → 소스 텍스트 그대로 출력
             try self.writeNodeSpan(node);
             return;
         }
-        // 합성 노드 → AST 기반 출력
+        // 합성 노드와 minify 출력은 AST 기반으로 공백/마지막 세미콜론을 정규화한다.
         try self.write("static");
         try self.writeSpace();
         try self.emitNode(node.data.unary.operand);

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2465,15 +2465,15 @@ pub const Codegen = struct {
     }
 
     // static_block: unary = { operand = body(block_statement) }
-    // 파서 노드는 writeNodeSpan으로 처리하지만,
-    // transformer가 생성한 합성 노드(span={0,0})는 AST 기반으로 출력한다.
+    // 파서 원본 노드는 writeNodeSpan, 합성 노드(span={0,0})와 minify 모드는
+    // 마지막 세미콜론 트리밍을 위해 AST 기반으로 출력한다.
     fn emitStaticBlock(self: *Codegen, node: Node) !void {
-        if (!(self.options.minify_whitespace and self.options.minify_syntax) and (node.span.start != 0 or node.span.end != 0)) {
-            // 파서 원본 노드 → 소스 텍스트 그대로 출력
+        const has_parser_span = node.span.start != 0 or node.span.end != 0;
+        const minify = self.options.minify_whitespace and self.options.minify_syntax;
+        if (has_parser_span and !minify) {
             try self.writeNodeSpan(node);
             return;
         }
-        // 합성 노드와 minify 출력은 AST 기반으로 공백/마지막 세미콜론을 정규화한다.
         try self.write("static");
         try self.writeSpace();
         try self.emitNode(node.data.unary.operand);

--- a/src/codegen/codegen_test/minify_sourcemap.zig
+++ b/src/codegen/codegen_test/minify_sourcemap.zig
@@ -76,6 +76,39 @@ test "Minify: for-of body var has semicolon" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "var y=x;") != null);
 }
 
+test "Minify: omits trailing semicolon before block boundary" {
+    var r = try e2eWithOptions(std.testing.allocator, "function f() { let x = 1; x++; } f();", .{ .minify_whitespace = true, .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function f(){let x=1;x++}f();", r.output);
+}
+
+test "Minify: keeps semicolon between adjacent block statements" {
+    var r = try e2eWithOptions(std.testing.allocator, "for (var i = 0; i < 3; i++) { var x = i; console.log(x); }", .{ .minify_whitespace = true, .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var x=i;console.log") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log(x)}") != null);
+}
+
+test "Minify: preserves ASI-sensitive boundaries inside block" {
+    var r = try e2eWithOptions(std.testing.allocator,
+        \\function f(a) {
+        \\  "use strict";
+        \\  if (a) return /x/.test(a);
+        \\  throw { value: [a] };
+        \\}
+    , .{ .minify_whitespace = true, .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"use strict\";if") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return /x/.test(a);throw") != null);
+    try std.testing.expect(std.mem.endsWith(u8, r.output, "throw {value:[a]}}"));
+}
+
+test "Minify: omits trailing class field semicolon before class body boundary" {
+    var r = try e2eWithOptions(std.testing.allocator, "class Foo { x = 1; static { foo(); } static y = 2; }", .{ .minify_whitespace = true, .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expectEqualStrings("class Foo{x=1;static{foo()}static y=2}", r.output);
+}
+
 // ============================================================
 // #493: template literal 내 식별자 rename
 // ============================================================


### PR DESCRIPTION
## Summary
- trim trailing semicolons before minified block/class-body boundaries when both whitespace and syntax minification are enabled
- emit parsed class static blocks through AST codegen in minify mode so their inner whitespace and trailing semicolons are normalized
- keep statement and generated-chunk boundaries conservative to avoid ASI/concatenation regressions

## Test Plan
- zig build test -Dtest-filter="Minify:"
- zig build test -Dtest-filter="Codegen:"
- zig build test
- cd tests/integration && bun test tests/tree-shake-precision.test.ts
- cd tests/integration && bun test tests/mangler-minify.test.ts
- zig build
- cd tests/benchmark && bun run smoke.ts --filter=svelte

## Svelte Smoke
- svelte-mount-min: ZTS 34KB, esbuild 37KB, rolldown 28KB
- svelte-full-min: ZTS 42KB, esbuild 40KB, rolldown 30KB
- exact manual svelte-full-min measurement: ZTS 42,527 bytes, esbuild 41,215 bytes