### PR TITLE
feat: 직접 module.exports CJS default import에서 interop 생략

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -291,11 +291,11 @@ test "CJS: empty CJS module" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_empty") != null);
 }
 
-test "CJS: __toESM wraps default import from CJS" {
+test "CJS: default import from direct module.exports uses require fast path" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "import lib from './lib.cjs';\nconsole.log(lib);");
-    try writeFile(tmp.dir, "lib.cjs", "module.exports = { value: 42 };");
+    try writeFile(tmp.dir, "lib.cjs", "module.exports = function value() { return 42; };");
 
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
@@ -306,9 +306,9 @@ test "CJS: __toESM wraps default import from CJS" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // default import는 __toESM으로 래핑되어야 함
-    // .ts importer → Babel 모드 (isNodeMode 없음)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "lib = require_lib();") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM") == null);
 }
 
 test "CJS: __toESM not applied to named imports" {
@@ -392,7 +392,10 @@ test "CJS: __toESM runtime helper injected with __commonJS" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "import lib from './lib.cjs';\nconsole.log(lib);");
-    try writeFile(tmp.dir, "lib.cjs", "module.exports = 42;");
+    try writeFile(tmp.dir, "lib.cjs",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\exports.default = 42;
+    );
 
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
@@ -504,6 +507,69 @@ test "CJS: namespace import from CJS uses __toESM" {
     try std.testing.expect(!result.hasErrors());
     // namespace import도 __toESM으로 래핑 (.ts → Babel 모드)
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
+}
+
+test "CJS: default import keeps __toESM when exports __esModule assignment exists" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import lib from './lib.cjs';\nconsole.log(lib);");
+    try writeFile(tmp.dir, "lib.cjs",
+        \\exports.__esModule = true;
+        \\module.exports = function value() { return 1; };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib()).default") != null);
+}
+
+test "CJS: default import keeps __toESM when module.exports __esModule assignment exists" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import lib from './lib.cjs';\nconsole.log(lib);");
+    try writeFile(tmp.dir, "lib.cjs",
+        \\module.exports = function value() { return 1; };
+        \\module.exports.__esModule = true;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib()).default") != null);
+}
+
+test "CJS: default import keeps __toESM when defineProperty __esModule marker exists" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import lib from './lib.cjs';\nconsole.log(lib);");
+    try writeFile(tmp.dir, "lib.cjs",
+        \\Object.defineProperty(module.exports, "__esModule", { value: true });
+        \\module.exports = function value() { return 1; };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib()).default") != null);
 }
 
 test "CJS: multiple ESM modules importing same CJS module" {
@@ -1833,7 +1899,8 @@ test "CJS: ESM-wrapped default import from CJS gets preamble assignment" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "value = __toESM(require_lib()).default;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "value = require_lib();") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "value = __toESM(require_lib()).default;") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "({value}") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "value;") != null);
 }

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2844,7 +2844,10 @@ test "#1621 non-minify: __esm/__export/__toCommonJS long names preserved" {
 
 // Helper: CJS 모듈을 default import 하면 preamble 에서 __toESM 래핑이 활성화됨.
 fn writeToEsmFixture(tmp_dir: std.fs.Dir) !void {
-    try writeFile(tmp_dir, "lib.cjs", "module.exports = { v: 42 };");
+    try writeFile(tmp_dir, "lib.cjs",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\exports.default = { v: 42 };
+    );
     try writeFile(tmp_dir, "entry.ts",
         \\import lib from './lib.cjs';
         \\console.log(lib.v);

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1572,7 +1572,8 @@ test "runtime helper: __copyProps uses getOwnPropertyNames, not Object.keys" {
     // ESM entry가 CJS를 import → __toESM/__copyProps 필요
     try writeFile(tmp.dir, "entry.ts", "import greet from './cjs-mod.js';\nconsole.log(greet());");
     try writeFile(tmp.dir, "cjs-mod.js",
-        \\module.exports = function greet() { return 'hello'; };
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\exports.default = function greet() { return 'hello'; };
     );
 
     const entry = try absPath(&tmp, "entry.ts");

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1769,7 +1769,8 @@ fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph, lin
             if (l.getResolvedBinding(module.index.toU32(), ib.local_span)) |rb| {
                 const canonical_mod = graph.getModule(rb.canonical.module_index) orelse continue;
                 if (canonical_mod.wrap_kind == .cjs and
-                    linker_mod.cjsImportNeedsToEsmInterop(false, rb.canonical.export_name))
+                    linker_mod.cjsImportNeedsToEsmInterop(false, rb.canonical.export_name) and
+                    !module.canUseDirectCjsDefaultImport(canonical_mod))
                 {
                     return true;
                 }
@@ -1782,7 +1783,7 @@ fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph, lin
         const record = module.import_records[ib.import_record_index];
         if (record.resolved.isNone()) continue;
         const target = graph.getModule(record.resolved) orelse continue;
-        if (target.wrap_kind == .cjs) return true;
+        if (target.wrap_kind == .cjs and !module.canUseDirectCjsDefaultImport(target)) return true;
     }
     return false;
 }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1631,10 +1631,12 @@ pub const ModuleGraph = struct {
             module.exports_kind = determineExportsKind(scan_result, module.path);
             module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
             module.has_cjs_export_signal = scan_result.has_module_exports or scan_result.has_exports_dot;
-            module.can_skip_cjs_default_interop = module.wrap_kind == .cjs and
-                scan_result.has_module_exports and
-                !scan_result.has_exports_dot and
-                !scan_result.has_esmodule_marker;
+            module.can_skip_cjs_default_interop = Module.computeCanSkipCjsDefaultInterop(
+                module.wrap_kind == .cjs,
+                scan_result.has_module_exports,
+                scan_result.has_exports_dot,
+                scan_result.has_esmodule_marker,
+            );
 
             // JSX synthetic import bindings 추가
             if (jsx_injected) {
@@ -1833,10 +1835,12 @@ pub const ModuleGraph = struct {
         module.exports_kind = if (preserve_esm) previous_kind else refreshed_kind;
         module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
         module.has_cjs_export_signal = refreshed_scan_result.has_module_exports or refreshed_scan_result.has_exports_dot;
-        module.can_skip_cjs_default_interop = module.wrap_kind == .cjs and
-            refreshed_scan_result.has_module_exports and
-            !refreshed_scan_result.has_exports_dot and
-            !refreshed_scan_result.has_esmodule_marker;
+        module.can_skip_cjs_default_interop = Module.computeCanSkipCjsDefaultInterop(
+            module.wrap_kind == .cjs,
+            refreshed_scan_result.has_module_exports,
+            refreshed_scan_result.has_exports_dot,
+            refreshed_scan_result.has_esmodule_marker,
+        );
 
         if (module.alias_table) |*table| table.deinit();
         module.alias_table = AliasTable.init(self.allocator);

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1593,6 +1593,7 @@ pub const ModuleGraph = struct {
                 .has_cjs_require = parser.scan_result.has_cjs_require,
                 .has_module_exports = parser.scan_result.has_module_exports,
                 .has_exports_dot = parser.scan_result.has_exports_dot,
+                .has_esmodule_marker = parser.scan_result.has_esmodule_marker,
             };
 
             // JSX automatic synthetic imports. `react` 는 key-after-spread 일 때만 주입 —
@@ -1630,6 +1631,10 @@ pub const ModuleGraph = struct {
             module.exports_kind = determineExportsKind(scan_result, module.path);
             module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
             module.has_cjs_export_signal = scan_result.has_module_exports or scan_result.has_exports_dot;
+            module.can_skip_cjs_default_interop = module.wrap_kind == .cjs and
+                scan_result.has_module_exports and
+                !scan_result.has_exports_dot and
+                !scan_result.has_esmodule_marker;
 
             // JSX synthetic import bindings 추가
             if (jsx_injected) {
@@ -1811,6 +1816,7 @@ pub const ModuleGraph = struct {
             .has_cjs_require = scan_result.has_cjs_require,
             .has_module_exports = scan_result.has_module_exports,
             .has_exports_dot = scan_result.has_exports_dot,
+            .has_esmodule_marker = scan_result.has_esmodule_marker,
         };
 
         try self.injectJsxSyntheticImportsForModule(module, arena_alloc, ast);
@@ -1827,6 +1833,10 @@ pub const ModuleGraph = struct {
         module.exports_kind = if (preserve_esm) previous_kind else refreshed_kind;
         module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
         module.has_cjs_export_signal = refreshed_scan_result.has_module_exports or refreshed_scan_result.has_exports_dot;
+        module.can_skip_cjs_default_interop = module.wrap_kind == .cjs and
+            refreshed_scan_result.has_module_exports and
+            !refreshed_scan_result.has_exports_dot and
+            !refreshed_scan_result.has_esmodule_marker;
 
         if (module.alias_table) |*table| table.deinit();
         module.alias_table = AliasTable.init(self.allocator);

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -53,6 +53,8 @@ pub const ScanResult = struct {
     has_module_exports: bool,
     /// exports.xxx = ... 할당 존재 여부
     has_exports_dot: bool,
+    /// exports.__esModule / module.exports.__esModule marker 존재 여부
+    has_esmodule_marker: bool = false,
 };
 
 /// AST를 순회하여 import/export/require를 추출하고 CJS 신호를 감지한다.
@@ -73,6 +75,7 @@ pub fn extractImportsWithCjsDetectionAndDefines(
     var has_cjs_require = false;
     var has_module_exports = false;
     var has_exports_dot = false;
+    var has_esmodule_marker = false;
 
     var dead_ranges: std.ArrayList(Span) = .empty;
     defer dead_ranges.deinit(allocator);
@@ -122,6 +125,9 @@ pub fn extractImportsWithCjsDetectionAndDefines(
                     try records.append(allocator, record);
                 } else if (tryExtractGlob(ast, node)) |record| {
                     try records.append(allocator, record);
+                } else if (isObjectDefinePropertyEsModuleMarker(ast, node)) {
+                    has_esmodule_marker = true;
+                    has_exports_dot = true;
                 } else if (!has_exports_dot and isObjectDefinePropertyExports(ast, node)) {
                     has_exports_dot = true;
                 }
@@ -135,7 +141,10 @@ pub fn extractImportsWithCjsDetectionAndDefines(
                 if (!has_module_exports and isModuleExportsAssign(ast, node)) {
                     has_module_exports = true;
                 }
-                if (!has_exports_dot and isExportsDotAssign(ast, node)) {
+                if (isEsModuleMarkerAssign(ast, node)) {
+                    has_esmodule_marker = true;
+                    has_exports_dot = true;
+                } else if (!has_exports_dot and isExportsDotAssign(ast, node)) {
                     has_exports_dot = true;
                 }
             },
@@ -149,6 +158,7 @@ pub fn extractImportsWithCjsDetectionAndDefines(
         .has_cjs_require = has_cjs_require,
         .has_module_exports = has_module_exports,
         .has_exports_dot = has_exports_dot,
+        .has_esmodule_marker = has_esmodule_marker,
     };
 }
 
@@ -630,30 +640,46 @@ fn tryExtractRequire(ast: *const Ast, node: Node) ?ImportRecord {
 /// Babel/TS CJS output often declares `__esModule` this way; after transformer pre-pass
 /// rewrites `require()` calls, this may be the remaining CJS signal.
 fn isObjectDefinePropertyExports(ast: *const Ast, node: Node) bool {
+    return getObjectDefinePropertyExportsTarget(ast, node) != null;
+}
+
+fn isObjectDefinePropertyEsModuleMarker(ast: *const Ast, node: Node) bool {
+    const args_start = getObjectDefinePropertyExportsTarget(ast, node) orelse return false;
+    if (!ast.hasExtra(args_start, 2)) return false;
+    const prop_idx = ast.readExtraNode(args_start, 1);
+    const prop = getStringLiteralText(ast, prop_idx) orelse return false;
+    return std.mem.eql(u8, prop, "__esModule");
+}
+
+fn getObjectDefinePropertyExportsTarget(ast: *const Ast, node: Node) ?u32 {
     const e = node.data.extra;
-    if (!ast.hasExtra(e, 2)) return false;
+    if (!ast.hasExtra(e, 2)) return null;
 
     const callee_idx = ast.readExtraNode(e, 0);
-    const callee_parts = getStaticMemberParts(ast, callee_idx) orelse return false;
-    if (!std.mem.eql(u8, callee_parts.object, "Object")) return false;
-    if (!std.mem.eql(u8, callee_parts.property, "defineProperty")) return false;
+    const callee_parts = getStaticMemberParts(ast, callee_idx) orelse return null;
+    if (!std.mem.eql(u8, callee_parts.object, "Object")) return null;
+    if (!std.mem.eql(u8, callee_parts.property, "defineProperty")) return null;
 
     const args_len = ast.readExtra(e, 2);
-    if (args_len == 0) return false;
+    if (args_len < 1) return null;
 
     const args_start = ast.readExtra(e, 1);
-    if (args_start >= ast.extra_data.items.len) return false;
+    if (args_start >= ast.extra_data.items.len) return null;
     const target_idx = ast.readExtraNode(args_start, 0);
 
-    if (target_idx.isNone() or @intFromEnum(target_idx) >= ast.nodes.items.len) return false;
+    if (target_idx.isNone() or @intFromEnum(target_idx) >= ast.nodes.items.len) return null;
     const target = ast.getNode(target_idx);
     if (target.tag == .identifier_reference and std.mem.eql(u8, ast.getText(target.span), "exports")) {
-        return true;
+        return args_start;
     }
 
-    const target_parts = getStaticMemberParts(ast, target_idx) orelse return false;
-    return std.mem.eql(u8, target_parts.object, "module") and
-        std.mem.eql(u8, target_parts.property, "exports");
+    const target_parts = getStaticMemberParts(ast, target_idx) orelse return null;
+    if (std.mem.eql(u8, target_parts.object, "module") and
+        std.mem.eql(u8, target_parts.property, "exports"))
+    {
+        return args_start;
+    }
+    return null;
 }
 
 const MemberParts = struct { object: []const u8, property: []const u8 };
@@ -691,6 +717,28 @@ fn getAssignMemberParts(ast: *const Ast, node: Node) ?MemberParts {
 fn isModuleExportsAssign(ast: *const Ast, node: Node) bool {
     const parts = getAssignMemberParts(ast, node) orelse return false;
     return std.mem.eql(u8, parts.object, "module") and std.mem.eql(u8, parts.property, "exports");
+}
+
+/// assignment_expression의 left가 exports.__esModule 또는 module.exports.__esModule인지 확인.
+fn isEsModuleMarkerAssign(ast: *const Ast, node: Node) bool {
+    const parts = getAssignMemberParts(ast, node) orelse return false;
+    if (std.mem.eql(u8, parts.object, "exports") and std.mem.eql(u8, parts.property, "__esModule")) {
+        return true;
+    }
+
+    const lhs_idx = node.data.binary.left;
+    if (lhs_idx.isNone() or @intFromEnum(lhs_idx) >= ast.nodes.items.len) return false;
+    const lhs_node = ast.getNode(lhs_idx);
+    if (lhs_node.tag != .static_member_expression) return false;
+    const outer_e = lhs_node.data.extra;
+    const outer_obj_idx = ast.readExtraNode(outer_e, 0);
+    const outer_prop_idx = ast.readExtraNode(outer_e, 1);
+    if (outer_obj_idx.isNone() or outer_prop_idx.isNone()) return false;
+    if (@intFromEnum(outer_obj_idx) >= ast.nodes.items.len or @intFromEnum(outer_prop_idx) >= ast.nodes.items.len) return false;
+    const outer_prop = ast.getNode(outer_prop_idx);
+    if (!std.mem.eql(u8, ast.getText(outer_prop.span), "__esModule")) return false;
+    const inner_parts = getStaticMemberParts(ast, outer_obj_idx) orelse return false;
+    return std.mem.eql(u8, inner_parts.object, "module") and std.mem.eql(u8, inner_parts.property, "exports");
 }
 
 /// assignment_expression의 left가 exports.xxx인지 확인.

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -41,6 +41,8 @@ const types = @import("types.zig");
 const ImportRecord = types.ImportRecord;
 const ImportKind = types.ImportKind;
 
+pub const ES_MODULE_MARKER = "__esModule";
+
 /// CJS 감지를 포함한 스캔 결과.
 pub const ScanResult = struct {
     /// 추출된 import/export/require 레코드
@@ -125,11 +127,9 @@ pub fn extractImportsWithCjsDetectionAndDefines(
                     try records.append(allocator, record);
                 } else if (tryExtractGlob(ast, node)) |record| {
                     try records.append(allocator, record);
-                } else if (isObjectDefinePropertyEsModuleMarker(ast, node)) {
-                    has_esmodule_marker = true;
+                } else if (classifyObjectDefinePropertyExports(ast, node)) |kind| {
                     has_exports_dot = true;
-                } else if (!has_exports_dot and isObjectDefinePropertyExports(ast, node)) {
-                    has_exports_dot = true;
+                    if (kind == .esmodule_marker) has_esmodule_marker = true;
                 }
             },
             .new_expression => {
@@ -639,16 +639,17 @@ fn tryExtractRequire(ast: *const Ast, node: Node) ?ImportRecord {
 /// `Object.defineProperty(exports, ...)` / `Object.defineProperty(module.exports, ...)`.
 /// Babel/TS CJS output often declares `__esModule` this way; after transformer pre-pass
 /// rewrites `require()` calls, this may be the remaining CJS signal.
-fn isObjectDefinePropertyExports(ast: *const Ast, node: Node) bool {
-    return getObjectDefinePropertyExportsTarget(ast, node) != null;
-}
+const DefinePropertyExportsKind = enum { other, esmodule_marker };
 
-fn isObjectDefinePropertyEsModuleMarker(ast: *const Ast, node: Node) bool {
-    const args_start = getObjectDefinePropertyExportsTarget(ast, node) orelse return false;
-    if (!ast.hasExtra(args_start, 2)) return false;
-    const prop_idx = ast.readExtraNode(args_start, 1);
-    const prop = getStringLiteralText(ast, prop_idx) orelse return false;
-    return std.mem.eql(u8, prop, "__esModule");
+fn classifyObjectDefinePropertyExports(ast: *const Ast, node: Node) ?DefinePropertyExportsKind {
+    const args_start = getObjectDefinePropertyExportsTarget(ast, node) orelse return null;
+    if (ast.hasExtra(args_start, 2)) {
+        const prop_idx = ast.readExtraNode(args_start, 1);
+        if (getStringLiteralText(ast, prop_idx)) |prop| {
+            if (std.mem.eql(u8, prop, ES_MODULE_MARKER)) return .esmodule_marker;
+        }
+    }
+    return .other;
 }
 
 fn getObjectDefinePropertyExportsTarget(ast: *const Ast, node: Node) ?u32 {
@@ -722,7 +723,7 @@ fn isModuleExportsAssign(ast: *const Ast, node: Node) bool {
 /// assignment_expression의 left가 exports.__esModule 또는 module.exports.__esModule인지 확인.
 fn isEsModuleMarkerAssign(ast: *const Ast, node: Node) bool {
     const parts = getAssignMemberParts(ast, node) orelse return false;
-    if (std.mem.eql(u8, parts.object, "exports") and std.mem.eql(u8, parts.property, "__esModule")) {
+    if (std.mem.eql(u8, parts.object, "exports") and std.mem.eql(u8, parts.property, ES_MODULE_MARKER)) {
         return true;
     }
 
@@ -736,7 +737,7 @@ fn isEsModuleMarkerAssign(ast: *const Ast, node: Node) bool {
     if (outer_obj_idx.isNone() or outer_prop_idx.isNone()) return false;
     if (@intFromEnum(outer_obj_idx) >= ast.nodes.items.len or @intFromEnum(outer_prop_idx) >= ast.nodes.items.len) return false;
     const outer_prop = ast.getNode(outer_prop_idx);
-    if (!std.mem.eql(u8, ast.getText(outer_prop.span), "__esModule")) return false;
+    if (!std.mem.eql(u8, ast.getText(outer_prop.span), ES_MODULE_MARKER)) return false;
     const inner_parts = getStaticMemberParts(ast, outer_obj_idx) orelse return false;
     return std.mem.eql(u8, inner_parts.object, "module") and std.mem.eql(u8, inner_parts.property, "exports");
 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2851,6 +2851,21 @@ pub const PreambleWriter = struct {
         }
     }
 
+    /// `module.exports = ...` shape 의 CJS default import 를 `__toESM` 래핑 없이
+    /// `[var ]local = req_var();` 로 직접 emit. canUseDirectCjsDefaultImport 가 true 일 때만 호출.
+    pub fn writeCjsDirectDefault(
+        self: *PreambleWriter,
+        local_name: []const u8,
+        req_var: []const u8,
+        assign_only: bool,
+    ) !void {
+        if (!assign_only) try self.write("var ");
+        try self.write(local_name);
+        try self.write(" = ");
+        try self.write(req_var);
+        try self.write("();\n");
+    }
+
     pub fn writeDevRequire(self: *PreambleWriter, local_name: []const u8, path: []const u8, suffix: ?[]const u8) !void {
         return self.writeDevRequireInterop(local_name, path, suffix, false, false);
     }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -383,7 +383,14 @@ pub fn buildMetadataForAst(
                         const hoisted_name = try self.allocator.dupe(u8, preamble_name);
                         errdefer self.allocator.free(hoisted_name);
                         try ns_var_list.append(self.allocator, hoisted_name);
-                        try preamble.writeCjsImportAssignOnly(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                        if (ib.importsDefault() and m.canUseDirectCjsDefaultImport(canonical_m_opt.?)) {
+                            try preamble.write(preamble_name);
+                            try preamble.write(" = ");
+                            try preamble.write(req_var);
+                            try preamble.write("();\n");
+                        } else {
+                            try preamble.writeCjsImportAssignOnly(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                        }
 
                         if (ib.local_symbol.semanticIndex()) |sym_idx| {
                             try renames.put(sym_idx, preamble_name);
@@ -407,9 +414,24 @@ pub fn buildMetadataForAst(
                 const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
                 // ESM-wrapped + synthetic binding: top-level에 이미 var 선언됨 → 할당만
                 if (is_synthetic and m.wrap_kind == .esm) {
-                    try preamble.writeCjsImportAssignOnly(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                    if (ib.importsDefault() and m.canUseDirectCjsDefaultImport(canonical_m_opt.?)) {
+                        try preamble.write(preamble_name);
+                        try preamble.write(" = ");
+                        try preamble.write(req_var);
+                        try preamble.write("();\n");
+                    } else {
+                        try preamble.writeCjsImportAssignOnly(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                    }
                 } else {
-                    try preamble.writeCjsImport(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                    if (ib.importsDefault() and m.canUseDirectCjsDefaultImport(canonical_m_opt.?)) {
+                        try preamble.write("var ");
+                        try preamble.write(preamble_name);
+                        try preamble.write(" = ");
+                        try preamble.write(req_var);
+                        try preamble.write("();\n");
+                    } else {
+                        try preamble.writeCjsImport(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
+                    }
                 }
                 continue;
             }
@@ -493,7 +515,15 @@ pub fn buildMetadataForAst(
                     const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, cjs_mod);
                     const interop_mode2: types.Interop = if (m.def_format.isEsm()) .node else .babel;
                     const effective_name = rb.canonical.export_name;
-                    try preamble.writeCjsImport(preamble_name, effective_name, req_var, false, interop_mode2);
+                    if (std.mem.eql(u8, effective_name, "default") and m.canUseDirectCjsDefaultImport(cjs_mod_opt.?)) {
+                        try preamble.write("var ");
+                        try preamble.write(preamble_name);
+                        try preamble.write(" = ");
+                        try preamble.write(req_var);
+                        try preamble.write("();\n");
+                    } else {
+                        try preamble.writeCjsImport(preamble_name, effective_name, req_var, false, interop_mode2);
+                    }
                     continue;
                 }
             }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -384,10 +384,7 @@ pub fn buildMetadataForAst(
                         errdefer self.allocator.free(hoisted_name);
                         try ns_var_list.append(self.allocator, hoisted_name);
                         if (ib.importsDefault() and m.canUseDirectCjsDefaultImport(canonical_m_opt.?)) {
-                            try preamble.write(preamble_name);
-                            try preamble.write(" = ");
-                            try preamble.write(req_var);
-                            try preamble.write("();\n");
+                            try preamble.writeCjsDirectDefault(preamble_name, req_var, true);
                         } else {
                             try preamble.writeCjsImportAssignOnly(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
                         }
@@ -415,20 +412,13 @@ pub fn buildMetadataForAst(
                 // ESM-wrapped + synthetic binding: top-level에 이미 var 선언됨 → 할당만
                 if (is_synthetic and m.wrap_kind == .esm) {
                     if (ib.importsDefault() and m.canUseDirectCjsDefaultImport(canonical_m_opt.?)) {
-                        try preamble.write(preamble_name);
-                        try preamble.write(" = ");
-                        try preamble.write(req_var);
-                        try preamble.write("();\n");
+                        try preamble.writeCjsDirectDefault(preamble_name, req_var, true);
                     } else {
                         try preamble.writeCjsImportAssignOnly(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
                     }
                 } else {
                     if (ib.importsDefault() and m.canUseDirectCjsDefaultImport(canonical_m_opt.?)) {
-                        try preamble.write("var ");
-                        try preamble.write(preamble_name);
-                        try preamble.write(" = ");
-                        try preamble.write(req_var);
-                        try preamble.write("();\n");
+                        try preamble.writeCjsDirectDefault(preamble_name, req_var, false);
                     } else {
                         try preamble.writeCjsImport(preamble_name, ib.imported_name, req_var, ib.kind == .namespace, interop_mode);
                     }
@@ -516,11 +506,7 @@ pub fn buildMetadataForAst(
                     const interop_mode2: types.Interop = if (m.def_format.isEsm()) .node else .babel;
                     const effective_name = rb.canonical.export_name;
                     if (std.mem.eql(u8, effective_name, "default") and m.canUseDirectCjsDefaultImport(cjs_mod_opt.?)) {
-                        try preamble.write("var ");
-                        try preamble.write(preamble_name);
-                        try preamble.write(" = ");
-                        try preamble.write(req_var);
-                        try preamble.write("();\n");
+                        try preamble.writeCjsDirectDefault(preamble_name, req_var, false);
                     } else {
                         try preamble.writeCjsImport(preamble_name, effective_name, req_var, false, interop_mode2);
                     }

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1125,7 +1125,7 @@ test "preamble: CJS module import — named import generates require_xxx" {
     try std.testing.expect(std.mem.indexOf(u8, preamble, ".x") != null);
 }
 
-test "preamble: CJS module import — default import generates __toESM" {
+test "preamble: CJS module import — direct module.exports default import skips __toESM" {
     // ESM에서 CJS 모듈의 default import를 가져올 때
     // __toESM 래퍼가 생성되는지 검증
     var tmp = std.testing.tmpDir(.{});
@@ -1143,9 +1143,31 @@ test "preamble: CJS module import — default import generates __toESM" {
 
     try std.testing.expect(md.cjs_import_preamble != null);
     const preamble = md.cjs_import_preamble.?;
-    // __toESM 래퍼 포함
+    try std.testing.expect(std.mem.indexOf(u8, preamble, "__toESM(") == null);
+    try std.testing.expect(std.mem.indexOf(u8, preamble, ".default") == null);
+    try std.testing.expect(std.mem.indexOf(u8, preamble, "require_c()") != null);
+}
+
+test "preamble: CJS module import — __esModule marker keeps __toESM default import" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import foo from './c';\nconsole.log(foo);");
+    try writeFile(tmp.dir, "c.js",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\exports.default = 42;
+    );
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "entry.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    var md = try buildMetadataForModule(&r, 0, true);
+    defer md.deinit();
+
+    try std.testing.expect(md.cjs_import_preamble != null);
+    const preamble = md.cjs_import_preamble.?;
     try std.testing.expect(std.mem.indexOf(u8, preamble, "__toESM(") != null);
-    // .default 접근
     try std.testing.expect(std.mem.indexOf(u8, preamble, ".default") != null);
 }
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -189,6 +189,9 @@ pub const Module = struct {
     /// scanner가 `module.exports`/`exports.*` 런타임 export 신호를 본 경우.
     /// export-star fallback은 빈 type barrel이 임의 이름을 claim하지 않도록 이 값으로 제한한다.
     has_cjs_export_signal: bool = false,
+    /// CJS default import를 `__toESM(require_x()).default` 대신 `require_x()`로 낮출 수 있는지.
+    /// 직접 `module.exports = ...` shape이고 `__esModule`/exports member 신호가 없을 때만 true.
+    can_skip_cjs_default_interop: bool = false,
     /// 모듈 정의 형식 (확장자/package.json 기반, Rolldown ModuleDefFormat)
     def_format: types.ModuleDefFormat = .unknown,
     /// Top-Level Await 사용 여부. TLA 모듈을 static import하는 모듈도 전이적으로 true.
@@ -409,6 +412,12 @@ pub const Module = struct {
     pub fn interop(self: *const Module, importee: *const Module) ?types.Interop {
         if (importee.exports_kind != .commonjs) return null;
         return if (self.def_format.isEsm()) .node else .babel;
+    }
+
+    pub fn canUseDirectCjsDefaultImport(self: *const Module, importee: *const Module) bool {
+        return importee.wrap_kind == .cjs and
+            importee.can_skip_cjs_default_interop and
+            !self.def_format.isEsm();
     }
 
     /// 번들 출력 순서 comparator.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -420,6 +420,18 @@ pub const Module = struct {
             !self.def_format.isEsm();
     }
 
+    /// `module.exports = ...` shape 한정 fast path (default import 의 `__toESM` skip).
+    /// `__esModule` marker 또는 `exports.x` 할당이 같이 있으면 named export 가 진짜 있을 수 있어
+    /// fast path 가 부정확해진다. wrap_kind 가 .cjs 인 모듈에만 의미 있음.
+    pub fn computeCanSkipCjsDefaultInterop(
+        is_cjs: bool,
+        has_module_exports: bool,
+        has_exports_dot: bool,
+        has_esmodule_marker: bool,
+    ) bool {
+        return is_cjs and has_module_exports and !has_exports_dot and !has_esmodule_marker;
+    }
+
     /// 번들 출력 순서 comparator.
     /// 래핑된 모듈(__esm/__commonJS)을 scope-hoisted 모듈보다 먼저 배치.
     /// var init_xxx = __esm(...) 선언이 init_xxx() 호출보다 앞에 와야 하므로,

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -882,6 +882,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                     scanRequireCall(self, expr, arg_list);
                     scanGlobCall(self, expr, arg_list);
                     scanRequireContextCall(self, expr, arg_list, call_span);
+                    scanObjectDefinePropertyCjs(self, expr, arg_list);
                 }
 
                 expr = try self.ast.addNode(.{
@@ -2287,6 +2288,41 @@ fn scanRequireContextCall(self: *Parser, callee: NodeIndex, arg_list: NodeList, 
     self.scan_result.has_cjs_require = true;
 }
 
+fn scanObjectDefinePropertyCjs(self: *Parser, callee: NodeIndex, arg_list: NodeList) void {
+    if (callee.isNone() or @intFromEnum(callee) >= self.ast.nodes.items.len) return;
+    const callee_node = self.ast.nodes.items[@intFromEnum(callee)];
+    if (callee_node.tag != .static_member_expression) return;
+    const e = callee_node.data.extra;
+    if (e + 1 >= self.ast.extra_data.items.len) return;
+
+    const obj_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+    const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+    if (obj_idx.isNone() or prop_idx.isNone()) return;
+    if (@intFromEnum(obj_idx) >= self.ast.nodes.items.len or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) return;
+    const obj = self.ast.nodes.items[@intFromEnum(obj_idx)];
+    const prop = self.ast.nodes.items[@intFromEnum(prop_idx)];
+    if (obj.tag != .identifier_reference) return;
+    if (!std.mem.eql(u8, self.ast.source[obj.span.start..obj.span.end], "Object")) return;
+    if (!std.mem.eql(u8, self.ast.source[prop.span.start..prop.span.end], "defineProperty")) return;
+
+    if (arg_list.len < 1 or arg_list.start >= self.ast.extra_data.items.len) return;
+    const target_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[arg_list.start]);
+    if (!isCjsExportTarget(self, target_idx)) return;
+
+    self.scan_result.has_exports_dot = true;
+    if (arg_list.len >= 2 and arg_list.start + 1 < self.ast.extra_data.items.len) {
+        const key_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[arg_list.start + 1]);
+        if (key_idx.isNone() or @intFromEnum(key_idx) >= self.ast.nodes.items.len) return;
+        const key_node = self.ast.nodes.items[@intFromEnum(key_idx)];
+        if (key_node.tag != .string_literal) return;
+        const raw = self.ast.source[key_node.span.start..key_node.span.end];
+        const key = import_scanner.stripQuotes(raw) orelse raw;
+        if (std.mem.eql(u8, key, "__esModule")) {
+            self.scan_result.has_esmodule_marker = true;
+        }
+    }
+}
+
 /// assignment_expression의 left에서 module.exports = ... / exports.x = ... 패턴을 감지한다.
 /// import_scanner.isModuleExportsAssign / isExportsDotAssign와 동일한 로직.
 fn scanAssignmentCjs(self: *Parser, left: NodeIndex) void {
@@ -2318,6 +2354,14 @@ fn scanAssignmentCjs(self: *Parser, left: NodeIndex) void {
         }
     } else if (std.mem.eql(u8, obj_text, "exports")) {
         // exports.x = ...
+        const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
+        if (!prop_idx.isNone() and @intFromEnum(prop_idx) < self.ast.nodes.items.len) {
+            const prop = self.ast.nodes.items[@intFromEnum(prop_idx)];
+            const prop_text = self.ast.source[prop.span.start..prop.span.end];
+            if (std.mem.eql(u8, prop_text, "__esModule")) {
+                self.scan_result.has_esmodule_marker = true;
+            }
+        }
         self.scan_result.has_exports_dot = true;
     } else if (obj.tag == .static_member_expression) {
         const inner_me = obj.data.extra;
@@ -2334,9 +2378,37 @@ fn scanAssignmentCjs(self: *Parser, left: NodeIndex) void {
         const inner_prop_text = self.ast.source[inner_prop.span.start..inner_prop.span.end];
         if (std.mem.eql(u8, inner_obj_text, "module") and std.mem.eql(u8, inner_prop_text, "exports")) {
             // module.exports.x = ...
+            const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
+            if (!prop_idx.isNone() and @intFromEnum(prop_idx) < self.ast.nodes.items.len) {
+                const prop = self.ast.nodes.items[@intFromEnum(prop_idx)];
+                const prop_text = self.ast.source[prop.span.start..prop.span.end];
+                if (std.mem.eql(u8, prop_text, "__esModule")) {
+                    self.scan_result.has_esmodule_marker = true;
+                }
+            }
             self.scan_result.has_exports_dot = true;
         }
     }
+}
+
+fn isCjsExportTarget(self: *Parser, target_idx: NodeIndex) bool {
+    if (target_idx.isNone() or @intFromEnum(target_idx) >= self.ast.nodes.items.len) return false;
+    const target = self.ast.nodes.items[@intFromEnum(target_idx)];
+    if (target.tag == .identifier_reference and std.mem.eql(u8, self.ast.source[target.span.start..target.span.end], "exports")) {
+        return true;
+    }
+    if (target.tag != .static_member_expression) return false;
+    const e = target.data.extra;
+    if (e + 1 >= self.ast.extra_data.items.len) return false;
+    const obj_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+    const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+    if (obj_idx.isNone() or prop_idx.isNone()) return false;
+    if (@intFromEnum(obj_idx) >= self.ast.nodes.items.len or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) return false;
+    const obj = self.ast.nodes.items[@intFromEnum(obj_idx)];
+    const prop = self.ast.nodes.items[@intFromEnum(prop_idx)];
+    return obj.tag == .identifier_reference and
+        std.mem.eql(u8, self.ast.source[obj.span.start..obj.span.end], "module") and
+        std.mem.eql(u8, self.ast.source[prop.span.start..prop.span.end], "exports");
 }
 
 /// 문자열 리터럴에서 따옴표를 제거한다.

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -2317,14 +2317,15 @@ fn scanObjectDefinePropertyCjs(self: *Parser, callee: NodeIndex, arg_list: NodeL
         if (key_node.tag != .string_literal) return;
         const raw = self.ast.source[key_node.span.start..key_node.span.end];
         const key = import_scanner.stripQuotes(raw) orelse raw;
-        if (std.mem.eql(u8, key, "__esModule")) {
+        if (std.mem.eql(u8, key, import_scanner.ES_MODULE_MARKER)) {
             self.scan_result.has_esmodule_marker = true;
         }
     }
 }
 
 /// assignment_expression의 left에서 module.exports = ... / exports.x = ... 패턴을 감지한다.
-/// import_scanner.isModuleExportsAssign / isExportsDotAssign와 동일한 로직.
+/// import_scanner.isModuleExportsAssign / isExportsDotAssign / isEsModuleMarkerAssign 과
+/// 같은 신호를 set 한다 (parser/import_scanner 두 경로 모두 ScanResult 채움).
 fn scanAssignmentCjs(self: *Parser, left: NodeIndex) void {
     if (left.isNone()) return;
     if (@intFromEnum(left) >= self.ast.nodes.items.len) return;
@@ -2354,13 +2355,8 @@ fn scanAssignmentCjs(self: *Parser, left: NodeIndex) void {
         }
     } else if (std.mem.eql(u8, obj_text, "exports")) {
         // exports.x = ...
-        const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
-        if (!prop_idx.isNone() and @intFromEnum(prop_idx) < self.ast.nodes.items.len) {
-            const prop = self.ast.nodes.items[@intFromEnum(prop_idx)];
-            const prop_text = self.ast.source[prop.span.start..prop.span.end];
-            if (std.mem.eql(u8, prop_text, "__esModule")) {
-                self.scan_result.has_esmodule_marker = true;
-            }
+        if (memberPropertyEqualsEsModule(self, me)) {
+            self.scan_result.has_esmodule_marker = true;
         }
         self.scan_result.has_exports_dot = true;
     } else if (obj.tag == .static_member_expression) {
@@ -2378,17 +2374,22 @@ fn scanAssignmentCjs(self: *Parser, left: NodeIndex) void {
         const inner_prop_text = self.ast.source[inner_prop.span.start..inner_prop.span.end];
         if (std.mem.eql(u8, inner_obj_text, "module") and std.mem.eql(u8, inner_prop_text, "exports")) {
             // module.exports.x = ...
-            const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
-            if (!prop_idx.isNone() and @intFromEnum(prop_idx) < self.ast.nodes.items.len) {
-                const prop = self.ast.nodes.items[@intFromEnum(prop_idx)];
-                const prop_text = self.ast.source[prop.span.start..prop.span.end];
-                if (std.mem.eql(u8, prop_text, "__esModule")) {
-                    self.scan_result.has_esmodule_marker = true;
-                }
+            if (memberPropertyEqualsEsModule(self, me)) {
+                self.scan_result.has_esmodule_marker = true;
             }
             self.scan_result.has_exports_dot = true;
         }
     }
+}
+
+/// static_member_expression `obj.prop` 의 `me` extra index 에서 prop identifier 텍스트가
+/// `__esModule` 인지. 호출자가 obj 식별을 끝낸 뒤 prop 부분만 확인할 때 사용.
+fn memberPropertyEqualsEsModule(self: *Parser, me: u32) bool {
+    if (me + 1 >= self.ast.extra_data.items.len) return false;
+    const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + 1]);
+    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) return false;
+    const prop = self.ast.nodes.items[@intFromEnum(prop_idx)];
+    return std.mem.eql(u8, self.ast.source[prop.span.start..prop.span.end], import_scanner.ES_MODULE_MARKER);
 }
 
 fn isCjsExportTarget(self: *Parser, target_idx: NodeIndex) bool {

--- a/src/parser/scan_results.zig
+++ b/src/parser/scan_results.zig
@@ -113,4 +113,5 @@ pub const ScanResult = struct {
     has_cjs_require: bool = false,
     has_module_exports: bool = false,
     has_exports_dot: bool = false,
+    has_esmodule_marker: bool = false,
 };

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -2177,6 +2177,8 @@ describe("ESM default re-export CJS interop (#812)", () => {
   });
 
   test("번들 출력에 __toESM 포함, bare require().default 없음", async () => {
+    // `__esModule` marker 있는 CJS → fast path 비활성화 → 기존 __toESM/.default invariant 검증.
+    // marker 없는 직접 `module.exports = ...` 케이스의 fast path 는 cjs_esm 유닛 테스트가 커버.
     const fixture = await createFixture({
       "index.js": `
         import val from './re.js';
@@ -2186,7 +2188,10 @@ describe("ESM default re-export CJS interop (#812)", () => {
         import val from './cjs.js';
         export default val;
       `,
-      "cjs.js": `module.exports = "ok";`,
+      "cjs.js": `
+        Object.defineProperty(exports, "__esModule", { value: true });
+        exports.default = "ok";
+      `,
     });
     cleanup = fixture.cleanup;
     const outFile = join(fixture.dir, "out.js");

--- a/tests/integration/tests/runtime-helpers.test.ts
+++ b/tests/integration/tests/runtime-helpers.test.ts
@@ -133,9 +133,11 @@ describe("런타임 헬퍼: __copyProps / __toCommonJS", () => {
 
   test("번들 출력에 getOwnPropertyNames/getOwnPropertyDescriptor가 포함된다", async () => {
     // __copyProps가 rolldown 방식의 프로퍼티 열거를 사용하는지 번들 코드로 검증.
+    // `__esModule` marker 로 fast path (`require_x()` 직접 사용) 비활성화 → __toESM/__copyProps 강제 emit.
+    // `module.exports.__esModule` 형태로 marker 를 두어 wrapper body 에 "module.exports" 텍스트 유지.
     const { dir, cleanup: c } = await createFixture({
       "index.ts": `import mod from './cjs.js'; console.log(mod);`,
-      "cjs.js": `module.exports = { x: 1 };`,
+      "cjs.js": `module.exports = { x: 1 }; module.exports.__esModule = true;`,
     });
     cleanup = c;
 


### PR DESCRIPTION
## 요약

- `module.exports = ...` 형태가 직접 확인되고 `__esModule` 또는 `exports.*` / `module.exports.*` 신호가 없는 CJS 모듈에 보수적인 fast-path fact를 추가했습니다.
- production bundle에서 해당 CJS 모듈의 default import를 `__toESM(require_x()).default` 대신 `require_x()`로 emit합니다.
- 같은 predicate를 runtime helper 주입 판단에도 사용해서, fast-path default import만 있는 번들에는 `__toESM` helper cluster가 들어가지 않게 했습니다.
- namespace import, `__esModule` marker가 있는 경우, `.mjs`/Node interop 경로는 기존 `__toESM` 동작을 유지합니다.

## 검증

- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `bun test tests/integration/tests/tree-shake-precision.test.ts`
- `bun test tests/benchmark/smoke-diagnostics.test.ts`
- `bun run tests/benchmark/smoke.ts --filter=object-assign,merge-descriptors,cjs-module-exports-object-member-value,cjs-esmodule-marker-pruning,safe-buffer,cookie,path-to-regexp,axios,rxjs`
- `git diff --check`
- 수정한 Zig 파일 대상 `zig fmt`

참고: `bun run fmt` / `bun run fmt:check`는 현재 repo의 `oxfmt` 설정을 파싱하지 못해서 실행 전 실패합니다. 에러는 `sortImports.groups`의 unknown group `ts-equals-import`입니다.

## Rebase

- `2026-04-28` 기준 `origin/main` (`210d6519`) 위로 rebase했습니다.
- rebase 후 `zig build test --summary all --prominent-compile-errors`를 다시 통과했습니다.