### PR TITLE
refactor(ast): centralize static-key-name extraction

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -16,7 +16,6 @@ const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Reference = @import("../semantic/symbol.zig").Reference;
 const ScopeId = @import("../semantic/scope.zig").ScopeId;
 const purity = @import("purity.zig");
-const ast_mod = @import("../parser/ast.zig");
 
 pub const StmtInfo = struct {
     node_idx: u32,
@@ -218,16 +217,6 @@ fn cjsExportNameFromLhs(ast: *const Ast, lhs: NodeIndex) ?[]const u8 {
     return null;
 }
 
-fn staticObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
-    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return null;
-    const key = ast.nodes.items[@intFromEnum(key_idx)];
-    return switch (key.tag) {
-        .identifier_reference => ast.getText(key.data.string_ref),
-        .string_literal => ast_mod.Ast.stripStringQuotes(ast.getText(key.span)),
-        else => null,
-    };
-}
-
 /// shorthand `{ x }` 는 right 가 none → left 가 곧 value. 그 외 explicit `{ k: v }` 는 right 가 value.
 fn objectPropertyValueNode(prop: Node) NodeIndex {
     return if (prop.data.binary.right.isNone()) prop.data.binary.left else prop.data.binary.right;
@@ -292,7 +281,7 @@ fn collectCjsObjectExportCandidates(
         const prop = ast.nodes.items[@intFromEnum(prop_idx)];
         if (prop.tag != .object_property) return null;
 
-        const name = staticObjectKeyName(ast, prop.data.binary.left) orelse return null;
+        const name = ast.staticKeyName(prop.data.binary.left) orelse return null;
         // `{__proto__: X}` 는 prototype 을 설정 — named export 가 아니라 reject.
         if (std.mem.eql(u8, name, "__proto__")) return null;
         const entry = try seen.getOrPut(allocator, name);

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1250,6 +1250,32 @@ pub const Ast = struct {
         }
         return self.source[span.start..span.end];
     }
+
+    /// object/method/class key 노드에서 정적 이름을 raw 형태로 추출한다.
+    /// identifier 계열, string_literal (따옴표 제거), numeric_literal,
+    /// computed_property_key (literal inner) 까지 처리. 그 외 (computed expr)
+    /// 는 null. 따옴표만 제거하므로 escape sequence 는 보존 — escape 해석이
+    /// 필요한 codegen 경로는 별도 helper 사용.
+    pub fn staticKeyName(self: *const Ast, key_idx: NodeIndex) ?[]const u8 {
+        if (key_idx.isNone() or @intFromEnum(key_idx) >= self.nodes.items.len) return null;
+        const n = self.getNode(key_idx);
+        return switch (n.tag) {
+            .identifier_reference, .binding_identifier, .private_identifier => self.getText(n.data.string_ref),
+            .string_literal => stripStringQuotes(self.getText(n.span)),
+            .numeric_literal => self.getText(n.span),
+            .computed_property_key => blk: {
+                const inner = n.data.unary.operand;
+                if (inner.isNone()) break :blk null;
+                const inner_n = self.getNode(inner);
+                break :blk switch (inner_n.tag) {
+                    .string_literal => stripStringQuotes(self.getText(inner_n.span)),
+                    .numeric_literal => self.getText(inner_n.span),
+                    else => null,
+                };
+            },
+            else => null,
+        };
+    }
 };
 
 // ============================================================

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -104,23 +104,10 @@ pub fn checkDuplicateConstructors(
 // ====================================================================
 
 /// key 노드의 이름이 target과 일치하는지 확인한다.
-/// identifier_reference와 string_literal(따옴표 자동 제거) 모두 처리.
+/// identifier 계열 / string_literal(따옴표 자동 제거) / numeric / computed-literal 모두 처리.
 fn matchKeyName(ast: *const Ast, key_idx: NodeIndex, target: []const u8) bool {
-    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return false;
-    const key_node = ast.getNode(key_idx);
-
-    if (key_node.tag == .identifier_reference) {
-        return std.mem.eql(u8, ast.getText(key_node.span), target);
-    }
-    if (key_node.tag == .string_literal) {
-        // 따옴표 제거: "name" → name
-        const raw = ast.getText(key_node.span);
-        if (raw.len >= 2) {
-            const inner = raw[1 .. raw.len - 1];
-            return std.mem.eql(u8, inner, target);
-        }
-    }
-    return false;
+    const name = ast.staticKeyName(key_idx) orelse return false;
+    return std.mem.eql(u8, name, target);
 }
 
 /// 에러를 errors 목록에 추가한다.


### PR DESCRIPTION
## Summary

\`Ast.staticKeyName\` 메서드 추가 (raw 형태). identifier 계열, \`string_literal\` (따옴표 제거), \`numeric_literal\`, \`computed_property_key\` 의 literal inner 까지 포괄.

\`stmt_info.staticObjectKeyName\` 와 \`checker.matchKeyName\` 이 같은 일을 하면서 각자 좁은 범위만 처리하던 것을 ast helper 호출로 통일. \`codegen.resolveKeyName\` 은 \`string_literal\` escape 시퀀스 해석이 필요해 별도 유지 (raw vs cooked 의미 차이).

## Test plan

- [x] \`zig build test\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)