### PR TITLE
chore(cli): zts.mjs flag parsing 을 registry 기반으로 통합

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -1,0 +1,318 @@
+/**
+ * ZTS CLI flag registry + parsing helpers.
+ *
+ * `zts.mjs` 의 `parseArgs` 가 60+ flag 를 hand-rolled if-chain 으로 처리하던 것을
+ * 메타데이터로 통합. 새 flag 추가 시 `FLAG_REGISTRY` 에 entry 한 줄만 추가하면
+ * `parseArgs` / `KNOWN_FLAGS` / typo-suggest / schema-sync 모두 자동 합류.
+ *
+ * 별도 파일로 분리한 이유: `zts.mjs` 의 top-level `await import("../dist/index.js")` 가
+ * NAPI 바인딩을 로드하므로 테스트가 `zts.mjs` 를 직접 import 하기 어렵다. registry 를
+ * 분리해 schema-sync 테스트가 정적 정규식 파싱 대신 실제 export 를 import 하도록 함
+ * (formatter 가 spec 을 multi-line 으로 reformat 해도 회귀 없음).
+ *
+ * spec 필드:
+ *   kind:    flag 의 의미 종류 (아래 종류 표 참조)
+ *   flag:    canonical flag (`--bundle`, `--outfile`)
+ *   target:  opts 객체의 key (`bundle`, `outfile`)
+ *   forms:   ["equal"] (`--key=val` 만), ["pair"] (`--key val` 만), ["equal","pair"] (둘 다)
+ *            kind 별 기본값 차이: bool/array/key-value/ns-array/enum-bool/string-bool 은 무시,
+ *            string/int 는 ["equal","pair"], csv 는 ["equal","pair"], ns-string 은 ["equal"].
+ *   aliases: 추가 flag 이름 (`-o`, `--tsconfig-path`).
+ *   extra:   부수효과 — 매칭 시 함께 set 할 키-값 (`{ watch: true }`).
+ *   default: bool 단독 등장 시 default 값 (kind="string-default" 의 metafile 패턴).
+ *   enum:    enum→bool 매핑 (`{ utf8: true }` → `--charset=utf8` 시 charsetUtf8=true).
+ *   noop:    true 면 매칭만 하고 set 안 함 (deprecated/TODO flag).
+ *
+ * kind:
+ *   bool          — boolean toggle. 정확 매칭만.
+ *   string        — string scalar.
+ *   int           — parseInt.
+ *   array         — array push (반복 지정 시 누적). `--external foo --external bar` → ["foo","bar"].
+ *   csv           — comma 분리 → array. `--env-prefix=A,B` → ["A","B"]. forms 기본 ["equal","pair"].
+ *   key-value     — colon prefix `--key:K=V` → opts[target][K] = V. `--define:NODE_ENV=prod`.
+ *   ns-array      — colon prefix `--key:VALUE` → opts[target].push(VALUE). `--inject:./prelude`.
+ *   ns-string     — colon prefix `--key:NS=VALUE` → opts[target] = VALUE (namespace 무시).
+ *                   `--banner:js=text` 가 `--banner=text` 와 동일 의미 (esbuild 호환).
+ *   string-default — bool 단독 시 default 값, `--key=val` 시 val 사용. `--metafile` 패턴.
+ *   enum-bool     — `--key=enumValue` 시 spec.enum 의 매핑 적용. `--charset=utf8` → charsetUtf8=true.
+ *   string-bool   — `--key=anything` → true, `--key=false` → false. default=true 옵션의 toggle.
+ */
+export const FLAG_REGISTRY = [
+  // ─── kind=bool — boolean toggle ───
+  { kind: "bool", flag: "--bundle", target: "bundle" },
+  { kind: "bool", flag: "--watch", target: "watch", aliases: ["-w"] },
+  { kind: "bool", flag: "--watch-json", target: "watchJson", extra: { watch: true } },
+  { kind: "bool", flag: "--open", target: "open" },
+  { kind: "bool", flag: "--minify", target: "minify" },
+  { kind: "bool", flag: "--minify-whitespace", target: "minifyWhitespace" },
+  { kind: "bool", flag: "--minify-identifiers", target: "minifyIdentifiers" },
+  { kind: "bool", flag: "--minify-syntax", target: "minifySyntax" },
+  { kind: "bool", flag: "--sourcemap", target: "sourcemap" },
+  { kind: "bool", flag: "--sourcemap-debug-ids", target: "sourcemapDebugIds" },
+  { kind: "bool", flag: "--splitting", target: "splitting" },
+  { kind: "bool", flag: "--analyze", target: "analyze", extra: { metafile: "meta.json" } },
+  { kind: "bool", flag: "--flow", target: "flow" },
+  { kind: "bool", flag: "--experimental-decorators", target: "experimentalDecorators" },
+  { kind: "bool", flag: "--emit-decorator-metadata", target: "emitDecoratorMetadata" },
+  { kind: "bool", flag: "--jsx-in-js", target: "jsxInJs" },
+  { kind: "bool", flag: "--verbatim-module-syntax", target: "verbatimModuleSyntax" },
+  { kind: "bool", flag: "--keep-names", target: "keepNames" },
+  { kind: "bool", flag: "--shim-missing-exports", target: "shimMissingExports" },
+  { kind: "bool", flag: "--ascii-only", target: "asciiOnly" },
+  { kind: "bool", flag: "--preserve-modules", target: "preserveModules" },
+  { kind: "bool", flag: "--preserve-symlinks", target: "preserveSymlinks", noop: true },
+  { kind: "bool", flag: "--jsx-dev", target: "jsxDev" },
+  { kind: "bool", flag: "--clean", target: "clean" },
+
+  // ─── kind=string — string scalar (`--key=value` 단방향) ───
+  { kind: "string", flag: "--format", target: "format", forms: ["equal"] },
+  { kind: "string", flag: "--platform", target: "platform", forms: ["equal"] },
+  { kind: "string", flag: "--jsx", target: "jsx", forms: ["equal"] },
+  { kind: "string", flag: "--jsx-factory", target: "jsxFactory", forms: ["equal"] },
+  { kind: "string", flag: "--jsx-fragment", target: "jsxFragment", forms: ["equal"] },
+  { kind: "string", flag: "--jsx-import-source", target: "jsxImportSource", forms: ["equal"] },
+  { kind: "string", flag: "--global-name", target: "globalName", forms: ["equal"] },
+  { kind: "string", flag: "--public-path", target: "publicPath", forms: ["equal"] },
+  { kind: "string", flag: "--entry-names", target: "entryNames", forms: ["equal"] },
+  { kind: "string", flag: "--chunk-names", target: "chunkNames", forms: ["equal"] },
+  { kind: "string", flag: "--asset-names", target: "assetNames", forms: ["equal"] },
+  { kind: "string", flag: "--quotes", target: "quotes", forms: ["equal"] },
+  { kind: "string", flag: "--log-level", target: "logLevel", forms: ["equal"] },
+  { kind: "string", flag: "--legal-comments", target: "legalComments", forms: ["equal"] },
+  {
+    kind: "string",
+    flag: "--preserve-modules-root",
+    target: "preserveModulesRoot",
+    forms: ["equal"],
+  },
+  { kind: "string", flag: "--rn-platform", target: "rnPlatform", forms: ["equal"] },
+  { kind: "string", flag: "--source-root", target: "sourceRoot", forms: ["equal"] },
+  { kind: "string", flag: "--banner", target: "banner", forms: ["equal"] },
+  { kind: "string", flag: "--footer", target: "footer", forms: ["equal"] },
+
+  // ─── kind=string — `--key value` 또는 `--key=value` 둘 다 ───
+  { kind: "string", flag: "--target", target: "target" },
+  { kind: "string", flag: "--browserslist", target: "browserslist" },
+  { kind: "string", flag: "--outbase", target: "outbase" },
+  { kind: "string", flag: "--outfile", target: "outfile", aliases: ["-o"], forms: ["pair"] },
+  { kind: "string", flag: "--outdir", target: "outdir", forms: ["pair"] },
+  { kind: "string", flag: "--certfile", target: "certfile", forms: ["pair"] },
+  { kind: "string", flag: "--keyfile", target: "keyfile", forms: ["pair"] },
+  // tsc-style alias (`-p`, `--project`) + NAPI naming alias (`--tsconfig-path`).
+  { kind: "string", flag: "--project", target: "project", aliases: ["-p", "--tsconfig-path"] },
+  { kind: "string", flag: "--config", target: "configPath" },
+  { kind: "string", flag: "--mode", target: "mode" },
+  { kind: "string", flag: "--workspace-config", target: "workspaceConfig" },
+  { kind: "string", flag: "--workspace", target: "workspace" },
+  { kind: "string", flag: "--env-dir", target: "envDir" },
+
+  // ─── kind=int — parseInt ───
+  { kind: "int", flag: "--watch-delay", target: "watchDelay", forms: ["equal"] },
+  { kind: "int", flag: "--jobs", target: "jobs", forms: ["equal"] },
+  { kind: "int", flag: "--port", target: "port" },
+
+  // ─── kind=string-default — bool 단독 시 default, `--key=val` 시 val ───
+  { kind: "string-default", flag: "--metafile", target: "metafile", default: "meta.json" },
+
+  // ─── kind=array — push (반복 지정) ───
+  { kind: "array", flag: "--external", target: "external" },
+  { kind: "array", flag: "--drop", target: "drop", forms: ["equal"] },
+  { kind: "array", flag: "--plugin", target: "pluginPaths", forms: ["pair"] },
+
+  // ─── kind=csv — `,` 분리 → array ───
+  { kind: "csv", flag: "--env-prefix", target: "envPrefixes" },
+  { kind: "csv", flag: "--resolve-extensions", target: "resolveExtensions", forms: ["equal"] },
+  { kind: "csv", flag: "--main-fields", target: "mainFields", forms: ["equal"] },
+
+  // ─── kind=key-value — `--key:K=V` → opts[target][K]=V ───
+  { kind: "key-value", flag: "--define", target: "define" },
+  { kind: "key-value", flag: "--alias", target: "alias" },
+  { kind: "key-value", flag: "--loader", target: "loader" },
+
+  // ─── kind=ns-array — `--key:VALUE` → opts[target].push(VALUE) ───
+  { kind: "ns-array", flag: "--inject", target: "inject" },
+
+  // ─── kind=ns-string — `--key:NS=VALUE` 호환 alias (NS 무시, banner=value 와 동일) ───
+  // BuildOptions 가 단일 string 인 동안 namespace key 는 무의미하지만 esbuild 사용자 호환.
+  // 향후 CSS bundling 도입 시 namespace 의미 회복.
+  { kind: "ns-string", flag: "--banner:js", target: "banner" },
+  { kind: "ns-string", flag: "--footer:js", target: "footer" },
+  { kind: "ns-string", flag: "--out-extension:.js", target: "outExtensionJs" },
+
+  // ─── kind=enum-bool — `--key=enumValue` → opts[target] = spec.enum[enumValue] ───
+  { kind: "enum-bool", flag: "--charset", target: "charsetUtf8", enum: { utf8: true } },
+
+  // ─── kind=string-bool — default=true 의 toggle. `--key=false` → false, 그 외 → true ───
+  { kind: "string-bool", flag: "--sources-content", target: "sourcesContent" },
+  { kind: "string-bool", flag: "--use-define-for-class-fields", target: "useDefineForClassFields" },
+];
+
+/** spec 의 canonical + alias 를 한 array 로. spec.flag (canonical) 항상 첫번째. */
+export const flagsOf = (spec) => [spec.flag, ...(spec.aliases ?? [])];
+
+/**
+ * 알려진 CLI flag 이름 (canonical + aliases) — typo-suggest 등 외부 소비자가 사용.
+ * `--serve`/`--host`/`--proxy` 는 if-chain 잔존이라 미포함 (next-arg optional / 특수 parser).
+ */
+export const KNOWN_FLAGS = Object.freeze(FLAG_REGISTRY.flatMap(flagsOf).sort());
+
+/**
+ * 단일 flag 토큰을 registry spec 들과 매칭. 매칭 시 `{ spec, action, consumed }` 반환.
+ * `action` 은 `applyFlagAction(opts, ...)` 가 해석할 결과 (kind 별 형태 다름).
+ *
+ *  - bool / string-default(단독)         → { type: "set", value }
+ *  - string / int                        → { type: "set", value }
+ *  - string-default(=val)                → { type: "set", value }
+ *  - array / ns-array                    → { type: "push", value }
+ *  - csv                                 → { type: "set", value: string[] }
+ *  - key-value                           → { type: "kv", key, value }
+ *  - ns-string                           → { type: "set", value }
+ *  - enum-bool                           → { type: "set", value: bool|undefined }
+ *  - string-bool                         → { type: "set", value: bool }
+ *  - noop                                → { type: "noop" }
+ */
+export function matchFlagFromRegistry(arg, args, i) {
+  for (const spec of FLAG_REGISTRY) {
+    const result = tryMatchSpec(spec, arg, args, i);
+    if (result) return result;
+  }
+  return null;
+}
+
+function tryMatchSpec(spec, arg, args, i) {
+  const allFlags = flagsOf(spec);
+  const formsDefault = ["equal", "pair"];
+  const forms = spec.forms ?? formsDefault;
+
+  switch (spec.kind) {
+    case "bool":
+      if (allFlags.includes(arg)) {
+        return spec.noop
+          ? { spec, action: { type: "noop" }, consumed: 1 }
+          : { spec, action: { type: "set", value: true }, consumed: 1 };
+      }
+      return null;
+
+    case "string":
+    case "int":
+      return tryMatchValueForms(spec, arg, args, i, allFlags, forms, (raw) =>
+        spec.kind === "int" ? parseInt(raw, 10) : raw,
+      );
+
+    case "csv":
+      return tryMatchValueForms(spec, arg, args, i, allFlags, forms, (raw) =>
+        raw.split(",").filter(Boolean),
+      );
+
+    case "string-default": {
+      // 단독 (`--metafile`) → default 값. `--metafile=path` → path.
+      if (allFlags.includes(arg)) {
+        return { spec, action: { type: "set", value: spec.default }, consumed: 1 };
+      }
+      return tryMatchValueForms(spec, arg, args, i, allFlags, ["equal"], (raw) => raw);
+    }
+
+    case "array":
+      return tryMatchValueForms(spec, arg, args, i, allFlags, forms, (raw) => raw, "push");
+
+    case "ns-array": {
+      // `--inject:./prelude` — primary flag 만, alias 미지원. forms 무시.
+      const prefix = spec.flag + ":";
+      if (arg.startsWith(prefix)) {
+        const value = arg.slice(prefix.length);
+        return { spec, action: { type: "push", value }, consumed: 1 };
+      }
+      return null;
+    }
+
+    case "key-value": {
+      // `--define:K=V` — primary flag 만, alias 미지원. forms 무시.
+      const prefix = spec.flag + ":";
+      if (arg.startsWith(prefix)) {
+        const [k, ...v] = arg.slice(prefix.length).split("=");
+        return { spec, action: { type: "kv", key: k, value: v.join("=") }, consumed: 1 };
+      }
+      return null;
+    }
+
+    case "ns-string": {
+      // `--banner:js=text` — spec.flag 가 이미 `--banner:js` 형태. forms=["equal"] 강제.
+      const prefix = spec.flag + "=";
+      if (arg.startsWith(prefix)) {
+        return { spec, action: { type: "set", value: arg.slice(prefix.length) }, consumed: 1 };
+      }
+      return null;
+    }
+
+    case "enum-bool": {
+      // `--charset=utf8` → opts.charsetUtf8 = true. enum 에 없는 값이면 noop (기존 동작 유지).
+      const prefix = spec.flag + "=";
+      if (arg.startsWith(prefix)) {
+        const raw = arg.slice(prefix.length);
+        const mapped = spec.enum[raw];
+        if (mapped === undefined) return { spec, action: { type: "noop" }, consumed: 1 };
+        return { spec, action: { type: "set", value: mapped }, consumed: 1 };
+      }
+      return null;
+    }
+
+    case "string-bool": {
+      // default=true 의 toggle. `--sources-content=false` → false, 그 외 → true.
+      const prefix = spec.flag + "=";
+      if (arg.startsWith(prefix)) {
+        const raw = arg.slice(prefix.length);
+        return { spec, action: { type: "set", value: raw !== "false" }, consumed: 1 };
+      }
+      return null;
+    }
+
+    default:
+      throw new Error(`unknown flag kind: ${spec.kind}`);
+  }
+}
+
+function tryMatchValueForms(spec, arg, args, i, allFlags, forms, parseValue, op = "set") {
+  if (forms.includes("equal")) {
+    for (const f of allFlags) {
+      // single-letter short flag (`-X`) 는 equal-form 미지원 — esbuild/getopt 관습.
+      if (f.length <= 2) continue;
+      const prefix = f + "=";
+      if (arg.startsWith(prefix)) {
+        const value = parseValue(arg.slice(prefix.length));
+        return { spec, action: { type: op, value }, consumed: 1 };
+      }
+    }
+  }
+  if (forms.includes("pair") && allFlags.includes(arg)) {
+    const raw = args[i + 1];
+    if (raw === undefined) return { spec, action: { type: "noop" }, consumed: 1 };
+    const value = parseValue(raw);
+    return { spec, action: { type: op, value }, consumed: 2 };
+  }
+  return null;
+}
+
+/**
+ * matchFlagFromRegistry 결과를 opts 에 적용. extra 가 있으면 함께 set.
+ */
+export function applyFlagAction(opts, spec, action) {
+  if (action.type === "noop") {
+    // pass — noop spec 또는 누락된 pair-form value
+  } else if (action.type === "set") {
+    opts[spec.target] = action.value;
+  } else if (action.type === "push") {
+    if (!Array.isArray(opts[spec.target])) opts[spec.target] = [];
+    opts[spec.target].push(action.value);
+  } else if (action.type === "kv") {
+    if (typeof opts[spec.target] !== "object" || opts[spec.target] === null) {
+      opts[spec.target] = {};
+    }
+    opts[spec.target][action.key] = action.value;
+  }
+
+  if (spec.extra) {
+    for (const k of Object.keys(spec.extra)) {
+      opts[k] = spec.extra[k];
+    }
+  }
+}

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { FLAG_REGISTRY, flagsOf } from "./cli-flags.mjs";
 import { NAPI_INTERNAL_ONLY_KEYS } from "../src/schema-allowlists.ts";
 
 const CLI_PATH = join(__dirname, "zts.mjs");
@@ -30,15 +31,10 @@ const WASM_INDEX_PATH = join(__dirname, "..", "..", "wasm", "index.ts");
 // ─── 정적 파싱 헬퍼 ──────────────────────────────────────────
 
 /**
- * zts.mjs 의 `parseArgs` 함수 안 `opts = { ... }` 객체 리터럴에서 키 추출.
- * `mergeConfigIntoOpts` 의 `opts[key] === undefined` 머지 조건이 정상 작동하려면
- * SCALAR/BOOL/ARRAY_KEYS 의 모든 키가 default 객체에 등록되어 있어야 한다.
+ * `bodyStart` (여는 `{` 다음 위치) 에서 시작해 brace-balanced 본문을 잘라낸다.
+ * 닫는 `}` 직전까지의 슬라이스를 반환. balance 안 맞으면 throw.
  */
-function extractOptsDefaultKeys(source: string): string[] {
-  const startMarker = "const opts = {";
-  const start = source.indexOf(startMarker, source.indexOf("function parseArgs(argv)"));
-  if (start < 0) throw new Error("opts default object not found in parseArgs");
-  const bodyStart = start + startMarker.length;
+function extractBracedBody(source: string, bodyStart: number, errorContext: string): string {
   let depth = 1;
   let i = bodyStart;
   while (i < source.length && depth > 0) {
@@ -47,15 +43,33 @@ function extractOptsDefaultKeys(source: string): string[] {
     else if (c === "}") depth -= 1;
     i += 1;
   }
-  const body = source.slice(bodyStart, i - 1);
+  if (depth !== 0) throw new Error(`${errorContext} not balanced`);
+  return source.slice(bodyStart, i - 1);
+}
+
+/** body 의 한 줄 단위 키 패턴 추출. 주석/빈 줄 skip. matcher 가 [name] 캡처 그룹 1을 반환. */
+function extractKeysByLine(body: string, matcher: RegExp): string[] {
   const keys: string[] = [];
   for (const rawLine of body.split("\n")) {
     const line = rawLine.trim();
     if (!line || line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) continue;
-    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:/);
+    const m = line.match(matcher);
     if (m) keys.push(m[1]);
   }
   return keys;
+}
+
+/**
+ * zts.mjs 의 `parseArgs` 함수 안 `opts = { ... }` 객체 리터럴에서 키 추출.
+ * `mergeConfigIntoOpts` 의 `opts[key] === undefined` 머지 조건이 정상 작동하려면
+ * SCALAR/BOOL/ARRAY_KEYS 의 모든 키가 default 객체에 등록되어 있어야 한다.
+ */
+function extractOptsDefaultKeys(source: string): string[] {
+  const startMarker = "const opts = {";
+  const start = source.indexOf(startMarker, source.indexOf("function parseArgs(argv)"));
+  if (start < 0) throw new Error("opts default object not found in parseArgs");
+  const body = extractBracedBody(source, start + startMarker.length, "opts default");
+  return extractKeysByLine(body, /^([a-zA-Z_][a-zA-Z0-9_]*)\s*:/);
 }
 
 /** zts.mjs 의 `mergeConfigIntoOpts` 안 SCALAR_KEYS / BOOL_KEYS / ARRAY_KEYS 리스트의 키 집합 추출. */
@@ -78,29 +92,58 @@ function extractMergeKeyLists(source: string): {
   };
 }
 
-/** zts.mjs 의 `parseArgs` 함수 본문에서 모든 flag 토큰 추출. namespace prefix (`--banner:js=`) 도 포함. */
+/**
+ * 모든 CLI flag 토큰 추출.
+ *
+ * registry-driven flag 는 import 한 `FLAG_REGISTRY` 의 spec 들을 직접 순회 (formatter 의
+ * multi-line reformat 으로 인한 정적 파서 회귀 회피). legacy if-chain (특수 형식 — `--serve`,
+ * `--host`, `--proxy`) 은 zts.mjs source 에서 정규식 추출.
+ */
 function extractCliFlags(source: string): string[] {
-  const startMarker = "function parseArgs(argv) {";
-  const start = source.indexOf(startMarker);
-  if (start < 0) throw new Error("parseArgs not found in zts.mjs");
-  let depth = 0;
-  let i = start + startMarker.length - 1;
-  let bodyEnd = -1;
-  for (; i < source.length; i += 1) {
-    const c = source[i];
-    if (c === "{") depth += 1;
-    else if (c === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        bodyEnd = i;
-        break;
+  const flags = new Set<string>();
+
+  // ─── (1) FLAG_REGISTRY (직접 import) ───────────────────────────────────────
+  for (const spec of FLAG_REGISTRY as readonly any[]) {
+    const formsDefault = ["equal", "pair"];
+    const forms: string[] =
+      spec.forms ??
+      (spec.kind === "string" || spec.kind === "int" || spec.kind === "array" || spec.kind === "csv"
+        ? formsDefault
+        : []);
+    const allFlags = flagsOf(spec) as string[];
+
+    for (const f of allFlags) {
+      switch (spec.kind) {
+        case "bool":
+          flags.add(f);
+          break;
+        case "string-default":
+          flags.add(f);
+          if (f.length > 2) flags.add(f + "=");
+          break;
+        case "ns-array":
+        case "key-value":
+          flags.add(f + ":*");
+          break;
+        case "ns-string":
+        case "enum-bool":
+        case "string-bool":
+          flags.add(f + "=");
+          break;
+        default:
+          // string / int / csv / array — single-letter short alias 는 equal-form 미지원.
+          if (forms.includes("equal") && f.length > 2) flags.add(f + "=");
+          if (forms.includes("pair")) flags.add(f);
       }
     }
   }
-  if (bodyEnd < 0) throw new Error("parseArgs body not balanced");
-  const body = source.slice(start, bodyEnd + 1);
 
-  const flags = new Set<string>();
+  // ─── (2) parseArgs 본문 안의 legacy if-chain (특수 형식 — serve/host/proxy) ──
+  const startMarker = "function parseArgs(argv) {";
+  const start = source.indexOf(startMarker);
+  if (start < 0) throw new Error("parseArgs not found in zts.mjs");
+  const body = extractBracedBody(source, start + startMarker.length, "parseArgs body");
+
   for (const m of body.matchAll(/arg === "(--[a-zA-Z][a-zA-Z0-9-]*)"/g)) flags.add(m[1]);
   for (const m of body.matchAll(/arg\.startsWith\("(--[a-zA-Z][a-zA-Z0-9-]*)="\)/g)) {
     flags.add(m[1] + "=");
@@ -121,24 +164,8 @@ function extractInterfaceKeys(source: string, interfaceName: string): string[] {
   const re = new RegExp(`(?:export\\s+)?interface\\s+${interfaceName}\\s*\\{`);
   const match = re.exec(source);
   if (!match) throw new Error(`${interfaceName} not found`);
-  const bodyStart = match.index + match[0].length;
-  let depth = 1;
-  let i = bodyStart;
-  while (i < source.length && depth > 0) {
-    const c = source[i];
-    if (c === "{") depth += 1;
-    else if (c === "}") depth -= 1;
-    i += 1;
-  }
-  const body = source.slice(bodyStart, i - 1);
-  const fields: string[] = [];
-  for (const rawLine of body.split("\n")) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("//") || line.startsWith("*") || line.startsWith("/*")) continue;
-    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*\??\s*:/);
-    if (m) fields.push(m[1]);
-  }
-  return fields;
+  const body = extractBracedBody(source, match.index + match[0].length, interfaceName);
+  return extractKeysByLine(body, /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\??\s*:/);
 }
 
 /**
@@ -154,16 +181,7 @@ function extractTypeMap(source: string, interfaceName: string): Map<string, stri
   const re = new RegExp(`(?:export\\s+)?interface\\s+${interfaceName}\\s*\\{`);
   const match = re.exec(source);
   if (!match) throw new Error(`${interfaceName} not found`);
-  const bodyStart = match.index + match[0].length;
-  let depth = 1;
-  let i = bodyStart;
-  while (i < source.length && depth > 0) {
-    const c = source[i];
-    if (c === "{") depth += 1;
-    else if (c === "}") depth -= 1;
-    i += 1;
-  }
-  const body = source.slice(bodyStart, i - 1);
+  const body = extractBracedBody(source, match.index + match[0].length, interfaceName);
   const out = new Map<string, string>();
   // 한 줄 단위 파싱 — 다중 줄 type 은 첫 줄만 보고 coarse 분류 (대부분 충분).
   for (const rawLine of body.split("\n")) {
@@ -282,6 +300,7 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     "--proxy",
     // tsconfig — CLI 용 alias (`--project`, `--tsconfig-path` 둘 다 BuildOptions 의 `tsconfigPath` 와 매핑)
     "--project",
+    "--project=",
     // RN — CLI 만 노출
     "--rn-platform",
     "--rn-platform=",
@@ -337,6 +356,9 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
   test("CLI flag 가 BuildOptions / TranspileOptions 키와 매칭되거나 cliOnlyFlags 에 등록", () => {
     const unmapped: { flag: string; candidate: string }[] = [];
     for (const flag of cliFlags) {
+      // single-letter short alias (`-o`, `-p`, `-w`) — canonical `--` flag 의 alias 라
+      // 별도 키 매핑 불필요. matchFlagFromRegistry 가 canonical 과 같은 target 으로 매핑.
+      if (/^-[a-z]$/.test(flag)) continue;
       if (cliOnlyFlags.has(flag)) continue;
       const candidate = flagToCandidateKey(flag);
       if (knownKeys.has(candidate)) continue;
@@ -354,6 +376,7 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
   test("BuildOptions / TranspileOptions 키가 CLI flag 로 노출되거나 buildOptionsOnlyKeys 에 등록", () => {
     const cliExposedKeys = new Set<string>();
     for (const flag of cliFlags) {
+      if (/^-[a-z]$/.test(flag)) continue;
       if (cliOnlyFlags.has(flag)) continue;
       const candidate = flagToCandidateKey(flag);
       if (knownKeys.has(candidate)) cliExposedKeys.add(candidate);
@@ -376,6 +399,8 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
   test("flag 명명 규칙 — 모든 CLI flag 는 lowercase + kebab + `:` namespace 만", () => {
     const bad: string[] = [];
     for (const flag of cliFlags) {
+      // single-letter short flag (`-o`, `-p`, `-w`) 는 별도 형식.
+      if (/^-[a-z]$/.test(flag)) continue;
       const stripped = flag.replace(/^--/, "").replace(/[:=*]/g, "").replace(/\./g, "");
       if (!/^[a-z][a-z0-9-]*$/.test(stripped)) bad.push(flag);
     }

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -32,12 +32,17 @@ const {
   loadIdentifiedConfig,
   loadWorkspace,
   mergeUserConfigs,
+  suggestKey,
   warnUnknownKeys,
 } = coreModule;
 import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { resolve, dirname, basename, extname, join } from "node:path";
 import { createServer } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
+
+import { applyFlagAction, KNOWN_FLAGS, matchFlagFromRegistry } from "./cli-flags.mjs";
+
+export { KNOWN_FLAGS };
 
 // ─── CLI 인자 파싱 ───
 
@@ -146,390 +151,33 @@ function parseArgs(argv) {
       continue;
     }
 
-    // flags
-    if (arg === "--bundle") {
-      opts.bundle = true;
+    // registry-driven 매칭. 새 flag 는 FLAG_REGISTRY 에 entry 한 줄만 추가.
+    const matched = matchFlagFromRegistry(arg, args, i);
+    if (matched) {
+      applyFlagAction(opts, matched.spec, matched.action);
+      i += matched.consumed - 1;
       continue;
     }
-    if (arg === "-w" || arg === "--watch") {
-      opts.watch = true;
-      continue;
-    }
-    if (arg === "--watch-json") {
-      opts.watch = true;
-      opts.watchJson = true;
-      continue;
-    }
+
+    // ─── 특수 형식 (registry 표현이 어색해 if-chain 잔존) ───
+
+    // `--serve [DIR]` — 다음 토큰이 flag 아니면 serveDir 로 사용 (next-arg optional, default 유지)
     if (arg === "--serve") {
       opts.serve = true;
-      // 다음 인자가 디렉토리 경로면 serveDir로 사용
       if (i + 1 < args.length && !args[i + 1].startsWith("-")) {
         opts.serveDir = args[++i];
       }
       continue;
     }
-    if (arg === "--open") {
-      opts.open = true;
-      continue;
-    }
-    if (arg === "--minify") {
-      opts.minify = true;
-      continue;
-    }
-    if (arg === "--sourcemap") {
-      opts.sourcemap = true;
-      continue;
-    }
-    if (arg === "--sourcemap-debug-ids") {
-      opts.sourcemapDebugIds = true;
-      continue;
-    }
-    if (arg === "--splitting") {
-      opts.splitting = true;
-      continue;
-    }
-    if (arg === "--metafile") {
-      opts.metafile = "meta.json";
-      continue;
-    }
-    if (arg === "--analyze") {
-      opts.analyze = true;
-      opts.metafile = "meta.json";
-      continue;
-    }
-    if (arg === "--flow") {
-      opts.flow = true;
-      continue;
-    }
-    if (arg === "--experimental-decorators") {
-      opts.experimentalDecorators = true;
-      continue;
-    }
-    if (arg === "--emit-decorator-metadata") {
-      opts.emitDecoratorMetadata = true;
-      continue;
-    }
-    if (arg === "--jsx-in-js") {
-      opts.jsxInJs = true;
-      continue;
-    }
-    if (arg === "--verbatim-module-syntax") {
-      opts.verbatimModuleSyntax = true;
-      continue;
-    }
-    if (arg === "--keep-names") {
-      opts.keepNames = true;
-      continue;
-    }
-    if (arg === "--shim-missing-exports") {
-      opts.shimMissingExports = true;
-      continue;
-    }
-    if (arg === "--ascii-only") {
-      opts.asciiOnly = true;
-      continue;
-    }
-    if (arg === "--preserve-symlinks") {
-      continue;
-    } // TODO
-    if (arg === "--preserve-modules") {
-      opts.preserveModules = true;
-      continue;
-    }
-    if (arg === "--jsx-dev") {
-      opts.jsxDev = true;
-      continue;
-    }
-    if (arg === "--clean") {
-      opts.clean = true;
-      continue;
-    }
-    if (arg === "--minify-whitespace") {
-      opts.minifyWhitespace = true;
-      continue;
-    }
-    if (arg === "--minify-identifiers") {
-      opts.minifyIdentifiers = true;
-      continue;
-    }
-    if (arg === "--minify-syntax") {
-      opts.minifySyntax = true;
-      continue;
-    }
 
-    // --key=value
-    if (arg.startsWith("--format=")) {
-      opts.format = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--platform=")) {
-      opts.platform = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--jsx=")) {
-      opts.jsx = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--jsx-factory=")) {
-      opts.jsxFactory = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--jsx-fragment=")) {
-      opts.jsxFragment = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--jsx-import-source=")) {
-      opts.jsxImportSource = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--global-name=")) {
-      opts.globalName = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--public-path=")) {
-      opts.publicPath = arg.split("=")[1];
-      continue;
-    }
-    // `--banner=<text>` 가 정식 — `BuildOptions.banner: string` 과 1:1 매핑.
-    // `--banner:js=<text>` 는 esbuild 호환 alias (silent — deprecated 경고 없음).
-    // BuildOptions 가 단일 string 인 동안은 namespace key (`:js`) 가 무의미하지만 esbuild 에서
-    // 옮겨 오는 사용자가 자연스럽게 동작하도록 유지. 향후 CSS bundling 도입 시 이 entry 가
-    // namespace 의미 회복.
-    if (arg.startsWith("--banner=")) {
-      opts.banner = arg.slice("--banner=".length);
-      continue;
-    }
-    if (arg.startsWith("--banner:js=")) {
-      opts.banner = arg.slice("--banner:js=".length);
-      continue;
-    }
-    if (arg.startsWith("--footer=")) {
-      opts.footer = arg.slice("--footer=".length);
-      continue;
-    }
-    if (arg.startsWith("--footer:js=")) {
-      opts.footer = arg.slice("--footer:js=".length);
-      continue;
-    }
-    if (arg.startsWith("--entry-names=")) {
-      opts.entryNames = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--chunk-names=")) {
-      opts.chunkNames = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--asset-names=")) {
-      opts.assetNames = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--quotes=")) {
-      opts.quotes = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--log-level=")) {
-      opts.logLevel = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--charset=")) {
-      if (arg.split("=")[1] === "utf8") opts.charsetUtf8 = true;
-      continue;
-    }
-    if (arg.startsWith("--sources-content=")) {
-      opts.sourcesContent = arg.split("=")[1] !== "false";
-      continue;
-    }
-    if (arg.startsWith("--use-define-for-class-fields=")) {
-      opts.useDefineForClassFields = arg.split("=")[1] !== "false";
-      continue;
-    }
-    if (arg.startsWith("--legal-comments=")) {
-      opts.legalComments = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--preserve-modules-root=")) {
-      opts.preserveModulesRoot = arg.split("=")[1];
-      continue;
-    }
-    // tsconfig.target 보다 우선해 사용자가 monorepo per-build 오버라이드 가능.
-    if (arg === "--target") {
-      opts.target = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--target=")) {
-      opts.target = arg.split("=")[1];
-      continue;
-    }
-    // browserslist 쿼리 — target 보다 우선. 콤마 구분 다중 쿼리는 NAPI 측에서 split.
-    if (arg === "--browserslist") {
-      opts.browserslist = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--browserslist=")) {
-      opts.browserslist = arg.slice("--browserslist=".length);
-      continue;
-    }
-    // 다중 entry 의 출력 디렉토리 구조 base — 공통 prefix 제거 기준.
-    if (arg === "--outbase") {
-      opts.outbase = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--outbase=")) {
-      opts.outbase = arg.slice("--outbase=".length);
-      continue;
-    }
-    if (arg.startsWith("--out-extension:.js=")) {
-      opts.outExtensionJs = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--source-root=")) {
-      opts.sourceRoot = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--watch-delay=")) {
-      opts.watchDelay = parseInt(arg.split("=")[1]);
-      continue;
-    }
-    if (arg.startsWith("--rn-platform=")) {
-      opts.rnPlatform = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--port=")) {
-      opts.port = parseInt(arg.split("=")[1]);
-      continue;
-    }
-    if (arg.startsWith("--host=")) {
-      opts.host = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--metafile=")) {
-      opts.metafile = arg.split("=")[1];
-      continue;
-    }
-    if (arg.startsWith("--jobs=")) {
-      opts.jobs = parseInt(arg.split("=")[1]);
-      continue;
-    }
-
-    // --key value
-    if (arg === "-o" || arg === "--outfile") {
-      opts.outfile = args[++i];
-      continue;
-    }
-    if (arg === "--outdir") {
-      opts.outdir = args[++i];
-      continue;
-    }
-    if (arg === "--port") {
-      opts.port = parseInt(args[++i]);
-      continue;
-    }
+    // `--host [VALUE]` — pair-form 이지만 누락 시 default "0.0.0.0".
+    // registry 의 string kind 와 의미 다름 (누락 시 undefined 가 아닌 명시 default).
     if (arg === "--host") {
       opts.host = args[++i] || "0.0.0.0";
       continue;
     }
-    if (arg === "--certfile") {
-      opts.certfile = args[++i];
-      continue;
-    }
-    if (arg === "--keyfile") {
-      opts.keyfile = args[++i];
-      continue;
-    }
-    if (arg === "-p" || arg === "--project" || arg === "--tsconfig-path") {
-      // `-p`, `--project` (tsc 전통), `--tsconfig-path` (NAPI `tsconfigPath` 와 이름 통일)
-      opts.project = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--tsconfig-path=")) {
-      opts.project = arg.slice("--tsconfig-path=".length);
-      continue;
-    }
-    if (arg === "--config") {
-      opts.configPath = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--config=")) {
-      opts.configPath = arg.slice("--config=".length);
-      continue;
-    }
-    if (arg === "--mode") {
-      opts.mode = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--mode=")) {
-      opts.mode = arg.slice("--mode=".length);
-      continue;
-    }
-    if (arg === "--workspace-config") {
-      opts.workspaceConfig = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--workspace-config=")) {
-      opts.workspaceConfig = arg.slice("--workspace-config=".length);
-      continue;
-    }
-    if (arg === "--workspace") {
-      opts.workspace = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--workspace=")) {
-      opts.workspace = arg.slice("--workspace=".length);
-      continue;
-    }
-    if (arg === "--env-prefix") {
-      opts.envPrefixes = args[++i].split(",").filter(Boolean);
-      continue;
-    }
-    if (arg.startsWith("--env-prefix=")) {
-      opts.envPrefixes = arg.slice("--env-prefix=".length).split(",").filter(Boolean);
-      continue;
-    }
-    if (arg === "--env-dir") {
-      opts.envDir = args[++i];
-      continue;
-    }
-    if (arg.startsWith("--env-dir=")) {
-      opts.envDir = arg.slice("--env-dir=".length);
-      continue;
-    }
-    if (arg === "--plugin") {
-      opts.pluginPaths.push(args[++i]);
-      continue;
-    }
 
-    // repeatable
-    if (arg === "--external") {
-      opts.external.push(args[++i]);
-      continue;
-    }
-    if (arg.startsWith("--external=")) {
-      opts.external.push(arg.split("=")[1]);
-      continue;
-    }
-    if (arg.startsWith("--inject:")) {
-      opts.inject.push(arg.split(":")[1]);
-      continue;
-    }
-    if (arg.startsWith("--define:")) {
-      const [k, ...v] = arg.slice("--define:".length).split("=");
-      opts.define[k] = v.join("=");
-      continue;
-    }
-    if (arg.startsWith("--alias:")) {
-      const [k, ...v] = arg.slice("--alias:".length).split("=");
-      opts.alias[k] = v.join("=");
-      continue;
-    }
-    if (arg.startsWith("--loader:")) {
-      const [ext, type] = arg.slice("--loader:".length).split("=");
-      opts.loader[ext] = type;
-      continue;
-    }
-    if (arg.startsWith("--drop=")) {
-      opts.drop.push(arg.split("=")[1]);
-      continue;
-    }
+    // dev-server proxy — `--proxy /api=http://localhost:8080` 형식 (특수 parser)
     if (arg.startsWith("--proxy")) {
       const [path, target] =
         arg.split("=").length > 1
@@ -538,18 +186,15 @@ function parseArgs(argv) {
       if (path && target) opts.proxy[path] = target;
       continue;
     }
-    if (arg.startsWith("--resolve-extensions=")) {
-      opts.resolveExtensions = arg.split("=")[1].split(",");
-      continue;
-    }
-    if (arg.startsWith("--main-fields=")) {
-      opts.mainFields = arg.split("=")[1].split(",");
-      continue;
-    }
 
-    // unknown
+    // unknown — typo 시 가장 가까운 known flag 제안 (Levenshtein, threshold 2).
     if (opts.logLevel !== "silent") {
-      console.error(`warning: unknown option '${arg}'`);
+      const suggestion = suggestKey(arg, KNOWN_FLAGS);
+      console.error(
+        suggestion
+          ? `warning: unknown option '${arg}' — did you mean '${suggestion}'?`
+          : `warning: unknown option '${arg}'`,
+      );
     }
   }
 


### PR DESCRIPTION
## 요약
- `packages/core/bin/zts.mjs` 의 60+ CLI flag hand-rolled if-chain (~520 줄) 을 별도 `cli-flags.mjs` 의 `FLAG_REGISTRY` (75 spec entry) 로 통합
- spec.kind 11 종 + 4 helper (`matchFlagFromRegistry` / `tryMatchSpec` / `tryMatchValueForms` / `applyFlagAction`) 로 모든 flag 처리
- 새 flag 추가 시 entry 한 줄만으로 `parseArgs` / `KNOWN_FLAGS` / typo-suggest / schema-sync 모두 자동 합류
- `--serve [DIR]` / `--host [VALUE]` / `--proxy ...` 만 특수 형식 (next-arg optional / 비표준 parser) 으로 if-chain 잔존

## 변경
**`packages/core/bin/cli-flags.mjs`** (신규)
- `FLAG_REGISTRY` — 75 spec entry. spec 필드: `kind / flag / target / forms? / aliases? / extra? / default? / enum? / noop?`
- 11 kind: `bool` (toggle, `extra` 로 부수효과), `string` (scalar), `int` (parseInt), `array` (push), `csv` (`,` 분리), `key-value` (`--key:K=V`), `ns-array` (`--key:VALUE` push), `ns-string` (`--banner:js=text` esbuild 호환), `string-default` (`--metafile` hybrid), `enum-bool` (`--charset=utf8` → bool), `string-bool` (default=true 의 `--key=false` toggle)
- helpers: `matchFlagFromRegistry`, `tryMatchSpec` (kind 별 switch), `tryMatchValueForms` (equal/pair-form 매칭, single-letter alias 는 equal 미지원), `applyFlagAction` (action.type set/push/kv/noop)
- `flagsOf(spec)` — canonical + alias 한 array (canonical 첫번째)
- `KNOWN_FLAGS` — frozen sorted array (typo-suggest 소비)

**`packages/core/bin/zts.mjs`**
- registry/helper 정의 제거 (cli-flags.mjs 로 분리), import 추가
- `parseArgs` 의 if-chain ~520 줄 → ~30 줄 (registry 매칭 + 특수 3개)
- unknown flag 분기에서 `suggestKey(arg, KNOWN_FLAGS)` 호출 — \"did you mean\" 제안 (#2109 인프라 활용)
- `KNOWN_FLAGS` re-export

**`packages/core/bin/zts-cli-schema-sync.test.ts`**
- `extractCliFlags` 가 정적 정규식 파싱 대신 실제 `FLAG_REGISTRY` import 사용 — formatter 의 multi-line reformat 으로 인한 silent 회귀 방지 (실제로 oxfmt 가 긴 spec 을 4 줄로 분할하는 회귀를 발견)
- brace-balance helper `extractBracedBody` + `extractKeysByLine` 로 4 정적 파서 (`extractOptsDefaultKeys` / `extractInterfaceKeys` / `extractTypeMap` / parseArgs body) 통합

## 별도 파일 분리 이유
`zts.mjs` 의 top-level `await import(\"../dist/index.js\")` 가 NAPI 바인딩을 로드하므로 schema-sync 테스트가 zts.mjs 자체를 import 하기 어려움. registry 만 분리해 테스트가 정적 파싱 대신 실제 export 를 import.

## 검증
- `bun test packages/core/` → 611/611 pass (내부 — references/swc fixture 회귀는 사전 존재, 변경과 무관)
- `bun test packages/core/bin/zts.test.ts packages/core/bin/zts-cli-schema-sync.test.ts` → 154/154 pass
- `bun run lint` → 0 warnings/errors
- `bun run fmt` → no diff after format (formatter 적용 후에도 154/154 pass)
- `zig build test` → 4071/4071 pass

## /simplify 결과
3 reviewer (reuse / quality / efficiency) 병렬 실행. 적용:
1. **typo-suggest 연결** (Reuse #1) — `KNOWN_FLAGS` export 했지만 unknown 분기 미연결 갭 해결
2. **registry → 별도 파일 + 직접 import** (Quality #9) — 정적 파서 fragile risk 근본 해결 (oxfmt 가 실제로 회귀 유발 확인)
3. **brace-balance helper** (Reuse #5) — schema-sync 의 4 정적 파서 통합 ~25 줄 절감
4. **`flagsOf(spec)` helper** (Quality #4) — `[spec.flag, ...(spec.aliases ?? [])]` 5곳 → 1곳

Skip: kind 압축 / switch flatten / JSDoc typedef / action.type indirection 정리 — 의도된 design 또는 file 컨벤션과 호환 (jsconfig 미설정 등).

## Closes
Closes #2122

🤖 Generated with [Claude Code](https://claude.com/claude-code)