### PR TITLE
feat(bundle): output.exports — auto / named / default / none

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -96,6 +96,8 @@ export const FLAG_REGISTRY = [
   },
   { kind: "string", flag: "--rn-platform", target: "rnPlatform", forms: ["equal"] },
   { kind: "string", flag: "--source-root", target: "sourceRoot", forms: ["equal"] },
+  // #2159 — `--output-exports=auto|named|default|none` (Rollup output.exports 호환).
+  { kind: "string", flag: "--output-exports", target: "outputExports", forms: ["equal"] },
   { kind: "string", flag: "--banner", target: "banner", forms: ["equal"] },
   { kind: "string", flag: "--footer", target: "footer", forms: ["equal"] },
 

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -75,6 +75,8 @@ function parseArgs(argv) {
     sourcemap: false,
     // undefined: NAPI 측이 missing 시 "linked" fallback. CLI/config 명시 시 override.
     sourcemapMode: undefined,
+    // undefined: NAPI 측이 missing 시 "auto" fallback (#2159).
+    outputExports: undefined,
     sourcemapDebugIds: false,
     sourcesContent: true,
     splitting: false,
@@ -488,6 +490,7 @@ function mergeConfigIntoOpts(opts, config) {
     "jobs",
     "logLevel",
     "logLimit",
+    "outputExports",
     "outExtensionJs",
     "metafile",
     "outfile",
@@ -623,6 +626,7 @@ async function runBundle(opts, config) {
     legalComments: opts.legalComments,
     logLevel: opts.logLevel,
     logLimit: opts.logLimit,
+    outputExports: opts.outputExports,
     resolveExtensions: opts.resolveExtensions.length > 0 ? opts.resolveExtensions : undefined,
     mainFields: opts.mainFields.length > 0 ? opts.mainFields : undefined,
     // NAPI 가 tsconfig paths / baseUrl 을 alias 로 변환해 resolver 에 주입하도록 전달.

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1512,6 +1512,130 @@ describe("@zts/core define/alias", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // ─── #2159 outputExports — Rollup output.exports 호환 ─────────────────────
+  test("outputExports='auto' default-only → module.exports = X", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-output-exports-auto-default-"));
+    writeFileSync(join(dir, "index.ts"), 'const x = "AUTO_DEFAULT_ONLY";\nexport default x;');
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      format: "cjs",
+      outputExports: "auto",
+    });
+    expect(result.errors.length).toBe(0);
+    const text = result.outputFiles[0].text;
+    expect(text).toContain("module.exports = ");
+    expect(text).not.toContain("__esModule");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("outputExports='auto' named-only → exports.X = X (no esModule flag)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-output-exports-auto-named-"));
+    writeFileSync(join(dir, "index.ts"), 'export const a = 1;\nexport const b = "AUTO_NAMED";');
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      format: "cjs",
+      outputExports: "auto",
+    });
+    expect(result.errors.length).toBe(0);
+    const text = result.outputFiles[0].text;
+    expect(text).toContain("exports.a = ");
+    expect(text).toContain("exports.b = ");
+    expect(text).not.toContain("__esModule");
+    expect(text).not.toContain("module.exports = ");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("outputExports='auto' mixed → exports.X + esModule flag", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-output-exports-auto-mixed-"));
+    writeFileSync(
+      join(dir, "index.ts"),
+      'export const a = "AUTO_MIXED_NAMED";\nexport default { x: "AUTO_MIXED_DEFAULT" };',
+    );
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      format: "cjs",
+      outputExports: "auto",
+    });
+    expect(result.errors.length).toBe(0);
+    const text = result.outputFiles[0].text;
+    expect(text).toContain("exports.a = ");
+    expect(text).toContain("exports.default = ");
+    expect(text).toContain("__esModule");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("outputExports='named' default-only → exports.default + esModule flag", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-output-exports-named-"));
+    writeFileSync(join(dir, "index.ts"), 'const x = "NAMED_DEFAULT";\nexport default x;');
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      format: "cjs",
+      outputExports: "named",
+    });
+    expect(result.errors.length).toBe(0);
+    const text = result.outputFiles[0].text;
+    expect(text).toContain("exports.default = ");
+    expect(text).toContain("__esModule");
+    expect(text).not.toContain("module.exports = ");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("outputExports='default' default-only → module.exports = X", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-output-exports-default-"));
+    writeFileSync(join(dir, "index.ts"), 'const x = "DEFAULT_MODE";\nexport default x;');
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      format: "cjs",
+      outputExports: "default",
+    });
+    expect(result.errors.length).toBe(0);
+    const text = result.outputFiles[0].text;
+    expect(text).toContain("module.exports = ");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("outputExports='default' + named 섞이면 result.errors 에 명시 진단", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-output-exports-conflict-"));
+    writeFileSync(
+      join(dir, "index.ts"),
+      'export const a = 1;\nexport default { x: "ALSO_HAS_DEFAULT" };',
+    );
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      format: "cjs",
+      outputExports: "default",
+    });
+    // graph diagnostic 으로 emit — std.log.warn 임시방편 X.
+    expect(result.errors.length).toBeGreaterThan(0);
+    const errMsg = result.errors[0].text;
+    expect(errMsg).toContain("output.exports");
+    expect(errMsg).toContain("default-only");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("outputExports='none' → 모든 export 출력 안 함", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-output-exports-none-"));
+    writeFileSync(join(dir, "index.ts"), "export const a = 1;\nexport default { x: 2 };");
+
+    const result = await build({
+      entryPoints: [join(dir, "index.ts")],
+      format: "cjs",
+      outputExports: "none",
+    });
+    expect(result.errors.length).toBe(0);
+    const text = result.outputFiles[0].text;
+    expect(text).not.toContain("module.exports = ");
+    expect(text).not.toContain("exports.a");
+    expect(text).not.toContain("exports.default");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   // ─── #2158 logLevel / logLimit NAPI 필터링 ─────────────────────────────────
   // unresolved import 은 ZTS 에서 errors 로 분류 (worker / optional 만 warnings).
   // 따라서 errors 검증 위주로 logLevel/logLimit 동작 확인.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -458,6 +458,17 @@ interface BuildOptionsCommon {
    * errors / warnings 각 배열에 동일 limit 적용 — 초과 항목은 자동 truncate.
    */
   logLimit?: number;
+  /**
+   * CJS / UMD entry export 형식 (Rollup `output.exports` 호환, #2159). ESM 출력에서는 무시.
+   *
+   *  - `"auto"` (default): default-only → `module.exports = X`. named-only → `exports.X = X`
+   *    (no `__esModule` flag). mixed → `exports.X = X` + `__esModule` flag.
+   *  - `"named"`: 항상 named (`exports.X = X`). default 있으면 `__esModule` flag 자동 추가
+   *    (rolldown `IfDefaultProp` 동작 — default 없을 때는 flag 없음).
+   *  - `"default"`: `module.exports = X` 단일 — default-only 일 때만. named 섞이면 warning + 빈 출력.
+   *  - `"none"`: export 출력 안 함.
+   */
+  outputExports?: "auto" | "named" | "default" | "none";
   /** tsconfig.json 인라인 JSON 오버라이드 */
   tsconfigRaw?: string;
   /**

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -263,6 +263,16 @@ fn parseLogFilterOptions(env: c.napi_env, obj: c.napi_value) LogFilterOptions {
     };
 }
 
+/// `outputExports` 옵션 (#2159) — `"auto"` / `"named"` / `"default"` / `"none"`.
+/// 미지정 또는 invalid 면 `.auto` (Rollup default).
+fn parseOutputExports(env: c.napi_env, obj: c.napi_value) bundler_mod.OutputExports {
+    var buf: [16]u8 = undefined;
+    const val = getNamedProperty(env, obj, "outputExports") orelse return .auto;
+    var len: usize = 0;
+    if (c.napi_get_value_string_utf8(env, val, &buf, buf.len, &len) != c.napi_ok) return .auto;
+    return bundler_mod.OutputExports.fromString(buf[0..len]) orelse .auto;
+}
+
 /// JS 배열 값을 문자열 슬라이스로 변환. (key 없이 직접 배열 값을 받는 버전)
 /// 빈 배열은 명시적으로 빈 slice 반환 (caller 가 "0개" 와 "invalid" 를 구분 가능).
 fn parseStringArray(env: c.napi_env, val: c.napi_value, alloc: std.mem.Allocator) ?[]const []const u8 {
@@ -3270,6 +3280,8 @@ fn parseBuildOptions(
         // #2155: bundle 모드에도 transpile 동일 drop console/debugger 적용.
         .drop_console = getObjectBool(env, opts_obj, "dropConsole", false),
         .drop_debugger = getObjectBool(env, opts_obj, "dropDebugger", false),
+        // #2159: CJS / UMD entry export 형식 — auto / named / default / none.
+        .output_exports = parseOutputExports(env, opts_obj),
         .pure = pure orelse &.{},
         .tsconfig_raw = tsconfig_raw,
         .node_paths = node_paths orelse &.{},

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -140,6 +140,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   "preserveSymlinks",
   // ─── Bundle 출력 ───
   "splitting",
+  "outputExports",
   "preserveModules",
   "preserveModulesRoot",
   "inlineDynamicImports",

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -59,6 +59,32 @@ pub const RN_DEFAULT_BLOCK_LIST: []const []const u8 = &.{
     "\\/__fixtures__\\/",
 };
 
+/// CJS / UMD 출력 시 entry export 형식 — Rollup `output.exports` 호환 (#2159).
+///
+///  - `auto` (default): default-only → `module.exports = X` 단일, named-only → `exports.X = X`,
+///                       mixed → 양쪽 + `__esModule` flag (interop)
+///  - `named`         : 항상 named (`exports.X = X` + `__esModule` flag if has default)
+///  - `default_`      : `module.exports = X` 단일 — default-only 일 때만, named 섞이면 에러
+///  - `none`          : export 출력 안 함
+///
+/// ESM 출력에서는 무시 (`export { ... }` 그대로 emit). `default_` trailing underscore 는 Zig keyword 회피.
+pub const OutputExports = enum {
+    auto,
+    named,
+    default_,
+    none,
+
+    /// CLI / NAPI string 입력을 enum 으로 변환. invalid 면 null.
+    /// `default` ↔ `.default_` 매핑은 Zig keyword 회피 (`SourceMapMode.inline_` 동일 패턴).
+    pub fn fromString(s: []const u8) ?OutputExports {
+        if (std.mem.eql(u8, s, "auto")) return .auto;
+        if (std.mem.eql(u8, s, "named")) return .named;
+        if (std.mem.eql(u8, s, "default")) return .default_;
+        if (std.mem.eql(u8, s, "none")) return .none;
+        return null;
+    }
+};
+
 pub const BundleOptions = struct {
     entry_points: []const []const u8,
     format: EmitOptions.Format = .esm,
@@ -257,6 +283,8 @@ pub const BundleOptions = struct {
     drop_console: bool = false,
     /// `--drop=debugger` (#2155). `debugger;` statement 를 transformer 에서 제거.
     drop_debugger: bool = false,
+    /// CJS / UMD entry export 출력 형식 (#2159). ESM 출력에서는 무시.
+    output_exports: OutputExports = .auto,
     /// --pure:NAME: 순수 함수로 마킹할 글로벌 함수명 목록
     pure: []const []const u8 = &.{},
     /// --tsconfig-raw: tsconfig.json 인라인 오버라이드 JSON
@@ -523,6 +551,7 @@ pub const Bundler = struct {
             .unsupported = base.unsupported,
             .keep_names = base.keep_names,
             .drop_labels = base.drop_labels,
+            .output_exports = self.options.output_exports,
             .jsx_runtime = base.jsx_runtime,
             .jsx_factory = base.jsx_factory,
             .jsx_fragment = base.jsx_fragment,

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -90,7 +90,7 @@ pub const InputHasher = struct {
 /// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
 /// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
 /// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
-const expected_emit_options_field_count: usize = 48;
+const expected_emit_options_field_count: usize = 49;
 
 comptime {
     const actual = @typeInfo(EmitOptions).@"struct".fields.len;
@@ -155,6 +155,7 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addU32(@intFromEnum(options.legal_comments));
     h.addBool(options.keep_names);
     h.addStrList(options.drop_labels);
+    h.addU32(@intFromEnum(options.output_exports));
     h.addU32(@intFromEnum(options.jsx_runtime));
     h.addStr(options.jsx_factory);
     h.addStr(options.jsx_fragment);

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -53,6 +53,7 @@ const plugin_mod = @import("plugin.zig");
 const external_imports = @import("emitter/external_imports.zig");
 const purity = @import("purity.zig");
 const TokenKind = @import("../lexer/token.zig").Kind;
+const Span = @import("../lexer/token.zig").Span;
 const semantic_symbol = @import("../semantic/symbol.zig");
 const Reference = semantic_symbol.Reference;
 const Symbol = semantic_symbol.Symbol;
@@ -133,6 +134,8 @@ pub const EmitOptions = struct {
     keep_names: bool = false,
     /// --drop-labels: 특정 라벨의 labeled statement 제거
     drop_labels: []const []const u8 = &.{},
+    /// CJS / UMD entry export 출력 형식 (#2159). ESM 에서는 무시.
+    output_exports: @import("bundler.zig").OutputExports = .auto,
     /// JSX 런타임 모드
     jsx_runtime: @import("../codegen/codegen.zig").JsxRuntime = .classic,
     /// classic 모드 JSX factory
@@ -1651,6 +1654,9 @@ pub fn emitModule(
     var wrapped_return_buf: ?[]const u8 = null;
     defer if (wrapped_return_buf) |buf| allocator.free(buf);
 
+    var cjs_exports_buf: ?[]const u8 = null;
+    defer if (cjs_exports_buf) |buf| allocator.free(buf);
+
     const final_exports = if (raw_final_exports) |fe| blk: {
         if (options.format.isWrappedFormat()) {
             if (options.format != .iife or options.global_name != null) {
@@ -1663,7 +1669,18 @@ pub fn emitModule(
             break :blk @as(?[]const u8, null);
         }
         if (options.format == .cjs) {
-            break :blk @as(?[]const u8, null);
+            // #2159: ESM `export { ... };` 를 CJS 의 `module.exports` / `exports.X` 형태로 변환.
+            // mode 별 분기 (auto/named/default_/none) 는 emitCjsEntryExports 에서 결정.
+            cjs_exports_buf = emitCjsEntryExports(allocator, fe, options.output_exports) catch |err| switch (err) {
+                error.OutputExportsDefaultRequiresSingleDefault => {
+                    // default mode 인데 named 섞임 — Rollup 도 동일 케이스 throw.
+                    // graph diagnostic 으로 emit (result.errors 노출, 사용자 fail-fast).
+                    if (linker) |l| try emitOutputExportsConflictDiag(l, module.path, options.output_exports);
+                    break :blk @as(?[]const u8, null);
+                },
+                else => return err,
+            };
+            break :blk cjs_exports_buf;
         }
         break :blk fe;
     } else null;
@@ -1690,6 +1707,172 @@ pub fn emitModule(
 
     // arena 해제 전에 복사 (caller 소유)
     return try allocator.dupe(u8, code);
+}
+
+// --- #2159 output.exports CJS 변환 ---
+
+const OutputExports = @import("bundler.zig").OutputExports;
+
+/// `output.exports = "default"` + named 섞인 케이스를 graph diagnostic 으로 emit (#2159).
+/// pending_diagnostics 와 동일하게 linker 의 `fatal_diagnostics` 에 append — `result.errors`
+/// 에 노출되어 사용자가 fail-fast 가능 (Rollup 도 동일 케이스 throw).
+fn emitOutputExportsConflictDiag(
+    linker: *const Linker,
+    module_path: []const u8,
+    mode: OutputExports,
+) !void {
+    const linker_mut = @constCast(linker);
+    linker_mut.diagnostics_mutex.lock();
+    defer linker_mut.diagnostics_mutex.unlock();
+    const msg = try std.fmt.allocPrint(
+        linker.allocator,
+        "output.exports=\"{s}\" requires default-only entry, but named exports are present (use 'auto' or 'named' instead)",
+        .{@tagName(mode)},
+    );
+    try linker_mut.fatal_diagnostics.append(linker.allocator, .{
+        .code = .output_exports_conflict,
+        .severity = .@"error",
+        .message = msg,
+        .file_path = try linker.allocator.dupe(u8, module_path),
+        .span = Span.EMPTY,
+        .step = .emit,
+    });
+}
+
+/// ESM `export { local, local2 as exported, default_local as default };\n` 를 CJS 출력으로 변환.
+/// mode 별 emit 분기:
+///   auto    : default-only → `module.exports = X`, named-only → `exports.X = X`, mixed → 양쪽 + esModule
+///   named   : 항상 named (`exports.X = X`) + esModule (default 있으면)
+///   default_: default-only 만 — `module.exports = X`. named 섞이면 error.
+///   none    : 빈 출력
+///
+/// caller-owned slice 반환. 빈 결과는 빈 string (null 아님 — caller 가 final_exports 자리에 넣음).
+fn emitCjsEntryExports(
+    allocator: std.mem.Allocator,
+    esm_export_str: []const u8,
+    mode: OutputExports,
+) ![]const u8 {
+    if (mode == .none) return try allocator.dupe(u8, "");
+
+    // ESM 형태 strip — `export { ... };\n` 의 `{` 와 `};` 사이 본문만.
+    // linker (linker/metadata.zig:buildFinalExports) 가 이 형식을 보장. mismatch 시
+    // debug assert 가 회귀 catch (release 는 silent fallback 으로 빈 출력).
+    const open = std.mem.indexOfScalar(u8, esm_export_str, '{') orelse return try allocator.dupe(u8, "");
+    const close = std.mem.lastIndexOfScalar(u8, esm_export_str, '}') orelse return try allocator.dupe(u8, "");
+    std.debug.assert(open < close);
+    if (close <= open + 1) return try allocator.dupe(u8, "");
+    const body = std.mem.trim(u8, esm_export_str[open + 1 .. close], " \t\n");
+
+    // entries 파싱 — `, ` 분리 → 각 entry `local` 또는 `local as exported`.
+    var entries: std.ArrayListUnmanaged(struct { local: []const u8, exported: []const u8 }) = .empty;
+    defer entries.deinit(allocator);
+
+    var it = std.mem.splitScalar(u8, body, ',');
+    while (it.next()) |raw_entry| {
+        const entry = std.mem.trim(u8, raw_entry, " \t\n");
+        if (entry.len == 0) continue;
+        const as_idx = std.mem.indexOf(u8, entry, " as ");
+        const local = if (as_idx) |i| std.mem.trim(u8, entry[0..i], " \t") else entry;
+        const exported = if (as_idx) |i| std.mem.trim(u8, entry[i + 4 ..], " \t") else entry;
+        try entries.append(allocator, .{ .local = local, .exported = exported });
+    }
+
+    if (entries.items.len == 0) return try allocator.dupe(u8, "");
+
+    // default / named 분리
+    var default_local: ?[]const u8 = null;
+    var has_named = false;
+    for (entries.items) |e| {
+        if (std.mem.eql(u8, e.exported, "default")) {
+            default_local = e.local;
+        } else {
+            has_named = true;
+        }
+    }
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    switch (mode) {
+        .none => {},
+        .default_ => {
+            if (has_named or default_local == null) return error.OutputExportsDefaultRequiresSingleDefault;
+            try out.writer(allocator).print("module.exports = {s};\n", .{default_local.?});
+        },
+        .named => {
+            for (entries.items) |e| {
+                try out.writer(allocator).print("exports.{s} = {s};\n", .{ e.exported, e.local });
+            }
+            if (default_local != null) {
+                try out.appendSlice(allocator, "Object.defineProperty(exports, \"__esModule\", {value: true});\n");
+            }
+        },
+        .auto => {
+            if (default_local) |dl| {
+                if (!has_named) {
+                    // default-only → single module.exports
+                    try out.writer(allocator).print("module.exports = {s};\n", .{dl});
+                } else {
+                    // mixed — named 형태 + esModule flag
+                    for (entries.items) |e| {
+                        try out.writer(allocator).print("exports.{s} = {s};\n", .{ e.exported, e.local });
+                    }
+                    try out.appendSlice(allocator, "Object.defineProperty(exports, \"__esModule\", {value: true});\n");
+                }
+            } else {
+                // named-only — esModule flag 없음 (Rollup 기본 auto 동작)
+                for (entries.items) |e| {
+                    try out.writer(allocator).print("exports.{s} = {s};\n", .{ e.exported, e.local });
+                }
+            }
+        },
+    }
+
+    return try out.toOwnedSlice(allocator);
+}
+
+test "emitCjsEntryExports: auto mode default-only → module.exports" {
+    const out = try emitCjsEntryExports(std.testing.allocator, "export { x as default };\n", .auto);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("module.exports = x;\n", out);
+}
+
+test "emitCjsEntryExports: auto mode named-only → exports.X (no esModule)" {
+    const out = try emitCjsEntryExports(std.testing.allocator, "export { a, b };\n", .auto);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("exports.a = a;\nexports.b = b;\n", out);
+}
+
+test "emitCjsEntryExports: auto mode mixed → exports.X + esModule" {
+    const out = try emitCjsEntryExports(std.testing.allocator, "export { a, b as default };\n", .auto);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "exports.a = a;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "exports.default = b;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "__esModule") != null);
+}
+
+test "emitCjsEntryExports: named mode → 항상 named + esModule (default 있으면)" {
+    const out = try emitCjsEntryExports(std.testing.allocator, "export { x as default };\n", .named);
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "exports.default = x;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "__esModule") != null);
+}
+
+test "emitCjsEntryExports: default_ mode default-only → module.exports" {
+    const out = try emitCjsEntryExports(std.testing.allocator, "export { x as default };\n", .default_);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("module.exports = x;\n", out);
+}
+
+test "emitCjsEntryExports: default_ mode named 섞이면 error" {
+    const result = emitCjsEntryExports(std.testing.allocator, "export { a, b as default };\n", .default_);
+    try std.testing.expectError(error.OutputExportsDefaultRequiresSingleDefault, result);
+}
+
+test "emitCjsEntryExports: none mode → 빈 string" {
+    const out = try emitCjsEntryExports(std.testing.allocator, "export { a, b };\n", .none);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("", out);
 }
 
 // --- CJS wrap functions (emitter/cjs_wrap.zig) ---

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1733,7 +1733,9 @@ fn emitOutputExportsConflictDiag(
         .code = .output_exports_conflict,
         .severity = .@"error",
         .message = msg,
-        .file_path = try linker.allocator.dupe(u8, module_path),
+        // borrowed — module.path 가 owner. 다른 진단 사이트 (linker/metadata.zig) 와 일관.
+        // linker.fatal_diagnostics deinit 은 message 만 free 하므로 owned dupe 시 leak.
+        .file_path = module_path,
         .span = Span.EMPTY,
         .step = .emit,
     });

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -65,6 +65,7 @@ pub const ChunkKind = chunk.ChunkKind;
 pub const ChunkGraph = chunk.ChunkGraph;
 pub const Bundler = bundler_core.Bundler;
 pub const BundleOptions = bundler_core.BundleOptions;
+pub const OutputExports = bundler_core.OutputExports;
 pub const BundleResult = bundler_core.BundleResult;
 pub const RN_BOOL_PRESET = bundler_core.RN_BOOL_PRESET;
 pub const RN_DEFAULT_ASSET_REGISTRY = bundler_core.RN_DEFAULT_ASSET_REGISTRY;

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -607,6 +607,8 @@ pub const BundlerDiagnostic = struct {
         require_context_invalid,
         /// require.context 매칭 핸들러 미구현 (host plugin resolveContext hook 없음). #1579 / #1771
         require_context_no_handler,
+        /// `output.exports = "default"` 모드 + named export 섞임. Rollup 도 동일 케이스 throw. #2159
+        output_exports_conflict,
     };
 
     pub const Severity = enum {

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,6 +34,8 @@ const CliOptions = struct {
     sourcemap: bool = false,
     /// 소스맵 출력 형식 (#2152) — esbuild/rolldown 호환.
     sourcemap_mode: lib.codegen.sourcemap.SourceMapMode = .linked,
+    /// CJS / UMD entry export 형식 (#2159) — Rollup output.exports 호환.
+    output_exports: lib.bundler.OutputExports = .auto,
     /// Sentry Debug ID (--sourcemap-debug-ids). 소스맵 + JS에 동일 UUID를 삽입.
     sourcemap_debug_ids: bool = false,
     /// Metro x_facebook_sources function map (--sourcemap-function-map).
@@ -515,6 +517,13 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
             const val = arg["--sourcemap=".len..];
             opts.sourcemap_mode = lib.codegen.sourcemap.SourceMapMode.fromString(val) orelse {
                 try stderr.print("zts: invalid --sourcemap value: {s} (expected: linked, external, inline)\n", .{val});
+                std.process.exit(1);
+            };
+        } else if (std.mem.startsWith(u8, arg, "--output-exports=")) {
+            // #2159 — `--output-exports=auto|named|default|none`
+            const val = arg["--output-exports=".len..];
+            opts.output_exports = lib.bundler.OutputExports.fromString(val) orelse {
+                try stderr.print("zts: invalid --output-exports value: {s} (expected: auto, named, default, none)\n", .{val});
                 std.process.exit(1);
             };
         } else if (std.mem.eql(u8, arg, "--sourcemap-debug-ids")) {
@@ -1902,6 +1911,7 @@ pub fn main() !void {
             .drop_labels = opts.drop_labels_list.items,
             .drop_console = opts.drop_console,
             .drop_debugger = opts.drop_debugger,
+            .output_exports = opts.output_exports,
             .pure = opts.pure_list.items,
             .tsconfig_raw = opts.tsconfig_raw,
             .node_paths = opts.node_paths_list.items,

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -132,6 +132,9 @@ pub const TranspileOptionsDto = struct {
     /// 출력 형식 — `"linked"` / `"external"` / `"inline"` (#2152). missing 시 linked.
     /// transpile 모드에선 미사용 (single-file, mode 의미 없음). bundler 만 사용.
     sourcemapMode: ?[]const u8 = null,
+    /// CJS / UMD entry export 형식 — `"auto"` / `"named"` / `"default"` / `"none"` (#2159).
+    /// missing 시 auto. transpile 모드에선 미사용 — bundler 만.
+    outputExports: ?[]const u8 = null,
     sourcemapDebugIds: ?bool = null,
     sourcesContent: ?bool = null,
     sourceRoot: ?[]const u8 = null,

--- a/src/transpile_options_dto_test.zig
+++ b/src/transpile_options_dto_test.zig
@@ -54,6 +54,7 @@ const bundler_only_fields = [_][]const u8{
     "inlineDynamicImports",
     "manualChunks",
     "sourcemapMode",
+    "outputExports",
 };
 
 /// TS interface 본문에서 필드명을 추출한다. 간단 파서: `interface <name> {` 블록


### PR DESCRIPTION
## 요약
**Rollup `output.exports` 호환 4 mode 구현 + ZTS 의 CJS entry export 누락 base case fix.**

## 발견된 base case 누락
이전 ZTS 는 `--format=cjs` 시 entry 의 export 자체가 emit 안 됨 — `emitter.zig:1665` 가 ESM `export { ... }` 를 null 로 처리만, CJS 대체 출력 없음. 외부 소비자가 require 해도 빈 객체. 본 PR 이 base case + mode 분기 모두 구현.

## Mode 동작

| Mode | default-only | named-only | mixed |
|---|---|---|---|
| `auto` (default) | `module.exports = X` | `exports.X = X` (no flag) | `exports.X` + esModule flag |
| `named` | `exports.default = X` + esModule flag | `exports.X = X` | `exports.X` + esModule flag |
| `default` | `module.exports = X` | **result.errors 진단** | **result.errors 진단** |
| `none` | 빈 출력 | 빈 출력 | 빈 출력 |

## 다른 번들러 정책 비교

| 번들러 | 옵션 | 호환 |
|---|---|---|
| Rollup | `output.exports` + `output.esModule` 별도 | ✅ 4 mode 동일 |
| rolldown | 동일 (Rollup 호환) | ✅ `IfDefaultProp` 동작 일치 |
| esbuild | 옵션 없음, 항상 named + flag | ⚠️ ZTS `named` mode 에 가까움 |
| rspack | `output.libraryExport` 별도 의미 | 비범위 |

ZTS 는 rolldown `IfDefaultProp` (named-only 에 flag 없음) — 보수적.

## 변경 (14 파일, +386 / -2)

**Zig 코어**:
- `src/bundler/bundler.zig`: `OutputExports` enum + `fromString` helper
- `src/bundler/emitter.zig`: `emitCjsEntryExports` helper + 7 unit test
- `src/bundler/types.zig`: `BundlerDiagnostic.ErrorCode.output_exports_conflict` 신설
- `src/bundler/compiled_cache.zig`: cache invalidation
- `src/main.zig`: Zig CLI `--output-exports=...` flag

**JS NAPI 경계**:
- `packages/core/src/napi_entry.zig`: `parseOutputExports`
- `packages/core/index.ts`: `BuildOptionsCommon.outputExports` TS 타입
- `packages/core/bin/zts.mjs` + `cli-flags.mjs`: opts default + flag
- `packages/core/src/typo-suggest.ts`: KNOWN_CONFIG_KEYS

**Schema sync**: `transpile_options_dto_test.zig` `bundler_only_fields` 등록

## /simplify 결과 (2 round 적용)

### Round 1
- ✅ `OutputExports.fromString` 추출 — `SourceMapMode.fromString` 컨벤션. NAPI / Zig CLI 양쪽 단축
- ✅ `std.debug.assert(open < close)` — debug 빌드 회귀 catch

### Round 2 (root cause fix)
- ✅ **`std.log.warn` 임시방편 → graph diagnostic 으로 wiring** (`feedback_approach` 임시방편 누적 금지 원칙)
  - `BundlerDiagnostic.ErrorCode.output_exports_conflict` 신설
  - `emitOutputExportsConflictDiag` helper — `linker.fatal_diagnostics` 에 owned message + path append
  - 사용자가 `result.errors` 검사로 fail-fast 가능 (Rollup 도 동일 케이스 throw)
  - **#2175 follow-up issue 본 PR 에 통합 + close**

### Follow-up (분리)
- #2176 — linker → emitter typed export struct 전달로 양방향 직렬화 제거 (architecture 정리, 별도 PR)

## 검증
- `zig build test` → 4086/4086 (7 emitCjsEntryExports unit + 기존)
- `bun test packages/core/` → 7 outputExports 통합 테스트 (auto×3 / named / default-only / default-conflict / none)
- `bun run lint` / `fmt` → 0 warnings

## Epic #2151 — P0 차단점 8개 모두 완료

- ✅ #2156 plugin lifecycle hook
- ✅ #2157 builtin loader (base64)
- ✅ #2154 preserveSymlinks
- ✅ #2152 sourcemap mode
- ✅ #2155 drop bundle
- ✅ #2153 alias regex
- ✅ #2158 logLevel NAPI
- ✅ #2159 output.exports ← **마지막**

Closes #2159
Closes #2175
Refs #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)