### PR TITLE
feat(bundler): prune CJS default member exports

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1431,7 +1431,7 @@ test "TreeShaking CJS: named Buffer import seeds module.exports buffer assignmen
     try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_EXPORTS_BUFFER_UNUSED_MARKER") == null);
 }
 
-test "TreeShaking CJS: default namespace and export star keep all static exports" {
+test "TreeShaking CJS: default member access prunes, namespace and export star keep all static exports" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "default.js", "import lib from './lib.js'; console.log(lib.used);");
@@ -1455,7 +1455,7 @@ test "TreeShaking CJS: default namespace and export star keep all static exports
     const default_result = try b_default.bundle();
     defer default_result.deinit(std.testing.allocator);
     try std.testing.expect(!default_result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, default_result.output, "CJS_UNUSED_MUST_STAY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, default_result.output, "CJS_UNUSED_MUST_STAY") == null);
 
     var b_namespace = Bundler.init(std.testing.allocator, .{ .entry_points = &.{namespace_entry} });
     defer b_namespace.deinit();
@@ -4496,4 +4496,100 @@ test "TreeShaking: namespace import preamble dropped when target excluded from b
     try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_TARGET_DROP_HEAVY") == null);
     // `var X = __toESM(require_cjslib_cjs(), 1)` 같은 orphan preamble 이 남으면 안 된다.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_cjslib") == null);
+}
+
+test "TreeShaking: CJS default import member access seeds only used export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import React from './react-like.cjs';
+        \\console.log(React.createElement());
+    );
+    try writeFile(tmp.dir, "react-like.cjs",
+        \\'use strict';
+        \\exports.createElement = function() { return 'CJS_DEFAULT_MEMBER_USED'; };
+        \\exports.useState = function() { return 'CJS_DEFAULT_MEMBER_UNUSED'; };
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_DEFAULT_MEMBER_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_DEFAULT_MEMBER_UNUSED") == null);
+}
+
+test "TreeShaking: CJS default import value escape keeps all exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import React from './react-like.cjs';
+        \\console.log(typeof React);
+    );
+    try writeFile(tmp.dir, "react-like.cjs",
+        \\'use strict';
+        \\exports.createElement = function() { return 'CJS_DEFAULT_ESCAPE_USED'; };
+        \\exports.useState = function() { return 'CJS_DEFAULT_ESCAPE_KEPT'; };
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_DEFAULT_ESCAPE_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_DEFAULT_ESCAPE_KEPT") != null);
+}
+
+test "TreeShaking: CJS default member access follows module.exports require proxy" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import React from './index.cjs';
+        \\console.log(React.createElement());
+    );
+    try writeFile(tmp.dir, "index.cjs",
+        \\'use strict';
+        \\{
+        \\  module.exports = require('./react-production.cjs');
+        \\}
+    );
+    try writeFile(tmp.dir, "react-production.cjs",
+        \\'use strict';
+        \\exports.createElement = function() { return 'CJS_DEFAULT_PROXY_USED'; };
+        \\exports.useState = function() { return 'CJS_DEFAULT_PROXY_UNUSED'; };
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_DEFAULT_PROXY_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CJS_DEFAULT_PROXY_UNUSED") == null);
 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -585,6 +585,15 @@ pub const Linker = struct {
         return self.graph.moduleAtMut(ModuleIndex.fromUsize(idx));
     }
 
+    fn isCjsDefaultBinding(self: *const Linker, importer: *const Module, ib: ImportBinding) bool {
+        if (ib.kind != .default) return false;
+        if (ib.import_record_index >= importer.import_records.len) return false;
+        const src_idx = importer.import_records[ib.import_record_index].resolved;
+        if (src_idx.isNone()) return false;
+        const src = self.graph.getModule(src_idx) orelse return false;
+        return src.wrap_kind == .cjs;
+    }
+
     /// 링킹 실행: export 맵 구축 → import 바인딩 해결.
     pub fn link(self: *Linker) !void {
         try self.buildExportMap();
@@ -1914,17 +1923,9 @@ pub const Linker = struct {
             // index 구축 전에 outer skip — AST 전체 순회 비용 회피 (#1735).
             const has_candidate = blk: {
                 for (importer.import_bindings) |ib| {
-                    const is_namespace = ib.kind == .namespace;
-                    const is_named_candidate = ib.kind == .named and ib.namespace_used_properties == null;
-                    const is_cjs_default_candidate = cjs_default: {
-                        if (ib.kind != .default) break :cjs_default false;
-                        if (ib.import_record_index >= importer.import_records.len) break :cjs_default false;
-                        const source_mod_idx = importer.import_records[ib.import_record_index].resolved;
-                        if (source_mod_idx.isNone()) break :cjs_default false;
-                        const source = self.graph.getModule(source_mod_idx) orelse break :cjs_default false;
-                        break :cjs_default source.wrap_kind == .cjs;
-                    };
-                    if (is_namespace or is_named_candidate or is_cjs_default_candidate) break :blk true;
+                    if (ib.kind == .namespace) break :blk true;
+                    if (ib.kind == .named and ib.namespace_used_properties == null) break :blk true;
+                    if (self.isCjsDefaultBinding(importer, ib)) break :blk true;
                 }
                 break :blk false;
             };
@@ -1953,10 +1954,8 @@ pub const Linker = struct {
                 if (!is_namespace and !is_named_candidate and !is_cjs_default_candidate) continue;
 
                 // `.named` 경로는 virtual namespace (re_export_namespace 타겟)일 때만 처리.
-                // `.namespace`와 CJS default는 항상 대상 — collectNamespaceAccesses 결과를
-                // scope-aware로 재평가한다. CJS default는 `import React from "react";
-                // React.createElement(...)` 같은 member-only 사용을 CJS export fact pruning과
-                // 연결하기 위한 정밀화다.
+                // `.namespace`/CJS default는 항상 scope-aware 재평가 대상 — member-only
+                // 사용 패턴을 export pruning으로 연결.
                 if (is_named_candidate) {
                     var is_virtual_ns = false;
                     for (source.export_bindings) |eb| {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1910,13 +1910,21 @@ pub const Linker = struct {
 
             if (sem.scope_maps.len == 0) continue;
 
-            // 분석 대상 (namespace 또는 virtual-namespace named) import 가 하나도 없으면
+            // 분석 대상 (namespace, virtual-namespace named, 또는 CJS default) import 가 하나도 없으면
             // index 구축 전에 outer skip — AST 전체 순회 비용 회피 (#1735).
             const has_candidate = blk: {
                 for (importer.import_bindings) |ib| {
                     const is_namespace = ib.kind == .namespace;
                     const is_named_candidate = ib.kind == .named and ib.namespace_used_properties == null;
-                    if (is_namespace or is_named_candidate) break :blk true;
+                    const is_cjs_default_candidate = cjs_default: {
+                        if (ib.kind != .default) break :cjs_default false;
+                        if (ib.import_record_index >= importer.import_records.len) break :cjs_default false;
+                        const source_mod_idx = importer.import_records[ib.import_record_index].resolved;
+                        if (source_mod_idx.isNone()) break :cjs_default false;
+                        const source = self.graph.getModule(source_mod_idx) orelse break :cjs_default false;
+                        break :cjs_default source.wrap_kind == .cjs;
+                    };
+                    if (is_namespace or is_named_candidate or is_cjs_default_candidate) break :blk true;
                 }
                 break :blk false;
             };
@@ -1937,14 +1945,18 @@ pub const Linker = struct {
             for (importer.import_bindings) |*ib| {
                 const is_namespace = ib.kind == .namespace;
                 const is_named_candidate = ib.kind == .named and ib.namespace_used_properties == null;
-                if (!is_namespace and !is_named_candidate) continue;
                 if (ib.import_record_index >= importer.import_records.len) continue;
                 const source_mod_idx = importer.import_records[ib.import_record_index].resolved;
                 if (source_mod_idx.isNone()) continue;
                 const source = self.graph.getModule(source_mod_idx) orelse continue;
+                const is_cjs_default_candidate = ib.kind == .default and source.wrap_kind == .cjs;
+                if (!is_namespace and !is_named_candidate and !is_cjs_default_candidate) continue;
 
                 // `.named` 경로는 virtual namespace (re_export_namespace 타겟)일 때만 처리.
-                // `.namespace`는 항상 대상 — collectNamespaceAccesses 결과를 scope-aware로 재평가.
+                // `.namespace`와 CJS default는 항상 대상 — collectNamespaceAccesses 결과를
+                // scope-aware로 재평가한다. CJS default는 `import React from "react";
+                // React.createElement(...)` 같은 member-only 사용을 CJS export fact pruning과
+                // 연결하기 위한 정밀화다.
                 if (is_named_candidate) {
                     var is_virtual_ns = false;
                     for (source.export_bindings) |eb| {
@@ -1971,9 +1983,10 @@ pub const Linker = struct {
                 defer access.deinit(self.allocator);
 
                 if (access.kind == .@"opaque") {
-                    // `.namespace`는 text-based 결과를 신뢰하지 않음 — null로 덮어써 fallback.
-                    // `.named` virtual ns는 null 유지(기존 동작).
-                    if (is_namespace) {
+                    // `.namespace`와 CJS default는 text-based 결과를 신뢰하지 않음 —
+                    // null로 덮어써 전체 namespace/default fallback. `.named` virtual ns는
+                    // null 유지(기존 동작).
+                    if (is_namespace or is_cjs_default_candidate) {
                         ib.namespace_used_properties = null;
                         ib.namespace_used_property_stmts = null;
                     }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -659,6 +659,18 @@ pub const TreeShaker = struct {
                     const target_mod_idx = @intFromEnum(rec.resolved);
                     const target_module = self.graph.getModule(rec.resolved) orelse continue;
                     if (target_module.wrap_kind != .cjs) continue;
+                    if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
+                        !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
+                        self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
+                        isModuleExportsRequireStmtForSpan(o, infos, @intCast(item.stmt), rec.span))
+                    {
+                        const target_infos = module_stmt_infos[target_mod_idx] orelse {
+                            try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                            continue;
+                        };
+                        try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
+                        continue;
+                    }
                     try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
                 }
             }
@@ -782,6 +794,17 @@ pub const TreeShaker = struct {
         }
 
         if (target_module_for_import.wrap_kind == .cjs and ib.kind == .default) {
+            if (ib.namespace_used_properties) |props| {
+                for (props, 0..) |prop_name, pi| {
+                    if (dispatch_stmt) |ds| gate: {
+                        const prop_stmts = ib.namespace_used_property_stmts orelse break :gate;
+                        if (pi >= prop_stmts.len) break :gate;
+                        if (!containsU32(prop_stmts[pi], ds)) continue;
+                    }
+                    try self.seedCjsExportOrAll(@intCast(target), prop_name, queue, module_stmt_infos, reachable_stmts);
+                }
+                return;
+            }
             try self.markAndSeedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
             return;
         }
@@ -928,6 +951,9 @@ pub const TreeShaker = struct {
             if (try self.seedNodeBufferModuleObjectExport(mod_idx, export_name, target_infos, queue, reachable_stmts)) {
                 return;
             }
+            if (try self.seedCjsModuleExportsRequireProxy(mod_idx, export_name, target_infos, queue, module_stmt_infos, reachable_stmts)) {
+                return;
+            }
             if (try self.seedCjsExportFactsByName(mod_idx, target_infos, export_name, queue, reachable_stmts)) {
                 return;
             }
@@ -963,6 +989,36 @@ pub const TreeShaker = struct {
                 reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
             }
             try self.enqueue(mod_idx, @intCast(si), reachable_stmts, queue);
+            return true;
+        }
+        return false;
+    }
+
+    fn seedCjsModuleExportsRequireProxy(
+        self: *TreeShaker,
+        mod_idx: u32,
+        export_name: []const u8,
+        infos: StmtInfos,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        module_stmt_infos: []?StmtInfos,
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!bool {
+        const m = self.getModule(mod_idx) orelse return false;
+        const ast = &(m.ast orelse return false);
+
+        for (infos.stmts, 0..) |stmt, si| {
+            const stmt_ni: usize = stmt.node_idx;
+            if (stmt_ni >= ast.nodes.items.len) continue;
+            const require_span = moduleExportsRequireSpanAt(ast, @enumFromInt(stmt_ni)) orelse continue;
+            const target = requireTargetForSpan(m, require_span) orelse continue;
+            const target_idx: u32 = @intFromEnum(target);
+            if (target_idx == mod_idx) continue;
+
+            if (reachable_stmts[mod_idx] == null) {
+                reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
+            }
+            try self.enqueue(mod_idx, @intCast(si), reachable_stmts, queue);
+            try self.seedCjsExportOrAll(target_idx, export_name, queue, module_stmt_infos, reachable_stmts);
             return true;
         }
         return false;
@@ -1143,6 +1199,23 @@ pub const TreeShaker = struct {
         }
     }
 
+    fn seedSideEffectStmts(
+        self: *TreeShaker,
+        mod_idx: u32,
+        infos: StmtInfos,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        self.included.set(mod_idx);
+        if (reachable_stmts[mod_idx] == null) {
+            reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
+        }
+        for (infos.stmts, 0..) |stmt, si| {
+            if (!stmt.has_side_effects) continue;
+            try self.enqueue(mod_idx, @intCast(si), reachable_stmts, queue);
+        }
+    }
+
     fn markAndSeedAllStmts(
         self: *TreeShaker,
         mod_idx: u32,
@@ -1153,6 +1226,30 @@ pub const TreeShaker = struct {
         try self.markAllExportsUsed(mod_idx);
         self.included.set(mod_idx);
         try self.seedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
+        try self.seedModuleExportsRequireProxyTargetsAll(mod_idx, queue, module_stmt_infos, reachable_stmts);
+    }
+
+    fn seedModuleExportsRequireProxyTargetsAll(
+        self: *TreeShaker,
+        mod_idx: u32,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        module_stmt_infos: []?StmtInfos,
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        const m = self.getModule(mod_idx) orelse return;
+        const infos = if (mod_idx < module_stmt_infos.len) module_stmt_infos[mod_idx] else null;
+        const target_infos = infos orelse return;
+        const ast = &(m.ast orelse return);
+        for (target_infos.stmts) |stmt| {
+            const stmt_ni = stmt.node_idx;
+            if (stmt_ni >= ast.nodes.items.len) continue;
+            const require_span = moduleExportsRequireSpanAt(ast, @enumFromInt(stmt_ni)) orelse continue;
+            const target = requireTargetForSpan(m, require_span) orelse continue;
+            const target_idx: u32 = @intFromEnum(target);
+            if (target_idx == mod_idx) continue;
+            if (self.isExportUsed(target_idx, ALL_EXPORTS_SENTINEL)) continue;
+            try self.markAndSeedAllStmts(target_idx, queue, module_stmt_infos, reachable_stmts);
+        }
     }
 
     fn collectDirectUsedExportNames(self: *TreeShaker, module_index: u32) !std.ArrayListUnmanaged([]const u8) {
@@ -1396,7 +1493,11 @@ pub const TreeShaker = struct {
             }
 
             if (target_module.wrap_kind == .cjs) {
-                if (ib.kind == .default or ib.kind == .namespace) {
+                if (ib.kind == .default and ib.namespace_used_properties != null) {
+                    for (ib.namespace_used_properties.?) |prop_name| {
+                        try self.markExportUsed(@intCast(target_mod), prop_name);
+                    }
+                } else if (ib.kind == .default or ib.kind == .namespace) {
                     try self.markAllExportsUsed(@intCast(target_mod));
                 } else {
                     try self.markExportUsed(@intCast(target_mod), ib.imported_name);
@@ -1890,14 +1991,14 @@ fn isModuleExportsAssignedNodeBufferObject(
     if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
     const expr = ast.nodes.items[@intFromEnum(expr_idx)];
     if (expr.tag != .assignment_expression) return false;
-    if (!isModuleExportsLhsForNodeBufferFact(ast, expr.data.binary.left)) return false;
+    if (!isModuleExportsLhs(ast, expr.data.binary.left)) return false;
     const rhs_idx = expr.data.binary.right;
     if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return false;
     const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
     return rhs.tag == .identifier_reference and buffer_names.contains(ast.getText(rhs.span));
 }
 
-fn isModuleExportsLhsForNodeBufferFact(ast: *const Ast, idx: NodeIndex) bool {
+fn isModuleExportsLhs(ast: *const Ast, idx: NodeIndex) bool {
     const parts = staticMemberParts(ast, idx) orelse return false;
     const obj = ast.nodes.items[@intFromEnum(parts.object)];
     const prop = ast.nodes.items[@intFromEnum(parts.property)];
@@ -1923,6 +2024,73 @@ fn isCjsNamedExportLhs(ast: *const Ast, idx: NodeIndex) bool {
         inner_prop.tag == .identifier_reference and
         std.mem.eql(u8, ast.getText(inner_obj.span), "module") and
         std.mem.eql(u8, ast.getText(inner_prop.span), "exports");
+}
+
+fn moduleExportsRequireSpanAt(ast: *const Ast, idx: NodeIndex) ?@import("../lexer/token.zig").Span {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const stmt = ast.nodes.items[@intFromEnum(idx)];
+    if (stmt.tag == .block_statement) {
+        const inner = singleBlockStatement(ast, idx) orelse return null;
+        return moduleExportsRequireSpanAt(ast, inner);
+    }
+    if (stmt.tag == .if_statement) {
+        const t = stmt.data.ternary;
+        if (moduleExportsRequireSpanAt(ast, t.b)) |span| return span;
+        if (!t.c.isNone()) return moduleExportsRequireSpanAt(ast, t.c);
+        return null;
+    }
+    if (stmt.tag != .expression_statement) return null;
+    const expr_idx = stmt.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return null;
+    const op: Kind = @enumFromInt(expr.data.binary.flags);
+    if (op != .eq) return null;
+    if (!isModuleExportsLhs(ast, expr.data.binary.left)) return null;
+
+    const rhs_idx = expr.data.binary.right;
+    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return null;
+    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+    if (rhs.tag != .call_expression) return null;
+    const e = rhs.data.extra;
+    if (!ast.hasExtra(e, 2)) return null;
+
+    const callee_idx = ast.readExtraNode(e, 0);
+    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return null;
+    const callee = ast.nodes.items[@intFromEnum(callee_idx)];
+    if (callee.tag != .identifier_reference or !std.mem.eql(u8, ast.getText(callee.span), "require")) return null;
+
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 1 or args_start >= ast.extra_data.items.len) return null;
+    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return null;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+    if (arg.tag != .string_literal) return null;
+    return arg.span;
+}
+
+fn requireTargetForSpan(m: *const Module, span: @import("../lexer/token.zig").Span) ?ModuleIndex {
+    for (m.import_records) |rec| {
+        if (rec.kind != .require) continue;
+        if (rec.resolved.isNone()) continue;
+        if (rec.span.start == span.start and rec.span.end == span.end) return rec.resolved;
+    }
+    return null;
+}
+
+fn isModuleExportsRequireStmtForSpan(
+    m: *const Module,
+    infos: StmtInfos,
+    stmt_idx: u32,
+    span: @import("../lexer/token.zig").Span,
+) bool {
+    if (stmt_idx >= infos.stmts.len) return false;
+    const ast = &(m.ast orelse return false);
+    const stmt_ni = infos.stmts[stmt_idx].node_idx;
+    if (stmt_ni >= ast.nodes.items.len) return false;
+    const require_span = moduleExportsRequireSpanAt(ast, @enumFromInt(stmt_ni)) orelse return false;
+    return require_span.start == span.start and require_span.end == span.end;
 }
 
 fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeIndex, property: NodeIndex } {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -662,7 +662,7 @@ pub const TreeShaker = struct {
                     if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
                         !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
                         self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
-                        isModuleExportsRequireStmtForSpan(o, infos, @intCast(item.stmt), rec.span))
+                        moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
                     {
                         const target_infos = module_stmt_infos[target_mod_idx] orelse {
                             try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
@@ -1009,8 +1009,7 @@ pub const TreeShaker = struct {
         for (infos.stmts, 0..) |stmt, si| {
             const stmt_ni: usize = stmt.node_idx;
             if (stmt_ni >= ast.nodes.items.len) continue;
-            const require_span = moduleExportsRequireSpanAt(ast, @enumFromInt(stmt_ni)) orelse continue;
-            const target = requireTargetForSpan(m, require_span) orelse continue;
+            const target = moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse continue;
             const target_idx: u32 = @intFromEnum(target);
             if (target_idx == mod_idx) continue;
 
@@ -1197,6 +1196,9 @@ pub const TreeShaker = struct {
             self.included.set(target);
             try self.seedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
         }
+        // module.exports = require("./impl") proxy 전파: 호출자가 mod_idx 전체를 live 로
+        // 본 이상 proxy target 도 fully include. opaque_visited 로 재진입 방어.
+        try self.seedModuleExportsRequireProxyTargetsAll(mod_idx, queue, module_stmt_infos, reachable_stmts);
     }
 
     fn seedSideEffectStmts(
@@ -1226,7 +1228,6 @@ pub const TreeShaker = struct {
         try self.markAllExportsUsed(mod_idx);
         self.included.set(mod_idx);
         try self.seedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
-        try self.seedModuleExportsRequireProxyTargetsAll(mod_idx, queue, module_stmt_infos, reachable_stmts);
     }
 
     fn seedModuleExportsRequireProxyTargetsAll(
@@ -1243,8 +1244,7 @@ pub const TreeShaker = struct {
         for (target_infos.stmts) |stmt| {
             const stmt_ni = stmt.node_idx;
             if (stmt_ni >= ast.nodes.items.len) continue;
-            const require_span = moduleExportsRequireSpanAt(ast, @enumFromInt(stmt_ni)) orelse continue;
-            const target = requireTargetForSpan(m, require_span) orelse continue;
+            const target = moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse continue;
             const target_idx: u32 = @intFromEnum(target);
             if (target_idx == mod_idx) continue;
             if (self.isExportUsed(target_idx, ALL_EXPORTS_SENTINEL)) continue;
@@ -1493,11 +1493,15 @@ pub const TreeShaker = struct {
             }
 
             if (target_module.wrap_kind == .cjs) {
-                if (ib.kind == .default and ib.namespace_used_properties != null) {
-                    for (ib.namespace_used_properties.?) |prop_name| {
-                        try self.markExportUsed(@intCast(target_mod), prop_name);
+                if (ib.kind == .default) {
+                    if (ib.namespace_used_properties) |props| {
+                        for (props) |prop_name| {
+                            try self.markExportUsed(@intCast(target_mod), prop_name);
+                        }
+                    } else {
+                        try self.markAllExportsUsed(@intCast(target_mod));
                     }
-                } else if (ib.kind == .default or ib.kind == .namespace) {
+                } else if (ib.kind == .namespace) {
                     try self.markAllExportsUsed(@intCast(target_mod));
                 } else {
                     try self.markExportUsed(@intCast(target_mod), ib.imported_name);
@@ -2070,7 +2074,8 @@ fn moduleExportsRequireSpanAt(ast: *const Ast, idx: NodeIndex) ?@import("../lexe
     return arg.span;
 }
 
-fn requireTargetForSpan(m: *const Module, span: @import("../lexer/token.zig").Span) ?ModuleIndex {
+fn moduleExportsRequireTargetAt(m: *const Module, ast: *const Ast, idx: NodeIndex) ?ModuleIndex {
+    const span = moduleExportsRequireSpanAt(ast, idx) orelse return null;
     for (m.import_records) |rec| {
         if (rec.kind != .require) continue;
         if (rec.resolved.isNone()) continue;
@@ -2079,18 +2084,18 @@ fn requireTargetForSpan(m: *const Module, span: @import("../lexer/token.zig").Sp
     return null;
 }
 
-fn isModuleExportsRequireStmtForSpan(
+fn moduleExportsRequireProxyMatches(
     m: *const Module,
     infos: StmtInfos,
     stmt_idx: u32,
-    span: @import("../lexer/token.zig").Span,
+    target: ModuleIndex,
 ) bool {
     if (stmt_idx >= infos.stmts.len) return false;
     const ast = &(m.ast orelse return false);
     const stmt_ni = infos.stmts[stmt_idx].node_idx;
     if (stmt_ni >= ast.nodes.items.len) return false;
-    const require_span = moduleExportsRequireSpanAt(ast, @enumFromInt(stmt_ni)) orelse return false;
-    return require_span.start == span.start and require_span.end == span.end;
+    const proxy_target = moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse return false;
+    return @intFromEnum(proxy_target) == @intFromEnum(target);
 }
 
 fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeIndex, property: NodeIndex } {


### PR DESCRIPTION
## Summary
- Track member-only usage for CJS default imports, e.g. `import React from "react"; React.createElement(...)`
- Seed only the used CJS export facts instead of marking the whole CJS module live
- Follow `module.exports = require(...)` proxy modules so React-style package entries prune through to the production CJS file

## Benchmark
- `react`: ZTS 15KB -> 3.9KB, rolldown 4.2KB, output MATCH
- `react-dom`: ZTS 444KB, rolldown 447KB, output MATCH

## Tests
- `zig build test`
- `zig build test -Dtest-filter="TreeShaking CJS"`
- `bun run tests/benchmark/smoke.ts --filter=react --keep-output=/tmp/zts-react-after8/outputs --json=/tmp/zts-react-after8/report.json`

Related: #2060