### PR TITLE
fix(function_map): prevent UAF on names.append OOM in internName

### DIFF
--- a/src/codegen/function_map.zig
+++ b/src/codegen/function_map.zig
@@ -129,20 +129,20 @@ pub const FunctionMapBuilder = struct {
     }
 
     fn internName(self: *FunctionMapBuilder, name: []const u8) !u32 {
-        const gop = try self.names_map.getOrPut(self.allocator, name);
-        if (!gop.found_existing) {
-            const owned = self.allocator.dupe(u8, name) catch |err| {
-                _ = self.names_map.remove(name);
-                return err;
-            };
-            errdefer self.allocator.free(owned);
-            const idx: u32 = @intCast(self.names.items.len);
-            try self.names.append(self.allocator, owned);
-            // `getOrPut` 의 key_ptr 은 caller 의 borrowed slice — owned 로 교체해 hashmap 도 자체 소유.
-            gop.key_ptr.* = owned;
-            gop.value_ptr.* = idx;
-        }
-        return gop.value_ptr.*;
+        // 기존 entry 가 있으면 owned key 를 그대로 재사용. miss 일 때만 dupe.
+        if (self.names_map.get(name)) |idx| return idx;
+
+        const owned = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned);
+
+        const idx: u32 = @intCast(self.names.items.len);
+        try self.names.append(self.allocator, owned);
+        errdefer _ = self.names.pop();
+
+        // owned key 로 등록 — caller 의 borrowed slice 가 hashmap 에 들어가지 않으므로
+        // 이후 entry lookup 이 caller lifetime 과 무관하게 안전.
+        try self.names_map.put(self.allocator, owned, idx);
+        return idx;
     }
 };
 


### PR DESCRIPTION
## Summary
`/simplify` 리뷰에서 발견한 UAF 버그 수정 — `FunctionMapBuilder.internName` 의 `names.append` 가 OOM 으로 실패할 때 `names_map` 에 caller 의 borrowed key 가 남아, caller lifetime 이후 다음 lookup 시 UAF.

## 원인 (Before)
```zig
const gop = try self.names_map.getOrPut(allocator, name);  // caller borrowed key 삽입
if (!gop.found_existing) {
    const owned = ... dupe ...;
    errdefer self.allocator.free(owned);
    try self.names.append(allocator, owned);  // OOM 시 errdefer 가 owned 만 free
    gop.key_ptr.* = owned;  // 여기 도달 못 함
}
```
→ append 실패 시 `names_map` 에 borrowed key 잔존 → caller lifetime 종료 후 hash lookup UAF.

## 수정 (After)
`get + put` 패턴 — owned key 등록 전엔 hashmap 에 어떤 entry 도 없음. 각 단계마다 명확한 errdefer rollback:
```zig
if (self.names_map.get(name)) |idx| return idx;
const owned = try allocator.dupe(...);
errdefer free(owned);
try self.names.append(allocator, owned);
errdefer _ = self.names.pop();
try self.names_map.put(allocator, owned, idx);
```

## Test plan
- [x] `zig build test` 통과
- [x] pre-push hook (zig fmt, oxlint, oxfmt) 통과
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)