### PR TITLE
innerGraph: overwritten dead write 제거

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -165,6 +165,278 @@ test "TreeShaking: innerGraph preserves entry exports" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_PRIVATE_UNUSED") == null);
 }
 
+test "TreeShaking: innerGraph prunes pure write-only assignment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = 1;
+        \\value = "INNER_GRAPH_DEAD_WRITE";
+        \\console.log("INNER_GRAPH_WRITE_ENTRY");
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_WRITE_ENTRY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_DEAD_WRITE") == null);
+}
+
+test "TreeShaking: innerGraph prunes overwritten pure assignment before read" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value;
+        \\value = "INNER_GRAPH_OVERWRITTEN_WRITE";
+        \\value = "INNER_GRAPH_FINAL_WRITE";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_FINAL_WRITE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_OVERWRITTEN_WRITE") == null);
+}
+
+test "TreeShaking: innerGraph preserves assignment read before overwrite" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value;
+        \\value = "INNER_GRAPH_READ_BEFORE_OVERWRITE";
+        \\console.log(value);
+        \\value = "INNER_GRAPH_READ_AFTER_OVERWRITE";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_READ_BEFORE_OVERWRITE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_READ_AFTER_OVERWRITE") != null);
+}
+
+test "TreeShaking: innerGraph preserves assignment with side-effect RHS" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = 1;
+        \\value = sideEffect();
+        \\console.log("INNER_GRAPH_SIDE_WRITE_ENTRY");
+        \\function sideEffect() {
+        \\  console.log("INNER_GRAPH_SIDE_WRITE");
+        \\  return 2;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SIDE_WRITE_ENTRY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SIDE_WRITE") != null);
+}
+
+test "TreeShaking: innerGraph preserves overwritten assignment with side-effect RHS" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value;
+        \\value = sideEffect();
+        \\value = "INNER_GRAPH_SIDE_OVERWRITE_FINAL";
+        \\console.log(value);
+        \\function sideEffect() {
+        \\  console.log("INNER_GRAPH_SIDE_OVERWRITE");
+        \\  return 1;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SIDE_OVERWRITE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SIDE_OVERWRITE_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph preserves assignment whose value is read" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = 1;
+        \\value = "INNER_GRAPH_LIVE_WRITE";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_LIVE_WRITE") != null);
+}
+
+test "TreeShaking: innerGraph preserves compound assignment before overwrite" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = 1;
+        \\value += 2;
+        \\value = "INNER_GRAPH_COMPOUND_FINAL";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "value += 2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_COMPOUND_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph preserves update expression before overwrite" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = 1;
+        \\value++;
+        \\value = "INNER_GRAPH_UPDATE_FINAL";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "value++") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_UPDATE_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph preserves member assignment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\const obj = {};
+        \\obj.value = "INNER_GRAPH_MEMBER_WRITE";
+        \\console.log("INNER_GRAPH_MEMBER_ENTRY");
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_MEMBER_ENTRY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_MEMBER_WRITE") != null);
+}
+
+test "TreeShaking: innerGraph preserves global assignment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\globalThis.value = "INNER_GRAPH_GLOBAL_WRITE";
+        \\console.log("INNER_GRAPH_GLOBAL_ENTRY");
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_GLOBAL_ENTRY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_GLOBAL_WRITE") != null);
+}
+
 test "TreeShaking: only used exports from dependency" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -51,6 +51,8 @@ const stmt_info_mod = @import("stmt_info.zig");
 const ExportBinding = @import("binding_scanner.zig").ExportBinding;
 const plugin_mod = @import("plugin.zig");
 const external_imports = @import("emitter/external_imports.zig");
+const purity = @import("purity.zig");
+const TokenKind = @import("../lexer/token.zig").Kind;
 
 pub const EmitOptions = struct {
     /// transformer pre-pass / emit 단계 transformer.init 양쪽에서 사용하는 옵션 base.
@@ -1326,6 +1328,14 @@ pub fn emitModule(
                                                 &md.skip_nodes,
                                             ) catch {};
                                         }
+                                        if (options.minify_syntax) {
+                                            markDeadOverwrittenAssignments(
+                                                transformer.ast,
+                                                md.symbol_ids,
+                                                &sem.unresolved_references,
+                                                &md.skip_nodes,
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -1834,6 +1844,110 @@ fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph, lin
 /// `module.exports = { used, unused }` object-shape 의 unused property 노드를
 /// transformer AST 쪽 인덱스로 변환해 `skip_nodes` 에 마킹.
 /// span -> new_ni map 을 1회 구축해 fact 마다 nodes 전체를 재스캔하던 O(F×N) 회피.
+const AssignmentInfo = struct {
+    stmt_idx: u32,
+    lhs_idx: u32,
+    sym_idx: u32,
+};
+
+fn markDeadOverwrittenAssignments(
+    ast: *const Ast,
+    symbol_ids: []const ?u32,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+    skip_nodes: *std.DynamicBitSet,
+) void {
+    if (ast.nodes.items.len == 0) return;
+    const root = ast.nodes.items[ast.nodes.items.len - 1];
+    if (root.tag != .program) return;
+    const list = root.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    const stmts = ast.extra_data.items[list.start .. list.start + list.len];
+
+    for (stmts, 0..) |raw_stmt, i| {
+        if (raw_stmt >= ast.nodes.items.len) continue;
+        if (raw_stmt < skip_nodes.capacity() and skip_nodes.isSet(raw_stmt)) continue;
+        const current = assignmentInfoForStmt(ast, raw_stmt, symbol_ids, unresolved_globals, true) orelse continue;
+
+        var j = i + 1;
+        while (j < stmts.len) : (j += 1) {
+            const next_raw = stmts[j];
+            if (next_raw >= ast.nodes.items.len) continue;
+            if (next_raw < skip_nodes.capacity() and skip_nodes.isSet(next_raw)) continue;
+
+            if (stmtReadsSymbolBeforeOverwrite(ast, next_raw, symbol_ids, current.sym_idx)) break;
+            if (assignmentInfoForStmt(ast, next_raw, symbol_ids, unresolved_globals, false)) |next_assign| {
+                if (next_assign.sym_idx == current.sym_idx) {
+                    if (current.stmt_idx < skip_nodes.capacity()) skip_nodes.set(current.stmt_idx);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn assignmentInfoForStmt(
+    ast: *const Ast,
+    stmt_idx: u32,
+    symbol_ids: []const ?u32,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+    require_pure_rhs: bool,
+) ?AssignmentInfo {
+    if (stmt_idx >= ast.nodes.items.len) return null;
+    const stmt = ast.nodes.items[stmt_idx];
+    if (stmt.tag != .expression_statement) return null;
+    const expr_idx = stmt.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return null;
+
+    const op: TokenKind = @enumFromInt(expr.data.binary.flags);
+    if (op != .eq) return null;
+
+    const lhs_idx = expr.data.binary.left;
+    if (lhs_idx.isNone() or @intFromEnum(lhs_idx) >= ast.nodes.items.len) return null;
+    const lhs = ast.nodes.items[@intFromEnum(lhs_idx)];
+    if (lhs.tag != .assignment_target_identifier and lhs.tag != .identifier_reference) return null;
+    const lhs_ni = @intFromEnum(lhs_idx);
+    if (lhs_ni >= symbol_ids.len) return null;
+    const sym_idx: u32 = @intCast(symbol_ids[lhs_ni] orelse return null);
+
+    const rhs_idx = expr.data.binary.right;
+    if (require_pure_rhs and !purity.isExprPure(ast, rhs_idx, unresolved_globals)) return null;
+
+    return .{
+        .stmt_idx = stmt_idx,
+        .lhs_idx = @intCast(lhs_ni),
+        .sym_idx = sym_idx,
+    };
+}
+
+fn stmtReadsSymbolBeforeOverwrite(
+    ast: *const Ast,
+    stmt_idx: u32,
+    symbol_ids: []const ?u32,
+    sym_idx: u32,
+) bool {
+    if (stmt_idx >= ast.nodes.items.len) return false;
+    const stmt = ast.nodes.items[stmt_idx];
+    const simple_assign = assignmentInfoForStmt(ast, stmt_idx, symbol_ids, null, false);
+
+    for (ast.nodes.items, 0..) |node, node_i| {
+        if (node.span.start < stmt.span.start or node.span.end > stmt.span.end) continue;
+        if (node_i >= symbol_ids.len) continue;
+        const node_sym: u32 = @intCast(symbol_ids[node_i] orelse continue);
+        if (node_sym != sym_idx) continue;
+
+        if (node.tag == .identifier_reference) return true;
+        if (node.tag == .assignment_target_identifier) {
+            if (simple_assign) |assign| {
+                if (assign.sym_idx == sym_idx and assign.lhs_idx == node_i) continue;
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
 fn markUnusedCjsObjectProperties(
     arena: std.mem.Allocator,
     module: *const Module,


### PR DESCRIPTION
## 요약

- innerGraph dead write 1단계로, 읽히기 전에 다음 write로 덮어써지는 pure top-level assignment를 제거합니다.
- 기존 StmtInfo reachability가 보수적으로 모든 writer stmt를 살리는 경로 뒤에, emit 직전 `skip_nodes`에 dead overwritten assignment만 추가 마킹합니다.
- `minify_syntax` 경로에서만 동작합니다.

## 제거 조건

- top-level expression statement
- simple `=` assignment
- LHS가 module-local identifier
- RHS가 pure
- 같은 symbol이 읽히기 전에 뒤쪽 top-level simple assignment가 다시 씀

## 보존 조건

- RHS side effect가 있는 assignment 보존
- 다음 write 전에 값이 읽히는 assignment 보존
- member/global assignment 보존
- compound assignment / update expression처럼 read+write 의미가 있는 형태는 제외

## TDD

- 먼저 `value = "dead"; value = "live"; console.log(value)` 케이스가 실패하는 것을 확인했습니다.
- 구현 후 해당 케이스가 통과하도록 했습니다.

## 테스트

- pure write-only assignment 제거
- overwritten pure assignment 제거
- read-before-overwrite assignment 보존
- side-effect RHS assignment 보존
- overwritten side-effect RHS assignment 보존
- read되는 assignment 보존
- compound assignment 보존
- update expression 보존
- member assignment 보존
- global assignment 보존

## 검증

- `zig build test --summary all --prominent-compile-errors`
- `zig build --summary all --prominent-compile-errors`
- `git diff --check`
- fixture 확인:
  - overwritten pure write 제거
  - read-before-overwrite write 보존