### PR TITLE
refactor(ast): unify staticKeyName API with escape decode (Phase 1)

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -16,7 +16,6 @@ const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Reference = @import("../semantic/symbol.zig").Reference;
 const ScopeId = @import("../semantic/scope.zig").ScopeId;
 const purity = @import("purity.zig");
-const string_escape = @import("../string_escape.zig");
 
 pub const StmtInfo = struct {
     node_idx: u32,
@@ -243,7 +242,7 @@ fn isModuleExportsLhs(ast: *const Ast, lhs: NodeIndex) bool {
 }
 
 /// `exports.foo` / `module.exports.foo` 의 prop NodeIndex 반환. 호출자가
-/// `decodedObjectKey` 등으로 owned 이름을 만들도록 한다.
+/// `ast.staticKeyName` 으로 owned 이름을 만들도록 한다.
 fn cjsExportNamePropFromLhs(ast: *const Ast, lhs: NodeIndex) ?NodeIndex {
     const outer = staticMemberParts(ast, lhs) orelse return null;
     const prop = ast.nodes.items[@intFromEnum(outer.property)];
@@ -257,38 +256,6 @@ fn cjsExportNamePropFromLhs(ast: *const Ast, lhs: NodeIndex) ?NodeIndex {
         return outer.property;
     }
     return null;
-}
-
-/// string_literal 의 escape 를 디코드해 owned UTF-8 반환. 잘못된 escape 는 null
-/// (caller 가 opaque 처리). 빈 입력/비-string_literal 도 null.
-fn decodedStringLiteralName(alloc: std.mem.Allocator, ast: *const Ast, idx: NodeIndex) !?[]u8 {
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
-    const n = ast.nodes.items[@intFromEnum(idx)];
-    if (n.tag != .string_literal) return null;
-    return string_escape.decodeJsStringLiteral(alloc, ast.getText(n.span)) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        error.InvalidStringLiteral, error.InvalidEscape => return null,
-    };
-}
-
-/// object key 노드에서 owned UTF-8 export name 을 만든다. identifier 계열은 dupe,
-/// string_literal 은 escape 디코드, numeric_literal 은 raw text dupe (ESM import 으로
-/// 직접 매칭 안 되지만 fact 등록을 거부할 이유는 없음 — 다른 키가 같은 stmt 에 있을 때
-/// 그쪽 prune 까지 막지 않게). computed_property_key 는 string_literal inner 만 허용.
-fn decodedObjectKey(alloc: std.mem.Allocator, ast: *const Ast, key_idx: NodeIndex) !?[]u8 {
-    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return null;
-    const key = ast.nodes.items[@intFromEnum(key_idx)];
-    return switch (key.tag) {
-        .identifier_reference, .binding_identifier, .private_identifier => try alloc.dupe(u8, ast.getText(key.data.string_ref)),
-        .numeric_literal => try alloc.dupe(u8, ast.getText(key.span)),
-        .string_literal => try decodedStringLiteralName(alloc, ast, key_idx),
-        .computed_property_key => blk: {
-            const inner = key.data.unary.operand;
-            if (inner.isNone()) break :blk null;
-            break :blk try decodedStringLiteralName(alloc, ast, inner);
-        },
-        else => null,
-    };
 }
 
 /// CJS object-shape export 의 value 위치가 named export 로 치환 안전한지 판정.
@@ -308,7 +275,7 @@ fn cjsExportCandidateForStmt(alloc: std.mem.Allocator, ast: *const Ast, stmt_nod
     const expr = ast.nodes.items[@intFromEnum(expr_idx)];
     if (expr.tag != .assignment_expression) return null;
     const prop_idx = cjsExportNamePropFromLhs(ast, expr.data.binary.left) orelse return null;
-    const export_name = (try decodedObjectKey(alloc, ast, prop_idx)) orelse return null;
+    const export_name = (try ast.staticKeyName(alloc, prop_idx)) orelse return null;
     return .{
         .export_name = export_name,
         .export_assignment_node = @intFromEnum(expr_idx),
@@ -430,7 +397,7 @@ fn cjsDefinePropertyExportCandidateForStmt(
     const descriptor_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 2]);
     if (!isCjsExportObjectExpr(ast, target_idx)) return null;
 
-    const export_name = (try decodedStringLiteralName(alloc, ast, export_name_idx)) orelse return null;
+    const export_name = (try ast.staticKeyName(alloc, export_name_idx)) orelse return null;
     var name_transferred = false;
     defer if (!name_transferred) alloc.free(export_name);
 
@@ -487,7 +454,7 @@ fn collectCjsObjectExportCandidates(
         const prop = ast.nodes.items[@intFromEnum(prop_idx)];
         if (prop.tag != .object_property) return null;
 
-        const name = (try decodedObjectKey(allocator, ast, prop.data.binary.left)) orelse return null;
+        const name = (try ast.staticKeyName(allocator, prop.data.binary.left)) orelse return null;
         var name_transferred = false;
         defer if (!name_transferred) allocator.free(name);
 

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const Span = @import("../lexer/token.zig").Span;
+const string_escape = @import("../string_escape.zig");
 
 // ============================================================
 // 인덱스 타입 — 포인터 대신 u32 인덱스로 노드를 참조 (D004)
@@ -1258,25 +1259,29 @@ pub const Ast = struct {
         return if (prop.data.binary.right.isNone()) prop.data.binary.left else prop.data.binary.right;
     }
 
-    /// object/method/class key 노드에서 정적 이름을 raw 형태로 추출한다.
-    /// identifier 계열, string_literal (따옴표 제거), numeric_literal,
+    /// object/method/class key 노드에서 정적 이름을 디코드된 owned UTF-8 로 추출한다.
+    /// identifier 계열, string_literal (escape 디코드), numeric_literal,
     /// computed_property_key (literal inner) 까지 처리. 그 외 (computed expr)
-    /// 는 null. 따옴표만 제거하므로 escape sequence 는 보존 — escape 해석이
-    /// 필요한 codegen 경로는 별도 helper 사용.
-    pub fn staticKeyName(self: *const Ast, key_idx: NodeIndex) ?[]const u8 {
+    /// 는 null. caller 가 반환된 slice 를 free 한다. invalid string literal
+    /// (불완전 escape 등) 도 null.
+    pub fn staticKeyName(
+        self: *const Ast,
+        alloc: std.mem.Allocator,
+        key_idx: NodeIndex,
+    ) std.mem.Allocator.Error!?[]u8 {
         if (key_idx.isNone() or @intFromEnum(key_idx) >= self.nodes.items.len) return null;
         const n = self.getNode(key_idx);
         return switch (n.tag) {
-            .identifier_reference, .binding_identifier, .private_identifier => self.getText(n.data.string_ref),
-            .string_literal => stripStringQuotes(self.getText(n.span)),
-            .numeric_literal => self.getText(n.span),
+            .identifier_reference, .binding_identifier, .private_identifier => try alloc.dupe(u8, self.getText(n.data.string_ref)),
+            .numeric_literal => try alloc.dupe(u8, self.getText(n.span)),
+            .string_literal => try decodeStringLiteralKey(self, alloc, key_idx),
             .computed_property_key => blk: {
                 const inner = n.data.unary.operand;
                 if (inner.isNone()) break :blk null;
                 const inner_n = self.getNode(inner);
                 break :blk switch (inner_n.tag) {
-                    .string_literal => stripStringQuotes(self.getText(inner_n.span)),
-                    .numeric_literal => self.getText(inner_n.span),
+                    .string_literal => try decodeStringLiteralKey(self, alloc, inner),
+                    .numeric_literal => try alloc.dupe(u8, self.getText(inner_n.span)),
                     else => null,
                 };
             },
@@ -1284,6 +1289,18 @@ pub const Ast = struct {
         };
     }
 };
+
+fn decodeStringLiteralKey(
+    ast: *const Ast,
+    alloc: std.mem.Allocator,
+    idx: NodeIndex,
+) std.mem.Allocator.Error!?[]u8 {
+    const n = ast.getNode(idx);
+    return string_escape.decodeJsStringLiteral(alloc, ast.getText(n.span)) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.InvalidStringLiteral, error.InvalidEscape => null,
+    };
+}
 
 // ============================================================
 // Function Declaration Flags (extra_data에 저장되는 비트 플래그)

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -81,7 +81,7 @@ pub fn checkDuplicateConstructors(
         if ((flags & (METHOD_FLAG_GETTER | METHOD_FLAG_SETTER | METHOD_FLAG_ASYNC | METHOD_FLAG_GENERATOR)) != 0) continue;
 
         // key가 "constructor" 문자열인지 확인
-        if (!matchKeyName(ast, key_idx, "constructor")) continue;
+        if (!try matchKeyName(allocator, ast, key_idx, "constructor")) continue;
 
         // TypeScript constructor overloads: body가 없는 시그니처는 허용.
         // body(extra[2])가 .none이면 overload 시그니처이므로 스킵.
@@ -104,9 +104,15 @@ pub fn checkDuplicateConstructors(
 // ====================================================================
 
 /// key 노드의 이름이 target과 일치하는지 확인한다.
-/// identifier 계열 / string_literal(따옴표 자동 제거) / numeric / computed-literal 모두 처리.
-fn matchKeyName(ast: *const Ast, key_idx: NodeIndex, target: []const u8) bool {
-    const name = ast.staticKeyName(key_idx) orelse return false;
+/// identifier 계열 / string_literal (escape 디코드) / numeric / computed-literal 모두 처리.
+fn matchKeyName(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    key_idx: NodeIndex,
+    target: []const u8,
+) std.mem.Allocator.Error!bool {
+    const name = (try ast.staticKeyName(allocator, key_idx)) orelse return false;
+    defer allocator.free(name);
     return std.mem.eql(u8, name, target);
 }
 
@@ -251,7 +257,7 @@ pub fn checkObjectDuplicateProto(
 
         // key가 "__proto__" 인지 확인
         const key_idx = node.data.binary.left;
-        if (!matchKeyName(ast, key_idx, "__proto__")) continue;
+        if (!try matchKeyName(allocator, ast, key_idx, "__proto__")) continue;
 
         if (first_proto_span) |_| {
             try addErrorCode(errors, allocator, node.span, try std.fmt.allocPrint(allocator, "Property name __proto__ appears more than once in object literal", .{}), .proto_duplicate);


### PR DESCRIPTION
## Summary
ast.staticKeyName 을 owned + escape-aware API 로 통합. Phase 1 — codegen 외 호출자 (`stmt_info`, `checker`) 마이그레이션. **codegen 영향 0** (codegen 은 자체 `resolveKeyName` 사용 중 — Phase 2 에서 통합 예정).

| 항목 | Before | After |
|---|---|---|
| 시그니처 | `(*const Ast, NodeIndex) ?[]const u8` | `(*const Ast, Allocator, NodeIndex) !?[]u8` |
| string_literal escape | stripStringQuotes only (raw) | `string_escape.decodeJsStringLiteral` |
| ownership | borrowed | **owned** (caller free) |

## 변경
- `ast.staticKeyName` signature 변경 + escape decode 일원화
- `checker.matchKeyName` 마이그레이션 (allocator 전파)
- `stmt_info`: `decodedObjectKey` / `decodedStringLiteralName` helper 제거, `ast.staticKeyName` 으로 통합
- `stmt_info` 의 `string_escape` import 제거 (의존성 ast 로 이전)

## 미세 동작 변화
- `computed_property_key` 의 inner 가 `numeric_literal` 인 경우: 이전 `stmt_info.decodedObjectKey` 는 reject 했으나 `ast.staticKeyName` 은 허용. ESM import 으로 매칭 불가능한 키라 부수효과 없음.

## Phase 2 (별도 PR 예정)
- codegen.resolveKeyName 제거 + ast.staticKeyName 으로 통합
- codegen 의 raw lifetime model 마이그레이션 (pending_fn_name owned, save/restore 시 free 책임)

## 성능 측정 (A 옵션 cost 검증)
codegen-heavy 합성 fixture (2000 method + 2000 prop + 2000 key) 에서 prototype 패치로 `resolveKeyName` 호출마다 alloc/free pair 추가 시뮬레이션:

```
main     codegen=0.382ms  emit.module.pass=0.983ms  total=39.713ms
proto_A  codegen=0.371ms  emit.module.pass=0.958ms  total=39.092ms
```

→ **노이즈 수준** (오히려 약간 빠름). 장기 부채 제거 가치가 perf 비용을 압도.

## Test plan
- [x] `zig build test` 통과 (escape 디코드 통합 테스트는 #2078 (closed) 의 6 케이스로 cover)
- [x] pre-push hook 통과
- [ ] CI (ReleaseFast) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)