### PR TITLE
fix(bundler): ESM export write 보존 및 함수 body dead-store 제거

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -324,6 +324,233 @@ test "TreeShaking: innerGraph preserves exported declaration initializer" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_EXPORTED_INIT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_EXPORTED_FINAL") != null);
+}
+
+test "TreeShaking: preserves top-level assignment to ESM export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export let value;
+        \\value = "INNER_GRAPH_ESM_TOP_LEVEL_WRITE";
+        \\value = "INNER_GRAPH_ESM_TOP_LEVEL_FINAL";
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_ESM_TOP_LEVEL_FINAL") != null);
+}
+
+test "TreeShaking: preserves imported top-level assignment to ESM export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from "./dep";
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "dep.ts",
+        \\export let value;
+        \\value = "INNER_GRAPH_ESM_IMPORTED_WRITE";
+        \\value = "INNER_GRAPH_ESM_IMPORTED_FINAL";
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_ESM_IMPORTED_FINAL") != null);
+}
+
+test "TreeShaking: preserves lru-cache style async assignment to ESM export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { metrics, tracing } from "./dep";
+        \\console.log(metrics.hasSubscribers, tracing.hasSubscribers);
+    );
+    try writeFile(tmp.dir, "dep.ts",
+        \\const dummy = { hasSubscribers: false };
+        \\export let metrics = dummy;
+        \\export let tracing = dummy;
+        \\Promise.resolve({
+        \\  channel() { return { hasSubscribers: "INNER_GRAPH_LRU_METRICS_FINAL" }; },
+        \\  tracingChannel() { return { hasSubscribers: "INNER_GRAPH_LRU_TRACING_FINAL" }; },
+        \\}).then((dc) => {
+        \\  metrics = dc.channel("lru-cache:metrics");
+        \\  tracing = dc.tracingChannel("lru-cache");
+        \\});
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_LRU_METRICS_FINAL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_LRU_TRACING_FINAL") != null);
+}
+
+test "TreeShaking: preserves reanimated style conditional assignment to ESM export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { measure } from "./dep";
+        \\console.log(measure);
+    );
+    try writeFile(tmp.dir, "dep.ts",
+        \\export let measure;
+        \\function measureNative() { return "INNER_GRAPH_REANIMATED_NATIVE"; }
+        \\function measureDefault() { return "INNER_GRAPH_REANIMATED_DEFAULT"; }
+        \\if (globalThis.__INNER_GRAPH_NATIVE__) {
+        \\  measure = measureNative;
+        \\} else {
+        \\  measure = measureDefault;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_REANIMATED_NATIVE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_REANIMATED_DEFAULT") != null);
+}
+
+test "TreeShaking: preserves tslib style self reassignment in ESM export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { assign } from "./dep";
+        \\console.log(assign);
+    );
+    try writeFile(tmp.dir, "dep.ts",
+        \\export var assign = function () {
+        \\  assign = Object.assign || function assignFallback(target) {
+        \\    target.marker = "INNER_GRAPH_TSLIB_ASSIGN_FALLBACK";
+        \\    return target;
+        \\  };
+        \\  return assign.apply(this, arguments);
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_TSLIB_ASSIGN_FALLBACK") != null);
+}
+
+test "TreeShaking: innerGraph prunes overwritten assignment inside ESM exported function body" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export function runAll() {
+        \\  let value;
+        \\  value = "INNER_GRAPH_ESM_FN_DEAD_WRITE";
+        \\  value = "INNER_GRAPH_ESM_FN_FINAL_WRITE";
+        \\  return value;
+        \\}
+        \\console.log(runAll());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_ESM_FN_FINAL_WRITE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_ESM_FN_DEAD_WRITE") == null);
+}
+
+test "TreeShaking: innerGraph prunes overwritten assignment inside ESM exported arrow body" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export const runAll = () => {
+        \\  let value;
+        \\  value = "INNER_GRAPH_ESM_ARROW_DEAD_WRITE";
+        \\  value = "INNER_GRAPH_ESM_ARROW_FINAL_WRITE";
+        \\  return value;
+        \\};
+        \\console.log(runAll());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_ESM_ARROW_FINAL_WRITE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_ESM_ARROW_DEAD_WRITE") == null);
 }
 
 test "TreeShaking: innerGraph preserves destructuring declaration initializer" {

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1276,6 +1276,20 @@ pub fn emitModule(
         // 마킹하는 것은 출력 크기 최적화지 correctness 가 아니다 — 포함해도 런타임 의미 동일.
         // dev 번들은 크기 허용, speed 우선 (Metro/esbuild 관습).
         if (!options.dev_mode) {
+            if ((module.wrap_kind == .esm or options.format == .esm) and options.minify_syntax) {
+                if (module.semantic) |sem| {
+                    markDeadOverwrittenFunctionBodiesOnly(
+                        arena_alloc,
+                        transformer.ast,
+                        md.symbol_ids,
+                        sem.references,
+                        sem.symbols.items,
+                        &sem.unresolved_references,
+                        &md.skip_nodes,
+                        module,
+                    ) catch {};
+                }
+            }
             if (used_export_names) |names| {
                 if (module.wrap_kind != .esm and (!is_entry or (shaker != null and options.minify_syntax))) {
                     stmt_shake: {
@@ -2071,8 +2085,32 @@ fn markDeadOverwrittenAssignments(
     const stmts = ast.extra_data.items[list.start .. list.start + list.len];
 
     var ref_index = try DeadStoreRefIndex.init(allocator, references);
+    defer ref_index.deinit(allocator);
 
     markDeadOverwrittenInStatementList(ast, stmts, symbol_ids, symbols, &ref_index, unresolved_globals, skip_nodes, module);
+}
+
+fn markDeadOverwrittenFunctionBodiesOnly(
+    allocator: std.mem.Allocator,
+    ast: *Ast,
+    symbol_ids: []const ?u32,
+    references: []const Reference,
+    symbols: []const Symbol,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+    skip_nodes: *std.DynamicBitSet,
+    module: *const Module,
+) !void {
+    if (ast.nodes.items.len == 0) return;
+    const root = ast.nodes.items[ast.nodes.items.len - 1];
+    if (root.tag != .program) return;
+
+    var ref_index = try DeadStoreRefIndex.init(allocator, references);
+    defer ref_index.deinit(allocator);
+
+    for (ast.nodes.items) |node| {
+        if (ast.functionBodyBlock(node) == null) continue;
+        markDeadOverwrittenFunctionBody(ast, node, symbol_ids, symbols, &ref_index, unresolved_globals, skip_nodes, module);
+    }
 }
 
 fn markDeadOverwrittenInStatementList(

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1276,6 +1276,10 @@ pub fn emitModule(
         // 마킹하는 것은 출력 크기 최적화지 correctness 가 아니다 — 포함해도 런타임 의미 동일.
         // dev 번들은 크기 허용, speed 우선 (Metro/esbuild 관습).
         if (!options.dev_mode) {
+            // ESM 모듈(.none scope-hoisted, .esm wrapper) 또는 ESM 출력 번들에서는
+            // 아래 statement-shake 게이트가 wrap_kind != .esm 경로만 타기 때문에
+            // 함수 body 안 dead-store 가 누락된다. ESM 경로는 top-level write 를
+            // 보존해야 하므로 (export let x; x = ...) 함수 body 만 별도 패스로 처리.
             if ((module.wrap_kind == .esm or options.format == .esm) and options.minify_syntax) {
                 if (module.semantic) |sem| {
                     markDeadOverwrittenFunctionBodiesOnly(

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -162,6 +162,12 @@ pub const ModuleStmtInfos = struct {
                     try queue.append(allocator, stmt_idx);
                 }
             }
+            for (self.writerStmts(sym_idx)) |writer_stmt| {
+                if (!reachable_stmts.isSet(writer_stmt)) {
+                    reachable_stmts.set(writer_stmt);
+                    try queue.append(allocator, writer_stmt);
+                }
+            }
         }
 
         // BFS: referenced_symbols → (declarer, writers) → dependent statements.

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -149,25 +149,13 @@ pub const ModuleStmtInfos = struct {
         // seed: side-effectful statements
         for (self.stmts, 0..) |stmt, i| {
             if (stmt.has_side_effects) {
-                reachable_stmts.set(i);
-                try queue.append(allocator, @intCast(i));
+                try seedStmt(allocator, &reachable_stmts, &queue, @intCast(i));
             }
         }
 
-        // seed: used exports가 선언된 statements
+        // seed: used exports가 선언된 statements + 같은 심볼의 writer statements
         for (used_export_sym_indices) |sym_idx| {
-            if (self.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
-                if (!reachable_stmts.isSet(stmt_idx)) {
-                    reachable_stmts.set(stmt_idx);
-                    try queue.append(allocator, stmt_idx);
-                }
-            }
-            for (self.writerStmts(sym_idx)) |writer_stmt| {
-                if (!reachable_stmts.isSet(writer_stmt)) {
-                    reachable_stmts.set(writer_stmt);
-                    try queue.append(allocator, writer_stmt);
-                }
-            }
+            try self.seedSymbolLiveStmts(allocator, &reachable_stmts, &queue, sym_idx);
         }
 
         // BFS: referenced_symbols → (declarer, writers) → dependent statements.
@@ -176,24 +164,39 @@ pub const ModuleStmtInfos = struct {
         while (head < queue.items.len) : (head += 1) {
             const stmt_idx = queue.items[head];
             for (self.stmts[stmt_idx].referenced_symbols) |ref_sym| {
-                if (self.declaredStmtBySymbol(ref_sym)) |dep_stmt| {
-                    if (!reachable_stmts.isSet(dep_stmt)) {
-                        reachable_stmts.set(dep_stmt);
-                        try queue.append(allocator, dep_stmt);
-                    }
-                }
-                for (self.writerStmts(ref_sym)) |writer_stmt| {
-                    if (!reachable_stmts.isSet(writer_stmt)) {
-                        reachable_stmts.set(writer_stmt);
-                        try queue.append(allocator, writer_stmt);
-                    }
-                }
+                try self.seedSymbolLiveStmts(allocator, &reachable_stmts, &queue, ref_sym);
             }
         }
 
         return reachable_stmts;
     }
+
+    fn seedSymbolLiveStmts(
+        self: *const ModuleStmtInfos,
+        allocator: std.mem.Allocator,
+        reachable: *std.DynamicBitSet,
+        queue: *std.ArrayListUnmanaged(u32),
+        sym_idx: u32,
+    ) !void {
+        if (self.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
+            try seedStmt(allocator, reachable, queue, stmt_idx);
+        }
+        for (self.writerStmts(sym_idx)) |writer_stmt| {
+            try seedStmt(allocator, reachable, queue, writer_stmt);
+        }
+    }
 };
+
+fn seedStmt(
+    allocator: std.mem.Allocator,
+    reachable: *std.DynamicBitSet,
+    queue: *std.ArrayListUnmanaged(u32),
+    stmt_idx: u32,
+) !void {
+    if (reachable.isSet(stmt_idx)) return;
+    reachable.set(stmt_idx);
+    try queue.append(allocator, stmt_idx);
+}
 
 const CjsExportCandidate = struct {
     /// owned UTF-8. fact 로 transferred 되거나 candidate 가 reject 시 caller 가 free.

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -606,9 +606,7 @@ pub const TreeShaker = struct {
                 for (m.export_bindings) |eb| {
                     if (eb.kind.isReExportAll()) continue;
                     const sym_idx = eb.symbol.semanticIndex() orelse continue;
-                    if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
-                        try self.enqueue(@intCast(i), stmt_idx, reachable_stmts, &queue);
-                    }
+                    try self.enqueueSymbolLiveStatements(@intCast(i), infos, sym_idx, reachable_stmts, &queue);
                 }
                 // dynamic import target도 re-export 체인 따라 transitive 모듈까지
                 // 전파해야 함(#1260). seedOpaqueModule은 opaque_visited로 중복 방지.
@@ -715,6 +713,26 @@ pub const TreeShaker = struct {
                     }
                 }
             }
+        }
+    }
+
+    fn enqueueSymbolLiveStatements(
+        self: *TreeShaker,
+        mod: u32,
+        infos: StmtInfos,
+        sym_idx: u32,
+        reachable: []?std.DynamicBitSet,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+    ) std.mem.Allocator.Error!void {
+        if (mod >= reachable.len) return;
+        if (reachable[mod] == null) {
+            reachable[mod] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
+        }
+        if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
+            try self.enqueue(mod, stmt_idx, reachable, queue);
+        }
+        for (infos.writerStmts(sym_idx)) |writer_stmt| {
+            try self.enqueue(mod, writer_stmt, reachable, queue);
         }
     }
 
@@ -866,12 +884,7 @@ pub const TreeShaker = struct {
                     const mid_local = self.linker.getExportLocalName(@intCast(target_mod), imported_name) orelse imported_name;
                     if (mid_sem.scope_maps[0].get(mid_local)) |mid_sym| {
                         if (module_stmt_infos[target_mod]) |mid_infos| {
-                            if (mid_infos.declaredStmtBySymbol(@intCast(mid_sym))) |mid_stmt| {
-                                if (reachable_stmts[target_mod] == null) {
-                                    reachable_stmts[target_mod] = try std.DynamicBitSet.initEmpty(self.allocator, mid_infos.stmts.len);
-                                }
-                                try self.enqueue(@intCast(target_mod), mid_stmt, reachable_stmts, queue);
-                            }
+                            try self.enqueueSymbolLiveStatements(@intCast(target_mod), mid_infos, @intCast(mid_sym), reachable_stmts, queue);
                         }
                     }
                 }
@@ -891,12 +904,7 @@ pub const TreeShaker = struct {
             try self.seedOpaqueModule(@intCast(canon_mod), queue, module_stmt_infos, reachable_stmts);
             return;
         };
-        const target_stmt = target_infos.declaredStmtBySymbol(@intCast(sym_idx)) orelse return;
-
-        if (reachable_stmts[canon_mod] == null) {
-            reachable_stmts[canon_mod] = try std.DynamicBitSet.initEmpty(self.allocator, target_infos.stmts.len);
-        }
-        try self.enqueue(@intCast(canon_mod), target_stmt, reachable_stmts, queue);
+        try self.enqueueSymbolLiveStatements(@intCast(canon_mod), target_infos, @intCast(sym_idx), reachable_stmts, queue);
 
         // side-effect statement는 enqueueStmt에서 lazy 시드됨
     }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -2295,12 +2295,10 @@ pub const SemanticAnalyzer = struct {
         if (!body_idx.isNone()) {
             const body_node = self.ast.getNode(body_idx);
             if (body_node.tag == .block_statement) {
-                // block body — 내부를 직접 순회 (block_statement가 스코프를 또 만들지 않도록).
-                // 일반 함수와 동일하게 var/function 을 사전 등록해 hoisting 을 반영한다.
-                // 누락되면 arrow body 안의 `var x = function() {}` 이 선언 위치보다 앞의 다른
-                // 함수에서 참조될 때 resolve 실패 → `reference_count == 0` 으로 dead-store 제거.
-                try self.predeclareVarDecls(body_node.data.list);
-                try self.visitNodeList(body_node.data.list);
+                // block body — 일반 함수와 동일한 function-body 경로를 사용한다.
+                // `visitStmtList` 를 거쳐야 Reference.scope_stmt_idx 가 arrow body 기준
+                // per-statement index 로 기록되어 innerGraph dead-store 판정이 정확해진다.
+                try self.visitFunctionBodyInner(body_idx);
             } else {
                 // expression body
                 try self.visitNode(body_idx);


### PR DESCRIPTION
## 요약
- ESM entry/export 경로에서도 exported function/arrow body 안의 overwritten assignment를 innerGraph dead-store pass로 제거합니다.
- `export let value; value = ...` 형태의 top-level ESM export write가 tree-shaking 중 사라지던 기존 버그를 수정했습니다.
- arrow function block body가 일반 function body 경로를 타도록 semantic analyzer를 수정해 `Reference.scope_stmt_idx`가 body statement 기준으로 기록되게 했습니다.

## 원인
- ESM module은 기존 statement-level shake 조건에서 빠지면서 exported function body 내부 dead-store 탐색이 누락되었습니다.
- top-level ESM export는 export seed가 선언 statement만 enqueue하고 같은 symbol의 후속 writer statement를 seed하지 않아 최종 assignment가 pure statement로 제거될 수 있었습니다.
- arrow block body는 `visitNodeList`로 직접 순회되어 statement index가 outer declaration 기준으로 남아 reference 기반 dead-store 매칭이 실패했습니다.

## 변경
- ESM/minify 경로에서 function body dead-store pass를 별도로 실행합니다.
- tree-shaker export seed와 `ModuleStmtInfos.computeReachable` seed가 export symbol의 declaration뿐 아니라 writer statements도 함께 enqueue하도록 변경했습니다.
- exported declaration initializer 테스트에 final write 검증을 추가하고, top-level/imported ESM export write 회귀 테스트를 추가했습니다.
- ESM exported function/arrow body dead-store 제거 테스트를 추가했습니다.
- 실제 라이브러리에서 확인한 패턴을 축약 fixture로 추가했습니다.
  - `lru-cache` style: async dynamic import 후 exported mutable binding 갱신
  - `react-native-reanimated` style: platform 조건에 따라 exported function binding 할당
  - `tslib` style: exported helper function 내부 self-reassignment

## 실제 패키지 확인
- 로컬 `node_modules`에서 `export let/var` 이후 같은 binding 재할당 후보를 검색했습니다.
  - 43개 패키지, 247개 후보 발견
- 실제 번들 스모크 통과:
  - `lru-cache/dist/esm/diagnostics-channel.js`: `metrics`, `tracing` assignment 보존
  - `tslib/tslib.es6.mjs`: `__assign` self-reassignment 보존
  - `d3-format/src/defaultLocale.js`: `format`, `formatPrefix` 갱신 패턴 보존
  - `d3-time-format/src/defaultLocale.js`: `timeFormat`, `timeParse`, `utcFormat`, `utcParse` 갱신 패턴 보존
- `react-native-reanimated` 전체 번들은 의존하는 `react-native/index.js` 파싱 에러로 막혀서, 소스 패턴을 축약 fixture로 고정했습니다.

## 검증
- `zig fmt src/bundler/tree_shaker.zig src/bundler/stmt_info.zig src/bundler/emitter.zig src/bundler/bundler_test/tree_shake.zig src/semantic/analyzer.zig`
- `zig build test --summary all --prominent-compile-errors` → 4067/4067 passed
- `zig build --summary all --prominent-compile-errors`
- `git diff --check`
- synthetic large fixture: 3000개 dead marker fixture, 5회 실행
  - dead markers: 0
  - final markers: 3000
  - real time: 0.71-0.72s