### PR TITLE
fix(benchmark): size-gap CJS export count disjoint + 테스트 stdout 캡처

### DIFF
--- a/tests/benchmark/size-gap.ts
+++ b/tests/benchmark/size-gap.ts
@@ -130,7 +130,7 @@ function countCjsExportPatterns(text: string): Record<CjsExportPattern, number> 
   return {
     "exports.x =": [...text.matchAll(/(^|[^\w$.])exports\.[A-Za-z_$][\w$]*\s*=/gm)].length,
     "module.exports.x =": [...text.matchAll(/\bmodule\.exports\.[A-Za-z_$][\w$]*\s*=/g)].length,
-    "module.exports =": [...text.matchAll(/\bmodule\.exports\s*=/g)].length,
+    "module.exports =": [...text.matchAll(/\bmodule\.exports\s*=\s*(?!\{)/g)].length,
     "module.exports = { ... }": [...text.matchAll(/\bmodule\.exports\s*=\s*\{/g)].length,
     "Object.defineProperty(..., { value })": [
       ...text.matchAll(

--- a/tests/benchmark/smoke-diagnostics.test.ts
+++ b/tests/benchmark/smoke-diagnostics.test.ts
@@ -64,10 +64,20 @@ describe("benchmark smoke diagnostics", () => {
   });
 
   test("size-gap.ts reports CJS export pattern audit for target projects", () => {
-    const r = runBun(["run", "tests/benchmark/size-gap.ts"]);
+    // 프로젝트 루트에서 `bun test` 가 부모일 때 자식 `bun` 의 stdout pipe 캡처가
+    // 비는 Bun 런타임 quirk 가 있다 (cwd 가 워크스페이스 하위면 정상). exec 전
+    // 셸 리다이렉트만 안전하게 stdout 을 받는다.
+    const dir = mkdtempSync(join(tmpdir(), "zts-size-gap-out-"));
+    const outPath = join(dir, "out.txt");
+    const r = spawnSync("sh", ["-c", `bun run tests/benchmark/size-gap.ts > "${outPath}"`], {
+      cwd: ROOT,
+      stdio: "pipe",
+      timeout: 180000,
+    });
 
     expect(r.status, r.stderr?.toString()).toBe(0);
-    const stdout = r.stdout.toString();
+    const stdout = readFileSync(outPath, "utf-8");
+    rmSync(dir, { recursive: true, force: true });
     expect(stdout).toContain("safe-buffer");
     expect(stdout).toContain("cookie");
     expect(stdout).toContain("path-to-regexp");


### PR DESCRIPTION
## 요약

#2093 머지 후 follow-up. 두 가지를 수정합니다.

1. **size-gap.ts 카운트 비대칭**: 신규 `\"module.exports =\"` 카운트 정규식이 lookahead 가 없어 `module.exports = { ... }` 와 이중 카운트됐다. markers 쪽 (`/\\bmodule\\.exports\\s*=\\s*(?!\\{)/g`) 과 동일한 negative lookahead 를 적용해 두 카테고리를 disjoint 로 정렬.
2. **smoke-diagnostics 테스트 stdout 캡처**: 프로젝트 루트에서 `bun test` 가 부모일 때 자식 `bun run` 의 stdout pipe 캡처가 비어 돌아오는 Bun 런타임 quirk 가 있다 (cwd 가 `tests/benchmark/` 면 정상). `pipe` / fd / `Bun.spawn` 모두 동일 증상이고 셸 리다이렉트만 안전. 임시 파일로 받아 읽도록 변경.

## 변경 사항

- `tests/benchmark/size-gap.ts`: `\"module.exports =\"` 카운트 정규식에 `(?!\\{)` lookahead 추가.
- `tests/benchmark/smoke-diagnostics.test.ts`: size-gap audit 테스트가 `sh -c \"bun run ... > <tmpfile>\"` 로 stdout 을 임시 파일에 받고 읽어들이도록 변경.

## 검증

- `bun test tests/benchmark/smoke-diagnostics.test.ts` (프로젝트 루트 cwd): 4 pass / 0 fail (이전: size-gap audit 1 fail)
- `cd tests/benchmark && bun test smoke-diagnostics.test.ts`: 4 pass / 0 fail (회귀 없음)
- `bun run tests/benchmark/size-gap.ts` 직접 실행 시 5개 프로젝트 모두 `module.exports =` 와 `module.exports = { ... }` 카운트가 disjoint 로 표시됨.
- `cd tests/integration && bun test tests/tree-shake-precision.test.ts`: 22 pass / 0 fail.

## 메모

- 카운트 정규식과 markers 정규식의 비대칭은 #2093 리뷰에서 발견했지만 그 PR 이 main 으로 머지된 후라 별도 PR 로 분리.
- Bun 런타임 quirk 는 단순 reproducer (`sh -c \"bun -e 'console.log(1)'\"` 로 받으면 정상, pipe/fd/Bun.spawn 모두 빈 stdout) 로 확인. 추후 Bun 측 이슈 보고 검토 가치 있음.