### PR TITLE
feat(loader): builtin loader 검증 + onLoad loader override forward (#2157)

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -6147,3 +6147,170 @@ describe("@zts/core plugin lifecycle", () => {
     rmSync(dir, { recursive: true });
   });
 });
+
+// ─── plugin onLoad loader override (#2157) ───
+
+import { spawnSync } from "node:child_process";
+
+/** 출력 코드를 dynamic import 로 실행해 console.log 결과를 캡처. plugin loader override 의
+ *  end-to-end 동작 검증 — bundle 결과가 실제 런타임에서 import 바인딩과 default export 가
+ *  올바르게 매칭됨을 검증한다. */
+async function runBundleStdout(code: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "zts-onload-run-"));
+  const out = join(dir, "out.mjs");
+  writeFileSync(out, code);
+  const captured: string[] = [];
+  const orig = console.log;
+  console.log = (...args: unknown[]) => {
+    captured.push(args.map((a) => String(a)).join(" "));
+  };
+  try {
+    await import(out);
+  } finally {
+    console.log = orig;
+    rmSync(dir, { recursive: true });
+  }
+  return captured.join("\n");
+}
+
+describe("@zts/core plugin onLoad loader", () => {
+  test("loader='text': string default export + Node 실행 결과 일치", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-text-"));
+    writeFileSync(join(dir, "entry.ts"), "import data from './README.md';\nconsole.log(data);");
+    writeFileSync(join(dir, "README.md"), "# hello world");
+    const plugin: ZtsPlugin = {
+      name: "md-as-text",
+      setup(build) {
+        build.onLoad({ filter: /\.md$/ }, (args) => ({
+          contents: readFileSync(args.path, "utf-8"),
+          loader: "text",
+        }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    expect(r.outputFiles[0].text).toContain('"# hello world"');
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("# hello world");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("loader='dataurl': data URL 인라인 + Node 실행 결과 일치", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-dataurl-"));
+    writeFileSync(join(dir, "entry.ts"), "import url from './pic.svg';\nconsole.log(url);");
+    writeFileSync(join(dir, "pic.svg"), "<svg/>");
+    const plugin: ZtsPlugin = {
+      name: "svg-as-dataurl",
+      setup(build) {
+        build.onLoad({ filter: /\.svg$/ }, (args) => ({
+          contents: readFileSync(args.path, "utf-8"),
+          loader: "dataurl",
+        }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    expect(r.outputFiles[0].text).toContain("data:image/svg+xml;base64,");
+    // base64('<svg/>') = 'PHN2Zy8+'
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("data:image/svg+xml;base64,PHN2Zy8+");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("loader='base64': 순수 base64 문자열 (data URL prefix 없음)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-b64-"));
+    writeFileSync(join(dir, "entry.ts"), "import s from './data.bin';\nconsole.log(s);");
+    writeFileSync(join(dir, "data.bin"), "Hi"); // base64('Hi') = 'SGk='
+    const plugin: ZtsPlugin = {
+      name: "bin-as-base64",
+      setup(build) {
+        build.onLoad({ filter: /\.bin$/ }, (args) => ({
+          // NAPI 가 현재 contents 를 string 으로만 받음 — utf-8 디코드된 string 전달.
+          // 진짜 binary safe (Uint8Array forward) 는 후속 PR.
+          contents: readFileSync(args.path, "utf-8"),
+          loader: "base64",
+        }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    expect(r.outputFiles[0].text).toContain('"SGk="');
+    expect(r.outputFiles[0].text).not.toContain("data:");
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("SGk=");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("loader='binary': Uint8Array default export + Node 실행 결과 일치", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-binary-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      "import bytes from './data.dat';\nconsole.log(bytes instanceof Uint8Array, bytes.length, bytes[0], bytes[1]);",
+    );
+    writeFileSync(join(dir, "data.dat"), "AB"); // ASCII safe
+    const plugin: ZtsPlugin = {
+      name: "dat-as-binary",
+      setup(build) {
+        // .dat 의 default loader 는 .none — onResolve 로 ZTS 가 모듈 등록할 path 를 명시,
+        // onLoad 가 raw bytes + binary loader override. NAPI string 한계로 utf-8 safe 데이터.
+        build.onResolve({ filter: /\.dat$/ }, (args) => ({ path: resolve(dir, args.path) }));
+        build.onLoad({ filter: /\.dat$/ }, (args) => ({
+          contents: readFileSync(args.path, "utf-8"),
+          loader: "binary",
+        }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    expect(r.outputFiles[0].text).toContain("__toBinary");
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("true 2 65 66");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("loader='empty': default export 가 undefined", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-empty-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      "import x from './any.skip';\nconsole.log(x === undefined);",
+    );
+    writeFileSync(join(dir, "any.skip"), "doesnt matter");
+    const plugin: ZtsPlugin = {
+      name: "skip-as-empty",
+      setup(build) {
+        build.onResolve({ filter: /\.skip$/ }, (args) => ({ path: resolve(dir, args.path) }));
+        build.onLoad({ filter: /\.skip$/ }, () => ({ contents: "", loader: "empty" }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("true");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("loader='bogus' (미지원 string): override 무시 → JS 모듈로 처리 (fromString null)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-bogus-"));
+    writeFileSync(join(dir, "entry.ts"), "import x from './v.custom';\nconsole.log(x);");
+    const plugin: ZtsPlugin = {
+      name: "custom-bogus",
+      setup(build) {
+        build.onResolve({ filter: /\.custom$/ }, (args) => ({ path: resolve(dir, args.path) }));
+        build.onLoad({ filter: /\.custom$/ }, () => ({
+          contents: "export default 42;",
+          // @ts-expect-error — 의도적으로 잘못된 값
+          loader: "bogus",
+        }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    // fromString null → loader_override null → default JS 처리 → 정상 import
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("42");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("loader 없이 반환: 기존 동작 (JS 모듈)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-default-"));
+    writeFileSync(join(dir, "entry.ts"), "import x from './v.custom';\nconsole.log(x);");
+    const plugin: ZtsPlugin = {
+      name: "custom-as-js",
+      setup(build) {
+        build.onResolve({ filter: /\.custom$/ }, (args) => ({ path: resolve(dir, args.path) }));
+        build.onLoad({ filter: /\.custom$/ }, () => ({ contents: "export default 42;" }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("42");
+    rmSync(dir, { recursive: true });
+  });
+});

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -223,6 +223,27 @@ fn getObjectString(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc
     return getStringArg(env, val, alloc);
 }
 
+/// `getObjectString` 와 동일하지만 빈 문자열도 valid 로 받음 (zero-length slice 반환).
+/// plugin onLoad 의 `contents: ""` (의도적 빈 module — `loader: 'empty'` 등) 케이스 보존.
+fn getObjectStringAllowEmpty(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const u8 {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+    var ty: c.napi_valuetype = undefined;
+    if (c.napi_typeof(env, val, &ty) != c.napi_ok or ty != c.napi_string) return null;
+    var len: usize = 0;
+    if (c.napi_get_value_string_utf8(env, val, null, 0, &len) != c.napi_ok) return null;
+    if (len == 0) {
+        const empty = alloc.alloc(u8, 0) catch return null;
+        return empty;
+    }
+    const buf = alloc.alloc(u8, len + 1) catch return null;
+    var actual: usize = 0;
+    if (c.napi_get_value_string_utf8(env, val, buf.ptr, len + 1, &actual) != c.napi_ok) {
+        alloc.free(buf);
+        return null;
+    }
+    return buf[0..actual];
+}
+
 fn getObjectStringArray(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const []const u8 {
     const val = getNamedProperty(env, obj, key) orelse return null;
     return parseStringArray(env, val, alloc);
@@ -642,6 +663,9 @@ const NapiPlugin = struct {
         /// JS plugin 의 onResolveContext 가 반환한 `{ context: string[] }` 의 string[] 부분.
         /// outer slice = native_alloc 소유 (graph 가 free), inner string = JS lifetime.
         context_matches: ?[]const []const u8 = null,
+        /// onLoad callback 의 `loader: 'text' | 'binary' | 'dataurl' | 'base64' | ...`. (#2157)
+        /// Loader.fromString 으로 변환된 결과. null = override 안 함.
+        loader_override: ?bundler_mod.types.Loader = null,
     };
 
     /// Per-call 요청 컨텍스트. 여러 워커 스레드가 동시에 호출해도 안전.
@@ -671,7 +695,8 @@ const NapiPlugin = struct {
         }
         resp.is_external = getObjectBool(env, js_result, "external", false);
         resp.is_disabled = getObjectBool(env, js_result, "disabled", false);
-        if (getObjectString(env, js_result, "contents", native_alloc)) |contents| {
+        // plugin onLoad 의 `contents` 는 빈 string 도 의도적 (loader: 'empty' 등) — allow empty.
+        if (getObjectStringAllowEmpty(env, js_result, "contents", native_alloc)) |contents| {
             resp.code = contents;
         }
         if (resp.code == null) {
@@ -689,6 +714,14 @@ const NapiPlugin = struct {
         // require.context 응답 파싱: { context: string[] } (#1579 Phase 2.5)
         if (getNamedProperty(env, js_result, "context")) |ctx_val| {
             resp.context_matches = parseStringArray(env, ctx_val, native_alloc);
+        }
+        // onLoad: loader override (#2157). resp.code 가 있을 때만 의미 있어 gate — onResolve /
+        // transform / lifecycle 응답에서 불필요한 NAPI getNamedProperty 회피.
+        if (resp.code != null) {
+            if (getObjectString(env, js_result, "loader", native_alloc)) |loader_str| {
+                defer native_alloc.free(loader_str);
+                resp.loader_override = bundler_mod.types.Loader.fromString(loader_str);
+            }
         }
         return resp;
     }
@@ -883,9 +916,17 @@ const NapiPlugin = struct {
         return null;
     }
 
-    fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+    fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.LoadResult {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
-        return self.callCodeHook(.load, path, null, alloc);
+        const resp = self.callHook(.load, path, null) orelse return null;
+        defer if (resp.resolved_path) |p| native_alloc.free(p);
+        const result_code = resp.code orelse return null;
+        const contents = alloc.dupe(u8, result_code) catch {
+            native_alloc.free(result_code);
+            return error.OutOfMemory;
+        };
+        native_alloc.free(result_code);
+        return .{ .contents = contents, .loader = resp.loader_override };
     }
 
     fn pluginTransform(ctx: ?*anyopaque, code: []const u8, id: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2253,6 +2253,58 @@ test "Asset loader: dataurl — base64 data URL" {
     try std.testing.expect(result.asset_outputs == null);
 }
 
+test "Asset loader: base64 — pure base64 string (no data URL prefix)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import s from './data.bin';\nconsole.log(s);");
+    try tmp.dir.writeFile(.{ .sub_path = "data.bin", .data = &.{ 0x48, 0x69 } }); // "Hi"
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .loader_overrides = &.{.{ .ext = ".bin", .loader = .base64 }},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // base64("Hi") = "SGk=" — pure base64, no data URL prefix
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"SGk=\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "data:") == null);
+    try std.testing.expect(result.asset_outputs == null);
+}
+
+test "Asset loader: copy — raw passthrough to asset output" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import url from './doc.pdf';\nconsole.log(url);");
+    try tmp.dir.writeFile(.{ .sub_path = "doc.pdf", .data = "PDF-RAW-CONTENTS" });
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .loader_overrides = &.{.{ .ext = ".pdf", .loader = .copy }},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // copy 도 file 처럼 hash 가 붙은 path 를 export 하고, raw bytes 가 asset_outputs 에 포함됨.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "doc-") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".pdf") != null);
+    try std.testing.expect(result.asset_outputs != null);
+    try std.testing.expectEqual(@as(usize, 1), result.asset_outputs.?.len);
+    try std.testing.expectEqualStrings("PDF-RAW-CONTENTS", result.asset_outputs.?[0].contents);
+}
+
 test "Asset loader: file — hash filename + asset output" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1197,12 +1197,33 @@ pub const ModuleGraph = struct {
                     return;
                 },
             };
-            if (load_result) |plugin_source| {
-                // 플러그인이 내용을 반환 → JS 모듈로 전환하여 아래 파싱 경로를 탐
-                module.module_type = .javascript;
-                module.loader = .javascript;
+            if (load_result) |plugin_result| {
+                // 플러그인이 내용을 반환. (#2157) `loader` 가 명시되면 raw bytes 를 그 loader 의
+                // 값 표현식으로 변환 (parseAssetModule 와 동일한 assetSourceFromBytes 헬퍼).
+                // asset 변환 성공 시 parseAssetModule 와 동일하게 ast 없이 종료 → emitter 의
+                // emitAssetModule 가 `module.exports = <source>` 로 wrap. JS 파이프라인 진입 시
+                // source 가 단순 표현식 ("text") 이라 default export 없는 빈 모듈로 emit 되어
+                // import binding 이 깨진다.
                 module.parse_arena = tmp_arena;
-                module.source = plugin_source;
+                const arena_alloc = tmp_arena.allocator();
+                if (plugin_result.loader) |loader_override| {
+                    module.loader = loader_override;
+                    if (self.assetSourceFromBytes(arena_alloc, loader_override, plugin_result.contents, module.path)) |expr| {
+                        module.source = expr;
+                        module.module_type = .javascript;
+                        module.exports_kind = .commonjs;
+                        module.wrap_kind = .cjs;
+                        module.side_effects = false;
+                        module.state = .ready;
+                        return;
+                    }
+                    // asset 변환 미지원 loader (file/copy/javascript/json/css/none): raw 그대로 JS 파이프라인.
+                    module.source = plugin_result.contents;
+                } else {
+                    module.loader = .javascript;
+                    module.source = plugin_result.contents;
+                }
+                module.module_type = .javascript;
                 // module_type 분기를 건너뛰고 JS 파싱 경로로 직접 이동
                 // (아래 "모듈별 Arena" 블록은 parse_arena가 이미 설정되어 있으므로 건너뜀)
             } else {
@@ -2598,65 +2619,57 @@ pub const ModuleGraph = struct {
     ///
     /// asset_registry 모드의 .file/.copy는 loader를 .javascript로 바꿔 fall-through
     /// 신호를 보내고, 호출자가 일반 JS 파이프라인을 이어 실행한다.
+    /// raw bytes 를 asset loader 의 값 표현식으로 변환 (`text` → `"<escaped>"`,
+    /// `dataurl` → `"data:<mime>;base64,..."`, `base64` / `binary` / `empty`).
+    /// `parseAssetModule` 와 plugin onLoad loader override 두 경로 모두 사용하는 single source.
+    /// `file` / `copy` 는 asset_outputs 라이프사이클이 별개라 제외 — caller 가 별도 처리.
+    /// `javascript` / `json` / `css` / `none` 은 변환 없이 raw contents 가 source — null 반환.
+    /// (#2157)
+    fn assetSourceFromBytes(
+        self: *ModuleGraph,
+        alloc: std.mem.Allocator,
+        loader: types.Loader,
+        raw: []const u8,
+        module_path: []const u8,
+    ) ?[]const u8 {
+        return switch (loader) {
+            .text => blk: {
+                const escaped = escapeJsString(alloc, raw) catch break :blk null;
+                break :blk std.fmt.allocPrint(alloc, "\"{s}\"", .{escaped}) catch null;
+            },
+            .dataurl => blk: {
+                const encoded = base64Encode(alloc, raw) catch break :blk null;
+                const full_mime = mime.fromExtension(module_path);
+                const mime_type = if (std.mem.indexOf(u8, full_mime, ";")) |semi|
+                    full_mime[0..semi]
+                else
+                    full_mime;
+                break :blk std.fmt.allocPrint(alloc, "\"data:{s};base64,{s}\"", .{ mime_type, encoded }) catch null;
+            },
+            .base64 => blk: {
+                const encoded = base64Encode(alloc, raw) catch break :blk null;
+                break :blk std.fmt.allocPrint(alloc, "\"{s}\"", .{encoded}) catch null;
+            },
+            .binary => blk: {
+                const encoded = base64Encode(alloc, raw) catch break :blk null;
+                const to_bin_name = runtime_helpers.helperName("__toBinary", self.transform_options_base.minify_whitespace);
+                break :blk std.fmt.allocPrint(alloc, "{s}(\"{s}\")", .{ to_bin_name, encoded }) catch null;
+            },
+            .empty => "undefined",
+            .file, .copy, .javascript, .json, .css, .none => null,
+        };
+    }
+
     fn parseAssetModule(self: *ModuleGraph, module: *Module) void {
         module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
         const arena_alloc = module.parse_arena.?.allocator();
 
         switch (module.loader) {
-            .text => {
-                // UTF-8 문자열로 읽어서 JS 문자열 리터럴 생성
-                const content = self.readModuleSource(module, arena_alloc, 100 * 1024 * 1024, .parse) orelse return;
-                const escaped = escapeJsString(arena_alloc, content) catch {
-                    module.state = .ready;
-                    return;
-                };
-                // source에는 값 표현식만 저장 (JSON 모듈과 동일 패턴)
-                // emitter에서 var asset_X = <source>; 형태로 출력
-                module.source = std.fmt.allocPrint(arena_alloc, "\"{s}\"", .{escaped}) catch {
-                    module.state = .ready;
-                    return;
-                };
-            },
-            .dataurl => {
-                // 바이너리 읽기 → base64 인코딩 → data URL 문자열
+            .text, .dataurl, .base64, .binary => {
+                // text/dataurl/base64/binary: 모두 raw bytes → JS 표현식 변환. assetSourceFromBytes
+                // 헬퍼가 plugin onLoad 경로와 공유 (#2157).
                 const raw = self.readModuleSource(module, arena_alloc, 100 * 1024 * 1024, .parse) orelse return;
-                const encoded = base64Encode(arena_alloc, raw) catch {
-                    module.state = .ready;
-                    return;
-                };
-                const full_mime = mime.fromExtension(module.path);
-                const mime_type = if (std.mem.indexOf(u8, full_mime, ";")) |semi|
-                    full_mime[0..semi]
-                else
-                    full_mime;
-
-                module.source = std.fmt.allocPrint(arena_alloc, "\"data:{s};base64,{s}\"", .{ mime_type, encoded }) catch {
-                    module.state = .ready;
-                    return;
-                };
-            },
-            .base64 => {
-                // 바이너리 읽기 → base64 인코딩 → 순수 base64 문자열 (data URL prefix 없음)
-                const raw = self.readModuleSource(module, arena_alloc, 100 * 1024 * 1024, .parse) orelse return;
-                const encoded = base64Encode(arena_alloc, raw) catch {
-                    module.state = .ready;
-                    return;
-                };
-                module.source = std.fmt.allocPrint(arena_alloc, "\"{s}\"", .{encoded}) catch {
-                    module.state = .ready;
-                    return;
-                };
-            },
-            .binary => {
-                // 바이너리 읽기 → base64 인코딩 → __toBinary("...") 호출 표현식
-                const raw = self.readModuleSource(module, arena_alloc, 100 * 1024 * 1024, .parse) orelse return;
-                const encoded = base64Encode(arena_alloc, raw) catch {
-                    module.state = .ready;
-                    return;
-                };
-                // #1621: minify 시 $tb 축약.
-                const to_bin_name = runtime_helpers.helperName("__toBinary", self.transform_options_base.minify_whitespace);
-                module.source = std.fmt.allocPrint(arena_alloc, "{s}(\"{s}\")", .{ to_bin_name, encoded }) catch {
+                module.source = self.assetSourceFromBytes(arena_alloc, module.loader, raw, module.path) orelse {
                     module.state = .ready;
                     return;
                 };

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -18,6 +18,14 @@ const ast_plugin_mod = @import("../transformer/ast_plugin.zig");
 pub const AstTransformCtx = ast_plugin_mod.AstTransformCtx;
 pub const FunctionInfo = ast_plugin_mod.FunctionInfo;
 
+/// `Plugin.load` 가 반환할 수 있는 결과 — esbuild `OnLoadResult`, Rollup `{ code, ... }` 호환.
+/// `loader` 가 non-null 이면 graph 가 그 값으로 module loader override (확장자 추론 무시).
+/// (#2157)
+pub const LoadResult = struct {
+    contents: []const u8,
+    loader: ?types.Loader = null,
+};
+
 /// 플러그인 훅에서 반환할 수 있는 에러 타입.
 /// anyerror를 쓰지 않고 specific error set으로 제한하여
 /// 호출부에서 switch로 명시적 처리 가능.
@@ -89,7 +97,10 @@ pub const Plugin = struct {
 
     /// 모듈 내용 로딩 (virtual module, 커스텀 로더).
     /// non-null 반환 시 파일 시스템 읽기를 건너뜀.
-    load: ?*const fn (ctx: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) PluginError!?[]const u8 = null,
+    /// `LoadResult.loader` 를 non-null 로 반환하면 graph 가 module loader 를 그 값으로 override
+    /// (확장자 기반 추론 무시) — esbuild `onLoad` callback 의 `loader: 'text' | 'binary' | ...`
+    /// 와 동일 의미. (#2157)
+    load: ?*const fn (ctx: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) PluginError!?LoadResult = null,
 
     /// 코드 변환 (codegen 직후, CJS 래핑 전).
     /// non-null 반환 시 원본 코드를 반환값으로 교체.
@@ -251,7 +262,7 @@ pub const PluginRunner = struct {
         self: *const PluginRunner,
         path: []const u8,
         allocator: std.mem.Allocator,
-    ) PluginError!?[]const u8 {
+    ) PluginError!?LoadResult {
         for (self.plugins) |p| {
             if (p.load) |hook| {
                 if (try hook(p.context, path, allocator)) |result| {

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -73,9 +73,10 @@ test "PluginRunner: resolveId first mode" {
 
 // --- load 훅 테스트 ---
 
-fn testLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn testLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.LoadResult {
     if (std.mem.endsWith(u8, path, ".custom")) {
-        return try allocator.dupe(u8, "export default 'custom-loaded';");
+        const contents = try allocator.dupe(u8, "export default 'custom-loaded';");
+        return .{ .contents = contents };
     }
     return null;
 }
@@ -88,8 +89,8 @@ test "PluginRunner: load first mode" {
 
     const result = try runner.runLoad("module.custom", std.testing.allocator);
     try std.testing.expect(result != null);
-    try std.testing.expectEqualStrings("export default 'custom-loaded';", result.?);
-    std.testing.allocator.free(result.?);
+    try std.testing.expectEqualStrings("export default 'custom-loaded';", result.?.contents);
+    std.testing.allocator.free(result.?.contents);
 
     // 매칭 안 되는 확장자 → null (파일 시스템에서 읽기)
     const result2 = try runner.runLoad("module.ts", std.testing.allocator);
@@ -352,13 +353,14 @@ test "Plugin integration: transform output invalidates compiled cache (#2038)" {
 
 var compiled_cache_load_marker: []const u8 = "A";
 
-fn cacheSensitiveLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn cacheSensitiveLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.LoadResult {
     if (!std.mem.endsWith(u8, path, "index.ts")) return null;
-    return std.fmt.allocPrint(
+    const contents = std.fmt.allocPrint(
         allocator,
         "const marker = \"plugin-load-cache-{s}-2038\";\nconsole.log(marker);\n",
         .{compiled_cache_load_marker},
     ) catch return error.OutOfMemory;
+    return .{ .contents = contents };
 }
 
 test "Plugin integration: load output invalidates compiled cache (#2038)" {
@@ -544,7 +546,7 @@ test "Plugin integration: resolveId null falls through to default resolver" {
 
 // --- load 훅이 null 반환 시 파일 시스템 폴백 ---
 
-fn nullLoadHook(_: ?*anyopaque, _: []const u8, _: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn nullLoadHook(_: ?*anyopaque, _: []const u8, _: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.LoadResult {
     return null;
 }
 

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -395,7 +395,7 @@ fn loadHook(
     ctx: ?*anyopaque,
     path: []const u8,
     allocator: std.mem.Allocator,
-) plugin_mod.PluginError!?[]const u8 {
+) plugin_mod.PluginError!?plugin_mod.LoadResult {
     if (!isVirtualId(path)) return null;
     const short = path[ID_PREFIX.len..];
     const m = findModule(short) orelse return null;
@@ -404,7 +404,8 @@ fn loadHook(
         @ptrCast(@alignCast(c))
     else
         &default_opts;
-    return try buildSource(allocator, m, opts.*);
+    const contents = try buildSource(allocator, m, opts.*);
+    return .{ .contents = contents };
 }
 
 fn findModule(short: []const u8) ?*const HelperModule {
@@ -607,9 +608,9 @@ test "smoke: 모든 MODULES 의 helper 가 source 에 export 됨" {
 test "loadHook: virtual ID → source 반환" {
     const allocator = std.testing.allocator;
     const opts = SourceOptions{};
-    const src = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/generator", allocator)).?;
-    defer allocator.free(src);
-    try std.testing.expect(std.mem.indexOf(u8, src, "__generator") != null);
+    const result = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/generator", allocator)).?;
+    defer allocator.free(result.contents);
+    try std.testing.expect(std.mem.indexOf(u8, result.contents, "__generator") != null);
 }
 
 test "loadHook: 비 virtual ID 는 null" {
@@ -629,9 +630,9 @@ test "loadHook: ctx 의 minify 옵션이 source 에 반영 (alias export)" {
     // ctx 캐스트 회귀 방지 — ctx 가 무시되면 default_opts 사용해서 alias 가 없을 것.
     const allocator = std.testing.allocator;
     const opts = SourceOptions{ .minify = true };
-    const src = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/generator", allocator)).?;
-    defer allocator.free(src);
-    try std.testing.expect(std.mem.indexOf(u8, src, "$gn as __generator") != null);
+    const result = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zts:runtime/generator", allocator)).?;
+    defer allocator.free(result.contents);
+    try std.testing.expect(std.mem.indexOf(u8, result.contents, "$gn as __generator") != null);
 }
 
 test "resolveIdHook: virtual specifier 만 가로챔" {
@@ -658,6 +659,6 @@ test "makePlugin: hook 호출이 ctx 통해 동작" {
     try std.testing.expect(resolved == .virtual);
 
     const loaded = (try p.load.?(p.context, "\x00zts:runtime/generator", allocator)).?;
-    defer allocator.free(loaded);
-    try std.testing.expect(std.mem.indexOf(u8, loaded, "__generator") != null);
+    defer allocator.free(loaded.contents);
+    try std.testing.expect(std.mem.indexOf(u8, loaded.contents, "__generator") != null);
 }


### PR DESCRIPTION
## Summary

Epic #2151 P0 마지막 차단점 (8/8). builtin loader 9종 (javascript/json/css/text/binary/dataurl/base64/file/copy/empty) 의 enum/emit 은 이미 구현되어 있어 잔여 작업은:

1. **누락 fixture** — `base64` 와 `copy` loader 별 통합 테스트 추가
2. **plugin onLoad 의 `loader` 반환값 end-to-end forward** — 모든 layer 가 값을 drop 중이던 문제의 root cause fix
3. **`assetSourceFromBytes` 헬퍼 추출** — `parseAssetModule` 와 plugin 분기가 동일 변환 로직 공유

Closes #2157

## Root cause: plugin onLoad loader 가 native 까지 forward 안 되던 이유

JS interface (`onLoad(args) → { contents, loader? }`) 는 schema 에 이미 정의되어 있었지만:

- NAPI `parseJsResult` 가 `loader` field 무시
- `Plugin.load` Zig 시그니처가 `?[]const u8` (contents 만 받음)
- graph 의 plugin load 분기가 `module.loader = .javascript` 로 hardcode

**모든 layer 가 loader 값을 drop** 중이었음. 각 drop 지점을 정확히 수정:

| Layer | 변경 |
|---|---|
| `Plugin.load` 시그니처 | `?[]const u8` → `?LoadResult { contents, loader? }` |
| `PluginRunner.runLoad` | 동반 변경 |
| NAPI `parseJsResult` | `loader` string 파싱 + `Loader.fromString` enum 변환 |
| NAPI `parseJsResult` gate | `resp.code != null` 일 때만 loader probe (다른 hook 응답에서 napi_get_named_property 회피) |
| `getObjectStringAllowEmpty` 헬퍼 | plugin 의 `contents: ""` (의도적 empty module) 보존 |
| graph plugin load 분기 | loader override 적용 + parseAssetModule 와 동일한 cjs wrap 시그널 (`exports_kind=.commonjs` / `wrap_kind=.cjs` / `side_effects=false`) + ast 없이 종료 |

## `assetSourceFromBytes` 헬퍼

`parseAssetModule` 의 text/dataurl/base64/binary/empty 변환 로직을 추출. plugin load 분기와 parseAssetModule 모두 동일 헬퍼 사용 — single source of truth (drift 방지).

## Test plan

### Zig (`bundler_test/minify_loader.zig`) — 2 신규
- [x] `base64` loader: pure base64 string (data URL prefix 없음)
- [x] `copy` loader: raw bytes 보존 + asset_outputs

### TypeScript (`packages/core/index.test.ts`) — 7 신규 (**모두 Node 실제 실행 검증**)
출력 코드를 dynamic import → console.log 캡처해서 실제 런타임 default export 정확성 확인.

- [x] `loader='text'`: string default export — Node stdout=`# hello world`
- [x] `loader='dataurl'`: data URL inline — Node stdout=`data:image/svg+xml;base64,PHN2Zy8+`
- [x] `loader='base64'`: 순수 base64 (prefix 없음) — Node stdout=`SGk=`
- [x] `loader='binary'`: Uint8Array — Node stdout=`true 2 65 66`
- [x] `loader='empty'`: default=undefined — Node stdout=`true`
- [x] `loader='bogus'` (미지원 string): `fromString` null → JS 모듈로 fallback — Node stdout=`42`
- [x] loader 미지정: 기존 JS module 동작 — Node stdout=`42`

### 회귀
- [x] `zig build test` 4099 tests — pass
- [x] `bun test packages/core/index.test.ts` 346 tests — pass
- [x] `bun test tests/integration/tests/bundle-smoke.test.ts` 145 — pass

## Follow-ups

- NAPI 의 plugin contents 가 utf-8 string 만 받음 — 진짜 binary safe (Uint8Array forward) 는 별도 PR
- `assetSourceFromBytes` 의 `.file/.copy` arm 은 plugin 입력 케이스 미지원 (asset_outputs 라이프사이클 별개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)