### PR TITLE
refactor(ast): host objectPropertyValue helper alongside staticKeyName

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -217,11 +217,6 @@ fn cjsExportNameFromLhs(ast: *const Ast, lhs: NodeIndex) ?[]const u8 {
     return null;
 }
 
-/// shorthand `{ x }` 는 right 가 none → left 가 곧 value. 그 외 explicit `{ k: v }` 는 right 가 value.
-fn objectPropertyValueNode(prop: Node) NodeIndex {
-    return if (prop.data.binary.right.isNone()) prop.data.binary.left else prop.data.binary.right;
-}
-
 /// CJS object-shape export 의 value 위치가 named export 로 치환 안전한지 판정.
 /// identifier_reference 만 허용해 tree_shaker 가 `rhs_symbol → declaring stmt` 로
 /// dependency 를 시드할 수 있게 한다 (리터럴 등은 의존 시드가 의미 없어 거부).
@@ -287,7 +282,7 @@ fn collectCjsObjectExportCandidates(
         const entry = try seen.getOrPut(allocator, name);
         if (entry.found_existing) return null;
 
-        const value = objectPropertyValueNode(prop);
+        const value = Ast.objectPropertyValue(prop);
         if (!isCjsObjectPropertyValueSafe(ast, value, unresolved_globals)) return null;
 
         try out.append(allocator, .{

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1251,6 +1251,13 @@ pub const Ast = struct {
         return self.source[span.start..span.end];
     }
 
+    /// object_property 노드에서 value 위치 노드를 반환한다.
+    /// shorthand `{ x }` 는 right 가 none → key (left) 가 곧 value.
+    /// 그 외 explicit `{ k: v }` 는 right 가 value.
+    pub fn objectPropertyValue(prop: Node) NodeIndex {
+        return if (prop.data.binary.right.isNone()) prop.data.binary.left else prop.data.binary.right;
+    }
+
     /// object/method/class key 노드에서 정적 이름을 raw 형태로 추출한다.
     /// identifier 계열, string_literal (따옴표 제거), numeric_literal,
     /// computed_property_key (literal inner) 까지 처리. 그 외 (computed expr)


### PR DESCRIPTION
## Summary

\`stmt_info.zig\` 의 file-local \`objectPropertyValueNode\` 를 \`Ast.objectPropertyValue\` 로 옮겨 \`staticKeyName\` 옆에 둠.

shorthand 분기 (\`right\` 가 none 이면 \`left\` 가 value) 라는 동일 invariant 가 codegen 의 object_property emit / parser 의 shorthand-default 처리에서도 나타나지만, 그쪽은 emit/parse 부가 로직과 묶여있어 단순 호출로 통일하기는 어렵다 — 본 PR 은 위치 이동 + future reuse 준비에 한정.

## Test plan

- [x] \`zig build test\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)