### PR TITLE
docs: add AGENTS guide link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines
+
+See [CLAUDE.md](./CLAUDE.md) for the contributor and agent guidelines for this repository.
+
+Treat `CLAUDE.md` as the source of truth for project workflow, commands, architecture notes, and coding expectations.


### PR DESCRIPTION
## Summary
Adds AGENTS.md as a lightweight pointer to CLAUDE.md.

## Changes
- Add AGENTS.md with CLAUDE.md as the source of truth for contributor and agent guidance.

## Test Plan
- [x] pre-push hook passed (`zig fmt --check src/`, `zig build test`, `oxlint`, `oxfmt --check`)

## Decision Impact
None