### PR TITLE
feat(config): Levenshtein "did you mean?" typo 검출

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -23,9 +23,11 @@ const {
   findConfigPath,
   findModeConfigPath,
   importAndResolveDefault,
+  KNOWN_CONFIG_KEYS,
   loadConfig,
   loadEnv,
   mergeUserConfigs,
+  warnUnknownKeys,
 } = coreModule;
 import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { resolve, dirname, basename, extname, join } from "node:path";
@@ -1248,6 +1250,11 @@ async function main() {
   // (config 가 .ts 면 loadConfig 내부에서 init() 이 idempotent 하게 호출됨)
   const { config, env: configEnv, dotenvVars } = await loadAutoConfig(opts);
   if (config) {
+    // unknown 키 검출 + Levenshtein "did you mean?" 제안 (#2109).
+    // 머지 전에 검사 — 사용자 typo 가 silent 무시되지 않도록.
+    if (opts.logLevel !== "silent") {
+      warnUnknownKeys(config, KNOWN_CONFIG_KEYS, { sourceLabel: "zts.config" });
+    }
     mergeConfigIntoOpts(opts, config);
   }
 

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2408,3 +2408,62 @@ describe("CLI: zts.config.{mode}.* 자동 머지", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+// ─── Typo "did you mean?" (#2109 / Phase 3-2) ─────────────────────────────────
+
+describe("CLI: zts.config typo 검출", () => {
+  test("typo 한 키에 대해 stderr 에 'did you mean ...?' 경고", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-typo-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('hi');");
+    // 'minfy' (typo) — 'minify' 제안되어야 함.
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ minfy: true }));
+    const { stderr, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("unknown config key 'minfy'");
+    expect(stderr).toContain("did you mean 'minify'");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("정확한 키만 있으면 경고 없음", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-no-typo-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('hi');");
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ format: "esm", minify: true }));
+    const { stderr, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("unknown config key");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("--log-level=silent: 경고 출력 안 함", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-typo-silent-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('hi');");
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ minfy: true }));
+    const { stderr, exitCode } = runCli(["--bundle", "--log-level=silent", join(dir, "entry.ts")], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("unknown config key");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("거리 초과 unknown 키: 'did you mean' 없이 단순 경고", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-typo-far-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('hi');");
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ kubernetes: true }));
+    const { stderr, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("unknown config key 'kubernetes'");
+    expect(stderr).not.toContain("did you mean");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("typo 가 있어도 빌드는 성공 (warning, not error)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-typo-warn-not-error-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('OK');");
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ minfy: true, format: "esm" }));
+    const { stdout, exitCode } = runCli(["--bundle", join(dir, "entry.ts")], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("OK");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -146,6 +146,7 @@ export {
 } from "./src/config-loader";
 export type { ConfigEnv, UserConfig, UserConfigFn, UserConfigInput } from "./src/config-loader";
 export { envToDefine, loadEnv } from "./src/load-env";
+export { KNOWN_CONFIG_KEYS, suggestKey, warnUnknownKeys } from "./src/typo-suggest";
 
 import type { UserConfigInput } from "./src/config-loader";
 

--- a/packages/core/src/typo-suggest.test.ts
+++ b/packages/core/src/typo-suggest.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import { KNOWN_CONFIG_KEYS, suggestKey, warnUnknownKeys } from "./typo-suggest.ts";
+
+describe("suggestKey", () => {
+  test("정확히 일치하는 known 키 — 본인 반환 (거리 0)", () => {
+    expect(suggestKey("format", ["format", "platform"])).toBe("format");
+  });
+
+  test("거리 1: 단일 글자 typo", () => {
+    expect(suggestKey("formatt", ["format", "platform"])).toBe("format");
+    expect(suggestKey("forat", ["format", "platform"])).toBe("format");
+  });
+
+  test("거리 2: 두 글자 typo (긴 키)", () => {
+    expect(suggestKey("entryPointts", ["entryPoints", "outdir"])).toBe("entryPoints");
+  });
+
+  test("threshold 초과: null 반환", () => {
+    expect(suggestKey("xxx", ["format", "platform"])).toBeNull();
+  });
+
+  test("known 비어있으면 null", () => {
+    expect(suggestKey("anything", [])).toBeNull();
+  });
+
+  test("unknown 빈 문자열은 null", () => {
+    expect(suggestKey("", ["format"])).toBeNull();
+  });
+
+  test("다중 매치: 가장 가까운 거리 우선", () => {
+    // 'forma' vs 'format' (1) and 'forman' (1) → tie. alphabetical.
+    expect(suggestKey("forma", ["format", "forman"])).toBe("forman");
+  });
+
+  test("매우 짧은 키 (3자 이하): 거리 1 까지만", () => {
+    // "abc" vs "abx" 거리 1 → OK
+    expect(suggestKey("abc", ["abx"])).toBe("abx");
+    // "abc" vs "xyz" 거리 3 → null (threshold 1 로 자동 조정)
+    expect(suggestKey("abc", ["xyz"])).toBeNull();
+  });
+
+  test("실제 BuildOptions 키 typo 시나리오", () => {
+    // "outdri" → "outdir"
+    expect(suggestKey("outdri", KNOWN_CONFIG_KEYS)).toBe("outdir");
+    // "minfy" → "minify"
+    expect(suggestKey("minfy", KNOWN_CONFIG_KEYS)).toBe("minify");
+    // "sourcemaps" → "sourcemap"
+    expect(suggestKey("sourcemaps", KNOWN_CONFIG_KEYS)).toBe("sourcemap");
+    // "platfrom" → "platform"
+    expect(suggestKey("platfrom", KNOWN_CONFIG_KEYS)).toBe("platform");
+  });
+
+  test("완전히 다른 단어는 제안 안 함", () => {
+    expect(suggestKey("kubernetes", KNOWN_CONFIG_KEYS)).toBeNull();
+  });
+});
+
+describe("warnUnknownKeys", () => {
+  test("known 키만 있으면 결과 빈 배열", () => {
+    const result = warnUnknownKeys({ format: "esm", minify: true }, ["format", "minify"], {
+      silent: true,
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("unknown 키 + 제안 동봉", () => {
+    const result = warnUnknownKeys({ formatt: "esm", outdri: "./dist" }, ["format", "outdir"], {
+      silent: true,
+    });
+    expect(result).toEqual([
+      { unknown: "formatt", suggestion: "format" },
+      { unknown: "outdri", suggestion: "outdir" },
+    ]);
+  });
+
+  test("제안 없는 unknown 키는 suggestion=null", () => {
+    const result = warnUnknownKeys({ kubernetes: 1 }, KNOWN_CONFIG_KEYS, { silent: true });
+    expect(result).toEqual([{ unknown: "kubernetes", suggestion: null }]);
+  });
+
+  test("config 일부가 known, 일부가 unknown", () => {
+    const result = warnUnknownKeys(
+      { format: "esm", outdri: "./dist", banner: "/* */" },
+      KNOWN_CONFIG_KEYS,
+      { silent: true },
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ unknown: "outdri", suggestion: "outdir" });
+  });
+
+  test("실제 콘솔 출력 (silent=false 기본) — sourceLabel 포함", () => {
+    const original = console.warn;
+    const calls: string[] = [];
+    console.warn = (msg: string) => calls.push(msg);
+    try {
+      warnUnknownKeys({ formatt: "esm" }, ["format"], { sourceLabel: "zts.config.ts" });
+    } finally {
+      console.warn = original;
+    }
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toContain("formatt");
+    expect(calls[0]).toContain("zts.config.ts");
+    expect(calls[0]).toContain("did you mean 'format'");
+  });
+});
+
+describe("KNOWN_CONFIG_KEYS", () => {
+  test("주요 BuildOptions 키 모두 등록", () => {
+    const required = [
+      "entryPoints",
+      "format",
+      "minify",
+      "sourcemap",
+      "external",
+      "alias",
+      "define",
+      "loader",
+      "plugins",
+      "extends",
+      "tsconfigPath",
+    ];
+    for (const k of required) {
+      expect(KNOWN_CONFIG_KEYS).toContain(k);
+    }
+  });
+
+  test("중복 키 없음", () => {
+    const unique = new Set(KNOWN_CONFIG_KEYS);
+    expect(unique.size).toBe(KNOWN_CONFIG_KEYS.length);
+  });
+});

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -1,0 +1,189 @@
+/**
+ * Typo 검출 및 "did you mean ...?" 제안 (#2109).
+ *
+ * `levenshtein` 으로 알려진 옵션 키와 비교해 거리 ≤ threshold 인 가장 가까운
+ * 키를 제안. config 파일의 unknown 키, CLI flag 의 unknown name 둘 다 사용.
+ */
+
+/** Wagner-Fischer DP, single-row 메모리. */
+function levenshtein(a: string, b: string): number {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // 짧은 쪽을 열로 — 메모리 절감.
+  const [s, l] = a.length <= b.length ? [a, b] : [b, a];
+
+  let prev = Array.from<number>({ length: s.length + 1 });
+  let curr = Array.from<number>({ length: s.length + 1 });
+  for (let i = 0; i <= s.length; i++) prev[i] = i;
+
+  for (let i = 1; i <= l.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= s.length; j++) {
+      const cost = l.charCodeAt(i - 1) === s.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(
+        prev[j] + 1, // 삭제
+        curr[j - 1] + 1, // 삽입
+        prev[j - 1] + cost, // 치환
+      );
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[s.length];
+}
+
+/**
+ * `unknown` 과 가장 가까운 `known` 키 중 거리 `<= threshold` 인 것 반환.
+ *
+ * threshold 기본 2 — 짧은 키 (3자 이하) 는 거리 2 만 허용해도 false positive 가
+ * 많아질 수 있으므로 길이별로 자동 조정 (`Math.min(threshold, ceil(len/3))`).
+ *
+ * 다중 매치 시 가장 짧은 거리, 동률이면 알파벳순.
+ */
+export function suggestKey(
+  unknown: string,
+  known: readonly string[],
+  threshold: number = 2,
+): string | null {
+  if (!unknown || known.length === 0) return null;
+  // 매우 짧은 unknown 은 false positive 우려 — 거리 1 까지만.
+  const adjusted = Math.min(threshold, Math.max(1, Math.ceil(unknown.length / 3)));
+
+  let best: string | null = null;
+  let bestDist = adjusted + 1;
+
+  for (const candidate of known) {
+    const d = levenshtein(unknown, candidate);
+    if (d > adjusted) continue;
+    if (d < bestDist || (d === bestDist && best !== null && candidate < best)) {
+      best = candidate;
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+/**
+ * config 객체의 모든 키를 검사해 unknown 발견 시 console.warn 으로 경고 + 제안.
+ *
+ * `silent: true` 면 출력 안 하고 `{ unknown, suggestion }` 배열만 반환 — 테스트용.
+ */
+export function warnUnknownKeys(
+  config: Record<string, unknown>,
+  known: readonly string[],
+  options: { silent?: boolean; sourceLabel?: string } = {},
+): Array<{ unknown: string; suggestion: string | null }> {
+  const result: Array<{ unknown: string; suggestion: string | null }> = [];
+  const knownSet = new Set(known);
+
+  for (const key of Object.keys(config)) {
+    if (knownSet.has(key)) continue;
+    const suggestion = suggestKey(key, known);
+    result.push({ unknown: key, suggestion });
+    if (!options.silent) {
+      const where = options.sourceLabel ? ` (${options.sourceLabel})` : "";
+      const hint = suggestion ? ` — did you mean '${suggestion}'?` : "";
+      console.warn(`@zts/core: unknown config key '${key}'${where}${hint}`);
+    }
+  }
+  return result;
+}
+
+/**
+ * 알려진 BuildOptions / TranspileOptions / config-only 키 (`extends` 등) 통합 목록.
+ *
+ * `BuildOptions` 타입에서 자동 추출하지 못해 (TS 타입 → 런타임 변환 미구현)
+ * 수동 동기화. 새 옵션 추가 시 이 리스트에 함께 추가.
+ *
+ * 단일 source of truth 화는 #2112 (Phase 3-5 schema sync) 의 책임 — 그 PR 이
+ * `BuildOptions` ↔ Zig DTO 양방향 검증을 도입하면서 이 리스트도 자동 생성 가능.
+ */
+export const KNOWN_CONFIG_KEYS: readonly string[] = [
+  // ─── 진입 ───
+  "entryPoints",
+  "outdir",
+  "outfile",
+  "outbase",
+  // ─── 포맷 / 타겟 ───
+  "format",
+  "platform",
+  "target",
+  "browserslist",
+  // ─── JSX ───
+  "jsx",
+  "jsxDev",
+  "jsxFactory",
+  "jsxFragment",
+  "jsxImportSource",
+  "jsxInJs",
+  "jsxSideEffects",
+  // ─── Minify ───
+  "minify",
+  "minifyWhitespace",
+  "minifyIdentifiers",
+  "minifySyntax",
+  // ─── Sourcemap ───
+  "sourcemap",
+  "sourcemapDebugIds",
+  "sourcesContent",
+  "sourceRoot",
+  // ─── 모듈 / Resolve ───
+  "external",
+  "alias",
+  "define",
+  "loader",
+  "conditions",
+  "resolveExtensions",
+  "mainFields",
+  "packagesExternal",
+  // ─── Bundle 출력 ───
+  "splitting",
+  "preserveModules",
+  "preserveModulesRoot",
+  "inlineDynamicImports",
+  "manualChunks",
+  "metafile",
+  "treeShaking",
+  "shimMissingExports",
+  "keepNames",
+  // ─── 코드 주입 ───
+  "banner",
+  "footer",
+  "intro",
+  "outro",
+  "inject",
+  "drop",
+  "dropLabels",
+  "pure",
+  "legalComments",
+  // ─── Naming ───
+  "entryNames",
+  "chunkNames",
+  "assetNames",
+  // ─── TypeScript / decorator ───
+  "experimentalDecorators",
+  "emitDecoratorMetadata",
+  "useDefineForClassFields",
+  "verbatimModuleSyntax",
+  "tsconfigPath",
+  "tsconfigRaw",
+  // ─── Rollup 호환 ───
+  "globalName",
+  "globals",
+  "publicPath",
+  // ─── Charset / quote ───
+  "charsetUtf8",
+  "asciiOnly",
+  "quotes",
+  // ─── 기타 ───
+  "flow",
+  "plugins",
+  "logLevel",
+  "logLimit",
+  "lineLimit",
+  "ignoreAnnotations",
+  "watchDelay",
+  "jobs",
+  // ─── config-only ───
+  "extends",
+];


### PR DESCRIPTION
## 요약
zts.config.* 의 알려지지 않은 키에 대해 Levenshtein 거리로 가장 가까운 known 키 제안. 사용자 typo 가 silent 무시되지 않도록 stderr 경고.

## 출력 예
```
@zts/core: unknown config key 'minfy' (zts.config) — did you mean 'minify'?
@zts/core: unknown config key 'outdri' (zts.config) — did you mean 'outdir'?
```

## 거리 정책
- 기본 `threshold=2` (긴 키 — 두 글자 typo 까지 검출)
- 짧은 키 (3자 이하) 는 자동으로 `threshold=1` 로 조정 — false positive 회피
- 다중 매치 시 최단 거리 우선, 동률 시 알파벳순

## API 추가
- `levenshtein(a, b)` — Wagner-Fischer DP, single-row 메모리
- `suggestKey(unknown, known, threshold=2)` — 가장 가까운 키 또는 null
- `warnUnknownKeys(config, known, opts)` — config 객체 검사 + console.warn
- `KNOWN_CONFIG_KEYS` — BuildOptions/TranspileOptions/config-only 통합 목록 (~70개)

## CLI 동작
- `loadAutoConfig` 후 `mergeConfigIntoOpts` 전에 검사
- `--log-level=silent` 시 출력 안 함
- 빌드 자체는 정상 진행 (warning, not error)

## 한계 / 의존성
- `KNOWN_CONFIG_KEYS` 가 `BuildOptions` 와 수동 동기화 — #2112 (schema sync) 가 근본 fix. 향후 자동 생성으로 전환.
- Zig CLI (`src/main.zig`) 측 적용은 별도 follow-up — DTO `parseFromSliceLeaky` 가 `ignore_unknown_fields: true` 라 unknown 키가 자체 drop됨. typo 검출하려면 raw JSON value walk 필요.

## 테스트
- `bun test packages/core/src/typo-suggest.test.ts` — 17 pass (단위)
- `bun test packages/core/bin/zts.test.ts` — 120 pass (5 신규)
- `zig build test` — 4032/4032 pass
- lint / fmt 통과

Closes #2109. Part of #2099. Phase 3 3/5.