### PR TITLE
refactor(emitter): drop redundant skip_nodes.capacity guards

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1261,8 +1261,7 @@ pub fn emitModule(
                                                 if (ni >= transformer.ast.nodes.items.len) continue;
                                                 const new_node = transformer.ast.nodes.items[ni];
                                                 if (new_node.span.start == ts_stmt.span.start and
-                                                    new_node.span.end == ts_stmt.span.end and
-                                                    ni < md.skip_nodes.capacity())
+                                                    new_node.span.end == ts_stmt.span.end)
                                                 {
                                                     md.skip_nodes.set(ni);
                                                     break;
@@ -1307,9 +1306,7 @@ pub fn emitModule(
                                     }
                                     if (infos.computeReachable(arena_alloc, used_sym_buf.items)) |reachable| {
                                         for (infos.stmts, 0..) |stmt, si| {
-                                            if (!reachable.isSet(si) and stmt.node_idx < md.skip_nodes.capacity()) {
-                                                md.skip_nodes.set(stmt.node_idx);
-                                            }
+                                            if (!reachable.isSet(si)) md.skip_nodes.set(stmt.node_idx);
                                         }
                                     } else |_| {}
                                 }


### PR DESCRIPTION
## Summary

`md.skip_nodes` 는 `linker/metadata.buildSkipNodes` 에서 `transformer.ast.nodes.items.len` 크기로 init. 두 호출 site 의 인덱스 (\`new_stmt_indices\` 의 \`ni\`, \`infos.stmts[].node_idx\`) 모두 같은 \`transformer.ast\` 의 노드 인덱스라 capacity 초과는 invariant 위반 — 가드 자체가 dead. 제거.

## Test plan

- [x] \`zig build test\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)