### PR TITLE
CJS export fact 충돌 보존

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -486,6 +486,52 @@ test "TreeShaking CJS: Object.defineProperty escape export name matches decoded 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_DEFINE_ESCAPE_MARKER") == null);
 }
 
+test "TreeShaking CJS: duplicate defineProperty export facts are preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function earlyImpl() { return "EARLY_DEFINE_DUP_MARKER"; }
+        \\function lateImpl() { return "LATE_DEFINE_DUP_MARKER"; }
+        \\Object.defineProperty(exports, "used", { value: earlyImpl, configurable: true });
+        \\Object.defineProperty(exports, "u\x73ed", { value: lateImpl, configurable: true });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LATE_DEFINE_DUP_MARKER") != null);
+}
+
+test "TreeShaking CJS: cross-kind duplicate export facts are preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\function earlyImpl() { return "EARLY_CROSS_DUP_MARKER"; }
+        \\function lateImpl() { return "LATE_CROSS_DUP_MARKER"; }
+        \\exports.used = earlyImpl;
+        \\Object.defineProperty(exports, "u\x73ed", { value: lateImpl, configurable: true });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LATE_CROSS_DUP_MARKER") != null);
+}
+
 test "TreeShaking CJS: named import prunes module.exports object shorthand property" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1797,6 +1797,7 @@ fn markUnusedCjsObjectProperties(
 ) !void {
     var has_unused = false;
     for (ts_infos.cjs_export_facts) |fact| {
+        if (!fact.is_safe_to_prune) continue;
         if (fact.kind == .object_property and !shaker.isExportUsed(mod_idx, fact.export_name)) {
             has_unused = true;
             break;
@@ -1815,6 +1816,7 @@ fn markUnusedCjsObjectProperties(
     }
 
     for (ts_infos.cjs_export_facts) |fact| {
+        if (!fact.is_safe_to_prune) continue;
         if (fact.kind != .object_property) continue;
         if (shaker.isExportUsed(mod_idx, fact.export_name)) continue;
         const prop_node_idx = fact.property_node orelse continue;

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -461,14 +461,16 @@ fn collectCjsObjectExportCandidates(
     const indices = ast.extra_data.items[list.start .. list.start + list.len];
     if (indices.len == 0) return null;
 
-    var seen: std.StringHashMapUnmanaged(void) = .{};
-    defer seen.deinit(allocator);
     var out: std.ArrayListUnmanaged(CjsExportCandidate) = .empty;
     var success = false;
     defer if (!success) {
         for (out.items) |c| allocator.free(c.export_name);
         out.deinit(allocator);
     };
+    // `seen` 키는 `out.items[*].export_name` 을 빌려쓴다. 에러 경로에서
+    // `out` 의 name 들이 해제되기 전에 `seen` 이 먼저 비워지도록 LIFO 순서를 맞춘다.
+    var seen: std.StringHashMapUnmanaged(void) = .{};
+    defer seen.deinit(allocator);
 
     for (indices) |raw_prop| {
         const prop_idx: NodeIndex = @enumFromInt(raw_prop);

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -98,10 +98,14 @@ pub const ModuleStmtInfos = struct {
     }
 
     pub fn cjsExportFactByName(self: *const ModuleStmtInfos, export_name: []const u8) ?CjsExportFact {
+        var found: ?CjsExportFact = null;
         for (self.cjs_export_facts) |fact| {
-            if (std.mem.eql(u8, fact.export_name, export_name)) return fact;
+            if (!fact.is_safe_to_prune) continue;
+            if (!std.mem.eql(u8, fact.export_name, export_name)) continue;
+            if (found != null) return null;
+            found = fact;
         }
-        return null;
+        return found;
     }
 
     /// symbol_index가 선언된 statement 인덱스 반환.
@@ -564,6 +568,28 @@ fn appendCjsDefinePropertyFact(
     return true;
 }
 
+fn invalidateConflictingCjsExportFacts(facts: []CjsExportFact, stmts: []StmtInfo) void {
+    for (facts, 0..) |fact, i| {
+        if (!fact.is_safe_to_prune) continue;
+        var has_conflict = false;
+        for (facts[i + 1 ..]) |*other| {
+            if (!other.is_safe_to_prune) continue;
+            if (!std.mem.eql(u8, fact.export_name, other.export_name)) continue;
+            other.is_safe_to_prune = false;
+            if (other.statement_index < stmts.len) {
+                stmts[other.statement_index].has_side_effects = true;
+            }
+            has_conflict = true;
+        }
+        if (has_conflict) {
+            facts[i].is_safe_to_prune = false;
+            if (fact.statement_index < stmts.len) {
+                stmts[fact.statement_index].has_side_effects = true;
+            }
+        }
+    }
+}
+
 /// statement span 배열에서 pos를 포함하는 statement를 binary search.
 /// statement span은 소스 순서로 비중첩.
 pub fn findStmtForPos(stmt_spans: []const Span, pos: u32) ?u32 {
@@ -868,6 +894,8 @@ pub fn buildFromSemantic(
         stmts[stmt_i].referenced_symbols = slice;
     }
 
+    invalidateConflictingCjsExportFacts(cjs_export_facts_buf.items, stmts);
+
     const sym_to_writer_stmts = try finalizeWriterBuckets(allocator, writer_buckets, sym_to_stmt);
 
     // 역인덱스 구축 (buildReverseIndex 재사용)
@@ -1051,6 +1079,8 @@ pub fn build(
             stmt.referenced_symbols = try referenced_bufs[stmt_i].toOwnedSlice(allocator);
         }
     }
+
+    invalidateConflictingCjsExportFacts(cjs_export_facts_buf.items, stmts);
 
     const sym_to_writer_stmts = try finalizeWriterBuckets(allocator, writer_bufs, sym_to_stmt);
 


### PR DESCRIPTION
Refs #2060

## 변경 사항
- decoded export name 기준으로 CJS export fact가 2개 이상 충돌하면 해당 fact들을 unsafe 처리합니다.
- 충돌 fact의 원본 statement를 side-effectful로 되돌려, named import가 해당 export를 직접 쓰지 않아도 redefine/throw/last-write 의미를 보존합니다.
- `cjsExportFactByName`은 unsafe fact를 무시하고, 안전 fact가 여러 개면 보수적으로 fact lookup을 포기합니다.
- emitter의 object-shape property pruning도 unsafe fact를 skip하도록 보강했습니다.

## 회귀 테스트
- `Object.defineProperty(exports, "used", ...)`와 `Object.defineProperty(exports, "u\\x73ed", ...)`가 decoded name 충돌 시 late definition을 보존
- `exports.used = ...`와 `Object.defineProperty(exports, "u\\x73ed", ...)`의 cross-kind 충돌도 보존

## 검증
- `zig build test --summary all --prominent-compile-errors` 통과 (3993/3993)
- `zig build --summary all --prominent-compile-errors` 통과
- `bun test tests/integration/tests/tree-shake-precision.test.ts` 통과 (7/7)
- `bun run tests/benchmark/smoke.ts --filter=safe-buffer,cookie,path-to-regexp,axios,rxjs` 통과 (ZTS 5/5, output match 5/5; 비교군 esbuild axios는 smoke 내에서 실패로 표시됨)

## Benchmark smoke size
- `safe-buffer`: ZTS 1.8KB / rolldown 1.7KB
- `cookie`: ZTS 3.3KB / rolldown 5.6KB
- `path-to-regexp`: ZTS 7.5KB / rolldown 8.0KB
- `axios`: ZTS 343KB / rolldown 405KB
- `rxjs`: ZTS 321KB / rolldown 319KB
- 평균 ratio(vs smallest): 0.89x