### PR TITLE
feat(config): zts.config.json manualChunks (record form) 매핑 (#2099 P3)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -86,6 +86,9 @@ const CliOptions = struct {
     /// --fallback:NAME=PATH (webpack resolve.fallback). 일반 해석 실패 시에만 적용.
     /// PATH 대신 "false"로 쓰면 빈 모듈로 대체.
     fallback_list: std.ArrayList(FallbackEntry) = .empty,
+    /// `zts.config.json` 의 `manualChunks` (record form: `[{name, patterns}]`) 매핑.
+    /// CLI flag 없음 — config.json 만. function form 은 JS-only 라 NAPI 경유.
+    manual_chunks_list: std.ArrayList(ManualChunkEntry) = .empty,
     /// --block-list=PATTERN (반복). Metro resolver.blockList 호환.
     /// JS regex source 스타일 문자열 (`\/ios\/`, `\.bak$` 등).
     block_list: std.ArrayList([]const u8) = .empty,
@@ -212,6 +215,7 @@ const CliOptions = struct {
     const LoaderOverride = @import("zts_lib").bundler.types.LoaderOverride;
     const LoaderEnum = @import("zts_lib").bundler.types.Loader;
     const LegalCommentsEnum = @import("zts_lib").bundler.types.LegalComments;
+    const ManualChunkEntry = @import("zts_lib").bundler.types.ManualChunkEntry;
 
     const LogLevel = enum {
         silent,
@@ -229,6 +233,7 @@ const CliOptions = struct {
         self.conditions_list.deinit(alloc);
         self.alias_list.deinit(alloc);
         self.fallback_list.deinit(alloc);
+        self.manual_chunks_list.deinit(alloc);
         self.block_list.deinit(alloc);
         self.loader_list.deinit(alloc);
         for (self.inject_list.items) |p| alloc.free(p);
@@ -376,9 +381,15 @@ fn applyZtsConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
         opts.preserve_modules_root = try allocator.dupe(u8, s);
     };
     if (dto.inlineDynamicImports == true) opts.inline_dynamic_imports = true;
-    // manualChunks: record form 만 지원. 현재 CliOptions 에 manual_chunks_list 가
-    // 없어 follow-up 으로 분리. CLI 의 `manualChunks` JSON 명시는 silent 무시 —
-    // 사용자 영향 없도록 #2105 follow-up 에 트래킹.
+    // manualChunks: record form 매핑 — `[{name, patterns}]`. function form 은 JS-only.
+    if (dto.manualChunks) |list| for (list) |e| {
+        const patterns = try allocator.alloc([]const u8, e.patterns.len);
+        for (e.patterns, 0..) |p, i| patterns[i] = try allocator.dupe(u8, p);
+        try opts.manual_chunks_list.append(allocator, .{
+            .name = try allocator.dupe(u8, e.name),
+            .patterns = patterns,
+        });
+    };
 }
 
 /// CLI 인자를 파싱하여 CliOptions를 반환한다.
@@ -1825,6 +1836,7 @@ pub fn main() !void {
             .alias = opts.alias_list.items,
             .ts_paths = resolved_paths.entries,
             .fallback = opts.fallback_list.items,
+            .manual_chunks = opts.manual_chunks_list.items,
             .block_list = opts.block_list.items,
             .public_path = opts.public_path orelse "",
             .banner_js = opts.banner_js,

--- a/tests/integration/tests/zts-config-bundler.test.ts
+++ b/tests/integration/tests/zts-config-bundler.test.ts
@@ -251,6 +251,40 @@ describe("Zig CLI: zts.config.json bundler-only 옵션 (#2105)", () => {
     expect(readFileSync(outFile, "utf8")).toContain("NO_CONFIG");
   });
 
+  test("manualChunks: record form 매핑 — vendor chunk 분리", async () => {
+    // 이전엔 zts.config.json 의 manualChunks 가 silent 무시됨. record form 매핑 검증.
+    const fixture = await createFixture({
+      "src/a.ts": 'export const a = "PKG_A";',
+      "src/b.ts": 'export const b = "PKG_B";',
+      "index.ts": 'import { a } from "./src/a";\nimport { b } from "./src/b";\nconsole.log(a, b);',
+      "zts.config.json": JSON.stringify({
+        manualChunks: [{ name: "vendor", patterns: ["src/a", "src/b"] }],
+      }),
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    const result = await runZtsInDir(fixture.dir, [
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "--outdir",
+      outDir,
+      "--splitting",
+      "--format=esm",
+    ]);
+    expect(result.exitCode).toBe(0);
+    const { readdirSync } = require("node:fs");
+    const files = readdirSync(outDir);
+    // manualChunks 가 적용되면 vendor chunk 분리 → 2+ 파일 emit.
+    expect(files.length).toBeGreaterThan(1);
+    // vendor chunk 가 a/b 마커를 포함.
+    const vendorFile = files.find((f: string) => f.startsWith("vendor"));
+    expect(vendorFile).toBeDefined();
+    const vendorContents = readFileSync(join(outDir, vendorFile!), "utf8");
+    expect(vendorContents).toContain("PKG_A");
+    expect(vendorContents).toContain("PKG_B");
+  });
+
   test("--inline-dynamic-imports CLI flag: dynamic target 이 entry chunk 에 흡수", async () => {
     // 이전엔 config.json `inlineDynamicImports` 만 노출되어 있었음. CLI flag 추가 검증.
     const fixture = await createFixture({


### PR DESCRIPTION
## Summary

memory P3 deferred — `applyZtsConfigJson` 의 manualChunks 매핑 누락 silent drift fix. 이전엔 사용자가 `zts.config.json` 에 `manualChunks: [{name, patterns}]` 명시해도 silent 무시.

## 변경

- `CliOptions` 에 `manual_chunks_list: ArrayList(ManualChunkEntry)` 필드 신설
- `applyZtsConfigJson` 의 TODO 주석 제거 → record form 매핑 추가
- BundleOptions forward (`.manual_chunks = opts.manual_chunks_list.items`)

CLI flag (`--manual-chunks=...`) 는 record form 의 복잡성 (name + patterns array) 때문에 별도 PR 검토 — function form 은 JS-only 라 NAPI 경유 그대로 유지.

## Test

- [x] zig build test 4099 — pass
- [x] 신규 통합 테스트: `zts.config.json` 의 `manualChunks` 가 vendor chunk 분리에 정상 적용
  - 2+ 출력 파일 + vendor 청크가 두 패키지 마커 포함 확인

## Phase 2/3 deferred 진행 상황

- ✅ #2182: AliasDto / ManualChunkDto 재사용
- ✅ #2183: TranspileOptionsDto → ConfigOptionsDto rename
- ✅ #2184: applyTranspileSharedFields helper + tsconfigPath drift fix
- ✅ #2185: --inline-dynamic-imports CLI flag
- ✅ 이번 PR: manualChunks JSON 매핑
- 잔여: `runConfigBundle` 테스트 helper (cosmetic)

Refs #2099

🤖 Generated with [Claude Code](https://claude.com/claude-code)