### PR TITLE
refactor(stmt_info): encapsulate sym -> stmt list lookups

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -99,6 +99,24 @@ pub const ModuleStmtInfos = struct {
         return self.symbol_to_stmt[sym_idx];
     }
 
+    /// symbol 을 read 하는 statement 인덱스들. 미등록 symbol 이면 빈 슬라이스.
+    pub fn referencingStmts(self: *const ModuleStmtInfos, sym_idx: u32) []const u32 {
+        if (sym_idx >= self.sym_to_referencing_stmts.len) return &.{};
+        return self.sym_to_referencing_stmts[sym_idx];
+    }
+
+    /// symbol 을 비선언 write 하는 statement 인덱스들. 미등록 symbol 이면 빈 슬라이스.
+    pub fn writerStmts(self: *const ModuleStmtInfos, sym_idx: u32) []const u32 {
+        if (sym_idx >= self.sym_to_writer_stmts.len) return &.{};
+        return self.sym_to_writer_stmts[sym_idx];
+    }
+
+    /// symbol 을 reference 하는 side-effectful statement 인덱스들. 미등록이면 빈 슬라이스.
+    pub fn sideEffectStmts(self: *const ModuleStmtInfos, sym_idx: u32) []const u32 {
+        if (sym_idx >= self.sym_to_side_effect_stmts.len) return &.{};
+        return self.sym_to_side_effect_stmts[sym_idx];
+    }
+
     /// used exports에서 도달 가능한 심볼 set을 BFS로 계산.
     /// 반환: symbol_index → reachable 여부를 나타내는 bitset.
     pub fn computeReachable(
@@ -142,12 +160,10 @@ pub const ModuleStmtInfos = struct {
                         try queue.append(allocator, dep_stmt);
                     }
                 }
-                if (ref_sym < self.sym_to_writer_stmts.len) {
-                    for (self.sym_to_writer_stmts[ref_sym]) |writer_stmt| {
-                        if (!reachable_stmts.isSet(writer_stmt)) {
-                            reachable_stmts.set(writer_stmt);
-                            try queue.append(allocator, writer_stmt);
-                        }
+                for (self.writerStmts(ref_sym)) |writer_stmt| {
+                    if (!reachable_stmts.isSet(writer_stmt)) {
+                        reachable_stmts.set(writer_stmt);
+                        try queue.append(allocator, writer_stmt);
                     }
                 }
             }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -412,12 +412,10 @@ pub const TreeShaker = struct {
         const sym_idx = sem.scope_maps[0].get(local_name) orelse return false;
 
         // 역인덱스로 이 심볼을 참조하는 statement 중 reachable한 것이 있는지 확인
-        if (sym_idx < infos.sym_to_referencing_stmts.len) {
-            for (infos.sym_to_referencing_stmts[sym_idx]) |si| {
-                if (!reachable.isSet(si)) continue;
-                if (isImportDeclarationStmt(m, infos, @intCast(si))) continue;
-                return true;
-            }
+        for (infos.referencingStmts(@intCast(sym_idx))) |si| {
+            if (!reachable.isSet(si)) continue;
+            if (isImportDeclarationStmt(m, infos, @intCast(si))) continue;
+            return true;
         }
         return false;
     }
@@ -619,10 +617,8 @@ pub const TreeShaker = struct {
                 // (1b) 같은 심볼에 대한 비선언 writer (예: TS 가 emit 하는 `var _a; ... _a = AST;`).
                 // declare 경로로는 var-only 선언만 살아남고 실제 값을 채우는 후속 할당이 누락되어
                 // `_a is not a constructor` 류 회귀가 발생한다.
-                if (ref_sym < infos.sym_to_writer_stmts.len) {
-                    for (infos.sym_to_writer_stmts[ref_sym]) |writer_stmt| {
-                        try self.enqueue(item.mod, writer_stmt, reachable_stmts, &queue);
-                    }
+                for (infos.writerStmts(ref_sym)) |writer_stmt| {
+                    try self.enqueue(item.mod, writer_stmt, reachable_stmts, &queue);
                 }
 
                 // (2) import binding: 타겟 모듈로 점프
@@ -691,12 +687,10 @@ pub const TreeShaker = struct {
             if (self.module_stmt_infos[mod]) |infos| {
                 if (stmt < infos.stmts.len) {
                     for (infos.stmts[stmt].declared_symbols) |declared_sym| {
-                        if (declared_sym < infos.sym_to_side_effect_stmts.len) {
-                            for (infos.sym_to_side_effect_stmts[declared_sym]) |si| {
-                                if (!reachable[mod].?.isSet(si)) {
-                                    reachable[mod].?.set(si);
-                                    try queue.append(self.allocator, .{ .mod = @intCast(mod), .stmt = @intCast(si) });
-                                }
+                        for (infos.sideEffectStmts(declared_sym)) |si| {
+                            if (!reachable[mod].?.isSet(si)) {
+                                reachable[mod].?.set(si);
+                                try queue.append(self.allocator, .{ .mod = @intCast(mod), .stmt = @intCast(si) });
                             }
                         }
                     }
@@ -932,10 +926,8 @@ pub const TreeShaker = struct {
         if (infos.declaredStmtBySymbol(rhs_sym)) |dep_stmt| {
             try self.enqueue(mod_idx, dep_stmt, reachable_stmts, queue);
         }
-        if (rhs_sym < infos.sym_to_writer_stmts.len) {
-            for (infos.sym_to_writer_stmts[rhs_sym]) |writer_stmt| {
-                try self.enqueue(mod_idx, writer_stmt, reachable_stmts, queue);
-            }
+        for (infos.writerStmts(rhs_sym)) |writer_stmt| {
+            try self.enqueue(mod_idx, writer_stmt, reachable_stmts, queue);
         }
     }
 


### PR DESCRIPTION
## Summary

\`ModuleStmtInfos\` 가 노출하던 \`sym_to_referencing_stmts\` / \`sym_to_writer_stmts\` / \`sym_to_side_effect_stmts\` 직접 인덱싱을 \`referencingStmts\` / \`writerStmts\` / \`sideEffectStmts\` 메서드로 캡슐화. 미등록 symbol 은 빈 슬라이스 반환.

caller (tree_shaker, computeReachable) 의 boundary check + 인덱싱이 단일 호출로 단순화되고 \`ModuleStmtInfos\` 내부 구조 변경 시 영향 범위가 좁아진다.

## Test plan

- [x] \`zig build test\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)