### PR TITLE
refactor(dto): applyTranspileSharedFields 헬퍼 — silent drift fix

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -320,46 +320,9 @@ fn applyZtsConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
     ) catch return error.InvalidConfig;
 
     // ─── TranspileOptions-shaped 필드 ──────────────────────────────────────
-    if (dto.target) |t| {
-        opts.es_target = t;
-        opts.unsupported = lib.transformer.TransformOptions.compat.fromESTarget(t);
-    }
-    if (dto.unsupported) |u| {
-        opts.unsupported = @bitCast(@as(u32, @bitCast(opts.unsupported)) | u);
-    }
-    if (dto.flow == true) opts.flow = true;
-    if (dto.jsxInJs == true) opts.jsx_in_js = true;
-    if (dto.jsx) |v| opts.jsx_runtime = v;
-    // 문자열 필드는 config 수명이 함수 종료 후 해제됨 → dupe 필수.
-    if (dto.jsxFactory) |s| if (s.len > 0 and !std.mem.eql(u8, s, "React.createElement")) {
-        opts.jsx_factory = try allocator.dupe(u8, s);
-    };
-    if (dto.jsxFragment) |s| if (s.len > 0 and !std.mem.eql(u8, s, "React.Fragment")) {
-        opts.jsx_fragment = try allocator.dupe(u8, s);
-    };
-    if (dto.jsxImportSource) |s| if (s.len > 0 and !std.mem.eql(u8, s, "react")) {
-        opts.jsx_import_source = try allocator.dupe(u8, s);
-    };
-    if (dto.dropConsole == true) opts.drop_console = true;
-    if (dto.dropDebugger == true) opts.drop_debugger = true;
-    if (dto.asciiOnly == true) opts.ascii_only = true;
-    if (dto.charsetUtf8 == true) opts.charset_utf8 = true;
-    if (dto.experimentalDecorators == true) opts.experimental_decorators = true;
-    if (dto.emitDecoratorMetadata == true) opts.emit_decorator_metadata = true;
-    if (dto.useDefineForClassFields == false) opts.use_define_for_class_fields = false;
-    if (dto.verbatimModuleSyntax == true) opts.verbatim_module_syntax = true;
-    if (dto.format) |v| opts.module_format = v;
-    if (dto.quotes) |v| opts.quote_style = v;
-    if (dto.platform) |v| opts.platform = v;
-    if (dto.minifyWhitespace == true) opts.minify_whitespace = true;
-    if (dto.minifyIdentifiers == true) opts.minify_identifiers = true;
-    if (dto.minifySyntax == true) opts.minify_syntax = true;
-    if (dto.sourcemap == true) opts.sourcemap = true;
-    if (dto.sourcemapDebugIds == true) opts.sourcemap_debug_ids = true;
-    if (dto.sourcesContent == false) opts.sources_content = false;
-    if (dto.sourceRoot) |s| if (s.len > 0) {
-        opts.source_root = try allocator.dupe(u8, s);
-    };
+    // optionsFromJson 과 공유 helper — silent drift 차단. dto 명시 시 항상 override
+    // (boolean 필드도 false 명시 가능). string 은 config 수명 만료 후 살아남도록 dupe.
+    try lib.transpile.applyTranspileSharedFields(opts, &dto, allocator, true);
 
     // ─── bundler-only 필드 (#2105) ─────────────────────────────────────────
     if (dto.external) |list| for (list) |s| {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -175,6 +175,82 @@ pub const LoaderDto = struct {
     loader: []const u8,
 };
 
+/// `ConfigOptionsDto` 의 transpile-shaped 필드를 target 으로 매핑하는 공통 helper.
+/// `optionsFromJson` (TranspileOptions) 와 `main.applyZtsConfigJson` (CliOptions) 가 공유 —
+/// 두 함수의 매핑이 drift 하지 않도록 single source of truth. (memory P2 deferred)
+///
+/// `dupe_strings` 가 true 면 string 필드를 `allocator.dupe` 로 복사 (long-lived target).
+/// false 면 dto 의 string slice 를 그대로 borrow (arena/parsed-from-json lifetime).
+///
+/// 모든 boolean 필드는 dto 명시 시 always override (true/false 둘 다 set). esbuild/rolldown
+/// 정책과 일치 — config 의 explicit 값이 default 를 덮어쓴다.
+///
+/// caller 가 처리해야 할 차이:
+/// - `define` (struct field name 차이: `define` vs `define_list`)
+/// - `stopAfter` (struct field name 차이: `stop_after` vs `core_stop_after`)
+/// - `tsconfig` merge / bundler-only 필드 (target struct 별로 다름)
+pub fn applyTranspileSharedFields(
+    target: anytype,
+    dto: *const ConfigOptionsDto,
+    allocator: std.mem.Allocator,
+    comptime dupe_strings: bool,
+) !void {
+    const compat = @import("transformer/compat.zig");
+
+    if (dto.target) |t| {
+        target.es_target = t;
+        // unsupported 가 명시되지 않았으면 target 으로부터 자동 도출.
+        if (dto.unsupported == null) {
+            target.unsupported = compat.fromESTarget(t);
+        }
+    }
+    if (dto.unsupported) |u| target.unsupported = @bitCast(u);
+    if (dto.flow) |v| target.flow = v;
+    if (dto.jsxInJs) |v| target.jsx_in_js = v;
+    if (dto.jsx) |v| target.jsx_runtime = v;
+    if (dto.jsxFactory) |s| if (s.len > 0) {
+        target.jsx_factory = if (dupe_strings) try allocator.dupe(u8, s) else s;
+    };
+    if (dto.jsxFragment) |s| if (s.len > 0) {
+        target.jsx_fragment = if (dupe_strings) try allocator.dupe(u8, s) else s;
+    };
+    if (dto.jsxImportSource) |s| if (s.len > 0) {
+        target.jsx_import_source = if (dupe_strings) try allocator.dupe(u8, s) else s;
+    };
+    if (dto.dropConsole) |v| target.drop_console = v;
+    if (dto.dropDebugger) |v| target.drop_debugger = v;
+    if (dto.asciiOnly) |v| target.ascii_only = v;
+    if (dto.charsetUtf8) |v| target.charset_utf8 = v;
+    if (dto.experimentalDecorators) |v| target.experimental_decorators = v;
+    if (dto.emitDecoratorMetadata) |v| target.emit_decorator_metadata = v;
+    if (dto.useDefineForClassFields) |v| target.use_define_for_class_fields = v;
+    if (dto.verbatimModuleSyntax) |v| target.verbatim_module_syntax = v;
+    if (dto.tsconfigPath) |s| if (s.len > 0) {
+        const dup = if (dupe_strings) try allocator.dupe(u8, s) else s;
+        // CliOptions 는 historical 이유로 같은 의미 필드를 `project_path` 로 보유 (`-p` /
+        // `--project` / `--tsconfig-path` 모두 이 한 필드로 통일). TranspileOptions 는
+        // `tsconfig_path` 사용. 둘 중 존재하는 쪽으로 set.
+        const T = @TypeOf(target.*);
+        if (@hasField(T, "tsconfig_path")) {
+            target.tsconfig_path = dup;
+        } else if (@hasField(T, "project_path")) {
+            target.project_path = dup;
+        }
+    };
+    if (dto.format) |v| target.module_format = v;
+    if (dto.quotes) |v| target.quote_style = v;
+    if (dto.platform) |v| target.platform = v;
+    if (dto.minifyWhitespace) |v| target.minify_whitespace = v;
+    if (dto.minifyIdentifiers) |v| target.minify_identifiers = v;
+    if (dto.minifySyntax) |v| target.minify_syntax = v;
+    if (dto.sourcemap) |v| target.sourcemap = v;
+    if (dto.sourcemapDebugIds) |v| target.sourcemap_debug_ids = v;
+    if (dto.sourcesContent) |v| target.sources_content = v;
+    if (dto.sourceRoot) |s| if (s.len > 0) {
+        target.source_root = if (dupe_strings) try allocator.dupe(u8, s) else s;
+    };
+}
+
 /// JSON payload를 파싱해 `TranspileOptions`로 변환한다.
 /// allocator는 arena 권장 — 반환된 값의 문자열/슬라이스 수명을 책임진다.
 ///
@@ -183,49 +259,8 @@ pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !Transpil
     const parsed = std.json.parseFromSliceLeaky(ConfigOptionsDto, allocator, json, .{ .ignore_unknown_fields = true }) catch return error.InvalidOptions;
 
     var opts: TranspileOptions = .{};
-    const compat = @import("transformer/compat.zig");
 
-    if (parsed.target) |t| opts.es_target = t;
-    if (parsed.unsupported) |u| {
-        opts.unsupported = @bitCast(u);
-    } else if (opts.es_target) |t| {
-        opts.unsupported = compat.fromESTarget(t);
-    }
-    if (parsed.flow) |v| opts.flow = v;
-    if (parsed.jsxInJs) |v| opts.jsx_in_js = v;
-    if (parsed.jsx) |v| opts.jsx_runtime = v;
-    if (parsed.jsxFactory) |s| if (s.len > 0) {
-        opts.jsx_factory = s;
-    };
-    if (parsed.jsxFragment) |s| if (s.len > 0) {
-        opts.jsx_fragment = s;
-    };
-    if (parsed.jsxImportSource) |s| if (s.len > 0) {
-        opts.jsx_import_source = s;
-    };
-    if (parsed.dropConsole) |v| opts.drop_console = v;
-    if (parsed.dropDebugger) |v| opts.drop_debugger = v;
-    if (parsed.asciiOnly) |v| opts.ascii_only = v;
-    if (parsed.charsetUtf8) |v| opts.charset_utf8 = v;
-    if (parsed.experimentalDecorators) |v| opts.experimental_decorators = v;
-    if (parsed.emitDecoratorMetadata) |v| opts.emit_decorator_metadata = v;
-    if (parsed.useDefineForClassFields) |v| opts.use_define_for_class_fields = v;
-    if (parsed.verbatimModuleSyntax) |v| opts.verbatim_module_syntax = v;
-    if (parsed.tsconfigPath) |s| if (s.len > 0) {
-        opts.tsconfig_path = s;
-    };
-    if (parsed.format) |v| opts.module_format = v;
-    if (parsed.quotes) |v| opts.quote_style = v;
-    if (parsed.platform) |v| opts.platform = v;
-    if (parsed.minifyWhitespace) |v| opts.minify_whitespace = v;
-    if (parsed.minifyIdentifiers) |v| opts.minify_identifiers = v;
-    if (parsed.minifySyntax) |v| opts.minify_syntax = v;
-    if (parsed.sourcemap) |v| opts.sourcemap = v;
-    if (parsed.sourcemapDebugIds) |v| opts.sourcemap_debug_ids = v;
-    if (parsed.sourcesContent) |v| opts.sources_content = v;
-    if (parsed.sourceRoot) |s| if (s.len > 0) {
-        opts.source_root = s;
-    };
+    try applyTranspileSharedFields(&opts, &parsed, allocator, false);
     if (parsed.define) |d| opts.define = d;
     if (parsed.stopAfter) |v| opts.stop_after = v;
 

--- a/tests/integration/tests/zts-config-bundler.test.ts
+++ b/tests/integration/tests/zts-config-bundler.test.ts
@@ -250,4 +250,28 @@ describe("Zig CLI: zts.config.json bundler-only 옵션 (#2105)", () => {
     expect(result.exitCode).toBe(0);
     expect(readFileSync(outFile, "utf8")).toContain("NO_CONFIG");
   });
+
+  test("tsconfigPath: zts.config.json 의 tsconfigPath 가 정상 적용 (이전엔 silent drop)", async () => {
+    // applyZtsConfigJson 이 tsconfigPath 매핑을 누락했던 silent drift 의 fix 검증.
+    // tsconfig.json 에 experimentalDecorators=true 명시 → @decorator 구문 파싱 통과.
+    const fixture = await createFixture({
+      "index.ts":
+        "function dec(t:any,k:string){}\nclass A { @dec method(){} }\nconsole.log('TSCONFIG_OK');",
+      "tsconfig.custom.json": JSON.stringify({
+        compilerOptions: { experimentalDecorators: true, target: "es2022" },
+      }),
+      "zts.config.json": JSON.stringify({ tsconfigPath: "tsconfig.custom.json" }),
+    });
+    cleanup = fixture.cleanup;
+
+    const outFile = join(fixture.dir, "out.js");
+    const result = await runZtsInDir(fixture.dir, [
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(outFile, "utf8")).toContain("TSCONFIG_OK");
+  });
 });


### PR DESCRIPTION
## Summary

memory P2 deferred 항목 — `ConfigOptionsDto` 의 transpile-shaped 필드 매핑이 두 함수에 중복되어 있던 silent drift fix.

## Root cause: 발견된 silent drift 사례

`applyZtsConfigJson` 이 `tsconfigPath` 매핑 누락 — 사용자가 `zts.config.json` 에 `tsconfigPath` 명시해도 **silent 무시**.

또 boolean 필드 시맨틱 차이:
- `optionsFromJson`: `if (dto.flow) |v| target.flow = v;` (explicit override)
- `applyZtsConfigJson`: `if (dto.flow == true) ...` (enable-only — false 명시 무시)

esbuild/rolldown 정책은 explicit override. `applyZtsConfigJson` 이 잘못.

## 변경

`src/transpile.zig` 에 `applyTranspileSharedFields(target, dto, allocator, dupe_strings)` helper 추가 — 두 caller 가 호출하는 single source of truth.

```zig
pub fn applyTranspileSharedFields(
    target: anytype,
    dto: *const ConfigOptionsDto,
    allocator: std.mem.Allocator,
    comptime dupe_strings: bool,
) !void { ... }
```

- `dupe_strings` comptime param: long-lived target (CliOptions) 은 `allocator.dupe`, arena target (TranspileOptions) 은 borrow
- `tsconfigPath` 매핑은 `@hasField` 로 양쪽 struct 의 이름 차이 (`tsconfig_path` vs `project_path`) 처리
- boolean 시맨틱 통일 (explicit override)

caller 가 처리하는 차이는 helper 밖으로 (의도적 분리):
- `define` (TranspileOptions) vs `define_list` (CliOptions, ArrayList)
- `stop_after` (TranspileOptions) vs `core_stop_after` (CliOptions)
- tsconfig merge (TranspileOptions 만)
- bundler-only 필드 (CliOptions 만)

## Test

- [x] zig build test 4099 — pass
- [x] @zts/core 349 — pass
- [x] zts-config-bundler integration 11 (+1 신규) — pass
- [x] **신규 테스트**: `zts.config.json` 의 `tsconfigPath` 가 정상 적용 (이전 silent drop fix 검증) — `experimentalDecorators=true` 가 적용되어 `@dec` 구문 파싱 통과 확인

## Phase 2 deferred 진행 상황

- ✅ #2182: AliasDto / ManualChunkDto 재사용
- ✅ #2183: TranspileOptionsDto → ConfigOptionsDto rename
- ✅ 이번 PR: shared helper 추출 + tsconfigPath drift fix
- 잔여 P3: `inline_dynamic_imports` CLI flag, `manualChunks` JSON DTO 매핑, `runConfigBundle` 테스트 helper

Refs #2099

🤖 Generated with [Claude Code](https://claude.com/claude-code)