### PR TITLE
feat(config): --mode + zts.config.{mode}.* 자동 머지

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -21,9 +21,11 @@ const {
   buildSync,
   envToDefine,
   findConfigPath,
+  findModeConfigPath,
   importAndResolveDefault,
   loadConfig,
   loadEnv,
+  mergeUserConfigs,
 } = coreModule;
 import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { resolve, dirname, basename, extname, join } from "node:path";
@@ -693,10 +695,16 @@ async function loadAutoConfig(opts) {
     Object.keys(dotenvVars).length === 0 ? process.env : { ...process.env, ...dotenvVars };
   const env = { command, mode, env: mergedEnv };
 
-  if (!configPath) return { config: null, env, dotenvVars };
+  // mode-specific config 자동 탐색 + 머지 (#2110). `--config <path>` 명시 시
+  // 그 파일이 단독 source — mode-specific 자동 탐색 안 함 (사용자 의도 존중).
+  const modeConfigPath = explicit ? null : findModeConfigPath(process.cwd(), mode);
+
+  if (!configPath && !modeConfigPath) return { config: null, env, dotenvVars };
 
   try {
-    const config = await loadConfig(configPath, env);
+    const baseConfig = configPath ? await loadConfig(configPath, env) : {};
+    const modeConfig = modeConfigPath ? await loadConfig(modeConfigPath, env) : null;
+    const config = modeConfig ? mergeUserConfigs(baseConfig, modeConfig) : baseConfig;
     return { config, env, dotenvVars };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
@@ -1024,14 +1032,20 @@ function computeRestartTriggers(opts) {
   const autoConfig = explicitConfig ?? findConfigPath(process.cwd());
   if (autoConfig) dirs.add(dirname(autoConfig));
 
-  const configBase = autoConfig ? basename(autoConfig) : null;
   const mode = opts.mode ?? (opts.serve || opts.watch ? "development" : "production");
+  // mode-specific config (`zts.config.${mode}.{ext}`) 변경도 restart trigger (#2110).
+  const modeConfig = explicitConfig ? null : findModeConfigPath(process.cwd(), mode);
+  if (modeConfig) dirs.add(dirname(modeConfig));
+
+  const configBase = autoConfig ? basename(autoConfig) : null;
+  const modeConfigBase = modeConfig ? basename(modeConfig) : null;
   const envBases = new Set([".env", ".env.local", `.env.${mode}`, `.env.${mode}.local`]);
 
   return {
     dirs,
     matches(filename) {
       const base = basename(filename);
+      if (modeConfigBase && base === modeConfigBase) return true;
       if (configBase && base === configBase) return true;
       if (envBases.has(base)) return true;
       return false;

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2288,3 +2288,123 @@ describe("CLI: .env 자동 로드", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+// ─── mode-specific config 자동 머지 (#2110 / Phase 3-3) ───
+
+describe("CLI: zts.config.{mode}.* 자동 머지", () => {
+  test("mode-specific config 가 base 를 override", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-mode-cfg-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('hi');");
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ banner: "/* base */" }));
+    writeFileSync(
+      join(dir, "zts.config.production.json"),
+      JSON.stringify({ banner: "/* prod-mode */" }),
+    );
+    const { stdout, exitCode } = runCli(["--bundle", "--mode=production", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* prod-mode */");
+    expect(stdout).not.toContain("/* base */");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("base + mode 머지: 둘 다 정의된 키 + 한쪽만 정의된 키", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-mode-merge-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log(__VER__, __BUILD__);");
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({
+        define: { __VER__: '"v1"', __BUILD__: '"prod"' },
+      }),
+    );
+    writeFileSync(
+      join(dir, "zts.config.production.json"),
+      JSON.stringify({
+        define: { __BUILD__: '"prod-override"' },
+      }),
+    );
+    const { stdout, exitCode } = runCli(["--bundle", "--mode=production", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    // base 의 __VER__ 그대로, mode 의 __BUILD__ override
+    expect(stdout).toContain('"v1"');
+    expect(stdout).toContain('"prod-override"');
+    expect(stdout).not.toContain('"prod"' + ")"); // 기존 prod 값 미사용
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("mode-specific 만 존재 (base 부재) — mode config 단독 사용", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-mode-only-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('x');");
+    writeFileSync(
+      join(dir, "zts.config.staging.json"),
+      JSON.stringify({ banner: "/* staging-only */" }),
+    );
+    const { stdout, exitCode } = runCli(["--bundle", "--mode=staging", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* staging-only */");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("mode 미매치: base 만 적용", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-mode-mismatch-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('y');");
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ banner: "/* base */" }));
+    writeFileSync(
+      join(dir, "zts.config.production.json"),
+      JSON.stringify({ banner: "/* prod-only */" }),
+    );
+    // --mode=development → .production config 무시.
+    const { stdout, exitCode } = runCli(["--bundle", "--mode=development", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* base */");
+    expect(stdout).not.toContain("/* prod-only */");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--config <path> 명시 시 mode-specific 자동 탐색 안 함", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-mode-explicit-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('z');");
+    writeFileSync(join(dir, "custom.config.json"), JSON.stringify({ banner: "/* explicit */" }));
+    // mode-specific 는 있지만 --config 명시했으므로 무시되어야 함.
+    writeFileSync(
+      join(dir, "zts.config.production.json"),
+      JSON.stringify({ banner: "/* should-be-ignored */" }),
+    );
+    const { stdout, exitCode } = runCli(
+      [
+        "--bundle",
+        "--config",
+        join(dir, "custom.config.json"),
+        "--mode=production",
+        join(dir, "entry.ts"),
+      ],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* explicit */");
+    expect(stdout).not.toContain("/* should-be-ignored */");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("mode-specific config TS 형식도 동작", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-mode-ts-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('q');");
+    writeFileSync(
+      join(dir, "zts.config.production.ts"),
+      `export default { banner: "/* TS_PROD */" as const };`,
+    );
+    const { stdout, exitCode } = runCli(["--bundle", "--mode=production", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* TS_PROD */");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -137,7 +137,13 @@ export function defineConfig<T extends UserConfigInput>(config: T): T {
   return config;
 }
 
-export { findConfigPath, importAndResolveDefault, loadConfig } from "./src/config-loader";
+export {
+  findConfigPath,
+  findModeConfigPath,
+  importAndResolveDefault,
+  loadConfig,
+  mergeUserConfigs,
+} from "./src/config-loader";
 export type { ConfigEnv, UserConfig, UserConfigFn, UserConfigInput } from "./src/config-loader";
 export { envToDefine, loadEnv } from "./src/load-env";
 

--- a/packages/core/src/config-loader.test.ts
+++ b/packages/core/src/config-loader.test.ts
@@ -4,7 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { init } from "../index";
-import { CONFIG_EXT_PRIORITY, findConfigPath, loadConfig } from "./config-loader";
+import {
+  CONFIG_EXT_PRIORITY,
+  findConfigPath,
+  findModeConfigPath,
+  loadConfig,
+  mergeUserConfigs,
+} from "./config-loader";
 
 beforeAll(() => init());
 
@@ -308,5 +314,127 @@ describe("loadConfig: 함수형 config", () => {
       env: {},
     });
     expect(config).toEqual({ format: "esm" });
+  });
+});
+
+// ─── mode-specific config (#2110 / Phase 3-3) ────────────────────────────────
+
+describe("findModeConfigPath", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-find-mode-cfg-"));
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  function reset() {
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir);
+  }
+
+  test("mode 빈 문자열이면 null", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.ts"), `export default {};`);
+    expect(findModeConfigPath(dir, "")).toBeNull();
+  });
+
+  test("mode-specific 파일 부재 시 null", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.ts"), `export default {};`);
+    expect(findModeConfigPath(dir, "production")).toBeNull();
+  });
+
+  test(".ts > .json 우선순위", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.production.ts"), `export default {};`);
+    writeFileSync(join(dir, "zts.config.production.json"), `{}`);
+    expect(findModeConfigPath(dir, "production")).toBe(join(dir, "zts.config.production.ts"));
+  });
+
+  test("mode 별 분기: production / development", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.production.ts"), `export default {};`);
+    writeFileSync(join(dir, "zts.config.development.ts"), `export default {};`);
+    expect(findModeConfigPath(dir, "production")).toBe(join(dir, "zts.config.production.ts"));
+    expect(findModeConfigPath(dir, "development")).toBe(join(dir, "zts.config.development.ts"));
+    expect(findModeConfigPath(dir, "staging")).toBeNull();
+  });
+
+  test("`.json` 도 자동 탐색 대상", () => {
+    reset();
+    writeFileSync(join(dir, "zts.config.production.json"), `{}`);
+    expect(findModeConfigPath(dir, "production")).toBe(join(dir, "zts.config.production.json"));
+  });
+});
+
+describe("mergeUserConfigs", () => {
+  test("scalar: mode 가 base 를 override", () => {
+    const merged = mergeUserConfigs({ format: "esm", target: "es2020" }, { format: "iife" });
+    expect(merged).toEqual({ format: "iife", target: "es2020" });
+  });
+
+  test("undefined 인 mode 키는 무시 (base 보존)", () => {
+    const merged = mergeUserConfigs({ format: "esm" }, { format: undefined });
+    expect(merged).toEqual({ format: "esm" });
+  });
+
+  test("객체 (define): shallow merge — base 키 + mode 키, mode 우선", () => {
+    const merged = mergeUserConfigs(
+      { define: { __VER__: '"v1"', __BUILD__: '"prod"' } },
+      { define: { __BUILD__: '"override"', __NEW__: '"x"' } },
+    );
+    expect(merged.define).toEqual({
+      __VER__: '"v1"',
+      __BUILD__: '"override"',
+      __NEW__: '"x"',
+    });
+  });
+
+  test("객체 (alias): shallow merge", () => {
+    const merged = mergeUserConfigs(
+      { alias: { "@a": "/path/a", "@b": "/path/b" } },
+      { alias: { "@b": "/override/b" } },
+    );
+    expect(merged.alias).toEqual({
+      "@a": "/path/a",
+      "@b": "/override/b",
+    });
+  });
+
+  test("배열 (entryPoints): mode 가 base 를 완전 대체 (concat 안 함)", () => {
+    const merged = mergeUserConfigs({ entryPoints: ["./base.ts"] }, { entryPoints: ["./mode.ts"] });
+    expect(merged.entryPoints).toEqual(["./mode.ts"]);
+  });
+
+  test("배열 (external): mode 가 base 대체", () => {
+    const merged = mergeUserConfigs({ external: ["react"] }, { external: ["react", "react-dom"] });
+    expect(merged.external).toEqual(["react", "react-dom"]);
+  });
+
+  test("plugins: 예외적으로 concat (Vite 호환)", () => {
+    const basePlugin = { name: "base-p", setup() {} };
+    const modePlugin = { name: "mode-p", setup() {} };
+    const merged = mergeUserConfigs({ plugins: [basePlugin] }, { plugins: [modePlugin] });
+    expect(merged.plugins).toEqual([basePlugin, modePlugin]);
+  });
+
+  test("base 에 없는 mode 전용 키 추가", () => {
+    const merged = mergeUserConfigs({ format: "esm" }, { minify: true });
+    expect(merged).toEqual({ format: "esm", minify: true });
+  });
+
+  test("mode 에 없는 base 전용 키 보존", () => {
+    const merged = mergeUserConfigs({ format: "esm", target: "es2020" }, { minify: true });
+    expect(merged).toEqual({ format: "esm", target: "es2020", minify: true });
+  });
+
+  test("배열 vs 객체 mismatch — mode 가 type 무관 override", () => {
+    // 비정상 입력이지만 panic 안 하고 mode 값으로 override.
+    const merged = mergeUserConfigs(
+      { external: ["react"] } as { external: string[] },
+      { external: undefined } as { external: undefined },
+    );
+    expect(merged.external).toEqual(["react"]); // undefined 는 skip
   });
 });

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -242,3 +242,65 @@ export function findConfigPath(cwd: string): string | null {
   }
   return null;
 }
+
+/**
+ * mode-specific config 파일 자동 탐색 — `zts.config.${mode}.{ext}` 형태 (#2110).
+ *
+ * Vite 의 mode 별 config 패턴: base `zts.config.ts` 가 default, `zts.config.production.ts`
+ * 같은 mode-specific 파일이 base 를 부분 override. mode 가 비어있거나 매칭 파일 없으면 null.
+ */
+export function findModeConfigPath(cwd: string, mode: string): string | null {
+  if (!mode) return null;
+  for (const ext of CONFIG_EXT_PRIORITY) {
+    const candidate = join(cwd, `zts.config.${mode}${ext}`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * base config + mode-specific config 머지. mode 가 base 를 override.
+ *
+ * 머지 정책 (Vite 호환):
+ *  - scalar / string: mode 값이 정의됐으면 그것 사용
+ *  - 배열: mode 가 정의됐으면 base 를 완전 대체 (concat 안 함 — 의도 명확화)
+ *  - 객체 (`define`/`alias`/`loader`): shallow merge — base 키 + mode 키 (mode 우선)
+ *
+ * `plugins` 는 concat (Vite 와 일치 — 둘 다 적용).
+ */
+export function mergeUserConfigs(base: UserConfig, mode: UserConfig): UserConfig {
+  const merged: UserConfig = { ...base };
+
+  for (const key of Object.keys(mode) as Array<keyof UserConfig>) {
+    const modeVal = mode[key];
+    if (modeVal === undefined) continue;
+
+    if (key === "plugins" && Array.isArray(modeVal) && Array.isArray(merged.plugins)) {
+      // plugins 는 concat — base 먼저, mode 추가.
+      (merged as Record<string, unknown>).plugins = [...merged.plugins, ...modeVal];
+      continue;
+    }
+
+    const baseVal = base[key];
+    if (
+      typeof baseVal === "object" &&
+      baseVal !== null &&
+      !Array.isArray(baseVal) &&
+      typeof modeVal === "object" &&
+      modeVal !== null &&
+      !Array.isArray(modeVal)
+    ) {
+      // 객체끼리 shallow merge — define/alias/loader 등.
+      (merged as Record<string, unknown>)[key] = {
+        ...(baseVal as Record<string, unknown>),
+        ...(modeVal as Record<string, unknown>),
+      };
+      continue;
+    }
+
+    // scalar / 배열 / 함수 / mode 만 정의됨 — 그대로 override.
+    (merged as Record<string, unknown>)[key] = modeVal as unknown;
+  }
+
+  return merged;
+}


### PR DESCRIPTION
## 요약
base config (`zts.config.{ext}`) + mode-specific config (`zts.config.${mode}.{ext}`) 자동 탐색 후 머지. Vite 호환 패턴.

## 사용 예
```ts
// zts.config.ts (base)
export default defineConfig({
  format: "esm",
  define: { __VER__: '"v1.0"' },
});

// zts.config.production.ts (mode-specific)
export default defineConfig({
  minify: true,
  define: { __BUILD__: '"prod"' },
});
```
```bash
zts --bundle --mode=production entry.ts
# → format=esm + minify=true + define={__VER__:"v1.0", __BUILD__:"prod"}
```

## API 추가
- `findModeConfigPath(cwd, mode)` — `CONFIG_EXT_PRIORITY` 우선순위로 mode-specific 자동 탐색
- `mergeUserConfigs(base, mode)` — 머지 정책:
  - scalar / 배열: mode 가 base override
  - 객체 (`define`/`alias`/`loader`): shallow merge — base 키 + mode 키, mode 우선
  - `plugins`: concat (Vite 호환)

## CLI 동작
- `loadAutoConfig` 가 `--mode` 값으로 `zts.config.${mode}.*` 자동 탐색 + 머지
- `--config <path>` 명시 시 mode-specific 자동 탐색 안 함 (사용자 의도 존중)
- `computeRestartTriggers` 가 mode-specific 파일 변경도 watch restart 대상에 포함

## 의존성
Phase 2-1 (#2103 함수형 config + `--mode`) + Phase 2-4 (#2106 `.env` mode 분기) 의 인프라 위에 직접 빌드.

## 테스트
- `bun test packages/core/src/config-loader.test.ts` — 45 pass (15 신규)
- `bun test packages/core/bin/zts.test.ts` — 121 pass (6 신규)
- `zig build test` — 4032/4032 pass
- lint / fmt 통과

Closes #2110. Part of #2099. Phase 3 1/5.