### PR TITLE
chore(lint): drive oxlint warnings to zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test:e2e": "bun run --cwd tests/e2e test",
     "test:all": "bun run test:integration && bun run test:e2e",
     "build:zts": "zig build -Doptimize=ReleaseFast",
-    "lint": "oxlint --ignore-pattern '**/fixtures/**' packages/ tests/integration tests/e2e tests/benchmark",
-    "lint:fix": "oxlint --fix --ignore-pattern '**/fixtures/**' packages/ tests/integration tests/e2e tests/benchmark",
+    "lint": "oxlint --ignore-pattern '**/fixtures/**' --ignore-pattern '**/dist/**' packages/ tests/integration tests/e2e tests/benchmark",
+    "lint:fix": "oxlint --fix --ignore-pattern '**/fixtures/**' --ignore-pattern '**/dist/**' packages/ tests/integration tests/e2e tests/benchmark",
     "fmt": "oxfmt format packages/ tests/integration tests/e2e tests/benchmark",
     "fmt:check": "oxfmt format --check packages/ tests/integration tests/e2e tests/benchmark",
     "playwright:install": "cd tests/e2e && bunx playwright install --with-deps chromium"

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -2814,14 +2814,14 @@ describe("옵션 조합 통합 테스트", () => {
           load(id) {
             if (id.endsWith("lib.ts")) hooks.push("load");
           },
-          transform(code) {
+          transform(_code) {
             hooks.push("transform");
           },
           renderChunk(code) {
             hooks.push("renderChunk");
             return `/* built */\n${code}`;
           },
-          generateBundle(outputs) {
+          generateBundle(_outputs) {
             hooks.push("generateBundle");
           },
         }),
@@ -2982,7 +2982,6 @@ describe("옵션 조합 통합 테스트", () => {
       globalName: "ILib",
     });
     expect(result.errors.length).toBe(0);
-    const ctx: any = {};
     new Function("var ILib; " + result.outputFiles[0].text + " return ILib;").call(null);
     // IIFE는 var ILib = (function() { ... })(); 형태
     const fn = new Function(result.outputFiles[0].text + "\nreturn ILib;");

--- a/packages/vite-plugin-zts/src/index.ts
+++ b/packages/vite-plugin-zts/src/index.ts
@@ -46,7 +46,7 @@ export function zts(options: ZtsPluginOptions = {}): Plugin {
     name: "vite-plugin-zts",
 
     // Vite 5: esbuild transform 비활성화, Vite 6+: 이미 Rolldown 기반이므로 불필요
-    config(_, env) {
+    config(_, _env) {
       // Vite 5 이하에서만 esbuild 비활성화 (Vite 6+는 Rolldown 사용)
       try {
         const viteVersion = parseInt(require("vite/package.json").version);

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -155,11 +155,6 @@ function readString(ptr: number, len: number): string {
   return decoder.decode(new Uint8Array(wasm!.memory.buffer, ptr, len));
 }
 
-function writeOptionalString(s?: string): [number, number] {
-  if (!s) return [0, 0];
-  return writeString(s);
-}
-
 // ─── Public API ───
 
 /// 입력을 WebAssembly instantiate 가능한 source 로 정규화. undefined 면 default

--- a/tests/integration/tests/compat-table.test.ts
+++ b/tests/integration/tests/compat-table.test.ts
@@ -6,7 +6,7 @@
  * ES5~ES2022 각 타겟별로 구문 변환 대상 feature의 exec 코드를
  * ZTS로 트랜스파일 후 실행하여 검증.
  */
-import { describe, test, expect } from "bun:test";
+import { describe, test } from "bun:test";
 import { resolve, join } from "node:path";
 import { writeFile, mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2638,7 +2638,7 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       const result = await bundleAndRun(
         {
           "index.ts": `
-            const r = 'hello'.replace(/(?<word>\\w+)/, \`<\$<word>>\`);
+            const r = 'hello'.replace(/(?<word>\\w+)/, \`<$<word>>\`);
             console.log(r);
           `,
         },
@@ -2655,7 +2655,7 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
         {
           "index.ts": `
             const re = /(?<a>\\w+)-(?<b>\\d+)/;
-            console.log('foo-42'.replace(re, \`[\$<b>:\$<a>]\`));
+            console.log('foo-42'.replace(re, \`[$<b>:$<a>]\`));
           `,
         },
         "index.ts",

--- a/tests/integration/tests/hmr.test.ts
+++ b/tests/integration/tests/hmr.test.ts
@@ -43,7 +43,7 @@ describe("HMR 통합 테스트", () => {
 
     // 4. 번들을 bun으로 실행하여 에러가 없는지 확인
     const run = spawn({ cmd: ["bun", "run", outFile], stdout: "pipe", stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [stdout, _stderr, exitCode] = await Promise.all([
       new Response(run.stdout).text(),
       new Response(run.stderr).text(),
       run.exited,

--- a/tests/integration/tests/rsc-directives.test.ts
+++ b/tests/integration/tests/rsc-directives.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { runZts, runZtsInDir, createFixture, createReactStubFixture, ZTS_BIN } from "./helpers";
+import { runZts, runZtsInDir, createFixture, createReactStubFixture } from "./helpers";
 import { readFileSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";

--- a/tests/integration/tests/stage3-decorator-smoke.test.ts
+++ b/tests/integration/tests/stage3-decorator-smoke.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import { createFixture, runZts } from "./helpers";
 import { join, resolve } from "node:path";
-import { symlink, mkdir, readFile } from "node:fs/promises";
+import { symlink, mkdir } from "node:fs/promises";
 import { spawnSync } from "bun";
 
 // Stage 3 Decorator 스모크 테스트

--- a/tests/integration/tests/tsc/es6-Symbols.test.ts
+++ b/tests/integration/tests/tsc/es6-Symbols.test.ts
@@ -1,5 +1,5 @@
 import { describe, test } from "bun:test";
-import { expectPass, expectError } from "./helpers";
+import { expectPass } from "./helpers";
 
 describe("TSC: es6/Symbols", () => {
   test("symbolDeclarationEmit1", async () => {


### PR DESCRIPTION
## Summary
- 빌드 산출물(`packages/*/dist/`) 을 oxlint `--ignore-pattern` 으로 제외 (51개 잡음 제거)
- 실제 소스의 13개 잔재 정리 → **oxlint 60 warnings → 0 warnings**

## Cleanup 분류
- **안 쓰는 import 4개 삭제** — `compat-table` `expect`, `rsc-directives` `ZTS_BIN`, `stage3-decorator-smoke` `readFile`, `tsc/es6-Symbols` `expectError` (모두 묶음 import 잔재)
- **콜백 시그니처용 parameter 4개에 `_` prefix** — `vite-plugin-zts` `config(_, _env)`, `hmr.test.ts` destructure `_stderr`, `core/index.test.ts` plugin hook `_code`/`_outputs`
- **진짜 dead variable 1개 삭제** — `core/index.test.ts:2985` `const ctx: any = {};`
- **미사용 helper 함수 1개 삭제** — `wasm/index.ts` `writeOptionalString` (callsite 0)
- **무의미한 escape 3개 정리** — `downlevel-edge.test.ts` template literal 안의 `\$` ≡ `$`

## Test plan
- [x] `bun run lint` → 0 warnings
- [x] `bun run fmt:check` → pass
- [x] pre-push hook (zig fmt + zig build test + oxlint + oxfmt) → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)