### PR TITLE
feat(plugin): onLoad contents 의 Uint8Array / Buffer 지원 (#2157 follow-up)

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -6260,6 +6260,75 @@ describe("@zts/core plugin onLoad loader", () => {
     rmSync(dir, { recursive: true });
   });
 
+  test("contents=Uint8Array (binary safe): 비-utf8 bytes 도 손실 없이 forward (#2157 follow-up)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-uint8-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      "import bytes from './data.bin';\nconsole.log(bytes.length, bytes[0], bytes[1], bytes[2], bytes[3]);",
+    );
+    // PNG magic header — 0x89 / 0xFF 같은 utf-8 invalid bytes 포함
+    const rawBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    writeFileSync(join(dir, "data.bin"), rawBytes);
+    const plugin: ZtsPlugin = {
+      name: "bin-as-binary-uint8",
+      setup(build) {
+        build.onResolve({ filter: /\.bin$/ }, (args) => ({ path: resolve(dir, args.path) }));
+        build.onLoad({ filter: /\.bin$/ }, (args) => ({
+          // 핵심: Uint8Array 그대로 forward — utf-8 디코드 손실 없음
+          contents: readFileSync(args.path),
+          loader: "binary",
+        }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    expect(r.outputFiles[0].text).toContain("__toBinary");
+    // 0x89 = 137, 0x50 = 80, 0x4e = 78, 0x47 = 71. utf-8 디코드 시 0x89 가 손실되어 invalid 였을 것.
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("4 137 80 78 71");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("contents=Uint8Array + loader='dataurl' (PNG raw bytes 보존)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-png-"));
+    writeFileSync(join(dir, "entry.ts"), "import url from './tiny.png';\nconsole.log(url);");
+    const rawBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic
+    writeFileSync(join(dir, "tiny.png"), rawBytes);
+    const plugin: ZtsPlugin = {
+      name: "png-as-dataurl-uint8",
+      setup(build) {
+        build.onLoad({ filter: /\.png$/ }, (args) => ({
+          contents: readFileSync(args.path),
+          loader: "dataurl",
+        }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    // base64([0x89,0x50,0x4e,0x47]) = 'iVBORw=='
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("data:image/png;base64,iVBORw==");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("contents=Buffer (Node Buffer): napi_is_buffer 경로로 raw bytes forward", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-onload-buffer-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      "import bytes from './data.raw';\nconsole.log(bytes.length, bytes[0], bytes[1]);",
+    );
+    const plugin: ZtsPlugin = {
+      name: "raw-as-buffer",
+      setup(build) {
+        build.onResolve({ filter: /\.raw$/ }, (args) => ({ path: resolve(dir, args.path) }));
+        // 핵심: Buffer.from(...) — Node.js Buffer 인스턴스 (Uint8Array subclass 지만 napi_is_buffer 별도)
+        build.onLoad({ filter: /\.raw$/ }, () => ({
+          contents: Buffer.from([0xff, 0xfe]),
+          loader: "binary",
+        }));
+      },
+    };
+    const r = await build({ entryPoints: [join(dir, "entry.ts")], plugins: [plugin] });
+    expect(await runBundleStdout(r.outputFiles[0].text)).toBe("2 255 254");
+    rmSync(dir, { recursive: true });
+  });
+
   test("loader='empty': default export 가 undefined", async () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-onload-empty-"));
     writeFileSync(

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -751,7 +751,9 @@ export interface PluginBuild {
   ): void;
   onLoad(
     options: { filter: RegExp },
-    callback: (args: { path: string }) => HookResult<{ contents: string; loader?: string }>,
+    callback: (args: {
+      path: string;
+    }) => HookResult<{ contents: string | Uint8Array; loader?: string }>,
   ): void;
   onTransform(
     options: { filter: RegExp },

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -223,25 +223,59 @@ fn getObjectString(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc
     return getStringArg(env, val, alloc);
 }
 
-/// `getObjectString` 와 동일하지만 빈 문자열도 valid 로 받음 (zero-length slice 반환).
-/// plugin onLoad 의 `contents: ""` (의도적 빈 module — `loader: 'empty'` 등) 케이스 보존.
-fn getObjectStringAllowEmpty(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const u8 {
+/// plugin onLoad 의 `contents` 가 string 일 수도 있고 Uint8Array/Buffer 일 수도 있음.
+/// 후자는 binary-safe (PNG/JPG 등 raw bytes 가 utf-8 invalid 일 수 있음). (#2157 follow-up)
+/// - string: utf-8 디코드된 byte slice 그대로 (빈 string 도 valid — `loader: 'empty'` 등)
+/// - Node.js Buffer: napi_is_buffer 로 먼저 확인 (V8 Uint8Array subclass 지만 공식 API 분리)
+/// - Uint8Array typed array: byteLength 만큼 raw bytes 복사
+/// - 그 외 type 또는 missing: null
+fn getObjectBytes(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const u8 {
     const val = getNamedProperty(env, obj, key) orelse return null;
     var ty: c.napi_valuetype = undefined;
-    if (c.napi_typeof(env, val, &ty) != c.napi_ok or ty != c.napi_string) return null;
-    var len: usize = 0;
-    if (c.napi_get_value_string_utf8(env, val, null, 0, &len) != c.napi_ok) return null;
-    if (len == 0) {
-        const empty = alloc.alloc(u8, 0) catch return null;
-        return empty;
+    if (c.napi_typeof(env, val, &ty) != c.napi_ok) return null;
+    if (ty == c.napi_string) {
+        var len: usize = 0;
+        if (c.napi_get_value_string_utf8(env, val, null, 0, &len) != c.napi_ok) return null;
+        if (len == 0) {
+            return alloc.alloc(u8, 0) catch null;
+        }
+        const buf = alloc.alloc(u8, len + 1) catch return null;
+        var actual: usize = 0;
+        if (c.napi_get_value_string_utf8(env, val, buf.ptr, len + 1, &actual) != c.napi_ok) {
+            alloc.free(buf);
+            return null;
+        }
+        return buf[0..actual];
     }
-    const buf = alloc.alloc(u8, len + 1) catch return null;
-    var actual: usize = 0;
-    if (c.napi_get_value_string_utf8(env, val, buf.ptr, len + 1, &actual) != c.napi_ok) {
-        alloc.free(buf);
-        return null;
+    // Node.js Buffer: napi_is_buffer 가 권위 있음. 일부 런타임에서 napi_is_typedarray 가
+    // false 일 가능성 있어 별도 처리.
+    var is_buffer: bool = false;
+    if (c.napi_is_buffer(env, val, &is_buffer) == c.napi_ok and is_buffer) {
+        var byte_len: usize = 0;
+        var data_ptr: ?*anyopaque = null;
+        if (c.napi_get_buffer_info(env, val, &data_ptr, &byte_len) != c.napi_ok) return null;
+        return copyBytesOrEmpty(alloc, data_ptr, byte_len);
     }
-    return buf[0..actual];
+    // Uint8Array / Uint8ClampedArray: raw bytes 복사. 다른 typed array (Int8Array/Float32Array 등)
+    // 는 silent reject — plugin 작성 실수 시 contents missing 으로 표면화.
+    var is_typed: bool = false;
+    if (c.napi_is_typedarray(env, val, &is_typed) != c.napi_ok or !is_typed) return null;
+    var ta_type: c.napi_typedarray_type = undefined;
+    var byte_len: usize = 0;
+    var data_ptr: ?*anyopaque = null;
+    if (c.napi_get_typedarray_info(env, val, &ta_type, &byte_len, &data_ptr, null, null) != c.napi_ok) return null;
+    if (ta_type != c.napi_uint8_array and ta_type != c.napi_uint8_clamped_array) return null;
+    return copyBytesOrEmpty(alloc, data_ptr, byte_len);
+}
+
+fn copyBytesOrEmpty(alloc: std.mem.Allocator, data_ptr: ?*anyopaque, byte_len: usize) ?[]const u8 {
+    if (byte_len == 0) {
+        return alloc.alloc(u8, 0) catch null;
+    }
+    const src_ptr: [*]const u8 = @ptrCast(data_ptr orelse return null);
+    const out = alloc.alloc(u8, byte_len) catch return null;
+    @memcpy(out, src_ptr[0..byte_len]);
+    return out;
 }
 
 fn getObjectStringArray(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const []const u8 {
@@ -695,8 +729,9 @@ const NapiPlugin = struct {
         }
         resp.is_external = getObjectBool(env, js_result, "external", false);
         resp.is_disabled = getObjectBool(env, js_result, "disabled", false);
-        // plugin onLoad 의 `contents` 는 빈 string 도 의도적 (loader: 'empty' 등) — allow empty.
-        if (getObjectStringAllowEmpty(env, js_result, "contents", native_alloc)) |contents| {
+        // plugin onLoad 의 `contents` — string / Uint8Array / Buffer 모두 받음. binary safe.
+        // 빈 string 도 의도적 (loader: 'empty' 등) — allow empty.
+        if (getObjectBytes(env, js_result, "contents", native_alloc)) |contents| {
             resp.code = contents;
         }
         if (resp.code == null) {


### PR DESCRIPTION
## Summary

#2157 머지 후 plugin onLoad 의 `contents` 가 NAPI 에서 **utf-8 string 으로만 forward** 되던 한계 해소. PNG/JPG/font 등 utf-8 invalid bytes (0x80+) 가 디코드 손실되는 문제.

Refs #2157

## Root cause

NAPI `parseJsResult` 의 contents 추출이 `getObjectString` (utf-8 only) 사용. plugin 이 `readFileSync(path)` 의 Buffer 를 반환해도 string 으로 강제 디코드되어 0x89 / 0xFE 같은 byte 가 mangled.

## 변경

### `getObjectBytes` 헬퍼 — 3 형태 모두 받음

- **string** (`napi_string`) → utf-8 디코드 (빈 string 도 valid, `loader: 'empty'` 케이스 보존)
- **Node.js Buffer** (`napi_is_buffer` true) → `napi_get_buffer_info` 로 raw bytes 추출
  - V8 Buffer 가 Uint8Array subclass 라 `napi_is_typedarray` 도 보통 true 반환하지만 일부 런타임 차이 회피용 별도 path
- **Uint8Array / Uint8ClampedArray** (`napi_is_typedarray` true + `napi_uint8_array` 타입) → `napi_get_typedarray_info` raw bytes 복사
- 그 외 (Int8Array / Float32Array / DataView 등) 또는 type 미스매치 → silent reject (기존 contents missing 처럼 표면화)

### 기타

- `getObjectStringAllowEmpty` 제거 (이번 PR 에서 dead — `getObjectBytes` 가 superset)
- TypeScript `PluginBuild.onLoad` callback: `contents: string | Uint8Array` 로 확장 (Buffer 는 Uint8Array subclass 라 type-system 상 호환)

## Test plan

### 신규 fixture (모두 Node 실제 실행 검증)

- [x] **PNG raw bytes 보존**: `Uint8Array([0x89, 0x50, 0x4E, 0x47])` + `loader: 'binary'` → `Uint8Array.length=4 [0]=137 [1]=80 [2]=78 [3]=71` (utf-8 디코드 시 0x89 손실됐을 것)
- [x] **PNG dataurl**: `Uint8Array([0x89, 0x50, 0x4E, 0x47])` + `loader: 'dataurl'` → `data:image/png;base64,iVBORw==`
- [x] **Buffer.from**: `Buffer.from([0xFF, 0xFE])` + `loader: 'binary'` → `length=2 [0]=255 [1]=254` (`napi_is_buffer` 경로 검증)

### 회귀

- [x] `zig build test` 4099 tests — pass
- [x] `bun test packages/core/index.test.ts` 349 tests (+3 신규) — pass

## Follow-ups

- 비-Uint8 typed array 명시적 에러 (현재 silent skip — plugin 작성 실수 시 contents missing 으로 표면화). `std.log.warn` 또는 NAPI throw 로 발견성 향상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)