### PR TITLE
fix(tree_shaker): cjs-wrap 모듈의 transformer-injected helper import 보존

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -450,6 +450,43 @@ test "TreeShaking CJS: module.exports object live export keeps require target ev
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_OBJECT_REQUIRE_EXPORT_MARKER") == null);
 }
 
+test "TreeShaking CJS: ES5 target preserves transformer-injected runtime helper module" {
+    // Regression: transformer 가 graph parse 단계에서 inject 한 runtime helper import
+    // (예: `import { __read } from "\x00zts:runtime/read"`) 는 semantic scope_maps 에
+    // 등록되지 않아 cjs-wrap 모듈에서 isImportLiveInModule 가 항상 false 를 반환했다.
+    // 결과: helper module 이 included 안 되어 dist 의 `__read` 호출이 정의를 못 찾아
+    // ReferenceError (semver@es5 smoke 회귀).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import lib from './lib.cjs'; console.log(lib.foo([1,2]));");
+    try writeFile(tmp.dir, "lib.cjs",
+        \\module.exports = {
+        \\  foo: function(arr) {
+        \\    var [a, b] = arr;
+        \\    return a + b;
+        \\  },
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = .{ .destructuring = true },
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // __read 호출이 emit 됐다면 정의도 함께 dist 에 있어야 한다.
+    if (std.mem.indexOf(u8, result.output, "__read(") != null) {
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "var __read") != null or
+            std.mem.indexOf(u8, result.output, "function __read") != null);
+    }
+}
+
 // ============================================================
 // @__PURE__ annotation tests
 // ============================================================

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -30,6 +30,7 @@ const purity = @import("purity.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const StmtInfos = stmt_info_mod.ModuleStmtInfos;
 const constant_facts = @import("constant_facts.zig");
+const runtime_helper_modules = @import("../runtime_helper_modules.zig");
 
 /// `used_exports`의 all-exports-used sentinel. 모듈의 전체 export가 사용됨을 표시.
 /// 일반 export 이름과 겹치지 않도록 의도적으로 JS 식별자 아닌 `"*"` 선택.
@@ -1302,7 +1303,13 @@ pub const TreeShaker = struct {
             const target_module = self.graph.getModule(rec.resolved) orelse continue;
 
             if (live_mod_idx) |idx| {
-                if (!self.isImportLiveInModule(idx, ib.local_name)) continue;
+                // Transformer 가 graph parse 단계에서 inject 한 runtime helper import 는
+                // semantic 의 scope_maps 에 등록되지 않아 isImportLiveInModule 가 항상
+                // false 를 반환 — cjs-wrap 모듈에서 이 분기에 걸리면 helper module 이
+                // included 되지 못하고 dist preamble 에서 사라진다 (`__read is not defined`).
+                // helper 는 transformer 가 명시 inject 한 것이므로 무조건 live 로 처리.
+                const is_runtime_helper = runtime_helper_modules.isVirtualId(target_module.path);
+                if (!is_runtime_helper and !self.isImportLiveInModule(idx, ib.local_name)) continue;
             }
 
             if (target_module.wrap_kind == .cjs) {


### PR DESCRIPTION
## 회귀 진단

\`semver@es5\` smoke 가 \`__read is not defined\` ReferenceError 로 FAIL.

### Root cause

\`22e29e64\` (\`fix: tree-shake static CJS named exports\`) 가 cjs-wrap 모듈에 대해서도 stmt-level live filter 를 활성화하면서:

1. transformer 가 graph parse 단계에서 ES5 destructuring 등을 위해 \`import { __read } from "\\x00zts:runtime/read"\` 같은 helper import 를 모듈 본문에 prepend
2. 이 binding 은 _semantic 분석 후_ 추가된 것 → \`sem.scope_maps[0].get("__read")\` 는 null 반환
3. \`isImportLiveInModule\` 가 \`return false\` (스코프에 없으면 dead)
4. cjs-wrap 모듈의 \`processModuleImportsInner\` 가 live filter 에서 \`continue\` → helper module 이 \`markExportUsed\` 받지 못함
5. tree-shaker fixedpoint 종료 시 helper module 이 \`included = false\` → emit 안 됨
6. dist 에 \`__read(...)\` 호출은 남고 \`var __read = function...\` 정의는 빠져 ReferenceError

22e29e64 이전엔 cjs-wrap 모듈이 \`live_mod_idx = null\` 로 wrap-level 처리되어 모든 binding 이 unconditional \`markExportUsed\` → helper module included.

## 수정

\`processModuleImportsInner\` 의 live filter 진입 직전에 target 이 runtime helper virtual module (\`\\x00zts:runtime/...\` prefix) 인지 검사하고, 그러면 live filter 를 skip 한다. transformer 가 helper 를 명시 inject 했다는 사실 자체가 helper 가 필요하다는 신호이므로 second-guess 하지 않는다.

## Test plan

- [x] \`zig build test\` 통과 (신규 회귀 테스트 + 기존 모두)
- [x] 회귀 테스트가 fix 없을 때 fail 함을 확인 (테스트가 진짜 회귀를 잡음)
- [x] \`semver\`, \`semver@es5\`, \`semver@es2019\` smoke 3/3 PASS
- [ ] CI smoke 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)