### PR TITLE
Object.freeze known pure call DCE 추가

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -602,6 +602,54 @@ test "TreeShaking CJS: named import prunes unused Object.defineProperty member v
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_DEFINE_MEMBER_MARKER") == null);
 }
 
+test "TreeShaking CJS: named import prunes safe __esModule defineProperty marker" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\function used() { return "USED_ESMODULE_MARKER"; }
+        \\function unused() { return "UNUSED_ESMODULE_MARKER"; }
+        \\Object.defineProperty(exports, "used", { value: used });
+        \\Object.defineProperty(exports, "unused", { value: unused });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_ESMODULE_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__esModule") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_ESMODULE_MARKER") == null);
+}
+
+test "TreeShaking CJS: default import keeps __esModule defineProperty marker" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import value from './lib.js'; console.log(value());");
+    try writeFile(tmp.dir, "lib.js",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\exports.default = function usedDefault() { return "USED_DEFAULT_ESMODULE_MARKER"; };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_DEFAULT_ESMODULE_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__esModule") != null);
+}
+
 test "TreeShaking CJS: unsafe Object.defineProperty export forms are preserved" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -615,7 +663,8 @@ test "TreeShaking CJS: unsafe Object.defineProperty export forms are preserved" 
         \\const key = "computed";
         \\const extra = { enumerable: true };
         \\const ns = { unused };
-        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\const marker = true;
+        \\Object.defineProperty(exports, "__esModule", { value: marker });
         \\Object.defineProperty(exports, "used", { value: used });
         \\Object.defineProperty(exports, "getter", { get() { return "UNSAFE_DEFINE_GETTER_MARKER"; } });
         \\Object.defineProperty(exports, "effect", { value: sideEffect() });

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -628,6 +628,56 @@ test "TreeShaking CJS: named import prunes safe __esModule defineProperty marker
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_ESMODULE_MARKER") == null);
 }
 
+test "TreeShaking CJS: named import prunes safe module.exports __esModule marker" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\Object.defineProperty(module.exports, "__esModule", { value: true });
+        \\function used() { return "USED_MODULE_EXPORTS_ESMODULE_MARKER"; }
+        \\function unused() { return "UNUSED_MODULE_EXPORTS_ESMODULE_MARKER"; }
+        \\Object.defineProperty(module.exports, "used", { value: used });
+        \\Object.defineProperty(module.exports, "unused", { value: unused });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_MODULE_EXPORTS_ESMODULE_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__esModule") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_MODULE_EXPORTS_ESMODULE_MARKER") == null);
+}
+
+test "TreeShaking CJS: named import keeps sibling side effects while pruning safe __esModule marker" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used);");
+    try writeFile(tmp.dir, "lib.js",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\console.log("USED_SIDE_EFFECT_ESMODULE_MARKER");
+        \\exports.used = "USED_SIDE_EFFECT_EXPORT_MARKER";
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_SIDE_EFFECT_ESMODULE_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_SIDE_EFFECT_EXPORT_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__esModule") == null);
+}
+
 test "TreeShaking CJS: default import keeps __esModule defineProperty marker" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -183,30 +183,29 @@ fn isKnownPureStaticCall(
     if (object.tag != .identifier_reference or property.tag != .identifier_reference) return false;
     if (!std.mem.eql(u8, ast.getText(object.span), "Object")) return false;
     if (!globals.contains("Object")) return false;
-    if (!std.mem.eql(u8, ast.getText(property.span), "freeze")) return false;
+    const property_name = ast.getText(property.span);
 
     const call_extra = node.data.extra;
     if (!ast.hasExtra(call_extra, 2)) return false;
     const args_start = ast.readExtra(call_extra, 1);
     const args_len = ast.readExtra(call_extra, 2);
-    if (args_len != 1 or args_start >= ast.extra_data.items.len) return false;
 
-    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
-    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
-    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
-    if (arg.tag == .spread_element) return false;
+    if (std.mem.eql(u8, property_name, "freeze")) {
+        if (args_len != 1 or args_start >= ast.extra_data.items.len) return false;
+        const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+        return isKnownPureFreezeArg(ast, arg_idx, unresolved_globals, depth);
+    }
 
-    const fresh_arg = switch (arg.tag) {
-        .object_expression,
-        .array_expression,
-        .function_expression,
-        .arrow_function_expression,
-        .class_expression,
-        => true,
-        .parenthesized_expression => return isKnownPureFreezeArg(ast, arg.data.unary.operand, unresolved_globals, depth),
-        else => false,
-    };
-    return fresh_arg and isNodePureDepth(ast, arg, unresolved_globals, depth);
+    if (std.mem.eql(u8, property_name, "assign")) {
+        if (args_len < 2 or args_start + args_len > ast.extra_data.items.len) return false;
+        for (ast.extra_data.items[args_start .. args_start + args_len]) |raw_arg| {
+            const arg_idx: NodeIndex = @enumFromInt(raw_arg);
+            if (!isKnownPureAssignObjectArg(ast, arg_idx, unresolved_globals, depth)) return false;
+        }
+        return true;
+    }
+
+    return false;
 }
 
 fn isKnownPureFreezeArg(
@@ -228,6 +227,46 @@ fn isKnownPureFreezeArg(
         else => false,
     };
     return fresh_arg and isNodePureDepth(ast, arg, unresolved_globals, depth);
+}
+
+fn isKnownPureAssignObjectArg(
+    ast: *const Ast,
+    arg_idx: NodeIndex,
+    unresolved_globals: ?*const GlobalRefSet,
+    depth: u32,
+) bool {
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+    return switch (arg.tag) {
+        .object_expression => isPlainObjectLiteralPure(ast, arg, unresolved_globals, depth),
+        .parenthesized_expression => isKnownPureAssignObjectArg(ast, arg.data.unary.operand, unresolved_globals, depth),
+        else => false,
+    };
+}
+
+fn isPlainObjectLiteralPure(
+    ast: *const Ast,
+    node: Node,
+    unresolved_globals: ?*const GlobalRefSet,
+    depth: u32,
+) bool {
+    const list = node.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return false;
+
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_prop| {
+        const prop_idx: NodeIndex = @enumFromInt(raw_prop);
+        if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return false;
+        const prop = ast.nodes.items[@intFromEnum(prop_idx)];
+        if (prop.tag != .object_property) return false;
+
+        const key_idx = prop.data.binary.left;
+        if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
+            if (ast.nodes.items[@intFromEnum(key_idx)].tag == .computed_property_key) return false;
+        }
+        if (!isExprPureDepth(ast, prop.data.binary.right, unresolved_globals, depth)) return false;
+    }
+
+    return true;
 }
 
 /// 빌트인 이름별 분류.

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -128,6 +128,7 @@ fn isCallOrNewPure(ast: *const Ast, node: Node, unresolved_globals: ?*const Glob
     const callee_idx: NodeIndex = @enumFromInt(ast.readExtra(node.data.extra, 0));
     if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return false;
     const callee = ast.nodes.items[@intFromEnum(callee_idx)];
+    if (isKnownPureStaticCall(ast, node, callee, globals, unresolved_globals, depth)) return true;
     if (callee.tag != .identifier_reference) return false;
 
     const name = ast.getText(callee.span);
@@ -155,6 +156,78 @@ fn isCallOrNewPure(ast: *const Ast, node: Node, unresolved_globals: ?*const Glob
         .error_ctor => isPureErrorArgs(ast, args_start, args_len, unresolved_globals, depth),
         .unconditional, .either => allArgsPure(ast, args_start, args_len, unresolved_globals, depth),
     };
+}
+
+fn isKnownPureStaticCall(
+    ast: *const Ast,
+    node: Node,
+    callee: Node,
+    globals: *const GlobalRefSet,
+    unresolved_globals: ?*const GlobalRefSet,
+    depth: u32,
+) bool {
+    if (node.tag != .call_expression) return false;
+    if (callee.tag != .static_member_expression) return false;
+    const member_extra = callee.data.extra;
+    if (!ast.hasExtra(member_extra, 2)) return false;
+    const member_flags = ast.readExtra(member_extra, 2);
+    if ((member_flags & ast_mod.MemberFlags.optional_chain) != 0) return false;
+
+    const object_idx = ast.readExtraNode(member_extra, 0);
+    const property_idx = ast.readExtraNode(member_extra, 1);
+    if (object_idx.isNone() or property_idx.isNone()) return false;
+    if (@intFromEnum(object_idx) >= ast.nodes.items.len or @intFromEnum(property_idx) >= ast.nodes.items.len) return false;
+
+    const object = ast.nodes.items[@intFromEnum(object_idx)];
+    const property = ast.nodes.items[@intFromEnum(property_idx)];
+    if (object.tag != .identifier_reference or property.tag != .identifier_reference) return false;
+    if (!std.mem.eql(u8, ast.getText(object.span), "Object")) return false;
+    if (!globals.contains("Object")) return false;
+    if (!std.mem.eql(u8, ast.getText(property.span), "freeze")) return false;
+
+    const call_extra = node.data.extra;
+    if (!ast.hasExtra(call_extra, 2)) return false;
+    const args_start = ast.readExtra(call_extra, 1);
+    const args_len = ast.readExtra(call_extra, 2);
+    if (args_len != 1 or args_start >= ast.extra_data.items.len) return false;
+
+    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+    if (arg.tag == .spread_element) return false;
+
+    const fresh_arg = switch (arg.tag) {
+        .object_expression,
+        .array_expression,
+        .function_expression,
+        .arrow_function_expression,
+        .class_expression,
+        => true,
+        .parenthesized_expression => return isKnownPureFreezeArg(ast, arg.data.unary.operand, unresolved_globals, depth),
+        else => false,
+    };
+    return fresh_arg and isNodePureDepth(ast, arg, unresolved_globals, depth);
+}
+
+fn isKnownPureFreezeArg(
+    ast: *const Ast,
+    arg_idx: NodeIndex,
+    unresolved_globals: ?*const GlobalRefSet,
+    depth: u32,
+) bool {
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+    const fresh_arg = switch (arg.tag) {
+        .object_expression,
+        .array_expression,
+        .function_expression,
+        .arrow_function_expression,
+        .class_expression,
+        => true,
+        .parenthesized_expression => return isKnownPureFreezeArg(ast, arg.data.unary.operand, unresolved_globals, depth),
+        else => false,
+    };
+    return fresh_arg and isNodePureDepth(ast, arg, unresolved_globals, depth);
 }
 
 /// 빌트인 이름별 분류.

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -128,7 +128,7 @@ fn isCallOrNewPure(ast: *const Ast, node: Node, unresolved_globals: ?*const Glob
     const callee_idx: NodeIndex = @enumFromInt(ast.readExtra(node.data.extra, 0));
     if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return false;
     const callee = ast.nodes.items[@intFromEnum(callee_idx)];
-    if (isKnownPureStaticCall(ast, node, callee, globals, unresolved_globals, depth)) return true;
+    if (isKnownPureStaticCall(ast, node, callee, unresolved_globals, depth)) return true;
     if (callee.tag != .identifier_reference) return false;
 
     const name = ast.getText(callee.span);
@@ -162,7 +162,6 @@ fn isKnownPureStaticCall(
     ast: *const Ast,
     node: Node,
     callee: Node,
-    globals: *const GlobalRefSet,
     unresolved_globals: ?*const GlobalRefSet,
     depth: u32,
 ) bool {
@@ -182,11 +181,11 @@ fn isKnownPureStaticCall(
     const property = ast.nodes.items[@intFromEnum(property_idx)];
     if (object.tag != .identifier_reference or property.tag != .identifier_reference) return false;
     if (!std.mem.eql(u8, ast.getText(object.span), "Object")) return false;
+    const globals = unresolved_globals orelse return false;
     if (!globals.contains("Object")) return false;
     const property_name = ast.getText(property.span);
 
     const call_extra = node.data.extra;
-    if (!ast.hasExtra(call_extra, 2)) return false;
     const args_start = ast.readExtra(call_extra, 1);
     const args_len = ast.readExtra(call_extra, 2);
 

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -853,12 +853,14 @@ test "known pure call: Object.assign with fresh pure objects is pure" {
     const src =
         \\const a = Object.assign({}, { tag: "pure" });
         \\const b = Object.assign({ base: 1 }, ({ extra: 2 }));
+        \\const c = Object.assign({}, { a: 1 }, { b: 2 });
     ;
     var ctx = try setup(alloc, src);
     defer ctx.deinit();
 
     try expectPure(&ctx, 0, true);
     try expectPure(&ctx, 1, true);
+    try expectPure(&ctx, 2, true);
     try std.testing.expect(!purity.isExprPure(&ctx.ast, initOfDecl(&ctx, 0), null));
 }
 
@@ -873,6 +875,11 @@ test "known pure call: Object.assign is guarded by target source and shadowing" 
         \\const d = Object.assign({}, sideEffect());
         \\const Object = { assign(target, source) { console.log("shadow-assign"); return target; } };
         \\const e = Object.assign({}, { tag: "shadowed" });
+        \\const f = Object.assign({}, { ...source });
+        \\const g = Object.assign({}, { [sideEffect()]: 1 });
+        \\const h = Object.assign({}, { method() { return 1; } });
+        \\const i = Object["assign"]({}, { tag: "computed-callee" });
+        \\const j = Object.assign?.({}, { tag: "optional-callee" });
     ;
     var ctx = try setup(alloc, src);
     defer ctx.deinit();
@@ -882,6 +889,11 @@ test "known pure call: Object.assign is guarded by target source and shadowing" 
     try expectPure(&ctx, 4, false);
     try expectPure(&ctx, 5, false);
     try expectPure(&ctx, 7, false);
+    try expectPure(&ctx, 8, false);
+    try expectPure(&ctx, 9, false);
+    try expectPure(&ctx, 10, false);
+    try expectPure(&ctx, 11, false);
+    try expectPure(&ctx, 12, false);
 }
 
 // ================================================================

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -848,6 +848,42 @@ test "known pure call: Object.freeze is guarded by shadowing and arg purity" {
     try expectPure(&ctx, 4, false);
 }
 
+test "known pure call: Object.assign with fresh pure objects is pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = Object.assign({}, { tag: "pure" });
+        \\const b = Object.assign({ base: 1 }, ({ extra: 2 }));
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+    try std.testing.expect(!purity.isExprPure(&ctx.ast, initOfDecl(&ctx, 0), null));
+}
+
+test "known pure call: Object.assign is guarded by target source and shadowing" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const target = {};
+        \\const a = Object.assign(target, { tag: "target" });
+        \\const source = { tag: "source" };
+        \\const b = Object.assign({}, source);
+        \\const c = Object.assign({}, { get x() { console.log("getter"); return 1; } });
+        \\const d = Object.assign({}, sideEffect());
+        \\const Object = { assign(target, source) { console.log("shadow-assign"); return target; } };
+        \\const e = Object.assign({}, { tag: "shadowed" });
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 1, false);
+    try expectPure(&ctx, 3, false);
+    try expectPure(&ctx, 4, false);
+    try expectPure(&ctx, 5, false);
+    try expectPure(&ctx, 7, false);
+}
+
 // ================================================================
 // null unresolved_globals — 기존 동작 유지 (#1567 호환)
 // ================================================================

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -817,6 +817,37 @@ test "pure annotation: /*#__PURE__*/ myFunc() 은 whitelist 무관하게 pure" {
     try expectPure(&ctx, 0, true);
 }
 
+test "known pure call: Object.freeze with pure arg is pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = Object.freeze({ tag: "pure" });
+        \\const b = Object.freeze([1, 2, 3]);
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 0, true);
+    try expectPure(&ctx, 1, true);
+    try std.testing.expect(!purity.isExprPure(&ctx.ast, initOfDecl(&ctx, 0), null));
+}
+
+test "known pure call: Object.freeze is guarded by shadowing and arg purity" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const a = Object.freeze(sideEffect());
+        \\const obj = {};
+        \\const c = Object.freeze(obj);
+        \\const Object = { freeze(value) { console.log("shadow-freeze"); return value; } };
+        \\const b = Object.freeze({ tag: "shadowed" });
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 0, false);
+    try expectPure(&ctx, 2, false);
+    try expectPure(&ctx, 4, false);
+}
+
 // ================================================================
 // null unresolved_globals — 기존 동작 유지 (#1567 호환)
 // ================================================================

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -294,6 +294,16 @@ fn isObjectDefinePropertyCallee(ast: *const Ast, callee_idx: NodeIndex) bool {
         std.mem.eql(u8, ast.getText(property.span), "defineProperty");
 }
 
+fn isGlobalObjectDefinePropertyCallee(
+    ast: *const Ast,
+    callee_idx: NodeIndex,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) bool {
+    if (!isObjectDefinePropertyCallee(ast, callee_idx)) return false;
+    const globals = unresolved_globals orelse return false;
+    return globals.contains("Object");
+}
+
 fn isCjsExportObjectExpr(ast: *const Ast, idx: NodeIndex) bool {
     if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
     const node = ast.nodes.items[@intFromEnum(idx)];
@@ -322,6 +332,12 @@ fn plainObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
         .string_literal => plainStringLiteralValue(ast, key_idx),
         else => null,
     };
+}
+
+fn isBooleanLiteral(ast: *const Ast, idx: NodeIndex, expected: []const u8) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    return node.tag == .boolean_literal and std.mem.eql(u8, ast.getText(node.span), expected);
 }
 
 fn isIdentifierReference(ast: *const Ast, idx: NodeIndex) bool {
@@ -523,6 +539,82 @@ fn cjsDefinePropertyExportCandidateForStmt(
         .rhs_node = descriptor_export.rhs_node,
         .kind = descriptor_export.kind,
     };
+}
+
+fn isSafeEsModuleDefinePropertyDescriptor(ast: *const Ast, descriptor_idx: NodeIndex) bool {
+    if (descriptor_idx.isNone() or @intFromEnum(descriptor_idx) >= ast.nodes.items.len) return false;
+    const descriptor = ast.nodes.items[@intFromEnum(descriptor_idx)];
+    if (descriptor.tag != .object_expression) return false;
+
+    const list = descriptor.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return false;
+
+    var seen: [4][]const u8 = undefined;
+    var seen_len: usize = 0;
+    var has_value_true = false;
+
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_prop| {
+        const prop_idx: NodeIndex = @enumFromInt(raw_prop);
+        if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return false;
+        const prop = ast.nodes.items[@intFromEnum(prop_idx)];
+        if (prop.tag != .object_property) return false;
+
+        const name = plainObjectKeyName(ast, prop.data.binary.left) orelse return false;
+        if (seen_len >= seen.len) return false;
+        for (seen[0..seen_len]) |prev| {
+            if (std.mem.eql(u8, prev, name)) return false;
+        }
+        seen[seen_len] = name;
+        seen_len += 1;
+
+        const value = Ast.objectPropertyValue(prop);
+        if (std.mem.eql(u8, name, "value")) {
+            if (!isBooleanLiteral(ast, value, "true")) return false;
+            has_value_true = true;
+        } else if (std.mem.eql(u8, name, "enumerable") or
+            std.mem.eql(u8, name, "configurable") or
+            std.mem.eql(u8, name, "writable"))
+        {
+            if (!isBooleanLiteral(ast, value, "true") and !isBooleanLiteral(ast, value, "false")) return false;
+        } else {
+            return false;
+        }
+    }
+
+    return has_value_true;
+}
+
+fn isSafeCjsEsModuleMarkerStmt(
+    alloc: std.mem.Allocator,
+    ast: *const Ast,
+    stmt_node: Node,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) !bool {
+    if (stmt_node.tag != .expression_statement) return false;
+    const expr_idx = stmt_node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .call_expression) return false;
+
+    const e = expr.data.extra;
+    if (!ast.hasExtra(e, 2)) return false;
+    const callee_idx = ast.readExtraNode(e, 0);
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 3) return false;
+    if (args_start + args_len > ast.extra_data.items.len) return false;
+    if (!isGlobalObjectDefinePropertyCallee(ast, callee_idx, unresolved_globals)) return false;
+
+    const target_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    const export_name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 1]);
+    const descriptor_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 2]);
+    if (!isCjsExportObjectExpr(ast, target_idx)) return false;
+
+    const export_name = (try ast.staticKeyName(alloc, export_name_idx)) orelse return false;
+    defer alloc.free(export_name);
+    if (!std.mem.eql(u8, export_name, "__esModule")) return false;
+
+    return isSafeEsModuleDefinePropertyDescriptor(ast, descriptor_idx);
 }
 
 fn collectCjsObjectExportCandidates(
@@ -844,6 +936,7 @@ fn buildStmtInfoSlot(
     } else if (collect_cjs_exports) {
         cjs_shape_extracted =
             try appendCjsDefinePropertyFact(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids) or
+            try isSafeCjsEsModuleMarkerStmt(allocator, ast, node, unresolved_globals) or
             try collectAndAppendCjsObjectFacts(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids);
     }
     const side_effects = if (node.tag == .import_declaration)

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -840,6 +840,16 @@ const projects: ProjectConfig[] = [
     },
   },
   {
+    name: "object-freeze-pure-call",
+    pkg: "(synthetic)",
+    entry: `import { used } from './_smoke_object_freeze_pure_call_lib.js';\nconsole.log(used);`,
+    files: {
+      "_smoke_object_freeze_pure_call_lib.js":
+        `export const used = "MATCH";\n` +
+        `const dead = Object.freeze({ marker: "UNUSED_SMOKE_OBJECT_FREEZE" });\n`,
+    },
+  },
+  {
     name: "on-finished",
     pkg: "on-finished",
     entry: `import onf from 'on-finished';\nconsole.log(typeof onf);`,

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -860,6 +860,19 @@ const projects: ProjectConfig[] = [
     },
   },
   {
+    name: "cjs-esmodule-marker-pruning",
+    pkg: "(synthetic)",
+    entry: `import { used } from './_smoke_cjs_esmodule_marker_pruning_lib.cjs';\nconsole.log(used());`,
+    files: {
+      "_smoke_cjs_esmodule_marker_pruning_lib.cjs":
+        `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+        `function used() { return "MATCH"; }\n` +
+        `function dead() { return "UNUSED_SMOKE_CJS_ESMODULE"; }\n` +
+        `Object.defineProperty(exports, "used", { value: used });\n` +
+        `Object.defineProperty(exports, "dead", { value: dead });\n`,
+    },
+  },
+  {
     name: "on-finished",
     pkg: "on-finished",
     entry: `import onf from 'on-finished';\nconsole.log(typeof onf);`,

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -850,6 +850,16 @@ const projects: ProjectConfig[] = [
     },
   },
   {
+    name: "object-assign-pure-call",
+    pkg: "(synthetic)",
+    entry: `import { used } from './_smoke_object_assign_pure_call_lib.js';\nconsole.log(used);`,
+    files: {
+      "_smoke_object_assign_pure_call_lib.js":
+        `export const used = "MATCH";\n` +
+        `const dead = Object.assign({}, { marker: "UNUSED_SMOKE_OBJECT_ASSIGN" });\n`,
+    },
+  },
+  {
     name: "on-finished",
     pkg: "on-finished",
     entry: `import onf from 'on-finished';\nconsole.log(typeof onf);`,

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -411,4 +411,44 @@ describe("known pure call 기반 DCE", () => {
     expect(out).toContain("shadow-freeze-marker");
     expect(bundle).toContain("shadow-freeze-value");
   });
+
+  test("unused Object.assign with fresh pure objects is dropped", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib";\nconsole.log(used);\n`,
+        "lib.ts":
+          `export const used = "MATCH";\n` +
+          `const merged = Object.assign({}, { marker: "unused-object-assign-marker" });\n`,
+      },
+      "index.ts",
+      "object-assign-pure",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).not.toContain("unused-object-assign-marker");
+  });
+
+  test("Object.assign with shadowed callee impure source or getter source is preserved", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import "./impure";\nimport "./getter";\nimport "./shadow";\n`,
+        "impure.ts":
+          `function sideEffect() { console.log("impure-assign-source-marker"); return {}; }\n` +
+          `Object.assign({}, sideEffect());\n`,
+        "getter.ts":
+          `Object.assign({}, { get value() { console.log("assign-getter-source-marker"); return 1; } });\n`,
+        "shadow.ts":
+          `const Object = { assign(target, source) { console.log("shadow-assign-marker"); return target; } };\n` +
+          `Object.assign({}, { marker: "shadow-assign-value" });\n`,
+      },
+      "index.ts",
+      "object-assign-unsafe",
+    );
+
+    const out = runBundleSource(bundle);
+    expect(out).toContain("impure-assign-source-marker");
+    expect(out).toContain("assign-getter-source-marker");
+    expect(out).toContain("shadow-assign-marker");
+    expect(bundle).toContain("shadow-assign-value");
+  });
 });

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -372,3 +372,43 @@ describe("#1665 class-level tree-shake 정밀도", () => {
     expect(bundle).toContain("class-static-effect-1665");
   });
 });
+
+describe("known pure call 기반 DCE", () => {
+  test("unused Object.freeze with pure arg is dropped", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib";\nconsole.log(used);\n`,
+        "lib.ts":
+          `export const used = "MATCH";\n` +
+          `const frozen = Object.freeze({ marker: "unused-object-freeze-marker" });\n` +
+          `console.log(used);\n`,
+      },
+      "index.ts",
+      "object-freeze-pure",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).not.toContain("unused-object-freeze-marker");
+  });
+
+  test("Object.freeze with shadowed callee or impure arg is preserved", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import "./impure";\nimport "./shadow";\n`,
+        "impure.ts":
+          `function sideEffect() { console.log("impure-freeze-arg-marker"); return {}; }\n` +
+          `Object.freeze(sideEffect());\n`,
+        "shadow.ts":
+          `const Object = { freeze(value) { console.log("shadow-freeze-marker"); return value; } };\n` +
+          `Object.freeze({ marker: "shadow-freeze-value" });\n`,
+      },
+      "index.ts",
+      "object-freeze-unsafe",
+    );
+
+    const out = runBundleSource(bundle);
+    expect(out).toContain("impure-freeze-arg-marker");
+    expect(out).toContain("shadow-freeze-marker");
+    expect(bundle).toContain("shadow-freeze-value");
+  });
+});

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -260,6 +260,42 @@ describe("CJS static export fact 기반 DCE", () => {
     expect(bundle).not.toContain("deadNs");
   });
 
+  test("Object.defineProperty __esModule marker — named import prunes safe marker", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib.cjs";\nconsole.log(used());\n`,
+        "lib.cjs":
+          `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+          `function used() { return "USED_ESMODULE_INTEGRATION"; }\n` +
+          `function unused() { return "UNUSED_ESMODULE_INTEGRATION"; }\n` +
+          `Object.defineProperty(exports, "used", { value: used });\n` +
+          `Object.defineProperty(exports, "unused", { value: unused });\n`,
+      },
+      "index.ts",
+      "cjs-esmodule-marker",
+    );
+
+    expect(runBundleSource(bundle)).toContain("USED_ESMODULE_INTEGRATION");
+    expect(bundle).not.toContain("__esModule");
+    expect(bundle).not.toContain("UNUSED_ESMODULE_INTEGRATION");
+  });
+
+  test("Object.defineProperty __esModule marker — default import keeps marker", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import value from "./lib.cjs";\nconsole.log(value());\n`,
+        "lib.cjs":
+          `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+          `exports.default = function usedDefault() { return "USED_DEFAULT_ESMODULE_INTEGRATION"; };\n`,
+      },
+      "index.ts",
+      "cjs-esmodule-default",
+    );
+
+    expect(runBundleSource(bundle)).toContain("USED_DEFAULT_ESMODULE_INTEGRATION");
+    expect(bundle).toContain("__esModule");
+  });
+
   test("Object.defineProperty getter export — module.exports target and arrow getter are supported", () => {
     const bundle = bundleFiles(
       {

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -471,8 +471,7 @@ describe("known pure call 기반 DCE", () => {
         "impure.ts":
           `function sideEffect() { console.log("impure-assign-source-marker"); return {}; }\n` +
           `Object.assign({}, sideEffect());\n`,
-        "getter.ts":
-          `Object.assign({}, { get value() { console.log("assign-getter-source-marker"); return 1; } });\n`,
+        "getter.ts": `Object.assign({}, { get value() { console.log("assign-getter-source-marker"); return 1; } });\n`,
         "shadow.ts":
           `const Object = { assign(target, source) { console.log("shadow-assign-marker"); return target; } };\n` +
           `Object.assign({}, { marker: "shadow-assign-value" });\n`,

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -296,6 +296,45 @@ describe("CJS static export fact 기반 DCE", () => {
     expect(bundle).toContain("__esModule");
   });
 
+  test("Object.defineProperty __esModule marker — module.exports target is pruned for named import", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib.cjs";\nconsole.log(used());\n`,
+        "lib.cjs":
+          `Object.defineProperty(module.exports, "__esModule", { value: true });\n` +
+          `function used() { return "USED_MODULE_EXPORTS_ESMODULE_INTEGRATION"; }\n` +
+          `function unused() { return "UNUSED_MODULE_EXPORTS_ESMODULE_INTEGRATION"; }\n` +
+          `Object.defineProperty(module.exports, "used", { value: used });\n` +
+          `Object.defineProperty(module.exports, "unused", { value: unused });\n`,
+      },
+      "index.ts",
+      "cjs-esmodule-module-exports",
+    );
+
+    expect(runBundleSource(bundle)).toContain("USED_MODULE_EXPORTS_ESMODULE_INTEGRATION");
+    expect(bundle).not.toContain("__esModule");
+    expect(bundle).not.toContain("UNUSED_MODULE_EXPORTS_ESMODULE_INTEGRATION");
+  });
+
+  test("Object.defineProperty __esModule marker — named import keeps sibling effects and prunes marker", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib.cjs";\nconsole.log(used);\n`,
+        "lib.cjs":
+          `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+          `console.log("USED_SIDE_EFFECT_ESMODULE_INTEGRATION");\n` +
+          `exports.used = "USED_SIDE_EFFECT_EXPORT_INTEGRATION";\n`,
+      },
+      "index.ts",
+      "cjs-esmodule-sibling-effect",
+    );
+
+    const out = runBundleSource(bundle);
+    expect(out).toContain("USED_SIDE_EFFECT_ESMODULE_INTEGRATION");
+    expect(out).toContain("USED_SIDE_EFFECT_EXPORT_INTEGRATION");
+    expect(bundle).not.toContain("__esModule");
+  });
+
   test("Object.defineProperty getter export — module.exports target and arrow getter are supported", () => {
     const bundle = bundleFiles(
       {
@@ -454,7 +493,7 @@ describe("known pure call 기반 DCE", () => {
         "index.ts": `import { used } from "./lib";\nconsole.log(used);\n`,
         "lib.ts":
           `export const used = "MATCH";\n` +
-          `const merged = Object.assign({}, { marker: "unused-object-assign-marker" });\n`,
+          `const merged = Object.assign({}, { marker: "unused-object-assign-marker" }, { extra: 1 });\n`,
       },
       "index.ts",
       "object-assign-pure",
@@ -467,11 +506,22 @@ describe("known pure call 기반 DCE", () => {
   test("Object.assign with shadowed callee impure source or getter source is preserved", () => {
     const bundle = bundleFiles(
       {
-        "index.ts": `import "./impure";\nimport "./getter";\nimport "./shadow";\n`,
+        "index.ts":
+          `import "./impure";\n` +
+          `import "./getter";\n` +
+          `import "./spread";\n` +
+          `import "./computed";\n` +
+          `import "./computed-callee";\n` +
+          `import "./shadow";\n`,
         "impure.ts":
           `function sideEffect() { console.log("impure-assign-source-marker"); return {}; }\n` +
           `Object.assign({}, sideEffect());\n`,
         "getter.ts": `Object.assign({}, { get value() { console.log("assign-getter-source-marker"); return 1; } });\n`,
+        "spread.ts": `const source = { marker: "assign-spread-source-marker" };\nObject.assign({}, { ...source });\n`,
+        "computed.ts":
+          `function key() { console.log("assign-computed-key-marker"); return "value"; }\n` +
+          `Object.assign({}, { [key()]: 1 });\n`,
+        "computed-callee.ts": `Object["assign"]({}, { marker: "assign-computed-callee-marker" });\n`,
         "shadow.ts":
           `const Object = { assign(target, source) { console.log("shadow-assign-marker"); return target; } };\n` +
           `Object.assign({}, { marker: "shadow-assign-value" });\n`,
@@ -483,7 +533,10 @@ describe("known pure call 기반 DCE", () => {
     const out = runBundleSource(bundle);
     expect(out).toContain("impure-assign-source-marker");
     expect(out).toContain("assign-getter-source-marker");
+    expect(out).toContain("assign-computed-key-marker");
     expect(out).toContain("shadow-assign-marker");
+    expect(bundle).toContain("assign-spread-source-marker");
+    expect(bundle).toContain("assign-computed-callee-marker");
     expect(bundle).toContain("shadow-assign-value");
   });
 });


### PR DESCRIPTION
## 요약

#2060 로드맵의 다음 단계로 `Object.freeze(...)` known pure call 처리를 추가했습니다. TDD 형태로 먼저 purity 단위 테스트를 추가해 실패를 확인한 뒤, 가장 좁은 안전 subset만 pure로 판정하도록 구현했습니다.

## 변경 사항

- `Object.freeze(<fresh pure arg>)` 호출을 side-effect 없는 expression으로 인식합니다.
- 허용 범위는 전역 `Object.freeze`에 대한 1개 인자 호출로 제한했습니다.
- 인자는 fresh expression만 허용합니다.
  - object / array / function / arrow function / class expression
  - 괄호로 감싼 동일 형태
- 다음 형태는 기존처럼 보존합니다.
  - shadowed `Object`
  - impure argument
  - identifier argument (`Object.freeze(obj)`)처럼 기존 객체 mutation 관찰 가능성이 있는 형태
  - optional chain / computed / non-static member / 인자 개수 불일치

## 테스트

- 단위 테스트: `src/bundler/purity_test.zig`
  - 순수한 fresh arg의 `Object.freeze`는 pure로 판정
  - shadowed callee, impure arg, identifier arg는 preserved
- 통합 회귀 테스트: `tests/integration/tests/tree-shake-precision.test.ts`
  - unused pure `Object.freeze` marker 제거
  - shadowed/impure `Object.freeze`는 보존
  - 기존 CJS precision 회귀(cookie 포함)도 같이 통과
- 스모크 테스트: `tests/benchmark/smoke.ts`
  - synthetic `object-freeze-pure-call` fixture 추가

## 검증

- `zig build test --summary all --prominent-compile-errors`
  - `4003/4003 tests passed`
- `zig build --summary all --prominent-compile-errors`
  - `5/5 steps succeeded`
- `bun test tests/integration/tests/tree-shake-precision.test.ts`
  - `15 pass, 0 fail`
- `bun run tests/benchmark/smoke.ts --filter=object-freeze-pure-call,safe-buffer,cookie,path-to-regexp,axios,rxjs`
  - ZTS `6/6 projects built successfully`
  - `6/6 outputs match baseline`
  - 참고: 비교 대상 esbuild의 axios baseline은 기존처럼 실패하지만, ZTS 결과와 스크립트 종료 코드는 정상입니다.