### PR TITLE
innerGraph: overwritten declaration initializer 제거

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -218,6 +218,167 @@ test "TreeShaking: innerGraph prunes overwritten pure assignment before read" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_OVERWRITTEN_WRITE") == null);
 }
 
+test "TreeShaking: innerGraph prunes overwritten pure declaration initializer" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = "INNER_GRAPH_DEAD_INIT";
+        \\value = "INNER_GRAPH_INIT_FINAL";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_INIT_FINAL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_DEAD_INIT") == null);
+}
+
+test "TreeShaking: innerGraph preserves declaration initializer read before overwrite" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = "INNER_GRAPH_LIVE_INIT";
+        \\console.log(value);
+        \\value = "INNER_GRAPH_AFTER_INIT_READ";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_LIVE_INIT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_AFTER_INIT_READ") != null);
+}
+
+test "TreeShaking: innerGraph preserves side-effect declaration initializer" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = sideEffect();
+        \\value = "INNER_GRAPH_SIDE_INIT_FINAL";
+        \\console.log(value);
+        \\function sideEffect() {
+        \\  console.log("INNER_GRAPH_SIDE_INIT");
+        \\  return 1;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SIDE_INIT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SIDE_INIT_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph preserves exported declaration initializer" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export let value = "INNER_GRAPH_EXPORTED_INIT";
+        \\value = "INNER_GRAPH_EXPORTED_FINAL";
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_EXPORTED_INIT") != null);
+}
+
+test "TreeShaking: innerGraph preserves destructuring declaration initializer" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let { value } = { value: "INNER_GRAPH_DESTRUCT_INIT" };
+        \\value = "INNER_GRAPH_DESTRUCT_FINAL";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_DESTRUCT_INIT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_DESTRUCT_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph preserves multi-declarator declaration initializer" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let first = "INNER_GRAPH_MULTI_INIT", second = "INNER_GRAPH_MULTI_SECOND";
+        \\first = "INNER_GRAPH_MULTI_FINAL";
+        \\console.log(first, second);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_MULTI_INIT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_MULTI_SECOND") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_MULTI_FINAL") != null);
+}
+
 test "TreeShaking: innerGraph preserves assignment read before overwrite" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1334,6 +1334,7 @@ pub fn emitModule(
                                                 md.symbol_ids,
                                                 &sem.unresolved_references,
                                                 &md.skip_nodes,
+                                                module,
                                             );
                                         }
                                     }
@@ -1851,10 +1852,11 @@ const AssignmentInfo = struct {
 };
 
 fn markDeadOverwrittenAssignments(
-    ast: *const Ast,
+    ast: *Ast,
     symbol_ids: []const ?u32,
     unresolved_globals: ?*const purity.GlobalRefSet,
     skip_nodes: *std.DynamicBitSet,
+    module: *const Module,
 ) void {
     if (ast.nodes.items.len == 0) return;
     const root = ast.nodes.items[ast.nodes.items.len - 1];
@@ -1866,6 +1868,7 @@ fn markDeadOverwrittenAssignments(
     for (stmts, 0..) |raw_stmt, i| {
         if (raw_stmt >= ast.nodes.items.len) continue;
         if (raw_stmt < skip_nodes.capacity() and skip_nodes.isSet(raw_stmt)) continue;
+        markDeadOverwrittenDeclarationInitializers(ast, raw_stmt, i, stmts, symbol_ids, unresolved_globals, module);
         const current = assignmentInfoForStmt(ast, raw_stmt, symbol_ids, unresolved_globals, true) orelse continue;
 
         var j = i + 1;
@@ -1883,6 +1886,69 @@ fn markDeadOverwrittenAssignments(
             }
         }
     }
+}
+
+fn markDeadOverwrittenDeclarationInitializers(
+    ast: *Ast,
+    stmt_idx: u32,
+    stmt_pos: usize,
+    stmts: []const u32,
+    symbol_ids: []const ?u32,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+    module: *const Module,
+) void {
+    if (stmt_idx >= ast.nodes.items.len) return;
+    const stmt = ast.nodes.items[stmt_idx];
+    if (stmt.tag != .variable_declaration) return;
+
+    const kind = ast.variableDeclarationKind(stmt);
+    if (kind == .@"const" or kind.isUsing()) return;
+
+    const e = stmt.data.extra;
+    if (e + 2 >= ast.extra_data.items.len) return;
+    const list_start = ast.extra_data.items[e + 1];
+    const list_len = ast.extra_data.items[e + 2];
+    if (list_len != 1 or list_start >= ast.extra_data.items.len) return;
+
+    const decl_idx = ast.extra_data.items[list_start];
+    if (decl_idx >= ast.nodes.items.len) return;
+    const decl = ast.nodes.items[decl_idx];
+    if (decl.tag != .variable_declarator) return;
+
+    const de = decl.data.extra;
+    if (de + 2 >= ast.extra_data.items.len) return;
+    const name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[de]);
+    const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[de + 2]);
+    if (name_idx.isNone() or init_idx.isNone()) return;
+    const name_ni = @intFromEnum(name_idx);
+    if (name_ni >= ast.nodes.items.len or name_ni >= symbol_ids.len) return;
+    const name = ast.nodes.items[name_ni];
+    if (name.tag != .binding_identifier) return;
+    const sym_idx: u32 = @intCast(symbol_ids[name_ni] orelse return);
+    if (isExportedSymbol(module, sym_idx)) return;
+    if (!purity.isExprPure(ast, init_idx, unresolved_globals)) return;
+
+    var j = stmt_pos + 1;
+    while (j < stmts.len) : (j += 1) {
+        const next_raw = stmts[j];
+        if (next_raw >= ast.nodes.items.len) continue;
+        if (stmtReadsSymbolBeforeOverwrite(ast, next_raw, symbol_ids, sym_idx)) break;
+        if (assignmentInfoForStmt(ast, next_raw, symbol_ids, unresolved_globals, false)) |next_assign| {
+            if (next_assign.sym_idx == sym_idx) {
+                ast.extra_data.items[de + 2] = @intFromEnum(NodeIndex.none);
+                break;
+            }
+        }
+    }
+}
+
+fn isExportedSymbol(module: *const Module, sym_idx: u32) bool {
+    for (module.export_bindings) |binding| {
+        if (binding.symbol.semanticIndex()) |export_sym| {
+            if (export_sym == sym_idx) return true;
+        }
+    }
+    return false;
 }
 
 fn assignmentInfoForStmt(


### PR DESCRIPTION
## 요약
- `--minify-syntax`의 innerGraph 경로에서 뒤에서 바로 덮어써지는 순수 선언 initializer를 제거합니다.
- `let value = "dead"; value = "live"; console.log(value);` 형태를 `var value; value = "live"; ...` 형태로 줄입니다.
- 범위는 보수적으로 제한했습니다: top-level `let`/`var`, 단일 declarator, simple identifier, 순수 initializer, read 전 단순 대입 overwrite만 처리합니다.

## 보수 조건
- `const`, `using`, destructuring, multi-declarator는 제외합니다.
- export binding은 제외합니다.
- side-effectful initializer는 보존합니다.
- overwrite 전 read가 있으면 initializer를 보존합니다.

## TDD / 테스트
- 먼저 실패 케이스를 추가해서 기존 출력에 `INNER_GRAPH_DEAD_INIT`이 남는 것을 확인했습니다.
- 추가한 케이스:
  - 순수 선언 initializer 제거
  - overwrite 전 read 보존
  - side-effect initializer 보존
  - exported initializer 보존
  - destructuring initializer 보존
  - multi-declarator initializer 보존

## 검증
- `zig fmt src/bundler/emitter.zig src/bundler/bundler_test/tree_shake.zig`
- `zig build test --summary all --prominent-compile-errors` → 4048/4048 passed
- `zig build --summary all --prominent-compile-errors`
- `git diff --check`
- fixture smoke: dead initializer 제거 및 live assignment 보존 확인