### PR TITLE
fix(bundler): CJS dynamic exports access 시 fact prune 비활성화 (mime-types 회귀)

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -774,6 +774,70 @@ fn invalidateConflictingCjsExportFacts(facts: []CjsExportFact, stmts: []StmtInfo
     }
 }
 
+/// CJS module 의 함수 body 안에서 `exports` 식별자가 동적으로 access 되면
+/// (예: `function init() { exports.X.push(...) }`), RHS purity 만으로는 export prune 안전성을
+/// 증명할 수 없다. mime-types 패턴 — top-level `exports.X = []` 가 RHS pure 라 prune
+/// 후보지만, 다른 함수 호출 시점에 `exports.X.push(...)` 로 mutate 됨.
+///
+/// 휴리스틱: 함수/메서드 노드 span 안에서 `exports` identifier 가 한 번이라도 발견되면
+/// 모든 fact invalidate (esbuild/rolldown 의 CJS black-box 정책). top-level 의 `exports.X = ...`
+/// 나 `Object.defineProperty(exports, ...)` 같은 패턴은 함수 밖이라 영향 없음.
+///
+/// `unresolved_globals` 가 `exports` 를 포함 안 하면 ESM 모듈이거나 user 가 `var exports = ...`
+/// 한 케이스라 작업 자체가 의미 없어 즉시 종료. 함수 이름 식별자는 `binding_identifier` 라
+/// 여기 outer loop 의 `identifier_reference` 검사를 거치지 않으므로 false-positive 안 일어남.
+fn invalidateFactsForNestedExportsAccess(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    facts: []CjsExportFact,
+    stmts: []StmtInfo,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) void {
+    if (facts.len == 0) return;
+    if (unresolved_globals) |g| {
+        if (!g.contains("exports")) return;
+    }
+
+    var fn_spans: std.ArrayListUnmanaged(Span) = .empty;
+    defer fn_spans.deinit(allocator);
+    for (ast.nodes.items) |node| {
+        switch (node.tag) {
+            .function_declaration,
+            .function_expression,
+            .arrow_function_expression,
+            .function,
+            .method_definition,
+            => fn_spans.append(allocator, node.span) catch return,
+            else => continue,
+        }
+    }
+    if (fn_spans.items.len == 0) return;
+
+    var has_nested = false;
+    outer: for (ast.nodes.items) |node| {
+        if (node.tag != .identifier_reference) continue;
+        if (node.span.end - node.span.start != "exports".len) continue;
+        if (!std.mem.eql(u8, ast.getText(node.span), "exports")) continue;
+        for (fn_spans.items) |fs| {
+            if (node.span.start >= fs.start and node.span.end <= fs.end and
+                (node.span.start != fs.start or node.span.end != fs.end))
+            {
+                has_nested = true;
+                break :outer;
+            }
+        }
+    }
+
+    if (!has_nested) return;
+    for (facts) |*f| {
+        if (!f.is_safe_to_prune) continue;
+        f.is_safe_to_prune = false;
+        if (f.statement_index < stmts.len) {
+            stmts[f.statement_index].has_side_effects = true;
+        }
+    }
+}
+
 /// statement span 배열에서 pos를 포함하는 statement를 binary search.
 /// statement span은 소스 순서로 비중첩.
 pub fn findStmtForPos(stmt_spans: []const Span, pos: u32) ?u32 {
@@ -1077,6 +1141,7 @@ pub fn buildFromSemantic(
     }
 
     invalidateConflictingCjsExportFacts(cjs_export_facts_buf.items, stmts);
+    invalidateFactsForNestedExportsAccess(allocator, ast, cjs_export_facts_buf.items, stmts, unresolved_globals);
 
     const sym_to_writer_stmts = try finalizeWriterBuckets(allocator, writer_buckets, sym_to_stmt);
 
@@ -1260,6 +1325,7 @@ pub fn build(
     }
 
     invalidateConflictingCjsExportFacts(cjs_export_facts_buf.items, stmts);
+    invalidateFactsForNestedExportsAccess(allocator, ast, cjs_export_facts_buf.items, stmts, unresolved_globals);
 
     const sym_to_writer_stmts = try finalizeWriterBuckets(allocator, writer_bufs, sym_to_stmt);
 

--- a/src/bundler/stmt_info_test.zig
+++ b/src/bundler/stmt_info_test.zig
@@ -237,3 +237,84 @@ test "stmt_info: multi-statement module with arrow closures (arktype pattern)" {
         try std.testing.expect(reachable.isSet(1)); // flatMorph import reachable
     }
 }
+
+fn buildTestInfosWithCjs(allocator: std.mem.Allocator, source: []const u8) !struct {
+    infos: ModuleStmtInfos,
+    arena: std.heap.ArenaAllocator,
+} {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var scanner = try Scanner.init(arena_alloc, source);
+    var parser = Parser.init(arena_alloc, &scanner);
+    _ = try parser.parse();
+
+    var analyzer = SemanticAnalyzer.init(arena_alloc, &parser.ast);
+    try analyzer.analyze();
+
+    const infos = (try build(
+        allocator,
+        &parser.ast,
+        analyzer.symbols.items,
+        analyzer.symbol_ids.items,
+        &analyzer.unresolved_references,
+        true,
+    )) orelse return error.NullResult;
+
+    return .{ .infos = infos, .arena = arena };
+}
+
+test "stmt_info: CJS export fact 가 함수 body 내부 dynamic exports access 시 prune 비활성화" {
+    const alloc = std.testing.allocator;
+    var r = try buildTestInfosWithCjs(alloc,
+        \\exports.a = 1;
+        \\exports.c = [];
+        \\exports.e = function init() { exports.c.push(99); };
+        \\exports.e();
+    );
+    defer r.infos.deinit();
+    defer r.arena.deinit();
+
+    // 함수 body 안에서 exports.c.push(...) 가 발견되므로 모든 fact 의 is_safe_to_prune = false
+    try std.testing.expect(r.infos.cjs_export_facts.len > 0);
+    for (r.infos.cjs_export_facts) |fact| {
+        try std.testing.expect(!fact.is_safe_to_prune);
+    }
+}
+
+test "stmt_info: CJS export fact 가 함수 body 없는 모듈에서는 prune 가능 유지" {
+    const alloc = std.testing.allocator;
+    var r = try buildTestInfosWithCjs(alloc,
+        \\exports.a = 1;
+        \\exports.b = "hello";
+        \\exports.c = [];
+    );
+    defer r.infos.deinit();
+    defer r.arena.deinit();
+
+    // 함수 정의가 없어 dynamic access 도 없음. 기존 prune 결정 유지.
+    try std.testing.expect(r.infos.cjs_export_facts.len > 0);
+    var any_safe = false;
+    for (r.infos.cjs_export_facts) |fact| {
+        if (fact.is_safe_to_prune) any_safe = true;
+    }
+    try std.testing.expect(any_safe);
+}
+
+test "stmt_info: 함수 RHS 가 exports 안 참조하면 prune 가능 유지" {
+    const alloc = std.testing.allocator;
+    var r = try buildTestInfosWithCjs(alloc,
+        \\exports.used = function used() { return 1; };
+        \\exports.unused = function unused() { return 2; };
+    );
+    defer r.infos.deinit();
+    defer r.arena.deinit();
+
+    try std.testing.expect(r.infos.cjs_export_facts.len > 0);
+    var any_safe = false;
+    for (r.infos.cjs_export_facts) |fact| {
+        if (fact.is_safe_to_prune) any_safe = true;
+    }
+    try std.testing.expect(any_safe);
+}


### PR DESCRIPTION
## Summary

- mime-types 가 ZTS 번들 후 `Cannot read properties of undefined (reading 'push')` 로 런타임 fail. PR #2177 머지 전 main 에서도 동일 발생 (사전 회귀)
- root cause: `cjsExportAssignmentHasSideEffects` 가 RHS purity 만으로 fact 의 prune 가능 여부 결정. 함수 body 안 dynamic `exports` access 추적 못함
- 함수/메서드 노드 span 안에서 `exports` identifier 가 한 번이라도 발견되면 모든 fact `is_safe_to_prune = false` 로 invalidate (esbuild/rolldown 의 CJS black-box 정책과 동일)

## Root cause 상세

mime-types `index.js`:
```js
exports._extensionConflicts = []   // RHS=array literal → pure → prune 가능
populateMaps(exports.extensions, exports.types)
function populateMaps(extensions, types) {
  ...
  exports._extensionConflicts.push([...])   // 호출 시점에 mutate
}
```

ZTS 번들 후:
- `exports._extensionConflicts = []` 가 prune 됨 (entry 가 `mime.lookup` 만 사용)
- `populateMaps()` 호출은 살아남음 (side-effect)
- 호출 → `exports._extensionConflicts.push(...)` → `_extensionConflicts is undefined` → throw

진정한 root cause = **fact prune 결정이 RHS purity 만으로 충분하다고 단정한 것**. 함수 body 안 동적 access 가능성은 추적 불가. esbuild/rolldown 도 동일 케이스에서 black-box 처리하여 모든 export statement 보존.

## 변경 사항

`stmt_info.zig` 에 `invalidateFactsForNestedExportsAccess` 추가:
1. `unresolved_globals` 가 `"exports"` 포함 안 하면 즉시 종료 (ESM 모듈/user 정의 변수 케이스)
2. function/method 노드 span 들을 사전 수집 (`function_declaration`, `function_expression`, `arrow_function_expression`, `function`, `method_definition`)
3. 모든 `exports` identifier_reference 노드를 iterate. 어떤 function span 안에 들어있으면 nested → 모든 fact invalidate
4. invalidate 시 `is_safe_to_prune = false` + `stmt.has_side_effects = true` (기존 `invalidateConflictingCjsExportFacts` 와 동일 패턴)

복잡도 O(N + E×F): N=AST 노드 수, E=`exports` identifier 수, F=function 노드 수.

## Test plan

- [x] 작은 repro `exports.X = []` + `function() { exports.X.push() }` 패턴 — fail → fix
- [x] mime-types — `text/javascript` 정상 출력
- [x] `zig build test` 전체 4090 tests pass (이전 회귀 22→0)
- [x] `tests/integration/tests/bundle-smoke.test.ts` 145 pass
- [x] benchmark smoke — mime-types ZTS OK + esbuild/rolldown/rspack 출력 MATCH
- [x] 단위 테스트 3개 추가 (`stmt_info_test.zig`):
  - 함수 body 내 dynamic exports access → 모든 fact prune 비활성화
  - 함수 정의 없는 모듈 → prune 가능 유지
  - 함수 RHS 가 exports 안 참조 → prune 가능 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)