### PR TITLE
refactor(dto): TranspileOptionsDto → ConfigOptionsDto rename

### DIFF
--- a/packages/core/napi.test.mjs
+++ b/packages/core/napi.test.mjs
@@ -18,7 +18,7 @@ const require = createRequire(import.meta.url);
 const addonPath = join(__dirname, "../../zig-out/lib/zts.node");
 const native = require(addonPath);
 
-// 옵션은 단일 JSON payload (camelCase, Zig TranspileOptionsDto와 매핑).
+// 옵션은 단일 JSON payload (camelCase, Zig ConfigOptionsDto와 매핑).
 // 기본값(useDefineForClassFields, sourcesContent 등)은 Zig 측에서 처리하므로 생략 가능.
 const call = (src, filename, opts = {}) => native.transpile(src, filename, JSON.stringify(opts));
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -91,7 +91,7 @@ fn getStringArg(env: c.napi_env, value: c.napi_value, alloc: std.mem.Allocator) 
 // ─── transpile 함수 ───
 
 /// transpile(source, filename, optionsJson)
-/// optionsJson: TranspileOptionsDto JSON payload (camelCase 키)
+/// optionsJson: ConfigOptionsDto JSON payload (camelCase 키)
 /// → { code: string, map?: string, errors?: string }
 fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
     var argc: usize = 3;

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -162,7 +162,7 @@ export function targetToUnsupported(target?: Target): number {
 // ─── JSON payload 구성 (Zig optionsFromJson과 1:1 매핑) ───
 
 /**
- * TranspileOptions를 Zig `TranspileOptionsDto` JSON으로 직렬화한다.
+ * TranspileOptions를 Zig `ConfigOptionsDto` JSON으로 직렬화한다.
  *
  * - 기본값은 생략 (payload 크기 최소화)
  * - enum 키는 Zig enum name과 일치 (예: "react-native" → "react_native")

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -94,7 +94,7 @@ const decodeFlags = transpile_mod.decodeFlags;
 
 /// 소스 코드를 트랜스파일한다.
 ///
-/// opts_json: TranspileOptionsDto JSON payload (ptr+len). camelCase 키. 빈 문자열이면 기본값.
+/// opts_json: ConfigOptionsDto JSON payload (ptr+len). camelCase 키. 빈 문자열이면 기본값.
 ///
 /// 반환값: packed u64 (상위 32비트: 포인터, 하위 32비트: 길이, 0=에러)
 export fn transpile(

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -1,4 +1,4 @@
-//! `TranspileOptionsDto` (Zig) ↔ `TranspileOptions` (TS) 필드 동기화 검증.
+//! `ConfigOptionsDto` (Zig) ↔ `TranspileOptions` (TS) 필드 동기화 검증.
 //!
 //! #1446에서 Zig struct가 JSON schema의 단일 소스가 됐지만, TS 쪽의
 //! `TranspileOptions` interface는 JSDoc/union 유지를 위해 handwritten으로
@@ -11,7 +11,7 @@
 //!     자체 처리하는 필드들 — filename/browserslist/minify 등).
 
 const std = @import("std");
-const TranspileOptionsDto = @import("transpile.zig").TranspileOptionsDto;
+const ConfigOptionsDto = @import("transpile.zig").ConfigOptionsDto;
 
 /// TS `TranspileOptions`에만 있는 (Zig로 전달되지 않거나 JS 래퍼가 해석하는)
 /// 필드. 리스트에 없는 TS-only 필드가 발견되면 테스트 실패 — 의도된 추가라면
@@ -125,12 +125,12 @@ test "schema diff: Zig DTO fields are covered by TS TranspileOptions" {
     try std.testing.expect(ts_fields.items.len > 0);
 
     // 1. Zig DTO 필드가 TS에 모두 있는지 (internal 필드는 zig_only_allowlist에서 제외)
-    const zig_fields = @typeInfo(TranspileOptionsDto).@"struct".fields;
+    const zig_fields = @typeInfo(ConfigOptionsDto).@"struct".fields;
     inline for (zig_fields) |f| {
         const is_internal = comptime contains(&zig_only_allowlist, f.name);
         if (!is_internal and !contains(ts_fields.items, f.name)) {
             std.debug.print(
-                "\n[schema drift] Zig TranspileOptionsDto.{s} is missing from TS TranspileOptions in packages/shared/index.ts\n",
+                "\n[schema drift] Zig ConfigOptionsDto.{s} is missing from TS TranspileOptions in packages/shared/index.ts\n",
                 .{f.name},
             );
             return error.ZigFieldMissingFromTs;

--- a/src/main.zig
+++ b/src/main.zig
@@ -313,7 +313,7 @@ fn applyZtsConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
     // raw DTO 파싱 — `optionsFromJson` 은 TranspileOptions 만 추출하므로 bundler-only
     // 필드를 동시에 매핑하려면 DTO 직접 파싱이 필요.
     const dto = std.json.parseFromSliceLeaky(
-        lib.transpile.TranspileOptionsDto,
+        lib.transpile.ConfigOptionsDto,
         arena_alloc,
         content,
         .{ .ignore_unknown_fields = true },

--- a/src/root.zig
+++ b/src/root.zig
@@ -57,5 +57,5 @@ test {
 
     // test files
     _ = @import("config_test.zig");
-    _ = @import("transpile_options_dto_test.zig");
+    _ = @import("config_options_dto_test.zig");
 }

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -105,7 +105,7 @@ pub const TranspileOptions = struct {
 ///
 /// 이 struct는 JSON schema emitter(tools/emit_schema.zig)가 comptime
 /// `@typeInfo`로 반사해 단일 소스 보장. 필드를 바꾸면 schema도 함께 재생성.
-pub const TranspileOptionsDto = struct {
+pub const ConfigOptionsDto = struct {
     target: ?@import("transformer/compat.zig").ESTarget = null,
     unsupported: ?u32 = null,
     flow: ?bool = null,
@@ -180,7 +180,7 @@ pub const LoaderDto = struct {
 ///
 /// 오류: JSON 파싱 실패 / 알 수 없는 enum 문자열 → error 반환.
 pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !TranspileOptions {
-    const parsed = std.json.parseFromSliceLeaky(TranspileOptionsDto, allocator, json, .{ .ignore_unknown_fields = true }) catch return error.InvalidOptions;
+    const parsed = std.json.parseFromSliceLeaky(ConfigOptionsDto, allocator, json, .{ .ignore_unknown_fields = true }) catch return error.InvalidOptions;
 
     var opts: TranspileOptions = .{};
     const compat = @import("transformer/compat.zig");


### PR DESCRIPTION
## Summary

#2099 epic Phase 2 follow-up — DTO rename 시리즈의 sub-step 2. PR #2182 에 이어 naming 정리.

`TranspileOptionsDto` 가 transpile-only 옵션이 아니라 **config 단계 전체** (transpile 옵션 ~35개 + bundler-only 15 필드) 를 carry. 이름이 misleading 해서 새 contributor 가 bundle 옵션을 잘못된 곳에 추가할 silent drift 위험.

## 변경 (cosmetic — 동작 변경 없음)

```
TranspileOptionsDto → ConfigOptionsDto
src/transpile_options_dto_test.zig → src/config_options_dto_test.zig
```

영향 받은 파일:
- `src/transpile.zig` — DTO 정의
- `src/main.zig` — CLI
- `src/root.zig` — test import
- `src/config_options_dto_test.zig` (rename)
- `packages/core/src/napi_entry.zig` — JSDoc 코멘트
- `packages/wasm/src/wasm_entry.zig` — JSDoc 코멘트
- `packages/shared/index.ts` — 직렬화 코멘트
- `packages/core/napi.test.mjs` — test 코멘트

## Test

- [x] zig build test 4099 — pass
- [x] @zts/core 349 — pass
- [x] schema-sync 테스트 그대로 통과 (`AliasDto == AliasEntry` lock-in 포함)

## DTO rename 시리즈 마무리

- ✅ #2182: `AliasDto` / `ManualChunkDto` → `bundler/types.AliasEntry` / `ManualChunkEntry` 재사용
- ✅ 이번 PR: `TranspileOptionsDto` → `ConfigOptionsDto`

memory `project_phase2_simplify_followups.md` P1 아키텍처 항목 두 개 모두 close. 잔여 (P2 helper 추출 / P3 CLI flag) 는 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)