### PR TITLE
chore(schema): 두 TS schema sync allowlist 를 NAPI_INTERNAL_ONLY_KEYS 로 통합

### DIFF
--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -20,6 +20,8 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { NAPI_INTERNAL_ONLY_KEYS } from "../src/schema-allowlists.ts";
+
 const CLI_PATH = join(__dirname, "zts.mjs");
 const INDEX_PATH = join(__dirname, "..", "index.ts");
 const SHARED_INDEX_PATH = join(__dirname, "..", "..", "shared", "index.ts");
@@ -301,63 +303,33 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
   ]);
 
   // BuildOptions/TranspileOptions 에 있고 CLI 에 없는 키 (의도적). 함수형/고급 옵션.
+  // 공통 NAPI internal 키는 `NAPI_INTERNAL_ONLY_KEYS` (schema-allowlists.ts) 재사용 — 새 internal
+  // 키 추가 시 그곳 1곳에만 등록하면 typo-suggest 와 cli-schema-sync 모두 자동 통과.
   const buildOptionsOnlyKeys: ReadonlySet<string> = new Set([
+    ...NAPI_INTERNAL_ONLY_KEYS,
     // 함수형 (CLI 표현 불가)
     "manualChunks",
     "plugins",
     // entry — positional argument (flag 아님)
     "entryPoints",
     "filename", // transpile 의 filename — stdin 모드일 때 의미, CLI 가 자동 결정
-    // Zig/NAPI 내부 또는 자동 결정 (사용자가 거의 안 만짐)
-    "allowOverwrite",
-    "assetRegistry",
-    "blockList",
-    "collectModuleCodes",
-    "configurableExports",
+    // 1:N 매핑으로 CLI 가 cover (cliOnlyFlags 의 namespace 형 flag 가 받음)
     "conditions",
-    "devMode",
     "dropConsole", // --drop=console 로 cover
     "dropDebugger", // --drop=debugger 로 cover
     "dropLabels",
-    "emitDiskSourcemap",
-    "entryErrorGuard",
-    "experimentalCodeCache",
-    "fallback",
-    "globalIdentifiers",
     "ignoreAnnotations",
     "inlineDynamicImports",
     "jsxSideEffects",
     "lineLimit",
-    "nodePaths",
-    "onReady",
-    "onRebuild",
     "outExtension", // namespace 객체 — `--out-extension:.js=` 가 일부 cover
     "outbase",
     "packagesExternal",
-    "polyfills",
-    "preserveSymlinks", // CLI 에 있긴 한데 boolean 형이라 별도 — TODO 향후 통합
-    "profile",
-    "profileFormat",
-    "profileLevel",
     "pure",
-    "reactRefresh",
-    "rootDir",
-    "runBeforeMain",
-    "scopeHoist",
-    "silentConsoleErrorPatterns",
     "stopAfter", // transpile 단독 — CLI 미노출 (디버그 옵션)
-    "strictExecutionOrder",
     "treeShaking",
-    "tsconfigRaw",
-    "verbatimModuleSyntax",
     "watch", // BuildOptions 의 watch 와 CLI --watch 는 의미 다름
-    "watchExclude",
-    "watchFolders",
-    "watchInclude",
-    "workletPluginVersion",
-    "workletTransform",
-    "write",
-    // CLI 에 boolean 형으로 노출되어 있지만 키가 미묘하게 다름 — `--ascii-only` ↔ TranspileOptions `asciiOnly` (OK), `--charset=` ↔ BuildOptions/TranspileOptions 는 charsetUtf8 boolean 만 (1:N 매핑)
+    // CLI 가 enum→boolean 변환 (`--charset=utf8` → charsetUtf8: true)
     "charsetUtf8",
     "analyze", // CLI 가 boolean flag, BuildOptions 는 boolean — 매칭되지만 alias 처리 누락 가능
   ]);

--- a/packages/core/src/schema-allowlists.ts
+++ b/packages/core/src/schema-allowlists.ts
@@ -1,0 +1,50 @@
+/**
+ * Schema sync 테스트 공통 allowlist — `BuildOptionsCommon` 에 정의되어 있지만 사용자가 직접
+ * 명시할 일 없는 **NAPI/internal/번들러-전용** 옵션 집합.
+ *
+ * 사용처:
+ *  - `packages/core/src/typo-suggest.test.ts`: `KNOWN_CONFIG_KEYS` 미포함 정당화 (사용자가
+ *    `zts.config.*` 에 적을 일 없으므로 typo 검출 대상 아님)
+ *  - `packages/core/bin/zts-cli-schema-sync.test.ts`: CLI flag 미노출 정당화
+ *
+ * Zig DTO sync (`src/transpile_options_dto_test.zig:ts_buildoptions_only_allowlist`) 는 별
+ * 언어라 별도 유지 — 새 internal 키 추가 시 양쪽 모두 갱신 필요. (TypeScript Compiler API
+ * 도입 + codegen 으로 single source 화는 ROI 낮아 보류, future work.)
+ *
+ * 새 internal 키 추가 시 여기 1곳에만 등록 → 두 TS 테스트 모두 자동 통과. 각 테스트의 추가
+ * allowlist (테스트만의 특수 케이스) 는 그대로 유지.
+ */
+export const NAPI_INTERNAL_ONLY_KEYS = [
+  "allowOverwrite",
+  "assetRegistry",
+  "blockList",
+  "collectModuleCodes",
+  "configurableExports",
+  "devMode",
+  "emitDiskSourcemap",
+  "entryErrorGuard",
+  "experimentalCodeCache",
+  "fallback",
+  "globalIdentifiers",
+  "nodePaths",
+  "onReady",
+  "onRebuild",
+  "polyfills",
+  "preserveSymlinks",
+  "profile",
+  "profileFormat",
+  "profileLevel",
+  "reactRefresh",
+  "rootDir",
+  "runBeforeMain",
+  "scopeHoist",
+  "silentConsoleErrorPatterns",
+  "strictExecutionOrder",
+  "tsconfigRaw",
+  "watchExclude",
+  "watchFolders",
+  "watchInclude",
+  "workletPluginVersion",
+  "workletTransform",
+  "write",
+] as const;

--- a/packages/core/src/typo-suggest.test.ts
+++ b/packages/core/src/typo-suggest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { NAPI_INTERNAL_ONLY_KEYS } from "./schema-allowlists.ts";
 import { KNOWN_CONFIG_KEYS, suggestKey, warnUnknownKeys } from "./typo-suggest.ts";
 
 describe("suggestKey", () => {
@@ -168,44 +169,13 @@ describe("KNOWN_CONFIG_KEYS", () => {
 
     const knownSet = new Set(KNOWN_CONFIG_KEYS);
     // typo-suggest 가 BuildOptions 와 drift 한 키만 보고. 의도적으로 KNOWN 에서 빠진 키는
-    // BUILD_OPTIONS_NOT_IN_KNOWN allowlist 에 등록.
+    // 공통 `NAPI_INTERNAL_ONLY_KEYS` (schema-allowlists.ts) + 이 테스트 전용 추가 키.
     const intentionallyMissing: ReadonlySet<string> = new Set([
-      // BuildOptions / NAPI 만 노출 — 사용자가 zts.config.* 에 직접 명시할 일 없음.
-      "allowOverwrite",
-      "analyze",
-      "blockList",
-      "collectModuleCodes",
-      "configurableExports",
-      "devMode",
-      "emitDiskSourcemap",
-      "entryErrorGuard",
-      "fallback",
-      "globalIdentifiers",
-      "nodePaths",
-      "onReady",
-      "onRebuild",
-      "outExtension",
-      "polyfills",
-      "preserveSymlinks",
-      "profile",
-      "profileFormat",
-      "profileLevel",
-      "reactRefresh",
-      "rootDir",
-      "runBeforeMain",
-      "silentConsoleErrorPatterns",
-      "scopeHoist",
-      "strictExecutionOrder",
-      "watchExclude",
-      "watchFolders",
-      "watchInclude",
-      "workletPluginVersion",
-      "workletTransform",
-      "experimentalCodeCache",
-      "assetRegistry",
-      "tsconfigRaw",
-      "watch",
-      "write",
+      ...NAPI_INTERNAL_ONLY_KEYS,
+      // typo-suggest 만의 추가 — KNOWN_CONFIG_KEYS 에서 의도적으로 빠진 외부 노출 키.
+      "analyze", // CLI flag 만 (`--analyze`), config 에 적을 일 없음
+      "outExtension", // CLI 의 `--out-extension:.js=` 가 outExtensionJs 로 분해됨
+      "watch", // BuildOptions 의 watch 는 NAPI 내부 (CLI --watch 와 다름)
     ]);
 
     const missing: string[] = [];


### PR DESCRIPTION
## Summary
PR #2138 simplify review 의 deferred #2 — `packages/core/src/typo-suggest.test.ts` 와 `packages/core/bin/zts-cli-schema-sync.test.ts` 가 NAPI/internal 전용 키 ~30개씩을 하드코딩한 allowlist 보유. 거의 동일해 새 internal 키 추가 시 양쪽 동기화 부담.

## 변경
- `packages/core/src/schema-allowlists.ts` 신설 — 공통 `NAPI_INTERNAL_ONLY_KEYS` 32개 export
- 두 테스트가 import 후 spread 로 자신만의 추가 키와 union

## 부수 효과
main 의 `zts-cli-schema-sync.test.ts` 에 잔존하던 `verbatimModuleSyntax` 도 자연스럽게 정리 — #2138 에서 CLI flag 추가됐으므로 더 이상 `buildOptionsOnly` 가 아님.

## Zig 는 별도 유지
`src/transpile_options_dto_test.zig:ts_buildoptions_only_allowlist` 는 별 언어라 별도. 새 internal 키 추가 시 양쪽 모두 갱신 필요. Single source 화는 TS Compiler API + codegen 필요해 ROI 낮아 보류.

## Test plan
- [x] `bun test packages/core/` — 606/606 (회귀 없음)
- [x] schema sync 통과 (verbatimModuleSyntax 자동 매칭 포함)
- [x] lint/fmt 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)