### PR TITLE
feat(config): extends 상속 + 순환 참조 감지

### DIFF
--- a/packages/core/src/config-loader.test.ts
+++ b/packages/core/src/config-loader.test.ts
@@ -438,3 +438,136 @@ describe("mergeUserConfigs", () => {
     expect(merged.external).toEqual(["react"]); // undefined 는 skip
   });
 });
+
+// ─── extends 상속 (#2108 / Phase 3-1) ──────────────────────────────────────
+
+describe("loadConfig: extends 상속", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-extends-"));
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  function reset() {
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir);
+  }
+
+  test("단일 string extends: base 머지 + override", async () => {
+    reset();
+    writeFileSync(
+      join(dir, "base.config.ts"),
+      `export default { format: "esm" as const, banner: "/* base */" };`,
+    );
+    writeFileSync(
+      join(dir, "main.config.ts"),
+      `export default { extends: "./base.config.ts", banner: "/* override */" };`,
+    );
+    const config = await loadConfig(join(dir, "main.config.ts"));
+    expect(config.format).toBe("esm");
+    expect(config.banner).toBe("/* override */");
+    expect((config as { extends?: unknown }).extends).toBeUndefined();
+  });
+
+  test("배열 extends: 왼쪽부터 적용 (오른쪽이 더 우선)", async () => {
+    reset();
+    writeFileSync(join(dir, "a.json"), JSON.stringify({ banner: "/* a */", target: "es2020" }));
+    writeFileSync(join(dir, "b.json"), JSON.stringify({ banner: "/* b */" }));
+    writeFileSync(
+      join(dir, "main.json"),
+      JSON.stringify({ extends: ["./a.json", "./b.json"], minify: true }),
+    );
+    const config = await loadConfig(join(dir, "main.json"));
+    // a → b → main 순서로 머지. b 가 a.banner override.
+    expect(config.banner).toBe("/* b */");
+    expect(config.target).toBe("es2020");
+    expect(config.minify).toBe(true);
+  });
+
+  test("3단계 chain: A extends B extends C", async () => {
+    reset();
+    writeFileSync(join(dir, "c.json"), JSON.stringify({ format: "esm", banner: "/* c */" }));
+    writeFileSync(join(dir, "b.json"), JSON.stringify({ extends: "./c.json", banner: "/* b */" }));
+    writeFileSync(join(dir, "a.json"), JSON.stringify({ extends: "./b.json", minify: true }));
+    const config = await loadConfig(join(dir, "a.json"));
+    expect(config.format).toBe("esm");
+    expect(config.banner).toBe("/* b */"); // c 의 banner 를 b 가 override
+    expect(config.minify).toBe(true);
+  });
+
+  test("define 객체 머지: extends + 현재 키 단위 합쳐짐", async () => {
+    reset();
+    writeFileSync(
+      join(dir, "base.json"),
+      JSON.stringify({ define: { __VER__: '"v1"', __ENV__: '"prod"' } }),
+    );
+    writeFileSync(
+      join(dir, "main.json"),
+      JSON.stringify({
+        extends: "./base.json",
+        define: { __ENV__: '"override"', __NEW__: '"x"' },
+      }),
+    );
+    const config = await loadConfig(join(dir, "main.json"));
+    expect(config.define).toEqual({
+      __VER__: '"v1"',
+      __ENV__: '"override"',
+      __NEW__: '"x"',
+    });
+  });
+
+  test("순환 참조 감지: A extends B extends A → throw", async () => {
+    reset();
+    writeFileSync(join(dir, "a.json"), JSON.stringify({ extends: "./b.json", banner: "/* a */" }));
+    writeFileSync(join(dir, "b.json"), JSON.stringify({ extends: "./a.json", banner: "/* b */" }));
+    await expect(loadConfig(join(dir, "a.json"))).rejects.toThrow(/circular extends detected/);
+  });
+
+  test("self extends: A extends A → throw", async () => {
+    reset();
+    writeFileSync(join(dir, "self.json"), JSON.stringify({ extends: "./self.json" }));
+    await expect(loadConfig(join(dir, "self.json"))).rejects.toThrow(/circular extends/);
+  });
+
+  test("extends 경로 부재 시 명확한 에러", async () => {
+    reset();
+    writeFileSync(join(dir, "main.json"), JSON.stringify({ extends: "./does-not-exist.json" }));
+    await expect(loadConfig(join(dir, "main.json"))).rejects.toThrow(/config file not found/);
+  });
+
+  test("절대 경로 extends 도 동작", async () => {
+    reset();
+    writeFileSync(join(dir, "base.json"), JSON.stringify({ banner: "/* abs-base */" }));
+    writeFileSync(join(dir, "main.json"), JSON.stringify({ extends: join(dir, "base.json") }));
+    const config = await loadConfig(join(dir, "main.json"));
+    expect(config.banner).toBe("/* abs-base */");
+  });
+
+  test("extends 가 mode-merge 와 함께 동작 (별도 단위 검증)", async () => {
+    reset();
+    writeFileSync(join(dir, "base.json"), JSON.stringify({ format: "esm", banner: "/* base */" }));
+    writeFileSync(join(dir, "main.json"), JSON.stringify({ extends: "./base.json", minify: true }));
+    const config = await loadConfig(join(dir, "main.json"));
+    expect(config.format).toBe("esm"); // extends 에서 상속
+    expect(config.banner).toBe("/* base */");
+    expect(config.minify).toBe(true); // 현재 config
+  });
+
+  test("extends 가 .ts 파일도 OK", async () => {
+    reset();
+    writeFileSync(
+      join(dir, "base.config.ts"),
+      `export default { format: "esm" as const, banner: "/* TS base */" };`,
+    );
+    writeFileSync(
+      join(dir, "main.config.json"),
+      JSON.stringify({ extends: "./base.config.ts", minify: true }),
+    );
+    const config = await loadConfig(join(dir, "main.config.json"));
+    expect(config.format).toBe("esm");
+    expect(config.banner).toBe("/* TS base */");
+    expect(config.minify).toBe(true);
+  });
+});

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -16,8 +16,16 @@ import { pathToFileURL } from "node:url";
 import type { BuildOptions } from "../index";
 import { init, transpile } from "../index";
 
-/** config 객체 형태 — 모든 BuildOptions 의 부분 집합. */
-export type UserConfig = Partial<BuildOptions>;
+/**
+ * config 객체 형태 — 모든 BuildOptions 의 부분 집합.
+ *
+ * `extends` (`#2108`) 는 다른 config 파일을 base 로 상속받는 식별자 — 단일 string
+ * 또는 배열. config-loader 가 로드 시 자동 해석하므로 최종 사용자 config 에는
+ * 노출되지 않는다 (resolveExtends 가 strip).
+ */
+export type UserConfig = Partial<BuildOptions> & {
+  extends?: string | string[];
+};
 
 /**
  * 함수형 config 호출 시 주입되는 컨텍스트 (Vite 호환 형태).
@@ -64,8 +72,35 @@ const JS_EXTS = new Set<string>(CONFIG_EXT_PRIORITY.slice(3, 6));
  */
 export async function loadConfig(filePath: string, env?: ConfigEnv): Promise<UserConfig> {
   const absPath = pathResolve(filePath);
-  const ext = extname(absPath).toLowerCase();
+  return loadConfigWithExtends(absPath, env, new Set());
+}
 
+/**
+ * `extends` 필드 재귀 해석 (#2108).
+ *
+ * 한 config 가 `extends: "./base"` 또는 `extends: [a, b]` 로 다른 config 를
+ * 상속받는다. 머지 규칙:
+ *  - 다중 extends 는 왼쪽부터 순차 적용 (오른쪽이 왼쪽 override)
+ *  - 마지막에 현재 config 가 모든 extends 를 override
+ *  - `mergeUserConfigs` 의 정책 (객체 shallow merge / 배열 mode override / plugins concat) 재사용
+ *
+ * 순환 참조 감지: `visited` Set 으로 추적 — `A extends B`, `B extends A` 시 throw.
+ *
+ * extends 경로는 현재 config 디렉토리 기준 상대 경로. 절대 경로도 허용.
+ */
+async function loadConfigWithExtends(
+  absPath: string,
+  env: ConfigEnv | undefined,
+  visited: Set<string>,
+): Promise<UserConfig> {
+  if (visited.has(absPath)) {
+    throw new Error(
+      `@zts/core: circular extends detected at ${absPath} (chain: ${[...visited, absPath].join(" → ")})`,
+    );
+  }
+  visited.add(absPath);
+
+  const ext = extname(absPath).toLowerCase();
   let raw: UserConfigInput;
   if (ext === ".json") {
     raw = loadJsonConfig(absPath);
@@ -79,7 +114,24 @@ export async function loadConfig(filePath: string, env?: ConfigEnv): Promise<Use
     );
   }
 
-  return resolveConfigValue(raw, env, absPath);
+  const resolved = await resolveConfigValue(raw, env, absPath);
+
+  // extends 필드 처리 — 재귀 해석 후 머지.
+  const extendsField = resolved.extends;
+  if (extendsField === undefined) return resolved;
+
+  const extendsPaths = Array.isArray(extendsField) ? extendsField : [extendsField];
+  const baseDir = dirname(absPath);
+  let merged: UserConfig = {};
+  for (const extPath of extendsPaths) {
+    const resolvedExt = pathResolve(baseDir, extPath);
+    const base = await loadConfigWithExtends(resolvedExt, env, new Set(visited));
+    merged = mergeUserConfigs(merged, base);
+  }
+
+  // base들 (모두 머지된 결과) → 현재 config (override)
+  const { extends: _extends, ...currentWithoutExtends } = resolved;
+  return mergeUserConfigs(merged, currentWithoutExtends as UserConfig);
 }
 
 /**


### PR DESCRIPTION
## 요약
config 가 다른 config 파일을 base 로 상속받는 `extends` 필드 추가. tsconfig 식 패턴.

## 사용 예
```ts
// base.config.ts
export default { format: "esm", banner: "/* base */" };

// zts.config.ts
export default defineConfig({
  extends: "./base.config.ts",
  minify: true,  // base override / 추가
});
```

## 머지 규칙
- 단일 string: `extends: "./path"` 또는 배열 `extends: [a, b]`
- 다중 extends 는 왼쪽부터 순차 적용 (오른쪽이 왼쪽 override)
- 마지막에 현재 config 가 모든 extends 를 override
- `mergeUserConfigs` 정책 재사용 (객체 shallow merge / 배열 override / plugins concat)
- 절대 경로 + 상대 경로 (현재 config 디렉토리 기준) 모두 지원

## 순환 참조 감지
`A extends B`, `B extends A` 또는 self-extends → 명확한 에러 메시지 (chain 표시):
```
@zts/core: circular extends detected at /path/a.json (chain: /path/a.json → /path/b.json → /path/a.json)
```

## Stacked PR
Base = `feat/config-mode-merge` (#2128) — `mergeUserConfigs` 재사용.

## 비범위
- npm 패키지 형태 extends (`extends: "@zts/configs/react"`) — 향후 확장
- HTTP/URL 기반 extends — 보안 우려로 미지원

## 테스트
- `bun test packages/core/src/config-loader.test.ts` — 55 pass (45→55, 10 신규: 단일/배열/3-chain/define 머지/순환 감지/self-extend/부재 에러/절대 경로/.ts 형식/mode 통합)
- `bun test packages/core/bin/zts.test.ts` — 121 pass (회귀 없음)
- `zig build test` — 4032/4032 pass

Closes #2108. Part of #2099. Phase 3 2/5.