### PR TITLE
CJS defineProperty getter export DCE 추가

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -212,6 +212,217 @@ test "TreeShaking CJS: used export keeps helper but unused private body is remov
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_PRIVATE_MARKER") == null);
 }
 
+test "TreeShaking CJS: node Buffer capability branch prunes safe-buffer fallback body" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { Buffer } from './lib.js'; console.log(Buffer.alloc(4).length);");
+    try writeFile(tmp.dir, "lib.js",
+        \\var buffer = require("buffer");
+        \\var Buffer = buffer.Buffer;
+        \\function copyProps(src, dst) {
+        \\  for (var key in src) dst[key] = src[key];
+        \\}
+        \\if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+        \\  module.exports = buffer;
+        \\} else {
+        \\  copyProps(buffer, exports);
+        \\  exports.Buffer = SafeBuffer;
+        \\}
+        \\function SafeBuffer(arg, encodingOrOffset, length) {
+        \\  return Buffer(arg, encodingOrOffset, length);
+        \\}
+        \\SafeBuffer.prototype = Object.create(Buffer.prototype);
+        \\copyProps(Buffer, SafeBuffer);
+        \\SafeBuffer.from = function(arg, encodingOrOffset, length) {
+        \\  if (typeof arg === "number") throw new TypeError("SAFE_BUFFER_FALLBACK_MARKER");
+        \\  return Buffer(arg, encodingOrOffset, length);
+        \\};
+        \\SafeBuffer.allocUnsafeSlow = function(size) {
+        \\  return buffer.SlowBuffer(size);
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = buffer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SAFE_BUFFER_FALLBACK_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "allocUnsafeSlow") == null);
+}
+
+test "TreeShaking CJS: unknown Buffer-like capability branch preserves fallback body" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { Buffer } from './lib.js'; console.log(typeof Buffer);");
+    try writeFile(tmp.dir, "lib.js",
+        \\var buffer = getRuntimeBuffer();
+        \\var Buffer = buffer.Buffer;
+        \\function getRuntimeBuffer() {
+        \\  return globalThis.runtimeBuffer;
+        \\}
+        \\if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+        \\  module.exports = buffer;
+        \\} else {
+        \\  exports.Buffer = SafeBuffer;
+        \\}
+        \\function SafeBuffer() {
+        \\  return "UNKNOWN_BUFFER_FALLBACK_MARKER";
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNKNOWN_BUFFER_FALLBACK_MARKER") != null);
+}
+
+test "TreeShaking CJS: node:buffer capability branch is treated like buffer" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { Buffer } from './lib.js'; console.log(Buffer.from('x').length);");
+    try writeFile(tmp.dir, "lib.js",
+        \\var buffer = require("node:buffer");
+        \\var Buffer = buffer.Buffer;
+        \\if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+        \\  module.exports = buffer;
+        \\} else {
+        \\  exports.Buffer = SafeBuffer;
+        \\}
+        \\function SafeBuffer() {
+        \\  return "NODE_PREFIX_FALLBACK_MARKER";
+        \\}
+        \\SafeBuffer.from = function() {
+        \\  return "NODE_PREFIX_SETUP_MARKER";
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = buffer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NODE_PREFIX_FALLBACK_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NODE_PREFIX_SETUP_MARKER") == null);
+}
+
+test "TreeShaking CJS: incomplete Buffer capability check does not prune fallback body" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { Buffer } from './lib.js'; console.log(typeof Buffer);");
+    try writeFile(tmp.dir, "lib.js",
+        \\var buffer = require("buffer");
+        \\var Buffer = buffer.Buffer;
+        \\if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe) {
+        \\  module.exports = buffer;
+        \\} else {
+        \\  exports.Buffer = SafeBuffer;
+        \\}
+        \\function SafeBuffer() {
+        \\  return "INCOMPLETE_CAPABILITY_FALLBACK_MARKER";
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INCOMPLETE_CAPABILITY_FALLBACK_MARKER") != null);
+}
+
+test "TreeShaking CJS: browser platform does not apply Node Buffer capability fact" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { Buffer } from './lib.js'; console.log(typeof Buffer);");
+    try writeFile(tmp.dir, "lib.js",
+        \\var buffer = require("buffer");
+        \\var Buffer = buffer.Buffer;
+        \\if (Buffer.from && Buffer.alloc && Buffer.allocUnsafe && Buffer.allocUnsafeSlow) {
+        \\  module.exports = buffer;
+        \\} else {
+        \\  exports.Buffer = SafeBuffer;
+        \\}
+        \\function SafeBuffer() {
+        \\  return "BROWSER_PLATFORM_FALLBACK_MARKER";
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "BROWSER_PLATFORM_FALLBACK_MARKER") != null);
+}
+
+test "TreeShaking CJS: named Buffer import seeds module.exports buffer assignment without exports fact" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { Buffer } from './lib.js'; console.log(Buffer.alloc(1).length);");
+    try writeFile(tmp.dir, "lib.js",
+        \\var buffer = require("buffer");
+        \\module.exports = buffer;
+        \\function unusedFallback() {
+        \\  return "MODULE_EXPORTS_BUFFER_UNUSED_MARKER";
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = buffer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_EXPORTS_BUFFER_UNUSED_MARKER") == null);
+}
+
 test "TreeShaking CJS: default namespace and export star keep all static exports" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -26,6 +26,7 @@ const ast_mod = @import("../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
+const Kind = @import("../lexer/token.zig").Kind;
 const purity = @import("purity.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const StmtInfos = stmt_info_mod.ModuleStmtInfos;
@@ -197,6 +198,10 @@ pub const TreeShaker = struct {
                     m.prebuilt_stmt_info = null;
                 };
             }
+        }
+
+        if (self.graph.resolve_cache.platform == .node) {
+            try self.applyNodeBufferCapabilityFacts();
         }
 
         // 자동 순수 판별: 진입점이 아닌 모듈의 top-level이 모두 순수하면 side_effects=false
@@ -896,10 +901,44 @@ pub const TreeShaker = struct {
             return;
         };
         const fact = target_infos.cjsExportFactByName(export_name) orelse {
+            if (try self.seedNodeBufferModuleObjectExport(mod_idx, export_name, target_infos, queue, reachable_stmts)) {
+                return;
+            }
             try self.markAndSeedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
             return;
         };
         try self.seedCjsExportFact(mod_idx, target_infos, fact, queue, reachable_stmts);
+    }
+
+    fn seedNodeBufferModuleObjectExport(
+        self: *TreeShaker,
+        mod_idx: u32,
+        export_name: []const u8,
+        infos: StmtInfos,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!bool {
+        if (self.graph.resolve_cache.platform != .node) return false;
+        if (!std.mem.eql(u8, export_name, "Buffer")) return false;
+        const m = self.getModule(mod_idx) orelse return false;
+        const ast = &(m.ast orelse return false);
+
+        var buffer_names: std.StringHashMapUnmanaged(void) = .{};
+        defer buffer_names.deinit(self.allocator);
+        collectNodeBufferModuleObjectNames(self.allocator, ast, &buffer_names) catch return false;
+        if (buffer_names.count() == 0) return false;
+
+        for (infos.stmts, 0..) |stmt, si| {
+            const stmt_ni: usize = stmt.node_idx;
+            if (stmt_ni >= ast.nodes.items.len) continue;
+            if (!isModuleExportsAssignedNodeBufferObject(ast, ast.nodes.items[stmt_ni], &buffer_names)) continue;
+            if (reachable_stmts[mod_idx] == null) {
+                reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
+            }
+            try self.enqueue(mod_idx, @intCast(si), reachable_stmts, queue);
+            return true;
+        }
+        return false;
     }
 
     fn seedCjsExportFact(
@@ -1380,6 +1419,21 @@ pub const TreeShaker = struct {
         }
     }
 
+    fn applyNodeBufferCapabilityFacts(self: *TreeShaker) !void {
+        const mod_count = self.graph.moduleCount();
+        for (0..mod_count) |i| {
+            const m = self.moduleAtMut(@intCast(i)) orelse continue;
+            if (m.wrap_kind != .cjs) continue;
+            const ast = &(m.ast orelse continue);
+            if (!foldNodeBufferCapabilityIfs(self.allocator, ast)) continue;
+
+            std.debug.assert(m.parse_arena != null);
+            self.graph.refreshAnalysisAfterAstMutation(m, m.parse_arena.?.allocator()) catch {
+                m.prebuilt_stmt_info = null;
+            };
+        }
+    }
+
     fn moduleHasAnyReachableStmt(self: *const TreeShaker, module_index: u32) bool {
         if (module_index >= self.reachable_stmts.len) return true;
         const reachable = self.reachable_stmts[module_index] orelse return false;
@@ -1451,4 +1505,391 @@ pub const TreeShaker = struct {
 fn containsU32(slice: []const u32, target: u32) bool {
     for (slice) |v| if (v == target) return true;
     return false;
+}
+
+fn foldNodeBufferCapabilityIfs(allocator: std.mem.Allocator, ast: *Ast) bool {
+    var buffer_names: std.StringHashMapUnmanaged(void) = .{};
+    defer buffer_names.deinit(allocator);
+    collectNodeBufferModuleObjectNames(allocator, ast, &buffer_names) catch return false;
+    if (buffer_names.count() == 0) return false;
+
+    var buffer_ctor_names: std.StringHashMapUnmanaged(void) = .{};
+    defer buffer_ctor_names.deinit(allocator);
+    collectNodeBufferCtorNames(allocator, ast, &buffer_names, &buffer_ctor_names) catch return false;
+    if (buffer_ctor_names.count() == 0) return false;
+
+    var dead_fallback_names: std.StringHashMapUnmanaged(void) = .{};
+    defer dead_fallback_names.deinit(allocator);
+
+    var changed = false;
+    for (ast.nodes.items, 0..) |node, i| {
+        if (node.tag != .if_statement) continue;
+        var caps: BufferCapabilitySet = .{};
+        if (!collectNodeBufferCapabilityCondition(ast, node.data.ternary.a, &buffer_ctor_names, &caps)) continue;
+        if (!caps.hasAll()) continue;
+        collectDeadAlternateCjsExportIdentifiers(allocator, ast, node.data.ternary.c, &dead_fallback_names) catch {};
+        const kept = singleBlockStatement(ast, node.data.ternary.b) orelse node.data.ternary.b;
+        const kept_ni = @intFromEnum(kept);
+        if (kept_ni >= ast.nodes.items.len) continue;
+        ast.nodes.items[i] = ast.nodes.items[kept_ni];
+        changed = true;
+    }
+    if (changed and dead_fallback_names.count() > 0) {
+        removeDeadFallbackSetupStatements(ast, &dead_fallback_names, &buffer_ctor_names);
+    }
+    return changed;
+}
+
+const BufferCapabilitySet = struct {
+    from: bool = false,
+    alloc: bool = false,
+    alloc_unsafe: bool = false,
+    alloc_unsafe_slow: bool = false,
+
+    fn add(self: *BufferCapabilitySet, name: []const u8) bool {
+        if (std.mem.eql(u8, name, "from")) {
+            self.from = true;
+            return true;
+        }
+        if (std.mem.eql(u8, name, "alloc")) {
+            self.alloc = true;
+            return true;
+        }
+        if (std.mem.eql(u8, name, "allocUnsafe")) {
+            self.alloc_unsafe = true;
+            return true;
+        }
+        if (std.mem.eql(u8, name, "allocUnsafeSlow")) {
+            self.alloc_unsafe_slow = true;
+            return true;
+        }
+        return false;
+    }
+
+    fn hasAll(self: BufferCapabilitySet) bool {
+        return self.from and self.alloc and self.alloc_unsafe and self.alloc_unsafe_slow;
+    }
+};
+
+fn collectNodeBufferCapabilityCondition(
+    ast: *const Ast,
+    idx: NodeIndex,
+    ctor_names: *const std.StringHashMapUnmanaged(void),
+    caps: *BufferCapabilitySet,
+) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    switch (node.tag) {
+        .parenthesized_expression => return collectNodeBufferCapabilityCondition(ast, node.data.unary.operand, ctor_names, caps),
+        .logical_expression => {
+            if (@as(Kind, @enumFromInt(node.data.binary.flags)) != .amp2) return false;
+            return collectNodeBufferCapabilityCondition(ast, node.data.binary.left, ctor_names, caps) and
+                collectNodeBufferCapabilityCondition(ast, node.data.binary.right, ctor_names, caps);
+        },
+        .static_member_expression => {
+            const parts = staticMemberParts(ast, idx) orelse return false;
+            const obj = ast.nodes.items[@intFromEnum(parts.object)];
+            if (obj.tag != .identifier_reference) return false;
+            if (!ctor_names.contains(ast.getText(obj.span))) return false;
+            const prop = ast.nodes.items[@intFromEnum(parts.property)];
+            if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
+            return caps.add(ast.getText(prop.span));
+        },
+        else => return false,
+    }
+}
+
+fn singleBlockStatement(ast: *const Ast, idx: NodeIndex) ?NodeIndex {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .block_statement) return null;
+    const list = node.data.list;
+    if (list.len != 1) return null;
+    if (list.start >= ast.extra_data.items.len) return null;
+    return @enumFromInt(ast.extra_data.items[list.start]);
+}
+
+fn collectDeadAlternateCjsExportIdentifiers(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    idx: NodeIndex,
+    out: *std.StringHashMapUnmanaged(void),
+) std.mem.Allocator.Error!void {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag == .block_statement) {
+        const list = node.data.list;
+        if (list.start + list.len > ast.extra_data.items.len) return;
+        for (ast.extra_data.items[list.start .. list.start + list.len]) |raw| {
+            try collectDeadAlternateCjsExportIdentifiers(allocator, ast, @enumFromInt(raw), out);
+        }
+        return;
+    }
+    if (node.tag != .expression_statement) return;
+    const expr_idx = node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return;
+    if (!isCjsNamedExportLhs(ast, expr.data.binary.left)) return;
+    const rhs_idx = expr.data.binary.right;
+    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return;
+    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+    if (rhs.tag != .identifier_reference) return;
+    try out.put(allocator, ast.getText(rhs.span), {});
+}
+
+fn removeDeadFallbackSetupStatements(
+    ast: *Ast,
+    dead_names: *const std.StringHashMapUnmanaged(void),
+    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
+) void {
+    const root = programNode(ast) orelse return;
+    const list = root.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
+        if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) continue;
+        const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
+        if (!isDeadFallbackSetupStatement(ast, stmt, dead_names, buffer_ctor_names)) continue;
+        ast.nodes.items[@intFromEnum(stmt_idx)] = .{
+            .tag = .empty_statement,
+            .span = stmt.span,
+            .data = .{ .none = 0 },
+        };
+    }
+}
+
+fn isDeadFallbackSetupStatement(
+    ast: *const Ast,
+    stmt: Node,
+    dead_names: *const std.StringHashMapUnmanaged(void),
+    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
+) bool {
+    if (stmt.tag != .expression_statement) return false;
+    const expr_idx = stmt.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag == .assignment_expression) {
+        const root = staticMemberRootIdentifier(ast, expr.data.binary.left) orelse return false;
+        return dead_names.contains(root);
+    }
+    if (expr.tag == .call_expression) {
+        return isDeadFallbackCopyCall(ast, expr, dead_names, buffer_ctor_names);
+    }
+    return false;
+}
+
+fn isDeadFallbackCopyCall(
+    ast: *const Ast,
+    call: Node,
+    dead_names: *const std.StringHashMapUnmanaged(void),
+    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
+) bool {
+    const e = call.data.extra;
+    if (!ast.hasExtra(e, 2)) return false;
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 2 or args_start + args_len > ast.extra_data.items.len) return false;
+    const first_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    const second_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 1]);
+    if (first_idx.isNone() or second_idx.isNone()) return false;
+    if (@intFromEnum(first_idx) >= ast.nodes.items.len or @intFromEnum(second_idx) >= ast.nodes.items.len) return false;
+    const first = ast.nodes.items[@intFromEnum(first_idx)];
+    const second = ast.nodes.items[@intFromEnum(second_idx)];
+    if (first.tag != .identifier_reference or second.tag != .identifier_reference) return false;
+    return buffer_ctor_names.contains(ast.getText(first.span)) and dead_names.contains(ast.getText(second.span));
+}
+
+fn staticMemberRootIdentifier(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
+    var current = idx;
+    while (true) {
+        const parts = staticMemberParts(ast, current) orelse return null;
+        const obj = ast.nodes.items[@intFromEnum(parts.object)];
+        if (obj.tag == .identifier_reference) return ast.getText(obj.span);
+        current = parts.object;
+    }
+}
+
+fn collectNodeBufferModuleObjectNames(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    out: *std.StringHashMapUnmanaged(void),
+) std.mem.Allocator.Error!void {
+    const root = programNode(ast) orelse return;
+    const list = root.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
+        try collectVarNamesMatchingInit(allocator, ast, stmt_idx, out, isRequireBufferCall);
+    }
+}
+
+fn collectNodeBufferCtorNames(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    buffer_names: *const std.StringHashMapUnmanaged(void),
+    out: *std.StringHashMapUnmanaged(void),
+) std.mem.Allocator.Error!void {
+    const root = programNode(ast) orelse return;
+    const list = root.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
+        if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) continue;
+        const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
+        if (stmt.tag != .variable_declaration) continue;
+        const e = stmt.data.extra;
+        if (!ast.hasExtra(e, 2)) continue;
+        const start = ast.readExtra(e, 1);
+        const len = ast.readExtra(e, 2);
+        if (start + len > ast.extra_data.items.len) continue;
+        for (ast.extra_data.items[start .. start + len]) |raw_decl| {
+            const decl_idx: NodeIndex = @enumFromInt(raw_decl);
+            if (decl_idx.isNone() or @intFromEnum(decl_idx) >= ast.nodes.items.len) continue;
+            const decl = ast.nodes.items[@intFromEnum(decl_idx)];
+            if (decl.tag != .variable_declarator) continue;
+            const de = decl.data.extra;
+            if (!ast.hasExtra(de, 2)) continue;
+            const name_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 0));
+            const init_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 2));
+            if (name_idx.isNone() or @intFromEnum(name_idx) >= ast.nodes.items.len) continue;
+            if (!isNodeBufferCtorRead(ast, init_idx, buffer_names)) continue;
+            const name = ast.nodes.items[@intFromEnum(name_idx)];
+            if (name.tag == .identifier_reference or name.tag == .binding_identifier or name.tag == .assignment_target_identifier) {
+                try out.put(allocator, ast.getText(name.span), {});
+            }
+        }
+    }
+}
+
+fn collectVarNamesMatchingInit(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    stmt_idx: NodeIndex,
+    out: *std.StringHashMapUnmanaged(void),
+    comptime predicate: fn (*const Ast, NodeIndex) bool,
+) std.mem.Allocator.Error!void {
+    if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) return;
+    const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
+    if (stmt.tag != .variable_declaration) return;
+    const e = stmt.data.extra;
+    if (!ast.hasExtra(e, 2)) return;
+    const start = ast.readExtra(e, 1);
+    const len = ast.readExtra(e, 2);
+    if (start + len > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[start .. start + len]) |raw_decl| {
+        const decl_idx: NodeIndex = @enumFromInt(raw_decl);
+        if (decl_idx.isNone() or @intFromEnum(decl_idx) >= ast.nodes.items.len) continue;
+        const decl = ast.nodes.items[@intFromEnum(decl_idx)];
+        if (decl.tag != .variable_declarator) continue;
+        const de = decl.data.extra;
+        if (!ast.hasExtra(de, 2)) continue;
+        const name_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 0));
+        const init_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 2));
+        if (!predicate(ast, init_idx)) continue;
+        if (name_idx.isNone() or @intFromEnum(name_idx) >= ast.nodes.items.len) continue;
+        const name = ast.nodes.items[@intFromEnum(name_idx)];
+        if (name.tag == .identifier_reference or name.tag == .binding_identifier or name.tag == .assignment_target_identifier) {
+            try out.put(allocator, ast.getText(name.span), {});
+        }
+    }
+}
+
+fn programNode(ast: *const Ast) ?Node {
+    if (ast.nodes.items.len == 0) return null;
+    const root = ast.nodes.items[ast.nodes.items.len - 1];
+    if (root.tag != .program) return null;
+    return root;
+}
+
+fn isRequireBufferCall(ast: *const Ast, idx: NodeIndex) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .call_expression) return false;
+    const e = node.data.extra;
+    if (!ast.hasExtra(e, 2)) return false;
+    const callee_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 0));
+    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return false;
+    const callee = ast.nodes.items[@intFromEnum(callee_idx)];
+    if (callee.tag != .identifier_reference or !std.mem.eql(u8, ast.getText(callee.span), "require")) return false;
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 1 or args_start >= ast.extra_data.items.len) return false;
+    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+    if (arg.tag != .string_literal) return false;
+    const spec = ast_mod.Ast.stripStringQuotes(ast.getText(arg.span));
+    return std.mem.eql(u8, spec, "buffer") or std.mem.eql(u8, spec, "node:buffer");
+}
+
+fn isNodeBufferCtorRead(
+    ast: *const Ast,
+    idx: NodeIndex,
+    buffer_names: *const std.StringHashMapUnmanaged(void),
+) bool {
+    const parts = staticMemberParts(ast, idx) orelse return false;
+    const obj = ast.nodes.items[@intFromEnum(parts.object)];
+    const prop = ast.nodes.items[@intFromEnum(parts.property)];
+    if (obj.tag != .identifier_reference) return false;
+    if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
+    return buffer_names.contains(ast.getText(obj.span)) and std.mem.eql(u8, ast.getText(prop.span), "Buffer");
+}
+
+fn isModuleExportsAssignedNodeBufferObject(
+    ast: *const Ast,
+    stmt: Node,
+    buffer_names: *const std.StringHashMapUnmanaged(void),
+) bool {
+    if (stmt.tag != .expression_statement) return false;
+    const expr_idx = stmt.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return false;
+    if (!isModuleExportsLhsForNodeBufferFact(ast, expr.data.binary.left)) return false;
+    const rhs_idx = expr.data.binary.right;
+    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return false;
+    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+    return rhs.tag == .identifier_reference and buffer_names.contains(ast.getText(rhs.span));
+}
+
+fn isModuleExportsLhsForNodeBufferFact(ast: *const Ast, idx: NodeIndex) bool {
+    const parts = staticMemberParts(ast, idx) orelse return false;
+    const obj = ast.nodes.items[@intFromEnum(parts.object)];
+    const prop = ast.nodes.items[@intFromEnum(parts.property)];
+    return obj.tag == .identifier_reference and
+        prop.tag == .identifier_reference and
+        std.mem.eql(u8, ast.getText(obj.span), "module") and
+        std.mem.eql(u8, ast.getText(prop.span), "exports");
+}
+
+fn isCjsNamedExportLhs(ast: *const Ast, idx: NodeIndex) bool {
+    const outer = staticMemberParts(ast, idx) orelse return false;
+    const prop = ast.nodes.items[@intFromEnum(outer.property)];
+    if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
+    const obj = ast.nodes.items[@intFromEnum(outer.object)];
+    if (obj.tag == .identifier_reference and std.mem.eql(u8, ast.getText(obj.span), "exports")) {
+        return true;
+    }
+    if (obj.tag != .static_member_expression) return false;
+    const inner = staticMemberParts(ast, outer.object) orelse return false;
+    const inner_obj = ast.nodes.items[@intFromEnum(inner.object)];
+    const inner_prop = ast.nodes.items[@intFromEnum(inner.property)];
+    return inner_obj.tag == .identifier_reference and
+        inner_prop.tag == .identifier_reference and
+        std.mem.eql(u8, ast.getText(inner_obj.span), "module") and
+        std.mem.eql(u8, ast.getText(inner_prop.span), "exports");
+}
+
+fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeIndex, property: NodeIndex } {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .static_member_expression) return null;
+    const e = node.data.extra;
+    if (!ast.hasExtra(e, 1)) return null;
+    const obj_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 0));
+    const prop_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 1));
+    if (obj_idx.isNone() or prop_idx.isNone()) return null;
+    if (@intFromEnum(obj_idx) >= ast.nodes.items.len or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
+    return .{ .object = obj_idx, .property = prop_idx };
 }

--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
@@ -22,6 +22,26 @@ interface Candidate {
   value: string;
   ztsCount: number;
 }
+
+interface CjsExportAudit {
+  sourceFileCount: number;
+  patternCounts: Record<CjsExportPattern, number>;
+  remainingMarkers: Candidate[];
+  removedMarkerCandidates: Candidate[];
+}
+
+type CjsExportPattern =
+  | "exports.x ="
+  | "module.exports.x ="
+  | "module.exports = { ... }"
+  | "Object.defineProperty(..., { value })";
+
+const cjsExportPatterns: CjsExportPattern[] = [
+  "exports.x =",
+  "module.exports.x =",
+  "module.exports = { ... }",
+  "Object.defineProperty(..., { value })",
+];
 
 function parseProjects(): string[] {
   const arg = process.argv.find((a) => a.startsWith("--projects="));
@@ -96,6 +116,104 @@ function countOccurrences(text: string, needle: string): number {
   return count;
 }
 
+function increment(map: Map<string, number>, value: string): void {
+  map.set(value, (map.get(value) ?? 0) + 1);
+}
+
+function countCjsExportPatterns(text: string): Record<CjsExportPattern, number> {
+  return {
+    "exports.x =": [...text.matchAll(/(^|[^\w$.])exports\.[A-Za-z_$][\w$]*\s*=/gm)].length,
+    "module.exports.x =": [...text.matchAll(/\bmodule\.exports\.[A-Za-z_$][\w$]*\s*=/g)]
+      .length,
+    "module.exports = { ... }": [...text.matchAll(/\bmodule\.exports\s*=\s*\{/g)].length,
+    "Object.defineProperty(..., { value })": [
+      ...text.matchAll(
+        /\bObject\.defineProperty\s*\(\s*(?:exports|module\.exports)\s*,\s*(["'`])(?:\\.|(?!\1).)+\1\s*,\s*\{[^}]*\bvalue\b/g,
+      ),
+    ].length,
+  };
+}
+
+function collectCjsExportMarkers(text: string): Map<string, number> {
+  const markers = new Map<string, number>();
+
+  for (const match of text.matchAll(/(^|[^\w$.])exports\.([A-Za-z_$][\w$]*)\s*=/gm)) {
+    increment(markers, `exports.${match[2]} =`);
+  }
+  for (const match of text.matchAll(/\bmodule\.exports\.([A-Za-z_$][\w$]*)\s*=/g)) {
+    increment(markers, `module.exports.${match[1]} =`);
+  }
+  for (const _match of text.matchAll(/\bmodule\.exports\s*=\s*\{/g)) {
+    increment(markers, "module.exports = {");
+  }
+  for (const match of text.matchAll(
+    /\bObject\.defineProperty\s*\(\s*(exports|module\.exports)\s*,\s*(["'`])((?:\\.|(?!\2).)+)\2\s*,\s*\{[^}]*\bvalue\b/g,
+  )) {
+    increment(
+      markers,
+      `Object.defineProperty(${match[1]}, ${JSON.stringify(match[3])}, { value })`,
+    );
+  }
+
+  return markers;
+}
+
+function readJavaScriptFiles(dir: string): { path: string; content: string }[] {
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return [];
+
+  const files: { path: string; content: string }[] = [];
+  const visit = (current: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === ".bin") continue;
+      const fullPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+      } else if (entry.isFile() && /\.(?:cjs|js|mjs)$/.test(entry.name)) {
+        files.push({ path: fullPath, content: readFileSync(fullPath, "utf-8") });
+      }
+    }
+  };
+  visit(dir);
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function packageSourceFiles(project: string): { path: string; content: string }[] {
+  const candidates = [
+    join(ROOT, "tests/benchmark/node_modules", project),
+    join(ROOT, "node_modules", project),
+  ];
+  for (const candidate of candidates) {
+    const files = readJavaScriptFiles(candidate);
+    if (files.length > 0) return files;
+  }
+  return [];
+}
+
+function cjsExportAudit(project: string, zts: string): CjsExportAudit {
+  const sourceFiles = packageSourceFiles(project);
+  const source = sourceFiles.map((file) => file.content).join("\n");
+  const sourceMarkers = collectCjsExportMarkers(source);
+  const ztsMarkers = collectCjsExportMarkers(zts);
+
+  const patternCounts = countCjsExportPatterns(source);
+  const remainingMarkers = [...ztsMarkers]
+    .map(([value, ztsCount]) => ({ value, ztsCount }))
+    .sort((a, b) => b.ztsCount - a.ztsCount || a.value.localeCompare(b.value))
+    .slice(0, 12);
+  const removedMarkerCandidates = [...sourceMarkers]
+    .filter(([value]) => !ztsMarkers.has(value))
+    .map(([value, ztsCount]) => ({ value, ztsCount }))
+    .sort((a, b) => b.ztsCount - a.ztsCount || a.value.localeCompare(b.value))
+    .slice(0, 12);
+
+  return {
+    sourceFileCount: sourceFiles.length,
+    patternCounts,
+    remainingMarkers,
+    removedMarkerCandidates,
+  };
+}
+
 function ztsOnlyStrings(zts: string, baseline: string): Candidate[] {
   const strings = new Set<string>();
   const re = /(["'`])((?:\\.|(?!\1).){16,})\1/g;
@@ -154,6 +272,12 @@ function formatCandidates(candidates: Candidate[]): string {
   return candidates.map((c) => `  - ${c.value} (${c.ztsCount}x)`).join("\n");
 }
 
+function formatPatternCounts(patternCounts: Record<CjsExportPattern, number>): string {
+  return cjsExportPatterns
+    .map((pattern) => `  - ${pattern}: ${patternCounts[pattern]}`)
+    .join("\n");
+}
+
 const projects = parseProjects();
 const tempDir = mkdtempSync(join(tmpdir(), "zts-size-gap-"));
 const keepDir = join(tempDir, "outputs");
@@ -190,6 +314,15 @@ try {
     console.log(formatCandidates(wrapperMarkers(zts, base)));
     console.log("\nTop-level declarations");
     console.log(formatCandidates(topLevelDeclarations(zts, base)));
+    const audit = cjsExportAudit(result.project, zts);
+    console.log("\nCJS export pattern audit");
+    console.log(`  Source JS files: ${audit.sourceFileCount}`);
+    console.log("  Pattern counts:");
+    console.log(formatPatternCounts(audit.patternCounts));
+    console.log("  Remaining ZTS export markers:");
+    console.log(formatCandidates(audit.remainingMarkers));
+    console.log("  Removed dead marker candidates:");
+    console.log(formatCandidates(audit.removedMarkerCandidates));
   }
 } finally {
   if (!process.argv.includes("--keep-temp")) {

--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -123,8 +123,7 @@ function increment(map: Map<string, number>, value: string): void {
 function countCjsExportPatterns(text: string): Record<CjsExportPattern, number> {
   return {
     "exports.x =": [...text.matchAll(/(^|[^\w$.])exports\.[A-Za-z_$][\w$]*\s*=/gm)].length,
-    "module.exports.x =": [...text.matchAll(/\bmodule\.exports\.[A-Za-z_$][\w$]*\s*=/g)]
-      .length,
+    "module.exports.x =": [...text.matchAll(/\bmodule\.exports\.[A-Za-z_$][\w$]*\s*=/g)].length,
     "module.exports = { ... }": [...text.matchAll(/\bmodule\.exports\s*=\s*\{/g)].length,
     "Object.defineProperty(..., { value })": [
       ...text.matchAll(
@@ -273,9 +272,7 @@ function formatCandidates(candidates: Candidate[]): string {
 }
 
 function formatPatternCounts(patternCounts: Record<CjsExportPattern, number>): string {
-  return cjsExportPatterns
-    .map((pattern) => `  - ${pattern}: ${patternCounts[pattern]}`)
-    .join("\n");
+  return cjsExportPatterns.map((pattern) => `  - ${pattern}: ${patternCounts[pattern]}`).join("\n");
 }
 
 const projects = parseProjects();

--- a/tests/benchmark/smoke-diagnostics.test.ts
+++ b/tests/benchmark/smoke-diagnostics.test.ts
@@ -63,15 +63,29 @@ describe("benchmark smoke diagnostics", () => {
     }
   });
 
-  test("size-gap.ts reports ZTS-only candidates for the target project", () => {
-    const r = runBun(["run", "tests/benchmark/size-gap.ts", "--projects=safe-buffer"]);
+  test("size-gap.ts reports CJS export pattern audit for target projects", () => {
+    const r = runBun([
+      "run",
+      "tests/benchmark/size-gap.ts",
+      "--projects=safe-buffer,cookie,path-to-regexp",
+    ]);
 
     expect(r.status, r.stderr?.toString()).toBe(0);
     const stdout = r.stdout.toString();
     expect(stdout).toContain("safe-buffer");
+    expect(stdout).toContain("cookie");
+    expect(stdout).toContain("path-to-regexp");
     expect(stdout).toContain("ZTS-only strings");
     expect(stdout).toContain("Wrapper markers");
     expect(stdout).toContain("Top-level declarations");
+    expect(stdout).toContain("CJS export pattern audit");
+    expect(stdout).toContain("Pattern counts:");
+    expect(stdout).toMatch(/exports\.x =: \d+/);
+    expect(stdout).toMatch(/module\.exports\.x =: \d+/);
+    expect(stdout).toMatch(/module\.exports = \{ \.\.\. \}: \d+/);
+    expect(stdout).toMatch(/Object\.defineProperty\(\.\.\., \{ value \}\): \d+/);
+    expect(stdout).toMatch(/Remaining ZTS export markers:\n(?:  - .+\n?)+/);
+    expect(stdout).toMatch(/Removed dead marker candidates:\n(?:  - .+\n?)+/);
   });
 
   test("--filter accepts comma-separated patterns and produces multiple results", () => {

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -168,6 +168,25 @@ describe("CJS static export fact 기반 DCE", () => {
     return existsSync(benchmarkNM) || existsSync(rootNM);
   };
 
+  test("safe-buffer — Buffer named import는 구형 Node fallback body를 끌고 오지 않음", () => {
+    if (!checkOrSkip("safe-buffer")) return;
+    const bundle = bundleIn(
+      BENCHMARK_DIR,
+      `import { Buffer } from "safe-buffer";\n` +
+        `console.log(Buffer.alloc(4).length === 4 ? "MATCH" : "MISS");\n`,
+      "safe-buffer-cjs-static-export",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).toMatch(/\bmodule\.exports\s*=\s*buffer\b/);
+    expect(bundle).not.toMatch(/\bexports\.Buffer\s*=/);
+    expect(bundle).not.toMatch(/\bmodule\.exports\.Buffer\s*=/);
+    expect(bundle).not.toMatch(/\bexports\.(?:alloc|allocUnsafe|allocUnsafeSlow|from)\s*=/);
+    expect(bundle).not.toMatch(/function\s+SafeBuffer\s*\(/);
+    expect(bundle).not.toContain("Argument must not be a number");
+    expect(bundle).not.toContain("allocUnsafeSlow");
+  });
+
   test("cookie — serialize named import는 parse 계열 body를 끌고 오지 않음", () => {
     if (!checkOrSkip("cookie")) return;
     const bundle = bundleIn(
@@ -181,6 +200,8 @@ describe("CJS static export fact 기반 DCE", () => {
     expect(runBundleSource(bundle)).toContain("MATCH");
     expect(bundle).not.toContain("argument str must be a string");
     expect(bundle).not.toMatch(/function\s+parse\s*\(/);
+    expect(bundle).not.toMatch(/\bexports\.(?:parse|parseCookie|parseSetCookie)\s*=/);
+    expect(bundle).not.toMatch(/\bmodule\.exports\.(?:parse|parseCookie|parseSetCookie)\s*=/);
   });
 
   test("path-to-regexp — match named import는 compile/stringify 계열 body를 끌고 오지 않음", () => {


### PR DESCRIPTION
Refs #2060

## 요약

`Object.defineProperty(exports, "x", { get() { return x; } })` 형태의 정적으로 안전한 CJS getter descriptor export fact를 추가했습니다.

live binding 의미를 보존하기 위해 getter body는 가장 좁은 safe subset만 허용합니다.

- `get() { return ident; }`
- `get: function() { return ident; }`
- `get: () => ident`
- descriptor key가 `"get"` string literal인 경우

## 변경 사항

- `CjsExportFact.Kind.define_property_getter`를 추가했습니다.
- `Object.defineProperty(exports|module.exports, name, descriptor)` fact 수집을 value descriptor에서 getter descriptor까지 확장했습니다.
- live getter fact는 defineProperty statement 자체를 reachable로 표시하되, 전체 statement를 BFS seed하지 않고 반환 identifier의 선언과 writer만 seed합니다.
- 동일 export name에 assignment/object/value/getter fact가 충돌하면 기존 conflict invalidation으로 모두 unsafe 처리되어 원문 semantics를 보존합니다.
- unsafe descriptor shape는 fact 대상에서 제외해 기존처럼 보존합니다.

## 안전하게 제외하는 형태

- setter 존재
- duplicate `get`/`value`/`set`
- descriptor spread
- computed descriptor key
- getter body가 `return identifier`가 아닌 경우
- getter body statement가 2개 이상인 경우
- async/generator getter
- call/member/new/conditional 등 non-identifier return
- aliased target/callee
- extra arg

## 테스트

- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `bun test tests/integration/tests/tree-shake-precision.test.ts -t "Object.defineProperty getter export"`
- `bun run tests/benchmark/smoke.ts --filter=safe-buffer,cookie,path-to-regexp,axios,rxjs`

## 리베이스

최신 `origin/main` (`016e8271`) 기준으로 리베이스했습니다.

## 참고

benchmark smoke에서 ZTS는 대상 5개 패키지 모두 build 성공 및 output MATCH입니다. 스크립트 출력상 `axios`의 esbuild baseline은 기존처럼 FAIL로 표시됩니다.