### PR TITLE
fix: tree-shaking 전에 linker constant 전파

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -893,6 +893,20 @@ pub const Bundler = struct {
         var shaker: ?TreeShaker = if (!self.options.dev_mode and self.options.scope_hoist and self.options.tree_shaking) blk: {
             var s = try TreeShaker.init(self.allocator, &graph, &(linker.?));
             try s.analyze(self.options.entry_points);
+            if (self.options.minify_syntax and !self.options.code_splitting) {
+                if (linker) |*l| {
+                    l.clearCanonicalNames();
+                    l.clearMangling();
+                    try l.computeRenames();
+                    if (self.options.minify_identifiers) {
+                        try l.computeMangling();
+                    }
+                    l.populateReExportAliases();
+                    l.populateImportSymbols();
+                    l.populateNamespaceAccesses();
+                    l.populateSymbolRefCounts();
+                }
+            }
             // metadata builder 가 `Module.is_included` 비트를 신뢰해 tree-shake 된 target 의
             // CJS preamble emit 을 건너뛸 수 있도록 plug. analyze() 가 끝난 뒤 mirror 가
             // 모든 모듈의 `is_included` 비트를 확정해 둔다.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -644,14 +644,10 @@ pub const Bundler = struct {
         // #1621: worker 청크도 minify 시 preamble 축약 이름 사용.
         worker_linker.minify_whitespace = self.options.minify_whitespace;
         try worker_linker.link();
-        try worker_linker.computeRenames();
-        if (self.options.minify_identifiers) {
-            try worker_linker.computeMangling();
-        }
-        worker_linker.populateReExportAliases();
-        worker_linker.populateImportSymbols();
-        worker_linker.populateNamespaceAccesses();
-        worker_linker.populateSymbolRefCounts();
+        try worker_linker.finalize(.{
+            .compute_renames = true,
+            .compute_mangling = self.options.minify_identifiers,
+        });
         defer worker_linker.deinit();
 
         // emit (IIFE 포맷)
@@ -860,23 +856,13 @@ pub const Bundler = struct {
             l.iife_globals = self.options.globals;
             if (mangle_report_enabled) l.mangle_report = &mangle_collector;
             try l.link();
-            if (!self.options.code_splitting) {
-                try l.computeRenames();
-                if (self.options.minify_identifiers) {
-                    try l.computeMangling();
-                }
-            }
-            // Phase 3b (#1328): re_export_alias 심볼의 canonical_name 채우기.
-            // computeRenames 이후에 호출해야 getCanonicalName이 최종 리네임을 반영.
-            l.populateReExportAliases();
-            // ImportBinding.symbol(source-side) + local_symbol(current-side) 채움.
-            l.populateImportSymbols();
-            // #1603 Phase 1b: `import { M }` → `export * as M from ...` (virtual namespace)
-            // 패턴에서 소비자 측 AST 멤버 접근을 수집해 namespace_used_properties 채움.
-            // tree-shaker가 source 모듈의 미사용 export를 정밀 prune 가능.
-            l.populateNamespaceAccesses();
-            // symbol-level ref_count 수집. tree-shaking companion metric.
-            l.populateSymbolRefCounts();
+            // Phase 3b (#1328): populateReExportAliases 가 canonical_name 을 채우려면
+            // computeRenames 이후여야 한다. populateImportSymbols / NamespaceAccesses /
+            // SymbolRefCounts (tree-shaking companion metric) 까지 한 번에 묶어 emit.
+            try l.finalize(.{
+                .compute_renames = !self.options.code_splitting,
+                .compute_mangling = self.options.minify_identifiers,
+            });
             break :blk l;
         } else null;
         defer if (linker) |*l| l.deinit();
@@ -894,18 +880,13 @@ pub const Bundler = struct {
             var s = try TreeShaker.init(self.allocator, &graph, &(linker.?));
             try s.analyze(self.options.entry_points);
             if (self.options.minify_syntax and !self.options.code_splitting) {
-                if (linker) |*l| {
-                    l.clearCanonicalNames();
-                    l.clearMangling();
-                    try l.computeRenames();
-                    if (self.options.minify_identifiers) {
-                        try l.computeMangling();
-                    }
-                    l.populateReExportAliases();
-                    l.populateImportSymbols();
-                    l.populateNamespaceAccesses();
-                    l.populateSymbolRefCounts();
-                }
+                // tree-shaker 가 module.semantic 을 재생성한 뒤이므로 stale rename/mangling
+                // 을 비우고 다시 계산해야 emit 단계에서 새 symbol id 를 따라가는 산출물이 된다.
+                try (&(linker.?)).finalize(.{
+                    .compute_renames = true,
+                    .compute_mangling = self.options.minify_identifiers,
+                    .clear_first = true,
+                });
             }
             // metadata builder 가 `Module.is_included` 비트를 신뢰해 tree-shake 된 target 의
             // CJS preamble emit 을 건너뛸 수 있도록 plug. analyze() 가 끝난 뒤 mirror 가

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -8,6 +8,26 @@ const test_helpers = @import("../test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
 
+fn expectNoDuplicatePrivateMethodParams(output: []const u8) !void {
+    var search_from: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, output, search_from, '#')) |hash_pos| {
+        const open_rel = std.mem.indexOfScalar(u8, output[hash_pos..], '(') orelse return;
+        const open = hash_pos + open_rel;
+        const close_rel = std.mem.indexOfScalar(u8, output[open + 1 ..], ')') orelse return;
+        const params = output[open + 1 .. open + 1 + close_rel];
+        var seen = std.StringHashMap(void).init(std.testing.allocator);
+        defer seen.deinit();
+        var it = std.mem.splitScalar(u8, params, ',');
+        while (it.next()) |raw| {
+            const name = std.mem.trim(u8, raw, " \t\r\n");
+            if (name.len == 0 or std.mem.indexOfAny(u8, name, "{}[]=.") != null) continue;
+            if (seen.contains(name)) return error.DuplicatePrivateMethodParameter;
+            try seen.put(name, {});
+        }
+        search_from = open + 1 + close_rel + 1;
+    }
+}
+
 test "Scope hoisting: arrow param shadow should not be renamed when namespace import conflicts" {
     // zod 패턴: import * as checks + (...checks) => { checks.map(...) }
     // 두 모듈의 namespace import 이름이 충돌해도, arrow 파라미터의 body 참조는 rename 안 됨
@@ -727,6 +747,244 @@ test "Minify: production env derived DEV flag folds through string methods" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "toLowerCase") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "startsWith") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log(\"prod\")") != null);
+}
+
+test "Minify: cross-module default DEV flag removes dead import fanout" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import DEV from './dev';
+        \\import { heavy } from './heavy';
+        \\if (DEV) {
+        \\  heavy();
+        \\}
+        \\console.log("prod");
+    );
+    try writeFile(tmp.dir, "dev.ts",
+        \\export default false;
+    );
+    try writeFile(tmp.dir, "heavy.ts",
+        \\export function heavy() {
+        \\  console.log("HEAVY_DEV_ONLY");
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "HEAVY_DEV_ONLY") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "heavy") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log(\"prod\")") != null);
+}
+
+test "Minify: cross-module derived default DEV flag removes long diagnostic branch" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { lifecycle_outside_component } from './errors';
+        \\lifecycle_outside_component("onMount");
+    );
+    try writeFile(tmp.dir, "dev-fallback.ts",
+        \\const node_env = "production";
+        \\export default node_env && !node_env.toLowerCase().startsWith("prod");
+    );
+    try writeFile(tmp.dir, "errors.ts",
+        \\import DEV from './dev-fallback';
+        \\export function lifecycle_outside_component(name: string) {
+        \\  if (DEV) {
+        \\    throw new Error(`lifecycle_outside_component ${name} LONG_DEV_DIAGNOSTIC`);
+        \\  } else {
+        \\    throw new Error("https://svelte.dev/e/lifecycle_outside_component");
+        \\  }
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LONG_DEV_DIAGNOSTIC") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "toLowerCase") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "startsWith") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "https://svelte.dev/e/lifecycle_outside_component") != null);
+}
+
+test "Minify: cross-module true DEV flag keeps live import fanout" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import DEV from './dev';
+        \\import { heavy } from './heavy';
+        \\if (DEV) {
+        \\  heavy();
+        \\}
+        \\console.log("after");
+    );
+    try writeFile(tmp.dir, "dev.ts",
+        \\export default true;
+    );
+    try writeFile(tmp.dir, "heavy.ts",
+        \\export function heavy() {
+        \\  console.log("HEAVY_LIVE_BRANCH");
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "HEAVY_LIVE_BRANCH") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log(\"after\")") != null);
+}
+
+test "Minify: re-exported default DEV flag removes dead import fanout" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { DEV } from './barrel';
+        \\import { heavy } from './heavy';
+        \\if (DEV) heavy();
+        \\console.log("prod");
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\export { default as DEV } from './dev';
+    );
+    try writeFile(tmp.dir, "dev.ts",
+        \\export default false;
+    );
+    try writeFile(tmp.dir, "heavy.ts",
+        \\export function heavy() {
+        \\  console.log("REEXPORTED_DEV_DEAD_BRANCH");
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "REEXPORTED_DEV_DEAD_BRANCH") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log(\"prod\")") != null);
+}
+
+test "Minify: constant fact materialization preserves object shorthand keys" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import DEV from './dev';
+        \\const obj = { DEV };
+        \\console.log(obj.DEV);
+    );
+    try writeFile(tmp.dir, "dev.ts",
+        \\export default false;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "{false") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DEV") != null);
+}
+
+test "Minify: refreshed semantic recomputes mangling after constant fact DCE" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import DEV from './dev';
+        \\import { dead } from './dead';
+        \\class Batch {
+        \\  #process(root, effects, deferred) {
+        \\    for (const effect of effects) {
+        \\      deferred.push(root + effect);
+        \\    }
+        \\    return deferred.length;
+        \\  }
+        \\  run(items) {
+        \\    const pending = [];
+        \\    return this.#process(1, items, pending);
+        \\  }
+        \\}
+        \\if (DEV) dead();
+        \\console.log(new Batch().run([1, 2, 3]));
+    );
+    try writeFile(tmp.dir, "dev.ts",
+        \\const node_env = "production";
+        \\export default node_env && !node_env.toLowerCase().startsWith("prod");
+    );
+    try writeFile(tmp.dir, "dead.ts",
+        \\export function dead() {
+        \\  console.log("PRIVATE_MANGLE_DEAD_BRANCH");
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "PRIVATE_MANGLE_DEAD_BRANCH") == null);
+    try expectNoDuplicatePrivateMethodParams(result.output);
 }
 
 test "TreeShaking: seedAllStmts propagates export * chain — cheerio pattern" {

--- a/src/bundler/constant_facts.zig
+++ b/src/bundler/constant_facts.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const ast_mod = @import("../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const Node = ast_mod.Node;
+const ConstValue = @import("../semantic/symbol.zig").ConstValue;
+
+fn markForbiddenSites(ast: *const Ast, forbidden: *std.DynamicBitSet) void {
+    for (ast.nodes.items) |node| {
+        if (node.tag != .object_property) continue;
+        if (!node.data.binary.right.isNone()) continue;
+        const key_ni = @intFromEnum(node.data.binary.left);
+        if (key_ni < forbidden.capacity()) forbidden.set(key_ni);
+    }
+}
+
+fn constValueNode(ast: *Ast, cv: ConstValue) ?Node {
+    return switch (cv.kind) {
+        .true_, .false_ => blk: {
+            const text = if (cv.kind == .true_) "true" else "false";
+            const span = ast.addString(text) catch return null;
+            break :blk .{
+                .tag = .boolean_literal,
+                .span = span,
+                .data = .{ .none = 0 },
+            };
+        },
+        .null_ => blk: {
+            const span = ast.addString("null") catch return null;
+            break :blk .{
+                .tag = .null_literal,
+                .span = span,
+                .data = .{ .none = 0 },
+            };
+        },
+        else => null,
+    };
+}
+
+/// Linker가 증명한 primitive constants를 AST read-site에 반영한다.
+/// codegen-only 치환은 branch body refs를 줄이지 못하므로, minify/DCE 전 literal로
+/// materialize해야 dead branch와 그 안의 imports가 다음 pass에서 사라질 수 있다.
+pub fn materialize(
+    allocator: std.mem.Allocator,
+    ast: *Ast,
+    symbol_ids: []const ?u32,
+    const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+) bool {
+    if (const_values.count() == 0) return false;
+
+    var forbidden = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
+    defer forbidden.deinit();
+    markForbiddenSites(ast, &forbidden);
+
+    var changed = false;
+    for (ast.nodes.items, 0..) |node, i| {
+        if (node.tag != .identifier_reference) continue;
+        if (i >= symbol_ids.len) continue;
+        if (forbidden.isSet(i)) continue;
+        const sym_id = symbol_ids[i] orelse continue;
+        const cv = const_values.get(sym_id) orelse continue;
+        const replacement = constValueNode(ast, cv) orelse continue;
+        ast.nodes.items[i] = replacement;
+        changed = true;
+    }
+    return changed;
+}

--- a/src/bundler/constant_facts.zig
+++ b/src/bundler/constant_facts.zig
@@ -2,16 +2,9 @@ const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const Node = ast_mod.Node;
+const ast_walk = @import("../parser/ast_walk.zig");
 const ConstValue = @import("../semantic/symbol.zig").ConstValue;
-
-fn markForbiddenSites(ast: *const Ast, forbidden: *std.DynamicBitSet) void {
-    for (ast.nodes.items) |node| {
-        if (node.tag != .object_property) continue;
-        if (!node.data.binary.right.isNone()) continue;
-        const key_ni = @intFromEnum(node.data.binary.left);
-        if (key_ni < forbidden.capacity()) forbidden.set(key_ni);
-    }
-}
+const minify_mod = @import("../transformer/minify.zig");
 
 fn constValueNode(ast: *Ast, cv: ConstValue) ?Node {
     return switch (cv.kind) {
@@ -49,10 +42,16 @@ pub fn materialize(
 
     var forbidden = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
     defer forbidden.deinit();
-    markForbiddenSites(ast, &forbidden);
+    minify_mod.markForbiddenInlineSites(ast, &forbidden);
+
+    // transformer 가 만든 orphan 노드까지 스캔하지 않도록 reachable 만 순회 (#1797 패턴).
+    const reachable = ast_walk.collectReachableNodeIndices(allocator, ast) catch return false;
+    defer allocator.free(reachable);
 
     var changed = false;
-    for (ast.nodes.items, 0..) |node, i| {
+    for (reachable) |ni| {
+        const i: usize = @intCast(ni);
+        const node = ast.nodes.items[i];
         if (node.tag != .identifier_reference) continue;
         if (i >= symbol_ids.len) continue;
         if (forbidden.isSet(i)) continue;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1165,14 +1165,10 @@ pub fn emitModule(
     // dev 에서 아무 minify 안 하는 것과 동일한 trade-off.
     if (!options.dev_mode) {
         const minify_mod = @import("../transformer/minify.zig");
-        const ctx: minify_mod.MinifyCtx = if (module.semantic) |sem| .{
-            .symbols = sem.symbols.items,
-            .symbol_ids = transformer.symbol_ids.items,
-            .scopes = sem.scopes,
-            .unresolved_globals = &sem.unresolved_references,
-            .references = sem.references,
-            .allow_top_level_inline = options.minify_syntax,
-        } else .empty;
+        const ctx: minify_mod.MinifyCtx = if (module.semantic != null)
+            minify_mod.MinifyCtx.fromSemantic(&module.semantic.?, transformer.symbol_ids.items, options.minify_syntax)
+        else
+            .empty;
         minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
     }
 

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -808,7 +808,7 @@ pub const ModuleGraph = struct {
     }
 
     fn replayCachedResolvedDeps(self: *ModuleGraph, mod_idx: usize) !void {
-        if (mod_idx >= self.modules.count()) return;
+        std.debug.assert(mod_idx < self.modules.count());
         const mod_index = ModuleIndex.fromUsize(mod_idx);
         const mod_ptr = self.modules.at(mod_idx);
 
@@ -1697,14 +1697,10 @@ pub const ModuleGraph = struct {
         const root = transformer.transform() catch return;
         if (self.transform_options_base.minify_syntax) {
             const minify_mod = @import("../transformer/minify.zig");
-            const ctx: minify_mod.MinifyCtx = if (module.semantic) |sem| .{
-                .symbols = sem.symbols.items,
-                .symbol_ids = transformer.symbol_ids.items,
-                .scopes = sem.scopes,
-                .unresolved_globals = &sem.unresolved_references,
-                .references = sem.references,
-                .allow_top_level_inline = true,
-            } else .empty;
+            const ctx: minify_mod.MinifyCtx = if (module.semantic != null)
+                minify_mod.MinifyCtx.fromSemantic(&module.semantic.?, transformer.symbol_ids.items, true)
+            else
+                .empty;
             minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
         }
 

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1694,7 +1694,19 @@ pub const ModuleGraph = struct {
         }
         transformer.line_offsets = module.line_offsets;
 
-        _ = transformer.transform() catch return;
+        const root = transformer.transform() catch return;
+        if (self.transform_options_base.minify_syntax) {
+            const minify_mod = @import("../transformer/minify.zig");
+            const ctx: minify_mod.MinifyCtx = if (module.semantic) |sem| .{
+                .symbols = sem.symbols.items,
+                .symbol_ids = transformer.symbol_ids.items,
+                .scopes = sem.scopes,
+                .unresolved_globals = &sem.unresolved_references,
+                .references = sem.references,
+                .allow_top_level_inline = true,
+            } else .empty;
+            minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
+        }
 
         // transformer 가 새 ast (clone) 에 transform 결과를 보유. module.ast 를 그 새 ast 로
         // swap. arena_alloc 가 owner 라 backing 은 안전. emit 단계 transformer 가 module.ast
@@ -1727,7 +1739,7 @@ pub const ModuleGraph = struct {
     /// AST mutation 이후 module 의 분석 산출물을 final AST 기준으로 재생성한다.
     /// 이 함수가 성공한 뒤에는 `module.ast`, semantic, import/export bindings,
     /// prebuilt_stmt_info, alias_table 이 같은 AST 기준이어야 한다 (#1913).
-    fn refreshAnalysisAfterAstMutation(
+    pub fn refreshAnalysisAfterAstMutation(
         self: *ModuleGraph,
         module: *Module,
         arena_alloc: std.mem.Allocator,

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -656,7 +656,9 @@ fn isObjectDefinePropertyExports(ast: *const Ast, node: Node) bool {
         std.mem.eql(u8, target_parts.property, "exports");
 }
 
-fn getStaticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: []const u8, property: []const u8 } {
+const MemberParts = struct { object: []const u8, property: []const u8 };
+
+fn getStaticMemberParts(ast: *const Ast, idx: NodeIndex) ?MemberParts {
     if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
     const node = ast.getNode(idx);
     if (node.tag != .static_member_expression) return null;
@@ -681,34 +683,8 @@ fn getStaticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: []con
 
 /// assignment_expression의 left가 `obj.prop` 형태의 static_member_expression인지 확인하고,
 /// object의 identifier 텍스트를 반환한다. property 텍스트도 함께 반환.
-fn getAssignMemberParts(ast: *const Ast, node: Node) ?struct { object: []const u8, property: []const u8 } {
-    const left_idx = node.data.binary.left;
-    if (left_idx.isNone()) return null;
-    const left_ni = @intFromEnum(left_idx);
-    if (left_ni >= ast.nodes.items.len) return null;
-    const left = ast.nodes.items[left_ni];
-    if (left.tag != .static_member_expression) return null;
-
-    const me = left.data.extra;
-    if (!ast.hasExtra(me, 1)) return null;
-
-    const obj_idx = ast.readExtraNode(me, 0);
-    if (obj_idx.isNone()) return null;
-    const obj_ni = @intFromEnum(obj_idx);
-    if (obj_ni >= ast.nodes.items.len) return null;
-    const obj = ast.nodes.items[obj_ni];
-    if (obj.tag != .identifier_reference) return null;
-
-    const prop_idx = ast.readExtraNode(me, 1);
-    if (prop_idx.isNone()) return null;
-    const prop_ni = @intFromEnum(prop_idx);
-    if (prop_ni >= ast.nodes.items.len) return null;
-    const prop = ast.nodes.items[prop_ni];
-
-    return .{
-        .object = ast.getText(obj.span),
-        .property = ast.getText(prop.span),
-    };
+fn getAssignMemberParts(ast: *const Ast, node: Node) ?MemberParts {
+    return getStaticMemberParts(ast, node.data.binary.left);
 }
 
 /// assignment_expression의 left가 module.exports인지 확인.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -34,6 +34,11 @@ const CompiledModule = @import("compiled_module.zig").CompiledModule;
 /// metadata.zig, codegen.zig, emitter.zig에서 공유.
 pub const NS_VAR_PREFIX = "__ns_";
 
+/// CJS named import의 expression rename 형태: `require_xxx().prop`.
+/// metadata.zig가 이 sentinel 형식으로 rename을 만들고 codegen이 substring 으로
+/// 식별하므로 양쪽이 동일한 marker를 참조해야 한다.
+pub const EXPR_RENAME_MARKER = "().";
+
 /// `__ns_N.prop` 형태의 namespace-access rename 인지 판정.
 pub inline fn isNamespaceRename(rename: []const u8) bool {
     return std.mem.startsWith(u8, rename, NS_VAR_PREFIX);
@@ -44,7 +49,7 @@ pub inline fn isNamespaceRename(rename: []const u8) bool {
 /// binding을 만들지 않는다. dev/HMR payload에서 원본 import가 CJS require로
 /// 재출력되면 같은 binding을 중복 생성하므로 여기서 skip 대상으로 본다.
 pub inline fn isImportExpressionRename(rename: []const u8) bool {
-    return isNamespaceRename(rename) or std.mem.indexOf(u8, rename, "().") != null;
+    return isNamespaceRename(rename) or std.mem.indexOf(u8, rename, EXPR_RENAME_MARKER) != null;
 }
 
 /// `Linker.collectUnifiedInput` 반환 컨테이너. unified_mangler.mangleAll 에
@@ -2606,6 +2611,28 @@ pub const Linker = struct {
         for (self.unified_module_scopes) |*b| b.deinit();
         if (self.unified_module_scopes.len > 0) self.allocator.free(self.unified_module_scopes);
         self.unified_module_scopes = &.{};
+    }
+
+    /// link() 이후 호출 — rename / mangling / populate* 시퀀스를 한 번에 실행.
+    /// bundler 본 path / worker 청크 / tree-shake post-recompute 가 같은 시퀀스를
+    /// 호출하므로 단일 엔트리로 묶어 drift 방지.
+    pub fn finalize(self: *Linker, opts: struct {
+        compute_renames: bool,
+        compute_mangling: bool,
+        clear_first: bool = false,
+    }) !void {
+        if (opts.clear_first) {
+            self.clearCanonicalNames();
+            self.clearMangling();
+        }
+        if (opts.compute_renames) {
+            try self.computeRenames();
+            if (opts.compute_mangling) try self.computeMangling();
+        }
+        self.populateReExportAliases();
+        self.populateImportSymbols();
+        self.populateNamespaceAccesses();
+        self.populateSymbolRefCounts();
     }
 
     /// 특정 모듈들만 대상으로 이름 충돌을 감지하고 리네임을 계산한다.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1173,6 +1173,7 @@ pub const Linker = struct {
     /// 모듈별 중첩 스코프 바인딩 이름을 하나의 HashSet으로 병합.
     /// computeRenames에서 한 번 호출하면, 이후 hasNestedBinding이 O(1)로 동작.
     fn buildNestedNameSets(self: *Linker) !void {
+        self.clearNestedNameSets();
         const count = self.graph.moduleCount();
         const sets = try self.allocator.alloc(std.StringHashMapUnmanaged(void), count);
         for (sets) |*s| s.* = .{};
@@ -1189,6 +1190,16 @@ pub const Linker = struct {
             }
         }
         self.nested_name_sets = sets;
+    }
+
+    fn clearNestedNameSets(self: *Linker) void {
+        for (self.nested_name_sets) |*set| {
+            set.deinit(self.allocator);
+        }
+        if (self.nested_name_sets.len > 0) {
+            self.allocator.free(self.nested_name_sets);
+        }
+        self.nested_name_sets = &.{};
     }
 
     /// ECMAScript 예약어 + CJS 런타임 + 브라우저/Node 주요 글로벌인지 확인.
@@ -2583,6 +2594,18 @@ pub const Linker = struct {
         // O(touched): putCanonicalName이 기록한 dirty 심볼만 reset.
         for (self.canonical_symbols.items) |sym| sym.canonical_name = "";
         self.canonical_symbols.clearRetainingCapacity();
+    }
+
+    /// unified mangling 산출물을 초기화한다. AST mutation 후 semantic을 재생성한 경우
+    /// old symbol id 기준 mangling 결과를 emit에 재사용하면 잘못된 rename이 적용된다.
+    pub fn clearMangling(self: *Linker) void {
+        if (self.unified_result) |*ur| {
+            ur.deinit();
+            self.unified_result = null;
+        }
+        for (self.unified_module_scopes) |*b| b.deinit();
+        if (self.unified_module_scopes.len > 0) self.allocator.free(self.unified_module_scopes);
+        self.unified_module_scopes = &.{};
     }
 
     /// 특정 모듈들만 대상으로 이름 충돌을 감지하고 리네임을 계산한다.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -26,6 +26,7 @@ const isNamespaceUsedAsValue = Linker.isNamespaceUsedAsValue;
 const isReservedName = Linker.isReservedName;
 const NamePair = PreambleWriter.NamePair;
 const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
+const EXPR_RENAME_MARKER = linker_mod.EXPR_RENAME_MARKER;
 
 /// #1791 Phase D: import binding 의 local 이 value 로 참조된 적이 있는지 조회.
 /// analyzer 가 각 Reference 에 `type_context` / `value_as_type` flag 를 기록하므로,
@@ -371,7 +372,7 @@ pub fn buildMetadataForAst(
                     const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
                     if (ib.kind == .named and !std.mem.eql(u8, ib.imported_name, "default")) {
                         if (ib.local_symbol.semanticIndex()) |sym_idx| {
-                            const direct_access = try std.fmt.allocPrint(self.allocator, "{s}().{s}", .{ req_var, ib.imported_name });
+                            const direct_access = try std.fmt.allocPrint(self.allocator, "{s}" ++ EXPR_RENAME_MARKER ++ "{s}", .{ req_var, ib.imported_name });
                             errdefer self.allocator.free(direct_access);
                             try owned_nested_renames.append(self.allocator, direct_access);
                             try renames.put(sym_idx, direct_access);
@@ -838,6 +839,7 @@ pub fn buildCrossModuleConstValues(
     _: @import("../module.zig").ModuleSemanticData,
 ) !std.AutoHashMapUnmanaged(u32, @import("../../semantic/symbol.zig").ConstValue) {
     var const_values: std.AutoHashMapUnmanaged(u32, @import("../../semantic/symbol.zig").ConstValue) = .{};
+    if (m.import_bindings.len == 0) return const_values;
     for (m.import_bindings) |ib| {
         if (ib.import_record_index >= m.import_records.len) continue;
         const rec = m.import_records[ib.import_record_index];

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -22,17 +22,26 @@ const ModuleGraph = @import("graph.zig").ModuleGraph;
 const ExportBinding = @import("binding_scanner.zig").ExportBinding;
 const ImportBinding = @import("binding_scanner.zig").ImportBinding;
 const Linker = @import("linker.zig").Linker;
-const Ast = @import("../parser/ast.zig").Ast;
-const Node = @import("../parser/ast.zig").Node;
-const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const ast_mod = @import("../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
 const purity = @import("purity.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const StmtInfos = stmt_info_mod.ModuleStmtInfos;
+const constant_facts = @import("constant_facts.zig");
 
 /// `used_exports`의 all-exports-used sentinel. 모듈의 전체 export가 사용됨을 표시.
 /// 일반 export 이름과 겹치지 않도록 의도적으로 JS 식별자 아닌 `"*"` 선택.
 /// (export_bindings의 `exported_name == "*"`는 wildcard re-export로 의미가 다름 — 같은 문자열, 다른 공간)
 pub const ALL_EXPORTS_SENTINEL: []const u8 = "*";
+
+fn isImportDeclarationStmt(m: *const Module, infos: StmtInfos, stmt_idx: u32) bool {
+    if (stmt_idx >= infos.stmts.len) return false;
+    const ast = &(m.ast orelse return false);
+    const ni: usize = infos.stmts[stmt_idx].node_idx;
+    return ni < ast.nodes.items.len and ast.nodes.items[ni].tag == .import_declaration;
+}
 
 pub const TreeShaker = struct {
     allocator: std.mem.Allocator,
@@ -161,6 +170,36 @@ pub const TreeShaker = struct {
                     self.entry_set.set(i);
                     break;
                 }
+            }
+        }
+
+        if (self.graph.transform_options_base.minify_syntax) {
+            // Linker가 증명한 cross-module constant를 tree-shaking 전 AST에 먼저 반영한다.
+            // 그래야 `if (DEV) heavy()` 같은 dead branch 안 import가 BFS seed로 번지지 않는다.
+            for (0..mod_count) |i| {
+                const m = self.moduleAtMut(@intCast(i)) orelse continue;
+                const sem = m.semantic orelse continue;
+                const ast = &(m.ast orelse continue);
+                var const_values = try self.linker.buildCrossModuleConstValues(m, sem);
+                const changed = constant_facts.materialize(self.allocator, ast, sem.symbol_ids, &const_values);
+                const_values.deinit(self.allocator);
+                if (!changed) continue;
+
+                const minify_mod = @import("../transformer/minify.zig");
+                const root = ast.transformed_root orelse NodeIndex.none;
+                const ctx: minify_mod.MinifyCtx = .{
+                    .symbols = sem.symbols.items,
+                    .symbol_ids = sem.symbol_ids,
+                    .scopes = sem.scopes,
+                    .unresolved_globals = &sem.unresolved_references,
+                    .references = sem.references,
+                    .allow_top_level_inline = true,
+                };
+                minify_mod.minify(ast, ctx, self.allocator, root);
+                const refresh_alloc = if (m.parse_arena) |*arena| arena.allocator() else self.allocator;
+                self.graph.refreshAnalysisAfterAstMutation(m, refresh_alloc) catch {
+                    m.prebuilt_stmt_info = null;
+                };
             }
         }
 
@@ -374,7 +413,9 @@ pub const TreeShaker = struct {
         // 역인덱스로 이 심볼을 참조하는 statement 중 reachable한 것이 있는지 확인
         if (sym_idx < infos.sym_to_referencing_stmts.len) {
             for (infos.sym_to_referencing_stmts[sym_idx]) |si| {
-                if (reachable.isSet(si)) return true;
+                if (!reachable.isSet(si)) continue;
+                if (isImportDeclarationStmt(m, infos, @intCast(si))) continue;
+                return true;
             }
         }
         return false;
@@ -580,6 +621,8 @@ pub const TreeShaker = struct {
                     if (self.sym_to_ib[item.mod]) |sym_map| {
                         if (ref_sym < sym_map.len) {
                             if (sym_map[ref_sym]) |ib_idx| {
+                                const owner = self.getModule(item.mod) orelse continue;
+                                if (isImportDeclarationStmt(owner, infos, item.stmt)) continue;
                                 try self.followImport(item.mod, ib_idx, item.stmt, &queue, module_stmt_infos, reachable_stmts);
                             }
                         }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -187,17 +187,12 @@ pub const TreeShaker = struct {
 
                 const minify_mod = @import("../transformer/minify.zig");
                 const root = ast.transformed_root orelse NodeIndex.none;
-                const ctx: minify_mod.MinifyCtx = .{
-                    .symbols = sem.symbols.items,
-                    .symbol_ids = sem.symbol_ids,
-                    .scopes = sem.scopes,
-                    .unresolved_globals = &sem.unresolved_references,
-                    .references = sem.references,
-                    .allow_top_level_inline = true,
-                };
+                const ctx = minify_mod.MinifyCtx.fromSemantic(&m.semantic.?, sem.symbol_ids, true);
                 minify_mod.minify(ast, ctx, self.allocator, root);
-                const refresh_alloc = if (m.parse_arena) |*arena| arena.allocator() else self.allocator;
-                self.graph.refreshAnalysisAfterAstMutation(m, refresh_alloc) catch {
+                // parse_arena 는 parse 단계에서 모든 모듈에 부착된다 (#1323). null 이면
+                // 분석 산출물이 self.allocator 로 새서 leak 되므로 invariant 로 강제.
+                std.debug.assert(m.parse_arena != null);
+                self.graph.refreshAnalysisAfterAstMutation(m, m.parse_arena.?.allocator()) catch {
                     m.prebuilt_stmt_info = null;
                 };
             }
@@ -601,6 +596,10 @@ pub const TreeShaker = struct {
             const infos = module_stmt_infos[item.mod] orelse continue;
             if (item.stmt >= infos.stmts.len) continue;
 
+            // item 단위 invariant — referenced_symbols 루프 밖으로 한 번만 계산.
+            const owner = self.getModule(item.mod);
+            const skip_import_followup = if (owner) |o| isImportDeclarationStmt(o, infos, item.stmt) else true;
+
             for (infos.stmts[item.stmt].referenced_symbols) |ref_sym| {
                 // (1) 로컬 심볼: 같은 모듈의 종속 statement
                 if (infos.declaredStmtBySymbol(ref_sym)) |dep_stmt| {
@@ -617,12 +616,11 @@ pub const TreeShaker = struct {
                 }
 
                 // (2) import binding: 타겟 모듈로 점프
+                if (skip_import_followup) continue;
                 if (item.mod < self.sym_to_ib.len) {
                     if (self.sym_to_ib[item.mod]) |sym_map| {
                         if (ref_sym < sym_map.len) {
                             if (sym_map[ref_sym]) |ib_idx| {
-                                const owner = self.getModule(item.mod) orelse continue;
-                                if (isImportDeclarationStmt(owner, infos, item.stmt)) continue;
                                 try self.followImport(item.mod, ib_idx, item.stmt, &queue, module_stmt_infos, reachable_stmts);
                             }
                         }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -655,13 +655,20 @@ pub const SemanticAnalyzer = struct {
         return self.current_scope; // fallback (shouldn't happen)
     }
 
-    /// 특정 스코프에서 이름으로 심볼을 찾는다.
-    /// per-scope HashMap으로 O(1) 조회 (이전: O(N) 선형 스캔).
-    fn findSymbolInScope(self: *const SemanticAnalyzer, scope_id: ScopeId, name: []const u8) ?Symbol {
+    /// 특정 스코프에서 이름으로 심볼 인덱스를 찾는다. 경계/.none/empty 매핑은 null.
+    fn findSymbolIndexInScope(self: *const SemanticAnalyzer, scope_id: ScopeId, name: []const u8) ?usize {
         if (scope_id.isNone()) return null;
         const idx = scope_id.toIndex();
         if (idx >= self.scope_maps.items.len) return null;
         const sym_idx = self.scope_maps.items[idx].get(name) orelse return null;
+        if (sym_idx >= self.symbols.items.len) return null;
+        return sym_idx;
+    }
+
+    /// 특정 스코프에서 이름으로 심볼을 찾는다.
+    /// per-scope HashMap으로 O(1) 조회 (이전: O(N) 선형 스캔).
+    fn findSymbolInScope(self: *const SemanticAnalyzer, scope_id: ScopeId, name: []const u8) ?Symbol {
+        const sym_idx = self.findSymbolIndexInScope(scope_id, name) orelse return null;
         return self.symbols.items[sym_idx];
     }
 
@@ -857,12 +864,7 @@ pub const SemanticAnalyzer = struct {
     /// 현재 스코프에서 이름으로 symbol을 찾아 no_side_effects 플래그를 설정.
     /// 현재 스코프에서 이름으로 심볼 인덱스를 찾는다.
     fn findSymbolInCurrentScope(self: *const SemanticAnalyzer, name_span: Span) ?usize {
-        const name = self.ast.getText(name_span);
-        const scope_idx = self.current_scope.toIndex();
-        if (scope_idx >= self.scope_maps.items.len) return null;
-        const sym_idx = self.scope_maps.items[scope_idx].get(name) orelse return null;
-        if (sym_idx >= self.symbols.items.len) return null;
-        return sym_idx;
+        return self.findSymbolIndexInScope(self.current_scope, self.ast.getText(name_span));
     }
 
     fn markSymbolNoSideEffects(self: *SemanticAnalyzer, name_span: Span) void {
@@ -886,14 +888,9 @@ pub const SemanticAnalyzer = struct {
     /// predeclare 1st pass에서 declareSymbol(node_idx=null)로 등록된 심볼은
     /// symbol_ids에 매핑이 없으므로, 2nd pass에서 skip 시 여기서 보충한다.
     fn setSymbolIdForPredeclared(self: *SemanticAnalyzer, name_span: Span, node_idx: u32) void {
-        const sym_idx = self.findSymbolInCurrentScope(name_span) orelse blk: {
-            const name = self.ast.getText(name_span);
-            const var_scope = self.findVarScope();
-            if (!var_scope.isNone() and var_scope.toIndex() < self.scope_maps.items.len) {
-                if (self.scope_maps.items[var_scope.toIndex()].get(name)) |idx| break :blk idx;
-            }
-            return;
-        };
+        const name = self.ast.getText(name_span);
+        const sym_idx = self.findSymbolIndexInScope(self.current_scope, name) orelse
+            self.findSymbolIndexInScope(self.findVarScope(), name) orelse return;
         if (node_idx < self.symbol_ids.items.len) {
             self.symbol_ids.items[node_idx] = @intCast(sym_idx);
         }

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -60,6 +60,23 @@ pub const MinifyCtx = struct {
         .unresolved_globals = null,
     };
 
+    /// `module.semantic` + 호출 사이트의 `symbol_ids` 로 ctx 를 생성. transformer 진행 중에는
+    /// transformer.symbol_ids 를, 정착된 분석 산출물을 다룰 때는 sem.symbol_ids 를 넘긴다.
+    pub fn fromSemantic(
+        sem: anytype,
+        symbol_ids: []const ?u32,
+        allow_top_level_inline: bool,
+    ) MinifyCtx {
+        return .{
+            .symbols = sem.symbols.items,
+            .symbol_ids = symbol_ids,
+            .scopes = sem.scopes,
+            .unresolved_globals = &sem.unresolved_references,
+            .references = sem.references,
+            .allow_top_level_inline = allow_top_level_inline,
+        };
+    }
+
     /// semantic 정보 3축 (symbols / symbol_ids / scopes) 이 모두 채워졌는지 확인.
     /// scopes 누락 시 eval / with 가드가 silent 통과되어 직접 eval 스코프 안의 변수가
     /// 잘못 제거될 수 있으므로, 세 필드 모두 요구하는 all-or-nothing 계약.
@@ -582,7 +599,7 @@ fn decrementRefsInExpr(ast: *const Ast, ctx: MinifyCtx, idx: NodeIndex) void {
 // 일반 expression inline (식별자 포함 init) 은 이 PR 범위 밖 — 개입 write 의
 // evaluate-order 안전성을 별도로 증명해야 함 (esbuild 의 sequence-rewrite).
 
-fn markForbiddenInlineSites(ast: *const Ast, forbidden: *std.DynamicBitSet) void {
+pub fn markForbiddenInlineSites(ast: *const Ast, forbidden: *std.DynamicBitSet) void {
     for (ast.nodes.items) |node| {
         if (node.tag != .object_property) continue;
         if (!node.data.binary.right.isNone()) continue;


### PR DESCRIPTION
## 요약
- linker가 증명한 cross-module primitive constant를 AST read-site에 materialize하는 공용 helper를 추가했습니다.
- tree-shaking 전에 `DEV=false` 같은 import default constant를 literal로 바꾸고 minify/재분석을 수행해 dead branch 안 import fanout이 BFS seed로 번지지 않게 했습니다.
- graph pre-pass에서도 minify_syntax일 때 transform 직후 minify를 수행해 `node_env.toLowerCase().startsWith("prod")` 형태의 derived default export가 linker const fact로 잡히게 했습니다.
- tree-shaker 이후 semantic이 재생성되면 linker rename/mangling 산출물도 stale해지므로, emit 전에 rename/mangling 상태를 재계산하도록 했습니다.
- import declaration 자체의 binding reference는 live value usage로 보지 않도록 필터링했습니다.

## 추가 테스트
- false default import가 dead branch import fanout을 제거하는지 확인
- derived default DEV flag가 긴 diagnostic branch를 제거하는지 확인
- true default import는 live branch/import를 보존하는지 확인
- re-exported default DEV flag도 dead branch import fanout을 제거하는지 확인
- object shorthand key 위치는 constant materialize 대상에서 제외되는지 확인
- refreshed semantic 이후 stale mangling으로 private method parameter가 중복 rename되지 않는지 확인

## 검증
- `zig build test --summary all` — 3971/3971 통과
- `zig build`
- `bun run tests/benchmark/smoke.ts --filter=svelte-`
- `bun run tests/benchmark/smoke.ts --filter=react`

## 확인한 크기 변화
- react: 16KB
- react-dom: 445KB
- svelte-mount: 81KB
- svelte-full: 87KB
- svelte-mount-min: 12KB, 실행 MATCH
- svelte-full-min: 14KB, 실행 MATCH