### PR TITLE
local re-export barrel도 lazy emit 스킵

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1708,6 +1708,141 @@ test "Integration: lazy barrel skips export-star module with unused ambiguous na
     try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
 }
 
+test "Integration: lazy barrel skips local named import re-export module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from './barrel';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import { value } from './real';
+        \\export { value };
+    );
+    try writeFile(tmp.dir, "real.ts", "export const value = 'LAZY_BARREL_LOCAL_IMPORT';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_LOCAL_IMPORT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
+test "Integration: lazy barrel skips local default import re-export module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from './barrel';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import value from './real';
+        \\export { value };
+    );
+    try writeFile(tmp.dir, "real.ts", "export default 'LAZY_BARREL_LOCAL_DEFAULT';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_LOCAL_DEFAULT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
+test "Integration: lazy barrel skips local re-export with explicit extensions" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { tsValue } from './barrel.ts';
+        \\import { jsValue } from './js-barrel.js';
+        \\console.log(tsValue, jsValue);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import { tsValue } from './real.ts';
+        \\export { tsValue };
+    );
+    try writeFile(tmp.dir, "real.ts", "export const tsValue = 'LAZY_BARREL_EXPLICIT_TS';");
+    try writeFile(tmp.dir, "js-barrel.js",
+        \\import { jsValue } from './real.js';
+        \\export { jsValue };
+    );
+    try writeFile(tmp.dir, "real.js", "export const jsValue = 'LAZY_BARREL_EXPLICIT_JS';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_EXPLICIT_TS") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_EXPLICIT_JS") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "js-barrel.js") == null);
+}
+
+test "Integration: lazy barrel skips local re-export with side-effect import preserved" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from './barrel';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import './side';
+        \\import { value } from './real';
+        \\export { value };
+    );
+    try writeFile(tmp.dir, "side.ts", "console.log('LAZY_BARREL_LOCAL_SIDE_EFFECT');");
+    try writeFile(tmp.dir, "real.ts", "export const value = 'LAZY_BARREL_LOCAL_SIDE_VALUE';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_LOCAL_SIDE_EFFECT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_LOCAL_SIDE_VALUE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") == null);
+}
+
 test "Integration: lazy barrel does not skip side-effectful re-export module" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1764,6 +1899,37 @@ test "Integration: lazy barrel does not skip namespace re-export module" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_NAMESPACE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") != null);
+}
+
+test "Integration: lazy barrel does not skip local namespace re-export module" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { ns } from './barrel';
+        \\console.log(ns.value);
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\import * as ns from './real';
+        \\export { ns };
+    );
+    try writeFile(tmp.dir, "real.ts", "export const value = 'LAZY_BARREL_LOCAL_NAMESPACE';");
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_BARREL_LOCAL_NAMESPACE") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "barrel.ts") != null);
 }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -980,8 +980,13 @@ fn shouldSkipLazyBarrelEmit(
     if (module.import_records.len == 0 or module.export_bindings.len == 0) return false;
 
     for (module.import_records) |rec| {
-        if (rec.kind != .re_export) return false;
+        if (rec.kind != .re_export and rec.kind != .static_import and rec.kind != .side_effect) return false;
         if (rec.is_external or rec.resolved == .none) return false;
+    }
+
+    for (module.import_bindings) |binding| {
+        if (binding.kind == .namespace) return false;
+        if (binding.isSynthetic()) return false;
     }
 
     for (module.export_bindings) |binding| {


### PR DESCRIPTION
## 요약

- 이전 lazy barrel 스킵 조건을 `import { x } from './m'; export { x };` 형태까지 확장했습니다.
- local named/default import 후 re-export하는 barrel은 body가 비어 있으므로 `emitModule` compile/codegen을 건너뜁니다.
- `import * as ns; export { ns }` namespace re-export는 계속 스킵하지 않습니다.
- side-effect import가 함께 있는 barrel은 source module의 side effect를 보존하면서 빈 barrel emit만 스킵합니다.
- `./foo.ts`, `./foo.js`처럼 명시적 확장자를 쓴 import specifier도 resolver가 정규화한 `ImportRecord.resolved` 기준으로 동일하게 동작합니다.

## 스킵 조건 변경

- import record 허용 범위: `.re_export` 외에 `.static_import`, `.side_effect` 추가
- namespace import binding은 제외
- synthetic import binding은 제외
- export binding은 기존처럼 `.re_export` 또는 `.re_export_star`만 허용

## 테스트

- local named import re-export barrel 스킵
- local default import re-export barrel 스킵
- explicit `.ts`/`.js` 확장자 specifier를 쓰는 local re-export barrel 스킵
- side-effect import가 함께 있는 local re-export barrel에서 side effect 보존 + barrel 스킵
- local namespace re-export barrel은 스킵하지 않는 회귀 테스트

## 검증

- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `git diff --check`
- fixture 출력 확인: local import re-export barrel에서 `barrel.ts`/`barrel.js` region 없이 source/entry만 출력됨