### PR TITLE
feat(config): 함수형 config + --config <path> + --mode flag

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -98,6 +98,8 @@ function parseArgs(argv) {
     drop: [],
     certfile: undefined,
     keyfile: undefined,
+    configPath: undefined, // --config <path> 명시 시 자동 탐색 우회
+    mode: undefined, // --mode <name> 함수형 config / mode 별 config 머지 (#2110) 에서 사용
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -362,6 +364,22 @@ function parseArgs(argv) {
       opts.project = arg.slice("--tsconfig-path=".length);
       continue;
     }
+    if (arg === "--config") {
+      opts.configPath = args[++i];
+      continue;
+    }
+    if (arg.startsWith("--config=")) {
+      opts.configPath = arg.slice("--config=".length);
+      continue;
+    }
+    if (arg === "--mode") {
+      opts.mode = args[++i];
+      continue;
+    }
+    if (arg.startsWith("--mode=")) {
+      opts.mode = arg.slice("--mode=".length);
+      continue;
+    }
     if (arg === "--plugin") {
       opts.pluginPaths.push(args[++i]);
       continue;
@@ -611,15 +629,33 @@ async function runTranspile(opts) {
 // ─── Bundle 모드 ───
 
 /**
- * cwd 에서 zts.config.* 자동 탐색 + 로드. 없으면 null.
+ * config 로드 — `--config <path>` 명시 시 그 경로, 아니면 cwd 자동 탐색.
+ *
+ * 함수형 config 는 CLI 모드/`--mode` 인자 기반의 `ConfigEnv` 로 호출된다:
+ *  - command: serve→"serve", watch→"watch", 그 외→"bundle"
+ *  - mode: `--mode <name>` 명시값 또는 command 기본 (serve/watch→"development", 그 외→"production")
+ *  - env: process.env (.env 파일 자동 로드는 #2106 에서 확장)
+ *
  * 실패 시 `Error("failed to load config — ...")` 를 throw — main 의 try/catch 가 처리.
- * `--config <path>` 명시 옵션은 #2103 (Phase 2-1) 에서 추가 예정.
  */
-async function loadAutoConfig() {
-  const configPath = findConfigPath(process.cwd());
+async function loadAutoConfig(opts) {
+  const explicit = opts.configPath ? resolve(opts.configPath) : null;
+  if (explicit && !existsSync(explicit)) {
+    throw new Error(`failed to load config — file not found: ${explicit}`);
+  }
+  const configPath = explicit ?? findConfigPath(process.cwd());
   if (!configPath) return null;
+
+  const command = opts.serve ? "serve" : opts.watch ? "watch" : "bundle";
+  const mode = opts.mode ?? (command === "bundle" ? "production" : "development");
+  const env = {
+    command,
+    mode,
+    env: process.env,
+  };
+
   try {
-    return await loadConfig(configPath);
+    return await loadConfig(configPath, env);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     throw new Error(`failed to load config — ${reason}`);
@@ -1095,7 +1131,7 @@ async function main() {
   // 명시적 --config <path> flag 는 #2103 (Phase 2-1) 에서 추가.
   // init() 은 entry 검사 후로 미뤄 no-args 경로의 NAPI dlopen 비용을 절감한다.
   // (config 가 .ts 면 loadConfig 내부에서 init() 이 idempotent 하게 호출됨)
-  const config = await loadAutoConfig();
+  const config = await loadAutoConfig(opts);
   if (config) {
     mergeConfigIntoOpts(opts, config);
   }

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -1524,3 +1524,98 @@ describe("CLI: zts.config 자동 탐색 + BuildOptions 머지", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+// ─── 함수형 config + --config <path> + --mode (#2103 / Phase 2-1) ───
+
+describe("CLI: 함수형 config + --config flag", () => {
+  test("함수형 config: 자동 탐색 + bundle 기본 mode", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-fn-cfg-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('FN_CFG');");
+    writeFileSync(
+      join(dir, "zts.config.ts"),
+      `export default ({ command, mode }: { command: string; mode: string }) => ({
+         banner: "/* " + command + ":" + mode + " */",
+       });`,
+    );
+    const { stdout, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* bundle:production */");
+    expect(stdout).toContain("FN_CFG");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("함수형 config: --mode 명시값 전달", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-fn-mode-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('x');");
+    writeFileSync(
+      join(dir, "zts.config.ts"),
+      `export default ({ mode }: { mode: string }) => ({
+         banner: "/* mode=" + mode + " */",
+       });`,
+    );
+    const { stdout, exitCode } = runCli(["--bundle", "--mode=staging", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* mode=staging */");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--config <path>: 명시 경로의 config 사용 (자동 탐색 우회)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-explicit-cfg-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('hi');");
+    // 기본 자동 탐색 대상 — 사용 안 됨을 검증
+    writeFileSync(join(dir, "zts.config.ts"), `export default { banner: "/* AUTO */" };`);
+    // 명시 config — 이게 사용되어야 함
+    writeFileSync(join(dir, "custom.config.ts"), `export default { banner: "/* CUSTOM */" };`);
+    const { stdout, exitCode } = runCli(
+      ["--bundle", "--config", join(dir, "custom.config.ts"), join(dir, "entry.ts")],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* CUSTOM */");
+    expect(stdout).not.toContain("/* AUTO */");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--config=<path> (= form) 도 동작", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cfg-eq-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('hi');");
+    writeFileSync(join(dir, "alt.config.ts"), `export default { banner: "/* ALT */" };`);
+    const { stdout, exitCode } = runCli(
+      ["--bundle", `--config=${join(dir, "alt.config.ts")}`, join(dir, "entry.ts")],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* ALT */");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--config 명시 + 파일 부재 시 명확한 에러로 exit 1", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cfg-missing-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('x');");
+    const { stderr, exitCode } = runCli(
+      ["--bundle", "--config", join(dir, "nope.config.ts"), join(dir, "entry.ts")],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("file not found");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("함수형 config + 객체 머지: BuildOptions 가 정상 적용됨", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-fn-merge-"));
+    writeFileSync(join(dir, "src.ts"), "export const X = 'FN_ENTRY';");
+    writeFileSync(
+      join(dir, "zts.config.ts"),
+      `export default () => ({
+         entryPoints: ["${join(dir, "src.ts").replace(/\\/g, "/")}"],
+         minify: true,
+       });`,
+    );
+    const { stdout, exitCode } = runCli(["--bundle"], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("FN_ENTRY");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -123,13 +123,24 @@ function findAddon(): string {
 
 /**
  * `zts.config.{ts,js}` 타입 체크/자동완성용 identity 헬퍼.
+ *
+ * 객체 또는 함수형 config 둘 다 지원:
+ * ```ts
+ * export default defineConfig({ format: "esm" });
+ * export default defineConfig(({ command, mode, env }) => ({
+ *   format: "esm",
+ *   minify: command === "bundle",
+ * }));
+ * ```
  */
-export function defineConfig<T extends Partial<BuildOptions>>(config: T): T {
+export function defineConfig<T extends UserConfigInput>(config: T): T {
   return config;
 }
 
 export { findConfigPath, importAndResolveDefault, loadConfig } from "./src/config-loader";
-export type { UserConfig } from "./src/config-loader";
+export type { ConfigEnv, UserConfig, UserConfigFn, UserConfigInput } from "./src/config-loader";
+
+import type { UserConfigInput } from "./src/config-loader";
 
 /**
  * NAPI 모듈을 로드한다.

--- a/packages/core/src/config-loader.test.ts
+++ b/packages/core/src/config-loader.test.ts
@@ -213,3 +213,100 @@ describe("findConfigPath", () => {
     expect(findConfigPath(dir)).toBeNull();
   });
 });
+
+// ─── 함수형 config (#2103 / Phase 2-1) ───
+
+describe("loadConfig: 함수형 config", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-fn-config-"));
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("함수형 config: env 인자로 호출되어 객체 반환", async () => {
+    const path = join(dir, "fn.config.ts");
+    writeFileSync(
+      path,
+      `export default ({ command, mode }: { command: string; mode: string }) => ({
+         format: command === "bundle" ? "esm" : "cjs",
+         minify: mode === "production",
+       });`,
+    );
+    const config = await loadConfig(path, {
+      command: "bundle",
+      mode: "production",
+      env: {},
+    });
+    expect(config).toEqual({ format: "esm", minify: true });
+  });
+
+  test("함수형 config: serve mode 분기", async () => {
+    const path = join(dir, "fn-serve.config.ts");
+    writeFileSync(
+      path,
+      `export default ({ command }: { command: string }) => ({
+         minify: command === "bundle",
+       });`,
+    );
+    const buildResult = await loadConfig(path, {
+      command: "bundle",
+      mode: "production",
+      env: {},
+    });
+    expect(buildResult.minify).toBe(true);
+
+    const serveResult = await loadConfig(path, {
+      command: "serve",
+      mode: "development",
+      env: {},
+    });
+    expect(serveResult.minify).toBe(false);
+  });
+
+  test("함수형 config: env 인자 없이 호출 시 production bundle 기본값", async () => {
+    const path = join(dir, "fn-default.config.ts");
+    writeFileSync(
+      path,
+      `export default ({ command, mode }: { command: string; mode: string }) => ({
+         banner: "/* " + command + ":" + mode + " */",
+       });`,
+    );
+    const config = await loadConfig(path);
+    expect(config.banner).toBe("/* bundle:production */");
+  });
+
+  test("함수형 config: async 함수도 지원", async () => {
+    const path = join(dir, "fn-async.config.ts");
+    writeFileSync(
+      path,
+      `export default async ({ command }: { command: string }) => {
+         return { format: command === "bundle" ? "esm" as const : "cjs" as const };
+       };`,
+    );
+    const config = await loadConfig(path, {
+      command: "bundle",
+      mode: "production",
+      env: {},
+    });
+    expect(config.format).toBe("esm");
+  });
+
+  test("함수형 config: object 반환 안 하면 throw", async () => {
+    const path = join(dir, "fn-bad.config.ts");
+    writeFileSync(path, `export default () => "not an object";`);
+    await expect(loadConfig(path)).rejects.toThrow(/functional config must return an object/);
+  });
+
+  test("객체 형태 config 도 변경 없이 동작 (regression)", async () => {
+    const path = join(dir, "obj.config.ts");
+    writeFileSync(path, `export default { format: "esm" as const };`);
+    const config = await loadConfig(path, {
+      command: "bundle",
+      mode: "production",
+      env: {},
+    });
+    expect(config).toEqual({ format: "esm" });
+  });
+});

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -16,8 +16,29 @@ import { pathToFileURL } from "node:url";
 import type { BuildOptions } from "../index";
 import { init, transpile } from "../index";
 
-/** Phase 1: 객체만 지원. 함수형 (Vite 식 `({ command, mode, env }) => ...`) 은 #2103 (Phase 2-1) 에서 추가. */
+/** config 객체 형태 — 모든 BuildOptions 의 부분 집합. */
 export type UserConfig = Partial<BuildOptions>;
+
+/**
+ * 함수형 config 호출 시 주입되는 컨텍스트 (Vite 호환 형태).
+ *
+ * - `command`: CLI 모드. `bundle` (default), `serve`, `watch`.
+ * - `mode`: `--mode <name>` 으로 지정. 미지정 시 command 별 기본값
+ *   (`serve`/`watch` → `development`, 그 외 → `production`).
+ * - `env`: `import.meta.env` 후보 변수 — 현재는 `process.env` 그대로 노출.
+ *   `.env` 자동 로드 + `VITE_*` prefix 필터는 #2106 (Phase 2-4) 에서 추가.
+ */
+export interface ConfigEnv {
+  command: "bundle" | "serve" | "watch";
+  mode: string;
+  env: Record<string, string | undefined>;
+}
+
+/** 함수형 config — `defineConfig(({ command, mode, env }) => ...)` 형태. */
+export type UserConfigFn = (env: ConfigEnv) => UserConfig | Promise<UserConfig>;
+
+/** config 파일이 export 가능한 형태 — 객체 또는 함수. */
+export type UserConfigInput = UserConfig | UserConfigFn;
 
 /**
  * 자동 탐색 우선순위. 동일 디렉토리에 다중 확장자 존재 시 첫 매치 반환.
@@ -36,24 +57,56 @@ const JS_EXTS = new Set<string>(CONFIG_EXT_PRIORITY.slice(3, 6));
  * 존재 여부는 사전 stat 으로 확인하지 않고 실제 read/import 의 ENOENT 를 catch
  * 한다 — TOCTOU 회피 + 1 syscall 절감.
  *
+ * 함수형 config 가 export 됐으면 `env` 인자를 전달해 호출하고 반환된 객체를 사용한다.
+ * `env` 미제공 시 적절한 기본값 (`command: "bundle", mode: "production"`) 으로 호출.
+ *
  * @throws 파일이 없거나, 확장자가 지원되지 않거나, 컴파일/평가가 실패하면 throw.
  */
-export async function loadConfig(filePath: string): Promise<UserConfig> {
+export async function loadConfig(filePath: string, env?: ConfigEnv): Promise<UserConfig> {
   const absPath = pathResolve(filePath);
   const ext = extname(absPath).toLowerCase();
 
+  let raw: UserConfigInput;
   if (ext === ".json") {
-    return loadJsonConfig(absPath);
+    raw = loadJsonConfig(absPath);
+  } else if (TS_EXTS.has(ext)) {
+    raw = await loadTsConfig(absPath);
+  } else if (JS_EXTS.has(ext)) {
+    raw = await loadJsConfig(absPath);
+  } else {
+    throw new Error(
+      `@zts/core: unsupported config extension "${ext}" for ${absPath}. Supported: .ts/.mts/.cts/.mjs/.js/.cjs/.json`,
+    );
   }
-  if (TS_EXTS.has(ext)) {
-    return loadTsConfig(absPath);
+
+  return resolveConfigValue(raw, env, absPath);
+}
+
+/**
+ * 함수형 config 처리. raw 가 함수면 env 와 호출하고 결과를 객체로 반환.
+ * env 미제공 시 production bundle 기본값 사용.
+ */
+async function resolveConfigValue(
+  raw: UserConfigInput,
+  env: ConfigEnv | undefined,
+  absPath: string,
+): Promise<UserConfig> {
+  if (typeof raw !== "function") {
+    return raw;
   }
-  if (JS_EXTS.has(ext)) {
-    return loadJsConfig(absPath);
+  const ctx: ConfigEnv = env ?? {
+    command: "bundle",
+    mode: "production",
+    env: process.env,
+  };
+  const result = await raw(ctx);
+  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+    const got = Array.isArray(result) ? "array" : typeof result;
+    throw new Error(
+      `@zts/core: functional config must return an object (got ${got}) from ${absPath}`,
+    );
   }
-  throw new Error(
-    `@zts/core: unsupported config extension "${ext}" for ${absPath}. Supported: .ts/.mts/.cts/.mjs/.js/.cjs/.json`,
-  );
+  return result;
 }
 
 function loadJsonConfig(absPath: string): UserConfig {
@@ -66,7 +119,7 @@ function loadJsonConfig(absPath: string): UserConfig {
   }
 }
 
-async function loadTsConfig(absPath: string): Promise<UserConfig> {
+async function loadTsConfig(absPath: string): Promise<UserConfigInput> {
   init();
   const source = readFileOrThrowNotFound(absPath);
   // ZTS parser 는 filename 의 `.cts` 확장자를 보고 CommonJS Script 모드로 진입해
@@ -87,7 +140,7 @@ async function loadTsConfig(absPath: string): Promise<UserConfig> {
   const tmpPath = join(dirname(absPath), tmpName);
   writeFileSync(tmpPath, result.code, "utf8");
   try {
-    return await importAndResolveDefault(tmpPath);
+    return await importAndResolveDefault<UserConfigInput>(tmpPath);
   } finally {
     try {
       unlinkSync(tmpPath);
@@ -98,15 +151,18 @@ async function loadTsConfig(absPath: string): Promise<UserConfig> {
   }
 }
 
-async function loadJsConfig(absPath: string): Promise<UserConfig> {
+async function loadJsConfig(absPath: string): Promise<UserConfigInput> {
   try {
-    return await importAndResolveDefault<UserConfig>(absPath);
+    return await importAndResolveDefault<UserConfigInput>(absPath);
   } catch (err) {
     if (err instanceof Error) {
       // config 컨텍스트로 에러 메시지 정정 (importAndResolveDefault 는 generic).
       err.message = err.message
         .replace("module not found", "config file not found")
-        .replace("module must export an object", "config must export an object");
+        .replace(
+          /module must be an object or function/,
+          "config must export an object or function",
+        );
     }
     throw err;
   }
@@ -114,16 +170,14 @@ async function loadJsConfig(absPath: string): Promise<UserConfig> {
 
 /**
  * 절대 경로를 `file://` URL 로 dynamic import 한 뒤 default export (없으면
- * namespace 객체) 를 반환한다. 객체가 아니거나 배열이면 throw.
+ * namespace 객체) 를 반환한다. 함수형 config 도 허용하므로 객체 또는 함수만 통과.
  *
  * `pathToFileURL` 으로 Windows 절대경로 (드라이브 문자) 를 안전하게 처리.
  * config 로더와 CLI 의 `--plugin <path>` 로더가 공유.
  *
  * 같은 프로세스에서 다중 reload 가 필요한 watch (#2107) 는 별도 cache-bust 적용 예정.
  */
-export async function importAndResolveDefault<T extends object = UserConfig>(
-  absPath: string,
-): Promise<T> {
+export async function importAndResolveDefault<T = UserConfig>(absPath: string): Promise<T> {
   const url = pathToFileURL(absPath).href;
   let mod: Record<string, unknown>;
   try {
@@ -136,9 +190,13 @@ export async function importAndResolveDefault<T extends object = UserConfig>(
     throw err;
   }
   const value = (mod as { default?: unknown }).default ?? mod;
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    const got = Array.isArray(value) ? "array" : typeof value;
-    throw new Error(`@zts/core: module must export an object (got ${got}) from ${absPath}`);
+  const valueType = typeof value;
+  if (
+    valueType !== "function" &&
+    (valueType !== "object" || value === null || Array.isArray(value))
+  ) {
+    const got = value === null ? "null" : Array.isArray(value) ? "array" : valueType;
+    throw new Error(`@zts/core: module must be an object or function (got ${got}) from ${absPath}`);
   }
   return value as T;
 }


### PR DESCRIPTION
## 요약
- `defineConfig(fn | object)` 시그니처 확장 — Vite 호환 함수형 config 지원.
- 함수형 config 는 `ConfigEnv = { command, mode, env }` 주입.
- `--config <path>` flag — 명시 경로 사용 (자동 탐색 우회).
- `--mode <name>` flag — 함수형 config 와 mode 별 config (#2110) 양쪽에 사용.

## 함수형 config 예
```ts
export default defineConfig(({ command, mode, env }) => ({
  format: "esm",
  minify: command === "bundle",
  define: { "process.env.NODE_ENV": JSON.stringify(mode) },
}));
```

## 컨텍스트 결정 규칙
- `command`: `--serve` → `"serve"`, `--watch` → `"watch"`, 그 외 → `"bundle"`
- `mode`: `--mode <name>` 명시값 또는 command 기본 (`serve`/`watch` → `"development"`, 그 외 → `"production"`)
- `env`: `process.env` (`.env` 자동 로드 + `VITE_*` prefix 필터는 #2106 에서 추가)

## API 추가
- `UserConfigFn` / `UserConfigInput` / `ConfigEnv` 타입 export
- `loadConfig(path, env?)` — 두 번째 인자로 env 주입
- `importAndResolveDefault` 가 함수 export 도 허용 (이전엔 객체만 — 함수형 config 통과)

## 비범위
- mode 별 config 파일 자동 머지 (`zts.config.production.ts`) — #2110 (Phase 3-3)
- `.env` 자동 로드 + `import.meta.env` 정적 치환 — #2106 (Phase 2-4)
- watch 시 config 파일 hot reload — #2107 (Phase 2-5)

## 테스트
- `bun test packages/core/src/config-loader.test.ts` — 30 pass (6 신규)
- `bun test packages/core/bin/zts.test.ts` — 86 pass (6 신규)
- `zig build test` — 4016/4016 pass
- lint / fmt 통과

Closes #2103. Part of #2099. Phase 2 첫 PR.