### PR TITLE
CJS pruning audit fixture 고정

### DIFF
--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -34,13 +34,17 @@ type CjsExportPattern =
   | "exports.x ="
   | "module.exports.x ="
   | "module.exports = { ... }"
-  | "Object.defineProperty(..., { value })";
+  | "Object.defineProperty(..., { value })"
+  | "Object.defineProperty(..., { value: member })"
+  | "Object.defineProperty(..., { get })";
 
 const cjsExportPatterns: CjsExportPattern[] = [
   "exports.x =",
   "module.exports.x =",
   "module.exports = { ... }",
   "Object.defineProperty(..., { value })",
+  "Object.defineProperty(..., { value: member })",
+  "Object.defineProperty(..., { get })",
 ];
 
 function parseProjects(): string[] {
@@ -128,6 +132,16 @@ function countCjsExportPatterns(text: string): Record<CjsExportPattern, number> 
     "Object.defineProperty(..., { value })": [
       ...text.matchAll(
         /\bObject\.defineProperty\s*\(\s*(?:exports|module\.exports)\s*,\s*(["'`])(?:\\.|(?!\1).)+\1\s*,\s*\{[^}]*\bvalue\b/g,
+      ),
+    ].length,
+    "Object.defineProperty(..., { value: member })": [
+      ...text.matchAll(
+        /\bObject\.defineProperty\s*\(\s*(?:exports|module\.exports)\s*,\s*(["'`])(?:\\.|(?!\1).)+\1\s*,\s*\{[^}]*\bvalue\s*:\s*[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*/g,
+      ),
+    ].length,
+    "Object.defineProperty(..., { get })": [
+      ...text.matchAll(
+        /\bObject\.defineProperty\s*\(\s*(?:exports|module\.exports)\s*,\s*(["'`])(?:\\.|(?!\1).)+\1\s*,\s*\{[^}]*\bget\b/g,
       ),
     ].length,
   };

--- a/tests/benchmark/smoke-diagnostics.test.ts
+++ b/tests/benchmark/smoke-diagnostics.test.ts
@@ -84,8 +84,15 @@ describe("benchmark smoke diagnostics", () => {
     expect(stdout).toMatch(/module\.exports\.x =: \d+/);
     expect(stdout).toMatch(/module\.exports = \{ \.\.\. \}: \d+/);
     expect(stdout).toMatch(/Object\.defineProperty\(\.\.\., \{ value \}\): \d+/);
+    expect(stdout).toMatch(/Object\.defineProperty\(\.\.\., \{ value: member \}\): \d+/);
+    expect(stdout).toMatch(/Object\.defineProperty\(\.\.\., \{ get \}\): \d+/);
     expect(stdout).toMatch(/Remaining ZTS export markers:\n(?:  - .+\n?)+/);
     expect(stdout).toMatch(/Removed dead marker candidates:\n(?:  - .+\n?)+/);
+    expect(stdout).toMatch(/## safe-buffer[\s\S]*Removed dead marker candidates:[\s\S]*exports\.Buffer =/);
+    expect(stdout).toMatch(/## cookie[\s\S]*Remaining ZTS export markers:[\s\S]*exports\.serialize =/);
+    expect(stdout).toMatch(/## cookie[\s\S]*Removed dead marker candidates:[\s\S]*exports\.parseCookie =/);
+    expect(stdout).toMatch(/## path-to-regexp[\s\S]*Remaining ZTS export markers:[\s\S]*exports\.match =/);
+    expect(stdout).toMatch(/## path-to-regexp[\s\S]*Removed dead marker candidates:[\s\S]*exports\.compile =/);
   });
 
   test("--filter accepts comma-separated patterns and produces multiple results", () => {


### PR DESCRIPTION
Refs #2060

## 요약

작은 CJS 패키지(`safe-buffer`, `cookie`, `path-to-regexp`)에서 지금까지의 CJS static export pruning 성과가 회귀하지 않도록 size-gap diagnostics fixture를 보강했습니다.

이번 PR은 새 DCE 최적화가 아니라 audit/fixture 고정입니다.

## 변경 사항

- `size-gap.ts`의 CJS export pattern audit에 최근 추가한 패턴을 포함했습니다.
  - `Object.defineProperty(..., { value: member })`
  - `Object.defineProperty(..., { get })`
- `smoke-diagnostics.test.ts`에서 작은 패키지별 핵심 CJS pruning marker를 섹션 단위로 고정했습니다.
  - `safe-buffer`: `exports.Buffer =` 제거 후보가 리포트됨
  - `cookie`: live `exports.serialize =`가 남고 dead `exports.parseCookie =`가 제거 후보로 리포트됨
  - `path-to-regexp`: live `exports.match =`가 남고 dead `exports.compile =`가 제거 후보로 리포트됨

## 검증

- `bun test tests/benchmark/smoke-diagnostics.test.ts`
- `bun run tests/benchmark/size-gap.ts --projects=safe-buffer,cookie,path-to-regexp`
- `bun run tests/benchmark/smoke.ts --filter=safe-buffer,cookie,path-to-regexp,axios,rxjs`

benchmark smoke에서 ZTS는 대상 5개 패키지 모두 build 성공 및 output MATCH입니다. 스크립트 출력상 `axios`의 esbuild baseline은 기존처럼 FAIL로 표시됩니다.