### PR TITLE
feat(emitter): use //#region markers for module/polyfill boundaries

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1101,8 +1101,8 @@ test "Bundler: require.context emits webpackContext IIFE (sync)" {
     // 원본 `require.context(...)` 호출은 남으면 안 됨 — IIFE 로 교체되어야.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require.context(") == null);
     // 매치 파일들이 번들에 실제로 포함되어야 — graph dep 등록 확인.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "// --- a.tsx ---") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "// --- b.tsx ---") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "//#region a.tsx") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "//#region b.tsx") != null);
     // `ctx(req)` 가 module exports 를 반환해야 — Metro/webpack require.context semantic.
     // `fn()` 만 호출하면 init 만 실행되고 exports 가 undefined 로 떨어져서 expo-router 등이
     // 빈 route module 을 보고 "Unmatched Route" 로 fallback.

--- a/src/bundler/bundler_test/patterns.zig
+++ b/src/bundler/bundler_test/patterns.zig
@@ -373,7 +373,8 @@ test "Format: minify removes module boundary comments" {
     defer b1.deinit();
     const r1 = try b1.bundle();
     defer r1.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.indexOf(u8, r1.output, "// ---") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "//#region ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r1.output, "//#endregion") != null);
 
     // minify=true → 경계 주석 없음
     var b2 = Bundler.init(std.testing.allocator, .{
@@ -385,7 +386,8 @@ test "Format: minify removes module boundary comments" {
     defer b2.deinit();
     const r2 = try b2.bundle();
     defer r2.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.indexOf(u8, r2.output, "// ---") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "//#region") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r2.output, "//#endregion") == null);
 }
 
 test "minifyIdentifiers: for-in LHS identifier should be renamed" {

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -391,9 +391,9 @@ pub fn emitWithTreeShaking(
 
     for (options.polyfills) |*poly| {
         if (!options.minify_whitespace) {
-            try output.appendSlice(allocator, "// --- polyfill: ");
+            try output.appendSlice(allocator, "//#region polyfill: ");
             try output.appendSlice(allocator, poly.name);
-            try output.appendSlice(allocator, " ---\n");
+            try output.append(allocator, '\n');
             output_line += 1;
         }
         try output.appendSlice(allocator, "(function(){");
@@ -420,6 +420,10 @@ pub fn emitWithTreeShaking(
 
         try output.appendSlice(allocator, "})();\n");
         output_line += 1;
+        if (!options.minify_whitespace) {
+            try output.appendSlice(allocator, "//#endregion\n");
+            output_line += 1;
+        }
     }
 
     // 런타임 헬퍼 주입
@@ -624,8 +628,8 @@ pub fn emitWithTreeShaking(
         const code = results[i].code orelse continue;
         module_output_estimate += code.len;
         if (!options.minify_whitespace) {
-            // `"// --- " + basename + " ---\n"` (12 + basename) + 모듈 말미 개행 1
-            module_output_estimate += std.fs.path.basename(m.path).len + 13;
+            // `"//#region " + basename + "\n"` (11 + basename) + `"//#endregion\n"` (13)
+            module_output_estimate += std.fs.path.basename(m.path).len + 24;
         }
     }
     try module_output.ensureTotalCapacity(allocator, module_output_estimate);
@@ -652,9 +656,9 @@ pub fn emitWithTreeShaking(
         }
 
         if (!options.minify_whitespace) {
-            try module_output.appendSlice(allocator, "// --- ");
+            try module_output.appendSlice(allocator, "//#region ");
             try module_output.appendSlice(allocator, std.fs.path.basename(m.path));
-            try module_output.appendSlice(allocator, " ---\n");
+            try module_output.append(allocator, '\n');
             module_line += 1;
         }
 
@@ -687,7 +691,7 @@ pub fn emitWithTreeShaking(
         try module_output.appendSlice(allocator, code_to_append);
         module_line += @intCast(std.mem.count(u8, code_to_append, "\n"));
         if (!options.minify_whitespace) {
-            try module_output.append(allocator, '\n');
+            try module_output.appendSlice(allocator, "//#endregion\n");
             module_line += 1;
         }
 

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -283,13 +283,13 @@ pub fn emitChunks(
                 code;
 
             if (!options.minify_whitespace) {
-                try chunk_output.appendSlice(allocator, "// --- ");
+                try chunk_output.appendSlice(allocator, "//#region ");
                 try chunk_output.appendSlice(allocator, std.fs.path.basename(m.path));
-                try chunk_output.appendSlice(allocator, " ---\n");
+                try chunk_output.append(allocator, '\n');
             }
             try chunk_output.appendSlice(allocator, stripped);
             if (!options.minify_whitespace) {
-                try chunk_output.append(allocator, '\n');
+                try chunk_output.appendSlice(allocator, "//#endregion\n");
             }
         }
 


### PR DESCRIPTION
## Summary

번들 출력의 모듈/폴리필 경계 주석을 `// --- BASENAME ---` 에서
`//#region BASENAME` + `//#endregion` 쌍으로 교체합니다.

- VSCode / JetBrains 가 region 폴딩으로 인식 → 큰 dev 번들에서 모듈 단위 접기·펼치기 가능 (rolldown 과 동일한 방식)
- 부수 효과로 마지막 모듈 뒤의 무의미한 trailing 빈 줄 제거 → esbuild/rolldown 과 동등한 `}\n})();\n` 마무리
- `--minify-whitespace` 모드에서는 기존과 동일하게 마커 미출력

## 변경 위치 (3곳)

| 파일 | 위치 | 컨텍스트 |
|---|---|---|
| `src/bundler/emitter.zig` | `output_line` 폴리필 루프 | polyfill entry 경계 |
| `src/bundler/emitter.zig` | `module_output` 모듈 루프 | single-bundle 모듈 경계 |
| `src/bundler/emitter/chunks.zig` | chunk 모듈 루프 | code-splitting chunk 내 모듈 경계 |

## 출력 비교

### 변경 전
```js
(() => {
// --- main.ts ---
const root = document.querySelector("#app");
function greet(name) { return `Hello, ${name}!`; }

})();
```

### 변경 후
```js
(() => {
//#region main.ts
const root = document.querySelector("#app");
function greet(name) { return `Hello, ${name}!`; }
//#endregion
})();
```

## Test plan
- [x] `zig build test` — 4010/4010 통과
- [x] `Format: minify removes module boundary comments` 테스트 갱신 (region 양쪽 마커 검증)
- [x] `Bundler: require.context emits webpackContext IIFE (sync)` 테스트 갱신 (a.tsx/b.tsx region 헤더 검증)
- [x] CLI 직접 실행 (`zts main.ts --bundle --format=iife`) 으로 출력 형식 육안 확인
- [x] `--minify-whitespace` 모드에서 마커 미출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)