### PR TITLE
refactor(cli): dispatchBuild 추출 — runWorkspace ↔ main dispatch 중복 제거

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -1327,6 +1327,31 @@ async function runServe(opts, config) {
   }
 }
 
+// ─── Build dispatch ───
+
+/**
+ * 단일/워크스페이스 흐름 공통 dispatch — 모드별 (`runServe`/`runWatch`/`runBundle`/`runTranspile`)
+ * 진입점 호출 + bundle 의 user error 카운트 반환. caller (main / runWorkspace) 가 exit 처리.
+ *
+ * 반환 형태가 다른 두 호출 사이트의 drift 를 차단 — 모드 분기/추가가 1곳에서 끝남.
+ */
+async function dispatchBuild(opts, config) {
+  if (opts.serve) {
+    await runServe(opts, config);
+    return { errors: 0 };
+  }
+  if (opts.watch) {
+    await runWatch(opts, config);
+    return { errors: 0 };
+  }
+  if (opts.bundle) {
+    const result = await runBundle(opts, config);
+    return { errors: result.errors.length };
+  }
+  await runTranspile(opts);
+  return { errors: 0 };
+}
+
 // ─── Workspace mode (#2111) ───
 
 /**
@@ -1435,16 +1460,8 @@ async function runWorkspace(opts, workspacePath) {
 
     init();
     try {
-      if (subOpts.serve) {
-        await runServe(subOpts, merged);
-      } else if (subOpts.watch) {
-        await runWatch(subOpts, merged);
-      } else if (subOpts.bundle) {
-        const result = await runBundle(subOpts, merged);
-        if (result.errors.length > 0) exitCode = 1;
-      } else {
-        await runTranspile(subOpts);
-      }
+      const r = await dispatchBuild(subOpts, merged);
+      if (r.errors > 0) exitCode = 1;
     } catch (err) {
       console.error(`error [workspace ${w.name}]: ${err.message}`);
       exitCode = 1;
@@ -1504,16 +1521,8 @@ async function main() {
   init();
 
   try {
-    if (opts.serve) {
-      await runServe(opts, config);
-    } else if (opts.watch) {
-      await runWatch(opts, config);
-    } else if (opts.bundle) {
-      const result = await runBundle(opts, config);
-      if (result.errors.length > 0) process.exit(1);
-    } else {
-      await runTranspile(opts);
-    }
+    const r = await dispatchBuild(opts, config);
+    if (r.errors > 0) process.exit(1);
   } catch (err) {
     console.error(`error: ${err.message}`);
     process.exit(1);


### PR DESCRIPTION
## Summary
PR #2138 simplify review 의 deferred #3 — `zts.mjs` 의 `main()` 과 `runWorkspace()` 가 거의 동일한 dispatch 분기 (`serve`/`watch`/`bundle`/`transpile`) 를 갖고 있어 drift 가능.

## 변경
- `dispatchBuild(opts, config)` 단일 함수 추출
- 반환값 `{ errors }` 으로 caller 가 exit 처리 (main = `process.exit`, workspace = `exitCode`)

## 효과
- 새 CLI 모드 추가 시 `dispatchBuild` 1곳만 수정
- 단일/워크스페이스 흐름 둘 다 자동 적용
- 두 호출 사이트의 분기 차이 (즉시 종료 vs exit 누적) 는 caller 가 명시적으로 처리

## Test plan
- [x] `bun test packages/core/` — 607/607 (회귀 없음)
- [x] lint/fmt 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)