### PR TITLE
feat(loader): base64 loader + 각 loader codegen 검증

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -2635,6 +2635,18 @@ pub const ModuleGraph = struct {
                     return;
                 };
             },
+            .base64 => {
+                // 바이너리 읽기 → base64 인코딩 → 순수 base64 문자열 (data URL prefix 없음)
+                const raw = self.readModuleSource(module, arena_alloc, 100 * 1024 * 1024, .parse) orelse return;
+                const encoded = base64Encode(arena_alloc, raw) catch {
+                    module.state = .ready;
+                    return;
+                };
+                module.source = std.fmt.allocPrint(arena_alloc, "\"{s}\"", .{encoded}) catch {
+                    module.state = .ready;
+                    return;
+                };
+            },
             .binary => {
                 // 바이너리 읽기 → base64 인코딩 → __toBinary("...") 호출 표현식
                 const raw = self.readModuleSource(module, arena_alloc, 100 * 1024 * 1024, .parse) orelse return;

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -434,6 +434,9 @@ pub const Loader = enum {
     /// 파일을 base64 data URL로 인라인.
     /// export default "data:image/png;base64,..."
     dataurl,
+    /// 파일을 base64 string 으로 인라인 (data URL prefix 없음).
+    /// export default "iVBORw0KG..."
+    base64,
     /// 파일을 UTF-8 문자열로 export.
     /// export default "file contents..."
     text,
@@ -468,10 +471,11 @@ pub const Loader = enum {
     }
 
     /// 문자열에서 Loader enum으로 변환 (CLI 파싱용).
-    /// "file", "dataurl", "text", "binary", "copy", "json", "css", "empty" 지원.
+    /// esbuild/rolldown 호환 — js/jsx/ts/tsx 4 string 모두 `.javascript` 로 normalize.
     pub fn fromString(s: []const u8) ?Loader {
         if (std.mem.eql(u8, s, "file")) return .file;
         if (std.mem.eql(u8, s, "dataurl")) return .dataurl;
+        if (std.mem.eql(u8, s, "base64")) return .base64;
         if (std.mem.eql(u8, s, "text")) return .text;
         if (std.mem.eql(u8, s, "binary")) return .binary;
         if (std.mem.eql(u8, s, "copy")) return .copy;
@@ -485,11 +489,11 @@ pub const Loader = enum {
         return null;
     }
 
-    /// asset 로더인지 (file/dataurl/text/binary/copy/empty).
+    /// asset 로더인지 (file/dataurl/base64/text/binary/copy/empty).
     /// JS/JSON/CSS가 아닌 로더.
     pub fn isAsset(self: Loader) bool {
         return switch (self) {
-            .file, .dataurl, .text, .binary, .copy, .empty => true,
+            .file, .dataurl, .base64, .text, .binary, .copy, .empty => true,
             else => false,
         };
     }

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1854,6 +1854,78 @@ describe("에셋 로더 + RN 프리셋", () => {
     expect(result.stderr).not.toContain("No loader");
     expect(result.stdout).toContain("undefined");
   });
+
+  // ─── #2157 builtin loader codegen 검증 ─────────────────────────────────────
+
+  test("loader=text → UTF-8 string default export", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `const greeting = require('./greeting.txt');\nconsole.log(greeting);`,
+    });
+    cleanup = fixture.cleanup;
+    writeFileSync(join(fixture.dir, "greeting.txt"), "Hello, ZTS!");
+
+    const result = await runZtsInDir(fixture.dir, [
+      "--bundle",
+      join(fixture.dir, "entry.ts"),
+      "--loader:.txt=text",
+    ]);
+    expect(result.stderr).not.toContain("No loader");
+    expect(result.stdout).toContain("Hello, ZTS!");
+  });
+
+  test("loader=base64 → 순수 base64 string (data URL prefix 없음)", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `const data = require('./blob.bin');\nconsole.log(data);`,
+    });
+    cleanup = fixture.cleanup;
+    writeFileSync(join(fixture.dir, "blob.bin"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const result = await runZtsInDir(fixture.dir, [
+      "--bundle",
+      join(fixture.dir, "entry.ts"),
+      "--loader:.bin=base64",
+    ]);
+    expect(result.stderr).not.toContain("No loader");
+    // PNG signature 첫 4 바이트 0x89 0x50 0x4e 0x47 → base64 "iVBORw=="
+    expect(result.stdout).toContain("iVBORw==");
+    // data URL prefix 가 없어야 함 (dataurl loader 와 구별).
+    expect(result.stdout).not.toContain("data:");
+  });
+
+  test("loader=binary → __toBinary base64 + Uint8Array runtime helper", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `const data = require('./blob.bin');\nconsole.log(data);`,
+    });
+    cleanup = fixture.cleanup;
+    writeFileSync(join(fixture.dir, "blob.bin"), Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05]));
+
+    const result = await runZtsInDir(fixture.dir, [
+      "--bundle",
+      join(fixture.dir, "entry.ts"),
+      "--loader:.bin=binary",
+    ]);
+    expect(result.stderr).not.toContain("No loader");
+    // base64("\x01\x02\x03\x04\x05") = "AQIDBAU="
+    expect(result.stdout).toContain('__toBinary("AQIDBAU=")');
+    // __toBinary runtime helper 가 inline
+    expect(result.stdout).toContain("Uint8Array");
+  });
+
+  test("loader=dataurl 의 MIME — .svg → image/svg+xml", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `const svg = require('./vec.svg');\nconsole.log(svg);`,
+    });
+    cleanup = fixture.cleanup;
+    writeFileSync(join(fixture.dir, "vec.svg"), '<svg xmlns="http://www.w3.org/2000/svg"/>');
+
+    const result = await runZtsInDir(fixture.dir, [
+      "--bundle",
+      join(fixture.dir, "entry.ts"),
+      "--loader:.svg=dataurl",
+    ]);
+    expect(result.stderr).not.toContain("No loader");
+    expect(result.stdout).toContain("data:image/svg+xml;base64,");
+  });
 });
 
 describe("JSON named exports", () => {


### PR DESCRIPTION
## 요약
- `Loader` enum 에 `.base64` variant 추가 — esbuild / rolldown 호환
- 4 통합 테스트로 builtin loader codegen 동작 회귀 lock (text / base64 / binary / dataurl-MIME)

## 변경

**`src/bundler/types.zig`**
- `Loader` enum: `.base64` variant — `dataurl` 처럼 base64 인코딩 + data URL prefix 만 제거
- `Loader.fromString`: `\"base64\"` 매핑 추가
- `Loader.isAsset`: `.base64` 포함

**`src/bundler/graph.zig` `parseAssetModule`**
- `.base64` arm: `base64Encode(arena_alloc, raw)` → `\"<encoded>\"` (dataurl 패턴 모방)

**`tests/integration/tests/bundle-smoke.test.ts`**
- `loader=text` UTF-8 string default export
- `loader=base64` 순수 base64 (data: prefix 없음)
- `loader=binary` `__toBinary(\"<base64>\")` + Uint8Array runtime
- `loader=dataurl` 의 MIME: `.svg` → `image/svg+xml`

## #2157 갭 분석 결과 (실제 작업)

이슈 본문 확장 후 검토하니 ZTS 가 이미 대부분 cover:
- ✅ `Loader` enum 9 종 정의 — text / binary / dataurl / file / copy / empty / json / css / javascript
- ✅ `mime.fromExtension` 29 ext cover (`src/server/mime.zig`) — image/font/wasm/audio/video
- ❌ `base64` 만 누락 → 본 PR 추가
- ❌ codegen 동작 회귀 검증 → 본 PR 통합 테스트

## Follow-up — #2162 로 분리

비표준 ext + 명시 loader 의 jsx/ts flags (module-level loader override) 는 `parser/transformer/graph` 의 ext-기반 로직 다수 변경이라 별도 PR. ROI 낮아 현재 통합 enum (`.javascript`) 유지.

## 검증
- `zig build test` → 4074/4074 pass
- `bun test bundle-smoke -t loader` → 8/8 pass
- `bun run lint` → 0 warnings/errors

Closes #2157
Refs #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)