### PR TITLE
CJS defineProperty getter export DCE 추가

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -8,9 +8,10 @@
 //! emitter: used_names 정제
 
 const std = @import("std");
-const Ast = @import("../parser/ast.zig").Ast;
-const Node = @import("../parser/ast.zig").Node;
-const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const ast_mod = @import("../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
 const Span = @import("../lexer/token.zig").Span;
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Reference = @import("../semantic/symbol.zig").Reference;
@@ -32,6 +33,7 @@ pub const CjsExportFact = struct {
         assignment,
         object_property,
         define_property_value,
+        define_property_getter,
 
         /// stmt 자체가 단일 export 라 BFS seed 시 stmt 전체를 enqueue 하면 충분한지.
         /// `assignment` (`exports.foo = rhs`) 만 그렇고, 나머지는 같은 stmt 안에 여러 export
@@ -322,11 +324,84 @@ fn plainObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
     };
 }
 
-fn definePropertyDescriptorValueNode(
+fn isIdentifierReference(ast: *const Ast, idx: NodeIndex) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
+    return ast.nodes.items[@intFromEnum(idx)].tag == .identifier_reference;
+}
+
+fn singleReturnIdentifierFromFunctionBody(ast: *const Ast, body_idx: NodeIndex) ?NodeIndex {
+    if (body_idx.isNone() or @intFromEnum(body_idx) >= ast.nodes.items.len) return null;
+    const body = ast.nodes.items[@intFromEnum(body_idx)];
+    if (body.tag != .block_statement) return null;
+
+    const list = body.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return null;
+    if (list.len != 1) return null;
+
+    const stmt_idx: NodeIndex = @enumFromInt(ast.extra_data.items[list.start]);
+    if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) return null;
+    const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
+    if (stmt.tag != .return_statement) return null;
+
+    const ret = stmt.data.unary.operand;
+    return if (isIdentifierReference(ast, ret)) ret else null;
+}
+
+fn zeroParamFunctionReturnIdentifier(ast: *const Ast, fn_idx: NodeIndex) ?NodeIndex {
+    if (fn_idx.isNone() or @intFromEnum(fn_idx) >= ast.nodes.items.len) return null;
+    const fn_node = ast.nodes.items[@intFromEnum(fn_idx)];
+
+    const body_slot: u32 = switch (fn_node.tag) {
+        .function_expression => 2,
+        .arrow_function_expression => 1,
+        else => return null,
+    };
+    const flags_slot: u32 = switch (fn_node.tag) {
+        .function_expression => 3,
+        .arrow_function_expression => 2,
+        else => unreachable,
+    };
+    if (!ast.hasExtra(fn_node.data.extra, flags_slot)) return null;
+
+    const flags = ast.readExtra(fn_node.data.extra, flags_slot);
+    switch (fn_node.tag) {
+        .function_expression => if ((flags & (ast_mod.FunctionFlags.is_async | ast_mod.FunctionFlags.is_generator)) != 0) return null,
+        .arrow_function_expression => if ((flags & ast_mod.ArrowFlags.is_async) != 0) return null,
+        else => unreachable,
+    }
+    if (ast.functionParamsList(fn_node).len != 0) return null;
+
+    const body_idx = ast.readExtraNode(fn_node.data.extra, body_slot);
+    if (fn_node.tag == .arrow_function_expression and isIdentifierReference(ast, body_idx)) {
+        return body_idx;
+    }
+    return singleReturnIdentifierFromFunctionBody(ast, body_idx);
+}
+
+fn methodReturnIdentifier(ast: *const Ast, method_idx: NodeIndex) ?NodeIndex {
+    if (method_idx.isNone() or @intFromEnum(method_idx) >= ast.nodes.items.len) return null;
+    const method = ast.nodes.items[@intFromEnum(method_idx)];
+    if (method.tag != .method_definition) return null;
+    if (!ast.hasExtra(method.data.extra, ast_mod.MethodExtra.flags)) return null;
+
+    const flags = ast.readExtra(method.data.extra, ast_mod.MethodExtra.flags);
+    if ((flags & (ast_mod.MethodFlags.is_async | ast_mod.MethodFlags.is_generator | ast_mod.MethodFlags.is_setter)) != 0) return null;
+    if (ast.functionParamsList(method).len != 0) return null;
+
+    const body_idx = ast.readExtraNode(method.data.extra, ast_mod.MethodExtra.body);
+    return singleReturnIdentifierFromFunctionBody(ast, body_idx);
+}
+
+const DefinePropertyDescriptorExport = struct {
+    rhs_node: NodeIndex,
+    kind: CjsExportFact.Kind,
+};
+
+fn definePropertyDescriptorExportNode(
     ast: *const Ast,
     descriptor_idx: NodeIndex,
     unresolved_globals: ?*const purity.GlobalRefSet,
-) ?NodeIndex {
+) ?DefinePropertyDescriptorExport {
     if (descriptor_idx.isNone() or @intFromEnum(descriptor_idx) >= ast.nodes.items.len) return null;
     const descriptor = ast.nodes.items[@intFromEnum(descriptor_idx)];
     if (descriptor.tag != .object_expression) return null;
@@ -336,20 +411,23 @@ fn definePropertyDescriptorValueNode(
     const indices = ast.extra_data.items[list.start .. list.start + list.len];
     if (indices.len == 0) return null;
 
-    // descriptor 의 정적 키는 최대 4 개 (value/writable/enumerable/configurable).
-    // get/set 은 진입 시 reject — accessor 는 prune 안전하지 않음.
-    var seen: [4][]const u8 = undefined;
+    // descriptor 의 정적 키만 허용한다. spread/computed/duplicate/accessor 혼합은
+    // defineProperty semantics 보존을 위해 fact 대상에서 제외한다.
+    var seen: [5][]const u8 = undefined;
     var seen_len: usize = 0;
-    var value_node: ?NodeIndex = null;
+    var result: ?DefinePropertyDescriptorExport = null;
 
     for (indices) |raw_prop| {
         const prop_idx: NodeIndex = @enumFromInt(raw_prop);
         if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
         const prop = ast.nodes.items[@intFromEnum(prop_idx)];
-        if (prop.tag != .object_property) return null;
 
-        const name = plainObjectKeyName(ast, prop.data.binary.left) orelse return null;
-        if (std.mem.eql(u8, name, "get") or std.mem.eql(u8, name, "set")) return null;
+        const key_idx = switch (prop.tag) {
+            .object_property => prop.data.binary.left,
+            .method_definition => ast.readExtraNode(prop.data.extra, ast_mod.MethodExtra.key),
+            else => return null,
+        };
+        const name = plainObjectKeyName(ast, key_idx) orelse return null;
         if (seen_len >= seen.len) return null;
         for (seen[0..seen_len]) |prev| {
             if (std.mem.eql(u8, prev, name)) return null;
@@ -357,18 +435,34 @@ fn definePropertyDescriptorValueNode(
         seen[seen_len] = name;
         seen_len += 1;
 
+        if (std.mem.eql(u8, name, "set")) return null;
+
+        if (prop.tag == .method_definition) {
+            if (!std.mem.eql(u8, name, "get")) return null;
+            if (result != null) return null;
+            const returned = methodReturnIdentifier(ast, prop_idx) orelse return null;
+            result = .{ .rhs_node = returned, .kind = .define_property_getter };
+            continue;
+        }
+
         const prop_value = Ast.objectPropertyValue(prop);
         if (prop_value.isNone() or @intFromEnum(prop_value) >= ast.nodes.items.len) return null;
-        if (!purity.isExprPure(ast, prop_value, unresolved_globals)) return null;
 
         if (std.mem.eql(u8, name, "value")) {
-            const value = ast.nodes.items[@intFromEnum(prop_value)];
-            if (value.tag != .identifier_reference) return null;
-            value_node = prop_value;
+            if (result != null) return null;
+            if (!purity.isExprPure(ast, prop_value, unresolved_globals)) return null;
+            if (!isIdentifierReference(ast, prop_value)) return null;
+            result = .{ .rhs_node = prop_value, .kind = .define_property_value };
+        } else if (std.mem.eql(u8, name, "get")) {
+            if (result != null) return null;
+            const returned = zeroParamFunctionReturnIdentifier(ast, prop_value) orelse return null;
+            result = .{ .rhs_node = returned, .kind = .define_property_getter };
+        } else {
+            if (!purity.isExprPure(ast, prop_value, unresolved_globals)) return null;
         }
     }
 
-    return value_node;
+    return result;
 }
 
 fn cjsDefinePropertyExportCandidateForStmt(
@@ -403,14 +497,14 @@ fn cjsDefinePropertyExportCandidateForStmt(
 
     if (std.mem.eql(u8, export_name, "__esModule")) return null;
 
-    const value_node = definePropertyDescriptorValueNode(ast, descriptor_idx, unresolved_globals) orelse return null;
+    const descriptor_export = definePropertyDescriptorExportNode(ast, descriptor_idx, unresolved_globals) orelse return null;
 
     name_transferred = true;
     return .{
         .export_name = export_name,
         .export_assignment_node = @intFromEnum(expr_idx),
-        .rhs_node = value_node,
-        .kind = .define_property_value,
+        .rhs_node = descriptor_export.rhs_node,
+        .kind = descriptor_export.kind,
     };
 }
 

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -815,6 +815,9 @@ pub const TreeShaker = struct {
                 return;
             };
             const fact = target_infos.cjsExportFactByName(canonical.export_name) orelse {
+                if (try self.seedCjsExportFactsByName(canon_mod, target_infos, canonical.export_name, queue, reachable_stmts)) {
+                    return;
+                }
                 try self.markAndSeedAllStmts(canon_mod, queue, module_stmt_infos, reachable_stmts);
                 return;
             };
@@ -904,6 +907,9 @@ pub const TreeShaker = struct {
             if (try self.seedNodeBufferModuleObjectExport(mod_idx, export_name, target_infos, queue, reachable_stmts)) {
                 return;
             }
+            if (try self.seedCjsExportFactsByName(mod_idx, target_infos, export_name, queue, reachable_stmts)) {
+                return;
+            }
             try self.markAndSeedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
             return;
         };
@@ -939,6 +945,23 @@ pub const TreeShaker = struct {
             return true;
         }
         return false;
+    }
+
+    fn seedCjsExportFactsByName(
+        self: *TreeShaker,
+        mod_idx: u32,
+        infos: StmtInfos,
+        export_name: []const u8,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!bool {
+        var found = false;
+        for (infos.cjs_export_facts) |fact| {
+            if (!std.mem.eql(u8, fact.export_name, export_name)) continue;
+            found = true;
+            try self.seedCjsExportFact(mod_idx, infos, fact, queue, reachable_stmts);
+        }
+        return found;
     }
 
     fn seedCjsExportFact(

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -218,6 +218,105 @@ describe("CJS static export fact 기반 DCE", () => {
     expect(bundle).not.toMatch(/function\s+compile\s*\(/);
     expect(bundle).not.toMatch(/function\s+stringify\s*\(/);
   });
+
+  test("Object.defineProperty getter export — used getter keeps returned helper and prunes unused getter", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib.cjs";\nconsole.log(used());\n`,
+        "lib.cjs":
+          `function usedHelper() { return "MATCH"; }\n` +
+          `function unusedHelper() { return "unused-getter-marker"; }\n` +
+          `Object.defineProperty(exports, "used", { enumerable: true, get() { return usedHelper; } });\n` +
+          `Object.defineProperty(exports, "unused", { enumerable: true, get: function() { return unusedHelper; } });\n`,
+      },
+      "index.ts",
+      "cjs-getter-export",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).toMatch(/function\s+usedHelper\s*\(/);
+    expect(bundle).not.toMatch(/function\s+unusedHelper\s*\(/);
+    expect(bundle).not.toContain("unused-getter-marker");
+    expect(bundle).not.toContain(`"unused"`);
+  });
+
+  test("Object.defineProperty getter export — module.exports target and arrow getter are supported", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { answer } from "./lib.cjs";\nconsole.log(answer === 42 ? "MATCH" : "MISS");\n`,
+        "lib.cjs":
+          `const answerValue = 42;\n` +
+          `const unusedValue = "module-exports-unused-getter";\n` +
+          `Object.defineProperty(module.exports, "answer", { "get": () => answerValue });\n` +
+          `Object.defineProperty(module.exports, "unused", { get: () => unusedValue });\n`,
+      },
+      "index.ts",
+      "cjs-module-exports-getter-export",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).toContain("answerValue");
+    expect(bundle).not.toContain("module-exports-unused-getter");
+  });
+
+  test("Object.defineProperty getter export — conflicts preserve assignment and getter", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { x } from "./lib.cjs";\nconsole.log(x === "B" ? "MATCH" : "MISS");\n`,
+        "lib.cjs":
+          `const a = "A";\n` +
+          `const b = "B";\n` +
+          `exports.x = a;\n` +
+          `Object.defineProperty(exports, "x", { get() { return b; } });\n`,
+      },
+      "index.ts",
+      "cjs-getter-conflict",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).toMatch(/\bexports\.x\s*=/);
+    expect(bundle).toContain("Object.defineProperty");
+  });
+
+  test("Object.defineProperty getter export — unsafe descriptor shapes stay preserved", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib.cjs";\nconsole.log(used);\n`,
+        "lib.cjs":
+          `const usedValue = "MATCH";\n` +
+          `const extra = { configurable: true };\n` +
+          `const alias = exports;\n` +
+          `const define = Object.defineProperty;\n` +
+          `Object.defineProperty(exports, "used", { value: usedValue });\n` +
+          `Object.defineProperty(exports, "setter", { set(v) { console.log("unsafe-setter-marker", v); } });\n` +
+          `Object.defineProperty(exports, "duplicate", { get() { return usedValue; }, get: function() { return usedValue; } });\n` +
+          `Object.defineProperty(exports, "spread", { ...extra, get() { return usedValue; } });\n` +
+          `Object.defineProperty(exports, "computed", { ["get"]: function() { return usedValue; } });\n` +
+          `Object.defineProperty(exports, "nonident", { get() { return usedValue + "-x"; } });\n` +
+          `Object.defineProperty(exports, "multi", { get() { const x = usedValue; return x; } });\n` +
+          `Object.defineProperty(alias, "aliasedTarget", { get() { return usedValue; } });\n` +
+          `define(exports, "aliasedCallee", { get() { return usedValue; } });\n` +
+          `Object.defineProperty(exports, "extraArg", { get() { return usedValue; } }, true);\n`,
+      },
+      "index.ts",
+      "cjs-getter-unsafe",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    for (const marker of [
+      "unsafe-setter-marker",
+      "duplicate",
+      "spread",
+      "computed",
+      "nonident",
+      "multi",
+      "aliasedTarget",
+      "aliasedCallee",
+      "extraArg",
+    ]) {
+      expect(bundle).toContain(marker);
+    }
+  });
 });
 
 describe("#1665 class-level tree-shake 정밀도", () => {


### PR DESCRIPTION
Refs #2060

## 요약

`Object.defineProperty(exports, "x", { get() { return x; } })` 형태의 정적으로 안전한 CJS getter descriptor export fact를 추가했습니다.

live binding 의미를 보존하기 위해 getter body는 가장 좁은 safe subset만 허용합니다.

- `get() { return ident; }`
- `get: function() { return ident; }`
- `get: () => ident`
- descriptor key가 `"get"` string literal인 경우

## 변경 사항

- `CjsExportFact.Kind.define_property_getter`를 추가했습니다.
- `Object.defineProperty(exports|module.exports, name, descriptor)` fact 수집을 value descriptor에서 getter descriptor까지 확장했습니다.
- live getter fact는 defineProperty statement 자체를 reachable로 표시하되, 전체 statement를 BFS seed하지 않고 반환 identifier의 선언과 writer만 seed합니다.
- 동일 export name에 assignment/object/value/getter fact가 충돌하면 기존 conflict invalidation으로 모두 unsafe 처리되어 원문 semantics를 보존합니다.
- 정적 CJS export fact가 존재하지만 conflict/unsafe로 단일 safe fact가 아닌 경우에도 모듈 전체 fallback으로 가지 않고, 해당 export name에 매칭되는 fact statement들만 seed하도록 수정했습니다. 이로써 `cookie`의 중복 `exports.serialize = stringifySetCookie` 패턴에서도 `parse` 계열 body가 딸려오지 않습니다.
- unsafe descriptor shape는 fact 대상에서 제외해 기존처럼 보존합니다.

## 안전하게 제외하는 형태

- setter 존재
- duplicate `get`/`value`/`set`
- descriptor spread
- computed descriptor key
- getter body가 `return identifier`가 아닌 경우
- getter body statement가 2개 이상인 경우
- async/generator getter
- call/member/new/conditional 등 non-identifier return
- aliased target/callee
- extra arg

## 테스트

- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `bun test tests/integration/tests/tree-shake-precision.test.ts`
- `bun run tests/benchmark/smoke.ts --filter=safe-buffer,cookie,path-to-regexp,axios,rxjs`

## 리베이스

최신 `origin/main` (`016e8271`) 기준으로 리베이스했습니다.

## 참고

benchmark smoke에서 ZTS는 대상 5개 패키지 모두 build 성공 및 output MATCH입니다. 스크립트 출력상 `axios`의 esbuild baseline은 기존처럼 FAIL로 표시됩니다.