### PR TITLE
minified __toESM 런타임 크기 축소

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -3285,10 +3285,13 @@ test "#1621 minify + decorator: __decorateClass/__decorateParam → $dC/$dK" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // decorator preamble: $dC (class/member) + $dK (param) + $dp2 (defProp2)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $dC=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $dK=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $dp2=Object.defineProperty") != null);
+    // decorator preamble: $dp2 + $gD + $dC + $dK 가 단일 var 선언 chain 으로 emit 된다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $dp2=Object.defineProperty,") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$dC=(decorators,target,key,kind)=>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$dK=(index,decorator)=>") != null);
+    // single var chain 회복: 중복 `var $dC=` / `var $dK=` 선언이 없어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $dC=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $dK=") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__decorateClass") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__decorateParam") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__defProp2") == null);

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2903,14 +2903,14 @@ test "#1621 minify: Object.* alias shortened ($dp/$cr/$gP/$gN/$gD/$hO/$cp)" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // Object.* alias 축약 선언 7종 전부 존재.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cr=Object.create") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $gP=Object.getPrototypeOf") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $dp=Object.defineProperty") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $gN=Object.getOwnPropertyNames") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $gD=Object.getOwnPropertyDescriptor") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $hO=Object.prototype.hasOwnProperty") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cp=") != null);
+    // Object.* alias 축약 선언 7종 전부 존재. 단일 var 선언으로 compact 될 수 있다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cr=Object.create,") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$gP=Object.getPrototypeOf") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$dp=Object.defineProperty") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$gN=Object.getOwnPropertyNames") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$gD=Object.getOwnPropertyDescriptor") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$hO=Object.prototype.hasOwnProperty") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$cp=") != null);
     // 원본 긴 이름 전부 미출현.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__create") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__getProtoOf") == null);
@@ -2919,6 +2919,82 @@ test "#1621 minify: Object.* alias shortened ($dp/$cr/$gP/$gN/$gD/$hO/$cp)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__getOwnPropDesc") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__hasOwn") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__copyProps") == null);
+}
+
+test "#1621 minify: __toESM compact __copyProps shape" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeToEsmFixture(tmp.dir);
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // Object.* alias는 하나의 var 선언으로 compact 되어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cr=Object.create,$gP=Object.getPrototypeOf,$dp=Object.defineProperty,$gN=Object.getOwnPropertyNames,$gD=Object.getOwnPropertyDescriptor,$hO=Object.prototype.hasOwnProperty,$cp=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ";var $gP=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ";var $dp=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ";var $gN=") == null);
+
+    // __copyProps는 내부 2-arg 호출만 사용하므로 except와 n 보조 변수를 다시 도입하지 않는다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "except") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "key!==") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "n=keys.length") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "i<n") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "i<keys.length") != null);
+
+    // 일반 minified variant는 짧은 arrow IIFE로 key를 capture하고 descriptor enumerable은 유지한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "get:(k=>()=>from[k])(key)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "enumerable:!(desc=$gD(from,key))||desc.enumerable") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "getOwnPropertyNames") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "getOwnPropertyDescriptor") != null);
+}
+
+test "#1621 minify+react-native: configurable __toESM stays ES5 and compact" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeToEsmFixture(tmp.dir);
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .platform = .react_native,
+        .configurable_exports = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // RN/Hermes variant는 ES5 function form과 configurable descriptor를 유지한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$cp=function(to,from,desc)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$tE=function(mod,isNodeMode,target)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "configurable:true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "get:(function(k){return from[k]}).bind(null,key)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "get:(k=>()=>from[k])(key)") == null);
+
+    // compacting invariant는 configurable variant에도 동일하게 적용된다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "except") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "key!==") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "n=keys.length") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "i<keys.length") != null);
 }
 
 test "#1621 minify: __commonJS body uses $r for __require" {

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -48,7 +48,9 @@ pub const CJS_RUNTIME_ES5_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=function(cb
 /// __esModule=true이면 원본 프로퍼티를 사용하되 default는 추가하지 않음.
 ///
 /// __copyProps: getOwnPropertyNames로 non-enumerable 포함 전체 프로퍼티를 복사하고,
-/// 원본 descriptor의 enumerable 플래그를 보존한다. bind로 key를 고정하여 var 루프에서도 안전.
+/// 원본 descriptor의 enumerable 플래그를 보존한다. key는 per-iteration으로 capture
+/// (비-min: bind, min: IIFE) 하여 var 루프에서도 안전.
+/// 호출자는 모두 2-arg (`__toESM`, `__toCommonJS`) 이므로 except 매개변수는 사용되지 않는다.
 /// 참고: references/rolldown/crates/rolldown/src/runtime/index.js:86
 pub const TOESM_RUNTIME =
     \\var __create = Object.create;
@@ -57,11 +59,11 @@ pub const TOESM_RUNTIME =
     \\var __getOwnPropNames = Object.getOwnPropertyNames;
     \\var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
     \\var __hasOwn = Object.prototype.hasOwnProperty;
-    \\var __copyProps = (to, from, except, desc) => {
+    \\var __copyProps = (to, from, desc) => {
     \\  if (from && typeof from === "object" || typeof from === "function") {
-    \\    for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+    \\    for (var keys = __getOwnPropNames(from), i = 0, key; i < keys.length; i++) {
     \\      key = keys[i];
-    \\      if (!__hasOwn.call(to, key) && key !== except)
+    \\      if (!__hasOwn.call(to, key))
     \\        __defProp(to, key, { get: ((k) => from[k]).bind(null, key), enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
     \\    }
     \\  }
@@ -97,11 +99,11 @@ pub const TOESM_RUNTIME_CONFIGURABLE =
     \\var __getOwnPropNames = Object.getOwnPropertyNames;
     \\var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
     \\var __hasOwn = Object.prototype.hasOwnProperty;
-    \\var __copyProps = function(to, from, except, desc) {
+    \\var __copyProps = function(to, from, desc) {
     \\  if (from && typeof from === "object" || typeof from === "function") {
-    \\    for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+    \\    for (var keys = __getOwnPropNames(from), i = 0, key; i < keys.length; i++) {
     \\      key = keys[i];
-    \\      if (!__hasOwn.call(to, key) && key !== except)
+    \\      if (!__hasOwn.call(to, key))
     \\        __defProp(to, key, { get: (function(k) { return from[k]; }).bind(null, key), enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable, configurable: true });
     \\    }
     \\  }
@@ -184,15 +186,15 @@ pub const DECORATOR_RUNTIME =
     \\
 ;
 pub const DECORATOR_RUNTIME_MIN =
-    "var " ++ NAMES.DEF_PROP_2_MIN ++ "=Object.defineProperty;" ++
-    "var " ++ NAMES.GET_OWN_PROP_DESC_MIN ++ "=Object.getOwnPropertyDescriptor;" ++
-    "var " ++ NAMES.DECORATE_CLASS_MIN ++ "=(decorators,target,key,kind)=>{" ++
+    "var " ++ NAMES.DEF_PROP_2_MIN ++ "=Object.defineProperty," ++
+    NAMES.GET_OWN_PROP_DESC_MIN ++ "=Object.getOwnPropertyDescriptor," ++
+    NAMES.DECORATE_CLASS_MIN ++ "=(decorators,target,key,kind)=>{" ++
     "var result=kind>1?void 0:kind?" ++ NAMES.GET_OWN_PROP_DESC_MIN ++ "(target,key):target;" ++
     "for(var i=decorators.length-1,decorator;i>=0;i--)" ++
     "if(decorator=decorators[i])result=(kind?decorator(target,key,result):decorator(result))||result;" ++
     "if(kind&&result)" ++ NAMES.DEF_PROP_2_MIN ++ "(target,key,result);" ++
-    "return result};" ++
-    "var " ++ NAMES.DECORATE_PARAM_MIN ++ "=(index,decorator)=>(target,key)=>decorator(target,key,index);";
+    "return result}," ++
+    NAMES.DECORATE_PARAM_MIN ++ "=(index,decorator)=>(target,key)=>decorator(target,key,index);";
 
 /// __metadata: emitDecoratorMetadata 시 Reflect.metadata 호출 (TypeScript 호환).
 /// design:type, design:paramtypes, design:returntype 메타데이터를 클래스/멤버에 부착.

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -71,18 +71,18 @@ pub const TOESM_RUNTIME =
     \\
 ;
 pub const TOESM_RUNTIME_MIN =
-    "var " ++ NAMES.CREATE_MIN ++ "=Object.create;" ++
-    "var " ++ NAMES.GET_PROTO_OF_MIN ++ "=Object.getPrototypeOf;" ++
-    "var " ++ NAMES.DEF_PROP_MIN ++ "=Object.defineProperty;" ++
-    "var " ++ NAMES.GET_OWN_PROP_NAMES_MIN ++ "=Object.getOwnPropertyNames;" ++
-    "var " ++ NAMES.GET_OWN_PROP_DESC_MIN ++ "=Object.getOwnPropertyDescriptor;" ++
-    "var " ++ NAMES.HAS_OWN_MIN ++ "=Object.prototype.hasOwnProperty;" ++
-    "var " ++ NAMES.COPY_PROPS_MIN ++ "=(to,from,except,desc)=>{" ++
+    "var " ++ NAMES.CREATE_MIN ++ "=Object.create," ++
+    NAMES.GET_PROTO_OF_MIN ++ "=Object.getPrototypeOf," ++
+    NAMES.DEF_PROP_MIN ++ "=Object.defineProperty," ++
+    NAMES.GET_OWN_PROP_NAMES_MIN ++ "=Object.getOwnPropertyNames," ++
+    NAMES.GET_OWN_PROP_DESC_MIN ++ "=Object.getOwnPropertyDescriptor," ++
+    NAMES.HAS_OWN_MIN ++ "=Object.prototype.hasOwnProperty," ++
+    NAMES.COPY_PROPS_MIN ++ "=(to,from,desc)=>{" ++
     "if(from&&typeof from===\"object\"||typeof from===\"function\"){" ++
-    "for(var keys=" ++ NAMES.GET_OWN_PROP_NAMES_MIN ++ "(from),i=0,n=keys.length,key;i<n;i++){" ++
+    "for(var keys=" ++ NAMES.GET_OWN_PROP_NAMES_MIN ++ "(from),i=0,key;i<keys.length;i++){" ++
     "key=keys[i];" ++
-    "if(!" ++ NAMES.HAS_OWN_MIN ++ ".call(to,key)&&key!==except)" ++
-    NAMES.DEF_PROP_MIN ++ "(to,key,{get:((k)=>from[k]).bind(null,key),enumerable:!(desc=" ++ NAMES.GET_OWN_PROP_DESC_MIN ++ "(from,key))||desc.enumerable})" ++
+    "if(!" ++ NAMES.HAS_OWN_MIN ++ ".call(to,key))" ++
+    NAMES.DEF_PROP_MIN ++ "(to,key,{get:(k=>()=>from[k])(key),enumerable:!(desc=" ++ NAMES.GET_OWN_PROP_DESC_MIN ++ "(from,key))||desc.enumerable})" ++
     "}}return to};" ++
     "var " ++ NAMES.TOESM_MIN ++ "=(mod,isNodeMode,target)=>(" ++
     "target=mod!=null?" ++ NAMES.CREATE_MIN ++ "(" ++ NAMES.GET_PROTO_OF_MIN ++ "(mod)):{}," ++
@@ -111,17 +111,17 @@ pub const TOESM_RUNTIME_CONFIGURABLE =
     \\
 ;
 pub const TOESM_RUNTIME_CONFIGURABLE_MIN =
-    "var " ++ NAMES.CREATE_MIN ++ "=Object.create;" ++
-    "var " ++ NAMES.GET_PROTO_OF_MIN ++ "=Object.getPrototypeOf;" ++
-    "var " ++ NAMES.DEF_PROP_MIN ++ "=Object.defineProperty;" ++
-    "var " ++ NAMES.GET_OWN_PROP_NAMES_MIN ++ "=Object.getOwnPropertyNames;" ++
-    "var " ++ NAMES.GET_OWN_PROP_DESC_MIN ++ "=Object.getOwnPropertyDescriptor;" ++
-    "var " ++ NAMES.HAS_OWN_MIN ++ "=Object.prototype.hasOwnProperty;" ++
-    "var " ++ NAMES.COPY_PROPS_MIN ++ "=function(to,from,except,desc){" ++
+    "var " ++ NAMES.CREATE_MIN ++ "=Object.create," ++
+    NAMES.GET_PROTO_OF_MIN ++ "=Object.getPrototypeOf," ++
+    NAMES.DEF_PROP_MIN ++ "=Object.defineProperty," ++
+    NAMES.GET_OWN_PROP_NAMES_MIN ++ "=Object.getOwnPropertyNames," ++
+    NAMES.GET_OWN_PROP_DESC_MIN ++ "=Object.getOwnPropertyDescriptor," ++
+    NAMES.HAS_OWN_MIN ++ "=Object.prototype.hasOwnProperty," ++
+    NAMES.COPY_PROPS_MIN ++ "=function(to,from,desc){" ++
     "if(from&&typeof from===\"object\"||typeof from===\"function\"){" ++
-    "for(var keys=" ++ NAMES.GET_OWN_PROP_NAMES_MIN ++ "(from),i=0,n=keys.length,key;i<n;i++){" ++
+    "for(var keys=" ++ NAMES.GET_OWN_PROP_NAMES_MIN ++ "(from),i=0,key;i<keys.length;i++){" ++
     "key=keys[i];" ++
-    "if(!" ++ NAMES.HAS_OWN_MIN ++ ".call(to,key)&&key!==except)" ++
+    "if(!" ++ NAMES.HAS_OWN_MIN ++ ".call(to,key))" ++
     NAMES.DEF_PROP_MIN ++ "(to,key,{get:(function(k){return from[k]}).bind(null,key),enumerable:!(desc=" ++ NAMES.GET_OWN_PROP_DESC_MIN ++ "(from,key))||desc.enumerable,configurable:true})" ++
     "}}return to};" ++
     "var " ++ NAMES.TOESM_MIN ++ "=function(mod,isNodeMode,target){" ++


### PR DESCRIPTION
## 요약
- minified `__toESM` 런타임의 Object alias 선언을 단일 `var` 선언으로 합쳤습니다.
- 내부 2-arg 호출만 사용하는 `__copyProps`에서 미사용 `except` 매개변수와 조건, `n=keys.length` 보조 변수를 제거했습니다.
- 일반 minified variant는 더 짧은 arrow IIFE getter capture를 사용하고, RN/Hermes configurable minified variant는 ES5 function form과 `configurable:true`를 유지합니다.
- minified 출력 shape 회귀 테스트를 강화해 compact invariant와 RN configurable invariant를 직접 검증합니다.

## 테스트
- `zig fmt src/bundler/runtime_helpers.zig src/bundler/bundler_test/minify_loader.zig`
- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `bun test --timeout 20000 tests/benchmark/smoke-diagnostics.test.ts`
- `bun run tests/benchmark/smoke.ts --filter=object-assign,merge-descriptors,cjs-esmodule-marker-pruning,safe-buffer,cookie,path-to-regexp,axios,rxjs`
- `git diff --check`

## 참고
- `bun run fmt && bun run fmt:check`는 기존 `oxfmt` 설정 오류(`sortImports.groups`의 알 수 없는 `ts-equals-import`)로 실행 전 단계에서 실패합니다. formatter 설정은 이 PR 범위에서 건드리지 않았습니다.