### PR TITLE
chore(deps): TypeScript 5.9.3 → 6.0.3 업그레이드

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "react": "^19.0.0",
         "styled-components": "^6.4.0",
         "tailwindcss": "^4.2.2",
+        "typescript": "^6.0.3",
         "vite": "^8.0.8",
       },
     },
@@ -195,7 +196,7 @@
         "oxc-transform": "^0.60.0",
         "rolldown": "^1.0.0-beta.0",
         "ts-loader": "^9.5.0",
-        "typescript": "^5.8.0",
+        "typescript": "^6.0.3",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.0",
         "zustand": "^5.0.12",
@@ -2556,7 +2557,7 @@
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
@@ -2956,7 +2957,7 @@
 
     "typedoc-plugin-markdown": ["typedoc-plugin-markdown@4.11.0", "", { "peerDependencies": { "typedoc": "0.28.x" } }, "sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -3238,6 +3239,8 @@
 
     "@xhmikosr/bin-check/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "@zts/benchmark/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
     "@zts/integration/@swc/cli": ["@swc/cli@0.8.1", "", { "dependencies": { "@swc/counter": "^0.1.3", "@xhmikosr/bin-wrapper": "^14.0.0", "commander": "^8.3.0", "minimatch": "^9.0.3", "piscina": "^4.3.1", "semver": "^7.3.8", "slash": "3.0.0", "source-map": "^0.7.3", "tinyglobby": "^0.2.13" }, "peerDependencies": { "@swc/core": "^1.2.66", "chokidar": "^5.0.0" }, "optionalPeers": ["chokidar"], "bin": { "swc": "bin/swc.js", "swcx": "bin/swcx.js", "spack": "bin/spack.js" } }, "sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ=="],
 
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -3300,8 +3303,6 @@
 
     "compat-table/cheerio": ["cheerio@0.20.0", "", { "dependencies": { "css-select": "~1.2.0", "dom-serializer": "~0.1.0", "entities": "~1.1.1", "htmlparser2": "~3.8.1", "lodash": "^4.1.0" }, "optionalDependencies": { "jsdom": "^7.0.2" } }, "sha512-e5jCTzJc28MWkrLLjB1mu3ks7rDQJLC5y/JMdQkOAEX/dmJk62rC6Xae1yvOO4xyCxLpzcth3jIZ7nypmjQ/0w=="],
 
-    "compat-table/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
-
     "compat-table/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -3321,8 +3322,6 @@
     "detective/acorn": ["acorn@5.7.4", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="],
 
     "documents/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
-
-    "documents/react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "documents/tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react": "^19.0.0",
     "styled-components": "^6.4.0",
     "tailwindcss": "^4.2.2",
+    "typescript": "^6.0.3",
     "vite": "^8.0.8"
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "declarationDir": "dist",
     "outDir": "dist",
+    "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,6 +8,9 @@
     "declaration": true,
     "declarationDir": "dist",
     "outDir": "dist",
+    // index.ts 가 ../shared/index 를 import 하므로 source root 가 packages/ 까지
+    // 확장된다. TS 6 의 TS5011 (inferred rootDir 거부) 회피 + 기존 emit layout
+    // (`dist/core/index.d.ts` + `dist/shared/*.d.ts`, package.json `types` 와 일치) 보존.
     "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,

--- a/tests/benchmark/package.json
+++ b/tests/benchmark/package.json
@@ -135,7 +135,7 @@
     "oxc-transform": "^0.60.0",
     "rolldown": "^1.0.0-beta.0",
     "ts-loader": "^9.5.0",
-    "typescript": "^5.8.0",
+    "typescript": "^6.0.3",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.0",
     "zustand": "^5.0.12"


### PR DESCRIPTION
## 요약
- 루트 `devDependencies` 에 `typescript: ^6.0.3` 명시 (이전엔 transitive resolution 으로 5.9.3).
- `tests/benchmark/package.json` 의 typescript `^5.8.0` → `^6.0.3`.
- `packages/core/tsconfig.json` 에 `rootDir: ".."` 추가 — TS 6 의 신규 `rootDir` warning (TS5011) 해소. 이미 `dist/core/index.d.ts` / `dist/shared/*.d.ts` 형태로 emit 되던 layout 과 동일 (package.json `"types": "dist/core/index.d.ts"`).

## TS 6 breaking change 노출 항목
- `TS5011: The common source directory of 'tsconfig.json' is '..'. The 'rootDir' setting must be explicitly set` — 이전엔 inferred 였던 것이 명시 강제. tsconfig 한 줄 추가로 해소.

## 검증
- `bun x tsc --version` → `6.0.3`
- `bun run --cwd packages/core build:dts` — emit clean 4 파일 (dist/core/index.d.ts + sub)
- `bun test packages/core/index.test.ts` — 314 pass
- `bun test packages/core/src/config-loader.test.ts` — 24 pass
- `bun test packages/core/bin/zts.test.ts` — 80 pass
- `bun test --cwd tests/integration` — 5 fail (main 과 동일, pre-existing)
- `bun run lint` / `bun run fmt:check` 통과
- `zig build test` — 4016/4016 pass

## 비범위
- `.ts` 확장자 명시 cleanup (Node 24 dist-less 실행) — 별도 PR 권장