### PR TITLE
fix(docs): hero mobile overflow — grid items min-w-0 + break-words

### DIFF
--- a/documents/src/components/landing/Hero.astro
+++ b/documents/src/components/landing/Hero.astro
@@ -28,23 +28,23 @@ const {
 } = Astro.props;
 ---
 
-<section class="not-content relative overflow-hidden">
+<section class="not-content relative overflow-x-clip">
   <div aria-hidden="true" class="pointer-events-none absolute inset-0 -z-10">
     <div class="absolute -top-32 -left-16 h-96 w-96 rounded-full bg-zig-500/15 blur-3xl"></div>
     <div class="absolute bottom-0 right-1/3 h-80 w-80 rounded-full bg-zig-600/10 blur-3xl"></div>
   </div>
   <div class="mx-auto max-w-6xl px-6 py-20 sm:py-24 lg:py-28">
     <div class="grid items-center gap-10 lg:grid-cols-2 lg:gap-14">
-      <div class="flex flex-col items-center gap-6 text-center lg:items-start lg:text-left">
+      <div class="flex min-w-0 flex-col items-center gap-6 text-center lg:items-start lg:text-left">
         <p class="font-mono text-xs uppercase tracking-[0.2em] text-zig-400">
           {eyebrow}
         </p>
-        <h1 class="whitespace-pre-line text-4xl font-bold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl">
+        <h1 class="whitespace-pre-line text-4xl font-bold leading-[1.1] tracking-tight break-words sm:text-5xl lg:text-6xl">
           <span class="bg-gradient-to-br from-zig-200 via-zig-400 to-zig-600 bg-clip-text text-transparent">
             {title}
           </span>
         </h1>
-        <p class="max-w-xl text-lg leading-relaxed text-[color:var(--sl-color-gray-2)]">
+        <p class="max-w-full text-lg leading-relaxed text-[color:var(--sl-color-gray-2)] sm:max-w-xl">
           {subtitle}
         </p>
         <div class="mt-2 flex flex-wrap justify-center gap-3 lg:justify-start">
@@ -65,7 +65,7 @@ const {
           }
         </div>
       </div>
-      <div class="relative">
+      <div class="relative min-w-0">
         <div class="absolute -inset-1 -z-10 rounded-xl bg-gradient-to-br from-zig-500/25 to-zig-700/10 blur-xl"></div>
         <div class="overflow-hidden rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-black)] shadow-2xl shadow-black/40">
           {


### PR DESCRIPTION
## Summary
splash 페이지 Hero 가 모바일 viewport 에서 부모 컨테이너 (`mx-auto max-w-6xl px-6`) 를 넘는 가로 폭으로 그려지는 문제 수정.

## 원인
grid item 의 default `min-width: auto` 때문에 ExpressiveCode 의 long line 이 column 을 강제 stretch. 모바일 single column 레이아웃에서 코드박스 width 가 viewport 초과.

## 수정 (Hero.astro 5줄)
| 변경 | 이유 |
|---|---|
| 텍스트 컬럼에 `min-w-0` | flex/grid item default `min-width: auto` 가 stretch 유발 |
| 코드박스 grid item 에 `min-w-0` | ExpressiveCode 가 column 강제 stretch 못 하게 |
| h1 에 `break-words` | 긴 한글/영문 단어 강제 줄바꿈 |
| subtitle `max-w-xl` → `max-w-full sm:max-w-xl` | 모바일 100% 폭 활용 |
| section `overflow-hidden` → `overflow-x-clip` | 세로 decorative blob 보존하면서 가로 안전망 |

## Test plan
- [x] `bun run build` 통과 (357 page built)
- [ ] 시각 확인은 사용자 측에서 다음 deploy 후 (Pages 배포 큐에 들어감)

🤖 Generated with [Claude Code](https://claude.com/claude-code)