### PR TITLE
feat(benchmark): smoke.ts --filter 콤마 분리 다중 패턴 지원

### DIFF
--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -36,36 +36,34 @@ function parseProjects(): string[] {
 }
 
 function runSmoke(projects: string[], keepDir: string, jsonPath: string): SmokeResult[] {
-  const results: SmokeResult[] = [];
-  for (const project of projects) {
-    const r = spawnSync(
-      "bun",
-      [
-        "run",
-        "tests/benchmark/smoke.ts",
-        `--filter=${project}`,
-        `--keep-output=${keepDir}`,
-        `--json=${jsonPath}`,
-      ],
-      {
-        cwd: ROOT,
-        stdio: "pipe",
-        timeout: 180000,
-      },
+  const r = spawnSync(
+    "bun",
+    [
+      "run",
+      "tests/benchmark/smoke.ts",
+      `--filter=${projects.join(",")}`,
+      `--keep-output=${keepDir}`,
+      `--json=${jsonPath}`,
+    ],
+    {
+      cwd: ROOT,
+      stdio: "pipe",
+      timeout: 600000,
+    },
+  );
+  if (r.status !== 0) {
+    throw new Error(
+      `smoke.ts failed for ${projects.join(",")}\n${r.stdout?.toString()}\n${r.stderr?.toString()}`,
     );
-    if (r.status !== 0) {
-      throw new Error(
-        `smoke.ts failed for ${project}\n${r.stdout?.toString()}\n${r.stderr?.toString()}`,
-      );
-    }
-    const report = JSON.parse(readFileSync(jsonPath, "utf-8"));
+  }
+  const report = JSON.parse(readFileSync(jsonPath, "utf-8"));
+  return projects.map((project) => {
     const exact = report.results.find((entry: SmokeResult) => entry.project === project);
     if (!exact) {
-      throw new Error(`smoke.ts did not produce an exact result for ${project}`);
+      throw new Error(`smoke.ts did not produce a result for ${project}`);
     }
-    results.push(exact);
-  }
-  return results;
+    return exact;
+  });
 }
 
 function readOutput(result?: BundlerResult): string {

--- a/tests/benchmark/smoke-diagnostics.test.ts
+++ b/tests/benchmark/smoke-diagnostics.test.ts
@@ -73,4 +73,25 @@ describe("benchmark smoke diagnostics", () => {
     expect(stdout).toContain("Wrapper markers");
     expect(stdout).toContain("Top-level declarations");
   });
+
+  test("--filter accepts comma-separated patterns and produces multiple results", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-smoke-multi-"));
+    const jsonPath = join(dir, "report.json");
+    try {
+      const r = runBun([
+        "run",
+        "tests/benchmark/smoke.ts",
+        "--filter=safe-buffer,cookie",
+        `--json=${jsonPath}`,
+      ]);
+
+      expect(r.status, r.stderr?.toString()).toBe(0);
+      const report = JSON.parse(readFileSync(jsonPath, "utf-8"));
+      const names = report.results.map((entry: { project: string }) => entry.project);
+      expect(names).toContain("safe-buffer");
+      expect(names).toContain("cookie");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -1102,17 +1102,24 @@ const projects: ProjectConfig[] = [
 
 console.log("ZTS Smoke Test — Real Project Bundling\n");
 
-// CLI: --filter=<패턴> 으로 이름 필터링 (예: --filter=@es5, --filter=lodash)
+// CLI: --filter=<패턴> 으로 이름 필터링 (예: --filter=@es5, --filter=lodash).
+// 콤마 분리로 여러 패턴 OR 매치: --filter=safe-buffer,cookie,path-to-regexp.
 const filterArg = process.argv.find((a) => a.startsWith("--filter="));
-const filterPattern = filterArg ? filterArg.split("=")[1] : null;
+const filterPatterns = filterArg
+  ? filterArg
+      .slice("--filter=".length)
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  : null;
 const keepOutputArg = process.argv.find((a) => a.startsWith("--keep-output="));
 const keepOutputDir = keepOutputArg
   ? resolve(keepOutputArg.slice("--keep-output=".length))
   : undefined;
 const jsonArg = process.argv.find((a) => a.startsWith("--json="));
 const jsonPath = jsonArg ? resolve(jsonArg.slice("--json=".length)) : undefined;
-const filteredProjects = filterPattern
-  ? projects.filter((p) => p.name.includes(filterPattern))
+const filteredProjects = filterPatterns
+  ? projects.filter((p) => filterPatterns.some((pattern) => p.name.includes(pattern)))
   : projects;
 
 if (keepOutputDir) {
@@ -1237,7 +1244,7 @@ if (jsonPath) {
     JSON.stringify(
       {
         generatedAt: new Date().toISOString(),
-        filter: filterPattern,
+        filter: filterPatterns,
         keepOutputDir,
         results,
         sizeComparisons,


### PR DESCRIPTION
## Summary

기존엔 `--filter` 가 substring 단일 패턴만 지원해 `size-gap.ts` 가 프로젝트당 `smoke.ts` 를 별도 spawn 했음 (3 프로젝트 기준 1.5~3분 직렬). 이제 한 번 호출로 여러 프로젝트 동시 처리.

- `tests/benchmark/smoke.ts` `--filter=a,b,c` 콤마 분리 OR 매치 (빈 토큰 무시).
- `tests/benchmark/size-gap.ts` `runSmoke` 가 콤마 결합으로 1회 spawn 후 JSON 결과를 요청 순서대로 매핑. timeout 도 다중 프로젝트 기준 600s 로 상향.
- `tests/benchmark/smoke-diagnostics.test.ts` 에 multi-filter 케이스 추가.

## Test plan

- [x] `bun run tests/benchmark/smoke.ts --filter=safe-buffer,cookie` 직접 실행 — 두 프로젝트 결과 모두 JSON 에 기록 확인
- [x] 단일 패턴 (\`--filter=cookie\`) 기존 동작 유지
- [ ] CI smoke-diagnostics.test.ts 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)