### PR TITLE
refactor(bundler): share __toESM predicate between linker and emitter

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -42,8 +42,9 @@ const error_codes = @import("../error_codes.zig");
 
 /// ZTS0002 TLA+non-ESM 경고 주석. comptime 고정 — 코드/메시지가 error_codes와 항상 일치.
 const tla_warning_comment = "/* [" ++ error_codes.Code.tla_requires_esm_format.format() ++ "] " ++ error_codes.Code.tla_requires_esm_format.message() ++ ". */\n";
-const Linker = @import("linker.zig").Linker;
-const LinkingMetadata = @import("linker.zig").LinkingMetadata;
+const linker_mod = @import("linker.zig");
+const Linker = linker_mod.Linker;
+const LinkingMetadata = linker_mod.LinkingMetadata;
 const TreeShaker = @import("tree_shaker.zig").TreeShaker;
 const statement_shaker = @import("statement_shaker.zig");
 const stmt_info_mod = @import("stmt_info.zig");
@@ -1730,9 +1731,7 @@ fn emitBundleRuntimeHelpers(
 }
 
 /// 한 모듈이 어떤 식으로든 CJS 모듈의 default/namespace 를 가져오면 __toESM 래핑이 필요.
-/// linker.zig:writeCjsImportInner / linker/metadata.zig:488 (re-export → CJS) 의 emit
-/// predicate 와 일치해야 한다 — 어긋나면 preamble 이 __toESM 을 부르는데 정의가 없는
-/// ReferenceError 가 발생 (#812 회귀).
+/// `linker.cjsImportNeedsToEsmInterop` 가 leaf predicate (linker 의 emit 분기와 공유).
 ///
 /// linker 가 있으면 `getResolvedBinding` 의 chain 끝까지 따라가 ESM re-export
 /// (`export { default } from "./cjs"`) 와 다단계 re-export 도 캐치. linker 가 없으면
@@ -1757,7 +1756,9 @@ fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph, lin
         if (linker) |l| {
             if (l.getResolvedBinding(module.index.toU32(), ib.local_span)) |rb| {
                 const canonical_mod = graph.getModule(rb.canonical.module_index) orelse continue;
-                if (canonical_mod.wrap_kind == .cjs and std.mem.eql(u8, rb.canonical.export_name, "default")) {
+                if (canonical_mod.wrap_kind == .cjs and
+                    linker_mod.cjsImportNeedsToEsmInterop(false, rb.canonical.export_name))
+                {
                     return true;
                 }
                 continue;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -44,6 +44,18 @@ pub inline fn isNamespaceRename(rename: []const u8) bool {
     return std.mem.startsWith(u8, rename, NS_VAR_PREFIX);
 }
 
+/// CJS 모듈을 가져오는 ESM-side import 가 `__toESM` 래핑을 필요로 하는지.
+/// namespace 또는 default import 면 `__toESM(req())` 형태로 emit, 그 외 named
+/// 는 `req().prop` 직접 접근으로 충분.
+///
+/// `PreambleWriter.writeCjsImportInner` 의 emit 분기와
+/// `emitter.moduleNeedsToEsmInterop` 의 detection 분기가 모두 이 함수를 통해
+/// 동일 invariant 를 유지한다 — 어긋나면 preamble 이 `__toESM` 을 부르는데
+/// 정의가 없는 ReferenceError 가 발생 (#812 회귀).
+pub inline fn cjsImportNeedsToEsmInterop(is_namespace: bool, imported_name: []const u8) bool {
+    return is_namespace or std.mem.eql(u8, imported_name, "default");
+}
+
 /// import 선언을 body에서 다시 emit하지 않아도 되는 expression rename인지 판정.
 /// CJS named import는 `require_xxx().prop` 직접 참조로 치환되며, 별도 local
 /// binding을 만들지 않는다. dev/HMR payload에서 원본 import가 CJS require로
@@ -2819,26 +2831,19 @@ pub const PreambleWriter = struct {
     ) !void {
         if (!assign_only) try self.write("var ");
         try self.write(local_name);
-        // Rolldown Interop: node → __toESM(req(), 1), babel → __toESM(req())
-        // #1621: minify 시 __toESM → $tE 축약.
-        const toesm_name: []const u8 = if (self.minify) rt.NAMES.TOESM_MIN else "__toESM";
-        const toesm_suffix: []const u8 = if (interop == .node) "(), 1)" else "())";
-        if (is_namespace) {
-            try self.write(" = ");
+        try self.write(" = ");
+        if (cjsImportNeedsToEsmInterop(is_namespace, imported_name)) {
+            // Rolldown Interop: node → __toESM(req(), 1), babel → __toESM(req())
+            // #1621: minify 시 __toESM → $tE 축약.
+            const toesm_name: []const u8 = if (self.minify) rt.NAMES.TOESM_MIN else "__toESM";
+            const toesm_suffix: []const u8 = if (interop == .node) "(), 1)" else "())";
             try self.write(toesm_name);
             try self.write("(");
             try self.write(req_var);
             try self.write(toesm_suffix);
+            if (!is_namespace) try self.write(".default");
             try self.write(";\n");
-        } else if (std.mem.eql(u8, imported_name, "default")) {
-            try self.write(" = ");
-            try self.write(toesm_name);
-            try self.write("(");
-            try self.write(req_var);
-            try self.write(toesm_suffix);
-            try self.write(".default;\n");
         } else {
-            try self.write(" = ");
             try self.write(req_var);
             try self.write("().");
             try self.write(imported_name);


### PR DESCRIPTION
## Summary

`linker.cjsImportNeedsToEsmInterop` 헬퍼를 leaf predicate 로 추출. 두 곳에서 같은 조건을 독립 평가하던 drift 위험 제거.

- `linker.PreambleWriter.writeCjsImportInner` 의 emit 분기는 이제 헬퍼 호출 후 namespace/default 두 \`__toESM\` 케이스를 하나로 합쳐 emit. emit 결과는 동일 (\`__toESM(req())\` + namespace 면 그대로, default 면 \`.default\` suffix).
- `emitter.moduleNeedsToEsmInterop` 의 linker chain 분기도 동일 헬퍼를 호출. 네이밍/조건이 어긋나면 `__toESM` 미정의 ReferenceError 가 발생하던 invariant (#812 회귀) 가 컴파일 단위로 강제됨.

## Test plan

- [x] `zig build test` 통과 (TreeShaking: named-only CJS import does not inject __toESM helper cluster + #812 회귀 테스트 모두 포함)
- [ ] CI bench (smoke.ts) 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)