### PR TITLE
chore(benchmark): align rolldown output format

### DIFF
--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -257,7 +257,7 @@ function testProject(p: ProjectConfig, options: SmokeOptions = {}): SmokeResult 
           "-o",
           rdOut,
           "--format",
-          "cjs",
+          format,
           "--platform",
           platform,
           ...rdExternalArgs,


### PR DESCRIPTION
## 요약
- benchmark smoke에서 rolldown의 `--format`을 하드코딩된 `cjs` 대신 프로젝트 설정의 `format` 값으로 전달합니다.
- ZTS/esbuild/rspack과 같은 출력 포맷 기준으로 비교되도록 맞췄습니다.

## 배경
기존 벤치마크는 대부분 ESM 프로젝트를 비교하면서도 rolldown만 CJS 산출물을 만들고 있었습니다. 이러면 번들러별 크기 비교에 포맷 차이가 섞입니다. 이번 PR은 먼저 출력 포맷 조건만 동일하게 맞추는 작은 변경입니다.

Zig 코드 변경은 없습니다. Zig 초보자 관점에서는 NAPI나 번들러 구현 로직이 아니라, 테스트 드라이버가 외부 번들러를 실행할 때 넘기는 CLI 인자만 바꾼 패치입니다.

## 검증
- `git diff --check`
- `bun run tests/benchmark/smoke.ts --filter=dotenv --json=/tmp/zts-format-align-pr-dotenv.json`
- 추가 확인: `dotenv`, `dayjs`, `cjs-module-exports-object-member-value`, `type-fest`, `lru-cache@es2021`, `semver@es5`, `lru-cache` smoke 실행 및 MATCH 확인
- rolldown 산출물이 ESM 형태(`import ...`, `export {}`)로 생성되는 것을 확인

## 범위 밖
- target 불일치로 남는 downlevel 크기 차이는 별도 이슈로 다루겠습니다.