### PR TITLE
refactor(dto): AliasDto / ManualChunkDto 를 bundler/types entry 타입 alias 로 통합

### DIFF
--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -18,6 +18,7 @@ const DefineEntry = @import("transformer/transformer.zig").DefineEntry;
 const Codegen = @import("codegen/codegen.zig").Codegen;
 const SourceMap = @import("codegen/sourcemap.zig");
 const Mangler = @import("codegen/mod.zig").mangler;
+const bundler_types = @import("bundler/types.zig");
 const LinkingMetadata = @import("bundler/linker.zig").LinkingMetadata;
 const rt = @import("bundler/runtime_helpers.zig");
 const Diagnostic = @import("diagnostic.zig").Diagnostic;
@@ -163,19 +164,15 @@ pub const TranspileOptionsDto = struct {
     manualChunks: ?[]const ManualChunkDto = null,
 };
 
-pub const AliasDto = struct {
-    from: []const u8,
-    to: []const u8,
-};
+/// `AliasDto` / `ManualChunkDto` 는 `bundler/types.zig` 의 entry 타입과 layout 동일 —
+/// silent drift 방지용 직접 재사용 (별도 DTO 유지 시 두 정의 동기화 의무 발생).
+/// `LoaderDto` 만 string 표현 vs enum 차이로 별도 유지.
+pub const AliasDto = bundler_types.AliasEntry;
+pub const ManualChunkDto = bundler_types.ManualChunkEntry;
 
 pub const LoaderDto = struct {
     ext: []const u8,
     loader: []const u8,
-};
-
-pub const ManualChunkDto = struct {
-    name: []const u8,
-    patterns: []const []const u8,
 };
 
 /// JSON payload를 파싱해 `TranspileOptions`로 변환한다.

--- a/src/transpile_options_dto_test.zig
+++ b/src/transpile_options_dto_test.zig
@@ -305,3 +305,12 @@ test "schema diff: bundler_only_fields are all in TS BuildOptionsCommon" {
         return error.TsBuildOptionMissingFromZig;
     }
 }
+
+test "AliasDto / ManualChunkDto 는 bundler/types entry 타입의 alias — drift 차단" {
+    const transpile = @import("transpile.zig");
+    const bundler_types_mod = @import("bundler/types.zig");
+
+    // type 자체가 같아야 — 한 정의 변경 시 다른 곳 자동 반영. drift 차단.
+    try std.testing.expect(transpile.AliasDto == bundler_types_mod.AliasEntry);
+    try std.testing.expect(transpile.ManualChunkDto == bundler_types_mod.ManualChunkEntry);
+}


### PR DESCRIPTION
## Summary

#2099 epic Phase 2 follow-up (memory `project_phase2_simplify_followups.md` P1 항목 일부). DTO rename 시리즈의 sub-step 1 — naming 변경 없이 **중복 type 정의 제거**.

`TranspileOptionsDto.AliasDto` / `ManualChunkDto` 가 `bundler/types.zig` 의 `AliasEntry` / `ManualChunkEntry` 와 layout 동일. 별도 정의 유지 시 silent drift 가능 — 한 곳 필드 추가 시 다른 쪽 누락 위험.

## 변경

```diff
-pub const AliasDto = struct {
-    from: []const u8,
-    to: []const u8,
-};
-pub const ManualChunkDto = struct {
-    name: []const u8,
-    patterns: []const []const u8,
-};
+pub const AliasDto = bundler_types.AliasEntry;
+pub const ManualChunkDto = bundler_types.ManualChunkEntry;
```

`LoaderDto` 는 string 표현 vs `Loader` enum 차이로 별도 유지.

## Test

- [x] type 동등성 lock-in 단위 테스트 추가 (`AliasDto == AliasEntry` 등 `==` 비교)
- [x] zig build test 4099 — pass
- [x] 기존 schema-sync 테스트 그대로 통과

## Follow-up

- 다음 PR: `TranspileOptionsDto` rename / split (`ConfigOptionsDto` + `BundleOptionsDto`) — DTO sub-step 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)