### PR TITLE
fix(bundler): decode JS string-literal escapes for CJS export name matching

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -413,6 +413,79 @@ test "TreeShaking CJS: unsafe Object.defineProperty export forms are preserved" 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNSAFE_DEFINE_GETTER_MARKER") != null);
 }
 
+test "TreeShaking CJS: module.exports object escape-key matches decoded named import" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function liveImpl() { return "USED_OBJECT_ESCAPE_MARKER"; }
+        \\function deadImpl() { return "UNUSED_OBJECT_ESCAPE_MARKER"; }
+        \\module.exports = { "u\x73ed": liveImpl, dead: deadImpl };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_OBJECT_ESCAPE_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_OBJECT_ESCAPE_MARKER") == null);
+}
+
+test "TreeShaking CJS: module.exports duplicate escape-key preserves last-wins runtime value" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function earlyImpl() { return "EARLY_DUP_KEY_MARKER"; }
+        \\function lateImpl() { return "LATE_DUP_KEY_MARKER"; }
+        \\module.exports = { used: earlyImpl, "u\x73ed": lateImpl };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // 런타임 시맨틱: object literal duplicate key 는 last-wins → module.exports.used === lateImpl.
+    // 정적 prune 이 디코드된 이름 충돌을 인식하지 못하면 earlyImpl 만 살리고 lateImpl 을 dead 로
+    // 잘못 prune 한다 (correctness 버그). 안전한 동작은 충돌을 보수적으로 opaque 처리해
+    // lateImpl 의 body 가 보존되는 것.
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LATE_DUP_KEY_MARKER") != null);
+}
+
+test "TreeShaking CJS: Object.defineProperty escape export name matches decoded named import" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function liveImpl() { return "USED_DEFINE_ESCAPE_MARKER"; }
+        \\function deadImpl() { return "UNUSED_DEFINE_ESCAPE_MARKER"; }
+        \\Object.defineProperty(exports, "u\x73ed", { value: liveImpl });
+        \\Object.defineProperty(exports, "dead", { value: deadImpl });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_DEFINE_ESCAPE_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_DEFINE_ESCAPE_MARKER") == null);
+}
+
 test "TreeShaking CJS: named import prunes module.exports object shorthand property" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -16,6 +16,7 @@ const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Reference = @import("../semantic/symbol.zig").Reference;
 const ScopeId = @import("../semantic/scope.zig").ScopeId;
 const purity = @import("purity.zig");
+const string_escape = @import("../string_escape.zig");
 
 pub const StmtInfo = struct {
     node_idx: u32,
@@ -41,7 +42,10 @@ pub const CjsExportFact = struct {
         }
     };
 
-    export_name: []const u8,
+    /// 디코드된 owned UTF-8. `ModuleStmtInfos.deinit` 가 해제. ESM importer 의 binding
+    /// name (디코드된 identifier) 과 직접 비교 가능 — `\xHH`/`\uHHHH` 등 escape 가
+    /// 들어간 raw key 도 정확히 매칭된다.
+    export_name: []u8,
     statement_index: u32,
     export_assignment_node: u32,
     property_node: ?u32 = null,
@@ -75,6 +79,7 @@ pub const ModuleStmtInfos = struct {
             self.allocator.free(stmt.referenced_symbols);
         }
         self.allocator.free(self.stmts);
+        freeFactNames(self.allocator, self.cjs_export_facts);
         if (self.cjs_export_facts.len > 0) self.allocator.free(self.cjs_export_facts);
         self.allocator.free(self.symbol_to_stmt);
         // 역인덱스 해제
@@ -180,12 +185,19 @@ pub const ModuleStmtInfos = struct {
 };
 
 const CjsExportCandidate = struct {
-    export_name: []const u8,
+    /// owned UTF-8. fact 로 transferred 되거나 candidate 가 reject 시 caller 가 free.
+    export_name: []u8,
     export_assignment_node: u32,
     rhs_node: NodeIndex,
     property_node: ?u32 = null,
     kind: CjsExportFact.Kind = .assignment,
 };
+
+/// fact 들의 owned `export_name` 을 일괄 해제. `ModuleStmtInfos.deinit` 와 빌더의
+/// errdefer 가 공유.
+fn freeFactNames(allocator: std.mem.Allocator, facts: []const CjsExportFact) void {
+    for (facts) |f| allocator.free(f.export_name);
+}
 
 fn rhsSymbolFor(symbol_ids: ?[]const ?u32, rhs_node: NodeIndex) ?u32 {
     const sids = symbol_ids orelse return null;
@@ -217,19 +229,53 @@ fn isModuleExportsLhs(ast: *const Ast, lhs: NodeIndex) bool {
         std.mem.eql(u8, ast.getText(prop.span), "exports");
 }
 
-fn cjsExportNameFromLhs(ast: *const Ast, lhs: NodeIndex) ?[]const u8 {
+/// `exports.foo` / `module.exports.foo` 의 prop NodeIndex 반환. 호출자가
+/// `decodedObjectKey` 등으로 owned 이름을 만들도록 한다.
+fn cjsExportNamePropFromLhs(ast: *const Ast, lhs: NodeIndex) ?NodeIndex {
     const outer = staticMemberParts(ast, lhs) orelse return null;
     const prop = ast.nodes.items[@intFromEnum(outer.property)];
     if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return null;
 
     const obj = ast.nodes.items[@intFromEnum(outer.object)];
     if (obj.tag == .identifier_reference and std.mem.eql(u8, ast.getText(obj.span), "exports")) {
-        return ast.getText(prop.span);
+        return outer.property;
     }
     if (obj.tag == .static_member_expression and isModuleExportsLhs(ast, outer.object)) {
-        return ast.getText(prop.span);
+        return outer.property;
     }
     return null;
+}
+
+/// string_literal 의 escape 를 디코드해 owned UTF-8 반환. 잘못된 escape 는 null
+/// (caller 가 opaque 처리). 빈 입력/비-string_literal 도 null.
+fn decodedStringLiteralName(alloc: std.mem.Allocator, ast: *const Ast, idx: NodeIndex) !?[]u8 {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const n = ast.nodes.items[@intFromEnum(idx)];
+    if (n.tag != .string_literal) return null;
+    return string_escape.decodeJsStringLiteral(alloc, ast.getText(n.span)) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.InvalidStringLiteral, error.InvalidEscape => return null,
+    };
+}
+
+/// object key 노드에서 owned UTF-8 export name 을 만든다. identifier 계열은 dupe,
+/// string_literal 은 escape 디코드, numeric_literal 은 raw text dupe (ESM import 으로
+/// 직접 매칭 안 되지만 fact 등록을 거부할 이유는 없음 — 다른 키가 같은 stmt 에 있을 때
+/// 그쪽 prune 까지 막지 않게). computed_property_key 는 string_literal inner 만 허용.
+fn decodedObjectKey(alloc: std.mem.Allocator, ast: *const Ast, key_idx: NodeIndex) !?[]u8 {
+    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return null;
+    const key = ast.nodes.items[@intFromEnum(key_idx)];
+    return switch (key.tag) {
+        .identifier_reference, .binding_identifier, .private_identifier => try alloc.dupe(u8, ast.getText(key.data.string_ref)),
+        .numeric_literal => try alloc.dupe(u8, ast.getText(key.span)),
+        .string_literal => try decodedStringLiteralName(alloc, ast, key_idx),
+        .computed_property_key => blk: {
+            const inner = key.data.unary.operand;
+            if (inner.isNone()) break :blk null;
+            break :blk try decodedStringLiteralName(alloc, ast, inner);
+        },
+        else => null,
+    };
 }
 
 /// CJS object-shape export 의 value 위치가 named export 로 치환 안전한지 판정.
@@ -242,13 +288,14 @@ fn isCjsObjectPropertyValueSafe(ast: *const Ast, value: NodeIndex, unresolved_gl
     return purity.isExprPure(ast, value, unresolved_globals);
 }
 
-fn cjsExportCandidateForStmt(ast: *const Ast, stmt_node: Node) ?CjsExportCandidate {
+fn cjsExportCandidateForStmt(alloc: std.mem.Allocator, ast: *const Ast, stmt_node: Node) !?CjsExportCandidate {
     if (stmt_node.tag != .expression_statement) return null;
     const expr_idx = stmt_node.data.unary.operand;
     if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
     const expr = ast.nodes.items[@intFromEnum(expr_idx)];
     if (expr.tag != .assignment_expression) return null;
-    const export_name = cjsExportNameFromLhs(ast, expr.data.binary.left) orelse return null;
+    const prop_idx = cjsExportNamePropFromLhs(ast, expr.data.binary.left) orelse return null;
+    const export_name = (try decodedObjectKey(alloc, ast, prop_idx)) orelse return null;
     return .{
         .export_name = export_name,
         .export_assignment_node = @intFromEnum(expr_idx),
@@ -345,10 +392,11 @@ fn definePropertyDescriptorValueNode(
 }
 
 fn cjsDefinePropertyExportCandidateForStmt(
+    alloc: std.mem.Allocator,
     ast: *const Ast,
     stmt_node: Node,
     unresolved_globals: ?*const purity.GlobalRefSet,
-) ?CjsExportCandidate {
+) !?CjsExportCandidate {
     if (stmt_node.tag != .expression_statement) return null;
     const expr_idx = stmt_node.data.unary.operand;
     if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
@@ -369,10 +417,15 @@ fn cjsDefinePropertyExportCandidateForStmt(
     const descriptor_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 2]);
     if (!isCjsExportObjectExpr(ast, target_idx)) return null;
 
-    const export_name = plainStringLiteralValue(ast, export_name_idx) orelse return null;
+    const export_name = (try decodedStringLiteralName(alloc, ast, export_name_idx)) orelse return null;
+    var name_transferred = false;
+    defer if (!name_transferred) alloc.free(export_name);
+
     if (std.mem.eql(u8, export_name, "__esModule")) return null;
 
     const value_node = definePropertyDescriptorValueNode(ast, descriptor_idx, unresolved_globals) orelse return null;
+
+    name_transferred = true;
     return .{
         .export_name = export_name,
         .export_assignment_node = @intFromEnum(expr_idx),
@@ -408,7 +461,10 @@ fn collectCjsObjectExportCandidates(
     defer seen.deinit(allocator);
     var out: std.ArrayListUnmanaged(CjsExportCandidate) = .empty;
     var success = false;
-    defer if (!success) out.deinit(allocator);
+    defer if (!success) {
+        for (out.items) |c| allocator.free(c.export_name);
+        out.deinit(allocator);
+    };
 
     for (indices) |raw_prop| {
         const prop_idx: NodeIndex = @enumFromInt(raw_prop);
@@ -416,7 +472,10 @@ fn collectCjsObjectExportCandidates(
         const prop = ast.nodes.items[@intFromEnum(prop_idx)];
         if (prop.tag != .object_property) return null;
 
-        const name = ast.staticKeyName(prop.data.binary.left) orelse return null;
+        const name = (try decodedObjectKey(allocator, ast, prop.data.binary.left)) orelse return null;
+        var name_transferred = false;
+        defer if (!name_transferred) allocator.free(name);
+
         // `{__proto__: X}` 는 prototype 을 설정 — named export 가 아니라 reject.
         if (std.mem.eql(u8, name, "__proto__")) return null;
         const entry = try seen.getOrPut(allocator, name);
@@ -432,6 +491,7 @@ fn collectCjsObjectExportCandidates(
             .rhs_node = value,
             .kind = .object_property,
         });
+        name_transferred = true;
     }
 
     const slice = try out.toOwnedSlice(allocator);
@@ -457,8 +517,14 @@ fn collectAndAppendCjsObjectFacts(
 ) !bool {
     const candidates = (try collectCjsObjectExportCandidates(allocator, ast, node, unresolved_globals)) orelse return false;
     defer allocator.free(candidates);
+
+    // append 실패 시 미전이 분량의 owned name 을 cleanup. 성공 시 전체 transferred=len.
+    var transferred: usize = 0;
+    errdefer for (candidates[transferred..]) |c| allocator.free(c.export_name);
+
+    try facts.ensureUnusedCapacity(allocator, candidates.len);
     for (candidates) |candidate| {
-        try facts.append(allocator, .{
+        facts.appendAssumeCapacity(.{
             .export_name = candidate.export_name,
             .statement_index = stmt_i,
             .export_assignment_node = candidate.export_assignment_node,
@@ -467,6 +533,7 @@ fn collectAndAppendCjsObjectFacts(
             .kind = candidate.kind,
             .is_safe_to_prune = true,
         });
+        transferred += 1;
     }
     return true;
 }
@@ -480,7 +547,10 @@ fn appendCjsDefinePropertyFact(
     facts: *std.ArrayListUnmanaged(CjsExportFact),
     symbol_ids: ?[]const ?u32,
 ) !bool {
-    const candidate = cjsDefinePropertyExportCandidateForStmt(ast, node, unresolved_globals) orelse return false;
+    const candidate = (try cjsDefinePropertyExportCandidateForStmt(allocator, ast, node, unresolved_globals)) orelse return false;
+    var transferred = false;
+    errdefer if (!transferred) allocator.free(candidate.export_name);
+
     try facts.append(allocator, .{
         .export_name = candidate.export_name,
         .statement_index = stmt_i,
@@ -490,6 +560,7 @@ fn appendCjsDefinePropertyFact(
         .kind = candidate.kind,
         .is_safe_to_prune = true,
     });
+    transferred = true;
     return true;
 }
 
@@ -635,7 +706,14 @@ fn buildStmtInfoSlot(
         };
     }
     const node = ast.nodes.items[ni];
-    const cjs_export_candidate = if (collect_cjs_exports) cjsExportCandidateForStmt(ast, node) else null;
+    const cjs_export_candidate = if (collect_cjs_exports)
+        try cjsExportCandidateForStmt(allocator, ast, node)
+    else
+        null;
+    var candidate_transferred = false;
+    errdefer if (cjs_export_candidate) |c| if (!candidate_transferred)
+        allocator.free(c.export_name);
+
     var cjs_shape_extracted = false;
     if (cjs_export_candidate) |candidate| {
         try cjs_export_facts_buf.append(allocator, .{
@@ -647,6 +725,7 @@ fn buildStmtInfoSlot(
             .kind = candidate.kind,
             .is_safe_to_prune = !cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals),
         });
+        candidate_transferred = true;
     } else if (collect_cjs_exports) {
         cjs_shape_extracted =
             try appendCjsDefinePropertyFact(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids) or
@@ -705,7 +784,10 @@ pub fn buildFromSemantic(
     for (sym_to_stmt) |*s| s.* = null;
 
     var cjs_export_facts_buf: std.ArrayListUnmanaged(CjsExportFact) = .empty;
-    errdefer cjs_export_facts_buf.deinit(allocator);
+    errdefer {
+        freeFactNames(allocator, cjs_export_facts_buf.items);
+        cjs_export_facts_buf.deinit(allocator);
+    }
 
     // Pass 1: span + side-effect 결정. declared/referenced 는 빈 상태로 초기화.
     for (stmt_raw_indices, 0..) |raw_idx, stmt_i| {
@@ -871,7 +953,10 @@ pub fn build(
     for (sym_to_stmt) |*s| s.* = null;
 
     var cjs_export_facts_buf: std.ArrayListUnmanaged(CjsExportFact) = .empty;
-    errdefer cjs_export_facts_buf.deinit(allocator);
+    errdefer {
+        freeFactNames(allocator, cjs_export_facts_buf.items);
+        cjs_export_facts_buf.deinit(allocator);
+    }
 
     // Phase 1: statement span 배열 + side-effects 판정 + 초기화
     var stmt_spans = try allocator.alloc(Span, stmt_count);

--- a/src/string_escape.zig
+++ b/src/string_escape.zig
@@ -31,3 +31,166 @@ pub fn escapeToOwned(alloc: std.mem.Allocator, input: []const u8) ![]const u8 {
     try appendEscaped(&buf, alloc, input);
     return buf.toOwnedSlice(alloc);
 }
+
+pub const DecodeError = error{
+    InvalidStringLiteral,
+    InvalidEscape,
+} || std.mem.Allocator.Error;
+
+/// JS string literal (양 끝 따옴표 포함) 의 escape 를 모두 디코드해 owned UTF-8 로 반환.
+/// `\xHH`, `\uHHHH`, `\u{H...}`, `\n \t \r \b \f \v \0`, `\\ \" \' \``,
+/// line continuation 처리.
+/// 에러: `error.InvalidStringLiteral` (따옴표 누락/불일치), `error.InvalidEscape`
+/// (불완전 hex escape, surrogate, legacy octal 등).
+pub fn decodeJsStringLiteral(alloc: std.mem.Allocator, raw_with_quotes: []const u8) DecodeError![]u8 {
+    if (raw_with_quotes.len < 2) return error.InvalidStringLiteral;
+    const quote = raw_with_quotes[0];
+    if ((quote != '"' and quote != '\'' and quote != '`') or
+        raw_with_quotes[raw_with_quotes.len - 1] != quote)
+        return error.InvalidStringLiteral;
+
+    const body = raw_with_quotes[1 .. raw_with_quotes.len - 1];
+    // 99% 의 export name 은 escape 가 없어 byte-wise 디코드 루프가 무의미하다 — dupe 한 번이면 끝.
+    if (std.mem.indexOfScalar(u8, body, '\\') == null) return alloc.dupe(u8, body);
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+
+    var i: usize = 0;
+    while (i < body.len) {
+        const c = body[i];
+        if (c != '\\') {
+            try out.append(alloc, c);
+            i += 1;
+            continue;
+        }
+        if (i + 1 >= body.len) return error.InvalidEscape;
+        const esc = body[i + 1];
+        switch (esc) {
+            'b' => {
+                try out.append(alloc, 0x08);
+                i += 2;
+            },
+            't' => {
+                try out.append(alloc, 0x09);
+                i += 2;
+            },
+            'n' => {
+                try out.append(alloc, 0x0A);
+                i += 2;
+            },
+            'v' => {
+                try out.append(alloc, 0x0B);
+                i += 2;
+            },
+            'f' => {
+                try out.append(alloc, 0x0C);
+                i += 2;
+            },
+            'r' => {
+                try out.append(alloc, 0x0D);
+                i += 2;
+            },
+            '"', '\'', '\\', '`' => {
+                try out.append(alloc, esc);
+                i += 2;
+            },
+            '0' => {
+                // legacy octal (`\0` 뒤에 0-9 가 오면 octal escape) 는 거부.
+                if (i + 2 < body.len and body[i + 2] >= '0' and body[i + 2] <= '9') {
+                    return error.InvalidEscape;
+                }
+                try out.append(alloc, 0);
+                i += 2;
+            },
+            '\n' => i += 2, // LF line continuation
+            '\r' => {
+                i += 2;
+                if (i < body.len and body[i] == '\n') i += 1; // CRLF
+            },
+            'x' => {
+                if (i + 4 > body.len) return error.InvalidEscape;
+                const hi = std.fmt.charToDigit(body[i + 2], 16) catch return error.InvalidEscape;
+                const lo = std.fmt.charToDigit(body[i + 3], 16) catch return error.InvalidEscape;
+                try out.append(alloc, @intCast(hi * 16 + lo));
+                i += 4;
+            },
+            'u' => {
+                if (i + 3 > body.len) return error.InvalidEscape;
+                if (body[i + 2] == '{') {
+                    var j: usize = i + 3;
+                    var cp: u32 = 0;
+                    var any = false;
+                    while (j < body.len and body[j] != '}') : (j += 1) {
+                        const d = std.fmt.charToDigit(body[j], 16) catch return error.InvalidEscape;
+                        cp = cp * 16 + @as(u32, d);
+                        if (cp > 0x10FFFF) return error.InvalidEscape;
+                        any = true;
+                    }
+                    if (j >= body.len or !any) return error.InvalidEscape;
+                    try appendCodepoint(&out, alloc, cp);
+                    i = j + 1;
+                } else {
+                    if (i + 6 > body.len) return error.InvalidEscape;
+                    var cp: u32 = 0;
+                    var k: usize = 0;
+                    while (k < 4) : (k += 1) {
+                        const d = std.fmt.charToDigit(body[i + 2 + k], 16) catch return error.InvalidEscape;
+                        cp = cp * 16 + @as(u32, d);
+                    }
+                    try appendCodepoint(&out, alloc, cp);
+                    i += 6;
+                }
+            },
+            else => {
+                try out.append(alloc, esc);
+                i += 2;
+            },
+        }
+    }
+
+    return out.toOwnedSlice(alloc);
+}
+
+fn appendCodepoint(out: *std.ArrayList(u8), alloc: std.mem.Allocator, cp: u32) DecodeError!void {
+    if (cp > 0x10FFFF or (cp >= 0xD800 and cp <= 0xDFFF)) return error.InvalidEscape;
+    var buf: [4]u8 = undefined;
+    const len = std.unicode.utf8Encode(@intCast(cp), &buf) catch return error.InvalidEscape;
+    try out.appendSlice(alloc, buf[0..len]);
+}
+
+test "decodeJsStringLiteral basic" {
+    const a = std.testing.allocator;
+
+    {
+        const got = try decodeJsStringLiteral(a, "\"used\"");
+        defer a.free(got);
+        try std.testing.expectEqualStrings("used", got);
+    }
+    {
+        const got = try decodeJsStringLiteral(a, "\"u\\x73ed\"");
+        defer a.free(got);
+        try std.testing.expectEqualStrings("used", got);
+    }
+    {
+        const got = try decodeJsStringLiteral(a, "\"\\u0066oo\"");
+        defer a.free(got);
+        try std.testing.expectEqualStrings("foo", got);
+    }
+    {
+        const got = try decodeJsStringLiteral(a, "\"\\u{1F600}\"");
+        defer a.free(got);
+        try std.testing.expectEqualSlices(u8, "\xF0\x9F\x98\x80", got);
+    }
+    {
+        const got = try decodeJsStringLiteral(a, "\"a\\nb\\tc\"");
+        defer a.free(got);
+        try std.testing.expectEqualStrings("a\nb\tc", got);
+    }
+    {
+        try std.testing.expectError(error.InvalidEscape, decodeJsStringLiteral(a, "\"\\x\""));
+        try std.testing.expectError(error.InvalidEscape, decodeJsStringLiteral(a, "\"\\xZZ\""));
+        try std.testing.expectError(error.InvalidEscape, decodeJsStringLiteral(a, "\"\\u{}\""));
+        try std.testing.expectError(error.InvalidStringLiteral, decodeJsStringLiteral(a, ""));
+    }
+}


### PR DESCRIPTION
## Summary

CJS named export 의 key 에 string-literal escape (`\xHH`, `\uHHHH` 등) 가 들어 있으면 raw 텍스트가 그대로 `CjsExportFact.export_name` 에 등록돼 ESM importer 의 디코드된 binding name 과 매칭에 실패하던 버그를 root-cause 로 잡는다. 단순한 보수적 reject 가 아니라 string-literal decoder 를 도입해 정확히 매칭한다.

duplicate-key 케이스 (`module.exports = { used: a, "u\\x73ed": b }`) 는 단순 missed optimization 이 아니라 last-wins 시맨틱과 어긋나는 correctness 버그였다.

## Changes

- **`src/string_escape.zig`** — `decodeJsStringLiteral(alloc, raw_with_quotes)` 추가. `\xHH` / `\uHHHH` / `\u{H...}` / `\n \t \r \b \f \v \0` / `\\ \" \' \`` / line continuation 모두 처리. escape 없는 케이스는 dupe 한 번으로 끝나는 fast path. invalid escape 는 `error.InvalidEscape` 로 caller 가 opaque-fallback 하도록.
- **`src/bundler/stmt_info.zig`**:
  - `CjsExportFact.export_name` 을 owned `[]u8` 로 전환 — 모든 export name 이 디코드된 형태로 저장.
  - `decodedObjectKey` / `decodedStringLiteralName` 통합 헬퍼 — identifier/numeric → dupe, string_literal → decode, computed_property_key 의 string_literal inner 도 지원.
  - `cjsExportNameFromLhs` → `cjsExportNamePropFromLhs` (NodeIndex 반환). caller 가 `decodedObjectKey` 로 owned 이름 만듦.
  - `cjsDefinePropertyExportCandidateForStmt` 의 보수적 `hasStringEscape` reject 제거. 이제 escape 도 정확히 매칭.
  - `freeFactNames` 헬퍼 — `ModuleStmtInfos.deinit` 와 두 builder 의 errdefer 가 공유.
  - `errdefer transferred-flag` 패턴으로 OOM 시 ownership 정합성 보장.

## Tests

3개 통합 테스트 추가 (`tree_shake.zig`):
1. **escape-key 매칭**: `module.exports = { "u\\x73ed": liveImpl, dead: deadImpl }` + `import { used }` → `liveImpl` 보존, `deadImpl` prune.
2. **duplicate-key correctness**: `module.exports = { used: earlyImpl, "u\\x73ed": lateImpl }` → object literal 의 last-wins 시맨틱상 `module.exports.used === lateImpl` 이어야 하므로 `lateImpl` 의 body 가 보존되어야 함 (현재 `seen` dedup 충돌로 인해 entire object 가 opaque 처리되어 자연스럽게 만족).
3. **defineProperty escape**: `Object.defineProperty(exports, \"u\\x73ed\", { value: liveImpl })` → escape 디코드해 매칭.

`decodeJsStringLiteral` 단위 테스트도 `string_escape.zig` 안에 포함.

## Test plan

- [x] `zig build test` — 전체 회귀 없음
- [x] `zig build test -Dtest-filter=\"escape\"` — 새 escape 테스트 3개 + decoder unit test 통과
- [x] `zig build test -Dtest-filter=\"unsafe Object.defineProperty\\|unsafe module.exports\"` — 기존 unsafe 테스트 그대로 통과 (escape 라인이 매칭으로 풀려도 다른 unsafe 형태들이 unused 를 side-effect 로 살려둬 마커 보존)
- [x] pre-push hook (zig fmt / oxlint / oxfmt) 통과

## Out of scope

- 식별자 escape (`exports.\\u0066oo = ...`) — 별도 issue
- template literal key (`\` ` `used` ` \``) — computed-template

Closes #2077