### PR TITLE
fix(cli): zts.config.outdir/outfile 단일 build silent drop 수정

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -45,8 +45,12 @@ function parseArgs(argv) {
   const args = argv.slice(2);
   const opts = {
     entryPoints: [],
-    outfile: null,
-    outdir: null,
+    // SCALAR_KEYS (mergeConfigIntoOpts) 의 다른 키들과 동일하게 `undefined` 기본값 사용.
+    // 과거 `null` 이었으나 머지 조건이 `=== undefined` 라 `zts.config.json` 의 outdir/outfile
+    // 만 silent drop 되는 회귀가 있었음. 모든 사용처가 truthy 검사 (`if (opts.outdir)`) 라
+    // null → undefined 변경은 동작 영향 없음.
+    outfile: undefined,
+    outdir: undefined,
     bundle: false,
     watch: false,
     watchJson: false,
@@ -1268,12 +1272,12 @@ async function runServe(opts, config) {
  * 단일 워크스페이스 entry 를 위한 `subOpts` 생성. `opts` deep clone → entry/root config
  * 머지 → entry.cwd 기준 path 정규화.
  *
- * `mergeConfigIntoOpts` 가 `opts[key] === undefined` 만 머지 대상으로 보지만 `parseArgs` 의
- * `outfile`/`outdir` 기본값은 `null` 이라 그 경로로는 적용 안 됨. workspace 에서는 entry
- * config 의 `outdir`/`outfile` 이 build 의도 자체이므로 직접 보강한다 (`null` → merged).
- *
  * `structuredClone` 사용 — `JSON.parse(JSON.stringify(opts))` 는 미래에 함수/Date/undefined
  * 필드가 추가되면 silent drop 위험.
+ *
+ * `outdir`/`outfile` 보강은 historical 잔재 — parseArgs default 가 과거 `null` 이라
+ * `mergeConfigIntoOpts` 의 `=== undefined` 머지 조건을 우회 못 했었음. default 가 `undefined`
+ * 가 된 후로는 mergeConfigIntoOpts 만으로 충분하지만 `== null` 은 둘 다 매치하므로 안전망으로 유지.
  */
 function buildSubOpts(opts, w, merged) {
   const subOpts = structuredClone(opts);

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -1687,6 +1687,51 @@ describe("CLI: zts.config 자동 탐색 + BuildOptions 머지", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("zts.config.json 의 outdir 이 자동 적용됨 (단일 build, CLI --outdir 미지정)", () => {
+    // 회귀 테스트: parseArgs 의 outfile/outdir 기본값이 `null` 이라서 mergeConfigIntoOpts
+    // 의 `=== undefined` 머지 조건을 우회 못 해 config.outdir 이 silent drop 되던 버그.
+    // workspace 흐름은 buildSubOpts 에서 보강했지만 단일 build 경로는 깨져 있었음.
+    const dir = mkdtempSync(join(tmpdir(), "zts-config-outdir-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('SINGLE_OUTDIR_OK');");
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({ entryPoints: ["./entry.ts"], outdir: "./dist" }),
+    );
+    const { stdout, exitCode } = runCli(["--bundle"], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("SINGLE_OUTDIR_OK"); // stdout 으로 빠지면 안 됨
+    expect(existsSync(join(dir, "dist"))).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("zts.config.json 의 outfile 이 자동 적용됨 (단일 build, CLI --outfile 미지정)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-config-outfile-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('SINGLE_OUTFILE_OK');");
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({ entryPoints: ["./entry.ts"], outfile: "./out.js" }),
+    );
+    const { stdout, exitCode } = runCli(["--bundle"], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("SINGLE_OUTFILE_OK");
+    expect(existsSync(join(dir, "out.js"))).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("CLI --outdir 이 config.outdir 을 override", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-config-outdir-override-"));
+    writeFileSync(join(dir, "entry.ts"), "console.log('hi');");
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({ entryPoints: ["./entry.ts"], outdir: "./from-config" }),
+    );
+    const { exitCode } = runCli(["--bundle", "--outdir", "./from-cli"], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(dir, "from-cli"))).toBe(true);
+    expect(existsSync(join(dir, "from-config"))).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("zts.config.ts 의 minify 가 적용됨", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-config-minify-"));
     writeFileSync(


### PR DESCRIPTION
## Summary
- `parseArgs` 의 `outfile`/`outdir` 기본값을 `null` → `undefined` 로 변경 — 다른 SCALAR_KEYS 와 일관
- `mergeConfigIntoOpts` 가 정상적으로 config 의 outdir/outfile 을 단일 build 흐름에서도 머지
- 회귀 테스트 3건 추가

## 재현 (수정 전)
```bash
$ cat zts.config.json
{"entryPoints":["./entry.ts"],"outdir":"./dist"}

$ zts --bundle
//#region entry.ts
console.log("...");      # stdout 으로 빠짐, dist 디렉토리 생성 안 됨!
//#endregion
```

## 원인
`parseArgs` 의 다른 SCALAR_KEYS (format/banner/jsxFactory/...) 는 모두 default `undefined` 인데 `outfile`/`outdir` 만 `null` 이라 `mergeConfigIntoOpts` 의 `opts[key] === undefined` 머지 조건을 우회 못 함. `null` → `undefined` 변경만으로 자연스럽게 동작.

workspace 흐름 (#2111) 은 `buildSubOpts` 에서 별도 보강했지만 단일 build 경로는 깨진 채 머지됨. 안전망 (`subOpts.outdir == null`) 은 유지 — `==` 는 null/undefined 모두 매치.

## Test plan
- [x] `bun test packages/core/bin/zts.test.ts -t outdir` — 6/6 (3건 신규 + 기존 3)
- [x] `bun test packages/core/bin/zts.test.ts -t outfile` — 1/1 (신규)
- [x] `bun test packages/core/` 전체 — 592/592 (회귀 없음)
- [x] lint/fmt 통과
- [x] manual: `mktemp -d` + `zts.config.json` outdir 만 → 정상 dist 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)