### PR TITLE
chore(simplify): chunk runtime split + early-exit (followup)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1685,6 +1685,7 @@ fn emitBundleRuntimeHelpers(
         if (m.wrap_kind == .esm) needs_esm_wrap_runtime = true;
         if (moduleNeedsToEsmInterop(m, graph, linker)) needs_to_esm_runtime = true;
         if (m.loader == .binary) needs_to_binary = true;
+        if (needs_cjs_runtime and needs_esm_wrap_runtime and needs_to_esm_runtime and needs_to_binary) break;
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
         // Node ESM 출력에 CJS wrapper가 섞이면 wrapper 내부 `require()`가 런타임에 미정의.
@@ -1796,24 +1797,33 @@ pub fn emitChunkRuntimeHelpers(
     allocator: std.mem.Allocator,
     chunk: *const Chunk,
     graph: *const ModuleGraph,
+    linker: ?*const Linker,
     options: *const EmitOptions,
     collected_helpers: ?RuntimeHelpers,
 ) !void {
     var needs_cjs_runtime = false;
     var needs_esm_wrap_runtime = false;
+    var needs_to_esm_runtime = false;
     var needs_to_binary = false;
     for (chunk.modules.items) |mod_idx| {
         const m = graph.getModule(mod_idx) orelse continue;
         if (m.wrap_kind == .cjs) needs_cjs_runtime = true;
         if (m.wrap_kind == .esm) needs_esm_wrap_runtime = true;
+        if (moduleNeedsToEsmInterop(m, graph, linker)) needs_to_esm_runtime = true;
         if (m.loader == .binary) needs_to_binary = true;
+        if (needs_cjs_runtime and needs_esm_wrap_runtime and needs_to_esm_runtime and needs_to_binary) break;
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
         // 단일 번들 경로와 동일: Node ESM + CJS wrap이면 createRequire shim 필요 (#1456)
         if (needs_cjs_runtime and options.platform == .node and options.format == .esm) {
             try rt.appendRequireShim(output, allocator, options.minify_whitespace);
         }
-        try rt.appendCjsRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
+        if (needs_cjs_runtime) {
+            try rt.appendCommonJsFactoryRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
+        }
+        if (needs_to_esm_runtime or needs_esm_wrap_runtime) {
+            try rt.appendToEsmRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);
+        }
     }
     if (needs_esm_wrap_runtime) {
         try rt.appendEsmWrapRuntime(output, allocator, options.minify_whitespace, options.configurable_exports);

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -96,7 +96,7 @@ pub fn emitChunks(
         }
 
         // 청크별 런타임 헬퍼 주입
-        try emitChunkRuntimeHelpers(&chunk_output, allocator, chunk, graph, options, null);
+        try emitChunkRuntimeHelpers(&chunk_output, allocator, chunk, graph, linker, options, null);
 
         // ESM external imports (#1962): chunk 모듈들이 보유한 external import 를
         // dedup 후 chunk top 에 단일 `import` 구문으로 prepend. emitChunks 는 ESM 전용 (line 46).

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -1255,15 +1255,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
 }
 
-/// CJS interop 런타임을 주입한다 (__commonJS + __toESM).
-/// configurable=true(RN)이면 ES5 호환 버전 사용.
-pub fn appendCjsRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
-    try appendCommonJsFactoryRuntime(buf, allocator, minify, configurable);
-    try appendToEsmRuntime(buf, allocator, minify, configurable);
-}
-
 /// __commonJS factory 만 주입. named-only CJS import (`require_xxx().name`) 는
 /// __toESM 클러스터가 필요 없으므로, namespace/default import 가 없을 때 호출.
+/// configurable=true(RN)이면 ES5 호환 버전 사용.
 pub fn appendCommonJsFactoryRuntime(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool, configurable: bool) !void {
     if (minify) {
         try buf.appendSlice(allocator, if (configurable) CJS_RUNTIME_ES5_MIN else CJS_RUNTIME_MIN);

--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -12,24 +12,11 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 
+import type { BundlerResult, SmokeResult } from "./smoke.ts";
+
 const ROOT = resolve(__dirname, "../..");
 
 type BundlerName = "esbuild" | "rolldown" | "rspack";
-
-interface SmokeBundlerResult {
-  build: boolean;
-  size: number;
-  outputPath?: string;
-}
-
-interface SmokeProjectResult {
-  project: string;
-  zts: SmokeBundlerResult;
-  esbuild: SmokeBundlerResult;
-  rolldown: SmokeBundlerResult;
-  rspack: SmokeBundlerResult;
-  outputMatch: boolean;
-}
 
 interface Candidate {
   value: string;
@@ -48,8 +35,8 @@ function parseProjects(): string[] {
     .filter(Boolean);
 }
 
-function runSmoke(projects: string[], keepDir: string, jsonPath: string): SmokeProjectResult[] {
-  const results: SmokeProjectResult[] = [];
+function runSmoke(projects: string[], keepDir: string, jsonPath: string): SmokeResult[] {
+  const results: SmokeResult[] = [];
   for (const project of projects) {
     const r = spawnSync(
       "bun",
@@ -72,7 +59,7 @@ function runSmoke(projects: string[], keepDir: string, jsonPath: string): SmokeP
       );
     }
     const report = JSON.parse(readFileSync(jsonPath, "utf-8"));
-    const exact = report.results.find((entry: SmokeProjectResult) => entry.project === project);
+    const exact = report.results.find((entry: SmokeResult) => entry.project === project);
     if (!exact) {
       throw new Error(`smoke.ts did not produce an exact result for ${project}`);
     }
@@ -81,15 +68,15 @@ function runSmoke(projects: string[], keepDir: string, jsonPath: string): SmokeP
   return results;
 }
 
-function readOutput(result?: SmokeBundlerResult): string {
+function readOutput(result?: BundlerResult): string {
   if (!result?.outputPath || !existsSync(result.outputPath)) return "";
   return readFileSync(result.outputPath, "utf-8");
 }
 
 function smallestBaseline(
-  result: SmokeProjectResult,
-): { name: BundlerName; result: SmokeBundlerResult } | null {
-  const candidates: { name: BundlerName; result: SmokeBundlerResult }[] = [
+  result: SmokeResult,
+): { name: BundlerName; result: BundlerResult } | null {
+  const candidates: { name: BundlerName; result: BundlerResult }[] = [
     { name: "esbuild", result: result.esbuild },
     { name: "rolldown", result: result.rolldown },
     { name: "rspack", result: result.rspack },
@@ -120,9 +107,14 @@ function ztsOnlyStrings(zts: string, baseline: string): Candidate[] {
     strings.add(value);
   }
   return [...strings]
-    .map((value) => ({ value, ztsCount: countOccurrences(zts, value) }))
-    .sort((a, b) => b.value.length * b.ztsCount - a.value.length * a.ztsCount)
-    .slice(0, 8);
+    .map((raw) => ({
+      value: JSON.stringify(raw).slice(0, 80),
+      ztsCount: countOccurrences(zts, raw),
+      weight: raw.length * countOccurrences(zts, raw),
+    }))
+    .sort((a, b) => b.weight - a.weight)
+    .slice(0, 8)
+    .map(({ value, ztsCount }) => ({ value, ztsCount }));
 }
 
 function wrapperMarkers(zts: string, baseline: string): Candidate[] {
@@ -144,14 +136,14 @@ function wrapperMarkers(zts: string, baseline: string): Candidate[] {
 }
 
 function topLevelDeclarations(zts: string, baseline: string): Candidate[] {
-  const names = new Set<string>();
   const re = /^(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)\b/gm;
+  const baselineNames = new Set<string>();
+  for (const match of baseline.matchAll(re)) {
+    baselineNames.add(match[1]);
+  }
+  const names = new Set<string>();
   for (const match of zts.matchAll(re)) {
-    const name = match[1];
-    const baselineDecl = new RegExp(`^(?:function|class|const|let|var)\\s+${name}\\b`, "m");
-    if (!baselineDecl.test(baseline)) {
-      names.add(name);
-    }
+    if (!baselineNames.has(match[1])) names.add(match[1]);
   }
   return [...names]
     .map((value) => ({ value, ztsCount: countOccurrences(zts, value) }))
@@ -172,14 +164,14 @@ const jsonPath = join(tempDir, "smoke.json");
 try {
   const results = runSmoke(projects, keepDir, jsonPath);
 
-  console.log("# ZTS Size Gap Diagnostics\n");
-  console.log(`Projects: ${projects.join(", ")}\n`);
+  console.log("# ZTS Size Gap Diagnostics");
+  console.log(`Projects: ${projects.join(", ")}`);
 
   for (const result of results) {
     const baseline = smallestBaseline(result);
+    console.log(`\n## ${result.project}`);
     if (!baseline) {
-      console.log(`## ${result.project}\n`);
-      console.log("No successful baseline output.\n");
+      console.log("No successful baseline output.");
       continue;
     }
 
@@ -187,21 +179,19 @@ try {
     const base = readOutput(baseline.result);
     const ratio = result.zts.size > 0 ? result.zts.size / baseline.result.size : 0;
 
-    console.log(`## ${result.project}\n`);
     console.log(
       `ZTS: ${result.zts.size} bytes | Baseline: ${baseline.name} ${baseline.result.size} bytes | Ratio: ${ratio.toFixed(2)}x | Output: ${result.outputMatch ? "MATCH" : "DIFF"}`,
     );
     console.log(
-      `Files: ${basename(result.zts.outputPath ?? "")} vs ${basename(baseline.result.outputPath ?? "")}\n`,
+      `Files: ${basename(result.zts.outputPath ?? "")} vs ${basename(baseline.result.outputPath ?? "")}`,
     );
 
-    console.log("ZTS-only strings");
+    console.log("\nZTS-only strings");
     console.log(formatCandidates(ztsOnlyStrings(zts, base)));
     console.log("\nWrapper markers");
     console.log(formatCandidates(wrapperMarkers(zts, base)));
     console.log("\nTop-level declarations");
     console.log(formatCandidates(topLevelDeclarations(zts, base)));
-    console.log("");
   }
 } finally {
   if (!process.argv.includes("--keep-temp")) {

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -26,7 +26,7 @@ const RSPACK_BIN = existsSync(join(__dirname, "node_modules/.bin/rspack"))
   ? join(__dirname, "node_modules/.bin/rspack")
   : join(ROOT, "node_modules/.bin/rspack");
 
-interface BundlerResult {
+export interface BundlerResult {
   build: boolean;
   size: number;
   time: number;
@@ -36,7 +36,7 @@ interface BundlerResult {
   stderrSummary?: string;
 }
 
-interface SmokeResult {
+export interface SmokeResult {
   project: string;
   zts: BundlerResult;
   esbuild: BundlerResult;


### PR DESCRIPTION
## Summary

이미 머지된 PR(small-package size-gap diagnostics) 의 /simplify 후속 정리. 정확성 1건 + 효율 1건 + 진단 도구 polish.

- `emitChunkRuntimeHelpers` 에도 `__toESM` 클러스터 split 적용. 이전엔 단일 번들 경로(`emitBundleRuntimeHelpers`)에만 적용되어 splitting 빌드는 named-only CJS import 에서도 항상 `__toESM` 클러스터를 emit하던 문제. transitive case 잡기 위해 `linker` 인자도 함께 전달.
- 두 helper 의 모듈 순회 루프 모두 4개 플래그가 모두 `true` 가 되면 `break` (early-exit). 큰 번들에서 `import_bindings` 재순회 비용 절감.
- 모든 호출자가 split 함수로 이전 → `appendCjsRuntime` wrapper 는 dead code 가 되어 제거.
- `tests/benchmark/size-gap.ts`: `smoke.ts` 의 `BundlerResult` / `SmokeResult` 를 `import type` 으로 가져와 type drift 제거. `topLevelDeclarations` 는 baseline 식별자를 한 번에 `Set` 으로 추출해 N×B 스캔을 O(1) 조회로. ZTS-only 문자열은 `JSON.stringify` 로 escape 해 줄바꿈 포함 시에도 보고서 레이아웃이 깨지지 않게 한다. 중복 trailing `\n` 정리.

## Test plan

- [x] `zig build test` 통과 (TreeShaking: named-only CJS import does not inject __toESM helper cluster 포함)
- [ ] CI bench (smoke.ts) 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)