### PR TITLE
feat(bundler): narrow export-star source fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ Zig 0.15.2 · C NAPI v8 (vendor/node-api-headers/) · Node.js 24+ / Bun 1.3+ · 
 3. main 직접 push 금지 — feature branch → PR → merge
 4. PR 올리기 **전** `/simplify` 필수 (파일 간 상호작용까지 검토 → 이후 PR 생성)
 5. `gh pr create` 시 `--label`, `--assignee` 항상 지정
-6. Zig 초보자에게 설명 포함
+6. PR 제목은 `feat(lexer): add numeric literal tokenization` 형식
+7. PR 본문, GitHub 이슈/PR 댓글, 리뷰 답변은 한국어로 작성
+8. Zig 초보자에게 설명 포함
 
 ## 외부 Consumer 동기화
 - **bungae monorepo** (`/Users/yoonhb/Documents/workspace/bungae/`) 가 ZTS 를 git submodule 로 참조. `.gitmodules` 에 branch 추적 없어서 ZTS 머지 후 수동 sync 필요:
@@ -39,8 +41,6 @@ Zig 0.15.2 · C NAPI v8 (vendor/node-api-headers/) · Node.js 24+ / Bun 1.3+ · 
 - **Arena 안 리소스는 개별 deinit 금지**. `arena_alloc`으로 만든 `DynamicBitSet`/`ArrayList` 등은 `arena.deinit()`이 일괄 해제. 개별 `defer X.deinit()`을 함께 걸면 `arena.deinit()` 이후에 실행되어 해제된 메모리 접근 → segfault (#1287).
 - 성공 경로에서 `arena.deinit()`을 명시 호출하지 말 것. `defer arena.deinit()` 하나로 충분.
 - `errdefer arena.deinit()`만 쓰고 성공 경로는 따로 관리하는 패턴은 위험 — defer 순서 실수 유발.
-
-PR 제목: `feat(lexer): add numeric literal tokenization` 형식.
 
 ## References
 Bun (src/js_parser.zig, js_lexer.zig) · oxc · SWC · esbuild · Hermes (Flow) · Metro (RN) · TypeScript · Test262 · tc39.es/ecma262

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -3858,7 +3858,7 @@ test "TreeShaking: chained export star named import prunes unrelated sources" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNRELATED_SOURCE_MARKER") == null);
 }
 
-test "TreeShaking: export star named import skips side-effectful unrelated source" {
+test "TreeShaking: export star named import drops unrelated source declared sideEffects:false" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -3858,6 +3858,64 @@ test "TreeShaking: chained export star named import prunes unrelated sources" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNRELATED_SOURCE_MARKER") == null);
 }
 
+test "TreeShaking: export star named import skips side-effectful unrelated source" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { scaleLinearLike } from './d3';
+        \\console.log(scaleLinearLike());
+    );
+    try writeFile(tmp.dir, "d3.ts",
+        \\export * from './scale';
+        \\export * from './time-format';
+    );
+    try writeFile(tmp.dir, "scale.ts",
+        \\export function scaleLinearLike() { return "LIVE_SCALE_LINEAR_MARKER"; }
+    );
+    try writeFile(tmp.dir, "time-format.ts",
+        \\export { default as timeFormatDefaultLocale, timeFormat } from './defaultLocale';
+    );
+    try writeFile(tmp.dir, "defaultLocale.ts",
+        \\import { formatLocale } from './locale';
+        \\export var timeFormat;
+        \\defaultLocale("UNUSED_TIME_FORMAT_DEFAULT_LOCALE_MARKER");
+        \\export default function defaultLocale(definition) {
+        \\  timeFormat = formatLocale(definition);
+        \\  return timeFormat;
+        \\}
+    );
+    try writeFile(tmp.dir, "locale.ts",
+        \\import { timeYear } from './time';
+        \\export function formatLocale(definition) {
+        \\  return definition + timeYear();
+        \\}
+    );
+    try writeFile(tmp.dir, "time.ts",
+        \\export function timeYear() { return "UNUSED_D3_TIME_YEAR_MARKER"; }
+    );
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LIVE_SCALE_LINEAR_MARKER") != null);
+    for ([_][]const u8{
+        "UNUSED_TIME_FORMAT_DEFAULT_LOCALE_MARKER",
+        "UNUSED_D3_TIME_YEAR_MARKER",
+    }) |m| {
+        try std.testing.expect(std.mem.indexOf(u8, result.output, m) == null);
+    }
+}
+
 test "TreeShaking: export star from CJS keeps wrapped source for named import" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -45,6 +45,13 @@ fn isImportDeclarationStmt(m: *const Module, infos: StmtInfos, stmt_idx: u32) bo
     return ni < ast.nodes.items.len and ast.nodes.items[ni].tag == .import_declaration;
 }
 
+/// 모듈을 evaluation 의존으로 끌어와야 하는 부수효과가 있는지.
+/// side_effects, wrapped (cjs/esm wrapper), dynamic-fallback exports kind 셋 중 하나라도
+/// 해당하면 prune 불가 — 평가 순서/시점 유지가 필요.
+inline fn moduleHasEvaluationEffect(mod: *const Module) bool {
+    return mod.side_effects or mod.wrap_kind.isWrapped() or mod.exports_kind == .esm_with_dynamic_fallback;
+}
+
 pub const TreeShaker = struct {
     allocator: std.mem.Allocator,
     /// Module storage 접근 포인터 (#1779 PR #2). 기존 `[]const Module` slice
@@ -1219,43 +1226,32 @@ pub const TreeShaker = struct {
             const m = self.getModule(@intCast(i)) orelse continue;
             for (m.export_bindings) |eb| {
                 if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
-                if (eb.import_record_index) |rec_idx| {
-                    if (rec_idx < m.import_records.len) {
-                        const src_idx = m.import_records[rec_idx].resolved;
-                        if (self.graph.getModule(src_idx) != null) {
-                            const src = @intFromEnum(src_idx);
-                            const src_module = self.graph.getModule(src_idx).?;
-                            if (check_used and eb.kind != .re_export_star and !self.isExportUsed(@intCast(i), eb.exported_name) and
-                                !src_module.side_effects and !src_module.wrap_kind.isWrapped() and src_module.exports_kind != .esm_with_dynamic_fallback)
-                            {
-                                continue;
-                            }
-                            if (check_used and eb.kind == .re_export_star and !self.isExportUsed(@intCast(i), ALL_EXPORTS_SENTINEL) and
-                                !src_module.side_effects and !src_module.wrap_kind.isWrapped() and src_module.exports_kind != .esm_with_dynamic_fallback)
-                            {
-                                // Named imports through `export *` are already resolved by seedExport().
-                                // Do not include every star source as an evaluation dependency unless the
-                                // whole namespace/all exports are used. Side-effectful or dynamic sources
-                                // still fall through to preserve evaluation semantics.
-                                continue;
-                            }
-                            if (!self.included.isSet(src)) {
-                                self.included.set(src);
-                                changed = true;
-                            }
-                            if (src_module.wrap_kind == .cjs and eb.kind == .re_export_star) {
-                                try self.markAllExportsUsed(@intCast(src));
-                            } else if (eb.kind == .re_export_namespace) {
-                                // #1603 Phase 1b: 모든 소비자의 `namespace_used_properties`를
-                                // 집계해 subset이 결정 가능하면 해당 member만 used로 마킹.
-                                // 하나라도 opaque(null)이면 전체 사용 fallback.
-                                if (try self.tryMarkReExportNsSubset(@intCast(i), eb.exported_name, @intCast(src))) continue;
-                                try self.markAllExportsUsed(@intCast(src));
-                            } else if (!check_used) {
-                                try self.markAllExportsUsed(@intCast(src));
-                            }
-                        }
-                    }
+                const rec_idx = eb.import_record_index orelse continue;
+                if (rec_idx >= m.import_records.len) continue;
+                const src_idx = m.import_records[rec_idx].resolved;
+                const src_module = self.graph.getModule(src_idx) orelse continue;
+                const src = @intFromEnum(src_idx);
+                // 평가 부수효과가 없는 source 는 사용된 export 가 있을 때만 끌어옴.
+                // `export *` 의 named import 는 seedExport 가 canonical source 로 직접 시드하므로,
+                // 전체 namespace 가 사용되지 않는 한 unrelated star source 까지 fan out 하지 않는다.
+                if (check_used and !moduleHasEvaluationEffect(src_module)) {
+                    const probe_name = if (eb.kind == .re_export_star) ALL_EXPORTS_SENTINEL else eb.exported_name;
+                    if (!self.isExportUsed(@intCast(i), probe_name)) continue;
+                }
+                if (!self.included.isSet(src)) {
+                    self.included.set(src);
+                    changed = true;
+                }
+                if (src_module.wrap_kind == .cjs and eb.kind == .re_export_star) {
+                    try self.markAllExportsUsed(@intCast(src));
+                } else if (eb.kind == .re_export_namespace) {
+                    // #1603 Phase 1b: 모든 소비자의 `namespace_used_properties`를
+                    // 집계해 subset이 결정 가능하면 해당 member만 used로 마킹.
+                    // 하나라도 opaque(null)이면 전체 사용 fallback.
+                    if (try self.tryMarkReExportNsSubset(@intCast(i), eb.exported_name, @intCast(src))) continue;
+                    try self.markAllExportsUsed(@intCast(src));
+                } else if (!check_used) {
+                    try self.markAllExportsUsed(@intCast(src));
                 }
             }
         }
@@ -1263,10 +1259,12 @@ pub const TreeShaker = struct {
     }
 
     /// included 모듈의 import_record 가 source 모듈을 evaluation 의존으로 끌어와야 하는지.
-    /// re-export / side_effect / require / worker / glob / require_context 는 항상 evaluation
-    /// 의존이라 보존. static_import 만 entry 또는 live binding 이 있을 때만 보존 — dead body
-    /// 안에서만 참조되는 named import 가 source 모듈을 fan out 시키지 않도록. dynamic_import 는
-    /// 별도 dyn_import_targets 경로로 처리되므로 여기선 false.
+    /// re-export 는 target 이 evaluation effect 를 갖거나 (side_effects/wrapped/dynamic-fallback),
+    /// 해당 stmt 가 reachable 일 때만 보존 — `export *` 가 unrelated source 까지 fan out 하지 않도록.
+    /// side_effect / require / worker / glob / require_context 는 항상 evaluation 의존이라 보존.
+    /// static_import 만 entry 또는 live binding 이 있을 때만 보존 — dead body 안에서만 참조되는
+    /// named import 가 source 모듈을 fan out 시키지 않도록. dynamic_import 는 별도
+    /// dyn_import_targets 경로로 처리되므로 여기선 false.
     fn shouldPreserveImportRecordForEvaluation(
         self: *const TreeShaker,
         m: *const Module,
@@ -1276,11 +1274,8 @@ pub const TreeShaker = struct {
     ) bool {
         if (rec_idx >= m.import_records.len) return false;
         if (m.import_records[rec_idx].kind == .re_export) {
-            const target_idx = m.import_records[rec_idx].resolved;
-            if (self.graph.getModule(target_idx)) |target_module| {
-                if (target_module.side_effects or target_module.wrap_kind.isWrapped() or target_module.exports_kind == .esm_with_dynamic_fallback) {
-                    return true;
-                }
+            if (self.graph.getModule(m.import_records[rec_idx].resolved)) |target| {
+                if (moduleHasEvaluationEffect(target)) return true;
             }
             return self.importRecordHasReachableStmt(m, mod_idx, rec_idx);
         }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1219,13 +1219,26 @@ pub const TreeShaker = struct {
             const m = self.getModule(@intCast(i)) orelse continue;
             for (m.export_bindings) |eb| {
                 if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
-                if (check_used and !self.isExportUsed(@intCast(i), eb.exported_name)) continue;
                 if (eb.import_record_index) |rec_idx| {
                     if (rec_idx < m.import_records.len) {
                         const src_idx = m.import_records[rec_idx].resolved;
                         if (self.graph.getModule(src_idx) != null) {
                             const src = @intFromEnum(src_idx);
                             const src_module = self.graph.getModule(src_idx).?;
+                            if (check_used and eb.kind != .re_export_star and !self.isExportUsed(@intCast(i), eb.exported_name) and
+                                !src_module.side_effects and !src_module.wrap_kind.isWrapped() and src_module.exports_kind != .esm_with_dynamic_fallback)
+                            {
+                                continue;
+                            }
+                            if (check_used and eb.kind == .re_export_star and !self.isExportUsed(@intCast(i), ALL_EXPORTS_SENTINEL) and
+                                !src_module.side_effects and !src_module.wrap_kind.isWrapped() and src_module.exports_kind != .esm_with_dynamic_fallback)
+                            {
+                                // Named imports through `export *` are already resolved by seedExport().
+                                // Do not include every star source as an evaluation dependency unless the
+                                // whole namespace/all exports are used. Side-effectful or dynamic sources
+                                // still fall through to preserve evaluation semantics.
+                                continue;
+                            }
                             if (!self.included.isSet(src)) {
                                 self.included.set(src);
                                 changed = true;
@@ -1261,8 +1274,17 @@ pub const TreeShaker = struct {
         rec_idx: u32,
         live_mod_idx: ?u32,
     ) bool {
-        if (live_mod_idx == null) return true;
         if (rec_idx >= m.import_records.len) return false;
+        if (m.import_records[rec_idx].kind == .re_export) {
+            const target_idx = m.import_records[rec_idx].resolved;
+            if (self.graph.getModule(target_idx)) |target_module| {
+                if (target_module.side_effects or target_module.wrap_kind.isWrapped() or target_module.exports_kind == .esm_with_dynamic_fallback) {
+                    return true;
+                }
+            }
+            return self.importRecordHasReachableStmt(m, mod_idx, rec_idx);
+        }
+        if (live_mod_idx == null) return true;
         return switch (m.import_records[rec_idx].kind) {
             .dynamic_import => false,
             .require => self.importRecordHasReachableStmt(m, live_mod_idx.?, rec_idx),


### PR DESCRIPTION
## Summary
- avoid including every `export *` source as an evaluation dependency when a named import already resolves to a precise ESM export
- keep conservative fallback for side-effectful, wrapped, dynamic fallback, CJS, and namespace/all-export cases
- add a D3-shaped regression test so unused `time-format -> defaultLocale -> time` style chains stay out when only an unrelated star export is imported

## Validation
- `zig build test -Dtest-filter="export star"`
- `zig build test -Dtest-filter="direct re-export"`
- `zig build test -Dtest-filter="sideEffects glob pattern"`
- `zig build test`
- `bun run build:zts`
- `bun run tests/benchmark/smoke.ts --filter=d3 --keep-output=/tmp/zts-d3-after/outputs --json=/tmp/zts-d3-after/report.json`

## Benchmark
- d3 ZTS: 110,108B -> 85,452B
- d3 rolldown: 98,813B
- output: MATCH

Related to #2060.