### PR TITLE
fix(bundler): reduce dotenv and toolkit bundle output

### DIFF
--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -595,6 +595,37 @@ test "JSON import: named exports + default export coexist" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"test\"") != null);
 }
 
+test "JSON require: CJS consumer emits default object without duplicate named exports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.cjs",
+        \\const version = require('./package.json').version;
+        \\console.log(version);
+    );
+    try writeFile(tmp.dir, "package.json",
+        \\{
+        \\  "name": "fixture",
+        \\  "version": "1.2.3",
+        \\  "scripts": { "test": "zts" },
+        \\  "devDependencies": { "zts": "workspace:*" }
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.cjs");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "version") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports.name") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports.scripts") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports.devDependencies") == null);
+}
+
 test "JSON import: non-object JSON has no named exports" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -4115,6 +4115,43 @@ test "TreeShaking: object literal method with impure computed key is preserved" 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "OBJECT_METHOD_COMPUTED_KEY_EFFECT") != null);
 }
 
+test "TreeShaking: unused pure computed object key initializer is pruned" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from './toolkit-pattern';
+        \\console.log(used);
+    );
+    try writeFile(tmp.dir, "toolkit-pattern.ts",
+        \\function nanoid() {
+        \\  return 'TOOLKIT_NANOID_SHOULD_DROP';
+        \\}
+        \\function createAsyncThunk() {
+        \\  return nanoid();
+        \\}
+        \\var asyncThunkSymbol = /* @__PURE__ */ Symbol.for("rtk-slice-createasyncthunk");
+        \\var asyncThunkCreator = { [asyncThunkSymbol]: createAsyncThunk };
+        \\export const used = 'TOOLKIT_USED_MARKER';
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TOOLKIT_USED_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TOOLKIT_NANOID_SHOULD_DROP") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "createAsyncThunk") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "asyncThunkCreator") == null);
+}
+
 // minimatch 회귀: TS 가 self-referential 클래스용으로 emit 하는 `var _a; class AST {...}; _a = AST;`
 // 패턴에서 후속 비선언 할당이 살아남아야 한다. 도달성 BFS 가 read 만 따르고 writer 엣지를 무시하면
 // `_a` 가 undefined 인 채로 클래스 메서드가 `new _a()` 호출 → "_a is not a constructor".

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1492,6 +1492,7 @@ pub fn emitModule(
         .module_format = if (module.wrap_kind.isWrapped()) .cjs else .esm,
         // __esm 모듈: exports.x/module.exports 생성 억제 (__export()가 대신 처리)
         .skip_cjs_exports = module.wrap_kind == .esm,
+        .skip_cjs_named_export_decls = module.module_type == .json and module.wrap_kind == .cjs,
         // __esm 모듈: const → var (TDZ 방지)
         .use_var_for_imports = module.wrap_kind == .esm,
         .linking_metadata = if (metadata) |*m| m else null,

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -5,7 +5,7 @@
 //!
 //! 판정 기준 (esbuild/rolldown 동일):
 //!   - 리터럴, 식별자 참조, 함수/arrow 표현식 → 순수
-//!   - 객체/배열 리터럴 → 원소가 모두 순수이면 순수 (computed key, spread 제외)
+//!   - 객체/배열 리터럴 → 원소가 모두 순수이면 순수 (computed key는 key/value 모두 순수할 때 허용, spread 제외)
 //!   - 삼항/이항/논리/단항 → 재귀 검사 (delete 제외)
 //!   - 멤버 접근 → 순수 (getter side effect는 실전에서 극히 드물어 무시, esbuild 동일)
 //!   - @__PURE__ call/new → 순수
@@ -430,10 +430,8 @@ fn isObjectPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalR
         switch (prop.tag) {
             .object_property => {
                 const key_idx = prop.data.binary.left;
-                if (!key_idx.isNone() and @intFromEnum(key_idx) < ast.nodes.items.len) {
-                    if (ast.nodes.items[@intFromEnum(key_idx)].tag == .computed_property_key) return false;
-                }
-                if (!isExprPureDepth(ast, prop.data.binary.right, unresolved_globals, depth)) return false;
+                if (computedObjectPropertyKeyHasSideEffects(ast, key_idx, unresolved_globals, depth)) return false;
+                if (!isExprPureDepth(ast, Ast.objectPropertyValue(prop), unresolved_globals, depth)) return false;
             },
             .method_definition => {
                 if (objectMethodHasSideEffects(ast, prop, unresolved_globals)) return false;
@@ -452,6 +450,18 @@ fn objectMethodHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?
     // Object literal methods/getters/setters create function values. Their params/body
     // are not evaluated while the object itself is constructed.
     return ast.extra_data.items[e + ast_mod.MethodExtra.deco_len] > 0;
+}
+
+fn computedObjectPropertyKeyHasSideEffects(
+    ast: *const Ast,
+    key_idx: NodeIndex,
+    unresolved_globals: ?*const GlobalRefSet,
+    depth: u32,
+) bool {
+    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return false;
+    const key_node = ast.nodes.items[@intFromEnum(key_idx)];
+    if (key_node.tag != .computed_property_key) return false;
+    return !isExprPureDepth(ast, key_node.data.unary.operand, unresolved_globals, depth);
 }
 
 fn isArrayPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalRefSet, depth: u32) bool {

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -250,6 +250,37 @@ test "pure builtin: spread arg blocks pure classification" {
     try std.testing.expect(!purity.isExprPure(&ctx.ast, init, &ctx.analyzer.unresolved_references));
 }
 
+test "object literal: pure computed key and pure value are pure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const key = Symbol();
+        \\const value = 1;
+        \\const obj = { [key]: value };
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 2, true);
+}
+
+test "object literal: impure computed key or value stays impure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const key = Symbol();
+        \\const a = { [sideEffect()]: 1 };
+        \\const b = { [key]: sideEffect() };
+        \\const c = { ...source };
+        \\const d = { [sideEffect()]() { return 1; } };
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 1, false);
+    try expectPure(&ctx, 2, false);
+    try expectPure(&ctx, 3, false);
+    try expectPure(&ctx, 4, false);
+}
+
 // ================================================================
 // Collection constructor — oxc-style strict rule (#1567 Phase A refinement)
 // ================================================================

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -99,6 +99,9 @@ pub const CodegenOptions = struct {
     /// __esm 래핑 모듈: CJS export 출력 억제 (exports.x, module.exports).
     /// __esm 모듈의 export는 emitter의 __export()가 처리하므로 codegen에서 생성하면 안 됨.
     skip_cjs_exports: bool = false,
+    /// JSON을 CJS require()로 소비할 때 synthetic named export declarations를 생략.
+    /// default object는 `module.exports = {...}`로 유지한다.
+    skip_cjs_named_export_decls: bool = false,
     /// 번들 모드에서 ESM이 아닐 때 import.meta → {} 치환 (esbuild 호환)
     replace_import_meta: bool = false,
     /// 타겟 플랫폼. import.meta polyfill 방식을 결정한다.
@@ -3123,6 +3126,8 @@ pub const Codegen = struct {
     /// CJS: export { foo } → exports.foo=foo;
     /// CJS: export { foo, default as Bar } from './bar' → exports.foo=require("./bar").foo;exports.Bar=require("./bar").default;
     fn emitExportNamedCJS(self: *Codegen, decl: NodeIndex, specs_start: u32, specs_len: u32, source: NodeIndex) !void {
+        if (self.options.skip_cjs_named_export_decls) return;
+
         if (!decl.isNone() and @intFromEnum(decl) < self.ast.nodes.items.len) {
             // export const x = 1 → const x=1; (+ exports.x=x; unless __esm)
             try self.emitNode(decl);


### PR DESCRIPTION
## 요약
- JSON을 CJS require()로 소비할 때 synthetic named export declarations를 생략해 package.json 객체 중복 출력을 제거합니다.
- object literal purity에서 pure computed key + pure value 케이스를 pure로 판정해 미사용 Redux Toolkit createAsyncThunk 경로가 제거되도록 합니다.
- ESM JSON named import 동작은 유지합니다.

## 테스트
- `zig build test`
- `zig build test -Dtest-filter="JSON require"`
- `zig build test -Dtest-filter="unused pure computed object key"`
- `zig build -Doptimize=ReleaseFast`
- `bun run tests/benchmark/smoke.ts --filter=dotenv --keep-output=/tmp/zts-size-fix/outputs --json=/tmp/zts-size-fix/dotenv.json`
- `bun run tests/benchmark/smoke.ts --filter=toolkit --keep-output=/tmp/zts-size-fix/outputs --json=/tmp/zts-size-fix/toolkit.json`

## 벤치마크 확인
- dotenv: ZTS 12000 bytes, rolldown 대비 0.99x, output MATCH
- toolkit: ZTS 32349 bytes, rolldown 대비 0.95x, output MATCH
- dotenv 산출물에서 `exports.name`, `exports.scripts`, `exports.devDependencies` 없음 확인
- toolkit 산출물에서 `createAsyncThunk`, `nanoid`, `asyncThunkCreator` 없음 확인