### PR TITLE
fix(bundler): #2051/#2052 — refresh 가 ESM 강등하고 tree-shaken target 의 preamble 도 emit

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -893,6 +893,10 @@ pub const Bundler = struct {
         var shaker: ?TreeShaker = if (!self.options.dev_mode and self.options.scope_hoist and self.options.tree_shaking) blk: {
             var s = try TreeShaker.init(self.allocator, &graph, &(linker.?));
             try s.analyze(self.options.entry_points);
+            // metadata builder 가 `Module.is_included` 비트를 신뢰해 tree-shake 된 target 의
+            // CJS preamble emit 을 건너뛸 수 있도록 plug. analyze() 가 끝난 뒤 mirror 가
+            // 모든 모듈의 `is_included` 비트를 확정해 둔다.
+            if (linker) |*l| l.tree_shaker_active = true;
             break :blk s;
         } else null;
         defer if (shaker) |*s| s.deinit();

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -2037,3 +2037,86 @@ test "TreeShaking: live statement preserves upstream module (#1551 anti-regressi
     try std.testing.expect(std.mem.indexOf(u8, result.output, "RUNTIME_STILL_NEEDED") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "hello") != null);
 }
+
+// kysely 회귀 #2052: TS interface-only 가 strip 후 빈 `export {}` 만 남고, post-transform
+// AST 에서 transformer 가 그 marker 까지 drop 하면 refresh 가 exports_kind 를 `.none` 으로
+// 강등 → markEsmCjsHybrid Pass 2 가 implicit CJS 로 승격 → resolveOrCjsFallback 이 첫 번째
+// `export *` source 의 빈 CJS wrapper 를 모든 named import 의 source 로 stick 시킴 →
+// 실제 정의가 있는 다음 `export *` 는 walk 안 되어 dummy-driver.js 가 tree-shake 된다.
+test "TreeShaking: export * chain through TS-stripped empty source still resolves named import" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { Bar } from './barrel';
+        \\console.log(new Bar().tag());
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\export * from './empty';
+        \\export * from './real';
+    );
+    try writeFile(tmp.dir, "empty.ts",
+        \\export {};
+    );
+    try writeFile(tmp.dir, "real.ts",
+        \\export class Bar {
+        \\  tag() { return 'EXPORT_STAR_CHAIN_KEPT'; }
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "EXPORT_STAR_CHAIN_KEPT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "class Bar") != null);
+}
+
+// cheerio 회귀 #2051: namespace import (`import * as ns from 'cjslib'`) 의 모든 소비자가
+// tree-shake 로 사라졌는데 ImportBinding 자체는 살아 있어 linker 가 `var ns =
+// __toESM(require_X(), 1)` 를 emit. 그러나 해당 CJS wrapper 는 모듈 미포함이라 정의되지
+// 않아 `require_X is not defined` ReferenceError. preamble emit 도 같이 drop 해야 한다.
+test "TreeShaking: namespace import preamble dropped when target excluded from bundle" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './lib';
+        \\console.log(used());
+    );
+    // lib.js 가 namespace 로 cjslib 을 import 하지만, 소비자 (`heavy`) 는 entry 에서 안 쓴다.
+    try writeFile(tmp.dir, "lib.js",
+        \\import * as cjslib from './cjslib.cjs';
+        \\export function used() { return 'NS_TARGET_DROP_USED'; }
+        \\export function heavy() { return cjslib.bar(); }
+    );
+    try writeFile(tmp.dir, "cjslib.cjs",
+        \\'use strict';
+        \\exports.bar = function() { return 'NS_TARGET_DROP_HEAVY'; };
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_TARGET_DROP_USED") != null);
+    // heavy() 는 사용 안 하므로 cjslib + 본문 모두 prune 되어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_TARGET_DROP_HEAVY") == null);
+    // `var X = __toESM(require_cjslib_cjs(), 1)` 같은 orphan preamble 이 남으면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_cjslib") == null);
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1658,8 +1658,7 @@ pub const ModuleGraph = struct {
         // (kysely/cheerio 회귀 #2052/#2051).
         const refreshed_kind = determineExportsKind(refreshed_scan_result, module.path);
         const previous_kind = module.exports_kind;
-        const preserve_esm = refreshed_kind == .none and
-            (previous_kind == .esm or previous_kind == .esm_with_dynamic_fallback);
+        const preserve_esm = refreshed_kind == .none and previous_kind.isEsm();
         module.exports_kind = if (preserve_esm) previous_kind else refreshed_kind;
         module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
 
@@ -2064,7 +2063,7 @@ pub const ModuleGraph = struct {
                     if (target.module_type == .json) {
                         target.exports_kind = .commonjs;
                         target.wrap_kind = .cjs;
-                    } else if (target.exports_kind == .esm or target.exports_kind == .esm_with_dynamic_fallback) {
+                    } else if (target.exports_kind.isEsm()) {
                         target.wrap_kind = .esm;
                     } else {
                         target.exports_kind = .commonjs;
@@ -2130,7 +2129,7 @@ pub const ModuleGraph = struct {
         if (self.resolve_cache.platform == .react_native or self.dev_mode) {
             var it = self.modules.iterator(0);
             while (it.next()) |m| {
-                if (m.wrap_kind == .none and (m.exports_kind == .esm or m.exports_kind == .esm_with_dynamic_fallback)) {
+                if (m.wrap_kind == .none and m.exports_kind.isEsm()) {
                     m.wrap_kind = .esm;
                 }
             }
@@ -2144,7 +2143,7 @@ pub const ModuleGraph = struct {
             while (it.next()) |m| {
                 if (m.dynamic_importers.items.len == 0) continue;
                 if (m.wrap_kind != .none) continue;
-                if (m.exports_kind != .esm and m.exports_kind != .esm_with_dynamic_fallback) continue;
+                if (!m.exports_kind.isEsm()) continue;
                 m.wrap_kind = .esm;
             }
         }
@@ -2268,7 +2267,7 @@ pub const ModuleGraph = struct {
     /// no-op. 변경 발생 시 true (Pass 2.5 fixpoint loop의 changed 플래그용).
     fn promoteToEsmWrap(target: *Module) bool {
         if (target.wrap_kind != .none) return false;
-        if (target.exports_kind != .esm and target.exports_kind != .esm_with_dynamic_fallback) return false;
+        if (!target.exports_kind.isEsm()) return false;
         target.wrap_kind = .esm;
         return true;
     }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1650,7 +1650,17 @@ pub const ModuleGraph = struct {
 
         try self.injectJsxSyntheticImportsForModule(module, arena_alloc, ast);
 
-        module.exports_kind = determineExportsKind(refreshed_scan_result, module.path);
+        // 기존 exports_kind 가 ESM 인데 post-transform scan 이 `.none` 으로 떨어지는 경우
+        // (예: TS interface-only 파일의 `export {};` 를 transformer 가 drop) ESM 분류를 유지한다.
+        // `.none` 으로 강등하면 Pass 2 markEsmCjsHybrid 가 node_modules + def_format unknown
+        // 모듈을 implicit CJS 로 승격시켜, `export *` chain 의 빈 source 가 CJS wrapper 로
+        // wrap 되고 `resolveOrCjsFallback` 이 잘못된 모듈을 named import 의 source 로 반환한다
+        // (kysely/cheerio 회귀 #2052/#2051).
+        const refreshed_kind = determineExportsKind(refreshed_scan_result, module.path);
+        const previous_kind = module.exports_kind;
+        const preserve_esm = refreshed_kind == .none and
+            (previous_kind == .esm or previous_kind == .esm_with_dynamic_fallback);
+        module.exports_kind = if (preserve_esm) previous_kind else refreshed_kind;
         module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
 
         if (module.alias_table) |*table| table.deinit();

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -388,6 +388,11 @@ pub const Linker = struct {
     /// 사용자 의도 (원본 import 보존) 를 존중한다. bundler 가 init 후 설정.
     verbatim_module_syntax: bool = false,
 
+    /// emitter 가 TreeShaker 와 함께 호출됐는지. true 면 metadata builder 가 모듈의
+    /// `is_included` 비트를 신뢰해 tree-shake 된 target 의 preamble emit 을 건너뛴다.
+    /// false (linker 단독 빌드 / unit test) 면 기존 동작 유지.
+    tree_shaker_active: bool = false,
+
     /// #1824 IIFE `--globals SPEC=GLOBAL` 매핑 (rollup `output.globals` 호환).
     /// `format == .iife` 일 때만 의미 있음. 매핑된 external specifier 는 UMD/AMD 와
     /// 동일한 factory-param preamble 경로로 처리되고, 매핑 안 된 external 은

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -394,6 +394,13 @@ pub fn buildMetadataForAst(
 
             // CJS 모듈에서 import하는 경우: preamble에서 require_xxx() 호출 생성
             if (canonical_m_opt != null and canonical_m_opt.?.wrap_kind == .cjs) {
+                // Tree-shake 가 target 을 번들에서 제외했으면 `__commonJS` wrapper 자체가
+                // emit 되지 않아 `require_xxx is not defined` ReferenceError 가 난다.
+                // namespace import (`import * as undici`) 의 모든 소비자가 다른 export 의
+                // tree-shake 로 사라진 케이스 (cheerio 회귀 #2051) 에서 발생하므로 preamble
+                // 도 같이 drop 한다. `tree_shaker_active` 가 false (linker 단독 unit test)
+                // 면 `is_included` 비트가 신뢰할 수 없으므로 가드를 적용하지 않는다.
+                if (self.tree_shaker_active and !canonical_m_opt.?.is_included) continue;
                 const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                 const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
                 const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -255,6 +255,10 @@ pub const ExportsKind = enum {
     esm,
     /// ESM + CJS 혼용 (export * from cjs 등)
     esm_with_dynamic_fallback,
+
+    pub fn isEsm(self: ExportsKind) bool {
+        return self == .esm or self == .esm_with_dynamic_fallback;
+    }
 };
 
 /// 모듈 래핑 방식 (esbuild WrapKind).


### PR DESCRIPTION
## 요약

`6e44d991 fix(bundler): post-transform analysis refresh` (#1913) 가 도입한 두 가지 회귀를 같이 정리합니다. 둘 다 `__commonJS` wrapper 가 emit 되지 않은 빈/제외된 모듈로 named/namespace import 가 stick 되어 런타임에 실패하던 케이스입니다.

Closes #2051 (cheerio)
Closes #2052 (kysely)

## 1. kysely (#2052) — `export *` chain 이 빈 source 에 stick

### 흐름
1. `where-interface.js` 원본: `export {};` (TS interface-only marker) → `exports_kind = .esm`
2. transformer 가 의미 없는 `export {};` 를 drop → AST 가 empty
3. `refreshAnalysisAfterAstMutation` 이 post-transform AST 기준으로 `exports_kind` 재계산 → `.none`
4. `markEsmCjsHybrid` Pass 2 (graph.zig:2082) 가 `.none` + node_modules + `def_format unknown` 모듈을 implicit CJS 로 승격 → `wrap_kind = .cjs`
5. `resolveOrCjsFallback` 이 빈 CJS-wrapped where-interface 를 모든 named import 의 source 로 stick → `dummy-driver.js` 가 reachability 그래프에서 빠져 tree-shake
6. `var DummyDriver = require_xxx().DummyDriver` 가 `({}).DummyDriver` → `TypeError: DummyDriver is not a constructor`

### 수정 (`src/bundler/graph.zig`)
refresh 단계에서 기존 `exports_kind` 가 ESM 인데 post-transform scan 이 `.none` 으로 떨어지면 ESM 분류 유지. CJS 신호 (require/module.exports) 를 새로 감지한 경우는 그대로 강등.

```zig
const refreshed_kind = determineExportsKind(refreshed_scan_result, module.path);
const previous_kind = module.exports_kind;
const preserve_esm = refreshed_kind == .none and previous_kind.isEsm();
module.exports_kind = if (preserve_esm) previous_kind else refreshed_kind;
```

## 2. cheerio (#2051) — namespace import 의 orphan preamble

### 흐름
1. cheerio 의 `index.js` 가 `import * as undici from 'undici'` (top-level, 다른 함수에서만 사용)
2. entry 는 `load` 만 import, undici 를 쓰는 `loadBuffer` 등은 unused 라 tree-shake
3. namespace `ImportBinding` 자체는 살아 있어 linker 가 `var undici = __toESM(require_undici_index(), 1)` emit
4. 하지만 undici 모듈 자체는 emitter 의 `if (!s.isIncluded(i)) continue` 에서 skip → `__commonJS` wrapper 안 만들어짐
5. `require_undici_index is not defined` ReferenceError

### 수정 (`src/bundler/linker/metadata.zig` + `src/bundler/linker.zig` + `src/bundler/bundler.zig`)
- `Linker.tree_shaker_active: bool` 추가, bundler 가 `TreeShaker.analyze()` 직후 set
- metadata builder 의 CJS preamble 분기에서 `tree_shaker_active && !canonical.is_included` 면 preamble 도 drop
- 가드: `tree_shaker_active=false` (linker 단독 unit test) 에서는 모든 모듈 `is_included=false` 가 기본값이라 잘못 prune 안 되도록 skip

```zig
if (canonical_m_opt != null and canonical_m_opt.?.wrap_kind == .cjs) {
    if (self.tree_shaker_active and !canonical_m_opt.?.is_included) continue;
    // ... writeCjsImport(...)
}
```

## 3. /simplify followup — `ExportsKind.isEsm()` 헬퍼

`(.esm or .esm_with_dynamic_fallback)` 2-variant 체크가 graph.zig 에 5곳 반복돼 있던 것을 같은 enum의 `ModuleDefFormat.isEsm()` 컨벤션 따라 `ExportsKind.isEsm()` 헬퍼 추가하고 모두 교체. 동작 변경 없음.

## 검증

### Smoke (`tests/benchmark/smoke.ts --filter=<name>`)

| Project | Before | After |
|---|---|---|
| neverthrow | OK | OK |
| minimatch | OK | OK |
| **cheerio** | **FAIL** (`require_undici_index is not defined`) | **OK MATCH** |
| **kysely** | **FAIL** (`DummyDriver is not a constructor`, 197KB) | **OK MATCH** (224KB, 회귀 전 수준) |

### Unit tests
`zig build test` — 3943/3943 통과. 기존 5개 통합 테스트 실패는 main 동일 (RN/Hermes/watch 메모리 — 이 PR 무관).

### 회귀 가드 (`bundler_test/tree_shake.zig` 신규)

```zig
test "TreeShaking: export * chain through TS-stripped empty source still resolves named import"
test "TreeShaking: namespace import preamble dropped when target excluded from bundle"
```

## 영향 범위

- 회귀 도입 commit: `6e44d991 fix(bundler): post-transform analysis refresh` (#1913)
- 직접 영향 받는 후속 commit: `d9cbd6fc fix(bundler): tighten binding local name invariants` (panic tripwire — 이 PR 머지 후에도 유효)
- 인접 PR (이미 머지됨): #2049 (minimatch writer-edge + neverthrow elided binding drop)

## Commits

- `bfae4e78` fix(bundler): preserve ESM kind + drop tree-shaken targets in CJS preamble
- `7ab74792` chore(simplify): /simplify followup — ExportsKind.isEsm 헬퍼 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)