### PR TITLE
CJS named import 헬퍼 오버헤드 줄이기

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1543,6 +1543,36 @@ test "TreeShaking: export star from CJS keeps wrapped source for named import" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_STAR_UNUSED_MARKER") != null);
 }
 
+test "TreeShaking: named-only CJS import does not inject __toESM helper cluster" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './source.cjs';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "source.cjs",
+        \\exports.used = function() { return "CJS_NAMED_ONLY_USED"; };
+        \\exports.unused = function() { return "CJS_NAMED_ONLY_UNUSED"; };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_NAMED_ONLY_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_source().used") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__copyProps") == null);
+}
+
 test "TreeShaking: unused direct re-export source with local init is pruned" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1676,10 +1676,12 @@ fn emitBundleRuntimeHelpers(
     // 런타임 헬퍼 주입: 래핑 모듈 유형에 따라 필요한 헬퍼 결정.
     var needs_cjs_runtime = false;
     var needs_esm_wrap_runtime = false;
+    var needs_to_esm_runtime = false;
     var needs_to_binary = false;
     for (sorted_modules) |m| {
         if (m.wrap_kind == .cjs) needs_cjs_runtime = true;
         if (m.wrap_kind == .esm) needs_esm_wrap_runtime = true;
+        if (moduleNeedsToEsmInterop(m, sorted_modules)) needs_to_esm_runtime = true;
         if (m.loader == .binary) needs_to_binary = true;
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
@@ -1688,8 +1690,14 @@ fn emitBundleRuntimeHelpers(
         if (needs_cjs_runtime and options.platform == .node and options.format == .esm) {
             try rt.appendRequireShim(output, allocator, options.minify_whitespace);
         }
-        // __toESM, __copyProps, __defProp은 CJS/ESM 양쪽에서 공유
-        try rt.appendCjsRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
+        if (needs_cjs_runtime) {
+            try rt.appendCommonJsFactoryRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
+        }
+        // __toCommonJS depends on __copyProps/__defProp, so ESM wrappers still need
+        // the __toESM helper cluster even if no CJS import site calls __toESM.
+        if (needs_to_esm_runtime or needs_esm_wrap_runtime) {
+            try rt.appendToEsmRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
+        }
     }
     if (needs_esm_wrap_runtime) {
         try rt.appendEsmWrapRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
@@ -1716,6 +1724,25 @@ fn emitBundleRuntimeHelpers(
     // 환경에서 dead code 0. consumer 가 환경 (e.g. expo) 감지 후 패턴 주입.
     try rt.emitConsoleErrorInterceptInto(output, allocator, options.silent_console_error_patterns, options.minify_whitespace);
     try emitOptionPathHelpers(output, allocator, needs_to_binary, options);
+}
+
+fn moduleNeedsToEsmInterop(module: *const Module, modules: []const *const Module) bool {
+    for (module.import_bindings) |ib| {
+        if (ib.import_record_index >= module.import_records.len) continue;
+        const record = module.import_records[ib.import_record_index];
+        if (record.resolved.isNone()) continue;
+        const target = findSortedModule(modules, record.resolved) orelse continue;
+        if (target.wrap_kind != .cjs) continue;
+        if (ib.kind == .namespace or ib.importsDefault()) return true;
+    }
+    return false;
+}
+
+fn findSortedModule(modules: []const *const Module, index: types.ModuleIndex) ?*const Module {
+    for (modules) |m| {
+        if (m.index == index) return m;
+    }
+    return null;
 }
 
 /// transformer 비트맵 외 경로의 helper (asset binary loader / `--keep-names` 옵션)

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -422,7 +422,7 @@ pub fn emitWithTreeShaking(
     }
 
     // 런타임 헬퍼 주입
-    try emitBundleRuntimeHelpers(&output, allocator, sorted.items, options);
+    try emitBundleRuntimeHelpers(&output, allocator, sorted.items, graph, options);
 
     // TLA 검증: 비-ESM 출력에서 TLA 사용 시 경고 주석 삽입.
     // Top-Level Await는 ESM 전용 기능이므로 CJS/IIFE/UMD/AMD 포맷에서는 동작하지 않는다.
@@ -1671,6 +1671,7 @@ fn emitBundleRuntimeHelpers(
     output: *std.ArrayList(u8),
     allocator: std.mem.Allocator,
     sorted_modules: []const *const Module,
+    graph: *const ModuleGraph,
     options: *const EmitOptions,
 ) !void {
     // 런타임 헬퍼 주입: 래핑 모듈 유형에 따라 필요한 헬퍼 결정.
@@ -1681,7 +1682,7 @@ fn emitBundleRuntimeHelpers(
     for (sorted_modules) |m| {
         if (m.wrap_kind == .cjs) needs_cjs_runtime = true;
         if (m.wrap_kind == .esm) needs_esm_wrap_runtime = true;
-        if (moduleNeedsToEsmInterop(m, sorted_modules)) needs_to_esm_runtime = true;
+        if (moduleNeedsToEsmInterop(m, graph)) needs_to_esm_runtime = true;
         if (m.loader == .binary) needs_to_binary = true;
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
@@ -1693,8 +1694,8 @@ fn emitBundleRuntimeHelpers(
         if (needs_cjs_runtime) {
             try rt.appendCommonJsFactoryRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
         }
-        // __toCommonJS depends on __copyProps/__defProp, so ESM wrappers still need
-        // the __toESM helper cluster even if no CJS import site calls __toESM.
+        // __toCommonJS는 __copyProps/__defProp 에 의존 → ESM wrap 런타임을 emit 하면
+        // 어떤 import site 도 __toESM 을 부르지 않더라도 __toESM 클러스터가 필요.
         if (needs_to_esm_runtime or needs_esm_wrap_runtime) {
             try rt.appendToEsmRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
         }
@@ -1726,23 +1727,19 @@ fn emitBundleRuntimeHelpers(
     try emitOptionPathHelpers(output, allocator, needs_to_binary, options);
 }
 
-fn moduleNeedsToEsmInterop(module: *const Module, modules: []const *const Module) bool {
+/// 한 모듈이 CJS 타겟에 대해 namespace/default import 를 가지면 __toESM 래핑이 필요.
+/// linker.zig:writeCjsImportInner 의 emit predicate 와 1:1 일치해야 한다 — 어긋나면
+/// preamble 이 __toESM 을 부르는데 정의가 없는 ReferenceError 가 발생.
+fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph) bool {
     for (module.import_bindings) |ib| {
         if (ib.import_record_index >= module.import_records.len) continue;
         const record = module.import_records[ib.import_record_index];
         if (record.resolved.isNone()) continue;
-        const target = findSortedModule(modules, record.resolved) orelse continue;
+        const target = graph.getModule(record.resolved) orelse continue;
         if (target.wrap_kind != .cjs) continue;
         if (ib.kind == .namespace or ib.importsDefault()) return true;
     }
     return false;
-}
-
-fn findSortedModule(modules: []const *const Module, index: types.ModuleIndex) ?*const Module {
-    for (modules) |m| {
-        if (m.index == index) return m;
-    }
-    return null;
 }
 
 /// transformer 비트맵 외 경로의 helper (asset binary loader / `--keep-names` 옵션)

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -1258,11 +1258,25 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
 /// CJS interop 런타임을 주입한다 (__commonJS + __toESM).
 /// configurable=true(RN)이면 ES5 호환 버전 사용.
 pub fn appendCjsRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
+    try appendCommonJsFactoryRuntime(buf, allocator, minify, configurable);
+    try appendToEsmRuntime(buf, allocator, minify, configurable);
+}
+
+/// CJS factory only. Named-only CJS imports can use require_xxx().name directly
+/// and do not need the ESM namespace interop helper cluster.
+pub fn appendCommonJsFactoryRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
     if (minify) {
         try buf.appendSlice(allocator, if (configurable) CJS_RUNTIME_ES5_MIN else CJS_RUNTIME_MIN);
-        try buf.appendSlice(allocator, if (configurable) TOESM_RUNTIME_CONFIGURABLE_MIN else TOESM_RUNTIME_MIN);
     } else {
         try buf.appendSlice(allocator, if (configurable) CJS_RUNTIME_ES5 else CJS_RUNTIME);
+    }
+}
+
+/// ESM namespace interop helpers (__toESM and its Object.* aliases).
+pub fn appendToEsmRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
+    if (minify) {
+        try buf.appendSlice(allocator, if (configurable) TOESM_RUNTIME_CONFIGURABLE_MIN else TOESM_RUNTIME_MIN);
+    } else {
         try buf.appendSlice(allocator, if (configurable) TOESM_RUNTIME_CONFIGURABLE else TOESM_RUNTIME);
     }
 }

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -1262,8 +1262,8 @@ pub fn appendCjsRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, m
     try appendToEsmRuntime(buf, allocator, minify, configurable);
 }
 
-/// CJS factory only. Named-only CJS imports can use require_xxx().name directly
-/// and do not need the ESM namespace interop helper cluster.
+/// __commonJS factory 만 주입. named-only CJS import (`require_xxx().name`) 는
+/// __toESM 클러스터가 필요 없으므로, namespace/default import 가 없을 때 호출.
 pub fn appendCommonJsFactoryRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
     if (minify) {
         try buf.appendSlice(allocator, if (configurable) CJS_RUNTIME_ES5_MIN else CJS_RUNTIME_MIN);
@@ -1272,7 +1272,7 @@ pub fn appendCommonJsFactoryRuntime(buf: *std.ArrayList(u8), allocator: std.mem.
     }
 }
 
-/// ESM namespace interop helpers (__toESM and its Object.* aliases).
+/// ESM namespace interop 헬퍼 (__toESM 와 __copyProps/__defProp 등 Object.* 별칭).
 pub fn appendToEsmRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
     if (minify) {
         try buf.appendSlice(allocator, if (configurable) TOESM_RUNTIME_CONFIGURABLE_MIN else TOESM_RUNTIME_MIN);

--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env bun
+/**
+ * Size-gap diagnostics for small package smoke benchmarks.
+ *
+ * Runs smoke.ts with preserved outputs, then compares ZTS against the smallest
+ * successful baseline bundle to surface likely size-gap causes.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "../..");
+
+type BundlerName = "esbuild" | "rolldown" | "rspack";
+
+interface SmokeBundlerResult {
+  build: boolean;
+  size: number;
+  outputPath?: string;
+}
+
+interface SmokeProjectResult {
+  project: string;
+  zts: SmokeBundlerResult;
+  esbuild: SmokeBundlerResult;
+  rolldown: SmokeBundlerResult;
+  rspack: SmokeBundlerResult;
+  outputMatch: boolean;
+}
+
+interface Candidate {
+  value: string;
+  ztsCount: number;
+}
+
+function parseProjects(): string[] {
+  const arg = process.argv.find((a) => a.startsWith("--projects="));
+  if (!arg) {
+    return ["safe-buffer", "cookie", "path-to-regexp"];
+  }
+  return arg
+    .slice("--projects=".length)
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+function runSmoke(projects: string[], keepDir: string, jsonPath: string): SmokeProjectResult[] {
+  const results: SmokeProjectResult[] = [];
+  for (const project of projects) {
+    const r = spawnSync(
+      "bun",
+      [
+        "run",
+        "tests/benchmark/smoke.ts",
+        `--filter=${project}`,
+        `--keep-output=${keepDir}`,
+        `--json=${jsonPath}`,
+      ],
+      {
+        cwd: ROOT,
+        stdio: "pipe",
+        timeout: 180000,
+      },
+    );
+    if (r.status !== 0) {
+      throw new Error(
+        `smoke.ts failed for ${project}\n${r.stdout?.toString()}\n${r.stderr?.toString()}`,
+      );
+    }
+    const report = JSON.parse(readFileSync(jsonPath, "utf-8"));
+    const exact = report.results.find((entry: SmokeProjectResult) => entry.project === project);
+    if (!exact) {
+      throw new Error(`smoke.ts did not produce an exact result for ${project}`);
+    }
+    results.push(exact);
+  }
+  return results;
+}
+
+function readOutput(result?: SmokeBundlerResult): string {
+  if (!result?.outputPath || !existsSync(result.outputPath)) return "";
+  return readFileSync(result.outputPath, "utf-8");
+}
+
+function smallestBaseline(result: SmokeProjectResult): { name: BundlerName; result: SmokeBundlerResult } | null {
+  const candidates: { name: BundlerName; result: SmokeBundlerResult }[] = [
+    { name: "esbuild", result: result.esbuild },
+    { name: "rolldown", result: result.rolldown },
+    { name: "rspack", result: result.rspack },
+  ].filter((c) => c.result.build && c.result.size > 0);
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, current) => (current.result.size < best.result.size ? current : best));
+}
+
+function countOccurrences(text: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let index = 0;
+  while ((index = text.indexOf(needle, index)) !== -1) {
+    count++;
+    index += needle.length;
+  }
+  return count;
+}
+
+function ztsOnlyStrings(zts: string, baseline: string): Candidate[] {
+  const strings = new Set<string>();
+  const re = /(["'`])((?:\\.|(?!\1).){16,})\1/g;
+  for (const match of zts.matchAll(re)) {
+    const value = match[2];
+    if (/^\s*$/.test(value) || baseline.includes(value)) continue;
+    strings.add(value);
+  }
+  return [...strings]
+    .map((value) => ({ value, ztsCount: countOccurrences(zts, value) }))
+    .sort((a, b) => b.value.length * b.ztsCount - a.value.length * a.ztsCount)
+    .slice(0, 8);
+}
+
+function wrapperMarkers(zts: string, baseline: string): Candidate[] {
+  const markers = [
+    "__commonJS",
+    "__export",
+    "__toESM",
+    "__copyProps",
+    "__reExport",
+    "__toCommonJS",
+    "module.exports",
+    "Object.defineProperty",
+    "__require",
+  ];
+  return markers
+    .filter((marker) => zts.includes(marker) && !baseline.includes(marker))
+    .map((value) => ({ value, ztsCount: countOccurrences(zts, value) }))
+    .sort((a, b) => b.ztsCount - a.ztsCount);
+}
+
+function topLevelDeclarations(zts: string, baseline: string): Candidate[] {
+  const names = new Set<string>();
+  const re = /^(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)\b/gm;
+  for (const match of zts.matchAll(re)) {
+    const name = match[1];
+    const baselineDecl = new RegExp(`^(?:function|class|const|let|var)\\s+${name}\\b`, "m");
+    if (!baselineDecl.test(baseline)) {
+      names.add(name);
+    }
+  }
+  return [...names]
+    .map((value) => ({ value, ztsCount: countOccurrences(zts, value) }))
+    .sort((a, b) => b.ztsCount - a.ztsCount)
+    .slice(0, 12);
+}
+
+function formatCandidates(candidates: Candidate[]): string {
+  if (candidates.length === 0) return "  - none";
+  return candidates.map((c) => `  - ${c.value} (${c.ztsCount}x)`).join("\n");
+}
+
+const projects = parseProjects();
+const tempDir = mkdtempSync(join(tmpdir(), "zts-size-gap-"));
+const keepDir = join(tempDir, "outputs");
+const jsonPath = join(tempDir, "smoke.json");
+
+try {
+  const results = runSmoke(projects, keepDir, jsonPath);
+
+  console.log("# ZTS Size Gap Diagnostics\n");
+  console.log(`Projects: ${projects.join(", ")}\n`);
+
+  for (const result of results) {
+    const baseline = smallestBaseline(result);
+    if (!baseline) {
+      console.log(`## ${result.project}\n`);
+      console.log("No successful baseline output.\n");
+      continue;
+    }
+
+    const zts = readOutput(result.zts);
+    const base = readOutput(baseline.result);
+    const ratio = result.zts.size > 0 ? result.zts.size / baseline.result.size : 0;
+
+    console.log(`## ${result.project}\n`);
+    console.log(
+      `ZTS: ${result.zts.size} bytes | Baseline: ${baseline.name} ${baseline.result.size} bytes | Ratio: ${ratio.toFixed(2)}x | Output: ${result.outputMatch ? "MATCH" : "DIFF"}`,
+    );
+    console.log(
+      `Files: ${basename(result.zts.outputPath ?? "")} vs ${basename(baseline.result.outputPath ?? "")}\n`,
+    );
+
+    console.log("ZTS-only strings");
+    console.log(formatCandidates(ztsOnlyStrings(zts, base)));
+    console.log("\nWrapper markers");
+    console.log(formatCandidates(wrapperMarkers(zts, base)));
+    console.log("\nTop-level declarations");
+    console.log(formatCandidates(topLevelDeclarations(zts, base)));
+    console.log("");
+  }
+} finally {
+  if (!process.argv.includes("--keep-temp")) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -86,14 +86,18 @@ function readOutput(result?: SmokeBundlerResult): string {
   return readFileSync(result.outputPath, "utf-8");
 }
 
-function smallestBaseline(result: SmokeProjectResult): { name: BundlerName; result: SmokeBundlerResult } | null {
+function smallestBaseline(
+  result: SmokeProjectResult,
+): { name: BundlerName; result: SmokeBundlerResult } | null {
   const candidates: { name: BundlerName; result: SmokeBundlerResult }[] = [
     { name: "esbuild", result: result.esbuild },
     { name: "rolldown", result: result.rolldown },
     { name: "rspack", result: result.rspack },
   ].filter((c) => c.result.build && c.result.size > 0);
   if (candidates.length === 0) return null;
-  return candidates.reduce((best, current) => (current.result.size < best.result.size ? current : best));
+  return candidates.reduce((best, current) =>
+    current.result.size < best.result.size ? current : best,
+  );
 }
 
 function countOccurrences(text: string, needle: string): number {

--- a/tests/benchmark/smoke-diagnostics.test.ts
+++ b/tests/benchmark/smoke-diagnostics.test.ts
@@ -63,18 +63,16 @@ describe("benchmark smoke diagnostics", () => {
     }
   });
 
-  test("size-gap.ts reports ZTS-only candidates for the target projects", () => {
+  test("size-gap.ts reports ZTS-only candidates for the target project", () => {
     const r = runBun([
       "run",
       "tests/benchmark/size-gap.ts",
-      "--projects=safe-buffer,cookie,path-to-regexp",
+      "--projects=safe-buffer",
     ]);
 
     expect(r.status, r.stderr?.toString()).toBe(0);
     const stdout = r.stdout.toString();
     expect(stdout).toContain("safe-buffer");
-    expect(stdout).toContain("cookie");
-    expect(stdout).toContain("path-to-regexp");
     expect(stdout).toContain("ZTS-only strings");
     expect(stdout).toContain("Wrapper markers");
     expect(stdout).toContain("Top-level declarations");

--- a/tests/benchmark/smoke-diagnostics.test.ts
+++ b/tests/benchmark/smoke-diagnostics.test.ts
@@ -64,11 +64,7 @@ describe("benchmark smoke diagnostics", () => {
   });
 
   test("size-gap.ts reports ZTS-only candidates for the target project", () => {
-    const r = runBun([
-      "run",
-      "tests/benchmark/size-gap.ts",
-      "--projects=safe-buffer",
-    ]);
+    const r = runBun(["run", "tests/benchmark/size-gap.ts", "--projects=safe-buffer"]);
 
     expect(r.status, r.stderr?.toString()).toBe(0);
     const stdout = r.stdout.toString();

--- a/tests/benchmark/smoke-diagnostics.test.ts
+++ b/tests/benchmark/smoke-diagnostics.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "../..");
+
+function runBun(args: string[]) {
+  return spawnSync("bun", args, {
+    cwd: ROOT,
+    stdio: "pipe",
+    timeout: 180000,
+  });
+}
+
+describe("benchmark smoke diagnostics", () => {
+  test("--keep-output preserves bundler outputs under the requested directory", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-smoke-keep-"));
+    try {
+      const r = runBun([
+        "run",
+        "tests/benchmark/smoke.ts",
+        "--filter=safe-buffer",
+        `--keep-output=${dir}`,
+      ]);
+
+      expect(r.status, r.stderr?.toString()).toBe(0);
+      const projectDir = join(dir, "safe-buffer");
+      expect(existsSync(join(projectDir, "dist-zts.js"))).toBe(true);
+      expect(existsSync(join(projectDir, "dist-esbuild.js"))).toBe(true);
+      expect(readdirSync(projectDir).some((name) => name.includes("rolldown"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("--json writes build args, output paths, sizes, output match, and stderr summaries", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-smoke-json-"));
+    const jsonPath = join(dir, "report.json");
+    try {
+      const r = runBun([
+        "run",
+        "tests/benchmark/smoke.ts",
+        "--filter=cookie",
+        `--json=${jsonPath}`,
+      ]);
+
+      expect(r.status, r.stderr?.toString()).toBe(0);
+      const report = JSON.parse(readFileSync(jsonPath, "utf-8"));
+      expect(report.results).toHaveLength(1);
+      const cookie = report.results[0];
+      expect(cookie.project).toBe("cookie");
+      expect(typeof cookie.outputMatch).toBe("boolean");
+      expect(cookie.zts.size).toBeGreaterThan(0);
+      expect(cookie.zts.outputPath).toContain("dist-zts.js");
+      expect(cookie.zts.buildArgs).toContain("--bundle");
+      expect(typeof cookie.zts.stderrSummary).toBe("string");
+      expect(cookie.esbuild.outputPath).toContain("dist-esbuild.js");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("size-gap.ts reports ZTS-only candidates for the target projects", () => {
+    const r = runBun([
+      "run",
+      "tests/benchmark/size-gap.ts",
+      "--projects=safe-buffer,cookie,path-to-regexp",
+    ]);
+
+    expect(r.status, r.stderr?.toString()).toBe(0);
+    const stdout = r.stdout.toString();
+    expect(stdout).toContain("safe-buffer");
+    expect(stdout).toContain("cookie");
+    expect(stdout).toContain("path-to-regexp");
+    expect(stdout).toContain("ZTS-only strings");
+    expect(stdout).toContain("Wrapper markers");
+    expect(stdout).toContain("Top-level declarations");
+  });
+});

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -9,9 +9,9 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync, existsSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 const ROOT = resolve(__dirname, "../..");
 const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
@@ -31,6 +31,9 @@ interface BundlerResult {
   size: number;
   time: number;
   stdout: string;
+  outputPath?: string;
+  buildArgs?: string[];
+  stderrSummary?: string;
 }
 
 interface SmokeResult {
@@ -64,7 +67,30 @@ function fileSize(path: string): number {
   }
 }
 
-const emptyResult: BundlerResult = { build: false, size: 0, time: 0, stdout: "" };
+const emptyResult: BundlerResult = {
+  build: false,
+  size: 0,
+  time: 0,
+  stdout: "",
+  outputPath: "",
+  buildArgs: [],
+  stderrSummary: "",
+};
+
+interface SmokeOptions {
+  keepOutputDir?: string;
+}
+
+function stderrSummary(stderr: string): string {
+  return stderr
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 8)
+    .join("\n")
+    .slice(0, 1000);
+}
 
 /** 단일 번들러로 빌드 + 실행하고 결과 반환 */
 function bundleAndRun(
@@ -75,7 +101,15 @@ function bundleAndRun(
 ): BundlerResult {
   const build = exec(bin, buildArgs, cwd);
   if (!build.ok) {
-    return { build: false, size: 0, time: build.time, stdout: "" };
+    return {
+      build: false,
+      size: 0,
+      time: build.time,
+      stdout: "",
+      outputPath: outFile,
+      buildArgs,
+      stderrSummary: stderrSummary(build.stderr),
+    };
   }
   const run = exec("node", [outFile]);
   return {
@@ -83,6 +117,9 @@ function bundleAndRun(
     size: fileSize(outFile),
     time: build.time,
     stdout: run.ok ? run.stdout : "",
+    outputPath: outFile,
+    buildArgs,
+    stderrSummary: stderrSummary(build.stderr || run.stderr),
   };
 }
 
@@ -103,8 +140,14 @@ function isProductionBuild(p: ProjectConfig): boolean {
   return p.production ?? true;
 }
 
-function testProject(p: ProjectConfig): SmokeResult {
-  const dir = mkdtempSync(join(tmpdir(), `zts-smoke-${p.name}-`));
+function testProject(p: ProjectConfig, options: SmokeOptions = {}): SmokeResult {
+  const dir = options.keepOutputDir
+    ? join(options.keepOutputDir, p.name)
+    : mkdtempSync(join(tmpdir(), `zts-smoke-${p.name}-`));
+  if (options.keepOutputDir) {
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+  }
   const result: SmokeResult = {
     project: p.name,
     zts: { ...emptyResult },
@@ -265,7 +308,9 @@ function testProject(p: ProjectConfig): SmokeResult {
       }
     }
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    if (!options.keepOutputDir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
     try {
       rmSync(entryFile);
     } catch {}
@@ -1060,15 +1105,23 @@ console.log("ZTS Smoke Test — Real Project Bundling\n");
 // CLI: --filter=<패턴> 으로 이름 필터링 (예: --filter=@es5, --filter=lodash)
 const filterArg = process.argv.find((a) => a.startsWith("--filter="));
 const filterPattern = filterArg ? filterArg.split("=")[1] : null;
+const keepOutputArg = process.argv.find((a) => a.startsWith("--keep-output="));
+const keepOutputDir = keepOutputArg ? resolve(keepOutputArg.slice("--keep-output=".length)) : undefined;
+const jsonArg = process.argv.find((a) => a.startsWith("--json="));
+const jsonPath = jsonArg ? resolve(jsonArg.slice("--json=".length)) : undefined;
 const filteredProjects = filterPattern
   ? projects.filter((p) => p.name.includes(filterPattern))
   : projects;
+
+if (keepOutputDir) {
+  mkdirSync(keepOutputDir, { recursive: true });
+}
 
 const results: SmokeResult[] = [];
 
 for (const p of filteredProjects) {
   process.stdout.write(`Testing ${p.name}... `);
-  const r = testProject(p);
+  const r = testProject(p, { keepOutputDir });
   results.push(r);
 
   const status = r.zts.build ? "OK" : "FAIL";
@@ -1172,6 +1225,24 @@ if (sizeComparisons.length > 0) {
   const larger = sizeComparisons.filter((c) => c.ratio > 1.1).length;
   console.log(
     `\nAverage ratio (vs smallest): ${avgRatio.toFixed(2)}x | Smaller: ${smaller} | Similar(±10%): ${similar} | Larger: ${larger}`,
+  );
+}
+
+if (jsonPath) {
+  mkdirSync(dirname(jsonPath), { recursive: true });
+  writeFileSync(
+    jsonPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        filter: filterPattern,
+        keepOutputDir,
+        results,
+        sizeComparisons,
+      },
+      null,
+      2,
+    ),
   );
 }
 

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -1106,7 +1106,9 @@ console.log("ZTS Smoke Test — Real Project Bundling\n");
 const filterArg = process.argv.find((a) => a.startsWith("--filter="));
 const filterPattern = filterArg ? filterArg.split("=")[1] : null;
 const keepOutputArg = process.argv.find((a) => a.startsWith("--keep-output="));
-const keepOutputDir = keepOutputArg ? resolve(keepOutputArg.slice("--keep-output=".length)) : undefined;
+const keepOutputDir = keepOutputArg
+  ? resolve(keepOutputArg.slice("--keep-output=".length))
+  : undefined;
 const jsonArg = process.argv.find((a) => a.startsWith("--json="));
 const jsonPath = jsonArg ? resolve(jsonArg.slice("--json=".length)) : undefined;
 const filteredProjects = filterPattern


### PR DESCRIPTION
## 요약
- smoke benchmark 진단 옵션을 추가했습니다: `--keep-output`, `--json`
- `tests/benchmark/size-gap.ts`를 추가해 ZTS와 가장 작은 baseline 산출물을 비교하고, ZTS-only 문자열/래퍼/선언 후보를 리포트합니다.
- named-only CJS import에서 사용하지 않는 `__toESM` / `__copyProps` helper cluster가 붙지 않도록 런타임 헬퍼 emit을 분리했습니다.
- 해당 동작을 고정하는 회귀 테스트를 추가했습니다.

## 결과
- `safe-buffer`: 2837 → 1888 bytes, smallest baseline 대비 1.61x → 1.07x
- `cookie`: 8362 → 7413 bytes, 1.46x → 1.30x
- `path-to-regexp`: 11898 → 10949 bytes, 1.44x → 1.33x
- 대상 3개 패키지 모두 output `MATCH` 유지

## 테스트
- `zig build test --summary all`
- `zig build`
- `bun test tests/benchmark/smoke-diagnostics.test.ts`
- `bun run tests/benchmark/size-gap.ts --projects=safe-buffer,cookie,path-to-regexp`
- `bun run tests/benchmark/smoke.ts --filter=safe-buffer`
- `bun run tests/benchmark/smoke.ts --filter=cookie`
- `bun run tests/benchmark/smoke.ts --filter=path-to-regexp`

참고: `bunx oxfmt format ...`은 현재 repo 설정의 `sortImports` 그룹 `ts-equals-import`를 oxfmt가 인식하지 못해 실행이 막혔습니다.