### PR TITLE
fix(bundler): object method purity로 Svelte fanout 축소

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1647,6 +1647,97 @@ test "TreeShaking: unused direct re-export Svelte custom-element fanout is prune
     try std.testing.expect(std.mem.indexOf(u8, result.output, "SVELTE_FANOUT_PROPS_HEAVY") == null);
 }
 
+test "TreeShaking: unused direct re-export source with object literal methods is pruned" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './runtime';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "runtime.ts",
+        \\export { used } from './live';
+        \\export { prop } from './props';
+    );
+    try writeFile(tmp.dir, "live.ts", "export function used() { return 'OBJECT_METHOD_REEXPORT_USED'; }");
+    try writeFile(tmp.dir, "heavy.ts",
+        \\export function heavy() {
+        \\  return 'OBJECT_METHOD_REEXPORT_HEAVY';
+        \\}
+    );
+    try writeFile(tmp.dir, "props.ts",
+        \\import { heavy } from './heavy';
+        \\const rest_props_handler = {
+        \\  get(target, key) {
+        \\    return target[key];
+        \\  },
+        \\  set(target, key, value) {
+        \\    heavy();
+        \\    target[key] = value;
+        \\    return true;
+        \\  },
+        \\  ownKeys(target) {
+        \\    return Reflect.ownKeys(target);
+        \\  }
+        \\};
+        \\export function prop(obj, key) {
+        \\  return new Proxy(obj, rest_props_handler)[key];
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_METHOD_REEXPORT_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_METHOD_REEXPORT_HEAVY") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "rest_props_handler") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Reflect.ownKeys") == null);
+}
+
+test "TreeShaking: object literal method with impure computed key is preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './side';
+        \\console.log(used);
+    );
+    try writeFile(tmp.dir, "side.ts",
+        \\function key() {
+        \\  console.log('OBJECT_METHOD_COMPUTED_KEY_EFFECT');
+        \\  return 'run';
+        \\}
+        \\const handler = {
+        \\  [key()]() {
+        \\    return 1;
+        \\  }
+        \\};
+        \\export const used = 'OBJECT_METHOD_COMPUTED_KEY_USED';
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_METHOD_COMPUTED_KEY_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_METHOD_COMPUTED_KEY_EFFECT") != null);
+}
+
 test "TreeShaking: unused direct re-export source preserves eval side effect only" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1738,6 +1738,41 @@ test "TreeShaking: object literal method with impure computed key is preserved" 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_METHOD_COMPUTED_KEY_EFFECT") != null);
 }
 
+// minimatch 회귀: TS 가 self-referential 클래스용으로 emit 하는 `var _a; class AST {...}; _a = AST;`
+// 패턴에서 후속 비선언 할당이 살아남아야 한다. 도달성 BFS 가 read 만 따르고 writer 엣지를 무시하면
+// `_a` 가 undefined 인 채로 클래스 메서드가 `new _a()` 호출 → "_a is not a constructor".
+test "TreeShaking: post-declaration assignment to top-level var is preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { make } from './lib';
+        \\console.log(make());
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\var _self;
+        \\class Box {
+        \\  static spawn() { return new _self(); }
+        \\  tag() { return 'POST_DECL_ASSIGN_TAG'; }
+        \\}
+        \\_self = Box;
+        \\export function make() { return Box.spawn().tag(); }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_self = Box") != null);
+}
+
 test "TreeShaking: unused direct re-export source preserves eval side effect only" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1753,6 +1753,11 @@ pub const ModuleGraph = struct {
         return false;
     }
 
+    /// post-transform AST 의 binding 을 source of truth 로 삼고, `previous` 에서 transformer
+    /// 가 직접 추가한 synthetic binding (JSX runtime 등 — span sentinel 로 식별) 만 보존한다.
+    /// 단순 append 로 합치면 Phase D 가 elide 한 import specifier 에 대응하는 stale binding
+    /// 이 살아남아 linker preamble 이 `var err = require_xxx().err` 같은 죽은 코드를 emit
+    /// 하거나 `non-synthetic import binding 'err' has no semantic local symbol` panic 을 낸다.
     fn mergeImportBindings(
         arena_alloc: std.mem.Allocator,
         previous: []const binding_scanner_mod.ImportBinding,
@@ -1760,8 +1765,9 @@ pub const ModuleGraph = struct {
     ) ![]binding_scanner_mod.ImportBinding {
         var bindings: std.ArrayList(binding_scanner_mod.ImportBinding) = .empty;
         errdefer bindings.deinit(arena_alloc);
-        try bindings.appendSlice(arena_alloc, previous);
-        for (transformed) |binding| {
+        try bindings.appendSlice(arena_alloc, transformed);
+        for (previous) |binding| {
+            if (!binding.isSynthetic()) continue;
             if (hasImportBinding(bindings.items, binding)) continue;
             try bindings.append(arena_alloc, binding);
         }

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -58,7 +58,8 @@ test "linker: direct import resolves to export" {
 test "linker: re-export chain resolved" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.ts", "import { x } from './b';");
+    // console.log(x): Phase D 가 미사용 named import 를 elide 하므로 value-use 추가
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b'; console.log(x);");
     try writeFile(tmp.dir, "b.ts", "export { x } from './c';");
     try writeFile(tmp.dir, "c.ts", "export const x = 1;");
 
@@ -77,7 +78,7 @@ test "linker: re-export chain resolved" {
 test "linker: missing export produces diagnostic" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.ts", "import { missing } from './b';");
+    try writeFile(tmp.dir, "a.ts", "import { missing } from './b'; console.log(missing);");
     try writeFile(tmp.dir, "b.ts", "export const x = 1;");
 
     var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
@@ -96,7 +97,7 @@ test "linker: missing export produces diagnostic" {
 test "linker: export * resolves through re-export all" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.ts", "import { x } from './b';");
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b'; console.log(x);");
     try writeFile(tmp.dir, "b.ts", "export * from './c';");
     try writeFile(tmp.dir, "c.ts", "export const x = 99;");
 
@@ -119,7 +120,7 @@ test "linker: export * from CJS resolves to CJS module" {
     // wrap_kind == .cjs인 모듈 자체를 반환해야 한다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.ts", "import { x } from './b';");
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b'; console.log(x);");
     try writeFile(tmp.dir, "b.ts", "export * from './c';");
     try writeFile(tmp.dir, "c.js", "module.exports = { x: 42 };");
 
@@ -145,7 +146,7 @@ test "linker: namespace re-export resolves to local binding" {
     // 로컬 바인딩을 그대로 반환해야 한다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.ts", "import { ns } from './b';");
+    try writeFile(tmp.dir, "a.ts", "import { ns } from './b'; console.log(ns);");
     try writeFile(tmp.dir, "b.ts", "import * as ns from './c';\nexport { ns };");
     try writeFile(tmp.dir, "c.ts", "export const x = 1;");
 
@@ -169,7 +170,7 @@ test "linker: resolveExportChain on CJS module returns null for named exports" {
     //  직접 호출 시에는 null)
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.ts", "import { x } from './b';");
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b'; console.log(x);");
     try writeFile(tmp.dir, "b.js", "module.exports = { x: 42 };");
 
     const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
@@ -433,7 +434,7 @@ test "linker: deep re-export chain (near depth limit)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     // 5단계 re-export 체인: a → b → c → d → e
-    try writeFile(tmp.dir, "a.ts", "import { x } from './b';");
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b'; console.log(x);");
     try writeFile(tmp.dir, "b.ts", "export { x } from './c';");
     try writeFile(tmp.dir, "c.ts", "export { x } from './d';");
     try writeFile(tmp.dir, "d.ts", "export { x } from './e';");
@@ -654,7 +655,7 @@ test "re-export alias: export { J as render } resolves to J" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     // preact 패턴: 함수를 다른 이름으로 re-export
-    try writeFile(tmp.dir, "entry.ts", "import { render } from './reexport';");
+    try writeFile(tmp.dir, "entry.ts", "import { render } from './reexport'; console.log(render);");
     try writeFile(tmp.dir, "reexport.ts", "export { J as render } from './impl';");
     try writeFile(tmp.dir, "impl.ts", "export function J() { return 42; }");
 
@@ -679,7 +680,7 @@ test "re-export alias: export { default as groupBy } — function declaration" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     // export default <function_declaration> → binding_scanner가 함수 이름 추출
-    try writeFile(tmp.dir, "entry.ts", "import { greet } from './barrel';");
+    try writeFile(tmp.dir, "entry.ts", "import { greet } from './barrel'; console.log(greet);");
     try writeFile(tmp.dir, "barrel.ts", "export { default as greet } from './impl';");
     try writeFile(tmp.dir, "impl.ts", "export default function hello() { return 'hi'; }");
 
@@ -700,7 +701,7 @@ test "re-export alias: export { default as X } — identifier reuses original na
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     // export default <identifier> → rolldown 방식: identifier 이름 재사용
-    try writeFile(tmp.dir, "entry.ts", "import { groupBy } from './barrel';");
+    try writeFile(tmp.dir, "entry.ts", "import { groupBy } from './barrel'; console.log(groupBy);");
     try writeFile(tmp.dir, "barrel.ts", "export { default as groupBy } from './groupBy';");
     try writeFile(tmp.dir, "groupBy.ts", "function groupBy(arr: any) { return arr; }\nexport default groupBy;");
 
@@ -831,7 +832,7 @@ test "re-export alias: double-hop chain (z -> y -> x)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     // 3-level alias chain: z → y → x → 최종 original
-    try writeFile(tmp.dir, "entry.ts", "import { z } from './hop1';");
+    try writeFile(tmp.dir, "entry.ts", "import { z } from './hop1'; console.log(z);");
     try writeFile(tmp.dir, "hop1.ts", "export { y as z } from './hop2';");
     try writeFile(tmp.dir, "hop2.ts", "export { x as y } from './origin';");
     try writeFile(tmp.dir, "origin.ts", "export function x() { return 1; }");
@@ -855,7 +856,7 @@ test "re-export alias: default class declaration resolves to class name" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     // export default class MyClass {} → local_name = "MyWidget"
-    try writeFile(tmp.dir, "entry.ts", "import { Widget } from './barrel';");
+    try writeFile(tmp.dir, "entry.ts", "import { Widget } from './barrel'; console.log(Widget);");
     try writeFile(tmp.dir, "barrel.ts", "export { default as Widget } from './impl';");
     try writeFile(tmp.dir, "impl.ts", "export default class MyWidget { render() {} }");
 

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -15,6 +15,7 @@
 //!   - 나머지 → 보수적으로 불순
 
 const std = @import("std");
+const ast_mod = @import("../parser/ast.zig");
 const Ast = @import("../parser/ast.zig").Ast;
 const Node = @import("../parser/ast.zig").Node;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
@@ -315,14 +316,31 @@ fn isObjectPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalR
         const prop_idx: NodeIndex = @enumFromInt(raw_idx);
         if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) continue;
         const prop = ast.nodes.items[@intFromEnum(prop_idx)];
-        if (prop.tag != .object_property) return false;
-        const key_idx = prop.data.binary.left;
-        if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
-            if (ast.nodes.items[@intFromEnum(key_idx)].tag == .computed_property_key) return false;
+        switch (prop.tag) {
+            .object_property => {
+                const key_idx = prop.data.binary.left;
+                if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
+                    if (ast.nodes.items[@intFromEnum(key_idx)].tag == .computed_property_key) return false;
+                }
+                if (!isExprPureDepth(ast, prop.data.binary.right, unresolved_globals, depth)) return false;
+            },
+            .method_definition => {
+                if (objectMethodHasSideEffects(ast, prop, unresolved_globals)) return false;
+            },
+            else => return false,
         }
-        if (!isExprPureDepth(ast, prop.data.binary.right, unresolved_globals, depth)) return false;
     }
     return true;
+}
+
+fn objectMethodHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet) bool {
+    const e = node.data.extra;
+    if (e + ast_mod.MethodExtra.deco_len >= ast.extra_data.items.len) return true;
+    if (computedKeyHasSideEffects(ast, e + ast_mod.MethodExtra.key, unresolved_globals)) return true;
+
+    // Object literal methods/getters/setters create function values. Their params/body
+    // are not evaluated while the object itself is constructed.
+    return ast.extra_data.items[e + ast_mod.MethodExtra.deco_len] > 0;
 }
 
 fn isArrayPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -37,6 +37,11 @@ pub const ModuleStmtInfos = struct {
     /// symbol_index → [all stmt indices that reference this symbol].
     /// tree_shaker.isImportLiveInModule()에서 O(1) 조회용.
     sym_to_referencing_stmts: []const []const u32,
+    /// symbol_index → [stmt indices that WRITE to this symbol but do not declare it].
+    /// `var _a; ... _a = AST;` 같은 TS-emit 패턴에서 비선언 할당이 read 와 함께 살아남도록
+    /// computeReachable BFS 가 추가 엣지로 사용. 선언 stmt 자체는 별도 경로(`symbol_to_stmt`)
+    /// 로 처리되므로 여기서는 제외.
+    sym_to_writer_stmts: []const []const u32,
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *ModuleStmtInfos) void {
@@ -55,6 +60,10 @@ pub const ModuleStmtInfos = struct {
             if (s.len > 0) self.allocator.free(s);
         }
         self.allocator.free(self.sym_to_referencing_stmts);
+        for (self.sym_to_writer_stmts) |s| {
+            if (s.len > 0) self.allocator.free(s);
+        }
+        self.allocator.free(self.sym_to_writer_stmts);
     }
 
     /// symbol_index가 선언된 statement 인덱스 반환.
@@ -94,7 +103,8 @@ pub const ModuleStmtInfos = struct {
             }
         }
 
-        // BFS: referenced_symbols → symbol_to_stmt → dependent statements
+        // BFS: referenced_symbols → (declarer, writers) → dependent statements.
+        // writer 엣지가 없으면 `_a = AST` 같은 비선언 할당이 read 만 도달해도 누락된다.
         var head: u32 = 0;
         while (head < queue.items.len) : (head += 1) {
             const stmt_idx = queue.items[head];
@@ -103,6 +113,14 @@ pub const ModuleStmtInfos = struct {
                     if (!reachable_stmts.isSet(dep_stmt)) {
                         reachable_stmts.set(dep_stmt);
                         try queue.append(allocator, dep_stmt);
+                    }
+                }
+                if (ref_sym < self.sym_to_writer_stmts.len) {
+                    for (self.sym_to_writer_stmts[ref_sym]) |writer_stmt| {
+                        if (!reachable_stmts.isSet(writer_stmt)) {
+                            reachable_stmts.set(writer_stmt);
+                            try queue.append(allocator, writer_stmt);
+                        }
                     }
                 }
             }
@@ -305,6 +323,16 @@ pub fn buildFromSemantic(
     }
     for (referenced_buckets) |*b| b.* = .empty;
 
+    // symbol → [stmts that write to it without declaring it]. computeReachable 가 read 가
+    // 살아 있을 때 writer stmt 도 enqueue 하기 위한 역인덱스. 같은 stmt 가 declare+write 인
+    // 경우는 Pass 3a 이후 finalize 단계에서 declared 를 exclude 해 제거한다.
+    var writer_buckets = try allocator.alloc(std.ArrayListUnmanaged(u32), symbols.len);
+    defer {
+        for (writer_buckets) |*b| b.deinit(allocator);
+        allocator.free(writer_buckets);
+    }
+    for (writer_buckets) |*b| b.* = .empty;
+
     for (references) |r| {
         if (r.stmt_idx == Reference.NO_STMT) continue;
         if (r.stmt_idx >= stmt_count) continue;
@@ -318,6 +346,9 @@ pub fn buildFromSemantic(
             try declared_buckets[r.stmt_idx].append(allocator, sym_u32);
         } else {
             try referenced_buckets[r.stmt_idx].append(allocator, sym_u32);
+            if (r.flags.write) {
+                try writer_buckets[sym_u32].append(allocator, r.stmt_idx);
+            }
         }
     }
 
@@ -340,6 +371,8 @@ pub fn buildFromSemantic(
         stmts[stmt_i].referenced_symbols = slice;
     }
 
+    const sym_to_writer_stmts = try finalizeWriterBuckets(allocator, writer_buckets, sym_to_stmt);
+
     // 역인덱스 구축 (buildReverseIndex 재사용)
     const reverse = try buildReverseIndex(allocator, stmts, symbols.len);
 
@@ -348,8 +381,41 @@ pub fn buildFromSemantic(
         .symbol_to_stmt = sym_to_stmt,
         .sym_to_side_effect_stmts = reverse.sym_to_side_effect_stmts,
         .sym_to_referencing_stmts = reverse.sym_to_referencing_stmts,
+        .sym_to_writer_stmts = sym_to_writer_stmts,
         .allocator = allocator,
     };
+}
+
+/// writer_buckets 를 stmts[].declared_symbols 의 declarer 와 중복 제거하여 final slice 로
+/// 변환한다. 같은 stmt 가 declare 한 심볼은 별도 경로(`symbol_to_stmt`)로 처리되므로 writer
+/// 엣지에서 제외해야 BFS 가 중복 enqueue 하지 않는다.
+fn finalizeWriterBuckets(
+    allocator: std.mem.Allocator,
+    writer_buckets: []std.ArrayListUnmanaged(u32),
+    sym_to_stmt: []const ?u32,
+) ![]const []const u32 {
+    const result = try allocator.alloc([]const u32, writer_buckets.len);
+    errdefer allocator.free(result);
+    for (result) |*r| r.* = &.{};
+
+    for (writer_buckets, 0..) |*bucket, sym| {
+        if (bucket.items.len == 0) continue;
+        std.mem.sort(u32, bucket.items, {}, std.sort.asc(u32));
+        const declarer: ?u32 = if (sym < sym_to_stmt.len) sym_to_stmt[sym] else null;
+        var out_len: usize = 0;
+        var last: ?u32 = null;
+        for (bucket.items) |stmt_idx| {
+            if (declarer) |d| if (d == stmt_idx) continue;
+            if (last != null and last.? == stmt_idx) continue;
+            last = stmt_idx;
+            bucket.items[out_len] = stmt_idx;
+            out_len += 1;
+        }
+        if (out_len > 0) {
+            result[sym] = try allocator.dupe(u32, bucket.items[0..out_len]);
+        }
+    }
+    return result;
 }
 
 /// AST + semantic data로부터 ModuleStmtInfos를 구축한다.
@@ -430,6 +496,15 @@ pub fn build(
     }
     for (referenced_bufs) |*b| b.* = .empty;
 
+    // symbol → [stmt indices that contain `assignment_target_identifier` for that symbol].
+    // 선언과 같은 stmt 인 경우는 finalize 단계에서 제거.
+    var writer_bufs = try allocator.alloc(std.ArrayListUnmanaged(u32), symbols.len);
+    defer {
+        for (writer_bufs) |*b| b.deinit(allocator);
+        allocator.free(writer_bufs);
+    }
+    for (writer_bufs) |*b| b.* = .empty;
+
     for (ast.nodes.items, 0..) |n, node_i| {
         const stmt_i = findStmtForPos(stmt_spans, n.span.start) orelse continue;
         if (node_i >= symbol_ids.len) continue;
@@ -462,6 +537,13 @@ pub fn build(
                 try referenced_bufs[stmt_i].append(allocator, sym_idx_u32);
             }
         }
+
+        if (n.tag == .assignment_target_identifier) {
+            const stmt_i_u32: u32 = @intCast(stmt_i);
+            if (std.mem.indexOfScalar(u32, writer_bufs[sym_idx].items, stmt_i_u32) == null) {
+                try writer_bufs[sym_idx].append(allocator, stmt_i_u32);
+            }
+        }
     }
 
     for (stmts, 0..) |*stmt, stmt_i| {
@@ -473,6 +555,8 @@ pub fn build(
         }
     }
 
+    const sym_to_writer_stmts = try finalizeWriterBuckets(allocator, writer_bufs, sym_to_stmt);
+
     // Phase 3: 역인덱스 구축
     const reverse = try buildReverseIndex(allocator, stmts, symbols.len);
 
@@ -481,6 +565,7 @@ pub fn build(
         .symbol_to_stmt = sym_to_stmt,
         .sym_to_side_effect_stmts = reverse.sym_to_side_effect_stmts,
         .sym_to_referencing_stmts = reverse.sym_to_referencing_stmts,
+        .sym_to_writer_stmts = sym_to_writer_stmts,
         .allocator = allocator,
     };
 }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -566,6 +566,15 @@ pub const TreeShaker = struct {
                     try self.enqueue(item.mod, dep_stmt, reachable_stmts, &queue);
                 }
 
+                // (1b) 같은 심볼에 대한 비선언 writer (예: TS 가 emit 하는 `var _a; ... _a = AST;`).
+                // declare 경로로는 var-only 선언만 살아남고 실제 값을 채우는 후속 할당이 누락되어
+                // `_a is not a constructor` 류 회귀가 발생한다.
+                if (ref_sym < infos.sym_to_writer_stmts.len) {
+                    for (infos.sym_to_writer_stmts[ref_sym]) |writer_stmt| {
+                        try self.enqueue(item.mod, writer_stmt, reachable_stmts, &queue);
+                    }
+                }
+
                 // (2) import binding: 타겟 모듈로 점프
                 if (item.mod < self.sym_to_ib.len) {
                     if (self.sym_to_ib[item.mod]) |sym_map| {

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -1108,26 +1108,49 @@ const total = results.length;
 console.log(`\n${passed}/${total} projects built successfully.`);
 console.log(`${matched}/${comparable} outputs match baseline.`);
 
-// Size comparison dashboard
-const sizeComparisons = results
-  .filter((r) => r.zts.build && r.esbuild.build && r.zts.size > 0 && r.esbuild.size > 0)
-  .map((r) => ({
-    name: r.project,
-    zts: r.zts.size,
-    esbuild: r.esbuild.size,
-    ratio: r.zts.size / r.esbuild.size,
-  }))
+// Size comparison dashboard — ZTS는 esbuild/rolldown/rspack 중 가장 작은 결과를 baseline 으로
+// 비교한다. 가장 빡센 기준이라 셋 중 어느 하나라도 더 작아지면 격차가 즉시 드러난다.
+type SizeComparison = {
+  name: string;
+  zts: number;
+  baselineName: "esbuild" | "rolldown" | "rspack";
+  baselineSize: number;
+  ratio: number;
+};
+
+const sizeComparisons: SizeComparison[] = results
+  .filter((r) => r.zts.build && r.zts.size > 0)
+  .flatMap((r) => {
+    const candidates: { name: SizeComparison["baselineName"]; size: number }[] = [];
+    if (r.esbuild.build && r.esbuild.size > 0)
+      candidates.push({ name: "esbuild", size: r.esbuild.size });
+    if (r.rolldown.build && r.rolldown.size > 0)
+      candidates.push({ name: "rolldown", size: r.rolldown.size });
+    if (r.rspack.build && r.rspack.size > 0)
+      candidates.push({ name: "rspack", size: r.rspack.size });
+    if (candidates.length === 0) return [];
+    const best = candidates.reduce((a, b) => (b.size < a.size ? b : a));
+    return [
+      {
+        name: r.project,
+        zts: r.zts.size,
+        baselineName: best.name,
+        baselineSize: best.size,
+        ratio: r.zts.size / best.size,
+      },
+    ];
+  })
   .sort((a, b) => b.ratio - a.ratio);
 
 if (sizeComparisons.length > 0) {
-  console.log("\n### Size Comparison (ZTS vs esbuild)\n");
-  console.log("| Project | ZTS | esbuild | rolldown | rspack | Ratio | Status |");
-  console.log("|---------|-----|---------|----------|--------|-------|--------|");
+  console.log("\n### Size Comparison (ZTS vs smallest of esbuild/rolldown/rspack)\n");
+  console.log("| Project | ZTS | esbuild | rolldown | rspack | Baseline | Ratio | Status |");
+  console.log("|---------|-----|---------|----------|--------|----------|-------|--------|");
   for (const c of sizeComparisons) {
     const r = results.find((r) => r.project === c.name)!;
     const status = c.ratio <= 1.1 ? "✅" : c.ratio <= 1.5 ? "⚠️" : "❌";
     console.log(
-      `| ${c.name} | ${fmtSize(c.zts)} | ${fmtSize(c.esbuild)} | ${fmtSize(r.rolldown.size)} | ${fmtSize(r.rspack.size)} | ${c.ratio.toFixed(2)}x | ${status} |`,
+      `| ${c.name} | ${fmtSize(c.zts)} | ${fmtSize(r.esbuild.size)} | ${fmtSize(r.rolldown.size)} | ${fmtSize(r.rspack.size)} | ${c.baselineName} | ${c.ratio.toFixed(2)}x | ${status} |`,
     );
   }
   const avgRatio = sizeComparisons.reduce((s, c) => s + c.ratio, 0) / sizeComparisons.length;
@@ -1135,7 +1158,7 @@ if (sizeComparisons.length > 0) {
   const similar = sizeComparisons.filter((c) => c.ratio >= 1 && c.ratio <= 1.1).length;
   const larger = sizeComparisons.filter((c) => c.ratio > 1.1).length;
   console.log(
-    `\nAverage ratio: ${avgRatio.toFixed(2)}x | Smaller: ${smaller} | Similar(±10%): ${similar} | Larger: ${larger}`,
+    `\nAverage ratio (vs smallest): ${avgRatio.toFixed(2)}x | Smaller: ${smaller} | Similar(±10%): ${similar} | Larger: ${larger}`,
   );
 }
 


### PR DESCRIPTION
## 요약

- object literal의 method/getter/setter 정의를 객체 생성 시점에는 순수한 값으로 판정하도록 수정했습니다.
- computed method key는 기존 class member와 같은 purity 검사로 보수적으로 유지합니다.
- Svelte `props.js` 형태의 unused direct re-export source가 top-level handler 객체 때문에 살아남던 fanout을 줄이는 회귀 테스트를 추가했습니다.

Refs #2046

## 검증

- `zig build test -Dtest-filter="object literal method"`
- `zig build test -Dtest-filter="direct re-export"`
- `zig build test -Dtest-filter="TreeShaking:"`
- `zig build`
- `zig build test`
- `cd tests/integration && bun test tests/tree-shake-precision.test.ts`
- `cd tests/integration && bun test tests/mangler-minify.test.ts`
- `cd tests/benchmark && bun run smoke.ts --filter=svelte`

## Svelte smoke

- `svelte-mount-min`: ZTS 34KB, esbuild 37KB, rolldown 28KB
- `svelte-full`: ZTS 84KB, esbuild 121KB, rolldown 104KB
- `svelte-full-min`: ZTS 38KB, esbuild 40KB, rolldown 30KB
