### PR TITLE
refactor(codegen): remove residual local dispatch helpers

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -473,16 +473,6 @@ pub const Codegen = struct {
         };
     }
 
-    /// binding_identifier 노드에서 이름 추출.
-    fn resolveBindingName(self: *const Codegen, idx: NodeIndex) ?[]const u8 {
-        if (idx.isNone()) return null;
-        const n = self.ast.getNode(idx);
-        return switch (n.tag) {
-            .binding_identifier => self.ast.getText(n.data.string_ref),
-            else => null,
-        };
-    }
-
     /// MemberExpression/identifier의 leaf 이름 추출 (assignment left 용). 항상 owned UTF-8
     /// 반환, caller 가 free.
     /// `a.b.c` → "c", `a["str"]` → "str", `a[expr]` → null
@@ -2712,8 +2702,7 @@ pub const Codegen = struct {
             // contextual name: binding_identifier = function/arrow/class → 변수명을 이름으로
             if (self.fn_map_builder != null and self.isFunctionLike(init_val)) {
                 const saved = self.pending_fn_name;
-                const binding = self.resolveBindingName(name);
-                self.pending_fn_name = if (binding) |s| try self.allocator.dupe(u8, s) else null;
+                self.pending_fn_name = try self.ast.staticKeyName(self.allocator, name);
                 defer {
                     if (self.pending_fn_name) |s| self.allocator.free(s);
                     self.pending_fn_name = saved;
@@ -3385,7 +3374,7 @@ pub const Codegen = struct {
                 const member = self.ast.getNode(@enumFromInt(raw_idx));
                 const member_name = self.ast.getNode(member.data.binary.left);
                 const raw_text = self.ast.getText(member_name.span);
-                const mt = stripStringQuotes(raw_text);
+                const mt = Ast.stripStringQuotes(raw_text);
                 const member_init_idx = member.data.binary.right;
 
                 if (!needs_rename and std.mem.eql(u8, mt, name_text)) {
@@ -3463,7 +3452,7 @@ pub const Codegen = struct {
             const member_name = self.ast.getNode(member_name_idx);
             const raw_text = self.ast.getText(member_name.span);
             // 문자열 리터럴 키의 따옴표 제거: 'a' → a, "a b" → a b
-            const member_text = stripStringQuotes(raw_text);
+            const member_text = Ast.stripStringQuotes(raw_text);
 
             // Color[Color["Red"] = 0] = "Red";
             try self.write(param_name);
@@ -3521,19 +3510,6 @@ pub const Codegen = struct {
         try self.write(";})(");
         try self.write(name_text);
         try self.write(" || {});");
-    }
-
-    /// 문자열 리터럴의 외부 따옴표를 제거한다.
-    /// 'a' → a, "a b" → a b, Red → Red (따옴표 없으면 그대로)
-    fn stripStringQuotes(text: []const u8) []const u8 {
-        if (text.len >= 2) {
-            const first = text[0];
-            const last = text[text.len - 1];
-            if ((first == '\'' or first == '"') and first == last) {
-                return text[1 .. text.len - 1];
-            }
-        }
-        return text;
     }
 
     const EnumMemberValue = union(enum) {


### PR DESCRIPTION
## Summary
Phase 2 (#2086) 의 마무리 — codegen 자체 dispatch 잔여 두 개 제거.

| 함수 | 제거 사유 | 통합 대상 |
|---|---|---|
| `resolveBindingName` | binding_identifier 만 처리 | `ast.staticKeyName` |
| `stripStringQuotes` (local) | `Ast.stripStringQuotes` 와 중복 | `Ast.stripStringQuotes` |

이로써 codegen 의 자체 key/identifier dispatch 함수 전부 제거. **`ast.staticKeyName` 이 codegen / stmt_info / checker 의 단일 진실 원천**.

## 변경
- `emitVariableDeclarator` 의 contextual name 추출 (line 2715) → `ast.staticKeyName` 직접 호출
- enum member name 추출 두 곳 (TS enum down-emit) → `Ast.stripStringQuotes` 사용

binding_identifier 외 BindingPattern (object/array) 은 기존과 동일하게 null. valid string literal 가정 하에 strip 동작 동일.

## Test plan
- [x] `zig build test` 통과
- [x] pre-push hook (zig fmt, oxlint, oxfmt) 통과
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)