### PR TITLE
fix(docs): make markdown tables responsive

### DIFF
--- a/documents/src/styles/custom.css
+++ b/documents/src/styles/custom.css
@@ -73,13 +73,16 @@ starlight-toc a {
 }
 
 .sl-markdown-content table {
-  display: table;
+  display: block;
   width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
   border-collapse: separate;
   border-spacing: 0;
   border: 1px solid var(--sl-color-gray-5);
   border-radius: 0.375rem;
-  overflow: hidden;
   font-size: 0.875rem;
 }
 


### PR DESCRIPTION
## 요약
- 문서 본문 표를 block scroll 컨테이너로 되돌려 모바일에서 페이지 전체 가로 overflow가 생기지 않게 수정했습니다.
- 기존 테이블 테두리/라운드 스타일은 유지하면서 표 내부에서만 가로 스크롤되도록 했습니다.

## 검증
- `cd documents && bun run build`
- `/zts/reference/options/` 모바일 폭 스크린샷으로 표가 본문 폭 안에 머무는 것 확인