### PR TITLE
refactor(bundler): consolidate computed key purity helper, sharpen tests

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -4177,19 +4177,19 @@ test "TreeShaking: unused pure computed object key initializer is pruned" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",
-        \\import { used } from './toolkit-pattern';
+        \\import { used } from './computed-key';
         \\console.log(used);
     );
-    try writeFile(tmp.dir, "toolkit-pattern.ts",
-        \\function nanoid() {
-        \\  return 'TOOLKIT_NANOID_SHOULD_DROP';
+    try writeFile(tmp.dir, "computed-key.ts",
+        \\function makeId() {
+        \\  return 'COMPUTED_KEY_INIT_SHOULD_DROP';
         \\}
-        \\function createAsyncThunk() {
-        \\  return nanoid();
+        \\function makeFactory() {
+        \\  return makeId();
         \\}
-        \\var asyncThunkSymbol = /* @__PURE__ */ Symbol.for("rtk-slice-createasyncthunk");
-        \\var asyncThunkCreator = { [asyncThunkSymbol]: createAsyncThunk };
-        \\export const used = 'TOOLKIT_USED_MARKER';
+        \\var keySymbol = /* @__PURE__ */ Symbol.for("computed-key-test");
+        \\var unusedHolder = { [keySymbol]: makeFactory };
+        \\export const used = 'COMPUTED_KEY_USED_MARKER';
     );
 
     const entry = try absPath(&tmp, "entry.ts");
@@ -4204,10 +4204,10 @@ test "TreeShaking: unused pure computed object key initializer is pruned" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "TOOLKIT_USED_MARKER") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "TOOLKIT_NANOID_SHOULD_DROP") == null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "createAsyncThunk") == null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "asyncThunkCreator") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "COMPUTED_KEY_USED_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "COMPUTED_KEY_INIT_SHOULD_DROP") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "makeFactory") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "unusedHolder") == null);
 }
 
 // minimatch 회귀: TS 가 self-referential 클래스용으로 emit 하는 `var _a; class AST {...}; _a = AST;`

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -430,7 +430,7 @@ fn isObjectPure(ast: *const Ast, node: Node, unresolved_globals: ?*const GlobalR
         switch (prop.tag) {
             .object_property => {
                 const key_idx = prop.data.binary.left;
-                if (computedObjectPropertyKeyHasSideEffects(ast, key_idx, unresolved_globals, depth)) return false;
+                if (computedKeyNodeHasSideEffects(ast, key_idx, unresolved_globals, depth)) return false;
                 if (!isExprPureDepth(ast, Ast.objectPropertyValue(prop), unresolved_globals, depth)) return false;
             },
             .method_definition => {
@@ -452,7 +452,7 @@ fn objectMethodHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?
     return ast.extra_data.items[e + ast_mod.MethodExtra.deco_len] > 0;
 }
 
-fn computedObjectPropertyKeyHasSideEffects(
+fn computedKeyNodeHasSideEffects(
     ast: *const Ast,
     key_idx: NodeIndex,
     unresolved_globals: ?*const GlobalRefSet,
@@ -647,12 +647,7 @@ pub fn classHasSideEffects(ast: *const Ast, node: Node, unresolved_globals: ?*co
 fn computedKeyHasSideEffects(ast: *const Ast, extra_offset: u32, unresolved_globals: ?*const GlobalRefSet) bool {
     if (extra_offset >= ast.extra_data.items.len) return true;
     const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_offset]);
-    if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return false;
-    const key_node = ast.nodes.items[@intFromEnum(key_idx)];
-    if (key_node.tag == .computed_property_key) {
-        return !isExprPureDepth(ast, key_node.data.unary.operand, unresolved_globals, 0);
-    }
-    return false;
+    return computedKeyNodeHasSideEffects(ast, key_idx, unresolved_globals, 0);
 }
 
 /// expression 이 **Symbol 값** 일 가능성이 있는지 정적 판정. 보수적 — 확실히 아니면 false,

--- a/src/bundler/purity_test.zig
+++ b/src/bundler/purity_test.zig
@@ -263,22 +263,49 @@ test "object literal: pure computed key and pure value are pure" {
     try expectPure(&ctx, 2, true);
 }
 
-test "object literal: impure computed key or value stays impure" {
+test "object literal: impure computed key is impure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const obj = { [sideEffect()]: 1 };
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 0, false);
+}
+
+test "object literal: impure value with pure computed key is impure" {
     const alloc = std.testing.allocator;
     const src =
         \\const key = Symbol();
-        \\const a = { [sideEffect()]: 1 };
-        \\const b = { [key]: sideEffect() };
-        \\const c = { ...source };
-        \\const d = { [sideEffect()]() { return 1; } };
+        \\const obj = { [key]: sideEffect() };
     ;
     var ctx = try setup(alloc, src);
     defer ctx.deinit();
 
     try expectPure(&ctx, 1, false);
-    try expectPure(&ctx, 2, false);
-    try expectPure(&ctx, 3, false);
-    try expectPure(&ctx, 4, false);
+}
+
+test "object literal: spread element is impure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const obj = { ...source };
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 0, false);
+}
+
+test "object literal: method with impure computed key is impure" {
+    const alloc = std.testing.allocator;
+    const src =
+        \\const obj = { [sideEffect()]() { return 1; } };
+    ;
+    var ctx = try setup(alloc, src);
+    defer ctx.deinit();
+
+    try expectPure(&ctx, 0, false);
 }
 
 // ================================================================


### PR DESCRIPTION
## Summary
- #2171 머지 후속 cleanup. `/simplify` 리뷰에서 발견된 3가지를 정리.
- `computedObjectPropertyKeyHasSideEffects` 가 기존 `computedKeyHasSideEffects` 와 사실상 같은 검사를 수행하던 중복을 제거 — 공통 inner 헬퍼 `computedKeyNodeHasSideEffects(NodeIndex, depth)` 로 통합. class-member 경로의 기존 `computedKeyHasSideEffects` 는 thin shim 으로 남겨 호출처 변경 없음.
- `purity_test.zig` 의 4-in-1 테스트(`impure computed key or value stays impure`)를 4개 narrow 테스트로 분할 — 주변 컨벤션과 일치, 실패 시 어떤 케이스가 깨졌는지 즉시 식별.
- `tree_shake.zig` 의 incident-bound 픽스처 명명(`toolkit-pattern.ts`/`TOOLKIT_*`/`createAsyncThunk`/`asyncThunkSymbol`)을 패턴-기반(`computed-key.ts`/`COMPUTED_KEY_*`/`makeFactory`/`keySymbol`/`unusedHolder`)으로 교체.

## Test plan
- [x] `zig build test` 통과
- [x] `purity_test.zig` 의 신규 4개 narrow 테스트 통과 (`impure computed key`, `impure value with pure computed key`, `spread element`, `method with impure computed key`)
- [x] `tree_shake.zig` 의 `unused pure computed object key initializer is pruned` 통과 (이름만 변경, 동작 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)