### PR TITLE
module.exports object member value DCE 추가

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -938,6 +938,29 @@ test "TreeShaking CJS: module.exports object keeps used helper and removes unuse
     try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_UNUSED_PRIVATE_MARKER") == null);
 }
 
+test "TreeShaking CJS: named import prunes module.exports object static member value" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { used } from './lib.js'; console.log(used());");
+    try writeFile(tmp.dir, "lib.js",
+        \\const liveNs = { value: function used() { return "USED_OBJECT_MEMBER_VALUE_MARKER"; } };
+        \\const deadNs = { value: function unused() { return "UNUSED_OBJECT_MEMBER_VALUE_MARKER"; } };
+        \\module.exports = { used: liveNs.value, unused: deadNs.value };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_OBJECT_MEMBER_VALUE_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_OBJECT_MEMBER_VALUE_MARKER") == null);
+}
+
 test "TreeShaking CJS: unsafe module.exports object shapes are preserved" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -260,14 +260,14 @@ fn cjsExportNamePropFromLhs(ast: *const Ast, lhs: NodeIndex) ?NodeIndex {
     return null;
 }
 
-/// CJS object-shape export 의 value 위치가 named export 로 치환 안전한지 판정.
-/// identifier_reference 만 허용해 tree_shaker 가 `rhs_symbol → declaring stmt` 로
-/// dependency 를 시드할 수 있게 한다 (리터럴 등은 의존 시드가 의미 없어 거부).
-fn isCjsObjectPropertyValueSafe(ast: *const Ast, value: NodeIndex, unresolved_globals: ?*const purity.GlobalRefSet) bool {
-    if (value.isNone() or @intFromEnum(value) >= ast.nodes.items.len) return false;
-    const value_node = ast.nodes.items[@intFromEnum(value)];
-    if (value_node.tag != .identifier_reference) return false;
-    return purity.isExprPure(ast, value, unresolved_globals);
+/// CJS object-shape export 의 value 위치에서 의존성 시드로 쓸 노드를 반환.
+/// identifier 는 그대로, `ns.member` 같은 정적 멤버는 base object (`ns`) 를 시드한다.
+/// tree_shaker 가 `rhs_symbol → declaring stmt` 로 dependency 를 살릴 수 없는
+/// 리터럴/동적 멤버/optional chain 등은 보수적으로 거부한다.
+fn cjsObjectPropertyValueSeedNode(ast: *const Ast, value: NodeIndex, unresolved_globals: ?*const purity.GlobalRefSet) ?NodeIndex {
+    if (value.isNone() or @intFromEnum(value) >= ast.nodes.items.len) return null;
+    if (!purity.isExprPure(ast, value, unresolved_globals)) return null;
+    return definePropertyDescriptorValueSeedNode(ast, value);
 }
 
 fn cjsExportCandidateForStmt(alloc: std.mem.Allocator, ast: *const Ast, stmt_node: Node) !?CjsExportCandidate {
@@ -666,14 +666,13 @@ fn collectCjsObjectExportCandidates(
         const entry = try seen.getOrPut(allocator, name);
         if (entry.found_existing) return null;
 
-        const value = Ast.objectPropertyValue(prop);
-        if (!isCjsObjectPropertyValueSafe(ast, value, unresolved_globals)) return null;
+        const seed_node = cjsObjectPropertyValueSeedNode(ast, Ast.objectPropertyValue(prop), unresolved_globals) orelse return null;
 
         try out.append(allocator, .{
             .export_name = name,
             .export_assignment_node = @intFromEnum(expr_idx),
             .property_node = @intFromEnum(prop_idx),
-            .rhs_node = value,
+            .rhs_node = seed_node,
             .kind = .object_property,
         });
         name_transferred = true;

--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -33,6 +33,7 @@ interface CjsExportAudit {
 type CjsExportPattern =
   | "exports.x ="
   | "module.exports.x ="
+  | "module.exports ="
   | "module.exports = { ... }"
   | "Object.defineProperty(..., { value })"
   | "Object.defineProperty(..., { value: member })"
@@ -41,6 +42,7 @@ type CjsExportPattern =
 const cjsExportPatterns: CjsExportPattern[] = [
   "exports.x =",
   "module.exports.x =",
+  "module.exports =",
   "module.exports = { ... }",
   "Object.defineProperty(..., { value })",
   "Object.defineProperty(..., { value: member })",
@@ -50,7 +52,7 @@ const cjsExportPatterns: CjsExportPattern[] = [
 function parseProjects(): string[] {
   const arg = process.argv.find((a) => a.startsWith("--projects="));
   if (!arg) {
-    return ["safe-buffer", "cookie", "path-to-regexp"];
+    return ["safe-buffer", "cookie", "path-to-regexp", "object-assign", "merge-descriptors"];
   }
   return arg
     .slice("--projects=".length)
@@ -128,6 +130,7 @@ function countCjsExportPatterns(text: string): Record<CjsExportPattern, number> 
   return {
     "exports.x =": [...text.matchAll(/(^|[^\w$.])exports\.[A-Za-z_$][\w$]*\s*=/gm)].length,
     "module.exports.x =": [...text.matchAll(/\bmodule\.exports\.[A-Za-z_$][\w$]*\s*=/g)].length,
+    "module.exports =": [...text.matchAll(/\bmodule\.exports\s*=/g)].length,
     "module.exports = { ... }": [...text.matchAll(/\bmodule\.exports\s*=\s*\{/g)].length,
     "Object.defineProperty(..., { value })": [
       ...text.matchAll(
@@ -158,6 +161,9 @@ function collectCjsExportMarkers(text: string): Map<string, number> {
   }
   for (const _match of text.matchAll(/\bmodule\.exports\s*=\s*\{/g)) {
     increment(markers, "module.exports = {");
+  }
+  for (const _match of text.matchAll(/\bmodule\.exports\s*=\s*(?!\{)/g)) {
+    increment(markers, "module.exports =");
   }
   for (const match of text.matchAll(
     /\bObject\.defineProperty\s*\(\s*(exports|module\.exports)\s*,\s*(["'`])((?:\\.|(?!\2).)+)\2\s*,\s*\{[^}]*\bvalue\b/g,

--- a/tests/benchmark/smoke-diagnostics.test.ts
+++ b/tests/benchmark/smoke-diagnostics.test.ts
@@ -64,17 +64,15 @@ describe("benchmark smoke diagnostics", () => {
   });
 
   test("size-gap.ts reports CJS export pattern audit for target projects", () => {
-    const r = runBun([
-      "run",
-      "tests/benchmark/size-gap.ts",
-      "--projects=safe-buffer,cookie,path-to-regexp",
-    ]);
+    const r = runBun(["run", "tests/benchmark/size-gap.ts"]);
 
     expect(r.status, r.stderr?.toString()).toBe(0);
     const stdout = r.stdout.toString();
     expect(stdout).toContain("safe-buffer");
     expect(stdout).toContain("cookie");
     expect(stdout).toContain("path-to-regexp");
+    expect(stdout).toContain("object-assign");
+    expect(stdout).toContain("merge-descriptors");
     expect(stdout).toContain("ZTS-only strings");
     expect(stdout).toContain("Wrapper markers");
     expect(stdout).toContain("Top-level declarations");
@@ -82,6 +80,7 @@ describe("benchmark smoke diagnostics", () => {
     expect(stdout).toContain("Pattern counts:");
     expect(stdout).toMatch(/exports\.x =: \d+/);
     expect(stdout).toMatch(/module\.exports\.x =: \d+/);
+    expect(stdout).toMatch(/module\.exports =: \d+/);
     expect(stdout).toMatch(/module\.exports = \{ \.\.\. \}: \d+/);
     expect(stdout).toMatch(/Object\.defineProperty\(\.\.\., \{ value \}\): \d+/);
     expect(stdout).toMatch(/Object\.defineProperty\(\.\.\., \{ value: member \}\): \d+/);
@@ -102,6 +101,12 @@ describe("benchmark smoke diagnostics", () => {
     );
     expect(stdout).toMatch(
       /## path-to-regexp[\s\S]*Removed dead marker candidates:[\s\S]*exports\.compile =/,
+    );
+    expect(stdout).toMatch(
+      /## object-assign[\s\S]*CJS export pattern audit[\s\S]*module\.exports =: 1/,
+    );
+    expect(stdout).toMatch(
+      /## merge-descriptors[\s\S]*CJS export pattern audit[\s\S]*module\.exports =: 1/,
     );
   });
 

--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -873,6 +873,17 @@ const projects: ProjectConfig[] = [
     },
   },
   {
+    name: "cjs-module-exports-object-member-value",
+    pkg: "(synthetic)",
+    entry: `import { used } from './_smoke_cjs_module_exports_object_member_value_lib.cjs';\nconsole.log(used());`,
+    files: {
+      "_smoke_cjs_module_exports_object_member_value_lib.cjs":
+        `const liveNs = { value: function used() { return "MATCH"; } };\n` +
+        `const deadNs = { value: function dead() { return "UNUSED_SMOKE_OBJECT_MEMBER_VALUE"; } };\n` +
+        `module.exports = { used: liveNs.value, dead: deadNs.value };\n`,
+    },
+  },
+  {
     name: "on-finished",
     pkg: "on-finished",
     entry: `import onf from 'on-finished';\nconsole.log(typeof onf);`,

--- a/tests/integration/tests/tree-shake-precision.test.ts
+++ b/tests/integration/tests/tree-shake-precision.test.ts
@@ -260,6 +260,25 @@ describe("CJS static export fact 기반 DCE", () => {
     expect(bundle).not.toContain("deadNs");
   });
 
+  test("module.exports object export — static member value keeps base object and prunes unused member export", () => {
+    const bundle = bundleFiles(
+      {
+        "index.ts": `import { used } from "./lib.cjs";\nconsole.log(used());\n`,
+        "lib.cjs":
+          `const liveNs = { value: function used() { return "MATCH"; } };\n` +
+          `const deadNs = { value: function unused() { return "unused-object-member-value-marker"; } };\n` +
+          `module.exports = { used: liveNs.value, unused: deadNs.value };\n`,
+      },
+      "index.ts",
+      "cjs-module-exports-object-member-value",
+    );
+
+    expect(runBundleSource(bundle)).toContain("MATCH");
+    expect(bundle).toContain("liveNs");
+    expect(bundle).not.toContain("unused-object-member-value-marker");
+    expect(bundle).not.toContain("deadNs");
+  });
+
   test("Object.defineProperty __esModule marker — named import prunes safe marker", () => {
     const bundle = bundleFiles(
       {


### PR DESCRIPTION
## 요약

#2060 로드맵의 CJS static export pruning 후속으로 `module.exports = { used: ns.value }` 형태의 object export value를 정밀 DCE 대상으로 확장했습니다.

기본 `module.exports = { used, unused }` fact 수집은 main에 이미 들어와 있어서, 이번 PR은 그 위에 `Object.defineProperty(..., { value: ns.member })`와 동일한 seed 전략을 적용합니다.

## 변경 사항

- `module.exports = { used: liveNs.value, unused: deadNs.value }` 형태를 지원합니다.
- object property value가 정적 member expression이면 base object identifier를 seed합니다.
  - `liveNs.value` -> `liveNs` 선언과 writer를 seed
- 기존처럼 다음 형태는 보수적으로 제외됩니다.
  - literal value
  - dynamic/computed member
  - optional chain
  - spread/getter/setter/method/computed key 등 unsafe object shape

## TDD 흐름

1. `test(cjs): cover module.exports object member values`
   - Zig bundler test, integration regression, smoke synthetic fixture를 먼저 추가했습니다.
   - 구현 전 `UNUSED_OBJECT_MEMBER_VALUE_MARKER`가 남아 실패하는 것을 확인했습니다.
2. `feat(cjs): support module.exports object member values`
   - object export value seed node를 identifier-only에서 `identifier.staticMember` base seed까지 확장했습니다.

## 검증

- `zig build test --summary all --prominent-compile-errors`
  - `4010/4010 tests passed`
- `zig build --summary all --prominent-compile-errors`
  - `5/5 steps succeeded`
- `bun test tests/integration/tests/tree-shake-precision.test.ts`
  - `22 pass, 0 fail`
- `bun run tests/benchmark/smoke.ts --filter=cjs-module-exports-object-member-value,cjs-esmodule-marker-pruning,object-assign-pure-call,object-freeze-pure-call,safe-buffer,cookie,path-to-regexp,axios,rxjs`
  - ZTS `9/9 projects built successfully`
  - `9/9 outputs match baseline`
- `bun run fmt && bun run fmt:check`
  - 로컬에서는 부모 번개 `.oxfmtrc.json`을 잠깐 제외하고 실행했습니다.

참고: smoke 비교 대상 중 axios esbuild baseline 실패는 기존 비교 대상 실패이며, ZTS 결과와 스크립트 종료 코드는 정상입니다.