### PR TITLE
CJS defineProperty member value export DCE 추가

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -578,6 +578,30 @@ test "TreeShaking CJS: module.exports defineProperty keeps helper and require ta
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_DEFINE_PRIVATE_MARKER") == null);
 }
 
+test "TreeShaking CJS: named import prunes unused Object.defineProperty member value" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\const liveNs = { value: function used() { return "USED_DEFINE_MEMBER_MARKER"; } };
+        \\const deadNs = { value: function unused() { return "UNUSED_DEFINE_MEMBER_MARKER"; } };
+        \\Object.defineProperty(exports, "used", { value: liveNs.value, enumerable: true });
+        \\Object.defineProperty(exports, "unused", { value: deadNs.value, enumerable: true });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_DEFINE_MEMBER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_DEFINE_MEMBER_MARKER") == null);
+}
+
 test "TreeShaking CJS: unsafe Object.defineProperty export forms are preserved" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -329,6 +329,26 @@ fn isIdentifierReference(ast: *const Ast, idx: NodeIndex) bool {
     return ast.nodes.items[@intFromEnum(idx)].tag == .identifier_reference;
 }
 
+fn definePropertyDescriptorValueSeedNode(ast: *const Ast, value_idx: NodeIndex) ?NodeIndex {
+    if (value_idx.isNone() or @intFromEnum(value_idx) >= ast.nodes.items.len) return null;
+    const value = ast.nodes.items[@intFromEnum(value_idx)];
+    if (value.tag == .identifier_reference) return value_idx;
+
+    if (value.tag != .static_member_expression) return null;
+    const e = value.data.extra;
+    if (!ast.hasExtra(e, 2)) return null;
+    const flags = ast.readExtra(e, 2);
+    if ((flags & ast_mod.MemberFlags.optional_chain) != 0) return null;
+
+    const object_idx = ast.readExtraNode(e, 0);
+    const property_idx = ast.readExtraNode(e, 1);
+    if (!isIdentifierReference(ast, object_idx)) return null;
+    if (property_idx.isNone() or @intFromEnum(property_idx) >= ast.nodes.items.len) return null;
+    const property = ast.nodes.items[@intFromEnum(property_idx)];
+    if (property.tag != .identifier_reference and property.tag != .private_identifier) return null;
+    return object_idx;
+}
+
 fn singleReturnIdentifierFromFunctionBody(ast: *const Ast, body_idx: NodeIndex) ?NodeIndex {
     if (body_idx.isNone() or @intFromEnum(body_idx) >= ast.nodes.items.len) return null;
     const body = ast.nodes.items[@intFromEnum(body_idx)];
@@ -451,8 +471,8 @@ fn definePropertyDescriptorExportNode(
         if (std.mem.eql(u8, name, "value")) {
             if (result != null) return null;
             if (!purity.isExprPure(ast, prop_value, unresolved_globals)) return null;
-            if (!isIdentifierReference(ast, prop_value)) return null;
-            result = .{ .rhs_node = prop_value, .kind = .define_property_value };
+            const seed_node = definePropertyDescriptorValueSeedNode(ast, prop_value) orelse return null;
+            result = .{ .rhs_node = seed_node, .kind = .define_property_value };
         } else if (std.mem.eql(u8, name, "get")) {
             if (result != null) return null;
             const returned = zeroParamFunctionReturnIdentifier(ast, prop_value) orelse return null;

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -329,24 +329,21 @@ fn isIdentifierReference(ast: *const Ast, idx: NodeIndex) bool {
     return ast.nodes.items[@intFromEnum(idx)].tag == .identifier_reference;
 }
 
+/// defineProperty descriptor 의 `value` 위치에서 의존성 시드로 쓸 노드를 반환.
+/// `liveNs.value` 같은 정적 멤버는 base object (`liveNs`) 를 시드로 돌려 tree_shaker
+/// 가 `rhs_symbol → declaring stmt` 로 base 의 declaring statement 를 살리게 한다.
+/// optional chain / 비-식별자 base / 동적 property 는 보수적으로 거부.
 fn definePropertyDescriptorValueSeedNode(ast: *const Ast, value_idx: NodeIndex) ?NodeIndex {
-    if (value_idx.isNone() or @intFromEnum(value_idx) >= ast.nodes.items.len) return null;
+    if (isIdentifierReference(ast, value_idx)) return value_idx;
+
+    const parts = staticMemberParts(ast, value_idx) orelse return null;
     const value = ast.nodes.items[@intFromEnum(value_idx)];
-    if (value.tag == .identifier_reference) return value_idx;
-
-    if (value.tag != .static_member_expression) return null;
-    const e = value.data.extra;
-    if (!ast.hasExtra(e, 2)) return null;
-    const flags = ast.readExtra(e, 2);
-    if ((flags & ast_mod.MemberFlags.optional_chain) != 0) return null;
-
-    const object_idx = ast.readExtraNode(e, 0);
-    const property_idx = ast.readExtraNode(e, 1);
-    if (!isIdentifierReference(ast, object_idx)) return null;
-    if (property_idx.isNone() or @intFromEnum(property_idx) >= ast.nodes.items.len) return null;
-    const property = ast.nodes.items[@intFromEnum(property_idx)];
+    if (!ast.hasExtra(value.data.extra, 2)) return null;
+    if ((ast.readExtra(value.data.extra, 2) & ast_mod.MemberFlags.optional_chain) != 0) return null;
+    if (!isIdentifierReference(ast, parts.object)) return null;
+    const property = ast.nodes.items[@intFromEnum(parts.property)];
     if (property.tag != .identifier_reference and property.tag != .private_identifier) return null;
-    return object_idx;
+    return parts.object;
 }
 
 fn singleReturnIdentifierFromFunctionBody(ast: *const Ast, body_idx: NodeIndex) ?NodeIndex {

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -127,6 +127,7 @@ interface ProjectConfig {
   name: string;
   pkg: string;
   entry: string;
+  files?: Record<string, string>;
   external?: string[];
   format?: "esm" | "cjs";
   platform?: "node" | "browser";
@@ -160,8 +161,17 @@ function testProject(p: ProjectConfig, options: SmokeOptions = {}): SmokeResult 
 
   // entry 파일을 benchmark 디렉토리에 작성 (node_modules resolve를 위해)
   const entryFile = join(__dirname, `_smoke_entry_${p.name}.ts`);
+  const extraFiles: string[] = [];
   try {
     writeFileSync(entryFile, p.entry);
+    if (p.files) {
+      for (const [relativePath, content] of Object.entries(p.files)) {
+        const filePath = join(__dirname, relativePath);
+        mkdirSync(dirname(filePath), { recursive: true });
+        writeFileSync(filePath, content);
+        extraFiles.push(filePath);
+      }
+    }
 
     // tsconfig.json 생성 (decorator 등 옵션이 필요한 경우)
     const tsconfigFile = join(__dirname, `_smoke_tsconfig_${p.name}.json`);
@@ -314,6 +324,11 @@ function testProject(p: ProjectConfig, options: SmokeOptions = {}): SmokeResult 
     try {
       rmSync(entryFile);
     } catch {}
+    for (const filePath of extraFiles) {
+      try {
+        rmSync(filePath);
+      } catch {}
+    }
     try {
       rmSync(tsconfigFile);
     } catch {}
@@ -811,6 +826,18 @@ const projects: ProjectConfig[] = [
     name: "cookie",
     pkg: "cookie",
     entry: `import { serialize } from 'cookie';\nconsole.log(serialize('a', 'b'));`,
+  },
+  {
+    name: "cjs-define-property-member-value",
+    pkg: "(synthetic)",
+    entry: `import { used } from './_smoke_cjs_define_property_member_value_lib.cjs';\nconsole.log(used());`,
+    files: {
+      "_smoke_cjs_define_property_member_value_lib.cjs":
+        `const liveNs = { value: function used() { return "MATCH"; } };\n` +
+        `const deadNs = { value: function unused() { return "UNUSED_SMOKE_DEFINE_MEMBER_VALUE"; } };\n` +
+        `Object.defineProperty(exports, "used", { value: liveNs.value });\n` +
+        `Object.defineProperty(exports, "unused", { value: deadNs.value });\n`,
+    },
   },
   {
     name: "on-finished",

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -240,6 +240,26 @@ describe("CJS static export fact 기반 DCE", () => {
     expect(bundle).not.toContain(`"unused"`);
   });
 
+  test("Object.defineProperty value export — static member value keeps base object and prunes unused member export", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib.cjs";\nconsole.log(used());\n`,
+        "lib.cjs":
+          `const liveNs = { value: function used() { return "MATCH"; } };\n` +
+          `const deadNs = { value: function unused() { return "unused-member-value-marker"; } };\n` +
+          `Object.defineProperty(exports, "used", { value: liveNs.value });\n` +
+          `Object.defineProperty(exports, "unused", { value: deadNs.value });\n`,
+      },
+      "index.ts",
+      "cjs-define-property-member-value",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).toContain("liveNs");
+    expect(bundle).not.toContain("unused-member-value-marker");
+    expect(bundle).not.toContain("deadNs");
+  });
+
   test("Object.defineProperty getter export — module.exports target and arrow getter are supported", () => {
     const bundle = bundleFiles(
       {


### PR DESCRIPTION
Refs #2060

## 요약

`Object.defineProperty(exports, "x", { value: ns.member })` 형태의 descriptor value export를 아주 좁게 정적 CJS fact 대상으로 확장했습니다.

기존에는 `{ value: identifier }`만 허용했기 때문에, descriptor value가 정적 member access인 경우 unused export pruning을 하지 못했습니다. 이번 PR은 purity 정책상 이미 pure로 취급되는 static member access 중에서도 seed 대상이 명확한 형태만 허용합니다.

## 허용 범위

- `Object.defineProperty(exports, "used", { value: ns.value })`
- `Object.defineProperty(module.exports, "used", { value: ns.value })`
- base object가 `identifier_reference`인 non-optional static member access
- property가 정적 identifier/private identifier인 경우

## 제외 범위

- computed member access: `ns["value"]`
- optional chain: `ns?.value`
- nested member: `ns.a.b`
- call/new/conditional 등 non-member expression
- 기존 unsafe descriptor 형태: duplicate key, spread, computed descriptor key, aliased target/callee, extra arg 등

## 구현

- descriptor `value`의 dependency seed node를 `identifier` 또는 `identifier.member`의 base identifier로 계산합니다.
- live fact는 기존과 동일하게 defineProperty statement 자체를 reachable로 표시하고, seed node의 declaration/writer만 BFS seed합니다.
- unused member value export는 defineProperty statement와 base object declaration이 함께 제거됩니다.

## 테스트

- 단위 테스트: `TreeShaking CJS: named import prunes unused Object.defineProperty member value`
- 회귀 테스트: `tree-shake-precision.test.ts`에 member value fixture 추가
- smoke 테스트: `cjs-define-property-member-value` synthetic project 추가

## 검증

- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `bun test tests/integration/tests/tree-shake-precision.test.ts`
- `bun run tests/benchmark/smoke.ts --filter=cjs-define-property-member-value,safe-buffer,cookie,path-to-regexp,axios,rxjs`

benchmark smoke에서 ZTS는 6/6 build 성공 및 6/6 output MATCH입니다. 스크립트 출력상 `axios`의 esbuild baseline은 기존처럼 FAIL로 표시됩니다.