### PR TITLE
CJS defineProperty value export DCE 추가

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -313,6 +313,106 @@ test "TreeShaking CJS: live export keeps CJS require target evaluation" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_REQUIRE_EXPORT_MARKER") == null);
 }
 
+test "TreeShaking CJS: named import prunes unused Object.defineProperty exports value" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function used() { return "USED_DEFINE_PROPERTY_MARKER"; }
+        \\function unused() { return "UNUSED_DEFINE_PROPERTY_MARKER"; }
+        \\Object.defineProperty(exports, "used", { value: used, enumerable: true });
+        \\Object.defineProperty(exports, "unused", { "value": unused, enumerable: true });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_DEFINE_PROPERTY_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_DEFINE_PROPERTY_MARKER") == null);
+}
+
+test "TreeShaking CJS: module.exports defineProperty keeps helper and require target" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\const helper = require("./helper.js");
+        \\function used() { return helper("USED_DEFINE_REQUIRE_TARGET_MARKER"); }
+        \\function unusedPrivate() { return "UNUSED_DEFINE_PRIVATE_MARKER"; }
+        \\Object.defineProperty(module.exports, "used", { value: used });
+        \\Object.defineProperty(module.exports, "unused", { value: unusedPrivate });
+    );
+    try writeFile(tmp.dir, "helper.js",
+        \\function helper(value) { return value; }
+        \\module.exports = helper;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_DEFINE_REQUIRE_TARGET_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = helper") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_DEFINE_PRIVATE_MARKER") == null);
+}
+
+test "TreeShaking CJS: unsafe Object.defineProperty export forms are preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function used() { return "USED_DEFINE_UNSAFE_MARKER"; }
+        \\function unused() { return "UNSAFE_DEFINE_UNUSED_FN_MARKER"; }
+        \\function sideEffect() { console.log("UNSAFE_DEFINE_EFFECT_MARKER"); return unused; }
+        \\const define = Object.defineProperty;
+        \\const e = exports;
+        \\const key = "computed";
+        \\const extra = { enumerable: true };
+        \\const ns = { unused };
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\Object.defineProperty(exports, "used", { value: used });
+        \\Object.defineProperty(exports, "getter", { get() { return "UNSAFE_DEFINE_GETTER_MARKER"; } });
+        \\Object.defineProperty(exports, "effect", { value: sideEffect() });
+        \\Object.defineProperty(exports, key, { value: unused });
+        \\Object.defineProperty(exports, 123, { value: unused });
+        \\Object.defineProperty(exports, "dup", { value: used, value: unused });
+        \\Object.defineProperty(exports, "spread", { value: unused, ...extra });
+        \\Object.defineProperty(exports, "computedDescriptor", { ["value"]: unused });
+        \\Object.defineProperty(exports, "member", { value: ns.unused });
+        \\Object.defineProperty(e, "targetAlias", { value: unused });
+        \\Object["defineProperty"](exports, "computedCallee", { value: unused });
+        \\Object.defineProperty(exports, "extraArg", { value: unused }, extra);
+        \\Object.defineProperty(exports, "u\\x73ed", { value: unused });
+        \\define(exports, "alias", { value: unused });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_DEFINE_UNSAFE_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__esModule") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_DEFINE_UNUSED_FN_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_DEFINE_EFFECT_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_DEFINE_GETTER_MARKER") != null);
+}
+
 test "TreeShaking CJS: named import prunes module.exports object shorthand property" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -31,6 +31,7 @@ pub const CjsExportFact = struct {
     pub const Kind = enum {
         assignment,
         object_property,
+        define_property_value,
     };
 
     export_name: []const u8,
@@ -241,6 +242,129 @@ fn cjsExportCandidateForStmt(ast: *const Ast, stmt_node: Node) ?CjsExportCandida
     };
 }
 
+fn isObjectDefinePropertyCallee(ast: *const Ast, callee_idx: NodeIndex) bool {
+    const outer = staticMemberParts(ast, callee_idx) orelse return false;
+    const object = ast.nodes.items[@intFromEnum(outer.object)];
+    const property = ast.nodes.items[@intFromEnum(outer.property)];
+    if (object.tag != .identifier_reference) return false;
+    return std.mem.eql(u8, ast.getText(object.span), "Object") and
+        std.mem.eql(u8, ast.getText(property.span), "defineProperty");
+}
+
+fn isCjsExportObjectExpr(ast: *const Ast, idx: NodeIndex) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag == .identifier_reference) {
+        return std.mem.eql(u8, ast.getText(node.span), "exports");
+    }
+    return isModuleExportsLhs(ast, idx);
+}
+
+fn hasStringEscape(raw: []const u8) bool {
+    return std.mem.indexOfScalar(u8, raw, '\\') != null;
+}
+
+fn plainObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
+    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return null;
+    const key = ast.nodes.items[@intFromEnum(key_idx)];
+    return switch (key.tag) {
+        .identifier_reference => ast.getText(key.data.string_ref),
+        .string_literal => blk: {
+            const raw = ast.getText(key.span);
+            if (hasStringEscape(raw)) break :blk null;
+            break :blk Ast.stripStringQuotes(raw);
+        },
+        else => null,
+    };
+}
+
+fn definePropertyDescriptorValueNode(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    descriptor_idx: NodeIndex,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) !?NodeIndex {
+    if (descriptor_idx.isNone() or @intFromEnum(descriptor_idx) >= ast.nodes.items.len) return null;
+    const descriptor = ast.nodes.items[@intFromEnum(descriptor_idx)];
+    if (descriptor.tag != .object_expression) return null;
+
+    const list = descriptor.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return null;
+    const indices = ast.extra_data.items[list.start .. list.start + list.len];
+    if (indices.len == 0) return null;
+
+    var seen: std.StringHashMapUnmanaged(void) = .{};
+    defer seen.deinit(allocator);
+    var value_node: ?NodeIndex = null;
+
+    for (indices) |raw_prop| {
+        const prop_idx: NodeIndex = @enumFromInt(raw_prop);
+        if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
+        const prop = ast.nodes.items[@intFromEnum(prop_idx)];
+        if (prop.tag != .object_property) return null;
+
+        const name = plainObjectKeyName(ast, prop.data.binary.left) orelse return null;
+        const entry = try seen.getOrPut(allocator, name);
+        if (entry.found_existing) return null;
+        if (std.mem.eql(u8, name, "get") or std.mem.eql(u8, name, "set")) return null;
+
+        const prop_value = Ast.objectPropertyValue(prop);
+        if (prop_value.isNone() or @intFromEnum(prop_value) >= ast.nodes.items.len) return null;
+        if (!purity.isExprPure(ast, prop_value, unresolved_globals)) return null;
+
+        if (std.mem.eql(u8, name, "value")) {
+            const value = ast.nodes.items[@intFromEnum(prop_value)];
+            if (value.tag != .identifier_reference) return null;
+            value_node = prop_value;
+        }
+    }
+
+    return value_node;
+}
+
+fn cjsDefinePropertyExportCandidateForStmt(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    stmt_node: Node,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) !?CjsExportCandidate {
+    if (stmt_node.tag != .expression_statement) return null;
+    const expr_idx = stmt_node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .call_expression) return null;
+
+    const e = expr.data.extra;
+    if (e + 2 >= ast.extra_data.items.len) return null;
+    const callee_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
+    const args_start = ast.extra_data.items[e + 1];
+    const args_len = ast.extra_data.items[e + 2];
+    if (args_len != 3) return null;
+    if (args_start + args_len > ast.extra_data.items.len) return null;
+    if (!isObjectDefinePropertyCallee(ast, callee_idx)) return null;
+
+    const target_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    const export_name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 1]);
+    const descriptor_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 2]);
+    if (!isCjsExportObjectExpr(ast, target_idx)) return null;
+
+    if (export_name_idx.isNone() or @intFromEnum(export_name_idx) >= ast.nodes.items.len) return null;
+    const export_name_node = ast.nodes.items[@intFromEnum(export_name_idx)];
+    if (export_name_node.tag != .string_literal) return null;
+    const export_name_raw = ast.getText(export_name_node.span);
+    if (hasStringEscape(export_name_raw)) return null;
+    const export_name = Ast.stripStringQuotes(export_name_raw);
+    if (std.mem.eql(u8, export_name, "__esModule")) return null;
+
+    const value_node = (try definePropertyDescriptorValueNode(allocator, ast, descriptor_idx, unresolved_globals)) orelse return null;
+    return .{
+        .export_name = export_name,
+        .export_assignment_node = @intFromEnum(expr_idx),
+        .rhs_node = value_node,
+        .kind = .define_property_value,
+    };
+}
+
 fn collectCjsObjectExportCandidates(
     allocator: std.mem.Allocator,
     ast: *const Ast,
@@ -335,6 +459,35 @@ fn collectAndAppendCjsObjectFacts(
             .is_safe_to_prune = true,
         });
     }
+    return true;
+}
+
+fn appendCjsDefinePropertyFact(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    node: Node,
+    stmt_i: u32,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+    facts: *std.ArrayListUnmanaged(CjsExportFact),
+    symbol_ids: ?[]const ?u32,
+) !bool {
+    const candidate = (try cjsDefinePropertyExportCandidateForStmt(allocator, ast, node, unresolved_globals)) orelse return false;
+    const rhs_symbol: ?u32 = if (symbol_ids) |sids|
+        if (!candidate.rhs_node.isNone() and @intFromEnum(candidate.rhs_node) < sids.len)
+            sids[@intFromEnum(candidate.rhs_node)]
+        else
+            null
+    else
+        null;
+    try facts.append(allocator, .{
+        .export_name = candidate.export_name,
+        .statement_index = stmt_i,
+        .export_assignment_node = candidate.export_assignment_node,
+        .property_node = candidate.property_node,
+        .rhs_symbol = rhs_symbol,
+        .kind = candidate.kind,
+        .is_safe_to_prune = true,
+    });
     return true;
 }
 
@@ -482,6 +635,7 @@ fn buildStmtInfoSlot(
     const node = ast.nodes.items[ni];
     const cjs_export_candidate = if (collect_cjs_exports) cjsExportCandidateForStmt(ast, node) else null;
     var safe_cjs_object_export = false;
+    var safe_cjs_define_property_export = false;
     if (cjs_export_candidate) |candidate| {
         const rhs_symbol: ?u32 = if (symbol_ids) |sids|
             if (!candidate.rhs_node.isNone() and @intFromEnum(candidate.rhs_node) < sids.len)
@@ -500,7 +654,16 @@ fn buildStmtInfoSlot(
             .is_safe_to_prune = !cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals),
         });
     } else if (collect_cjs_exports) {
-        safe_cjs_object_export = try collectAndAppendCjsObjectFacts(
+        safe_cjs_define_property_export = try appendCjsDefinePropertyFact(
+            allocator,
+            ast,
+            node,
+            stmt_i,
+            unresolved_globals,
+            cjs_export_facts_buf,
+            symbol_ids,
+        );
+        if (!safe_cjs_define_property_export) safe_cjs_object_export = try collectAndAppendCjsObjectFacts(
             allocator,
             ast,
             node,
@@ -514,6 +677,8 @@ fn buildStmtInfoSlot(
         false
     else if (cjs_export_candidate) |candidate|
         cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals)
+    else if (safe_cjs_define_property_export)
+        false
     else if (safe_cjs_object_export)
         false
     else

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -32,6 +32,13 @@ pub const CjsExportFact = struct {
         assignment,
         object_property,
         define_property_value,
+
+        /// stmt 자체가 단일 export 라 BFS seed 시 stmt 전체를 enqueue 하면 충분한지.
+        /// `assignment` (`exports.foo = rhs`) 만 그렇고, 나머지는 같은 stmt 안에 여러 export
+        /// 가 공존할 수 있어 호출자가 rhs symbol 만 시드한다.
+        pub fn seedsWholeStatement(self: Kind) bool {
+            return self == .assignment;
+        }
     };
 
     export_name: []const u8,
@@ -45,8 +52,7 @@ pub const CjsExportFact = struct {
 
 pub const ModuleStmtInfos = struct {
     stmts: []StmtInfo,
-    /// 정적으로 증명된 CJS named export assignment.
-    /// 대상은 `exports.foo = ...`, `module.exports.foo = ...` 뿐이다.
+    /// 정적으로 증명된 CJS named export. 형태별 분기는 `CjsExportFact.Kind` 참고.
     cjs_export_facts: []const CjsExportFact = &.{},
     /// symbol_index → stmt_index (선언 역매핑). 없으면 null.
     symbol_to_stmt: []const ?u32,
@@ -181,6 +187,14 @@ const CjsExportCandidate = struct {
     kind: CjsExportFact.Kind = .assignment,
 };
 
+fn rhsSymbolFor(symbol_ids: ?[]const ?u32, rhs_node: NodeIndex) ?u32 {
+    const sids = symbol_ids orelse return null;
+    if (rhs_node.isNone()) return null;
+    const idx = @intFromEnum(rhs_node);
+    if (idx >= sids.len) return null;
+    return sids[idx];
+}
+
 fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeIndex, property: NodeIndex } {
     if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
     const node = ast.nodes.items[@intFromEnum(idx)];
@@ -260,8 +274,15 @@ fn isCjsExportObjectExpr(ast: *const Ast, idx: NodeIndex) bool {
     return isModuleExportsLhs(ast, idx);
 }
 
-fn hasStringEscape(raw: []const u8) bool {
-    return std.mem.indexOfScalar(u8, raw, '\\') != null;
+/// string_literal 의 escape 가 풀린 형태로 비교 안 하므로 raw 와 source-after-decode
+/// 가 다른 경우는 reject — 잘못된 export 매칭을 막는 보수적 가드.
+fn plainStringLiteralValue(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const n = ast.nodes.items[@intFromEnum(idx)];
+    if (n.tag != .string_literal) return null;
+    const raw = ast.getText(n.span);
+    if (std.mem.indexOfScalar(u8, raw, '\\') != null) return null;
+    return Ast.stripStringQuotes(raw);
 }
 
 fn plainObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
@@ -269,21 +290,16 @@ fn plainObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
     const key = ast.nodes.items[@intFromEnum(key_idx)];
     return switch (key.tag) {
         .identifier_reference => ast.getText(key.data.string_ref),
-        .string_literal => blk: {
-            const raw = ast.getText(key.span);
-            if (hasStringEscape(raw)) break :blk null;
-            break :blk Ast.stripStringQuotes(raw);
-        },
+        .string_literal => plainStringLiteralValue(ast, key_idx),
         else => null,
     };
 }
 
 fn definePropertyDescriptorValueNode(
-    allocator: std.mem.Allocator,
     ast: *const Ast,
     descriptor_idx: NodeIndex,
     unresolved_globals: ?*const purity.GlobalRefSet,
-) !?NodeIndex {
+) ?NodeIndex {
     if (descriptor_idx.isNone() or @intFromEnum(descriptor_idx) >= ast.nodes.items.len) return null;
     const descriptor = ast.nodes.items[@intFromEnum(descriptor_idx)];
     if (descriptor.tag != .object_expression) return null;
@@ -293,8 +309,10 @@ fn definePropertyDescriptorValueNode(
     const indices = ast.extra_data.items[list.start .. list.start + list.len];
     if (indices.len == 0) return null;
 
-    var seen: std.StringHashMapUnmanaged(void) = .{};
-    defer seen.deinit(allocator);
+    // descriptor 의 정적 키는 최대 4 개 (value/writable/enumerable/configurable).
+    // get/set 은 진입 시 reject — accessor 는 prune 안전하지 않음.
+    var seen: [4][]const u8 = undefined;
+    var seen_len: usize = 0;
     var value_node: ?NodeIndex = null;
 
     for (indices) |raw_prop| {
@@ -304,9 +322,13 @@ fn definePropertyDescriptorValueNode(
         if (prop.tag != .object_property) return null;
 
         const name = plainObjectKeyName(ast, prop.data.binary.left) orelse return null;
-        const entry = try seen.getOrPut(allocator, name);
-        if (entry.found_existing) return null;
         if (std.mem.eql(u8, name, "get") or std.mem.eql(u8, name, "set")) return null;
+        if (seen_len >= seen.len) return null;
+        for (seen[0..seen_len]) |prev| {
+            if (std.mem.eql(u8, prev, name)) return null;
+        }
+        seen[seen_len] = name;
+        seen_len += 1;
 
         const prop_value = Ast.objectPropertyValue(prop);
         if (prop_value.isNone() or @intFromEnum(prop_value) >= ast.nodes.items.len) return null;
@@ -323,11 +345,10 @@ fn definePropertyDescriptorValueNode(
 }
 
 fn cjsDefinePropertyExportCandidateForStmt(
-    allocator: std.mem.Allocator,
     ast: *const Ast,
     stmt_node: Node,
     unresolved_globals: ?*const purity.GlobalRefSet,
-) !?CjsExportCandidate {
+) ?CjsExportCandidate {
     if (stmt_node.tag != .expression_statement) return null;
     const expr_idx = stmt_node.data.unary.operand;
     if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
@@ -335,10 +356,10 @@ fn cjsDefinePropertyExportCandidateForStmt(
     if (expr.tag != .call_expression) return null;
 
     const e = expr.data.extra;
-    if (e + 2 >= ast.extra_data.items.len) return null;
-    const callee_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
-    const args_start = ast.extra_data.items[e + 1];
-    const args_len = ast.extra_data.items[e + 2];
+    if (!ast.hasExtra(e, 2)) return null;
+    const callee_idx = ast.readExtraNode(e, 0);
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
     if (args_len != 3) return null;
     if (args_start + args_len > ast.extra_data.items.len) return null;
     if (!isObjectDefinePropertyCallee(ast, callee_idx)) return null;
@@ -348,15 +369,10 @@ fn cjsDefinePropertyExportCandidateForStmt(
     const descriptor_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 2]);
     if (!isCjsExportObjectExpr(ast, target_idx)) return null;
 
-    if (export_name_idx.isNone() or @intFromEnum(export_name_idx) >= ast.nodes.items.len) return null;
-    const export_name_node = ast.nodes.items[@intFromEnum(export_name_idx)];
-    if (export_name_node.tag != .string_literal) return null;
-    const export_name_raw = ast.getText(export_name_node.span);
-    if (hasStringEscape(export_name_raw)) return null;
-    const export_name = Ast.stripStringQuotes(export_name_raw);
+    const export_name = plainStringLiteralValue(ast, export_name_idx) orelse return null;
     if (std.mem.eql(u8, export_name, "__esModule")) return null;
 
-    const value_node = (try definePropertyDescriptorValueNode(allocator, ast, descriptor_idx, unresolved_globals)) orelse return null;
+    const value_node = definePropertyDescriptorValueNode(ast, descriptor_idx, unresolved_globals) orelse return null;
     return .{
         .export_name = export_name,
         .export_assignment_node = @intFromEnum(expr_idx),
@@ -442,19 +458,12 @@ fn collectAndAppendCjsObjectFacts(
     const candidates = (try collectCjsObjectExportCandidates(allocator, ast, node, unresolved_globals)) orelse return false;
     defer allocator.free(candidates);
     for (candidates) |candidate| {
-        const rhs_symbol: ?u32 = if (symbol_ids) |sids|
-            if (!candidate.rhs_node.isNone() and @intFromEnum(candidate.rhs_node) < sids.len)
-                sids[@intFromEnum(candidate.rhs_node)]
-            else
-                null
-        else
-            null;
         try facts.append(allocator, .{
             .export_name = candidate.export_name,
             .statement_index = stmt_i,
             .export_assignment_node = candidate.export_assignment_node,
             .property_node = candidate.property_node,
-            .rhs_symbol = rhs_symbol,
+            .rhs_symbol = rhsSymbolFor(symbol_ids, candidate.rhs_node),
             .kind = candidate.kind,
             .is_safe_to_prune = true,
         });
@@ -471,20 +480,13 @@ fn appendCjsDefinePropertyFact(
     facts: *std.ArrayListUnmanaged(CjsExportFact),
     symbol_ids: ?[]const ?u32,
 ) !bool {
-    const candidate = (try cjsDefinePropertyExportCandidateForStmt(allocator, ast, node, unresolved_globals)) orelse return false;
-    const rhs_symbol: ?u32 = if (symbol_ids) |sids|
-        if (!candidate.rhs_node.isNone() and @intFromEnum(candidate.rhs_node) < sids.len)
-            sids[@intFromEnum(candidate.rhs_node)]
-        else
-            null
-    else
-        null;
+    const candidate = cjsDefinePropertyExportCandidateForStmt(ast, node, unresolved_globals) orelse return false;
     try facts.append(allocator, .{
         .export_name = candidate.export_name,
         .statement_index = stmt_i,
         .export_assignment_node = candidate.export_assignment_node,
         .property_node = candidate.property_node,
-        .rhs_symbol = rhs_symbol,
+        .rhs_symbol = rhsSymbolFor(symbol_ids, candidate.rhs_node),
         .kind = candidate.kind,
         .is_safe_to_prune = true,
     });
@@ -634,52 +636,27 @@ fn buildStmtInfoSlot(
     }
     const node = ast.nodes.items[ni];
     const cjs_export_candidate = if (collect_cjs_exports) cjsExportCandidateForStmt(ast, node) else null;
-    var safe_cjs_object_export = false;
-    var safe_cjs_define_property_export = false;
+    var cjs_shape_extracted = false;
     if (cjs_export_candidate) |candidate| {
-        const rhs_symbol: ?u32 = if (symbol_ids) |sids|
-            if (!candidate.rhs_node.isNone() and @intFromEnum(candidate.rhs_node) < sids.len)
-                sids[@intFromEnum(candidate.rhs_node)]
-            else
-                null
-        else
-            null;
         try cjs_export_facts_buf.append(allocator, .{
             .export_name = candidate.export_name,
             .statement_index = stmt_i,
             .export_assignment_node = candidate.export_assignment_node,
             .property_node = candidate.property_node,
-            .rhs_symbol = rhs_symbol,
+            .rhs_symbol = rhsSymbolFor(symbol_ids, candidate.rhs_node),
             .kind = candidate.kind,
             .is_safe_to_prune = !cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals),
         });
     } else if (collect_cjs_exports) {
-        safe_cjs_define_property_export = try appendCjsDefinePropertyFact(
-            allocator,
-            ast,
-            node,
-            stmt_i,
-            unresolved_globals,
-            cjs_export_facts_buf,
-            symbol_ids,
-        );
-        if (!safe_cjs_define_property_export) safe_cjs_object_export = try collectAndAppendCjsObjectFacts(
-            allocator,
-            ast,
-            node,
-            stmt_i,
-            unresolved_globals,
-            cjs_export_facts_buf,
-            symbol_ids,
-        );
+        cjs_shape_extracted =
+            try appendCjsDefinePropertyFact(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids) or
+            try collectAndAppendCjsObjectFacts(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids);
     }
     const side_effects = if (node.tag == .import_declaration)
         false
     else if (cjs_export_candidate) |candidate|
         cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals)
-    else if (safe_cjs_define_property_export)
-        false
-    else if (safe_cjs_object_export)
+    else if (cjs_shape_extracted)
         false
     else
         purity.stmtHasSideEffects(ast, node, unresolved_globals);

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -914,7 +914,7 @@ pub const TreeShaker = struct {
             reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
         }
 
-        if (fact.kind != .object_property) {
+        if (fact.kind != .object_property and fact.kind != .define_property_value) {
             try self.enqueue(mod_idx, fact.statement_index, reachable_stmts, queue);
             return;
         }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -914,7 +914,7 @@ pub const TreeShaker = struct {
             reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
         }
 
-        if (fact.kind != .object_property and fact.kind != .define_property_value) {
+        if (fact.kind.seedsWholeStatement()) {
             try self.enqueue(mod_idx, fact.statement_index, reachable_stmts, queue);
             return;
         }


### PR DESCRIPTION
Refs #2060

## 변경 사항
- `Object.defineProperty(exports, "name", { value: identifier })` 및 `Object.defineProperty(module.exports, "name", { value: identifier })` 형태를 CJS named export fact로 수집합니다.
- named CJS import가 해당 export를 사용할 때 value identifier의 선언과 의존성만 live 처리하도록 tree-shaker seed 경로를 확장했습니다.
- 사용되지 않은 defineProperty export statement는 기존 statement reachability 기반 `skip_nodes` 경로로 제거됩니다.
- getter/setter descriptor, descriptor spread, duplicate descriptor key, computed descriptor key, side-effectful/non-identifier value, aliased/computed callee, target alias, computed/non-string/escaped export name, `__esModule` defineProperty 등은 fact를 만들지 않고 기존 보존 동작을 유지합니다.

## 회귀 테스트
- `exports` 대상 defineProperty value export에서 unused export 제거
- `module.exports` 대상 defineProperty value export에서 helper 및 live value 내부 `require()` target 평가 보존
- string literal descriptor key `{ "value": id }` 허용
- duplicate `value`, descriptor spread, computed descriptor key, non-identifier value, target alias, computed callee, extra arg, escaped export name 보존
- getter descriptor, side-effectful value, aliased callee, computed/non-string export name, `__esModule` defineProperty 보존

## 검증
- `zig build test --summary all --prominent-compile-errors` 통과 (3987/3987)
- `zig build --summary all --prominent-compile-errors` 통과
- `bun test tests/integration/tests/tree-shake-precision.test.ts` 통과 (7/7)
- `bun run tests/benchmark/smoke.ts --filter=safe-buffer,cookie,path-to-regexp,axios,rxjs` 통과 (ZTS 5/5, output match 5/5; 비교군 esbuild axios는 smoke 내에서 실패로 표시됨)

## Benchmark smoke size
- `safe-buffer`: ZTS 1.8KB / rolldown 1.7KB
- `cookie`: ZTS 3.3KB / rolldown 5.6KB
- `path-to-regexp`: ZTS 7.5KB / rolldown 8.0KB
- `axios`: ZTS 343KB / rolldown 405KB
- `rxjs`: ZTS 321KB / rolldown 319KB
- 평균 ratio(vs smallest): 0.89x