### PR TITLE
feat(config): .env 자동 로드 + import.meta.env 정적 치환

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -661,7 +661,8 @@ async function runTranspile(opts) {
  * 함수형 config 는 CLI 모드/`--mode` 인자 기반의 `ConfigEnv` 로 호출된다:
  *  - command: serve→"serve", watch→"watch", 그 외→"bundle"
  *  - mode: `--mode <name>` 명시값 또는 command 기본 (serve/watch→"development", 그 외→"production")
- *  - env: process.env (.env 파일 자동 로드는 #2106 에서 확장)
+ *  - env: dotenv 파일 + process.env 머지. shell env 가 file 보다 우선 (CI 가 .env
+ *    값을 override 가능 — Vite/dotenv 16+ 와 일치).
  *
  * 실패 시 `Error("failed to load config — ...")` 를 throw — main 의 try/catch 가 처리.
  */
@@ -679,11 +680,18 @@ async function loadAutoConfig(opts) {
   const envDir = opts.envDir ? resolve(opts.envDir) : process.cwd();
   const dotenvVars = loadEnv(mode, envDir, opts.envPrefixes);
 
-  const env = {
-    command,
-    mode,
-    env: { ...process.env, ...dotenvVars },
-  };
+  // dotenv 키 중 shell env 에도 정의된 건 shell 값으로 override (CI/배포 시 .env
+  // 수정 없이 override — Vite/dotenv 16+ 와 일치). dotenvVars 자체를 final source 로
+  // 갱신하면 envToDefine 에 그대로 전달 가능 (별도 머지 불필요).
+  for (const k of Object.keys(dotenvVars)) {
+    const shellValue = process.env[k];
+    if (shellValue !== undefined) dotenvVars[k] = shellValue;
+  }
+
+  // dotenv 파일 부재 시 process.env spread 회피 (보통 100+ 키 복사 방지).
+  const mergedEnv =
+    Object.keys(dotenvVars).length === 0 ? process.env : { ...process.env, ...dotenvVars };
+  const env = { command, mode, env: mergedEnv };
 
   if (!configPath) return { config: null, env, dotenvVars };
 

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -14,8 +14,17 @@ try {
 } catch {
   coreModule = await import("../index.ts");
 }
-const { init, transpile, build, buildSync, findConfigPath, importAndResolveDefault, loadConfig } =
-  coreModule;
+const {
+  init,
+  transpile,
+  build,
+  buildSync,
+  envToDefine,
+  findConfigPath,
+  importAndResolveDefault,
+  loadConfig,
+  loadEnv,
+} = coreModule;
 import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { resolve, dirname, basename, extname, join } from "node:path";
 import { createServer } from "node:http";
@@ -100,6 +109,8 @@ function parseArgs(argv) {
     keyfile: undefined,
     configPath: undefined, // --config <path> 명시 시 자동 탐색 우회
     mode: undefined, // --mode <name> 함수형 config / mode 별 config 머지 (#2110) 에서 사용
+    envPrefixes: undefined, // --env-prefix=VITE_,ZTS_ — undefined 면 loadEnv default 사용
+    envDir: undefined, // --env-dir <path> — undefined 면 cwd
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -380,6 +391,22 @@ function parseArgs(argv) {
       opts.mode = arg.slice("--mode=".length);
       continue;
     }
+    if (arg === "--env-prefix") {
+      opts.envPrefixes = args[++i].split(",").filter(Boolean);
+      continue;
+    }
+    if (arg.startsWith("--env-prefix=")) {
+      opts.envPrefixes = arg.slice("--env-prefix=".length).split(",").filter(Boolean);
+      continue;
+    }
+    if (arg === "--env-dir") {
+      opts.envDir = args[++i];
+      continue;
+    }
+    if (arg.startsWith("--env-dir=")) {
+      opts.envDir = arg.slice("--env-dir=".length);
+      continue;
+    }
     if (arg === "--plugin") {
       opts.pluginPaths.push(args[++i]);
       continue;
@@ -644,18 +671,25 @@ async function loadAutoConfig(opts) {
     throw new Error(`failed to load config — file not found: ${explicit}`);
   }
   const configPath = explicit ?? findConfigPath(process.cwd());
-  if (!configPath) return null;
 
   const command = opts.serve ? "serve" : opts.watch ? "watch" : "bundle";
   const mode = opts.mode ?? (command === "bundle" ? "production" : "development");
+
+  // .env 파일 4단계 우선순위로 로드 (#2106). prefix 미지정 시 default `["VITE_", "ZTS_"]`.
+  const envDir = opts.envDir ? resolve(opts.envDir) : process.cwd();
+  const dotenvVars = loadEnv(mode, envDir, opts.envPrefixes);
+
   const env = {
     command,
     mode,
-    env: process.env,
+    env: { ...process.env, ...dotenvVars },
   };
 
+  if (!configPath) return { config: null, env, dotenvVars };
+
   try {
-    return await loadConfig(configPath, env);
+    const config = await loadConfig(configPath, env);
+    return { config, env, dotenvVars };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     throw new Error(`failed to load config — ${reason}`);
@@ -1126,14 +1160,20 @@ async function runServe(opts, config) {
 async function main() {
   const opts = parseArgs(process.argv);
 
-  // config 자동 탐색 + 머지 (CLI > config > tsconfig). entry 검사 전에 적용해야
-  // config 의 entryPoints 가 검사 통과에 기여한다.
-  // 명시적 --config <path> flag 는 #2103 (Phase 2-1) 에서 추가.
+  // config 자동 탐색 + .env 로드 + 머지 (CLI > config > tsconfig). entry 검사 전에
+  // 적용해야 config 의 entryPoints 가 검사 통과에 기여한다.
   // init() 은 entry 검사 후로 미뤄 no-args 경로의 NAPI dlopen 비용을 절감한다.
   // (config 가 .ts 면 loadConfig 내부에서 init() 이 idempotent 하게 호출됨)
-  const config = await loadAutoConfig(opts);
+  const { config, env: configEnv, dotenvVars } = await loadAutoConfig(opts);
   if (config) {
     mergeConfigIntoOpts(opts, config);
+  }
+
+  // import.meta.env.* + import.meta.env.MODE/PROD/DEV/SSR 정적 치환을 define 으로
+  // 자동 주입. 사용자 명시 define 이 동일 키를 덮어쓰면 그대로 우선.
+  const envDefine = envToDefine(dotenvVars, configEnv.mode);
+  for (const [key, value] of Object.entries(envDefine)) {
+    if (opts.define[key] === undefined) opts.define[key] = value;
   }
 
   if (opts.entryPoints.length === 0 && !opts.stdin && !opts.serve) {

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -1619,3 +1619,84 @@ describe("CLI: 함수형 config + --config flag", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+// ─── .env 자동 로드 + import.meta.env 정적 치환 (#2106 / Phase 2-4) ───
+
+describe("CLI: .env 자동 로드", () => {
+  test(".env 의 VITE_* 키가 import.meta.env 로 정적 치환됨", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-env-vite-"));
+    writeFileSync(join(dir, ".env"), "VITE_API=https://prod.example.com");
+    writeFileSync(join(dir, "entry.ts"), "console.log(import.meta.env.VITE_API);");
+    const { stdout, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("https://prod.example.com");
+    expect(stdout).not.toContain("import.meta.env.VITE_API");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("import.meta.env.MODE / PROD / DEV 자동 주입", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-env-mode-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      `console.log("mode=" + import.meta.env.MODE);
+       console.log("prod=" + import.meta.env.PROD);`,
+    );
+    const { stdout, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("production");
+    expect(stdout).toContain("true");
+    expect(stdout).not.toContain("import.meta.env.MODE");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test(".env.{mode}.local 우선순위 (4단계)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-env-priority-"));
+    writeFileSync(join(dir, ".env"), "VITE_K=base");
+    writeFileSync(join(dir, ".env.local"), "VITE_K=local");
+    writeFileSync(join(dir, ".env.production"), "VITE_K=prod");
+    writeFileSync(join(dir, ".env.production.local"), "VITE_K=prod-local");
+    writeFileSync(join(dir, "entry.ts"), "console.log(import.meta.env.VITE_K);");
+    const { stdout, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("prod-local");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--mode <name> 으로 mode 별 분기", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-env-mode-flag-"));
+    writeFileSync(join(dir, ".env.production"), "VITE_HOST=prod");
+    writeFileSync(join(dir, ".env.development"), "VITE_HOST=dev");
+    writeFileSync(join(dir, "entry.ts"), "console.log(import.meta.env.VITE_HOST);");
+
+    const buildResult = runCli(["--bundle", "--mode=production", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(buildResult.exitCode).toBe(0);
+    expect(buildResult.stdout).toContain("prod");
+
+    const devResult = runCli(["--bundle", "--mode=development", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(devResult.exitCode).toBe(0);
+    expect(devResult.stdout).toContain("dev");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--env-prefix=CUSTOM_ 로 prefix 변경", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-env-prefix-"));
+    writeFileSync(join(dir, ".env"), "VITE_NOT_EXPOSED=hidden\nCUSTOM_API=allowed");
+    writeFileSync(
+      join(dir, "entry.ts"),
+      "console.log(import.meta.env.CUSTOM_API);\nconsole.log(import.meta.env.VITE_NOT_EXPOSED);",
+    );
+    const { stdout, exitCode } = runCli(
+      ["--bundle", "--env-prefix=CUSTOM_", join(dir, "entry.ts")],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("allowed");
+    // VITE_NOT_EXPOSED 는 정적 치환 안 일어나 import.meta.env 참조 그대로 (런타임 undefined).
+    expect(stdout).toContain("import.meta.env.VITE_NOT_EXPOSED");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -57,7 +57,15 @@ function readRedirectedProcessOutput(
   return { stdout, stderr, exitCode: result.status ?? 1 };
 }
 
-function runCli(args: string[], options: { input?: string; cwd?: string; timeout?: number } = {}) {
+function runCli(
+  args: string[],
+  options: {
+    input?: string;
+    cwd?: string;
+    timeout?: number;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+) {
   const command = [RUNTIME, CLI, ...args].map(shellQuote).join(" ");
   return readRedirectedProcessOutput(command, options);
 }
@@ -1679,6 +1687,20 @@ describe("CLI: .env 자동 로드", () => {
     });
     expect(devResult.exitCode).toBe(0);
     expect(devResult.stdout).toContain("dev");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("shell env 가 .env 파일을 override (CI/배포 시 .env 수정 불필요)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-env-shell-override-"));
+    writeFileSync(join(dir, ".env"), "VITE_HOST=fromFile");
+    writeFileSync(join(dir, "entry.ts"), "console.log(import.meta.env.VITE_HOST);");
+    const { stdout, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], {
+      cwd: dir,
+      env: { ...process.env, VITE_HOST: "fromShell" },
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("fromShell");
+    expect(stdout).not.toContain("fromFile");
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -139,6 +139,7 @@ export function defineConfig<T extends UserConfigInput>(config: T): T {
 
 export { findConfigPath, importAndResolveDefault, loadConfig } from "./src/config-loader";
 export type { ConfigEnv, UserConfig, UserConfigFn, UserConfigInput } from "./src/config-loader";
+export { envToDefine, loadEnv } from "./src/load-env";
 
 import type { UserConfigInput } from "./src/config-loader";
 

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -213,6 +213,19 @@ function readFileOrThrowNotFound(absPath: string): string {
 }
 
 /**
+ * 파일 부재를 정상 케이스로 처리하는 read. ENOENT 면 null, 그 외는 throw.
+ * `.env` 같은 optional 파일 로딩 (`load-env.ts`) 에서 사용.
+ */
+export function readFileIfExists(absPath: string): string | null {
+  try {
+    return readFileSync(absPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
  * cwd 에서 `zts.config.*` 자동 탐색. 우선순위는 `CONFIG_EXT_PRIORITY` 참조.
  *
  * 동기 stat (`existsSync`) 사용 — CLI 시작 시 한 번만 호출되므로 비용 무시 가능.

--- a/packages/core/src/load-env.test.ts
+++ b/packages/core/src/load-env.test.ts
@@ -96,6 +96,24 @@ describe("loadEnv", () => {
     });
   });
 
+  test("unquoted value 뒤의 인라인 주석 제거 (dotenv 16+ 호환)", () => {
+    reset();
+    writeFileSync(
+      join(dir, ".env"),
+      [
+        "VITE_PLAIN=val # 인라인 주석",
+        'VITE_QUOTED="val # not comment"',
+        "VITE_NO_SPACE=foo#noStrip",
+      ].join("\n"),
+    );
+    const env = loadEnv("production", dir);
+    expect(env.VITE_PLAIN).toBe("val");
+    // quoted 값 안의 # 는 보존.
+    expect(env.VITE_QUOTED).toBe("val # not comment");
+    // # 앞에 공백 없으면 strip 안 됨 (보수적 — 사용자 의도 가능).
+    expect(env.VITE_NO_SPACE).toBe("foo#noStrip");
+  });
+
   test("따옴표로 감싼 값은 따옴표 제거", () => {
     reset();
     writeFileSync(

--- a/packages/core/src/load-env.test.ts
+++ b/packages/core/src/load-env.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { envToDefine, loadEnv } from "./load-env.ts";
+
+describe("loadEnv", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-load-env-"));
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  function reset() {
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir);
+  }
+
+  test(".env 파일이 없으면 빈 객체", () => {
+    reset();
+    expect(loadEnv("production", dir)).toEqual({});
+  });
+
+  test(".env 단일 파일: prefix 일치 키만 노출", () => {
+    reset();
+    writeFileSync(
+      join(dir, ".env"),
+      "VITE_API=https://api.example.com\nSECRET_KEY=hidden\nZTS_FLAG=on",
+    );
+    const env = loadEnv("production", dir);
+    expect(env).toEqual({
+      VITE_API: "https://api.example.com",
+      ZTS_FLAG: "on",
+    });
+    expect(env.SECRET_KEY).toBeUndefined();
+  });
+
+  test("4단계 우선순위: .env < .env.local < .env.{mode} < .env.{mode}.local", () => {
+    reset();
+    writeFileSync(join(dir, ".env"), "VITE_KEY=base");
+    writeFileSync(join(dir, ".env.local"), "VITE_KEY=local");
+    writeFileSync(join(dir, ".env.production"), "VITE_KEY=prod");
+    writeFileSync(join(dir, ".env.production.local"), "VITE_KEY=prod-local");
+    expect(loadEnv("production", dir).VITE_KEY).toBe("prod-local");
+
+    rmSync(join(dir, ".env.production.local"));
+    expect(loadEnv("production", dir).VITE_KEY).toBe("prod");
+
+    rmSync(join(dir, ".env.production"));
+    expect(loadEnv("production", dir).VITE_KEY).toBe("local");
+
+    rmSync(join(dir, ".env.local"));
+    expect(loadEnv("production", dir).VITE_KEY).toBe("base");
+  });
+
+  test("mode 별 분기: development 모드는 .env.development 사용", () => {
+    reset();
+    writeFileSync(join(dir, ".env"), "VITE_HOST=base");
+    writeFileSync(join(dir, ".env.development"), "VITE_HOST=dev");
+    writeFileSync(join(dir, ".env.production"), "VITE_HOST=prod");
+    expect(loadEnv("development", dir).VITE_HOST).toBe("dev");
+    expect(loadEnv("production", dir).VITE_HOST).toBe("prod");
+    expect(loadEnv("staging", dir).VITE_HOST).toBe("base");
+  });
+
+  test("커스텀 prefix: 단일 string + 배열 둘 다 지원", () => {
+    reset();
+    writeFileSync(join(dir, ".env"), "VITE_A=1\nMY_B=2\nNEXT_PUBLIC_C=3");
+    expect(loadEnv("production", dir, "MY_")).toEqual({ MY_B: "2" });
+    expect(loadEnv("production", dir, ["MY_", "NEXT_PUBLIC_"])).toEqual({
+      MY_B: "2",
+      NEXT_PUBLIC_C: "3",
+    });
+  });
+
+  test("주석 / 빈 라인 / invalid 키 무시", () => {
+    reset();
+    writeFileSync(
+      join(dir, ".env"),
+      [
+        "# top comment",
+        "",
+        "VITE_OK=1",
+        "# inline comment is whole-line only",
+        "  VITE_TRIM = 2  ",
+        "1INVALID=skipped",
+        "=onlyEqual",
+      ].join("\n"),
+    );
+    expect(loadEnv("production", dir)).toEqual({
+      VITE_OK: "1",
+      VITE_TRIM: "2",
+    });
+  });
+
+  test("따옴표로 감싼 값은 따옴표 제거", () => {
+    reset();
+    writeFileSync(
+      join(dir, ".env"),
+      `VITE_DOUBLE="hello world"\nVITE_SINGLE='single quoted'\nVITE_PLAIN=plain`,
+    );
+    expect(loadEnv("production", dir)).toEqual({
+      VITE_DOUBLE: "hello world",
+      VITE_SINGLE: "single quoted",
+      VITE_PLAIN: "plain",
+    });
+  });
+
+  test("value 안의 = 보존", () => {
+    reset();
+    writeFileSync(join(dir, ".env"), "VITE_URL=https://example.com?q=1&r=2");
+    expect(loadEnv("production", dir).VITE_URL).toBe("https://example.com?q=1&r=2");
+  });
+});
+
+describe("envToDefine", () => {
+  test("MODE/PROD/DEV/SSR 자동 주입 + 사용자 키 포함", () => {
+    const define = envToDefine({ VITE_API: "https://api" }, "production");
+    expect(define).toEqual({
+      "import.meta.env.MODE": '"production"',
+      "import.meta.env.PROD": "true",
+      "import.meta.env.DEV": "false",
+      "import.meta.env.SSR": "false",
+      "import.meta.env.VITE_API": '"https://api"',
+    });
+  });
+
+  test("development mode: PROD=false, DEV=true", () => {
+    const define = envToDefine({}, "development");
+    expect(define["import.meta.env.PROD"]).toBe("false");
+    expect(define["import.meta.env.DEV"]).toBe("true");
+  });
+
+  test("값에 따옴표/특수문자 있어도 JSON.stringify 로 안전하게 직렬화", () => {
+    const define = envToDefine({ VITE_QUOTE: 'has "quotes" and \\backslash' }, "production");
+    expect(define["import.meta.env.VITE_QUOTE"]).toBe('"has \\"quotes\\" and \\\\backslash"');
+  });
+});

--- a/packages/core/src/load-env.ts
+++ b/packages/core/src/load-env.ts
@@ -7,16 +7,20 @@
  *  3. `.env.${mode}` (mode-specific, committed)
  *  4. `.env.${mode}.local` (mode-specific, gitignored)
  *
- * `prefixes` 로 시작하는 키만 반환 (default `["VITE_", "ZTS_"]`).
+ * `prefixes` 로 시작하는 키만 반환. default 는 `["VITE_", "ZTS_"]` 두 개:
+ *  - `VITE_` — Vite 호환 prefix (사용자가 Vite 에서 마이그레이션 시 동일 동작)
+ *  - `ZTS_` — ZTS 전용 prefix (Vite 와 의도적으로 구분된 키 노출 시)
+ *
  * 빈 문자열 prefix `""` 를 포함하면 전체 노출 — 주의해서 사용.
  */
 
-import { readFileSync } from "node:fs";
 import { resolve as pathResolve } from "node:path";
+
+import { readFileIfExists } from "./config-loader.ts";
 
 /**
  * `.env` 라인 1개를 `KEY=value` 로 파싱. 단순한 dotenv 호환 파서:
- *  - `#` 주석 라인 무시
+ *  - `#` 주석 라인 무시 (라인 처음 또는 unquoted value 뒤의 ` # ...` 도 strip)
  *  - `=` 첫 번째만 split — value 안의 `=` 는 보존
  *  - value 가 `"..."` / `'...'` 로 감싸져 있으면 따옴표 제거 (escape sequence 미해석)
  *  - 빈 라인 / 키 없는 라인 무시
@@ -29,24 +33,21 @@ function parseDotenvLine(line: string): [string, string] | null {
   const key = trimmed.slice(0, eqIdx).trim();
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null;
   let value = trimmed.slice(eqIdx + 1).trim();
-  if (
+  const quoted =
     (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
+    (value.startsWith("'") && value.endsWith("'"));
+  if (quoted) {
     value = value.slice(1, -1);
+  } else {
+    // unquoted value: ` # comment` 인라인 주석 제거 (dotenv 16+ / Vite 호환).
+    value = value.replace(/\s+#.*$/, "");
   }
   return [key, value];
 }
 
-/** `.env` 파일 1개 파싱. 부재 시 빈 객체. */
 function parseDotenvFile(filePath: string): Record<string, string> {
-  let content: string;
-  try {
-    content = readFileSync(filePath, "utf8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
-    throw err;
-  }
+  const content = readFileIfExists(filePath);
+  if (content === null) return {};
   const out: Record<string, string> = {};
   for (const line of content.split(/\r?\n/)) {
     const parsed = parseDotenvLine(line);
@@ -79,7 +80,6 @@ export function loadEnv(
     Object.assign(merged, parseDotenvFile(`${dir}/${file}`));
   }
 
-  // prefix 필터.
   const filtered: Record<string, string> = {};
   for (const [key, value] of Object.entries(merged)) {
     if (prefixList.some((p) => key.startsWith(p))) {
@@ -100,6 +100,8 @@ export function envToDefine(env: Record<string, string>, mode: string): Record<s
     "import.meta.env.MODE": JSON.stringify(mode),
     "import.meta.env.PROD": JSON.stringify(mode === "production"),
     "import.meta.env.DEV": JSON.stringify(mode !== "production"),
+    // ZTS 는 현재 SSR 빌드를 별도 mode 로 구분하지 않아 항상 false. 향후 SSR 지원 시
+    // BuildOptions 의 ssr 플래그 (또는 새 옵션) 와 연동해야 함.
     "import.meta.env.SSR": JSON.stringify(false),
   };
   for (const [key, value] of Object.entries(env)) {

--- a/packages/core/src/load-env.ts
+++ b/packages/core/src/load-env.ts
@@ -1,0 +1,109 @@
+/**
+ * `.env` 파일 로더 (Vite 호환).
+ *
+ * 4단계 우선순위 (낮은 → 높은) 로 머지:
+ *  1. `.env` (general, committed)
+ *  2. `.env.local` (general, gitignored)
+ *  3. `.env.${mode}` (mode-specific, committed)
+ *  4. `.env.${mode}.local` (mode-specific, gitignored)
+ *
+ * `prefixes` 로 시작하는 키만 반환 (default `["VITE_", "ZTS_"]`).
+ * 빈 문자열 prefix `""` 를 포함하면 전체 노출 — 주의해서 사용.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve as pathResolve } from "node:path";
+
+/**
+ * `.env` 라인 1개를 `KEY=value` 로 파싱. 단순한 dotenv 호환 파서:
+ *  - `#` 주석 라인 무시
+ *  - `=` 첫 번째만 split — value 안의 `=` 는 보존
+ *  - value 가 `"..."` / `'...'` 로 감싸져 있으면 따옴표 제거 (escape sequence 미해석)
+ *  - 빈 라인 / 키 없는 라인 무시
+ */
+function parseDotenvLine(line: string): [string, string] | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+  const eqIdx = trimmed.indexOf("=");
+  if (eqIdx <= 0) return null;
+  const key = trimmed.slice(0, eqIdx).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null;
+  let value = trimmed.slice(eqIdx + 1).trim();
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+  return [key, value];
+}
+
+/** `.env` 파일 1개 파싱. 부재 시 빈 객체. */
+function parseDotenvFile(filePath: string): Record<string, string> {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+  const out: Record<string, string> = {};
+  for (const line of content.split(/\r?\n/)) {
+    const parsed = parseDotenvLine(line);
+    if (parsed) out[parsed[0]] = parsed[1];
+  }
+  return out;
+}
+
+/**
+ * `mode` 와 `envDir` 기준으로 `.env*` 파일 4종을 우선순위대로 로드 + 머지하고,
+ * `prefixes` 로 시작하는 키만 반환.
+ *
+ * @param mode `--mode <name>` 으로 전달되는 값. 보통 `"production"` / `"development"`.
+ * @param envDir `.env` 파일을 찾을 디렉토리. CLI 의 cwd 기본.
+ * @param prefixes 노출할 키 prefix 목록. default `["VITE_", "ZTS_"]`. 단일 string 도 허용.
+ */
+export function loadEnv(
+  mode: string,
+  envDir: string,
+  prefixes: string | string[] = ["VITE_", "ZTS_"],
+): Record<string, string> {
+  const prefixList = Array.isArray(prefixes) ? prefixes : [prefixes];
+  const dir = pathResolve(envDir);
+
+  // 우선순위: 뒤로 갈수록 덮어씀.
+  const files = [`.env`, `.env.local`, `.env.${mode}`, `.env.${mode}.local`];
+
+  const merged: Record<string, string> = {};
+  for (const file of files) {
+    Object.assign(merged, parseDotenvFile(`${dir}/${file}`));
+  }
+
+  // prefix 필터.
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(merged)) {
+    if (prefixList.some((p) => key.startsWith(p))) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
+}
+
+/**
+ * `loadEnv` 결과 + 빌드 컨텍스트를 `import.meta.env.*` define 으로 변환.
+ *
+ * `import.meta.env.MODE` / `PROD` / `DEV` / `SSR` 를 자동 주입한다 (Vite 호환).
+ * 사용자 정의 키는 모두 `JSON.stringify` 로 직렬화해 ZTS define 에 안전한 리터럴 형태로 전달.
+ */
+export function envToDefine(env: Record<string, string>, mode: string): Record<string, string> {
+  const define: Record<string, string> = {
+    "import.meta.env.MODE": JSON.stringify(mode),
+    "import.meta.env.PROD": JSON.stringify(mode === "production"),
+    "import.meta.env.DEV": JSON.stringify(mode !== "production"),
+    "import.meta.env.SSR": JSON.stringify(false),
+  };
+  for (const [key, value] of Object.entries(env)) {
+    define[`import.meta.env.${key}`] = JSON.stringify(value);
+  }
+  return define;
+}


### PR DESCRIPTION
## 요약
- `loadEnv(mode, envDir, prefixes?)` Vite 호환 API.
- 4단계 우선순위 머지: `.env < .env.local < .env.{mode} < .env.{mode}.local`.
- `import.meta.env.{MODE,PROD,DEV,SSR}` 자동 주입.
- prefix 필터 (default `["VITE_", "ZTS_"]`).
- CLI `--env-prefix` / `--env-dir` flag.
- 사용자 정의 `--define:K=V` 가 자동 주입된 `import.meta.env.*` 보다 우선.

## 사용 예
```env
# .env
VITE_API=https://api.example.com
SECRET_KEY=hidden  # prefix 불일치 — 노출 안 됨

# .env.production
VITE_API=https://prod.api.example.com  # 더 우선
```

```ts
console.log(import.meta.env.VITE_API); // bundle-time 정적 치환됨
console.log(import.meta.env.MODE);      // "production"
console.log(import.meta.env.PROD);      // true
```

## 함수형 config 와의 통합
함수형 config 의 `env` 인자에 loaded .env 가 포함됨:
```ts
export default defineConfig(({ env }) => ({
  define: { __FEATURE_FLAG__: env.VITE_FEATURE_FLAG ?? "false" },
}));
```

## 비범위
- Dev server runtime 에서 `import.meta.env` 객체 자체 노출 (build-time 만 처리)
- watch 시 `.env` 변경 hot reload — #2107 (Phase 2-5) 와 함께 검토
- mode 별 config 파일 (`zts.config.production.ts`) 자동 머지 — #2110 (Phase 3-3)

## 테스트
- `bun test packages/core/src/load-env.test.ts` — 11 pass
- `bun test packages/core/src/config-loader.test.ts` — 30 pass
- `bun test packages/core/bin/zts.test.ts` — 91 pass (5 신규)
- `zig build test` — 4016/4016 pass
- lint / fmt 통과

Closes #2106. Part of #2099.