### PR TITLE
innerGraph dead-store 판정을 Reference 기반으로 전환

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -467,6 +467,34 @@ test "TreeShaking: innerGraph prunes overwritten assignment inside block body" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_BLOCK_DEAD_WRITE") == null);
 }
 
+test "TreeShaking: innerGraph prunes overwritten declaration initializer inside block body" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\{
+        \\  let value = "INNER_GRAPH_BLOCK_DEAD_INIT";
+        \\  value = "INNER_GRAPH_BLOCK_INIT_FINAL";
+        \\  console.log(value);
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_BLOCK_INIT_FINAL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_BLOCK_DEAD_INIT") == null);
+}
+
 test "TreeShaking: innerGraph preserves function body assignment captured by closure before overwrite" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -693,6 +721,93 @@ test "TreeShaking: innerGraph preserves update expression before overwrite" {
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "value++") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_UPDATE_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph Reference matching keeps shadowed symbols distinct" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value;
+        \\value = "INNER_GRAPH_SHADOW_OUTER_DEAD";
+        \\{
+        \\  let value;
+        \\  value = "INNER_GRAPH_SHADOW_INNER_LIVE";
+        \\  console.log(value);
+        \\}
+        \\value = "INNER_GRAPH_SHADOW_OUTER_FINAL";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SHADOW_OUTER_DEAD") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SHADOW_INNER_LIVE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SHADOW_OUTER_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph ignores type-only references for overwrite liveness" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value = "INNER_GRAPH_TYPE_ONLY_INIT";
+        \\type Box = typeof value;
+        \\value = "INNER_GRAPH_TYPE_ONLY_FINAL";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_TYPE_ONLY_INIT") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_TYPE_ONLY_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph preserves previous write before RHS self-read overwrite" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let value;
+        \\value = "INNER_GRAPH_SELF_READ_PREV";
+        \\value = value + "INNER_GRAPH_SELF_READ_NEXT";
+        \\console.log(value);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SELF_READ_PREV") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_SELF_READ_NEXT") != null);
 }
 
 test "TreeShaking: innerGraph preserves member assignment" {

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -53,6 +53,9 @@ const plugin_mod = @import("plugin.zig");
 const external_imports = @import("emitter/external_imports.zig");
 const purity = @import("purity.zig");
 const TokenKind = @import("../lexer/token.zig").Kind;
+const semantic_symbol = @import("../semantic/symbol.zig");
+const Reference = semantic_symbol.Reference;
+const Symbol = semantic_symbol.Symbol;
 
 pub const EmitOptions = struct {
     /// transformer pre-pass / emit 단계 transformer.init 양쪽에서 사용하는 옵션 base.
@@ -1330,12 +1333,15 @@ pub fn emitModule(
                                         }
                                         if (options.minify_syntax) {
                                             markDeadOverwrittenAssignments(
+                                                arena_alloc,
                                                 transformer.ast,
                                                 md.symbol_ids,
+                                                sem.references,
+                                                sem.symbols.items,
                                                 &sem.unresolved_references,
                                                 &md.skip_nodes,
                                                 module,
-                                            );
+                                            ) catch {};
                                         }
                                     }
                                 }
@@ -1851,13 +1857,201 @@ const AssignmentInfo = struct {
     sym_idx: u32,
 };
 
+const RefKey = struct {
+    symbol_id: u32,
+    scope_id: u32,
+};
+
+const RefEvent = struct {
+    ref_pos: u32,
+    node_idx: u32,
+    stmt_idx: u32,
+    symbol_id: u32,
+    scope_id: u32,
+    flags: semantic_symbol.ReferenceFlags,
+
+    fn isRead(self: RefEvent) bool {
+        return self.flags.read;
+    }
+
+    fn isPureWrite(self: RefEvent) bool {
+        return self.flags.write and !self.flags.read;
+    }
+};
+
+const DeadStoreRefIndex = struct {
+    const EventList = std.ArrayListUnmanaged(RefEvent);
+
+    by_key: std.AutoHashMapUnmanaged(RefKey, EventList) = .empty,
+    all_events: std.ArrayListUnmanaged(RefEvent) = .empty,
+    declare_events: std.ArrayListUnmanaged(RefEvent) = .empty,
+
+    fn init(allocator: std.mem.Allocator, references: []const Reference) !DeadStoreRefIndex {
+        var index: DeadStoreRefIndex = .{};
+        errdefer index.deinit(allocator);
+
+        for (references, 0..) |ref, ref_pos| {
+            if (ref.scope_stmt_idx == Reference.NO_STMT) continue;
+
+            const symbol_id: u32 = @intFromEnum(ref.symbol_id);
+            const scope_id: u32 = @intFromEnum(ref.scope_id);
+            const event: RefEvent = .{
+                .ref_pos = @intCast(ref_pos),
+                .node_idx = @intFromEnum(ref.node_index),
+                .stmt_idx = ref.scope_stmt_idx,
+                .symbol_id = symbol_id,
+                .scope_id = scope_id,
+                .flags = ref.flags,
+            };
+
+            if (ref.flags.declare) {
+                try index.declare_events.append(allocator, event);
+                continue;
+            }
+            if (!ref.isValueUse()) continue;
+            if (ref.node_index.isNone()) continue;
+
+            try index.all_events.append(allocator, event);
+            const key: RefKey = .{ .symbol_id = symbol_id, .scope_id = scope_id };
+            const gop = try index.by_key.getOrPut(allocator, key);
+            if (!gop.found_existing) gop.value_ptr.* = .{};
+            try gop.value_ptr.append(allocator, event);
+        }
+
+        return index;
+    }
+
+    fn deinit(self: *DeadStoreRefIndex, allocator: std.mem.Allocator) void {
+        var it = self.by_key.valueIterator();
+        while (it.next()) |events| {
+            events.deinit(allocator);
+        }
+        self.by_key.deinit(allocator);
+        self.all_events.deinit(allocator);
+        self.declare_events.deinit(allocator);
+    }
+
+    fn findWriteForNode(self: *const DeadStoreRefIndex, symbol_id: u32, node_idx: u32) ?RefEvent {
+        for (self.all_events.items) |event| {
+            if (event.symbol_id == symbol_id and event.node_idx == node_idx and event.isPureWrite()) return event;
+        }
+        return null;
+    }
+
+    fn findUniquePureWriteInStmt(self: *const DeadStoreRefIndex, symbol_id: u32, stmt_idx: u32) ?RefEvent {
+        var found: ?RefEvent = null;
+        for (self.all_events.items) |event| {
+            if (event.symbol_id != symbol_id) continue;
+            if (event.stmt_idx != stmt_idx) continue;
+            if (!event.isPureWrite()) continue;
+            if (found != null) return null;
+            found = event;
+        }
+        return found;
+    }
+
+    fn findWriteForAssignment(self: *const DeadStoreRefIndex, symbol_id: u32, node_idx: u32, stmt_idx: u32) ?RefEvent {
+        return self.findWriteForNode(symbol_id, node_idx) orelse self.findUniquePureWriteInStmt(symbol_id, stmt_idx);
+    }
+
+    fn findDeclare(self: *const DeadStoreRefIndex, symbol_id: u32, scope_id: u32, stmt_idx: u32) ?RefEvent {
+        for (self.declare_events.items) |event| {
+            if (event.symbol_id == symbol_id and event.scope_id == scope_id and event.stmt_idx == stmt_idx) return event;
+        }
+        return null;
+    }
+
+    fn firstSameScopeEventAfter(self: *const DeadStoreRefIndex, event: RefEvent) ?RefEvent {
+        const events = self.by_key.get(.{ .symbol_id = event.symbol_id, .scope_id = event.scope_id }) orelse return null;
+        for (events.items) |candidate| {
+            if (candidate.ref_pos <= event.ref_pos) continue;
+            if (candidate.stmt_idx < event.stmt_idx) continue;
+            return candidate;
+        }
+        return null;
+    }
+
+    fn hasReadBetween(self: *const DeadStoreRefIndex, symbol_id: u32, start_ref_pos: u32, end_ref_pos: u32) bool {
+        for (self.all_events.items) |event| {
+            if (event.symbol_id != symbol_id) continue;
+            if (event.ref_pos <= start_ref_pos or event.ref_pos >= end_ref_pos) continue;
+            if (event.isRead()) return true;
+        }
+        return false;
+    }
+
+    fn hasReadInStmt(self: *const DeadStoreRefIndex, symbol_id: u32, stmt_idx: u32, except_ref_pos: u32) bool {
+        for (self.all_events.items) |event| {
+            if (event.symbol_id != symbol_id) continue;
+            if (event.stmt_idx != stmt_idx) continue;
+            if (event.ref_pos == except_ref_pos) continue;
+            if (event.isRead()) return true;
+        }
+        return false;
+    }
+};
+
+test "DeadStoreRefIndex matches transformed assignment by unique same-statement write" {
+    const allocator = std.testing.allocator;
+    const old_lhs_node: NodeIndex = @enumFromInt(10);
+    const transformed_lhs_node: u32 = 200;
+    const references = [_]Reference{
+        .{
+            .node_index = old_lhs_node,
+            .scope_id = @enumFromInt(1),
+            .symbol_id = @enumFromInt(2),
+            .stmt_idx = 0,
+            .scope_stmt_idx = 3,
+            .flags = .{ .write = true },
+        },
+    };
+
+    var index = try DeadStoreRefIndex.init(allocator, &references);
+    defer index.deinit(allocator);
+
+    try std.testing.expect(index.findWriteForNode(2, transformed_lhs_node) == null);
+    const event = index.findWriteForAssignment(2, transformed_lhs_node, 3) orelse return error.MissingWriteEvent;
+    try std.testing.expectEqual(@as(u32, @intFromEnum(old_lhs_node)), event.node_idx);
+    try std.testing.expectEqual(@as(u32, 3), event.stmt_idx);
+}
+
+test "DeadStoreRefIndex does not guess when same-statement writes are ambiguous" {
+    const allocator = std.testing.allocator;
+    const references = [_]Reference{
+        .{
+            .node_index = @enumFromInt(10),
+            .scope_id = @enumFromInt(1),
+            .symbol_id = @enumFromInt(2),
+            .stmt_idx = 0,
+            .scope_stmt_idx = 3,
+            .flags = .{ .write = true },
+        },
+        .{
+            .node_index = @enumFromInt(11),
+            .scope_id = @enumFromInt(1),
+            .symbol_id = @enumFromInt(2),
+            .stmt_idx = 0,
+            .scope_stmt_idx = 3,
+            .flags = .{ .write = true },
+        },
+    };
+
+    var index = try DeadStoreRefIndex.init(allocator, &references);
+    defer index.deinit(allocator);
+
+    try std.testing.expect(index.findWriteForAssignment(2, 200, 3) == null);
+}
+
 fn markDeadOverwrittenAssignments(
+    allocator: std.mem.Allocator,
     ast: *Ast,
     symbol_ids: []const ?u32,
+    references: []const Reference,
+    symbols: []const Symbol,
     unresolved_globals: ?*const purity.GlobalRefSet,
     skip_nodes: *std.DynamicBitSet,
     module: *const Module,
-) void {
+) !void {
     if (ast.nodes.items.len == 0) return;
     const root = ast.nodes.items[ast.nodes.items.len - 1];
     if (root.tag != .program) return;
@@ -1865,13 +2059,18 @@ fn markDeadOverwrittenAssignments(
     if (list.start + list.len > ast.extra_data.items.len) return;
     const stmts = ast.extra_data.items[list.start .. list.start + list.len];
 
-    markDeadOverwrittenInStatementList(ast, stmts, symbol_ids, unresolved_globals, skip_nodes, module);
+    var ref_index = try DeadStoreRefIndex.init(allocator, references);
+    defer ref_index.deinit(allocator);
+
+    markDeadOverwrittenInStatementList(ast, stmts, symbol_ids, symbols, &ref_index, unresolved_globals, skip_nodes, module);
 }
 
 fn markDeadOverwrittenInStatementList(
     ast: *Ast,
     stmts: []const u32,
     symbol_ids: []const ?u32,
+    symbols: []const Symbol,
+    ref_index: *const DeadStoreRefIndex,
     unresolved_globals: ?*const purity.GlobalRefSet,
     skip_nodes: *std.DynamicBitSet,
     module: *const Module,
@@ -1879,27 +2078,26 @@ fn markDeadOverwrittenInStatementList(
     for (stmts, 0..) |raw_stmt, i| {
         if (raw_stmt >= ast.nodes.items.len) continue;
         if (raw_stmt < skip_nodes.capacity() and skip_nodes.isSet(raw_stmt)) continue;
-        markDeadOverwrittenDeclarationInitializers(ast, raw_stmt, i, stmts, symbol_ids, unresolved_globals, module);
+        markDeadOverwrittenDeclarationInitializers(ast, raw_stmt, i, stmts, symbol_ids, symbols, ref_index, unresolved_globals, module);
         const current = assignmentInfoForStmt(ast, raw_stmt, symbol_ids, unresolved_globals, true) orelse continue;
+        const current_write = ref_index.findWriteForAssignment(current.sym_idx, current.lhs_idx, @intCast(i)) orelse continue;
+        const next_event = ref_index.firstSameScopeEventAfter(current_write) orelse continue;
+        if (!next_event.isPureWrite()) continue;
+        if (ref_index.hasReadBetween(current.sym_idx, current_write.ref_pos, next_event.ref_pos)) continue;
+        if (ref_index.hasReadInStmt(current.sym_idx, next_event.stmt_idx, next_event.ref_pos)) continue;
 
-        var j = i + 1;
-        while (j < stmts.len) : (j += 1) {
-            const next_raw = stmts[j];
-            if (next_raw >= ast.nodes.items.len) continue;
-            if (next_raw < skip_nodes.capacity() and skip_nodes.isSet(next_raw)) continue;
-
-            if (stmtReadsSymbolBeforeOverwrite(ast, next_raw, symbol_ids, current.sym_idx)) break;
-            if (assignmentInfoForStmt(ast, next_raw, symbol_ids, unresolved_globals, false)) |next_assign| {
-                if (next_assign.sym_idx == current.sym_idx) {
-                    if (current.stmt_idx < skip_nodes.capacity()) skip_nodes.set(current.stmt_idx);
-                    break;
-                }
-            }
-        }
+        if (next_event.stmt_idx <= i or next_event.stmt_idx >= stmts.len) continue;
+        const next_raw = stmts[next_event.stmt_idx];
+        if (next_raw >= ast.nodes.items.len) continue;
+        if (next_raw < skip_nodes.capacity() and skip_nodes.isSet(next_raw)) continue;
+        const next_assign = assignmentInfoForStmt(ast, next_raw, symbol_ids, unresolved_globals, false) orelse continue;
+        if (next_assign.sym_idx != current.sym_idx) continue;
+        if (ref_index.findWriteForAssignment(next_assign.sym_idx, next_assign.lhs_idx, next_event.stmt_idx) == null) continue;
+        if (current.stmt_idx < skip_nodes.capacity()) skip_nodes.set(current.stmt_idx);
     }
 
     for (stmts) |raw_stmt| {
-        markDeadOverwrittenNestedStatementLists(ast, raw_stmt, symbol_ids, unresolved_globals, skip_nodes, module);
+        markDeadOverwrittenNestedStatementLists(ast, raw_stmt, symbol_ids, symbols, ref_index, unresolved_globals, skip_nodes, module);
     }
 }
 
@@ -1907,6 +2105,8 @@ fn markDeadOverwrittenNestedStatementLists(
     ast: *Ast,
     node_idx: u32,
     symbol_ids: []const ?u32,
+    symbols: []const Symbol,
+    ref_index: *const DeadStoreRefIndex,
     unresolved_globals: ?*const purity.GlobalRefSet,
     skip_nodes: *std.DynamicBitSet,
     module: *const Module,
@@ -1918,17 +2118,19 @@ fn markDeadOverwrittenNestedStatementLists(
         const list = node.data.list;
         if (list.start + list.len <= ast.extra_data.items.len) {
             const stmts = ast.extra_data.items[list.start .. list.start + list.len];
-            markDeadOverwrittenInStatementList(ast, stmts, symbol_ids, unresolved_globals, skip_nodes, module);
+            markDeadOverwrittenInStatementList(ast, stmts, symbol_ids, symbols, ref_index, unresolved_globals, skip_nodes, module);
         }
     }
 
-    markDeadOverwrittenFunctionBody(ast, node, symbol_ids, unresolved_globals, skip_nodes, module);
+    markDeadOverwrittenFunctionBody(ast, node, symbol_ids, symbols, ref_index, unresolved_globals, skip_nodes, module);
 }
 
 fn markDeadOverwrittenFunctionBody(
     ast: *Ast,
     node: ast_mod.Node,
     symbol_ids: []const ?u32,
+    symbols: []const Symbol,
+    ref_index: *const DeadStoreRefIndex,
     unresolved_globals: ?*const purity.GlobalRefSet,
     skip_nodes: *std.DynamicBitSet,
     module: *const Module,
@@ -1940,7 +2142,7 @@ fn markDeadOverwrittenFunctionBody(
                 const list = body.data.list;
                 if (list.start + list.len <= ast.extra_data.items.len) {
                     const stmts = ast.extra_data.items[list.start .. list.start + list.len];
-                    markDeadOverwrittenInStatementList(ast, stmts, symbol_ids, unresolved_globals, skip_nodes, module);
+                    markDeadOverwrittenInStatementList(ast, stmts, symbol_ids, symbols, ref_index, unresolved_globals, skip_nodes, module);
                 }
             }
         }
@@ -1965,6 +2167,8 @@ fn markDeadOverwrittenDeclarationInitializers(
     stmt_pos: usize,
     stmts: []const u32,
     symbol_ids: []const ?u32,
+    symbols: []const Symbol,
+    ref_index: *const DeadStoreRefIndex,
     unresolved_globals: ?*const purity.GlobalRefSet,
     module: *const Module,
 ) void {
@@ -1996,21 +2200,24 @@ fn markDeadOverwrittenDeclarationInitializers(
     const name = ast.nodes.items[name_ni];
     if (name.tag != .binding_identifier) return;
     const sym_idx: u32 = @intCast(symbol_ids[name_ni] orelse return);
+    if (sym_idx >= symbols.len) return;
     if (isExportedSymbol(module, sym_idx)) return;
     if (!purity.isExprPure(ast, init_idx, unresolved_globals)) return;
 
-    var j = stmt_pos + 1;
-    while (j < stmts.len) : (j += 1) {
-        const next_raw = stmts[j];
-        if (next_raw >= ast.nodes.items.len) continue;
-        if (stmtReadsSymbolBeforeOverwrite(ast, next_raw, symbol_ids, sym_idx)) break;
-        if (assignmentInfoForStmt(ast, next_raw, symbol_ids, unresolved_globals, false)) |next_assign| {
-            if (next_assign.sym_idx == sym_idx) {
-                ast.extra_data.items[de + 2] = @intFromEnum(NodeIndex.none);
-                break;
-            }
-        }
-    }
+    const decl_scope = @intFromEnum(symbols[sym_idx].scope_id);
+    const declare_event = ref_index.findDeclare(sym_idx, decl_scope, @intCast(stmt_pos)) orelse return;
+    const next_event = ref_index.firstSameScopeEventAfter(declare_event) orelse return;
+    if (!next_event.isPureWrite()) return;
+    if (ref_index.hasReadBetween(sym_idx, declare_event.ref_pos, next_event.ref_pos)) return;
+    if (ref_index.hasReadInStmt(sym_idx, next_event.stmt_idx, next_event.ref_pos)) return;
+    if (next_event.stmt_idx <= stmt_pos or next_event.stmt_idx >= stmts.len) return;
+
+    const next_raw = stmts[next_event.stmt_idx];
+    if (next_raw >= ast.nodes.items.len) return;
+    const next_assign = assignmentInfoForStmt(ast, next_raw, symbol_ids, unresolved_globals, false) orelse return;
+    if (next_assign.sym_idx != sym_idx) return;
+    if (ref_index.findWriteForAssignment(next_assign.sym_idx, next_assign.lhs_idx, next_event.stmt_idx) == null) return;
+    ast.extra_data.items[de + 2] = @intFromEnum(NodeIndex.none);
 }
 
 fn isExportedSymbol(module: *const Module, sym_idx: u32) bool {
@@ -2056,33 +2263,6 @@ fn assignmentInfoForStmt(
         .lhs_idx = @intCast(lhs_ni),
         .sym_idx = sym_idx,
     };
-}
-
-fn stmtReadsSymbolBeforeOverwrite(
-    ast: *const Ast,
-    stmt_idx: u32,
-    symbol_ids: []const ?u32,
-    sym_idx: u32,
-) bool {
-    if (stmt_idx >= ast.nodes.items.len) return false;
-    const stmt = ast.nodes.items[stmt_idx];
-    const simple_assign = assignmentInfoForStmt(ast, stmt_idx, symbol_ids, null, false);
-
-    for (ast.nodes.items, 0..) |node, node_i| {
-        if (node.span.start < stmt.span.start or node.span.end > stmt.span.end) continue;
-        if (node_i >= symbol_ids.len) continue;
-        const node_sym: u32 = @intCast(symbol_ids[node_i] orelse continue);
-        if (node_sym != sym_idx) continue;
-
-        if (node.tag == .identifier_reference) return true;
-        if (node.tag == .assignment_target_identifier) {
-            if (simple_assign) |assign| {
-                if (assign.sym_idx == sym_idx and assign.lhs_idx == node_i) continue;
-            }
-            return true;
-        }
-    }
-    return false;
 }
 
 fn markUnusedCjsObjectProperties(

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1971,6 +1971,17 @@ const DeadStoreRefIndex = struct {
         return null;
     }
 
+    /// `start_event` 다음에 같은 symbol 을 덮어쓰는 pure write event 를 반환한다.
+    /// 사이에 read 가 있거나 같은 statement 안에서 read 가 같이 있으면 보존을 위해 null.
+    /// closure 등 다른 scope 의 read 도 보존해야 하므로 read 검사는 모든 scope 를 본다.
+    fn findOverwriteAfter(self: *const DeadStoreRefIndex, start_event: RefEvent) ?RefEvent {
+        const next_event = self.firstSameScopeEventAfter(start_event) orelse return null;
+        if (!next_event.isPureWrite()) return null;
+        if (self.hasReadBetween(start_event.symbol_id, start_event.ref_pos, next_event.ref_pos)) return null;
+        if (self.hasReadInStmt(start_event.symbol_id, next_event.stmt_idx, next_event.ref_pos)) return null;
+        return next_event;
+    }
+
     fn hasReadBetween(self: *const DeadStoreRefIndex, symbol_id: u32, start_ref_pos: u32, end_ref_pos: u32) bool {
         for (self.all_events.items) |event| {
             if (event.symbol_id != symbol_id) continue;
@@ -2060,7 +2071,6 @@ fn markDeadOverwrittenAssignments(
     const stmts = ast.extra_data.items[list.start .. list.start + list.len];
 
     var ref_index = try DeadStoreRefIndex.init(allocator, references);
-    defer ref_index.deinit(allocator);
 
     markDeadOverwrittenInStatementList(ast, stmts, symbol_ids, symbols, &ref_index, unresolved_globals, skip_nodes, module);
 }
@@ -2081,11 +2091,7 @@ fn markDeadOverwrittenInStatementList(
         markDeadOverwrittenDeclarationInitializers(ast, raw_stmt, i, stmts, symbol_ids, symbols, ref_index, unresolved_globals, module);
         const current = assignmentInfoForStmt(ast, raw_stmt, symbol_ids, unresolved_globals, true) orelse continue;
         const current_write = ref_index.findWriteForAssignment(current.sym_idx, current.lhs_idx, @intCast(i)) orelse continue;
-        const next_event = ref_index.firstSameScopeEventAfter(current_write) orelse continue;
-        if (!next_event.isPureWrite()) continue;
-        if (ref_index.hasReadBetween(current.sym_idx, current_write.ref_pos, next_event.ref_pos)) continue;
-        if (ref_index.hasReadInStmt(current.sym_idx, next_event.stmt_idx, next_event.ref_pos)) continue;
-
+        const next_event = ref_index.findOverwriteAfter(current_write) orelse continue;
         if (next_event.stmt_idx <= i or next_event.stmt_idx >= stmts.len) continue;
         const next_raw = stmts[next_event.stmt_idx];
         if (next_raw >= ast.nodes.items.len) continue;
@@ -2135,7 +2141,7 @@ fn markDeadOverwrittenFunctionBody(
     skip_nodes: *std.DynamicBitSet,
     module: *const Module,
 ) void {
-    if (functionBodyBlock(ast, node)) |body_idx| {
+    if (ast.functionBodyBlock(node)) |body_idx| {
         if (@intFromEnum(body_idx) < ast.nodes.items.len) {
             const body = ast.nodes.items[@intFromEnum(body_idx)];
             if (body.tag == .block_statement) {
@@ -2147,18 +2153,6 @@ fn markDeadOverwrittenFunctionBody(
             }
         }
     }
-}
-
-fn functionBodyBlock(ast: *const Ast, node: ast_mod.Node) ?NodeIndex {
-    const body_slot: u32 = switch (node.tag) {
-        .arrow_function_expression => 1,
-        .function_declaration, .function_expression, .function, .method_definition => 2,
-        else => return null,
-    };
-    if (node.data.extra + body_slot >= ast.extra_data.items.len) return null;
-    const body_idx: NodeIndex = @enumFromInt(ast.extra_data.items[node.data.extra + body_slot]);
-    if (body_idx.isNone()) return null;
-    return body_idx;
 }
 
 fn markDeadOverwrittenDeclarationInitializers(
@@ -2206,10 +2200,7 @@ fn markDeadOverwrittenDeclarationInitializers(
 
     const decl_scope = @intFromEnum(symbols[sym_idx].scope_id);
     const declare_event = ref_index.findDeclare(sym_idx, decl_scope, @intCast(stmt_pos)) orelse return;
-    const next_event = ref_index.firstSameScopeEventAfter(declare_event) orelse return;
-    if (!next_event.isPureWrite()) return;
-    if (ref_index.hasReadBetween(sym_idx, declare_event.ref_pos, next_event.ref_pos)) return;
-    if (ref_index.hasReadInStmt(sym_idx, next_event.stmt_idx, next_event.ref_pos)) return;
+    const next_event = ref_index.findOverwriteAfter(declare_event) orelse return;
     if (next_event.stmt_idx <= stmt_pos or next_event.stmt_idx >= stmts.len) return;
 
     const next_raw = stmts[next_event.stmt_idx];

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -384,15 +384,10 @@ fn zeroParamFunctionReturnIdentifier(ast: *const Ast, fn_idx: NodeIndex) ?NodeIn
     if (fn_idx.isNone() or @intFromEnum(fn_idx) >= ast.nodes.items.len) return null;
     const fn_node = ast.nodes.items[@intFromEnum(fn_idx)];
 
-    const body_slot: u32 = switch (fn_node.tag) {
-        .function_expression => 2,
-        .arrow_function_expression => 1,
-        else => return null,
-    };
     const flags_slot: u32 = switch (fn_node.tag) {
         .function_expression => 3,
         .arrow_function_expression => 2,
-        else => unreachable,
+        else => return null,
     };
     if (!ast.hasExtra(fn_node.data.extra, flags_slot)) return null;
 
@@ -404,7 +399,7 @@ fn zeroParamFunctionReturnIdentifier(ast: *const Ast, fn_idx: NodeIndex) ?NodeIn
     }
     if (ast.functionParamsList(fn_node).len != 0) return null;
 
-    const body_idx = ast.readExtraNode(fn_node.data.extra, body_slot);
+    const body_idx = ast.functionBodyBlock(fn_node) orelse return null;
     if (fn_node.tag == .arrow_function_expression and isIdentifierReference(ast, body_idx)) {
         return body_idx;
     }

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1082,6 +1082,23 @@ pub const Ast = struct {
         return params_node.data.list;
     }
 
+    /// 함수형 노드의 body NodeIndex 를 반환한다.
+    /// 지원 태그: function_declaration / function_expression / function /
+    /// arrow_function_expression / method_definition. arrow 는 extra[1], 나머지는 extra[2].
+    /// (params 슬롯 다음 칸 — `functionParamsList` 와 같은 슬롯 규칙.)
+    /// body 가 없거나 잘못된 경우 null.
+    pub fn functionBodyBlock(self: *const Ast, node: Node) ?NodeIndex {
+        const body_slot: u32 = switch (node.tag) {
+            .arrow_function_expression => 1,
+            .function_declaration, .function_expression, .function, .method_definition => 2,
+            else => return null,
+        };
+        if (!self.hasExtra(node.data.extra, body_slot)) return null;
+        const body_idx = self.readExtraNode(node.data.extra, body_slot);
+        if (body_idx.isNone()) return null;
+        return body_idx;
+    }
+
     /// 함수형 노드의 파라미터 슬라이스를 반환한다 (각 element는 NodeIndex의 raw u32).
     /// 지원 태그: function_declaration / function_expression / function /
     /// arrow_function_expression / method_definition.


### PR DESCRIPTION
## 요약
- innerGraph dead-store 제거의 read-before-overwrite 판정을 AST span scan 기반에서 `Reference[]` event index 기반으로 전환했습니다.
- `minify_syntax` 경로에서 semantic reference를 사용해 같은 symbol/scope의 다음 value event를 확인하고, 기존 AST/purity/export/destructuring/multi-declarator guard는 유지했습니다.
- `Reference.node_index`가 parser 시점이고 emit 대상 AST가 transformer 이후인 경우를 처리하기 위해, node id 직접 매칭이 실패하면 같은 scope statement의 단일 pure write event로 assignment reference를 확정합니다.

## 주요 변경
- `markDeadOverwrittenAssignments`에 `references`/`symbols`를 전달합니다.
- dead-store용 `DeadStoreRefIndex`를 만들어 value-use read/write event와 declare event를 분리해 조회합니다.
- 기존 `stmtReadsSymbolBeforeOverwrite` span scan을 제거했습니다.
- assignment 제거는 candidate LHS write reference를 node id 또는 same-statement unique write event로 매칭하고, 다음 same-symbol/same-scope event가 pure write이며 같은 statement 안 self-read가 없을 때만 수행합니다.
- declaration initializer 제거도 declaration 후보/purity/export guard는 유지하고, read-before-overwrite 판단만 Reference index로 수행합니다.

## 테스트
- 기존 innerGraph dead-store 테스트 유지
- 추가 회귀 테스트
  - shadowing: outer/inner 같은 이름의 symbol 혼동 방지
  - type-only reference: `typeof` type query를 runtime read로 오인하지 않음
  - RHS self-read: `x = x + ...` 앞 write 보존
  - direct block 안 declaration initializer 제거
  - transformed AST node id와 parser Reference node id가 달라도 같은 statement의 단일 write로 매칭
  - 같은 statement 안 write가 여러 개면 임의로 매칭하지 않음

## 검증
- `zig fmt src/bundler/emitter.zig src/bundler/bundler_test/tree_shake.zig`
- `zig build test --summary all --prominent-compile-errors` (`4059/4059 tests passed`)
- `zig build --summary all --prominent-compile-errors`
- `git diff --check`
- synthetic large fixture: 2,500개 overwritten assignment 패턴에서 dead marker 0개, live marker 2,500개 확인
- smoke timing: 0.42s / 0.42s / 0.57s

## 범위 밖
- ESM entry의 exported function body까지 dead-store pass 호출 범위를 확장하는 것은 이번 PR에서 제외했습니다. 현재 PR은 기존 지원 범위의 판정 로직을 Reference 기반으로 교체하는 데 집중합니다.