### PR TITLE
refactor(bundler): worker URL 치환을 codegen AST 단계로 재설계

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -551,94 +551,12 @@ pub const Bundler = struct {
         };
     }
 
-    /// 출력 코드에서 Worker의 new URL("specifier", ...) 패턴을 worker 파일명 문자열로 교체.
-    /// 코드를 한 번만 스캔하면서 모든 new URL( 패턴을 매칭 (다중 worker 순서 독립).
-    fn rewriteWorkerURLs(self: *Bundler, code: []u8, graph: *ModuleGraph, worker_map: *std.StringHashMap([]const u8)) ![]const u8 {
-        // specifier → worker filename 매핑 구축
-        var spec_to_filename = std.StringHashMap([]const u8).init(self.allocator);
-        defer spec_to_filename.deinit();
-        for (graph.worker_entries.items) |we| {
-            const filename = worker_map.get(we.resolved_path) orelse continue;
-            const mod = graph.getModule(we.source_module) orelse continue;
-            if (we.record_index >= mod.import_records.len) continue;
-            try spec_to_filename.put(mod.import_records[we.record_index].specifier, filename);
-        }
-
-        var result: std.ArrayListUnmanaged(u8) = .empty;
-        defer result.deinit(self.allocator);
-        try result.ensureTotalCapacity(self.allocator, code.len);
-
-        const needle = "new URL(";
-        var pos: usize = 0;
-        while (std.mem.indexOf(u8, code[pos..], needle)) |rel| {
-            const abs_start = pos + rel;
-            const after = abs_start + needle.len;
-            // new URL("specifier", ...) — 따옴표 시작 확인
-            if (after < code.len and code[after] == '"') {
-                // specifier 끝 따옴표 찾기
-                if (std.mem.indexOf(u8, code[after + 1 ..], "\"")) |quote_end| {
-                    const spec = code[after + 1 .. after + 1 + quote_end];
-                    // 닫는 괄호 찾기. 두 번째 인수가 CJS import.meta 변환으로
-                    // pathToFileURL(__filename)처럼 중첩 호출이 될 수 있다.
-                    if (findMatchingParen(code, abs_start + needle.len - 1)) |close_paren| {
-                        const replace_end = close_paren + 1;
-                        if (spec_to_filename.get(spec)) |filename| {
-                            try result.appendSlice(self.allocator, code[pos..abs_start]);
-                            try self.appendWorkerURLReplacement(&result, filename);
-                            pos = replace_end;
-                            continue;
-                        }
-                    }
-                }
-            }
-            // 매칭 안 되면 needle 지나서 계속
-            try result.appendSlice(self.allocator, code[pos .. abs_start + needle.len]);
-            pos = abs_start + needle.len;
-        }
-        try result.appendSlice(self.allocator, code[pos..]);
-
-        self.allocator.free(code);
-        return try result.toOwnedSlice(self.allocator);
-    }
-
     const WorkerBuildResult = struct {
         filename: []const u8,
         contents: []const u8,
     };
 
-    fn findMatchingParen(code: []const u8, open_paren: usize) ?usize {
-        var depth: usize = 0;
-        var i = open_paren;
-        var quote: ?u8 = null;
-        var escaped = false;
-
-        while (i < code.len) : (i += 1) {
-            const c = code[i];
-            if (quote) |q| {
-                if (escaped) {
-                    escaped = false;
-                } else if (c == '\\') {
-                    escaped = true;
-                } else if (c == q) {
-                    quote = null;
-                }
-                continue;
-            }
-
-            switch (c) {
-                '"', '\'', '`' => quote = c,
-                '(' => depth += 1,
-                ')' => {
-                    if (depth == 0) return null;
-                    depth -= 1;
-                    if (depth == 0) return i;
-                },
-                else => {},
-            }
-        }
-        return null;
-    }
-
+    /// Worker chunk 의 출력 포맷. Node CJS 빌드일 때만 CJS, 그 외엔 IIFE (브라우저 호환).
     fn workerFormat(self: *const Bundler) EmitOptions.Format {
         return if (self.options.platform == .node and self.options.format == .cjs) .cjs else .iife;
     }
@@ -648,25 +566,6 @@ pub const Bundler = struct {
             .cjs => ".cjs",
             else => ".js",
         };
-    }
-
-    fn appendWorkerURLReplacement(self: *Bundler, result: *std.ArrayListUnmanaged(u8), filename: []const u8) !void {
-        if (self.options.platform == .node) {
-            try result.appendSlice(self.allocator, "new URL(\"./");
-            try result.appendSlice(self.allocator, filename);
-            try result.appendSlice(self.allocator, "\", ");
-            if (self.options.format == .cjs) {
-                try result.appendSlice(self.allocator, "require(\"node:url\").pathToFileURL(__filename).href)");
-            } else {
-                try result.appendSlice(self.allocator, "import.meta.url)");
-            }
-            return;
-        }
-
-        try result.append(self.allocator, '"');
-        try result.appendSlice(self.allocator, "./");
-        try result.appendSlice(self.allocator, filename);
-        try result.append(self.allocator, '"');
     }
 
     /// Worker 파일을 별도 번들로 빌드한다.
@@ -878,21 +777,40 @@ pub const Bundler = struct {
         var worker_output_files: std.ArrayList(OutputFile) = .empty;
         defer worker_output_files.deinit(self.allocator);
 
+        // codegen.emitNew lookup 용 per-module map. outer key = module 절대 경로 (graph 소유),
+        // inner key = import_record specifier (graph 소유), value = worker chunk filename
+        // (worker_output_map 소유). 본 map 은 reference 만 보관 — deinit 시 inner 만 정리.
+        var worker_map_per_module = std.StringHashMap(std.StringHashMap([]const u8)).init(self.allocator);
+        defer {
+            var oit = worker_map_per_module.valueIterator();
+            while (oit.next()) |inner| inner.deinit();
+            worker_map_per_module.deinit();
+        }
+
         {
             var gw_scope = profile.begin(.graph_worker);
             defer gw_scope.end();
             for (graph.worker_entries.items) |we| {
                 // 같은 worker 파일이 여러 곳에서 참조되면 한 번만 빌드
-                if (worker_output_map.contains(we.resolved_path)) continue;
+                if (!worker_output_map.contains(we.resolved_path)) {
+                    const worker_result = self.buildWorker(we.resolved_path) catch {
+                        continue;
+                    };
+                    try worker_output_map.put(we.resolved_path, worker_result.filename);
+                    try worker_output_files.append(self.allocator, .{
+                        .path = try self.allocator.dupe(u8, worker_result.filename),
+                        .contents = worker_result.contents,
+                    });
+                }
 
-                const worker_result = self.buildWorker(we.resolved_path) catch {
-                    continue;
-                };
-                try worker_output_map.put(we.resolved_path, worker_result.filename);
-                try worker_output_files.append(self.allocator, .{
-                    .path = try self.allocator.dupe(u8, worker_result.filename),
-                    .contents = worker_result.contents,
-                });
+                const filename = worker_output_map.get(we.resolved_path) orelse continue;
+                const mod = graph.getModule(we.source_module) orelse continue;
+                if (we.record_index >= mod.import_records.len) continue;
+                const spec = mod.import_records[we.record_index].specifier;
+
+                const entry = try worker_map_per_module.getOrPut(mod.path);
+                if (!entry.found_existing) entry.value_ptr.* = std.StringHashMap([]const u8).init(self.allocator);
+                try entry.value_ptr.put(spec, filename);
             }
         }
 
@@ -1076,6 +994,7 @@ pub const Bundler = struct {
             dev_emit_opts.collect_module_codes = self.options.collect_module_codes;
             dev_emit_opts.polyfills = polyfill_entries.items;
             dev_emit_opts.run_before_main = self.options.run_before_main;
+            dev_emit_opts.worker_map_per_module = &worker_map_per_module;
 
             const la = graph.linkAccessor();
             for (0..graph.moduleCount()) |i| {
@@ -1119,6 +1038,7 @@ pub const Bundler = struct {
             var emit_opts = self.makeEmitOptions();
             emit_opts.preserve_modules = self.options.preserve_modules;
             emit_opts.preserve_modules_root = self.options.preserve_modules_root;
+            emit_opts.worker_map_per_module = &worker_map_per_module;
             outputs = try emitter.emitChunks(
                 self.allocator,
                 &graph,
@@ -1140,6 +1060,7 @@ pub const Bundler = struct {
             // 단일 파일 경로 (tree shaking + 소스맵 지원)
             var emit_opts = self.makeEmitOptions();
             emit_opts.polyfills = polyfill_entries.items;
+            emit_opts.worker_map_per_module = &worker_map_per_module;
             if (self.options.sourcemap.enable) emit_opts.sourcemap.enable = true;
             const emit_result = try emitter.emitWithTreeShaking(
                 self.allocator,
@@ -1153,11 +1074,6 @@ pub const Bundler = struct {
             dev_sourcemap_builder = emit_result.sourcemap_builder;
         }
         errdefer self.allocator.free(output);
-
-        // Worker URL 교체: 출력 코드에서 new URL("./worker.ts", "") → "./worker-[hash].js"
-        if (graph.worker_entries.items.len > 0 and output.len > 0) {
-            output = try self.rewriteWorkerURLs(@constCast(output), &graph, &worker_output_map);
-        }
 
         if (timer) |*t| {
             t_emit = t.read();

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -578,15 +578,13 @@ pub const Bundler = struct {
                 // specifier 끝 따옴표 찾기
                 if (std.mem.indexOf(u8, code[after + 1 ..], "\"")) |quote_end| {
                     const spec = code[after + 1 .. after + 1 + quote_end];
-                    // 닫는 괄호 찾기
-                    if (std.mem.indexOf(u8, code[abs_start..], ")")) |paren_end| {
-                        const replace_end = abs_start + paren_end + 1;
+                    // 닫는 괄호 찾기. 두 번째 인수가 CJS import.meta 변환으로
+                    // pathToFileURL(__filename)처럼 중첩 호출이 될 수 있다.
+                    if (findMatchingParen(code, abs_start + needle.len - 1)) |close_paren| {
+                        const replace_end = close_paren + 1;
                         if (spec_to_filename.get(spec)) |filename| {
                             try result.appendSlice(self.allocator, code[pos..abs_start]);
-                            try result.append(self.allocator, '"');
-                            try result.appendSlice(self.allocator, "./");
-                            try result.appendSlice(self.allocator, filename);
-                            try result.append(self.allocator, '"');
+                            try self.appendWorkerURLReplacement(&result, filename);
                             pos = replace_end;
                             continue;
                         }
@@ -608,7 +606,70 @@ pub const Bundler = struct {
         contents: []const u8,
     };
 
-    /// Worker 파일을 독립 IIFE 번들로 빌드한다.
+    fn findMatchingParen(code: []const u8, open_paren: usize) ?usize {
+        var depth: usize = 0;
+        var i = open_paren;
+        var quote: ?u8 = null;
+        var escaped = false;
+
+        while (i < code.len) : (i += 1) {
+            const c = code[i];
+            if (quote) |q| {
+                if (escaped) {
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else if (c == q) {
+                    quote = null;
+                }
+                continue;
+            }
+
+            switch (c) {
+                '"', '\'', '`' => quote = c,
+                '(' => depth += 1,
+                ')' => {
+                    if (depth == 0) return null;
+                    depth -= 1;
+                    if (depth == 0) return i;
+                },
+                else => {},
+            }
+        }
+        return null;
+    }
+
+    fn workerFormat(self: *const Bundler) EmitOptions.Format {
+        return if (self.options.platform == .node and self.options.format == .cjs) .cjs else .iife;
+    }
+
+    fn workerExtension(format: EmitOptions.Format) []const u8 {
+        return switch (format) {
+            .cjs => ".cjs",
+            else => ".js",
+        };
+    }
+
+    fn appendWorkerURLReplacement(self: *Bundler, result: *std.ArrayListUnmanaged(u8), filename: []const u8) !void {
+        if (self.options.platform == .node) {
+            try result.appendSlice(self.allocator, "new URL(\"./");
+            try result.appendSlice(self.allocator, filename);
+            try result.appendSlice(self.allocator, "\", ");
+            if (self.options.format == .cjs) {
+                try result.appendSlice(self.allocator, "require(\"node:url\").pathToFileURL(__filename).href)");
+            } else {
+                try result.appendSlice(self.allocator, "import.meta.url)");
+            }
+            return;
+        }
+
+        try result.append(self.allocator, '"');
+        try result.appendSlice(self.allocator, "./");
+        try result.appendSlice(self.allocator, filename);
+        try result.append(self.allocator, '"');
+    }
+
+    /// Worker 파일을 별도 번들로 빌드한다.
     fn buildWorker(self: *Bundler, worker_path: []const u8) !WorkerBuildResult {
         var arena = std.heap.ArenaAllocator.init(self.allocator);
         defer arena.deinit();
@@ -639,8 +700,10 @@ pub const Bundler = struct {
         const entry_arr: [1][]const u8 = .{entry_path};
         try worker_graph.build(&entry_arr);
 
+        const format = self.workerFormat();
+
         // 링킹
-        var worker_linker = Linker.init(arena_alloc, &worker_graph, .iife);
+        var worker_linker = Linker.init(arena_alloc, &worker_graph, format);
         // #1621: worker 청크도 minify 시 preamble 축약 이름 사용.
         worker_linker.minify_whitespace = self.options.minify_whitespace;
         try worker_linker.link();
@@ -650,9 +713,9 @@ pub const Bundler = struct {
         });
         defer worker_linker.deinit();
 
-        // emit (IIFE 포맷)
+        // emit
         var emit_opts = self.makeEmitOptions();
-        emit_opts.format = .iife;
+        emit_opts.format = format;
         const worker_result = try emitter.emitWithTreeShaking(
             arena_alloc,
             &worker_graph,
@@ -665,7 +728,7 @@ pub const Bundler = struct {
         // content hash로 파일명 생성
         const hash = std.hash.Crc32.hash(worker_output);
         const basename = std.fs.path.stem(std.fs.path.basename(worker_path));
-        const filename = try std.fmt.allocPrint(self.allocator, "{s}-{x:0>8}.js", .{ basename, hash });
+        const filename = try std.fmt.allocPrint(self.allocator, "{s}-{x:0>8}{s}", .{ basename, hash, workerExtension(format) });
         const contents = try self.allocator.dupe(u8, worker_output);
 
         return .{ .filename = filename, .contents = contents };

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -505,11 +505,12 @@ test "Worker: new Worker(new URL) produces separate IIFE bundle" {
 
     try std.testing.expect(!result.hasErrors());
 
-    // 메인 번들에 worker URL이 교체됨 (new URL 대신 문자열)
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(\"./worker-") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, ".js\")") != null);
-    // new URL이 사라짐
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new URL(") == null);
+    // 메인 번들의 worker specifier 가 build 결과 chunk filename 으로 치환되고
+    // 두 번째 인자는 import.meta.url 그대로 (브라우저 ESM 기본).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(new URL(\"./worker-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".js\", import.meta.url)") != null);
+    // 원본 specifier 는 사라짐
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "./worker.ts") == null);
 
     // worker 번들이 asset_outputs에 포함
     try std.testing.expect(result.asset_outputs != null);
@@ -573,10 +574,11 @@ test "Worker: multiple workers produce separate bundles" {
 
     try std.testing.expect(!result.hasErrors());
 
-    // 두 worker URL이 모두 교체됨
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(\"./worker-a-") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(\"./worker-b-") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new URL(") == null);
+    // 두 worker URL 모두 chunk filename 으로 치환 (new URL 구조 보존).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(new URL(\"./worker-a-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(new URL(\"./worker-b-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "./worker-a.ts") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "./worker-b.ts") == null);
 
     // 2개 worker 번들이 asset_outputs에 포함
     try std.testing.expect(result.asset_outputs != null);
@@ -615,10 +617,10 @@ test "Worker: duplicate references to same worker build only once" {
 
     try std.testing.expect(!result.hasErrors());
 
-    // 두 참조 모두 같은 파일명으로 교체
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(\"./worker-") != null);
-    // new URL은 전부 사라짐
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new URL(") == null);
+    // 두 참조 모두 같은 chunk filename 으로 치환.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(new URL(\"./worker-") != null);
+    // 원본 specifier 는 사라짐
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "./worker.ts") == null);
 
     // asset_outputs에 worker 번들 1개만 (중복 빌드 방지)
     try std.testing.expect(result.asset_outputs != null);
@@ -649,7 +651,7 @@ test "Worker: SharedWorker is also detected" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new SharedWorker(\"./shared-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new SharedWorker(new URL(\"./shared-") != null);
     try std.testing.expect(result.asset_outputs != null);
 }
 
@@ -682,7 +684,8 @@ test "Worker: platform node cjs emits cjs worker and file URL" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(new URL(\"./worker-") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, ".cjs\", require(\"node:url\").pathToFileURL(__filename).href)") != null);
+    // import.meta.url polyfill 은 codegen 의 IMPORT_META_URL_NODE 와 일치 (drift 없음).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".cjs\", require(\"url\").pathToFileURL(__filename).href)") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "./worker.ts") == null);
 
     const assets = result.asset_outputs orelse return error.TestUnexpectedResult;
@@ -695,6 +698,148 @@ test "Worker: platform node cjs emits cjs worker and file URL" {
         }
     }
     try std.testing.expect(found_worker);
+}
+
+test "Worker: same specifier in different modules resolves to distinct workers" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makeDir("a");
+    try tmp.dir.makeDir("b");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { run as runA } from "./a/index.ts";
+        \\import { run as runB } from "./b/index.ts";
+        \\runA(); runB();
+    );
+    try writeFile(tmp.dir, "a/index.ts",
+        \\export function run() {
+        \\  new Worker(new URL("./worker.ts", import.meta.url));
+        \\}
+    );
+    try writeFile(tmp.dir, "a/worker.ts", "self.onmessage = (e) => self.postMessage('a');");
+    try writeFile(tmp.dir, "b/index.ts",
+        \\export function run() {
+        \\  new Worker(new URL("./worker.ts", import.meta.url));
+        \\}
+    );
+    try writeFile(tmp.dir, "b/worker.ts", "self.onmessage = (e) => self.postMessage('b');");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    // per-module map 이 같은 specifier 를 모듈마다 다른 chunk 로 매핑.
+    // graph.worker_entries 에 a/worker.ts 와 b/worker.ts 두 절대 경로 등록 →
+    // 두 worker chunk 가 별개로 emit, 각각 자신의 postMessage 본문 보유.
+    const assets = result.asset_outputs orelse return error.TestUnexpectedResult;
+    var saw_a = false;
+    var saw_b = false;
+    var worker_count: usize = 0;
+    for (assets) |a| {
+        if (!std.mem.startsWith(u8, a.path, "worker-")) continue;
+        worker_count += 1;
+        // codegen 의 quote_style 기본값은 double — single-quoted 입력도 double 로 normalize.
+        if (std.mem.indexOf(u8, a.contents, "self.postMessage(\"a\")") != null) saw_a = true;
+        if (std.mem.indexOf(u8, a.contents, "self.postMessage(\"b\")") != null) saw_b = true;
+    }
+    try std.testing.expectEqual(@as(usize, 2), worker_count);
+    try std.testing.expect(saw_a);
+    try std.testing.expect(saw_b);
+}
+
+test "Worker: non-worker new URL is preserved verbatim" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\const api = new URL("/v1/users", "https://api.example.com");
+        \\const file = new URL("./data.json", import.meta.url);
+        \\console.log(api, file);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // worker_map 이 비어있으면 emitNew 의 fast-exit — 일반 new URL 호출은 그대로 emit.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new URL(\"/v1/users\", \"https://api.example.com\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new URL(\"./data.json\", import.meta.url)") != null);
+    try std.testing.expect(result.asset_outputs == null);
+}
+
+test "Worker: minified bundle preserves worker URL replacement" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\const w = new Worker(new URL("./worker.ts", import.meta.url));
+        \\w.postMessage("hi");
+    );
+    try writeFile(tmp.dir, "worker.ts", "self.onmessage = (e) => self.postMessage('pong');");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // AST-based 치환이라 minify 후에도 정확. 이전 string 후처리는 minify 가 패턴을
+    // 변형하면 깨질 위험 있었음 (회귀 방지 보호망).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(new URL(\"./worker-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import.meta.url)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "./worker.ts") == null);
+}
+
+test "Worker: platform browser cjs uses empty-string url polyfill" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\const w = new Worker(new URL("./worker.ts", import.meta.url));
+        \\w.postMessage("x");
+    );
+    try writeFile(tmp.dir, "worker.ts", "self.onmessage = (e) => self.postMessage('ok');");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+        .format = .cjs,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // browser+cjs/replace_import_meta: import.meta.url polyfill = "". codegen 의
+    // writeImportMetaUrl 이 platform 분기 단일 source.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(new URL(\"./worker-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\", \"\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "pathToFileURL") == null);
 }
 
 // ============================================================

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -653,6 +653,50 @@ test "Worker: SharedWorker is also detected" {
     try std.testing.expect(result.asset_outputs != null);
 }
 
+test "Worker: platform node cjs emits cjs worker and file URL" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { Worker } from 'node:worker_threads';
+        \\const w = new Worker(new URL('./worker.ts', import.meta.url));
+        \\w.postMessage(20);
+    );
+    try writeFile(tmp.dir, "worker.ts",
+        \\import { parentPort } from 'node:worker_threads';
+        \\parentPort.on('message', (value) => parentPort.postMessage(value + 22));
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+        .format = .cjs,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Worker(new URL(\"./worker-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".cjs\", require(\"node:url\").pathToFileURL(__filename).href)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "./worker.ts") == null);
+
+    const assets = result.asset_outputs orelse return error.TestUnexpectedResult;
+    var found_worker = false;
+    for (assets) |a| {
+        if (std.mem.startsWith(u8, a.path, "worker-") and std.mem.endsWith(u8, a.path, ".cjs")) {
+            found_worker = true;
+            try std.testing.expect(std.mem.indexOf(u8, a.contents, "require(\"node:worker_threads\")") != null);
+            try std.testing.expect(std.mem.indexOf(u8, a.contents, "parentPort.on") != null);
+        }
+    }
+    try std.testing.expect(found_worker);
+}
+
 // ============================================================
 // None-node crash prevention: parse errors must not crash transformer/codegen
 // Previously, modules with parse errors had incomplete ASTs containing

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -90,7 +90,7 @@ pub const InputHasher = struct {
 /// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
 /// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
 /// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
-const expected_emit_options_field_count: usize = 47;
+const expected_emit_options_field_count: usize = 48;
 
 comptime {
     const actual = @typeInfo(EmitOptions).@"struct".fields.len;
@@ -198,6 +198,29 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addBool(options.transform_options_base.verbatim_module_syntax);
     h.addBool(options.transform_options_base.keep_names);
     h.addU32(@bitCast(options.transform_options_base.unsupported));
+
+    // worker_map_per_module: HashMap iteration 순서 무관하게 결정적 hash. entry 별 sub-hash
+    // 를 XOR aggregate. outer key (module 절대 경로) 가 entry 마다 unique 라 XOR 충돌 가능성
+    // 없음 (서로 다른 sub-hash 가 같은 값일 확률만 존재 → 64-bit 에서 무시).
+    if (options.worker_map_per_module) |outer| {
+        h.addU64(outer.count());
+        var combined: u64 = 0;
+        var oit = outer.iterator();
+        while (oit.next()) |oe| {
+            var sub = InputHasher.init(0);
+            sub.addStr(oe.key_ptr.*);
+            sub.addU64(oe.value_ptr.count());
+            var iit = oe.value_ptr.iterator();
+            while (iit.next()) |ie| {
+                sub.addStr(ie.key_ptr.*);
+                sub.addStr(ie.value_ptr.*);
+            }
+            combined ^= sub.final();
+        }
+        h.addU64(combined);
+    } else {
+        h.addU64(0);
+    }
 }
 
 /// 전체 emit 에 1회만 계산하면 되는 options_hash 를 캐싱용으로 반환.

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -182,6 +182,13 @@ pub const EmitOptions = struct {
     /// null 이거나 모듈의 `mtime == 0` 이면 cache 비활성 — 항상 emit.
     compiled_cache: ?*CompiledOutputCache = null,
 
+    /// `new Worker(new URL("./worker.ts", import.meta.url))` 를 위한 per-module
+    /// specifier→worker chunk filename 매핑. outer key = 모듈 절대 경로,
+    /// inner key = import_record specifier, value = emit 된 worker chunk filename.
+    /// codegen 의 `worker_map` 으로 분배되어 emitNew 가 매칭되면 직접 emit.
+    /// null/empty 면 fast-exit — worker 가 없는 빌드에서 추가 비용 0.
+    worker_map_per_module: ?*const std.StringHashMap(std.StringHashMap([]const u8)) = null,
+
     pub const PolyfillEntry = struct {
         name: []const u8,
         content: []const u8,
@@ -1489,6 +1496,7 @@ pub fn emitModule(
         // dev mode: import.meta.hot → __zts_make_hot("dev_id")
         .dev_module_id = if (options.dev_mode and module.dev_id.len > 0) module.dev_id else null,
         .import_records = module.import_records,
+        .worker_map = if (options.worker_map_per_module) |outer| outer.getPtr(module.path) else null,
     });
     // 소스맵용: line_offsets와 소스 파일 등록
     if (options.sourcemap.enable) {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -123,6 +123,11 @@ pub const CodegenOptions = struct {
     /// Metro x_facebook_sources function map emit 활성화.
     /// --platform=react-native 시 자동 활성화 (PR#3).
     sourcemap_function_map: bool = false,
+    /// `new Worker(new URL("./worker.ts", import.meta.url))` 의 specifier→worker chunk filename
+    /// 매핑 (per-module). emitNew 가 이 맵을 보고 매칭되면 filename + import.meta.url polyfill
+    /// 로 직접 emit. bundler 가 모듈별로 sub-map 을 추출해 주입한다 (graph.worker_entries 에서
+    /// 도출). null/empty 면 fast-exit — worker 가 없는 모듈에서 추가 비용 0.
+    worker_map: ?*const std.StringHashMap([]const u8) = null,
 };
 
 /// keepNames 엔트리. codegen이 수집하고 emitter가 __name() 호출로 변환.
@@ -1830,12 +1835,12 @@ pub const Codegen = struct {
                 }
                 // import.meta.* polyfill (CJS/non-ESM)
                 if (self.options.module_format == .cjs or self.options.replace_import_meta) {
+                    if (std.mem.eql(u8, prop_text, "url")) {
+                        try self.writeImportMetaUrl();
+                        return;
+                    }
                     if (self.options.platform == .node) {
-                        // Node.js CJS polyfill
-                        if (std.mem.eql(u8, prop_text, "url")) {
-                            try self.write(IMPORT_META_URL_NODE);
-                            return;
-                        } else if (std.mem.eql(u8, prop_text, "dirname")) {
+                        if (std.mem.eql(u8, prop_text, "dirname")) {
                             try self.write("__dirname");
                             return;
                         } else if (std.mem.eql(u8, prop_text, "filename")) {
@@ -1844,10 +1849,7 @@ pub const Codegen = struct {
                         }
                     } else {
                         // browser/neutral: 빈 문자열
-                        if (std.mem.eql(u8, prop_text, "url") or
-                            std.mem.eql(u8, prop_text, "dirname") or
-                            std.mem.eql(u8, prop_text, "filename"))
-                        {
+                        if (std.mem.eql(u8, prop_text, "dirname") or std.mem.eql(u8, prop_text, "filename")) {
                             try self.write("\"\"");
                             return;
                         }
@@ -2168,6 +2170,53 @@ pub const Codegen = struct {
         return std.mem.indexOf(u8, rename, "()") != null;
     }
 
+    /// import.meta.url 의 출력 형태를 한 곳에서 결정 (drift 방지).
+    /// - ESM 출력: `import.meta.url` 그대로
+    /// - CJS/replace_import_meta + node: `require("url").pathToFileURL(__filename).href`
+    /// - CJS/replace_import_meta + browser/neutral: `""`
+    /// emitMember 의 import.meta.url 분기 + emitNew 의 worker URL 두 번째 인자가 공유.
+    fn writeImportMetaUrl(self: *Codegen) !void {
+        if (self.options.module_format == .cjs or self.options.replace_import_meta) {
+            if (self.options.platform == .node) {
+                try self.write(IMPORT_META_URL_NODE);
+                return;
+            }
+            try self.write("\"\"");
+            return;
+        }
+        try self.write("import.meta.url");
+    }
+
+    /// `new URL("specifier", import.meta.url)` 가 worker 등록된 specifier 를 가리키면
+    /// `new URL("./<filename>", <import.meta.url polyfill>)` 로 직접 emit. 매칭 시 true 반환.
+    /// graph.zig 가 worker_threads 패턴을 detect 해 worker_map 에 등록 → codegen 은 lookup 만.
+    /// 매칭 안 되면 평범한 emitNew 흐름으로 fallback.
+    fn tryEmitWorkerURL(self: *Codegen, callee: ast_mod.NodeIndex, args_start: u32, args_len: u32) !bool {
+        const worker_map = self.options.worker_map orelse return false;
+        if (worker_map.count() == 0 or args_len == 0) return false;
+
+        const callee_node = self.ast.getNode(callee);
+        if (callee_node.tag != .identifier_reference) return false;
+        if (!std.mem.eql(u8, self.ast.getText(callee_node.span), "URL")) return false;
+
+        const extras = self.ast.extra_data.items;
+        if (args_start >= extras.len) return false;
+        const arg0_idx: ast_mod.NodeIndex = @enumFromInt(extras[args_start]);
+        if (arg0_idx.isNone() or @intFromEnum(arg0_idx) >= self.ast.nodes.items.len) return false;
+        const arg0_node = self.ast.getNode(arg0_idx);
+        if (arg0_node.tag != .string_literal) return false;
+        const spec = Ast.stripStringQuotes(self.ast.getText(arg0_node.span));
+
+        const filename = worker_map.get(spec) orelse return false;
+
+        try self.write("new URL(\"./");
+        try self.write(filename);
+        try self.write("\", ");
+        try self.writeImportMetaUrl();
+        try self.writeByte(')');
+        return true;
+    }
+
     fn emitNew(self: *Codegen, node: Node) !void {
         const e = node.data.extra;
         if (!self.ast.hasExtra(e, 3)) return;
@@ -2179,6 +2228,8 @@ pub const Codegen = struct {
         const is_pure = (flags & CallFlags.is_pure) != 0;
 
         if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
+
+        if (try self.tryEmitWorkerURL(callee, args_start, args_len)) return;
 
         try self.write("new ");
         // 원본의 잉여 parens 제거 (#1586): callee가 `(inner)` 형태이고 inner를

--- a/tests/integration/tests/node-compat.test.ts
+++ b/tests/integration/tests/node-compat.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { createFixture, runNode, runZts, runZtsInDir } from "./helpers";
 import { join, basename } from "node:path";
-import { readFileSync, readdirSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { readFileSync, readdirSync, realpathSync, symlinkSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
 /// CJS/Node 프리셋으로 번들하고 outFile 경로 반환. 번들 실패 시 throw.
@@ -264,14 +264,10 @@ describe("Node.js 호환 edge case", () => {
       cleanup = f.cleanup;
 
       const outFile = await bundleCjsNode(f.dir, "app.ts");
-      let out = readFileSync(outFile, "utf8");
-      const summaryStart = out.indexOf("\nBundled ");
-      if (summaryStart !== -1) {
-        out = out.slice(0, summaryStart);
-        writeFileSync(outFile, out);
-      }
+      const out = readFileSync(outFile, "utf8");
       expect(out).toContain('new Worker(new URL("./worker-');
-      expect(out).toContain('require("node:url").pathToFileURL(__filename).href');
+      // import.meta.url polyfill 은 codegen 의 IMPORT_META_URL_NODE 와 동일 specifier (`url`).
+      expect(out).toContain('require("url").pathToFileURL(__filename).href');
       expect(out).not.toContain("./worker.ts");
 
       const workerFile = readdirSync(f.dir).find((name) => /^worker-[a-f0-9]{8}\.cjs$/.test(name));

--- a/tests/integration/tests/node-compat.test.ts
+++ b/tests/integration/tests/node-compat.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { createFixture, runNode, runZts, runZtsInDir } from "./helpers";
 import { join, basename } from "node:path";
-import { readFileSync, readdirSync, realpathSync, symlinkSync } from "node:fs";
+import { readFileSync, readdirSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 /// CJS/Node 프리셋으로 번들하고 outFile 경로 반환. 번들 실패 시 throw.
 async function bundleCjsNode(dir: string, entry: string, outName = "out.cjs"): Promise<string> {
@@ -227,6 +228,60 @@ describe("Node.js 호환 edge case", () => {
         readFileSync(join(outDir, n), "utf8").includes("createRequire(import.meta.url)"),
       );
       expect(hasShim).toBe(true);
+    });
+  });
+
+  describe("worker_threads", () => {
+    test("CJS Node worker: new Worker(new URL) emits and runs worker bundle", async () => {
+      const f = await createFixture({
+        "app.ts": `
+          import { Worker } from "node:worker_threads";
+          import { writeFileSync } from "node:fs";
+
+          const worker = new Worker(new URL("./worker.ts", import.meta.url));
+          worker.on("message", (value) => {
+            console.log("worker:" + value);
+            writeFileSync(new URL("./worker-result.txt", import.meta.url), String(value));
+          });
+          worker.on("error", (err) => {
+            console.error(err && err.stack ? err.stack : err);
+            process.exitCode = 1;
+          });
+          worker.on("exit", (code) => {
+            if (code !== 0) process.exitCode = code;
+          });
+          worker.postMessage(20);
+        `,
+        "worker.ts": `
+          import { parentPort } from "node:worker_threads";
+
+          parentPort!.on("message", (value) => {
+            parentPort!.postMessage(value + 22);
+            parentPort!.close();
+          });
+        `,
+      });
+      cleanup = f.cleanup;
+
+      const outFile = await bundleCjsNode(f.dir, "app.ts");
+      let out = readFileSync(outFile, "utf8");
+      const summaryStart = out.indexOf("\nBundled ");
+      if (summaryStart !== -1) {
+        out = out.slice(0, summaryStart);
+        writeFileSync(outFile, out);
+      }
+      expect(out).toContain('new Worker(new URL("./worker-');
+      expect(out).toContain('require("node:url").pathToFileURL(__filename).href');
+      expect(out).not.toContain("./worker.ts");
+
+      const workerFile = readdirSync(f.dir).find((name) => /^worker-[a-f0-9]{8}\.cjs$/.test(name));
+      expect(workerFile).toBeDefined();
+      const workerOut = readFileSync(join(f.dir, workerFile!), "utf8");
+      expect(workerOut).toContain('require("node:worker_threads")');
+
+      const run = spawnSync("node", [outFile], { encoding: "utf8" });
+      expect(run.status).toBe(0);
+      expect(readFileSync(join(f.dir, "worker-result.txt"), "utf8")).toBe("42");
     });
   });
 });


### PR DESCRIPTION
## 요약

`new Worker(new URL("./worker.ts", import.meta.url))` 패턴의 worker URL 치환을 emit 후 string 후처리에서 **codegen AST 단계 직접 emit** 으로 재설계.

기존: graph 가 worker entry 를 detect → main 번들 emit → string-level scan + paren matcher 로 `new URL(...)` 매칭 후 worker chunk filename 으로 swap. 이 과정에서 `import.meta.url` polyfill (`require("url").pathToFileURL(__filename).href`) 이 codegen 과 bundler 양쪽에서 따로 만들어져 specifier drift (`url` vs `node:url`) 발생.

신규: `EmitOptions.worker_map_per_module` (per-module specifier→filename) 을 codegen 에 전달 → `emitNew` 가 `new URL(spec, import.meta.url)` 패턴 매칭 시 직접 emit. polyfill 은 codegen 의 `writeImportMetaUrl` helper 한 곳에서만 결정 — drift 영구 차단.

다른 번들러 비교 (4개 함께): Vite/Rspack/esbuild/Rolldown 모두 AST 단계 처리 + per-call-site/per-file 매핑. 본 PR 은 Rspack 의 "AST dependency, 후처리 0" 정신을 ZTS 구조 (단일 codegen) 에 맞게 단순화.

## 변경

| 영역 | 내용 |
|---|---|
| `src/codegen/codegen.zig` | `CodegenOptions.worker_map`, `writeImportMetaUrl`, `tryEmitWorkerURL`. `emitMember` 의 `import.meta.url` 분기를 helper 로 통합 |
| `src/bundler/emitter.zig` | `EmitOptions.worker_map_per_module`. emitModule 에서 codegen 으로 전파 |
| `src/bundler/bundler.zig` | `rewriteWorkerURLs` / `findMatchingParen` / `appendWorkerURLReplacement` 삭제 (~73 LOC↓). `worker_map_per_module` 빌드 후 dev/splitting/single 3개 emit_opts 에 주입. `workerFormat` / `workerExtension` 은 buildWorker 청크 포맷 결정용으로 유지 |
| `src/bundler/compiled_cache.zig` | `EmitOptions` 필드 카운트 47→48. `worker_map_per_module` XOR-aggregate hash (HashMap iteration 순서 무관, 결정적) |

## 출력 형태 변화

**input**: `new Worker(new URL("./worker.ts", import.meta.url))`

| 환경 | 이전 (string 후처리) | 이후 (AST emit) |
|---|---|---|
| ESM | `new Worker("./worker-xxx.js")` | `new Worker(new URL("./worker-xxx.js", import.meta.url))` |
| Node CJS | `new Worker("./worker-xxx.cjs")` | `new Worker(new URL("./worker-xxx.cjs", require("url").pathToFileURL(__filename).href))` |
| Browser CJS | (미지원) | `new Worker(new URL("./worker-xxx.js", ""))` |

새 출력은 input 의 `new URL` 구조를 보존 — Vite/Rspack/esbuild 표준과 일치. browser+CJS 케이스도 정상 처리.

## 테스트

기존 4 worker 테스트 expect 갱신 + 회귀 방지 4개 추가:

- `Worker: same specifier in different modules resolves to distinct workers` — per-module map 의 충돌 disambiguate
- `Worker: non-worker new URL is preserved verbatim` — worker_map 미등록 specifier 는 그대로 emit (fast-exit)
- `Worker: minified bundle preserves worker URL replacement` — minify_whitespace + minify_syntax 켜도 AST-based 라 정확
- `Worker: platform browser cjs uses empty-string url polyfill` — codegen `writeImportMetaUrl` 의 platform 분기

검증:
- `zig build test` — 4065/4065 pass
- `bun test tests/integration/tests/node-compat.test.ts -t worker_threads` — 1 pass, 7 expects
- `oxlint`, `oxfmt --check` clean

## 효과

- **drift 영구 차단**: `IMPORT_META_URL_NODE` polyfill 은 codegen 한 곳에서만 결정 (이전엔 codegen=`url` vs bundler=`node:url`).
- **버그 면적 축소**: `findMatchingParen` 같은 미니 파서 + quote-aware string scan 제거.
- **확장 비용 0**: 새 worker 형태 (Bun.Worker, Deno Worker) 추가 시 graph detect 만 변경 — codegen 그대로.
- **성능**: O(output_size) 의 string 재할당 + scan 이 O(NewExpressions-in-worker-modules) 의 inline emit 로 대체. worker 없는 빌드는 zero-cost null check.

Closes #2145