### PR TITLE
feat(resolve): alias 의 array (Vite 식 RegExp) 지원

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1401,6 +1401,90 @@ describe("@zts/core define/alias", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // ─── #2153 array-form alias (Vite 식 RegExp / 함수형 find) ──────────────────
+  test("alias array: string find — exact 매칭", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-alias-array-string-"));
+    writeFileSync(join(dir, "real.ts"), 'export const x = "ALIAS_ARRAY_STRING_VALUE";');
+    writeFileSync(join(dir, "index.ts"), 'import { x } from "virtual";\nconsole.log(x);');
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      alias: [{ find: "virtual", replacement: join(dir, "real.ts") }],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("ALIAS_ARRAY_STRING_VALUE");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("alias array: RegExp find — capture group 치환 ($1)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-alias-array-regex-"));
+    writeFileSync(join(dir, "components.ts"), 'export const Btn = "ALIAS_REGEX_BTN";');
+    writeFileSync(join(dir, "index.ts"), 'import { Btn } from "@/components";\nconsole.log(Btn);');
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      // `@/components` → `<dir>/components` (디렉토리는 index 자동 또는 .ts 추가 — 여기선 정확 path 매핑).
+      alias: [{ find: /^@\/(.*)$/, replacement: join(dir, "$1.ts") }],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("ALIAS_REGEX_BTN");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("alias array: 매칭 순서 — 첫번째 매치 적용", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-alias-array-order-"));
+    writeFileSync(join(dir, "first.ts"), 'export const v = "ALIAS_FIRST_MATCH";');
+    writeFileSync(join(dir, "second.ts"), 'export const v = "ALIAS_SECOND_MATCH";');
+    writeFileSync(join(dir, "index.ts"), 'import { v } from "shared";\nconsole.log(v);');
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      alias: [
+        { find: "shared", replacement: join(dir, "first.ts") },
+        { find: "shared", replacement: join(dir, "second.ts") },
+      ],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("ALIAS_FIRST_MATCH");
+    expect(result.outputFiles[0].text).not.toContain("ALIAS_SECOND_MATCH");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("alias array: RegExp `g` flag 도 매 import 안전 적용 (lastIndex 부작용 없음)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-alias-array-gflag-"));
+    writeFileSync(join(dir, "a.ts"), 'export const a = "ALIAS_GFLAG_A";');
+    writeFileSync(join(dir, "b.ts"), 'export const b = "ALIAS_GFLAG_B";');
+    writeFileSync(
+      join(dir, "index.ts"),
+      'import { a } from "@/a";\nimport { b } from "@/b";\nconsole.log(a, b);',
+    );
+
+    // `g` flag — find.test() 패턴이었다면 두 번째 호출에서 lastIndex 부작용으로 false 반환.
+    // String.prototype.search 는 g flag 무시하므로 두 import 모두 매칭되어야 함.
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      alias: [{ find: /^@\/(.*)$/g, replacement: join(dir, "$1.ts") }],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("ALIAS_GFLAG_A");
+    expect(result.outputFiles[0].text).toContain("ALIAS_GFLAG_B");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("alias array: buildSync 에서 throw (host RegExp 위임 plugin 필요)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-alias-array-sync-"));
+    writeFileSync(join(dir, "index.ts"), 'console.log("hi");');
+
+    expect(() =>
+      buildSync({
+        entryPoints: [join(dir, "index.ts")],
+        alias: [{ find: /^@\//, replacement: dir + "/" }],
+      }),
+    ).toThrow(/array-form alias.*async build/);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("define: async build에서도 동작", async () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-define-async-"));
     writeFileSync(join(dir, "index.ts"), "console.log(VERSION);");

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -359,11 +359,19 @@ interface BuildOptionsCommon {
    * 키는 식별자 또는 `obj.prop` 같은 멤버 표현식, 값은 JS 표현식 문자열.
    * 예: `{ "__DEV__": "false", "process.env.NODE_ENV": '"production"' }` */
   define?: Record<string, string>;
-  /** Import 경로 별칭 (esbuild `alias` 호환).
+  /** Import 경로 별칭 — 두 형태 지원 (esbuild / Vite 호환):
+   *
+   * 1. **Object 형태** (esbuild `alias`): exact + prefix 매칭. 정해진 specifier 만 치환.
+   *    예: `{ react: "preact/compat" }` — `react` 또는 `react/hooks` → `preact/compat[/hooks]`
+   *
+   * 2. **Array 형태** (Vite `resolve.alias`, #2153): `RegExp` find 지원. 매칭 순서대로 첫번째 적용.
+   *    `find` 가 string 이면 prefix 매칭, RegExp 이면 host runtime 이 매칭 + `replacement` 로 치환.
+   *    예: `[{ find: /^@\/(.*)$/, replacement: "./src/$1" }]`
+   *
    * 일반 해석 **전에 무조건** 치환됨 — 설치된 실제 패키지가 있어도 무시.
    * Optional shim 용도로는 `fallback`을 쓸 것 (실패 시에만 적용).
-   * 예: `{ react: "preact/compat", "react-dom": "preact/compat" }` */
-  alias?: Record<string, string>;
+   * Array 형태는 build() 만 지원 (host RegExp 위임 — buildSync 미지원). */
+  alias?: Record<string, string> | Array<{ find: string | RegExp; replacement: string }>;
   /** Fallback resolution — 일반 해석이 **실패했을 때만** 적용됨 (webpack `resolve.fallback` / Metro `resolver.extraNodeModules` 호환).
    * 값이 문자열이면 해당 specifier로 재해석, `false`면 빈 모듈로 대체.
    * 예: `{ crypto: "crypto-browserify", fs: false }` */
@@ -993,12 +1001,48 @@ function createPluginDispatcher(plugins: ZtsPlugin[]) {
  * write/outdir는 JS에서 처리, plugins는 dispatcher로 변환되므로 제거.
  * target/outfile은 Zig가 파싱하므로 그대로 전달.
  */
+/**
+ * Array 형태 alias (Vite `resolve.alias`, #2153) 를 onResolve plugin 으로 변환.
+ * Zig native 는 array/RegExp alias 를 모르므로 host JS 에서 plugin hook 으로 위임 —
+ * #1579 require.context 가 host RegExp 에 위임하는 것과 동일 패턴.
+ *
+ * 매칭 순서: array 순서대로 첫 매치 사용 (Vite/Webpack 동일).
+ * - `find` 가 string 이면 exact + prefix 매칭 (`react` 매치는 `react/hooks` 도)
+ * - `find` 가 RegExp 이면 `String.prototype.replace` 로 치환 ($1 capture group 등)
+ */
+function arrayAliasToPlugin(
+  aliasArray: ReadonlyArray<{ find: string | RegExp; replacement: string }>,
+): ZtsPlugin {
+  return {
+    name: "zts:array-alias",
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        for (const { find, replacement } of aliasArray) {
+          if (find instanceof RegExp) {
+            // `String.search` 는 RegExp.test 와 달리 `g`/`y` flag 의 lastIndex 를
+            // mutate 하지 않는다 — 같은 alias entry 가 여러 import 에 반복 적용돼도 안전.
+            if (args.path.search(find) !== -1) {
+              return { path: args.path.replace(find, replacement) };
+            }
+          } else if (args.path === find || args.path.startsWith(find + "/")) {
+            return { path: args.path.replace(find, replacement) };
+          }
+        }
+        return null;
+      });
+    },
+  };
+}
+
 function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   const napiOptions: Record<string, unknown> = { ...options };
   delete napiOptions.write;
   delete napiOptions.outdir;
   delete napiOptions.plugins;
   delete napiOptions.allowOverwrite;
+  // Array 형태 alias 는 plugin 으로 위임 (build() 에서 처리). NAPI 로 전달하면 Zig 가
+  // Record 형태만 받으므로 type mismatch — 명시 삭제.
+  if (Array.isArray(napiOptions.alias)) delete napiOptions.alias;
   // manualChunks 는 `_manualChunks` 전용 슬롯으로 재전달 (plugin dispatcher 패턴).
   // napi_entry.zig 가 TSFN 으로 감싸 Zig resolver 로 변환.
   delete napiOptions.manualChunks;
@@ -1112,7 +1156,12 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
 
   const napiOptions = prepareNapiOptions(options);
 
-  const dispatcher = options.plugins?.length ? createPluginDispatcher(options.plugins) : null;
+  // Array 형태 alias (#2153) — onResolve plugin 으로 변환해 user plugins 앞에 prepend.
+  // 다른 plugin 의 onResolve 보다 먼저 매칭되어 alias 치환이 우선 적용 (Vite 동작).
+  const arrayAlias = Array.isArray(options.alias) ? options.alias : null;
+  const userPlugins = options.plugins ?? [];
+  const allPlugins = arrayAlias ? [arrayAliasToPlugin(arrayAlias), ...userPlugins] : userPlugins;
+  const dispatcher = allPlugins.length ? createPluginDispatcher(allPlugins) : null;
   if (dispatcher) napiOptions._pluginDispatcher = dispatcher;
 
   if (dispatcher) await dispatcher("buildStart", options, null);
@@ -1145,6 +1194,12 @@ export function buildSync(options: BuildOptions): BuildResult {
   if (options.plugins?.length) {
     throw new Error(
       "@zts/core: plugins are only supported with build() (async). Use build() instead of buildSync().",
+    );
+  }
+  // Array 형태 alias 는 host RegExp 위임이 plugin hook 기반이라 buildSync 미지원.
+  if (Array.isArray(options.alias)) {
+    throw new Error(
+      "@zts/core: array-form alias (with RegExp / Vite-style) requires async build(). Use Record<string, string> form for buildSync, or call build() instead.",
     );
   }
 


### PR DESCRIPTION
## 요약
esbuild `alias` (Record 형태) 에 더해 **Vite `resolve.alias` array 형태** 지원 (#2153). RegExp find + capture group 치환 (`\$1`) 로 Vite/Webpack 사용자가 ZTS 이주 시 첫 충돌 지점 (`@/components` 패턴) 해소.

## API

```ts
build({
  alias: [
    // RegExp 매칭 + capture 치환 (Vite 식)
    { find: /^@\\/(.*)$/, replacement: "./src/\$1.ts" },
    // string find — exact + prefix 매칭 (esbuild 식)
    { find: "react", replacement: "preact/compat" },
  ],
});
```

기존 `alias: { "react": "preact/compat" }` Record 형태도 그대로 유지 (backward compat).

## 변경

**`packages/core/index.ts`**
- `BuildOptionsCommon.alias` 타입 union 확장 — `Record | Array<{find, replacement}>`
- `arrayAliasToPlugin(aliasArray)` helper — onResolve plugin 으로 변환
- `prepareNapiOptions`: array alias 면 NAPI 전송 전 삭제 (Zig 는 Record 만 받음)
- `build()`: array alias 감지 시 plugin 을 user plugins **앞에 prepend** (Vite 동작 — alias 가 다른 plugin 보다 먼저)
- `buildSync()`: array alias 면 명시적 throw — host RegExp 위임이 plugin hook 기반이라 동기 실행 불가

**Zig 측 변경 0줄** — host JS 가 plugin 으로 위임 (#1579 require.context 의 host RegExp 위임 패턴 모방).

## /simplify 결과
- ✅ **RegExp `g`/`y` flag `lastIndex` 부작용 회피** — `find.test()` → `args.path.search(find) !== -1`. g flag regex 회귀 테스트 추가
- 의도된 design (skip): plugin prepend 위치 (Vite 동작), buildSync throw, string prefix 매칭 (esbuild 호환), 함수형 alias 미지원

**Follow-up #2169** — array alias 를 native (Zig) resolver 로 직접 처리. TSFN dispatcher overhead 제거. \`--timing\` 측정 후 진행 (\`feedback_measure_before_optimize\` 원칙).

## 검증 — 통합 테스트 5개
- string find exact 매칭
- RegExp find + capture group (\`\$1\`) 치환
- 매칭 순서 (첫 번째 매치 적용)
- `g` flag regex 의 여러 import 안전 처리 (lastIndex 부작용 회귀 lock)
- buildSync 에서 명시적 throw

## 검증 — 빌드/린트
- `bun test packages/core/` → 321/321 pass (5 new + 316 기존)
- `zig build test` → 4074/4074 pass
- schema-sync (alias union type 변경 영향) → 29/29 pass
- `bun run lint` / `fmt` → 0 warnings

Closes #2153
Refs #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)