### PR TITLE
fix(bundler): node resolve에서 module 필드 우선

### DIFF
--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -138,6 +138,41 @@ test "PackageJson: main field fallback" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-main\"") != null);
 }
 
+test "PackageJson: react-native platform follows Metro main field order" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { value } from 'rnpkg';\nconsole.log(value);");
+    try writeFile(tmp.dir, "node_modules/rnpkg/package.json",
+        \\{
+        \\  "name": "rnpkg",
+        \\  "react-native": "./rn.js",
+        \\  "browser": "./browser.js",
+        \\  "module": "./module.js",
+        \\  "main": "./main.js"
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/rnpkg/rn.js", "export const value = 'from-react-native';");
+    try writeFile(tmp.dir, "node_modules/rnpkg/browser.js", "export const value = 'from-browser';");
+    try writeFile(tmp.dir, "node_modules/rnpkg/module.js", "export const value = 'from-module';");
+    try writeFile(tmp.dir, "node_modules/rnpkg/main.js", "export const value = 'from-main';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-react-native\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-browser\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-module\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-main\"") == null);
+}
+
 test "PackageJson: no package.json index.js fallback" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -135,15 +135,16 @@ pub const ResolveCache = struct {
     }
 
     /// 플랫폼별 기본 main_fields 순서. 사용자가 --main-fields를 지정하지 않으면 적용.
-    /// esbuild/rolldown 호환: browser는 "browser" 필드(string)로 main을 교체해야 debug 같은
-    /// 패키지가 올바르게 브라우저 빌드로 해석된다.
+    /// Rspack/Webpack-style ESM-friendly 기본값: `module` 필드를 `main`보다 우선한다.
+    /// browser는 "browser" 필드(string)로 main을 교체해야 debug 같은 패키지가 올바르게
+    /// 브라우저 빌드로 해석된다.
     fn defaultMainFieldsFor(platform: Platform) []const []const u8 {
         const f = pkg_json.field;
         return switch (platform) {
             .browser => &.{ f.browser, f.module, f.main },
-            .node => &.{ f.main, f.module },
-            .neutral => &.{ f.main, f.module },
-            .react_native => &.{ f.react_native, f.browser, f.module, f.main },
+            .node => &.{ f.module, f.main },
+            .neutral => &.{ f.module, f.main },
+            .react_native => &.{ f.react_native, f.browser, f.main },
         };
     }
 

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -224,7 +224,7 @@ pub const Resolver = struct {
     /// RN 예: .ios.ts, .ios.tsx, .native.ts, .native.tsx, .ts, .tsx, .js, .jsx, .json
     custom_extensions: []const []const u8 = &.{},
     /// package.json 필드 해석 순서 (--main-fields). 비어있으면 기본 순서 (module → main).
-    /// RN 예: react-native, browser, main, module
+    /// RN 예: react-native, browser, main
     main_fields: []const []const u8 = &.{},
     /// 디렉토리 엔트리 캐시. null이면 캐시 없이 매번 stat() 호출 (테스트용).
     dir_cache: ?*DirEntryCache = null,


### PR DESCRIPTION
## 배경

Smoke size 비교에서 `graphql` 번들이 ZTS만 474KB로 크게 나왔습니다. 확인해보니 production 여부 문제가 아니라 package.json entry 선택 문제였습니다.

`graphql` package.json은 다음처럼 `main`과 `module`을 둘 다 제공합니다.

```json
{ "main": "index", "module": "index.mjs" }
```

기존 ResolveCache의 node/neutral 기본 main_fields가 `main,module` 순서라 ZTS가 CJS `index.js` barrel을 먼저 잡고 있었습니다. 이 경우 GraphQL 전체 surface가 CJS require graph로 들어와 tree-shaking이 거의 불가능해집니다.

## 문서 확인

- Node 런타임 공식 필드는 `main` / `exports` / `type` / `imports` 중심이며, top-level `module`은 Node 표준 필드가 아닙니다.
- esbuild/rolldown의 `platform=node` 기본값은 호환성을 위해 `main,module`입니다.
- webpack/rspack의 node target 기본값은 `module,main`입니다.
- Metro의 React Native 기본 `resolverMainFields`는 `react-native,browser,main`입니다. `module`은 RN 기본 순서에 없습니다.

따라서 이번 변경은 “Node 런타임 호환 기본값”이 아니라, ZTS 번들러의 node/neutral 기본값을 rspack/webpack과 같은 ESM-friendly 기준으로 맞추는 변경입니다. React Native는 Metro 호환을 우선해서 `react-native,browser,main`을 유지합니다.

## 변경 내용

- node/neutral 기본 main_fields를 `module,main`으로 변경
- react-native 기본 main_fields를 Metro와 동일한 `react-native,browser,main`으로 정리
- RN main field order 회귀 테스트 추가

## 로컬 확인

```sh
zig build test --summary all -- "PackageJson: module field preferred over main"
zig build test --summary all -- "PackageJson: react-native platform follows Metro main field order"
zig build -Doptimize=ReleaseFast
bun run tests/benchmark/smoke.ts --filter=graphql
```

결과:

```text
graphql: ZTS 474KB -> 53KB
rspack baseline: 100KB
ratio: 4.76x fail -> 0.53x pass
```

## 참고

`graphql`이 패치 후 rspack보다 더 작게 나오는 이유는 `index.mjs`를 잡으면서 ESM tree-shaking이 먹고, ZTS가 unused parser exports 일부를 제거하며 compact 출력까지 겹치기 때문입니다.
