### PR TITLE
CJS module.exports 객체 형태 named export DCE 지원

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -313,6 +313,143 @@ test "TreeShaking CJS: live export keeps CJS require target evaluation" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_REQUIRE_EXPORT_MARKER") == null);
 }
 
+test "TreeShaking CJS: named import prunes module.exports object shorthand property" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function used() { return "USED_OBJECT_SHORTHAND_MARKER"; }
+        \\function unused() { return "UNUSED_OBJECT_SHORTHAND_MARKER"; }
+        \\module.exports = { used, unused };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_OBJECT_SHORTHAND_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_OBJECT_SHORTHAND_MARKER") == null);
+}
+
+test "TreeShaking CJS: named import prunes module.exports object explicit and string properties" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used, alias } from './lib.js'; console.log(used(), alias());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function usedImpl() { return "USED_OBJECT_EXPLICIT_MARKER"; }
+        \\function aliasImpl() { return "USED_OBJECT_STRING_KEY_MARKER"; }
+        \\function unusedImpl() { return "UNUSED_OBJECT_EXPLICIT_MARKER"; }
+        \\module.exports = { used: usedImpl, "alias": aliasImpl, unused: unusedImpl };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_OBJECT_EXPLICIT_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_OBJECT_STRING_KEY_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_OBJECT_EXPLICIT_MARKER") == null);
+}
+
+test "TreeShaking CJS: module.exports object keeps used helper and removes unused private declaration" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function helper() { return "OBJECT_HELPER_MARKER"; }
+        \\function used() { return helper(); }
+        \\function unusedPrivate() { return "OBJECT_UNUSED_PRIVATE_MARKER"; }
+        \\module.exports = { used, unused: unusedPrivate };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_HELPER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_UNUSED_PRIVATE_MARKER") == null);
+}
+
+test "TreeShaking CJS: unsafe module.exports object shapes are preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used);");
+    try writeFile(tmp.dir, "lib.js",
+        \\function unused() { return "UNSAFE_OBJECT_UNUSED_FN_MARKER"; }
+        \\function sideEffect() { console.log("UNSAFE_OBJECT_EFFECT_MARKER"); return unused; }
+        \\const key = "computed";
+        \\const extra = { spread: unused };
+        \\const used = "UNSAFE_OBJECT_USED_MARKER";
+        \\module.exports = {
+        \\  used,
+        \\  [key]: unused,
+        \\  ...extra,
+        \\  get getter() { return "UNSAFE_OBJECT_GETTER_MARKER"; },
+        \\  method() { return "UNSAFE_OBJECT_METHOD_MARKER"; },
+        \\  effect: sideEffect(),
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_OBJECT_USED_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_OBJECT_UNUSED_FN_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_OBJECT_EFFECT_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_OBJECT_GETTER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_OBJECT_METHOD_MARKER") != null);
+}
+
+test "TreeShaking CJS: module.exports object live export keeps require target evaluation" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\const helper = require("./helper.js");
+        \\function used() { return helper("USED_OBJECT_REQUIRE_TARGET_MARKER"); }
+        \\function unused() { return "UNUSED_OBJECT_REQUIRE_EXPORT_MARKER"; }
+        \\module.exports = { used, unused };
+    );
+    try writeFile(tmp.dir, "helper.js",
+        \\function helper(value) { return value; }
+        \\module.exports = helper;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_OBJECT_REQUIRE_TARGET_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = helper") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_OBJECT_REQUIRE_EXPORT_MARKER") == null);
+}
+
 // ============================================================
 // @__PURE__ annotation tests
 // ============================================================

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1269,6 +1269,24 @@ pub fn emitModule(
                                                 }
                                             }
                                         }
+                                        if (!s.isExportUsed(mod_idx, "*")) {
+                                            for (ts_infos.cjs_export_facts) |fact| {
+                                                if (fact.kind != .object_property) continue;
+                                                const prop_node_idx = fact.property_node orelse continue;
+                                                if (s.isExportUsed(mod_idx, fact.export_name)) continue;
+                                                const source_ast = module.ast orelse continue;
+                                                if (prop_node_idx >= source_ast.nodes.items.len) continue;
+                                                const prop_span = source_ast.nodes.items[prop_node_idx].span;
+                                                for (transformer.ast.nodes.items, 0..) |new_node, new_ni| {
+                                                    if (new_node.tag != .object_property) continue;
+                                                    if (new_node.span.start != prop_span.start or new_node.span.end != prop_span.end) continue;
+                                                    if (new_ni < md.skip_nodes.capacity()) {
+                                                        md.skip_nodes.set(new_ni);
+                                                    }
+                                                    break;
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -16,6 +16,7 @@ const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Reference = @import("../semantic/symbol.zig").Reference;
 const ScopeId = @import("../semantic/scope.zig").ScopeId;
 const purity = @import("purity.zig");
+const ast_mod = @import("../parser/ast.zig");
 
 pub const StmtInfo = struct {
     node_idx: u32,
@@ -28,10 +29,17 @@ pub const StmtInfo = struct {
 };
 
 pub const CjsExportFact = struct {
+    pub const Kind = enum {
+        assignment,
+        object_property,
+    };
+
     export_name: []const u8,
     statement_index: u32,
     export_assignment_node: u32,
+    property_node: ?u32 = null,
     rhs_symbol: ?u32 = null,
+    kind: Kind = .assignment,
     is_static: bool = true,
     is_safe_to_prune: bool = true,
 };
@@ -80,9 +88,14 @@ pub const ModuleStmtInfos = struct {
     }
 
     pub fn cjsExportStmtByName(self: *const ModuleStmtInfos, export_name: []const u8) ?u32 {
+        const fact = self.cjsExportFactByName(export_name) orelse return null;
+        return fact.statement_index;
+    }
+
+    pub fn cjsExportFactByName(self: *const ModuleStmtInfos, export_name: []const u8) ?CjsExportFact {
         for (self.cjs_export_facts) |fact| {
             if (fact.is_static and std.mem.eql(u8, fact.export_name, export_name)) {
-                return fact.statement_index;
+                return fact;
             }
         }
         return null;
@@ -156,6 +169,8 @@ const CjsExportCandidate = struct {
     export_name: []const u8,
     export_assignment_node: u32,
     rhs_node: NodeIndex,
+    property_node: ?u32 = null,
+    kind: CjsExportFact.Kind = .assignment,
 };
 
 fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeIndex, property: NodeIndex } {
@@ -191,6 +206,36 @@ fn cjsExportNameFromLhs(ast: *const Ast, lhs: NodeIndex) ?[]const u8 {
     return ast.getText(prop.span);
 }
 
+fn isModuleExportsLhs(ast: *const Ast, lhs: NodeIndex) bool {
+    const parts = staticMemberParts(ast, lhs) orelse return false;
+    const obj = ast.nodes.items[@intFromEnum(parts.object)];
+    const prop = ast.nodes.items[@intFromEnum(parts.property)];
+    if (obj.tag != .identifier_reference) return false;
+    return std.mem.eql(u8, ast.getText(obj.span), "module") and
+        std.mem.eql(u8, ast.getText(prop.span), "exports");
+}
+
+fn staticObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
+    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return null;
+    const key = ast.nodes.items[@intFromEnum(key_idx)];
+    return switch (key.tag) {
+        .identifier_reference => ast.getText(key.data.string_ref),
+        .string_literal => ast_mod.Ast.stripStringQuotes(ast.getText(key.span)),
+        else => null,
+    };
+}
+
+fn objectPropertyValueNode(prop: Node) NodeIndex {
+    return if (prop.data.binary.right.isNone()) prop.data.binary.left else prop.data.binary.right;
+}
+
+fn isCjsObjectPropertyValueFactSafe(ast: *const Ast, value: NodeIndex, unresolved_globals: ?*const purity.GlobalRefSet) bool {
+    if (value.isNone() or @intFromEnum(value) >= ast.nodes.items.len) return false;
+    const value_node = ast.nodes.items[@intFromEnum(value)];
+    if (value_node.tag != .identifier_reference) return false;
+    return purity.isExprPure(ast, value, unresolved_globals);
+}
+
 fn cjsExportCandidateForStmt(ast: *const Ast, stmt_node: Node) ?CjsExportCandidate {
     if (stmt_node.tag != .expression_statement) return null;
     const expr_idx = stmt_node.data.unary.operand;
@@ -203,6 +248,64 @@ fn cjsExportCandidateForStmt(ast: *const Ast, stmt_node: Node) ?CjsExportCandida
         .export_assignment_node = @intFromEnum(expr_idx),
         .rhs_node = expr.data.binary.right,
     };
+}
+
+fn collectCjsObjectExportCandidates(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    stmt_node: Node,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) !?[]CjsExportCandidate {
+    if (stmt_node.tag != .expression_statement) return null;
+    const expr_idx = stmt_node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return null;
+    if (!isModuleExportsLhs(ast, expr.data.binary.left)) return null;
+
+    const rhs_idx = expr.data.binary.right;
+    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return null;
+    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+    if (rhs.tag != .object_expression) return null;
+
+    const list = rhs.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return null;
+    const indices = ast.extra_data.items[list.start .. list.start + list.len];
+    if (indices.len == 0) return null;
+
+    var seen: std.StringHashMapUnmanaged(void) = .{};
+    defer seen.deinit(allocator);
+    var out: std.ArrayListUnmanaged(CjsExportCandidate) = .empty;
+    errdefer out.deinit(allocator);
+    var success = false;
+    defer if (!success) out.deinit(allocator);
+
+    for (indices) |raw_prop| {
+        const prop_idx: NodeIndex = @enumFromInt(raw_prop);
+        if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
+        const prop = ast.nodes.items[@intFromEnum(prop_idx)];
+        if (prop.tag != .object_property) return null;
+
+        const name = staticObjectKeyName(ast, prop.data.binary.left) orelse return null;
+        if (std.mem.eql(u8, name, "__proto__")) return null;
+        const entry = try seen.getOrPut(allocator, name);
+        if (entry.found_existing) return null;
+
+        const value = objectPropertyValueNode(prop);
+        if (!isCjsObjectPropertyValueFactSafe(ast, value, unresolved_globals)) return null;
+
+        try out.append(allocator, .{
+            .export_name = name,
+            .export_assignment_node = @intFromEnum(expr_idx),
+            .property_node = @intFromEnum(prop_idx),
+            .rhs_node = value,
+            .kind = .object_property,
+        });
+    }
+
+    const slice = try out.toOwnedSlice(allocator);
+    success = true;
+    return slice;
 }
 
 fn cjsExportAssignmentHasSideEffects(ast: *const Ast, candidate: CjsExportCandidate, unresolved_globals: ?*const purity.GlobalRefSet) bool {
@@ -381,18 +484,38 @@ pub fn buildFromSemantic(
         } else {
             const node = ast.nodes.items[ni];
             const cjs_export_candidate = if (collect_cjs_exports) cjsExportCandidateForStmt(ast, node) else null;
+            var safe_cjs_object_export = false;
             if (cjs_export_candidate) |candidate| {
                 try cjs_export_facts_buf.append(allocator, .{
                     .export_name = candidate.export_name,
                     .statement_index = @intCast(stmt_i),
                     .export_assignment_node = candidate.export_assignment_node,
+                    .property_node = candidate.property_node,
+                    .kind = candidate.kind,
                     .is_safe_to_prune = !cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals),
                 });
+            } else if (collect_cjs_exports) {
+                if (try collectCjsObjectExportCandidates(allocator, ast, node, unresolved_globals)) |candidates| {
+                    defer allocator.free(candidates);
+                    safe_cjs_object_export = true;
+                    for (candidates) |candidate| {
+                        try cjs_export_facts_buf.append(allocator, .{
+                            .export_name = candidate.export_name,
+                            .statement_index = @intCast(stmt_i),
+                            .export_assignment_node = candidate.export_assignment_node,
+                            .property_node = candidate.property_node,
+                            .kind = candidate.kind,
+                            .is_safe_to_prune = true,
+                        });
+                    }
+                }
             }
             const side_effects = if (node.tag == .import_declaration)
                 false
             else if (cjs_export_candidate) |candidate|
                 cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals)
+            else if (safe_cjs_object_export)
+                false
             else
                 purity.stmtHasSideEffects(ast, node, unresolved_globals);
             stmts[stmt_i] = .{
@@ -576,6 +699,7 @@ pub fn build(
         const node = ast.nodes.items[ni];
         stmt_spans[stmt_i] = node.span;
         const cjs_export_candidate = if (collect_cjs_exports) cjsExportCandidateForStmt(ast, node) else null;
+        var safe_cjs_object_export = false;
         if (cjs_export_candidate) |candidate| {
             const rhs_symbol: ?u32 = if (!candidate.rhs_node.isNone() and @intFromEnum(candidate.rhs_node) < symbol_ids.len)
                 symbol_ids[@intFromEnum(candidate.rhs_node)]
@@ -585,14 +709,38 @@ pub fn build(
                 .export_name = candidate.export_name,
                 .statement_index = @intCast(stmt_i),
                 .export_assignment_node = candidate.export_assignment_node,
+                .property_node = candidate.property_node,
                 .rhs_symbol = rhs_symbol,
+                .kind = candidate.kind,
                 .is_safe_to_prune = !cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals),
             });
+        } else if (collect_cjs_exports) {
+            if (try collectCjsObjectExportCandidates(allocator, ast, node, unresolved_globals)) |candidates| {
+                defer allocator.free(candidates);
+                safe_cjs_object_export = true;
+                for (candidates) |candidate| {
+                    const rhs_symbol: ?u32 = if (!candidate.rhs_node.isNone() and @intFromEnum(candidate.rhs_node) < symbol_ids.len)
+                        symbol_ids[@intFromEnum(candidate.rhs_node)]
+                    else
+                        null;
+                    try cjs_export_facts_buf.append(allocator, .{
+                        .export_name = candidate.export_name,
+                        .statement_index = @intCast(stmt_i),
+                        .export_assignment_node = candidate.export_assignment_node,
+                        .property_node = candidate.property_node,
+                        .rhs_symbol = rhs_symbol,
+                        .kind = candidate.kind,
+                        .is_safe_to_prune = true,
+                    });
+                }
+            }
         }
         const side_effects = if (node.tag == .import_declaration)
             false
         else if (cjs_export_candidate) |candidate|
             cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals)
+        else if (safe_cjs_object_export)
+            false
         else
             purity.stmtHasSideEffects(ast, node, unresolved_globals);
         stmts[stmt_i] = .{

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -814,14 +814,11 @@ pub const TreeShaker = struct {
                 try self.markAndSeedAllStmts(canon_mod, queue, module_stmt_infos, reachable_stmts);
                 return;
             };
-            const target_stmt = target_infos.cjsExportStmtByName(canonical.export_name) orelse {
+            const fact = target_infos.cjsExportFactByName(canonical.export_name) orelse {
                 try self.markAndSeedAllStmts(canon_mod, queue, module_stmt_infos, reachable_stmts);
                 return;
             };
-            if (reachable_stmts[canon_mod] == null) {
-                reachable_stmts[canon_mod] = try std.DynamicBitSet.initEmpty(self.allocator, target_infos.stmts.len);
-            }
-            try self.enqueue(canon_mod, target_stmt, reachable_stmts, queue);
+            try self.seedCjsExportFact(canon_mod, target_infos, fact, queue, reachable_stmts);
             return;
         }
 
@@ -903,14 +900,43 @@ pub const TreeShaker = struct {
             try self.markAndSeedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
             return;
         };
-        const target_stmt = target_infos.cjsExportStmtByName(export_name) orelse {
+        const fact = target_infos.cjsExportFactByName(export_name) orelse {
             try self.markAndSeedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
             return;
         };
+        try self.seedCjsExportFact(mod_idx, target_infos, fact, queue, reachable_stmts);
+    }
+
+    fn seedCjsExportFact(
+        self: *TreeShaker,
+        mod_idx: u32,
+        infos: StmtInfos,
+        fact: stmt_info_mod.CjsExportFact,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
         if (reachable_stmts[mod_idx] == null) {
-            reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, target_infos.stmts.len);
+            reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
         }
-        try self.enqueue(mod_idx, target_stmt, reachable_stmts, queue);
+
+        if (fact.kind != .object_property) {
+            try self.enqueue(mod_idx, fact.statement_index, reachable_stmts, queue);
+            return;
+        }
+
+        if (fact.statement_index < infos.stmts.len) {
+            reachable_stmts[mod_idx].?.set(fact.statement_index);
+        }
+
+        const rhs_sym = fact.rhs_symbol orelse return;
+        if (infos.declaredStmtBySymbol(rhs_sym)) |dep_stmt| {
+            try self.enqueue(mod_idx, dep_stmt, reachable_stmts, queue);
+        }
+        if (rhs_sym < infos.sym_to_writer_stmts.len) {
+            for (infos.sym_to_writer_stmts[rhs_sym]) |writer_stmt| {
+                try self.enqueue(mod_idx, writer_stmt, reachable_stmts, queue);
+            }
+        }
     }
 
     /// StmtInfo 없는 모듈 (entry, CJS 등)의 import를 BFS로 전파.

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3923,6 +3923,7 @@ pub const Codegen = struct {
         for (indices) |raw_idx| {
             const node_idx: NodeIndex = @enumFromInt(raw_idx);
             if (node_idx.isNone()) continue;
+            if (self.isSkipped(node_idx)) continue;
             if (!first) try self.write(sep);
             first = false;
             try self.emitNode(node_idx);


### PR DESCRIPTION
Refs #2060

## 개요

`module.exports = { ... }` 형태의 정적으로 안전한 CommonJS object-shape export에 대해 named import 기반 DCE를 지원합니다.

이번 PR에서 fact를 생성하는 범위는 다음으로 제한했습니다.

- `module.exports = { used, unused }`
- `module.exports = { used: used, unused: unused }`
- `module.exports = { "used": used, "unused": unused }`

정적으로 안전하지 않은 형태는 fact를 만들지 않고 기존 보존 동작을 유지합니다.

- computed key
- spread
- getter/setter 및 method shorthand
- `__proto__`
- side-effectful value
- identifier value가 아닌 object property value
- 중복 property name

## 변경 사항

- CJS export fact에 `object_property` variant를 추가했습니다.
- named CJS import가 object-shape fact를 가리킬 때 전체 object assignment의 모든 참조를 살리지 않고, 사용된 property value의 심볼만 도달성 seed로 사용합니다.
- 출력 단계에서 사용되지 않은 안전 object property를 `skip_nodes`로 제거합니다.
- `skip_nodes`로 생략된 list item이 separator만 남기지 않도록 codegen list emission을 보정했습니다.

## TDD / 회귀 테스트

먼저 `src/bundler/bundler_test/tree_shake.zig`에 실패하는 회귀 테스트를 추가한 뒤 구현했습니다.

추가 커버리지:

- shorthand object property named import DCE
- explicit property와 string key property DCE
- used export helper 유지 및 unused private declaration 제거
- computed key/spread/getter/method/side-effectful value 보존
- live object export 내부 `require()` target 평가 보존

## 검증

- `zig build test --summary all --prominent-compile-errors`: 통과, 3983/3983 tests passed
- `zig build --summary all --prominent-compile-errors`: 통과
- `bun test tests/integration/tests/tree-shake-precision.test.ts`: 통과, 7 pass
- `bun run tests/benchmark/smoke.ts --filter=safe-buffer,cookie,path-to-regexp,axios,rxjs`: ZTS 5/5 build 성공, 5/5 output MATCH

참고: benchmark smoke에서 `axios`의 esbuild run은 기존 스크립트 출력상 FAIL로 표시되지만, ZTS는 OK이고 rolldown/rspack 기준 output은 MATCH입니다.