### PR TITLE
fix: 정적 CJS named export tree-shaking

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -139,6 +139,180 @@ test "TreeShaking: side-effect-only import preserved" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "myPolyfill") != null);
 }
 
+test "TreeShaking CJS: named import prunes unused exports dot assignment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function used() { return "USED_MARKER"; }
+        \\function unused() { return "UNUSED_EXPORT_MARKER"; }
+        \\exports.used = used;
+        \\exports.unused = unused;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_EXPORT_MARKER") == null);
+}
+
+test "TreeShaking CJS: named import prunes unused module exports dot assignment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function used() { return "USED_MODULE_EXPORT_MARKER"; }
+        \\function unused() { return "UNUSED_MODULE_EXPORT_MARKER"; }
+        \\module.exports.used = used;
+        \\module.exports.unused = unused;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_MODULE_EXPORT_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_MODULE_EXPORT_MARKER") == null);
+}
+
+test "TreeShaking CJS: used export keeps helper but unused private body is removed" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function helper() { return "HELPER_MARKER"; }
+        \\function used() { return helper(); }
+        \\function unusedPrivate() { return "UNUSED_PRIVATE_MARKER"; }
+        \\exports.used = used;
+        \\exports.unused = unusedPrivate;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "HELPER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_PRIVATE_MARKER") == null);
+}
+
+test "TreeShaking CJS: default namespace and export star keep all static exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "default.js", "import lib from './lib.js'; console.log(lib.used);");
+    try writeFile(tmp.dir, "namespace.js", "import * as lib from './lib.js'; console.log(lib.used);");
+    try writeFile(tmp.dir, "star-entry.js", "import { used } from './barrel.js'; console.log(used);");
+    try writeFile(tmp.dir, "barrel.js", "export * from './lib.js';");
+    try writeFile(tmp.dir, "lib.js",
+        \\exports.used = "CJS_USED";
+        \\exports.unused = "CJS_UNUSED_MUST_STAY";
+    );
+
+    const default_entry = try absPath(&tmp, "default.js");
+    defer std.testing.allocator.free(default_entry);
+    const namespace_entry = try absPath(&tmp, "namespace.js");
+    defer std.testing.allocator.free(namespace_entry);
+    const star_entry = try absPath(&tmp, "star-entry.js");
+    defer std.testing.allocator.free(star_entry);
+
+    var b_default = Bundler.init(std.testing.allocator, .{ .entry_points = &.{default_entry} });
+    defer b_default.deinit();
+    const default_result = try b_default.bundle();
+    defer default_result.deinit(std.testing.allocator);
+    try std.testing.expect(!default_result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, default_result.output, "CJS_UNUSED_MUST_STAY") != null);
+
+    var b_namespace = Bundler.init(std.testing.allocator, .{ .entry_points = &.{namespace_entry} });
+    defer b_namespace.deinit();
+    const namespace_result = try b_namespace.bundle();
+    defer namespace_result.deinit(std.testing.allocator);
+    try std.testing.expect(!namespace_result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, namespace_result.output, "CJS_UNUSED_MUST_STAY") != null);
+
+    var b_star = Bundler.init(std.testing.allocator, .{ .entry_points = &.{star_entry} });
+    defer b_star.deinit();
+    const star_result = try b_star.bundle();
+    defer star_result.deinit(std.testing.allocator);
+    try std.testing.expect(!star_result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, star_result.output, "CJS_UNUSED_MUST_STAY") != null);
+}
+
+test "TreeShaking CJS: dynamic export patterns and effectful RHS are preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used);");
+    try writeFile(tmp.dir, "lib.js",
+        \\function sideEffect() { console.log("EFFECTFUL_UNUSED_MARKER"); return 1; }
+        \\const key = "computed";
+        \\exports.used = "USED_DYNAMIC_CASE";
+        \\exports.unused = sideEffect();
+        \\exports[key] = "COMPUTED_MUST_STAY";
+        \\Object.defineProperty(exports, "getter", { get() { return "GETTER_MUST_STAY"; } });
+        \\module.exports = { used: exports.used, objectUnused: "OBJECT_MUST_STAY" };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_DYNAMIC_CASE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "EFFECTFUL_UNUSED_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "COMPUTED_MUST_STAY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "GETTER_MUST_STAY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_MUST_STAY") != null);
+}
+
+test "TreeShaking CJS: live export keeps CJS require target evaluation" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\const helper = require("./helper.js");
+        \\function used() { return helper("USED_REQUIRE_TARGET_MARKER"); }
+        \\function unused() { return "UNUSED_REQUIRE_EXPORT_MARKER"; }
+        \\exports.used = used;
+        \\exports.unused = unused;
+    );
+    try writeFile(tmp.dir, "helper.js",
+        \\function helper(value) { return value; }
+        \\module.exports = helper;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_REQUIRE_TARGET_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = helper") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_REQUIRE_EXPORT_MARKER") == null);
+}
+
 // ============================================================
 // @__PURE__ annotation tests
 // ============================================================

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1224,7 +1224,7 @@ pub fn emitModule(
         // dev 번들은 크기 허용, speed 우선 (Metro/esbuild 관습).
         if (!options.dev_mode) {
             if (used_export_names) |names| {
-                if (!is_entry and !module.wrap_kind.isWrapped()) {
+                if (!is_entry and module.wrap_kind != .esm) {
                     stmt_shake: {
                         const sem = module.semantic orelse {
                             statement_shaker.markUnusedStatements(
@@ -1273,7 +1273,7 @@ pub fn emitModule(
                             }
                         } else {
                             // tree-shaker 없으면 기존 방식 (모듈 내부 computeReachable)
-                            if (stmt_info_mod.build(arena_alloc, transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references)) |maybe_infos| {
+                            if (stmt_info_mod.build(arena_alloc, transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references, module.wrap_kind == .cjs)) |maybe_infos| {
                                 if (maybe_infos) |infos| {
                                     var used_sym_buf: std.ArrayListUnmanaged(u32) = .empty;
                                     defer used_sym_buf.deinit(arena_alloc);

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1250,6 +1250,7 @@ pub const ModuleGraph = struct {
                         analyzer.symbols.items,
                         analyzer.references.items,
                         if (module.semantic) |*s| &s.unresolved_references else null,
+                        false,
                     ) catch null;
                 }
             } else |_| {}
@@ -1478,6 +1479,7 @@ pub const ModuleGraph = struct {
                     analyzer.symbols.items,
                     analyzer.references.items,
                     if (module.semantic) |*s| &s.unresolved_references else null,
+                    false,
                 ) catch null;
             }
         }
@@ -1775,6 +1777,7 @@ pub const ModuleGraph = struct {
                 analyzer.symbols.items,
                 analyzer.references.items,
                 if (module.semantic) |*s| &s.unresolved_references else null,
+                false,
             );
         }
 

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -695,8 +695,29 @@ fn isModuleExportsAssign(ast: *const Ast, node: Node) bool {
 
 /// assignment_expression의 left가 exports.xxx인지 확인.
 fn isExportsDotAssign(ast: *const Ast, node: Node) bool {
-    const parts = getAssignMemberParts(ast, node) orelse return false;
-    return std.mem.eql(u8, parts.object, "exports");
+    const lhs_idx = node.data.binary.left;
+    if (getAssignMemberParts(ast, node)) |parts| {
+        if (std.mem.eql(u8, parts.object, "exports")) return true;
+    }
+
+    if (lhs_idx.isNone() or @intFromEnum(lhs_idx) >= ast.nodes.items.len) return false;
+    const lhs_node = ast.getNode(lhs_idx);
+    if (lhs_node.tag != .static_member_expression) return false;
+    const outer_e = lhs_node.data.extra;
+    const outer_obj_idx = ast.readExtraNode(outer_e, 0);
+    if (outer_obj_idx.isNone() or @intFromEnum(outer_obj_idx) >= ast.nodes.items.len) return false;
+    const outer_obj = ast.getNode(outer_obj_idx);
+    if (outer_obj.tag != .static_member_expression) return false;
+    const inner_e = outer_obj.data.extra;
+    const obj_idx = ast.readExtraNode(inner_e, 0);
+    const prop_idx = ast.readExtraNode(inner_e, 1);
+    if (obj_idx.isNone() or prop_idx.isNone()) return false;
+    if (@intFromEnum(obj_idx) >= ast.nodes.items.len or @intFromEnum(prop_idx) >= ast.nodes.items.len) return false;
+    const obj = ast.getNode(obj_idx);
+    const prop = ast.getNode(prop_idx);
+    return obj.tag == .identifier_reference and
+        std.mem.eql(u8, ast.getText(obj.span), "module") and
+        std.mem.eql(u8, ast.getText(prop.span), "exports");
 }
 
 /// string_literal 노드의 텍스트를 따옴표 없이 반환한다.

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -27,8 +27,20 @@ pub const StmtInfo = struct {
     referenced_symbols: []const u32,
 };
 
+pub const CjsExportFact = struct {
+    export_name: []const u8,
+    statement_index: u32,
+    export_assignment_node: u32,
+    rhs_symbol: ?u32 = null,
+    is_static: bool = true,
+    is_safe_to_prune: bool = true,
+};
+
 pub const ModuleStmtInfos = struct {
     stmts: []StmtInfo,
+    /// 정적으로 증명된 CJS named export assignment.
+    /// 대상은 `exports.foo = ...`, `module.exports.foo = ...` 뿐이다.
+    cjs_export_facts: []const CjsExportFact = &.{},
     /// symbol_index → stmt_index (선언 역매핑). 없으면 null.
     symbol_to_stmt: []const ?u32,
     /// symbol_index → [side-effect stmt indices that reference this symbol].
@@ -50,6 +62,7 @@ pub const ModuleStmtInfos = struct {
             self.allocator.free(stmt.referenced_symbols);
         }
         self.allocator.free(self.stmts);
+        if (self.cjs_export_facts.len > 0) self.allocator.free(self.cjs_export_facts);
         self.allocator.free(self.symbol_to_stmt);
         // 역인덱스 해제
         for (self.sym_to_side_effect_stmts) |s| {
@@ -64,6 +77,15 @@ pub const ModuleStmtInfos = struct {
             if (s.len > 0) self.allocator.free(s);
         }
         self.allocator.free(self.sym_to_writer_stmts);
+    }
+
+    pub fn cjsExportStmtByName(self: *const ModuleStmtInfos, export_name: []const u8) ?u32 {
+        for (self.cjs_export_facts) |fact| {
+            if (fact.is_static and std.mem.eql(u8, fact.export_name, export_name)) {
+                return fact.statement_index;
+            }
+        }
+        return null;
     }
 
     /// symbol_index가 선언된 statement 인덱스 반환.
@@ -129,6 +151,63 @@ pub const ModuleStmtInfos = struct {
         return reachable_stmts;
     }
 };
+
+const CjsExportCandidate = struct {
+    export_name: []const u8,
+    export_assignment_node: u32,
+    rhs_node: NodeIndex,
+};
+
+fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeIndex, property: NodeIndex } {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .static_member_expression) return null;
+    const e = node.data.extra;
+    if (!ast.hasExtra(e, 1)) return null;
+    const obj_idx = ast.readExtraNode(e, 0);
+    const prop_idx = ast.readExtraNode(e, 1);
+    if (obj_idx.isNone() or prop_idx.isNone()) return null;
+    if (@intFromEnum(obj_idx) >= ast.nodes.items.len or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
+    return .{ .object = obj_idx, .property = prop_idx };
+}
+
+fn cjsExportNameFromLhs(ast: *const Ast, lhs: NodeIndex) ?[]const u8 {
+    const outer = staticMemberParts(ast, lhs) orelse return null;
+    const prop = ast.nodes.items[@intFromEnum(outer.property)];
+    if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return null;
+
+    const obj = ast.nodes.items[@intFromEnum(outer.object)];
+    if (obj.tag == .identifier_reference and std.mem.eql(u8, ast.getText(obj.span), "exports")) {
+        return ast.getText(prop.span);
+    }
+
+    if (obj.tag != .static_member_expression) return null;
+    const inner = staticMemberParts(ast, outer.object) orelse return null;
+    const inner_obj = ast.nodes.items[@intFromEnum(inner.object)];
+    const inner_prop = ast.nodes.items[@intFromEnum(inner.property)];
+    if (inner_obj.tag != .identifier_reference) return null;
+    if (!std.mem.eql(u8, ast.getText(inner_obj.span), "module")) return null;
+    if (!std.mem.eql(u8, ast.getText(inner_prop.span), "exports")) return null;
+    return ast.getText(prop.span);
+}
+
+fn cjsExportCandidateForStmt(ast: *const Ast, stmt_node: Node) ?CjsExportCandidate {
+    if (stmt_node.tag != .expression_statement) return null;
+    const expr_idx = stmt_node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return null;
+    const export_name = cjsExportNameFromLhs(ast, expr.data.binary.left) orelse return null;
+    return .{
+        .export_name = export_name,
+        .export_assignment_node = @intFromEnum(expr_idx),
+        .rhs_node = expr.data.binary.right,
+    };
+}
+
+fn cjsExportAssignmentHasSideEffects(ast: *const Ast, candidate: CjsExportCandidate, unresolved_globals: ?*const purity.GlobalRefSet) bool {
+    return !purity.isExprPure(ast, candidate.rhs_node, unresolved_globals);
+}
 
 /// statement span 배열에서 pos를 포함하는 statement를 binary search.
 /// statement span은 소스 순서로 비중첩.
@@ -256,6 +335,7 @@ pub fn buildFromSemantic(
     symbols: []const Symbol,
     references: []const Reference,
     unresolved_globals: ?*const purity.GlobalRefSet,
+    collect_cjs_exports: bool,
 ) !?ModuleStmtInfos {
     // program 노드 (마지막 노드)에서 top-level statement 인덱스 추출
     if (ast.nodes.items.len == 0) return null;
@@ -282,6 +362,9 @@ pub fn buildFromSemantic(
     errdefer allocator.free(sym_to_stmt);
     for (sym_to_stmt) |*s| s.* = null;
 
+    var cjs_export_facts_buf: std.ArrayListUnmanaged(CjsExportFact) = .empty;
+    errdefer cjs_export_facts_buf.deinit(allocator);
+
     // Pass 1: span + side-effect 결정. declared/referenced 는 빈 상태로 초기화.
     for (stmt_raw_indices, 0..) |raw_idx, stmt_i| {
         const idx: NodeIndex = @enumFromInt(raw_idx);
@@ -297,7 +380,21 @@ pub fn buildFromSemantic(
             };
         } else {
             const node = ast.nodes.items[ni];
-            const side_effects = if (node.tag == .import_declaration) false else purity.stmtHasSideEffects(ast, node, unresolved_globals);
+            const cjs_export_candidate = if (collect_cjs_exports) cjsExportCandidateForStmt(ast, node) else null;
+            if (cjs_export_candidate) |candidate| {
+                try cjs_export_facts_buf.append(allocator, .{
+                    .export_name = candidate.export_name,
+                    .statement_index = @intCast(stmt_i),
+                    .export_assignment_node = candidate.export_assignment_node,
+                    .is_safe_to_prune = !cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals),
+                });
+            }
+            const side_effects = if (node.tag == .import_declaration)
+                false
+            else if (cjs_export_candidate) |candidate|
+                cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals)
+            else
+                purity.stmtHasSideEffects(ast, node, unresolved_globals);
             stmts[stmt_i] = .{
                 .node_idx = @intCast(ni),
                 .span = node.span,
@@ -376,8 +473,11 @@ pub fn buildFromSemantic(
     // 역인덱스 구축 (buildReverseIndex 재사용)
     const reverse = try buildReverseIndex(allocator, stmts, symbols.len);
 
+    const cjs_export_facts = try cjs_export_facts_buf.toOwnedSlice(allocator);
+
     return .{
         .stmts = stmts,
+        .cjs_export_facts = cjs_export_facts,
         .symbol_to_stmt = sym_to_stmt,
         .sym_to_side_effect_stmts = reverse.sym_to_side_effect_stmts,
         .sym_to_referencing_stmts = reverse.sym_to_referencing_stmts,
@@ -425,6 +525,7 @@ pub fn build(
     symbols: []const Symbol,
     symbol_ids: []const ?u32,
     unresolved_globals: ?*const purity.GlobalRefSet,
+    collect_cjs_exports: bool,
 ) !?ModuleStmtInfos {
     // program 노드 (마지막 노드)
     if (ast.nodes.items.len == 0) return null;
@@ -451,6 +552,9 @@ pub fn build(
     errdefer allocator.free(sym_to_stmt);
     for (sym_to_stmt) |*s| s.* = null;
 
+    var cjs_export_facts_buf: std.ArrayListUnmanaged(CjsExportFact) = .empty;
+    errdefer cjs_export_facts_buf.deinit(allocator);
+
     // Phase 1: statement span 배열 + side-effects 판정 + 초기화
     var stmt_spans = try allocator.alloc(Span, stmt_count);
     defer allocator.free(stmt_spans);
@@ -471,7 +575,26 @@ pub fn build(
         }
         const node = ast.nodes.items[ni];
         stmt_spans[stmt_i] = node.span;
-        const side_effects = if (node.tag == .import_declaration) false else purity.stmtHasSideEffects(ast, node, unresolved_globals);
+        const cjs_export_candidate = if (collect_cjs_exports) cjsExportCandidateForStmt(ast, node) else null;
+        if (cjs_export_candidate) |candidate| {
+            const rhs_symbol: ?u32 = if (!candidate.rhs_node.isNone() and @intFromEnum(candidate.rhs_node) < symbol_ids.len)
+                symbol_ids[@intFromEnum(candidate.rhs_node)]
+            else
+                null;
+            try cjs_export_facts_buf.append(allocator, .{
+                .export_name = candidate.export_name,
+                .statement_index = @intCast(stmt_i),
+                .export_assignment_node = candidate.export_assignment_node,
+                .rhs_symbol = rhs_symbol,
+                .is_safe_to_prune = !cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals),
+            });
+        }
+        const side_effects = if (node.tag == .import_declaration)
+            false
+        else if (cjs_export_candidate) |candidate|
+            cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals)
+        else
+            purity.stmtHasSideEffects(ast, node, unresolved_globals);
         stmts[stmt_i] = .{
             .node_idx = @intCast(ni),
             .span = node.span,
@@ -560,8 +683,11 @@ pub fn build(
     // Phase 3: 역인덱스 구축
     const reverse = try buildReverseIndex(allocator, stmts, symbols.len);
 
+    const cjs_export_facts = try cjs_export_facts_buf.toOwnedSlice(allocator);
+
     return .{
         .stmts = stmts,
+        .cjs_export_facts = cjs_export_facts,
         .symbol_to_stmt = sym_to_stmt,
         .sym_to_side_effect_stmts = reverse.sym_to_side_effect_stmts,
         .sym_to_referencing_stmts = reverse.sym_to_referencing_stmts,

--- a/src/bundler/stmt_info_test.zig
+++ b/src/bundler/stmt_info_test.zig
@@ -34,6 +34,7 @@ fn buildTestInfos(allocator: std.mem.Allocator, source: []const u8) !struct {
         analyzer.symbols.items,
         analyzer.symbol_ids.items,
         &analyzer.unresolved_references,
+        false,
     )) orelse return error.NullResult;
 
     return .{ .infos = infos, .arena = arena };

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -277,14 +277,16 @@ pub const TreeShaker = struct {
         self.prebuilt_mask = prebuilt_mask;
         for (0..mod_count) |i| {
             const m = self.getModule(@intCast(i)) orelse continue;
-            // wrapped(CJS/ESM wrap)는 body 전체가 한 function으로 래핑되어 statement 경계가
-            // 무의미 — 모듈 단위 포함/제외만. entry 포함 non-wrapped 모두 stmt-level 도달성 분석.
-            if (m.wrap_kind.isWrapped()) continue;
+            // CJS wrapper도 원본 top-level statement 경계를 유지하므로 named export fact로
+            // 정밀 DCE가 가능하다. __esm wrapper는 init 함수 단위 의미가 강해 기존 opaque 처리 유지.
+            if (m.wrap_kind == .esm) continue;
 
-            if (m.prebuilt_stmt_info) |prebuilt| {
-                module_stmt_infos[i] = prebuilt;
-                prebuilt_mask.set(i);
-                continue;
+            if (m.wrap_kind != .cjs) {
+                if (m.prebuilt_stmt_info) |prebuilt| {
+                    module_stmt_infos[i] = prebuilt;
+                    prebuilt_mask.set(i);
+                    continue;
+                }
             }
 
             const sem = m.semantic orelse continue;
@@ -295,6 +297,7 @@ pub const TreeShaker = struct {
                 sem.symbols.items,
                 sem.symbol_ids,
                 &sem.unresolved_references,
+                m.wrap_kind == .cjs,
             ) catch null;
         }
 
@@ -317,8 +320,7 @@ pub const TreeShaker = struct {
             for (0..mod_count) |i| {
                 if (!self.included.isSet(i)) continue;
                 const m = self.getModule(@intCast(i)) orelse continue;
-                // wrapped만 StmtInfo 없음 → live 필터 불가. 나머지(entry 포함)는 live_mod_idx 경로.
-                const live_idx: ?u32 = if (m.wrap_kind.isWrapped()) null else @intCast(i);
+                const live_idx: ?u32 = if (m.wrap_kind == .esm) null else @intCast(i);
                 if (try self.processModuleImportsInner(m.*, live_idx)) changed = true;
             }
 
@@ -327,20 +329,24 @@ pub const TreeShaker = struct {
             for (0..mod_count) |i| {
                 if (!self.included.isSet(i)) continue;
                 const m = self.getModule(@intCast(i)) orelse continue;
-                const live_idx: ?u32 = if (m.wrap_kind.isWrapped()) null else @intCast(i);
+                const live_idx: ?u32 = if (m.wrap_kind == .esm) null else @intCast(i);
                 for (m.import_records, 0..) |rec, rec_i| {
                     if (rec.resolved.isNone()) continue;
                     const target = @intFromEnum(rec.resolved);
                     const tmod = self.graph.getModule(rec.resolved) orelse continue;
-                    if (self.included.isSet(target)) continue;
 
                     const preserve = self.shouldPreserveImportRecordForEvaluation(m, @intCast(i), @intCast(rec_i), live_idx);
                     const must_include = rec.kind == .require or
                         ((rec.kind == .side_effect or rec.kind == .re_export) and preserve) or
                         ((tmod.side_effects or tmod.wrap_kind.isWrapped()) and preserve);
                     if (!must_include) continue;
-                    self.included.set(target);
-                    changed = true;
+                    if (!self.included.isSet(target)) {
+                        self.included.set(target);
+                        changed = true;
+                    }
+                    if (rec.kind == .require and tmod.wrap_kind == .cjs and preserve) {
+                        try self.markAllExportsUsed(@intCast(target));
+                    }
                 }
             }
 
@@ -560,6 +566,10 @@ pub const TreeShaker = struct {
                 for (infos.stmts, 0..) |_, si| {
                     try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
                 }
+            } else if (m.side_effects and m.side_effects_user_defined) {
+                for (infos.stmts, 0..) |_, si| {
+                    try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                }
             } else if (m.side_effects) {
                 for (infos.stmts, 0..) |stmt, si| {
                     if (stmt.has_side_effects) {
@@ -625,6 +635,18 @@ pub const TreeShaker = struct {
                             }
                         }
                     }
+                }
+            }
+
+            if (owner) |o| {
+                for (o.import_records, 0..) |rec, rec_i| {
+                    if (rec.kind != .require) continue;
+                    if (rec.resolved.isNone()) continue;
+                    if (!self.importRecordBelongsToStmt(infos, @intCast(item.stmt), @intCast(rec_i), o)) continue;
+                    const target_mod_idx = @intFromEnum(rec.resolved);
+                    const target_module = self.graph.getModule(rec.resolved) orelse continue;
+                    if (target_module.wrap_kind != .cjs) continue;
+                    try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
                 }
             }
         }
@@ -702,9 +724,13 @@ pub const TreeShaker = struct {
         const rec = m.import_records[ib.import_record_index];
         if (rec.resolved.isNone()) return;
         const target = @intFromEnum(rec.resolved);
-        if (self.graph.getModule(rec.resolved) == null) return;
+        const target_module_for_import = self.graph.getModule(rec.resolved) orelse return;
 
         if (ib.kind == .namespace) {
+            if (target_module_for_import.wrap_kind == .cjs) {
+                try self.markAndSeedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
+                return;
+            }
             if (ib.namespace_used_properties) |props| {
                 for (props, 0..) |prop_name, pi| {
                     // per-prop stmt 정보와 dispatch_stmt가 모두 있을 때만 gating 적용.
@@ -721,6 +747,16 @@ pub const TreeShaker = struct {
                 self.included.set(target);
                 try self.seedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
             }
+            return;
+        }
+
+        if (target_module_for_import.wrap_kind == .cjs and ib.kind == .default) {
+            try self.markAndSeedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
+            return;
+        }
+
+        if (target_module_for_import.wrap_kind == .cjs and ib.kind == .named) {
+            try self.seedCjsExportOrAll(@intCast(target), ib.imported_name, queue, module_stmt_infos, reachable_stmts);
             return;
         }
 
@@ -768,6 +804,26 @@ pub const TreeShaker = struct {
 
         try self.markExportUsed(canon_mod, canonical.export_name);
         self.included.set(canon_mod);
+
+        if (canon_m.wrap_kind == .cjs) {
+            if (canon_mod != target_mod) {
+                try self.markAndSeedAllStmts(canon_mod, queue, module_stmt_infos, reachable_stmts);
+                return;
+            }
+            const target_infos = module_stmt_infos[canon_mod] orelse {
+                try self.markAndSeedAllStmts(canon_mod, queue, module_stmt_infos, reachable_stmts);
+                return;
+            };
+            const target_stmt = target_infos.cjsExportStmtByName(canonical.export_name) orelse {
+                try self.markAndSeedAllStmts(canon_mod, queue, module_stmt_infos, reachable_stmts);
+                return;
+            };
+            if (reachable_stmts[canon_mod] == null) {
+                reachable_stmts[canon_mod] = try std.DynamicBitSet.initEmpty(self.allocator, target_infos.stmts.len);
+            }
+            try self.enqueue(canon_mod, target_stmt, reachable_stmts, queue);
+            return;
+        }
 
         // namespace barrel re-export: canonical이 namespace import를 가리키면
         // 소스 모듈의 모든 export를 시드해야 함 (import * as z; export { z } 패턴)
@@ -830,6 +886,31 @@ pub const TreeShaker = struct {
         try self.enqueue(@intCast(canon_mod), target_stmt, reachable_stmts, queue);
 
         // side-effect statement는 enqueueStmt에서 lazy 시드됨
+    }
+
+    fn seedCjsExportOrAll(
+        self: *TreeShaker,
+        mod_idx: u32,
+        export_name: []const u8,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        module_stmt_infos: []?StmtInfos,
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        try self.markExportUsed(mod_idx, export_name);
+        self.included.set(mod_idx);
+        const infos = if (mod_idx < module_stmt_infos.len) module_stmt_infos[mod_idx] else null;
+        const target_infos = infos orelse {
+            try self.markAndSeedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
+            return;
+        };
+        const target_stmt = target_infos.cjsExportStmtByName(export_name) orelse {
+            try self.markAndSeedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
+            return;
+        };
+        if (reachable_stmts[mod_idx] == null) {
+            reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, target_infos.stmts.len);
+        }
+        try self.enqueue(mod_idx, target_stmt, reachable_stmts, queue);
     }
 
     /// StmtInfo 없는 모듈 (entry, CJS 등)의 import를 BFS로 전파.
@@ -1006,6 +1087,12 @@ pub const TreeShaker = struct {
 
         const reexport_idx: ModuleIndex = @enumFromInt(reexport_mod);
         const src_idx: ModuleIndex = @enumFromInt(src_mod);
+        if (self.getModule(src_mod)) |src_module| {
+            if (src_module.wrap_kind == .cjs) {
+                try self.markAndSeedAllStmts(src_mod, queue, module_stmt_infos, reachable_stmts);
+                return;
+            }
+        }
         for (names.items) |name| {
             const from_reexport = self.linker.resolveExportChain(reexport_idx, name, 0) orelse continue;
             const from_src = self.linker.resolveExportChain(src_idx, name, 0) orelse {
@@ -1036,11 +1123,14 @@ pub const TreeShaker = struct {
                         const src_idx = m.import_records[rec_idx].resolved;
                         if (self.graph.getModule(src_idx) != null) {
                             const src = @intFromEnum(src_idx);
+                            const src_module = self.graph.getModule(src_idx).?;
                             if (!self.included.isSet(src)) {
                                 self.included.set(src);
                                 changed = true;
                             }
-                            if (eb.kind == .re_export_namespace) {
+                            if (src_module.wrap_kind == .cjs and eb.kind == .re_export_star) {
+                                try self.markAllExportsUsed(@intCast(src));
+                            } else if (eb.kind == .re_export_namespace) {
                                 // #1603 Phase 1b: 모든 소비자의 `namespace_used_properties`를
                                 // 집계해 subset이 결정 가능하면 해당 member만 used로 마킹.
                                 // 하나라도 opaque(null)이면 전체 사용 fallback.
@@ -1073,9 +1163,34 @@ pub const TreeShaker = struct {
         if (rec_idx >= m.import_records.len) return false;
         return switch (m.import_records[rec_idx].kind) {
             .dynamic_import => false,
+            .require => self.importRecordHasReachableStmt(m, live_mod_idx.?, rec_idx),
             .static_import => self.entry_set.isSet(mod_idx) or self.importRecordHasLiveBinding(m, mod_idx, rec_idx),
             else => true,
         };
+    }
+
+    fn importRecordHasReachableStmt(self: *const TreeShaker, m: *const Module, mod_idx: u32, rec_idx: u32) bool {
+        if (mod_idx >= self.module_stmt_infos.len or mod_idx >= self.reachable_stmts.len) return true;
+        const infos = self.module_stmt_infos[mod_idx] orelse return true;
+        const reachable = self.reachable_stmts[mod_idx] orelse return false;
+        if (rec_idx >= m.import_records.len) return false;
+        for (infos.stmts, 0..) |stmt, stmt_i| {
+            if (!reachable.isSet(stmt_i)) continue;
+            if (m.import_records[rec_idx].span.start >= stmt.span.start and
+                m.import_records[rec_idx].span.start < stmt.span.end)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn importRecordBelongsToStmt(self: *const TreeShaker, infos: StmtInfos, stmt_idx: u32, rec_idx: u32, m: *const Module) bool {
+        _ = self;
+        if (stmt_idx >= infos.stmts.len or rec_idx >= m.import_records.len) return false;
+        const stmt = infos.stmts[stmt_idx];
+        const rec = m.import_records[rec_idx];
+        return rec.span.start >= stmt.span.start and rec.span.start < stmt.span.end;
     }
 
     /// `isImportLiveInModule` 은 reachable_stmts 미초기화 시 보수적으로 true 를 반환하지만,
@@ -1166,10 +1281,23 @@ pub const TreeShaker = struct {
             const rec = m.import_records[ib.import_record_index];
             if (rec.resolved.isNone()) continue;
             const target_mod = @intFromEnum(rec.resolved);
-            if (self.graph.getModule(rec.resolved) == null) continue;
+            const target_module = self.graph.getModule(rec.resolved) orelse continue;
 
             if (live_mod_idx) |idx| {
                 if (!self.isImportLiveInModule(idx, ib.local_name)) continue;
+            }
+
+            if (target_module.wrap_kind == .cjs) {
+                if (ib.kind == .default or ib.kind == .namespace) {
+                    try self.markAllExportsUsed(@intCast(target_mod));
+                } else {
+                    try self.markExportUsed(@intCast(target_mod), ib.imported_name);
+                }
+                if (!self.included.isSet(target_mod)) {
+                    self.included.set(target_mod);
+                    newly_included = true;
+                }
+                continue;
             }
 
             const canonical = self.linker.resolveExportChain(rec.resolved, ib.imported_name, 0);

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -2303,9 +2303,8 @@ fn scanAssignmentCjs(self: *Parser, left: NodeIndex) void {
     if (obj_idx.isNone()) return;
     if (@intFromEnum(obj_idx) >= self.ast.nodes.items.len) return;
     const obj = self.ast.nodes.items[@intFromEnum(obj_idx)];
-    if (obj.tag != .identifier_reference) return;
 
-    const obj_text = self.ast.source[obj.span.start..obj.span.end];
+    const obj_text = if (obj.tag == .identifier_reference) self.ast.source[obj.span.start..obj.span.end] else "";
 
     if (std.mem.eql(u8, obj_text, "module")) {
         // module.exports = ...
@@ -2320,6 +2319,23 @@ fn scanAssignmentCjs(self: *Parser, left: NodeIndex) void {
     } else if (std.mem.eql(u8, obj_text, "exports")) {
         // exports.x = ...
         self.scan_result.has_exports_dot = true;
+    } else if (obj.tag == .static_member_expression) {
+        const inner_me = obj.data.extra;
+        if (inner_me + 1 >= self.ast.extra_data.items.len) return;
+        const inner_obj_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[inner_me]);
+        const inner_prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[inner_me + 1]);
+        if (inner_obj_idx.isNone() or inner_prop_idx.isNone()) return;
+        if (@intFromEnum(inner_obj_idx) >= self.ast.nodes.items.len or
+            @intFromEnum(inner_prop_idx) >= self.ast.nodes.items.len) return;
+        const inner_obj = self.ast.nodes.items[@intFromEnum(inner_obj_idx)];
+        const inner_prop = self.ast.nodes.items[@intFromEnum(inner_prop_idx)];
+        if (inner_obj.tag != .identifier_reference) return;
+        const inner_obj_text = self.ast.source[inner_obj.span.start..inner_obj.span.end];
+        const inner_prop_text = self.ast.source[inner_prop.span.start..inner_prop.span.end];
+        if (std.mem.eql(u8, inner_obj_text, "module") and std.mem.eql(u8, inner_prop_text, "exports")) {
+            // module.exports.x = ...
+            self.scan_result.has_exports_dot = true;
+        }
     }
 }
 

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -64,6 +64,17 @@ function hasTopLevelFunction(bundle: string, name: string): boolean {
   return re.test(bundle);
 }
 
+function runBundleSource(bundle: string): string {
+  const r = spawnSync(process.execPath, ["-e", bundle], {
+    stdio: "pipe",
+    timeout: 30000,
+  });
+  if (r.status !== 0) {
+    throw new Error(`node run failed: ${r.stderr?.toString().slice(0, 400)}`);
+  }
+  return r.stdout.toString();
+}
+
 describe("#1558 Phase 5 tree-shake 정밀도", () => {
   const checkOrSkip = (pkg: string) => {
     const benchmarkNM = join(BENCHMARK_DIR, "node_modules", pkg);
@@ -147,6 +158,44 @@ describe("#1558 Phase 5 tree-shake 정밀도", () => {
       const re = new RegExp(`(^|\\n)(function|const|var|let)\\s+${name}\\b`, "m");
       expect(re.test(bundle), `dead identifier "${name}" leaked to bundle`).toBe(false);
     }
+  });
+});
+
+describe("CJS static export fact 기반 DCE", () => {
+  const checkOrSkip = (pkg: string) => {
+    const benchmarkNM = join(BENCHMARK_DIR, "node_modules", pkg);
+    const rootNM = join(ROOT, "node_modules", pkg);
+    return existsSync(benchmarkNM) || existsSync(rootNM);
+  };
+
+  test("cookie — serialize named import는 parse 계열 body를 끌고 오지 않음", () => {
+    if (!checkOrSkip("cookie")) return;
+    const bundle = bundleIn(
+      BENCHMARK_DIR,
+      `import { serialize } from "cookie";\n` +
+        `const out = serialize("session", "abc");\n` +
+        `console.log(out.includes("session=abc") ? "MATCH" : "MISS");\n`,
+      "cookie-cjs-static-export",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).not.toContain("argument str must be a string");
+    expect(bundle).not.toMatch(/function\s+parse\s*\(/);
+  });
+
+  test("path-to-regexp — match named import는 compile/stringify 계열 body를 끌고 오지 않음", () => {
+    if (!checkOrSkip("path-to-regexp")) return;
+    const bundle = bundleIn(
+      BENCHMARK_DIR,
+      `import { match } from "path-to-regexp";\n` +
+        `const fn = match("/user/:id");\n` +
+        `console.log(fn("/user/42")?.params.id === "42" ? "MATCH" : "MISS");\n`,
+      "path-to-regexp-cjs-static-export",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).not.toMatch(/function\s+compile\s*\(/);
+    expect(bundle).not.toMatch(/function\s+stringify\s*\(/);
   });
 });
 


### PR DESCRIPTION
## 관련 이슈
- Refs #2060

## 요약
- `exports.foo = ...`, `module.exports.foo = ...` 형태의 정적 CJS named export를 statement-level fact로 수집합니다.
- CJS named import가 해당 export assignment statement만 reachability seed로 살리도록 연결했습니다.
- live CJS statement 안의 `require()` 대상 CJS wrapper는 평가가 필요하므로 전체 seed로 보존합니다. 이 경로가 빠져 axios/rxjs 등 기존 통과 패키지가 깨졌던 회귀를 수정했습니다.
- 사용되지 않는 정적 CJS export와 그 export만 참조하던 private declaration은 제거됩니다.
- default import, namespace import, `export * from CJS`, computed key, `defineProperty`/getter, effectful RHS assignment는 기존처럼 보수적으로 보존합니다.
- small package size gap 회귀 방지를 위해 Zig regression test와 benchmark precision test를 추가했습니다.

## 검증
- `zig build test --summary all` (`3978/3978`)
- `zig build`
- `bun test tests/benchmark/smoke-diagnostics.test.ts`
- `bun test tests/integration/tests/tree-shake-precision.test.ts`
- `bun run tests/benchmark/size-gap.ts --projects=safe-buffer,cookie,path-to-regexp`
- `bun run tests/benchmark/smoke.ts --filter=safe-buffer`
- `bun run tests/benchmark/smoke.ts --filter=cookie`
- `bun run tests/benchmark/smoke.ts --filter=path-to-regexp`
- `bun run tests/benchmark/smoke.ts --filter=axios` (`MATCH`)
- `bun run tests/benchmark/smoke.ts --filter=rxjs` (`MATCH`)
- CI 댓글에 있던 CJS-heavy 실패군 로컬 재확인: `express`, `react`, `commander`, `jsonwebtoken`, `micromatch`, `debug`, `yaml`, `vue`, `react-dom`, `qs`, `ajv`, `picomatch`, `statuses` 모두 `MATCH`

## 벤치마크 결과
- `safe-buffer`: `MATCH`, 1888 bytes, rolldown 기준 `1.07x`
- `cookie`: `MATCH`, 3343 bytes, rolldown 기준 `0.59x`
- `path-to-regexp`: `MATCH`, 7693 bytes, rolldown 기준 `0.93x`
- `axios`: `MATCH`, 343KB, rolldown 기준 `0.86x`
- `rxjs`: `MATCH`, 321KB, rolldown 기준 `1.04x`