### PR TITLE
fix(watch): HMR rebuild 메모리 소유권 문제 수정

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -595,12 +595,14 @@ pub const ModuleGraph = struct {
                     const saved_deps = mod.dependencies;
                     const saved_importers = mod.importers;
                     const saved_dynamic = mod.dynamic_imports;
+                    const saved_dynamic_importers = mod.dynamic_importers;
                     mod.* = cached.module;
                     mod.index = saved_index;
                     mod.path = saved_path;
                     mod.dependencies = saved_deps;
                     mod.importers = saved_importers;
                     mod.dynamic_imports = saved_dynamic;
+                    mod.dynamic_importers = saved_dynamic_importers;
                     mod.mtime = mtime;
                     // parse_arena 소유권 이전: store → graph.
                     cached.module.parse_arena = null;

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -40,13 +40,22 @@ pub const PersistentModuleStore = struct {
     }
 
     fn freeCachedModule(self: *PersistentModuleStore, cached: *CachedModule) void {
+        for (cached.module.import_records) |record| {
+            if (record.kind == .require_context) {
+                if (record.context_matches) |matches| {
+                    for (matches) |s| self.allocator.free(s);
+                    self.allocator.free(matches);
+                }
+            }
+        }
         // parse_arena / alias_table 가 아직 store 에 있으면 해제.
         if (cached.module.parse_arena) |*arena| arena.deinit();
         if (cached.module.alias_table) |*t| t.deinit();
-        // dependencies/importers/dynamic_imports ArrayList 해제
+        // dependencies/importers/dynamic_imports/dynamic_importers ArrayList 해제
         cached.module.dependencies.deinit(self.allocator);
         cached.module.importers.deinit(self.allocator);
         cached.module.dynamic_imports.deinit(self.allocator);
+        cached.module.dynamic_importers.deinit(self.allocator);
         // import_specifiers 해제
         for (cached.import_specifiers) |s| self.allocator.free(s);
         self.allocator.free(cached.import_specifiers);
@@ -75,10 +84,12 @@ pub const PersistentModuleStore = struct {
 
         // Module 복사 — parse_arena 소유권 이전
         var cached_module = module.*;
-        // dependencies/importers/dynamic_imports를 빈 상태로 — graph deinit에서 원본이 해제되므로
+        // dependencies/importers/dynamic_imports/dynamic_importers를 빈 상태로 —
+        // graph deinit에서 원본이 해제되므로 store에 shallow copy를 남기면 안 된다.
         cached_module.dependencies = .empty;
         cached_module.importers = .empty;
         cached_module.dynamic_imports = .empty;
+        cached_module.dynamic_importers = .empty;
 
         // parse_arena / alias_table 소유권 이전: module → store.
         // alias_table 은 AliasTable struct (ArrayList backing) 로 graph module 과
@@ -88,6 +99,7 @@ pub const PersistentModuleStore = struct {
         // (특히 nested_name_sets HashMap backing 의 Header.capacity) 을 덮어쓴다.
         module.parse_arena = null;
         module.alias_table = null;
+        module.import_records = &.{};
 
         if (had_existing) {
             // 기존 키 재사용 — put은 값만 업데이트
@@ -172,10 +184,12 @@ test "PersistentModuleStore: alias_table ownership 왕복 (rebuild 2회)" {
     module.alias_table = symbol_mod.AliasTable.init(allocator);
     _ = try module.alias_table.?.declare("foo");
     _ = try module.alias_table.?.declare("bar");
+    try module.dynamic_importers.append(allocator, @enumFromInt(1));
 
     // build 1 end: store 로 소유권 이전.
     store.putModule("/virtual/mod.ts", &module, 1);
     try testing.expect(module.alias_table == null); // graph 는 더이상 소유하지 않음
+    try testing.expectEqual(@as(usize, 0), store.modules.getPtr("/virtual/mod.ts").?.module.dynamic_importers.items.len);
 
     // graph.deinit 시뮬레이션 — alias_table 이 null 이므로 deinit 이 no-op 이어야 함.
     module.deinit(allocator);
@@ -186,10 +200,12 @@ test "PersistentModuleStore: alias_table ownership 왕복 (rebuild 2회)" {
     const saved_deps = mod2.dependencies;
     const saved_importers = mod2.importers;
     const saved_dynamic = mod2.dynamic_imports;
+    const saved_dynamic_importers = mod2.dynamic_importers;
     mod2 = cached.module;
     mod2.dependencies = saved_deps;
     mod2.importers = saved_importers;
     mod2.dynamic_imports = saved_dynamic;
+    mod2.dynamic_importers = saved_dynamic_importers;
     cached.module.parse_arena = null;
     cached.module.alias_table = null;
     try testing.expect(mod2.alias_table != null);

--- a/src/server/file_watcher.zig
+++ b/src/server/file_watcher.zig
@@ -99,7 +99,6 @@ const KqueueBackend = struct {
 
     const WatchEntry = struct {
         fd: i32,
-        path: []const u8, // allocator 소유
     };
 
     fn init(allocator: std.mem.Allocator) !KqueueBackend {
@@ -116,7 +115,7 @@ const KqueueBackend = struct {
         var it = self.watch_fds.iterator();
         while (it.next()) |entry| {
             posix.close(entry.value_ptr.fd);
-            allocator.free(entry.value_ptr.path);
+            allocator.free(entry.key_ptr.*);
         }
         self.watch_fds.deinit();
         self.fd_to_path.deinit();
@@ -148,12 +147,17 @@ const KqueueBackend = struct {
 
         _ = try posix.kevent(self.kq, &changelist, &.{}, null);
 
-        self.watch_fds.put(path, .{ .fd = fd, .path = path_owned }) catch {
+        self.watch_fds.put(path_owned, .{ .fd = fd }) catch {
             posix.close(fd);
             allocator.free(path_owned);
             return;
         };
-        self.fd_to_path.put(fd, path_owned) catch {};
+        self.fd_to_path.put(fd, path_owned) catch {
+            _ = self.watch_fds.remove(path_owned);
+            posix.close(fd);
+            allocator.free(path_owned);
+            return;
+        };
     }
 
     fn removePath(self: *KqueueBackend, allocator: std.mem.Allocator, path: []const u8) void {
@@ -169,7 +173,7 @@ const KqueueBackend = struct {
             _ = posix.kevent(self.kq, &changelist, &.{}, null) catch {};
             _ = self.fd_to_path.remove(kv.value.fd);
             posix.close(kv.value.fd);
-            allocator.free(kv.value.path);
+            allocator.free(kv.key);
         }
     }
 
@@ -177,7 +181,7 @@ const KqueueBackend = struct {
         var it = self.watch_fds.iterator();
         while (it.next()) |entry| {
             posix.close(entry.value_ptr.fd);
-            allocator.free(entry.value_ptr.path);
+            allocator.free(entry.key_ptr.*);
         }
         self.watch_fds.clearRetainingCapacity();
         self.fd_to_path.clearRetainingCapacity();

--- a/src/server/file_watcher_test.zig
+++ b/src/server/file_watcher_test.zig
@@ -45,6 +45,26 @@ test "FileWatcher: remove path" {
     try std.testing.expectEqual(@as(usize, 0), watcher.watchCount());
 }
 
+test "FileWatcher: owns added path memory" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "owned.txt", .data = "owned" });
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, "owned.txt");
+
+    var watcher = try FileWatcher.init(std.testing.allocator);
+    defer watcher.deinit();
+
+    try watcher.addPath(path);
+    std.testing.allocator.free(path);
+
+    const same_path = try tmp.dir.realpathAlloc(std.testing.allocator, "owned.txt");
+    defer std.testing.allocator.free(same_path);
+
+    watcher.removePath(same_path);
+    try std.testing.expectEqual(@as(usize, 0), watcher.watchCount());
+}
+
 test "FileWatcher: clear paths" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## 요약

HMR watch rebuild 중 macOS에서 `malloc: pointer being freed was not allocated`로 프로세스가 종료되는 문제를 수정합니다.

실제 Expo/Bungae dev server에서 파일을 한 번 수정하면 다음과 같은 형태로 죽었습니다.

```text
bun.exe malloc: *** error for object 0x792f73726573552f: pointer being freed was not allocated
```

해당 포인터 값은 little-endian으로 해석하면 `/Users/y...` 경로 문자열처럼 보였고, 조사 결과 watch/rebuild 경로에서 path 또는 module-owned slice의 소유권이 여러 객체에 얕게 공유되는 문제가 있었습니다.

## 원인

이번 crash는 단일 원인이라기보다 watch rebuild 경로에 숨어 있던 소유권 문제가 겹쳐 있었습니다.

### 1. `PersistentModuleStore`가 `dynamic_importers`를 얕게 보관

`PersistentModuleStore.putModule()`은 graph module을 cache module로 옮길 때 `dependencies`, `importers`, `dynamic_imports`는 비우고 있었지만 `dynamic_importers`는 그대로 shallow copy하고 있었습니다.

그 결과 다음 흐름에서 해제된 ArrayList backing을 다시 만질 수 있었습니다.

1. build graph의 `Module.dynamic_importers`가 allocator-owned backing을 가짐
2. `putModule()`이 module struct를 통째로 복사하면서 store cache에도 같은 backing 포인터가 들어감
3. graph deinit 또는 다음 rebuild 과정에서 한쪽이 backing을 해제
4. 다른 쪽이 같은 backing을 다시 deinit/free하면서 heap corruption 가능

### 2. cache hit 복원 시 `dynamic_importers`를 graph-local 필드로 보존하지 않음

`buildIncremental()`의 cache hit 경로는 `mod.* = cached.module`로 cache module을 복원한 뒤 graph-local 필드를 다시 덮어씁니다. 기존에는 `dependencies`, `importers`, `dynamic_imports`만 보존했고 `dynamic_importers`는 보존하지 않았습니다.

`dynamic_importers`도 graph traversal 중 새로 구성되는 graph-local edge이므로 cache module에서 가져오면 안 됩니다. 이번 변경에서 cache hit 복원 시 `dynamic_importers`도 현재 graph의 값을 보존하도록 했습니다.

### 3. `require.context`의 `context_matches`가 store로 넘어간 뒤 graph에서도 다시 free됨

`Module.deinit()`은 `import_records` 중 `require_context` record의 `context_matches`를 명시적으로 free합니다. 그런데 `putModule()`에서 `parse_arena` 소유권을 store로 넘긴 뒤에도 graph 쪽 `module.import_records`가 그대로 남아 있었습니다.

이 상태에서 graph deinit이 실행되면, store로 넘어간 module 데이터의 일부를 graph가 다시 해제하려고 합니다. 실제 Expo 재현에서 crash 경계는 다음과 같았습니다.

- rebuild bundle 완료
- emit 완료
- store transfer 완료
- `graph.deinit()` 시작
- `Module.deinit()` 내부에서 invalid free

따라서 `putModule()`에서 store로 소유권을 넘긴 뒤 graph 쪽 `module.import_records`를 빈 slice로 비워, graph deinit이 더 이상 store-owned require.context matches를 free하지 않도록 했습니다.

`freeCachedModule()`에서는 store가 cache module을 폐기할 때 `require.context`의 `context_matches`를 직접 해제합니다. 이때 `parse_arena.deinit()`보다 먼저 `import_records`를 순회해야 하므로 해제 순서도 명확히 정리했습니다.

### 4. macOS kqueue watcher가 borrowed path를 map key로 들고 있음

macOS `KqueueBackend.addPath()`는 `path_owned`를 만들고도 `watch_fds.put(path, ...)`로 호출자가 넘긴 borrowed slice를 map key로 저장하고 있었습니다.

watch rebuild에서는 `rebuild_result.module_paths`처럼 rebuild result가 소유한 임시 path slice가 watcher로 들어갈 수 있습니다. result deinit 이후 watcher map key가 dangling pointer가 될 수 있으므로, `watch_fds`의 key 자체가 owned path가 되도록 바꿨습니다.

변경 후 구조는 다음과 같습니다.

- `watch_fds` key: allocator-owned path
- `WatchEntry`: fd만 보관
- `fd_to_path`: 같은 owned path slice를 이벤트 역참조용으로 borrow
- remove/deinit/clear 시 owned key를 한 번만 free

## 변경 내용

- `src/bundler/module_store.zig`
  - cache module deinit 시 `require.context`의 `context_matches`를 store가 해제하도록 추가
  - `parse_arena` 해제 전에 `import_records`를 먼저 순회하도록 순서 보장
  - `dynamic_importers`도 cache store에서 shallow copy하지 않도록 `.empty` 처리
  - graph module에서 store로 소유권을 넘긴 뒤 `module.import_records = &.{}` 처리
  - 기존 alias_table ownership 회귀 테스트에 `dynamic_importers` 케이스 추가

- `src/bundler/graph.zig`
  - cache hit 복원 시 `dynamic_importers`도 graph-local field로 보존

- `src/server/file_watcher.zig`
  - macOS kqueue backend의 `watch_fds` key를 owned path로 변경
  - `WatchEntry.path` 제거
  - remove/deinit/clear에서 key를 단일 ownership으로 free
  - `fd_to_path.put` 실패 시 watch map entry와 fd/path를 정리하도록 보강

- `src/server/file_watcher_test.zig`
  - `addPath()` 호출 직후 원본 path 메모리를 free해도 watcher가 자체 path ownership으로 `removePath()`를 수행할 수 있는 회귀 테스트 추가

## 검증

로컬에서 다음을 확인했습니다.

```text
zig build test --summary all
```

결과:

```text
Build Summary: 5/5 steps succeeded
3902/3902 tests passed
```

또한 `@zts/core` native addon을 재빌드한 뒤 Bungae Expo dev server에서 실제 HMR watch rebuild 경로를 재현했습니다.

```text
BUNGAE_HMR_PROFILE=1 ZTS_PROFILE=all ZTS_PROFILE_LEVEL=detailed BUNGAE_CODEGEN_PROFILE=1 bun run bungae:start:expo
```

`examples/ExpoApp/components/themed-text.tsx`에 임시 주석을 추가하는 방식으로 이전에 crash가 났던 경로를 다시 밟았고, 이번에는 프로세스가 죽지 않고 rebuild가 완료되었습니다.

관측된 rebuild 로그:

```text
Graph changed [ios] (1 files, 454.249833ms) [detect=26.091167ms graph=363.929584ms link=11.214958ms shake=0.000333ms emit=36.317ms delta=1.631917ms reparsed=0]
```

## 참고: 성능 이슈는 별도 문제

이번 PR은 crash를 막는 메모리 소유권 수정입니다. 위 rebuild가 약 454ms 걸린 이유는 parser/codegen이 아니라 graph rediscovery/resolve 쪽입니다.

해당 로그 기준 병목은 다음과 같습니다.

```text
graph=363.9ms
graphDiscover=362.7ms
resolve=300.4ms
parse=0.37ms
codegen=1.94ms
reparsed=0
```

즉 파일은 거의 재파싱하지 않았지만, cache-hit 모듈들도 import graph resolve를 다시 밟고 있습니다. 100ms 이하 HMR을 목표로 하려면 이 PR 이후 별도 작업으로 resolved import 결과나 module path set을 persistent store에 더 적극적으로 보존해서 graph rediscovery를 줄여야 합니다.

## 리스크

- `PersistentModuleStore`의 ownership 경계가 더 엄격해집니다. store로 넘긴 후 graph module은 더 이상 `import_records`를 deinit하지 않습니다.
- `require.context` matches는 store cache가 소유하고 `freeCachedModule()`에서 해제합니다.
- macOS kqueue watcher의 path key ownership이 변경되어 path free 위치가 value가 아니라 map key 기준으로 바뀝니다. Linux inotify와 mtime backend의 동작은 변경하지 않았습니다.
