### PR TITLE
chore(simplify): outbase silent drop + globalIdentifiers 중복 + opts default sync

### DIFF
--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -27,6 +27,55 @@ const WASM_INDEX_PATH = join(__dirname, "..", "..", "wasm", "index.ts");
 
 // ─── 정적 파싱 헬퍼 ──────────────────────────────────────────
 
+/**
+ * zts.mjs 의 `parseArgs` 함수 안 `opts = { ... }` 객체 리터럴에서 키 추출.
+ * `mergeConfigIntoOpts` 의 `opts[key] === undefined` 머지 조건이 정상 작동하려면
+ * SCALAR/BOOL/ARRAY_KEYS 의 모든 키가 default 객체에 등록되어 있어야 한다.
+ */
+function extractOptsDefaultKeys(source: string): string[] {
+  const startMarker = "const opts = {";
+  const start = source.indexOf(startMarker, source.indexOf("function parseArgs(argv)"));
+  if (start < 0) throw new Error("opts default object not found in parseArgs");
+  const bodyStart = start + startMarker.length;
+  let depth = 1;
+  let i = bodyStart;
+  while (i < source.length && depth > 0) {
+    const c = source[i];
+    if (c === "{") depth += 1;
+    else if (c === "}") depth -= 1;
+    i += 1;
+  }
+  const body = source.slice(bodyStart, i - 1);
+  const keys: string[] = [];
+  for (const rawLine of body.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) continue;
+    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:/);
+    if (m) keys.push(m[1]);
+  }
+  return keys;
+}
+
+/** zts.mjs 의 `mergeConfigIntoOpts` 안 SCALAR_KEYS / BOOL_KEYS / ARRAY_KEYS 리스트의 키 집합 추출. */
+function extractMergeKeyLists(source: string): {
+  scalar: string[];
+  bool: string[];
+  array: string[];
+} {
+  const extractList = (label: string): string[] => {
+    const idx = source.indexOf(`const ${label} = [`);
+    if (idx < 0) throw new Error(`${label} not found`);
+    const closeIdx = source.indexOf("];", idx);
+    const body = source.slice(idx, closeIdx);
+    return [...body.matchAll(/"([a-zA-Z_][a-zA-Z0-9_]*)"/g)].map((m) => m[1]);
+  };
+  return {
+    scalar: extractList("SCALAR_KEYS"),
+    bool: extractList("BOOL_KEYS"),
+    array: extractList("ARRAY_KEYS"),
+  };
+}
+
 /** zts.mjs 의 `parseArgs` 함수 본문에서 모든 flag 토큰 추출. namespace prefix (`--banner:js=`) 도 포함. */
 function extractCliFlags(source: string): string[] {
   const startMarker = "function parseArgs(argv) {";
@@ -307,6 +356,24 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
       if (!/^[a-z][a-z0-9-]*$/.test(stripped)) bad.push(flag);
     }
     expect(bad).toEqual([]);
+  });
+
+  // SCALAR_KEYS / BOOL_KEYS / ARRAY_KEYS 의 모든 키가 parseArgs `opts` default 객체에 등록돼 있어야
+  // `mergeConfigIntoOpts` 의 머지 조건 (`opts[key] === undefined`) 가 정상 작동.
+  // 회귀 패턴: outdir/outfile null → undefined (#2135), outbase 누락 (이번 fix). 자동 감지.
+  test("mergeConfigIntoOpts 의 SCALAR_KEYS / BOOL_KEYS / ARRAY_KEYS 가 모두 opts default 에 존재", () => {
+    const optsKeys = new Set(extractOptsDefaultKeys(cliSource));
+    const lists = extractMergeKeyLists(cliSource);
+    const missing: string[] = [];
+    for (const k of [...lists.scalar, ...lists.bool, ...lists.array]) {
+      if (!optsKeys.has(k)) missing.push(k);
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `[schema drift] SCALAR/BOOL/ARRAY_KEYS 에는 있지만 parseArgs opts default 에 없음: ${missing.join(", ")}\n` +
+          `parseArgs 의 opts 객체에 default 추가 (보통 \`undefined\` / \`false\` / \`[]\`).`,
+      );
+    }
   });
 });
 

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -119,6 +119,7 @@ function parseArgs(argv) {
     emitDecoratorMetadata: false,
     verbatimModuleSyntax: undefined,
     browserslist: undefined,
+    outbase: undefined,
     drop: [],
     certfile: undefined,
     keyfile: undefined,
@@ -365,7 +366,16 @@ function parseArgs(argv) {
       continue;
     }
     if (arg.startsWith("--browserslist=")) {
-      opts.browserslist = arg.split("=")[1];
+      opts.browserslist = arg.slice("--browserslist=".length);
+      continue;
+    }
+    // 다중 entry 의 출력 디렉토리 구조 base — 공통 prefix 제거 기준.
+    if (arg === "--outbase") {
+      opts.outbase = args[++i];
+      continue;
+    }
+    if (arg.startsWith("--outbase=")) {
+      opts.outbase = arg.slice("--outbase=".length);
       continue;
     }
     if (arg.startsWith("--out-extension:.js=")) {
@@ -971,6 +981,7 @@ async function runBundle(opts, config) {
     jsxImportSource: opts.jsxImportSource,
     inject: opts.inject.map((p) => resolve(p)),
     jobs: opts.jobs,
+    outbase: opts.outbase,
     plugins: plugins.length > 0 ? plugins : undefined,
   };
 

--- a/packages/core/src/typo-suggest.test.ts
+++ b/packages/core/src/typo-suggest.test.ts
@@ -203,7 +203,6 @@ describe("KNOWN_CONFIG_KEYS", () => {
       "workletTransform",
       "experimentalCodeCache",
       "assetRegistry",
-      "globalIdentifiers",
       "tsconfigRaw",
       "watch",
       "write",


### PR DESCRIPTION
## Summary
PR #2138 머지 시 누락된 simplify follow-up commit 재적용.

## Fixes

### 1. outbase silent drop
`mergeConfigIntoOpts` 의 SCALAR_KEYS 에는 `outbase` 가 있지만 parseArgs default / buildOpts forward / CLI flag 모두 누락 — `zts.config.outbase` 가 NAPI 까지 안 감.

- parseArgs default 추가 (`outbase: undefined`)
- CLI flag `--outbase` / `--outbase=` 추가
- buildOpts forward 추가

### 2. `globalIdentifiers` 중복 등록 제거
`typo-suggest.test.ts` 의 `intentionallyMissing` Set 에 두 번 등장 (line 183/206). Set 이라 무해하지만 실수 신호.

### 3. schema sync 에 opts default ↔ KEYS 리스트 sync 검증 추가
`mergeConfigIntoOpts` 의 SCALAR_KEYS / BOOL_KEYS / ARRAY_KEYS 가 모두 parseArgs 의 `opts` default 객체에 등록돼 있어야 머지 조건 (`=== undefined`) 정상 작동.

회귀 패턴:
- outdir/outfile null → undefined (#2135)
- outbase 누락 (이번 fix)

`extractOptsDefaultKeys` + `extractMergeKeyLists` 헬퍼 추가 → 양쪽 키 집합 자동 비교.

## Test plan
- [x] `bun test packages/core/` — 607/607 통과
- [x] schema sync 가 outbase 통과 (allowlist 자동 매칭)
- [x] lint/fmt 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)