### PR TITLE
innerGraph: entry pure local DCE

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -80,6 +80,91 @@ test "TreeShaking: entry point exports preserved in bundle" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "const b = 2;") != null);
 }
 
+test "TreeShaking: innerGraph prunes unused pure entry locals" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const used = "INNER_GRAPH_USED_CONST";
+        \\const unused = "INNER_GRAPH_UNUSED_CONST";
+        \\function usedFn() { return "INNER_GRAPH_USED_FN"; }
+        \\function unusedFn() { return "INNER_GRAPH_UNUSED_FN"; }
+        \\console.log(used, usedFn());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_USED_CONST") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_USED_FN") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_UNUSED_CONST") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_UNUSED_FN") == null);
+}
+
+test "TreeShaking: innerGraph preserves entry side-effect initializer" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const unused = sideEffect();
+        \\console.log("INNER_GRAPH_ENTRY");
+        \\function sideEffect() {
+        \\  console.log("INNER_GRAPH_SIDE_EFFECT_INIT");
+        \\  return 1;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_ENTRY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SIDE_EFFECT_INIT") != null);
+}
+
+test "TreeShaking: innerGraph preserves entry exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export const publicValue = "INNER_GRAPH_PUBLIC_EXPORT";
+        \\const privateUnused = "INNER_GRAPH_PRIVATE_UNUSED";
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_PUBLIC_EXPORT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_PRIVATE_UNUSED") == null);
+}
+
 test "TreeShaking: only used exports from dependency" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1272,7 +1272,7 @@ pub fn emitModule(
         // dev 번들은 크기 허용, speed 우선 (Metro/esbuild 관습).
         if (!options.dev_mode) {
             if (used_export_names) |names| {
-                if (!is_entry and module.wrap_kind != .esm) {
+                if (module.wrap_kind != .esm and (!is_entry or (shaker != null and options.minify_syntax))) {
                     stmt_shake: {
                         const sem = module.semantic orelse {
                             statement_shaker.markUnusedStatements(

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -563,12 +563,25 @@ pub const TreeShaker = struct {
                 reachable_stmts[i] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
             }
 
-            // entry는 번들 진입점 — 모든 top-level statement가 실행되어야 하므로 전체 시드.
+            // entry는 번들 진입점이지만 pure local declaration은 실행 의미가 없다.
+            // side-effect statement와 entry export seed만 살리고, local-only pure statement는
+            // BFS dependency로 필요할 때만 도달시킨다.
             // side_effects=true 모듈은 side-effect stmt만 시드.
             // side_effects=false 모듈은 enqueue의 lazy 시드로 처리 (사용 시에만).
             if (self.entry_set.isSet(i)) {
-                for (infos.stmts, 0..) |_, si| {
-                    try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                var has_entry_side_effect_stmt = false;
+                for (infos.stmts) |stmt| {
+                    if (stmt.has_side_effects) {
+                        has_entry_side_effect_stmt = true;
+                        break;
+                    }
+                }
+                const prune_pure_entry_locals = self.graph.transform_options_base.minify_syntax and
+                    (has_entry_side_effect_stmt or m.export_bindings.len > 0);
+                for (infos.stmts, 0..) |stmt, si| {
+                    if (!prune_pure_entry_locals or stmt.has_side_effects) {
+                        try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                    }
                 }
             } else if (m.side_effects and m.side_effects_user_defined) {
                 for (infos.stmts, 0..) |_, si| {


### PR DESCRIPTION
## 요약

- innerGraph 1단계로 entry 모듈의 pure local top-level statement를 `minify_syntax` 최적화 경로에서 제거합니다.
- 기존 기본 번들 출력은 유지합니다. side-effect 없는 단일 entry 선언처럼 보존 기대가 있는 케이스는 그대로 출력됩니다.
- entry 전체를 무조건 live로 시드하지 않고, 최적화 모드에서는 side-effect statement와 public export seed를 기준으로 BFS dependency만 살립니다.

## 동작 범위

- `minify_syntax`가 켜진 scope-hoist/tree-shaking 경로에서만 entry local DCE 적용
- side-effect statement가 있거나 entry export가 있는 경우에만 pure local pruning 활성화
- side-effect initializer는 보존
- entry export는 public surface로 보존
- non-entry statement tree-shaking 기존 동작은 유지

## 테스트

- unused pure entry `const` / `function` 제거
- side-effect initializer 보존
- entry export 보존 및 private unused local 제거

## 검증

- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `git diff --check`
- fixture 확인:
  - `--minify-syntax`에서 unused entry local 제거
  - side-effect 없는 단일 entry declaration은 기존처럼 보존