### PR TITLE
chore(workspace): resolveWorkspaceEntries / ResolvedWorkspace export 제거

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -162,12 +162,10 @@ export {
   identifyWorkspaceEntries,
   loadIdentifiedConfig,
   loadWorkspace,
-  resolveWorkspaceEntries,
   WORKSPACE_EXT_PRIORITY,
 } from "./src/workspace.ts";
 export type {
   IdentifiedWorkspace,
-  ResolvedWorkspace,
   Workspace,
   WorkspaceEntry,
   WorkspaceEntryInline,

--- a/packages/core/src/workspace.test.ts
+++ b/packages/core/src/workspace.test.ts
@@ -11,7 +11,6 @@ import {
   identifyWorkspaceEntries,
   loadIdentifiedConfig,
   loadWorkspace,
-  resolveWorkspaceEntries,
 } from "./workspace.ts";
 
 beforeAll(() => init());
@@ -112,13 +111,13 @@ describe("loadWorkspace", () => {
   });
 });
 
-describe("resolveWorkspaceEntries", () => {
+describe("identifyWorkspaceEntries", () => {
   let dir: string;
 
   beforeAll(() => {
-    dir = mkdtempSync(join(tmpdir(), "zts-workspace-resolve-"));
+    dir = mkdtempSync(join(tmpdir(), "zts-workspace-identify-"));
     // Layout:
-    //   <dir>/packages/app          — package.json name="my-app" + zts.config.ts
+    //   <dir>/packages/app          — package.json name="my-app" + zts.config.json
     //   <dir>/packages/lib-a        — package.json name="@scope/a"
     //   <dir>/packages/lib-b        — (no package.json — fallback to dirname)
     //   <dir>/packages/.hidden      — should NOT match * glob
@@ -129,7 +128,10 @@ describe("resolveWorkspaceEntries", () => {
     const app = join(pkgs, "app");
     mkdirSync(app);
     writeFileSync(join(app, "package.json"), JSON.stringify({ name: "my-app" }));
-    writeFileSync(join(app, "zts.config.ts"), `export default { format: "esm" as const }`);
+    writeFileSync(
+      join(app, "zts.config.json"),
+      JSON.stringify({ format: "esm", entryPoints: ["./entry.ts"] }),
+    );
 
     const libA = join(pkgs, "lib-a");
     mkdirSync(libA);
@@ -145,105 +147,6 @@ describe("resolveWorkspaceEntries", () => {
 
   afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
-  test("string path — config 자동 탐색 + package.json name 사용", async () => {
-    const r = await resolveWorkspaceEntries(["./packages/app"], dir);
-    expect(r).toHaveLength(1);
-    expect(r[0]?.name).toBe("my-app");
-    expect(r[0]?.source).toBe("path");
-    expect(r[0]?.config.format).toBe("esm");
-  });
-
-  test("string path — config 없으면 빈 config + package.json fallback", async () => {
-    const r = await resolveWorkspaceEntries(["./packages/lib-a"], dir);
-    expect(r).toHaveLength(1);
-    expect(r[0]?.name).toBe("@scope/a");
-    expect(r[0]?.config).toEqual({});
-  });
-
-  test("string path — package.json 없으면 디렉토리명 fallback", async () => {
-    const r = await resolveWorkspaceEntries(["./packages/lib-b"], dir);
-    expect(r).toHaveLength(1);
-    expect(r[0]?.name).toBe("lib-b");
-  });
-
-  test("glob `./packages/*` — 매칭 디렉토리 모두, hidden/node_modules 제외", async () => {
-    const r = await resolveWorkspaceEntries(["./packages/*"], dir);
-    const names = r.map((e) => e.name).sort();
-    expect(names).toEqual(["@scope/a", "lib-b", "my-app"]);
-    expect(r.every((e) => e.source === "glob")).toBe(true);
-  });
-
-  test("glob `./packages/lib-*` — prefix 매칭", async () => {
-    const r = await resolveWorkspaceEntries(["./packages/lib-*"], dir);
-    const names = r.map((e) => e.name).sort();
-    expect(names).toEqual(["@scope/a", "lib-b"]);
-  });
-
-  test("inline object — name 추출 + cwd = rootDir + source=inline", async () => {
-    const r = await resolveWorkspaceEntries(
-      [{ name: "shared", entryPoints: ["./shared.ts"] }],
-      dir,
-    );
-    expect(r).toHaveLength(1);
-    expect(r[0]?.name).toBe("shared");
-    expect(r[0]?.cwd).toBe(dir);
-    expect(r[0]?.source).toBe("inline");
-    expect(r[0]?.config.entryPoints).toEqual(["./shared.ts"]);
-    const cfg = r[0]?.config as { name?: string } | undefined;
-    expect(cfg?.name).toBeUndefined();
-  });
-
-  test("3종 형식 동시 사용", async () => {
-    const r = await resolveWorkspaceEntries(
-      ["./packages/app", "./packages/lib-*", { name: "inline-x", entryPoints: ["x"] }],
-      dir,
-    );
-    const names = r.map((e) => e.name).sort();
-    expect(names).toEqual(["@scope/a", "inline-x", "lib-b", "my-app"]);
-  });
-
-  test("glob `**` 미지원 — throw", async () => {
-    expect(resolveWorkspaceEntries(["./packages/**"], dir)).rejects.toThrow(/'\*\*'/);
-  });
-
-  test("glob 디렉토리부 `*` 미지원 — throw", async () => {
-    expect(resolveWorkspaceEntries(["./*/foo"], dir)).rejects.toThrow(/'\*' in directory/);
-  });
-
-  test("존재하지 않는 디렉토리 glob — 빈 결과", async () => {
-    const r = await resolveWorkspaceEntries(["./nonexistent/*"], dir);
-    expect(r).toEqual([]);
-  });
-
-  test("dedup: 같은 cwd 가 path + glob 양쪽에 매칭되면 첫 번째만 유지", async () => {
-    const r = await resolveWorkspaceEntries(["./packages/app", "./packages/*"], dir);
-    const apps = r.filter((e) => e.name === "my-app");
-    expect(apps).toHaveLength(1);
-    expect(apps[0]?.source).toBe("path"); // path 가 먼저 선언됐으므로 path 가 살아남아야 함
-  });
-});
-
-describe("identifyWorkspaceEntries", () => {
-  let dir: string;
-
-  beforeAll(() => {
-    dir = mkdtempSync(join(tmpdir(), "zts-workspace-identify-"));
-    const pkgs = join(dir, "packages");
-    mkdirSync(pkgs, { recursive: true });
-    const app = join(pkgs, "app");
-    mkdirSync(app);
-    writeFileSync(join(app, "package.json"), JSON.stringify({ name: "my-app" }));
-    writeFileSync(
-      join(app, "zts.config.json"),
-      JSON.stringify({ format: "esm", entryPoints: ["./entry.ts"] }),
-    );
-    const lib = join(pkgs, "lib");
-    mkdirSync(lib);
-    writeFileSync(join(lib, "package.json"), JSON.stringify({ name: "my-lib" }));
-  });
-
-  afterAll(() => rmSync(dir, { recursive: true, force: true }));
-
   test("inlineConfig 분리 — inline entry 만 채워짐", () => {
     const r = identifyWorkspaceEntries(
       ["./packages/app", { name: "shared", entryPoints: ["./shared/x.ts"] }],
@@ -255,18 +158,92 @@ describe("identifyWorkspaceEntries", () => {
     expect((r[1]?.inlineConfig as { name?: string } | null)?.name).toBeUndefined();
   });
 
-  test("config 로드 없이 식별만 — package.json 만 읽음", () => {
+  test("string path — package.json name 사용 (config 로드 없음)", () => {
     const r = identifyWorkspaceEntries(["./packages/app"], dir);
+    expect(r).toHaveLength(1);
     expect(r[0]?.name).toBe("my-app");
     expect(r[0]?.cwd).toBe(join(dir, "packages", "app"));
     expect(r[0]?.source).toBe("path");
     expect(r[0]?.inlineConfig).toBeNull();
   });
 
-  test("dedup 적용 — 같은 cwd 첫 번째만", () => {
-    const r = identifyWorkspaceEntries(["./packages/app", "./packages/app", "./packages/*"], dir);
+  test("string path — scoped package.json name 사용", () => {
+    const r = identifyWorkspaceEntries(["./packages/lib-a"], dir);
+    expect(r[0]?.name).toBe("@scope/a");
+  });
+
+  test("string path — package.json 없으면 디렉토리명 fallback", () => {
+    const r = identifyWorkspaceEntries(["./packages/lib-b"], dir);
+    expect(r[0]?.name).toBe("lib-b");
+  });
+
+  test("glob `./packages/*` — 매칭 디렉토리 모두, hidden/node_modules 제외", () => {
+    const r = identifyWorkspaceEntries(["./packages/*"], dir);
+    const names = r.map((e) => e.name).sort();
+    expect(names).toEqual(["@scope/a", "lib-b", "my-app"]);
+    expect(r.every((e) => e.source === "glob")).toBe(true);
+  });
+
+  test("glob `./packages/lib-*` — prefix 매칭", () => {
+    const r = identifyWorkspaceEntries(["./packages/lib-*"], dir);
+    const names = r.map((e) => e.name).sort();
+    expect(names).toEqual(["@scope/a", "lib-b"]);
+  });
+
+  test("inline object — name 추출 + cwd = rootDir + source=inline", () => {
+    const r = identifyWorkspaceEntries([{ name: "shared", entryPoints: ["./shared.ts"] }], dir);
+    expect(r).toHaveLength(1);
+    expect(r[0]?.name).toBe("shared");
+    expect(r[0]?.cwd).toBe(dir);
+    expect(r[0]?.source).toBe("inline");
+  });
+
+  test("3종 형식 동시 사용", () => {
+    const r = identifyWorkspaceEntries(
+      ["./packages/app", "./packages/lib-*", { name: "inline-x", entryPoints: ["x"] }],
+      dir,
+    );
+    const names = r.map((e) => e.name).sort();
+    expect(names).toEqual(["@scope/a", "inline-x", "lib-b", "my-app"]);
+  });
+
+  test("glob `**` 미지원 — throw", () => {
+    expect(() => identifyWorkspaceEntries(["./packages/**"], dir)).toThrow(/'\*\*'/);
+  });
+
+  test("glob 디렉토리부 `*` 미지원 — throw", () => {
+    expect(() => identifyWorkspaceEntries(["./*/foo"], dir)).toThrow(/'\*' in directory/);
+  });
+
+  test("존재하지 않는 디렉토리 glob — 빈 결과", () => {
+    const r = identifyWorkspaceEntries(["./nonexistent/*"], dir);
+    expect(r).toEqual([]);
+  });
+
+  test("dedup: 같은 cwd 가 path + glob 양쪽에 매칭되면 첫 번째만 (path) 유지", () => {
+    const r = identifyWorkspaceEntries(["./packages/app", "./packages/*"], dir);
+    const apps = r.filter((e) => e.name === "my-app");
+    expect(apps).toHaveLength(1);
+    expect(apps[0]?.source).toBe("path");
+  });
+
+  test("dedup: 동일 path 중복 선언", () => {
+    const r = identifyWorkspaceEntries(["./packages/app", "./packages/app"], dir);
     const apps = r.filter((e) => e.cwd === join(dir, "packages", "app"));
     expect(apps).toHaveLength(1);
+  });
+
+  test("identify 후 loadIdentifiedConfig 로 zts.config 자동 탐색 + 로드", async () => {
+    const ids = identifyWorkspaceEntries(["./packages/app"], dir);
+    const config = await loadIdentifiedConfig(ids[0]!);
+    expect(config.format).toBe("esm");
+    expect(config.entryPoints).toEqual(["./entry.ts"]);
+  });
+
+  test("identify 후 loadIdentifiedConfig — config 없는 디렉토리는 빈 객체", async () => {
+    const ids = identifyWorkspaceEntries(["./packages/lib-a"], dir);
+    const config = await loadIdentifiedConfig(ids[0]!);
+    expect(config).toEqual({});
   });
 });
 

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -174,25 +174,9 @@ export async function loadWorkspace(filePath: string, env?: ConfigEnv): Promise<
 }
 
 /**
- * 단일 워크스페이스 build target — name + cwd + 로드/머지 완료된 config.
+ * 식별 단계 결과 — cwd/name/source 만 확정하고 config 로드는 보류.
  *
- * `resolveWorkspaceEntries` 의 최종 결과 형태. CLI (`zts.mjs`) 는 이걸로 build flow 를 돈다.
- */
-export interface ResolvedWorkspace {
-  /** 사용자/CLI 가 식별자로 쓰는 이름. inline 은 `entry.name`, path/glob 는 package.json `name` 또는 디렉토리명. */
-  name: string;
-  /** build 가 실행될 절대 디렉토리. inline 은 root, path/glob 은 매칭 디렉토리. */
-  cwd: string;
-  /** entry 자체 config — root 와의 머지는 caller (zts.mjs) 가 책임. */
-  config: UserConfig;
-  /** 디버그/로그용 — 어떤 entry 형식에서 왔는지. */
-  source: "path" | "glob" | "inline";
-}
-
-/**
- * 식별 단계 결과 — `IdentifiedWorkspace` 는 cwd/name/source 만 확정하고 config 로드는 보류.
- *
- * `loadIdentifiedConfig` 로 후처리해야 `ResolvedWorkspace` 와 동등해진다.
+ * `loadIdentifiedConfig` 로 후처리하면 `config: UserConfig` 가 채워진 build target 형태로 완성.
  */
 export interface IdentifiedWorkspace {
   /** 워크스페이스 식별자 — `--workspace=<name>` 필터 키. */
@@ -288,48 +272,6 @@ export async function loadIdentifiedConfig(
 }
 
 /**
- * entries 를 실제 `ResolvedWorkspace` 목록으로 해석 (식별 + 모든 config 병렬 로드).
- *
- * @deprecated 단순 case (필터 없이 모든 entry 빌드) 외에는 비효율. 권장 패턴:
- * ```ts
- * const ids = identifyWorkspaceEntries(entries, rootDir);
- * const filtered = filterWorkspaces(ids, opts.workspace);     // 필터 후
- * const resolved = await Promise.all(                          // 살아남은 entry 만 config 로드
- *   filtered.map(async (w) => ({ ...w, config: await loadIdentifiedConfig(w, env) })),
- * );
- * ```
- * 위 패턴이 `--workspace=<name>` 시 N-1 개 entry 의 비싼 TS config self-compile 회피.
- * 이 wrapper 는 모든 entry 를 무조건 로드 — 단순 사용 시에만 사용.
- *
- *  - string path: 디렉토리 → `findConfigPath` 로 zts.config.* 탐색 후 로드
- *  - string glob (`*` 포함): `expandGlob` 로 매칭 디렉토리 enumerate, 각각 path 처리
- *  - inline object: 그대로 (cwd = `rootDir`)
- *
- * 같은 cwd 가 중복 매칭되면 한 번만 처리 (선언 순서 첫 번째). config 로드는 `Promise.all`
- * 로 병렬화 — I/O bound 라 동시 실행 안전.
- *
- * @param entries `loadWorkspace` 가 반환한 검증된 entries 배열
- * @param rootDir workspace 파일이 있는 디렉토리 (절대 경로 권장)
- * @param env `loadConfig` 에 전달할 함수형 config 컨텍스트 (없으면 `defaultConfigEnv()`)
- * @returns 해석된 워크스페이스 목록 — config 로드 완료
- */
-export async function resolveWorkspaceEntries(
-  entries: Workspace,
-  rootDir: string,
-  env?: ConfigEnv,
-): Promise<ResolvedWorkspace[]> {
-  const ids = identifyWorkspaceEntries(entries, rootDir);
-  return Promise.all(
-    ids.map(async (w) => ({
-      name: w.name,
-      cwd: w.cwd,
-      source: w.source,
-      config: await loadIdentifiedConfig(w, env),
-    })),
-  );
-}
-
-/**
  * 매우 단순한 glob 확장. **trailing `*`** (또는 `*` 가 들어간 디렉토리명 패턴) 만 지원.
  * `./packages/*`, `./apps/web-*`, `./pkg-*` 등.
  *
@@ -416,9 +358,9 @@ function detectPackageName(absDir: string): string {
 /**
  * `--workspace=<name>` 필터. 매칭 0개면 throw — 사용자 typo 보호 (가능한 후보 노출).
  *
- * `IdentifiedWorkspace` / `ResolvedWorkspace` 둘 다 받도록 generic — `name` 필드만 보면 되므로
- * config 로드 전 (`identifyWorkspaceEntries` 결과) 에 적용해도, 후 (`resolveWorkspaceEntries`)
- * 에 적용해도 동일 동작. config 로드는 비싸므로 식별 단계 후 즉시 필터를 권장.
+ * `name` 필드를 가진 객체면 모두 받도록 generic — `IdentifiedWorkspace` 든 caller 가 정의한
+ * 후속 형태든 동일 동작. config 로드는 비싸므로 `identifyWorkspaceEntries` 결과에 즉시 필터
+ * 후 `loadIdentifiedConfig` 호출을 권장.
  *
  * `name` 일치만 사용 — Vitest 의 `--project` 와 동일. glob/regex 매칭은 향후 확장.
  *


### PR DESCRIPTION
## Summary
PR #2140 에서 `@deprecated` 표시했던 `resolveWorkspaceEntries` 와 `ResolvedWorkspace` export 자체 제거. 사용자 지시 ("하위버전 고려 X, deprecated 그냥 제거") 반영.

## 변경
- `resolveWorkspaceEntries` 함수 제거 (workspace.ts)
- `ResolvedWorkspace` interface 제거 (사용처가 `resolveWorkspaceEntries` 만)
- index.ts 의 두 export 제거
- `filterWorkspaces` JSDoc 의 `ResolvedWorkspace` 언급 정리 (`name` 필드만 보는 generic)
- workspace.test.ts 의 `resolveWorkspaceEntries` describe 블록 제거 + 가치 있는 케이스 (string path/scoped pkg/dirname fallback / glob 매칭 / 3종 형식 / `**` 미지원 / 디렉토리부 `*` 미지원 / 빈 결과 / dedup) 를 `identifyWorkspaceEntries` describe 로 이전

## API 마이그레이션
이전:
```ts
import { resolveWorkspaceEntries } from "@zts/core";
const resolved = await resolveWorkspaceEntries(entries, rootDir);
```

이후:
```ts
import { identifyWorkspaceEntries, loadIdentifiedConfig } from "@zts/core";
const ids = identifyWorkspaceEntries(entries, rootDir);
const resolved = await Promise.all(ids.map(async (w) => ({ ...w, config: await loadIdentifiedConfig(w) })));
```

`--workspace=<name>` 필터 시에는 `filterWorkspaces(ids, name)` 를 중간에 끼워서 비싼 TS config 로드 회피.

## Test plan
- [x] `bun test packages/core/` — 608/608 (회귀 없음, 1개 추가 — identify+loadId 통합 케이스)
- [x] `bun run build:js` / `build:dts` 통과 (export 제거 후에도 d.ts 정상)
- [x] lint/fmt 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)