### PR TITLE
순수 lazy barrel emit 스킵

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1545,6 +1545,255 @@ test "Integration: barrel file tree-shaking with sideEffects=false" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"b\"") == null);
 }
 
+test "Integration: lazy barrel skips empty direct re-export module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from './barrel';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "barrel.ts", "export { value } from './real';");
+    try writeFile(tmp.dir, "real.ts", "export const value = 'LAZY_BARREL_USED';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log(value)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
+test "Integration: lazy barrel skips multiple direct re-export sources" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { a, b } from './barrel';
+        \\console.log(a, b);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\export { a } from './a';
+        \\export { b } from './b';
+    );
+    try writeFile(tmp.dir, "a.ts", "export const a = 'LAZY_BARREL_A';");
+    try writeFile(tmp.dir, "b.ts", "export const b = 'LAZY_BARREL_B';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_A") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_B") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
+test "Integration: lazy barrel skips default-as-named direct re-export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from './barrel';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "barrel.ts", "export { default as value } from './real';");
+    try writeFile(tmp.dir, "real.ts", "export default 'LAZY_BARREL_DEFAULT';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_DEFAULT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
+test "Integration: lazy barrel skips export-star re-export module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './barrel';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "barrel.ts", "export * from './source';");
+    try writeFile(tmp.dir, "source.ts",
+        \\export function used() { return 'LAZY_BARREL_STAR_USED'; }
+        \\export function unused() { return 'LAZY_BARREL_STAR_UNUSED'; }
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_STAR_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_STAR_UNUSED") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
+test "Integration: lazy barrel skips export-star module with unused ambiguous names" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { onlyA } from './barrel';
+        \\console.log(onlyA);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\export * from './a';
+        \\export * from './b';
+    );
+    try writeFile(tmp.dir, "a.ts",
+        \\export const onlyA = 'LAZY_BARREL_ONLY_A';
+        \\export const shared = 'LAZY_BARREL_SHARED_A';
+    );
+    try writeFile(tmp.dir, "b.ts",
+        \\export const onlyB = 'LAZY_BARREL_ONLY_B';
+        \\export const shared = 'LAZY_BARREL_SHARED_B';
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_ONLY_A") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_ONLY_B") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_SHARED_A") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_SHARED_B") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
+test "Integration: lazy barrel does not skip side-effectful re-export module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from './barrel';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\console.log('BARREL_SIDE_EFFECT');
+        \\export { value } from './real';
+    );
+    try writeFile(tmp.dir, "real.ts", "export const value = 'SIDE_EFFECT_BARREL_USED';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "SIDE_EFFECT_BARREL_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "BARREL_SIDE_EFFECT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") != null);
+}
+
+test "Integration: lazy barrel does not skip namespace re-export module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { ns } from './barrel';
+        \\console.log(ns.value);
+    );
+    try writeFile(tmp.dir, "barrel.ts", "export * as ns from './real';");
+    try writeFile(tmp.dir, "real.ts", "export const value = 'LAZY_BARREL_NAMESPACE';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_NAMESPACE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") != null);
+}
+
+test "Integration: lazy barrel skips auto-pure package-default re-export module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from './barrel';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "barrel.ts", "export { value } from './real';");
+    try writeFile(tmp.dir, "real.ts", "export const value = 'PACKAGE_DEFAULT_BARREL';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "PACKAGE_DEFAULT_BARREL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
 test "Integration: barrel file without sideEffects keeps all" {
     // sideEffects 필드 없으면 보수적으로 전부 포함
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -500,6 +500,12 @@ pub fn emitWithTreeShaking(
     defer allocator.free(input_hashes);
     @memset(input_hashes, 0);
 
+    for (sorted.items, 0..) |m, i| {
+        const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
+        if (!shouldSkipLazyBarrelEmit(m, options, shaker, is_entry)) continue;
+        hit_mask[i] = true;
+    }
+
     const options_hash: u64 = if (options.compiled_cache != null)
         cache_mod.computeOptionsHash(options)
     else
@@ -507,6 +513,7 @@ pub fn emitWithTreeShaking(
 
     if (options.compiled_cache) |cache| {
         for (sorted.items, 0..) |m, i| {
+            if (hit_mask[i]) continue;
             if (m.mtime == 0) {
                 cache.skipped_no_mtime += 1;
                 continue; // mtime unknown → cache 비활성
@@ -953,6 +960,37 @@ pub const makeModuleId = dev.makeModuleId;
 pub fn sourcemapSourcePath(path: []const u8, options: *const EmitOptions) []const u8 {
     if (options.platform == .react_native) return path;
     return makeModuleId(path, options.root_dir);
+}
+
+fn shouldSkipLazyBarrelEmit(
+    module: *const Module,
+    options: *const EmitOptions,
+    shaker: ?*const TreeShaker,
+    is_entry: bool,
+) bool {
+    if (shaker == null) return false;
+    if (is_entry or module.is_entry_point) return false;
+    if (options.dev_mode or options.preserve_modules) return false;
+    if (module.wrap_kind != .none) return false;
+    if (module.uses_top_level_await or module.is_context_dep) return false;
+    if (module.cycle_group != 0) return false;
+    if (module.side_effects) return false;
+    if (module.legal_comments.len != 0) return false;
+    if (module.ast == null) return false;
+    if (module.import_records.len == 0 or module.export_bindings.len == 0) return false;
+
+    for (module.import_records) |rec| {
+        if (rec.kind != .re_export) return false;
+        if (rec.is_external or rec.resolved == .none) return false;
+    }
+
+    for (module.export_bindings) |binding| {
+        if (binding.kind != .re_export and binding.kind != .re_export_star) return false;
+        const rec_idx = binding.import_record_index orelse return false;
+        if (rec_idx >= module.import_records.len) return false;
+    }
+
+    return true;
 }
 
 // --- Chunks functions (emitter/chunks.zig) ---


### PR DESCRIPTION
## 요약

- `sideEffects:false` 또는 auto-purity로 순수하다고 판정된 barrel은 `emitModule` 단계에서 compile/codegen을 건너뜁니다.
- direct named re-export와 `export * from` re-export barrel 모두 최종 번들에서 빈 `//#region barrel.ts` 구간을 남기지 않습니다.
- side effect가 있거나 namespace re-export처럼 런타임 보조 코드가 필요한 re-export 모듈은 기존처럼 emit되도록 보수 조건을 유지했습니다.

## 스킵 조건

- tree-shaking 활성 상태
- 엔트리 아님
- dev mode / preserve modules 아님
- wrap/TLA/context/cycle 없음
- `side_effects == false`
- legal comment 없음
- 모든 import record가 `re_export`
- 모든 export binding이 direct `.re_export` 또는 `.re_export_star`
- `.re_export_namespace`는 계속 제외

## 테스트

- 순수 direct re-export barrel이 `barrel.ts` region 없이 출력되는 통합 테스트
- 여러 source로 direct re-export하는 barrel도 스킵되는 테스트
- `default as named` direct re-export도 스킵되는 테스트
- `export * from` barrel도 스킵되는 테스트
- `export *` source 간 충돌 이름이 있어도 unused ambiguous export는 제거되고 barrel은 스킵되는 테스트
- auto-pure package-default re-export barrel도 스킵되는 테스트
- side-effectful barrel은 스킵되지 않는 회귀 테스트
- namespace re-export barrel은 스킵되지 않는 회귀 테스트

## 검증

- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `git diff --check`
- fixture 출력 확인: `export * from` barrel에서 `barrel.ts` region 없이 source/entry만 출력됨