### PR TITLE
fix(cli): --banner / --footer 정식 형태 추가 + esbuild alias 정리

### DIFF
--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -190,6 +190,13 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     // charset — CLI 는 `--charset=utf8/ascii` 식 enum, BuildOptions/TranspileOptions 는
     // `charsetUtf8: boolean` (1:N 매핑). zts.mjs 에서 enum→boolean 변환.
     "--charset=",
+    // banner/footer — `--banner=`/`--footer=` 가 정식 (BuildOptions 와 1:1).
+    // `--banner:js=`/`--footer:js=` 는 esbuild 호환 silent alias — 동일 키로 매핑.
+    "--banner:js=",
+    "--footer:js=",
+    // out-extension — esbuild 식 namespace (`--out-extension:.js=`). BuildOptions 의
+    // `outExtension: string` (단일) 와 1:N. zts.mjs 가 `.js` 만 받아 단일 string 으로 변환.
+    "--out-extension:.js=",
   ]);
 
   // BuildOptions/TranspileOptions 에 있고 CLI 에 없는 키 (의도적). 함수형/고급 옵션.
@@ -268,10 +275,6 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
       if (cliOnlyFlags.has(flag)) continue;
       const candidate = flagToCandidateKey(flag);
       if (knownKeys.has(candidate)) continue;
-      // banner:js / footer:js — 도출 후보가 `bannerJs`/`footerJs` 인데 실제 키는 `banner`/`footer`.
-      // CLI namespace 패턴이 BuildOptions 와 다른 의도된 케이스 — 별도 통과.
-      const stripped = candidate.replace(/Js$/, "");
-      if (knownKeys.has(stripped)) continue;
       unmapped.push({ flag, candidate });
     }
     if (unmapped.length > 0) {
@@ -288,12 +291,7 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     for (const flag of cliFlags) {
       if (cliOnlyFlags.has(flag)) continue;
       const candidate = flagToCandidateKey(flag);
-      if (knownKeys.has(candidate)) {
-        cliExposedKeys.add(candidate);
-        continue;
-      }
-      const stripped = candidate.replace(/Js$/, "");
-      if (knownKeys.has(stripped)) cliExposedKeys.add(stripped);
+      if (knownKeys.has(candidate)) cliExposedKeys.add(candidate);
     }
 
     const missing: string[] = [];

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -275,12 +275,25 @@ function parseArgs(argv) {
       opts.publicPath = arg.split("=")[1];
       continue;
     }
+    // `--banner=<text>` 가 정식 — `BuildOptions.banner: string` 과 1:1 매핑.
+    // `--banner:js=<text>` 는 esbuild 호환 alias (silent — deprecated 경고 없음).
+    // BuildOptions 가 단일 string 인 동안은 namespace key (`:js`) 가 무의미하지만 esbuild 에서
+    // 옮겨 오는 사용자가 자연스럽게 동작하도록 유지. 향후 CSS bundling 도입 시 이 entry 가
+    // namespace 의미 회복.
+    if (arg.startsWith("--banner=")) {
+      opts.banner = arg.slice("--banner=".length);
+      continue;
+    }
     if (arg.startsWith("--banner:js=")) {
-      opts.banner = arg.split("=").slice(1).join("=");
+      opts.banner = arg.slice("--banner:js=".length);
+      continue;
+    }
+    if (arg.startsWith("--footer=")) {
+      opts.footer = arg.slice("--footer=".length);
       continue;
     }
     if (arg.startsWith("--footer:js=")) {
-      opts.footer = arg.split("=").slice(1).join("=");
+      opts.footer = arg.slice("--footer:js=".length);
       continue;
     }
     if (arg.startsWith("--entry-names=")) {

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -284,7 +284,7 @@ describe("CLI: bundle", () => {
     rmSync(extDir, { recursive: true, force: true });
   });
 
-  test("번들 + --banner:js + --footer:js", () => {
+  test("번들 + --banner:js + --footer:js (esbuild 호환 alias)", () => {
     const { stdout, exitCode } = runCli([
       "--bundle",
       join(dir, "entry.ts"),
@@ -294,6 +294,29 @@ describe("CLI: bundle", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("/* banner */");
     expect(stdout).toContain("/* footer */");
+  });
+
+  test("번들 + --banner + --footer (정식 형태 — BuildOptions.banner 와 1:1)", () => {
+    const { stdout, exitCode } = runCli([
+      "--bundle",
+      join(dir, "entry.ts"),
+      "--banner=/* TOP */",
+      "--footer=/* BOTTOM */",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* TOP */");
+    expect(stdout).toContain("/* BOTTOM */");
+  });
+
+  test("--banner 가 = 안의 = 도 보존", () => {
+    // `--banner=key=value` 같이 value 안에 = 가 있어도 split 으로 truncation 안 됨.
+    const { stdout, exitCode } = runCli([
+      "--bundle",
+      join(dir, "entry.ts"),
+      "--banner=/* key=value */",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("/* key=value */");
   });
 
   test("번들 + --clean (outdir 정리 후 빌드)", () => {


### PR DESCRIPTION
## Summary
`--banner=<text>` / `--footer=<text>` 정식 형태 추가 — `BuildOptions.banner: string` / `footer: string` 과 1:1 매핑. 기존 `--banner:js=` / `--footer:js=` 는 esbuild 호환 silent alias 로 유지.

## 동기
- 기존엔 namespace 형 `--banner:js=` 만 노출이라 BuildOptions 의 단순 `banner: string` 과 일관성 파손
- 사용자 mental model 이 어긋남: namespace 가 있으면 `--banner:css=` 같은 확장이 가능하리라 기대하지만 BuildOptions 가 단일 string
- esbuild 사용자 호환은 유지해야 — `--banner:js=` 는 silent alias

## 변경
1. `--banner=<text>` / `--footer=<text>` 추가 — 정식 형태
2. `--banner:js=` / `--footer:js=` 는 그대로 동작 (deprecated 경고 없음 — 무한 호환)
3. `arg.split("=")` 대신 `slice(prefix.length)` — value 안의 `=` 도 보존 (`--banner=key=value` OK)
4. schema sync 테스트 (#2136) 갱신:
   - `Js$` strip 후처리 제거 — alias 를 cliOnlyFlags 에 명시적 등록
   - `--out-extension:.js=` 도 같은 카테고리로 분류

## 향후 호환
`BuildOptions.banner` 가 union 으로 확장될 때 (`string | { js?: string; css?: string }`) `--banner:js=` namespace 가 자연스럽게 의미 회복. 현재는 단일 string 이라 `:js` 가 무의미하지만 silent alias 로 동작.

## Test plan
- [x] `bun test packages/core/bin/zts.test.ts -t banner` — 3/3 통과 (정식 + alias + value 안 `=` 보존)
- [x] `bun test packages/core/` 전체 — 601/601 (회귀 없음)
- [x] schema sync 테스트도 통과 (alias 명시적 등록)
- [x] lint/fmt 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)