### PR TITLE
feat(cli): zts.config.{ts,mjs,js,cjs,json} 자동 탐색

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -128,7 +128,7 @@ export function defineConfig<T extends Partial<BuildOptions>>(config: T): T {
   return config;
 }
 
-export { loadConfig } from "./src/config-loader";
+export { findConfigPath, loadConfig } from "./src/config-loader";
 export type { UserConfig } from "./src/config-loader";
 
 /**

--- a/packages/core/src/config-loader.test.ts
+++ b/packages/core/src/config-loader.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { init } from "../index";
-import { loadConfig } from "./config-loader";
+import { CONFIG_EXT_PRIORITY, findConfigPath, loadConfig } from "./config-loader";
 
 beforeAll(() => init());
 
@@ -133,5 +133,83 @@ describe("loadConfig", () => {
     writeFileSync(path, `export default { format: "cjs" as const };`);
     const second = await loadConfig(path);
     expect(second.format).toBe("cjs");
+  });
+});
+
+describe("findConfigPath", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-find-config-"));
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  function reset() {
+    rmSync(dir, { recursive: true, force: true });
+    require("node:fs").mkdirSync(dir);
+  }
+
+  test("config 부재 시 null", () => {
+    reset();
+    expect(findConfigPath(dir)).toBeNull();
+  });
+
+  test(".ts 단독", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.ts"), `export default {};`);
+    expect(findConfigPath(dir)).toBe(join(dir, "zts.config.ts"));
+  });
+
+  test(".json 단독", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.json"), `{}`);
+    expect(findConfigPath(dir)).toBe(join(dir, "zts.config.json"));
+  });
+
+  test("우선순위: .ts > .mts > .cts > .mjs > .js > .cjs > .json", () => {
+    // CONFIG_EXT_PRIORITY 가 [".ts", ".mts", ".cts", ".mjs", ".js", ".cjs", ".json"] 임을 검증.
+    reset();
+    // 모든 확장자 동시 존재 → .ts 선택
+    for (const ext of CONFIG_EXT_PRIORITY) {
+      writeFileSync(join(dir, `zts.config${ext}`), ext === ".json" ? "{}" : `export default {};`);
+    }
+    expect(findConfigPath(dir)).toBe(join(dir, "zts.config.ts"));
+  });
+
+  test("점진적 fallback: .ts 만 제거하면 .mts", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.mts"), `export default {};`);
+    writeFileSync(join(dir, "zts.config.json"), `{}`);
+    expect(findConfigPath(dir)).toBe(join(dir, "zts.config.mts"));
+  });
+
+  test("점진적 fallback: .mjs 단독이면 .mjs", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.mjs"), `export default {};`);
+    expect(findConfigPath(dir)).toBe(join(dir, "zts.config.mjs"));
+  });
+
+  test("점진적 fallback: .cjs 단독이면 .cjs", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.cjs"), `module.exports = {};`);
+    expect(findConfigPath(dir)).toBe(join(dir, "zts.config.cjs"));
+  });
+
+  test("findConfigPath + loadConfig 통합", async () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.ts"), `export default { format: "esm" as const };`);
+    const path = findConfigPath(dir);
+    expect(path).toBe(join(dir, "zts.config.ts"));
+    const config = await loadConfig(path!);
+    expect(config.format).toBe("esm");
+  });
+
+  test("zts.config 가 아닌 다른 이름은 무시", () => {
+    reset();
+    writeFileSync(join(dir, "zts.ts"), `export default {};`);
+    writeFileSync(join(dir, "config.ts"), `export default {};`);
+    writeFileSync(join(dir, "zts-config.ts"), `export default {};`);
+    expect(findConfigPath(dir)).toBeNull();
   });
 });

--- a/packages/core/src/config-loader.test.ts
+++ b/packages/core/src/config-loader.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -147,7 +147,7 @@ describe("findConfigPath", () => {
 
   function reset() {
     rmSync(dir, { recursive: true, force: true });
-    require("node:fs").mkdirSync(dir);
+    mkdirSync(dir);
   }
 
   test("config 부재 시 null", () => {

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -19,8 +19,16 @@ import { init, transpile } from "../index";
 /** Phase 1: 객체만 지원. 함수형 (Vite 식 `({ command, mode, env }) => ...`) 은 #2103 (Phase 2-1) 에서 추가. */
 export type UserConfig = Partial<BuildOptions>;
 
-const TS_EXTS = new Set([".ts", ".mts", ".cts"]);
-const JS_EXTS = new Set([".mjs", ".js", ".cjs"]);
+/**
+ * 자동 탐색 우선순위. 동일 디렉토리에 다중 확장자 존재 시 첫 매치 반환.
+ * 사용자가 의도적으로 여러 형식을 두는 경우는 거의 없으므로 silent precedence 로 충분.
+ *
+ * 같은 배열에서 `TS_EXTS`/`JS_EXTS` 를 derive — 새 확장자 추가 시 한 곳만 고침.
+ */
+export const CONFIG_EXT_PRIORITY = [".ts", ".mts", ".cts", ".mjs", ".js", ".cjs", ".json"] as const;
+
+const TS_EXTS = new Set<string>(CONFIG_EXT_PRIORITY.slice(0, 3));
+const JS_EXTS = new Set<string>(CONFIG_EXT_PRIORITY.slice(3, 6));
 
 /**
  * config 파일을 로드한다. 확장자에 따라 self-compile 또는 직접 import.
@@ -128,15 +136,14 @@ function readFileOrThrowNotFound(absPath: string): string {
 }
 
 /**
- * 자동 탐색 우선순위. 동일 디렉토리에 다중 확장자 존재 시 첫 매치 반환.
- * 사용자가 의도적으로 여러 형식을 두는 경우는 거의 없으므로 silent precedence 로 충분.
- */
-export const CONFIG_EXT_PRIORITY = [".ts", ".mts", ".cts", ".mjs", ".js", ".cjs", ".json"] as const;
-
-/**
  * cwd 에서 `zts.config.*` 자동 탐색. 우선순위는 `CONFIG_EXT_PRIORITY` 참조.
  *
+ * 동기 stat (`existsSync`) 사용 — CLI 시작 시 한 번만 호출되므로 비용 무시 가능.
  * parent 디렉토리 traversal 은 모노레포 워크스페이스 (#2111 / Phase 3-4) 에서 처리.
+ *
+ * Note: Zig CLI (`src/main.zig:293` `applyZtsConfigJson`) 은 현재 `.json` 만
+ * 직접 처리한다. 다른 확장자는 JS CLI (`zts.mjs`) 만 자동 탐색하므로 두 경로의
+ * 동작이 의도적으로 갈린다. 통합은 #2105 (Phase 2-3 bundler 옵션 매핑) 에서.
  */
 export function findConfigPath(cwd: string): string | null {
   for (const ext of CONFIG_EXT_PRIORITY) {

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -9,7 +9,7 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, extname, join, resolve as pathResolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -125,4 +125,23 @@ function readFileOrThrowNotFound(absPath: string): string {
     }
     throw err;
   }
+}
+
+/**
+ * 자동 탐색 우선순위. 동일 디렉토리에 다중 확장자 존재 시 첫 매치 반환.
+ * 사용자가 의도적으로 여러 형식을 두는 경우는 거의 없으므로 silent precedence 로 충분.
+ */
+export const CONFIG_EXT_PRIORITY = [".ts", ".mts", ".cts", ".mjs", ".js", ".cjs", ".json"] as const;
+
+/**
+ * cwd 에서 `zts.config.*` 자동 탐색. 우선순위는 `CONFIG_EXT_PRIORITY` 참조.
+ *
+ * parent 디렉토리 traversal 은 모노레포 워크스페이스 (#2111 / Phase 3-4) 에서 처리.
+ */
+export function findConfigPath(cwd: string): string | null {
+  for (const ext of CONFIG_EXT_PRIORITY) {
+    const candidate = join(cwd, `zts.config${ext}`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
 }


### PR DESCRIPTION
## 요약
- `findConfigPath(cwd)` 추가. 우선순위: `.ts > .mts > .cts > .mjs > .js > .cjs > .json`.
- 7개 확장자 우선순위 + 동일 디렉토리 다중 확장자 fallback 검증 테스트.
- parent 디렉토리 traversal 은 #2111 (Phase 3-4 workspace) 에서 처리.

## Stacked PR
Base = `feat/config-ts-loader` (#2113). PR #2113 머지 후 자동으로 `main` 으로 base 변경.

## 비범위
- zts.mjs 자동 호출 통합 — #2101 (Phase 1-2) 에서 BuildOptions 머지와 함께 활성화

## 테스트
- `bun test packages/core/src/config-loader.test.ts` — 24 pass
- `zig build test` — 4016/4016 pass

Closes #2102. Part of #2099.