### PR TITLE
feat(bundle): drop console / debugger 를 bundle 모드에 적용

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -608,6 +608,9 @@ async function runBundle(opts, config) {
     asciiOnly: opts.asciiOnly,
     quotes: opts.quotes,
     drop: opts.drop.length > 0 ? opts.drop : undefined,
+    // bundle 모드도 transpile 과 동일하게 drop console/debugger 적용 (#2155).
+    dropConsole: opts.drop.includes("console"),
+    dropDebugger: opts.drop.includes("debugger"),
     useDefineForClassFields: opts.useDefineForClassFields,
     experimentalDecorators: opts.experimentalDecorators,
     emitDecoratorMetadata: opts.emitDecoratorMetadata,

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -304,6 +304,47 @@ describe("@zts/core buildSync", () => {
     expect(result.outputFiles[0].text).toContain("react");
     rmSync(extDir, { recursive: true, force: true });
   });
+
+  // ─── #2155 bundle 모드도 drop console / debugger 적용 ────────────────────────
+  test("dropConsole: bundle 모드에서 console 호출 제거", () => {
+    const dropDir = mkdtempSync(join(tmpdir(), "zts-bundle-drop-console-"));
+    writeFileSync(
+      join(dropDir, "app.ts"),
+      'console.log("DROP_CONSOLE_REMOVED"); export const x = "DROP_CONSOLE_KEPT";',
+    );
+    const result = buildSync({
+      entryPoints: [join(dropDir, "app.ts")],
+      dropConsole: true,
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).not.toContain("DROP_CONSOLE_REMOVED");
+    expect(result.outputFiles[0].text).toContain("DROP_CONSOLE_KEPT");
+    rmSync(dropDir, { recursive: true, force: true });
+  });
+
+  test("dropDebugger: bundle 모드에서 debugger 문 제거", () => {
+    const dropDir = mkdtempSync(join(tmpdir(), "zts-bundle-drop-debugger-"));
+    writeFileSync(join(dropDir, "app.ts"), 'debugger;\nexport const x = "DROP_DEBUGGER_KEPT";');
+    const result = buildSync({
+      entryPoints: [join(dropDir, "app.ts")],
+      dropDebugger: true,
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).not.toContain("debugger");
+    expect(result.outputFiles[0].text).toContain("DROP_DEBUGGER_KEPT");
+    rmSync(dropDir, { recursive: true, force: true });
+  });
+
+  test("dropConsole 미지정: bundle 모드는 console 호출 보존 (기존 동작)", () => {
+    const keepDir = mkdtempSync(join(tmpdir(), "zts-bundle-drop-keep-"));
+    writeFileSync(join(keepDir, "app.ts"), 'console.log("KEEP_CONSOLE_VALUE");');
+    const result = buildSync({
+      entryPoints: [join(keepDir, "app.ts")],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("KEEP_CONSOLE_VALUE");
+    rmSync(keepDir, { recursive: true, force: true });
+  });
 });
 
 describe("@zts/core build (async)", () => {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -429,6 +429,10 @@ interface BuildOptionsCommon {
   analyze?: boolean;
   /** 제거할 labeled statement의 라벨 이름 목록 */
   dropLabels?: string[];
+  /** `console.*` 호출 expression statement 를 transformer 에서 제거 (#2155). bundle/transpile 동일 적용. */
+  dropConsole?: boolean;
+  /** `debugger;` statement 를 transformer 에서 제거 (#2155). bundle/transpile 동일 적용. */
+  dropDebugger?: boolean;
   /** 순수 함수로 마킹할 글로벌 함수명 목록 */
   pure?: string[];
   /** tsconfig.json 인라인 JSON 오버라이드 */

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3226,6 +3226,9 @@ fn parseBuildOptions(
         .jsx_side_effects = getObjectBool(env, opts_obj, "jsxSideEffects", false),
         .analyze = getObjectBool(env, opts_obj, "analyze", false),
         .drop_labels = drop_labels orelse &.{},
+        // #2155: bundle 모드에도 transpile 동일 drop console/debugger 적용.
+        .drop_console = getObjectBool(env, opts_obj, "dropConsole", false),
+        .drop_debugger = getObjectBool(env, opts_obj, "dropDebugger", false),
         .pure = pure orelse &.{},
         .tsconfig_raw = tsconfig_raw,
         .node_paths = node_paths orelse &.{},

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -148,14 +148,17 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   "treeShaking",
   "shimMissingExports",
   "keepNames",
+  // ─── Drop ───
+  "drop",
+  "dropConsole",
+  "dropDebugger",
+  "dropLabels",
   // ─── 코드 주입 ───
   "banner",
   "footer",
   "intro",
   "outro",
   "inject",
-  "drop",
-  "dropLabels",
   "pure",
   "legalComments",
   // ─── Naming ───

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -253,6 +253,10 @@ pub const BundleOptions = struct {
     jsx_side_effects: bool = false,
     /// --drop-labels: 제거할 labeled statement의 라벨 이름 목록
     drop_labels: []const []const u8 = &.{},
+    /// `--drop=console` (#2155). console 호출 expression statement 를 transformer 에서 제거.
+    drop_console: bool = false,
+    /// `--drop=debugger` (#2155). `debugger;` statement 를 transformer 에서 제거.
+    drop_debugger: bool = false,
     /// --pure:NAME: 순수 함수로 마킹할 글로벌 함수명 목록
     pure: []const []const u8 = &.{},
     /// --tsconfig-raw: tsconfig.json 인라인 오버라이드 JSON
@@ -487,6 +491,8 @@ pub const Bundler = struct {
             .verbatim_module_syntax = self.options.verbatim_module_syntax,
             .unsupported = self.options.unsupported,
             .drop_labels = self.options.drop_labels,
+            .drop_console = self.options.drop_console,
+            .drop_debugger = self.options.drop_debugger,
             .jsx_runtime = self.options.jsx_runtime,
             .jsx_factory = self.options.jsx_factory,
             .jsx_fragment = self.options.jsx_fragment,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1900,6 +1900,8 @@ pub fn main() !void {
             .ignore_annotations = opts.ignore_annotations,
             .jsx_side_effects = opts.jsx_side_effects,
             .drop_labels = opts.drop_labels_list.items,
+            .drop_console = opts.drop_console,
+            .drop_debugger = opts.drop_debugger,
             .pure = opts.pure_list.items,
             .tsconfig_raw = opts.tsconfig_raw,
             .node_paths = opts.node_paths_list.items,


### PR DESCRIPTION
## 요약
기존 ZTS 의 `--drop=console` / `--drop=debugger` 는 **transpile 모드에서만** 동작 — `transformer.zig:752-757` 의 처리 로직은 이미 있지만 **bundler 가 옵션 forwarding 안 함**. 결과적으로 `bundle + minify` 시 프로덕션 빌드의 console 호출이 그대로 남던 문제.

본 PR 은 **옵션 forwarding 만 추가** (신규 처리 로직 0줄):

## 변경
- `src/bundler/bundler.zig`: `BundleOptions` 에 `drop_console` / `drop_debugger` boolean 필드 + `buildTransformOptionsBase` 가 transformer 로 forward
- `src/main.zig`: Zig CLI 의 BundleOptions 빌드에서 두 필드 전달
- `packages/core/src/napi_entry.zig`: NAPI 경계에서 `getObjectBool("dropConsole"/"dropDebugger")` parse + BundleOptions 에 set
- `packages/core/bin/zts.mjs`: buildOpts 에 `dropConsole: opts.drop.includes("console")` boolean 분해
- `packages/core/index.ts`: `BuildOptionsCommon.dropConsole` / `dropDebugger` 타입
- `packages/core/src/typo-suggest.ts`: KNOWN_CONFIG_KEYS 에 등록 + 기존 중복 (`drop` / `dropLabels` 가 두 섹션에 있던 것) 정리해 단일 "Drop" 섹션으로 그룹핑

## 검증 — 통합 테스트 3개
- `dropConsole: true` 로 bundle 시 `console.log(...)` 출력에서 제거 + entry export 보존
- `dropDebugger: true` 로 bundle 시 `debugger;` 제거
- `dropConsole` 미지정 시 console 호출 보존 (기존 동작)

## /simplify 결과
- ✅ `|| undefined` 비일관 패턴 단순화 — 같은 buildOpts 의 다른 boolean (`keepNames` 등) 과 일관되게 직접 boolean 전달
- 의도된 design (skip): wiring-only PR 이라 helper 추출 불필요, `isConsoleCall` 비용은 transformer 기존 hot path 재사용

## 검증
- `zig build test` → 4074/4074 pass
- `bun test packages/core/index.test.ts` → 320/320 pass (3 new + 317 기존)
- schema-sync / typo-suggest 테스트 → 29/29 pass (KNOWN_CONFIG_KEYS 중복 제거 후)
- `bun run lint` / `fmt` → 0 warnings

Closes #2155
Refs #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)