### PR TITLE
feat(config): .ts/.js config self-compile loader

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -128,6 +128,9 @@ export function defineConfig<T extends Partial<BuildOptions>>(config: T): T {
   return config;
 }
 
+export { loadConfig } from "./src/config-loader";
+export type { UserConfig } from "./src/config-loader";
+
 /**
  * NAPI 모듈을 로드한다.
  * 이미 로드된 경우 무시한다.

--- a/packages/core/src/config-loader.test.ts
+++ b/packages/core/src/config-loader.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { init } from "../index";
+import { loadConfig } from "./config-loader";
+
+beforeAll(() => init());
+
+describe("loadConfig", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-config-loader-"));
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  test(".ts: TS 문법 + export default 로드", async () => {
+    const path = join(dir, "ts.config.ts");
+    writeFileSync(
+      path,
+      `interface Cfg { format: string; entryPoints: string[] }
+       const cfg: Cfg = { format: "esm", entryPoints: ["./src/index.ts"] };
+       export default cfg;`,
+    );
+    const config = await loadConfig(path);
+    expect(config).toEqual({ format: "esm", entryPoints: ["./src/index.ts"] });
+  });
+
+  test(".mts: TS export default", async () => {
+    const path = join(dir, "mts.config.mts");
+    writeFileSync(path, `export default { format: "cjs" as const };`);
+    const config = await loadConfig(path);
+    expect(config).toEqual({ format: "cjs" });
+  });
+
+  test(".cts: TS export default", async () => {
+    const path = join(dir, "cts.config.cts");
+    writeFileSync(path, `export default { minify: true };`);
+    const config = await loadConfig(path);
+    expect(config).toEqual({ minify: true });
+  });
+
+  test(".mjs: ESM export default", async () => {
+    const path = join(dir, "mjs.config.mjs");
+    writeFileSync(path, `export default { format: "esm" };`);
+    const config = await loadConfig(path);
+    expect(config).toEqual({ format: "esm" });
+  });
+
+  test(".js: ESM export default (Bun 실행 환경)", async () => {
+    const path = join(dir, "js.config.js");
+    writeFileSync(path, `export default { format: "esm" };`);
+    const config = await loadConfig(path);
+    expect(config).toEqual({ format: "esm" });
+  });
+
+  test(".cjs: CommonJS module.exports", async () => {
+    const path = join(dir, "cjs.config.cjs");
+    writeFileSync(path, `module.exports = { format: "cjs" };`);
+    const config = await loadConfig(path);
+    expect(config).toEqual({ format: "cjs" });
+  });
+
+  test(".json: 그대로 파싱", async () => {
+    const path = join(dir, "json.config.json");
+    writeFileSync(path, `{"format":"esm","minify":true}`);
+    const config = await loadConfig(path);
+    expect(config).toEqual({ format: "esm", minify: true });
+  });
+
+  test("defineConfig 헬퍼로 정의된 객체 로드", async () => {
+    const path = join(dir, "define.config.ts");
+    writeFileSync(
+      path,
+      `import { defineConfig } from "${resolveImportPath()}";
+       export default defineConfig({ format: "esm", entryPoints: ["./a.ts"] });`,
+    );
+    const config = await loadConfig(path);
+    expect(config).toEqual({ format: "esm", entryPoints: ["./a.ts"] });
+  });
+
+  test("default export 가 없으면 namespace 객체로 fallback", async () => {
+    const path = join(dir, "named.config.mjs");
+    writeFileSync(path, `export const format = "esm"; export const minify = false;`);
+    const config = await loadConfig(path);
+    expect(config.format).toBe("esm");
+    expect(config.minify).toBe(false);
+  });
+
+  test("파일 부재 시 명확한 에러", async () => {
+    const path = join(dir, "does-not-exist.config.ts");
+    await expect(loadConfig(path)).rejects.toThrow(/config file not found/);
+  });
+
+  test("미지원 확장자 거부", async () => {
+    const path = join(dir, "weird.config.toml");
+    writeFileSync(path, `format = "esm"`);
+    await expect(loadConfig(path)).rejects.toThrow(/unsupported config extension/);
+  });
+
+  test("TS 컴파일 실패 시 사용자에게 에러 노출", async () => {
+    const path = join(dir, "broken.config.ts");
+    writeFileSync(path, `export default { format: "esm" `); // 닫는 brace 없음
+    await expect(loadConfig(path)).rejects.toThrow();
+  });
+
+  test("JSON 파싱 실패 시 친절한 에러", async () => {
+    const path = join(dir, "broken.config.json");
+    writeFileSync(path, `{ "format": "esm",,, }`);
+    await expect(loadConfig(path)).rejects.toThrow(/failed to parse JSON config/);
+  });
+
+  test("non-object export 거부 (배열/숫자)", async () => {
+    const path = join(dir, "array.config.mjs");
+    writeFileSync(path, `export default [1, 2, 3];`);
+    await expect(loadConfig(path)).rejects.toThrow(/must export an object/);
+  });
+
+  // watch 재로드 (mtime 기반 cache-bust) 는 #2107 (Phase 2-5) 에서 본격 처리.
+  // .ts/.mts/.cts 경로는 매 호출마다 새 tmp 파일을 생성하므로 자연스럽게 캐시를 우회한다.
+  test(".ts 재호출: 매번 fresh transpile (tmp 파일 random)", async () => {
+    const path = join(dir, "rerun.config.ts");
+    writeFileSync(path, `export default { format: "esm" as const };`);
+    const first = await loadConfig(path);
+    expect(first.format).toBe("esm");
+
+    writeFileSync(path, `export default { format: "cjs" as const };`);
+    const second = await loadConfig(path);
+    expect(second.format).toBe("cjs");
+  });
+});
+
+function resolveImportPath(): string {
+  // 테스트에서 임시 디렉토리에 작성된 .ts config 가 @zts/core 의 defineConfig 를
+  // import 하려면 절대 경로 또는 file:// URL 이 필요하다. 여기서는 packages/core/index.ts
+  // 의 절대 경로를 반환한다.
+  const here = new URL(import.meta.url);
+  // src/config-loader.test.ts → ../index.ts
+  const indexUrl = new URL("../index.ts", here);
+  return indexUrl.href;
+}

--- a/packages/core/src/config-loader.test.ts
+++ b/packages/core/src/config-loader.test.ts
@@ -73,9 +73,12 @@ describe("loadConfig", () => {
 
   test("defineConfig 헬퍼로 정의된 객체 로드", async () => {
     const path = join(dir, "define.config.ts");
+    // packages/core/index.ts 를 file:// URL 로 참조 — 임시 디렉토리에 작성된
+    // .ts config 가 ZTS transpile 후 동적 import 될 때 절대 경로로 해석.
+    const indexUrl = new URL("../index.ts", import.meta.url).href;
     writeFileSync(
       path,
-      `import { defineConfig } from "${resolveImportPath()}";
+      `import { defineConfig } from "${indexUrl}";
        export default defineConfig({ format: "esm", entryPoints: ["./a.ts"] });`,
     );
     const config = await loadConfig(path);
@@ -132,13 +135,3 @@ describe("loadConfig", () => {
     expect(second.format).toBe("cjs");
   });
 });
-
-function resolveImportPath(): string {
-  // 테스트에서 임시 디렉토리에 작성된 .ts config 가 @zts/core 의 defineConfig 를
-  // import 하려면 절대 경로 또는 file:// URL 이 필요하다. 여기서는 packages/core/index.ts
-  // 의 절대 경로를 반환한다.
-  const here = new URL(import.meta.url);
-  // src/config-loader.test.ts → ../index.ts
-  const indexUrl = new URL("../index.ts", here);
-  return indexUrl.href;
-}

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -9,7 +9,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, extname, join, resolve as pathResolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -25,14 +25,13 @@ const JS_EXTS = new Set([".mjs", ".js", ".cjs"]);
 /**
  * config 파일을 로드한다. 확장자에 따라 self-compile 또는 직접 import.
  *
- * @throws path 가 존재하지 않거나, 확장자가 지원되지 않거나, 컴파일/평가가 실패하면 throw.
+ * 존재 여부는 사전 stat 으로 확인하지 않고 실제 read/import 의 ENOENT 를 catch
+ * 한다 — TOCTOU 회피 + 1 syscall 절감.
+ *
+ * @throws 파일이 없거나, 확장자가 지원되지 않거나, 컴파일/평가가 실패하면 throw.
  */
 export async function loadConfig(filePath: string): Promise<UserConfig> {
   const absPath = pathResolve(filePath);
-  if (!existsSync(absPath)) {
-    throw new Error(`@zts/core: config file not found: ${absPath}`);
-  }
-
   const ext = extname(absPath).toLowerCase();
 
   if (ext === ".json") {
@@ -50,7 +49,7 @@ export async function loadConfig(filePath: string): Promise<UserConfig> {
 }
 
 function loadJsonConfig(absPath: string): UserConfig {
-  const raw = readFileSync(absPath, "utf8");
+  const raw = readFileOrThrowNotFound(absPath);
   try {
     return JSON.parse(raw) as UserConfig;
   } catch (err) {
@@ -61,10 +60,12 @@ function loadJsonConfig(absPath: string): UserConfig {
 
 async function loadTsConfig(absPath: string): Promise<UserConfig> {
   init();
-  const source = readFileSync(absPath, "utf8");
-  // ZTS 는 `.cts` 를 CommonJS-only TS 로 취급해 ESM 구문을 거부한다.
-  // 사용자가 `.cts` 에 `export default {...}` 를 쓴 의도는 TS 식 ESM 이므로
-  // 파싱 단계에서만 `.ts` 로 가장한다 (에러 메시지에는 실제 경로 사용).
+  const source = readFileOrThrowNotFound(absPath);
+  // ZTS parser 는 filename 의 `.cts` 확장자를 보고 CommonJS Script 모드로 진입해
+  // 최상위 `export default` 를 거부한다 (`src/parser/parser.zig:283` 부근). 사용자가
+  // `.cts` 에 `export default {...}` 를 쓴 의도는 TS 식 ESM 이므로 파싱 단계에서만
+  // 가상의 `.ts` 로 호출한다 — 에러 메시지·sourcemap 에는 실제 경로가 그대로 사용된다.
+  // FIXME: `transpile()` 에 `moduleType: "module"` 같은 명시 옵션이 추가되면 이전.
   const parseFilename = absPath.endsWith(".cts") ? absPath.slice(0, -4) + ".ts" : absPath;
   const result = transpile(source, {
     filename: parseFilename,
@@ -82,8 +83,9 @@ async function loadTsConfig(absPath: string): Promise<UserConfig> {
   } finally {
     try {
       unlinkSync(tmpPath);
-    } catch {
-      // 삭제 실패는 무시 — 사용자가 추후 정리 가능
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(`@zts/core: failed to remove tmp config ${tmpPath}: ${reason}`);
     }
   }
 }
@@ -93,9 +95,18 @@ async function loadJsConfig(absPath: string): Promise<UserConfig> {
 }
 
 async function importAndResolveDefault(absPath: string): Promise<UserConfig> {
-  // cache-bust 쿼리: watch 모드에서 같은 경로의 config 가 재로드되어야 한다.
-  const url = pathToFileURL(absPath).href + `?t=${Date.now()}`;
-  const mod = await import(url);
+  // 같은 프로세스에서 다중 reload 가 필요한 watch (#2107) 는 별도 cache-bust 적용 예정.
+  const url = pathToFileURL(absPath).href;
+  let mod: Record<string, unknown>;
+  try {
+    mod = await import(url);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ERR_MODULE_NOT_FOUND" || code === "ENOENT") {
+      throw new Error(`@zts/core: config file not found: ${absPath}`);
+    }
+    throw err;
+  }
   const config = (mod as { default?: unknown }).default ?? mod;
   if (typeof config !== "object" || config === null || Array.isArray(config)) {
     throw new Error(
@@ -103,4 +114,15 @@ async function importAndResolveDefault(absPath: string): Promise<UserConfig> {
     );
   }
   return config as UserConfig;
+}
+
+function readFileOrThrowNotFound(absPath: string): string {
+  try {
+    return readFileSync(absPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`@zts/core: config file not found: ${absPath}`);
+    }
+    throw err;
+  }
 }

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -1,0 +1,106 @@
+/**
+ * zts.config.{ts,mts,cts,mjs,js,cjs,json} 로더.
+ *
+ * `.ts/.mts/.cts` 는 NAPI `transpile()` 로 self-compile 후 dynamic import.
+ * `.mjs/.js/.cjs` 는 직접 dynamic import. `.json` 은 readFileSync + JSON.parse.
+ *
+ * tmp 파일은 config 옆에 작성해 사용자의 node_modules resolution 을 보존한다
+ * (esbuild `esbuild.config.bundled-*.mjs` 패턴).
+ */
+
+import { randomBytes } from "node:crypto";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, extname, join, resolve as pathResolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { BuildOptions } from "../index";
+import { init, transpile } from "../index";
+
+/** Phase 1: 객체만 지원. 함수형 (Vite 식 `({ command, mode, env }) => ...`) 은 #2103 (Phase 2-1) 에서 추가. */
+export type UserConfig = Partial<BuildOptions>;
+
+const TS_EXTS = new Set([".ts", ".mts", ".cts"]);
+const JS_EXTS = new Set([".mjs", ".js", ".cjs"]);
+
+/**
+ * config 파일을 로드한다. 확장자에 따라 self-compile 또는 직접 import.
+ *
+ * @throws path 가 존재하지 않거나, 확장자가 지원되지 않거나, 컴파일/평가가 실패하면 throw.
+ */
+export async function loadConfig(filePath: string): Promise<UserConfig> {
+  const absPath = pathResolve(filePath);
+  if (!existsSync(absPath)) {
+    throw new Error(`@zts/core: config file not found: ${absPath}`);
+  }
+
+  const ext = extname(absPath).toLowerCase();
+
+  if (ext === ".json") {
+    return loadJsonConfig(absPath);
+  }
+  if (TS_EXTS.has(ext)) {
+    return loadTsConfig(absPath);
+  }
+  if (JS_EXTS.has(ext)) {
+    return loadJsConfig(absPath);
+  }
+  throw new Error(
+    `@zts/core: unsupported config extension "${ext}" for ${absPath}. Supported: .ts/.mts/.cts/.mjs/.js/.cjs/.json`,
+  );
+}
+
+function loadJsonConfig(absPath: string): UserConfig {
+  const raw = readFileSync(absPath, "utf8");
+  try {
+    return JSON.parse(raw) as UserConfig;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`@zts/core: failed to parse JSON config ${absPath}: ${reason}`);
+  }
+}
+
+async function loadTsConfig(absPath: string): Promise<UserConfig> {
+  init();
+  const source = readFileSync(absPath, "utf8");
+  // ZTS 는 `.cts` 를 CommonJS-only TS 로 취급해 ESM 구문을 거부한다.
+  // 사용자가 `.cts` 에 `export default {...}` 를 쓴 의도는 TS 식 ESM 이므로
+  // 파싱 단계에서만 `.ts` 로 가장한다 (에러 메시지에는 실제 경로 사용).
+  const parseFilename = absPath.endsWith(".cts") ? absPath.slice(0, -4) + ".ts" : absPath;
+  const result = transpile(source, {
+    filename: parseFilename,
+    format: "esm",
+  });
+  if (result.errors) {
+    throw new Error(`@zts/core: config compile failed in ${absPath}\n${result.errors}`);
+  }
+
+  const tmpName = `.zts-config.bundled-${randomBytes(6).toString("hex")}.mjs`;
+  const tmpPath = join(dirname(absPath), tmpName);
+  writeFileSync(tmpPath, result.code, "utf8");
+  try {
+    return await importAndResolveDefault(tmpPath);
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // 삭제 실패는 무시 — 사용자가 추후 정리 가능
+    }
+  }
+}
+
+async function loadJsConfig(absPath: string): Promise<UserConfig> {
+  return importAndResolveDefault(absPath);
+}
+
+async function importAndResolveDefault(absPath: string): Promise<UserConfig> {
+  // cache-bust 쿼리: watch 모드에서 같은 경로의 config 가 재로드되어야 한다.
+  const url = pathToFileURL(absPath).href + `?t=${Date.now()}`;
+  const mod = await import(url);
+  const config = (mod as { default?: unknown }).default ?? mod;
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    throw new Error(
+      `@zts/core: config must export an object (got ${Array.isArray(config) ? "array" : typeof config}) from ${absPath}`,
+    );
+  }
+  return config as UserConfig;
+}


### PR DESCRIPTION
## 요약
- `zts.config.{ts,mts,cts,mjs,js,cjs,json}` 7종 확장자 로드.
- `.ts/.mts/.cts` 는 NAPI `transpile()` 로 self-compile 후 dynamic import.
- tmp 파일은 config 옆에 작성해 사용자 `node_modules` resolution 을 보존 (esbuild `*.bundled-*.mjs` 패턴).
- `.cts` 는 ZTS 가 CJS-only 로 취급하므로 파싱 단계에서만 `.ts` 로 가장 (에러 메시지에는 실제 경로 유지).

## 비범위
- 자동 탐색 — #2102 (Phase 1-3)
- BuildOptions 머지 — #2101 (Phase 1-2)
- 함수형 config + watch reload — #2103, #2107 (Phase 2)

## 테스트
- `bun test packages/core/src/config-loader.test.ts` — 15 pass
- `zig build test` — 4016/4016 pass
- `bun run lint` / `bun run fmt:check` — 통과

Closes #2100. Part of #2099.